### PR TITLE
feat: phase 9 — users, terms, and options RPC

### DIFF
--- a/packages/core/src/auth/rbac.test.ts
+++ b/packages/core/src/auth/rbac.test.ts
@@ -107,7 +107,7 @@ describe("requireCapability", () => {
 
   test("passes silently for a satisfied capability", () => {
     expect(() =>
-      requireCapability(resolver, { role: "admin" }, "user:manage"),
+      requireCapability(resolver, { role: "admin" }, "user:edit"),
     ).not.toThrow();
   });
 });
@@ -122,7 +122,13 @@ describe("CORE_CAPABILITIES baseline", () => {
       "post:edit_any",
       "post:delete",
       "taxonomy:manage",
-      "user:manage",
+      "user:list",
+      "user:edit_own",
+      "user:create",
+      "user:edit",
+      "user:promote",
+      "user:delete",
+      "option:manage",
     ]) {
       expect(CORE_CAPABILITIES[name]).toBeDefined();
     }

--- a/packages/core/src/auth/rbac.ts
+++ b/packages/core/src/auth/rbac.ts
@@ -26,6 +26,15 @@ export function roleLevel(role: UserRole): number {
 // `capabilityType: 'post'` (the default) just inherit `post:*` via the
 // dedupe rule in `registerPostType`. `user`/`plugin`/`option` aren't tied
 // to content entities so they only live here.
+//
+// `user:*` mirrors WordPress's split: list is editor+, profile self-edit is
+// any authenticated user, but creating / editing / promoting / deleting
+// other users is admin-only. `promote` is separate from `edit` because role
+// escalation is more sensitive than a name/avatar change.
+// `option:manage` is a single gate over both reads and writes, matching WP's
+// `manage_options`. Options can contain admin-only config; if a specific
+// option needs broader read access, expose it via a dedicated RPC procedure
+// that reads it server-side — don't widen `option.*`.
 export const CORE_CAPABILITIES: Readonly<Record<string, UserRole>> =
   Object.freeze({
     "post:read": "subscriber",
@@ -35,7 +44,12 @@ export const CORE_CAPABILITIES: Readonly<Record<string, UserRole>> =
     "post:edit_any": "editor",
     "post:delete": "editor",
     "taxonomy:manage": "editor",
-    "user:manage": "admin",
+    "user:list": "editor",
+    "user:edit_own": "subscriber",
+    "user:create": "admin",
+    "user:edit": "admin",
+    "user:promote": "admin",
+    "user:delete": "admin",
     "plugin:manage": "admin",
     "option:manage": "admin",
   });

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -1,9 +1,15 @@
 import type { NewPost, Post, PostStatus } from "../db/schema/posts.js";
+import type { Term } from "../db/schema/terms.js";
 import type { User } from "../db/schema/users.js";
 import type {
   PostCreateInput,
   PostUpdateInput,
 } from "./procedures/post/schemas.js";
+import type {
+  TermCreateInput,
+  TermListInput,
+  TermUpdateInput,
+} from "./procedures/term/schemas.js";
 import type {
   UserInviteInput,
   UserListInput,
@@ -48,6 +54,19 @@ declare module "../hooks/types.js" {
 
     "rpc:user.disable:output": (output: User) => User;
     "rpc:user.delete:output": (output: User) => User;
+
+    "rpc:term.list:input": (input: TermListInput) => TermListInput;
+    "rpc:term.list:output": (output: readonly Term[]) => readonly Term[];
+
+    "rpc:term.get:output": (output: Term) => Term;
+
+    "rpc:term.create:input": (input: TermCreateInput) => TermCreateInput;
+    "rpc:term.create:output": (output: Term) => Term;
+
+    "rpc:term.update:input": (input: TermUpdateInput) => TermUpdateInput;
+    "rpc:term.update:output": (output: Term) => Term;
+
+    "rpc:term.delete:output": (output: Term) => Term;
 
     [K: `${string}:before_save`]: (post: NewPost) => NewPost;
   }

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -1,6 +1,8 @@
+import type { Option } from "../db/schema/options.js";
 import type { NewPost, Post, PostStatus } from "../db/schema/posts.js";
 import type { Term } from "../db/schema/terms.js";
 import type { User } from "../db/schema/users.js";
+import type { OptionSetInput } from "./procedures/option/schemas.js";
 import type {
   PostCreateInput,
   PostUpdateInput,
@@ -67,6 +69,12 @@ declare module "../hooks/types.js" {
     "rpc:term.update:output": (output: Term) => Term;
 
     "rpc:term.delete:output": (output: Term) => Term;
+
+    "rpc:option.list:output": (output: readonly Option[]) => readonly Option[];
+    "rpc:option.get:output": (output: Option) => Option;
+    "rpc:option.set:input": (input: OptionSetInput) => OptionSetInput;
+    "rpc:option.set:output": (output: Option) => Option;
+    "rpc:option.delete:output": (output: Option) => Option;
 
     [K: `${string}:before_save`]: (post: NewPost) => NewPost;
   }

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -1,8 +1,14 @@
 import type { NewPost, Post, PostStatus } from "../db/schema/posts.js";
+import type { User } from "../db/schema/users.js";
 import type {
   PostCreateInput,
   PostUpdateInput,
 } from "./procedures/post/schemas.js";
+import type {
+  UserInviteInput,
+  UserListInput,
+  UserUpdateInput,
+} from "./procedures/user/schemas.js";
 
 declare module "../hooks/types.js" {
   interface FilterRegistry {
@@ -25,6 +31,23 @@ declare module "../hooks/types.js" {
 
     "rpc:post.trash:input": (input: { id: number }) => typeof input;
     "rpc:post.trash:output": (output: Post) => Post;
+
+    "rpc:user.list:input": (input: UserListInput) => UserListInput;
+    "rpc:user.list:output": (output: readonly User[]) => readonly User[];
+
+    "rpc:user.get:output": (output: User) => User;
+
+    "rpc:user.invite:input": (input: UserInviteInput) => UserInviteInput;
+    "rpc:user.invite:output": (output: {
+      user: User;
+      inviteToken: string;
+    }) => typeof output;
+
+    "rpc:user.update:input": (input: UserUpdateInput) => UserUpdateInput;
+    "rpc:user.update:output": (output: User) => User;
+
+    "rpc:user.disable:output": (output: User) => User;
+    "rpc:user.delete:output": (output: User) => User;
 
     [K: `${string}:before_save`]: (post: NewPost) => NewPost;
   }

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -28,6 +28,20 @@ export type {
   PostTrashInput,
   PostUpdateInput,
 } from "./procedures/post/schemas.js";
+export { optionRouter } from "./procedures/option/index.js";
+export type { OptionRouter } from "./procedures/option/index.js";
+export {
+  optionDeleteInputSchema,
+  optionGetInputSchema,
+  optionListInputSchema,
+  optionSetInputSchema,
+} from "./procedures/option/schemas.js";
+export type {
+  OptionDeleteInput,
+  OptionGetInput,
+  OptionListInput,
+  OptionSetInput,
+} from "./procedures/option/schemas.js";
 export { termRouter } from "./procedures/term/index.js";
 export type { TermRouter } from "./procedures/term/index.js";
 export {

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -28,6 +28,22 @@ export type {
   PostTrashInput,
   PostUpdateInput,
 } from "./procedures/post/schemas.js";
+export { termRouter } from "./procedures/term/index.js";
+export type { TermRouter } from "./procedures/term/index.js";
+export {
+  termCreateInputSchema,
+  termDeleteInputSchema,
+  termGetInputSchema,
+  termListInputSchema,
+  termUpdateInputSchema,
+} from "./procedures/term/schemas.js";
+export type {
+  TermCreateInput,
+  TermDeleteInput,
+  TermGetInput,
+  TermListInput,
+  TermUpdateInput,
+} from "./procedures/term/schemas.js";
 export { userRouter } from "./procedures/user/index.js";
 export type { UserRouter } from "./procedures/user/index.js";
 export {

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -28,5 +28,23 @@ export type {
   PostTrashInput,
   PostUpdateInput,
 } from "./procedures/post/schemas.js";
+export { userRouter } from "./procedures/user/index.js";
+export type { UserRouter } from "./procedures/user/index.js";
+export {
+  userDeleteInputSchema,
+  userDisableInputSchema,
+  userGetInputSchema,
+  userInviteInputSchema,
+  userListInputSchema,
+  userUpdateInputSchema,
+} from "./procedures/user/schemas.js";
+export type {
+  UserDeleteInput,
+  UserDisableInput,
+  UserGetInput,
+  UserInviteInput,
+  UserListInput,
+  UserUpdateInput,
+} from "./procedures/user/schemas.js";
 export { appRouter } from "./router.js";
 export type { AppRouter } from "./router.js";

--- a/packages/core/src/rpc/procedures/option/delete.ts
+++ b/packages/core/src/rpc/procedures/option/delete.ts
@@ -1,0 +1,25 @@
+import { eq } from "../../../db/index.js";
+import { options } from "../../../db/schema/options.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { optionDeleteInputSchema } from "./schemas.js";
+
+const CAPABILITY = "option:manage";
+
+export const del = base
+  .use(authenticated)
+  .input(optionDeleteInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+
+    const [deleted] = await context.db
+      .delete(options)
+      .where(eq(options.name, input.name))
+      .returning();
+    if (!deleted) {
+      throw errors.NOT_FOUND({ data: { kind: "option", id: input.name } });
+    }
+    return context.hooks.applyFilter("rpc:option.delete:output", deleted);
+  });

--- a/packages/core/src/rpc/procedures/option/get.ts
+++ b/packages/core/src/rpc/procedures/option/get.ts
@@ -1,0 +1,24 @@
+import { eq } from "../../../db/index.js";
+import { options } from "../../../db/schema/options.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { optionGetInputSchema } from "./schemas.js";
+
+const CAPABILITY = "option:manage";
+
+export const get = base
+  .use(authenticated)
+  .input(optionGetInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+
+    const row = await context.db.query.options.findFirst({
+      where: eq(options.name, input.name),
+    });
+    if (!row) {
+      throw errors.NOT_FOUND({ data: { kind: "option", id: input.name } });
+    }
+    return context.hooks.applyFilter("rpc:option.get:output", row);
+  });

--- a/packages/core/src/rpc/procedures/option/index.ts
+++ b/packages/core/src/rpc/procedures/option/index.ts
@@ -1,0 +1,13 @@
+import { del } from "./delete.js";
+import { get } from "./get.js";
+import { list } from "./list.js";
+import { set } from "./set.js";
+
+export const optionRouter = {
+  list,
+  get,
+  set,
+  delete: del,
+} as const;
+
+export type OptionRouter = typeof optionRouter;

--- a/packages/core/src/rpc/procedures/option/list.ts
+++ b/packages/core/src/rpc/procedures/option/list.ts
@@ -1,0 +1,40 @@
+import { and, asc, eq, like } from "../../../db/index.js";
+import { options } from "../../../db/schema/options.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { optionListInputSchema } from "./schemas.js";
+
+const CAPABILITY = "option:manage";
+
+export const list = base
+  .use(authenticated)
+  .input(optionListInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+
+    const conditions = [];
+    if (input.autoloadedOnly === true) {
+      conditions.push(eq(options.isAutoloaded, true));
+    }
+    if (input.prefix) {
+      // SQLite's LIKE treats `_` and `%` as wildcards. Option names commonly
+      // contain underscores (e.g. `mail_smtp_host`), and escaping would need
+      // an ESCAPE clause drizzle doesn't expose on `like()`. Treating them
+      // as wildcards is an acceptable minor over-match — this is an admin-
+      // only surface and the name shape is already constrained by valibot.
+      conditions.push(like(options.name, `${input.prefix}%`));
+    }
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const rows = await context.db
+      .select()
+      .from(options)
+      .where(where)
+      .orderBy(asc(options.name))
+      .limit(input.limit)
+      .offset(input.offset);
+
+    return context.hooks.applyFilter("rpc:option.list:output", rows);
+  });

--- a/packages/core/src/rpc/procedures/option/option.test.ts
+++ b/packages/core/src/rpc/procedures/option/option.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "vitest";
+
+import { eq } from "../../../db/index.js";
+import { options } from "../../../db/schema/options.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("option.set", () => {
+  test("admin can insert a new option; autoload defaults to true", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const row = await h.client.option.set({
+      name: "site_title",
+      value: "Hello",
+    });
+    expect(row.name).toBe("site_title");
+    expect(row.value).toBe("Hello");
+    expect(row.isAutoloaded).toBe(true);
+  });
+
+  test("setting an existing option is an upsert (no CONFLICT)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.option.set({ name: "brand", value: "v1" });
+    const updated = await h.client.option.set({
+      name: "brand",
+      value: "v2",
+    });
+    expect(updated.value).toBe("v2");
+
+    const rows = await h.context.db
+      .select()
+      .from(options)
+      .where(eq(options.name, "brand"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.value).toBe("v2");
+  });
+
+  test("isAutoloaded can be explicitly disabled", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const row = await h.client.option.set({
+      name: "secret",
+      value: "x",
+      isAutoloaded: false,
+    });
+    expect(row.isAutoloaded).toBe(false);
+  });
+
+  test("editor cannot set options (admin-only gate)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await expect(
+      h.client.option.set({ name: "whatever", value: "nope" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "option:manage" },
+    });
+  });
+
+  test("rejects option names with disallowed characters", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    // leading space is rejected by the regex after v.trim() strips it; the
+    // input validator surfaces a ORPC-level input error, not a FORBIDDEN.
+    await expect(
+      h.client.option.set({ name: "bad name!", value: "x" }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("option.get", () => {
+  test("admin can read an option", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.option.set({ name: "k", value: "v" });
+    const got = await h.client.option.get({ name: "k" });
+    expect(got.value).toBe("v");
+  });
+
+  test("NOT_FOUND for a missing option", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.option.get({ name: "missing" }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      data: { kind: "option", id: "missing" },
+    });
+  });
+
+  test("editor cannot read options (reads gated by option:manage too)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await expect(h.client.option.get({ name: "k" })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "option:manage" },
+    });
+  });
+});
+
+describe("option.list", () => {
+  test("admin lists all options by default, sorted by name", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.option.set({ name: "zebra", value: "1" });
+    await h.client.option.set({ name: "alpha", value: "2" });
+    const rows = await h.client.option.list({});
+    expect(rows.map((r) => r.name)).toEqual(["alpha", "zebra"]);
+  });
+
+  test("autoloadedOnly narrows to rows with isAutoloaded=true", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.option.set({
+      name: "auto_yes",
+      value: "a",
+      isAutoloaded: true,
+    });
+    await h.client.option.set({
+      name: "auto_no",
+      value: "b",
+      isAutoloaded: false,
+    });
+    const rows = await h.client.option.list({ autoloadedOnly: true });
+    expect(rows.map((r) => r.name)).toEqual(["auto_yes"]);
+  });
+
+  test("prefix filters by leading substring", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.option.set({ name: "mail_smtp_host", value: "x" });
+    await h.client.option.set({ name: "mail_smtp_port", value: "y" });
+    await h.client.option.set({ name: "other", value: "z" });
+    const rows = await h.client.option.list({ prefix: "mail_" });
+    expect(rows.map((r) => r.name).sort()).toEqual([
+      "mail_smtp_host",
+      "mail_smtp_port",
+    ]);
+  });
+});
+
+describe("option.delete", () => {
+  test("admin can delete an option", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.option.set({ name: "gone", value: "x" });
+    const deleted = await h.client.option.delete({ name: "gone" });
+    expect(deleted.name).toBe("gone");
+
+    await expect(h.client.option.get({ name: "gone" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  test("NOT_FOUND when the option does not exist", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.option.delete({ name: "ghost" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("editor cannot delete options", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await expect(h.client.option.delete({ name: "x" })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "option:manage" },
+    });
+  });
+});

--- a/packages/core/src/rpc/procedures/option/schemas.ts
+++ b/packages/core/src/rpc/procedures/option/schemas.ts
@@ -1,0 +1,51 @@
+import * as v from "valibot";
+
+// Option names follow a permissive WordPress-ish convention — allow letters,
+// digits, underscores, dashes, dots. Kept reasonably tight to prevent wild
+// keys from consumers; 191 mirrors the MySQL UTF8MB4 PK index limit the
+// schema would hit on a future MySQL port.
+const optionNameSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(191),
+  v.regex(/^[a-zA-Z0-9_.-]+$/, "option name must be alphanumeric with _ - ."),
+);
+
+// Values are opaque strings — callers JSON-encode structured data themselves,
+// matching wp_options' semantics. 1 MB cap prevents runaway inserts from
+// becoming migration hazards.
+const optionValueSchema = v.pipe(v.string(), v.maxLength(1_000_000));
+
+export const optionListInputSchema = v.object({
+  autoloadedOnly: v.optional(v.boolean()),
+  prefix: v.optional(
+    v.pipe(
+      v.string(),
+      v.trim(),
+      v.minLength(1),
+      v.maxLength(191),
+      v.regex(/^[a-zA-Z0-9_.-]+$/, "prefix must be alphanumeric with _ - ."),
+    ),
+  ),
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(500)),
+    100,
+  ),
+  offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+});
+
+export const optionGetInputSchema = v.object({ name: optionNameSchema });
+
+export const optionSetInputSchema = v.object({
+  name: optionNameSchema,
+  value: optionValueSchema,
+  isAutoloaded: v.optional(v.boolean()),
+});
+
+export const optionDeleteInputSchema = v.object({ name: optionNameSchema });
+
+export type OptionListInput = v.InferOutput<typeof optionListInputSchema>;
+export type OptionGetInput = v.InferOutput<typeof optionGetInputSchema>;
+export type OptionSetInput = v.InferOutput<typeof optionSetInputSchema>;
+export type OptionDeleteInput = v.InferOutput<typeof optionDeleteInputSchema>;

--- a/packages/core/src/rpc/procedures/option/set.ts
+++ b/packages/core/src/rpc/procedures/option/set.ts
@@ -1,0 +1,44 @@
+import { options } from "../../../db/schema/options.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { optionSetInputSchema } from "./schemas.js";
+
+const CAPABILITY = "option:manage";
+
+export const set = base
+  .use(authenticated)
+  .input(optionSetInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+    const filtered = await context.hooks.applyFilter(
+      "rpc:option.set:input",
+      input,
+    );
+
+    const update: { value: string; isAutoloaded?: boolean } = {
+      value: filtered.value,
+    };
+    if (filtered.isAutoloaded !== undefined) {
+      update.isAutoloaded = filtered.isAutoloaded;
+    }
+
+    const [upserted] = await context.db
+      .insert(options)
+      .values({
+        name: filtered.name,
+        value: filtered.value,
+        isAutoloaded: filtered.isAutoloaded ?? true,
+      })
+      .onConflictDoUpdate({
+        target: options.name,
+        set: update,
+      })
+      .returning();
+    if (!upserted) {
+      throw errors.CONFLICT({ data: { reason: "upsert_failed" } });
+    }
+
+    return context.hooks.applyFilter("rpc:option.set:output", upserted);
+  });

