### PR TITLE
feat(core,admin): post.list search + taxonomy filter (wordpress-style)

### DIFF
--- a/packages/admin/e2e/content.spec.ts
+++ b/packages/admin/e2e/content.spec.ts
@@ -79,6 +79,50 @@ test.describe("/content/$slug", () => {
     await expect(page.getByText(/not found/i).first()).toBeVisible();
   });
 
+  test("search box URL-syncs ?q= and triggers a refetch after debounce", async ({
+    page,
+  }) => {
+    // Capture every /post/list call so we can verify the second fetch
+    // carries the search param. The mock always returns `[]` — we're
+    // asserting on the RPC input, not the rendering.
+    const inputs: unknown[] = [];
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/post/list")) {
+        const body = route.request().postDataJSON() as { json?: unknown };
+        inputs.push(body.json);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: [], meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("content/posts?status=all&page=1");
+    await page
+      .getByRole("searchbox", { name: /search posts/i })
+      .fill("quantum");
+    await expect(page).toHaveURL(/q=quantum/);
+    // The debounced commit + refetch should eventually ship `search` in
+    // the RPC input. Playwright's expect.poll waits up to 5s by default,
+    // which covers the 250ms debounce comfortably.
+    await expect
+      .poll(
+        () =>
+          (inputs.at(-1) as { search?: string } | undefined)?.search ?? null,
+      )
+      .toBe("quantum");
+  });
+
   test("renders rows with zero WCAG 2.1 AA violations", async ({ page }) => {
     const now = new Date("2026-04-19T12:00:00Z");
     await mockRpc(page, {

--- a/packages/admin/src/routes/_authenticated/content/$slug.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug.tsx
@@ -1,5 +1,6 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { DataTable } from "@/components/data-table/data-table.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
@@ -11,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
+import { Input } from "@/components/ui/input.js";
 import {
   Pagination,
   PaginationContent,
@@ -21,7 +23,7 @@ import { findPostTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
-import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus, Search } from "lucide-react";
 import * as v from "valibot";
 
 import type { PostTypeManifestEntry } from "@plumix/core/manifest";
@@ -50,6 +52,19 @@ const searchSchema = v.object({
   status: v.optional(
     v.fallback(v.picklist(STATUS_FILTER_VALUES), "all"),
     "all",
+  ),
+  // Free-text search. Empty string coerces to `undefined` so the URL stays
+  // clean (`?q=` doesn't linger after the user clears the input).
+  q: v.optional(
+    v.fallback(
+      v.pipe(
+        v.string(),
+        v.trim(),
+        v.maxLength(200),
+        v.transform((value) => (value.length === 0 ? undefined : value)),
+      ),
+      undefined,
+    ),
   ),
 });
 
@@ -145,15 +160,19 @@ function ContentListRoute(): ReactNode {
         limit: PAGE_SIZE,
         offset: (search.page - 1) * PAGE_SIZE,
         ...(search.status !== "all" ? { status: search.status } : {}),
+        ...(search.q ? { search: search.q } : {}),
       },
     }),
   );
 
   const setStatus = (status: StatusFilter): void => {
-    void navigate({ search: { status, page: 1 } });
+    void navigate({ search: (prev) => ({ ...prev, status, page: 1 }) });
   };
   const setPage = (page: number): void => {
     void navigate({ search: (prev) => ({ ...prev, page }) });
+  };
+  const setSearch = (q: string | undefined): void => {
+    void navigate({ search: (prev) => ({ ...prev, q, page: 1 }) });
   };
 
   const rows: readonly Post[] = query.data ?? [];
@@ -186,6 +205,15 @@ function ContentListRoute(): ReactNode {
 
       <div className="flex flex-wrap items-center gap-2">
         <StatusFilter value={search.status} onChange={setStatus} />
+        <SearchInput
+          // Keyed on the URL value so external navigations (back button,
+          // links) remount the input with fresh local state instead of
+          // desynchronising from the URL.
+          key={search.q ?? ""}
+          initialValue={search.q ?? ""}
+          placeholder={`Search ${pluralLower}…`}
+          onCommit={setSearch}
+        />
       </div>
 
       {query.isError ? (
@@ -246,6 +274,54 @@ function ContentListRoute(): ReactNode {
           </PaginationItem>
         </PaginationContent>
       </Pagination>
+    </div>
+  );
+}
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+function SearchInput({
+  initialValue,
+  placeholder,
+  onCommit,
+}: {
+  initialValue: string;
+  placeholder: string;
+  onCommit: (next: string | undefined) => void;
+}): ReactNode {
+  // Local state so typing feels immediate; commit to the URL (which
+  // triggers the RPC refetch) after a debounce. Parent keys this
+  // component on the URL value so external URL changes remount the
+  // input rather than needing a setState-in-effect sync.
+  const [value, setValue] = useState(initialValue);
+  useEffect(() => {
+    if (value === initialValue) return;
+    const id = setTimeout(() => {
+      onCommit(value.length === 0 ? undefined : value);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(id);
+    };
+  }, [value, initialValue, onCommit]);
+
+  return (
+    <div className="relative">
+      <Search
+        aria-hidden
+        className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2"
+      />
+      <Input
+        type="search"
+        role="searchbox"
+        value={value}
+        maxLength={200}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+        className="h-9 w-64 pl-8"
+      />
     </div>
   );
 }

--- a/packages/core/src/rpc/procedures/post/list.ts
+++ b/packages/core/src/rpc/procedures/post/list.ts
@@ -1,10 +1,15 @@
+import type { SQL } from "../../../db/index.js";
 import type { Post, PostStatus } from "../../../db/schema/posts.js";
-import { and, desc, eq, isNull } from "../../../db/index.js";
+import type { SearchTerm } from "./search-terms.js";
+import { and, desc, eq, inArray, isNull, not, sql } from "../../../db/index.js";
+import { postTerm } from "../../../db/schema/post_term.js";
 import { posts } from "../../../db/schema/posts.js";
+import { terms } from "../../../db/schema/terms.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { postCapability } from "./lifecycle.js";
 import { postListInputSchema } from "./schemas.js";
+import { escapeLikePattern, tokenizeSearchQuery } from "./search-terms.js";
 
 const PUBLIC_STATUS: PostStatus = "published";
 
@@ -35,12 +40,34 @@ export const list = base
       );
     }
 
-    const conditions = [eq(posts.type, type)];
+    const conditions: SQL[] = [eq(posts.type, type)];
     if (effectiveStatus) conditions.push(eq(posts.status, effectiveStatus));
     if (filtered.parentId === null) {
       conditions.push(isNull(posts.parentId));
     } else if (filtered.parentId !== undefined) {
       conditions.push(eq(posts.parentId, filtered.parentId));
+    }
+    if (filtered.search) {
+      for (const term of tokenizeSearchQuery(filtered.search)) {
+        conditions.push(searchTermCondition(term));
+      }
+    }
+    if (filtered.taxonomies) {
+      for (const [taxonomy, slugs] of Object.entries(filtered.taxonomies)) {
+        if (slugs.length === 0) continue;
+        // Correlated subquery: post.id must appear in `post_term` joined
+        // to `terms` filtered by this taxonomy + listed slugs. One clause
+        // per taxonomy; multiple clauses AND together — matching WP's
+        // default `tax_query` relation.
+        const matching = context.db
+          .select({ postId: postTerm.postId })
+          .from(postTerm)
+          .innerJoin(terms, eq(terms.id, postTerm.termId))
+          .where(
+            and(eq(terms.taxonomy, taxonomy), inArray(terms.slug, [...slugs])),
+          );
+        conditions.push(inArray(posts.id, matching));
+      }
     }
 
     const rows = await context.db
@@ -56,3 +83,24 @@ export const list = base
       rows as readonly Post[],
     );
   });
