### PR TITLE
feat: phase 3 — auth, hooks, plugin api, capabilities

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,11 +19,15 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@oslojs/crypto": "^1.0.1",
+    "@oslojs/encoding": "^1.1.0",
+    "@oslojs/webauthn": "^1.0.0",
     "drizzle-orm": "catalog:",
     "drizzle-valibot": "catalog:",
     "valibot": "catalog:"
   },
   "devDependencies": {
+    "@libsql/client": "^0.17.2",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
     "drizzle-kit": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",

--- a/packages/core/src/auth/bootstrap.test.ts
+++ b/packages/core/src/auth/bootstrap.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import { createTestDb } from "../test/harness.js";
+import { provisionUser } from "./bootstrap.js";
+
+describe("first-user-admin bootstrap", () => {
+  test("first user becomes admin regardless of requested defaultRole", async () => {
+    const db = await createTestDb();
+    const result = await provisionUser(db, {
+      email: "first@example.com",
+      defaultRole: "subscriber",
+    });
+    expect(result.bootstrapped).toBe(true);
+    expect(result.user.role).toBe("admin");
+  });
+
+  test("subsequent users get the supplied defaultRole, never admin", async () => {
+    const db = await createTestDb();
+    await provisionUser(db, { email: "first@example.com" });
+    const result = await provisionUser(db, {
+      email: "second@example.com",
+      defaultRole: "author",
+    });
+    expect(result.bootstrapped).toBe(false);
+    expect(result.user.role).toBe("author");
+  });
+});

--- a/packages/core/src/auth/bootstrap.ts
+++ b/packages/core/src/auth/bootstrap.ts
@@ -1,0 +1,50 @@
+import type { Db } from "../context/app.js";
+import type { User, UserRole } from "../db/schema/users.js";
+import { users } from "../db/schema/users.js";
+
+export interface BootstrappedUser {
+  readonly user: User;
+  /** True iff this call promoted the user to admin via the bootstrap rule. */
+  readonly bootstrapped: boolean;
+}
+
+/**
+ * Provision a user, automatically granting `admin` to the very first user.
+ *
+ * Safe because Plumix has no open registration: provisioning happens only
+ * via passkey enrollment, OAuth callback, or invite — each requires the
+ * deployer to wire it up.
+ *
+ * Note: count-then-insert is racy under concurrent provisioning. Acceptable
+ * here because the bootstrap window is the first request of a fresh install;
+ * a hardened path will land alongside the OAuth/invite flows.
+ */
+export async function provisionUser(
+  db: Db,
+  input: {
+    readonly email: string;
+    readonly name?: string | null;
+    readonly avatarUrl?: string | null;
+    readonly defaultRole?: UserRole;
+    readonly emailVerified?: boolean;
+  },
+): Promise<BootstrappedUser> {
+  const isFirst = (await db.$count(users)) === 0;
+  const role: UserRole = isFirst
+    ? "admin"
+    : (input.defaultRole ?? "subscriber");
+
+  const [user] = await db
+    .insert(users)
+    .values({
+      email: input.email,
+      name: input.name ?? null,
+      avatarUrl: input.avatarUrl ?? null,
+      role,
+      emailVerifiedAt: input.emailVerified ? new Date() : null,
+    })
+    .returning();
+
+  if (!user) throw new Error("provisionUser: insert returned no row");
+  return { user, bootstrapped: isFirst };
+}

--- a/packages/core/src/auth/cookies.test.ts
+++ b/packages/core/src/auth/cookies.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  isSecureRequest,
+  readSessionCookie,
+  SESSION_COOKIE_NAME,
+} from "./cookies.js";
+
+describe("readSessionCookie", () => {
+  test("only accepts the session from the Cookie header — never from URL or body", () => {
+    // The Copenhagen Book rule: session IDs must not be readable from query
+    // strings or form submissions. Our reader is cookie-only by construction.
+    const req = new Request(
+      `https://x.example/?${SESSION_COOKIE_NAME}=stolen`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: `${SESSION_COOKIE_NAME}=stolen`,
+      },
+    );
+    expect(readSessionCookie(req)).toBeNull();
+  });
+
+  test("parses the cookie value when present in the Cookie header", () => {
+    const req = new Request("https://x.example", {
+      headers: {
+        cookie: `other=foo; ${SESSION_COOKIE_NAME}=abc; trailing=bar`,
+      },
+    });
+    expect(readSessionCookie(req)).toBe("abc");
+  });
+});
+
+describe("isSecureRequest", () => {
+  test("controls the Secure flag based on request protocol", () => {
+    expect(isSecureRequest(new Request("https://x.example"))).toBe(true);
+    expect(isSecureRequest(new Request("http://x.example"))).toBe(false);
+  });
+});