--- a/packages/core/src/rpc/procedures/post/schemas.ts
+++ b/packages/core/src/rpc/procedures/post/schemas.ts
@@ -1,18 +1,13 @@
 import * as v from "valibot";
 
 import { postInsertSchema } from "../../../db/schema/posts.js";
+import { slugSchema } from "../../schemas.js";
 
-const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const MAX_CONTENT_BYTES = 1_000_000;
 const MAX_EXCERPT_LENGTH = 600;
 
 const trimmedText = (max: number) =>
   v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(max));
-
-const slugSchema = v.pipe(
-  trimmedText(200),
-  v.regex(slugPattern, "slug must be kebab-case ASCII"),
-);
 
 const postIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
 

--- a/packages/core/src/rpc/procedures/term/create.ts
+++ b/packages/core/src/rpc/procedures/term/create.ts
@@ -1,0 +1,63 @@
+import { and, eq, isUniqueConstraintError } from "../../../db/index.js";
+import { terms } from "../../../db/schema/terms.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { taxonomyCapability } from "./helpers.js";
+import { termCreateInputSchema } from "./schemas.js";
+
+export const create = base
+  .use(authenticated)
+  .input(termCreateInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:term.create:input",
+      input,
+    );
+
+    if (!context.plugins.taxonomies.has(filtered.taxonomy)) {
+      throw errors.NOT_FOUND({
+        data: { kind: "taxonomy", id: filtered.taxonomy },
+      });
+    }
+
+    const editCap = taxonomyCapability(filtered.taxonomy, "edit");
+    if (!context.auth.can(editCap)) {
+      throw errors.FORBIDDEN({ data: { capability: editCap } });
+    }
+
+    if (filtered.parentId !== undefined && filtered.parentId !== null) {
+      const parent = await context.db.query.terms.findFirst({
+        where: and(
+          eq(terms.id, filtered.parentId),
+          eq(terms.taxonomy, filtered.taxonomy),
+        ),
+      });
+      if (!parent) {
+        throw errors.CONFLICT({ data: { reason: "parent_mismatch" } });
+      }
+    }
+
+    let created;
+    try {
+      [created] = await context.db
+        .insert(terms)
+        .values({
+          taxonomy: filtered.taxonomy,
+          name: filtered.name,
+          slug: filtered.slug,
+          description: filtered.description ?? null,
+          parentId: filtered.parentId ?? null,
+        })
+        .returning();
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw errors.CONFLICT({ data: { reason: "slug_taken" } });
+      }
+      throw error;
+    }
+    if (!created) {
+      throw errors.CONFLICT({ data: { reason: "insert_failed" } });
+    }
+
+    return context.hooks.applyFilter("rpc:term.create:output", created);
+  });

