### PR TITLE
feat: phase 7 — auth validation + migrate DX closeout

### DIFF
--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -22,11 +22,12 @@ Emits the worker bundle to `dist/plumix_minimal/`.
 
 ```bash
 pnpm exec plumix migrate generate
-pnpm exec drizzle-kit generate --schema .plumix/schema.ts --dialect sqlite --out drizzle
 pnpm exec wrangler d1 create plumix_minimal
 # paste the returned database_id into wrangler.jsonc
-pnpm exec plumix migrate apply plumix_minimal --remote
+pnpm exec plumix migrate apply --remote
 pnpm exec plumix deploy
 ```
+
+`plumix migrate generate` chains `drizzle-kit generate` for you (requires `drizzle-kit` as a devDependency). `plumix migrate apply` auto-discovers the D1 database name from `wrangler.jsonc` / `wrangler.toml` — pass it explicitly (`plumix migrate apply <db-name>`) if you have more than one.
 
 Every `plumix` subcommand (`doctor`, `types`, `migrate generate`, `deploy`, …) is reachable via `pnpm exec plumix <cmd>` — only the conventional `dev`/`build` are wrapped as scripts.

--- a/packages/core/src/auth/config.test.ts
+++ b/packages/core/src/auth/config.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "vitest";
+
+import type { PlumixAuthInput } from "./config.js";
+import { auth, PlumixConfigError } from "./config.js";
+
+const validPasskey = {
+  rpName: "Plumix",
+  rpId: "cms.example",
+  origin: "https://cms.example",
+};
+
+function rejected(input: PlumixAuthInput): PlumixConfigError {
+  try {
+    auth(input);
+  } catch (error) {
+    if (error instanceof PlumixConfigError) return error;
+    throw error;
+  }
+  throw new Error("expected auth() to throw PlumixConfigError");
+}
+
+describe("auth()", () => {
+  test("accepts a minimal valid config", () => {
+    const config = auth({ passkey: validPasskey });
+    expect(config.kind).toBe("plumix");
+    expect(config.passkey).toEqual(validPasskey);
+    expect(config.sessions).toBeUndefined();
+  });
+
+  test("accepts a config with a full session policy", () => {
+    const sessions = {
+      maxAgeSeconds: 60,
+      absoluteMaxAgeSeconds: 120,
+      refreshThreshold: 0.5,
+    };
+    const config = auth({ passkey: validPasskey, sessions });
+    expect(config.sessions).toEqual(sessions);
+  });
+
+  test("rejects empty passkey.rpName with a pathed issue", () => {
+    const error = rejected({ passkey: { ...validPasskey, rpName: "" } });
+    expect(error.issues).toEqual([
+      { path: "passkey.rpName", message: "rpName must be a non-empty string" },
+    ]);
+    expect(error.message).toContain("passkey.rpName");
+  });
+
+  test("rejects a non-URL origin", () => {
+    const error = rejected({
+      passkey: { ...validPasskey, origin: "not-a-url" },
+    });
+    expect(error.issues[0]?.path).toBe("passkey.origin");
+  });
+
+  test("rejects a negative maxAgeSeconds", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      sessions: {
+        maxAgeSeconds: -1,
+        absoluteMaxAgeSeconds: 120,
+        refreshThreshold: 0.5,
+      },
+    });
+    expect(error.issues[0]?.path).toBe("sessions.maxAgeSeconds");
+  });
+
+  test("rejects a non-integer maxAgeSeconds", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      sessions: {
+        maxAgeSeconds: 1.5,
+        absoluteMaxAgeSeconds: 120,
+        refreshThreshold: 0.5,
+      },
+    });
+    expect(error.issues[0]?.path).toBe("sessions.maxAgeSeconds");
+    expect(error.issues[0]?.message).toContain("integer");
+  });
+
+  test("rejects refreshThreshold outside [0, 1]", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      sessions: {
+        maxAgeSeconds: 60,
+        absoluteMaxAgeSeconds: 120,
+        refreshThreshold: 1.5,
+      },
+    });
+    expect(error.issues[0]?.path).toBe("sessions.refreshThreshold");
+  });
+
+  test("rejects absoluteMaxAgeSeconds below maxAgeSeconds", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      sessions: {
+        maxAgeSeconds: 120,
+        absoluteMaxAgeSeconds: 60,
+        refreshThreshold: 0.5,
+      },
+    });
+    expect(error.issues[0]?.message).toContain(
+      "absoluteMaxAgeSeconds must be ≥ maxAgeSeconds",
+    );
+  });
+
+  test("collects multiple issues when several fields are wrong", () => {
+    const error = rejected({
+      passkey: { rpName: "", rpId: "", origin: "bad" },
+    });
+    const paths = error.issues.map((i) => i.path);
+    expect(paths).toContain("passkey.rpName");
+  });
+});

