### PR TITLE
feat(core,admin): cpt-aware admin list + /content/$slug routing

### DIFF
--- a/packages/admin/e2e/content.spec.ts
+++ b/packages/admin/e2e/content.spec.ts
@@ -1,9 +1,18 @@
 import { expect, test } from "@playwright/test";
 
 import { expectNoAxeViolations } from "./support/axe.js";
-import { AUTHED_ADMIN, mockRpc } from "./support/rpc-mock.js";
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  mockRpc,
+} from "./support/rpc-mock.js";
 
-test.describe("/posts", () => {
+test.describe("/content/$slug", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
   test("renders skeleton rows while loading, with zero WCAG 2.1 AA violations", async ({
     page,
   }) => {
@@ -35,7 +44,7 @@ test.describe("/posts", () => {
       return route.fulfill({ status: 404, body: "not-mocked" });
     });
 
-    await page.goto("posts?status=all&page=1");
+    await page.goto("content/posts?status=all&page=1");
     await expect(page.getByRole("heading", { name: "Posts" })).toBeVisible();
     await expect(
       page.getByRole("region", { name: /loading posts/i }),
@@ -52,10 +61,22 @@ test.describe("/posts", () => {
       "/auth/session": AUTHED_ADMIN,
       "/post/list": [],
     });
-    await page.goto("posts?status=all&page=1");
+    await page.goto("content/posts?status=all&page=1");
     await expect(page.getByRole("heading", { name: "Posts" })).toBeVisible();
     await expect(page.getByText("No posts yet")).toBeVisible();
     await expectNoAxeViolations(page);
+  });
+
+  test("renders the router's not-found state when the slug isn't registered", async ({
+    page,
+  }) => {
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    const response = await page.goto("content/unknown-type?status=all&page=1");
+    // TanStack Router's `notFound()` returns a 404-style render — not a
+    // literal HTTP 404 since we're behind Vite's SPA dev server, so assert
+    // the router's default "Not Found" marker instead.
+    expect(response?.status()).toBeLessThan(500);
+    await expect(page.getByText(/not found/i).first()).toBeVisible();
   });
 
   test("renders rows with zero WCAG 2.1 AA violations", async ({ page }) => {
@@ -95,7 +116,7 @@ test.describe("/posts", () => {
         },
       ],
     });
-    await page.goto("posts?status=all&page=1");
+    await page.goto("content/posts?status=all&page=1");
     await expect(page.getByText("Hello world")).toBeVisible();
     await expectNoAxeViolations(page);
   });

--- a/packages/admin/e2e/dashboard.spec.ts
+++ b/packages/admin/e2e/dashboard.spec.ts
@@ -1,15 +1,33 @@
 import { expect, test } from "@playwright/test";
 
 import { expectNoAxeViolations } from "./support/axe.js";
-import { AUTHED_ADMIN, mockSession } from "./support/rpc-mock.js";
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  mockSession,
+} from "./support/rpc-mock.js";
 
 test.describe("/ (dashboard)", () => {
-  test("renders authed landing with zero WCAG 2.1 AA violations", async ({
+  test("renders content tiles from the manifest with zero WCAG 2.1 AA violations", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+    await mockSession(page, AUTHED_ADMIN);
+    await page.goto("");
+    await expect(page.getByRole("heading", { name: /welcome/i })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /browse posts/i }),
+    ).toHaveAttribute("href", /\/content\/posts/);
+    await expectNoAxeViolations(page);
+  });
+
+  test("renders the empty-state card when no post types are registered", async ({
     page,
   }) => {
     await mockSession(page, AUTHED_ADMIN);
     await page.goto("");
-    await expect(page.getByRole("heading", { name: /welcome/i })).toBeVisible();
+    await expect(page.getByText("No content types yet")).toBeVisible();
     await expectNoAxeViolations(page);
   });
 });

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -1,6 +1,7 @@
 import type { Page, Route } from "@playwright/test";
 
 import type { AuthSessionOutput } from "@plumix/core";
+import type { PlumixManifest } from "@plumix/core/manifest";
 import type { Post } from "@plumix/core/schema";
 
 // The e2e webServer is just Vite — no real backend — so every /_plumix/rpc
@@ -50,9 +51,57 @@ export function mockSession(
   return mockRpc(page, { "/auth/session": body });
 }
 
+/**
+ * Inject a manifest into the admin HTML before the module script loads.
+ * Standalone `vite dev` ships an empty-manifest placeholder; specs that
+ * need a registered post type (to hit `/content/$slug`) install a
+ * synthetic one via this helper. Uses `page.route` to mutate the HTML
+ * response so `readManifest()` sees the populated tag on first parse.
+ */
+export async function mockManifest(
+  page: Page,
+  manifest: PlumixManifest,
+): Promise<void> {
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    if (request.resourceType() !== "document") {
+      await route.fallback();
+      return;
+    }
+    const response = await route.fetch();
+    const html = await response.text();
+    const payload = JSON.stringify(manifest).replaceAll("</", "<\\/");
+    const next = html.replace(
+      /<script id="plumix-manifest"[^>]*>[\s\S]*?<\/script>/i,
+      `<script id="plumix-manifest" type="application/json">${payload}</script>`,
+    );
+    await route.fulfill({
+      response,
+      body: next,
+      headers: { ...response.headers(), "content-length": String(next.length) },
+    });
+  });
+}
+
+// Default post-type manifest fixture — one entry, slug `posts`, shared
+// by specs that just need "something to list" without caring about the
+// specifics.
+export const MANIFEST_WITH_POST: PlumixManifest = {
+  postTypes: [
+    {
+      name: "post",
+      adminSlug: "posts",
+      label: "Posts",
+      labels: { singular: "Post", plural: "Posts" },
+    },
+  ],
+};
+
 // Fixture: an authed admin session. Reused across every spec that needs a
 // logged-in user — specs override individual fields via spread if they need