--- a/packages/core/src/rpc/procedures/term/delete.ts
+++ b/packages/core/src/rpc/procedures/term/delete.ts
@@ -1,0 +1,35 @@
+import { eq } from "../../../db/index.js";
+import { terms } from "../../../db/schema/terms.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { taxonomyCapability } from "./helpers.js";
+import { termDeleteInputSchema } from "./schemas.js";
+
+export const del = base
+  .use(authenticated)
+  .input(termDeleteInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const existing = await context.db.query.terms.findFirst({
+      where: eq(terms.id, input.id),
+    });
+    if (!existing) {
+      throw errors.NOT_FOUND({ data: { kind: "term", id: input.id } });
+    }
+
+    const deleteCap = taxonomyCapability(existing.taxonomy, "delete");
+    if (!context.auth.can(deleteCap)) {
+      throw errors.FORBIDDEN({ data: { capability: deleteCap } });
+    }
+
+    // post_term cascades via the FK; children terms get parentId = null via
+    // the terms.parentId self-reference `onDelete: set null`.
+    const [deleted] = await context.db
+      .delete(terms)
+      .where(eq(terms.id, existing.id))
+      .returning();
+    if (!deleted) {
+      throw errors.CONFLICT({ data: { reason: "delete_failed" } });
+    }
+
+    return context.hooks.applyFilter("rpc:term.delete:output", deleted);
+  });

--- a/packages/core/src/rpc/procedures/term/get.ts
+++ b/packages/core/src/rpc/procedures/term/get.ts
@@ -1,0 +1,26 @@
+import { eq } from "../../../db/index.js";
+import { terms } from "../../../db/schema/terms.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { taxonomyCapability } from "./helpers.js";
+import { termGetInputSchema } from "./schemas.js";
+
+export const get = base
+  .use(authenticated)
+  .input(termGetInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const row = await context.db.query.terms.findFirst({
+      where: eq(terms.id, input.id),
+    });
+    if (!row) {
+      throw errors.NOT_FOUND({ data: { kind: "term", id: input.id } });
+    }
+
+    const readCap = taxonomyCapability(row.taxonomy, "read");
+    if (!context.auth.can(readCap)) {
+      // Hide existence — mirror post.get's "no oracle" rule.
+      throw errors.NOT_FOUND({ data: { kind: "term", id: input.id } });
+    }
+
+    return context.hooks.applyFilter("rpc:term.get:output", row);
+  });

--- a/packages/core/src/rpc/procedures/term/helpers.ts
+++ b/packages/core/src/rpc/procedures/term/helpers.ts
@@ -1,0 +1,39 @@
+import type { Db } from "../../../context/app.js";
+import type { Term } from "../../../db/schema/terms.js";
+import { eq } from "../../../db/index.js";
+import { terms } from "../../../db/schema/terms.js";
+
+export function taxonomyCapability(taxonomy: string, action: string): string {
+  return `${taxonomy}:${action}`;
+}
+
+/**
+ * Follow the parent chain from `candidateParentId` toward the root.
+ * Returns true iff `selfId` appears in the chain — i.e., setting
+ * selfId.parentId = candidateParentId would create a cycle.
+ * Caps traversal depth so a pre-existing cycle can't spin forever;
+ * returns true on cap-hit as a conservative default (refuse the change
+ * rather than risk extending a corrupt cycle we couldn't finish walking).
+ * Explicit annotation on `row` works around a drizzle recursive-type quirk.
+ */
+export async function parentWouldCreateCycle(
+  db: Db,
+  selfId: number,
+  candidateParentId: number,
+): Promise<boolean> {
+  const MAX_DEPTH = 100;
+  let currentId: number | null = candidateParentId;
+  for (let hop = 0; hop < MAX_DEPTH && currentId !== null; hop++) {
+    if (currentId === selfId) return true;
+    const row: Pick<Term, "parentId"> | undefined =
+      await db.query.terms.findFirst({
+        columns: { parentId: true },
+        where: eq(terms.id, currentId),
+      });
+    if (!row) return false;
+    currentId = row.parentId;
+  }
+  // Exhausted the cap without reaching the root — pre-existing corrupt cycle
+  // or impossibly deep tree. Treat as unsafe.
+  return currentId !== null;
+}

--- a/packages/core/src/rpc/procedures/term/index.ts
+++ b/packages/core/src/rpc/procedures/term/index.ts
@@ -1,0 +1,15 @@
+import { create } from "./create.js";
+import { del } from "./delete.js";
+import { get } from "./get.js";
+import { list } from "./list.js";
+import { update } from "./update.js";
+
+export const termRouter = {
+  list,
+  get,
+  create,
+  update,
+  delete: del,
+} as const;
+
+export type TermRouter = typeof termRouter;

--- a/packages/core/src/rpc/procedures/term/list.ts
+++ b/packages/core/src/rpc/procedures/term/list.ts
@@ -1,0 +1,47 @@
+import { and, asc, eq, isNull, like } from "../../../db/index.js";
+import { terms } from "../../../db/schema/terms.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { taxonomyCapability } from "./helpers.js";
+import { termListInputSchema } from "./schemas.js";
+
+export const list = base
+  .use(authenticated)
+  .input(termListInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:term.list:input",
+      input,
+    );
+
+    if (!context.plugins.taxonomies.has(filtered.taxonomy)) {
+      throw errors.NOT_FOUND({
+        data: { kind: "taxonomy", id: filtered.taxonomy },
+      });
+    }
+
+    const readCap = taxonomyCapability(filtered.taxonomy, "read");
+    if (!context.auth.can(readCap)) {
+      throw errors.FORBIDDEN({ data: { capability: readCap } });
+    }
+
+    const conditions = [eq(terms.taxonomy, filtered.taxonomy)];
+    if (filtered.parentId === null) {
+      conditions.push(isNull(terms.parentId));
+    } else if (filtered.parentId !== undefined) {
+      conditions.push(eq(terms.parentId, filtered.parentId));
+    }
+    if (filtered.search && filtered.search.length > 0) {
+      conditions.push(like(terms.name, `%${filtered.search}%`));
+    }
+
+    const rows = await context.db
+      .select()
+      .from(terms)
+      .where(and(...conditions))
+      .orderBy(asc(terms.name), asc(terms.id))
+      .limit(filtered.limit)
+      .offset(filtered.offset);
+
+    return context.hooks.applyFilter("rpc:term.list:output", rows);
+  });