--- a/packages/core/src/auth/config.test.ts
+++ b/packages/core/src/auth/config.test.ts
@@ -37,6 +37,15 @@ describe("auth()", () => {
     expect(config.sessions).toEqual(sessions);
   });
 
+  test("accepts absoluteMaxAgeSeconds equal to maxAgeSeconds (≥, not >)", () => {
+    const sessions = {
+      maxAgeSeconds: 120,
+      absoluteMaxAgeSeconds: 120,
+      refreshThreshold: 0.5,
+    };
+    expect(() => auth({ passkey: validPasskey, sessions })).not.toThrow();
+  });
+
   test("rejects empty passkey.rpName with a pathed issue", () => {
     const error = rejected({ passkey: { ...validPasskey, rpName: "" } });
     expect(error.issues).toEqual([

--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -1,3 +1,5 @@
+import * as v from "valibot";
+
 import type { PasskeyConfig } from "./passkey/config.js";
 import type { SessionPolicy } from "./sessions.js";
 
@@ -12,7 +14,74 @@ export interface PlumixAuthConfig {
   readonly sessions?: SessionPolicy;
 }
 
+export interface PlumixConfigIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export class PlumixConfigError extends Error {
+  readonly issues: readonly PlumixConfigIssue[];
+
+  constructor(message: string, issues: readonly PlumixConfigIssue[]) {
+    super(message);
+    this.name = "PlumixConfigError";
+    this.issues = issues;
+  }
+}
+
+const passkeySchema = v.object({
+  rpName: v.pipe(v.string(), v.nonEmpty("rpName must be a non-empty string")),
+  rpId: v.pipe(v.string(), v.nonEmpty("rpId must be a non-empty string")),
+  origin: v.pipe(v.string(), v.url("origin must be a valid URL")),
+});
+
+const sessionPolicySchema = v.pipe(
+  v.object({
+    maxAgeSeconds: v.pipe(
+      v.number(),
+      v.integer("maxAgeSeconds must be an integer"),
+      v.minValue(1, "maxAgeSeconds must be ≥ 1"),
+    ),
+    absoluteMaxAgeSeconds: v.pipe(
+      v.number(),
+      v.integer("absoluteMaxAgeSeconds must be an integer"),
+      v.minValue(1, "absoluteMaxAgeSeconds must be ≥ 1"),
+    ),
+    refreshThreshold: v.pipe(
+      v.number(),
+      v.minValue(0, "refreshThreshold must be in [0, 1]"),
+      v.maxValue(1, "refreshThreshold must be in [0, 1]"),
+    ),
+  }),
+  v.check(
+    (s) => s.absoluteMaxAgeSeconds >= s.maxAgeSeconds,
+    "absoluteMaxAgeSeconds must be ≥ maxAgeSeconds",
+  ),
+);
+
+const authInputSchema = v.object({
+  passkey: passkeySchema,
+  sessions: v.optional(sessionPolicySchema),
+});
+
+function toIssues(
+  issues: readonly v.BaseIssue<unknown>[],
+): PlumixConfigIssue[] {
+  return issues.map((issue) => ({
+    path: v.getDotPath(issue) ?? "",
+    message: issue.message,
+  }));
+}
+
 export function auth(input: PlumixAuthInput): PlumixAuthConfig {
+  const result = v.safeParse(authInputSchema, input);
+  if (!result.success) {
+    const issues = toIssues(result.issues);
+    const summary = issues
+      .map((i) => (i.path ? `${i.path}: ${i.message}` : i.message))
+      .join("; ");
+    throw new PlumixConfigError(`Invalid auth() config — ${summary}`, issues);
+  }
   return {
     kind: "plumix",
     passkey: input.passkey,

--- a/packages/plumix/src/cli/commands/migrate.test.ts
+++ b/packages/plumix/src/cli/commands/migrate.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -9,7 +9,7 @@ import type {
   PlumixApp,
 } from "@plumix/core";
 
-import { migrateCommand } from "./migrate.js";
+import { migrateCommand, migrateGenerateDeps } from "./migrate.js";
 
 function fakeApp(): PlumixApp {
   return {
@@ -46,6 +46,7 @@ describe("migrate dispatch", () => {
 
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
   });
 
   test("apply delegates to runtimeMigrate.apply with the remaining argv", async () => {
@@ -88,6 +89,102 @@ describe("migrate dispatch", () => {
       await expect(
         migrateCommand.run(ctx({ cwd: dir, argv: [sub] })),
       ).rejects.toMatchObject({ code: "UNKNOWN_SUBCOMMAND" });
+    }
+  });
+});
+
+describe("migrate generate", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "plumix-migrate-gen-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  test("writes .plumix/schema.ts, then spawns drizzle-kit generate", async () => {
+    vi.spyOn(migrateGenerateDeps, "resolveDrizzleKitBin").mockReturnValue(
+      "/fake/drizzle-kit/bin.cjs",
+    );
+    const spawn = vi
+      .spyOn(migrateGenerateDeps, "spawnInherit")
+      .mockResolvedValue();
+
+    await migrateCommand.run(ctx({ cwd: dir, argv: ["generate"] }));
+
+    const schema = readFileSync(join(dir, ".plumix/schema.ts"), "utf8");
+    expect(schema).toContain("export");
+
+    expect(spawn).toHaveBeenCalledOnce();
+    const [command, args, options] = spawn.mock.calls[0] ?? [];
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual([
+      "/fake/drizzle-kit/bin.cjs",
+      "generate",
+      "--schema",
+      ".plumix/schema.ts",
+      "--dialect",
+      "sqlite",
+      "--out",
+      "drizzle",
+    ]);
+    expect(options).toEqual({ cwd: dir });
+  });
+
+  test("defaulting to the generate subcommand (no argv) behaves the same", async () => {
+    vi.spyOn(migrateGenerateDeps, "resolveDrizzleKitBin").mockReturnValue(
+      "/fake/drizzle-kit/bin.cjs",
+    );
+    const spawn = vi
+      .spyOn(migrateGenerateDeps, "spawnInherit")
+      .mockResolvedValue();
+
+    await migrateCommand.run(ctx({ cwd: dir, argv: [] }));
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  test("throws a structured CliError when drizzle-kit is not installed", async () => {
+    vi.spyOn(migrateGenerateDeps, "resolveDrizzleKitBin").mockReturnValue(null);
+    const spawn = vi
+      .spyOn(migrateGenerateDeps, "spawnInherit")
+      .mockResolvedValue();
+
+    await expect(
+      migrateCommand.run(ctx({ cwd: dir, argv: ["generate"] })),
+    ).rejects.toMatchObject({
+      code: "MIGRATE_GENERATE_NO_DRIZZLE_KIT",
+      hint: expect.stringContaining("pnpm add -D drizzle-kit") as unknown,
+    });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test("propagates a non-zero exit from drizzle-kit", async () => {
+    vi.spyOn(migrateGenerateDeps, "resolveDrizzleKitBin").mockReturnValue(
+      "/fake/drizzle-kit/bin.cjs",
+    );
+    vi.spyOn(migrateGenerateDeps, "spawnInherit").mockRejectedValue(
+      Object.assign(new Error("drizzle-kit exited with code 1"), {
+        code: "SPAWN_NONZERO_EXIT",
+      }),
+    );
+
+    await expect(
+      migrateCommand.run(ctx({ cwd: dir, argv: ["generate"] })),
+    ).rejects.toMatchObject({ code: "SPAWN_NONZERO_EXIT" });
+  });
+});
+
+describe("resolveDrizzleKitBin", () => {
+  test("returns null when drizzle-kit cannot be resolved from cwd", () => {
+    const empty = mkdtempSync(join(tmpdir(), "plumix-empty-"));
+    try {
+      const bin = migrateGenerateDeps.resolveDrizzleKitBin(empty);
+      expect(bin).toBeNull();
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
     }
   });
 });

--- a/packages/plumix/src/cli/commands/migrate.ts
+++ b/packages/plumix/src/cli/commands/migrate.ts
@@ -1,17 +1,23 @@
 import { mkdirSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
-import type { CommandDefinition } from "@plumix/core";
+import type { CommandContext, CommandDefinition } from "@plumix/core";
 import { CliError, generateSchemaSource } from "@plumix/core";
 
 import { report } from "../report.js";
+import { spawnInherit } from "../spawn.js";
+
+const SCHEMA_OUT = ".plumix/schema.ts";
+const MIGRATIONS_OUT = "drizzle";
 
 export const migrateCommand: CommandDefinition = {
   describe: "Generate or apply database migrations",
   async run(ctx) {
     const sub = ctx.argv[0];
     if (sub === undefined || sub === "generate") {
-      migrateGenerate(ctx.cwd, ctx.app.config);
+      await migrateGenerate(ctx);
       return;
     }
     if (Object.hasOwn(ctx.runtimeMigrate, sub)) {
@@ -31,23 +37,60 @@ export const migrateCommand: CommandDefinition = {
   },
 };
 
-function migrateGenerate(
+async function migrateGenerate(ctx: CommandContext): Promise<void> {
+  const { cwd, app } = ctx;
+  const schemaPath = writeSchema(cwd, app.config);
+
+  const bin = migrateGenerateDeps.resolveDrizzleKitBin(cwd);
+  if (bin === null) {
+    throw new CliError("drizzle-kit is not installed in this project", {
+      code: "MIGRATE_GENERATE_NO_DRIZZLE_KIT",
+      hint: "Install it as a devDependency (e.g. `pnpm add -D drizzle-kit`) and rerun `plumix migrate generate`.",
+    });
+  }
+
+  report.info("Running drizzle-kit generate…");
+  await migrateGenerateDeps.spawnInherit(
+    process.execPath,
+    [
+      bin,
+      "generate",
+      "--schema",
+      schemaPath,
+      "--dialect",
+      "sqlite",
+      "--out",
+      MIGRATIONS_OUT,
+    ],
+    { cwd },
+  );
+  report.success(`Migrations emitted in ${MIGRATIONS_OUT}/`);
+}
+
+function writeSchema(
   cwd: string,
   config: Parameters<typeof generateSchemaSource>[0],
-): void {
+): string {
   const { source } = generateSchemaSource(config);
-  const outFile = resolve(cwd, ".plumix/schema.ts");
+  const outFile = resolve(cwd, SCHEMA_OUT);
   mkdirSync(dirname(outFile), { recursive: true });
   writeFileSync(outFile, source, "utf8");
-
-  const relPath = relative(cwd, outFile) || outFile;
-  report.success(`Schema emitted: ${relPath}`);
-  report.info("");
-  report.info("Next: run drizzle-kit to generate the migration SQL:");
-  report.info(
-    `  pnpm exec drizzle-kit generate --schema ${relPath} --dialect sqlite --out drizzle`,
-  );
-  report.info("");
-  report.info("Apply on Cloudflare D1:");
-  report.info("  pnpm exec wrangler d1 migrations apply <db-name>");
+  const rel = relative(cwd, outFile) || outFile;
+  report.success(`Schema emitted: ${rel}`);
+  return rel;
 }
+
+function resolveDrizzleKitBin(cwd: string): string | null {
+  try {
+    const req = createRequire(pathToFileURL(resolve(cwd, "package.json")).href);
+    return req.resolve("drizzle-kit/bin.cjs");
+  } catch {
+    return null;
+  }
+}
+
+// Mutable seam for tests — swap without vi.mock ceremony.
+export const migrateGenerateDeps = {
+  resolveDrizzleKitBin,
+  spawnInherit,
+};

--- a/packages/plumix/src/cli/spawn.ts
+++ b/packages/plumix/src/cli/spawn.ts
@@ -1,0 +1,43 @@
+import { spawn } from "node:child_process";
+
+import { CliError } from "@plumix/core";
+
+interface SpawnOptions {
+  readonly cwd: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+}
+
+export function spawnInherit(
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      stdio: "inherit",
+    });
+    child.once("error", (cause) => {
+      reject(
+        new CliError(`Failed to start ${command}`, {
+          code: "SPAWN_FAILED",
+          hint: `Is ${command} installed and on PATH?`,
+          cause,
+        }),
+      );
+    });
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new CliError(
+          `${command} exited with ${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`}`,
+          { code: "SPAWN_NONZERO_EXIT" },
+        ),
+      );
+    });
+  });
+}

--- a/packages/plumix/test/cli.test.ts
+++ b/packages/plumix/test/cli.test.ts
@@ -7,8 +7,9 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { migrateGenerateDeps } from "../src/cli/commands/migrate.js";
 import { run } from "../src/cli/index.js";
 
 // Inline config object — avoids importing "plumix" from a tmp dir, which
@@ -53,15 +54,25 @@ describe("plumix CLI dispatch", () => {
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
     process.exit = originalExit;
+    vi.restoreAllMocks();
   });
 
-  test("migrate generate writes .plumix/schema.ts", async () => {
+  test("migrate generate writes .plumix/schema.ts and invokes drizzle-kit", async () => {
+    vi.spyOn(migrateGenerateDeps, "resolveDrizzleKitBin").mockReturnValue(
+      "/fake/drizzle-kit/bin.cjs",
+    );
+    const spawn = vi
+      .spyOn(migrateGenerateDeps, "spawnInherit")
+      .mockResolvedValue();
+
     await run(["migrate", "generate", "--cwd", dir]);
+
     const emitted = join(dir, ".plumix/schema.ts");
     expect(existsSync(emitted)).toBe(true);
     expect(readFileSync(emitted, "utf8")).toContain(
       'export * from "plumix/schema";',
     );
+    expect(spawn).toHaveBeenCalledOnce();
     expect(exitCode).toBeUndefined();
   });
 

--- a/packages/runtimes/cloudflare/package.json
+++ b/packages/runtimes/cloudflare/package.json
@@ -56,7 +56,9 @@
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.32.3",
     "@plumix/core": "workspace:*",
+    "jsonc-parser": "^3.3.1",
     "plumix": "workspace:*",
+    "smol-toml": "^1.6.1",
     "vite": "catalog:"
   },
   "peerDependencies": {

--- a/packages/runtimes/cloudflare/src/commands/migrate-apply.test.ts
+++ b/packages/runtimes/cloudflare/src/commands/migrate-apply.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { CommandContext, PlumixApp } from "@plumix/core";
+
+import { migrateApplyCommand, migrateApplyDeps } from "./migrate-apply.js";
+
+function ctx(overrides: Partial<CommandContext>): CommandContext {
+  return {
+    app: {} as unknown as PlumixApp,
+    cwd: "/tmp/fake",
+    configPath: "/tmp/fake/plumix.config.ts",
+    argv: [],
+    runtimeMigrate: {},
+    ...overrides,
+  };
+}
+
+describe("migrate apply", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("uses an explicit positional db name and passes flags through", async () => {
+    const spawn = vi
+      .spyOn(migrateApplyDeps, "spawnInherit")
+      .mockResolvedValue();
+    vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue(null);
+
+    await migrateApplyCommand.run(
+      ctx({ argv: ["my-db", "--remote", "--preview"] }),
+    );
+
+    expect(spawn).toHaveBeenCalledOnce();
+    const [command, args] = spawn.mock.calls[0] ?? [];
+    expect(command).toBe("wrangler");
+    expect(args).toEqual([
+      "d1",
+      "migrations",
+      "apply",
+      "my-db",
+      "--remote",
+      "--preview",
+    ]);
+  });
+
+  test("auto-discovers a single D1 db from wrangler config", async () => {
+    const spawn = vi
+      .spyOn(migrateApplyDeps, "spawnInherit")
+      .mockResolvedValue();
+    vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue({
+      filename: "wrangler.jsonc",
+      d1Databases: [{ binding: "DB", database_name: "only-db" }],
+    });
+
+    await migrateApplyCommand.run(ctx({ argv: ["--remote"] }));
+
+    const [, args] = spawn.mock.calls[0] ?? [];
+    expect(args).toEqual(["d1", "migrations", "apply", "only-db", "--remote"]);
+  });
+
+  test("auto-discovers when called with no args", async () => {
+    const spawn = vi
+      .spyOn(migrateApplyDeps, "spawnInherit")
+      .mockResolvedValue();
+    vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue({
+      filename: "wrangler.toml",
+      d1Databases: [{ binding: "DB", database_name: "only-db" }],
+    });
+
+    await migrateApplyCommand.run(ctx({ argv: [] }));
+
+    const [, args] = spawn.mock.calls[0] ?? [];
+    expect(args).toEqual(["d1", "migrations", "apply", "only-db"]);
+  });
+
+  test("throws MIGRATE_APPLY_MISSING_DB when no name and no wrangler config", async () => {
+    vi.spyOn(migrateApplyDeps, "spawnInherit").mockResolvedValue();
+    vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue(null);
+
+    await expect(
+      migrateApplyCommand.run(ctx({ argv: [] })),
+    ).rejects.toMatchObject({
+      code: "MIGRATE_APPLY_MISSING_DB",
+      hint: expect.stringContaining("wrangler.jsonc") as unknown,
+    });
+  });
+
+  test("throws MIGRATE_APPLY_NO_D1 when config has no d1_databases", async () => {
+    vi.spyOn(migrateApplyDeps, "spawnInherit").mockResolvedValue();
+    vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue({
+      filename: "wrangler.jsonc",
+      d1Databases: [],
+    });
+
+    await expect(
+      migrateApplyCommand.run(ctx({ argv: [] })),
+    ).rejects.toMatchObject({ code: "MIGRATE_APPLY_NO_D1" });
+  });
+
+  test("throws MIGRATE_APPLY_AMBIGUOUS_DB when config has multiple D1 dbs", async () => {
+    vi.spyOn(migrateApplyDeps, "spawnInherit").mockResolvedValue();
+    vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue({
+      filename: "wrangler.jsonc",
+      d1Databases: [
+        { binding: "A", database_name: "alpha" },
+        { binding: "B", database_name: "beta" },
+      ],
+    });
+
+    await expect(
+      migrateApplyCommand.run(ctx({ argv: [] })),
+    ).rejects.toMatchObject({
+      code: "MIGRATE_APPLY_AMBIGUOUS_DB",
+      message: expect.stringContaining("alpha") as unknown,
+    });
+  });
+});

--- a/packages/runtimes/cloudflare/src/commands/migrate-apply.ts
+++ b/packages/runtimes/cloudflare/src/commands/migrate-apply.ts
@@ -1,22 +1,71 @@
 import type { CommandDefinition } from "@plumix/core";
 import { CliError } from "@plumix/core";
 
+import { loadWranglerConfig } from "../wrangler-config.js";
 import { spawnInherit } from "./spawn.js";
 
 export const migrateApplyCommand: CommandDefinition = {
   describe: "Apply pending D1 migrations (wrangler d1 migrations apply)",
   async run(ctx) {
-    const [databaseName, ...rest] = ctx.argv;
-    if (!databaseName) {
-      throw new CliError("Missing D1 database name", {
-        code: "MIGRATE_APPLY_MISSING_DB",
-        hint: "Run `plumix migrate apply <database-name> [--remote|--local]`. The name matches `database_name` in wrangler.jsonc.",
-      });
-    }
-    await spawnInherit(
+    const { databaseName, passthroughArgs } = resolveDatabaseName(
+      ctx.argv,
+      ctx.cwd,
+    );
+    await migrateApplyDeps.spawnInherit(
       "wrangler",
-      ["d1", "migrations", "apply", databaseName, ...rest],
+      ["d1", "migrations", "apply", databaseName, ...passthroughArgs],
       { cwd: ctx.cwd },
     );
   },
+};
+
+function resolveDatabaseName(
+  argv: readonly string[],
+  cwd: string,
+): { databaseName: string; passthroughArgs: readonly string[] } {
+  const [first, ...rest] = argv;
+  // Positional wins over auto-discovery. A leading flag means no positional.
+  if (first !== undefined && !first.startsWith("-")) {
+    return { databaseName: first, passthroughArgs: rest };
+  }
+
+  const config = migrateApplyDeps.loadWranglerConfig(cwd);
+  if (config === null) {
+    throw new CliError("Missing D1 database name", {
+      code: "MIGRATE_APPLY_MISSING_DB",
+      hint: "Pass the database name: `plumix migrate apply <database-name>`. Or add a wrangler.jsonc / wrangler.toml with a `d1_databases` entry so Plumix can auto-discover it.",
+    });
+  }
+
+  const [firstName, ...moreNames] = config.d1Databases
+    .map((db) => db.database_name)
+    .filter(
+      (name): name is string => typeof name === "string" && name.length > 0,
+    );
+
+  if (firstName === undefined) {
+    throw new CliError(
+      `No d1_databases entries with a database_name in ${config.filename}`,
+      {
+        code: "MIGRATE_APPLY_NO_D1",
+        hint: "Add a `d1_databases` entry with a `database_name`, or pass the name explicitly: `plumix migrate apply <database-name>`.",
+      },
+    );
+  }
+  if (moreNames.length > 0) {
+    throw new CliError(
+      `Multiple D1 databases found in ${config.filename}: ${[firstName, ...moreNames].join(", ")}`,
+      {
+        code: "MIGRATE_APPLY_AMBIGUOUS_DB",
+        hint: "Pass the name explicitly: `plumix migrate apply <database-name>`.",
+      },
+    );
+  }
+  return { databaseName: firstName, passthroughArgs: argv };
+}
+
+// Mutable seam for tests — swap without vi.mock ceremony.
+export const migrateApplyDeps = {
+  loadWranglerConfig,
+  spawnInherit,
 };

--- a/packages/runtimes/cloudflare/src/wrangler-config.test.ts
+++ b/packages/runtimes/cloudflare/src/wrangler-config.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { loadWranglerConfig } from "./wrangler-config.js";
+
+describe("loadWranglerConfig", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "plumix-wrangler-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns null when no wrangler config is present", () => {
+    expect(loadWranglerConfig(dir)).toBeNull();
+  });
+
+  test("parses wrangler.jsonc with comments and trailing commas", () => {
+    writeFileSync(
+      join(dir, "wrangler.jsonc"),
+      `{
+  // main worker
+  "name": "app",
+  "d1_databases": [
+    { "binding": "DB", "database_name": "prod", }, // trailing comma
+  ],
+}`,
+      "utf8",
+    );
+    const config = loadWranglerConfig(dir);
+    expect(config).not.toBeNull();
+    expect(config?.filename).toBe("wrangler.jsonc");
+    expect(config?.d1Databases).toEqual([
+      { binding: "DB", database_name: "prod" },
+    ]);
+  });
+
+  test("parses wrangler.json (strict JSON)", () => {
+    writeFileSync(
+      join(dir, "wrangler.json"),
+      JSON.stringify({
+        name: "app",
+        d1_databases: [
+          { binding: "DB", database_name: "prod", database_id: "abc" },
+        ],
+      }),
+      "utf8",
+    );
+    const config = loadWranglerConfig(dir);
+    expect(config?.filename).toBe("wrangler.json");
+    expect(config?.d1Databases[0]?.database_name).toBe("prod");
+  });
+
+  test("parses wrangler.toml", () => {
+    writeFileSync(
+      join(dir, "wrangler.toml"),
+      `name = "app"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "prod"
+database_id = "abc"
+`,
+      "utf8",
+    );
+    const config = loadWranglerConfig(dir);
+    expect(config?.filename).toBe("wrangler.toml");
+    expect(config?.d1Databases[0]?.database_name).toBe("prod");
+  });
+
+  test("returns wrangler.jsonc when both .jsonc and .toml exist (precedence)", () => {
+    writeFileSync(join(dir, "wrangler.jsonc"), '{"name":"jsonc"}', "utf8");
+    writeFileSync(join(dir, "wrangler.toml"), 'name = "toml"\n', "utf8");
+    expect(loadWranglerConfig(dir)?.filename).toBe("wrangler.jsonc");
+  });
+
+  test("returns an empty d1Databases list when the field is absent", () => {
+    writeFileSync(join(dir, "wrangler.json"), '{"name":"app"}', "utf8");
+    expect(loadWranglerConfig(dir)?.d1Databases).toEqual([]);
+  });
+
+  test("throws when wrangler.jsonc has a syntax error", () => {
+    writeFileSync(join(dir, "wrangler.jsonc"), "{ not: valid json", "utf8");
+    expect(() => loadWranglerConfig(dir)).toThrow(/Failed to parse/);
+  });
+});

--- a/packages/runtimes/cloudflare/src/wrangler-config.ts
+++ b/packages/runtimes/cloudflare/src/wrangler-config.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ParseError } from "jsonc-parser";
+import { parse as parseJsonc } from "jsonc-parser";
+import { parse as parseToml } from "smol-toml";
+
+interface D1BindingEntry {
+  readonly binding?: string;
+  readonly database_name?: string;
+  readonly database_id?: string;
+}
+
+// Wrangler's config search order — first match wins.
+const WRANGLER_FILENAMES = ["wrangler.jsonc", "wrangler.json", "wrangler.toml"];
+
+interface LoadedWranglerConfig {
+  readonly filename: string;
+  readonly d1Databases: readonly D1BindingEntry[];
+}
+
+/**
+ * Locate and parse the wrangler config in `cwd`. Returns null if none of
+ * `wrangler.jsonc`, `wrangler.json`, `wrangler.toml` is present. Throws
+ * if a file is present but unparseable.
+ */
+export function loadWranglerConfig(cwd: string): LoadedWranglerConfig | null {
+  for (const filename of WRANGLER_FILENAMES) {
+    const path = join(cwd, filename);
+    const text = tryRead(path);
+    if (text === null) continue;
+
+    const parsed = filename.endsWith(".toml")
+      ? parseToml(text)
+      : parseJsoncStrict(text, filename);
+
+    const rawD1 = (parsed as { d1_databases?: unknown }).d1_databases;
+    const d1Databases: D1BindingEntry[] = Array.isArray(rawD1)
+      ? rawD1.filter(
+          (entry): entry is D1BindingEntry =>
+            typeof entry === "object" &&
+            entry !== null &&
+            !Array.isArray(entry),
+        )
+      : [];
+
+    return { filename, d1Databases };
+  }
+  return null;
+}
+
+function tryRead(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+function parseJsoncStrict(text: string, filename: string): unknown {
+  const errors: ParseError[] = [];
+  const value: unknown = parseJsonc(text, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    throw new Error(
+      `Failed to parse ${filename}: ${errors.length} syntax error(s)`,
+    );
+  }
+  return value;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,9 +354,15 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2)
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       plumix:
         specifier: workspace:*
         version: link:../../plumix
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.6.1
       vite:
         specifier: 'catalog:'
         version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -3340,6 +3346,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -6987,6 +6996,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:


### PR DESCRIPTION
## What does this PR do?

Phase 7 — closes the two Phase 6 deferrals that block a one-command dev loop (drizzle-kit fold-in, D1 db-name auto-discovery) and adds valibot runtime validation to the `auth()` factory so config mistakes surface at startup instead of inside request handling.

**What's in scope (4 commits, each independently green on every CI gate):**

- **`feat(core): validate auth() input with valibot`** — parse `auth(...)` input through a valibot schema at call time and throw `PlumixConfigError` (exported from `@plumix/core/auth`) with flattened dot-path issues. Validates: `passkey.rpName`/`rpId` are non-empty strings, `passkey.origin` is a valid URL, `sessions.{max,absoluteMax}AgeSeconds` are positive integers, `sessions.refreshThreshold` is in `[0, 1]`, and `sessions.absoluteMaxAgeSeconds ≥ sessions.maxAgeSeconds`. Non-breaking: every previously-valid config still parses. Previously, malformed configs would fail deep in WebAuthn verification or produce nonsensical cookie expiries; now you get `Invalid auth() config — passkey.rpName: rpName must be a non-empty string` at startup.

- **`feat(plumix): fold drizzle-kit generate into migrate generate`** — `plumix migrate generate` now chains `drizzle-kit generate --schema .plumix/schema.ts --dialect sqlite --out drizzle` directly after the schema emit. Drizzle-kit is resolved via `createRequire` from the user's cwd so local devDependencies win. Stdio is inherited so drizzle-kit's own output streams straight through. When drizzle-kit isn't installed, a structured `CliError` (code `MIGRATE_GENERATE_NO_DRIZZLE_KIT`) tells the user exactly how to install it. Drizzle-kit stays an optional peer dep — the fold-in only activates when the user opts in. Reduces the published dev loop from two commands to one and eliminates copy-paste drift between Plumix's expected schema path and the user's invocation.

- **`feat(runtime-cloudflare): auto-discover D1 db name in migrate apply`** — positional `<db-name>` is now optional. When omitted (or when the first arg is a flag), walk `wrangler.jsonc` → `wrangler.json` → `wrangler.toml` in `cwd` (wrangler's own search order), parse whichever exists, and auto-use the single `d1_databases[].database_name`. Ambiguity and edge cases surface as structured `CliError`s: `MIGRATE_APPLY_MISSING_DB` (no positional and no wrangler config), `MIGRATE_APPLY_NO_D1` (config exists but no D1 entries), `MIGRATE_APPLY_AMBIGUOUS_DB` (multiple D1s, enumerated in the message). Explicit positional still wins. Parsing uses `jsonc-parser` (handles comments + trailing commas) for JSONC/JSON and `smol-toml` for TOML — both single-consumer deps, kept direct per repo catalog hygiene.

- **`test(core): cover absoluteMaxAge equal to maxAge in auth() schema`** — regression guard for the `≥` (not `>`) invariant on the `absoluteMaxAgeSeconds` vs `maxAgeSeconds` cross-field check. Picked up from the find-bugs pass (L4).

**What's out of scope (tracked internally for follow-up):**

- D1 sessions bookmark for read-your-writes consistency — still the Phase 6 situation: three open design questions (Drizzle compat, bookmark transport, scope) plus a `DatabaseAdapter.connect` contract change. Queued as Phase 8.
- `users` and `terms`/taxonomy RPC procedures — depend on the D1 sessions bookmark landing first (otherwise every admin-UI mutation-then-read races). Queued as Phase 8.
- External-IdP `cloudflareAccess()` adapter — needs a `buildApp` narrowing refactor (passkey/sessions are unconditional today) plus JWKS fetch + rotation + JWT verification. Its own phase.
- Auth `secret` field for token encryption / cookie signing — no concrete use site today (session tokens are already 192-bit random + SHA-256 hashed; CSRF is stateless). Adding when we have a real consumer (e.g. magic-link URL signing).
- Lifting the shared `spawnInherit` helper into `@plumix/core` — currently duplicated between `packages/plumix/src/cli/spawn.ts` and `packages/runtimes/cloudflare/src/commands/spawn.ts`. Defer until a third CLI-hosting package emerges.
- Wrangler config shape validation (warning on malformed `d1_databases`), wrangler parse errors surfacing line/column info — minor DX polish.

## Type of change

- [x] Feature — valibot auth validation, drizzle-kit fold-in, D1 auto-discovery
- [x] Test — regression guard for the auth session-policy equality edge case
- [ ] **Breaking** — none. `auth()` still accepts every previously-valid input; `migrate apply` positional still wins; `migrate generate` required drizzle-kit before (via an advertised manual step) and still does now.

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (185 tests: 140 core + 23 CF adapter + 18 plumix CLI + 4 example smoke/build = +28 vs Phase 6)
- [x] `pnpm format`, `pnpm knip`, `pnpm publint`, `pnpm attw` all green
- [x] Passed `sentry-skills` review pipeline: code-simplifier (applied per commit) → find-bugs (L4 addressed as commit 4; L1–L3/L5 acknowledged as pre-1.0 follow-ups) → code-review (M1 flagged as future consolidation, not blocking). Security-review skipped by design — no HTTP / auth-flow / crypto surfaces touched this phase.

## AI-generated code disclosure

- [x] This PR includes AI-generated code