--- a/packages/core/src/auth/cookies.ts
+++ b/packages/core/src/auth/cookies.ts
@@ -1,0 +1,98 @@
+export const SESSION_COOKIE_NAME = "plumix_session";
+
+export interface SessionCookieOptions {
+  readonly name?: string;
+  /** Cookie Max-Age in seconds. Mirrors the session's sliding TTL. */
+  readonly maxAgeSeconds: number;
+  /** Set Secure when serving over HTTPS — auto-detected from request URL. */
+  readonly secure: boolean;
+  readonly sameSite?: "Lax" | "Strict" | "None";
+  readonly path?: string;
+  readonly domain?: string;
+}
+
+/**
+ * Build a Set-Cookie value following Copenhagen Book guidance:
+ * HttpOnly + Secure-when-https + SameSite=Lax + explicit Max-Age + Path=/.
+ * Domain is intentionally omitted (host-only cookies are stricter than wildcard).
+ */
+export function buildSessionCookie(
+  value: string,
+  options: SessionCookieOptions,
+): string {
+  const {
+    name = SESSION_COOKIE_NAME,
+    maxAgeSeconds,
+    secure,
+    sameSite = "Lax",
+    path = "/",
+    domain,
+  } = options;
+
+  const parts = [
+    `${name}=${value}`,
+    `Path=${path}`,
+    `Max-Age=${maxAgeSeconds}`,
+    "HttpOnly",
+    `SameSite=${sameSite}`,
+  ];
+  if (secure) parts.push("Secure");
+  if (domain) parts.push(`Domain=${domain}`);
+  return parts.join("; ");
+}
+
+/** Build a Set-Cookie that immediately deletes the session cookie. */
+export function buildSessionDeletionCookie(
+  options: Omit<SessionCookieOptions, "maxAgeSeconds">,
+): string {
+  const {
+    name = SESSION_COOKIE_NAME,
+    secure,
+    sameSite = "Lax",
+    path = "/",
+    domain,
+  } = options;
+  const parts = [
+    `${name}=`,
+    `Path=${path}`,
+    "Max-Age=0",
+    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+    "HttpOnly",
+    `SameSite=${sameSite}`,
+  ];
+  if (secure) parts.push("Secure");
+  if (domain) parts.push(`Domain=${domain}`);
+  return parts.join("; ");
+}
+
+/**
+ * Parse a single named cookie out of a request's Cookie header. We accept
+ * the cookie ONLY from the Cookie header — never from URL or form (Copenhagen
+ * Book explicit rule: session IDs must not be readable from form submissions
+ * or query parameters).
+ */
+export function readSessionCookie(
+  request: Request,
+  name: string = SESSION_COOKIE_NAME,
+): string | null {
+  const header = request.headers.get("cookie");
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    const key = part.slice(0, eq).trim();
+    if (key !== name) continue;
+    const value = part.slice(eq + 1).trim();
+    return value === "" ? null : value;
+  }
+  return null;
+}
+
+/** True when the request was served over HTTPS — controls the Secure flag. */
+export function isSecureRequest(request: Request): boolean {
+  try {
+    return new URL(request.url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/auth/csrf.test.ts
+++ b/packages/core/src/auth/csrf.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  CSRF_HEADER_NAME,
+  CSRF_HEADER_VALUE,
+  hasCsrfHeader,
+  hasMatchingOrigin,
+} from "./csrf.js";
+
+function req(method: string, headers: Record<string, string> = {}): Request {
+  return new Request("https://cms.example.com/_plumix/rpc/post.list", {
+    method,
+    headers,
+  });
+}
+
+const allowed = ["https://cms.example.com"];
+
+describe("CSRF defences", () => {
+  test("custom header is required for non-safe methods, GETs pass through", () => {
+    expect(hasCsrfHeader(req("GET"))).toBe(true);
+    expect(hasCsrfHeader(req("POST"))).toBe(false);
+    expect(
+      hasCsrfHeader(req("POST", { [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE })),
+    ).toBe(true);
+  });
+
+  test("Origin must match the allowlist; cross-origin POSTs are rejected", () => {
+    expect(
+      hasMatchingOrigin(req("POST", { origin: "https://cms.example.com" }), {
+        allowed,
+      }),
+    ).toBe(true);
+    expect(
+      hasMatchingOrigin(req("POST", { origin: "https://attacker.example" }), {
+        allowed,
+      }),
+    ).toBe(false);
+  });
+
+  test("falls back to Referer when Origin is absent (some legacy clients)", () => {
+    expect(
+      hasMatchingOrigin(
+        req("POST", { referer: "https://cms.example.com/admin" }),
+        { allowed },
+      ),
+    ).toBe(true);
+    expect(hasMatchingOrigin(req("POST"), { allowed })).toBe(false);
+  });
+});

--- a/packages/core/src/auth/csrf.ts
+++ b/packages/core/src/auth/csrf.ts
@@ -1,0 +1,86 @@
+/**
+ * Two-layered CSRF protection per ARCHITECTURE.md §"CSRF protection":
+ *
+ * 1. RPC + auth endpoints: require a custom `X-Plumix-Request: 1` header.
+ *    Browsers cannot set custom headers on cross-origin requests without a
+ *    CORS preflight, and Plumix does not enable CORS — so a forged request
+ *    from another origin cannot include this header.
+ *
+ * 2. Public route mutations (POST/PUT/PATCH/DELETE): validate the Origin
+ *    header (or Referer if Origin is absent) against the site origin. This
+ *    is stateless and CDN-cache compatible.
+ *
+ * Combined with `SameSite=Lax` on the session cookie this covers all modern
+ * browsers; Origin/Referer check covers older clients without SameSite support.
+ */
+
+export const CSRF_HEADER_NAME = "X-Plumix-Request";
+export const CSRF_HEADER_VALUE = "1";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+export function isSafeMethod(method: string): boolean {
+  return SAFE_METHODS.has(method.toUpperCase());
+}
+
+/**
+ * True when the request includes the expected `X-Plumix-Request` header.
+ * Use on RPC and auth endpoints. Returns true for safe (non-mutating)
+ * methods so GETs aren't blocked.
+ */
+export function hasCsrfHeader(request: Request): boolean {
+  if (isSafeMethod(request.method)) return true;
+  return request.headers.get(CSRF_HEADER_NAME) === CSRF_HEADER_VALUE;
+}
+
+export interface OriginCheckOptions {
+  /** Allowed origins (e.g. `https://cms.example.com`). Compared exactly. */
+  readonly allowed: readonly string[];
+}
+
+/**
+ * Validate Origin (or Referer) for non-safe methods. Returns false on
+ * mismatch / missing header. Safe methods always pass.
+ */
+export function hasMatchingOrigin(
+  request: Request,
+  options: OriginCheckOptions,
+): boolean {
+  if (isSafeMethod(request.method)) return true;
+  const origin = request.headers.get("origin");
+  if (origin) return options.allowed.includes(origin);
+
+  // Some legacy clients omit Origin on same-origin POSTs — fall back to Referer.
+  const referer = request.headers.get("referer");
+  if (!referer) return false;
+  try {
+    const refOrigin = new URL(referer).origin;
+    return options.allowed.includes(refOrigin);
+  } catch {
+    return false;
+  }
+}
+
+export class CsrfError extends Error {
+  constructor(message = "CSRF check failed") {
+    super(message);
+    this.name = "CsrfError";
+  }
+}
+
+export function requireCsrf(request: Request): void {
+  if (!hasCsrfHeader(request)) {
+    throw new CsrfError(
+      `Missing required header ${CSRF_HEADER_NAME}: ${CSRF_HEADER_VALUE}`,
+    );
+  }
+}
+
+export function requireMatchingOrigin(
+  request: Request,
+  options: OriginCheckOptions,
+): void {
+  if (!hasMatchingOrigin(request, options)) {
+    throw new CsrfError("Origin / Referer does not match site");
+  }
+}

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,0 +1,1 @@
+export * from "./rbac.js";

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,1 +1,7 @@
+export * from "./bootstrap.js";
+export * from "./cookies.js";
+export * from "./csrf.js";
+export * from "./passkey/index.js";
 export * from "./rbac.js";
+export * from "./sessions.js";
+export * from "./tokens.js";

--- a/packages/core/src/auth/passkey/authenticate.test.ts
+++ b/packages/core/src/auth/passkey/authenticate.test.ts
@@ -1,0 +1,181 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+import type { PasskeyKeyPair } from "../../test/fixtures/webauthn.js";
+import { credentials } from "../../db/schema/credentials.js";
+import { users } from "../../db/schema/users.js";
+import {
+  buildAssertion,
+  buildAttestation,
+  generatePasskeyKeyPair,
+  randomCredentialId,
+} from "../../test/fixtures/webauthn.js";
+import { createTestDb } from "../../test/harness.js";
+import { finishAuthentication } from "./authenticate.js";
+import { issueChallenge } from "./challenges.js";
+import { resolvePasskeyConfig } from "./config.js";
+import { finishRegistration } from "./register.js";
+
+const config = resolvePasskeyConfig({
+  rpName: "Plumix Test",
+  rpId: "cms.example.com",
+  origin: "https://cms.example.com",
+});
+
+interface RegisteredFixture {
+  readonly db: Awaited<ReturnType<typeof createTestDb>>;
+  readonly keyPair: PasskeyKeyPair;
+  readonly credentialId: Uint8Array;
+  readonly credentialIdBase64Url: string;
+}
+
+async function registerFixtureCredential(): Promise<RegisteredFixture> {
+  const db = await createTestDb();
+  const [user] = await db
+    .insert(users)
+    .values({ email: "u@example.com", role: "admin" })
+    .returning({ id: users.id });
+  if (!user) throw new Error("seed");
+
+  const { challenge } = await issueChallenge(db, 60_000, user.id);
+  const keyPair = generatePasskeyKeyPair();
+  const credentialId = randomCredentialId();
+  const att = buildAttestation({
+    keyPair,
+    rpId: config.rpId,
+    origin: config.origin,
+    challenge,
+    credentialId,
+  });
+  const verified = await finishRegistration(db, config, {
+    id: att.credentialIdBase64Url,
+    rawId: att.credentialIdBase64Url,
+    type: "public-key",
+    response: {
+      clientDataJSON: att.clientDataJSON,
+      attestationObject: att.attestationObject,
+    },
+  });
+  await db.insert(credentials).values({
+    id: verified.credentialId,
+    userId: user.id,
+    publicKey: Buffer.from(verified.publicKey),
+    counter: verified.signatureCounter,
+    deviceType: "single_device",
+    isBackedUp: false,
+    transports: [...verified.transports],
+  });
+
+  return {
+    db,
+    keyPair,
+    credentialId,
+    credentialIdBase64Url: att.credentialIdBase64Url,
+  };
+}
+
+describe("finishAuthentication", () => {
+  test("verifies a valid assertion end-to-end and updates the counter", async () => {
+    const fx = await registerFixtureCredential();
+    const { challenge } = await issueChallenge(fx.db, 60_000);
+    const assertion = buildAssertion({
+      keyPair: fx.keyPair,
+      rpId: config.rpId,
+      origin: config.origin,
+      challenge,
+      counter: 1,
+    });
+
+    const result = await finishAuthentication(fx.db, config, {
+      id: fx.credentialIdBase64Url,
+      rawId: fx.credentialIdBase64Url,
+      type: "public-key",
+      response: {
+        clientDataJSON: assertion.clientDataJSON,
+        authenticatorData: assertion.authenticatorData,
+        signature: assertion.signature,
+      },
+    });
+
+    expect(result.newSignatureCounter).toBe(1);
+  });
+
+  test("rejects a counter that did not strictly increase (clone defence)", async () => {
+    const fx = await registerFixtureCredential();
+    // Bump stored counter beyond what the assertion will report.
+    await fx.db
+      .update(credentials)
+      .set({ counter: 5 })
+      .where(eq(credentials.id, fx.credentialIdBase64Url));
+
+    const { challenge } = await issueChallenge(fx.db, 60_000);
+    const assertion = buildAssertion({
+      keyPair: fx.keyPair,
+      rpId: config.rpId,
+      origin: config.origin,
+      challenge,
+      counter: 3, // less than stored 5 → replay
+    });
+    await expect(
+      finishAuthentication(fx.db, config, {
+        id: fx.credentialIdBase64Url,
+        rawId: fx.credentialIdBase64Url,
+        type: "public-key",
+        response: {
+          clientDataJSON: assertion.clientDataJSON,
+          authenticatorData: assertion.authenticatorData,
+          signature: assertion.signature,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "counter_replay" });
+  });
+
+  test("rejects an assertion whose origin does not match", async () => {
+    const fx = await registerFixtureCredential();
+    const { challenge } = await issueChallenge(fx.db, 60_000);
+    const assertion = buildAssertion({
+      keyPair: fx.keyPair,
+      rpId: config.rpId,
+      origin: "https://attacker.example",
+      challenge,
+      counter: 1,
+    });
+    await expect(
+      finishAuthentication(fx.db, config, {
+        id: fx.credentialIdBase64Url,
+        rawId: fx.credentialIdBase64Url,
+        type: "public-key",
+        response: {
+          clientDataJSON: assertion.clientDataJSON,
+          authenticatorData: assertion.authenticatorData,
+          signature: assertion.signature,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "invalid_origin" });
+  });
+
+  test("rejects an assertion signed by a different key", async () => {
+    const fx = await registerFixtureCredential();
+    const { challenge } = await issueChallenge(fx.db, 60_000);
+    const wrongKey = generatePasskeyKeyPair();
+    const assertion = buildAssertion({
+      keyPair: wrongKey,
+      rpId: config.rpId,
+      origin: config.origin,
+      challenge,
+      counter: 1,
+    });
+    await expect(
+      finishAuthentication(fx.db, config, {
+        id: fx.credentialIdBase64Url,
+        rawId: fx.credentialIdBase64Url,
+        type: "public-key",
+        response: {
+          clientDataJSON: assertion.clientDataJSON,
+          authenticatorData: assertion.authenticatorData,
+          signature: assertion.signature,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "invalid_signature" });
+  });
+});

--- a/packages/core/src/auth/passkey/authenticate.ts
+++ b/packages/core/src/auth/passkey/authenticate.ts
@@ -1,0 +1,168 @@
+import {
+  decodePKIXECDSASignature,
+  decodeSEC1PublicKey,
+  p256,
+  verifyECDSASignature,
+} from "@oslojs/crypto/ecdsa";
+import { sha256 } from "@oslojs/crypto/sha2";
+import {
+  decodeBase64urlIgnorePadding,
+  encodeBase64urlNoPadding,
+} from "@oslojs/encoding";
+import {
+  ClientDataType,
+  createAssertionSignatureMessage,
+  parseAuthenticatorData,
+  parseClientDataJSON,
+} from "@oslojs/webauthn";
+import { eq } from "drizzle-orm";
+
+import type { Db } from "../../context/app.js";
+import type { Credential } from "../../db/schema/credentials.js";
+import type { ResolvedPasskeyConfig } from "./config.js";
+import type { AuthenticationOptions, AuthenticationResponse } from "./types.js";
+import { credentials } from "../../db/schema/credentials.js";
+import { consumeChallenge, issueChallenge } from "./challenges.js";
+import { PasskeyError } from "./errors.js";
+
+export interface BeginAuthenticationInput {
+  readonly allowCredentials?: readonly Credential[];
+}
+
+export async function beginAuthentication(
+  db: Db,
+  config: ResolvedPasskeyConfig,
+  input: BeginAuthenticationInput = {},
+): Promise<AuthenticationOptions> {
+  const { challenge } = await issueChallenge(db, config.challengeTtlMs);
+  return {
+    challenge,
+    rpId: config.rpId,
+    timeout: 60_000,
+    userVerification: "preferred",
+    allowCredentials: input.allowCredentials?.map((c) => ({
+      type: "public-key" as const,
+      id: c.id,
+      transports: c.transports ?? undefined,
+    })),
+  };
+}
+
+export interface VerifiedAuthentication {
+  readonly credential: Credential;
+  readonly newSignatureCounter: number;
+}
+
+/**
+ * Verify an assertion. Order of checks (Copenhagen Book):
+ * 1. challenge consumed atomically (no double-spend)
+ * 2. clientData type === webauthn.get
+ * 3. origin === expected
+ * 4. RP-ID hash matches
+ * 5. user-present flag set
+ * 6. counter strictly greater than stored (replay defence; counter == 0 means
+ *    the authenticator does not implement counters — accept once)
+ * 7. ECDSA signature verifies over `authenticatorData || sha256(clientDataJSON)`
+ */
+export async function finishAuthentication(
+  db: Db,
+  config: ResolvedPasskeyConfig,
+  response: AuthenticationResponse,
+): Promise<VerifiedAuthentication> {
+  let clientDataBytes: Uint8Array;
+  let authenticatorDataBytes: Uint8Array;
+  let signatureBytes: Uint8Array;
+  try {
+    clientDataBytes = decodeBase64urlIgnorePadding(
+      response.response.clientDataJSON,
+    );
+    authenticatorDataBytes = decodeBase64urlIgnorePadding(
+      response.response.authenticatorData,
+    );
+    signatureBytes = decodeBase64urlIgnorePadding(response.response.signature);
+  } catch {
+    throw new PasskeyError(
+      "invalid_response",
+      "Malformed base64url in authentication response",
+    );
+  }
+
+  const clientData = parseClientDataJSON(clientDataBytes);
+  if (clientData.type !== ClientDataType.Get) {
+    throw new PasskeyError("invalid_client_data", "Expected webauthn.get");
+  }
+
+  const challengeString = encodeBase64urlNoPadding(clientData.challenge);
+  const challenge = await consumeChallenge(db, challengeString);
+  if (!challenge) throw new PasskeyError("challenge_not_found");
+
+  if (clientData.origin !== config.origin) {
+    throw new PasskeyError(
+      "invalid_origin",
+      `Expected origin ${config.origin}, got ${clientData.origin}`,
+    );
+  }
+
+  const credential = await db
+    .select()
+    .from(credentials)
+    .where(eq(credentials.id, response.id))
+    .get();
+  if (!credential) throw new PasskeyError("credential_not_found");
+
+  const authenticatorData = parseAuthenticatorData(authenticatorDataBytes);
+  if (!authenticatorData.verifyRelyingPartyIdHash(config.rpId)) {
+    throw new PasskeyError("invalid_rp_id");
+  }
+  if (!authenticatorData.userPresent)
+    throw new PasskeyError("user_presence_missing");
+
+  // Counter == 0 is "authenticator doesn't track" — accept; otherwise it must
+  // strictly increase. A non-increasing counter signals a cloned authenticator.
+  if (
+    authenticatorData.signatureCounter !== 0 &&
+    authenticatorData.signatureCounter <= credential.counter
+  ) {
+    throw new PasskeyError("counter_replay");
+  }
+
+  const signedMessage = createAssertionSignatureMessage(
+    authenticatorDataBytes,
+    clientDataBytes,
+  );
+  const messageHash = sha256(signedMessage);
+  const publicKey = decodeSEC1PublicKey(
+    p256,
+    ensureUint8Array(credential.publicKey),
+  );
+  const signature = decodePKIXECDSASignature(signatureBytes);
+
+  if (!verifyECDSASignature(publicKey, messageHash, signature)) {
+    throw new PasskeyError("invalid_signature");
+  }
+
+  await db
+    .update(credentials)
+    .set({
+      counter: authenticatorData.signatureCounter,
+      lastUsedAt: new Date(),
+    })
+    .where(eq(credentials.id, credential.id));
+
+  return {
+    credential,
+    newSignatureCounter: authenticatorData.signatureCounter,
+  };
+}
+
+// Drivers vary on BLOB representation: better-sqlite3 returns Buffer (a
+// Uint8Array subclass — handled by the first branch), libsql/D1 may return
+// ArrayBuffer. Normalise to a plain Uint8Array for oslo's SEC1 decoder.
+function ensureUint8Array(value: unknown): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  throw new PasskeyError(
+    "invalid_response",
+    "Stored public key has unexpected type",
+  );
+}

--- a/packages/core/src/auth/passkey/challenges.test.ts
+++ b/packages/core/src/auth/passkey/challenges.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+
+import { createTestDb } from "../../test/harness.js";
+import { consumeChallenge, issueChallenge } from "./challenges.js";
+
+describe("challenge store", () => {
+  test("atomic single-use: a consumed challenge cannot be replayed", async () => {
+    const db = await createTestDb();
+    const { challenge } = await issueChallenge(db, 60_000);
+    const first = await consumeChallenge(db, challenge);
+    const second = await consumeChallenge(db, challenge);
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+  });
+
+  test("expired challenge resolves to null even though the row existed", async () => {
+    const db = await createTestDb();
+    const { challenge } = await issueChallenge(db, -1_000);
+    expect(await consumeChallenge(db, challenge)).toBeNull();
+  });
+});

--- a/packages/core/src/auth/passkey/challenges.ts
+++ b/packages/core/src/auth/passkey/challenges.ts
@@ -1,0 +1,60 @@
+import { eq } from "drizzle-orm";
+
+import type { Db } from "../../context/app.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { generateToken, hashToken } from "../tokens.js";
+
+const CHALLENGE_TYPE = "webauthn_challenge" as const;
+
+export interface IssuedChallenge {
+  /** Raw challenge (sent to the browser, base64url). */
+  readonly challenge: string;
+  readonly expiresAt: Date;
+}
+
+export interface ChallengeRecord {
+  readonly userId: number | null;
+  readonly expiresAt: Date;
+}
+
+/**
+ * Persist a single-use WebAuthn challenge. We hash the raw challenge and
+ * store the hash so a DB read does not yield a usable challenge to an
+ * attacker (defence in depth — the challenge is also short-lived).
+ */
+export async function issueChallenge(
+  db: Db,
+  ttlMs: number,
+  userId: number | null = null,
+): Promise<IssuedChallenge> {
+  const challenge = generateToken();
+  const hash = await hashToken(challenge);
+  const expiresAt = new Date(Date.now() + ttlMs);
+  await db.insert(authTokens).values({
+    hash,
+    type: CHALLENGE_TYPE,
+    userId,
+    expiresAt,
+  });
+  return { challenge, expiresAt };
+}
+
+/**
+ * Atomic single-use consume: SQLite `RETURNING` deletes and reads the row in
+ * one round-trip — no race window between read and delete (Copenhagen Book:
+ * "atomic deletion to prevent race conditions").
+ */
+export async function consumeChallenge(
+  db: Db,
+  rawChallenge: string,
+): Promise<ChallengeRecord | null> {
+  if (!rawChallenge) return null;
+  const hash = await hashToken(rawChallenge);
+  const [row] = await db
+    .delete(authTokens)
+    .where(eq(authTokens.hash, hash))
+    .returning();
+  if (row?.type !== CHALLENGE_TYPE) return null;
+  if (row.expiresAt.getTime() < Date.now()) return null;
+  return { userId: row.userId, expiresAt: row.expiresAt };
+}

--- a/packages/core/src/auth/passkey/config.ts
+++ b/packages/core/src/auth/passkey/config.ts
@@ -1,0 +1,32 @@
+export interface PasskeyConfig {
+  /** Display name shown in the OS passkey prompt. */
+  readonly rpName: string;
+  /** RP-ID — usually the bare hostname, no protocol. */
+  readonly rpId: string;
+  /** Expected origin string the browser puts in clientDataJSON. */
+  readonly origin: string;
+}
+
+export interface ResolvedPasskeyConfig extends PasskeyConfig {
+  readonly challengeTtlMs: number;
+  readonly maxCredentialsPerUser: number;
+}
+
+export const PASSKEY_DEFAULTS = {
+  challengeTtlMs: 5 * 60 * 1000,
+  maxCredentialsPerUser: 10,
+} as const;
+
+export function resolvePasskeyConfig(
+  config: PasskeyConfig,
+  overrides: Partial<typeof PASSKEY_DEFAULTS> = {},
+): ResolvedPasskeyConfig {
+  return {
+    rpName: config.rpName,
+    rpId: config.rpId,
+    origin: config.origin,
+    challengeTtlMs: overrides.challengeTtlMs ?? PASSKEY_DEFAULTS.challengeTtlMs,
+    maxCredentialsPerUser:
+      overrides.maxCredentialsPerUser ?? PASSKEY_DEFAULTS.maxCredentialsPerUser,
+  };
+}

--- a/packages/core/src/auth/passkey/errors.ts
+++ b/packages/core/src/auth/passkey/errors.ts
@@ -1,0 +1,29 @@
+// challenge_expired is folded into challenge_not_found — `consumeChallenge`
+// returns null whether the row was missing or just expired, since the
+// distinction is meaningless to the caller (and leaking it would help
+// timing-distinguish stale from never-issued).
+export type PasskeyErrorCode =
+  | "challenge_not_found"
+  | "invalid_client_data"
+  | "invalid_origin"
+  | "invalid_rp_id"
+  | "user_presence_missing"
+  | "unsupported_attestation_format"
+  | "unsupported_algorithm"
+  | "credential_already_registered"
+  | "credential_limit_reached"
+  | "credential_not_found"
+  | "invalid_signature"
+  | "counter_replay"
+  | "user_not_found"
+  | "invalid_response";
+
+export class PasskeyError extends Error {
+  readonly code: PasskeyErrorCode;
+
+  constructor(code: PasskeyErrorCode, message?: string) {
+    super(message ?? code);
+    this.name = "PasskeyError";
+    this.code = code;
+  }
+}

--- a/packages/core/src/auth/passkey/index.ts
+++ b/packages/core/src/auth/passkey/index.ts
@@ -1,0 +1,6 @@
+export * from "./authenticate.js";
+export * from "./challenges.js";
+export * from "./config.js";
+export * from "./errors.js";
+export * from "./register.js";
+export * from "./types.js";

--- a/packages/core/src/auth/passkey/register.test.ts
+++ b/packages/core/src/auth/passkey/register.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "vitest";
+
+import { users } from "../../db/schema/users.js";
+import {
+  buildAttestation,
+  generatePasskeyKeyPair,
+  randomCredentialId,
+} from "../../test/fixtures/webauthn.js";
+import { createTestDb } from "../../test/harness.js";
+import { issueChallenge } from "./challenges.js";
+import { PASSKEY_DEFAULTS, resolvePasskeyConfig } from "./config.js";
+import { PasskeyError } from "./errors.js";
+import { finishRegistration, persistCredential } from "./register.js";
+
+const config = resolvePasskeyConfig({
+  rpName: "Plumix Test",
+  rpId: "cms.example.com",
+  origin: "https://cms.example.com",
+});
+
+async function seedUserId(
+  db: Awaited<ReturnType<typeof createTestDb>>,
+): Promise<number> {
+  const [user] = await db
+    .insert(users)
+    .values({ email: "u@example.com", role: "admin" })
+    .returning({ id: users.id });
+  if (!user) throw new Error("seed");
+  return user.id;
+}
+
+describe("finishRegistration (positive ceremony with ES256)", () => {
+  test("verifies origin, RP-ID, attestation=none, and extracts the SEC1 public key", async () => {
+    const db = await createTestDb();
+    const userId = await seedUserId(db);
+    const { challenge } = await issueChallenge(db, 60_000, userId);
+    const keyPair = generatePasskeyKeyPair();
+    const credentialId = randomCredentialId();
+
+    const att = buildAttestation({
+      keyPair,
+      rpId: config.rpId,
+      origin: config.origin,
+      challenge,
+      credentialId,
+    });
+
+    const verified = await finishRegistration(db, config, {
+      id: att.credentialIdBase64Url,
+      rawId: att.credentialIdBase64Url,
+      type: "public-key",
+      response: {
+        clientDataJSON: att.clientDataJSON,
+        attestationObject: att.attestationObject,
+      },
+    });
+
+    expect(verified.publicKey).toEqual(keyPair.publicKeySec1);
+    expect(verified.signatureCounter).toBe(0);
+  });
+});
+
+describe("finishRegistration (security checks)", () => {
+  test("rejects a response whose origin does not match the configured origin", async () => {
+    const db = await createTestDb();
+    const userId = await seedUserId(db);
+    const { challenge } = await issueChallenge(db, 60_000, userId);
+    const keyPair = generatePasskeyKeyPair();
+    const credentialId = randomCredentialId();
+    const att = buildAttestation({
+      keyPair,
+      rpId: config.rpId,
+      origin: "https://attacker.example",
+      challenge,
+      credentialId,
+    });
+
+    await expect(
+      finishRegistration(db, config, {
+        id: att.credentialIdBase64Url,
+        rawId: att.credentialIdBase64Url,
+        type: "public-key",
+        response: {
+          clientDataJSON: att.clientDataJSON,
+          attestationObject: att.attestationObject,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "invalid_origin" });
+  });
+
+  test("a missing/used challenge stops registration before any crypto runs", async () => {
+    const db = await createTestDb();
+    const keyPair = generatePasskeyKeyPair();
+    const credentialId = randomCredentialId();
+    const att = buildAttestation({
+      keyPair,
+      rpId: config.rpId,
+      origin: config.origin,
+      challenge: "never-issued",
+      credentialId,
+    });
+    await expect(
+      finishRegistration(db, config, {
+        id: att.credentialIdBase64Url,
+        rawId: att.credentialIdBase64Url,
+        type: "public-key",
+        response: {
+          clientDataJSON: att.clientDataJSON,
+          attestationObject: att.attestationObject,
+        },
+      }),
+    ).rejects.toBeInstanceOf(PasskeyError);
+  });
+});
+
+describe("persistCredential", () => {
+  test("rejects a duplicate credential id (would silently re-bind otherwise)", async () => {
+    const db = await createTestDb();
+    const userId = await seedUserId(db);
+    const verified = {
+      credentialId: "dup",
+      publicKey: new Uint8Array([0x04, ...new Uint8Array(64)]),
+      signatureCounter: 0,
+      transports: [] as const,
+    };
+    await persistCredential(db, {
+      userId,
+      verified,
+      maxPerUser: PASSKEY_DEFAULTS.maxCredentialsPerUser,
+    });
+    await expect(
+      persistCredential(db, {
+        userId,
+        verified,
+        maxPerUser: PASSKEY_DEFAULTS.maxCredentialsPerUser,
+      }),
+    ).rejects.toMatchObject({ code: "credential_already_registered" });
+  });
+
+  test("enforces the per-user credential limit", async () => {
+    const db = await createTestDb();
+    const userId = await seedUserId(db);
+    await persistCredential(db, {
+      userId,
+      verified: {
+        credentialId: "c1",
+        publicKey: new Uint8Array([0x04, ...new Uint8Array(64)]),
+        signatureCounter: 0,
+        transports: [],
+      },
+      maxPerUser: 1,
+    });
+    await expect(
+      persistCredential(db, {
+        userId,
+        verified: {
+          credentialId: "c2",
+          publicKey: new Uint8Array([0x04, ...new Uint8Array(64)]),
+          signatureCounter: 0,
+          transports: [],
+        },
+        maxPerUser: 1,
+      }),
+    ).rejects.toMatchObject({ code: "credential_limit_reached" });
+  });
+});

--- a/packages/core/src/auth/passkey/register.ts
+++ b/packages/core/src/auth/passkey/register.ts
@@ -1,0 +1,232 @@
+import { ECDSAPublicKey, p256 } from "@oslojs/crypto/ecdsa";
+import {
+  decodeBase64urlIgnorePadding,
+  encodeBase64urlNoPadding,
+} from "@oslojs/encoding";
+import {
+  AttestationStatementFormat,
+  ClientDataType,
+  coseAlgorithmES256,
+  coseAlgorithmRS256,
+  coseEllipticCurveP256,
+  COSEKeyType,
+  parseAttestationObject,
+  parseClientDataJSON,
+} from "@oslojs/webauthn";
+import { eq } from "drizzle-orm";
+
+import type { Db } from "../../context/app.js";
+import type {
+  Credential,
+  CredentialTransport,
+} from "../../db/schema/credentials.js";
+import type { ResolvedPasskeyConfig } from "./config.js";
+import type { RegistrationOptions, RegistrationResponse } from "./types.js";
+import { credentials } from "../../db/schema/credentials.js";
+import { consumeChallenge, issueChallenge } from "./challenges.js";
+import { PasskeyError } from "./errors.js";
+
+export interface BeginRegistrationInput {
+  readonly userId: number;
+  readonly userEmail: string;
+  readonly userDisplayName?: string;
+  readonly excludeCredentials?: readonly Credential[];
+}
+
+export async function beginRegistration(
+  db: Db,
+  config: ResolvedPasskeyConfig,
+  input: BeginRegistrationInput,
+): Promise<RegistrationOptions> {
+  const { challenge } = await issueChallenge(
+    db,
+    config.challengeTtlMs,
+    input.userId,
+  );
+  const userIdBytes = new TextEncoder().encode(String(input.userId));
+  return {
+    challenge,
+    rp: { name: config.rpName, id: config.rpId },
+    user: {
+      id: encodeBase64urlNoPadding(userIdBytes),
+      name: input.userEmail,
+      displayName: input.userDisplayName ?? input.userEmail,
+    },
+    pubKeyCredParams: [
+      // ES256 first — covers Apple, Android, Windows Hello, YubiKey.
+      { type: "public-key", alg: coseAlgorithmES256 },
+      // Advertise RS256 for older Windows Hello, but reject in verify (v1 = ES256 only).
+      { type: "public-key", alg: coseAlgorithmRS256 },
+    ],
+    timeout: 60_000,
+    attestation: "none",
+    authenticatorSelection: {
+      residentKey: "preferred",
+      userVerification: "preferred",
+    },
+    excludeCredentials: input.excludeCredentials?.map((c) => ({
+      type: "public-key" as const,
+      id: c.id,
+      transports: c.transports ?? undefined,
+    })),
+  };
+}
+
+export interface VerifiedRegistration {
+  readonly credentialId: string;
+  /** SEC1-uncompressed P-256 public key, ready for storage. */
+  readonly publicKey: Uint8Array;
+  readonly signatureCounter: number;
+  readonly transports: readonly CredentialTransport[];
+}
+
+/**
+ * Verify a registration response and extract the credential. Steps follow
+ * the Copenhagen Book ceremony: client data type → challenge → origin →
+ * RP-ID hash → user-present → attestation format → algorithm → public key.
+ */
+export async function finishRegistration(
+  db: Db,
+  config: ResolvedPasskeyConfig,
+  response: RegistrationResponse,
+): Promise<VerifiedRegistration> {
+  let clientDataBytes: Uint8Array;
+  let attestationBytes: Uint8Array;
+  try {
+    clientDataBytes = decodeBase64urlIgnorePadding(
+      response.response.clientDataJSON,
+    );
+    attestationBytes = decodeBase64urlIgnorePadding(
+      response.response.attestationObject,
+    );
+  } catch {
+    throw new PasskeyError(
+      "invalid_response",
+      "Malformed base64url in registration response",
+    );
+  }
+
+  const clientData = parseClientDataJSON(clientDataBytes);
+  if (clientData.type !== ClientDataType.Create) {
+    throw new PasskeyError("invalid_client_data", "Expected webauthn.create");
+  }
+
+  const challengeString = encodeBase64urlNoPadding(clientData.challenge);
+  const challenge = await consumeChallenge(db, challengeString);
+  if (!challenge) throw new PasskeyError("challenge_not_found");
+
+  if (clientData.origin !== config.origin) {
+    throw new PasskeyError(
+      "invalid_origin",
+      `Expected origin ${config.origin}, got ${clientData.origin}`,
+    );
+  }
+
+  const attestation = parseAttestationObject(attestationBytes);
+  if (
+    attestation.attestationStatement.format !== AttestationStatementFormat.None
+  ) {
+    // We advertised attestation: "none" — anything else means the authenticator
+    // ignored us; we don't verify other formats so we refuse rather than trust.
+    throw new PasskeyError("unsupported_attestation_format");
+  }
+
+  const { authenticatorData } = attestation;
+  if (!authenticatorData.verifyRelyingPartyIdHash(config.rpId)) {
+    throw new PasskeyError("invalid_rp_id");
+  }
+  if (!authenticatorData.userPresent)
+    throw new PasskeyError("user_presence_missing");
+
+  if (!authenticatorData.credential) {
+    throw new PasskeyError(
+      "invalid_response",
+      "No credential data in attestation",
+    );
+  }
+  const { credential } = authenticatorData;
+
+  const algorithm = credential.publicKey.algorithm();
+  if (algorithm !== coseAlgorithmES256) {
+    // RS256 was advertised for compatibility but we deliberately don't
+    // implement RSA verify in v1 — ES256 covers ~all real-world authenticators.
+    throw new PasskeyError("unsupported_algorithm", `algorithm ${algorithm}`);
+  }
+  if (credential.publicKey.type() !== COSEKeyType.EC2) {
+    throw new PasskeyError(
+      "unsupported_algorithm",
+      "Expected EC2 key for ES256",
+    );
+  }
+  const cose = credential.publicKey.ec2();
+  if (cose.curve !== coseEllipticCurveP256) {
+    throw new PasskeyError("unsupported_algorithm", "Expected P-256 curve");
+  }
+  const publicKey = new ECDSAPublicKey(
+    p256,
+    cose.x,
+    cose.y,
+  ).encodeSEC1Uncompressed();
+
+  return {
+    credentialId: response.id,
+    publicKey,
+    signatureCounter: authenticatorData.signatureCounter,
+    transports: response.response.transports ?? [],
+  };
+}
+
+export interface PersistCredentialInput {
+  readonly userId: number;
+  readonly verified: VerifiedRegistration;
+  readonly name?: string;
+  readonly maxPerUser: number;
+}
+
+/**
+ * Persist a verified credential. Enforces the per-user limit and refuses to
+ * register the same credential id twice (which would silently re-bind it).
+ */
+export async function persistCredential(
+  db: Db,
+  input: PersistCredentialInput,
+): Promise<Credential> {
+  const userCount = await db.$count(
+    credentials,
+    eq(credentials.userId, input.userId),
+  );
+  if (userCount >= input.maxPerUser) {
+    throw new PasskeyError("credential_limit_reached");
+  }
+
+  const collision = await db
+    .select({ id: credentials.id })
+    .from(credentials)
+    .where(eq(credentials.id, input.verified.credentialId))
+    .get();
+  if (collision) throw new PasskeyError("credential_already_registered");
+
+  const [row] = await db
+    .insert(credentials)
+    .values({
+      id: input.verified.credentialId,
+      userId: input.userId,
+      // Drizzle's `blob({ mode: "buffer" })` types this column as `Buffer`.
+      // The cast is only for the type checker — at runtime the libsql / D1
+      // driver accepts a Uint8Array (Buffer is a Uint8Array subclass). When
+      // the cloudflare adapter lands in Phase 4 we may switch the schema
+      // mode so this dance is unnecessary.
+      publicKey: input.verified.publicKey as Buffer,
+      counter: input.verified.signatureCounter,
+      // Backup-eligible flag parsing isn't exposed by @oslojs/webauthn yet;
+      // conservative default until it is.
+      deviceType: "single_device",
+      isBackedUp: false,
+      transports: [...input.verified.transports],
+      name: input.name ?? null,
+    })
+    .returning();
+
+  if (!row) throw new Error("persistCredential: insert returned no row");
+  return row;
+}

--- a/packages/core/src/auth/passkey/types.ts
+++ b/packages/core/src/auth/passkey/types.ts
@@ -1,0 +1,66 @@
+import type { CredentialTransport } from "../../db/schema/credentials.js";
+
+// WebAuthn options shapes — what the server hands the browser. Mirrors the
+// PublicKeyCredentialCreationOptions / RequestOptions shape but with strings
+// (base64url-encoded) instead of ArrayBuffers, so it serializes to JSON.
+
+export interface PublicKeyCredentialDescriptor {
+  readonly type: "public-key";
+  readonly id: string;
+  readonly transports?: readonly CredentialTransport[];
+}
+
+export interface RegistrationOptions {
+  readonly challenge: string;
+  readonly rp: { readonly name: string; readonly id: string };
+  readonly user: {
+    readonly id: string;
+    readonly name: string;
+    readonly displayName: string;
+  };
+  readonly pubKeyCredParams: readonly {
+    readonly type: "public-key";
+    readonly alg: number;
+  }[];
+  readonly timeout?: number;
+  readonly attestation: "none";
+  readonly authenticatorSelection?: {
+    readonly residentKey?: "discouraged" | "preferred" | "required";
+    readonly userVerification?: "discouraged" | "preferred" | "required";
+  };
+  readonly excludeCredentials?: readonly PublicKeyCredentialDescriptor[];
+}
+
+export interface AuthenticationOptions {
+  readonly challenge: string;
+  readonly rpId: string;
+  readonly timeout?: number;
+  readonly userVerification?: "discouraged" | "preferred" | "required";
+  readonly allowCredentials?: readonly PublicKeyCredentialDescriptor[];
+}
+
+// What the browser POSTs back. Already base64url-decoded structurally where
+// the spec uses ArrayBuffer.
+
+export interface RegistrationResponse {
+  readonly id: string;
+  readonly rawId: string;
+  readonly type: "public-key";
+  readonly response: {
+    readonly clientDataJSON: string;
+    readonly attestationObject: string;
+    readonly transports?: readonly CredentialTransport[];
+  };
+}
+
+export interface AuthenticationResponse {
+  readonly id: string;
+  readonly rawId: string;
+  readonly type: "public-key";
+  readonly response: {
+    readonly clientDataJSON: string;
+    readonly authenticatorData: string;
+    readonly signature: string;
+    readonly userHandle?: string;
+  };
+}

--- a/packages/core/src/auth/rbac.test.ts
+++ b/packages/core/src/auth/rbac.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "vitest";
+
+import { createPluginRegistry } from "../plugin/manifest.js";
+import {
+  CapabilityError,
+  CORE_CAPABILITIES,
+  createCapabilityResolver,
+  requireCapability,
+  roleLevel,
+} from "./rbac.js";
+
+describe("role hierarchy", () => {
+  test("admin outranks every other role", () => {
+    expect(roleLevel("admin")).toBeGreaterThan(roleLevel("editor"));
+    expect(roleLevel("editor")).toBeGreaterThan(roleLevel("author"));
+    expect(roleLevel("author")).toBeGreaterThan(roleLevel("contributor"));
+    expect(roleLevel("contributor")).toBeGreaterThan(roleLevel("subscriber"));
+  });
+});
+
+describe("createCapabilityResolver", () => {
+  const emptyRegistry = createPluginRegistry();
+
+  test("grants core capability when role meets the minimum", () => {
+    const resolver = createCapabilityResolver(emptyRegistry);
+    expect(resolver.hasCapability("author", "post:publish")).toBe(true);
+    expect(resolver.hasCapability("editor", "post:publish")).toBe(true);
+    expect(resolver.hasCapability("admin", "post:publish")).toBe(true);
+  });
+
+  test("denies core capability when role is below minimum", () => {
+    const resolver = createCapabilityResolver(emptyRegistry);
+    expect(resolver.hasCapability("contributor", "post:publish")).toBe(false);
+    expect(resolver.hasCapability("subscriber", "post:edit_any")).toBe(false);
+  });
+
+  test("returns false for unknown capability (no implicit grant)", () => {
+    const resolver = createCapabilityResolver(emptyRegistry);
+    expect(resolver.hasCapability("admin", "nope:nothing")).toBe(false);
+    expect(resolver.requiredRole("nope:nothing")).toBeNull();
+  });
+
+  test("plugin-registered capabilities are looked up alongside core", () => {
+    const registry = createPluginRegistry();
+    registry.capabilities.set("seo:manage", {
+      name: "seo:manage",
+      minRole: "editor",
+      registeredBy: "seo",
+    });
+    const resolver = createCapabilityResolver(registry);
+    expect(resolver.hasCapability("editor", "seo:manage")).toBe(true);
+    expect(resolver.hasCapability("author", "seo:manage")).toBe(false);
+  });
+
+  test("plugin capability overrides core (last-write-wins on lookup)", () => {
+    const registry = createPluginRegistry();
+    // Simulate a plugin tightening `post:delete` from editor to admin.
+    registry.capabilities.set("post:delete", {
+      name: "post:delete",
+      minRole: "admin",
+      registeredBy: "strict",
+    });
+    const resolver = createCapabilityResolver(registry);
+    expect(resolver.hasCapability("editor", "post:delete")).toBe(false);
+    expect(resolver.hasCapability("admin", "post:delete")).toBe(true);
+  });
+
+  test("post-type-derived caps resolve at their registered min-role", () => {
+    const registry = createPluginRegistry();
+    registry.capabilities.set("landing_page:publish", {
+      name: "landing_page:publish",
+      minRole: "author",
+      registeredBy: "blog",
+    });
+    const resolver = createCapabilityResolver(registry);
+    expect(resolver.hasCapability("contributor", "landing_page:publish")).toBe(
+      false,
+    );
+    expect(resolver.hasCapability("author", "landing_page:publish")).toBe(true);
+  });
+});
+
+describe("requireCapability", () => {
+  const resolver = createCapabilityResolver(createPluginRegistry());
+
+  test("throws unauthorized when user is null", () => {
+    expect(() => requireCapability(resolver, null, "post:read")).toThrow(
+      CapabilityError,
+    );
+    try {
+      requireCapability(resolver, null, "post:read");
+    } catch (err) {
+      expect((err as CapabilityError).code).toBe("unauthorized");
+    }
+  });
+
+  test("throws forbidden when role is too low", () => {
+    try {
+      requireCapability(resolver, { role: "subscriber" }, "post:publish");
+    } catch (err) {
+      expect((err as CapabilityError).code).toBe("forbidden");
+      expect((err as CapabilityError).capability).toBe("post:publish");
+      return;
+    }
+    throw new Error("should have thrown");
+  });
+
+  test("passes silently for a satisfied capability", () => {
+    expect(() =>
+      requireCapability(resolver, { role: "admin" }, "user:manage"),
+    ).not.toThrow();
+  });
+});
+
+describe("CORE_CAPABILITIES baseline", () => {
+  test("covers the capability names used by first-party surfaces", () => {
+    for (const name of [
+      "post:read",
+      "post:create",
+      "post:edit_own",
+      "post:publish",
+      "post:edit_any",
+      "post:delete",
+      "taxonomy:manage",
+      "user:manage",
+    ]) {
+      expect(CORE_CAPABILITIES[name]).toBeDefined();
+    }
+  });
+});

--- a/packages/core/src/auth/rbac.ts
+++ b/packages/core/src/auth/rbac.ts
@@ -1,0 +1,151 @@
+import type { UserRole } from "../db/schema/users.js";
+import type { PluginRegistry, PostTypeOptions } from "../plugin/manifest.js";
+import { USER_ROLES } from "../db/schema/users.js";
+
+/**
+ * Role hierarchy (ascending). A role with a higher level has all capabilities
+ * of lower roles — e.g., editor satisfies any capability whose minRole is
+ * author, contributor, or subscriber.
+ */
+export const ROLE_LEVEL: Readonly<Record<UserRole, number>> = Object.freeze(
+  USER_ROLES.reduce<Record<UserRole, number>>(
+    (acc, role, index) => {
+      acc[role] = index;
+      return acc;
+    },
+    {} as Record<UserRole, number>,
+  ),
+);
+
+export function roleLevel(role: UserRole): number {
+  return ROLE_LEVEL[role];
+}
+
+// `post:*` and `taxonomy:manage` are the built-in fallbacks — present even
+// before any plugin registers a type. Plugins registering a post type with
+// `capabilityType: 'post'` (the default) just inherit `post:*` via the
+// dedupe rule in `registerPostType`. `user`/`plugin`/`option` aren't tied
+// to content entities so they only live here.
+export const CORE_CAPABILITIES: Readonly<Record<string, UserRole>> =
+  Object.freeze({
+    "post:read": "subscriber",
+    "post:create": "contributor",
+    "post:edit_own": "contributor",
+    "post:publish": "author",
+    "post:edit_any": "editor",
+    "post:delete": "editor",
+    "taxonomy:manage": "editor",
+    "user:manage": "admin",
+    "plugin:manage": "admin",
+    "option:manage": "admin",
+  });
+
+export const POST_TYPE_CAPABILITY_ACTIONS = {
+  read: "subscriber",
+  create: "contributor",
+  edit_own: "contributor",
+  publish: "author",
+  edit_any: "editor",
+  delete: "editor",
+} as const satisfies Record<string, UserRole>;
+
+export const TAXONOMY_CAPABILITY_ACTIONS = {
+  read: "subscriber",
+  assign: "contributor",
+  edit: "editor",
+  delete: "editor",
+  manage: "editor",
+} as const satisfies Record<string, UserRole>;
+
+export interface DerivedCapability {
+  readonly name: string;
+  readonly minRole: UserRole;
+}
+
+function deriveCapabilities(
+  base: string,
+  actions: Record<string, UserRole>,
+): readonly DerivedCapability[] {
+  return Object.entries(actions).map(([action, minRole]) => ({
+    name: `${base}:${action}`,
+    minRole,
+  }));
+}
+
+export function derivePostTypeCapabilities(
+  postTypeName: string,
+  options: PostTypeOptions,
+): readonly DerivedCapability[] {
+  // Sharing `capabilityType` across post types pools their permissions —
+  // that's how the built-in `post` scheme extends to plugin-registered types.
+  return deriveCapabilities(
+    options.capabilityType ?? postTypeName,
+    POST_TYPE_CAPABILITY_ACTIONS,
+  );
+}
+
+export function deriveTaxonomyCapabilities(
+  taxonomyName: string,
+): readonly DerivedCapability[] {
+  return deriveCapabilities(taxonomyName, TAXONOMY_CAPABILITY_ACTIONS);
+}
+
+export interface CapabilityResolver {
+  /** Returns the minimum role required for a capability, or null if unknown. */
+  requiredRole(capability: string): UserRole | null;
+  /** True iff the given role meets the capability's minimum role. */
+  hasCapability(role: UserRole, capability: string): boolean;
+}
+
+export function createCapabilityResolver(
+  plugins: PluginRegistry,
+): CapabilityResolver {
+  return {
+    requiredRole(capability) {
+      const fromPlugin = plugins.capabilities.get(capability);
+      if (fromPlugin) return fromPlugin.minRole;
+      return CORE_CAPABILITIES[capability] ?? null;
+    },
+    hasCapability(role, capability) {
+      const required = this.requiredRole(capability);
+      if (required === null) return false;
+      return roleLevel(role) >= roleLevel(required);
+    },
+  };
+}
+
+export class CapabilityError extends Error {
+  readonly code: "unauthorized" | "forbidden";
+  readonly capability: string;
+
+  constructor(
+    code: "unauthorized" | "forbidden",
+    capability: string,
+    message?: string,
+  ) {
+    super(message ?? `${code}: ${capability}`);
+    this.name = "CapabilityError";
+    this.code = code;
+    this.capability = capability;
+  }
+}
+
+export function requireCapability(
+  resolver: CapabilityResolver,
+  user: { role: UserRole } | null,
+  capability: string,
+): void {
+  if (!user)
+    throw new CapabilityError(
+      "unauthorized",
+      capability,
+      "Authentication required",
+    );
+  if (!resolver.hasCapability(user.role, capability)) {
+    throw new CapabilityError(
+      "forbidden",
+      capability,
+      `Missing capability: ${capability}`,
+    );
+  }
+}

--- a/packages/core/src/auth/sessions.test.ts
+++ b/packages/core/src/auth/sessions.test.ts
@@ -1,0 +1,111 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+import type { SessionPolicy } from "./sessions.js";
+import { users } from "../db/schema/users.js";
+import { createTestDb } from "../test/harness.js";
+import {
+  createSession,
+  DEFAULT_SESSION_POLICY,
+  invalidateSession,
+  validateSession,
+} from "./sessions.js";
+import { hashToken } from "./tokens.js";
+
+async function seedUser(db: Awaited<ReturnType<typeof createTestDb>>) {
+  const [user] = await db
+    .insert(users)
+    .values({ email: "alice@example.com", role: "admin" })
+    .returning();
+  if (!user) throw new Error("seed failed");
+  return user;
+}
+
+describe("session lifecycle", () => {
+  test("round-trips a token while storing only its SHA-256 hash in the DB", async () => {
+    const db = await createTestDb();
+    const user = await seedUser(db);
+    const { token, session } = await createSession(db, { userId: user.id });
+
+    expect(session.id).not.toBe(token);
+    expect(session.id).toBe(await hashToken(token));
+
+    const validated = await validateSession(db, token);
+    expect(validated?.user.id).toBe(user.id);
+  });
+
+  test("rejects a tampered token (hash miss → no row found)", async () => {
+    const db = await createTestDb();
+    const user = await seedUser(db);
+    const { token } = await createSession(db, { userId: user.id });
+    const tampered = token.slice(0, -1) + (token.endsWith("a") ? "b" : "a");
+    expect(await validateSession(db, tampered)).toBeNull();
+  });
+
+  test("expired session is rejected and the row is purged", async () => {
+    const db = await createTestDb();
+    const user = await seedUser(db);
+    const policy: SessionPolicy = {
+      ...DEFAULT_SESSION_POLICY,
+      maxAgeSeconds: -10,
+    };
+    const { token } = await createSession(db, { userId: user.id }, policy);
+    expect(await validateSession(db, token, policy)).toBeNull();
+    expect(await validateSession(db, token, policy)).toBeNull();
+  });
+
+  test("sliding window extends expiresAt past the threshold", async () => {
+    const db = await createTestDb();
+    const user = await seedUser(db);
+    const policy: SessionPolicy = {
+      maxAgeSeconds: 60,
+      absoluteMaxAgeSeconds: 3600,
+      refreshThreshold: 0,
+    };
+    const { token, session: original } = await createSession(
+      db,
+      { userId: user.id },
+      policy,
+    );
+    // SQLite stores timestamps at second precision — wait past the next tick
+    // so the refreshed expiresAt lands in a different second.
+    await new Promise((r) => setTimeout(r, 1100));
+    const validated = await validateSession(db, token, policy);
+    expect(validated?.refreshed).toBe(true);
+    expect(validated?.session.expiresAt.getTime()).toBeGreaterThan(
+      original.expiresAt.getTime(),
+    );
+  });
+
+  test("absolute cap forbids extending past createdAt + absoluteMaxAge", async () => {
+    const db = await createTestDb();
+    const user = await seedUser(db);
+    const policy: SessionPolicy = {
+      maxAgeSeconds: 60,
+      absoluteMaxAgeSeconds: 1,
+      refreshThreshold: 0,
+    };
+    const { token } = await createSession(db, { userId: user.id }, policy);
+    await new Promise((r) => setTimeout(r, 1100));
+    expect(await validateSession(db, token, policy)).toBeNull();
+  });
+
+  test("disabled user can no longer validate — session is purged", async () => {
+    const db = await createTestDb();
+    const user = await seedUser(db);
+    const { token } = await createSession(db, { userId: user.id });
+    await db
+      .update(users)
+      .set({ disabledAt: new Date() })
+      .where(eq(users.id, user.id));
+    expect(await validateSession(db, token)).toBeNull();
+  });
+
+  test("invalidateSession deletes by hash so the token stops working", async () => {
+    const db = await createTestDb();
+    const user = await seedUser(db);
+    const { token } = await createSession(db, { userId: user.id });
+    await invalidateSession(db, token);
+    expect(await validateSession(db, token)).toBeNull();
+  });
+});

--- a/packages/core/src/auth/sessions.ts
+++ b/packages/core/src/auth/sessions.ts
@@ -1,0 +1,160 @@
+import { eq, lt } from "drizzle-orm";
+
+import type { Db } from "../context/app.js";
+import type { Session } from "../db/schema/sessions.js";
+import type { User } from "../db/schema/users.js";
+import { sessions } from "../db/schema/sessions.js";
+import { users } from "../db/schema/users.js";
+import { generateToken, hashToken } from "./tokens.js";
+
+const SECONDS_PER_DAY = 60 * 60 * 24;
+
+export interface SessionPolicy {
+  /** Sliding-window duration. The cookie's Max-Age and DB expiresAt. */
+  readonly maxAgeSeconds: number;
+  /** Hard ceiling regardless of activity — re-auth required past this. */
+  readonly absoluteMaxAgeSeconds: number;
+  /** Refresh expiry only when more than this fraction of life has elapsed. */
+  readonly refreshThreshold: number;
+}
+
+export const DEFAULT_SESSION_POLICY: SessionPolicy = {
+  maxAgeSeconds: 30 * SECONDS_PER_DAY,
+  absoluteMaxAgeSeconds: 90 * SECONDS_PER_DAY,
+  refreshThreshold: 0.5,
+};
+
+export interface CreateSessionInput {
+  readonly userId: number;
+  readonly ipAddress?: string | null;
+  readonly userAgent?: string | null;
+}
+
+export interface CreatedSession {
+  /** Raw token to send to the client as a cookie value. Never stored. */
+  readonly token: string;
+  readonly session: Session;
+  readonly expiresAt: Date;
+}
+
+export interface ValidatedSession {
+  readonly session: Session;
+  readonly user: User;
+  /** True if `expiresAt` was extended on this validation. */
+  readonly refreshed: boolean;
+}
+
+/**
+ * Mint a new session: random token → SHA-256 hash → row keyed by hash.
+ * The raw token is returned exactly once for the cookie; the DB never sees it.
+ */
+export async function createSession(
+  db: Db,
+  input: CreateSessionInput,
+  policy: SessionPolicy = DEFAULT_SESSION_POLICY,
+): Promise<CreatedSession> {
+  const token = generateToken();
+  const id = await hashToken(token);
+  const expiresAt = new Date(Date.now() + policy.maxAgeSeconds * 1000);
+
+  const [session] = await db
+    .insert(sessions)
+    .values({
+      id,
+      userId: input.userId,
+      expiresAt,
+      ipAddress: input.ipAddress ?? null,
+      userAgent: input.userAgent ?? null,
+    })
+    .returning();
+
+  if (!session) throw new Error("createSession: insert returned no row");
+  return { token, session, expiresAt };
+}
+
+/**
+ * Validate a raw session token from the cookie. Returns null on any failure
+ * (no row, expired, beyond absolute cap). Slides expiresAt when over the
+ * refresh threshold; deletes the row on absolute-cap breach so a stolen
+ * token past the ceiling is purged on first use.
+ */
+export async function validateSession(
+  db: Db,
+  rawToken: string,
+  policy: SessionPolicy = DEFAULT_SESSION_POLICY,
+): Promise<ValidatedSession | null> {
+  if (!rawToken) return null;
+
+  const id = await hashToken(rawToken);
+  const row = await db
+    .select({ session: sessions, user: users })
+    .from(sessions)
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(eq(sessions.id, id))
+    .get();
+
+  if (!row) return null;
+
+  const now = Date.now();
+  const expiresAtMs = row.session.expiresAt.getTime();
+  const createdAtMs = row.session.createdAt.getTime();
+
+  if (
+    now >= expiresAtMs ||
+    now >= createdAtMs + policy.absoluteMaxAgeSeconds * 1000
+  ) {
+    await db.delete(sessions).where(eq(sessions.id, id));
+    return null;
+  }
+
+  if (row.user.disabledAt) {
+    await db.delete(sessions).where(eq(sessions.id, id));
+    return null;
+  }
+
+  const elapsedFraction = (now - createdAtMs) / (policy.maxAgeSeconds * 1000);
+  if (elapsedFraction < policy.refreshThreshold) {
+    return { session: row.session, user: row.user, refreshed: false };
+  }
+
+  const newExpiryMs = Math.min(
+    now + policy.maxAgeSeconds * 1000,
+    createdAtMs + policy.absoluteMaxAgeSeconds * 1000,
+  );
+  if (newExpiryMs === expiresAtMs) {
+    return { session: row.session, user: row.user, refreshed: false };
+  }
+
+  const newExpiry = new Date(newExpiryMs);
+  await db
+    .update(sessions)
+    .set({ expiresAt: newExpiry })
+    .where(eq(sessions.id, id));
+  return {
+    session: { ...row.session, expiresAt: newExpiry },
+    user: row.user,
+    refreshed: true,
+  };
+}
+
+export async function invalidateSession(
+  db: Db,
+  rawToken: string,
+): Promise<void> {
+  if (!rawToken) return;
+  const id = await hashToken(rawToken);
+  await db.delete(sessions).where(eq(sessions.id, id));
+}
+
+/** Used on role/permission change. */
+export async function invalidateAllSessionsForUser(
+  db: Db,
+  userId: number,
+): Promise<void> {
+  await db.delete(sessions).where(eq(sessions.userId, userId));
+}
+
+/** Bulk-delete expired rows. Caller decides cadence (cron / on-demand). */
+export async function pruneExpiredSessions(db: Db): Promise<void> {
+  await db.delete(sessions).where(lt(sessions.expiresAt, new Date()));
+}

--- a/packages/core/src/auth/tokens.ts
+++ b/packages/core/src/auth/tokens.ts
@@ -1,0 +1,27 @@
+import { constantTimeEqual } from "@oslojs/crypto/subtle";
+import { encodeBase64urlNoPadding, encodeHexLowerCase } from "@oslojs/encoding";
+
+// 192 bits — comfortably inside the Copenhagen Book's 120–256 band.
+const TOKEN_BYTES = 24;
+
+const ENCODER = new TextEncoder();
+
+export function generateToken(): string {
+  const bytes = new Uint8Array(TOKEN_BYTES);
+  crypto.getRandomValues(bytes);
+  return encodeBase64urlNoPadding(bytes);
+}
+
+/**
+ * SHA-256(token), hex-encoded. The DB stores only the hash so a snapshot
+ * leak does not yield live tokens. Native WebCrypto on the hot path.
+ */
+export async function hashToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", ENCODER.encode(token));
+  return encodeHexLowerCase(new Uint8Array(digest));
+}
+
+/** Constant-time string equality — `constantTimeEqual` short-circuits on length mismatch. */
+export function safeEqual(a: string, b: string): boolean {
+  return constantTimeEqual(ENCODER.encode(a), ENCODER.encode(b));
+}

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -1,0 +1,44 @@
+import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
+
+import type * as coreSchema from "../db/schema/index.js";
+import type { HookExecutor } from "../hooks/registry.js";
+import type { PluginRegistry } from "../plugin/manifest.js";
+import type { PlumixEnv } from "../runtime/bindings.js";
+
+export type CoreSchema = typeof coreSchema;
+
+export type Db<TSchema extends Record<string, unknown> = CoreSchema> =
+  BaseSQLiteDatabase<"async" | "sync", unknown, TSchema>;
+
+export interface AuthenticatedUser {
+  readonly id: number;
+  readonly email: string;
+  readonly role: string;
+}
+
+export interface Logger {
+  debug(message: string, meta?: Record<string, unknown>): void;
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: Record<string, unknown>): void;
+}
+
+export interface AppContext<
+  TSchema extends Record<string, unknown> = CoreSchema,
+> {
+  readonly db: Db<TSchema>;
+  readonly env: PlumixEnv;
+  readonly request: Request;
+  readonly user: AuthenticatedUser | null;
+  readonly hooks: HookExecutor;
+  readonly plugins: PluginRegistry;
+  readonly logger: Logger;
+  can(capability: string): boolean;
+}
+
+export const consoleLogger: Logger = {
+  debug: (m, meta) => console.debug(m, meta ?? ""),
+  info: (m, meta) => console.info(m, meta ?? ""),
+  warn: (m, meta) => console.warn(m, meta ?? ""),
+  error: (m, meta) => console.error(m, meta ?? ""),
+};

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1,0 +1,2 @@
+export * from "./app.js";
+export * from "./stores.js";

--- a/packages/core/src/context/stores.ts
+++ b/packages/core/src/context/stores.ts
@@ -1,0 +1,39 @@
+// `node:async_hooks` is supported on Node, Bun, Deno (Node-compat), and
+// Cloudflare Workers (with `nodejs_compat` — already required by Plumix).
+// When TC39 AsyncContext ships, swap the import here; consumers stay unchanged.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { AppContext } from "./app.js";
+
+export const requestStore = new AsyncLocalStorage<AppContext>();
+
+export interface HookFrame {
+  readonly hook: string;
+  readonly plugin: string | null;
+}
+
+export const hookStore = new AsyncLocalStorage<HookFrame>();
+
+export interface TraceSpan {
+  readonly name: string;
+  readonly startedAt: number;
+  readonly children: TraceSpan[];
+  readonly annotations: Record<string, unknown>;
+}
+
+export const traceStore = new AsyncLocalStorage<TraceSpan>();
+
+export const txStore = new AsyncLocalStorage<unknown>();
+
+export function getContext(): AppContext {
+  const ctx = requestStore.getStore();
+  if (!ctx)
+    throw new Error(
+      "No request context — getContext() called outside requestStore.run()",
+    );
+  return ctx;
+}
+
+export function tryGetContext(): AppContext | null {
+  return requestStore.getStore() ?? null;
+}

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./registry.js";
+export * from "./types.js";

--- a/packages/core/src/hooks/registry.test.ts
+++ b/packages/core/src/hooks/registry.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { HookRegistry } from "./registry.js";
+
+// Augment the empty registries with test-only hook names so the real type
+// machinery (FilterInput / ActionArgs extraction) is exercised end-to-end.
+declare module "./types.js" {
+  interface FilterRegistry {
+    "test:pipeline": (value: { readonly count: number }) => {
+      readonly count: number;
+    };
+    "test:passthrough": (value: string) => string;
+    "test:with_rest": (value: number, multiplier: number) => number;
+  }
+  interface ActionRegistry {
+    "test:fired": () => void;
+    "test:args": (userId: number, detail: string) => void;
+    "test:throws": () => void;
+  }
+}
+
+describe("applyFilter", () => {
+  test("returns input unchanged when no filters are registered", async () => {
+    const registry = new HookRegistry();
+    const result = await registry.applyFilter("test:passthrough", "unchanged");
+    expect(result).toBe("unchanged");
+  });
+
+  test("runs filters in priority order (lower first), stable on ties", async () => {
+    const registry = new HookRegistry();
+    const order: string[] = [];
+    registry.addFilter(
+      "test:passthrough",
+      (v) => {
+        order.push("b100-first");
+        return v + "-b";
+      },
+      { priority: 100 },
+    );
+    registry.addFilter(
+      "test:passthrough",
+      (v) => {
+        order.push("a50");
+        return v + "-a";
+      },
+      { priority: 50 },
+    );
+    registry.addFilter(
+      "test:passthrough",
+      (v) => {
+        order.push("b100-second");
+        return v + "-c";
+      },
+      { priority: 100 },
+    );
+    const result = await registry.applyFilter("test:passthrough", "start");
+    expect(order).toEqual(["a50", "b100-first", "b100-second"]);
+    expect(result).toBe("start-a-b-c");
+  });
+
+  test("cloning shields the caller's input from in-filter mutation", async () => {
+    const registry = new HookRegistry();
+    registry.addFilter("test:pipeline", (value) => {
+      // Filter mutates the argument it received.
+      (value as { count: number }).count = 999;
+      return value;
+    });
+
+    const input = { count: 1 };
+    await registry.applyFilter("test:pipeline", input);
+    // Caller's original object is untouched — the filter operated on a clone.
+    expect(input.count).toBe(1);
+  });
+
+  test("threads extra positional args to every filter", async () => {
+    const registry = new HookRegistry();
+    registry.addFilter("test:with_rest", (v, mul) => v * mul);
+    registry.addFilter("test:with_rest", (v, mul) => v + mul);
+    const out = await registry.applyFilter("test:with_rest", 3, 10);
+    expect(out).toBe(40); // (3 * 10) + 10
+  });
+});
+
+describe("doAction", () => {
+  test("invokes all handlers even if one throws", async () => {
+    const registry = new HookRegistry({
+      onActionFailure: () => {
+        /* swallow for this test */
+      },
+    });
+    const fired = vi.fn();
+    registry.addAction("test:throws", () => {
+      throw new Error("boom");
+    });
+    registry.addAction("test:throws", fired);
+    await registry.doAction("test:throws");
+    expect(fired).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes positional args through", async () => {
+    const registry = new HookRegistry();
+    const handler = vi.fn();
+    registry.addAction("test:args", handler);
+    await registry.doAction("test:args", 42, "hello");
+    expect(handler).toHaveBeenCalledWith(42, "hello");
+  });
+
+  test("reports failed actions via onActionFailure with plugin and hook", async () => {
+    const failure = vi.fn();
+    const registry = new HookRegistry({ onActionFailure: failure });
+    registry.addAction(
+      "test:throws",
+      () => {
+        throw new Error("boom");
+      },
+      { plugin: "seo" },
+    );
+    await registry.doAction("test:throws");
+    expect(failure).toHaveBeenCalledTimes(1);
+    expect(failure.mock.calls[0]?.[0]).toMatchObject({
+      hook: "test:throws",
+      plugin: "seo",
+    });
+  });
+});

--- a/packages/core/src/hooks/registry.ts
+++ b/packages/core/src/hooks/registry.ts
@@ -1,0 +1,163 @@
+import type {
+  ActionArgs,
+  ActionFn,
+  ActionName,
+  FilterFn,
+  FilterInput,
+  FilterName,
+  FilterRest,
+  HookOptions,
+} from "./types.js";
+import { hookStore } from "../context/stores.js";
+import { DEFAULT_HOOK_PRIORITY } from "./types.js";
+
+interface FilterEntry {
+  readonly plugin: string | null;
+  readonly priority: number;
+  readonly insertOrder: number;
+  readonly fn: (value: unknown, ...rest: unknown[]) => unknown;
+}
+
+interface ActionEntry {
+  readonly plugin: string | null;
+  readonly priority: number;
+  readonly insertOrder: number;
+  readonly fn: (...args: unknown[]) => unknown;
+}
+
+export interface HookExecutor {
+  applyFilter<TName extends FilterName>(
+    name: TName,
+    input: FilterInput<TName>,
+    ...rest: FilterRest<TName>
+  ): Promise<FilterInput<TName>>;
+  doAction<TName extends ActionName>(
+    name: TName,
+    ...args: ActionArgs<TName>
+  ): Promise<void>;
+}
+
+type OnActionFailure = (info: {
+  hook: string;
+  plugin: string | null;
+  error: unknown;
+}) => void;
+
+export interface HookRegistryOptions {
+  readonly onActionFailure?: OnActionFailure;
+}
+
+export class HookRegistry implements HookExecutor {
+  readonly #filters = new Map<string, FilterEntry[]>();
+  readonly #actions = new Map<string, ActionEntry[]>();
+  #counter = 0;
+  readonly #onActionFailure: OnActionFailure;
+
+  constructor(options: HookRegistryOptions = {}) {
+    this.#onActionFailure =
+      options.onActionFailure ??
+      (({ hook, plugin, error }) => {
+        console.warn(
+          `[plumix] action failed hook=${hook} plugin=${plugin ?? "core"}`,
+          error,
+        );
+      });
+  }
+
+  addFilter<TName extends FilterName>(
+    name: TName,
+    fn: FilterFn<TName>,
+    options: HookOptions & { plugin?: string | null } = {},
+  ): void {
+    const entries = this.#filters.get(name) ?? [];
+    entries.push({
+      plugin: options.plugin ?? null,
+      priority: options.priority ?? DEFAULT_HOOK_PRIORITY,
+      insertOrder: this.#counter++,
+      fn: fn as FilterEntry["fn"],
+    });
+    this.#filters.set(name, entries);
+  }
+
+  addAction<TName extends ActionName>(
+    name: TName,
+    fn: ActionFn<TName>,
+    options: HookOptions & { plugin?: string | null } = {},
+  ): void {
+    const entries = this.#actions.get(name) ?? [];
+    entries.push({
+      plugin: options.plugin ?? null,
+      priority: options.priority ?? DEFAULT_HOOK_PRIORITY,
+      insertOrder: this.#counter++,
+      fn: fn as ActionEntry["fn"],
+    });
+    this.#actions.set(name, entries);
+  }
+
+  async applyFilter<TName extends FilterName>(
+    name: TName,
+    input: FilterInput<TName>,
+    ...rest: FilterRest<TName>
+  ): Promise<FilterInput<TName>> {
+    const entries = this.#filters.get(name);
+    if (!entries || entries.length === 0) return input;
+
+    const sorted = sortEntries(entries);
+    let current: unknown = input;
+    for (const entry of sorted) {
+      // structuredClone isolates each filter — mutations inside one filter
+      // can't leak into the next. Clone cost is negligible vs. hook work.
+      const snapshot = structuredClone(current);
+      current = await hookStore.run({ hook: name, plugin: entry.plugin }, () =>
+        entry.fn(snapshot, ...(rest as unknown[])),
+      );
+    }
+    return current as FilterInput<TName>;
+  }
+
+  async doAction<TName extends ActionName>(
+    name: TName,
+    ...args: ActionArgs<TName>
+  ): Promise<void> {
+    const entries = this.#actions.get(name);
+    if (!entries || entries.length === 0) return;
+
+    const sorted = sortEntries(entries);
+    const invocations = sorted.map((entry) =>
+      hookStore.run({ hook: name, plugin: entry.plugin }, () =>
+        Promise.resolve().then(() => entry.fn(...(args as unknown[]))),
+      ),
+    );
+
+    const results = await Promise.allSettled(invocations);
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result?.status === "rejected") {
+        const entry = sorted[i];
+        if (entry) {
+          this.#onActionFailure({
+            hook: name,
+            plugin: entry.plugin,
+            error: result.reason,
+          });
+        }
+      }
+    }
+  }
+
+  listFilters(name: string): readonly FilterEntry[] {
+    return this.#filters.get(name) ?? [];
+  }
+
+  listActions(name: string): readonly ActionEntry[] {
+    return this.#actions.get(name) ?? [];
+  }
+}
+
+function sortEntries<T extends { priority: number; insertOrder: number }>(
+  entries: T[],
+): T[] {
+  return [...entries].sort(
+    (a, b) => a.priority - b.priority || a.insertOrder - b.insertOrder,
+  );
+}

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -1,0 +1,54 @@
+// Plugin authors and core hooks both extend these registries via TypeScript
+// module augmentation. The Vite plugin emits typed declarations from
+// `registerPostType` / `registerTaxonomy` / `registerFilter` / `registerAction`
+// calls so cross-plugin autocompletion works without manual type wiring.
+//
+// Each registry value is the handler signature for that hook name.
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface FilterRegistry {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ActionRegistry {}
+
+// `keyof` of an empty interface is `never`; after module augmentation by the
+// Vite plugin (and by tests), it becomes a string-literal union.
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+export type FilterName = keyof FilterRegistry & string;
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+export type ActionName = keyof ActionRegistry & string;
+
+// Filters are pipelines: each handler receives the previous handler's return
+// value as its first argument and returns the (possibly transformed) value.
+// `(value, ...rest) => value | Promise<value>`.
+export type FilterFn<TName extends FilterName> = FilterRegistry[TName] extends (
+  ...args: infer A
+) => infer R
+  ? (...args: A) => R
+  : never;
+
+// Filter input type = first parameter type. Rest params = everything else.
+// Extracted via Parameters<T> + tuple slicing so `applyFilter(name, input, ...rest)`
+// is type-safe at the call site.
+export type FilterInput<TName extends FilterName> = Parameters<
+  FilterRegistry[TName]
+>[0];
+
+export type FilterRest<TName extends FilterName> =
+  Parameters<FilterRegistry[TName]> extends [unknown, ...infer R] ? R : [];
+
+export type ActionFn<TName extends ActionName> = ActionRegistry[TName] extends (
+  ...args: infer A
+) => unknown
+  ? (...args: A) => void | Promise<void>
+  : never;
+
+export type ActionArgs<TName extends ActionName> =
+  ActionRegistry[TName] extends (...args: infer A) => unknown ? A : never;
+
+export interface HookOptions {
+  /** Lower runs first. Default: 100. Stable tie-break by registration order. */
+  readonly priority?: number;
+}
+
+export const DEFAULT_HOOK_PRIORITY = 100;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,9 @@
+export * from "./auth/index.js";
 export * from "./config.js";
+export * from "./context/index.js";
 export * from "./db/schema/index.js";
-export * from "./plugin/define.js";
+export * from "./hooks/index.js";
+export * from "./plugin/index.js";
 export type * from "./runtime/adapter.js";
 export type * from "./runtime/bindings.js";
 export type * from "./runtime/slots.js";

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -1,0 +1,165 @@
+import type { DerivedCapability } from "../auth/rbac.js";
+import type { UserRole } from "../db/schema/users.js";
+import type { HookRegistry } from "../hooks/registry.js";
+import type {
+  ActionArgs,
+  ActionFn,
+  ActionName,
+  FilterFn,
+  FilterInput,
+  FilterName,
+  FilterRest,
+  HookOptions,
+} from "../hooks/types.js";
+import type {
+  MetaBoxOptions,
+  MetaOptions,
+  MutablePluginRegistry,
+  PostTypeOptions,
+  TaxonomyOptions,
+} from "./manifest.js";
+import {
+  derivePostTypeCapabilities,
+  deriveTaxonomyCapabilities,
+} from "../auth/rbac.js";
+import { DuplicateRegistrationError } from "./manifest.js";
+
+export interface PluginSetupContext {
+  readonly id: string;
+
+  /** Subscribe to an existing (core or other-plugin) filter. */
+  addFilter<TName extends FilterName>(
+    name: TName,
+    fn: FilterFn<TName>,
+    options?: HookOptions,
+  ): void;
+
+  /** Subscribe to an existing (core or other-plugin) action. */
+  addAction<TName extends ActionName>(
+    name: TName,
+    fn: ActionFn<TName>,
+    options?: HookOptions,
+  ): void;
+
+  /**
+   * Declare a plugin-owned filter. The short name is auto-prefixed with the
+   * plugin id — `ctx.registerFilter('meta_tags', ...)` becomes `<plugin>:meta_tags`.
+   * Other plugins listen via the full prefixed name.
+   */
+  registerFilter<TName extends FilterName>(
+    shortName: string,
+    fn: FilterFn<TName>,
+    options?: HookOptions,
+  ): void;
+
+  registerAction<TName extends ActionName>(
+    shortName: string,
+    fn: ActionFn<TName>,
+    options?: HookOptions,
+  ): void;
+
+  registerPostType(name: string, options: PostTypeOptions): void;
+  registerTaxonomy(name: string, options: TaxonomyOptions): void;
+  registerMeta(key: string, options: MetaOptions): void;
+  registerMetaBox(id: string, options: MetaBoxOptions): void;
+  registerCapability(name: string, minRole: UserRole): void;
+}
+
+interface CreatePluginContextArgs {
+  readonly pluginId: string;
+  readonly hooks: HookRegistry;
+  readonly registry: MutablePluginRegistry;
+}
+
+export function createPluginSetupContext({
+  pluginId,
+  hooks,
+  registry,
+}: CreatePluginContextArgs): PluginSetupContext {
+  // First writer wins — sharing a capabilityType across post types is the
+  // supported way to pool permissions, so derived caps must not throw on
+  // conflict. Explicit `registerCapability` still does.
+  const addDerivedCaps = (caps: readonly DerivedCapability[]): void => {
+    for (const cap of caps) {
+      if (registry.capabilities.has(cap.name)) continue;
+      registry.capabilities.set(cap.name, { ...cap, registeredBy: pluginId });
+    }
+  };
+
+  return {
+    id: pluginId,
+
+    addFilter: (name, fn, options) => {
+      hooks.addFilter(name, fn, { ...options, plugin: pluginId });
+    },
+
+    addAction: (name, fn, options) => {
+      hooks.addAction(name, fn, { ...options, plugin: pluginId });
+    },
+
+    registerFilter: (shortName, fn, options) => {
+      const prefixed = `${pluginId}:${shortName}` as FilterName;
+      hooks.addFilter(prefixed, fn as FilterFn<FilterName>, {
+        ...options,
+        plugin: pluginId,
+      });
+    },
+
+    registerAction: (shortName, fn, options) => {
+      const prefixed = `${pluginId}:${shortName}` as ActionName;
+      hooks.addAction(prefixed, fn as ActionFn<ActionName>, {
+        ...options,
+        plugin: pluginId,
+      });
+    },
+
+    registerPostType: (name, options) => {
+      if (registry.postTypes.has(name))
+        throw new DuplicateRegistrationError("post type", name);
+      registry.postTypes.set(name, {
+        ...options,
+        name,
+        registeredBy: pluginId,
+      });
+      addDerivedCaps(derivePostTypeCapabilities(name, options));
+    },
+
+    registerTaxonomy: (name, options) => {
+      if (registry.taxonomies.has(name))
+        throw new DuplicateRegistrationError("taxonomy", name);
+      registry.taxonomies.set(name, {
+        ...options,
+        name,
+        registeredBy: pluginId,
+      });
+      addDerivedCaps(deriveTaxonomyCapabilities(name));
+    },
+
+    registerMeta: (key, options) => {
+      if (registry.metaKeys.has(key))
+        throw new DuplicateRegistrationError("meta key", key);
+      registry.metaKeys.set(key, { ...options, key, registeredBy: pluginId });
+    },
+
+    registerMetaBox: (id, options) => {
+      if (registry.metaBoxes.has(id))
+        throw new DuplicateRegistrationError("meta box", id);
+      registry.metaBoxes.set(id, { ...options, id, registeredBy: pluginId });
+    },
+
+    registerCapability: (name, minRole) => {
+      if (registry.capabilities.has(name)) {
+        throw new DuplicateRegistrationError("capability", name);
+      }
+      registry.capabilities.set(name, {
+        name,
+        minRole,
+        registeredBy: pluginId,
+      });
+    },
+  };
+}
+
+// Re-exported from our local FilterRest helper so the type used by hook wrapper
+// logic is expressible at call sites without digging into internals.
+export type { ActionArgs, FilterInput, FilterRest };

--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -1,9 +1,7 @@
-export interface PluginContext {
-  readonly id: string;
-}
+import type { PluginSetupContext } from "./context.js";
 
 export type PluginSetup<TConfig> = (
-  ctx: PluginContext,
+  ctx: PluginSetupContext,
   config: TConfig,
 ) => void | Promise<void>;
 

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -1,0 +1,4 @@
+export * from "./context.js";
+export * from "./define.js";
+export * from "./manifest.js";
+export * from "./register.js";

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1,0 +1,118 @@
+import type { UserRole } from "../db/schema/users.js";
+
+export interface PostTypeOptions {
+  readonly label: string;
+  readonly labels?: { readonly singular?: string };
+  readonly description?: string;
+  readonly supports?: readonly string[];
+  readonly taxonomies?: readonly string[];
+  readonly isHierarchical?: boolean;
+  readonly isPublic?: boolean;
+  readonly hasArchive?: boolean | string;
+  readonly rewrite?: {
+    readonly slug?: string;
+    readonly isHierarchical?: boolean;
+  };
+  readonly capabilityType?: string;
+  readonly menuPosition?: number;
+  readonly menuIcon?: string;
+}
+
+export interface TaxonomyOptions {
+  readonly label: string;
+  readonly labels?: { readonly singular?: string };
+  readonly description?: string;
+  readonly isHierarchical?: boolean;
+  readonly postTypes?: readonly string[];
+  readonly isPublic?: boolean;
+  readonly isInQuickEdit?: boolean;
+  readonly hasAdminColumn?: boolean;
+  readonly rewrite?: {
+    readonly slug?: string;
+    readonly isHierarchical?: boolean;
+  };
+}
+
+export type MetaScalarType = "string" | "number" | "boolean" | "json";
+
+export interface MetaOptions {
+  readonly type: MetaScalarType;
+  readonly default?: unknown;
+  readonly postTypes: readonly string[];
+  readonly sanitize?: (value: unknown) => unknown;
+}
+
+export interface MetaBoxField {
+  readonly key: string;
+  readonly label: string;
+  readonly inputType: string;
+  readonly maxLength?: number;
+}
+
+export interface MetaBoxOptions {
+  readonly label: string;
+  readonly context?: "side" | "normal" | "advanced";
+  readonly priority?: "high" | "default" | "low";
+  readonly postTypes: readonly string[];
+  readonly capability?: string;
+  readonly fields: readonly MetaBoxField[];
+}
+
+export interface RegisteredPostType extends PostTypeOptions {
+  readonly name: string;
+  readonly registeredBy: string | null;
+}
+
+export interface RegisteredTaxonomy extends TaxonomyOptions {
+  readonly name: string;
+  readonly registeredBy: string | null;
+}
+
+export interface RegisteredMeta extends MetaOptions {
+  readonly key: string;
+  readonly registeredBy: string | null;
+}
+
+export interface RegisteredMetaBox extends MetaBoxOptions {
+  readonly id: string;
+  readonly registeredBy: string | null;
+}
+
+export interface RegisteredCapability {
+  readonly name: string;
+  readonly minRole: UserRole;
+  readonly registeredBy: string | null;
+}
+
+export interface PluginRegistry {
+  readonly postTypes: ReadonlyMap<string, RegisteredPostType>;
+  readonly taxonomies: ReadonlyMap<string, RegisteredTaxonomy>;
+  readonly metaKeys: ReadonlyMap<string, RegisteredMeta>;
+  readonly metaBoxes: ReadonlyMap<string, RegisteredMetaBox>;
+  readonly capabilities: ReadonlyMap<string, RegisteredCapability>;
+}
+
+export interface MutablePluginRegistry extends PluginRegistry {
+  readonly postTypes: Map<string, RegisteredPostType>;
+  readonly taxonomies: Map<string, RegisteredTaxonomy>;
+  readonly metaKeys: Map<string, RegisteredMeta>;
+  readonly metaBoxes: Map<string, RegisteredMetaBox>;
+  readonly capabilities: Map<string, RegisteredCapability>;
+}
+
+export function createPluginRegistry(): MutablePluginRegistry {
+  return {
+    postTypes: new Map(),
+    taxonomies: new Map(),
+    metaKeys: new Map(),
+    metaBoxes: new Map(),
+    capabilities: new Map(),
+  };
+}
+
+export class DuplicateRegistrationError extends Error {
+  constructor(kind: string, name: string) {
+    super(`${kind} "${name}" is already registered`);
+    this.name = "DuplicateRegistrationError";
+  }
+}

--- a/packages/core/src/plugin/register.test.ts
+++ b/packages/core/src/plugin/register.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry } from "../hooks/registry.js";
+import { definePlugin } from "./define.js";
+import { DuplicateRegistrationError } from "./manifest.js";
+import { installPlugins } from "./register.js";
+
+declare module "../hooks/types.js" {
+  interface FilterRegistry {
+    "post:before_save": (post: { readonly title: string }) => {
+      readonly title: string;
+    };
+    "seo:meta_tags": (tags: { readonly title: string }) => {
+      readonly title: string;
+    };
+    "landing_page:before_save": (post: { readonly title: string }) => {
+      readonly title: string;
+    };
+  }
+  interface ActionRegistry {
+    "post:published": (postId: number) => void;
+  }
+}
+
+describe("installPlugins", () => {
+  test("auto-prefixes plugin-registered filters with the plugin id", async () => {
+    const hooks = new HookRegistry();
+    const seo = definePlugin("seo", (ctx) => {
+      ctx.registerFilter("meta_tags", (tags: { readonly title: string }) => ({
+        title: `seo:${tags.title}`,
+      }));
+    });
+
+    const { hooks: result } = await installPlugins({ hooks, plugins: [seo] });
+    const out = await result.applyFilter("seo:meta_tags", { title: "hello" });
+    expect(out).toEqual({ title: "seo:hello" });
+  });
+
+  test("plugins can subscribe to core-owned hooks without prefix", async () => {
+    const hooks = new HookRegistry();
+    const stamp = definePlugin("stamp", (ctx) => {
+      ctx.addFilter("post:before_save", (post) => ({
+        title: `[stamped] ${post.title}`,
+      }));
+    });
+
+    await installPlugins({ hooks, plugins: [stamp] });
+    const out = await hooks.applyFilter("post:before_save", { title: "hi" });
+    expect(out).toEqual({ title: "[stamped] hi" });
+  });
+
+  test("registers post types into the manifest with plugin attribution", async () => {
+    const hooks = new HookRegistry();
+    const blog = definePlugin("blog", (ctx) => {
+      ctx.registerPostType("landing_page", {
+        label: "Landing Pages",
+        isHierarchical: false,
+      });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [blog] });
+    const entry = registry.postTypes.get("landing_page");
+    expect(entry).toBeDefined();
+    expect(entry?.label).toBe("Landing Pages");
+    expect(entry?.registeredBy).toBe("blog");
+  });
+
+  test("throws on duplicate post-type registration across plugins", async () => {
+    const hooks = new HookRegistry();
+    const a = definePlugin("a", (ctx) => {
+      ctx.registerPostType("docs", { label: "Docs A" });
+    });
+    const b = definePlugin("b", (ctx) => {
+      ctx.registerPostType("docs", { label: "Docs B" });
+    });
+
+    await expect(
+      installPlugins({ hooks, plugins: [a, b] }),
+    ).rejects.toBeInstanceOf(DuplicateRegistrationError);
+  });
+
+  test("auto-derives the capability set from a post type, using the post type name", async () => {
+    const hooks = new HookRegistry();
+    const blog = definePlugin("blog", (ctx) => {
+      ctx.registerPostType("landing_page", { label: "Landing Pages" });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [blog] });
+    expect(registry.capabilities.get("landing_page:create")?.minRole).toBe(
+      "contributor",
+    );
+    expect(registry.capabilities.get("landing_page:publish")?.minRole).toBe(
+      "author",
+    );
+    expect(registry.capabilities.get("landing_page:edit_any")?.minRole).toBe(
+      "editor",
+    );
+    expect(registry.capabilities.get("landing_page:delete")?.registeredBy).toBe(
+      "blog",
+    );
+  });
+
+  test("capabilityType is the cap namespace — shared types pool their permissions", async () => {
+    const hooks = new HookRegistry();
+    const a = definePlugin("a", (ctx) => {
+      ctx.registerPostType("docs", { label: "Docs", capabilityType: "post" });
+    });
+    const b = definePlugin("b", (ctx) => {
+      ctx.registerPostType("guides", {
+        label: "Guides",
+        capabilityType: "post",
+      });
+    });
+    // Two plugins share `capabilityType: 'post'` — derivation must not throw.
+    await expect(
+      installPlugins({ hooks, plugins: [a, b] }),
+    ).resolves.toBeDefined();
+  });
+
+  test("taxonomy registration derives the {name}:{action} cap set", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("geo", (ctx) => {
+      ctx.registerTaxonomy("region", { label: "Regions" });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(registry.capabilities.get("region:assign")?.minRole).toBe(
+      "contributor",
+    );
+    expect(registry.capabilities.get("region:manage")?.minRole).toBe("editor");
+  });
+
+  test("registerCapability is the escape hatch for plugin-specific caps", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("seo", (ctx) => {
+      ctx.registerCapability("seo:manage", "editor");
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(registry.capabilities.get("seo:manage")).toEqual({
+      name: "seo:manage",
+      minRole: "editor",
+      registeredBy: "seo",
+    });
+  });
+});

--- a/packages/core/src/plugin/register.ts
+++ b/packages/core/src/plugin/register.ts
@@ -1,0 +1,39 @@
+import type { AnyPluginDescriptor } from "../config.js";
+import type { HookRegistry } from "../hooks/registry.js";
+import type { MutablePluginRegistry, PluginRegistry } from "./manifest.js";
+import { createPluginSetupContext } from "./context.js";
+import { createPluginRegistry } from "./manifest.js";
+
+export interface PluginInstallResult {
+  readonly hooks: HookRegistry;
+  readonly registry: PluginRegistry;
+}
+
+interface InstallPluginsArgs {
+  readonly hooks: HookRegistry;
+  readonly plugins: readonly AnyPluginDescriptor[];
+  readonly registry?: MutablePluginRegistry;
+}
+
+/**
+ * Run every plugin's `setup(ctx, config)` once, at app build time.
+ * Collects the manifest of post types / taxonomies / meta / capabilities and
+ * registers all filters/actions with the shared hook registry.
+ */
+export async function installPlugins({
+  hooks,
+  plugins,
+  registry = createPluginRegistry(),
+}: InstallPluginsArgs): Promise<PluginInstallResult> {
+  for (const descriptor of plugins) {
+    const ctx = createPluginSetupContext({
+      pluginId: descriptor.id,
+      hooks,
+      registry,
+    });
+    // Plugin configs are opaque at the framework level — each plugin supplies
+    // its own TConfig. `undefined` is the common case for zero-config plugins.
+    await descriptor.setup(ctx, undefined as never);
+  }
+  return { hooks, registry };
+}

--- a/packages/core/src/test/fixtures/webauthn.ts
+++ b/packages/core/src/test/fixtures/webauthn.ts
@@ -1,0 +1,273 @@
+// Test-only WebAuthn fixture builder. Uses node:crypto to generate a real
+// ES256 key pair, build authenticator data + clientDataJSON, sign assertions,
+// and CBOR-encode an attestation object with `fmt: "none"`. The output is
+// indistinguishable from what a real browser would POST — the same
+// finish{Registration,Authentication} verify path runs end-to-end against it.
+//
+// Not part of the public surface; tests only. node:crypto is fine here
+// (tests run on Node).
+
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
+import type { createPrivateKey } from "node:crypto";
+import { encodeBase64urlNoPadding } from "@oslojs/encoding";
+
+const ATTESTED_FLAG = 0x40;
+const USER_PRESENT_FLAG = 0x01;
+
+const COSE_KTY = 1;
+const COSE_ALG = 3;
+const COSE_EC2_CRV = -1;
+const COSE_EC2_X = -2;
+const COSE_EC2_Y = -3;
+const COSE_KTY_EC2 = 2;
+const COSE_ALG_ES256 = -7;
+const COSE_CURVE_P256 = 1;
+
+export interface PasskeyKeyPair {
+  readonly privateKey: ReturnType<typeof createPrivateKey>;
+  readonly publicKeyX: Uint8Array;
+  readonly publicKeyY: Uint8Array;
+  /** SEC1-uncompressed (0x04 || X || Y), 65 bytes — what we store in DB. */
+  readonly publicKeySec1: Uint8Array;
+}
+
+export function generatePasskeyKeyPair(): PasskeyKeyPair {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  const jwk = publicKey.export({ format: "jwk" });
+  if (typeof jwk.x !== "string" || typeof jwk.y !== "string") {
+    throw new Error("EC keypair export missing x/y");
+  }
+  const x = base64urlToBytes(jwk.x);
+  const y = base64urlToBytes(jwk.y);
+  return {
+    privateKey,
+    publicKeyX: x,
+    publicKeyY: y,
+    publicKeySec1: concatBytes(new Uint8Array([0x04]), x, y),
+  };
+}
+
+function base64urlToBytes(input: string): Uint8Array {
+  const pad = input.length % 4 === 0 ? "" : "=".repeat(4 - (input.length % 4));
+  const b64 = (input + pad).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(b64);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+function u32(n: number): Uint8Array {
+  const b = new Uint8Array(4);
+  new DataView(b.buffer).setUint32(0, n, false);
+  return b;
+}
+
+function u16(n: number): Uint8Array {
+  const b = new Uint8Array(2);
+  new DataView(b.buffer).setUint16(0, n, false);
+  return b;
+}
+
+// CBOR encoder — minimal, just what attestation needs.
+const TYPE_UINT = 0;
+const TYPE_NEG_INT = 1;
+const TYPE_BYTES = 2;
+const TYPE_TEXT = 3;
+const TYPE_MAP = 5;
+
+function cborHead(major: number, value: number): Uint8Array {
+  const tag = major << 5;
+  if (value < 24) return new Uint8Array([tag | value]);
+  if (value < 0x100) return new Uint8Array([tag | 24, value]);
+  if (value < 0x10000) {
+    const out = new Uint8Array(3);
+    out[0] = tag | 25;
+    new DataView(out.buffer).setUint16(1, value, false);
+    return out;
+  }
+  if (value < 0x100000000) {
+    const out = new Uint8Array(5);
+    out[0] = tag | 26;
+    new DataView(out.buffer).setUint32(1, value, false);
+    return out;
+  }
+  throw new Error("cbor head value too large");
+}
+
+function cborInt(n: number): Uint8Array {
+  if (n >= 0) return cborHead(TYPE_UINT, n);
+  return cborHead(TYPE_NEG_INT, -1 - n);
+}
+
+function cborText(s: string): Uint8Array {
+  const bytes = new TextEncoder().encode(s);
+  return concatBytes(cborHead(TYPE_TEXT, bytes.length), bytes);
+}
+
+function cborBytes(bytes: Uint8Array): Uint8Array {
+  return concatBytes(cborHead(TYPE_BYTES, bytes.length), bytes);
+}
+
+/** Encode a CBOR map whose entries are pre-encoded (key, value) pairs. */
+function cborMap(entries: readonly [Uint8Array, Uint8Array][]): Uint8Array {
+  return concatBytes(cborHead(TYPE_MAP, entries.length), ...entries.flat());
+}
+
+function encodeCosePublicKey(x: Uint8Array, y: Uint8Array): Uint8Array {
+  return cborMap([
+    [cborInt(COSE_KTY), cborInt(COSE_KTY_EC2)],
+    [cborInt(COSE_ALG), cborInt(COSE_ALG_ES256)],
+    [cborInt(COSE_EC2_CRV), cborInt(COSE_CURVE_P256)],
+    [cborInt(COSE_EC2_X), cborBytes(x)],
+    [cborInt(COSE_EC2_Y), cborBytes(y)],
+  ]);
+}
+
+interface BuildAuthenticatorDataInput {
+  readonly rpId: string;
+  readonly counter: number;
+  readonly userVerified?: boolean;
+  /** Provide credentialId + COSE-encoded pubkey to set the AT (attested) flag. */
+  readonly attested?: {
+    readonly credentialId: Uint8Array;
+    readonly cosePublicKey: Uint8Array;
+  };
+}
+
+function buildAuthenticatorData(
+  input: BuildAuthenticatorDataInput,
+): Uint8Array {
+  const rpIdHash = createHash("sha256").update(input.rpId).digest();
+  let flags = USER_PRESENT_FLAG;
+  if (input.userVerified) flags |= 0x04;
+  if (input.attested) flags |= ATTESTED_FLAG;
+
+  const head = concatBytes(
+    new Uint8Array(rpIdHash),
+    new Uint8Array([flags]),
+    u32(input.counter),
+  );
+  if (!input.attested) return head;
+
+  const aaguid = new Uint8Array(16); // all zeros — fine for "none" attestation
+  return concatBytes(
+    head,
+    aaguid,
+    u16(input.attested.credentialId.length),
+    input.attested.credentialId,
+    input.attested.cosePublicKey,
+  );
+}
+
+function buildClientDataJSON(
+  type: "webauthn.create" | "webauthn.get",
+  challenge: string,
+  origin: string,
+): Uint8Array {
+  return new TextEncoder().encode(
+    JSON.stringify({ type, challenge, origin, crossOrigin: false }),
+  );
+}
+
+function buildAttestationObjectNone(authData: Uint8Array): Uint8Array {
+  return cborMap([
+    [cborText("fmt"), cborText("none")],
+    [cborText("attStmt"), cborMap([])],
+    [cborText("authData"), cborBytes(authData)],
+  ]);
+}
+
+interface BuildAssertionInput {
+  readonly keyPair: PasskeyKeyPair;
+  readonly rpId: string;
+  readonly origin: string;
+  readonly challenge: string;
+  readonly counter: number;
+}
+
+interface BuiltAssertion {
+  readonly clientDataJSON: string;
+  readonly authenticatorData: string;
+  readonly signature: string;
+}
+
+export function buildAssertion(input: BuildAssertionInput): BuiltAssertion {
+  const clientDataBytes = buildClientDataJSON(
+    "webauthn.get",
+    input.challenge,
+    input.origin,
+  );
+  const authData = buildAuthenticatorData({
+    rpId: input.rpId,
+    counter: input.counter,
+  });
+  const clientDataHash = createHash("sha256").update(clientDataBytes).digest();
+  // The same shape `createAssertionSignatureMessage` produces on the server.
+  const message = concatBytes(authData, new Uint8Array(clientDataHash));
+  // Node's sign('sha256', ..., privateKey) emits DER-encoded ECDSA by default.
+  const sigDer = sign("sha256", message, input.keyPair.privateKey);
+  return {
+    clientDataJSON: encodeBase64urlNoPadding(clientDataBytes),
+    authenticatorData: encodeBase64urlNoPadding(authData),
+    signature: encodeBase64urlNoPadding(new Uint8Array(sigDer)),
+  };
+}
+
+interface BuildAttestationInput {
+  readonly keyPair: PasskeyKeyPair;
+  readonly rpId: string;
+  readonly origin: string;
+  readonly challenge: string;
+  readonly credentialId: Uint8Array;
+  readonly counter?: number;
+}
+
+interface BuiltAttestation {
+  readonly clientDataJSON: string;
+  readonly attestationObject: string;
+  readonly credentialIdBase64Url: string;
+}
+
+export function buildAttestation(
+  input: BuildAttestationInput,
+): BuiltAttestation {
+  const cose = encodeCosePublicKey(
+    input.keyPair.publicKeyX,
+    input.keyPair.publicKeyY,
+  );
+  const authData = buildAuthenticatorData({
+    rpId: input.rpId,
+    counter: input.counter ?? 0,
+    attested: { credentialId: input.credentialId, cosePublicKey: cose },
+  });
+  const attObject = buildAttestationObjectNone(authData);
+  const clientDataBytes = buildClientDataJSON(
+    "webauthn.create",
+    input.challenge,
+    input.origin,
+  );
+  return {
+    clientDataJSON: encodeBase64urlNoPadding(clientDataBytes),
+    attestationObject: encodeBase64urlNoPadding(attObject),
+    credentialIdBase64Url: encodeBase64urlNoPadding(input.credentialId),
+  };
+}
+
+export function randomCredentialId(): Uint8Array {
+  const out = new Uint8Array(16);
+  crypto.getRandomValues(out);
+  return out;
+}

--- a/packages/core/src/test/harness.ts
+++ b/packages/core/src/test/harness.ts
@@ -1,0 +1,45 @@
+import { createClient } from "@libsql/client";
+import {
+  generateSQLiteDrizzleJson,
+  generateSQLiteMigration,
+} from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/libsql";
+
+import * as schema from "../db/schema/index.js";
+
+type TestDb = ReturnType<typeof drizzle<typeof schema>>;
+
+const schemaImports = schema as unknown as Record<string, unknown>;
+
+let cachedStatements: string[] | null = null;
+
+// drizzle-kit's `api` surface is loosely typed (`SQLiteSchema` is opaque);
+// we treat it as a black-box snapshot blob and only read its `id` field.
+async function compileSchemaSql(): Promise<string[]> {
+  if (cachedStatements) return cachedStatements;
+  // Empty ↔ current snapshot diff yields the full create-from-scratch SQL.
+  // `casing: "snake_case"` matches drizzle.config.ts so column names line up.
+  /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+  const empty = await generateSQLiteDrizzleJson({}, undefined, "snake_case");
+  const current = await generateSQLiteDrizzleJson(
+    schemaImports,
+    empty.id as string,
+    "snake_case",
+  );
+  cachedStatements = await generateSQLiteMigration(empty, current);
+  /* eslint-enable */
+  return cachedStatements;
+}
+
+/**
+ * Per-test in-memory libsql database with the full core schema applied.
+ * Pure JS — works on Node, Bun, Deno, CI without native deps.
+ */
+export async function createTestDb(): Promise<TestDb> {
+  const client = createClient({ url: ":memory:" });
+  const db = drizzle(client, { schema, casing: "snake_case" });
+  const statements = await compileSchemaSql();
+  for (const stmt of statements) await db.run(sql.raw(stmt));
+  return db;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@plumix/typescript-config/internal-package.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,15 @@ importers:
 
   packages/core:
     dependencies:
+      '@oslojs/crypto':
+        specifier: ^1.0.1
+        version: 1.0.1
+      '@oslojs/encoding':
+        specifier: ^1.1.0
+        version: 1.1.0
+      '@oslojs/webauthn':
+        specifier: ^1.0.0
+        version: 1.0.0
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2)
@@ -128,6 +137,9 @@ importers:
         specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.3)
     devDependencies:
+      '@libsql/client':
+        specifier: ^0.17.2
+        version: 0.17.2
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
@@ -1208,6 +1220,30 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oslojs/asn1@1.0.0':
+    resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
+
+  '@oslojs/binary@1.0.0':
+    resolution: {integrity: sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==}
+
+  '@oslojs/cbor@1.0.0':
+    resolution: {integrity: sha512-AY6Lknexs7n2xp8Cgey95c+975VG7XOk4UEdRdNFxHmDDbuf47OC/LAVRsl14DeTLwo8W6xr3HLFwUFmKcndTQ==}
+
+  '@oslojs/crypto@1.0.0':
+    resolution: {integrity: sha512-dVz8TkkgYdr3tlwxHd7SCYGxoN7ynwHLA0nei/Aq9C+ERU0BK+U8+/3soEzBUxUNKYBf42351DyJUZ2REla50w==}
+
+  '@oslojs/crypto@1.0.1':
+    resolution: {integrity: sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==}
+
+  '@oslojs/encoding@1.0.0':
+    resolution: {integrity: sha512-dyIB0SdZgMm5BhGwdSp8rMxEFIopLKxDG1vxIBaiogyom6ZqH2aXPb6DEC2WzOOWKdPSq1cxdNeRx2wAn1Z+ZQ==}
+
+  '@oslojs/encoding@1.1.0':
+    resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@oslojs/webauthn@1.0.0':
+    resolution: {integrity: sha512-2ZRpbt3msNURwvjmavzq9vrNlxUnWFBGMYqbC1kO3fYBLskL7r4DiLJT1wbtLoI+hclFwjhl48YhRFBl6RWg1A==}
 
   '@oxc-parser/binding-android-arm-eabi@0.121.0':
     resolution: {integrity: sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==}
@@ -4363,12 +4399,10 @@ snapshots:
       - bufferutil
       - encoding
       - utf-8-validate
-    optional: true
 
   '@libsql/core@0.17.2':
     dependencies:
       js-base64: 3.7.8
-    optional: true
 
   '@libsql/darwin-arm64@0.5.29':
     optional: true
@@ -4386,7 +4420,6 @@ snapshots:
       - bufferutil
       - encoding
       - utf-8-validate
-    optional: true
 
   '@libsql/isomorphic-ws@0.1.5':
     dependencies:
@@ -4395,7 +4428,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    optional: true
 
   '@libsql/linux-arm-gnueabihf@0.5.29':
     optional: true
@@ -4443,8 +4475,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@neon-rs/load@0.0.4':
-    optional: true
+  '@neon-rs/load@0.0.4': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4457,6 +4488,38 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oslojs/asn1@1.0.0':
+    dependencies:
+      '@oslojs/binary': 1.0.0
+
+  '@oslojs/binary@1.0.0': {}
+
+  '@oslojs/cbor@1.0.0':
+    dependencies:
+      '@oslojs/binary': 1.0.0
+
+  '@oslojs/crypto@1.0.0':
+    dependencies:
+      '@oslojs/asn1': 1.0.0
+      '@oslojs/binary': 1.0.0
+
+  '@oslojs/crypto@1.0.1':
+    dependencies:
+      '@oslojs/asn1': 1.0.0
+      '@oslojs/binary': 1.0.0
+
+  '@oslojs/encoding@1.0.0': {}
+
+  '@oslojs/encoding@1.1.0': {}
+
+  '@oslojs/webauthn@1.0.0':
+    dependencies:
+      '@oslojs/asn1': 1.0.0
+      '@oslojs/binary': 1.0.0
+      '@oslojs/cbor': 1.0.0
+      '@oslojs/crypto': 1.0.0
+      '@oslojs/encoding': 1.0.0
 
   '@oxc-parser/binding-android-arm-eabi@0.121.0':
     optional: true
@@ -4743,7 +4806,6 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.6.0
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
@@ -5182,7 +5244,6 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
-    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5190,8 +5251,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  data-uri-to-buffer@4.0.1:
-    optional: true
+  data-uri-to-buffer@4.0.1: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5229,8 +5289,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  detect-libc@2.0.2:
-    optional: true
+  detect-libc@2.0.2: {}
 
   detect-libc@2.1.2: {}
 
@@ -5643,7 +5702,6 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
-    optional: true
 
   fflate@0.8.2: {}
 
@@ -5678,7 +5736,6 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
-    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -5951,8 +6008,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  js-base64@3.7.8:
-    optional: true
+  js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -6025,7 +6081,6 @@ snapshots:
       '@libsql/linux-x64-gnu': 0.5.29
       '@libsql/linux-x64-musl': 0.5.29
       '@libsql/win32-x64-msvc': 0.5.29
-    optional: true
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -6162,8 +6217,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-domexception@1.0.0:
-    optional: true
+  node-domexception@1.0.0: {}
 
   node-emoji@2.2.0:
     dependencies:
@@ -6182,14 +6236,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-    optional: true
 
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-    optional: true
 
   node-releases@2.0.37: {}
 
@@ -6361,8 +6413,7 @@ snapshots:
 
   prettier@3.8.3: {}
 
-  promise-limit@2.7.0:
-    optional: true
+  promise-limit@2.7.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -6667,8 +6718,7 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tr46@0.0.3:
-    optional: true
+  tr46@0.0.3: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -6844,17 +6894,14 @@ snapshots:
 
   walk-up-path@4.0.0: {}
 
-  web-streams-polyfill@3.3.3:
-    optional: true
+  web-streams-polyfill@3.3.3: {}
 
-  webidl-conversions@3.0.1:
-    optional: true
+  webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    optional: true
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -6924,8 +6971,7 @@ snapshots:
       js-yaml: 4.1.1
       write-file-atomic: 5.0.1
 
-  ws@8.20.0:
-    optional: true
+  ws@8.20.0: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,10 +120,10 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260417.1)
+        version: 0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2)
       drizzle-valibot:
         specifier: 'catalog:'
-        version: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260417.1))(valibot@1.3.1(typescript@6.0.3))
+        version: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2))(valibot@1.3.1(typescript@6.0.3))
       valibot:
         specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.3)
