### PR TITLE
feat(core,runtime-cloudflare): SPA deep-link fallback for /_plumix/admin/*

### DIFF
--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -6,6 +6,7 @@ import type { UserRole } from "../db/schema/users.js";
 import type { HookExecutor } from "../hooks/registry.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
+import type { AssetsBinding } from "../runtime/slots.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 
 export type CoreSchema = typeof coreSchema;
@@ -53,6 +54,12 @@ export interface AppContext<
    * dropped on runtimes that opt out.
    */
   readonly after: AfterResponse;
+  /**
+   * Platform asset serving, when the runtime exposes one. Populated by
+   * the CF adapter from `env.ASSETS`; undefined on runtimes without an
+   * asset layer. Consumed by the dispatcher to serve admin SPA deep-links.
+   */
+  readonly assets?: AssetsBinding;
 }
 
 export type AuthenticatedAppContext<
@@ -70,6 +77,7 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly user?: AuthenticatedUser | null;
   readonly logger?: Logger;
   readonly after?: AfterResponse;
+  readonly assets?: AssetsBinding;
 }
 
 const dropPromise: AfterResponse = () => undefined;
@@ -92,6 +100,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
         user !== null && resolver.hasCapability(user.role, capability),
     },
     after: args.after ?? dropPromise,
+    assets: args.assets,
   };
 }
 

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -47,6 +47,21 @@ describe("dispatcher — routing", () => {
     );
   });
 