--- a/packages/core/src/rpc/procedures/term/schemas.ts
+++ b/packages/core/src/rpc/procedures/term/schemas.ts
@@ -1,0 +1,66 @@
+import * as v from "valibot";
+
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const termIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
+
+const taxonomySchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(100),
+);
+
+const nameSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(200),
+);
+
+const slugSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(200),
+  v.regex(slugPattern, "slug must be kebab-case ASCII"),
+);
+
+const descriptionSchema = v.nullable(v.pipe(v.string(), v.maxLength(10_000)));
+
+export const termListInputSchema = v.object({
+  taxonomy: taxonomySchema,
+  parentId: v.optional(v.nullable(termIdSchema)),
+  search: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200))),
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(200)),
+    50,
+  ),
+  offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+});
+
+export const termGetInputSchema = v.object({ id: termIdSchema });
+
+export const termCreateInputSchema = v.object({
+  taxonomy: taxonomySchema,
+  name: nameSchema,
+  slug: slugSchema,
+  description: v.optional(descriptionSchema),
+  parentId: v.optional(v.nullable(termIdSchema)),
+});
+
+export const termUpdateInputSchema = v.object({
+  id: termIdSchema,
+  name: v.optional(nameSchema),
+  slug: v.optional(slugSchema),
+  description: v.optional(descriptionSchema),
+  parentId: v.optional(v.nullable(termIdSchema)),
+});
+
+export const termDeleteInputSchema = v.object({ id: termIdSchema });
+
+export type TermListInput = v.InferOutput<typeof termListInputSchema>;
+export type TermGetInput = v.InferOutput<typeof termGetInputSchema>;
+export type TermCreateInput = v.InferOutput<typeof termCreateInputSchema>;
+export type TermUpdateInput = v.InferOutput<typeof termUpdateInputSchema>;
+export type TermDeleteInput = v.InferOutput<typeof termDeleteInputSchema>;

--- a/packages/core/src/rpc/procedures/term/schemas.ts
+++ b/packages/core/src/rpc/procedures/term/schemas.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
 
-const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+import { slugSchema } from "../../schemas.js";
 
 const termIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
 
@@ -16,14 +16,6 @@ const nameSchema = v.pipe(
   v.trim(),
   v.minLength(1),
   v.maxLength(200),
-);
-
-const slugSchema = v.pipe(
-  v.string(),
-  v.trim(),
-  v.minLength(1),
-  v.maxLength(200),
-  v.regex(slugPattern, "slug must be kebab-case ASCII"),
 );
 
 const descriptionSchema = v.nullable(v.pipe(v.string(), v.maxLength(10_000)));

--- a/packages/core/src/rpc/procedures/term/term.test.ts
+++ b/packages/core/src/rpc/procedures/term/term.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, test } from "vitest";
+
+import type { UserRole } from "../../../db/schema/users.js";
+import { eq } from "../../../db/index.js";
+import { terms } from "../../../db/schema/terms.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+function first<T>(rows: T[]): T {
+  const [row] = rows;
+  if (!row) throw new Error("expected at least one row from the db");
+  return row;
+}
+
+// "category" is the canonical hierarchical taxonomy in WP; used here as the
+// fixture because term RPC requires a registered taxonomy to operate.
+function taxonomyRegistry() {
+  const registry = createPluginRegistry();
+  registry.taxonomies.set("category", {
+    name: "category",
+    label: "Categories",
+    isHierarchical: true,
+    registeredBy: "test",
+  });
+  const caps: Record<string, UserRole> = {
+    "category:read": "subscriber",
+    "category:assign": "contributor",
+    "category:edit": "editor",
+    "category:delete": "editor",
+  };
+  for (const [name, minRole] of Object.entries(caps)) {
+    registry.capabilities.set(name, { name, minRole, registeredBy: "test" });
+  }
+  return registry;
+}
+
+describe("term.list", () => {
+  test("returns terms in the requested taxonomy", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "subscriber", plugins });
+    await h.context.db.insert(terms).values([
+      { taxonomy: "category", name: "Alpha", slug: "alpha" },
+      { taxonomy: "category", name: "Beta", slug: "beta" },
+    ]);
+
+    const rows = await h.client.term.list({ taxonomy: "category" });
+    expect(rows.map((r) => r.slug).sort()).toEqual(["alpha", "beta"]);
+  });
+
+  test("unregistered taxonomy is NOT_FOUND (signals 'no such taxonomy')", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    await expect(
+      h.client.term.list({ taxonomy: "unknown" }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      data: { kind: "taxonomy", id: "unknown" },
+    });
+  });
+
+  test("parentId=null returns only top-level terms", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "subscriber", plugins });
+    const root = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "Root", slug: "root" })
+        .returning(),
+    );
+    await h.context.db.insert(terms).values({
+      taxonomy: "category",
+      name: "Child",
+      slug: "child",
+      parentId: root.id,
+    });
+    const top = await h.client.term.list({
+      taxonomy: "category",
+      parentId: null,
+    });
+    expect(top.map((r) => r.slug)).toEqual(["root"]);
+  });
+});
+
+describe("term.get", () => {
+  test("returns the term", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "subscriber", plugins });
+    const row = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "Got", slug: "got" })
+        .returning(),
+    );
+
+    const got = await h.client.term.get({ id: row.id });
+    expect(got.slug).toBe("got");
+  });
+
+  test("404 when the term does not exist", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "subscriber", plugins });
+    await expect(h.client.term.get({ id: 9999 })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      data: { kind: "term", id: 9999 },
+    });
+  });
+});
+
+describe("term.create", () => {
+  test("editor can create a term", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    const created = await h.client.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+    expect(created.slug).toBe("news");
+  });
+
+  test("author cannot create (cap is editor+)", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "author", plugins });
+    await expect(
+      h.client.term.create({
+        taxonomy: "category",
+        name: "Nope",
+        slug: "nope",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "category:edit" },
+    });
+  });
+
+  test("slug collision within taxonomy → CONFLICT", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    await h.client.term.create({
+      taxonomy: "category",
+      name: "Dup",
+      slug: "dup",
+    });
+    await expect(
+      h.client.term.create({
+        taxonomy: "category",
+        name: "Dup2",
+        slug: "dup",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "slug_taken" },
+    });
+  });
+
+  test("parent in a different taxonomy → CONFLICT", async () => {
+    const plugins = taxonomyRegistry();
+    plugins.taxonomies.set("post_tag", {
+      name: "post_tag",
+      label: "Tags",
+      registeredBy: "test",
+    });
+    plugins.capabilities.set("post_tag:edit", {
+      name: "post_tag:edit",
+      minRole: "editor",
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    const otherTaxRow = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "post_tag", name: "Tag", slug: "tag-1" })
+        .returning(),
+    );
+    await expect(
+      h.client.term.create({
+        taxonomy: "category",
+        name: "Child",
+        slug: "child",
+        parentId: otherTaxRow.id,
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "parent_mismatch" },
+    });
+  });
+});
+
+describe("term.update", () => {
+  test("editor can rename a term", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    const row = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "Old", slug: "old" })
+        .returning(),
+    );
+    const updated = await h.client.term.update({
+      id: row.id,
+      name: "New Name",
+    });
+    expect(updated.name).toBe("New Name");
+  });
+
+  test("subscriber cannot update", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "subscriber", plugins });
+    const row = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "Name", slug: "name" })
+        .returning(),
+    );
+    await expect(
+      h.client.term.update({ id: row.id, name: "Hax" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "category:edit" },
+    });
+  });
+
+  test("setting parent = self → CONFLICT (parent_is_self)", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    const row = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "Self", slug: "self" })
+        .returning(),
+    );
+    await expect(
+      h.client.term.update({ id: row.id, parentId: row.id }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "parent_is_self" },
+    });
+  });
+
+  test("cycle detection rejects setting parent to a descendant", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    // A -> B -> C (B's parent is A; C's parent is B).
+    const a = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "A", slug: "a" })
+        .returning(),
+    );
+    const b = first(
+      await h.context.db
+        .insert(terms)
+        .values({
+          taxonomy: "category",
+          name: "B",
+          slug: "b",
+          parentId: a.id,
+        })
+        .returning(),
+    );
+    const c = first(
+      await h.context.db
+        .insert(terms)
+        .values({
+          taxonomy: "category",
+          name: "C",
+          slug: "c",
+          parentId: b.id,
+        })
+        .returning(),
+    );
+    // Attempting A.parent = C would form a cycle A -> C -> B -> A.
+    await expect(
+      h.client.term.update({ id: a.id, parentId: c.id }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "parent_cycle" },
+    });
+  });
+
+  test("slug collision on update → CONFLICT", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    const a = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "A", slug: "a-slug" })
+        .returning(),
+    );
+    await h.context.db
+      .insert(terms)
+      .values({ taxonomy: "category", name: "B", slug: "b-slug" });
+    await expect(
+      h.client.term.update({ id: a.id, slug: "b-slug" }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "slug_taken" },
+    });
+  });
+});
+
+describe("term.delete", () => {
+  test("editor can delete a term; children have parentId nulled", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    const parent = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "P", slug: "p" })
+        .returning(),
+    );
+    const child = first(
+      await h.context.db
+        .insert(terms)
+        .values({
+          taxonomy: "category",
+          name: "C",
+          slug: "c",
+          parentId: parent.id,
+        })
+        .returning(),
+    );
+
+    await h.client.term.delete({ id: parent.id });
+
+    const orphan = await h.context.db.query.terms.findFirst({
+      where: eq(terms.id, child.id),
+    });
+    expect(orphan?.parentId).toBeNull();
+  });
+
+  test("author cannot delete", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "author", plugins });
+    const row = first(
+      await h.context.db
+        .insert(terms)
+        .values({ taxonomy: "category", name: "X", slug: "x" })
+        .returning(),
+    );
+    await expect(h.client.term.delete({ id: row.id })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "category:delete" },
+    });
+  });
+
+  test("404 when the term does not exist", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    await expect(h.client.term.delete({ id: 9999 })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+});

