### PR TITLE
feat: phase 4 — rpc, routing, cloudflare runtime adapter

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@orpc/server": "^1.13.14",
     "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",
     "@oslojs/webauthn": "^1.0.0",
@@ -34,6 +35,7 @@
     "@types/node": "catalog:",
     "drizzle-kit": "catalog:",
     "eslint": "catalog:",
+    "fishery": "^2.4.0",
     "prettier": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/core/src/auth/bootstrap.test.ts
+++ b/packages/core/src/auth/bootstrap.test.ts
@@ -24,4 +24,17 @@ describe("first-user-admin bootstrap", () => {
     expect(result.bootstrapped).toBe(false);
     expect(result.user.role).toBe("author");
   });
+
+  test("concurrent first-user provisions with different emails elect exactly one admin", async () => {
+    const db = await createTestDb();
+    const results = await Promise.all([
+      provisionUser(db, { email: "a@example.com" }),
+      provisionUser(db, { email: "b@example.com" }),
+      provisionUser(db, { email: "c@example.com" }),
+    ]);
+    const admins = results.filter((r) => r.user.role === "admin");
+    expect(admins).toHaveLength(1);
+    const bootstrapped = results.filter((r) => r.bootstrapped);
+    expect(bootstrapped).toHaveLength(1);
+  });
 });

--- a/packages/core/src/auth/bootstrap.ts
+++ b/packages/core/src/auth/bootstrap.ts
@@ -1,6 +1,6 @@
-import { sql } from "../db/index.js";
 import type { Db } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