+  test("POST /_plumix/admin is rejected with 405 even when an assets binding is present", async () => {
+    const assets = {
+      fetch: (): Promise<Response> =>
+        Promise.resolve(new Response("should-not-be-called", { status: 200 })),
+    };
+    const h = await createDispatcherHarness({ assets });
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin/posts", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD");
+  });
+
   test("/_plumix/admin/<asset-like-miss>.js returns 404 without serving HTML", async () => {
     const assets = {
       fetch: (): Promise<Response> =>

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -10,13 +10,56 @@ describe("dispatcher — routing", () => {
     expect(await response.text()).toBe("<h1>Plumix</h1>");
   });
 
-  test("/_plumix/admin returns 404 with the admin-not-available hint", async () => {
+  test("/_plumix/admin returns 404 with admin-not-available when no assets binding is configured", async () => {
     const h = await createDispatcherHarness();
     const response = await h.dispatch(
       plumixRequest("/_plumix/admin", { method: "GET" }),
     );
     expect(response.status).toBe(404);
     expect(response.headers.get("x-plumix-hint")).toBe("admin-not-available");
+  });
+
+  test("/_plumix/admin/<deep-link> serves admin index.html via the assets binding", async () => {
+    const indexBody = "<!doctype html><title>admin</title>";
+    const calls: Request[] = [];
+    const assets = {
+      fetch(request: Request): Promise<Response> {
+        calls.push(request);
+        return Promise.resolve(
+          new Response(indexBody, {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+        );
+      },
+    };
+    const h = await createDispatcherHarness({ assets });
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin/posts/new", { method: "GET" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(indexBody);
+    expect(calls).toHaveLength(1);
+    expect(new URL(calls[0]?.url ?? "").pathname).toBe(
+      "/_plumix/admin/index.html",
+    );
+  });
+
+  test("/_plumix/admin/<asset-like-miss>.js returns 404 without serving HTML", async () => {
+    const assets = {
+      fetch: (): Promise<Response> =>
+        Promise.resolve(new Response("should-not-be-called", { status: 200 })),
+    };
+    const h = await createDispatcherHarness({ assets });
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin/chunks/missing-abc.js", { method: "GET" }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("admin-asset-not-found");
   });
 
   test("unknown /_plumix/* path returns 404", async () => {

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -99,6 +99,12 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
 }
 
 async function serveAdmin(ctx: AppContext): Promise<Response> {
+  // Admin is a static SPA — only GET/HEAD are meaningful. Reject everything
+  // else here rather than forward to env.ASSETS, whose behavior on non-GET
+  // methods is unspecified and platform-dependent.
+  if (ctx.request.method !== "GET" && ctx.request.method !== "HEAD") {
+    return methodNotAllowed(["GET", "HEAD"]);
+  }
   if (ctx.assets === undefined) {
     return notFound("admin-not-available");
   }

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -16,6 +16,10 @@ const RPC_PREFIX = "/_plumix/rpc";
 const ADMIN_PREFIX = "/_plumix/admin";
 const PLUMIX_PREFIX = "/_plumix/";
 
+// Filenames look like `index.html`, `chunk-abc.js`, `fonts/g.woff2` — paths
+// with a dot-suffix after the last slash. Deep-link SPA routes never match.
+const ASSET_LIKE = /\.[^/]+$/;
+
 type RouteHandler = (ctx: AppContext, app: PlumixApp) => Promise<Response>;
 
 const POST_AUTH_ROUTES = new Map<string, RouteHandler>([
@@ -82,7 +86,7 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   }
 
   if (pathname === ADMIN_PREFIX || pathname.startsWith(`${ADMIN_PREFIX}/`)) {
-    return notFound("admin-not-available");
+    return serveAdmin(ctx);
   }
 
   if (pathname.startsWith(PLUMIX_PREFIX)) {
@@ -92,4 +96,21 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   return new Response("<h1>Plumix</h1>", {
     headers: { "content-type": "text/html; charset=utf-8" },
   });
+}
+
+async function serveAdmin(ctx: AppContext): Promise<Response> {
+  if (ctx.assets === undefined) {
+    return notFound("admin-not-available");
+  }
+  const { pathname } = new URL(ctx.request.url);
+  // Asset-shaped paths (chunk-abc.js, missing.woff2) either hit the runtime's
+  // asset layer before the worker or represent a real 404. Don't mask a
+  // missing asset by returning HTML — the browser loader would choke.
+  if (ASSET_LIKE.test(pathname)) {
+    return notFound("admin-asset-not-found");
+  }
+  // SPA deep link: admin's client router owns routing past /_plumix/admin/.
+  // Hand the client its index.html so it can resolve the path.
+  const indexUrl = new URL(`${ADMIN_PREFIX}/index.html`, ctx.request.url);
+  return ctx.assets.fetch(new Request(indexUrl, ctx.request));
 }

--- a/packages/core/src/runtime/slots.ts
+++ b/packages/core/src/runtime/slots.ts
@@ -66,3 +66,14 @@ export interface ObjectStorage {
 export interface KV {
   readonly kind: string;
 }
+
+/**
+ * Runtime-provided static asset serving. Exposed so the core dispatcher can
+ * serve admin SPA deep-links (`/_plumix/admin/<anything>`) by delegating
+ * back to the platform's asset layer — Cloudflare's `env.ASSETS` binding
+ * today, equivalents in future Node/Bun adapters. Omitted when the runtime
+ * has no asset layer, in which case deep-link requests 404 with a hint.
+ */
+export interface AssetsBinding {
+  fetch(request: Request): Promise<Response>;
+}

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -9,6 +9,7 @@ import type {
 } from "../hooks/types.js";
 import type { PlumixApp } from "../runtime/app.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
+import type { AssetsBinding } from "../runtime/slots.js";
 import type { Factories } from "./factories.js";
 import type { FetchOptions } from "./request.js";
 import type { ActionSpy, FilterSpy } from "./spies.js";
@@ -43,6 +44,11 @@ export interface CreateDispatcherHarnessOptions {
    * the escape hatch for anything the harness doesn't abstract.
    */
   readonly env?: PlumixEnv;
+  /**
+   * Platform asset layer (e.g. Cloudflare's env.ASSETS). Provide a mock
+   * when exercising the dispatcher's /_plumix/admin/* SPA fallback.
+   */
+  readonly assets?: AssetsBinding;
 }
 
 export interface DispatcherHarness {
@@ -98,6 +104,7 @@ function withRequest(
   app: PlumixApp,
   db: TestDb,
   env: PlumixEnv,
+  assets: AssetsBinding | undefined,
   request: Request,
   user: User | null,
 ): AppContext {
@@ -111,6 +118,7 @@ function withRequest(
     user: user
       ? { id: user.id, email: user.email, role: user.role }
       : undefined,
+    assets,
   });
 }
 
@@ -132,18 +140,26 @@ export async function createDispatcherHarness(
   });
   const app = await buildApp(config);
   const dispatcher = createPlumixDispatcher(app);
+  const { assets } = options;
 
   const harness: DispatcherHarness = {
     db,
     app,
     env,
     dispatch: async (request, user = null) => {
-      const ctx = withRequest(app, db, env, request, user);
+      const ctx = withRequest(app, db, env, assets, request, user);
       return dispatcher(ctx);
     },
     fetch: async (path, fetchOptions = {}) => {
       const request = await buildRequest(db, path, fetchOptions);
-      const ctx = withRequest(app, db, env, request, fetchOptions.as ?? null);
+      const ctx = withRequest(
+        app,
+        db,
+        env,
+        assets,
+        request,
+        fetchOptions.as ?? null,
+      );
       const response = await dispatcher(ctx);
       return new TestResponse(response);
     },

--- a/packages/runtimes/cloudflare/src/adapter.test.ts
+++ b/packages/runtimes/cloudflare/src/adapter.test.ts
@@ -160,6 +160,15 @@ describe("cloudflare adapter — buildFetchHandler", () => {
     expect(response.status).toBe(404);
     expect(response.headers.get("x-plumix-hint")).toBe("admin-not-available");
   });
+
+  test("a malformed env.ASSETS (no fetch function) falls back to admin-not-available", async () => {
+    const response = await invoke(
+      new Request("https://cms.example/_plumix/admin"),
+      { ASSETS: { fetch: "not-a-function" } },
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("admin-not-available");
+  });
 });
 
 function captureAdapter(): {

--- a/packages/runtimes/cloudflare/src/adapter.test.ts
+++ b/packages/runtimes/cloudflare/src/adapter.test.ts
@@ -131,6 +131,35 @@ describe("cloudflare adapter — buildFetchHandler", () => {
     );
     expect(response.status).toBe(403);
   });
+
+  test("env.ASSETS is exposed through the assets slot so /_plumix/admin/ deep links resolve", async () => {
+    const indexBody = "<!doctype html><title>admin</title>";
+    const ASSETS = {
+      fetch: (_request: Request): Promise<Response> =>
+        Promise.resolve(
+          new Response(indexBody, {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+        ),
+    };
+
+    const response = await invoke(
+      new Request("https://cms.example/_plumix/admin/posts/new"),
+      { ASSETS },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(indexBody);
+  });
+
+  test("/_plumix/admin/ without an ASSETS binding returns admin-not-available", async () => {
+    const response = await invoke(
+      new Request("https://cms.example/_plumix/admin"),
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("admin-not-available");
+  });
 });
 
 function captureAdapter(): {

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 import type {
+  AssetsBinding,
   Db,
   FetchHandler,
   PlumixApp,
@@ -33,12 +34,11 @@ function isExecutionContext(value: unknown): value is ExecutionContext {
 }
 
 // Cloudflare Workers Assets exposes a Fetcher on env.ASSETS when the
-// wrangler config declares an `assets` binding. Missing when the deploy
-// doesn't configure one — in that case the core dispatcher falls back to
-// returning admin-not-available for /_plumix/admin/* requests.
-function readAssetsBinding(
-  env: unknown,
-): { fetch(request: Request): Promise<Response> } | undefined {
+// wrangler config declares `assets.binding: "ASSETS"`. Consumers using a
+// different binding name here get no admin serving — the core dispatcher
+// falls back to `admin-not-available` for /_plumix/admin/*. Convention
+// over config; `ASSETS` is what `examples/minimal/wrangler.jsonc` ships.
+function readAssetsBinding(env: unknown): AssetsBinding | undefined {
   if (typeof env !== "object" || env === null) return undefined;
   const candidate = (env as { readonly ASSETS?: unknown }).ASSETS;
   if (
@@ -47,7 +47,7 @@ function readAssetsBinding(
     "fetch" in candidate &&
     typeof (candidate as { fetch: unknown }).fetch === "function"
   ) {
-    return candidate as { fetch(request: Request): Promise<Response> };
+    return candidate as AssetsBinding;
   }
   return undefined;
 }

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -32,6 +32,26 @@ function isExecutionContext(value: unknown): value is ExecutionContext {
   );
 }
 
+// Cloudflare Workers Assets exposes a Fetcher on env.ASSETS when the
+// wrangler config declares an `assets` binding. Missing when the deploy
+// doesn't configure one — in that case the core dispatcher falls back to
+// returning admin-not-available for /_plumix/admin/* requests.
+function readAssetsBinding(
+  env: unknown,
+): { fetch(request: Request): Promise<Response> } | undefined {
+  if (typeof env !== "object" || env === null) return undefined;
+  const candidate = (env as { readonly ASSETS?: unknown }).ASSETS;
+  if (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    "fetch" in candidate &&
+    typeof (candidate as { fetch: unknown }).fetch === "function"
+  ) {
+    return candidate as { fetch(request: Request): Promise<Response> };
+  }
+  return undefined;
+}
+
 /**
  * Walk the configured slot adapters for their declared `requiredBindings`
  * and assert every key is present on `env`. Called once per Worker isolate
@@ -184,6 +204,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
         hooks: app.hooks,
         plugins: app.plugins,
         after,
+        assets: readAssetsBinding(env),
       });
       const response = await requestStore.run(appCtx, () => dispatcher(appCtx));
       return finalize(response);


### PR DESCRIPTION
## Summary

Deep-linking into the admin (e.g. `/_plumix/admin/posts/new`) now serves admin's `index.html` instead of 404'ing. Unblocks every feature route that follows — the moment login lands, refreshing the browser on the login page would have been broken without this.

## How it works

1. **Core defines `AssetsBinding` slot**: minimal `fetch(request): Promise<Response>` contract on `AppContext.assets`. Undefined when the runtime has no asset layer.
2. **Dispatcher's `/_plumix/admin/*` branch**:
   - No assets slot → the existing `admin-not-available` 404 (preserves the hint string)
   - Path ending in a file extension (`missing.js`, `chunk-abc.woff2`) → `404 admin-asset-not-found` (don't mask asset misses with HTML)
   - Otherwise → `ctx.assets.fetch(<admin-prefix>/index.html)` and return that response
3. **CF adapter** reads `env.ASSETS` via a shape-checked `readAssetsBinding` helper and passes it to `createAppContext`. Missing binding → undefined slot → dispatcher falls back to `admin-not-available`.

## Scope discipline

Happy-path GETs to `/_plumix/admin/index.html` and static assets still go through **Cloudflare Workers Assets before the worker runs** (via the `assets` binding in `wrangler.jsonc` from PR #25). The dispatcher only ever sees deep-link SPA routes and asset misses — this PR handles those two cases, nothing more.

Worth noting: CSRF narrowing was a review finding earlier but isn't needed — `hasCsrfHeader` and `hasMatchingOrigin` already short-circuit for safe methods at [csrf.ts:32](packages/core/src/auth/csrf.ts:32) and [csrf.ts:49](packages/core/src/auth/csrf.ts:49). Admin GETs have always been passing through.

## Test coverage

- **Dispatcher tests** (2 new): SPA fallback returns index.html with the correct fetched URL; asset-shaped misses 404 without touching the assets binding body.
- **CF adapter tests** (2 new): `env.ASSETS` deep-link resolves through the slot; missing binding preserves the `admin-not-available` path.
- **Existing 287/287 core tests + 68/68 CF adapter tests still green**.

## What's deferred

- **Playwright against live worker** — e2e spec currently runs against admin's Vite dev server. A follow-up can rework it to exercise `plumix dev` end-to-end (CF Assets + worker + admin + RPC). Unchanged from PR #25's deferred list.
- **Caching / immutable headers for static assets** — CF Assets defaults are fine for now; revisit if observation shows unnecessary re-downloads.

## Test plan

- [ ] CI green across all jobs
- [ ] `pnpm --filter @plumix/core test` — 287 pass
- [ ] `pnpm --filter @plumix/runtime-cloudflare test` — 68 pass
- [ ] Manually: `cd examples/minimal && pnpm dev`, then `curl -i http://localhost:5173/_plumix/admin/posts/new` returns 200 + admin HTML
- [ ] Manually: `curl -i http://localhost:5173/_plumix/admin/missing.js` returns 404