--- a/packages/core/src/rpc/procedures/term/update.ts
+++ b/packages/core/src/rpc/procedures/term/update.ts
@@ -1,0 +1,79 @@
+import type { NewTerm } from "../../../db/schema/terms.js";
+import { and, eq, isUniqueConstraintError } from "../../../db/index.js";
+import { terms } from "../../../db/schema/terms.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { stripUndefined } from "../post/helpers.js";
+import { parentWouldCreateCycle, taxonomyCapability } from "./helpers.js";
+import { termUpdateInputSchema } from "./schemas.js";
+
+export const update = base
+  .use(authenticated)
+  .input(termUpdateInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:term.update:input",
+      input,
+    );
+
+    const existing = await context.db.query.terms.findFirst({
+      where: eq(terms.id, filtered.id),
+    });
+    if (!existing) {
+      throw errors.NOT_FOUND({ data: { kind: "term", id: filtered.id } });
+    }
+
+    const editCap = taxonomyCapability(existing.taxonomy, "edit");
+    if (!context.auth.can(editCap)) {
+      throw errors.FORBIDDEN({ data: { capability: editCap } });
+    }
+
+    if (
+      filtered.parentId !== undefined &&
+      filtered.parentId !== null &&
+      filtered.parentId !== existing.parentId
+    ) {
+      if (filtered.parentId === existing.id) {
+        throw errors.CONFLICT({ data: { reason: "parent_is_self" } });
+      }
+      const parent = await context.db.query.terms.findFirst({
+        where: and(
+          eq(terms.id, filtered.parentId),
+          eq(terms.taxonomy, existing.taxonomy),
+        ),
+      });
+      if (!parent) {
+        throw errors.CONFLICT({ data: { reason: "parent_mismatch" } });
+      }
+      if (
+        await parentWouldCreateCycle(context.db, existing.id, filtered.parentId)
+      ) {
+        throw errors.CONFLICT({ data: { reason: "parent_cycle" } });
+      }
+    }
+
+    const { id: _id, ...changes } = filtered;
+    const patch: Partial<NewTerm> = stripUndefined(changes);
+    if (Object.keys(patch).length === 0) {
+      return context.hooks.applyFilter("rpc:term.update:output", existing);
+    }
+
+    let updated;
+    try {
+      [updated] = await context.db
+        .update(terms)
+        .set(patch)
+        .where(eq(terms.id, existing.id))
+        .returning();
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw errors.CONFLICT({ data: { reason: "slug_taken" } });
+      }
+      throw error;
+    }
+    if (!updated) {
+      throw errors.CONFLICT({ data: { reason: "update_failed" } });
+    }
+
+    return context.hooks.applyFilter("rpc:term.update:output", updated);
+  });

--- a/packages/core/src/rpc/procedures/user/delete.ts
+++ b/packages/core/src/rpc/procedures/user/delete.ts
@@ -1,0 +1,75 @@
+import { and, count, eq } from "../../../db/index.js";
+import { posts } from "../../../db/schema/posts.js";
+import { users } from "../../../db/schema/users.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { otherActiveAdminExists } from "./helpers.js";
+import { userDeleteInputSchema } from "./schemas.js";
+
+const CAPABILITY = "user:delete";
+
+export const del = base
+  .use(authenticated)
+  .input(userDeleteInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+
+    const existing = await context.db.query.users.findFirst({
+      where: eq(users.id, input.id),
+    });
+    if (!existing) {
+      throw errors.NOT_FOUND({ data: { kind: "user", id: input.id } });
+    }
+
+    // posts.authorId FK is onDelete: restrict — reassign first or refuse.
+    const [countRow] = await context.db
+      .select({ value: count() })
+      .from(posts)
+      .where(eq(posts.authorId, existing.id));
+    const postCount = countRow?.value ?? 0;
+
+    if (postCount > 0) {
+      if (input.reassignPostsTo === undefined) {
+        throw errors.CONFLICT({ data: { reason: "has_posts" } });
+      }
+      if (input.reassignPostsTo === existing.id) {
+        throw errors.CONFLICT({ data: { reason: "reassign_to_self" } });
+      }
+      const target = await context.db.query.users.findFirst({
+        where: eq(users.id, input.reassignPostsTo),
+      });
+      if (!target) {
+        throw errors.NOT_FOUND({
+          data: { kind: "user", id: input.reassignPostsTo },
+        });
+      }
+      await context.db
+        .update(posts)
+        .set({ authorId: input.reassignPostsTo })
+        .where(eq(posts.authorId, existing.id));
+    }
+
+    // Atomic last-admin guard — see user/update.ts for the same pattern.
+    const whereClause =
+      existing.role === "admin"
+        ? and(
+            eq(users.id, existing.id),
+            otherActiveAdminExists(context.db, existing.id),
+          )
+        : eq(users.id, existing.id);
+
+    const [deleted] = await context.db
+      .delete(users)
+      .where(whereClause)
+      .returning();
+    if (!deleted) {
+      if (existing.role === "admin") {
+        throw errors.CONFLICT({ data: { reason: "last_admin" } });
+      }
+      throw errors.CONFLICT({ data: { reason: "delete_failed" } });
+    }
+
+    return context.hooks.applyFilter("rpc:user.delete:output", deleted);
+  });

--- a/packages/core/src/rpc/procedures/user/disable.ts
+++ b/packages/core/src/rpc/procedures/user/disable.ts
@@ -1,0 +1,54 @@
+import { invalidateAllSessionsForUser } from "../../../auth/sessions.js";
+import { and, eq } from "../../../db/index.js";
+import { users } from "../../../db/schema/users.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { otherActiveAdminExists } from "./helpers.js";
+import { userDisableInputSchema } from "./schemas.js";
+
+const CAPABILITY = "user:edit";
+
+export const disable = base
+  .use(authenticated)
+  .input(userDisableInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+
+    const existing = await context.db.query.users.findFirst({
+      where: eq(users.id, input.id),
+    });
+    if (!existing) {
+      throw errors.NOT_FOUND({ data: { kind: "user", id: input.id } });
+    }
+    if (existing.disabledAt) {
+      return context.hooks.applyFilter("rpc:user.disable:output", existing);
+    }
+
+    // Last-admin guard inlined into the WHERE clause — atomic with the write,
+    // so two concurrent disables of different admins can't both pass.
+    const whereClause =
+      existing.role === "admin"
+        ? and(
+            eq(users.id, existing.id),
+            otherActiveAdminExists(context.db, existing.id),
+          )
+        : eq(users.id, existing.id);
+
+    const [updated] = await context.db
+      .update(users)
+      .set({ disabledAt: new Date() })
+      .where(whereClause)
+      .returning();
+    if (!updated) {
+      if (existing.role === "admin") {
+        throw errors.CONFLICT({ data: { reason: "last_admin" } });
+      }
+      throw errors.CONFLICT({ data: { reason: "update_failed" } });
+    }
+
+    await invalidateAllSessionsForUser(context.db, updated.id);
+
+    return context.hooks.applyFilter("rpc:user.disable:output", updated);
+  });

--- a/packages/core/src/rpc/procedures/user/get.ts
+++ b/packages/core/src/rpc/procedures/user/get.ts
@@ -1,0 +1,27 @@
+import { eq } from "../../../db/index.js";
+import { users } from "../../../db/schema/users.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { userGetInputSchema } from "./schemas.js";
+
+// Listing gates access to arbitrary user records; self-lookup is always
+// allowed via `user:edit_own` so admin UIs can render "your profile".
+const LIST_CAPABILITY = "user:list";
+
+export const get = base
+  .use(authenticated)
+  .input(userGetInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const isSelf = context.user.id === input.id;
+    if (!isSelf && !context.auth.can(LIST_CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: LIST_CAPABILITY } });
+    }
+
+    const row = await context.db.query.users.findFirst({
+      where: eq(users.id, input.id),
+    });
+    if (!row) {
+      throw errors.NOT_FOUND({ data: { kind: "user", id: input.id } });
+    }
+    return context.hooks.applyFilter("rpc:user.get:output", row);
+  });