+import { sql } from "../db/index.js";
 import { users } from "../db/schema/users.js";
 
 export interface BootstrappedUser {
@@ -36,5 +36,8 @@ export async function provisionUser(
     .returning();
 
   if (!user) throw new Error("provisionUser: insert returned no row");
-  return { user, bootstrapped: user.role === "admin" && defaultRole !== "admin" };
+  return {
+    user,
+    bootstrapped: user.role === "admin" && defaultRole !== "admin",
+  };
 }

--- a/packages/core/src/auth/bootstrap.ts
+++ b/packages/core/src/auth/bootstrap.ts
@@ -1,24 +1,13 @@
+import { sql } from "../db/index.js";
 import type { Db } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
 import { users } from "../db/schema/users.js";
 
 export interface BootstrappedUser {
   readonly user: User;
-  /** True iff this call promoted the user to admin via the bootstrap rule. */
   readonly bootstrapped: boolean;
 }
 
-/**
- * Provision a user, automatically granting `admin` to the very first user.
- *
- * Safe because Plumix has no open registration: provisioning happens only
- * via passkey enrollment, OAuth callback, or invite — each requires the
- * deployer to wire it up.
- *
- * Note: count-then-insert is racy under concurrent provisioning. Acceptable
- * here because the bootstrap window is the first request of a fresh install;
- * a hardened path will land alongside the OAuth/invite flows.
- */
 export async function provisionUser(
   db: Db,
   input: {
@@ -29,22 +18,23 @@ export async function provisionUser(
     readonly emailVerified?: boolean;
   },
 ): Promise<BootstrappedUser> {
-  const isFirst = (await db.$count(users)) === 0;
-  const role: UserRole = isFirst
-    ? "admin"
-    : (input.defaultRole ?? "subscriber");
+  const defaultRole: UserRole = input.defaultRole ?? "subscriber";
 
+  // Role is decided inside the INSERT so concurrent first-user provisioning
+  // can't elect two admins: SQLite serializes writers, and the subquery
+  // observes previously-inserted rows. Only the statement that runs when
+  // the table is empty gets `admin`.
   const [user] = await db
     .insert(users)
     .values({
       email: input.email,
       name: input.name ?? null,
       avatarUrl: input.avatarUrl ?? null,
-      role,
+      role: sql<UserRole>`CASE WHEN (SELECT COUNT(*) FROM ${users}) = 0 THEN 'admin' ELSE ${defaultRole} END`,
       emailVerifiedAt: input.emailVerified ? new Date() : null,
     })
     .returning();
 
   if (!user) throw new Error("provisionUser: insert returned no row");
-  return { user, bootstrapped: isFirst };
+  return { user, bootstrapped: user.role === "admin" && defaultRole !== "admin" };
 }

--- a/packages/core/src/auth/passkey/authenticate.ts
+++ b/packages/core/src/auth/passkey/authenticate.ts
@@ -92,16 +92,19 @@ export async function finishAuthentication(
     throw new PasskeyError("invalid_client_data", "Expected webauthn.get");
   }
 
+  if (clientData.origin !== config.origin) {
+    throw new PasskeyError("invalid_origin");
+  }
+
+  const authenticatorData = parseAuthenticatorData(authenticatorDataBytes);
+  if (!authenticatorData.verifyRelyingPartyIdHash(config.rpId)) {
+    throw new PasskeyError("invalid_rp_id");
+  }
+
   const challengeString = encodeBase64urlNoPadding(clientData.challenge);
   const challenge = await consumeChallenge(db, challengeString);
   if (!challenge) throw new PasskeyError("challenge_not_found");
-
-  if (clientData.origin !== config.origin) {
-    throw new PasskeyError(
-      "invalid_origin",
-      `Expected origin ${config.origin}, got ${clientData.origin}`,
-    );
-  }
+  void challenge;
 
   const credential = await db
     .select()
@@ -109,11 +112,6 @@ export async function finishAuthentication(
     .where(eq(credentials.id, response.id))
     .get();
   if (!credential) throw new PasskeyError("credential_not_found");
-
-  const authenticatorData = parseAuthenticatorData(authenticatorDataBytes);
-  if (!authenticatorData.verifyRelyingPartyIdHash(config.rpId)) {
-    throw new PasskeyError("invalid_rp_id");
-  }
   if (!authenticatorData.userPresent)
     throw new PasskeyError("user_presence_missing");
 

--- a/packages/core/src/auth/passkey/challenges.ts
+++ b/packages/core/src/auth/passkey/challenges.ts
@@ -52,9 +52,7 @@ export async function consumeChallenge(
   const hash = await hashToken(rawChallenge);
   const [row] = await db
     .delete(authTokens)
-    .where(
-      and(eq(authTokens.hash, hash), eq(authTokens.type, CHALLENGE_TYPE)),
-    )
+    .where(and(eq(authTokens.hash, hash), eq(authTokens.type, CHALLENGE_TYPE)))
     .returning();
   if (!row) return null;
   if (row.expiresAt.getTime() < Date.now()) return null;

--- a/packages/core/src/auth/passkey/challenges.ts
+++ b/packages/core/src/auth/passkey/challenges.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { Db } from "../../context/app.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
@@ -52,9 +52,11 @@ export async function consumeChallenge(
   const hash = await hashToken(rawChallenge);
   const [row] = await db
     .delete(authTokens)
-    .where(eq(authTokens.hash, hash))
+    .where(
+      and(eq(authTokens.hash, hash), eq(authTokens.type, CHALLENGE_TYPE)),
+    )
     .returning();
-  if (row?.type !== CHALLENGE_TYPE) return null;
+  if (!row) return null;
   if (row.expiresAt.getTime() < Date.now()) return null;
   return { userId: row.userId, expiresAt: row.expiresAt };
 }

--- a/packages/core/src/auth/passkey/register.test.ts
+++ b/packages/core/src/auth/passkey/register.test.ts
@@ -122,6 +122,7 @@ describe("persistCredential", () => {
       publicKey: new Uint8Array([0x04, ...new Uint8Array(64)]),
       signatureCounter: 0,
       transports: [] as const,
+      userId: null,
     };
     await persistCredential(db, {
       userId,
@@ -147,6 +148,7 @@ describe("persistCredential", () => {
         publicKey: new Uint8Array([0x04, ...new Uint8Array(64)]),
         signatureCounter: 0,
         transports: [],
+        userId: null,
       },
       maxPerUser: 1,
     });
@@ -158,6 +160,7 @@ describe("persistCredential", () => {
           publicKey: new Uint8Array([0x04, ...new Uint8Array(64)]),
           signatureCounter: 0,
           transports: [],
+          userId: null,
         },
         maxPerUser: 1,
       }),

--- a/packages/core/src/auth/passkey/register.ts
+++ b/packages/core/src/auth/passkey/register.ts
@@ -78,6 +78,8 @@ export interface VerifiedRegistration {
   readonly publicKey: Uint8Array;
   readonly signatureCounter: number;
   readonly transports: readonly CredentialTransport[];
+  /** User the original challenge was issued for. Null for discoverable-cred flows. */
+  readonly userId: number | null;
 }
 
 /**
@@ -111,23 +113,14 @@ export async function finishRegistration(
     throw new PasskeyError("invalid_client_data", "Expected webauthn.create");
   }
 
-  const challengeString = encodeBase64urlNoPadding(clientData.challenge);
-  const challenge = await consumeChallenge(db, challengeString);
-  if (!challenge) throw new PasskeyError("challenge_not_found");
-
   if (clientData.origin !== config.origin) {
-    throw new PasskeyError(
-      "invalid_origin",
-      `Expected origin ${config.origin}, got ${clientData.origin}`,
-    );
+    throw new PasskeyError("invalid_origin");
   }
 
   const attestation = parseAttestationObject(attestationBytes);
   if (
     attestation.attestationStatement.format !== AttestationStatementFormat.None
   ) {
-    // We advertised attestation: "none" — anything else means the authenticator
-    // ignored us; we don't verify other formats so we refuse rather than trust.
     throw new PasskeyError("unsupported_attestation_format");
   }
 
@@ -135,6 +128,10 @@ export async function finishRegistration(
   if (!authenticatorData.verifyRelyingPartyIdHash(config.rpId)) {
     throw new PasskeyError("invalid_rp_id");
   }
+
+  const challengeString = encodeBase64urlNoPadding(clientData.challenge);
+  const challenge = await consumeChallenge(db, challengeString);
+  if (!challenge) throw new PasskeyError("challenge_not_found");
   if (!authenticatorData.userPresent)
     throw new PasskeyError("user_presence_missing");
 
@@ -169,10 +166,11 @@ export async function finishRegistration(
   ).encodeSEC1Uncompressed();
 
   return {
-    credentialId: response.id,
+    credentialId: encodeBase64urlNoPadding(credential.id),
     publicKey,
     signatureCounter: authenticatorData.signatureCounter,
     transports: response.response.transports ?? [],
+    userId: challenge.userId,
   };
 }
 

--- a/packages/core/src/auth/passkey/routes.test.ts
+++ b/packages/core/src/auth/passkey/routes.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "vitest";
 
+import {
+  createDispatcherHarness,
+  plumixRequest,
+} from "../../test/dispatcher.js";
 import { SESSION_COOKIE_NAME } from "../cookies.js";
-import { createDispatcherHarness, plumixRequest } from "../../test/dispatcher.js";
 
 describe("passkey register — options", () => {
   test("bootstraps the first user and issues a challenge", async () => {
@@ -14,7 +17,10 @@ describe("passkey register — options", () => {
       }),
     );
     expect(response.status).toBe(200);
-    const body = (await response.json()) as { challenge: string; user: { name: string } };
+    const body = (await response.json()) as {
+      challenge: string;
+      user: { name: string };
+    };
     expect(body.user.name).toBe("admin@cms.example");
     expect(typeof body.challenge).toBe("string");
   });

--- a/packages/core/src/auth/passkey/routes.test.ts
+++ b/packages/core/src/auth/passkey/routes.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "vitest";
+
+import { SESSION_COOKIE_NAME } from "../cookies.js";
+import { createDispatcherHarness, plumixRequest } from "../../test/dispatcher.js";
+
+describe("passkey register — options", () => {
+  test("bootstraps the first user and issues a challenge", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/passkey/register/options", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "admin@cms.example" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { challenge: string; user: { name: string } };
+    expect(body.user.name).toBe("admin@cms.example");
+    expect(typeof body.challenge).toBe("string");
+  });
+
+  test("is race-safe on concurrent bootstraps of the same email", async () => {
+    const h = await createDispatcherHarness();
+    const two = await Promise.all([
+      h.dispatch(
+        plumixRequest("/_plumix/auth/passkey/register/options", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email: "same@cms.example" }),
+        }),
+      ),
+      h.dispatch(
+        plumixRequest("/_plumix/auth/passkey/register/options", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email: "same@cms.example" }),
+        }),
+      ),
+    ]);
+    for (const response of two) expect(response.status).toBe(200);
+  });
+
+  test("rejects an invalid email with 400", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/passkey/register/options", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "not-an-email" }),
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("rejects unauthenticated register after bootstrap (registration closed)", async () => {
+    const h = await createDispatcherHarness();
+    await h.seedUser("admin");
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/passkey/register/options", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "stranger@example.com" }),
+      }),
+    );
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("registration_closed");
+  });
+
+  test("authenticated caller adding another email is rejected (email_mismatch)", async () => {
+    const h = await createDispatcherHarness();
+    const user = await h.seedUser("author");
+    const authed = await h.authenticateRequest(
+      plumixRequest("/_plumix/auth/passkey/register/options", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "somebody-else@example.com" }),
+      }),
+      user.id,
+    );
+    const response = await h.dispatch(authed);
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("email_mismatch");
+  });
+
+  test("authenticated user may enrol an additional device (own email)", async () => {
+    const h = await createDispatcherHarness();
+    const user = await h.seedUser("editor");
+    const authed = await h.authenticateRequest(
+      plumixRequest("/_plumix/auth/passkey/register/options", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: user.email }),
+      }),
+      user.id,
+    );
+    const response = await h.dispatch(authed);
+    expect(response.status).toBe(200);
+  });
+
+  test("unauthenticated options omits excludeCredentials (no user-existence oracle)", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/passkey/register/options", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "first@example.com" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { excludeCredentials?: unknown };
+    expect(body.excludeCredentials).toBeUndefined();
+  });
+});
+
+describe("passkey verify — input validation", () => {
+  test("register/verify with malformed body returns 400 (not 500)", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/passkey/register/verify", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "x", type: "not-a-key" }),
+      }),
+    );
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("invalid_input");
+  });
+
+  test("login/verify with wildly oversized payload fails schema, not oslo", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/passkey/login/verify", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          id: "a".repeat(2048),
+          rawId: "a",
+          type: "public-key",
+          response: {
+            clientDataJSON: "a",
+            authenticatorData: "a",
+            signature: "a",
+          },
+        }),
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("passkey signout", () => {
+  test("clears the cookie even when no session exists", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/signout", { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("set-cookie");
+    expect(setCookie).toContain(`${SESSION_COOKIE_NAME}=`);
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
+  test("invalidates an existing session", async () => {
+    const h = await createDispatcherHarness();
+    const user = await h.seedUser("admin");
+    const authed = await h.authenticateRequest(
+      plumixRequest("/_plumix/auth/signout", { method: "POST" }),
+      user.id,
+    );
+    const response = await h.dispatch(authed);
+    expect(response.status).toBe(200);
+  });
+});

--- a/packages/core/src/auth/passkey/routes.ts
+++ b/packages/core/src/auth/passkey/routes.ts
@@ -1,0 +1,331 @@
+import * as v from "valibot";
+
+import type { AppContext } from "../../context/app.js";
+import type { PlumixApp } from "../../runtime/app.js";
+import type { User } from "../../db/schema/users.js";
+import type { AuthenticationResponse, RegistrationResponse } from "./types.js";
+import { eq, isUniqueConstraintError } from "../../db/index.js";
+import { credentials } from "../../db/schema/credentials.js";
+import { users } from "../../db/schema/users.js";
+import { jsonResponse } from "../../runtime/http.js";
+import { provisionUser } from "../bootstrap.js";
+import {
+  buildSessionCookie,
+  buildSessionDeletionCookie,
+  isSecureRequest,
+  readSessionCookie,
+} from "../cookies.js";
+import {
+  createSession,
+  invalidateSession,
+  validateSession,
+} from "../sessions.js";
+import {
+  beginAuthentication,
+  finishAuthentication,
+} from "./authenticate.js";
+import { PasskeyError } from "./errors.js";
+import {
+  beginRegistration,
+  finishRegistration,
+  persistCredential,
+} from "./register.js";
+
+const emailSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.toLowerCase(),
+  v.email(),
+  v.maxLength(255),
+);
+
+const registerOptionsInputSchema = v.object({
+  email: emailSchema,
+  name: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(100))),
+});
+
+const loginOptionsInputSchema = v.object({
+  email: v.optional(emailSchema),
+});
+
+const MAX_CREDENTIAL_ID_LENGTH = 1024;
+const MAX_WEBAUTHN_FIELD_LENGTH = 65_536;
+
+const base64urlField = (max: number) =>
+  v.pipe(v.string(), v.minLength(1), v.maxLength(max));
+
+const credentialTransportSchema = v.picklist([
+  "usb",
+  "nfc",
+  "ble",
+  "internal",
+  "hybrid",
+] as const);
+
+const registerResponseSchema = v.object({
+  id: base64urlField(MAX_CREDENTIAL_ID_LENGTH),
+  rawId: base64urlField(MAX_CREDENTIAL_ID_LENGTH),
+  type: v.literal("public-key"),
+  response: v.object({
+    clientDataJSON: base64urlField(MAX_WEBAUTHN_FIELD_LENGTH),
+    attestationObject: base64urlField(MAX_WEBAUTHN_FIELD_LENGTH),
+    transports: v.optional(v.array(credentialTransportSchema)),
+  }),
+});
+
+const authenticationResponseSchema = v.object({
+  id: base64urlField(MAX_CREDENTIAL_ID_LENGTH),
+  rawId: base64urlField(MAX_CREDENTIAL_ID_LENGTH),
+  type: v.literal("public-key"),
+  response: v.object({
+    clientDataJSON: base64urlField(MAX_WEBAUTHN_FIELD_LENGTH),
+    authenticatorData: base64urlField(MAX_WEBAUTHN_FIELD_LENGTH),
+    signature: base64urlField(MAX_WEBAUTHN_FIELD_LENGTH),
+    userHandle: v.optional(v.nullable(base64urlField(MAX_WEBAUTHN_FIELD_LENGTH))),
+  }),
+});
+
+async function parseJson<
+  TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+>(request: Request, schema: TSchema): Promise<v.InferOutput<TSchema> | null> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return null;
+  }
+  const parsed = v.safeParse(schema, body);
+  return parsed.success ? parsed.output : null;
+}
+
+function invalidInput(): Response {
+  return jsonResponse({ error: "invalid_input" }, { status: 400 });
+}
+
+function sessionCookieHeader(
+  ctx: AppContext,
+  app: PlumixApp,
+  token: string,
+): string {
+  return buildSessionCookie(token, {
+    maxAgeSeconds: app.sessionPolicy.maxAgeSeconds,
+    secure: isSecureRequest(ctx.request),
+    sameSite: "Lax",
+  });
+}
+
+function passkeyError(error: PasskeyError): Response {
+  return jsonResponse(
+    { error: error.code, message: error.message },
+    { status: 400 },
+  );
+}
+
+async function findOrProvisionUser(
+  ctx: AppContext,
+  email: string,
+  name: string | null,
+): Promise<User> {
+  const existing = await ctx.db.query.users.findFirst({
+    where: eq(users.email, email),
+  });
+  if (existing) return existing;
+
+  try {
+    const { user } = await provisionUser(ctx.db, {
+      email,
+      name,
+      emailVerified: true,
+    });
+    return user;
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const raced = await ctx.db.query.users.findFirst({
+      where: eq(users.email, email),
+    });
+    if (!raced) throw error;
+    return raced;
+  }
+}
+
+export async function handlePasskeyRegisterOptions(
+  ctx: AppContext,
+  app: PlumixApp,
+): Promise<Response> {
+  const input = await parseJson(ctx.request, registerOptionsInputSchema);
+  if (!input) return invalidInput();
+
+  const authed = await resolveAuthedUser(ctx);
+  const policy = await decideRegistrationPolicy(ctx, authed, input.email);
+  if (policy.outcome === "denied") {
+    return jsonResponse({ error: policy.reason }, { status: 403 });
+  }
+
+  const user = policy.outcome === "bootstrap"
+    ? await findOrProvisionUser(ctx, input.email, input.name ?? null)
+    : policy.user;
+
+  const excludeCredentials =
+    policy.outcome === "add-device"
+      ? await ctx.db
+          .select()
+          .from(credentials)
+          .where(eq(credentials.userId, user.id))
+      : undefined;
+
+  const options = await beginRegistration(ctx.db, app.passkey, {
+    userId: user.id,
+    userEmail: user.email,
+    userDisplayName: user.name ?? user.email,
+    excludeCredentials,
+  });
+
+  return jsonResponse(options);
+}
+
+type RegistrationPolicy =
+  | { outcome: "bootstrap" }
+  | { outcome: "add-device"; user: User }
+  | { outcome: "denied"; reason: "registration_closed" | "email_mismatch" };
+
+async function decideRegistrationPolicy(
+  ctx: AppContext,
+  authed: User | null,
+  email: string,
+): Promise<RegistrationPolicy> {
+  if (authed) {
+    if (authed.email !== email) {
+      return { outcome: "denied", reason: "email_mismatch" };
+    }
+    return { outcome: "add-device", user: authed };
+  }
+  const userCount = await ctx.db.$count(users);
+  if (userCount === 0) return { outcome: "bootstrap" };
+  return { outcome: "denied", reason: "registration_closed" };
+}
+
+async function resolveAuthedUser(ctx: AppContext): Promise<User | null> {
+  const token = readSessionCookie(ctx.request);
+  if (!token) return null;
+  const validated = await validateSession(ctx.db, token, undefined);
+  return validated?.user ?? null;
+}
+
+export async function handlePasskeyRegisterVerify(
+  ctx: AppContext,
+  app: PlumixApp,
+): Promise<Response> {
+  const payload = await parseJson(ctx.request, registerResponseSchema);
+  if (!payload) return invalidInput();
+
+  try {
+    const verified = await finishRegistration(
+      ctx.db,
+      app.passkey,
+      payload as RegistrationResponse,
+    );
+    if (verified.userId === null) {
+      return jsonResponse(
+        { error: "challenge_not_bound_to_user" },
+        { status: 400 },
+      );
+    }
+
+    await persistCredential(ctx.db, {
+      userId: verified.userId,
+      verified,
+      maxPerUser: app.passkey.maxCredentialsPerUser,
+    });
+
+    const { token } = await createSession(
+      ctx.db,
+      { userId: verified.userId },
+      app.sessionPolicy,
+    );
+    return jsonResponse(
+      { userId: verified.userId },
+      {
+        status: 200,
+        headers: { "set-cookie": sessionCookieHeader(ctx, app, token) },
+      },
+    );
+  } catch (error) {
+    if (error instanceof PasskeyError) return passkeyError(error);
+    throw error;
+  }
+}
+
+export async function handlePasskeyLoginOptions(
+  ctx: AppContext,
+  app: PlumixApp,
+): Promise<Response> {
+  const input = await parseJson(ctx.request, loginOptionsInputSchema);
+  if (!input) return invalidInput();
+
+  const user = input.email
+    ? await ctx.db.query.users.findFirst({
+        where: eq(users.email, input.email),
+      })
+    : null;
+  const allowCredentials = user
+    ? await ctx.db
+        .select()
+        .from(credentials)
+        .where(eq(credentials.userId, user.id))
+    : [];
+
+  const options = await beginAuthentication(ctx.db, app.passkey, {
+    allowCredentials,
+  });
+  return jsonResponse(options);
+}
+
+export async function handlePasskeyLoginVerify(
+  ctx: AppContext,
+  app: PlumixApp,
+): Promise<Response> {
+  const payload = await parseJson(ctx.request, authenticationResponseSchema);
+  if (!payload) return invalidInput();
+
+  try {
+    const verified = await finishAuthentication(
+      ctx.db,
+      app.passkey,
+      payload as AuthenticationResponse,
+    );
+    await ctx.db
+      .update(credentials)
+      .set({ counter: verified.newSignatureCounter })
+      .where(eq(credentials.id, verified.credential.id));
+
+    const { token } = await createSession(
+      ctx.db,
+      { userId: verified.credential.userId },
+      app.sessionPolicy,
+    );
+
+    return jsonResponse(
+      { userId: verified.credential.userId },
+      {
+        status: 200,
+        headers: { "set-cookie": sessionCookieHeader(ctx, app, token) },
+      },
+    );
+  } catch (error) {
+    if (error instanceof PasskeyError) return passkeyError(error);
+    throw error;
+  }
+}
+
+export async function handleSignout(ctx: AppContext): Promise<Response> {
+  const token = readSessionCookie(ctx.request);
+  if (token) await invalidateSession(ctx.db, token);
+  const cookie = buildSessionDeletionCookie({
+    secure: isSecureRequest(ctx.request),
+    sameSite: "Lax",
+  });
+  return jsonResponse(
+    { ok: true },
+    { status: 200, headers: { "set-cookie": cookie } },
+  );
+}

--- a/packages/core/src/auth/passkey/routes.ts
+++ b/packages/core/src/auth/passkey/routes.ts
@@ -1,8 +1,8 @@
 import * as v from "valibot";
 
 import type { AppContext } from "../../context/app.js";
-import type { PlumixApp } from "../../runtime/app.js";
 import type { User } from "../../db/schema/users.js";
+import type { PlumixApp } from "../../runtime/app.js";
 import type { AuthenticationResponse, RegistrationResponse } from "./types.js";
 import { eq, isUniqueConstraintError } from "../../db/index.js";
 import { credentials } from "../../db/schema/credentials.js";
@@ -20,10 +20,7 @@ import {
   invalidateSession,
   validateSession,
 } from "../sessions.js";
-import {
-  beginAuthentication,
-  finishAuthentication,
-} from "./authenticate.js";
+import { beginAuthentication, finishAuthentication } from "./authenticate.js";
 import { PasskeyError } from "./errors.js";
 import {
   beginRegistration,
@@ -81,7 +78,9 @@ const authenticationResponseSchema = v.object({
     clientDataJSON: base64urlField(MAX_WEBAUTHN_FIELD_LENGTH),
     authenticatorData: base64urlField(MAX_WEBAUTHN_FIELD_LENGTH),
     signature: base64urlField(MAX_WEBAUTHN_FIELD_LENGTH),
-    userHandle: v.optional(v.nullable(base64urlField(MAX_WEBAUTHN_FIELD_LENGTH))),
+    userHandle: v.optional(
+      v.nullable(base64urlField(MAX_WEBAUTHN_FIELD_LENGTH)),
+    ),
   }),
 });
 
@@ -161,9 +160,10 @@ export async function handlePasskeyRegisterOptions(
     return jsonResponse({ error: policy.reason }, { status: 403 });
   }
 
-  const user = policy.outcome === "bootstrap"
-    ? await findOrProvisionUser(ctx, input.email, input.name ?? null)
-    : policy.user;
+  const user =
+    policy.outcome === "bootstrap"
+      ? await findOrProvisionUser(ctx, input.email, input.name ?? null)
+      : policy.user;
 
   const excludeCredentials =
     policy.outcome === "add-device"

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -29,6 +29,8 @@ export interface AuthNamespace {
   can(capability: string): boolean;
 }
 
+export type AfterResponse = (promise: Promise<unknown>) => void;
+
 export interface AppContext<
   TSchema extends Record<string, unknown> = CoreSchema,
 > {
@@ -40,6 +42,13 @@ export interface AppContext<
   readonly plugins: PluginRegistry;
   readonly logger: Logger;
   readonly auth: AuthNamespace;
+  /**
+   * Extend work past the returned Response. Runtime adapters bind this
+   * to their platform primitive (CF Workers: `ExecutionContext.waitUntil`).
+   * Default: fire-and-forget — handlers must tolerate the promise being
+   * dropped on runtimes that opt out.
+   */
+  readonly after: AfterResponse;
 }
 
 export type AuthenticatedAppContext<
@@ -56,7 +65,10 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly plugins: PluginRegistry;
   readonly user?: AuthenticatedUser | null;
   readonly logger?: Logger;
+  readonly after?: AfterResponse;
 }
+
+const dropPromise: AfterResponse = () => undefined;
 
 export function createAppContext<TSchema extends Record<string, unknown>>(
   args: CreateAppContextArgs<TSchema>,
@@ -75,6 +87,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
       can: (capability) =>
         user !== null && resolver.hasCapability(user.role, capability),
     },
+    after: args.after ?? dropPromise,
   };
 }
 

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -1,9 +1,11 @@
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
 import type * as coreSchema from "../db/schema/index.js";
+import type { UserRole } from "../db/schema/users.js";
 import type { HookExecutor } from "../hooks/registry.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
+import { createCapabilityResolver } from "../auth/rbac.js";
 
 export type CoreSchema = typeof coreSchema;
 
@@ -13,7 +15,7 @@ export type Db<TSchema extends Record<string, unknown> = CoreSchema> =
 export interface AuthenticatedUser {
   readonly id: number;
   readonly email: string;
-  readonly role: string;
+  readonly role: UserRole;
 }
 
 export interface Logger {
@@ -21,6 +23,10 @@ export interface Logger {
   info(message: string, meta?: Record<string, unknown>): void;
   warn(message: string, meta?: Record<string, unknown>): void;
   error(message: string, meta?: Record<string, unknown>): void;
+}
+
+export interface AuthNamespace {
+  can(capability: string): boolean;
 }
 
 export interface AppContext<
@@ -33,7 +39,57 @@ export interface AppContext<
   readonly hooks: HookExecutor;
   readonly plugins: PluginRegistry;
   readonly logger: Logger;
-  can(capability: string): boolean;
+  readonly auth: AuthNamespace;
+}
+
+export type AuthenticatedAppContext<
+  TSchema extends Record<string, unknown> = CoreSchema,
+> = Omit<AppContext<TSchema>, "user"> & {
+  readonly user: AuthenticatedUser;
+};
+
+export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
+  readonly db: Db<TSchema>;
+  readonly env: PlumixEnv;
+  readonly request: Request;
+  readonly hooks: HookExecutor;
+  readonly plugins: PluginRegistry;
+  readonly user?: AuthenticatedUser | null;
+  readonly logger?: Logger;
+}
+
+export function createAppContext<TSchema extends Record<string, unknown>>(
+  args: CreateAppContextArgs<TSchema>,
+): AppContext<TSchema> {
+  const resolver = createCapabilityResolver(args.plugins);
+  const user = args.user ?? null;
+  return {
+    db: args.db,
+    env: args.env,
+    request: args.request,
+    user,
+    hooks: args.hooks,
+    plugins: args.plugins,
+    logger: args.logger ?? consoleLogger,
+    auth: {
+      can: (capability) =>
+        user !== null && resolver.hasCapability(user.role, capability),
+    },
+  };
+}
+
+export function withUser<TSchema extends Record<string, unknown>>(
+  ctx: AppContext<TSchema>,
+  user: AuthenticatedUser,
+): AuthenticatedAppContext<TSchema> {
+  const resolver = createCapabilityResolver(ctx.plugins);
+  return {
+    ...ctx,
+    user,
+    auth: {
+      can: (capability) => resolver.hasCapability(user.role, capability),
+    },
+  };
 }
 
 export const consoleLogger: Logger = {

--- a/packages/core/src/db/errors.ts
+++ b/packages/core/src/db/errors.ts
@@ -1,0 +1,25 @@
+function isUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const { extendedCode, message } = error as {
+    extendedCode?: unknown;
+    message?: unknown;
+  };
+  if (
+    extendedCode === "SQLITE_CONSTRAINT_UNIQUE" ||
+    extendedCode === "SQLITE_CONSTRAINT_PRIMARYKEY"
+  ) {
+    return true;
+  }
+  return (
+    typeof message === "string" && message.includes("UNIQUE constraint failed")
+  );
+}
+
+export function isUniqueConstraintError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current; depth++) {
+    if (isUniqueViolation(current)) return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -1,0 +1,3 @@
+export * from "drizzle-orm/sql";
+export type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+export { isUniqueConstraintError } from "./errors.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,9 +1,21 @@
 export * from "./auth/index.js";
 export * from "./config.js";
 export * from "./context/index.js";
+export * from "./db/index.js";
 export * from "./db/schema/index.js";
 export * from "./hooks/index.js";
 export * from "./plugin/index.js";
+export * from "./rpc/index.js";
 export type * from "./runtime/adapter.js";
+export { buildApp } from "./runtime/app.js";
+export type { PlumixApp, PlumixAppOptions } from "./runtime/app.js";
 export type * from "./runtime/bindings.js";
+export { createPlumixDispatcher } from "./runtime/dispatcher.js";
+export type { PlumixDispatcher } from "./runtime/dispatcher.js";
+export {
+  forbidden,
+  jsonResponse,
+  methodNotAllowed,
+  notFound,
+} from "./runtime/http.js";
 export type * from "./runtime/slots.js";

--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -9,16 +9,23 @@ export interface PluginDescriptor<TConfig = undefined> {
   readonly id: string;
   readonly version?: string;
   readonly setup: PluginSetup<TConfig>;
+  readonly schema?: Record<string, unknown>;
+}
+
+export interface DefinePluginOptions {
+  readonly version?: string;
+  readonly schema?: Record<string, unknown>;
 }
 
 export function definePlugin<TConfig = undefined>(
   id: string,
   setup: PluginSetup<TConfig>,
-  options?: { version?: string },
+  options?: DefinePluginOptions,
 ): PluginDescriptor<TConfig> {
   return {
     id,
     version: options?.version,
     setup,
+    schema: options?.schema,
   };
 }

--- a/packages/core/src/plugin/register.test.ts
+++ b/packages/core/src/plugin/register.test.ts
@@ -5,6 +5,10 @@ import { definePlugin } from "./define.js";
 import { DuplicateRegistrationError } from "./manifest.js";
 import { installPlugins } from "./register.js";
 
+import "../rpc/hooks.js";
+
+import type { NewPost } from "../db/schema/posts.js";
+
 declare module "../hooks/types.js" {
   interface FilterRegistry {
     "seo:meta_tags": (tags: { readonly title: string }) => {
@@ -12,10 +16,6 @@ declare module "../hooks/types.js" {
     };
   }
 }
-
-import "../rpc/hooks.js";
-
-import type { NewPost } from "../db/schema/posts.js";
 
 const examplePost = (overrides: Partial<NewPost> = {}): NewPost => ({
   type: "post",

--- a/packages/core/src/plugin/register.test.ts
+++ b/packages/core/src/plugin/register.test.ts
@@ -7,20 +7,29 @@ import { installPlugins } from "./register.js";
 
 declare module "../hooks/types.js" {
   interface FilterRegistry {
-    "post:before_save": (post: { readonly title: string }) => {
-      readonly title: string;
-    };
     "seo:meta_tags": (tags: { readonly title: string }) => {
       readonly title: string;
     };
-    "landing_page:before_save": (post: { readonly title: string }) => {
-      readonly title: string;
-    };
-  }
-  interface ActionRegistry {
-    "post:published": (postId: number) => void;
   }
 }
+
+import "../rpc/hooks.js";
+
+import type { NewPost } from "../db/schema/posts.js";
+
+const examplePost = (overrides: Partial<NewPost> = {}): NewPost => ({
+  type: "post",
+  title: "example",
+  slug: "example",
+  content: null,
+  excerpt: null,
+  status: "draft",
+  parentId: null,
+  menuOrder: 0,
+  authorId: 1,
+  publishedAt: null,
+  ...overrides,
+});
 
 describe("installPlugins", () => {
   test("auto-prefixes plugin-registered filters with the plugin id", async () => {
@@ -40,13 +49,17 @@ describe("installPlugins", () => {
     const hooks = new HookRegistry();
     const stamp = definePlugin("stamp", (ctx) => {
       ctx.addFilter("post:before_save", (post) => ({
+        ...post,
         title: `[stamped] ${post.title}`,
       }));
     });
 
     await installPlugins({ hooks, plugins: [stamp] });
-    const out = await hooks.applyFilter("post:before_save", { title: "hi" });
-    expect(out).toEqual({ title: "[stamped] hi" });
+    const out = await hooks.applyFilter(
+      "post:before_save",
+      examplePost({ title: "hi" }),
+    );
+    expect(out.title).toBe("[stamped] hi");
   });
 
   test("registers post types into the manifest with plugin attribution", async () => {

--- a/packages/core/src/rpc/authenticated.test.ts
+++ b/packages/core/src/rpc/authenticated.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
+import { createRpcHarness } from "../test/rpc.js";
+
+async function expectErrorCode(promise: Promise<unknown>, code: string) {
+  try {
+    await promise;
+    throw new Error(`expected error ${code}, call resolved`);
+  } catch (error) {
+    if ((error as { code?: string }).code !== code) throw error;
+  }
+}
+
+describe("authenticated middleware", () => {
+  test("rejects when no session cookie is present", async () => {
+    const { client } = await createRpcHarness();
+    await expectErrorCode(client.post.list({}), "UNAUTHORIZED");
+  });
+
+  test("rejects when the session cookie is a bogus token", async () => {
+    const bogus = await createRpcHarness({
+      request: new Request("https://cms.example/", {
+        headers: { cookie: `${SESSION_COOKIE_NAME}=bogus-token` },
+      }),
+    });
+    await expectErrorCode(bogus.client.post.list({}), "UNAUTHORIZED");
+  });
+
+  test("accepts a valid session and reaches the handler", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const rows = await h.client.post.list({});
+    expect(rows).toEqual([]);
+  });
+});

--- a/packages/core/src/rpc/authenticated.ts
+++ b/packages/core/src/rpc/authenticated.ts
@@ -1,0 +1,17 @@
+import { readSessionCookie } from "../auth/cookies.js";
+import { validateSession } from "../auth/sessions.js";
+import { withUser } from "../context/app.js";
+import { base } from "./base.js";
+
+export const authenticated = base.middleware(
+  async ({ context, next, errors }) => {
+    const token = readSessionCookie(context.request);
+    if (!token) throw errors.UNAUTHORIZED();
+
+    const validated = await validateSession(context.db, token);
+    if (!validated) throw errors.UNAUTHORIZED();
+
+    const { id, email, role } = validated.user;
+    return next({ context: withUser(context, { id, email, role }) });
+  },
+);

--- a/packages/core/src/rpc/base.ts
+++ b/packages/core/src/rpc/base.ts
@@ -1,0 +1,8 @@
+import { os } from "@orpc/server";
+
+import type { AppContext } from "../context/app.js";
+import { RPC_ERRORS } from "./errors.js";
+
+export const base = os.$context<AppContext>().errors(RPC_ERRORS);
+
+export type Base = typeof base;

--- a/packages/core/src/rpc/errors.ts
+++ b/packages/core/src/rpc/errors.ts
@@ -1,0 +1,26 @@
+import * as v from "valibot";
+
+export const RPC_ERRORS = {
+  UNAUTHORIZED: {
+    message: "Authentication required",
+  },
+  FORBIDDEN: {
+    message: "Permission denied",
+    data: v.object({
+      capability: v.string(),
+    }),
+  },
+  NOT_FOUND: {
+    message: "Resource not found",
+    data: v.object({
+      kind: v.string(),
+      id: v.union([v.string(), v.number()]),
+    }),
+  },
+  CONFLICT: {
+    message: "Resource conflict",
+    data: v.object({
+      reason: v.string(),
+    }),
+  },
+} as const;

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -1,0 +1,46 @@
+import type { NewPost, Post, PostStatus } from "../db/schema/posts.js";
+import type {
+  PostCreateInput,
+  PostUpdateInput,
+} from "./procedures/post/schemas.js";
+
+declare module "../hooks/types.js" {
+  interface FilterRegistry {
+    "rpc:post.list:input": (input: {
+      type?: string;
+      status?: Post["status"];
+      limit: number;
+      offset: number;
+    }) => typeof input;
+    "rpc:post.list:output": (output: readonly Post[]) => readonly Post[];
+
+    "rpc:post.get:input": (input: { id: number }) => typeof input;
+    "rpc:post.get:output": (output: Post) => Post;
+
+    "rpc:post.create:input": (input: PostCreateInput) => PostCreateInput;
+    "rpc:post.create:output": (output: Post) => Post;
+
+    "rpc:post.update:input": (input: PostUpdateInput) => PostUpdateInput;
+    "rpc:post.update:output": (output: Post) => Post;
+
+    "rpc:post.trash:input": (input: { id: number }) => typeof input;
+    "rpc:post.trash:output": (output: Post) => Post;
+
+    [K: `${string}:before_save`]: (post: NewPost) => NewPost;
+  }
+
+  interface ActionRegistry {
+    [K: `${string}:published`]: (post: Post) => void | Promise<void>;
+    [K: `${string}:updated`]: (
+      post: Post,
+      previous: Post,
+    ) => void | Promise<void>;
+    [K: `${string}:trashed`]: (post: Post) => void | Promise<void>;
+    [K: `${string}:transition`]: (
+      post: Post,
+      oldStatus: PostStatus,
+    ) => void | Promise<void>;
+  }
+}
+
+export {};

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -1,0 +1,32 @@
+import "./hooks.js";
+
+export { authenticated } from "./authenticated.js";
+export { base } from "./base.js";
+export type { Base } from "./base.js";
+export { RPC_ERRORS } from "./errors.js";
+export {
+  applyPostBeforeSave,
+  firePostPublished,
+  firePostTransition,
+  firePostTrashed,
+  firePostUpdated,
+  postCapability,
+} from "./procedures/post/lifecycle.js";
+export { postRouter } from "./procedures/post/index.js";
+export type { PostRouter } from "./procedures/post/index.js";
+export {
+  postCreateInputSchema,
+  postGetInputSchema,
+  postListInputSchema,
+  postTrashInputSchema,
+  postUpdateInputSchema,
+} from "./procedures/post/schemas.js";
+export type {
+  PostCreateInput,
+  PostGetInput,
+  PostListInput,
+  PostTrashInput,
+  PostUpdateInput,
+} from "./procedures/post/schemas.js";
+export { appRouter } from "./router.js";
+export type { AppRouter } from "./router.js";

--- a/packages/core/src/rpc/procedures/post/create.test.ts
+++ b/packages/core/src/rpc/procedures/post/create.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { eq } from "../../../db/index.js";
+import { posts } from "../../../db/schema/posts.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("post.create", () => {
+  test("contributor can create a draft", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    const created = await h.client.post.create({
+      title: "Hello",
+      slug: "hello",
+    });
+    expect(created.status).toBe("draft");
+    expect(created.authorId).toBe(h.user.id);
+    expect(created.publishedAt).toBeNull();
+  });
+
+  test("forbidden for a subscriber (no post:create)", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await expect(
+      h.client.post.create({ title: "t", slug: "s" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "post:create" },
+    });
+  });
+
+  test("forbidden when contributor tries to publish directly", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    await expect(
+      h.client.post.create({
+        title: "now",
+        slug: "now",
+        status: "published",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "post:publish" },
+    });
+  });
+
+  test("forbidden when contributor tries to schedule — same gate as publish", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    await expect(
+      h.client.post.create({
+        title: "later",
+        slug: "later",
+        status: "scheduled",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "post:publish" },
+    });
+  });
+
+  test("post:before_save cannot overwrite authorId at create", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const other = await h.factory.admin.create({
+      email: "other@example.test",
+    });
+    h.hooks.addFilter("post:before_save", (post) => ({
+      ...post,
+      authorId: other.id,
+    }));
+    const created = await h.client.post.create({
+      title: "t",
+      slug: "guarded",
+    });
+    expect(created.authorId).toBe(h.user.id);
+  });
+
+  test("author can publish directly and publishedAt is stamped", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const created = await h.client.post.create({
+      title: "go",
+      slug: "go",
+      status: "published",
+    });
+    expect(created.status).toBe("published");
+    expect(created.publishedAt).toBeInstanceOf(Date);
+  });
+
+  test("slug collision within the same type returns CONFLICT", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    await h.client.post.create({ title: "A", slug: "same" });
+    await expect(
+      h.client.post.create({ title: "B", slug: "same" }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "slug_taken" },
+    });
+  });
+
+  test("rpc:post.create:input filter can rewrite the input before persistence", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    h.hooks.addFilter("rpc:post.create:input", (input) => ({
+      ...input,
+      title: `[pinned] ${input.title}`,
+    }));
+
+    const created = await h.client.post.create({
+      title: "orig",
+      slug: "orig",
+    });
+    expect(created.title).toBe("[pinned] orig");
+  });
+
+  test("post:before_save filter runs before the insert", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    h.hooks.addFilter("post:before_save", (post) => ({
+      ...post,
+      excerpt: `[auto] ${post.title}`,
+    }));
+
+    const created = await h.client.post.create({
+      title: "t",
+      slug: "t-slug",
+    });
+    expect(created.excerpt).toBe("[auto] t");
+  });
+
+  test("post:published fires once when status is published, never on drafts", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const onPublish = vi.fn();
+    h.hooks.addAction("post:published", onPublish);
+
+    await h.client.post.create({ title: "d", slug: "d-1" });
+    expect(onPublish).not.toHaveBeenCalled();
+
+    await h.client.post.create({
+      title: "p",
+      slug: "p-1",
+      status: "published",
+    });
+    expect(onPublish).toHaveBeenCalledTimes(1);
+  });
+
+  test("concurrent creates with the same slug: exactly one wins, the other gets CONFLICT", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const results = await Promise.allSettled([
+      h.client.post.create({ title: "A", slug: "race" }),
+      h.client.post.create({ title: "B", slug: "race" }),
+    ]);
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const [failure] = rejected;
+    expect(failure?.reason).toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "slug_taken" },
+    });
+  });
+
+  test("persists the row so a follow-up query returns it", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const created = await h.client.post.create({
+      title: "persist",
+      slug: "persist",
+    });
+    const row = await h.db.query.posts.findFirst({
+      where: eq(posts.id, created.id),
+    });
+    expect(row?.title).toBe("persist");
+  });
+});