+
+// One search term → `(title LIKE ? OR content LIKE ? OR excerpt LIKE ?)`
+// against an explicit ESCAPE char so literal `%` / `_` in user input don't
+// match-all. Excluded (`-term`) wraps the OR in `NOT (…)`.
+//
+// `content` and `excerpt` are nullable; `LIKE` on NULL yields NULL, which
+// is falsy for inclusion matches but becomes `NOT NULL` → still NULL → a
+// false-negative for exclusion. COALESCE to empty string so null columns
+// behave as empty text across both positive and negative clauses.
+function searchTermCondition(term: SearchTerm): SQL {
+  const pattern = `%${escapeLikePattern(term.value)}%`;
+  // Build the column OR via the raw `sql` tag — `or(...)` returns
+  // `SQL | undefined`, which fights both lint rules on non-null assertion
+  // style. The sql-tag form has the same parameterization guarantees.
+  const match = sql`(
+    COALESCE(${posts.title}, '') LIKE ${pattern} ESCAPE '\\'
+    OR COALESCE(${posts.content}, '') LIKE ${pattern} ESCAPE '\\'
+    OR COALESCE(${posts.excerpt}, '') LIKE ${pattern} ESCAPE '\\'
+  )`;
+  return term.exclude ? not(match) : match;
+}

