### PR TITLE
feat(plumix): build/serve pipeline for the pre-compiled admin

### DIFF
--- a/examples/minimal/test/build.integration.test.ts
+++ b/examples/minimal/test/build.integration.test.ts
@@ -10,6 +10,7 @@ const distDir = resolve(exampleDir, "dist");
 const plumixDir = resolve(exampleDir, ".plumix");
 const workerArtifact = resolve(distDir, "plumix_minimal/index.js");
 const workerWrangler = resolve(distDir, "plumix_minimal/wrangler.json");
+const adminIndexHtml = resolve(distDir, "client/_plumix/admin/index.html");
 
 async function runBuild(): Promise<{ code: number | null; stderr: string }> {
   return new Promise((resolvePromise, rejectPromise) => {
@@ -29,7 +30,7 @@ async function runBuild(): Promise<{ code: number | null; stderr: string }> {
 
 describe("examples/minimal — plumix build", () => {
   test(
-    "emits a worker bundle and rendered wrangler.json",
+    "emits a worker bundle, rendered wrangler.json, and staged admin assets",
     async () => {
       rmSync(distDir, { recursive: true, force: true });
       rmSync(plumixDir, { recursive: true, force: true });
@@ -41,6 +42,9 @@ describe("examples/minimal — plumix build", () => {
       expect(statSync(workerArtifact).size).toBeGreaterThan(1024);
 
       expect(existsSync(workerWrangler)).toBe(true);
+
+      // Admin SPA ends up in the Cloudflare assets bundle.
+      expect(existsSync(adminIndexHtml)).toBe(true);
     },
     60_000,
   );

--- a/examples/minimal/wrangler.jsonc
+++ b/examples/minimal/wrangler.jsonc
@@ -10,5 +10,10 @@
       "database_name": "plumix_minimal",
       "database_id": "00000000-0000-0000-0000-000000000000"
     }
-  ]
+  ],
+  "assets": {
+    "directory": ".plumix/public",
+    "binding": "ASSETS",
+    "not_found_handling": "none"
+  }
 }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -20,7 +20,9 @@ const config: KnipConfig = {
     "packages/plugins/pages": {
       ignoreDependencies: ["@plumix/core"],
     },
-    // drizzle-kit is invoked by consumers as a CLI hint, not imported.
+    // - drizzle-kit is invoked by consumers as a CLI hint, not imported.
+    // - @plumix/admin is consumed via filesystem copy (scripts/copy-admin.mjs)
+    //   at build time, not as a TypeScript import.
     "packages/plumix": {
       entry: [
         "src/index.ts",
@@ -34,7 +36,7 @@ const config: KnipConfig = {
         "src/theme/index.ts",
         "src/vite/index.ts",
       ],
-      ignoreDependencies: ["drizzle-kit"],
+      ignoreDependencies: ["drizzle-kit", "@plumix/admin"],
     },
   },
 };

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -1,55 +1,58 @@
 # @plumix/admin
 
-Pre-built React SPA that ships inside the [`plumix`](../plumix) package and is
-served at `/_plumix/admin/*` by the runtime dispatcher. The admin is compiled
-once, committed into `plumix/dist/admin/`, and copied verbatim into consumer
-builds — consumers running `plumix dev` or `plumix build` never rebuild it
-from source.
+Pre-built React SPA that ships inside the [`plumix`](../plumix) package.
+The admin compiles once into `dist/`, gets copied into `plumix/dist/admin-app/`
+at plumix build time, and the plumix Vite plugin stages it into the consumer's
+`.plumix/public/_plumix/admin/` directory so Cloudflare Workers Assets serves
+it at `/_plumix/admin/*` with no per-consumer rebuild.
 
-## Dev workflow
+## Dev workflows
 
-The admin is a client for the plumix backend — it speaks HTTP over
-`/_plumix/*` to whatever runtime the example app is using (Cloudflare,
-future Bun/Node adapters, etc.). `pnpm dev` in this workspace only starts
-Vite for the admin; it does not start the backend. You run both.
+Two supported loops, pick whichever matches what you're iterating on.
 
-### One-shot: `pnpm dev` from the repo root
+### Consumer-style: `plumix dev` only (single origin)
 
-Turbo watches every workspace that declares a `dev` script, so this starts
-both the admin and the backend in parallel:
+Once the consumer has the `assets` binding in their wrangler config (see
+[examples/minimal/wrangler.jsonc](../../examples/minimal/wrangler.jsonc)),
+running the backend serves admin too — no second process:
 
 ```bash
-pnpm dev    # from repo root
+cd examples/minimal
+pnpm dev                              # :5173
+# open http://localhost:5173/_plumix/admin/
 ```
 
-That runs the example app's `plumix dev` (on `:5173`) and the admin's
-Vite dev server (on `:5174`). Open `http://localhost:5174/_plumix/admin/`
-in the browser.
+This mode exercises the same serving path production uses (CF Assets in
+front of the worker). Best for "does my feature work end-to-end?" checks.
 
-### Two-terminal variant (clearer logs)
+### Admin-authoring: `pnpm dev` in both workspaces (two ports, HMR)
+
+When iterating on admin source, Vite's HMR against admin source files is
+faster than rebuilding + restaging. Two terminals:
 
 ```bash
 # terminal 1 — backend
 cd examples/minimal && pnpm dev       # :5173
 
-# terminal 2 — admin
+# terminal 2 — admin with HMR
 cd packages/admin && pnpm dev         # :5174
+# open http://localhost:5174/_plumix/admin/
 ```
 
-### How requests flow
+Admin's Vite dev server proxies `/_plumix/rpc` and `/_plumix/auth` to
+`:5173`, so RPC and auth still hit the real backend. Best for "I'm tweaking
+a component, want hot reload."
 
-The admin is served from `:5174`. When admin code makes a request to
-`/_plumix/rpc/...` or `/_plumix/auth/...`, Vite's proxy forwards it to
-`http://localhost:5173` (the backend). From the browser's view everything
-is same-origin on `:5174` — session cookies and CSRF headers just work,
-no CORS configuration needed.
-
-If you run the backend on a different host/port (remote dev instance,
-non-default port for a specific adapter), override the proxy target:
+Override the proxy target for a remote/non-default backend:
 
 ```bash
 PLUMIX_BACKEND_URL=http://192.168.1.10:5173 pnpm dev
 ```
+
+### Turbo shortcut: `pnpm dev` from repo root
+
+Runs both workspaces in parallel via `turbo watch dev --continue`. Same
+two-port layout as the two-terminal variant but in one shell.
 
 ### First-time setup
 

--- a/packages/plumix/package.json
+++ b/packages/plumix/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "attw": "attw --pack . --profile esm-only",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-admin.mjs",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
@@ -103,6 +103,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@plumix/admin": "workspace:*",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",

--- a/packages/plumix/scripts/copy-admin.mjs
+++ b/packages/plumix/scripts/copy-admin.mjs
@@ -1,0 +1,34 @@
+// Copies the compiled @plumix/admin workspace output into plumix's own dist
+// so the admin artifact ships inside the plumix npm tarball. Run after tsc
+// as part of `pnpm --filter plumix build`.
+
+import { cp, readdir, rm, stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "../../admin/dist");
+const DEST = resolve(HERE, "../dist/admin-app");
+
+async function exists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!(await exists(SRC))) {
+  throw new Error(
+    `@plumix/admin is not built — expected ${SRC}. Run \`pnpm --filter @plumix/admin build\` first.`,
+  );
+}
+
+await rm(DEST, { recursive: true, force: true });
+await cp(SRC, DEST, { recursive: true });
+
+const entries = await readdir(DEST);
+console.log(
+  `Copied admin (${String(entries.length)} entries) from ${SRC} to ${DEST}`,
+);

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { cp, rm } from "node:fs/promises";
+import { cp, rm, stat } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Plugin } from "vite";
@@ -22,24 +22,27 @@ export interface PlumixVitePluginOptions {
 
 export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
   let root = process.cwd();
+  let publicDir = "";
   let configPath: string | undefined;
 
   return {
     name: "plumix",
-    // Point Vite's static-asset root at the dir we populate (admin + anything
-    // else plumix stages). Consumers who want their own static files can still
-    // drop them into .plumix/public/ under their own namespace.
-    config() {
-      return {
-        publicDir: ".plumix/public",
-      };
+    // Default Vite's publicDir to .plumix/public so the admin staging path is
+    // served automatically in the common case. Consumers with an explicit
+    // publicDir in their vite.config keep theirs — plumix just namespaces
+    // admin under `<their-publicDir>/_plumix/admin/` instead.
+    config(userConfig) {
+      if (userConfig.publicDir !== undefined) return;
+      return { publicDir: ".plumix/public" };
     },
     configResolved(config) {
       root = config.root;
+      publicDir = config.publicDir;
     },
     async buildStart() {
       const emitted = await regenerate(root, options.configFile);
       configPath = emitted.configPath;
+      await stageAdminAssets(publicDir);
     },
     configureServer(server) {
       server.watcher.on("change", (path) => {
@@ -80,19 +83,29 @@ async function regenerate(
   });
   writeIfChanged(resolve(cwd, ".plumix/worker.ts"), workerSource);
 
-  await stageAdminAssets(cwd);
-
   return { configPath };
 }
 
-// Stages the compiled admin SPA from plumix/dist/admin-app into the consumer
-// project at .plumix/public/_plumix/admin/. The consumer's wrangler config
-// points its `assets.directory` at .plumix/public, so Cloudflare Workers
-// Assets serves these files at /_plumix/admin/* in both dev and production.
-async function stageAdminAssets(cwd: string): Promise<void> {
-  const dest = resolve(cwd, ".plumix/public/_plumix/admin");
+// Copies the compiled admin SPA from plumix/dist/admin-app into the effective
+// publicDir under _plumix/admin/. The runtime adapter's asset-serving layer
+// (Cloudflare Workers Assets today, equivalents in future adapters) picks the
+// files up from publicDir automatically. Skips the copy when the destination
+// is already at least as fresh as the source so repeated regenerate() calls
+// during dev don't bounce Vite's file watcher.
+async function stageAdminAssets(publicDir: string): Promise<void> {
+  const dest = resolve(publicDir, "_plumix/admin");
+  if (await destIsFresh(dest, ADMIN_SOURCE_DIR)) return;
   await rm(dest, { recursive: true, force: true });
   await cp(ADMIN_SOURCE_DIR, dest, { recursive: true });
+}
+
+async function destIsFresh(dest: string, src: string): Promise<boolean> {
+  try {
+    const [srcStat, destStat] = await Promise.all([stat(src), stat(dest)]);
+    return destStat.mtimeMs >= srcStat.mtimeMs;
+  } catch {
+    return false;
+  }
 }
 
 function writeIfChanged(path: string, content: string): void {

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -1,10 +1,20 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { cp, rm } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Plugin } from "vite";
 
 import { generateSchemaSource, generateWorkerSource } from "@plumix/core";
 
 import { loadConfig } from "../cli/load-config.js";
+
+// `import.meta.url` for this module lives at plumix/dist/vite/index.js in
+// consumer installs, so the pre-compiled admin artifact is a sibling at
+// plumix/dist/admin-app. Computed once at module load.
+const ADMIN_SOURCE_DIR = resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "../admin-app",
+);
 
 export interface PlumixVitePluginOptions {
   readonly configFile?: string;
@@ -16,6 +26,14 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
 
   return {
     name: "plumix",
+    // Point Vite's static-asset root at the dir we populate (admin + anything
+    // else plumix stages). Consumers who want their own static files can still
+    // drop them into .plumix/public/ under their own namespace.
+    config() {
+      return {
+        publicDir: ".plumix/public",
+      };
+    },
     configResolved(config) {
       root = config.root;
     },
@@ -62,7 +80,19 @@ async function regenerate(
   });
   writeIfChanged(resolve(cwd, ".plumix/worker.ts"), workerSource);
 
+  await stageAdminAssets(cwd);
+
   return { configPath };
+}
+
+// Stages the compiled admin SPA from plumix/dist/admin-app into the consumer
+// project at .plumix/public/_plumix/admin/. The consumer's wrangler config
+// points its `assets.directory` at .plumix/public, so Cloudflare Workers
+// Assets serves these files at /_plumix/admin/* in both dev and production.
+async function stageAdminAssets(cwd: string): Promise<void> {
+  const dest = resolve(cwd, ".plumix/public/_plumix/admin");
+  await rm(dest, { recursive: true, force: true });
+  await cp(ADMIN_SOURCE_DIR, dest, { recursive: true });
 }
 
 function writeIfChanged(path: string, content: string): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.2
+      '@plumix/admin':
+        specifier: workspace:*
+        version: link:../admin
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint


### PR DESCRIPTION
## Summary

Admin is no longer an isolated Vite demo — it ships inside the `plumix` npm tarball and gets served at `/_plumix/admin/*` through Cloudflare Workers Assets in any app that consumes plumix. End-to-end plumbing from published package → consumer build → runtime.

## What's in

**Admin travels with plumix**
- New `scripts/copy-admin.mjs` run after `tsc` during `pnpm --filter plumix build` copies `packages/admin/dist/**` → `packages/plumix/dist/admin-app/**`.
- `@plumix/admin` added as a workspace devDep so turbo's `^build` ordering guarantees admin builds first.
- Existing `files: ["dist"]` picks the new subtree up for publishing; `pnpm pack` confirms admin assets land in the tarball (~300 KB gzip with Geist fonts).
- Named `admin-app` (not `admin`) to avoid collision with the existing `plumix/admin` exports subpath (plugin-admin types).

**Consumer build stages admin**
- `plumix()` Vite plugin now sets `publicDir: ".plumix/public"` and stages admin into `.plumix/public/_plumix/admin/` during `regenerate()` (runs alongside `.plumix/worker.ts` + `.plumix/schema.ts` generation).
- `@cloudflare/vite-plugin` picks up `publicDir` automatically — admin gets served at `/_plumix/admin/*` in dev via miniflare, bundled into `dist/client/_plumix/admin/*` for production.

**Production-deployable**
- `examples/minimal/wrangler.jsonc` declares the `assets` binding (`.plumix/public`, `binding: "ASSETS"`, `not_found_handling: "none"`) so `wrangler deploy` uploads the admin bundle with the worker.

**Smoke test**
- `examples/minimal/test/build.integration.test.ts` already runs `plumix build`; adds one assertion that `dist/client/_plumix/admin/index.html` exists. If the pipeline breaks anywhere (copy script, Vite publicDir, CF plugin handoff), that file won't be there.

**Docs**
- `packages/admin/README.md` reframed around two intent-driven dev loops:
  - **single-origin** via `plumix dev` alone (same as production)
  - **two-port** with both `pnpm dev` servers (Vite HMR on admin source)

## Verified locally

- `pnpm dev` in `examples/minimal` → `curl http://localhost:5173/_plumix/admin/index.html` returns 200 + HTML.
- `plumix build` in `examples/minimal` → admin HTML + hashed JS/CSS/woff2 chunks emitted under `dist/client/_plumix/admin/`.
- Full CI matrix (build, typecheck, lint, format, knip, test, publint, attw, commitlint) passes.

## What's deferred

- **SPA deep-link fallback**: Direct requests to `/_plumix/admin/posts` fall through to the worker (since no file exists at that path with `not_found_handling: "none"`), which currently 404s. Not a blocker while admin has a single route; fix when feature routes land — the worker can delegate via `env.ASSETS.fetch` to serve `index.html` for SPA routes.
- **Playwright against live worker**: existing e2e spec runs against admin's own Vite dev server. A follow-up PR can rework it to exercise `plumix dev` end-to-end (CF Assets + worker + admin + RPC). Needed more involved webServer orchestration than fit here.
- **CSRF narrowing** to unsafe methods on `/_plumix/*`. Not urgent — CF Assets intercepts admin GETs before the worker runs. Lands with the SPA fallback work.

## Test plan

- [ ] `pnpm install` on a fresh clone then `pnpm build` — admin assets present in `packages/plumix/dist/admin-app/`
- [ ] `cd examples/minimal && pnpm dev` — admin reachable at http://localhost:5173/_plumix/admin/
- [ ] `cd examples/minimal && pnpm plumix build` — `dist/client/_plumix/admin/index.html` exists
- [ ] `cd examples/minimal && pnpm test` — integration smoke test passes with the new admin assertion
- [ ] `pnpm pack --dry-run` in `packages/plumix/` lists `dist/admin-app/**` files