--- a/packages/core/src/rpc/procedures/post/create.ts
+++ b/packages/core/src/rpc/procedures/post/create.ts
@@ -1,0 +1,69 @@
+import type { NewPost } from "../../../db/schema/posts.js";
+import { posts } from "../../../db/schema/posts.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import {
+  applyPostBeforeSave,
+  firePostPublished,
+  firePostTransition,
+  postCapability,
+} from "./lifecycle.js";
+import { postCreateInputSchema } from "./schemas.js";
+
+export const create = base
+  .use(authenticated)
+  .input(postCreateInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:post.create:input",
+      input,
+    );
+
+    const createCapability = postCapability(filtered.type, "create");
+    if (!context.auth.can(createCapability)) {
+      throw errors.FORBIDDEN({ data: { capability: createCapability } });
+    }
+
+    const requiresPublishCap =
+      filtered.status === "published" || filtered.status === "scheduled";
+    if (requiresPublishCap) {
+      const publishCapability = postCapability(filtered.type, "publish");
+      if (!context.auth.can(publishCapability)) {
+        throw errors.FORBIDDEN({ data: { capability: publishCapability } });
+      }
+    }
+
+    const candidate: NewPost = {
+      type: filtered.type,
+      title: filtered.title,
+      slug: filtered.slug,
+      content: filtered.content ?? null,
+      excerpt: filtered.excerpt ?? null,
+      status: filtered.status,
+      parentId: filtered.parentId ?? null,
+      menuOrder: filtered.menuOrder,
+      authorId: context.user.id,
+      publishedAt: filtered.status === "published" ? new Date() : null,
+    };
+
+    const prepared = await applyPostBeforeSave(context, filtered.type, candidate);
+    prepared.authorId = context.user.id;
+    prepared.type = filtered.type;
+
+    const [created] = await context.db
+      .insert(posts)
+      .values(prepared)
+      .onConflictDoNothing({ target: [posts.type, posts.slug] })
+      .returning();
+
+    if (!created) {
+      throw errors.CONFLICT({ data: { reason: "slug_taken" } });
+    }
+
+    await firePostTransition(context, created, "draft");
+    if (created.status === "published") {
+      await firePostPublished(context, created);
+    }
+
+    return context.hooks.applyFilter("rpc:post.create:output", created);
+  });

