### PR TITLE
feat(test): expose plumix/test — factories, harness DX kit, spies, assertions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,10 @@
     "./schema": {
       "types": "./dist/db/schema/index.d.ts",
       "default": "./dist/db/schema/index.js"
+    },
+    "./test": {
+      "types": "./dist/test/index.d.ts",
+      "default": "./dist/test/index.js"
     }
   },
   "scripts": {
@@ -29,23 +33,23 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@libsql/client": "^0.17.2",
     "@orpc/server": "^1.13.14",
     "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",
     "@oslojs/webauthn": "^1.0.0",
+    "drizzle-kit": "catalog:",
     "drizzle-orm": "catalog:",
     "drizzle-valibot": "catalog:",
+    "fishery": "^2.4.0",
     "valibot": "catalog:"
   },
   "devDependencies": {
-    "@libsql/client": "^0.17.2",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
     "@types/node": "catalog:",
-    "drizzle-kit": "catalog:",
     "eslint": "catalog:",
-    "fishery": "^2.4.0",
     "prettier": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/core/src/auth/passkey/authenticate.test.ts
+++ b/packages/core/src/auth/passkey/authenticate.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import type { PasskeyKeyPair } from "../../test/fixtures/webauthn.js";
 import { credentials } from "../../db/schema/credentials.js";
 import { users } from "../../db/schema/users.js";
+import { credentialFactory } from "../../test/factories.js";
 import {
   buildAssertion,
   buildAttestation,
@@ -56,13 +57,11 @@ async function registerFixtureCredential(): Promise<RegisteredFixture> {
       attestationObject: att.attestationObject,
     },
   });
