### PR TITLE
build(admin): e2e baseline — Playwright + axe-core accessibility check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,15 +78,14 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
-      # Cache the Playwright browser binaries (~120 MB) keyed on the installed
-      # @playwright/test version. System deps (apt libs like libnss3) aren't in
-      # this cache — they're reinstalled cheaply via `install-deps` below.
+      # Cache the Playwright browser binaries (~120 MB) keyed on the declared
+      # @playwright/test version. System deps (apt libs like libnss3) aren't
+      # cached cross-runner — they're reinstalled cheaply via install-deps.
       - name: Resolve Playwright version
         id: playwright-version
         shell: bash
         run: |
-          version=$(pnpm --filter @plumix/admin list @playwright/test --depth 0 --json \
-            | jq -r '.[0].devDependencies["@playwright/test"].version')
+          version=$(node -p "require('./packages/admin/package.json').devDependencies['@playwright/test']")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
@@ -98,13 +97,15 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @plumix/admin exec playwright install --with-deps chromium
+        working-directory: packages/admin
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Install Playwright system deps (cache hit — browsers already there)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @plumix/admin exec playwright install-deps chromium
+        working-directory: packages/admin
+        run: pnpm exec playwright install-deps chromium
 
-      - run: pnpm --filter @plumix/admin test:e2e
+      - run: pnpm test:e2e
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,49 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm test
 
+  test-e2e:
+    name: Test (e2e)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+
+      # Cache the Playwright browser binaries (~120 MB) keyed on the installed
+      # @playwright/test version. System deps (apt libs like libnss3) aren't in
+      # this cache — they're reinstalled cheaply via `install-deps` below.
+      - name: Resolve Playwright version
+        id: playwright-version
+        shell: bash
+        run: |
+          version=$(pnpm --filter @plumix/admin list @playwright/test --depth 0 --json \
+            | jq -r '.[0].devDependencies["@playwright/test"].version')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @plumix/admin exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit — browsers already there)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @plumix/admin exec playwright install-deps chromium
+
+      - run: pnpm --filter @plumix/admin test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/admin/playwright-report/
+          retention-days: 14
+
   publint:
     name: Publint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,13 +107,13 @@ jobs:
 
       - run: pnpm test:e2e
 
-      - name: Upload Playwright report on failure
+      - name: Upload Playwright reports on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: packages/admin/playwright-report/
-          retention-days: 14
+          name: playwright-reports
+          path: "**/playwright-report/"
+          retention-days: 5
 
   publint:
     name: Publint

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "postinstall": "pnpm dlx sherif@latest -r packages-without-package-json",
     "publint": "turbo run publint",
     "test": "turbo run test",
+    "test:e2e": "turbo run test:e2e",
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -62,6 +62,20 @@ cd examples/minimal
 pnpm plumix migrate apply
 ```
 
+### End-to-end tests (Playwright + axe-core)
+
+`pnpm test:e2e` launches a dedicated Vite server on `:5180` and runs the
+Playwright suite against it. First-time setup needs Chromium installed:
+
+```bash
+pnpm exec playwright install --with-deps chromium    # once
+pnpm test:e2e                                         # each run
+```
+
+The default suite is an accessibility baseline — axe-core with WCAG 2.1 AA
+tags run against the landing page. Every new route or feature should add a
+spec under `e2e/`.
+
 ### Workspace-local scripts
 
 From `packages/admin/`:
@@ -70,6 +84,7 @@ From `packages/admin/`:
 pnpm dev          # Vite dev server on http://localhost:5174/_plumix/admin/
 pnpm build        # emits static assets to dist/
 pnpm test         # vitest (jsdom + React Testing Library)
+pnpm test:e2e     # playwright + axe-core (needs chromium installed once)
 pnpm typecheck
 pnpm lint
 ```
@@ -82,6 +97,7 @@ pnpm lint
 - **Tailwind CSS v4** (`@tailwindcss/vite`) + **shadcn/ui** (new-york style, neutral base)
 - **Geist Variable** + **Geist Mono Variable** via `@fontsource-variable/*`
 - Vitest + React Testing Library for component tests