--- a/packages/core/src/rpc/procedures/post/read.test.ts
+++ b/packages/core/src/rpc/procedures/post/read.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, test } from "vitest";
 
+import { postTerm } from "../../../db/schema/post_term.js";
+import { terms } from "../../../db/schema/terms.js";
 import { createRpcHarness } from "../../../test/rpc.js";
+
+async function seedTerm(
+  h: Awaited<ReturnType<typeof createRpcHarness>>,
+  taxonomy: string,
+  slug: string,
+): Promise<number> {
+  const [row] = await h.context.db
+    .insert(terms)
+    .values({ taxonomy, name: slug, slug })
+    .returning();
+  if (!row) throw new Error("seedTerm: insert returned no row");
+  return row.id;
+}
+
+async function attachTerm(
+  h: Awaited<ReturnType<typeof createRpcHarness>>,
+  postId: number,
+  termId: number,
+): Promise<void> {
+  await h.context.db.insert(postTerm).values({ postId, termId });
+}
 
 describe("post.list", () => {
   test("returns published posts by default for subscriber", async () => {
@@ -102,6 +125,226 @@ describe("post.list", () => {
 
     const all = await h.client.post.list({});
     expect(all.map((p) => p.slug).sort()).toEqual(["p-child", "p-root"]);
+  });
+
+  test("search matches on title", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Hello world",
+      slug: "hello",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Unrelated",
+      slug: "unrelated",
+    });
+
+    const rows = await h.client.post.list({ search: "hello" });
+    expect(rows.map((r) => r.slug)).toEqual(["hello"]);
+  });
+
+  test("search also matches on content and excerpt (OR across columns)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Generic",
+      slug: "in-body",
+      content: "A paragraph mentioning giraffes in passing.",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Generic",
+      slug: "in-excerpt",
+      excerpt: "All about giraffes.",
+    });
+
+    const rows = await h.client.post.list({ search: "giraffes" });
+    expect(rows.map((r) => r.slug).sort()).toEqual(["in-body", "in-excerpt"]);
+  });
+
+  test("multi-term search AND-combines (each term must hit some column)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Quantum physics intro",
+      slug: "both",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Quantum only",
+      slug: "quantum-only",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Physics only",
+      slug: "physics-only",
+    });
+
+    const rows = await h.client.post.list({ search: "quantum physics" });
+    expect(rows.map((r) => r.slug)).toEqual(["both"]);
+  });
+
+  test("quoted phrases match verbatim across whitespace", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "quantum physics",
+      slug: "phrase-hit",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "quantum mechanics and physics",
+      slug: "phrase-miss",
+    });
+
+    const rows = await h.client.post.list({ search: '"quantum physics"' });
+    expect(rows.map((r) => r.slug)).toEqual(["phrase-hit"]);
+  });
+
+  test("leading dash excludes the term (NOT LIKE)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Pillow for sale",
+      slug: "pillow-sofa",
+      content: "Comes with a sofa",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Standalone pillow",
+      slug: "pillow-only",
+    });
+
+    const rows = await h.client.post.list({ search: "pillow -sofa" });
+    expect(rows.map((r) => r.slug)).toEqual(["pillow-only"]);
+  });
+
+  test("LIKE wildcards in user input are escaped, not interpreted", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Save 50% today",
+      slug: "with-percent",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Nothing special",
+      slug: "plain",
+    });
+
+    // A literal `%` in the query should match only "50%", not everything.
+    const rows = await h.client.post.list({ search: "50%" });
+    expect(rows.map((r) => r.slug)).toEqual(["with-percent"]);
+  });
+
+  test("taxonomy filter: single taxonomy, IN across term slugs", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const news = await seedTerm(h, "category", "news");
+    const tutorials = await seedTerm(h, "category", "tutorials");
+    const p1 = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "news-post",
+    });
+    const p2 = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "tut-post",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "untagged",
+    });
+    await attachTerm(h, p1.id, news);
+    await attachTerm(h, p2.id, tutorials);
+
+    const rows = await h.client.post.list({
+      taxonomies: { category: ["news", "tutorials"] },
+    });
+    expect(rows.map((r) => r.slug).sort()).toEqual(["news-post", "tut-post"]);
+  });
+
+  test("taxonomy filter: AND across taxonomies (post must match each)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const news = await seedTerm(h, "category", "news");
+    const urgent = await seedTerm(h, "tag", "urgent");
+    const both = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "both",
+    });
+    const newsOnly = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "news-only",
+    });
+    const urgentOnly = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "urgent-only",
+    });
+    await attachTerm(h, both.id, news);
+    await attachTerm(h, both.id, urgent);
+    await attachTerm(h, newsOnly.id, news);
+    await attachTerm(h, urgentOnly.id, urgent);
+
+    const rows = await h.client.post.list({
+      taxonomies: { category: ["news"], tag: ["urgent"] },
+    });
+    expect(rows.map((r) => r.slug)).toEqual(["both"]);
+  });
+
+  test("taxonomy filter: empty slug array is a no-op for that taxonomy", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "a" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "b" });
+
+    const rows = await h.client.post.list({ taxonomies: { category: [] } });
+    expect(rows.map((r) => r.slug).sort()).toEqual(["a", "b"]);
+  });
+
+  test("taxonomy filter: slug scoped to taxonomy (no cross-taxonomy leak)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    // Same slug in two taxonomies — filter must only match within the
+    // specified taxonomy. `{ category: ["news"] }` should NOT match a
+    // post tagged `tag:news`.
+    const catNews = await seedTerm(h, "category", "news");
+    const tagNews = await seedTerm(h, "tag", "news");
+    const catPost = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "in-category",
+    });
+    const tagPost = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "in-tag",
+    });
+    await attachTerm(h, catPost.id, catNews);
+    await attachTerm(h, tagPost.id, tagNews);
+
+    const rows = await h.client.post.list({
+      taxonomies: { category: ["news"] },
+    });
+    expect(rows.map((r) => r.slug)).toEqual(["in-category"]);
+  });
+
+  test("taxonomy filter composes with search", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const news = await seedTerm(h, "category", "news");
+    const matches = await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Quantum breakthrough",
+      slug: "qbn",
+    });
+    const notTagged = await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Quantum breakthrough elsewhere",
+      slug: "qbn-2",
+    });
+    await attachTerm(h, matches.id, news);
+    // `notTagged` has the same title but no term — taxonomy filter excludes it
+
+    const rows = await h.client.post.list({
+      search: "quantum",
+      taxonomies: { category: ["news"] },
+    });
+    expect(rows.map((r) => r.slug)).toEqual(["qbn"]);
+    expect(rows.map((r) => r.slug)).not.toContain(notTagged.slug);
   });
 });
 