@@ -137,6 +137,9 @@ importers:
       '@plumix/typescript-config':
         specifier: workspace:*
         version: link:../../tooling/typescript
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
       drizzle-kit:
         specifier: 'catalog:'
         version: 0.31.10
@@ -151,7 +154,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/create-plumix-app:
     devDependencies:
@@ -246,7 +249,7 @@ importers:
         version: link:../core
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260417.1)
+        version: 0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2)
       valibot:
         specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.3)
@@ -283,7 +286,7 @@ importers:
         version: link:../../core
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260417.1)
+        version: 0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -1122,6 +1125,63 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@libsql/client@0.17.2':
+    resolution: {integrity: sha512-0aw0S3iQMHvOxfRt5j1atoCCPMT3gjsB2PS8/uxSM1DcDn39xqz6RlgSMxtP8I3JsxIXAFuw7S41baLEw0Zi+Q==}
+
+  '@libsql/core@0.17.2':
+    resolution: {integrity: sha512-L8qv12HZ/jRBcETVR3rscP0uHNxh+K3EABSde6scCw7zfOdiLqO3MAkJaeE1WovPsjXzsN/JBoZED4+7EZVT3g==}
+
+  '@libsql/darwin-arm64@0.5.29':
+    resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.29':
+    resolution: {integrity: sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.9.0':
+    resolution: {integrity: sha512-pxQ1986AuWfPX4oXzBvLwBnfgKDE5OMhAdR/5cZmRaB4Ygz5MecQybvwZupnRz341r2CtFmbk/BhSu7k2Lm+Jw==}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    resolution: {integrity: sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    resolution: {integrity: sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    resolution: {integrity: sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    resolution: {integrity: sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    resolution: {integrity: sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.29':
+    resolution: {integrity: sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
+    cpu: [x64]
+    os: [win32]
+
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
 
@@ -1133,6 +1193,9 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1586,6 +1649,9 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1997,9 +2063,16 @@ packages:
       typescript:
         optional: true
 
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2032,6 +2105,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2357,6 +2434,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -2387,6 +2468,10 @@ packages:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2665,6 +2750,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2712,6 +2800,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libsql@0.5.29:
+    resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2892,6 +2985,11 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
@@ -2899,6 +2997,19 @@ packages:
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -3073,6 +3184,9 @@ packages:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3325,6 +3439,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -3510,6 +3627,16 @@ packages:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3551,6 +3678,18 @@ packages:
   write-yaml-file@5.0.0:
     resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
     engines: {node: '>=16.14'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -4213,6 +4352,72 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@libsql/client@0.17.2':
+    dependencies:
+      '@libsql/core': 0.17.2
+      '@libsql/hrana-client': 0.9.0
+      js-base64: 3.7.8
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    optional: true
+
+  '@libsql/core@0.17.2':
+    dependencies:
+      js-base64: 3.7.8
+    optional: true
+
+  '@libsql/darwin-arm64@0.5.29':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.29':
+    optional: true
+
+  '@libsql/hrana-client@0.9.0':
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5
+      cross-fetch: 4.1.0
+      js-base64: 3.7.8
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    optional: true
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.29':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    optional: true
+
   '@loaderkit/resolve@1.0.4':
     dependencies:
       '@braidai/lang': 1.1.2
@@ -4236,6 +4441,9 @@ snapshots:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@neon-rs/load@0.0.4':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4532,6 +4740,11 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
+    optional: true
+
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -4691,13 +4904,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -4964,11 +5177,21 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  cross-fetch@4.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+    optional: true
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  data-uri-to-buffer@4.0.1:
+    optional: true
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5006,6 +5229,9 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  detect-libc@2.0.2:
+    optional: true
+
   detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
@@ -5025,13 +5251,14 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260417.1):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260417.1
+      '@libsql/client': 0.17.2
 
-  drizzle-valibot@0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260417.1))(valibot@1.3.1(typescript@6.0.3)):
+  drizzle-valibot@0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2))(valibot@1.3.1(typescript@6.0.3)):
     dependencies:
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260417.1)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2)
       valibot: 1.3.1(typescript@6.0.3)
 
   dunder-proto@1.0.1:
@@ -5412,6 +5639,12 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+    optional: true
+
   fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
@@ -5441,6 +5674,11 @@ snapshots:
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -5713,6 +5951,9 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  js-base64@3.7.8:
+    optional: true
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -5769,6 +6010,22 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libsql@0.5.29:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.29
+      '@libsql/darwin-x64': 0.5.29
+      '@libsql/linux-arm-gnueabihf': 0.5.29
+      '@libsql/linux-arm-musleabihf': 0.5.29
+      '@libsql/linux-arm64-gnu': 0.5.29
+      '@libsql/linux-arm64-musl': 0.5.29
+      '@libsql/linux-x64-gnu': 0.5.29
+      '@libsql/linux-x64-musl': 0.5.29
+      '@libsql/win32-x64-msvc': 0.5.29
+    optional: true
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -5905,6 +6162,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-domexception@1.0.0:
+    optional: true
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -5918,6 +6178,18 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+    optional: true
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+    optional: true
 
   node-releases@2.0.37: {}
 
@@ -6088,6 +6360,9 @@ snapshots:
       '@ianvs/prettier-plugin-sort-imports': 4.7.1(prettier@3.8.3)
 
   prettier@3.8.3: {}
+
+  promise-limit@2.7.0:
+    optional: true
 
   prop-types@15.8.1:
     dependencies:
@@ -6392,6 +6667,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3:
+    optional: true
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -6522,7 +6800,7 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -6530,17 +6808,17 @@ snapshots:
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -6557,14 +6835,26 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
     transitivePeerDependencies:
       - msw
 
   walk-up-path@4.0.0: {}
+
+  web-streams-polyfill@3.3.3:
+    optional: true
+
+  webidl-conversions@3.0.1:
+    optional: true
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    optional: true
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -6633,6 +6923,9 @@ snapshots:
     dependencies:
       js-yaml: 4.1.1
       write-file-atomic: 5.0.1
+
+  ws@8.20.0:
+    optional: true
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Phase 3 per [PLAN.md](PLAN.md). Adds the per-request engine surface plugins consume — context stores, hooks, plugin registrations, RBAC — and the WebAuthn-backed auth runtime. Nothing serves HTTP yet; that's Phase 4.

Two commits, each independently reviewable:

1. **`feat(core): hooks, plugin api, rbac`** — build-time scaffolding
2. **`feat(core): session, csrf, and webauthn passkey auth`** — runtime auth

## Key calls to review

### Two distinct ctx surfaces, no god-object
- **`PluginSetupContext`** ([plugin/context.ts](packages/core/src/plugin/context.ts)) — passed to `definePlugin(id, (ctx) => …)` once at app build. Auto-prefixes plugin-owned filters/actions with the plugin id. Carries `registerPostType` / `registerTaxonomy` / `registerMeta` / `registerMetaBox` / `registerCapability`.
- **`AppContext`** ([context/app.ts](packages/core/src/context/app.ts)) — per-request, populated from `requestStore.run(ctx, …)`. Carries `db`, `user`, `request`, `env`, `hooks`, `plugins`, `logger`, `can`. This is what hook handlers and (future) RPC procedures type against.
- `ThemeSetupContext` is Phase 5/6 — explicitly not introduced.

### ALS portability
`node:async_hooks` works on Node, Bun, Deno (Node-compat layer), and Cloudflare Workers (with `nodejs_compat` — already required by Plumix, [ARCHITECTURE.md:56](docs/reference/ARCHITECTURE.md#L56)). Comment at the import site spells this out so reviewers don't have to ask. TC39 `AsyncContext` migration is a single-file swap when it ships.

### Crypto split by frequency
- **Hot path** (every authed request) — native `crypto.subtle.digest('SHA-256', …)` for session-token hashing. No async cost beyond the one already-present `await`.
- **Login ceremonies** — `@oslojs/crypto/ecdsa` + `@oslojs/webauthn` for SEC1/PKIX/CBOR work. ~5–10 ms per login on workerd, irrelevant against the 30 s CPU budget.
- `constantTimeEqual` from `@oslojs/crypto/subtle` for token compares (no native equivalent).
- All deps direct to `@plumix/core` rather than the workspace catalog — they have a single consumer for now per the catalog hygiene rule.

### Session model (Copenhagen Book + Lucia idioms)
- 192-bit random token in cookie, `sha256(token)` stored as `sessions.id` — DB snapshot does not yield live tokens.
- Sliding 30 d window + absolute 90 d cap (`createdAt + 90d` — no schema change vs Phase 2).
- Cookie reader is **cookie-only** — never URL or form body (Copenhagen rule).
- `invalidateAllSessionsForUser(userId)` is exposed for the role-change path (admin wires it up later).
- `Secure` flag toggles based on request protocol so localhost dev (`http://localhost:8787`) still sees the cookie.

### CSRF — two layers, both passing through safe methods
- RPC + auth: require `X-Plumix-Request: 1` header. Browsers can't set custom headers cross-origin without CORS preflight, and Plumix doesn't enable CORS, so this defeats forged requests.
- Public mutations: validate `Origin` (or `Referer` fallback) against an allowlist.

### WebAuthn (ES256 only for v1)
- Atomic single-use challenge consume via `DELETE … RETURNING` (one round-trip; no read/delete race).
- Reject any attestation format other than `none` — we advertised `none` in registration options, so anything else means the authenticator ignored us and we don't verify it.
- ES256 only: RS256 is advertised in `pubKeyCredParams` for compatibility but rejected on the verify path. Covers ~all real-world authenticators (Apple, Android, Windows Hello, YubiKey).
- Counter strictly-increasing check with the `counter==0` exemption (authenticators that don't track).
- Tests use deterministic ES256 fixtures generated from `node:crypto` — full positive registration + authentication ceremonies run end-to-end through the same verify path a browser would hit.

### Hooks
- Filters run sequentially in priority order (lower first, stable tie-break by registration order); each filter receives a `structuredClone` of the previous output so mutations are harmless.
- Actions run via `Promise.allSettled` — a throwing action does not block siblings; failures are surfaced via `onActionFailure`.
- `applyFilter` is fully typed via TypeScript module augmentation — `Parameters<FilterRegistry[K]>[0]` extracts the input, the rest are forwarded as-is.

### Tests — business logic only, no coverage theatre
49 tests across hooks / plugin / rbac / sessions / cookies / csrf / passkey-{challenges,register,authenticate} / bootstrap. The fixture builder is ~250 LOC of CBOR encoder + WebCrypto wrapping that lets the verify path run unmodified against synthetic inputs — that pays for itself when oslo upgrades change parsing behaviour. No tests for the cookie deletion attribute string or the `isSecureRequest` one-liner.

## Out of scope (Phase 4+ / week 2)
- HTTP routing & RPC dispatch — Phase 4 owns the `_plumix/auth/*` and `_plumix/rpc/*` endpoints
- OAuth / magic links / invite flows — schema is ready (Phase 2), wiring lands later
- Rate limiting (Cloudflare's edge rate-limit binding owns this; runtime-adapter concern)
- WebAuthn `user.id` should be an opaque random handle, not `String(userId)` — flagged for follow-up; needs a per-user random column
- Bootstrap count-then-insert race — single-instance dev is fine; hardening lands with OAuth/invite flows
- `plumix/test` public subpath — this PR ships the test harness internally; the public surface lands in Phase 7

## Test plan

- [ ] All eight CI jobs green
- [ ] `pnpm --filter @plumix/core test` → 49 passing
- [ ] `pnpm knip` clean
- [ ] `pnpm publint && pnpm attw` clean (no surface change to publishable packages — `@plumix/core` stays private)