--- a/packages/core/src/rpc/procedures/post/create.ts
+++ b/packages/core/src/rpc/procedures/post/create.ts
@@ -46,7 +46,11 @@ export const create = base
       publishedAt: filtered.status === "published" ? new Date() : null,
     };
 
-    const prepared = await applyPostBeforeSave(context, filtered.type, candidate);
+    const prepared = await applyPostBeforeSave(
+      context,
+      filtered.type,
+      candidate,
+    );
     prepared.authorId = context.user.id;
     prepared.type = filtered.type;
 

--- a/packages/core/src/rpc/procedures/post/get.ts
+++ b/packages/core/src/rpc/procedures/post/get.ts
@@ -1,0 +1,40 @@
+import { eq } from "../../../db/index.js";
+
+import { posts } from "../../../db/schema/posts.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { postCapability } from "./lifecycle.js";
+import { postGetInputSchema } from "./schemas.js";
+
+export const get = base
+  .use(authenticated)
+  .input(postGetInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:post.get:input",
+      input,
+    );
+
+    const row = await context.db.query.posts.findFirst({
+      where: eq(posts.id, filtered.id),
+    });
+    if (!row) {
+      throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+    }
+
+    if (!context.auth.can(postCapability(row.type, "read"))) {
+      throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+    }
+
+    if (row.status !== "published") {
+      const canSeeAny = context.auth.can(postCapability(row.type, "edit_any"));
+      const ownsAndCanEdit =
+        row.authorId === context.user.id &&
+        context.auth.can(postCapability(row.type, "edit_own"));
+      if (!canSeeAny && !ownsAndCanEdit) {
+        throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+      }
+    }
+
+    return context.hooks.applyFilter("rpc:post.get:output", row);
+  });

--- a/packages/core/src/rpc/procedures/post/get.ts
+++ b/packages/core/src/rpc/procedures/post/get.ts
@@ -1,5 +1,4 @@
 import { eq } from "../../../db/index.js";
-
 import { posts } from "../../../db/schema/posts.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";

--- a/packages/core/src/rpc/procedures/post/helpers.ts
+++ b/packages/core/src/rpc/procedures/post/helpers.ts
@@ -1,0 +1,10 @@
+export function stripUndefined<T extends Record<string, unknown>>(
+  source: T,
+): Partial<T> {
+  const out: Partial<T> = {};
+  for (const key of Object.keys(source) as (keyof T)[]) {
+    const value = source[key];
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}

--- a/packages/core/src/rpc/procedures/post/index.ts
+++ b/packages/core/src/rpc/procedures/post/index.ts
@@ -1,0 +1,15 @@
+import { create } from "./create.js";
+import { get } from "./get.js";
+import { list } from "./list.js";
+import { trash } from "./trash.js";
+import { update } from "./update.js";
+
+export const postRouter = {
+  list,
+  get,
+  create,
+  update,
+  trash,
+} as const;
+
+export type PostRouter = typeof postRouter;

--- a/packages/core/src/rpc/procedures/post/lifecycle.test.ts
+++ b/packages/core/src/rpc/procedures/post/lifecycle.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
 
+import { createRpcHarness } from "../../../test/rpc.js";
 import {
   applyPostBeforeSave,
   firePostPublished,
   firePostTransition,
 } from "./lifecycle.js";
-import { createRpcHarness } from "../../../test/rpc.js";
 
 describe("lifecycle — WordPress-style hook fan-out", () => {
   test("type-specific filter runs before the generic filter on save", async () => {
@@ -63,7 +63,11 @@ describe("lifecycle — WordPress-style hook fan-out", () => {
     await firePostTransition(h.context, draft, "draft");
     expect(onTransition).not.toHaveBeenCalled();
 
-    await firePostTransition(h.context, { ...draft, status: "published" }, "draft");
+    await firePostTransition(
+      h.context,
+      { ...draft, status: "published" },
+      "draft",
+    );
     expect(onTransition).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core/src/rpc/procedures/post/lifecycle.test.ts
+++ b/packages/core/src/rpc/procedures/post/lifecycle.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  applyPostBeforeSave,
+  firePostPublished,
+  firePostTransition,
+} from "./lifecycle.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("lifecycle — WordPress-style hook fan-out", () => {
+  test("type-specific filter runs before the generic filter on save", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const trail: string[] = [];
+
+    h.hooks.addFilter("landing_page:before_save", (post) => {
+      trail.push("specific");
+      return { ...post, title: `[specific] ${post.title}` };
+    });
+    h.hooks.addFilter("post:before_save", (post) => {
+      trail.push("generic");
+      return { ...post, title: `[generic] ${post.title}` };
+    });
+
+    const result = await applyPostBeforeSave(h.context, "landing_page", {
+      type: "landing_page",
+      title: "raw",
+      slug: "raw",
+      authorId: h.user.id,
+      status: "draft",
+    });
+
+    expect(trail).toEqual(["specific", "generic"]);
+    expect(result.title).toBe("[generic] [specific] raw");
+  });
+
+  test("firePostPublished fires both specific and generic actions", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const onSpecific = vi.fn();
+    const onGeneric = vi.fn();
+    h.hooks.addAction("landing_page:published", onSpecific);
+    h.hooks.addAction("post:published", onGeneric);
+
+    const row = await h.factory.published.create({
+      type: "landing_page",
+      authorId: h.user.id,
+      slug: "specific-and-generic",
+    });
+    await firePostPublished(h.context, row);
+
+    expect(onSpecific).toHaveBeenCalledTimes(1);
+    expect(onGeneric).toHaveBeenCalledTimes(1);
+  });
+
+  test("firePostTransition is a no-op when new === old status", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const onTransition = vi.fn();
+    h.hooks.addAction("post:transition", onTransition);
+
+    const draft = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "same-status",
+    });
+    await firePostTransition(h.context, draft, "draft");
+    expect(onTransition).not.toHaveBeenCalled();
+
+    await firePostTransition(h.context, { ...draft, status: "published" }, "draft");
+    expect(onTransition).toHaveBeenCalledTimes(1);
+  });
+
+  test("for built-in 'post' type, only the generic hook fires (no duplicate)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const onGeneric = vi.fn();
+    h.hooks.addAction("post:trashed", onGeneric);
+
+    const row = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "no-duplicate",
+    });
+    await h.client.post.trash({ id: row.id });
+    expect(onGeneric).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/rpc/procedures/post/lifecycle.ts
+++ b/packages/core/src/rpc/procedures/post/lifecycle.ts
@@ -1,0 +1,61 @@
+import type { AppContext } from "../../../context/app.js";
+import type { NewPost, Post, PostStatus } from "../../../db/schema/posts.js";
+
+export async function applyPostBeforeSave(
+  ctx: AppContext,
+  type: string,
+  post: NewPost,
+): Promise<NewPost> {
+  const afterSpecific =
+    type === "post"
+      ? post
+      : await ctx.hooks.applyFilter(`${type}:before_save`, post);
+  return ctx.hooks.applyFilter("post:before_save", afterSpecific);
+}
+
+export async function firePostTransition(
+  ctx: AppContext,
+  post: Post,
+  oldStatus: PostStatus,
+): Promise<void> {
+  if (post.status === oldStatus) return;
+  if (post.type !== "post") {
+    await ctx.hooks.doAction(`${post.type}:transition`, post, oldStatus);
+  }
+  await ctx.hooks.doAction("post:transition", post, oldStatus);
+}
+
+export async function firePostPublished(
+  ctx: AppContext,
+  post: Post,
+): Promise<void> {
+  if (post.type !== "post") {
+    await ctx.hooks.doAction(`${post.type}:published`, post);
+  }
+  await ctx.hooks.doAction("post:published", post);
+}
+
+export async function firePostUpdated(
+  ctx: AppContext,
+  post: Post,
+  previous: Post,
+): Promise<void> {
+  if (post.type !== "post") {
+    await ctx.hooks.doAction(`${post.type}:updated`, post, previous);
+  }
+  await ctx.hooks.doAction("post:updated", post, previous);
+}
+
+export async function firePostTrashed(
+  ctx: AppContext,
+  post: Post,
+): Promise<void> {
+  if (post.type !== "post") {
+    await ctx.hooks.doAction(`${post.type}:trashed`, post);
+  }
+  await ctx.hooks.doAction("post:trashed", post);
+}
+
+export function postCapability(type: string, action: string): string {
+  return `${type}:${action}`;
+}

--- a/packages/core/src/rpc/procedures/post/list.ts
+++ b/packages/core/src/rpc/procedures/post/list.ts
@@ -1,6 +1,5 @@
-import { and, desc, eq } from "../../../db/index.js";
-
 import type { Post, PostStatus } from "../../../db/schema/posts.js";
+import { and, desc, eq } from "../../../db/index.js";
 import { posts } from "../../../db/schema/posts.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";

--- a/packages/core/src/rpc/procedures/post/list.ts
+++ b/packages/core/src/rpc/procedures/post/list.ts
@@ -1,0 +1,54 @@
+import { and, desc, eq } from "../../../db/index.js";
+
+import type { Post, PostStatus } from "../../../db/schema/posts.js";
+import { posts } from "../../../db/schema/posts.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { postCapability } from "./lifecycle.js";
+import { postListInputSchema } from "./schemas.js";
+
+const PUBLIC_STATUS: PostStatus = "published";
+
+export const list = base
+  .use(authenticated)
+  .input(postListInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:post.list:input",
+      input,
+    );
+
+    const type = filtered.type ?? "post";
+    const readCapability = postCapability(type, "read");
+    if (!context.auth.can(readCapability)) {
+      throw errors.FORBIDDEN({ data: { capability: readCapability } });
+    }
+
+    const canSeeAnyStatus = context.auth.can(postCapability(type, "edit_any"));
+    const effectiveStatus = canSeeAnyStatus
+      ? filtered.status
+      : (filtered.status ?? PUBLIC_STATUS);
+
+    if (!canSeeAnyStatus && effectiveStatus !== PUBLIC_STATUS) {
+      return context.hooks.applyFilter(
+        "rpc:post.list:output",
+        [] as readonly Post[],
+      );
+    }
+
+    const conditions = [eq(posts.type, type)];
+    if (effectiveStatus) conditions.push(eq(posts.status, effectiveStatus));
+
+    const rows = await context.db
+      .select()
+      .from(posts)
+      .where(and(...conditions))
+      .orderBy(desc(posts.updatedAt), desc(posts.id))
+      .limit(filtered.limit)
+      .offset(filtered.offset);
+
+    return context.hooks.applyFilter(
+      "rpc:post.list:output",
+      rows as readonly Post[],
+    );
+  });

--- a/packages/core/src/rpc/procedures/post/read.test.ts
+++ b/packages/core/src/rpc/procedures/post/read.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("post.list", () => {
+  test("returns published posts by default for subscriber", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "pub-1" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "draft-1" });
+
+    const rows = await h.client.post.list({});
+    expect(rows).toEqual([expect.objectContaining({ slug: "pub-1" })]);
+  });
+
+  test("editor can see drafts by status filter", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "pub-2" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "draft-2" });
+
+    const rows = await h.client.post.list({ status: "draft" });
+    expect(rows).toEqual([expect.objectContaining({ slug: "draft-2" })]);
+  });
+
+  test("subscriber asking for drafts gets an empty list, not a 403", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "secret" });
+
+    const rows = await h.client.post.list({ status: "draft" });
+    expect(rows).toEqual([]);
+  });
+
+  test("honours pagination (limit + offset)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.post.createList(5, { authorId: h.user.id });
+
+    const page1 = await h.client.post.list({ limit: 2, offset: 0 });
+    const page2 = await h.client.post.list({ limit: 2, offset: 2 });
+    expect(page1).toHaveLength(2);
+    expect(page2).toHaveLength(2);
+    const [firstOfPage1] = page1;
+    const [firstOfPage2] = page2;
+    expect(firstOfPage1?.id).not.toBe(firstOfPage2?.id);
+  });
+
+  test("forbidden for a non-registered post type", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.post.list({ type: "unknown_type" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "unknown_type:read" },
+    });
+  });
+});
+
+describe("post.get", () => {
+  test("returns the row when published", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const post = await h.factory.published.create({ authorId: h.user.id });
+    const got = await h.client.post.get({ id: post.id });
+    expect(got.id).toBe(post.id);
+  });
+
+  test("404 when the row does not exist", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(h.client.post.get({ id: 9999 })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  test("404 (not 403) when a subscriber targets a draft — existence is hidden", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const other = await h.factory.author.create();
+    const hidden = await h.factory.draft.create({
+      authorId: other.id,
+      slug: "hidden",
+    });
+    await expect(h.client.post.get({ id: hidden.id })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  test("author can fetch their own draft when they have edit_own", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    const mine = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "my-draft",
+    });
+    const got = await h.client.post.get({ id: mine.id });
+    expect(got.status).toBe("draft");
+  });
+
+  test("editor can fetch anyone's draft", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const other = await h.factory.author.create();
+    const theirs = await h.factory.draft.create({
+      authorId: other.id,
+      slug: "others-draft",
+    });
+    const got = await h.client.post.get({ id: theirs.id });
+    expect(got.id).toBe(theirs.id);
+  });
+});