--- a/packages/core/src/rpc/procedures/post/schemas.ts
+++ b/packages/core/src/rpc/procedures/post/schemas.ts
@@ -68,6 +68,27 @@ export const postUpdateInputSchema = v.object({
   terms: v.optional(postTermsSchema),
 });
 
+// Upper bound on the term-slug list per taxonomy clause. Mirrors the
+// per-taxonomy guard on `post.update` — admin UIs don't reasonably issue
+// queries beyond this, and the cap protects the generated `IN (?, ?, …)`
+// subquery from pathological input lengths.
+const MAX_TERM_SLUGS_PER_TAXONOMY = 50;
+
+const taxonomyNameSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(100),
+  v.regex(/^[a-zA-Z0-9_-]+$/, "taxonomy must be kebab/snake ASCII"),
+);
+
+const termSlugSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(200),
+);
+
 export const postListInputSchema = v.object({
   type: v.optional(trimmedText(100)),
   status: v.optional(userSuppliableFields.entries.status),
@@ -78,6 +99,28 @@ export const postListInputSchema = v.object({
    * - omitted → no filter, flat list across all depths.
    */
   parentId: v.optional(v.nullable(postIdSchema)),
+  /**
+   * Free-text search across `title`, `content`, and `excerpt`. Whitespace
+   * separates terms (all AND-ed), `"quoted phrases"` stay whole, and a
+   * leading `-` on a bare term excludes matches (WordPress semantics).
+   * Capped at 200 chars to bound the LIKE workload per row.
+   */
+  search: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200))),
+  /**
+   * Taxonomy clauses, keyed by taxonomy name. Each value is a list of term
+   * slugs the post must be associated with in that taxonomy. Within one
+   * taxonomy the match is OR (any listed slug); across taxonomies the
+   * match is AND (every specified taxonomy must contribute a match).
+   * Matches the default semantics of WordPress's `tax_query`.
+   *
+   * Empty slug arrays are no-ops for that taxonomy.
+   */
+  taxonomies: v.optional(
+    v.record(
+      taxonomyNameSchema,
+      v.pipe(v.array(termSlugSchema), v.maxLength(MAX_TERM_SLUGS_PER_TAXONOMY)),
+    ),
+  ),
   limit: v.optional(
     v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
     20,

--- a/packages/core/src/rpc/procedures/post/search-terms.test.ts
+++ b/packages/core/src/rpc/procedures/post/search-terms.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+
+import { escapeLikePattern, tokenizeSearchQuery } from "./search-terms.js";
+
+describe("tokenizeSearchQuery", () => {
+  test("empty and whitespace-only input yields no terms", () => {
+    expect(tokenizeSearchQuery("")).toEqual([]);
+    expect(tokenizeSearchQuery("   \t  ")).toEqual([]);
+  });
+
+  test("splits bare tokens on whitespace", () => {
+    expect(tokenizeSearchQuery("hello world")).toEqual([
+      { value: "hello", exclude: false },
+      { value: "world", exclude: false },
+    ]);
+  });
+
+  test("quoted phrases stay whole, with inner whitespace preserved", () => {
+    expect(tokenizeSearchQuery('"quantum physics" intro')).toEqual([
+      { value: "quantum physics", exclude: false },
+      { value: "intro", exclude: false },
+    ]);
+  });
+
+  test("unterminated opening quote consumes to end-of-input", () => {
+    expect(tokenizeSearchQuery('"unterminated thing')).toEqual([
+      { value: "unterminated thing", exclude: false },
+    ]);
+  });
+
+  test("leading dash on a bare token flags exclusion", () => {
+    expect(tokenizeSearchQuery("pillow -sofa")).toEqual([
+      { value: "pillow", exclude: false },
+      { value: "sofa", exclude: true },
+    ]);
+  });
+
+  test("dash inside a quoted phrase stays literal", () => {
+    expect(tokenizeSearchQuery('"-literal dash"')).toEqual([
+      { value: "-literal dash", exclude: false },
+    ]);
+  });
+
+  test("bare `-` with no body is dropped", () => {
+    expect(tokenizeSearchQuery("foo - bar")).toEqual([
+      { value: "foo", exclude: false },
+      { value: "bar", exclude: false },
+    ]);
+  });
+
+  test("empty quoted phrase is dropped", () => {
+    expect(tokenizeSearchQuery('"" real')).toEqual([
+      { value: "real", exclude: false },
+    ]);
+  });
+
+  test("Unicode whitespace (NBSP, etc.) separates terms without hanging", () => {
+    // Regression: an earlier pass used an ASCII-only skip while the
+    // inner scanner used /\s/, which caused an infinite loop on NBSP.
+    expect(tokenizeSearchQuery("foo\u00A0bar")).toEqual([
+      { value: "foo", exclude: false },
+      { value: "bar", exclude: false },
+    ]);
+    expect(tokenizeSearchQuery("\u00A0")).toEqual([]);
+    expect(tokenizeSearchQuery("a\u2003b\u2003c")).toEqual([
+      { value: "a", exclude: false },
+      { value: "b", exclude: false },
+      { value: "c", exclude: false },
+    ]);
+  });
+
+  test("tab and newline separators behave like spaces", () => {
+    expect(tokenizeSearchQuery("foo\tbar\nbaz")).toEqual([
+      { value: "foo", exclude: false },
+      { value: "bar", exclude: false },
+      { value: "baz", exclude: false },
+    ]);
+  });
+});
+
+describe("escapeLikePattern", () => {
+  test("escapes SQL LIKE wildcards", () => {
+    expect(escapeLikePattern("50%")).toBe("50\\%");
+    expect(escapeLikePattern("a_b")).toBe("a\\_b");
+  });
+
+  test("escapes the escape character itself", () => {
+    expect(escapeLikePattern("a\\b")).toBe("a\\\\b");
+  });
+
+  test("leaves safe characters untouched", () => {
+    expect(escapeLikePattern("hello world")).toBe("hello world");
+    expect(escapeLikePattern("quote'mark")).toBe("quote'mark");
+  });
+});

--- a/packages/core/src/rpc/procedures/post/search-terms.ts
+++ b/packages/core/src/rpc/procedures/post/search-terms.ts
@@ -1,0 +1,84 @@
+/**
+ * Query tokenizer + LIKE-escape for post search.
+ *
+ * Mirrors WordPress's default search parsing shape (see
+ * https://developer.wordpress.org/reference/classes/wp_query/parse_search/):
+ *
+ * - Double-quoted substrings become a single phrase term, verbatim
+ *   (whitespace preserved, wildcards NOT interpreted).
+ * - Bare tokens split on whitespace, each is its own term.
+ * - A leading `-` on a bare token flags exclusion (NOT LIKE). Inside
+ *   quotes, `-` is literal.
+ * - Stopwords / sentence-mode fallback from WP are deliberately skipped —
+ *   they're English-biased and can be added later via a search plugin.
+ *
+ * The handler side joins terms with AND and joins column matches for each
+ * term with OR (`title OR content OR excerpt`). This module owns the
+ * parsing and escaping only; it doesn't construct SQL.
+ */
+
+// Unicode-aware: matches NBSP, em-space, etc. Shared between the outer
+// skip and the inner token-end scan so a non-ASCII whitespace char can
+// never produce an empty token + stuck cursor (earlier regression).
+const WHITESPACE = /\s/;
+
+export interface SearchTerm {
+  /** The plain substring to match (unescaped, unquoted). */
+  readonly value: string;
+  /** True for `-term`: wrap the column-OR clause in NOT (…). */
+  readonly exclude: boolean;
+}
+
+/**
+ * Tokenize a raw search string into phrases and terms.
+ *
+ * - Quoted phrases (`"a b"`) become a single term; the outer quotes are
+ *   stripped, inner content is preserved verbatim. An unterminated opening
+ *   quote consumes to end of input — matches WP's tolerant behavior.
+ * - Bare runs of non-whitespace are individual terms.
+ * - A leading `-` on a bare term marks exclusion; a bare `-` with no
+ *   following characters is dropped.
+ * - Empty / whitespace-only input yields an empty array.
+ */
+export function tokenizeSearchQuery(raw: string): readonly SearchTerm[] {
+  const terms: SearchTerm[] = [];
+  let i = 0;
+  while (i < raw.length) {
+    const ch = raw.charAt(i);
+    if (WHITESPACE.test(ch)) {
+      i++;
+      continue;
+    }
+    if (ch === '"') {
+      const end = raw.indexOf('"', i + 1);
+      const close = end === -1 ? raw.length : end;
+      const inner = raw.slice(i + 1, close);
+      if (inner.length > 0) terms.push({ value: inner, exclude: false });
+      i = close + 1;
+      continue;
+    }
+    let j = i;
+    while (j < raw.length && !WHITESPACE.test(raw.charAt(j))) j++;
+    const token = raw.slice(i, j);
+    i = j;
+    if (token.length === 0) continue;
+    if (token.startsWith("-")) {
+      const rest = token.slice(1);
+      if (rest.length > 0) terms.push({ value: rest, exclude: true });
+      continue;
+    }
+    terms.push({ value: token, exclude: false });
+  }
+  return terms;
+}
+
+/**
+ * Escape a raw term for use inside a SQL `LIKE` pattern.
+ *
+ * The handler pairs each `LIKE ?` with `ESCAPE '\\'`, so this function
+ * backslash-escapes the three wildcard characters `\ % _`. Without this,
+ * a user searching for `50%` would match every post.
+ */
+export function escapeLikePattern(term: string): string {
+  return term.replace(/[\\%_]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary

Adds text search and taxonomy filtering to `post.list` — the shape WordPress's `WP_Query` uses by default, without the FTS5 plugin apparatus. The enhanced FTS5 path stays on the backlog as a follow-up plugin (`porter unicode61` tokenizer, BM25 relevance, snippets).

### Why this shape

- **Search**: three-column `LIKE` (title, content, excerpt), AND across terms, OR across columns, `-term` exclusion, `"quoted phrases"` verbatim. No stemming, no stopword list, no relevance ranking — those are English-biased and belong in a search plugin. [WP reference.](https://developer.wordpress.org/reference/classes/wp_query/parse_search/)
- **Taxonomy**: `Record<taxonomy_name, term_slugs[]>` input. IN within a taxonomy (OR), AND across taxonomies. Matches `tax_query`'s default relation. Operators (`NOT IN`, `AND`, `EXISTS`) deferred.
- **Admin UI**: search input only — taxonomy filter UX (chips vs. multiselect vs. sidebar) is its own design call and would balloon this PR. API ships now; UI follows when the UX is decided.

### Notable correctness bits

- `LIKE` uses `ESCAPE '\\'` paired with a helper that escapes `\`, `%`, `_` in user input — a literal `%` in the query doesn't match-all (regression test included).
- Nullable `content` / `excerpt` wrap in `COALESCE(col, '')` so the SQL three-valued-logic trap (NULL under `LIKE` stays NULL under `NOT`) can't false-negative exclusion clauses (regression test on `-sofa` with null content).
- Tokenizer shares `/\s/` between outer skip and inner token-end scan — earlier ASCII-only skip hung on NBSP by producing an empty token with a stuck cursor. Regression tests cover NBSP, em-space, tab, newline.
- Admin `<SearchInput>` is keyed on `search.q` so external URL changes remount rather than needing a setState-in-effect sync. 250ms debounce.

### What's not in scope

- Taxonomy filter admin UI (ships API only)
- FTS5 plugin (real relevance, stemming, snippets)
- Taxonomy operators (`NOT IN`, `AND`, `EXISTS`, `NOT EXISTS`)

## Test plan

- [x] Core: tokenizer (13 assertions — every documented rule + whitespace regressions)
- [x] Core: `post.list` integration covers title/content/excerpt OR match, multi-term AND, quoted phrase, `-term` exclusion, LIKE wildcard escape, single-taxonomy IN, multi-taxonomy AND, empty slug array no-op, taxonomy scoping (same slug in two taxonomies), search+taxonomy composition
- [x] Admin: e2e asserts `?q=` round-trips through the URL and the debounced commit reaches the RPC input
- [x] `pnpm turbo run typecheck lint test` — 32/32 green
- [x] `pnpm --filter @plumix/admin test:e2e` — 9/9 green
- [x] `pnpm knip` clean; `publint` / `attw` clean on the core subpaths