--- a/packages/core/src/rpc/procedures/user/helpers.ts
+++ b/packages/core/src/rpc/procedures/user/helpers.ts
@@ -1,0 +1,25 @@
+import type { Db } from "../../../context/app.js";
+import { and, eq, exists, isNull, ne } from "../../../db/index.js";
+import { users } from "../../../db/schema/users.js";
+
+/**
+ * Subquery: true when an active admin OTHER than `excludeUserId` exists.
+ *
+ * Used as an atomic WHERE-clause predicate on UPDATE/DELETE against
+ * `users` so the last-admin check happens at write time — not in a
+ * read-then-write pair that two concurrent demotions could both pass.
+ */
+export function otherActiveAdminExists(db: Db, excludeUserId: number) {
+  return exists(
+    db
+      .select({ v: users.id })
+      .from(users)
+      .where(
+        and(
+          eq(users.role, "admin"),
+          isNull(users.disabledAt),
+          ne(users.id, excludeUserId),
+        ),
+      ),
+  );
+}

--- a/packages/core/src/rpc/procedures/user/index.ts
+++ b/packages/core/src/rpc/procedures/user/index.ts
@@ -1,0 +1,17 @@
+import { del } from "./delete.js";
+import { disable } from "./disable.js";
+import { get } from "./get.js";
+import { invite } from "./invite.js";
+import { list } from "./list.js";
+import { update } from "./update.js";
+
+export const userRouter = {
+  list,
+  get,
+  invite,
+  update,
+  disable,
+  delete: del,
+} as const;
+
+export type UserRouter = typeof userRouter;

--- a/packages/core/src/rpc/procedures/user/invite.ts
+++ b/packages/core/src/rpc/procedures/user/invite.ts
@@ -1,0 +1,60 @@
+import { generateToken, hashToken } from "../../../auth/tokens.js";
+import { isUniqueConstraintError } from "../../../db/index.js";
+import { authTokens } from "../../../db/schema/auth_tokens.js";
+import { users } from "../../../db/schema/users.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { userInviteInputSchema } from "./schemas.js";
+
+const CREATE_CAPABILITY = "user:create";
+const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const invite = base
+  .use(authenticated)
+  .input(userInviteInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CREATE_CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CREATE_CAPABILITY } });
+    }
+    const filtered = await context.hooks.applyFilter(
+      "rpc:user.invite:input",
+      input,
+    );
+
+    const token = generateToken();
+    const tokenHash = await hashToken(token);
+    const expiresAt = new Date(Date.now() + INVITE_TTL_MS);
+
+    let created;
+    try {
+      [created] = await context.db
+        .insert(users)
+        .values({
+          email: filtered.email,
+          name: filtered.name ?? null,
+          role: filtered.role,
+        })
+        .returning();
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw errors.CONFLICT({ data: { reason: "email_taken" } });
+      }
+      throw error;
+    }
+    if (!created) {
+      throw errors.CONFLICT({ data: { reason: "insert_failed" } });
+    }
+
+    await context.db.insert(authTokens).values({
+      hash: tokenHash,
+      userId: created.id,
+      email: filtered.email,
+      type: "invite",
+      role: filtered.role,
+      invitedBy: context.user.id,
+      expiresAt,
+    });
+
+    const output = { user: created, inviteToken: token };
+    return context.hooks.applyFilter("rpc:user.invite:output", output);
+  });

--- a/packages/core/src/rpc/procedures/user/list.ts
+++ b/packages/core/src/rpc/procedures/user/list.ts
@@ -1,0 +1,37 @@
+import { and, desc, eq, like } from "../../../db/index.js";
+import { users } from "../../../db/schema/users.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { userListInputSchema } from "./schemas.js";
+
+const CAPABILITY = "user:list";
+
+export const list = base
+  .use(authenticated)
+  .input(userListInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+    const filtered = await context.hooks.applyFilter(
+      "rpc:user.list:input",
+      input,
+    );
+
+    const conditions = [];
+    if (filtered.role) conditions.push(eq(users.role, filtered.role));
+    if (filtered.search && filtered.search.length > 0) {
+      conditions.push(like(users.email, `%${filtered.search}%`));
+    }
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const rows = await context.db
+      .select()
+      .from(users)
+      .where(where)
+      .orderBy(desc(users.createdAt), desc(users.id))
+      .limit(filtered.limit)
+      .offset(filtered.offset);
+
+    return context.hooks.applyFilter("rpc:user.list:output", rows);
+  });

--- a/packages/core/src/rpc/procedures/user/schemas.ts
+++ b/packages/core/src/rpc/procedures/user/schemas.ts
@@ -1,0 +1,67 @@
+import * as v from "valibot";
+
+import { USER_ROLES } from "../../../db/schema/users.js";
+
+const userIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
+
+const emailSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(254),
+  v.email("email must be a valid address"),
+);
+
+const nameSchema = v.pipe(v.string(), v.trim(), v.maxLength(200));
+
+const avatarUrlSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.maxLength(2048),
+  v.url(),
+);
+
+const roleSchema = v.picklist(USER_ROLES);
+
+const searchSchema = v.pipe(v.string(), v.trim(), v.maxLength(200));
+
+export const userListInputSchema = v.object({
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
+    20,
+  ),
+  offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+  role: v.optional(roleSchema),
+  search: v.optional(searchSchema),
+});
+
+export const userGetInputSchema = v.object({ id: userIdSchema });
+
+export const userInviteInputSchema = v.object({
+  email: emailSchema,
+  role: v.optional(roleSchema, "subscriber"),
+  name: v.optional(v.nullable(nameSchema)),
+});
+
+export const userUpdateInputSchema = v.object({
+  id: userIdSchema,
+  email: v.optional(emailSchema),
+  name: v.optional(v.nullable(nameSchema)),
+  avatarUrl: v.optional(v.nullable(avatarUrlSchema)),
+  role: v.optional(roleSchema),
+});
+
+export const userDisableInputSchema = v.object({ id: userIdSchema });
+
+export const userDeleteInputSchema = v.object({
+  id: userIdSchema,
+  /** Reassign this user's authored posts to the given user id before deletion. */
+  reassignPostsTo: v.optional(userIdSchema),
+});
+
+export type UserListInput = v.InferOutput<typeof userListInputSchema>;
+export type UserGetInput = v.InferOutput<typeof userGetInputSchema>;
+export type UserInviteInput = v.InferOutput<typeof userInviteInputSchema>;
+export type UserUpdateInput = v.InferOutput<typeof userUpdateInputSchema>;
+export type UserDisableInput = v.InferOutput<typeof userDisableInputSchema>;
+export type UserDeleteInput = v.InferOutput<typeof userDeleteInputSchema>;

--- a/packages/core/src/rpc/procedures/user/update.ts
+++ b/packages/core/src/rpc/procedures/user/update.ts
@@ -1,0 +1,95 @@
+import type { NewUser } from "../../../db/schema/users.js";
+import { invalidateAllSessionsForUser } from "../../../auth/sessions.js";
+import { and, eq, isUniqueConstraintError } from "../../../db/index.js";
+import { users } from "../../../db/schema/users.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { stripUndefined } from "../post/helpers.js";
+import { otherActiveAdminExists } from "./helpers.js";
+import { userUpdateInputSchema } from "./schemas.js";
+
+const EDIT_OWN_CAPABILITY = "user:edit_own";
+const EDIT_CAPABILITY = "user:edit";
+const PROMOTE_CAPABILITY = "user:promote";
+
+export const update = base
+  .use(authenticated)
+  .input(userUpdateInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:user.update:input",
+      input,
+    );
+
+    const existing = await context.db.query.users.findFirst({
+      where: eq(users.id, filtered.id),
+    });
+    if (!existing) {
+      throw errors.NOT_FOUND({ data: { kind: "user", id: filtered.id } });
+    }
+
+    const isSelf = existing.id === context.user.id;
+    const canEdit = isSelf
+      ? context.auth.can(EDIT_OWN_CAPABILITY)
+      : context.auth.can(EDIT_CAPABILITY);
+    if (!canEdit) {
+      throw errors.FORBIDDEN({
+        data: { capability: isSelf ? EDIT_OWN_CAPABILITY : EDIT_CAPABILITY },
+      });
+    }
+
+    // Role changes are a separate privilege — even self-edits can't promote.
+    const wantsRoleChange =
+      filtered.role !== undefined && filtered.role !== existing.role;
+    if (wantsRoleChange && !context.auth.can(PROMOTE_CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: PROMOTE_CAPABILITY } });
+    }
+    const demotingAdmin =
+      wantsRoleChange && existing.role === "admin" && filtered.role !== "admin";
+
+    const { id: _id, ...changes } = filtered;
+    const patch: Partial<NewUser> = stripUndefined(changes);
+    if (Object.keys(patch).length === 0) {
+      return context.hooks.applyFilter("rpc:user.update:output", existing);
+    }
+
+    // Last-admin guard inlined into the UPDATE WHERE clause: the row only
+    // updates if another active admin still exists at write time. Closes a
+    // TOCTOU race where two concurrent demotions could each pass a separate
+    // "isLastActiveAdmin" check and both succeed, locking everyone out.
+    const whereClause = demotingAdmin
+      ? and(
+          eq(users.id, existing.id),
+          otherActiveAdminExists(context.db, existing.id),
+        )
+      : eq(users.id, existing.id);
+
+    let updated;
+    try {
+      [updated] = await context.db
+        .update(users)
+        .set(patch)
+        .where(whereClause)
+        .returning();
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw errors.CONFLICT({ data: { reason: "email_taken" } });
+      }
+      throw error;
+    }
+    if (!updated) {
+      if (demotingAdmin) {
+        throw errors.CONFLICT({ data: { reason: "last_admin" } });
+      }
+      throw errors.CONFLICT({ data: { reason: "update_failed" } });
+    }
+
+    // Any role change → existing sessions carry a cached role via AppContext
+    // until they expire. Invalidate so the next request re-auths and picks up
+    // the new role (tightens demotions immediately; upgrades, too).
+    if (wantsRoleChange) {
+      await invalidateAllSessionsForUser(context.db, updated.id);
+    }
+
+    return context.hooks.applyFilter("rpc:user.update:output", updated);
+  });