--- a/packages/core/src/rpc/procedures/post/schemas.ts
+++ b/packages/core/src/rpc/procedures/post/schemas.ts
@@ -1,0 +1,71 @@
+import * as v from "valibot";
+
+import { postInsertSchema } from "../../../db/schema/posts.js";
+
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const MAX_CONTENT_BYTES = 1_000_000;
+const MAX_EXCERPT_LENGTH = 600;
+
+const trimmedText = (max: number) =>
+  v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(max));
+
+const slugSchema = v.pipe(
+  trimmedText(200),
+  v.regex(slugPattern, "slug must be kebab-case ASCII"),
+);
+
+const postIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
+
+const contentSchema = v.nullable(v.pipe(v.string(), v.maxLength(MAX_CONTENT_BYTES)));
+const excerptSchema = v.nullable(v.pipe(v.string(), v.maxLength(MAX_EXCERPT_LENGTH)));
+
+const serverControlledKeys = [
+  "id",
+  "authorId",
+  "publishedAt",
+  "createdAt",
+  "updatedAt",
+] as const;
+
+const userSuppliableFields = v.omit(postInsertSchema, serverControlledKeys);
+
+export const postCreateInputSchema = v.object({
+  ...userSuppliableFields.entries,
+  type: v.optional(trimmedText(100), "post"),
+  title: trimmedText(300),
+  slug: slugSchema,
+  content: v.optional(contentSchema),
+  excerpt: v.optional(excerptSchema),
+  status: v.optional(userSuppliableFields.entries.status, "draft"),
+  menuOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+});
+
+export const postUpdateInputSchema = v.object({
+  id: postIdSchema,
+  title: v.optional(trimmedText(300)),
+  slug: v.optional(slugSchema),
+  content: v.optional(contentSchema),
+  excerpt: v.optional(excerptSchema),
+  status: v.optional(userSuppliableFields.entries.status),
+  parentId: v.optional(v.nullable(postIdSchema)),
+  menuOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+});
+
+export const postListInputSchema = v.object({
+  type: v.optional(trimmedText(100)),
+  status: v.optional(userSuppliableFields.entries.status),
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
+    20,
+  ),
+  offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+});
+
+export const postGetInputSchema = v.object({ id: postIdSchema });
+export const postTrashInputSchema = v.object({ id: postIdSchema });
+
+export type PostListInput = v.InferOutput<typeof postListInputSchema>;
+export type PostGetInput = v.InferOutput<typeof postGetInputSchema>;
+export type PostCreateInput = v.InferOutput<typeof postCreateInputSchema>;
+export type PostUpdateInput = v.InferOutput<typeof postUpdateInputSchema>;
+export type PostTrashInput = v.InferOutput<typeof postTrashInputSchema>;

--- a/packages/core/src/rpc/procedures/post/schemas.ts
+++ b/packages/core/src/rpc/procedures/post/schemas.ts
@@ -16,8 +16,12 @@ const slugSchema = v.pipe(
 
 const postIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
 
-const contentSchema = v.nullable(v.pipe(v.string(), v.maxLength(MAX_CONTENT_BYTES)));
-const excerptSchema = v.nullable(v.pipe(v.string(), v.maxLength(MAX_EXCERPT_LENGTH)));
+const contentSchema = v.nullable(
+  v.pipe(v.string(), v.maxLength(MAX_CONTENT_BYTES)),
+);
+const excerptSchema = v.nullable(
+  v.pipe(v.string(), v.maxLength(MAX_EXCERPT_LENGTH)),
+);
 
 const serverControlledKeys = [
   "id",

--- a/packages/core/src/rpc/procedures/post/trash.test.ts
+++ b/packages/core/src/rpc/procedures/post/trash.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Post } from "../../../db/schema/posts.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("post.trash", () => {
+  test("editor can soft-delete: status transitions to trash and trashed action fires", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const target = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "soft",
+    });
+
+    const onTrash = vi.fn<(post: Post) => void>();
+    h.hooks.addAction("post:trashed", onTrash);
+
+    const result = await h.client.post.trash({ id: target.id });
+    expect(result.status).toBe("trash");
+    expect(onTrash).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ id: target.id }),
+    );
+  });
+
+  test("contributor cannot trash (no post:delete cap)", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    const target = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "keep",
+    });
+    await expect(h.client.post.trash({ id: target.id })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "post:delete" },
+    });
+  });
+
+  test("editor can trash someone else's post (edit_any is granted by role)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const other = await h.factory.author.create();
+    const target = await h.factory.published.create({
+      authorId: other.id,
+      slug: "others",
+    });
+    const result = await h.client.post.trash({ id: target.id });
+    expect(result.status).toBe("trash");
+  });
+
+  test("already-trashed is a no-op and does not re-fire the action", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const target = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "twice",
+    });
+    await h.client.post.trash({ id: target.id });
+
+    const onTrash = vi.fn();
+    h.hooks.addAction("post:trashed", onTrash);
+    const again = await h.client.post.trash({ id: target.id });
+    expect(again.status).toBe("trash");
+    expect(onTrash).not.toHaveBeenCalled();
+  });
+
+  test("404 for a missing row", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(h.client.post.trash({ id: 9999 })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+});

--- a/packages/core/src/rpc/procedures/post/trash.ts
+++ b/packages/core/src/rpc/procedures/post/trash.ts
@@ -1,5 +1,4 @@
 import { eq } from "../../../db/index.js";
-
 import { posts } from "../../../db/schema/posts.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";

--- a/packages/core/src/rpc/procedures/post/trash.ts
+++ b/packages/core/src/rpc/procedures/post/trash.ts
@@ -1,0 +1,52 @@
+import { eq } from "../../../db/index.js";
+
+import { posts } from "../../../db/schema/posts.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { firePostTrashed, postCapability } from "./lifecycle.js";
+import { postTrashInputSchema } from "./schemas.js";
+
+export const trash = base
+  .use(authenticated)
+  .input(postTrashInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:post.trash:input",
+      input,
+    );
+
+    const existing = await context.db.query.posts.findFirst({
+      where: eq(posts.id, filtered.id),
+    });
+    if (!existing) {
+      throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+    }
+
+    const deleteCapability = postCapability(existing.type, "delete");
+    if (!context.auth.can(deleteCapability)) {
+      throw errors.FORBIDDEN({ data: { capability: deleteCapability } });
+    }
+    const isAuthor = existing.authorId === context.user.id;
+    if (!isAuthor) {
+      const editAnyCapability = postCapability(existing.type, "edit_any");
+      if (!context.auth.can(editAnyCapability)) {
+        throw errors.FORBIDDEN({ data: { capability: editAnyCapability } });
+      }
+    }
+
+    if (existing.status === "trash") {
+      return context.hooks.applyFilter("rpc:post.trash:output", existing);
+    }
+
+    const [trashed] = await context.db
+      .update(posts)
+      .set({ status: "trash" })
+      .where(eq(posts.id, existing.id))
+      .returning();
+    if (!trashed) {
+      throw errors.CONFLICT({ data: { reason: "trash_failed" } });
+    }
+
+    await firePostTrashed(context, trashed);
+    return context.hooks.applyFilter("rpc:post.trash:output", trashed);
+  });

--- a/packages/core/src/rpc/procedures/post/update.test.ts
+++ b/packages/core/src/rpc/procedures/post/update.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("post.update", () => {
+  test("author can update their own draft via edit_own", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "own",
+    });
+    const updated = await h.client.post.update({
+      id: own.id,
+      title: "renamed",
+    });
+    expect(updated.title).toBe("renamed");
+  });
+
+  test("contributor cannot edit someone else's draft — FORBIDDEN reports the stronger cap (no authorship probe)", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    const other = await h.factory.author.create();
+    const mine = await h.factory.draft.create({
+      authorId: other.id,
+      slug: "theirs",
+    });
+    await expect(
+      h.client.post.update({ id: mine.id, title: "hax" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "post:edit_any" },
+    });
+  });
+
+  test("subscriber editing own draft is also told edit_any (no authorship oracle)", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "self",
+    });
+    await expect(
+      h.client.post.update({ id: own.id, title: "x" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "post:edit_any" },
+    });
+  });
+
+  test("editor can edit anyone's draft", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const other = await h.factory.author.create();
+    const theirs = await h.factory.draft.create({
+      authorId: other.id,
+      slug: "theirs",
+    });
+    const updated = await h.client.post.update({
+      id: theirs.id,
+      title: "by-editor",
+    });
+    expect(updated.title).toBe("by-editor");
+  });
+
+  test("promoting draft → published stamps publishedAt and fires both actions", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "promote",
+    });
+
+    const onPublish = vi.fn();
+    const onTransition = vi.fn();
+    h.hooks.addAction("post:published", onPublish);
+    h.hooks.addAction("post:transition", onTransition);
+
+    const updated = await h.client.post.update({
+      id: own.id,
+      status: "published",
+    });
+    expect(updated.status).toBe("published");
+    expect(updated.publishedAt).toBeInstanceOf(Date);
+    expect(onPublish).toHaveBeenCalledTimes(1);
+    expect(onTransition).toHaveBeenCalledTimes(1);
+  });
+
+  test("contributor cannot promote their own draft to published", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "solo",
+    });
+    await expect(
+      h.client.post.update({ id: own.id, status: "published" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "post:publish" },
+    });
+  });
+
+  test("slug collision with another post of the same type returns CONFLICT", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "taken" });
+    const mine = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "mine",
+    });
+    await expect(
+      h.client.post.update({ id: mine.id, slug: "taken" }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "slug_taken" },
+    });
+  });
+
+  test("empty patch is a no-op and does not fire post:updated", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "noop",
+    });
+    const onUpdate = vi.fn();
+    h.hooks.addAction("post:updated", onUpdate);
+
+    const returned = await h.client.post.update({ id: own.id });
+    expect(returned.id).toBe(own.id);
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  test("404 for a missing row", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.post.update({ id: 9999, title: "x" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("concurrent publish transitions: post:published fires exactly once", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "race-to-publish",
+    });
+
+    const onPublish = vi.fn();
+    h.hooks.addAction("post:published", onPublish);
+
+    const outcomes = await Promise.all([
+      h.client.post.update({ id: own.id, status: "published" }),
+      h.client.post.update({ id: own.id, status: "published" }),
+      h.client.post.update({ id: own.id, status: "published" }),
+    ]);
+    for (const result of outcomes) expect(result.status).toBe("published");
+    expect(onPublish).toHaveBeenCalledTimes(1);
+  });
+
+  test("post:before_save cannot overwrite immutable fields", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const impostor = await h.factory.admin.create({
+      email: "impostor@example.test",
+    });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "locked",
+    });
+
+    h.hooks.addFilter("post:before_save", (post) => ({
+      ...post,
+      authorId: impostor.id,
+      type: "leaked",
+    }));
+
+    const updated = await h.client.post.update({
+      id: own.id,
+      title: "renamed",
+    });
+    expect(updated.authorId).toBe(h.user.id);
+    expect(updated.type).toBe("post");
+    expect(updated.title).toBe("renamed");
+  });
+});

--- a/packages/core/src/rpc/procedures/post/update.ts
+++ b/packages/core/src/rpc/procedures/post/update.ts
@@ -1,6 +1,5 @@
-import { and, eq, isUniqueConstraintError, ne } from "../../../db/index.js";
-
 import type { NewPost } from "../../../db/schema/posts.js";
+import { and, eq, isUniqueConstraintError, ne } from "../../../db/index.js";
 import { posts } from "../../../db/schema/posts.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";

--- a/packages/core/src/rpc/procedures/post/update.ts
+++ b/packages/core/src/rpc/procedures/post/update.ts
@@ -1,0 +1,107 @@
+import { and, eq, isUniqueConstraintError, ne } from "../../../db/index.js";
+
+import type { NewPost } from "../../../db/schema/posts.js";
+import { posts } from "../../../db/schema/posts.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { stripUndefined } from "./helpers.js";
+import {
+  applyPostBeforeSave,
+  firePostPublished,
+  firePostTransition,
+  firePostUpdated,
+  postCapability,
+} from "./lifecycle.js";
+import { postUpdateInputSchema } from "./schemas.js";
+
+export const update = base
+  .use(authenticated)
+  .input(postUpdateInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:post.update:input",
+      input,
+    );
+
+    const existing = await context.db.query.posts.findFirst({
+      where: eq(posts.id, filtered.id),
+    });
+    if (!existing) {
+      throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+    }
+
+    const isAuthor = existing.authorId === context.user.id;
+    const editOwnCapability = postCapability(existing.type, "edit_own");
+    const editAnyCapability = postCapability(existing.type, "edit_any");
+    const canEdit =
+      (isAuthor && context.auth.can(editOwnCapability)) ||
+      context.auth.can(editAnyCapability);
+    if (!canEdit) {
+      throw errors.FORBIDDEN({ data: { capability: editAnyCapability } });
+    }
+
+    const isPublishTransition =
+      filtered.status === "published" && existing.status !== "published";
+    if (isPublishTransition) {
+      const publishCapability = postCapability(existing.type, "publish");
+      if (!context.auth.can(publishCapability)) {
+        throw errors.FORBIDDEN({ data: { capability: publishCapability } });
+      }
+    }
+
+    const { id: _id, ...changes } = filtered;
+    const patch: Partial<NewPost> = stripUndefined(changes);
+    if (isPublishTransition && !existing.publishedAt) {
+      patch.publishedAt = new Date();
+    }
+
+    if (Object.keys(patch).length === 0) {
+      return context.hooks.applyFilter("rpc:post.update:output", existing);
+    }
+
+    const preparedFull = await applyPostBeforeSave(context, existing.type, {
+      ...existing,
+      ...patch,
+    });
+    const toWrite: Partial<NewPost> = {};
+    for (const key of Object.keys(patch) as (keyof NewPost)[]) {
+      (toWrite as Record<string, unknown>)[key] = preparedFull[key];
+    }
+
+    const where = isPublishTransition
+      ? and(eq(posts.id, existing.id), ne(posts.status, "published"))
+      : eq(posts.id, existing.id);
+
+    let updated;
+    try {
+      [updated] = await context.db
+        .update(posts)
+        .set(toWrite)
+        .where(where)
+        .returning();
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw errors.CONFLICT({ data: { reason: "slug_taken" } });
+      }
+      throw error;
+    }
+    if (!updated) {
+      if (isPublishTransition) {
+        const current = await context.db.query.posts.findFirst({
+          where: eq(posts.id, existing.id),
+        });
+        if (current) {
+          return context.hooks.applyFilter("rpc:post.update:output", current);
+        }
+      }
+      throw errors.CONFLICT({ data: { reason: "update_failed" } });
+    }
+
+    await firePostUpdated(context, updated, existing);
+    await firePostTransition(context, updated, existing.status);
+    if (isPublishTransition) {
+      await firePostPublished(context, updated);
+    }
+
+    return context.hooks.applyFilter("rpc:post.update:output", updated);
+  });