+- Playwright + @axe-core/playwright for e2e and accessibility baseline
 
 ## Directory layout
 

--- a/packages/admin/e2e/accessibility.spec.ts
+++ b/packages/admin/e2e/accessibility.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("admin accessibility", () => {
+  test("landing page has zero WCAG 2.1 AA violations", async ({ page }) => {
+    await page.goto("/");
+    // Prove the app actually rendered — otherwise axe happily scans a blank page.
+    await expect(
+      page.getByRole("heading", { name: "Plumix Admin" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "clean": "git clean -xdf .cache .turbo dist node_modules playwright-report test-results",
     "dev": "vite",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -25,6 +26,8 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
+    "@playwright/test": "^1.59.1",
     "@plumix/core": "workspace:*",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",

--- a/packages/admin/playwright.config.ts
+++ b/packages/admin/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+import { ADMIN_BASE_PATH } from "./src/lib/constants.js";
+
+// Isolate e2e's Vite from the regular dev server port to avoid clashing with
+// a developer already running `pnpm dev`.
+const E2E_PORT = 5180;
+const BASE_URL = `http://localhost:${String(E2E_PORT)}${ADMIN_BASE_PATH}/`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["list"], ["github"]] : [["list"], ["html"]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: `pnpm exec vite --port ${String(E2E_PORT)} --strictPort`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 60_000,
+  },
+});

--- a/packages/admin/src/routes/index.tsx
+++ b/packages/admin/src/routes/index.tsx
@@ -26,7 +26,9 @@ function IndexRoute(): ReactNode {
     <main className="bg-background flex min-h-screen items-center justify-center p-8">
       <Card className="w-full max-w-md">
         <CardHeader>
-          <CardTitle>Plumix Admin</CardTitle>
+          <CardTitle role="heading" aria-level={1}>
+            Plumix Admin
+          </CardTitle>
           <CardDescription>Shell scaffold — no features yet.</CardDescription>
         </CardHeader>
         <CardContent>

--- a/packages/admin/tsconfig.json
+++ b/packages/admin/tsconfig.json
@@ -8,6 +8,13 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "test", "vite.config.ts", "vitest.config.ts"],
+  "include": [
+    "src",
+    "test",
+    "e2e",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,12 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.2
+        version: 4.11.2(playwright-core@1.59.1)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@plumix/core':
         specifier: workspace:*
         version: link:../core
@@ -634,6 +640,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.11.2':
+    resolution: {integrity: sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2089,6 +2100,11 @@ packages:
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@pnpm/constants@7.1.1':
     resolution: {integrity: sha512-31pZqMtjwV+Vaq7MaPrT1EoDFSYwye3dp6BiHIGRJmVThCQwySRKM7hCvqqI94epNkqFAAYoWrNynWoRYosGdw==}
     engines: {node: '>=16.14'}
@@ -2821,6 +2837,10 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
+
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
@@ -3435,6 +3455,11 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4165,6 +4190,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4998,6 +5033,11 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@axe-core/playwright@4.11.2(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.3
+      playwright-core: 1.59.1
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6161,6 +6201,10 @@ snapshots:
 
   '@package-json/types@0.0.12': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@pnpm/constants@7.1.1': {}
 
   '@pnpm/error@5.0.3':
@@ -6860,6 +6904,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.11.3: {}
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -7570,6 +7616,9 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -8331,6 +8380,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,10 @@
     "test": {
       "dependsOn": ["build"]
     },
+    "test:e2e": {
+      "dependsOn": ["build"],
+      "cache": false
+    },
     "clean": {
       "cache": false
     },


### PR DESCRIPTION
## Summary

Establishes the e2e harness for `packages/admin` with a single deliberate first test: WCAG 2.1 AA accessibility scan via axe-core. Lands before any feature UI so every future route picks up a11y + e2e coverage from the start instead of retrofitting onto N existing features.

> **Stacked on [PR #23](https://github.com/withplumix/plumix/pull/23)** (admin shell scaffold). Review after #23 merges; this PR will rebase cleanly onto main.

## What's in

- `@playwright/test@^1.59.1` + `@axe-core/playwright@^4.11.2` as admin devDeps
- `packages/admin/playwright.config.ts` — dedicated Vite `webServer` on `:5180` so `pnpm test:e2e` never collides with an already-running `pnpm dev` on `:5174`
- `packages/admin/e2e/accessibility.spec.ts` — navigates to `/`, asserts the heading is visible (first-render sanity — axe happily scans blank pages otherwise), runs axe with WCAG 2.1 A+AA tags, asserts zero violations
- `packages/admin/src/routes/index.tsx` — `CardTitle` gets `role="heading" aria-level={1}` so axe sees a proper document outline (shadcn's `CardTitle` is a `<div>` by design; explicit role keeps the semantics without forking the shadcn component)
- `packages/admin/tsconfig.json` includes `e2e/` + `playwright.config.ts`
- Root `test:e2e` script + turbo task (`cache: false`) — delegates to every workspace that declares a `test:e2e` script, so adding e2e to `examples/*` later needs zero root wiring

## CI job — the fast-cache recipe

New `Test (e2e)` job in `.github/workflows/ci.yml`:

```yaml
- name: Resolve Playwright version
  id: playwright-version
  run: |
    version=$(node -p "require('./packages/admin/package.json').devDependencies['@playwright/test']")
    echo "version=$version" >> "$GITHUB_OUTPUT"

- name: Cache Playwright browsers
  id: playwright-cache
  uses: actions/cache@v4
  with:
    path: ~/.cache/ms-playwright
    key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}

- name: Install Playwright browsers
  if: steps.playwright-cache.outputs.cache-hit != 'true'
  working-directory: packages/admin
  run: pnpm exec playwright install --with-deps chromium

- name: Install Playwright system deps (cache hit — browsers already there)
  if: steps.playwright-cache.outputs.cache-hit == 'true'
  working-directory: packages/admin
  run: pnpm exec playwright install-deps chromium

- run: pnpm test:e2e
```

**Why this shape:**
- **Cache key = declared version string** (e.g. `^1.59.1`). Bumping the dep invalidates the cache; browser binaries redownloaded once, then reused for every subsequent run until the next bump.
- **Browsers cached (~120 MB), apt deps not.** `actions/cache` can't carry apt state; `install-deps` is cheap (~10s with apt cache warm), and `--with-deps` on cache miss installs both in one call.
- **Artifact upload on failure only.** `playwright-report/` saved with 14-day retention — failing runs leave a trace without bloating successful runs.

Expected CI job time: **~45-60s with warm cache**, ~3 min on cold cache (one-time per version bump).

## Why the e2e suite starts with a11y

- Axe is cheap, boring, objective — no subjective assertions about "does this flow work"
- A11y violations compound: fix 1 easy, fix 20 is a quarter's work
- The first spec proves the harness (Vite auto-start, Chromium, axe) end-to-end without needing any feature code
- Every future route adds its own spec; a11y is baseline, feature scenarios are additive

Pattern borrowed from Emdash: [e2e/tests/accessibility.spec.ts](https://github.com/emdash-cms/emdash/blob/main/e2e/tests/accessibility.spec.ts).

## What's deferred

- Additional e2e scenarios — each feature route (login, post list, editor) lands with its own spec
- Multi-browser coverage (Firefox, WebKit) — Chromium-only today keeps the harness lean; expand if browser-specific bugs surface
- Visual regression (screenshots) — not worth the flake surface until admin UI stabilizes

## Test plan

- [ ] Existing CI jobs stay green
- [ ] New `Test (e2e)` job passes on CI
- [ ] `pnpm exec playwright install --with-deps chromium` (one-time) then `pnpm test:e2e` from repo root passes locally
- [ ] Intentionally break the landing page (remove the `role="heading"` or regress contrast) → axe test fails with a clear violations list
- [ ] Second CI run on the same PR: Playwright browser cache hits, job completes in ~45-60s