--- a/packages/core/src/rpc/procedures/user/user.test.ts
+++ b/packages/core/src/rpc/procedures/user/user.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from "vitest";
+
+import { eq } from "../../../db/index.js";
+import { posts } from "../../../db/schema/posts.js";
+import { sessions } from "../../../db/schema/sessions.js";
+import { users } from "../../../db/schema/users.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("user.list", () => {
+  test("editor+ can list users; others get FORBIDDEN", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.user.create({ email: "a@example.test" });
+    const rows = await h.client.user.list({});
+    expect(rows.length).toBeGreaterThanOrEqual(2); // the authed editor + the created user
+  });
+
+  test("subscriber cannot list users", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await expect(h.client.user.list({})).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "user:list" },
+    });
+  });
+
+  test("role filter narrows results", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.factory.editor.create({ email: "e@example.test" });
+    await h.factory.subscriber.create({ email: "s@example.test" });
+    const editors = await h.client.user.list({ role: "editor" });
+    expect(editors.every((u) => u.role === "editor")).toBe(true);
+    expect(editors.some((u) => u.email === "e@example.test")).toBe(true);
+  });
+
+  test("search filters by email substring", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.factory.user.create({ email: "alice@example.test" });
+    await h.factory.user.create({ email: "bob@example.test" });
+    const matched = await h.client.user.list({ search: "alice" });
+    expect(matched.map((u) => u.email)).toEqual(["alice@example.test"]);
+  });
+});
+
+describe("user.get", () => {
+  test("self-lookup always allowed (no user:list needed)", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const got = await h.client.user.get({ id: h.user.id });
+    expect(got.id).toBe(h.user.id);
+  });
+
+  test("subscriber looking up another user is FORBIDDEN", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const other = await h.factory.user.create({ email: "other@example.test" });
+    await expect(h.client.user.get({ id: other.id })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  test("editor can look up any user", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const other = await h.factory.subscriber.create();
+    const got = await h.client.user.get({ id: other.id });
+    expect(got.id).toBe(other.id);
+  });
+
+  test("404 when the target id does not exist", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(h.client.user.get({ id: 999999 })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+});
+
+describe("user.invite", () => {
+  test("admin can invite; returns user row + opaque invite token", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const { user, inviteToken } = await h.client.user.invite({
+      email: "new@example.test",
+      role: "author",
+    });
+    expect(user.email).toBe("new@example.test");
+    expect(user.role).toBe("author");
+    expect(typeof inviteToken).toBe("string");
+    expect(inviteToken.length).toBeGreaterThan(20);
+  });
+
+  test("editor cannot invite (user:create is admin-only)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await expect(
+      h.client.user.invite({ email: "x@example.test" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "user:create" },
+    });
+  });
+
+  test("duplicate email → CONFLICT", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.factory.user.create({ email: "dup@example.test" });
+    await expect(
+      h.client.user.invite({ email: "dup@example.test" }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "email_taken" },
+    });
+  });
+});
+
+describe("user.update", () => {
+  test("subscriber can edit own profile (name)", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const updated = await h.client.user.update({
+      id: h.user.id,
+      name: "Renamed",
+    });
+    expect(updated.name).toBe("Renamed");
+  });
+
+  test("subscriber cannot change own role", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await expect(
+      h.client.user.update({ id: h.user.id, role: "admin" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "user:promote" },
+    });
+  });
+
+  test("subscriber cannot edit another user", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const other = await h.factory.user.create({ email: "o@example.test" });
+    await expect(
+      h.client.user.update({ id: other.id, name: "hi" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "user:edit" },
+    });
+  });
+
+  test("admin can promote another user", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.editor.create();
+    const updated = await h.client.user.update({
+      id: target.id,
+      role: "admin",
+    });
+    expect(updated.role).toBe("admin");
+  });
+
+  test("promoting demotes existing sessions for the target", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.editor.create();
+    // Seed a session so we can verify invalidation happens.
+    await h.context.db.insert(sessions).values({
+      id: "seed-session-id",
+      userId: target.id,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await h.client.user.update({ id: target.id, role: "author" });
+
+    const remaining = await h.context.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.userId, target.id));
+    expect(remaining).toEqual([]);
+  });
+
+  test("cannot demote the last active admin", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.user.update({ id: h.user.id, role: "editor" }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "last_admin" },
+    });
+  });
+
+  test("demoting an admin works when another active admin exists", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.factory.admin.create({ email: "other-admin@example.test" });
+    const updated = await h.client.user.update({
+      id: h.user.id,
+      role: "editor",
+    });
+    expect(updated.role).toBe("editor");
+  });
+
+  test("duplicate email on update → CONFLICT", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const a = await h.factory.user.create({ email: "a@example.test" });
+    await h.factory.user.create({ email: "b@example.test" });
+    await expect(
+      h.client.user.update({ id: a.id, email: "b@example.test" }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "email_taken" },
+    });
+  });
+});
+
+describe("user.disable", () => {
+  test("admin can disable a user; sessions get invalidated", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.editor.create();
+    await h.context.db.insert(sessions).values({
+      id: "disable-target-session",
+      userId: target.id,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const updated = await h.client.user.disable({ id: target.id });
+    expect(updated.disabledAt).toBeInstanceOf(Date);
+
+    const remaining = await h.context.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.userId, target.id));
+    expect(remaining).toEqual([]);
+  });
+
+  test("cannot disable the last active admin", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.user.disable({ id: h.user.id }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "last_admin" },
+    });
+  });
+
+  test("disabling an already-disabled user is idempotent", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.editor.create();
+    const first = await h.client.user.disable({ id: target.id });
+    const second = await h.client.user.disable({ id: target.id });
+    expect(second.disabledAt).toEqual(first.disabledAt);
+  });
+});
+
+describe("user.delete", () => {
+  test("admin can delete a user with no authored posts", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.subscriber.create();
+    const deleted = await h.client.user.delete({ id: target.id });
+    expect(deleted.id).toBe(target.id);
+
+    const after = await h.context.db.query.users.findFirst({
+      where: eq(users.id, target.id),
+    });
+    expect(after).toBeUndefined();
+  });
+
+  test("refuses to delete a user with posts when no reassign target given", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const author = await h.factory.author.create();
+    await h.factory.post.create({ authorId: author.id });
+    await expect(h.client.user.delete({ id: author.id })).rejects.toMatchObject(
+      {
+        code: "CONFLICT",
+        data: { reason: "has_posts" },
+      },
+    );
+  });
+
+  test("reassigns posts when reassignPostsTo is provided", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const author = await h.factory.author.create();
+    const heir = await h.factory.author.create();
+    const post = await h.factory.post.create({ authorId: author.id });
+
+    await h.client.user.delete({ id: author.id, reassignPostsTo: heir.id });
+
+    const moved = await h.context.db.query.posts.findFirst({
+      where: eq(posts.id, post.id),
+    });
+    expect(moved?.authorId).toBe(heir.id);
+  });
+
+  test("cannot delete the last active admin", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(h.client.user.delete({ id: h.user.id })).rejects.toMatchObject(
+      {
+        code: "CONFLICT",
+        data: { reason: "last_admin" },
+      },
+    );
+  });
+
+  test("editor cannot delete users", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const target = await h.factory.subscriber.create();
+    await expect(h.client.user.delete({ id: target.id })).rejects.toMatchObject(
+      {
+        code: "FORBIDDEN",
+        data: { capability: "user:delete" },
+      },
+    );
+  });
+});

--- a/packages/core/src/rpc/router.ts
+++ b/packages/core/src/rpc/router.ts
@@ -1,8 +1,10 @@
 import { postRouter } from "./procedures/post/index.js";
