### PR TITLE
feat(core,plumix,admin): plugin manifest scaffold — postTypes slice

### DIFF
--- a/examples/minimal/test/build.integration.test.ts
+++ b/examples/minimal/test/build.integration.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync, rmSync, statSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -45,6 +45,14 @@ describe("examples/minimal — plumix build", () => {
 
       // Admin SPA ends up in the Cloudflare assets bundle.
       expect(existsSync(adminIndexHtml)).toBe(true);
+
+      // Manifest placeholder is replaced by the vite plugin with a
+      // config-derived payload. `examples/minimal` registers no plugins,
+      // so postTypes is empty but the tag must still be present.
+      const adminHtml = readFileSync(adminIndexHtml, "utf8");
+      expect(adminHtml).toMatch(
+        /<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\]\}<\/script>/,
+      );
     },
     60_000,
   );

--- a/packages/admin/index.html
+++ b/packages/admin/index.html
@@ -8,7 +8,9 @@
   </head>
   <body>
     <div id="root"></div>
-    <script id="plumix-manifest" type="application/json">{"postTypes":[]}</script>
+    <script id="plumix-manifest" type="application/json">
+      { "postTypes": [] }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/admin/index.html
+++ b/packages/admin/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script id="plumix-manifest" type="application/json">{"postTypes":[]}</script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { readManifest } from "./manifest.js";
+
+function withManifestScript(json: string): Document {
+  const doc = document.implementation.createHTMLDocument("test");
+  const script = doc.createElement("script");
+  script.id = "plumix-manifest";
+  script.type = "application/json";
+  script.textContent = json;
+  doc.body.appendChild(script);
+  return doc;
+}
+
+describe("readManifest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns empty manifest when the script tag is absent", () => {
+    const doc = document.implementation.createHTMLDocument("test");
+    expect(readManifest(doc)).toEqual({ postTypes: [] });
+  });
+
+  test("parses the injected JSON payload", () => {
+    const doc = withManifestScript(
+      JSON.stringify({
+        postTypes: [{ name: "post", label: "Posts" }],
+      }),
+    );
+    expect(readManifest(doc)).toEqual({
+      postTypes: [{ name: "post", label: "Posts" }],
+    });
+  });
+
+  test("empty payload falls back to empty manifest", () => {
+    const doc = withManifestScript("");
+    expect(readManifest(doc)).toEqual({ postTypes: [] });
+  });
+
+  test("malformed JSON logs and falls back without throwing", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // swallow expected error log
+    });
+    const doc = withManifestScript("{not-json");
+    expect(readManifest(doc)).toEqual({ postTypes: [] });
+    expect(errSpy).toHaveBeenCalledOnce();
+  });
+
+  test("non-array postTypes coerces to empty array", () => {
+    const doc = withManifestScript(JSON.stringify({ postTypes: "oops" }));
+    expect(readManifest(doc)).toEqual({ postTypes: [] });
+  });
+});

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -1,0 +1,31 @@
+import type { PlumixManifest } from "@plumix/core/manifest";
+import { emptyManifest, MANIFEST_SCRIPT_ID } from "@plumix/core/manifest";
+
+// Parse the inline `<script id="plumix-manifest">` payload injected by the
+// plumix vite plugin at consumer-build time. Falls back to an empty manifest
+// if the tag is missing or malformed so the admin shell still renders
+// (useful for `vite dev` inside the admin workspace, where the plugin isn't
+// wired and the placeholder ships with `{"postTypes":[]}`).
+export function readManifest(doc: Document = document): PlumixManifest {
+  const el = doc.getElementById(MANIFEST_SCRIPT_ID);
+  if (!el) return emptyManifest();
+  const text = el.textContent;
+  if (text.trim() === "") return emptyManifest();
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return normalize(parsed);
+  } catch {
+    // Broken JSON is always a build-pipeline bug. Log loudly in dev and
+    // degrade gracefully so the rest of the shell can still render.
+    console.error(
+      `[plumix] failed to parse #${MANIFEST_SCRIPT_ID} payload; falling back to an empty manifest`,
+    );
+    return emptyManifest();
+  }
+}
+
+function normalize(value: unknown): PlumixManifest {
+  if (!value || typeof value !== "object") return emptyManifest();
+  const postTypes = (value as { postTypes?: unknown }).postTypes;
+  return { postTypes: Array.isArray(postTypes) ? postTypes : [] };
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,10 @@
     "./validation": {
       "types": "./dist/rpc/validation.d.ts",
       "default": "./dist/rpc/validation.js"
+    },
+    "./manifest": {
+      "types": "./dist/plugin/manifest.d.ts",
+      "default": "./dist/plugin/manifest.js"
     }
   },
   "scripts": {

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -122,4 +122,24 @@ describe("injectManifestIntoHtml", () => {
     expect(out).toContain(`<script type="module" src="/src/main.tsx">`);
     expect(out).toContain(`<div id="root"></div>`);
   });
+
+  test("matches uppercase SCRIPT tags (minifier-agnostic)", () => {
+    const html = `<SCRIPT ID="plumix-manifest" TYPE="application/json">{"postTypes":[]}</SCRIPT>`;
+    const out = injectManifestIntoHtml(html, {
+      postTypes: [{ name: "post", label: "Posts" }],
+    });
+    expect(out).toContain(`{"postTypes":[{"name":"post","label":"Posts"}]}`);
+  });
+
+  test("tolerates whitespace inside the placeholder body", () => {
+    const html = `<script id="plumix-manifest" type="application/json">
+      { "postTypes": [] }
+    </script>`;
+    const out = injectManifestIntoHtml(html, {
+      postTypes: [{ name: "post", label: "Posts" }],
+    });
+    expect(out).toMatch(
+      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","label":"Posts"\}\]\}<\/script>$/,
+    );
+  });
 });

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -82,9 +82,11 @@ describe("serializeManifestScript", () => {
   test("round-trips through JSON.parse after unescaping the slash", () => {
     const manifest = { postTypes: [{ name: "post", label: "x</y>" }] };
     const tag = serializeManifestScript(manifest);
-    const payload = tag
-      .replace(/^<script[^>]*>/, "")
-      .replace(/<\/script>$/, "");
+    const prefix = `<script id="${MANIFEST_SCRIPT_ID}" type="application/json">`;
+    const suffix = `</script>`;
+    expect(tag.startsWith(prefix)).toBe(true);
+    expect(tag.endsWith(suffix)).toBe(true);
+    const payload = tag.slice(prefix.length, -suffix.length);
     expect(JSON.parse(payload.replaceAll("<\\/", "</"))).toEqual(manifest);
   });
 });

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry } from "../hooks/registry.js";
+import { definePlugin } from "./define.js";
+import {
+  buildManifest,
+  createPluginRegistry,
+  emptyManifest,
+  injectManifestIntoHtml,
+  MANIFEST_SCRIPT_ID,
+  serializeManifestScript,
+} from "./manifest.js";
+import { installPlugins } from "./register.js";
+
+describe("buildManifest", () => {
+  test("empty registry yields an empty manifest", () => {
+    const manifest = buildManifest(createPluginRegistry());
+    expect(manifest).toEqual(emptyManifest());
+  });
+
+  test("projects registered post types, dropping server-only fields", async () => {
+    const hooks = new HookRegistry();
+    const blog = definePlugin("blog", (ctx) => {
+      ctx.registerPostType("post", {
+        label: "Posts",
+        labels: { singular: "Post" },
+        supports: ["title", "editor"],
+        taxonomies: ["category"],
+        rewrite: { slug: "posts" },
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [blog] });
+
+    const manifest = buildManifest(registry);
+
+    expect(manifest.postTypes).toEqual([
+      {
+        name: "post",
+        label: "Posts",
+        labels: { singular: "Post" },
+        supports: ["title", "editor"],
+        taxonomies: ["category"],
+      },
+    ]);
+    const entry = manifest.postTypes[0] as unknown as Record<string, unknown>;
+    expect(entry.registeredBy).toBeUndefined();
+    expect(entry.rewrite).toBeUndefined();
+  });
+
+  test("orders post types by menuPosition, unspecified last", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("mixed", (ctx) => {
+      ctx.registerPostType("late", { label: "Late", menuPosition: 50 });
+      ctx.registerPostType("unpositioned", { label: "Unpositioned" });
+      ctx.registerPostType("early", { label: "Early", menuPosition: 5 });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    const names = buildManifest(registry).postTypes.map((pt) => pt.name);
+    expect(names).toEqual(["early", "late", "unpositioned"]);
+  });
+});
+
+describe("serializeManifestScript", () => {
+  test("emits a json script tag with the expected id", () => {
+    const tag = serializeManifestScript({
+      postTypes: [{ name: "post", label: "Posts" }],
+    });
+    expect(tag).toContain(`id="${MANIFEST_SCRIPT_ID}"`);
+    expect(tag).toContain(`type="application/json"`);
+    expect(tag).toContain(`{"postTypes":[{"name":"post","label":"Posts"}]}`);
+  });
+
+  test("neutralises </ sequences in payload so the tag can't be broken out of", () => {
+    const tag = serializeManifestScript({
+      postTypes: [{ name: "post", label: "</script><b>x</b>" }],
+    });
+    expect(tag).not.toContain("</script><b>");
+    expect(tag).toMatch(/<\\\/script>/);
+  });
+
+  test("round-trips through JSON.parse after unescaping the slash", () => {
+    const manifest = { postTypes: [{ name: "post", label: "x</y>" }] };
+    const tag = serializeManifestScript(manifest);
+    const payload = tag
+      .replace(/^<script[^>]*>/, "")
+      .replace(/<\/script>$/, "");
+    expect(JSON.parse(payload.replaceAll("<\\/", "</"))).toEqual(manifest);
+  });
+});
+
+describe("injectManifestIntoHtml", () => {
+  const TEMPLATE = `<!doctype html><html><body>
+<div id="root"></div>
+<script id="plumix-manifest" type="application/json">{"postTypes":[]}</script>
+<script type="module" src="/src/main.tsx"></script>
+</body></html>`;
+
+  test("replaces the placeholder with the serialised manifest", () => {
+    const out = injectManifestIntoHtml(TEMPLATE, {
+      postTypes: [{ name: "post", label: "Posts" }],
+    });
+    expect(out).toContain(`{"postTypes":[{"name":"post","label":"Posts"}]}`);
+    expect(out).not.toContain(`{"postTypes":[]}`);
+  });
+
+  test("is idempotent when the manifest is already injected", () => {
+    const manifest = { postTypes: [{ name: "post", label: "Posts" }] };
+    const once = injectManifestIntoHtml(TEMPLATE, manifest);
+    const twice = injectManifestIntoHtml(once, manifest);
+    expect(twice).toBe(once);
+  });
+
+  test("throws when the placeholder tag is missing", () => {
+    expect(() =>
+      injectManifestIntoHtml("<!doctype html><html></html>", emptyManifest()),
+    ).toThrow(/placeholder/);
+  });
+
+  test("preserves surrounding script tags", () => {
+    const out = injectManifestIntoHtml(TEMPLATE, emptyManifest());
+    expect(out).toContain(`<script type="module" src="/src/main.tsx">`);
+    expect(out).toContain(`<div id="root"></div>`);
+  });
+});

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -116,3 +116,110 @@ export class DuplicateRegistrationError extends Error {
     this.name = "DuplicateRegistrationError";
   }
 }
+
+/**
+ * Shape serialised into the admin's `<script id="plumix-manifest">` payload.
+ * Intentionally a strict subset of `RegisteredPostType`: drops
+ * `registeredBy` (plugin attribution is server-only debug metadata) and
+ * `rewrite` (URL mapping is evaluated server-side). Add fields only when the
+ * admin UI needs them.
+ */
+export interface PostTypeManifestEntry {
+  readonly name: string;
+  readonly label: string;
+  readonly labels?: { readonly singular?: string };
+  readonly description?: string;
+  readonly supports?: readonly string[];
+  readonly taxonomies?: readonly string[];
+  readonly isHierarchical?: boolean;
+  readonly isPublic?: boolean;
+  readonly hasArchive?: boolean | string;
+  readonly capabilityType?: string;
+  readonly menuPosition?: number;
+  readonly menuIcon?: string;
+}
+
+export interface PlumixManifest {
+  readonly postTypes: readonly PostTypeManifestEntry[];
+}
+
+/** Script tag id that carries the JSON-encoded manifest in the admin HTML. */
+export const MANIFEST_SCRIPT_ID = "plumix-manifest";
+
+export function emptyManifest(): PlumixManifest {
+  return { postTypes: [] };
+}
+
+/**
+ * Project a registry snapshot into its manifest form — the subset that ships
+ * to the admin bundle. Post types are ordered by `menuPosition` (ascending;
+ * unspecified → Infinity) with registration order as tiebreaker, matching
+ * how the sidebar should render them.
+ */
+export function buildManifest(registry: PluginRegistry): PlumixManifest {
+  const entries = Array.from(registry.postTypes.values()).map(
+    toPostTypeEntry,
+  );
+  entries.sort((a, b) => {
+    const ap = a.menuPosition ?? Number.POSITIVE_INFINITY;
+    const bp = b.menuPosition ?? Number.POSITIVE_INFINITY;
+    return ap - bp;
+  });
+  return { postTypes: entries };
+}
+
+function toPostTypeEntry(pt: RegisteredPostType): PostTypeManifestEntry {
+  const entry: Mutable<PostTypeManifestEntry> = {
+    name: pt.name,
+    label: pt.label,
+  };
+  if (pt.labels !== undefined) entry.labels = pt.labels;
+  if (pt.description !== undefined) entry.description = pt.description;
+  if (pt.supports !== undefined) entry.supports = pt.supports;
+  if (pt.taxonomies !== undefined) entry.taxonomies = pt.taxonomies;
+  if (pt.isHierarchical !== undefined) entry.isHierarchical = pt.isHierarchical;
+  if (pt.isPublic !== undefined) entry.isPublic = pt.isPublic;
+  if (pt.hasArchive !== undefined) entry.hasArchive = pt.hasArchive;
+  if (pt.capabilityType !== undefined) entry.capabilityType = pt.capabilityType;
+  if (pt.menuPosition !== undefined) entry.menuPosition = pt.menuPosition;
+  if (pt.menuIcon !== undefined) entry.menuIcon = pt.menuIcon;
+  return entry;
+}
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+/**
+ * Serialise a manifest into the `<script>` markup injected into the admin
+ * `index.html`. The payload lives inside a `type="application/json"` block,
+ * so it isn't executed — but a stray `</script>` sequence would still end
+ * the tag and leak the remainder into the document. Escape the slash to
+ * neutralise that, which is the standard JSON-in-HTML-script hardening.
+ */
+export function serializeManifestScript(manifest: PlumixManifest): string {
+  const safe = JSON.stringify(manifest).replaceAll("</", "<\\/");
+  return `<script id="${MANIFEST_SCRIPT_ID}" type="application/json">${safe}</script>`;
+}
+
+const MANIFEST_SCRIPT_RE = new RegExp(
+  `<script id="${MANIFEST_SCRIPT_ID}"[^>]*>[\\s\\S]*?</script>`,
+);
+
+/**
+ * Replace the `<script id="plumix-manifest">` placeholder in the admin's
+ * `index.html` with a freshly serialised manifest. Throws if the placeholder
+ * is missing — that's an indicator that the admin bundle is out of date
+ * (was built without the placeholder), and silently appending would mask
+ * the staleness.
+ */
+export function injectManifestIntoHtml(
+  html: string,
+  manifest: PlumixManifest,
+): string {
+  if (!MANIFEST_SCRIPT_RE.test(html)) {
+    throw new Error(
+      `Admin index.html is missing the <script id="${MANIFEST_SCRIPT_ID}"> ` +
+        `placeholder. Rebuild @plumix/admin.`,
+    );
+  }
+  return html.replace(MANIFEST_SCRIPT_RE, serializeManifestScript(manifest));
+}

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -157,9 +157,7 @@ export function emptyManifest(): PlumixManifest {
  * how the sidebar should render them.
  */
 export function buildManifest(registry: PluginRegistry): PlumixManifest {
-  const entries = Array.from(registry.postTypes.values()).map(
-    toPostTypeEntry,
-  );
+  const entries = Array.from(registry.postTypes.values()).map(toPostTypeEntry);
   entries.sort((a, b) => {
     const ap = a.menuPosition ?? Number.POSITIVE_INFINITY;
     const bp = b.menuPosition ?? Number.POSITIVE_INFINITY;
@@ -200,8 +198,13 @@ export function serializeManifestScript(manifest: PlumixManifest): string {
   return `<script id="${MANIFEST_SCRIPT_ID}" type="application/json">${safe}</script>`;
 }
 
+// Case-insensitive match on the script tag — Vite's bundler today emits
+// lowercase tags and we control the placeholder, but minifiers upstream
+// could normalise to uppercase and we'd rather match than silently fall
+// through to the fail-fast branch.
 const MANIFEST_SCRIPT_RE = new RegExp(
   `<script id="${MANIFEST_SCRIPT_ID}"[^>]*>[\\s\\S]*?</script>`,
+  "i",
 );
 
 /**

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -152,9 +152,10 @@ export function emptyManifest(): PlumixManifest {
 
 /**
  * Project a registry snapshot into its manifest form — the subset that ships
- * to the admin bundle. Post types are ordered by `menuPosition` (ascending;
- * unspecified → Infinity) with registration order as tiebreaker, matching
- * how the sidebar should render them.
+ * to the admin bundle. Post types are ordered by `menuPosition` ascending,
+ * with unspecified positions last. Among entries with the same (or no)
+ * `menuPosition` the registration order wins — `Array.prototype.sort` is
+ * stable per ES2019, and the registry's `Map` preserves insertion order.
  */
 export function buildManifest(registry: PluginRegistry): PlumixManifest {
   const entries = Array.from(registry.postTypes.values()).map(toPostTypeEntry);
@@ -166,25 +167,42 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
   return { postTypes: entries };
 }
 
+// Explicit allowlist — only the destructured keys ship to the browser.
+// Adding a field to `PostTypeOptions` / `RegisteredPostType` does NOT
+// automatically leak it; it must be added here AND to `PostTypeManifestEntry`
+// to surface in the admin. `registeredBy` and `rewrite` are intentionally
+// excluded: the first is debug metadata, the second is server-side URL
+// mapping.
 function toPostTypeEntry(pt: RegisteredPostType): PostTypeManifestEntry {
-  const entry: Mutable<PostTypeManifestEntry> = {
-    name: pt.name,
-    label: pt.label,
+  const {
+    name,
+    label,
+    labels,
+    description,
+    supports,
+    taxonomies,
+    isHierarchical,
+    isPublic,
+    hasArchive,
+    capabilityType,
+    menuPosition,
+    menuIcon,
+  } = pt;
+  return {
+    name,
+    label,
+    labels,
+    description,
+    supports,
+    taxonomies,
+    isHierarchical,
+    isPublic,
+    hasArchive,
+    capabilityType,
+    menuPosition,
+    menuIcon,
   };
-  if (pt.labels !== undefined) entry.labels = pt.labels;
-  if (pt.description !== undefined) entry.description = pt.description;
-  if (pt.supports !== undefined) entry.supports = pt.supports;
-  if (pt.taxonomies !== undefined) entry.taxonomies = pt.taxonomies;
-  if (pt.isHierarchical !== undefined) entry.isHierarchical = pt.isHierarchical;
-  if (pt.isPublic !== undefined) entry.isPublic = pt.isPublic;
-  if (pt.hasArchive !== undefined) entry.hasArchive = pt.hasArchive;
-  if (pt.capabilityType !== undefined) entry.capabilityType = pt.capabilityType;
-  if (pt.menuPosition !== undefined) entry.menuPosition = pt.menuPosition;
-  if (pt.menuIcon !== undefined) entry.menuIcon = pt.menuIcon;
-  return entry;
 }
-
-type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
 /**
  * Serialise a manifest into the `<script>` markup injected into the admin

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -1,10 +1,19 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { cp, rm, stat } from "node:fs/promises";
+import { cp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Plugin } from "vite";
 
-import { generateSchemaSource, generateWorkerSource } from "@plumix/core";
+import type { PlumixManifest } from "@plumix/core";
+import {
+  buildManifest,
+  emptyManifest,
+  generateSchemaSource,
+  generateWorkerSource,
+  HookRegistry,
+  injectManifestIntoHtml,
+  installPlugins,
+} from "@plumix/core";
 
 import { loadConfig } from "../cli/load-config.js";
 
@@ -42,13 +51,14 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     async buildStart() {
       const emitted = await regenerate(root, options.configFile);
       configPath = emitted.configPath;
-      await stageAdminAssets(publicDir);
+      await stageAdminAssets(publicDir, emitted.manifest);
     },
     configureServer(server) {
       server.watcher.on("change", (path) => {
         if (!configPath || resolve(path) !== configPath) return;
         void regenerate(root, options.configFile)
-          .then(() => {
+          .then(async (emitted) => {
+            await stageAdminAssets(publicDir, emitted.manifest);
             server.ws.send({ type: "full-reload" });
           })
           .catch((error: unknown) => {
@@ -73,13 +83,14 @@ export async function emitPlumixSources(
   cwd: string,
   explicitConfig?: string,
 ): Promise<{ configPath: string }> {
-  return regenerate(cwd, explicitConfig);
+  const { configPath } = await regenerate(cwd, explicitConfig);
+  return { configPath };
 }
 
 async function regenerate(
   cwd: string,
   explicitConfig: string | undefined,
-): Promise<{ configPath: string }> {
+): Promise<{ configPath: string; manifest: PlumixManifest }> {
   const { config, configPath } = await loadConfig(cwd, explicitConfig);
 
   const schemaSource = generateSchemaSource(config).source;
@@ -90,20 +101,57 @@ async function regenerate(
   });
   writeIfChanged(resolve(cwd, ".plumix/worker.ts"), workerSource);
 
-  return { configPath };
+  const manifest = await computeManifest(config.plugins);
+
+  return { configPath, manifest };
+}
+
+type PluginDescriptors = Parameters<typeof installPlugins>[0]["plugins"];
+
+// Run plugin `setup()` callbacks into a throwaway hook registry just to
+// capture what's been registered. The admin manifest only cares about the
+// resulting post-type / taxonomy / meta snapshot — hooks wired up here are
+// discarded. If a plugin throws on setup we surface it as-is: a broken
+// config should fail the build, not silently ship an empty manifest.
+async function computeManifest(
+  plugins: PluginDescriptors,
+): Promise<PlumixManifest> {
+  if (plugins.length === 0) return emptyManifest();
+  const { registry } = await installPlugins({
+    hooks: new HookRegistry(),
+    plugins,
+  });
+  return buildManifest(registry);
 }
 
 // Copies the compiled admin SPA from plumix/dist/admin-app into the effective
 // publicDir under _plumix/admin/. The runtime adapter's asset-serving layer
 // (Cloudflare Workers Assets today, equivalents in future adapters) picks the
-// files up from publicDir automatically. Skips the copy when the destination
-// is already at least as fresh as the source so repeated regenerate() calls
-// during dev don't bounce Vite's file watcher.
-async function stageAdminAssets(publicDir: string): Promise<void> {
+// files up from publicDir automatically. Skips the bulk copy when the
+// destination is already at least as fresh as the source so repeated
+// regenerate() calls during dev don't bounce Vite's file watcher — but
+// always rewrites `index.html` with the current manifest, since that one
+// depends on consumer config rather than admin source mtime.
+async function stageAdminAssets(
+  publicDir: string,
+  manifest: PlumixManifest,
+): Promise<void> {
   const dest = resolve(publicDir, "_plumix/admin");
-  if (await destIsFresh(dest, ADMIN_SOURCE_DIR)) return;
-  await rm(dest, { recursive: true, force: true });
-  await cp(ADMIN_SOURCE_DIR, dest, { recursive: true });
+  if (!(await destIsFresh(dest, ADMIN_SOURCE_DIR))) {
+    await rm(dest, { recursive: true, force: true });
+    await cp(ADMIN_SOURCE_DIR, dest, { recursive: true });
+  }
+  await injectManifest(resolve(dest, "index.html"), manifest);
+}
+
+async function injectManifest(
+  indexHtmlPath: string,
+  manifest: PlumixManifest,
+): Promise<void> {
+  const html = await readFile(indexHtmlPath, "utf8");
+  const next = injectManifestIntoHtml(html, manifest);
+  if (next === html) return;
+  await writeFile(indexHtmlPath, next, "utf8");
 }
 
 async function destIsFresh(dest: string, src: string): Promise<boolean> {

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -7,7 +7,6 @@ import type { Plugin } from "vite";
 import type { PlumixManifest } from "@plumix/core";
 import {
   buildManifest,
-  emptyManifest,
   generateSchemaSource,
   generateWorkerSource,
   HookRegistry,
@@ -113,10 +112,11 @@ type PluginDescriptors = Parameters<typeof installPlugins>[0]["plugins"];
 // resulting post-type / taxonomy / meta snapshot — hooks wired up here are
 // discarded. If a plugin throws on setup we surface it as-is: a broken
 // config should fail the build, not silently ship an empty manifest.
+// Note: plugin `setup()` callbacks run on every dev config-file change, so
+// plugins should keep setup free of IO.
 async function computeManifest(
   plugins: PluginDescriptors,
 ): Promise<PlumixManifest> {
-  if (plugins.length === 0) return emptyManifest();
   const { registry } = await installPlugins({
     hooks: new HookRegistry(),
     plugins,


### PR DESCRIPTION
## Summary

Scaffolds the `<script id="plumix-manifest">` pipeline so the admin UI can read registered post types at render time without a session round-trip. Post types are static per install (derived from `registerPostType` at config evaluation) and belong in a build-time manifest; user capabilities stay on `auth.session` where they're actually per-user.

This is the first slice — **`postTypes` only** — of the manifest work on the Phase 11 queue. Meta-boxes and plugin-admin chunks will extend the same registry in follow-up PRs.

### What changed

- **`@plumix/core/manifest`** subpath adds `buildManifest`, `emptyManifest`, `serializeManifestScript`, `injectManifestIntoHtml`, and the `PlumixManifest` / `PostTypeManifestEntry` types. The client payload is a strict projection of `RegisteredPostType` — drops server-only fields (`registeredBy`, `rewrite`) and escapes `</` inside the JSON body to neutralise script-tag breakout.
- **`packages/admin/index.html`** ships a `{"postTypes":[]}` placeholder so standalone `vite dev` inside the admin workspace still renders.
- **Vite plugin (`plumix/vite`)** runs plugin `setup()` against a throwaway hook registry at `regenerate()` to snapshot the manifest, then rewrites `_plumix/admin/index.html` on both `buildStart` and config-change reloads. Bulk asset copy keeps its mtime freshness check; only the index.html is always rewritten, since the manifest depends on consumer config rather than admin source mtime.
- **Admin `readManifest()`** parses the inline script with safe fallbacks (missing tag → empty, empty text → empty, malformed JSON → logs + empty, wrong shape → empty).

### Why it's not on `auth.session`

Post types don't change per user or per session — they're registered by plugins at config time. Putting them on the session would force a JS round-trip before the sidebar can render, and split the source of truth for registry-derived data across the manifest (meta boxes, plugin chunks) and the session. Keeping the session lean to user-scoped data (future: `user.capabilities: string[]`) is cleaner and matches the architecture doc.

### Follow-ups unblocked

- CPT-aware list (sidebar iterates `manifest.postTypes`, filters by `user.capabilities`; `/posts` → `/posts/$type`)
- `<PostEditorPage>` with `$type` in the URL
- `metaBoxes` slice of the manifest → meta-box sidebar renderer

## Test plan

- [x] `pnpm turbo run typecheck lint test build` across the workspace — 32/32 tasks green
- [x] `packages/core` — new `buildManifest` / `serializeManifestScript` / `injectManifestIntoHtml` unit tests (menu-position ordering, server-only-field stripping, `</` escape, idempotent replace, fail-fast on missing placeholder)
- [x] `packages/admin` — new `readManifest` DOM tests (happy-path parse + missing-tag, empty, malformed-JSON, wrong-shape fallbacks)
- [x] `examples/minimal` build integration test asserts the staged `index.html` carries the rewritten manifest tag end-to-end
- [x] `publint` + `attw` green on core (new `./manifest` subpath)
- [x] `pnpm knip` clean