-// something specific.
+// something specific. Capabilities list covers the gates the admin UI
+// checks (post sidebar, dashboard tiles, etc.); keep in sync with what
+// `capabilitiesForRole("admin", ...)` returns for a bare install.
 export const AUTHED_ADMIN: AuthSessionOutput = {
   user: {
     id: 1,
@@ -60,6 +109,23 @@ export const AUTHED_ADMIN: AuthSessionOutput = {
     name: "Admin",
     avatarUrl: null,
     role: "admin",
+    capabilities: [
+      "option:manage",
+      "plugin:manage",
+      "post:create",
+      "post:delete",
+      "post:edit_any",
+      "post:edit_own",
+      "post:publish",
+      "post:read",
+      "taxonomy:manage",
+      "user:create",
+      "user:delete",
+      "user:edit",
+      "user:edit_own",
+      "user:list",
+      "user:promote",
+    ],
   },
   needsBootstrap: false,
 };

--- a/packages/admin/src/components/shell/app-sidebar.tsx
+++ b/packages/admin/src/components/shell/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar.js";
+import { visiblePostTypes } from "@/lib/manifest.js";
 import { Link } from "@tanstack/react-router";
 import { FileText, LayoutDashboard } from "lucide-react";
 
@@ -30,28 +31,41 @@ interface NavGroup {
   readonly items: readonly NavItem[];
 }
 
-// Hard-coded for now — when plugin admin chunks land (Phase 11 follow-up)
-// this becomes a registry fed by the manifest. `exact` controls TanStack
-// Router's active-link matching; `/` must opt in or it'd match every route.
-const NAV: readonly NavGroup[] = [
-  {
-    label: "Overview",
-    items: [
-      {
-        to: "/",
-        label: "Dashboard",
-        icon: LayoutDashboard,
-        exact: true,
-      },
-    ],
-  },
-  {
-    label: "Content",
-    items: [{ to: "/posts", label: "Posts", icon: FileText }],
-  },
-];
+// `exact` controls TanStack Router's active-link matching; `/` must opt in
+// or it'd match every route.
+const OVERVIEW_GROUP: NavGroup = {
+  label: "Overview",
+  items: [
+    {
+      to: "/",
+      label: "Dashboard",
+      icon: LayoutDashboard,
+      exact: true,
+    },
+  ],
+};
 
-export function AppSidebar({ user }: { user: UserIdentity }): ReactNode {
+function buildContentGroup(capabilities: readonly string[]): NavGroup | null {
+  const items = visiblePostTypes(capabilities).map<NavItem>((pt) => ({
+    to: `/content/${pt.adminSlug}`,
+    label: pt.labels?.plural ?? pt.label,
+    icon: FileText,
+  }));
+  if (items.length === 0) return null;
+  return { label: "Content", items };
+}
+
+export function AppSidebar({
+  user,
+  capabilities,
+}: {
+  user: UserIdentity;
+  capabilities: readonly string[];
+}): ReactNode {
+  const contentGroup = buildContentGroup(capabilities);
+  const groups = contentGroup
+    ? [OVERVIEW_GROUP, contentGroup]
+    : [OVERVIEW_GROUP];
   return (
     <Sidebar collapsible="icon" variant="inset">
       <SidebarHeader>
@@ -77,7 +91,7 @@ export function AppSidebar({ user }: { user: UserIdentity }): ReactNode {
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        {NAV.map((group) => (
+        {groups.map((group) => (
           <SidebarGroup key={group.label}>
             <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
             <SidebarGroupContent>

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { readManifest } from "./manifest.js";
+import type { PlumixManifest } from "@plumix/core/manifest";
+
+import {
+  findPostTypeBySlug,
+  readManifest,
+  visiblePostTypes,
+} from "./manifest.js";
 
 function withManifestScript(json: string): Document {
   const doc = document.implementation.createHTMLDocument("test");
@@ -50,5 +56,54 @@ describe("readManifest", () => {
   test("non-array postTypes coerces to empty array", () => {
     const doc = withManifestScript(JSON.stringify({ postTypes: "oops" }));
     expect(readManifest(doc)).toEqual({ postTypes: [] });
+  });
+});
+
+describe("findPostTypeBySlug", () => {
+  const source: PlumixManifest = {
+    postTypes: [
+      { name: "post", adminSlug: "posts", label: "Posts" },
+      { name: "product", adminSlug: "products", label: "Products" },
+    ],
+  };
+
+  test("returns the matching entry", () => {
+    expect(findPostTypeBySlug("products", source)?.name).toBe("product");
+  });
+
+  test("returns undefined when no entry matches", () => {
+    expect(findPostTypeBySlug("nope", source)).toBeUndefined();
+  });
+});
+
+describe("visiblePostTypes", () => {
+  const source: PlumixManifest = {
+    postTypes: [
+      { name: "post", adminSlug: "posts", label: "Posts" },
+      {
+        name: "product",
+        adminSlug: "products",
+        label: "Products",
+        capabilityType: "product",
+      },
+      {
+        name: "news",
+        adminSlug: "news",
+        label: "News",
+        capabilityType: "post",
+      },
+    ],
+  };
+
+  test("filters by `${capabilityType}:edit_own`; unset capabilityType uses name", () => {
+    const caps = ["post:edit_own", "post:read"];
+    const visible = visiblePostTypes(caps, source).map((pt) => pt.name);
+    // `post` → "post:edit_own" ✓; `news` shares capabilityType "post" ✓;
+    // `product` needs "product:edit_own" which isn't granted ✗
+    expect(visible).toEqual(["post", "news"]);
+  });
+
+  test("returns empty when no capabilities match", () => {
+    expect(visiblePostTypes([], source)).toEqual([]);
   });
 });

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -1,4 +1,7 @@
-import type { PlumixManifest } from "@plumix/core/manifest";
+import type {
+  PlumixManifest,
+  PostTypeManifestEntry,
+} from "@plumix/core/manifest";
 import { emptyManifest, MANIFEST_SCRIPT_ID } from "@plumix/core/manifest";
 
 // Parse the inline `<script id="plumix-manifest">` payload injected by the
@@ -28,4 +31,47 @@ function normalize(value: unknown): PlumixManifest {
   if (!value || typeof value !== "object") return emptyManifest();
   const postTypes = (value as { postTypes?: unknown }).postTypes;
   return { postTypes: Array.isArray(postTypes) ? postTypes : [] };
+}
+
+/**
+ * Module-level manifest parsed once at admin-bundle load. The manifest is
+ * baked into the HTML at plumix build time and cannot change for the
+ * lifetime of the page — no cache / query wrapper needed, anyone who wants
+ * it just imports this const.
+ *
+ * Tests that need a different manifest should call `readManifest(customDoc)`
+ * directly rather than mutating this singleton.
+ */
+export const manifest: PlumixManifest = readManifest();
+
+/**
+ * Look up a registered post type by its admin slug (the `/content/$slug`
+ * route param). Returns `undefined` when the slug doesn't match anything —
+ * the route component should render a 404-style not-found state in that
+ * case rather than a blank screen.
+ */
+export function findPostTypeBySlug(
+  slug: string,
+  source: PlumixManifest = manifest,
+): PostTypeManifestEntry | undefined {
+  return source.postTypes.find((pt) => pt.adminSlug === slug);
+}
+
+/**
+ * Sidebar gate: which post types should show up in the admin nav for a
+ * user with the given capability set. Uses the post type's
+ * `capabilityType` (or its `name` when unset) to build the capability
+ * string and checks for `${capabilityType}:edit_own` — the lowest bar
+ * that implies "this user has any business editing this content type".
+ * Subscribers (read-only) are intentionally excluded.
+ */
+export function visiblePostTypes(
+  capabilities: readonly string[],
+  source: PlumixManifest = manifest,
+): readonly PostTypeManifestEntry[] {
+  const caps = new Set(capabilities);
+  return source.postTypes.filter((pt) => {
+    const cap = `${pt.capabilityType ?? pt.name}:edit_own`;
+    return caps.has(cap);
+  });
 }

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -13,8 +13,8 @@ import { Route as AuthRouteImport } from "./routes/_auth";
 import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
 import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
+import { Route as AuthenticatedContentSlugRouteImport } from "./routes/_authenticated/content/$slug";
 import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
-import { Route as AuthenticatedPostsIndexRouteImport } from "./routes/_authenticated/posts/index";
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: "/_authenticated",
@@ -39,23 +39,24 @@ const AuthBootstrapRoute = AuthBootstrapRouteImport.update({
   path: "/bootstrap",
   getParentRoute: () => AuthRoute,
 } as any);
-const AuthenticatedPostsIndexRoute = AuthenticatedPostsIndexRouteImport.update({
-  id: "/posts/",
-  path: "/posts/",
-  getParentRoute: () => AuthenticatedRoute,
-} as any);
+const AuthenticatedContentSlugRoute =
+  AuthenticatedContentSlugRouteImport.update({
+    id: "/content/$slug",
+    path: "/content/$slug",
+    getParentRoute: () => AuthenticatedRoute,
+  } as any);
 
 export interface FileRoutesByFullPath {
   "/": typeof AuthenticatedIndexRoute;
   "/bootstrap": typeof AuthBootstrapRoute;
   "/login": typeof AuthLoginRoute;
-  "/posts/": typeof AuthenticatedPostsIndexRoute;
+  "/content/$slug": typeof AuthenticatedContentSlugRoute;
 }
 export interface FileRoutesByTo {
   "/": typeof AuthenticatedIndexRoute;
   "/bootstrap": typeof AuthBootstrapRoute;
   "/login": typeof AuthLoginRoute;
-  "/posts": typeof AuthenticatedPostsIndexRoute;
+  "/content/$slug": typeof AuthenticatedContentSlugRoute;
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
@@ -64,13 +65,13 @@ export interface FileRoutesById {
   "/_auth/bootstrap": typeof AuthBootstrapRoute;
   "/_auth/login": typeof AuthLoginRoute;
   "/_authenticated/": typeof AuthenticatedIndexRoute;
-  "/_authenticated/posts/": typeof AuthenticatedPostsIndexRoute;
+  "/_authenticated/content/$slug": typeof AuthenticatedContentSlugRoute;
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/" | "/bootstrap" | "/login" | "/posts/";
+  fullPaths: "/" | "/bootstrap" | "/login" | "/content/$slug";
   fileRoutesByTo: FileRoutesByTo;
-  to: "/" | "/bootstrap" | "/login" | "/posts";
+  to: "/" | "/bootstrap" | "/login" | "/content/$slug";
   id:
     | "__root__"
     | "/_auth"
@@ -78,7 +79,7 @@ export interface FileRouteTypes {
     | "/_auth/bootstrap"
     | "/_auth/login"
     | "/_authenticated/"
-    | "/_authenticated/posts/";
+    | "/_authenticated/content/$slug";
   fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
@@ -123,11 +124,11 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AuthBootstrapRouteImport;
       parentRoute: typeof AuthRoute;
     };
-    "/_authenticated/posts/": {
-      id: "/_authenticated/posts/";
-      path: "/posts";
-      fullPath: "/posts/";
-      preLoaderRoute: typeof AuthenticatedPostsIndexRouteImport;
+    "/_authenticated/content/$slug": {
+      id: "/_authenticated/content/$slug";
+      path: "/content/$slug";
+      fullPath: "/content/$slug";
+      preLoaderRoute: typeof AuthenticatedContentSlugRouteImport;
       parentRoute: typeof AuthenticatedRoute;
     };
   }
@@ -147,12 +148,12 @@ const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren);
 
 interface AuthenticatedRouteChildren {
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute;
-  AuthenticatedPostsIndexRoute: typeof AuthenticatedPostsIndexRoute;
+  AuthenticatedContentSlugRoute: typeof AuthenticatedContentSlugRoute;
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
-  AuthenticatedPostsIndexRoute: AuthenticatedPostsIndexRoute,
+  AuthenticatedContentSlugRoute: AuthenticatedContentSlugRoute,
 };
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/packages/admin/src/routes/__root.tsx
+++ b/packages/admin/src/routes/__root.tsx
@@ -15,8 +15,21 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
     await context.queryClient.ensureQueryData(sessionQueryOptions());
   },
   component: RootLayout,
+  notFoundComponent: NotFound,
 });
 
 function RootLayout(): ReactNode {
   return <Outlet />;
+}
+
+function NotFound(): ReactNode {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-2 p-6 text-center">
+      <h1 className="text-2xl font-semibold">Not found</h1>
+      <p className="text-muted-foreground text-sm">
+        The page you're looking for doesn't exist or the resource isn't
+        registered. Check the URL and try again.
+      </p>
+    </div>
+  );
 }

--- a/packages/admin/src/routes/_authenticated.tsx
+++ b/packages/admin/src/routes/_authenticated.tsx
@@ -26,7 +26,7 @@ function AppShell(): ReactNode {
   return (
     <TooltipProvider delayDuration={100}>
       <SidebarProvider>
-        <AppSidebar user={user} />
+        <AppSidebar user={user} capabilities={user.capabilities} />
         <SidebarInset>
           <ShellHeader />
           <main className="flex-1 overflow-y-auto p-6">

--- a/packages/admin/src/routes/_authenticated/content/$slug.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug.tsx
@@ -17,12 +17,14 @@ import {
   PaginationItem,
 } from "@/components/ui/pagination.js";
 import { toDate } from "@/lib/dates.js";
+import { findPostTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import * as v from "valibot";
 
+import type { PostTypeManifestEntry } from "@plumix/core/manifest";
 import type { Post, PostStatus } from "@plumix/core/schema";
 
 const PAGE_SIZE = 20;
@@ -40,7 +42,7 @@ const POST_STATUSES: readonly PostStatus[] = [
 const STATUS_FILTER_VALUES = [...POST_STATUSES, "all"] as const;
 type StatusFilter = (typeof STATUS_FILTER_VALUES)[number];
 
-const postsSearchSchema = v.object({
+const searchSchema = v.object({
   page: v.optional(
     v.fallback(v.pipe(v.number(), v.integer(), v.minValue(1)), 1),
     1,
@@ -114,18 +116,32 @@ const columns: ColumnDef<Post>[] = [
   },
 ];
 
-export const Route = createFileRoute("/_authenticated/posts/")({
-  validateSearch: (search) => v.parse(postsSearchSchema, search),
-  component: PostsListRoute,
+export const Route = createFileRoute("/_authenticated/content/$slug")({
+  validateSearch: (search) => v.parse(searchSchema, search),
+  // Resolve the manifest entry in `beforeLoad` so the route component never
+  // has to handle a missing post type. `notFound()` is TanStack Router's
+  // control-flow throw — it bubbles up to the nearest `notFoundComponent`,
+  // which the admin renders as a generic 404.
+  beforeLoad: ({ params }): { postType: PostTypeManifestEntry } => {
+    const postType = findPostTypeBySlug(params.slug);
+    if (!postType) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
+    return { postType };
+  },
+  component: ContentListRoute,
 });
 
-function PostsListRoute(): ReactNode {
+function ContentListRoute(): ReactNode {
   const search = Route.useSearch();
+  const { postType } = Route.useRouteContext();
   const navigate = useNavigate({ from: Route.fullPath });
 
   const query = useQuery(
     orpc.post.list.queryOptions({
       input: {
+        type: postType.name,
         limit: PAGE_SIZE,
         offset: (search.page - 1) * PAGE_SIZE,
         ...(search.status !== "all" ? { status: search.status } : {}),
@@ -147,19 +163,24 @@ function PostsListRoute(): ReactNode {
   // doesn't expose a total count today; accept the edge case until it does.
   const canNext = rows.length === PAGE_SIZE;
 
+  const pluralLabel = postType.labels?.plural ?? postType.label;
+  const singularLabel = postType.labels?.singular ?? postType.label;
+  const pluralLower = pluralLabel.toLowerCase();
+  const singularLower = singularLabel.toLowerCase();
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">Posts</h1>
+          <h1 className="text-2xl font-semibold">{pluralLabel}</h1>
           <p className="text-muted-foreground text-sm">
-            Manage posts. Draft, scheduled, and trashed items only show for
-            users with the edit-any capability.
+            Manage {pluralLower}. Draft, scheduled, and trashed items only show
+            for users with the edit-any capability.
           </p>
         </div>
-        <Button disabled title="Post editor lands in a follow-up PR">
+        <Button disabled title="Editor lands in a follow-up PR">
           <Plus />
-          New post
+          New {singularLower}
         </Button>
       </div>
 
@@ -172,7 +193,7 @@ function PostsListRoute(): ReactNode {
           <AlertDescription>
             {query.error instanceof Error
               ? query.error.message
-              : "Couldn't load posts. Try again."}
+              : `Couldn't load ${pluralLower}. Try again.`}
           </AlertDescription>
         </Alert>
       ) : (
@@ -180,8 +201,13 @@ function PostsListRoute(): ReactNode {
           columns={columns}
           data={rows}
           isLoading={query.isPending}
-          loadingLabel="Loading posts"
-          emptyState={<PostsEmptyState />}
+          loadingLabel={`Loading ${pluralLower}`}
+          emptyState={
+            <EmptyState
+              singularLower={singularLower}
+              pluralLower={pluralLower}
+            />
+          }
         />
       )}
 
@@ -250,20 +276,26 @@ function StatusFilter({
   );
 }
 
-function PostsEmptyState(): ReactNode {
+function EmptyState({
+  singularLower,
+  pluralLower,
+}: {
+  singularLower: string;
+  pluralLower: string;
+}): ReactNode {
   return (
     <div className="flex flex-col items-center gap-2 py-12 text-center">
       <Card className="max-w-sm border-dashed">
         <CardHeader>
-          <CardTitle>No posts yet</CardTitle>
+          <CardTitle>No {pluralLower} yet</CardTitle>
           <CardDescription>
-            Create your first post to see it here.
+            Create your first {singularLower} to see it here.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Button disabled className="w-full">
             <Plus />
-            New post
+            New {singularLower}
           </Button>
         </CardContent>
       </Card>

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
+import { visiblePostTypes } from "@/lib/manifest.js";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, FileText } from "lucide-react";
 
@@ -17,6 +18,7 @@ export const Route = createFileRoute("/_authenticated/")({
 function DashboardIndex(): ReactNode {
   const { user } = Route.useRouteContext();
   const greeting = user.name ?? user.email;
+  const tiles = visiblePostTypes(user.capabilities);
 
   return (
     <div className="flex flex-col gap-6">
@@ -27,25 +29,50 @@ function DashboardIndex(): ReactNode {
         </p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <Card>
+      {tiles.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {tiles.map((pt) => {
+            const label = pt.labels?.plural ?? pt.label;
+            const labelLower = label.toLowerCase();
+            return (
+              <Card key={pt.name}>
+                <CardHeader>
+                  <div className="bg-primary/10 text-primary mb-2 flex size-10 items-center justify-center rounded-md">
+                    <FileText className="size-5" aria-hidden />
+                  </div>
+                  <CardTitle>{label}</CardTitle>
+                  <CardDescription>
+                    {pt.description ??
+                      `Write, edit, and publish ${labelLower}.`}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button asChild variant="outline" className="w-full">
+                    <Link
+                      to="/content/$slug"
+                      params={{ slug: pt.adminSlug }}
+                      search={{ status: "all", page: 1 }}
+                    >
+                      Browse {labelLower}
+                      <ArrowRight />
+                    </Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      ) : (
+        <Card className="max-w-xl border-dashed">
           <CardHeader>
-            <div className="bg-primary/10 text-primary mb-2 flex size-10 items-center justify-center rounded-md">
-              <FileText className="size-5" />
-            </div>
-            <CardTitle>Posts</CardTitle>
-            <CardDescription>Write, edit, and publish content.</CardDescription>
+            <CardTitle>No content types yet</CardTitle>
+            <CardDescription>
+              Add a plugin that registers a post type (e.g.{" "}
+              <code>@plumix/plugin-blog</code>) to see it here.
+            </CardDescription>
           </CardHeader>
-          <CardContent>
-            <Button asChild variant="outline" className="w-full">
-              <Link to="/posts" search={{ status: "all", page: 1 }}>
-                Browse posts
-                <ArrowRight />
-              </Link>
-            </Button>
-          </CardContent>
         </Card>
-      </div>
+      )}
     </div>
   );
 }

--- a/packages/core/src/auth/rbac.ts
+++ b/packages/core/src/auth/rbac.ts
@@ -159,6 +159,35 @@ export class CapabilityError extends Error {
   }
 }
 
+/**
+ * Flatten every capability the given role is granted — core plus every
+ * plugin-registered capability (including the derived `{type}:{action}`
+ * entries). Sorted for deterministic output so wire payloads are stable
+ * across identical inputs (tests, caching, etc.).
+ *
+ * The returned list is intended for shipping to the admin on `auth.session`
+ * so client code can gate nav items and actions without knowing the
+ * role-hierarchy rules.
+ */
+export function capabilitiesForRole(
+  role: UserRole,
+  plugins: PluginRegistry,
+): readonly string[] {
+  const level = roleLevel(role);
+  // Set — a plugin registering a post type with `capabilityType: 'post'`
+  // duplicates the derived `post:read` etc. caps into `plugins.capabilities`
+  // on top of the entries already present in CORE_CAPABILITIES. Dedupe so
+  // the wire payload doesn't carry `["post:read", "post:read", ...]`.
+  const granted = new Set<string>();
+  for (const [name, minRole] of Object.entries(CORE_CAPABILITIES)) {
+    if (roleLevel(minRole) <= level) granted.add(name);
+  }
+  for (const [name, cap] of plugins.capabilities) {
+    if (roleLevel(cap.minRole) <= level) granted.add(name);
+  }
+  return [...granted].sort();
+}
+
 export function requireCapability(
   resolver: CapabilityResolver,
   user: { role: UserRole } | null,

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -5,6 +5,8 @@ import { definePlugin } from "./define.js";
 import {
   buildManifest,
   createPluginRegistry,
+  deriveAdminSlug,
+  DuplicateAdminSlugError,
   emptyManifest,
   injectManifestIntoHtml,
   MANIFEST_SCRIPT_ID,
@@ -36,6 +38,7 @@ describe("buildManifest", () => {
     expect(manifest.postTypes).toEqual([
       {
         name: "post",
+        adminSlug: "posts",
         label: "Posts",
         labels: { singular: "Post" },
         supports: ["title", "editor"],
@@ -45,6 +48,42 @@ describe("buildManifest", () => {
     const entry = manifest.postTypes[0] as unknown as Record<string, unknown>;
     expect(entry.registeredBy).toBeUndefined();
     expect(entry.rewrite).toBeUndefined();
+  });
+
+  test("uses labels.plural (slugified) for adminSlug when provided", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("shop", (ctx) => {
+      ctx.registerPostType("product", {
+        label: "Product",
+        labels: { singular: "Product", plural: "Product Catalog" },
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(buildManifest(registry).postTypes[0]?.adminSlug).toBe(
+      "product-catalog",
+    );
+  });
+
+  test("falls back to `${name}s` when labels.plural is not set", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("shop", (ctx) => {
+      ctx.registerPostType("product", { label: "Product" });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(buildManifest(registry).postTypes[0]?.adminSlug).toBe("products");
+  });
+
+  test("throws DuplicateAdminSlugError when two types resolve to the same slug", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("clash", (ctx) => {
+      ctx.registerPostType("product", {
+        label: "Products",
+        labels: { plural: "Items" },
+      });
+      ctx.registerPostType("item", { label: "Items" });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(() => buildManifest(registry)).toThrow(DuplicateAdminSlugError);
   });
 
   test("orders post types by menuPosition, unspecified last", async () => {
@@ -61,26 +100,48 @@ describe("buildManifest", () => {
   });
 });
 
+describe("deriveAdminSlug", () => {
+  test("slugifies the plural when set", () => {
+    expect(deriveAdminSlug("product", "Products")).toBe("products");
+    expect(deriveAdminSlug("article", "News & Updates")).toBe("news-updates");
+  });
+
+  test("falls back to `${name}s` when plural is unset", () => {
+    expect(deriveAdminSlug("post")).toBe("posts");
+    expect(deriveAdminSlug("landing_page")).toBe("landing-pages");
+  });
+
+  test("throws when the derived slug would be empty", () => {
+    expect(() => deriveAdminSlug("x", "---")).toThrow(/empty/);
+  });
+});
+
 describe("serializeManifestScript", () => {
   test("emits a json script tag with the expected id", () => {
     const tag = serializeManifestScript({
-      postTypes: [{ name: "post", label: "Posts" }],
+      postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
     });
     expect(tag).toContain(`id="${MANIFEST_SCRIPT_ID}"`);
     expect(tag).toContain(`type="application/json"`);
-    expect(tag).toContain(`{"postTypes":[{"name":"post","label":"Posts"}]}`);
+    expect(tag).toContain(
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}]}`,
+    );
   });
 
   test("neutralises </ sequences in payload so the tag can't be broken out of", () => {
     const tag = serializeManifestScript({
-      postTypes: [{ name: "post", label: "</script><b>x</b>" }],
+      postTypes: [
+        { name: "post", adminSlug: "posts", label: "</script><b>x</b>" },
+      ],
     });
     expect(tag).not.toContain("</script><b>");
     expect(tag).toMatch(/<\\\/script>/);
   });
 
   test("round-trips through JSON.parse after unescaping the slash", () => {
-    const manifest = { postTypes: [{ name: "post", label: "x</y>" }] };
+    const manifest = {
+      postTypes: [{ name: "post", adminSlug: "posts", label: "x</y>" }],
+    };
     const tag = serializeManifestScript(manifest);
     const prefix = `<script id="${MANIFEST_SCRIPT_ID}" type="application/json">`;
     const suffix = `</script>`;
@@ -100,14 +161,18 @@ describe("injectManifestIntoHtml", () => {
 
   test("replaces the placeholder with the serialised manifest", () => {
     const out = injectManifestIntoHtml(TEMPLATE, {
-      postTypes: [{ name: "post", label: "Posts" }],
+      postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
     });
-    expect(out).toContain(`{"postTypes":[{"name":"post","label":"Posts"}]}`);
+    expect(out).toContain(
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}]}`,
+    );
     expect(out).not.toContain(`{"postTypes":[]}`);
   });
 
   test("is idempotent when the manifest is already injected", () => {
-    const manifest = { postTypes: [{ name: "post", label: "Posts" }] };
+    const manifest = {
+      postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+    };
     const once = injectManifestIntoHtml(TEMPLATE, manifest);
     const twice = injectManifestIntoHtml(once, manifest);
     expect(twice).toBe(once);
@@ -128,9 +193,11 @@ describe("injectManifestIntoHtml", () => {
   test("matches uppercase SCRIPT tags (minifier-agnostic)", () => {
     const html = `<SCRIPT ID="plumix-manifest" TYPE="application/json">{"postTypes":[]}</SCRIPT>`;
     const out = injectManifestIntoHtml(html, {
-      postTypes: [{ name: "post", label: "Posts" }],
+      postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
     });
-    expect(out).toContain(`{"postTypes":[{"name":"post","label":"Posts"}]}`);
+    expect(out).toContain(
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}]}`,
+    );
   });
 
   test("tolerates whitespace inside the placeholder body", () => {
@@ -138,10 +205,10 @@ describe("injectManifestIntoHtml", () => {
       { "postTypes": [] }
     </script>`;
     const out = injectManifestIntoHtml(html, {
-      postTypes: [{ name: "post", label: "Posts" }],
+      postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
     });
     expect(out).toMatch(
-      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","label":"Posts"\}\]\}<\/script>$/,
+      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\]\}<\/script>$/,
     );
   });
 });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -225,14 +225,7 @@ export class DuplicateAdminSlugError extends Error {
  */
 export function deriveAdminSlug(name: string, plural?: string): string {
   const source = plural ?? `${name}s`;
-  // Two separate anchored replaces rather than `/^-+|-+$/g` — CodeQL flags
-  // the alternation form as a polynomial-regex risk on dash-heavy inputs,
-  // and splitting it is equally readable and provably linear.
-  const slug = source
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+/, "")
-    .replace(/-+$/, "");
+  const slug = slugify(source);
   if (slug.length === 0) {
     const from = plural === undefined ? "its name" : `plural="${plural}"`;
     throw new Error(
@@ -240,6 +233,30 @@ export function deriveAdminSlug(name: string, plural?: string): string {
     );
   }
   return slug;
+}
+
+// Hand-rolled single-pass slugifier rather than chained `.replace()` calls.
+// The regex form (`/[^a-z0-9]+/g` plus a trim) trips CodeQL's polynomial-
+// regex detector on library-exposed inputs; this loop is provably O(n),
+// regex-free, and produces the same output: lowercase ASCII alphanumerics
+// separated by single dashes, no leading/trailing dashes.
+function slugify(input: string): string {
+  const lower = input.toLowerCase();
+  let result = "";
+  let pendingDash = false;
+  for (let i = 0; i < lower.length; i++) {
+    const code = lower.charCodeAt(i);
+    const isAlphaNum =
+      (code >= 97 && code <= 122) || (code >= 48 && code <= 57);
+    if (isAlphaNum) {
+      if (pendingDash && result.length > 0) result += "-";
+      result += lower[i];
+      pendingDash = false;
+    } else {
+      pendingDash = true;
+    }
+  }
+  return result;
 }
 
 // Explicit allowlist — only the destructured keys ship to the browser.

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -2,7 +2,17 @@ import type { UserRole } from "../db/schema/users.js";
 
 export interface PostTypeOptions {
   readonly label: string;
-  readonly labels?: { readonly singular?: string };
+  /**
+   * Human-readable label variants. `plural` also drives the admin URL slug
+   * (`/content/<slugified-plural>`) unless overridden; omit it and the slug
+   * falls back to `${name}s`, which is acceptable for English-named types
+   * but surfaces an "anglos" for `name: "angle"` etc. — plugins with
+   * irregular plurals should set `labels.plural` explicitly.
+   */
+  readonly labels?: {
+    readonly singular?: string;
+    readonly plural?: string;
+  };
   readonly description?: string;
   readonly supports?: readonly string[];
   readonly taxonomies?: readonly string[];
@@ -123,11 +133,20 @@ export class DuplicateRegistrationError extends Error {
  * `registeredBy` (plugin attribution is server-only debug metadata) and
  * `rewrite` (URL mapping is evaluated server-side). Add fields only when the
  * admin UI needs them.
+ *
+ * `adminSlug` is derived at build time (see `buildManifest`) and is what the
+ * admin router uses for `/content/$slug`. Keeping it in the manifest rather
+ * than re-deriving client-side lets the collision check run once on the
+ * server and ships the final routing key as authoritative.
  */
 export interface PostTypeManifestEntry {
   readonly name: string;
+  readonly adminSlug: string;
   readonly label: string;
-  readonly labels?: { readonly singular?: string };
+  readonly labels?: {
+    readonly singular?: string;
+    readonly plural?: string;
+  };
   readonly description?: string;
   readonly supports?: readonly string[];
   readonly taxonomies?: readonly string[];
@@ -156,6 +175,10 @@ export function emptyManifest(): PlumixManifest {
  * with unspecified positions last. Among entries with the same (or no)
  * `menuPosition` the registration order wins — `Array.prototype.sort` is
  * stable per ES2019, and the registry's `Map` preserves insertion order.
+ *
+ * Throws `DuplicateAdminSlugError` if two post types resolve to the same
+ * admin slug — the admin router can't disambiguate `/content/$slug` in that
+ * case, and catching it at build time is cheaper than a 404 at runtime.
  */
 export function buildManifest(registry: PluginRegistry): PlumixManifest {
   const entries = Array.from(registry.postTypes.values()).map(toPostTypeEntry);
@@ -164,7 +187,55 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
     const bp = b.menuPosition ?? Number.POSITIVE_INFINITY;
     return ap - bp;
   });
+  assertUniqueAdminSlugs(entries);
   return { postTypes: entries };
+}
+
+function assertUniqueAdminSlugs(
+  entries: readonly PostTypeManifestEntry[],
+): void {
+  const seen = new Map<string, string>();
+  for (const entry of entries) {
+    const existing = seen.get(entry.adminSlug);
+    if (existing !== undefined) {
+      throw new DuplicateAdminSlugError(existing, entry.name, entry.adminSlug);
+    }
+    seen.set(entry.adminSlug, entry.name);
+  }
+}
+
+export class DuplicateAdminSlugError extends Error {
+  constructor(firstPostType: string, secondPostType: string, slug: string) {
+    super(
+      `Post types "${firstPostType}" and "${secondPostType}" both resolve ` +
+        `to the admin slug "${slug}". Set \`labels.plural\` on one of them ` +
+        `to disambiguate.`,
+    );
+    this.name = "DuplicateAdminSlugError";
+  }
+}
+
+/**
+ * Derive the URL-safe admin slug for a post type. Prefers `plural` when
+ * set (allows "fish" → `fish`, "children" → `children`, etc.), falls back
+ * to `${name}s` which is English-biased but matches the common case.
+ * Non-alphanumerics collapse to single dashes; leading/trailing dashes
+ * are trimmed. Empty results throw — an empty slug would shadow
+ * `/content/` itself in TanStack Router.
+ */
+export function deriveAdminSlug(name: string, plural?: string): string {
+  const source = plural ?? `${name}s`;
+  const slug = source
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (slug.length === 0) {
+    const from = plural === undefined ? "its name" : `plural="${plural}"`;
+    throw new Error(
+      `Cannot derive an admin slug for post type "${name}" from ${from} — result was empty.`,
+    );
+  }
+  return slug;
 }
 
 // Explicit allowlist — only the destructured keys ship to the browser.
@@ -190,6 +261,7 @@ function toPostTypeEntry(pt: RegisteredPostType): PostTypeManifestEntry {
   } = pt;
   return {
     name,
+    adminSlug: deriveAdminSlug(name, labels?.plural),
     label,
     labels,
     description,

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -225,10 +225,14 @@ export class DuplicateAdminSlugError extends Error {
  */
 export function deriveAdminSlug(name: string, plural?: string): string {
   const source = plural ?? `${name}s`;
+  // Two separate anchored replaces rather than `/^-+|-+$/g` — CodeQL flags
+  // the alternation form as a polynomial-regex risk on dash-heavy inputs,
+  // and splitting it is equally readable and provably linear.
   const slug = source
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
   if (slug.length === 0) {
     const from = plural === undefined ? "its name" : `plural="${plural}"`;
     throw new Error(

--- a/packages/core/src/rpc/procedures/auth/auth.test.ts
+++ b/packages/core/src/rpc/procedures/auth/auth.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 
 import { SESSION_COOKIE_NAME } from "../../../auth/cookies.js";
+import { HookRegistry } from "../../../hooks/registry.js";
+import { definePlugin } from "../../../plugin/define.js";
+import { installPlugins } from "../../../plugin/register.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
 describe("auth.session", () => {
@@ -17,17 +20,64 @@ describe("auth.session", () => {
     expect(result).toEqual({ user: null, needsBootstrap: false });
   });
 
-  test("authed caller returns full profile; needsBootstrap is false", async () => {
+  test("authed caller returns full profile + resolved capabilities; needsBootstrap is false", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
     const result = await h.client.auth.session({});
     expect(result.needsBootstrap).toBe(false);
-    expect(result.user).toEqual({
+    expect(result.user).toMatchObject({
       id: h.user.id,
       email: h.user.email,
       name: h.user.name,
       avatarUrl: h.user.avatarUrl,
       role: "admin",
     });
+    // Admin role grants every core capability — spot-check the set covers
+    // read/write gates the admin UI will actually query.
+    expect(result.user?.capabilities).toEqual(
+      expect.arrayContaining([
+        "post:read",
+        "post:edit_any",
+        "user:list",
+        "plugin:manage",
+      ]),
+    );
+  });
+
+  test("subscriber role returns only the low-privilege capabilities", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const result = await h.client.auth.session({});
+    expect(result.user?.capabilities).toEqual(["post:read", "user:edit_own"]);
+  });
+
+  test("plugin-registered post type surfaces derived capabilities without duplicating the core set", async () => {
+    const hooks = new HookRegistry();
+    const shop = definePlugin("shop", (ctx) => {
+      // Plugin-registered post type with its own capability namespace —
+      // surfaces on the session…
+      ctx.registerPostType("product", {
+        label: "Product",
+        capabilityType: "product",
+      });
+      // …AND register a post type that shares the core `post` capability
+      // namespace, which used to produce duplicate `post:*` entries in the
+      // session's capability list.
+      ctx.registerPostType("news", { label: "News", capabilityType: "post" });
+    });
+    const { registry: plugins } = await installPlugins({
+      hooks,
+      plugins: [shop],
+    });
+    const h = await createRpcHarness({ authAs: "editor", hooks, plugins });
+    const result = await h.client.auth.session({});
+
+    expect(result.user?.capabilities).toEqual(
+      expect.arrayContaining(["product:read", "product:edit_any"]),
+    );
+    // Regression: derived `post:*` entries from the `news` post type alias
+    // the core capabilities — dedupe in `capabilitiesForRole` must prevent
+    // duplicate wire entries.
+    const caps = result.user?.capabilities ?? [];
+    expect(caps.length).toBe(new Set(caps).size);
   });
 
   test("stale / unknown session cookie → user: null; bootstrap flag still correct", async () => {

--- a/packages/core/src/rpc/procedures/auth/schemas.ts
+++ b/packages/core/src/rpc/procedures/auth/schemas.ts
@@ -8,6 +8,13 @@ const sessionUserSchema = v.object({
   name: v.nullable(v.string()),
   avatarUrl: v.nullable(v.string()),
   role: v.picklist(USER_ROLES),
+  /**
+   * Effective capability names granted to this user — core + derived
+   * post-type/taxonomy caps + plugin-defined caps, resolved server-side
+   * from the role hierarchy. The admin uses this to gate nav items and
+   * UI actions without re-implementing the role → capability mapping.
+   */
+  capabilities: v.array(v.string()),
 });
 
 export const authSessionOutputSchema = v.object({

--- a/packages/core/src/rpc/procedures/auth/session.ts
+++ b/packages/core/src/rpc/procedures/auth/session.ts
@@ -1,5 +1,6 @@
 import type { AuthSessionOutput } from "./schemas.js";
 import { readSessionCookie } from "../../../auth/cookies.js";
+import { capabilitiesForRole } from "../../../auth/rbac.js";
 import { validateSession } from "../../../auth/sessions.js";
 import { users } from "../../../db/schema/users.js";
 import { base } from "../../base.js";
@@ -16,7 +17,14 @@ export const session = base.handler(
       if (validated) {
         const { id, email, name, avatarUrl, role } = validated.user;
         return {
-          user: { id, email, name, avatarUrl, role },
+          user: {
+            id,
+            email,
+            name,
+            avatarUrl,
+            role,
+            capabilities: [...capabilitiesForRole(role, context.plugins)],
+          },
           needsBootstrap: false,
         };
       }


### PR DESCRIPTION
## Summary

Turns the admin from a single-post-type shell into a true CPT host. Sidebar iterates the manifest's registered post types and gates each entry by the logged-in user's effective capabilities; URLs move from `/posts` to `/content/$slug` where `$slug` comes from the post type's plural label.

Depends on and builds directly on the manifest scaffold from [#29](https://github.com/withplumix/plumix/pull/29).

### Core

- `PostTypeOptions.labels.plural?: string` drives the admin URL slug. Default is `${name}s`; plugins with irregular plurals set it explicitly.
- `PostTypeManifestEntry.adminSlug: string` is derived at build time via `deriveAdminSlug(name, plural?)`. `buildManifest` runs a collision check and throws `DuplicateAdminSlugError` if two post types resolve to the same slug — caught at build time, not as a 404 in the browser.
- `auth.session` output gains `user.capabilities: readonly string[]`. Server resolves it with `capabilitiesForRole(role, plugins)`; **deduped with a Set** — the derived `{type}:{action}` caps from plugin-registered post types share names with `CORE_CAPABILITIES`, and a raw iteration would ship `["post:read", "post:read", ...]`. Regression test covers this.
- Root router gets a `notFoundComponent` — unknown slugs get a proper 404 state instead of TanStack Router's bare `<p>`.

### Admin

- `packages/admin/src/lib/manifest.ts` exports:
  - `manifest = readManifest()` — module-level const, parsed once from the HTML script tag, no TanStack Query wrapper (manifest is static for the page lifetime)
  - `findPostTypeBySlug(slug)` — returns the entry or `undefined`; used in route `beforeLoad`
  - `visiblePostTypes(caps)` — filters by `${capabilityType ?? name}:edit_own`, i.e. "this user has any business editing this type". Subscribers with only `:read` don't see the nav item.
- Sidebar's Content group now derives from `visiblePostTypes`; hidden entirely when nothing's registered.
- `/posts` deleted; `/content/$slug` replaces it with manifest-driven slug resolution. `beforeLoad` 404s on unknown slugs.
- Dashboard landing iterates `visiblePostTypes` for tiles, with an empty-state card when nothing's registered.

### Why `/content/$slug` instead of `/posts/$type` or `/$slug`

- `/posts/$type` produces `/posts/post`, `/posts/page` — the "posts" namespace is simultaneously the nav group and one concrete type. Awkward.
- `/$slug` at root would make every registered post type a reserved admin-root route; collisions with `/settings`, `/users`, future admin sections.
- `/content/$slug` aligns with the sidebar's "Content" group, keeps non-content admin routes at root, and matches how users already navigate the app.

## Test plan

- [x] Core: `deriveAdminSlug` slugification + empty-input throw; `buildManifest` collision detection; `auth.session` returns capabilities per role and dedupes plugin-derived caps end-to-end
- [x] Admin: unit tests for `findPostTypeBySlug` / `visiblePostTypes`; e2e covers `/content/posts` (loading, empty, rows), unknown-slug not-found, dashboard tile + empty state
- [x] `pnpm turbo run typecheck lint test` — 15/15 green
- [x] `pnpm --filter @plumix/admin test:e2e` — 8/8 green
- [x] `publint` / `attw` clean on core subpaths
- [x] `pnpm knip` clean