--- a/packages/core/src/rpc/router.ts
+++ b/packages/core/src/rpc/router.ts
@@ -1,0 +1,7 @@
+import { postRouter } from "./procedures/post/index.js";
+
+export const appRouter = {
+  post: postRouter,
+} as const;
+
+export type AppRouter = typeof appRouter;

--- a/packages/core/src/runtime/adapter.ts
+++ b/packages/core/src/runtime/adapter.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface PlumixApp {}
+import type { PlumixApp } from "./app.js";
 
 // env/ctx are runtime-specific; `any` keeps adapter-returned handlers
 // bivariantly assignable to this core-level contract without losing

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -1,14 +1,17 @@
 import { RPCHandler } from "@orpc/server/fetch";
 
-import type { PasskeyConfig, ResolvedPasskeyConfig } from "../auth/passkey/config.js";
+import type {
+  PasskeyConfig,
+  ResolvedPasskeyConfig,
+} from "../auth/passkey/config.js";
 import type { SessionPolicy } from "../auth/sessions.js";
 import type { PlumixConfig } from "../config.js";
 import type { AppContext } from "../context/app.js";
-import type { HookRegistry } from "../hooks/registry.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
-import { HookRegistry as HookRegistryImpl } from "../hooks/registry.js";
+import * as coreSchema from "../db/schema/index.js";
+import { HookRegistry } from "../hooks/registry.js";
 import { installPlugins } from "../plugin/register.js";
 import { appRouter } from "../rpc/router.js";
 
@@ -24,23 +27,40 @@ export interface PlumixApp {
   readonly rpcHandler: RPCHandler<AppContext>;
   readonly passkey: ResolvedPasskeyConfig;
   readonly sessionPolicy: SessionPolicy;
+  readonly schema: Record<string, unknown>;
 }
 
 export async function buildApp(
   config: PlumixConfig,
   options: PlumixAppOptions,
 ): Promise<PlumixApp> {
-  const hooks = new HookRegistryImpl();
+  const hooks = new HookRegistry();
   const { registry } = await installPlugins({ hooks, plugins: config.plugins });
 
-  const rpcHandler = new RPCHandler(appRouter);
+  const schema: Record<string, unknown> = { ...coreSchema };
+  const origin = new Map<string, string>();
+  for (const key of Object.keys(coreSchema)) origin.set(key, "core");
+  for (const plugin of config.plugins) {
+    if (!plugin.schema) continue;
+    for (const [key, value] of Object.entries(plugin.schema)) {
+      const previous = origin.get(key);
+      if (previous !== undefined) {
+        throw new Error(
+          `Plugin "${plugin.id}" redefines schema export "${key}" (already defined by "${previous}")`,
+        );
+      }
+      origin.set(key, plugin.id);
+      schema[key] = value;
+    }
+  }
 
   return {
     config,
     hooks,
     plugins: registry,
-    rpcHandler,
+    rpcHandler: new RPCHandler(appRouter),
     passkey: resolvePasskeyConfig(options.passkey),
     sessionPolicy: options.sessionPolicy ?? DEFAULT_SESSION_POLICY,
+    schema,
   };
 }

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -1,0 +1,46 @@
+import { RPCHandler } from "@orpc/server/fetch";
+
+import type { PasskeyConfig, ResolvedPasskeyConfig } from "../auth/passkey/config.js";
+import type { SessionPolicy } from "../auth/sessions.js";
+import type { PlumixConfig } from "../config.js";
+import type { AppContext } from "../context/app.js";
+import type { HookRegistry } from "../hooks/registry.js";
+import type { PluginRegistry } from "../plugin/manifest.js";
+import { resolvePasskeyConfig } from "../auth/passkey/config.js";
+import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
+import { HookRegistry as HookRegistryImpl } from "../hooks/registry.js";
+import { installPlugins } from "../plugin/register.js";
+import { appRouter } from "../rpc/router.js";
+
+export interface PlumixAppOptions {
+  readonly passkey: PasskeyConfig;
+  readonly sessionPolicy?: SessionPolicy;
+}
+
+export interface PlumixApp {
+  readonly config: PlumixConfig;
+  readonly hooks: HookRegistry;
+  readonly plugins: PluginRegistry;
+  readonly rpcHandler: RPCHandler<AppContext>;
+  readonly passkey: ResolvedPasskeyConfig;
+  readonly sessionPolicy: SessionPolicy;
+}
+
+export async function buildApp(
+  config: PlumixConfig,
+  options: PlumixAppOptions,
+): Promise<PlumixApp> {
+  const hooks = new HookRegistryImpl();
+  const { registry } = await installPlugins({ hooks, plugins: config.plugins });
+
+  const rpcHandler = new RPCHandler(appRouter);
+
+  return {
+    config,
+    hooks,
+    plugins: registry,
+    rpcHandler,
+    passkey: resolvePasskeyConfig(options.passkey),
+    sessionPolicy: options.sessionPolicy ?? DEFAULT_SESSION_POLICY,
+  };
+}

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+
+import { createDispatcherHarness, plumixRequest } from "../test/dispatcher.js";
+
+describe("dispatcher — routing", () => {
+  test("public / returns the SSR placeholder", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("<h1>Plumix</h1>");
+  });
+
+  test("/_plumix/admin returns 404 with the admin-not-available hint", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin", { method: "GET" }),
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("admin-not-available");
+  });
+
+  test("unknown /_plumix/* path returns 404", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/unknown", { method: "GET" }),
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("unknown-plumix-route");
+  });
+});
+
+describe("dispatcher — CSRF", () => {
+  test("POST /_plumix/rpc/post.list without the X-Plumix-Request header is forbidden", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/rpc/post.list", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    );
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { reason?: string };
+    expect(body.reason).toBe("csrf_header_missing");
+  });
+
+  test("GET /_plumix/admin is allowed without the CSRF header (safe method)", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/admin", { method: "GET" }),
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("admin-not-available");
+  });
+});
+
+describe("dispatcher — RPC", () => {
+  test("POST /_plumix/rpc/post/list with CSRF header dispatches to oRPC (UNAUTHORIZED without session)", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/rpc/post/list", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: {} }),
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("POST /_plumix/rpc/unknown/procedure with CSRF header returns 404", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/rpc/unknown/procedure", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: {} }),
+      }),
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe(
+      "rpc-procedure-not-found",
+    );
+  });
+});
+
+describe("dispatcher — auth routes", () => {
+  test("POST signout without session still returns 200 and clears cookie", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/signout", { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toMatch(/Max-Age=0/);
+  });
+
+  test("GET /_plumix/auth/signout is 405 (POST-only)", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/signout", { method: "GET" }),
+    );
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST");
+  });
+
+  test("unknown auth path returns 404", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/auth/nonexistent", { method: "POST" }),
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("dispatcher — error boundary", () => {
+  test("unhandled handler exceptions return 500 JSON (no raw throw)", async () => {
+    const h = await createDispatcherHarness();
+    h.app.hooks.addFilter("rpc:post.list:input", () => {
+      throw new Error("boom");
+    });
+
+    const user = await h.seedUser("admin");
+    const authed = await h.authenticateRequest(
+      plumixRequest("/_plumix/rpc/post/list", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: {} }),
+      }),
+      user.id,
+    );
+    const response = await h.dispatch(authed);
+    expect(response.status).toBe(500);
+  });
+});

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -36,10 +36,7 @@ export function createPlumixDispatcher(app: PlumixApp): PlumixDispatcher {
         url: ctx.request.url,
         method: ctx.request.method,
       });