+import { termRouter } from "./procedures/term/index.js";
 import { userRouter } from "./procedures/user/index.js";
 
 export const appRouter = {
   post: postRouter,
+  term: termRouter,
   user: userRouter,
 } as const;
 

--- a/packages/core/src/rpc/router.ts
+++ b/packages/core/src/rpc/router.ts
@@ -1,7 +1,9 @@
 import { postRouter } from "./procedures/post/index.js";
+import { userRouter } from "./procedures/user/index.js";
 
 export const appRouter = {
   post: postRouter,
+  user: userRouter,
 } as const;
 
 export type AppRouter = typeof appRouter;

--- a/packages/core/src/rpc/router.ts
+++ b/packages/core/src/rpc/router.ts
@@ -1,3 +1,4 @@
+import { optionRouter } from "./procedures/option/index.js";
 import { postRouter } from "./procedures/post/index.js";
 import { termRouter } from "./procedures/term/index.js";
 import { userRouter } from "./procedures/user/index.js";
@@ -6,6 +7,7 @@ export const appRouter = {
   post: postRouter,
   term: termRouter,
   user: userRouter,
+  option: optionRouter,
 } as const;
 
 export type AppRouter = typeof appRouter;

--- a/packages/core/src/rpc/schemas.ts
+++ b/packages/core/src/rpc/schemas.ts
@@ -1,0 +1,16 @@
+import * as v from "valibot";
+
+// Slug shape shared across RPC inputs — matches the URL-safe kebab-case
+// convention used for post and term slugs. Kept loose on length (200) since
+// neither table enforces a tighter limit at the schema level; individual
+// routers can tighten further via v.pipe(slugSchema, v.maxLength(N)) if a
+// stricter bound emerges.
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const slugSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(200),
+  v.regex(slugPattern, "slug must be kebab-case ASCII"),
+);


### PR DESCRIPTION
## What does this PR do?

Phase 9 — the last pre-admin-UI phase. Delivers the three data-layer RPC routers that an admin UI needs at minimum: \`user.*\` (profile + invite + role management), \`term.*\` (taxonomy CRUD), and \`option.*\` (site-wide settings). Mirrors the \`post\` RPC shape and builds on the capability/hook infrastructure that's been in place since Phase 3. With this in, every remaining item on the pre-admin checklist (framework choice, asset pipeline, plugin admin surface) is an admin-UI-phase decision, not a data-layer gap.

**What's in scope (4 commits, each independently green on every CI gate):**

- **\`feat(core): add users RPC procedures\`** — introduces the users router (\`list / get / invite / update / disable / delete\`) and splits the old single \`user:manage\` capability into six WordPress-aligned caps: \`user:list\` (editor+), \`user:edit_own\` (subscriber), \`user:create\` / \`user:edit\` / \`user:promote\` / \`user:delete\` (admin). \`promote\` is a separate capability from \`edit\` because role escalation is a distinct privilege — matches WP's \`promote_users\` vs \`edit_users\` split. \`update\` applies a meta-cap pattern: self-edits need \`user:edit_own\`, other-edits need \`user:edit\`, role changes additionally need \`user:promote\`. \`get\` always allows self-lookup (no \`user:list\` required) so admin UIs can render "your profile" without escalating every authenticated user to editor. \`disable\` + role-change invalidate the target's sessions via the existing \`invalidateAllSessionsForUser\` so cached AppContexts can't keep serving stale privileges. \`delete\` refuses by default when the target has authored posts (posts.authorId FK is \`onDelete: restrict\`) — callers must pass a \`reassignPostsTo\` user id to re-home the content first. \`invite\` creates the row and issues an opaque 192-bit invite token (SHA-256 hashed in DB, plaintext returned to the calling admin) with a 7-day TTL; admins share the invite URL manually until the email pipeline lands.

- **\`feat(core): add terms RPC procedures\`** — the terms router (\`list / get / create / update / delete\`) built on the per-taxonomy capability pattern already derived by \`deriveTaxonomyCapabilities\` (\`\${taxonomy}:read|assign|edit|delete\`). Taxonomies must be plugin-registered before their terms are touchable — unregistered taxonomies return NOT_FOUND rather than pretending to be empty. \`get\` hides existence from callers without the read cap (no oracle — same pattern the posts router uses). Hierarchy handling validates that parents are in the same taxonomy (\`parent_mismatch\`), that parent !== self (\`parent_is_self\`), and that setting a parent wouldn't form a cycle by walking up to 100 hops (\`parent_cycle\`). Delete leverages the existing FK behavior: \`post_term\` cascades, child terms' \`parentId\` nulls out via the self-referential \`onDelete: set null\`. Attaching terms to posts is intentionally out of scope — belongs to an extended post.update contract in a later phase.

- **\`feat(core): add options RPC procedures\`** — the options router (\`list / get / set / delete\`) gated by a single \`option:manage\` capability (admin) for both reads and writes. Matches WP's \`manage_options\` consolidation; if a specific option needs broader read access, the right move is to expose it via a dedicated RPC that reads it server-side, not to widen \`option.*\`. Secrets (SMTP creds, API keys) belong in Worker bindings / env, not in the options table — the schema comment spells that out. \`set\` is an upsert that preserves \`isAutoloaded\` on updates unless the caller explicitly overrides it, so admin UIs can change a value without accidentally flipping the autoload flag. \`list\` supports \`autoloadedOnly\` (efficient bootstrap reads — matches the \`alloptions\` cache pattern) and a \`prefix\` LIKE (for grouped reads like all \`mail_*\` options). Names are constrained by a tight valibot regex (\`[a-zA-Z0-9_.-]+\`, ≤191 chars — the MySQL UTF8MB4 PK index limit a future port would hit). Values are opaque text; callers JSON-encode structured data themselves, mirroring \`wp_options\` semantics.

- **\`fix(core): close last-admin TOCTOU + conservative cycle-walk on depth cap\`** — two defence-in-depth fixes surfaced by \`sentry-skills:find-bugs\` on the preceding three commits. (1) The last-admin guard on \`user.update / disable / delete\` was a read-then-write pair — two concurrent demotions of two different admins could each pass their own \`isLastActiveAdmin\` check and both succeed, locking everyone out. Inlined the guard into the UPDATE/DELETE WHERE clause via a new \`otherActiveAdminExists(db, excludeUserId)\` helper (EXISTS subquery). D1 serializes writes on the primary, so the check and the write now execute atomically. When the write returns zero rows we map to \`CONFLICT last_admin\`. (2) \`term/helpers.parentWouldCreateCycle\` previously returned \`false\` (i.e. "safe to proceed") when its \`MAX_DEPTH=100\` cap was exhausted without reaching a root — a pre-existing corrupt cycle longer than 100 hops could therefore be silently extended. Inverted the default: return \`true\` on cap-hit, so ambiguous chains are refused rather than permitted.

**What's out of scope (tracked internally for follow-up):**

- **Admin UI itself** — frontend framework choice (React / Solid / Preact / vanilla), asset serving pattern (inline bundle vs CF Workers Assets vs R2), and plugin admin surface API. These are the opening commits of the next phase, not gaps in this one.
- **Invite email delivery** — invites currently return the token plaintext to the inviting admin for manual URL sharing. Email / magic-link pipeline is a separate phase.
- **Non-transactional invite** (find-bugs L2) — \`users\` insert followed by \`auth_tokens\` insert without a batch/transaction. If the second insert fails, a user row exists with no credentials and no pending invite. Low severity — admin can delete and re-invite. Fix is a simple \`db.batch([...])\` or \`db.transaction(...)\`.
- **\`user.delete\` reassigning to a disabled user** (find-bugs L3) — currently validates that the target exists but not its state. Bookkeeping hazard, not an attack vector.
- **Attaching terms to posts via \`post.update\`** — post update schema needs a \`terms\` field. Separate concern from term CRUD.
- **Public-config escape hatch for options** — if a non-admin read-use-case for a specific option emerges (e.g. site title for a public endpoint), expose it via a dedicated RPC that reads the option server-side. Don't widen the option router's cap surface.

## Type of change

- [x] Feature — \`user.*\`, \`term.*\`, \`option.*\` routers
- [x] Fix — TOCTOU in user demotion; cycle-walk cap-hit default
- [x] **Breaking** — \`user:manage\` replaced by six granular caps. Pre-1.0; no compatibility shim per repo policy. No first-party code depended on the old cap (verified via grep); the change was a test-only string swap.

## Checklist

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm build\` passes
- [x] \`pnpm test\` passes (279 tests: 198 core + 59 CF adapter + 18 plumix CLI + 4 example smoke/build = +58 vs Phase 8)
- [x] \`pnpm format\`, \`pnpm knip\`, \`pnpm publint\`, \`pnpm attw\` all green
- [x] Passed trimmed \`sentry-skills\` pipeline: code-simplifier (applied per commit) → find-bugs (M1 TOCTOU + L1 cycle-cap addressed as fix commit 4; L2 non-transactional invite + L3 reassign-to-disabled flagged as pre-1.0 polish) → security-review (0 findings; authorization, IDOR, invite-token handling, SQL, CSRF, session invalidation, and post-fix TOCTOU all verified).

## AI-generated code disclosure

- [x] This PR includes AI-generated code