-  await db.insert(credentials).values({
+  await credentialFactory.transient({ db }).create({
     id: verified.credentialId,
     userId: user.id,
     publicKey: Buffer.from(verified.publicKey),
     counter: verified.signatureCounter,
-    deviceType: "single_device",
-    isBackedUp: false,
     transports: [...verified.transports],
   });
 

--- a/packages/core/src/auth/passkey/routes.test.ts
+++ b/packages/core/src/auth/passkey/routes.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 
 import { eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
-import { credentials } from "../../db/schema/credentials.js";
 import { users } from "../../db/schema/users.js";
 import {
   createDispatcherHarness,
@@ -181,12 +180,11 @@ describe("invite register — options", () => {
     const user = await h.seedUser(opts.role ?? "author");
     const token = generateToken();
     const tokenHash = await hashToken(token);
-    await h.db.insert(authTokens).values({
+    await h.factory.invite.create({
       hash: tokenHash,
       userId: user.id,
       email: user.email,
       role: opts.role ?? "author",
-      type: "invite",
       expiresAt: new Date(Date.now() + (opts.expiresInMs ?? 60_000)),
     });
     return { user, token, tokenHash };
@@ -262,14 +260,9 @@ describe("invite register — options", () => {
     const h = await createDispatcherHarness();
     const { user, token } = await seedInvite(h);
     // Seed a credential as if the user had already registered.
-    await h.db.insert(credentials).values({
-      id: "cred-id-1",
+    await h.factory.credential.create({
       userId: user.id,
-      publicKey: new Uint8Array([1, 2, 3]) as unknown as Buffer,
-      counter: 0,
-      deviceType: "single_device",
-      isBackedUp: false,
-      transports: ["internal"],
+      publicKey: Buffer.from([1, 2, 3]),
     });
 
     const response = await h.dispatch(
@@ -360,12 +353,11 @@ describe("invite register — verify", () => {
     const user = await h.seedUser("editor");
     const token = generateToken();
     const tokenHash = await hashToken(token);
-    await h.db.insert(authTokens).values({
+    await h.factory.invite.create({
       hash: tokenHash,
       userId: user.id,
       email: user.email,
       role: "editor",
-      type: "invite",
       expiresAt: new Date(Date.now() - 60_000),
     });
     const response = await h.dispatch(

--- a/packages/core/src/rpc/authenticated.test.ts
+++ b/packages/core/src/rpc/authenticated.test.ts
@@ -2,20 +2,12 @@ import { describe, expect, test } from "vitest";
 
 import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
 import { createRpcHarness } from "../test/rpc.js";
-
-async function expectErrorCode(promise: Promise<unknown>, code: string) {
-  try {
-    await promise;
-    throw new Error(`expected error ${code}, call resolved`);
-  } catch (error) {
-    if ((error as { code?: string }).code !== code) throw error;
-  }
-}
+import { expectError } from "../test/spies.js";
 
 describe("authenticated middleware", () => {
   test("rejects when no session cookie is present", async () => {
     const { client } = await createRpcHarness();
-    await expectErrorCode(client.post.list({}), "UNAUTHORIZED");
+    await expectError(client.post.list({}), { code: "UNAUTHORIZED" });
   });
 
   test("rejects when the session cookie is a bogus token", async () => {
@@ -24,7 +16,7 @@ describe("authenticated middleware", () => {
         headers: { cookie: `${SESSION_COOKIE_NAME}=bogus-token` },
       }),
     });
-    await expectErrorCode(bogus.client.post.list({}), "UNAUTHORIZED");
+    await expectError(bogus.client.post.list({}), { code: "UNAUTHORIZED" });
   });
 
   test("accepts a valid session and reaches the handler", async () => {

--- a/packages/core/src/rpc/procedures/post/create.test.ts
+++ b/packages/core/src/rpc/procedures/post/create.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { eq } from "../../../db/index.js";
 import { posts } from "../../../db/schema/posts.js";
@@ -122,18 +122,17 @@ describe("post.create", () => {
 
   test("post:published fires once when status is published, never on drafts", async () => {
     const h = await createRpcHarness({ authAs: "author" });
-    const onPublish = vi.fn();
-    h.hooks.addAction("post:published", onPublish);
+    const onPublish = h.spyAction("post:published");
 
     await h.client.post.create({ title: "d", slug: "d-1" });
-    expect(onPublish).not.toHaveBeenCalled();
+    onPublish.assertNotCalled();
 
     await h.client.post.create({
       title: "p",
       slug: "p-1",
       status: "published",
     });
-    expect(onPublish).toHaveBeenCalledTimes(1);
+    onPublish.assertCalledOnce();
   });
 
   test("concurrent creates with the same slug: exactly one wins, the other gets CONFLICT", async () => {

--- a/packages/core/src/rpc/procedures/post/update.test.ts
+++ b/packages/core/src/rpc/procedures/post/update.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { posts } from "../../../db/schema/posts.js";
 import { createRpcHarness } from "../../../test/rpc.js";
@@ -67,10 +67,8 @@ describe("post.update", () => {
       slug: "promote",
     });
 
-    const onPublish = vi.fn();
-    const onTransition = vi.fn();
-    h.hooks.addAction("post:published", onPublish);
-    h.hooks.addAction("post:transition", onTransition);
+    const onPublish = h.spyAction("post:published");
+    const onTransition = h.spyAction("post:transition");
 
     const updated = await h.client.post.update({
       id: own.id,
@@ -78,8 +76,8 @@ describe("post.update", () => {
     });
     expect(updated.status).toBe("published");
     expect(updated.publishedAt).toBeInstanceOf(Date);
-    expect(onPublish).toHaveBeenCalledTimes(1);
-    expect(onTransition).toHaveBeenCalledTimes(1);
+    onPublish.assertCalledOnce();
+    onTransition.assertCalledOnce();
   });
 
   test("contributor cannot promote their own draft to published", async () => {
@@ -117,12 +115,11 @@ describe("post.update", () => {
       authorId: h.user.id,
       slug: "noop",
     });
-    const onUpdate = vi.fn();
-    h.hooks.addAction("post:updated", onUpdate);
+    const onUpdate = h.spyAction("post:updated");
 
     const returned = await h.client.post.update({ id: own.id });
     expect(returned.id).toBe(own.id);
-    expect(onUpdate).not.toHaveBeenCalled();
+    onUpdate.assertNotCalled();
   });
 
   test("404 for a missing row", async () => {
@@ -139,8 +136,7 @@ describe("post.update", () => {
       slug: "race-to-publish",
     });
 
-    const onPublish = vi.fn();
-    h.hooks.addAction("post:published", onPublish);
+    const onPublish = h.spyAction("post:published");
 
     const outcomes = await Promise.all([
       h.client.post.update({ id: own.id, status: "published" }),
@@ -148,7 +144,7 @@ describe("post.update", () => {
       h.client.post.update({ id: own.id, status: "published" }),
     ]);
     for (const result of outcomes) expect(result.status).toBe("published");
-    expect(onPublish).toHaveBeenCalledTimes(1);
+    onPublish.assertCalledOnce();
   });
 
   test("post:before_save cannot overwrite immutable fields", async () => {

--- a/packages/core/src/rpc/procedures/user/user.test.ts
+++ b/packages/core/src/rpc/procedures/user/user.test.ts
@@ -150,10 +150,9 @@ describe("user.update", () => {
     const h = await createRpcHarness({ authAs: "admin" });
     const target = await h.factory.editor.create();
     // Seed a session so we can verify invalidation happens.
-    await h.context.db.insert(sessions).values({
+    await h.factory.session.create({
       id: "seed-session-id",
       userId: target.id,
-      expiresAt: new Date(Date.now() + 60_000),
     });
 
     await h.client.user.update({ id: target.id, role: "author" });
@@ -202,10 +201,9 @@ describe("user.disable", () => {
   test("admin can disable a user; sessions get invalidated", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
     const target = await h.factory.editor.create();
-    await h.context.db.insert(sessions).values({
+    await h.factory.session.create({
       id: "disable-target-session",
       userId: target.id,
-      expiresAt: new Date(Date.now() + 60_000),
     });
 
     const updated = await h.client.user.disable({ id: target.id });

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -1,6 +1,17 @@
 import type { AppContext } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
+import type {
+  ActionArgs,
+  ActionName,
+  FilterInput,
+  FilterName,
+  FilterRest,
+} from "../hooks/types.js";
 import type { PlumixApp } from "../runtime/app.js";
+import type { PlumixEnv } from "../runtime/bindings.js";
+import type { Factories } from "./factories.js";
+import type { FetchOptions } from "./request.js";
+import type { ActionSpy, FilterSpy } from "./spies.js";
 import { auth } from "../auth/config.js";
 import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
 import { createSession } from "../auth/sessions.js";
@@ -8,8 +19,10 @@ import { plumix } from "../config.js";
 import { createAppContext } from "../context/app.js";
 import { buildApp } from "../runtime/app.js";
 import { createPlumixDispatcher } from "../runtime/dispatcher.js";
-import { userFactory } from "./factories.js";
+import { factoriesFor, userFactory } from "./factories.js";
 import { createTestDb } from "./harness.js";
+import { buildRequest, TestResponse } from "./request.js";
+import { spyAction, spyFilter } from "./spies.js";
 
 type TestDb = Awaited<ReturnType<typeof createTestDb>>;
 
@@ -23,18 +36,54 @@ const stubDatabase = {
   connect: () => ({ db: {} }),
 };
 
-interface DispatcherHarness {
+export interface CreateDispatcherHarnessOptions {
+  /**
+   * Runtime environment bindings (KV, R2, Durable Objects, etc.). Exposed
+   * on `h.env` so tests can assert on or interact with bindings directly —
+   * the escape hatch for anything the harness doesn't abstract.
+   */
+  readonly env?: PlumixEnv;
+}
+
+export interface DispatcherHarness {
   readonly db: TestDb;
   readonly app: PlumixApp;
+  /** Pass-through env bindings. Empty by default; override via harness options. */
+  readonly env: PlumixEnv;
   readonly dispatch: (
     request: Request,
     user?: User | null,
   ) => Promise<Response>;
+  /**
+   * Build and dispatch a request in one call. Returns a TestResponse with
+   * chainable assertion helpers. Frontend tests should reach for this
+   * first; use `dispatch` only when you need to build the Request yourself.
+   */
+  readonly fetch: (
+    path: string,
+    options?: FetchOptions,
+  ) => Promise<TestResponse>;
   readonly authenticateRequest: (
     request: Request,
     userId: number,
   ) => Promise<Request>;
   readonly seedUser: (role?: UserRole) => Promise<User>;
+  /** Pre-bound factories. Mirrors the `factory` surface of createRpcHarness. */
+  readonly factory: Factories;
+  /**
+   * Record every invocation of the named action. Call assertions on the
+   * returned spy (`.assertCalledOnce()`, `.assertCalledWith(...)`).
+   */
+  readonly spyAction: <TName extends ActionName>(
+    name: TName,
+  ) => ActionSpy<ActionArgs<TName>>;
+  /**
+   * Record every invocation of the named filter. Pass-through by default;
+   * call `.override(fn)` on the returned spy to transform values.
+   */
+  readonly spyFilter: <TName extends FilterName>(
+    name: TName,
+  ) => FilterSpy<FilterInput<TName>, FilterRest<TName>>;
 }
 
 const noop = (): void => undefined;
@@ -48,12 +97,13 @@ const silentLogger = {
 function withRequest(
   app: PlumixApp,
   db: TestDb,
+  env: PlumixEnv,
   request: Request,
   user: User | null,
 ): AppContext {
   return createAppContext({
     db,
-    env: {} as AppContext["env"],
+    env,
     request,
     hooks: app.hooks,
     plugins: app.plugins,
@@ -64,8 +114,11 @@ function withRequest(
   });
 }
 
-export async function createDispatcherHarness(): Promise<DispatcherHarness> {
+export async function createDispatcherHarness(
+  options: CreateDispatcherHarnessOptions = {},
+): Promise<DispatcherHarness> {
   const db = await createTestDb();
+  const env = options.env ?? ({} as PlumixEnv);
   const config = plumix({
     runtime: stubAdapter,
     database: stubDatabase,
@@ -80,12 +133,19 @@ export async function createDispatcherHarness(): Promise<DispatcherHarness> {
   const app = await buildApp(config);
   const dispatcher = createPlumixDispatcher(app);
 
-  return {
+  const harness: DispatcherHarness = {
     db,
     app,
+    env,
     dispatch: async (request, user = null) => {
-      const ctx = withRequest(app, db, request, user);
+      const ctx = withRequest(app, db, env, request, user);
       return dispatcher(ctx);
+    },
+    fetch: async (path, fetchOptions = {}) => {
+      const request = await buildRequest(db, path, fetchOptions);
+      const ctx = withRequest(app, db, env, request, fetchOptions.as ?? null);
+      const response = await dispatcher(ctx);
+      return new TestResponse(response);
     },
     authenticateRequest: async (request, userId) => {
       const { token } = await createSession(db, { userId });
@@ -95,7 +155,11 @@ export async function createDispatcherHarness(): Promise<DispatcherHarness> {
     },
     seedUser: async (role = "subscriber") =>
       userFactory.transient({ db }).create({ role }),
+    factory: factoriesFor(db),
+    spyAction: (name) => spyAction(app.hooks, name),
+    spyFilter: (name) => spyFilter(app.hooks, name),
   };
+  return harness;
 }
 
 export function plumixRequest(path: string, init: RequestInit = {}): Request {

--- a/packages/core/src/test/factories.ts
+++ b/packages/core/src/test/factories.ts
@@ -1,9 +1,19 @@
 import { Factory } from "fishery";
 
 import type { Db } from "../context/app.js";
+import type { AuthToken, NewAuthToken } from "../db/schema/auth_tokens.js";
+import type {
+  Credential,
+  CredentialTransport,
+  NewCredential,
+} from "../db/schema/credentials.js";
 import type { NewPost, Post } from "../db/schema/posts.js";
+import type { NewTerm, Term } from "../db/schema/terms.js";
 import type { NewUser, User } from "../db/schema/users.js";
+import { authTokens } from "../db/schema/auth_tokens.js";
+import { credentials } from "../db/schema/credentials.js";
 import { posts } from "../db/schema/posts.js";
+import { terms } from "../db/schema/terms.js";
 import { users } from "../db/schema/users.js";
 
 interface DbTransient {
@@ -76,6 +86,94 @@ export const draftPost = postFactory.params({ status: "draft" });
 export const publishedPost = postFactory.params({ status: "published" });
 export const trashedPost = postFactory.params({ status: "trash" });
 
+export const termFactory = Factory.define<NewTerm, DbTransient, Term>(
+  ({ sequence, transientParams, onCreate, params }) => {
+    onCreate(async (attrs) => {
+      const db = requireDb(transientParams);
+      const [row] = await db.insert(terms).values(attrs).returning();
+      if (!row) throw new Error("termFactory: insert returned no row");
+      return row;
+    });
+
+    return {
+      taxonomy: params.taxonomy ?? "category",
+      name: params.name ?? `Term ${sequence}`,
+      slug: params.slug ?? `term-${sequence}-${Date.now()}`,
+      description: params.description ?? null,
+      parentId: params.parentId ?? null,
+    };
+  },
+);
+
+export const categoryTerm = termFactory.params({ taxonomy: "category" });
+export const tagTerm = termFactory.params({ taxonomy: "tag" });
+
+// Invite factory writes an auth_tokens row of type "invite". The caller
+// supplies a user whose id is bound; the default expiry is 24h.
+export const inviteFactory = Factory.define<
+  NewAuthToken,
+  DbTransient,
+  AuthToken
+>(({ transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(authTokens).values(attrs).returning();
+    if (!row) throw new Error("inviteFactory: insert returned no row");
+    return row;
+  });
+
+  const userId = params.userId;
+  if (userId === undefined) {
+    throw new Error("inviteFactory: userId is required");
+  }
+  return {
+    hash: params.hash ?? `invite-hash-${Date.now()}-${Math.random()}`,
+    userId,
+    email: params.email ?? null,
+    type: "invite" as const,
+    role: params.role ?? "author",
+    invitedBy: params.invitedBy ?? null,
+    expiresAt: params.expiresAt ?? new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
+});
+
+// Pre-seeded credential for tests that exercise "already registered" flows.
+// Callers must supply userId and publicKey; everything else has a sensible
+// default. Buffer cast mirrors the runtime pattern in register.ts.
+export const credentialFactory = Factory.define<
+  NewCredential,
+  DbTransient,
+  Credential
+>(({ sequence, transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(credentials).values(attrs).returning();
+    if (!row) throw new Error("credentialFactory: insert returned no row");
+    return row;
+  });
+
+  const userId = params.userId;
+  if (userId === undefined) {
+    throw new Error("credentialFactory: userId is required");
+  }
+  const publicKey = params.publicKey;
+  if (publicKey === undefined) {
+    throw new Error("credentialFactory: publicKey is required");
+  }
+  return {
+    id: params.id ?? `cred-${sequence}-${Date.now()}`,
+    userId,
+    publicKey: publicKey as Buffer,
+    counter: params.counter ?? 0,
+    deviceType: params.deviceType ?? "single_device",
+    isBackedUp: params.isBackedUp ?? false,
+    transports: params.transports
+      ? [...params.transports]
+      : (["internal"] as CredentialTransport[]),
+    name: params.name ?? null,
+  };
+});
+
 export interface Factories {
   readonly user: typeof userFactory;
   readonly admin: typeof adminUser;
@@ -87,6 +185,11 @@ export interface Factories {
   readonly draft: typeof draftPost;
   readonly published: typeof publishedPost;
   readonly trashed: typeof trashedPost;
+  readonly term: typeof termFactory;
+  readonly category: typeof categoryTerm;
+  readonly tag: typeof tagTerm;
+  readonly invite: typeof inviteFactory;
+  readonly credential: typeof credentialFactory;
 }
 
 export function factoriesFor(db: Db): Factories {
@@ -101,5 +204,10 @@ export function factoriesFor(db: Db): Factories {
     draft: draftPost.transient({ db }),
     published: publishedPost.transient({ db }),
     trashed: trashedPost.transient({ db }),
+    term: termFactory.transient({ db }),
+    category: categoryTerm.transient({ db }),
+    tag: tagTerm.transient({ db }),
+    invite: inviteFactory.transient({ db }),
+    credential: credentialFactory.transient({ db }),
   };
 }

--- a/packages/core/src/test/factories.ts
+++ b/packages/core/src/test/factories.ts
@@ -1,19 +1,36 @@
 import { Factory } from "fishery";
 
 import type { Db } from "../context/app.js";
+import type {
+  AllowedDomain,
+  NewAllowedDomain,
+} from "../db/schema/allowed_domains.js";
 import type { AuthToken, NewAuthToken } from "../db/schema/auth_tokens.js";
 import type {
   Credential,
   CredentialTransport,
   NewCredential,
 } from "../db/schema/credentials.js";
+import type { NewOption, Option } from "../db/schema/options.js";
+import type { NewPostMeta, PostMeta } from "../db/schema/post_meta.js";
+import type { NewPostTerm, PostTerm } from "../db/schema/post_term.js";
 import type { NewPost, Post } from "../db/schema/posts.js";
+import type { NewSession, Session } from "../db/schema/sessions.js";
+import type { NewTermMeta, TermMeta } from "../db/schema/term_meta.js";
 import type { NewTerm, Term } from "../db/schema/terms.js";
+import type { NewUserMeta, UserMeta } from "../db/schema/user_meta.js";
 import type { NewUser, User } from "../db/schema/users.js";
+import { allowedDomains } from "../db/schema/allowed_domains.js";
 import { authTokens } from "../db/schema/auth_tokens.js";
 import { credentials } from "../db/schema/credentials.js";
+import { options } from "../db/schema/options.js";
+import { postMeta } from "../db/schema/post_meta.js";
+import { postTerm } from "../db/schema/post_term.js";
 import { posts } from "../db/schema/posts.js";
+import { sessions } from "../db/schema/sessions.js";
+import { termMeta } from "../db/schema/term_meta.js";
 import { terms } from "../db/schema/terms.js";
+import { userMeta } from "../db/schema/user_meta.js";
 import { users } from "../db/schema/users.js";
 
 interface DbTransient {
@@ -137,6 +154,166 @@ export const inviteFactory = Factory.define<
   };
 });
 
+// Session factory — seeds a row without running the WebAuthn dance. Useful
+// for admin-UI tests that want an authenticated context straight away.
+export const sessionFactory = Factory.define<NewSession, DbTransient, Session>(
+  ({ sequence, transientParams, onCreate, params }) => {
+    onCreate(async (attrs) => {
+      const db = requireDb(transientParams);
+      const [row] = await db.insert(sessions).values(attrs).returning();
+      if (!row) throw new Error("sessionFactory: insert returned no row");
+      return row;
+    });
+
+    const userId = params.userId;
+    if (userId === undefined) {
+      throw new Error("sessionFactory: userId is required");
+    }
+    return {
+      id: params.id ?? `session-${sequence}-${Date.now()}`,
+      userId,
+      expiresAt: params.expiresAt ?? new Date(Date.now() + 24 * 60 * 60 * 1000),
+      ipAddress: params.ipAddress ?? null,
+      userAgent: params.userAgent ?? null,
+    };
+  },
+);
+
+// Site options (key/value store). Autoloaded defaults to true — matches the
+// most common plugin usage.
+export const optionFactory = Factory.define<NewOption, DbTransient, Option>(
+  ({ sequence, transientParams, onCreate, params }) => {
+    onCreate(async (attrs) => {
+      const db = requireDb(transientParams);
+      const [row] = await db.insert(options).values(attrs).returning();
+      if (!row) throw new Error("optionFactory: insert returned no row");
+      return row;
+    });
+
+    return {
+      name: params.name ?? `option-${sequence}-${Date.now()}`,
+      value: params.value ?? "",
+      isAutoloaded: params.isAutoloaded ?? true,
+    };
+  },
+);
+
+// post_term join row. Caller passes postId + termId; sortOrder defaults to 0.
+export const postTermFactory = Factory.define<
+  NewPostTerm,
+  DbTransient,
+  PostTerm
+>(({ transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(postTerm).values(attrs).returning();
+    if (!row) throw new Error("postTermFactory: insert returned no row");
+    return row;
+  });
+
+  const postId = params.postId;
+  const termId = params.termId;
+  if (postId === undefined || termId === undefined) {
+    throw new Error("postTermFactory: postId and termId are required");
+  }
+  return {
+    postId,
+    termId,
+    sortOrder: params.sortOrder ?? 0,
+  };
+});
+
+// Generic meta-row factories. Caller supplies the owner id; key/value have
+// sequence-derived defaults.
+export const postMetaFactory = Factory.define<
+  NewPostMeta,
+  DbTransient,
+  PostMeta
+>(({ sequence, transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(postMeta).values(attrs).returning();
+    if (!row) throw new Error("postMetaFactory: insert returned no row");
+    return row;
+  });
+
+  const postId = params.postId;
+  if (postId === undefined) {
+    throw new Error("postMetaFactory: postId is required");
+  }
+  return {
+    postId,
+    key: params.key ?? `meta-key-${sequence}`,
+    value: params.value ?? "",
+  };
+});
+
+export const userMetaFactory = Factory.define<
+  NewUserMeta,
+  DbTransient,
+  UserMeta
+>(({ sequence, transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(userMeta).values(attrs).returning();
+    if (!row) throw new Error("userMetaFactory: insert returned no row");
+    return row;
+  });
+
+  const userId = params.userId;
+  if (userId === undefined) {
+    throw new Error("userMetaFactory: userId is required");
+  }
+  return {
+    userId,
+    key: params.key ?? `meta-key-${sequence}`,
+    value: params.value ?? "",
+  };
+});
+
+export const termMetaFactory = Factory.define<
+  NewTermMeta,
+  DbTransient,
+  TermMeta
+>(({ sequence, transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(termMeta).values(attrs).returning();
+    if (!row) throw new Error("termMetaFactory: insert returned no row");
+    return row;
+  });
+
+  const termId = params.termId;
+  if (termId === undefined) {
+    throw new Error("termMetaFactory: termId is required");
+  }
+  return {
+    termId,
+    key: params.key ?? `meta-key-${sequence}`,
+    value: params.value ?? "",
+  };
+});
+
+// Allowed-domain entry for tests that exercise domain-gated self-signup.
+export const allowedDomainFactory = Factory.define<
+  NewAllowedDomain,
+  DbTransient,
+  AllowedDomain
+>(({ sequence, transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(allowedDomains).values(attrs).returning();
+    if (!row) throw new Error("allowedDomainFactory: insert returned no row");
+    return row;
+  });
+
+  return {
+    domain: params.domain ?? `example-${sequence}.test`,
+    defaultRole: params.defaultRole ?? "subscriber",
+    isEnabled: params.isEnabled ?? true,
+  };
+});
+
 // Pre-seeded credential for tests that exercise "already registered" flows.
 // Callers must supply userId and publicKey; everything else has a sensible
 // default. Buffer cast mirrors the runtime pattern in register.ts.
@@ -190,6 +367,13 @@ export interface Factories {
   readonly tag: typeof tagTerm;
   readonly invite: typeof inviteFactory;
   readonly credential: typeof credentialFactory;
+  readonly session: typeof sessionFactory;
+  readonly option: typeof optionFactory;
+  readonly postTerm: typeof postTermFactory;
+  readonly postMeta: typeof postMetaFactory;
+  readonly userMeta: typeof userMetaFactory;
+  readonly termMeta: typeof termMetaFactory;
+  readonly allowedDomain: typeof allowedDomainFactory;
 }
 
 export function factoriesFor(db: Db): Factories {
@@ -209,5 +393,12 @@ export function factoriesFor(db: Db): Factories {
     tag: tagTerm.transient({ db }),
     invite: inviteFactory.transient({ db }),
     credential: credentialFactory.transient({ db }),
+    session: sessionFactory.transient({ db }),
+    option: optionFactory.transient({ db }),
+    postTerm: postTermFactory.transient({ db }),
+    postMeta: postMetaFactory.transient({ db }),
+    userMeta: userMetaFactory.transient({ db }),
+    termMeta: termMetaFactory.transient({ db }),
+    allowedDomain: allowedDomainFactory.transient({ db }),
   };
 }

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -32,8 +32,25 @@ export type { Factories } from "./factories.js";
 export { createTestDb } from "./harness.js";
 
 export { createDispatcherHarness, plumixRequest } from "./dispatcher.js";
+export type {
+  DispatcherHarness,
+  CreateDispatcherHarnessOptions,
+} from "./dispatcher.js";
 
 export { createRpcHarness } from "./rpc.js";
+export type {
+  RpcHarness,
+  AuthenticatedRpcHarness,
+  RpcHarnessBase,
+  BaseRpcHarnessOptions,
+  AuthenticatedHarnessOptions,
+} from "./rpc.js";
+
+export { buildRequest, TestResponse } from "./request.js";
+export type { FetchOptions } from "./request.js";
+
+export { spyAction, spyFilter, expectError } from "./spies.js";
+export type { ActionSpy, ActionCall, FilterSpy, FilterCall } from "./spies.js";
 
 // WebAuthn fixtures — build deterministic attestation / assertion payloads
 // without touching a real browser. Used by plumix's own passkey tests and

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -52,6 +52,8 @@ export type { FetchOptions } from "./request.js";
 export { spyAction, spyFilter, expectError } from "./spies.js";
 export type { ActionSpy, ActionCall, FilterSpy, FilterCall } from "./spies.js";
 
+export { deepEqual, partialMatch } from "./match.js";
+
 // WebAuthn fixtures — build deterministic attestation / assertion payloads
 // without touching a real browser. Used by plumix's own passkey tests and
 // available for plugin authors extending the auth surface.

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -1,0 +1,40 @@
+// Public test-harness surface for downstream consumers of `plumix/test`.
+// Every symbol here is intended for use from test files in themes, plugins,
+// and end-user apps — not from production runtime code.
+
+export {
+  userFactory,
+  adminUser,
+  editorUser,
+  authorUser,
+  contributorUser,
+  subscriberUser,
+  postFactory,
+  draftPost,
+  publishedPost,
+  trashedPost,
+  termFactory,
+  categoryTerm,
+  tagTerm,
+  inviteFactory,
+  credentialFactory,
+  factoriesFor,
+} from "./factories.js";
+export type { Factories } from "./factories.js";
+
+export { createTestDb } from "./harness.js";
+
+export { createDispatcherHarness, plumixRequest } from "./dispatcher.js";
+
+export { createRpcHarness } from "./rpc.js";
+
+// WebAuthn fixtures — build deterministic attestation / assertion payloads
+// without touching a real browser. Used by plumix's own passkey tests and
+// available for plugin authors extending the auth surface.
+export {
+  buildAssertion,
+  buildAttestation,
+  generatePasskeyKeyPair,
+  randomCredentialId,
+} from "./fixtures/webauthn.js";
+export type { PasskeyKeyPair } from "./fixtures/webauthn.js";

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -18,6 +18,13 @@ export {
   tagTerm,
   inviteFactory,
   credentialFactory,
+  sessionFactory,
+  optionFactory,
+  postTermFactory,
+  postMetaFactory,
+  userMetaFactory,
+  termMetaFactory,
+  allowedDomainFactory,
   factoriesFor,
 } from "./factories.js";
 export type { Factories } from "./factories.js";

--- a/packages/core/src/test/match.test.ts
+++ b/packages/core/src/test/match.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+
+import { deepEqual, partialMatch } from "./match.js";
+
+describe("deepEqual", () => {
+  test("primitives", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("a", "a")).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+    expect(deepEqual(NaN, NaN)).toBe(true); // Object.is
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+  });
+
+  test("dates compare by timestamp, not identity", () => {
+    const a = new Date("2020-01-01T00:00:00Z");
+    const b = new Date("2020-01-01T00:00:00Z");
+    expect(deepEqual(a, b)).toBe(true);
+    expect(deepEqual(a, new Date("2020-01-02T00:00:00Z"))).toBe(false);
+  });
+
+  test("arrays", () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(deepEqual([1, [2, 3]], [1, [2, 3]])).toBe(true);
+    expect(deepEqual([1, 2], { 0: 1, 1: 2, length: 2 })).toBe(false);
+  });
+
+  test("objects strict-equal on keys", () => {
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+
+  test("nested", () => {
+    expect(
+      deepEqual({ a: [1, { b: new Date(0) }] }, { a: [1, { b: new Date(0) }] }),
+    ).toBe(true);
+  });
+});
+
+describe("partialMatch", () => {
+  test("actual may have extra keys", () => {
+    expect(partialMatch({ a: 1, b: 2, c: 3 }, { a: 1 })).toBe(true);
+    expect(partialMatch({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  test("arrays must match length and elements (not subset)", () => {
+    expect(partialMatch([1, 2], [1, 2])).toBe(true);
+    expect(partialMatch([1, 2, 3], [1, 2])).toBe(false);
+  });
+
+  test("nested partial match", () => {
+    expect(
+      partialMatch(
+        { code: "NOT_FOUND", data: { kind: "post", id: 5, extra: true } },
+        { code: "NOT_FOUND", data: { kind: "post", id: 5 } },
+      ),
+    ).toBe(true);
+  });
+
+  test("primitives use strict equality", () => {
+    expect(partialMatch(1, 1)).toBe(true);
+    expect(partialMatch(1, 2)).toBe(false);
+    expect(partialMatch(null, null)).toBe(true);
+    expect(partialMatch(undefined, undefined)).toBe(true);
+  });
+});

--- a/packages/core/src/test/match.ts
+++ b/packages/core/src/test/match.ts
@@ -1,0 +1,82 @@
+// Runner-agnostic deep equality helpers used by the test DX kit. Kept
+// deliberately minimal — we don't want to ship a competitor to chai/expect,
+// just enough to let TestResponse and expectError work without importing
+// vitest.
+
+/**
+ * Strict deep equality. Arrays, plain objects, and primitives only —
+ * Date compares via getTime; everything else falls back to Object.is.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  if (a === null || b === null) return false;
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (Array.isArray(b)) return false;
+
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+    if (
+      !deepEqual(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key],
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Partial-match: every key in `expected` must be deepEqual to the same key
+ * in `actual`, but `actual` may have extra keys. For arrays, length must
+ * match and each element is recursively partial-matched. Mirrors
+ * `expect.toMatchObject` semantics, at a level of rigor that's good enough
+ * for test-harness assertions.
+ */
+export function partialMatch(actual: unknown, expected: unknown): boolean {
+  if (Object.is(actual, expected)) return true;
+  if (expected instanceof Date) {
+    return actual instanceof Date && actual.getTime() === expected.getTime();
+  }
+  if (typeof expected !== "object" || expected === null) {
+    return Object.is(actual, expected);
+  }
+  if (typeof actual !== "object" || actual === null) return false;
+
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length !== expected.length) {
+      return false;
+    }
+    for (let i = 0; i < expected.length; i++) {
+      if (!partialMatch(actual[i], expected[i])) return false;
+    }
+    return true;
+  }
+  if (Array.isArray(actual)) return false;
+
+  for (const key of Object.keys(expected)) {
+    const expectedValue = (expected as Record<string, unknown>)[key];
+    if (!Object.prototype.hasOwnProperty.call(actual, key)) return false;
+    if (
+      !partialMatch((actual as Record<string, unknown>)[key], expectedValue)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/core/src/test/request.ts
+++ b/packages/core/src/test/request.ts
@@ -1,0 +1,206 @@
+import type { LibSQLDatabase } from "drizzle-orm/libsql";
+import { expect } from "vitest";
+
+import type * as schema from "../db/schema/index.js";
+import type { User } from "../db/schema/users.js";
+import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
+import { createSession } from "../auth/sessions.js";
+
+type TestDb = LibSQLDatabase<typeof schema>;
+
+export interface FetchOptions {
+  readonly method?:
+    | "GET"
+    | "POST"
+    | "PUT"
+    | "PATCH"
+    | "DELETE"
+    | "HEAD"
+    | "OPTIONS";
+  readonly headers?: HeadersInit;
+  readonly body?: BodyInit;
+  /**
+   * JSON body. Mutually exclusive with `body`. Sets content-type to
+   * application/json and serialises via JSON.stringify. Do NOT nest an oRPC
+   * envelope here — the RPC client (h.client) handles wire format itself.
+   */
+  readonly json?: unknown;
+  /**
+   * Impersonate a user. Creates a session, attaches the cookie to this
+   * request. Use null (the default) for anonymous requests.
+   */
+  readonly as?: User | null;
+  /**
+   * Treat the path as a /_plumix/* request and auto-add the custom CSRF
+   * header. Defaults to auto-detect based on path prefix.
+   */
+  readonly withCsrfHeader?: boolean;
+}
+
+const ORIGIN = "https://cms.example";
+
+export async function buildRequest(
+  db: TestDb,
+  path: string,
+  options: FetchOptions = {},
+): Promise<Request> {
+  const url = path.startsWith("http") ? path : `${ORIGIN}${path}`;
+  const headers = new Headers(options.headers);
+
+  if (options.json !== undefined) {
+    if (options.body !== undefined) {
+      throw new Error("buildRequest: pass either `json` or `body`, not both");
+    }
+    if (!headers.has("content-type")) {
+      headers.set("content-type", "application/json");
+    }
+  }
+
+  const needsCsrf =
+    options.withCsrfHeader ?? new URL(url).pathname.startsWith("/_plumix/");
+  if (needsCsrf && !headers.has("x-plumix-request")) {
+    headers.set("x-plumix-request", "1");
+  }
+
+  if (options.as) {
+    const { token } = await createSession(db, { userId: options.as.id });
+    const existing = headers.get("cookie");
+    const cookie = `${SESSION_COOKIE_NAME}=${token}`;
+    headers.set("cookie", existing ? `${existing}; ${cookie}` : cookie);
+  }
+
+  const init: RequestInit = {
+    method: options.method ?? (options.json !== undefined ? "POST" : "GET"),
+    headers,
+  };
+  if (options.json !== undefined) {
+    init.body = JSON.stringify(options.json);
+  } else if (options.body !== undefined) {
+    init.body = options.body;
+  }
+  return new Request(url, init);
+}
+
+/**
+ * Wraps a Response with chainable assertion helpers. Returned from
+ * harness.fetch() — callers never construct this directly.
+ */
+export class TestResponse {
+  readonly #response: Response;
+  readonly #bodyText: Promise<string>;
+
+  constructor(response: Response) {
+    this.#response = response;
+    this.#bodyText = response.clone().text();
+  }
+
+  get raw(): Response {
+    return this.#response;
+  }
+
+  get status(): number {
+    return this.#response.status;
+  }
+
+  get headers(): Headers {
+    return this.#response.headers;
+  }
+
+  async text(): Promise<string> {
+    return this.#bodyText;
+  }
+
+  async json<T = unknown>(): Promise<T> {
+    const text = await this.#bodyText;
+    return JSON.parse(text) as T;
+  }
+
+  assertStatus(code: number): this {
+    if (this.#response.status !== code) {
+      throw new Error(
+        `assertStatus: expected ${code}, got ${this.#response.status}`,
+      );
+    }
+    return this;
+  }
+
+  assertHeader(name: string, expected: string | RegExp): this {
+    const actual = this.#response.headers.get(name);
+    if (actual === null) {
+      throw new Error(`assertHeader: header "${name}" is absent`);
+    }
+    const matches =
+      typeof expected === "string"
+        ? actual === expected
+        : expected.test(actual);
+    if (!matches) {
+      throw new Error(
+        `assertHeader: "${name}" was "${actual}", expected ${String(expected)}`,
+      );
+    }
+    return this;
+  }
+
+  async assertJson(expected: unknown): Promise<this> {
+    const body = await this.json();
+    expect(body).toEqual(expected);
+    return this;
+  }
+
+  async assertJsonMatch(expected: unknown): Promise<this> {
+    const body = await this.json();
+    expect(body).toMatchObject(expected as Record<string, unknown>);
+    return this;
+  }
+
+  async assertBodyContains(needle: string | RegExp): Promise<this> {
+    const body = await this.text();
+    const ok =
+      typeof needle === "string" ? body.includes(needle) : needle.test(body);
+    if (!ok) {
+      throw new Error(
+        `assertBodyContains: body did not contain ${String(needle)}`,
+      );
+    }
+    return this;
+  }
+
+  /**
+   * Assert a Set-Cookie header was issued for the named cookie. Does not
+   * inspect the value — use assertHeader("set-cookie", /pattern/) for that.
+   */
+  assertCookieSet(name: string): this {
+    const set = this.#response.headers.get("set-cookie");
+    if (!set?.includes(`${name}=`)) {
+      throw new Error(`assertCookieSet: no Set-Cookie for "${name}"`);
+    }
+    return this;
+  }
+
+  assertRedirect(location?: string | RegExp): this {
+    const status = this.#response.status;
+    if (status < 300 || status >= 400) {
+      throw new Error(`assertRedirect: status ${status} is not a redirect`);
+    }
+    if (location !== undefined) {
+      this.assertHeader("location", location);
+    }
+    return this;
+  }
+
+  /**
+   * Assert the request resolved to the named template.
+   *
+   * @throws NotImplementedError
+   *
+   * The template layer is not built yet (Phase 11+ per PLAN.md). Once
+   * themes land, this will read from a request-scoped tracker populated
+   * by the template resolver. The surface is locked in now so tests
+   * written against it work verbatim later.
+   */
+  assertTemplate(_name: string): this {
+    throw new Error(
+      "assertTemplate is not yet implemented — theme / template system lands with the themes phase. API is stable; call sites written now will work once the feature ships.",
+    );
+  }
+}

--- a/packages/core/src/test/request.ts
+++ b/packages/core/src/test/request.ts
@@ -1,10 +1,10 @@
 import type { LibSQLDatabase } from "drizzle-orm/libsql";
-import { expect } from "vitest";
 
 import type * as schema from "../db/schema/index.js";
 import type { User } from "../db/schema/users.js";
 import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
 import { createSession } from "../auth/sessions.js";
+import { deepEqual, partialMatch } from "./match.js";
 
 type TestDb = LibSQLDatabase<typeof schema>;
 
@@ -143,13 +143,21 @@ export class TestResponse {
 
   async assertJson(expected: unknown): Promise<this> {
     const body = await this.json();
-    expect(body).toEqual(expected);
+    if (!deepEqual(body, expected)) {
+      throw new Error(
+        `assertJson: body did not equal expected\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(body)}`,
+      );
+    }
     return this;
   }
 
   async assertJsonMatch(expected: unknown): Promise<this> {
     const body = await this.json();
-    expect(body).toMatchObject(expected as Record<string, unknown>);
+    if (!partialMatch(body, expected)) {
+      throw new Error(
+        `assertJsonMatch: body did not match expected shape\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(body)}`,
+      );
+    }
     return this;
   }
 

--- a/packages/core/src/test/rpc.ts
+++ b/packages/core/src/test/rpc.ts
@@ -3,42 +3,73 @@ import { createRouterClient } from "@orpc/server";
 
 import type { AppContext, Db } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
-import type { HookExecutor } from "../hooks/registry.js";
+import type { HookExecutor, HookRegistry } from "../hooks/registry.js";
+import type {
+  ActionArgs,
+  ActionName,
+  FilterInput,
+  FilterName,
+  FilterRest,
+} from "../hooks/types.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
+import type { PlumixEnv } from "../runtime/bindings.js";
 import type { Factories } from "./factories.js";
+import type { ActionSpy, FilterSpy } from "./spies.js";
 import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
 import { createSession } from "../auth/sessions.js";
 import { createAppContext } from "../context/app.js";
-import { HookRegistry } from "../hooks/registry.js";
+import { HookRegistry as HookRegistryImpl } from "../hooks/registry.js";
 import { createPluginRegistry } from "../plugin/manifest.js";
 import { appRouter } from "../rpc/router.js";
 import { factoriesFor, userFactory } from "./factories.js";
 import { createTestDb } from "./harness.js";
+import { spyAction, spyFilter } from "./spies.js";
 
 type TestDb = Awaited<ReturnType<typeof createTestDb>>;
 
-interface BaseRpcHarnessOptions {
+export interface BaseRpcHarnessOptions {
   readonly hooks?: HookRegistry;
   readonly plugins?: PluginRegistry;
   readonly request?: Request;
+  /**
+   * Runtime environment bindings (KV, R2, etc.) — exposed on `h.env`.
+   * Empty object by default; override for tests that need specific bindings.
+   */
+  readonly env?: PlumixEnv;
 }
 
-interface AuthenticatedHarnessOptions extends BaseRpcHarnessOptions {
+export interface AuthenticatedHarnessOptions extends BaseRpcHarnessOptions {
   readonly authAs: UserRole;
 }
 
-interface RpcHarnessBase<TUser extends User | null> {
+export interface RpcHarnessBase<TUser extends User | null> {
   readonly db: TestDb;
   readonly hooks: HookRegistry;
   readonly plugins: PluginRegistry;
+  readonly env: PlumixEnv;
   readonly context: AppContext;
   readonly client: RouterClient<typeof appRouter>;
   readonly user: TUser;
   readonly factory: Factories;
+  readonly spyAction: <TName extends ActionName>(
+    name: TName,
+  ) => ActionSpy<ActionArgs<TName>>;
+  readonly spyFilter: <TName extends FilterName>(
+    name: TName,
+  ) => FilterSpy<FilterInput<TName>, FilterRest<TName>>;
+  /**
+   * Return a new harness bound to the given user (or freshly seeded user of
+   * the given role). The underlying db / hooks / plugins / env are shared,
+   * so state survives the swap — use this for tests that exercise multiple
+   * roles in a single scenario.
+   */
+  readonly actingAs: (
+    userOrRole: User | UserRole,
+  ) => Promise<AuthenticatedRpcHarness>;
 }
 
-type RpcHarness = RpcHarnessBase<User | null>;
-type AuthenticatedRpcHarness = RpcHarnessBase<User>;
+export type RpcHarness = RpcHarnessBase<User | null>;
+export type AuthenticatedRpcHarness = RpcHarnessBase<User>;
 
 const noop = (): void => undefined;
 const silentLogger = {
@@ -50,13 +81,14 @@ const silentLogger = {
 
 function buildContext(
   db: Db,
+  env: PlumixEnv,
   hooks: HookExecutor,
   plugins: PluginRegistry,
   request: Request,
 ): AppContext {
   return createAppContext({
     db,
-    env: {} as AppContext["env"],
+    env,
     request,
     hooks,
     plugins,
@@ -81,22 +113,36 @@ async function authenticatedRequest(
 
 function assemble<TUser extends User | null>(
   db: TestDb,
+  env: PlumixEnv,
   hooks: HookRegistry,
   plugins: PluginRegistry,
   request: Request,
   user: TUser,
 ): RpcHarnessBase<TUser> {
-  const context = buildContext(db, hooks, plugins, request);
+  const context = buildContext(db, env, hooks, plugins, request);
   const client = createRouterClient(appRouter, { context });
-  return {
+
+  const harness: RpcHarnessBase<TUser> = {
     db,
+    env,
     hooks,
     plugins,
     context,
     client,
     user,
     factory: factoriesFor(db),
+    spyAction: (name) => spyAction(hooks, name),
+    spyFilter: (name) => spyFilter(hooks, name),
+    actingAs: async (userOrRole) => {
+      const targetUser: User =
+        typeof userOrRole === "string"
+          ? await userFactory.transient({ db }).create({ role: userOrRole })
+          : userOrRole;
+      const req = await authenticatedRequest(db, targetUser.id);
+      return assemble(db, env, hooks, plugins, req, targetUser);
+    },
   };
+  return harness;
 }
 
 export function createRpcHarness(
@@ -109,17 +155,18 @@ export async function createRpcHarness(
   options: BaseRpcHarnessOptions & { authAs?: UserRole } = {},
 ): Promise<RpcHarness> {
   const db = await createTestDb();
-  const hooks = options.hooks ?? new HookRegistry();
+  const hooks = options.hooks ?? new HookRegistryImpl();
   const plugins = options.plugins ?? createPluginRegistry();
+  const env = options.env ?? ({} as PlumixEnv);
 
   if (!options.request && options.authAs) {
     const user = await userFactory
       .transient({ db })
       .create({ role: options.authAs });
     const request = await authenticatedRequest(db, user.id);
-    return assemble(db, hooks, plugins, request, user);
+    return assemble(db, env, hooks, plugins, request, user);
   }
 
   const request = options.request ?? unauthenticatedRequest();
-  return assemble<User | null>(db, hooks, plugins, request, null);
+  return assemble<User | null>(db, env, hooks, plugins, request, null);
 }

--- a/packages/core/src/test/spies.ts
+++ b/packages/core/src/test/spies.ts
@@ -1,5 +1,3 @@
-import { expect } from "vitest";
-
 import type { HookRegistry } from "../hooks/registry.js";
 import type {
   ActionArgs,
@@ -8,15 +6,26 @@ import type {
   FilterName,
   FilterRest,
 } from "../hooks/types.js";
+import { partialMatch } from "./match.js";
 
 export interface ActionCall<TArgs extends readonly unknown[]> {
   readonly args: TArgs;
 }
 
-export interface ActionSpy<TArgs extends readonly unknown[]> {
+export interface FilterCall<TValue, TRest extends readonly unknown[]> {
+  readonly input: TValue;
+  readonly rest: TRest;
+}
+
+interface SpyBaseReadonly<TCall> {
   readonly called: boolean;
   readonly callCount: number;
-  readonly calls: readonly ActionCall<TArgs>[];
+  readonly calls: readonly TCall[];
+}
+
+export interface ActionSpy<
+  TArgs extends readonly unknown[],
+> extends SpyBaseReadonly<ActionCall<TArgs>> {
   readonly lastArgs: TArgs | undefined;
   assertCalled(): ActionSpy<TArgs>;
   assertCalledOnce(): ActionSpy<TArgs>;
@@ -28,15 +37,10 @@ export interface ActionSpy<TArgs extends readonly unknown[]> {
   reset(): void;
 }
 
-export interface FilterCall<TValue, TRest extends readonly unknown[]> {
-  readonly input: TValue;
-  readonly rest: TRest;
-}
-
-export interface FilterSpy<TValue, TRest extends readonly unknown[]> {
-  readonly called: boolean;
-  readonly callCount: number;
-  readonly calls: readonly FilterCall<TValue, TRest>[];
+export interface FilterSpy<
+  TValue,
+  TRest extends readonly unknown[],
+> extends SpyBaseReadonly<FilterCall<TValue, TRest>> {
   readonly lastInput: TValue | undefined;
   assertCalled(): FilterSpy<TValue, TRest>;
   assertCalledOnce(): FilterSpy<TValue, TRest>;
@@ -52,7 +56,64 @@ export interface FilterSpy<TValue, TRest extends readonly unknown[]> {
   override(
     transform: (input: TValue, ...rest: TRest) => TValue | Promise<TValue>,
   ): void;
+}
+
+/**
+ * Shared assertion / state helpers for both spy flavours. `self` is a
+ * thunk so the methods return the concrete spy type for chaining — the
+ * base only knows how to count and reset the call array.
+ */
+function buildSpyBase<TCall, TSpy>(
+  label: string,
+  calls: TCall[],
+  self: () => TSpy,
+): SpyBaseReadonly<TCall> & {
+  assertCalled(): TSpy;
+  assertCalledOnce(): TSpy;
+  assertCalledTimes(n: number): TSpy;
+  assertNotCalled(): TSpy;
   reset(): void;
+} {
+  return {
+    get called() {
+      return calls.length > 0;
+    },
+    get callCount() {
+      return calls.length;
+    },
+    get calls() {
+      return calls;
+    },
+    assertCalled() {
+      if (calls.length === 0) {
+        throw new Error(`${label}: expected to be called, was not`);
+      }
+      return self();
+    },
+    assertCalledOnce() {
+      if (calls.length !== 1) {
+        throw new Error(
+          `${label}: expected exactly 1 call, got ${calls.length}`,
+        );
+      }
+      return self();
+    },
+    assertCalledTimes(n) {
+      if (calls.length !== n) {
+        throw new Error(`${label}: expected ${n} calls, got ${calls.length}`);
+      }
+      return self();
+    },
+    assertNotCalled() {
+      if (calls.length > 0) {
+        throw new Error(`${label}: expected no calls, got ${calls.length}`);
+      }
+      return self();
+    },
+    reset() {
+      calls.length = 0;
+    },
+  };
 }
 
 /**
@@ -69,60 +130,21 @@ export function spyAction<TName extends ActionName>(
     calls.push({ args });
   }) as never);
 
+  const label = `spyAction(${name})`;
   const spy: ActionSpy<ActionArgs<TName>> = {
-    get called() {
-      return calls.length > 0;
-    },
-    get callCount() {
-      return calls.length;
-    },
-    get calls() {
-      return calls;
-    },
+    ...buildSpyBase<
+      ActionCall<ActionArgs<TName>>,
+      ActionSpy<ActionArgs<TName>>
+    >(label, calls, () => spy),
     get lastArgs() {
       return calls[calls.length - 1]?.args;
-    },
-    assertCalled() {
-      if (calls.length === 0) {
-        throw new Error(`spyAction(${name}): expected to be called, was not`);
-      }
-      return spy;
-    },
-    assertCalledOnce() {
-      if (calls.length !== 1) {
-        throw new Error(
-          `spyAction(${name}): expected exactly 1 call, got ${calls.length}`,
-        );
-      }
-      return spy;
-    },
-    assertCalledTimes(n) {
-      if (calls.length !== n) {
-        throw new Error(
-          `spyAction(${name}): expected ${n} calls, got ${calls.length}`,
-        );
-      }
-      return spy;
-    },
-    assertNotCalled() {
-      if (calls.length > 0) {
-        throw new Error(
-          `spyAction(${name}): expected no calls, got ${calls.length}`,
-        );
-      }
-      return spy;
     },
     assertCalledWith(matcher) {
       for (const call of calls) {
         const result = matcher(...call.args);
         if (result === true || result === undefined) return spy;
       }
-      throw new Error(
-        `spyAction(${name}): no call matched the supplied matcher`,
-      );
-    },
-    reset() {
-      calls.length = 0;
+      throw new Error(`${label}: no call matched the supplied matcher`);
     },
   };
   return spy;
@@ -132,6 +154,12 @@ export function spyAction<TName extends ActionName>(
  * Install a recording filter on the named hook. By default it's a
  * pass-through; call `.override(fn)` to transform the value. Still records
  * every invocation regardless.
+ *
+ * @remarks
+ * Identity note: the hook registry `structuredClone`s each filter input
+ * before passing it to listeners, so `spy.calls[i].input` is a clone, not
+ * the caller-supplied reference. Use equality matchers
+ * (`deepEqual` / `toEqual` / `toMatchObject`) — not identity / `toBe`.
  */
 export function spyFilter<TName extends FilterName>(
   hooks: HookRegistry,
@@ -154,72 +182,36 @@ export function spyFilter<TName extends FilterName>(
     return input;
   }) as never);
 
+  const label = `spyFilter(${name})`;
   const spy: FilterSpy<FilterInput<TName>, FilterRest<TName>> = {
-    get called() {
-      return calls.length > 0;
-    },
-    get callCount() {
-      return calls.length;
-    },
-    get calls() {
-      return calls;
-    },
+    ...buildSpyBase<
+      FilterCall<FilterInput<TName>, FilterRest<TName>>,
+      FilterSpy<FilterInput<TName>, FilterRest<TName>>
+    >(label, calls, () => spy),
     get lastInput() {
       return calls[calls.length - 1]?.input;
-    },
-    assertCalled() {
-      if (calls.length === 0) {
-        throw new Error(`spyFilter(${name}): expected to be called, was not`);
-      }
-      return spy;
-    },
-    assertCalledOnce() {
-      if (calls.length !== 1) {
-        throw new Error(
-          `spyFilter(${name}): expected exactly 1 call, got ${calls.length}`,
-        );
-      }
-      return spy;
-    },
-    assertCalledTimes(n) {
-      if (calls.length !== n) {
-        throw new Error(
-          `spyFilter(${name}): expected ${n} calls, got ${calls.length}`,
-        );
-      }
-      return spy;
-    },
-    assertNotCalled() {
-      if (calls.length > 0) {
-        throw new Error(
-          `spyFilter(${name}): expected no calls, got ${calls.length}`,
-        );
-      }
-      return spy;
     },
     assertCalledWith(matcher) {
       for (const call of calls) {
         const result = matcher(call.input, ...call.rest);
         if (result === true || result === undefined) return spy;
       }
-      throw new Error(
-        `spyFilter(${name}): no call matched the supplied matcher`,
-      );
+      throw new Error(`${label}: no call matched the supplied matcher`);
     },
     override(fn) {
       transform = fn;
-    },
-    reset() {
-      calls.length = 0;
     },
   };
   return spy;
 }
 
 /**
- * Convenience: assert an oRPC procedure rejects with a specific error code
- * (and optionally matches a data shape). Replaces the widely-copied
+ * Assert that a promise rejects with a specific error code (and optionally
+ * matches a partial data shape). Replaces the widely-copied
  * `.rejects.toMatchObject({ code, data })` idiom.
+ *
+ * Runner-agnostic — throws plain Errors, so it works under vitest, jest,
+ * node:test, bun test, or anything that surfaces thrown errors as failures.
  */
 export async function expectError(
   promise: Promise<unknown>,
@@ -236,9 +228,18 @@ export async function expectError(
       `expectError: expected rejection with code="${expected.code}", promise resolved`,
     );
   }
-  const shape: Record<string, unknown> = { code: expected.code };
-  if (expected.data !== undefined) {
-    shape.data = expected.data;
+  const actualCode = (caught as { code?: unknown }).code;
+  if (actualCode !== expected.code) {
+    throw new Error(
+      `expectError: expected code="${expected.code}", got "${String(actualCode)}"`,
+    );
   }
-  expect(caught).toMatchObject(shape);
+  if (expected.data !== undefined) {
+    const actualData = (caught as { data?: unknown }).data;
+    if (!partialMatch(actualData, expected.data)) {
+      throw new Error(
+        `expectError: data did not match — expected ${JSON.stringify(expected.data)}, got ${JSON.stringify(actualData)}`,
+      );
+    }
+  }
 }

--- a/packages/core/src/test/spies.ts
+++ b/packages/core/src/test/spies.ts
@@ -1,0 +1,244 @@
+import { expect } from "vitest";
+
+import type { HookRegistry } from "../hooks/registry.js";
+import type {
+  ActionArgs,
+  ActionName,
+  FilterInput,
+  FilterName,
+  FilterRest,
+} from "../hooks/types.js";
+
+export interface ActionCall<TArgs extends readonly unknown[]> {
+  readonly args: TArgs;
+}
+
+export interface ActionSpy<TArgs extends readonly unknown[]> {
+  readonly called: boolean;
+  readonly callCount: number;
+  readonly calls: readonly ActionCall<TArgs>[];
+  readonly lastArgs: TArgs | undefined;
+  assertCalled(): ActionSpy<TArgs>;
+  assertCalledOnce(): ActionSpy<TArgs>;
+  assertCalledTimes(n: number): ActionSpy<TArgs>;
+  assertNotCalled(): ActionSpy<TArgs>;
+  assertCalledWith(
+    matcher: (...args: TArgs) => boolean | void,
+  ): ActionSpy<TArgs>;
+  reset(): void;
+}
+
+export interface FilterCall<TValue, TRest extends readonly unknown[]> {
+  readonly input: TValue;
+  readonly rest: TRest;
+}
+
+export interface FilterSpy<TValue, TRest extends readonly unknown[]> {
+  readonly called: boolean;
+  readonly callCount: number;
+  readonly calls: readonly FilterCall<TValue, TRest>[];
+  readonly lastInput: TValue | undefined;
+  assertCalled(): FilterSpy<TValue, TRest>;
+  assertCalledOnce(): FilterSpy<TValue, TRest>;
+  assertCalledTimes(n: number): FilterSpy<TValue, TRest>;
+  assertNotCalled(): FilterSpy<TValue, TRest>;
+  assertCalledWith(
+    matcher: (input: TValue, ...rest: TRest) => boolean | void,
+  ): FilterSpy<TValue, TRest>;
+  /**
+   * Replace the pass-through with a transform. The spy still records every
+   * call, but the filter chain now sees the transform's return value.
+   */
+  override(
+    transform: (input: TValue, ...rest: TRest) => TValue | Promise<TValue>,
+  ): void;
+  reset(): void;
+}
+
+/**
+ * Install a recording listener on the named action. Captures every call's
+ * args for later assertion. Adding the spy is non-destructive — other
+ * listeners continue to run normally.
+ */
+export function spyAction<TName extends ActionName>(
+  hooks: HookRegistry,
+  name: TName,
+): ActionSpy<ActionArgs<TName>> {
+  const calls: ActionCall<ActionArgs<TName>>[] = [];
+  hooks.addAction(name, ((...args: ActionArgs<TName>) => {
+    calls.push({ args });
+  }) as never);
+
+  const spy: ActionSpy<ActionArgs<TName>> = {
+    get called() {
+      return calls.length > 0;
+    },
+    get callCount() {
+      return calls.length;
+    },
+    get calls() {
+      return calls;
+    },
+    get lastArgs() {
+      return calls[calls.length - 1]?.args;
+    },
+    assertCalled() {
+      if (calls.length === 0) {
+        throw new Error(`spyAction(${name}): expected to be called, was not`);
+      }
+      return spy;
+    },
+    assertCalledOnce() {
+      if (calls.length !== 1) {
+        throw new Error(
+          `spyAction(${name}): expected exactly 1 call, got ${calls.length}`,
+        );
+      }
+      return spy;
+    },
+    assertCalledTimes(n) {
+      if (calls.length !== n) {
+        throw new Error(
+          `spyAction(${name}): expected ${n} calls, got ${calls.length}`,
+        );
+      }
+      return spy;
+    },
+    assertNotCalled() {
+      if (calls.length > 0) {
+        throw new Error(
+          `spyAction(${name}): expected no calls, got ${calls.length}`,
+        );
+      }
+      return spy;
+    },
+    assertCalledWith(matcher) {
+      for (const call of calls) {
+        const result = matcher(...call.args);
+        if (result === true || result === undefined) return spy;
+      }
+      throw new Error(
+        `spyAction(${name}): no call matched the supplied matcher`,
+      );
+    },
+    reset() {
+      calls.length = 0;
+    },
+  };
+  return spy;
+}
+
+/**
+ * Install a recording filter on the named hook. By default it's a
+ * pass-through; call `.override(fn)` to transform the value. Still records
+ * every invocation regardless.
+ */
+export function spyFilter<TName extends FilterName>(
+  hooks: HookRegistry,
+  name: TName,
+): FilterSpy<FilterInput<TName>, FilterRest<TName>> {
+  const calls: FilterCall<FilterInput<TName>, FilterRest<TName>>[] = [];
+  let transform:
+    | ((
+        input: FilterInput<TName>,
+        ...rest: FilterRest<TName>
+      ) => FilterInput<TName> | Promise<FilterInput<TName>>)
+    | null = null;
+
+  hooks.addFilter(name, (async (
+    input: FilterInput<TName>,
+    ...rest: FilterRest<TName>
+  ): Promise<FilterInput<TName>> => {
+    calls.push({ input, rest });
+    if (transform) return transform(input, ...rest);
+    return input;
+  }) as never);
+
+  const spy: FilterSpy<FilterInput<TName>, FilterRest<TName>> = {
+    get called() {
+      return calls.length > 0;
+    },
+    get callCount() {
+      return calls.length;
+    },
+    get calls() {
+      return calls;
+    },
+    get lastInput() {
+      return calls[calls.length - 1]?.input;
+    },
+    assertCalled() {
+      if (calls.length === 0) {
+        throw new Error(`spyFilter(${name}): expected to be called, was not`);
+      }
+      return spy;
+    },
+    assertCalledOnce() {
+      if (calls.length !== 1) {
+        throw new Error(
+          `spyFilter(${name}): expected exactly 1 call, got ${calls.length}`,
+        );
+      }
+      return spy;
+    },
+    assertCalledTimes(n) {
+      if (calls.length !== n) {
+        throw new Error(
+          `spyFilter(${name}): expected ${n} calls, got ${calls.length}`,
+        );
+      }
+      return spy;
+    },
+    assertNotCalled() {
+      if (calls.length > 0) {
+        throw new Error(
+          `spyFilter(${name}): expected no calls, got ${calls.length}`,
+        );
+      }
+      return spy;
+    },
+    assertCalledWith(matcher) {
+      for (const call of calls) {
+        const result = matcher(call.input, ...call.rest);
+        if (result === true || result === undefined) return spy;
+      }
+      throw new Error(
+        `spyFilter(${name}): no call matched the supplied matcher`,
+      );
+    },
+    override(fn) {
+      transform = fn;
+    },
+    reset() {
+      calls.length = 0;
+    },
+  };
+  return spy;
+}
+
+/**
+ * Convenience: assert an oRPC procedure rejects with a specific error code
+ * (and optionally matches a data shape). Replaces the widely-copied
+ * `.rejects.toMatchObject({ code, data })` idiom.
+ */
+export async function expectError(
+  promise: Promise<unknown>,
+  expected: { readonly code: string; readonly data?: unknown },
+): Promise<void> {
+  let caught: unknown = undefined;
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+  }
+  if (caught === undefined) {
+    throw new Error(
+      `expectError: expected rejection with code="${expected.code}", promise resolved`,
+    );
+  }
+  const shape: Record<string, unknown> = { code: expected.code };
+  if (expected.data !== undefined) {
+    shape.data = expected.data;
+  }
+  expect(caught).toMatchObject(shape);
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts", "src/test/**"]
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/plumix/src/test/index.ts
+++ b/packages/plumix/src/test/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "@plumix/core/test";

--- a/packages/plumix/test/test-subpath.test.ts
+++ b/packages/plumix/test/test-subpath.test.ts
@@ -1,0 +1,60 @@
+// Import through the published subpath — fails if the barrel in
+// @plumix/core/test drifts from what plumix/test re-exports, or if a
+// future build config accidentally drops the test subpath from dist.
+import {
+  categoryTerm,
+  createDispatcherHarness,
+  createRpcHarness,
+  createTestDb,
+  credentialFactory,
+  factoriesFor,
+  inviteFactory,
+  plumixRequest,
+  postFactory,
+  publishedPost,
+  tagTerm,
+  termFactory,
+  userFactory,
+} from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+describe("plumix/test subpath", () => {
+  test("re-exports the full factory + harness surface", () => {
+    for (const exp of [
+      userFactory,
+      postFactory,
+      publishedPost,
+      termFactory,
+      categoryTerm,
+      tagTerm,
+      inviteFactory,
+      credentialFactory,
+      factoriesFor,
+      createTestDb,
+      createDispatcherHarness,
+      createRpcHarness,
+      plumixRequest,
+    ]) {
+      expect(exp).toBeDefined();
+    }
+  });
+
+  test("factoriesFor returns a db-bound factory bundle", async () => {
+    const db = await createTestDb();
+    const factories = factoriesFor(db);
+    expect(factories.user).toBeDefined();
+    expect(factories.post).toBeDefined();
+    expect(factories.term).toBeDefined();
+    expect(factories.invite).toBeDefined();
+    expect(factories.credential).toBeDefined();
+  });
+
+  test("term + category + tag factories persist through the db", async () => {
+    const db = await createTestDb();
+    const factories = factoriesFor(db);
+    const category = await factories.category.create();
+    expect(category.taxonomy).toBe("category");
+    const tag = await factories.tag.create();
+    expect(tag.taxonomy).toBe("tag");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@libsql/client':
+        specifier: ^0.17.2
+        version: 0.17.2
       '@orpc/server':
         specifier: ^1.13.14
         version: 1.13.14(ws@8.20.0)
@@ -164,19 +167,22 @@ importers:
       '@oslojs/webauthn':
         specifier: ^1.0.0
         version: 1.0.0
+      drizzle-kit:
+        specifier: 'catalog:'
+        version: 0.31.10
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2)
       drizzle-valibot:
         specifier: 'catalog:'
         version: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260417.1)(@libsql/client@0.17.2))(valibot@1.3.1(typescript@6.0.3))
+      fishery:
+        specifier: ^2.4.0
+        version: 2.4.0
       valibot:
         specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.3)
     devDependencies:
-      '@libsql/client':
-        specifier: ^0.17.2
-        version: 0.17.2
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
@@ -189,15 +195,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
-      drizzle-kit:
-        specifier: 'catalog:'
-        version: 0.31.10
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)
-      fishery:
-        specifier: ^2.4.0
-        version: 2.4.0
       prettier:
         specifier: 'catalog:'
         version: 3.8.3


### PR DESCRIPTION
## Summary

Ships the public \`plumix/test\` surface so theme, plugin, and end-user-app
authors can write terse integration tests against a Plumix app without
reaching into internal modules.

### 1. Factory coverage (every persisted schema)
Added: \`termFactory\` (+ categoryTerm/tagTerm), \`inviteFactory\`,
\`credentialFactory\`, \`sessionFactory\`, \`optionFactory\`, \`postTermFactory\`,
\`postMetaFactory\`, \`userMetaFactory\`, \`termMetaFactory\`, \`allowedDomainFactory\`.
Existing userFactory / postFactory / role + status variants retained.
\`factoriesFor(db)\` now bundles the full set behind a db-bound object.
Internal passkey / user tests migrated to use them (authenticate, routes,
user) — validates the DX on the same day it lands.

### 2. \`@plumix/core/test\` + \`plumix/test\` subpath
- \`@plumix/core\` exposes a \`./test\` export; \`tsconfig.build.json\` includes
  \`src/test/\` in dist.
- \`fishery\`, \`@libsql/client\`, \`drizzle-kit\` moved from devDeps to runtime
  deps (harness imports them directly).
- \`plumix/src/test/index.ts\` re-exports from \`@plumix/core/test\`, matching
  the \`plumix/schema\` pattern.
- Smoke test in \`packages/plumix/test/test-subpath.test.ts\` imports through
  the published subpath so a dist regression breaks tests, not consumers.

### 3. Test DX kit — request/spies/assertions/env/actingAs
New helpers exposed from \`plumix/test\`:

- **\`h.fetch(path, { method, json, as, withCsrfHeader })\`** (dispatcher
  harness) returns a \`TestResponse\` with chainable \`.assertStatus()\` /
  \`.assertHeader()\` / \`.assertJson()\` / \`.assertBodyContains()\` /
  \`.assertCookieSet()\` / \`.assertRedirect()\`. The \`json\` option serialises
  and sets content-type; \`as: User\` attaches a session cookie.
- **\`TestResponse.assertTemplate(name)\`** — API locked, throws
  \`NotImplementedError\` until the themes phase lands.
- **\`h.actingAs(userOrRole)\`** (RPC harness) — returns a new scoped harness
  bound to the target user. DB / hooks / plugins / env are shared, so
  tests can alternate roles mid-scenario.
- **\`h.spyAction(name)\` / \`h.spyFilter(name)\`** — recording wrappers with
  \`.assertCalledOnce()\` / \`.assertCalledWith(matcher)\` / \`.assertNotCalled()\` /
  \`.override(fn)\` (filters only). Replaces the repeated
  \`vi.fn() + h.hooks.addAction()\` idiom.
- **\`expectError(promise, { code, data? })\`** — one-liner for typed error
  rejection assertions; replaces the custom \`expectErrorCode\` helper.
- **\`h.env\` + \`env\` option** on both harnesses — escape hatch for tests
  that interact with runtime bindings (KV, R2, DOs) directly. Empty
  object by default.

Existing \`post.create\` / \`post.update\` / \`authenticated\` tests dogfood the
spy + expectError surface. The typed RPC client (\`h.client\`) remains the
primary path for RPC tests; \`fetch\` is for frontend / theme / raw-HTTP.

## Test plan

- [x] \`pnpm typecheck\` green (13/13)
- [x] \`pnpm test:unit\` passes (245 core + 59 CF + 8 plumix)
- [x] \`pnpm test:integration\` passes (245 + 59 + 4 minimal)
- [x] \`pnpm lint\`, \`pnpm format\`, \`pnpm knip\` clean
- [x] \`pnpm publint\` and \`pnpm attw\` green for every publishable package
- [ ] CI green end-to-end

## Notes

- The branch has two \`fixup!\` commits that I couldn't autosquash cleanly
  due to interleaved barrel edits. Recommend **squash-and-merge** for a
  tidy main history; the commit message above covers the whole scope.
- \`assertTemplate()\` is intentionally a stub — the surface is locked so
  tests written against it will work verbatim once themes land.