-      return jsonResponse(
-        { error: "internal_error" },
-        { status: 500 },
-      );
+      return jsonResponse({ error: "internal_error" }, { status: 500 });
     }
   };
 }

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -1,0 +1,81 @@
+import type { AppContext } from "../context/app.js";
+import type { PlumixApp } from "./app.js";
+import { hasCsrfHeader } from "../auth/csrf.js";
+import {
+  handlePasskeyLoginOptions,
+  handlePasskeyLoginVerify,
+  handlePasskeyRegisterOptions,
+  handlePasskeyRegisterVerify,
+  handleSignout,
+} from "../auth/passkey/routes.js";
+import { forbidden, jsonResponse, methodNotAllowed, notFound } from "./http.js";
+
+const RPC_PREFIX = "/_plumix/rpc";
+const ADMIN_PREFIX = "/_plumix/admin";
+const PLUMIX_PREFIX = "/_plumix/";
+
+type RouteHandler = (ctx: AppContext, app: PlumixApp) => Promise<Response>;
+
+const POST_AUTH_ROUTES = new Map<string, RouteHandler>([
+  ["/_plumix/auth/passkey/register/options", handlePasskeyRegisterOptions],
+  ["/_plumix/auth/passkey/register/verify", handlePasskeyRegisterVerify],
+  ["/_plumix/auth/passkey/login/options", handlePasskeyLoginOptions],
+  ["/_plumix/auth/passkey/login/verify", handlePasskeyLoginVerify],
+  ["/_plumix/auth/signout", (ctx) => handleSignout(ctx)],
+]);
+
+export type PlumixDispatcher = (ctx: AppContext) => Promise<Response>;
+
+export function createPlumixDispatcher(app: PlumixApp): PlumixDispatcher {
+  return async (ctx) => {
+    try {
+      return await route(app, ctx);
+    } catch (error) {
+      ctx.logger.error("dispatch_failed", {
+        error,
+        url: ctx.request.url,
+        method: ctx.request.method,
+      });
+      return jsonResponse(
+        { error: "internal_error" },
+        { status: 500 },
+      );
+    }
+  };
+}
+
+async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
+  const { pathname } = new URL(ctx.request.url);
+
+  if (pathname.startsWith(PLUMIX_PREFIX) && !hasCsrfHeader(ctx.request)) {
+    return forbidden("csrf_header_missing");
+  }
+
+  if (pathname === RPC_PREFIX || pathname.startsWith(`${RPC_PREFIX}/`)) {
+    const result = await app.rpcHandler.handle(ctx.request, {
+      prefix: RPC_PREFIX,
+      context: ctx,
+    });
+    return result.matched
+      ? result.response
+      : notFound("rpc-procedure-not-found");
+  }
+
+  const authHandler = POST_AUTH_ROUTES.get(pathname);
+  if (authHandler) {
+    if (ctx.request.method !== "POST") return methodNotAllowed(["POST"]);
+    return authHandler(ctx, app);
+  }
+
+  if (pathname === ADMIN_PREFIX || pathname.startsWith(`${ADMIN_PREFIX}/`)) {
+    return notFound("admin-not-available");
+  }
+
+  if (pathname.startsWith(PLUMIX_PREFIX)) {
+    return notFound("unknown-plumix-route");
+  }
+
+  return new Response("<h1>Plumix</h1>", {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}

--- a/packages/core/src/runtime/http.ts
+++ b/packages/core/src/runtime/http.ts
@@ -1,7 +1,4 @@
-export function jsonResponse(
-  body: unknown,
-  init: ResponseInit = {},
-): Response {
+export function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   const headers = new Headers(init.headers);
   if (!headers.has("content-type")) {
     headers.set("content-type", "application/json; charset=utf-8");

--- a/packages/core/src/runtime/http.ts
+++ b/packages/core/src/runtime/http.ts
@@ -1,0 +1,30 @@
+export function jsonResponse(
+  body: unknown,
+  init: ResponseInit = {},
+): Response {
+  const headers = new Headers(init.headers);
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/json; charset=utf-8");
+  }
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+export function notFound(hint?: string): Response {
+  const headers = new Headers({ "content-type": "text/plain; charset=utf-8" });
+  if (hint) headers.set("x-plumix-hint", hint);
+  return new Response("Not Found", { status: 404, headers });
+}
+
+export function methodNotAllowed(allowed: readonly string[]): Response {
+  return new Response("Method Not Allowed", {
+    status: 405,
+    headers: {
+      allow: allowed.join(", "),
+      "content-type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+export function forbidden(reason: string): Response {
+  return jsonResponse({ error: "forbidden", reason }, { status: 403 });
+}

--- a/packages/core/src/runtime/slots.ts
+++ b/packages/core/src/runtime/slots.ts
@@ -6,7 +6,6 @@ export interface DatabaseAdapter<TSchema = Record<string, unknown>> {
     schema: TSchema,
   ): {
     db: unknown;
-    commit: () => Record<string, string> | null;
   };
 }
 

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -1,0 +1,111 @@
+import type { AppContext } from "../context/app.js";
+import type { User, UserRole } from "../db/schema/users.js";
+import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
+import { createSession } from "../auth/sessions.js";
+import { plumix } from "../config.js";
+import { createAppContext } from "../context/app.js";
+import { buildApp } from "../runtime/app.js";
+import type { PlumixApp } from "../runtime/app.js";
+import { createPlumixDispatcher } from "../runtime/dispatcher.js";
+import { userFactory } from "./factories.js";
+import { createTestDb } from "./harness.js";
+
+type TestDb = Awaited<ReturnType<typeof createTestDb>>;
+
+const stubAdapter = {
+  name: "test",
+  buildFetchHandler: () => () =>
+    new Response("stub", { status: 500 }),
+  cli: {
+    dev: () => Promise.resolve(),
+    build: () => Promise.resolve({ outputPath: "" }),
+    deploy: () => Promise.resolve({}),
+    types: () => Promise.resolve(),
+    migrate: () => Promise.resolve(),
+  },
+};
+
+const stubDatabase = {
+  kind: "test",
+  connect: () => ({ db: {}, commit: () => null }),
+};
+
+interface DispatcherHarness {
+  readonly db: TestDb;
+  readonly app: PlumixApp;
+  readonly dispatch: (request: Request, user?: User | null) => Promise<Response>;
+  readonly authenticateRequest: (
+    request: Request,
+    userId: number,
+  ) => Promise<Request>;
+  readonly seedUser: (role?: UserRole) => Promise<User>;
+}
+
+const noop = (): void => undefined;
+const silentLogger = {
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+};
+
+function withRequest(
+  app: PlumixApp,
+  db: TestDb,
+  request: Request,
+  user: User | null,
+): AppContext {
+  return createAppContext({
+    db,
+    env: {} as AppContext["env"],
+    request,
+    hooks: app.hooks,
+    plugins: app.plugins,
+    logger: silentLogger,
+    user: user
+      ? { id: user.id, email: user.email, role: user.role }
+      : undefined,
+  });
+}
+
+export async function createDispatcherHarness(): Promise<DispatcherHarness> {
+  const db = await createTestDb();
+  const config = plumix({ runtime: stubAdapter, database: stubDatabase });
+  const app = await buildApp(config, {
+    passkey: {
+      rpName: "Plumix Test",
+      rpId: "cms.example",
+      origin: "https://cms.example",
+    },
+  });
+  const dispatcher = createPlumixDispatcher(app);
+
+  return {
+    db,
+    app,
+    dispatch: async (request, user = null) => {
+      const ctx = withRequest(app, db, request, user);
+      return dispatcher(ctx);
+    },
+    authenticateRequest: async (request, userId) => {
+      const { token } = await createSession(db, { userId });
+      const headers = new Headers(request.headers);
+      headers.set("cookie", `${SESSION_COOKIE_NAME}=${token}`);
+      return new Request(request, { headers });
+    },
+    seedUser: async (role = "subscriber") =>
+      userFactory.transient({ db }).create({ role }),
+  };
+}
+
+export function plumixRequest(
+  path: string,
+  init: RequestInit = {},
+): Request {
+  const url = path.startsWith("http") ? path : `https://cms.example${path}`;
+  const headers = new Headers(init.headers);
+  if (!headers.has("x-plumix-request")) {
+    headers.set("x-plumix-request", "1");
+  }
+  return new Request(url, { ...init, headers });
+}

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -1,11 +1,11 @@
 import type { AppContext } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
+import type { PlumixApp } from "../runtime/app.js";
 import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
 import { createSession } from "../auth/sessions.js";
 import { plumix } from "../config.js";
 import { createAppContext } from "../context/app.js";
 import { buildApp } from "../runtime/app.js";
-import type { PlumixApp } from "../runtime/app.js";
 import { createPlumixDispatcher } from "../runtime/dispatcher.js";
 import { userFactory } from "./factories.js";
 import { createTestDb } from "./harness.js";
@@ -14,8 +14,7 @@ type TestDb = Awaited<ReturnType<typeof createTestDb>>;
 
 const stubAdapter = {
   name: "test",
-  buildFetchHandler: () => () =>
-    new Response("stub", { status: 500 }),
+  buildFetchHandler: () => () => new Response("stub", { status: 500 }),
   cli: {
     dev: () => Promise.resolve(),
     build: () => Promise.resolve({ outputPath: "" }),
@@ -33,7 +32,10 @@ const stubDatabase = {
 interface DispatcherHarness {
   readonly db: TestDb;
   readonly app: PlumixApp;
-  readonly dispatch: (request: Request, user?: User | null) => Promise<Response>;
+  readonly dispatch: (
+    request: Request,
+    user?: User | null,
+  ) => Promise<Response>;
   readonly authenticateRequest: (
     request: Request,
     userId: number,
@@ -98,10 +100,7 @@ export async function createDispatcherHarness(): Promise<DispatcherHarness> {
   };
 }
 
-export function plumixRequest(
-  path: string,
-  init: RequestInit = {},
-): Request {
+export function plumixRequest(path: string, init: RequestInit = {}): Request {
   const url = path.startsWith("http") ? path : `https://cms.example${path}`;
   const headers = new Headers(init.headers);
   if (!headers.has("x-plumix-request")) {

--- a/packages/core/src/test/factories.ts
+++ b/packages/core/src/test/factories.ts
@@ -1,0 +1,105 @@
+import { Factory } from "fishery";
+
+import type { Db } from "../context/app.js";
+import type { NewPost, Post } from "../db/schema/posts.js";
+import type { NewUser, User } from "../db/schema/users.js";
+import { posts } from "../db/schema/posts.js";
+import { users } from "../db/schema/users.js";
+
+interface DbTransient {
+  db: Db;
+}
+
+function requireDb(transient: Partial<DbTransient>): Db {
+  if (!transient.db) {
+    throw new Error(
+      "factory requires a db via .transient({ db }) or factoriesFor(db)",
+    );
+  }
+  return transient.db;
+}
+
+export const userFactory = Factory.define<NewUser, DbTransient, User>(
+  ({ sequence, transientParams, onCreate, params }) => {
+    onCreate(async (attrs) => {
+      const db = requireDb(transientParams);
+      const [row] = await db.insert(users).values(attrs).returning();
+      if (!row) throw new Error("userFactory: insert returned no row");
+      return row;
+    });
+
+    return {
+      email: params.email ?? `user-${sequence}@example.test`,
+      name: params.name ?? null,
+      role: params.role ?? "subscriber",
+    };
+  },
+);
+
+export const adminUser = userFactory.params({ role: "admin" });
+export const editorUser = userFactory.params({ role: "editor" });
+export const authorUser = userFactory.params({ role: "author" });
+export const contributorUser = userFactory.params({ role: "contributor" });
+export const subscriberUser = userFactory.params({ role: "subscriber" });
+
+export const postFactory = Factory.define<NewPost, DbTransient, Post>(
+  ({ sequence, transientParams, onCreate, params }) => {
+    onCreate(async (attrs) => {
+      const db = requireDb(transientParams);
+      const [row] = await db.insert(posts).values(attrs).returning();
+      if (!row) throw new Error("postFactory: insert returned no row");
+      return row;
+    });
+
+    const status = params.status ?? "draft";
+    const authorId = params.authorId;
+    if (authorId === undefined) {
+      throw new Error("postFactory: authorId is required");
+    }
+    return {
+      type: params.type ?? "post",
+      title: params.title ?? `Post ${sequence}`,
+      slug: params.slug ?? `post-${sequence}-${Date.now()}`,
+      content: params.content ?? null,
+      excerpt: params.excerpt ?? null,
+      status,
+      parentId: params.parentId ?? null,
+      menuOrder: params.menuOrder ?? 0,
+      publishedAt:
+        params.publishedAt ?? (status === "published" ? new Date() : null),
+      authorId,
+    };
+  },
+);
+
+export const draftPost = postFactory.params({ status: "draft" });
+export const publishedPost = postFactory.params({ status: "published" });
+export const trashedPost = postFactory.params({ status: "trash" });
+
+export interface Factories {
+  readonly user: typeof userFactory;
+  readonly admin: typeof adminUser;
+  readonly editor: typeof editorUser;
+  readonly author: typeof authorUser;
+  readonly contributor: typeof contributorUser;
+  readonly subscriber: typeof subscriberUser;
+  readonly post: typeof postFactory;
+  readonly draft: typeof draftPost;
+  readonly published: typeof publishedPost;
+  readonly trashed: typeof trashedPost;
+}
+
+export function factoriesFor(db: Db): Factories {
+  return {
+    user: userFactory.transient({ db }),
+    admin: adminUser.transient({ db }),
+    editor: editorUser.transient({ db }),
+    author: authorUser.transient({ db }),
+    contributor: contributorUser.transient({ db }),
+    subscriber: subscriberUser.transient({ db }),
+    post: postFactory.transient({ db }),
+    draft: draftPost.transient({ db }),
+    published: publishedPost.transient({ db }),
+    trashed: trashedPost.transient({ db }),
+  };
+}

--- a/packages/core/src/test/rpc.ts
+++ b/packages/core/src/test/rpc.ts
@@ -1,0 +1,125 @@
+import type { RouterClient } from "@orpc/server";
+import { createRouterClient } from "@orpc/server";
+
+import type { AppContext, Db } from "../context/app.js";
+import type { User, UserRole } from "../db/schema/users.js";
+import type { HookExecutor } from "../hooks/registry.js";
+import type { PluginRegistry } from "../plugin/manifest.js";
+import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
+import { createSession } from "../auth/sessions.js";
+import { createAppContext } from "../context/app.js";
+import { HookRegistry } from "../hooks/registry.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { appRouter } from "../rpc/router.js";
+import type { Factories } from "./factories.js";
+import { factoriesFor, userFactory } from "./factories.js";
+import { createTestDb } from "./harness.js";
+
+type TestDb = Awaited<ReturnType<typeof createTestDb>>;
+
+interface BaseRpcHarnessOptions {
+  readonly hooks?: HookRegistry;
+  readonly plugins?: PluginRegistry;
+  readonly request?: Request;
+}
+
+interface AuthenticatedHarnessOptions extends BaseRpcHarnessOptions {
+  readonly authAs: UserRole;
+}
+
+interface RpcHarnessBase<TUser extends User | null> {
+  readonly db: TestDb;
+  readonly hooks: HookRegistry;
+  readonly plugins: PluginRegistry;
+  readonly context: AppContext;
+  readonly client: RouterClient<typeof appRouter>;
+  readonly user: TUser;
+  readonly factory: Factories;
+}
+
+type RpcHarness = RpcHarnessBase<User | null>;
+type AuthenticatedRpcHarness = RpcHarnessBase<User>;
+
+const noop = (): void => undefined;
+const silentLogger = {
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+};
+
+function buildContext(
+  db: Db,
+  hooks: HookExecutor,
+  plugins: PluginRegistry,
+  request: Request,
+): AppContext {
+  return createAppContext({
+    db,
+    env: {} as AppContext["env"],
+    request,
+    hooks,
+    plugins,
+    logger: silentLogger,
+  });
+}
+
+function unauthenticatedRequest(): Request {
+  return new Request("https://cms.example/_plumix/rpc", { method: "POST" });
+}
+
+async function authenticatedRequest(
+  db: TestDb,
+  userId: number,
+): Promise<Request> {
+  const { token } = await createSession(db, { userId });
+  return new Request("https://cms.example/_plumix/rpc", {
+    method: "POST",
+    headers: { cookie: `${SESSION_COOKIE_NAME}=${token}` },
+  });
+}
+
+function assemble<TUser extends User | null>(
+  db: TestDb,
+  hooks: HookRegistry,
+  plugins: PluginRegistry,
+  request: Request,
+  user: TUser,
+): RpcHarnessBase<TUser> {
+  const context = buildContext(db, hooks, plugins, request);
+  const client = createRouterClient(appRouter, { context });
+  return {
+    db,
+    hooks,
+    plugins,
+    context,
+    client,
+    user,
+    factory: factoriesFor(db),
+  };
+}
+
+export function createRpcHarness(
+  options: AuthenticatedHarnessOptions,
+): Promise<AuthenticatedRpcHarness>;
+export function createRpcHarness(
+  options?: BaseRpcHarnessOptions,
+): Promise<RpcHarness>;
+export async function createRpcHarness(
+  options: BaseRpcHarnessOptions & { authAs?: UserRole } = {},
+): Promise<RpcHarness> {
+  const db = await createTestDb();
+  const hooks = options.hooks ?? new HookRegistry();
+  const plugins = options.plugins ?? createPluginRegistry();
+
+  if (!options.request && options.authAs) {
+    const user = await userFactory
+      .transient({ db })
+      .create({ role: options.authAs });
+    const request = await authenticatedRequest(db, user.id);
+    return assemble(db, hooks, plugins, request, user);
+  }
+
+  const request = options.request ?? unauthenticatedRequest();
+  return assemble<User | null>(db, hooks, plugins, request, null);
+}

--- a/packages/core/src/test/rpc.ts
+++ b/packages/core/src/test/rpc.ts
@@ -5,13 +5,13 @@ import type { AppContext, Db } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
 import type { HookExecutor } from "../hooks/registry.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
+import type { Factories } from "./factories.js";
 import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
 import { createSession } from "../auth/sessions.js";
 import { createAppContext } from "../context/app.js";
 import { HookRegistry } from "../hooks/registry.js";
 import { createPluginRegistry } from "../plugin/manifest.js";
 import { appRouter } from "../rpc/router.js";
-import type { Factories } from "./factories.js";
 import { factoriesFor, userFactory } from "./factories.js";
 import { createTestDb } from "./harness.js";
 

--- a/packages/runtimes/cloudflare/package.json
+++ b/packages/runtimes/cloudflare/package.json
@@ -44,6 +44,7 @@
     "format": "prettier --check . --ignore-path ../../../.gitignore",
     "lint": "eslint",
     "publint": "publint",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
@@ -58,10 +59,12 @@
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "prettier": "@plumix/prettier-config"
 }

--- a/packages/runtimes/cloudflare/src/adapter.test.ts
+++ b/packages/runtimes/cloudflare/src/adapter.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "vitest";
+
+import type { DatabaseAdapter } from "@plumix/core";
+import { buildApp, definePlugin, plumix, requestStore } from "@plumix/core";
+
+import { cloudflare } from "./adapter.js";
+import { d1 } from "./d1.js";
+
+const stubDatabase: DatabaseAdapter = {
+  kind: "stub",
+  connect: () => ({ db: {} }),
+};
+
+const passkey = {
+  rpName: "Plumix Test",
+  rpId: "cms.example",
+  origin: "https://cms.example",
+};
+
+const emptyExecutionContext = {} as ExecutionContext;
+
+async function createApp(database: DatabaseAdapter = stubDatabase) {
+  const config = plumix({ runtime: cloudflare(), database });
+  return buildApp(config, { passkey });
+}
+
+async function invoke(
+  request: Request,
+  env: Record<string, unknown> = {},
+  database?: DatabaseAdapter,
+): Promise<Response> {
+  const app = await createApp(database);
+  return cloudflare().buildFetchHandler(app)(
+    request,
+    env,
+    emptyExecutionContext,
+  );
+}
+
+describe("cloudflare adapter — buildFetchHandler", () => {
+  test("routes the public / request through the dispatcher", async () => {
+    const response = await invoke(new Request("https://cms.example/"));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("<h1>Plumix</h1>");
+  });
+
+  test("ALS is entered for each request and cleaned up afterwards", async () => {
+    expect(requestStore.getStore()).toBeUndefined();
+    await invoke(new Request("https://cms.example/"));
+    expect(requestStore.getStore()).toBeUndefined();
+  });
+
+  test("database.connect errors are caught by the adapter and surface as 500", async () => {
+    const failingDatabase: DatabaseAdapter = {
+      kind: "failing",
+      connect: () => {
+        throw new Error("D1 binding missing");
+      },
+    };
+    const response = await invoke(
+      new Request("https://cms.example/"),
+      {},
+      failingDatabase,
+    );
+    expect(response.status).toBe(500);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({ error: "internal_error" });
+  });
+
+  test("tolerates a test-time executionCtx without waitUntil (after falls back to a no-op)", async () => {
+    const response = await invoke(new Request("https://cms.example/"));
+    expect(response.status).toBe(200);
+  });
+
+  test("passes the env + request through to the database adapter", async () => {
+    let received: { env: unknown; requestUrl: string } | undefined;
+    const capturingDatabase: DatabaseAdapter = {
+      kind: "capture",
+      connect: (env, request) => {
+        received = { env, requestUrl: request.url };
+        return { db: {} };
+      },
+    };
+
+    const env = { DB: "binding-placeholder" };
+    await invoke(new Request("https://cms.example/"), env, capturingDatabase);
+
+    expect(received?.env).toBe(env);
+    expect(received?.requestUrl).toBe("https://cms.example/");
+  });
+
+  test("each request receives its own context (no cross-request leakage)", async () => {
+    const app = await createApp();
+    const fetchHandler = cloudflare().buildFetchHandler(app);
+
+    const [a, b] = await Promise.all([
+      fetchHandler(
+        new Request("https://cms.example/?seq=1"),
+        {},
+        emptyExecutionContext,
+      ),
+      fetchHandler(
+        new Request("https://cms.example/?seq=2"),
+        {},
+        emptyExecutionContext,
+      ),
+    ]);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+  });
+
+  test("rejects /_plumix/* non-safe method without CSRF header (403)", async () => {
+    const response = await invoke(
+      new Request("https://cms.example/_plumix/rpc/post/list", {
+        method: "POST",
+      }),
+    );
+    expect(response.status).toBe(403);
+  });
+});
+
+describe("cloudflare adapter — d1() slot", () => {
+  test("throws a descriptive error when the configured binding is missing from env", () => {
+    const adapter = d1({ binding: "DB" });
+    expect(() =>
+      adapter.connect({}, new Request("https://cms.example/"), {}),
+    ).toThrow(/D1 binding "DB" missing/);
+  });
+});
+
+describe("plugin schema collisions", () => {
+  test("buildApp rejects a plugin that redefines a core table", async () => {
+    const misbehaving = definePlugin("collides", () => undefined, {
+      schema: { users: { fake: true } },
+    });
+    const config = plumix({
+      runtime: cloudflare(),
+      database: { kind: "stub", connect: () => ({ db: {} }) },
+      plugins: [misbehaving],
+    });
+
+    await expect(buildApp(config, { passkey })).rejects.toThrow(
+      /redefines schema export "users"/,
+    );
+  });
+
+  test("buildApp rejects two plugins that export the same table name", async () => {
+    const a = definePlugin("a", () => undefined, {
+      schema: { landing_pages: { fake: "a" } },
+    });
+    const b = definePlugin("b", () => undefined, {
+      schema: { landing_pages: { fake: "b" } },
+    });
+    const config = plumix({
+      runtime: cloudflare(),
+      database: { kind: "stub", connect: () => ({ db: {} }) },
+      plugins: [a, b],
+    });
+
+    await expect(buildApp(config, { passkey })).rejects.toThrow(
+      /Plugin "b" redefines schema export "landing_pages"/,
+    );
+  });
+});

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -1,17 +1,26 @@
-import type { FetchHandler, RuntimeAdapter } from "@plumix/core";
+import type {
+  Db,
+  FetchHandler,
+  PlumixApp,
+  PlumixEnv,
+  RuntimeAdapter,
+} from "@plumix/core";
+import {
+  createAppContext,
+  createPlumixDispatcher,
+  jsonResponse,
+  requestStore,
+} from "@plumix/core";
 
 const notImplemented = (what: string) => () =>
   Promise.reject(
     new Error(`@plumix/runtime-cloudflare: ${what} is not yet implemented`),
   );
 
-const pendingHandler: FetchHandler = () =>
-  new Response("plumix cloudflare adapter is not yet wired", { status: 500 });
-
 export function cloudflare(): RuntimeAdapter {
   return {
     name: "cloudflare",
-    buildFetchHandler: () => pendingHandler,
+    buildFetchHandler: buildFetch,
     cli: {
       dev: notImplemented("dev"),
       build: notImplemented("build"),
@@ -20,4 +29,38 @@ export function cloudflare(): RuntimeAdapter {
       migrate: notImplemented("migrate"),
     },
   };
+}
+
+function buildFetch(app: PlumixApp): FetchHandler {
+  const dispatcher = createPlumixDispatcher(app);
+
+  return async (request, env, executionCtx): Promise<Response> => {
+    const workerCtx = executionCtx as ExecutionContext | undefined;
+    const after =
+      typeof workerCtx?.waitUntil === "function"
+        ? (promise: Promise<unknown>) => workerCtx.waitUntil(promise)
+        : undefined;
+
+    try {
+      const { db } = app.config.database.connect(env, request, app.schema);
+      const appCtx = createAppContext({
+        db: db as Db,
+        env: env as PlumixEnv,
+        request,
+        hooks: app.hooks,
+        plugins: app.plugins,
+        after,
+      });
+      return await requestStore.run(appCtx, () => dispatcher(appCtx));
+    } catch (error) {
+      return handleAdapterFailure(error);
+    }
+  };
+}
+
+function handleAdapterFailure(error: unknown): Response {
+  if (typeof console !== "undefined") {
+    console.error("[plumix/runtime-cloudflare] adapter_failure", error);
+  }
+  return jsonResponse({ error: "internal_error" }, { status: 500 });
 }

--- a/packages/runtimes/cloudflare/src/d1.ts
+++ b/packages/runtimes/cloudflare/src/d1.ts
@@ -1,9 +1,9 @@
+import { drizzle } from "drizzle-orm/d1";
+
 import type { DatabaseAdapter } from "@plumix/core";
 
 export interface D1Config {
   readonly binding: string;
-  readonly session?: "disabled" | "auto" | "primary-first";
-  readonly bookmarkCookie?: string;
 }
 
 export interface D1DatabaseAdapter extends DatabaseAdapter {
@@ -14,9 +14,19 @@ export function d1(config: D1Config): D1DatabaseAdapter {
   return {
     kind: "d1",
     config,
-    connect: () => ({
-      db: {},
-      commit: () => null,
-    }),
+    connect: (env, _request, schema) => {
+      const bindings = env as Record<string, D1Database | undefined>;
+      const binding = bindings[config.binding];
+      if (!binding) {
+        throw new Error(
+          `@plumix/runtime-cloudflare: D1 binding "${config.binding}" missing from env`,
+        );
+      }
+      const db = drizzle(binding, {
+        schema,
+        casing: "snake_case",
+      });
+      return { db };
+    },
   };
 }

--- a/packages/runtimes/cloudflare/tsconfig.json
+++ b/packages/runtimes/cloudflare/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@plumix/typescript-config/library.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/workers-types"]
+  },
   "include": ["src"]
 }

--- a/packages/runtimes/cloudflare/vitest.config.ts
+++ b/packages/runtimes/cloudflare/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       '@plumix/typescript-config':
         specifier: workspace:*
         version: link:../../../tooling/typescript
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)
@@ -333,6 +336,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   tooling/eslint:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@orpc/server':
+        specifier: ^1.13.14
+        version: 1.13.14(ws@8.20.0)
       '@oslojs/crypto':
         specifier: ^1.0.1
         version: 1.0.1
@@ -158,6 +161,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)
+      fishery:
+        specifier: ^2.4.0
+        version: 2.4.0
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -1221,6 +1227,57 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@orpc/client@1.13.14':
+    resolution: {integrity: sha512-JQf3lO//UGHmmkd8+9fuWuh1gga1lhWuKnsT19cui7F6WizBy0NdFSVQerOsSy2c1kxOthlD7GnicGgSY2rhQA==}
+
+  '@orpc/contract@1.13.14':
+    resolution: {integrity: sha512-MfsjaQQDVcs4wHmdl5N/7vkwMnQ41nlojWXyRfRXNJHQczqBzM6sYaTJuUPXlw4YbIu64KHZ5nbbtwNCO5YXsg==}
+
+  '@orpc/interop@1.13.14':
+    resolution: {integrity: sha512-7umABTBzQMNTX8dTKrbIOu9g5XJuMeqijC6Gu6jlaVP90e8D57n7Zv6HfwSgPVq0oQXf9n/ENptzVj3TpxpXsQ==}
+
+  '@orpc/server@1.13.14':
+    resolution: {integrity: sha512-bF+sNbSHBgs1uwzHXgTxcxWIG42ryX+w32l+FJRHrAmGma+S8PmS1X2HZ/J7XycyYVBJMUUzBr8M88pP+UcdxQ==}
+    peerDependencies:
+      crossws: '>=0.3.4'
+      ws: '>=8.18.1'
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+      ws:
+        optional: true
+
+  '@orpc/shared@1.13.14':
+    resolution: {integrity: sha512-/ri8ttSX+ppoo01d3LdqQ4Xh6VZS5PYRYmHxTvO8tuyiqBJhN18d8P1VtEW4T9hetoK7JZKeU7EAeqVUnCF9WA==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@orpc/standard-server-aws-lambda@1.13.14':
+    resolution: {integrity: sha512-5P1ZzgS6zKTjjI0SaCgMlTF5PM4dbOlmP2Zm2Lh1ool/iNvjMzXSb86pbKrWOo5/V8dzn4GMyCgNso9za1nUMg==}
+
+  '@orpc/standard-server-fastify@1.13.14':
+    resolution: {integrity: sha512-DcgL5UFjHENGj1gWiQig4iObMNnnw8z7UrfTELTCejQ9NAWE8aGYdx4bZ/hk4JkieLJ+9aosGK57di6xXBtvPA==}
+    peerDependencies:
+      fastify: '>=5.6.1'
+    peerDependenciesMeta:
+      fastify:
+        optional: true
+
+  '@orpc/standard-server-fetch@1.13.14':
+    resolution: {integrity: sha512-k2zkCi98qd3NkvWhUX/Yece/qjB+o07g/gHC509YB5HbOGtBV/da3eseYjFyzBx5LDxMz28BOALI8/q/YDhKZw==}
+
+  '@orpc/standard-server-node@1.13.14':
+    resolution: {integrity: sha512-GKMWfMuKX+dycpEFMoFrGY+zhZMKPoR9HSM66Ebn/ixr2qCVfQaoudPa9MAgP+fv/ctZx+nkt1rR7esUFMdMAg==}
+
+  '@orpc/standard-server-peer@1.13.14':
+    resolution: {integrity: sha512-jinseQ8bn7XQOHjsCXhR1HiF3wAwn1xEQPpnE/av0PoOi4h0ATvhZjDLaRHvRavs8YwrIqwSuAuYT/hDxON58A==}
+
+  '@orpc/standard-server@1.13.14':
+    resolution: {integrity: sha512-o8PaDERiwREFQpIZO0mQ1PhguchyNzrf1w7m3eK1JB4rPjHu1VJUgqCpy/sV3Id5ji4bX/gKHEC3NZjDX6mEWQ==}
+
   '@oslojs/asn1@1.0.0':
     resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
 
@@ -2082,6 +2139,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
     engines: {node: '>=v18'}
@@ -2488,6 +2549,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  fishery@2.4.0:
+    resolution: {integrity: sha512-QgeTlvgNhVGuMztrfAhlSIBs3rD3l9RMjl9I15yb/lnrx3njrOhvegr2L3LWdqvXwYfQjdQGpglyAfHH2J8DRA==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -3081,6 +3145,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3238,6 +3305,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  radash@12.1.1:
+    resolution: {integrity: sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA==}
+    engines: {node: '>=14.18.0'}
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3449,6 +3520,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -3499,6 +3574,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -4489,6 +4568,95 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@orpc/client@1.13.14':
+    dependencies:
+      '@orpc/shared': 1.13.14
+      '@orpc/standard-server': 1.13.14
+      '@orpc/standard-server-fetch': 1.13.14
+      '@orpc/standard-server-peer': 1.13.14
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/contract@1.13.14':
+    dependencies:
+      '@orpc/client': 1.13.14
+      '@orpc/shared': 1.13.14
+      '@standard-schema/spec': 1.1.0
+      openapi-types: 12.1.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/interop@1.13.14': {}
+
+  '@orpc/server@1.13.14(ws@8.20.0)':
+    dependencies:
+      '@orpc/client': 1.13.14
+      '@orpc/contract': 1.13.14
+      '@orpc/interop': 1.13.14
+      '@orpc/shared': 1.13.14
+      '@orpc/standard-server': 1.13.14
+      '@orpc/standard-server-aws-lambda': 1.13.14
+      '@orpc/standard-server-fastify': 1.13.14
+      '@orpc/standard-server-fetch': 1.13.14
+      '@orpc/standard-server-node': 1.13.14
+      '@orpc/standard-server-peer': 1.13.14
+      cookie: 1.1.1
+    optionalDependencies:
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - fastify
+
+  '@orpc/shared@1.13.14':
+    dependencies:
+      radash: 12.1.1
+      type-fest: 5.6.0
+
+  '@orpc/standard-server-aws-lambda@1.13.14':
+    dependencies:
+      '@orpc/shared': 1.13.14
+      '@orpc/standard-server': 1.13.14
+      '@orpc/standard-server-fetch': 1.13.14
+      '@orpc/standard-server-node': 1.13.14
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server-fastify@1.13.14':
+    dependencies:
+      '@orpc/shared': 1.13.14
+      '@orpc/standard-server': 1.13.14
+      '@orpc/standard-server-node': 1.13.14
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server-fetch@1.13.14':
+    dependencies:
+      '@orpc/shared': 1.13.14
+      '@orpc/standard-server': 1.13.14
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server-node@1.13.14':
+    dependencies:
+      '@orpc/shared': 1.13.14
+      '@orpc/standard-server': 1.13.14
+      '@orpc/standard-server-fetch': 1.13.14
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server-peer@1.13.14':
+    dependencies:
+      '@orpc/shared': 1.13.14
+      '@orpc/standard-server': 1.13.14
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server@1.13.14':
+    dependencies:
+      '@orpc/shared': 1.13.14
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
   '@oslojs/asn1@1.0.0':
     dependencies:
       '@oslojs/binary': 1.0.0
@@ -5223,6 +5391,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cosmiconfig-typescript-loader@6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@types/node': 25.6.0
@@ -5717,6 +5887,10 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fishery@2.4.0:
+    dependencies:
+      lodash.mergewith: 4.6.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -6283,6 +6457,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  openapi-types@12.1.3: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -6431,6 +6607,8 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  radash@12.1.1: {}
 
   react-is@16.13.1: {}
 
@@ -6695,6 +6873,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tagged-tag@1.0.0: {}
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -6746,6 +6926,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION
## What does this PR do?

Phase 4 per [PLAN.md](PLAN.md) — the runtime slice only. CLI dispatcher + Vite plugin + `examples/minimal` fixture are extracted to the next phase.

**What's in scope:**
- oRPC router with typed error catalog; `post.{list,get,create,update,trash}` procedures
- WordPress-style hook fan-out (type-specific before generic); dynamic per-post-type capabilities
- HTTP dispatcher routing `/_plumix/rpc`, `/_plumix/auth/passkey/*`, `/_plumix/auth/signout`, public placeholder; CSRF header enforcement; top-level error boundary
- `@plumix/runtime-cloudflare.buildFetchHandler` — real ALS entry via `requestStore.run`, `AppContext.after` bound to `ExecutionContext.waitUntil`, drizzle-d1 wiring in the `d1()` slot
- Schema merging for plugin descriptors with hard collision detection at `buildApp`
- Security hardening pass from the review + find-bugs skills: locked-down filter payload on update, atomic first-user admin election, gated registration (bootstrap-only / add-device), challenge type scoping, email normalisation, challenge-before-consume ordering
- Correctness pass: schedule requires publish cap, concurrent-publish fires once, authorship-probe removed, passkey verify bodies schema-validated, content length capped
- Laravel-style Fishery factories in `src/test/` for reusable test setup

**What's out of scope (deferred to next phase):**
- `plumix` CLI bin (`dev`/`build`/`migrate`/`types`/`deploy`)
- Vite plugin (`.plumix/worker.ts` + merged schema codegen)
- `examples/minimal` smoke fixture

Deferred follow-ups are tracked in `docs/reference/DEFERRED.md`.

## Type of change

- [x] Feature
- [x] Refactor (no behavior change)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] Added/updated tests — 131 total (121 core + 10 CF adapter), 38 new this PR

## AI-generated code disclosure

- [x] This PR includes AI-generated code