### PR TITLE
feat(core,admin): post.list filter gaps — trash view, status arrays, authorId, ordering

### DIFF
--- a/packages/admin/e2e/content.spec.ts
+++ b/packages/admin/e2e/content.spec.ts
@@ -123,6 +123,80 @@ test.describe("/content/$slug", () => {
       .toBe("quantum");
   });
 
+  test("Mine toggle URL-syncs author=mine and sends session.user.id as authorId", async ({
+    page,
+  }) => {
+    const inputs: unknown[] = [];
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/post/list")) {
+        const body = route.request().postDataJSON() as { json?: unknown };
+        inputs.push(body.json);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: [], meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("content/posts?status=all&page=1");
+    await page.getByRole("button", { name: "Mine" }).click();
+    await expect(page).toHaveURL(/author=mine/);
+    await expect
+      .poll(
+        () =>
+          (inputs.at(-1) as { authorId?: number } | undefined)?.authorId ??
+          null,
+      )
+      .toBe(AUTHED_ADMIN.user?.id);
+  });
+
+  test("column sort: clicking Title header sets orderBy=title and defaults to asc", async ({
+    page,
+  }) => {
+    const inputs: unknown[] = [];
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/post/list")) {
+        const body = route.request().postDataJSON() as { json?: unknown };
+        inputs.push(body.json);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: [], meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("content/posts?status=all&page=1");
+    await page.getByRole("button", { name: /sort by title/i }).click();
+    await expect(page).toHaveURL(/orderBy=title/);
+    await expect(page).toHaveURL(/order=asc/);
+    await expect
+      .poll(
+        () =>
+          (inputs.at(-1) as { orderBy?: string } | undefined)?.orderBy ?? null,
+      )
+      .toBe("title");
+  });
+
   test("renders rows with zero WCAG 2.1 AA violations", async ({ page }) => {
     const now = new Date("2026-04-19T12:00:00Z");
     await mockRpc(page, {

--- a/packages/admin/src/routes/_authenticated/content/$slug.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug.tsx
@@ -1,6 +1,6 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { DataTable } from "@/components/data-table/data-table.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
@@ -23,7 +23,15 @@ import { findPostTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
-import { ChevronLeft, ChevronRight, Plus, Search } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Search,
+} from "lucide-react";
 import * as v from "valibot";
 
 import type { PostTypeManifestEntry } from "@plumix/core/manifest";
@@ -43,6 +51,25 @@ const POST_STATUSES: readonly PostStatus[] = [
 ];
 const STATUS_FILTER_VALUES = [...POST_STATUSES, "all"] as const;
 type StatusFilter = (typeof STATUS_FILTER_VALUES)[number];
+
+// Local copy of core's `POST_LIST_ORDER_COLUMNS` to keep the valibot
+// picklist tree-shakeable (same rationale as `POST_STATUSES` above —
+// importing the core runtime symbol would pull drizzle into the admin
+// bundle). Must stay in sync with `postListInputSchema.orderBy`; a drift
+// would fail server-side validation at runtime, not compile time.
+const ORDER_BY_VALUES = [
+  "updated_at",
+  "published_at",
+  "title",
+  "menu_order",
+] as const;
+type OrderBy = (typeof ORDER_BY_VALUES)[number];
+
+const ORDER_VALUES = ["asc", "desc"] as const;
+type Order = (typeof ORDER_VALUES)[number];
+
+const AUTHOR_VALUES = ["all", "mine"] as const;
+type AuthorFilter = (typeof AUTHOR_VALUES)[number];
 
 const searchSchema = v.object({
   page: v.optional(
@@ -66,6 +93,12 @@ const searchSchema = v.object({
       undefined,
     ),
   ),
+  author: v.optional(v.fallback(v.picklist(AUTHOR_VALUES), "all"), "all"),
+  orderBy: v.optional(
+    v.fallback(v.picklist(ORDER_BY_VALUES), "updated_at"),
+    "updated_at",
+  ),
+  order: v.optional(v.fallback(v.picklist(ORDER_VALUES), "desc"), "desc"),
 });
 
 const STATUS_VARIANT: Record<
@@ -91,45 +124,73 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
   timeStyle: "short",
 });
 
-const columns: ColumnDef<Post>[] = [
-  {
-    accessorKey: "title",
-    header: "Title",
-    cell: ({ row }) => (
-      <div className="flex flex-col">
-        <span className="font-medium">
-          {row.original.title || (
-            <span className="text-muted-foreground italic">(no title)</span>
-          )}
+function buildColumns({
+  activeOrderBy,
+  activeOrder,
+  onSort,
+}: {
+  activeOrderBy: OrderBy;
+  activeOrder: Order;
+  onSort: (column: OrderBy, defaultDirection: Order) => void;
+}): ColumnDef<Post>[] {
+  return [
+    {
+      accessorKey: "title",
+      header: () => (
+        <SortableHeader
+          label="Title"
+          column="title"
+          defaultDirection="asc"
+          activeOrderBy={activeOrderBy}
+          activeOrder={activeOrder}
+          onSort={onSort}
+        />
+      ),
+      cell: ({ row }) => (
+        <div className="flex flex-col">
+          <span className="font-medium">
+            {row.original.title || (
+              <span className="text-muted-foreground italic">(no title)</span>
+            )}
+          </span>
+          <span className="text-muted-foreground text-xs">
+            {row.original.slug}
+          </span>
+        </div>
+      ),
+    },
+    {
+      accessorKey: "status",
+      header: "Status",
+      cell: ({ row }) => (
+        <Badge
+          variant={STATUS_VARIANT[row.original.status]}
+          className="capitalize"
+        >
+          {row.original.status}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: "updatedAt",
+      header: () => (
+        <SortableHeader
+          label="Updated"
+          column="updated_at"
+          defaultDirection="desc"
+          activeOrderBy={activeOrderBy}
+          activeOrder={activeOrder}
+          onSort={onSort}
+        />
+      ),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-sm">
+          {dateFormatter.format(toDate(row.original.updatedAt))}
         </span>
-        <span className="text-muted-foreground text-xs">
-          {row.original.slug}
-        </span>
-      </div>
-    ),
-  },
-  {
-    accessorKey: "status",
-    header: "Status",
-    cell: ({ row }) => (
-      <Badge
-        variant={STATUS_VARIANT[row.original.status]}
-        className="capitalize"
-      >
-        {row.original.status}
-      </Badge>
-    ),
-  },
-  {
-    accessorKey: "updatedAt",
-    header: "Updated",
-    cell: ({ row }) => (
-      <span className="text-muted-foreground text-sm">
-        {dateFormatter.format(toDate(row.original.updatedAt))}
-      </span>
-    ),
-  },
-];
+      ),
+    },
+  ];
+}
 
 export const Route = createFileRoute("/_authenticated/content/$slug")({
   validateSearch: (search) => v.parse(searchSchema, search),
@@ -150,7 +211,7 @@ export const Route = createFileRoute("/_authenticated/content/$slug")({
 
 function ContentListRoute(): ReactNode {
   const search = Route.useSearch();
-  const { postType } = Route.useRouteContext();
+  const { user, postType } = Route.useRouteContext();
   const navigate = useNavigate({ from: Route.fullPath });
 
   const query = useQuery(
@@ -159,21 +220,62 @@ function ContentListRoute(): ReactNode {
         type: postType.name,
         limit: PAGE_SIZE,
         offset: (search.page - 1) * PAGE_SIZE,
+        orderBy: search.orderBy,
+        order: search.order,
         ...(search.status !== "all" ? { status: search.status } : {}),
         ...(search.q ? { search: search.q } : {}),
+        ...(search.author === "mine" ? { authorId: user.id } : {}),
       },
     }),
   );
 
-  const setStatus = (status: StatusFilter): void => {
-    void navigate({ search: (prev) => ({ ...prev, status, page: 1 }) });
-  };
-  const setPage = (page: number): void => {
-    void navigate({ search: (prev) => ({ ...prev, page }) });
-  };
-  const setSearch = (q: string | undefined): void => {
-    void navigate({ search: (prev) => ({ ...prev, q, page: 1 }) });
-  };
+  // useCallback keeps these navigation handlers stable across renders so
+  // the `columns` memo below (and any future memoised consumers) don't
+  // invalidate on every tick.
+  const setStatus = useCallback(
+    (status: StatusFilter): void => {
+      void navigate({ search: (prev) => ({ ...prev, status, page: 1 }) });
+    },
+    [navigate],
+  );
+  const setPage = useCallback(
+    (page: number): void => {
+      void navigate({ search: (prev) => ({ ...prev, page }) });
+    },
+    [navigate],
+  );
+  const setSearch = useCallback(
+    (q: string | undefined): void => {
+      void navigate({ search: (prev) => ({ ...prev, q, page: 1 }) });
+    },
+    [navigate],
+  );
+  const setAuthor = useCallback(
+    (author: AuthorFilter): void => {
+      void navigate({ search: (prev) => ({ ...prev, author, page: 1 }) });
+    },
+    [navigate],
+  );
+  // Clicking a sortable header: if it's already the active column, flip
+  // direction; otherwise pick the column with a sensible default
+  // direction (asc for alphabetical, desc for date-ish).
+  const setSort = useCallback(
+    (column: OrderBy, defaultDirection: Order): void => {
+      void navigate({
+        search: (prev) => ({
+          ...prev,
+          orderBy: column,
+          order: nextSortOrder(
+            prev.orderBy === column,
+            prev.order,
+            defaultDirection,
+          ),
+          page: 1,
+        }),
+      });
+    },
+    [navigate],
+  );
 
   const rows: readonly Post[] = query.data ?? [];
   const canPrev = search.page > 1;
@@ -187,14 +289,24 @@ function ContentListRoute(): ReactNode {
   const pluralLower = pluralLabel.toLowerCase();
   const singularLower = singularLabel.toLowerCase();
 
+  const columns = useMemo(
+    () =>
+      buildColumns({
+        activeOrderBy: search.orderBy,
+        activeOrder: search.order,
+        onSort: setSort,
+      }),
+    [search.orderBy, search.order, setSort],
+  );
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold">{pluralLabel}</h1>
           <p className="text-muted-foreground text-sm">
-            Manage {pluralLower}. Draft, scheduled, and trashed items only show
-            for users with the edit-any capability.
+            Manage {pluralLower}. "All" shows drafts, scheduled, and published
+            items; trashed items live in their own view.
           </p>
         </div>
         <Button disabled title="Editor lands in a follow-up PR">
@@ -205,6 +317,7 @@ function ContentListRoute(): ReactNode {
 
       <div className="flex flex-wrap items-center gap-2">
         <StatusFilter value={search.status} onChange={setStatus} />
+        <AuthorFilter value={search.author} onChange={setAuthor} />
         <SearchInput
           // Keyed on the URL value so external navigations (back button,
           // links) remount the input with fresh local state instead of
@@ -274,6 +387,93 @@ function ContentListRoute(): ReactNode {
           </PaginationItem>
         </PaginationContent>
       </Pagination>
+    </div>
+  );
+}
+
+// If the user clicks the already-active column, flip direction;
+// otherwise pick the caller's sensible default (asc for alphabetical,
+// desc for date-ish).
+function nextSortOrder(
+  isActiveColumn: boolean,
+  currentOrder: Order,
+  defaultDirection: Order,
+): Order {
+  if (!isActiveColumn) return defaultDirection;
+  return currentOrder === "asc" ? "desc" : "asc";
+}
+
+// Three visual states: inactive (generic updown icon), active-asc (up),
+// active-desc (down). The icon doubles as the a11y hint via the button's
+// aria-label on the parent.
+function SortIndicator({
+  isActive,
+  order,
+}: {
+  isActive: boolean;
+  order: Order;
+}): ReactNode {
+  if (!isActive) return <ArrowUpDown aria-hidden className="size-3.5" />;
+  if (order === "asc") return <ArrowUp aria-hidden className="size-3.5" />;
+  return <ArrowDown aria-hidden className="size-3.5" />;
+}
+
+function SortableHeader({
+  label,
+  column,
+  defaultDirection,
+  activeOrderBy,
+  activeOrder,
+  onSort,
+}: {
+  label: string;
+  column: OrderBy;
+  defaultDirection: Order;
+  activeOrderBy: OrderBy;
+  activeOrder: Order;
+  onSort: (column: OrderBy, defaultDirection: Order) => void;
+}): ReactNode {
+  const isActive = activeOrderBy === column;
+  const nextDirection = nextSortOrder(isActive, activeOrder, defaultDirection);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        onSort(column, defaultDirection);
+      }}
+      className="hover:text-foreground -ml-2 inline-flex items-center gap-1 rounded px-2 py-1 text-left font-medium transition-colors"
+      aria-label={`Sort by ${label} (${nextDirection})`}
+      aria-pressed={isActive}
+    >
+      {label}
+      <SortIndicator isActive={isActive} order={activeOrder} />
+    </button>
+  );
+}
+
+function AuthorFilter({
+  value,
+  onChange,
+}: {
+  value: AuthorFilter;
+  onChange: (next: AuthorFilter) => void;
+}): ReactNode {
+  return (
+    <div role="group" aria-label="Filter by author" className="flex gap-1">
+      {AUTHOR_VALUES.map((opt) => (
+        <Button
+          key={opt}
+          variant={value === opt ? "default" : "outline"}
+          size="sm"
+          onClick={() => {
+            onChange(opt);
+          }}
+          aria-pressed={value === opt}
+          className="capitalize"
+        >
+          {opt === "all" ? "All authors" : "Mine"}
+        </Button>
+      ))}
     </div>
   );
 }

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -51,7 +51,17 @@ function DashboardIndex(): ReactNode {
                     <Link
                       to="/content/$slug"
                       params={{ slug: pt.adminSlug }}
-                      search={{ status: "all", page: 1 }}
+                      // Pass every search-param default explicitly — the
+                      // generated route type requires all non-optional
+                      // fields. Omitting any would fail typecheck even
+                      // though valibot falls back at runtime.
+                      search={{
+                        status: "all",
+                        page: 1,
+                        author: "all",
+                        orderBy: "updated_at",
+                        order: "desc",
+                      }}
                     >
                       Browse {labelLower}
                       <ArrowRight />

--- a/packages/core/src/rpc/procedures/post/list.ts
+++ b/packages/core/src/rpc/procedures/post/list.ts
@@ -1,7 +1,19 @@
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
+
 import type { SQL } from "../../../db/index.js";
 import type { Post, PostStatus } from "../../../db/schema/posts.js";
+import type { PostListOrderColumn } from "./schemas.js";
 import type { SearchTerm } from "./search-terms.js";
-import { and, desc, eq, inArray, isNull, not, sql } from "../../../db/index.js";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  not,
+  sql,
+} from "../../../db/index.js";
 import { postTerm } from "../../../db/schema/post_term.js";
 import { posts } from "../../../db/schema/posts.js";
 import { terms } from "../../../db/schema/terms.js";
@@ -29,11 +41,8 @@ export const list = base
     }
 
     const canSeeAnyStatus = context.auth.can(postCapability(type, "edit_any"));
-    const effectiveStatus = canSeeAnyStatus
-      ? filtered.status
-      : (filtered.status ?? PUBLIC_STATUS);
-
-    if (!canSeeAnyStatus && effectiveStatus !== PUBLIC_STATUS) {
+    const statusClause = resolveStatusClause(filtered.status, canSeeAnyStatus);
+    if (statusClause === "forbidden") {
       return context.hooks.applyFilter(
         "rpc:post.list:output",
         [] as readonly Post[],
@@ -41,7 +50,10 @@ export const list = base
     }
 
     const conditions: SQL[] = [eq(posts.type, type)];
-    if (effectiveStatus) conditions.push(eq(posts.status, effectiveStatus));
+    conditions.push(statusClause);
+    if (filtered.authorId !== undefined) {
+      conditions.push(eq(posts.authorId, filtered.authorId));
+    }
     if (filtered.parentId === null) {
       conditions.push(isNull(posts.parentId));
     } else if (filtered.parentId !== undefined) {
@@ -70,11 +82,15 @@ export const list = base
       }
     }
 
+    const orderCol = ORDER_COLUMNS[filtered.orderBy];
+    const primary = filtered.order === "asc" ? asc(orderCol) : desc(orderCol);
+    // `posts.id` is always a desc tiebreaker — pagination must be stable
+    // across ties on the user-selected order column.
     const rows = await context.db
       .select()
       .from(posts)
       .where(and(...conditions))
-      .orderBy(desc(posts.updatedAt), desc(posts.id))
+      .orderBy(primary, desc(posts.id))
       .limit(filtered.limit)
       .offset(filtered.offset);
 
@@ -83,6 +99,67 @@ export const list = base
       rows as readonly Post[],
     );
   });
+
+// Whitelist map from wire-level column names to drizzle column refs.
+// Keeping it here (not in schemas.ts) lets schemas.ts stay runtime-free of
+// drizzle imports.
+const ORDER_COLUMNS: Record<PostListOrderColumn, AnySQLiteColumn> = {
+  updated_at: posts.updatedAt,
+  published_at: posts.publishedAt,
+  title: posts.title,
+  menu_order: posts.menuOrder,
+};
+
+const TRASH_STATUS: PostStatus = "trash";
+
+/**
+ * Resolve the caller's `status` input into a WHERE clause, honoring the
+ * capability check.
+ *
+ * - User can see any status + `undefined` → exclude trash (WP "All" tab).
+ * - User can see any status + explicit list/string → match as given.
+ * - User cannot see any status → pin to `published`; if they asked for
+ *   anything else, short-circuit with "forbidden" so the caller returns
+ *   an empty result (not a 403 — WP's admin also silently filters).
+ *
+ * Input type is what valibot's `v.union([picklist, v.array(picklist)])`
+ * produces — the array inner type widens to `PostStatus | undefined`
+ * through valibot's pipe, so we filter at the boundary.
+ */
+type StatusInput = PostStatus | readonly (PostStatus | undefined)[] | undefined;
+
+function resolveStatusClause(
+  input: StatusInput,
+  canSeeAnyStatus: boolean,
+): SQL | "forbidden" {
+  const normalized = normalizeStatusInput(input);
+
+  if (!canSeeAnyStatus) {
+    if (normalized === undefined) return eq(posts.status, PUBLIC_STATUS);
+    if (normalized.length === 1 && normalized[0] === PUBLIC_STATUS) {
+      return eq(posts.status, PUBLIC_STATUS);
+    }
+    return "forbidden";
+  }
+
+  if (normalized === undefined) return not(eq(posts.status, TRASH_STATUS));
+  const [only, ...rest] = normalized;
+  if (only !== undefined && rest.length === 0) return eq(posts.status, only);
+  return inArray(posts.status, normalized);
+}
+
+// Collapse the valibot-widened input into a non-empty list or `undefined`.
+// `v.minLength(1)` on the array schema blocks empty-array input at the
+// boundary, but defend here too so the resolver's contract is explicit.
+function normalizeStatusInput(
+  input: StatusInput,
+): readonly PostStatus[] | undefined {
+  if (input === undefined) return undefined;
+  const list = Array.isArray(input)
+    ? input.filter((s): s is PostStatus => s !== undefined)
+    : [input as PostStatus];
+  return list.length === 0 ? undefined : list;
+}
 
 // One search term → `(title LIKE ? OR content LIKE ? OR excerpt LIKE ?)`
 // against an explicit ESCAPE char so literal `%` / `_` in user input don't

--- a/packages/core/src/rpc/procedures/post/read.test.ts
+++ b/packages/core/src/rpc/procedures/post/read.test.ts
@@ -346,6 +346,138 @@ describe("post.list", () => {
     expect(rows.map((r) => r.slug)).toEqual(["qbn"]);
     expect(rows.map((r) => r.slug)).not.toContain(notTagged.slug);
   });
+
+  test("default (no status) excludes trashed posts — matches WP's All tab", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "pub" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "draft" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "trashed",
+      status: "trash",
+    });
+
+    const rows = await h.client.post.list({});
+    expect(rows.map((r) => r.slug).sort()).toEqual(["draft", "pub"]);
+  });
+
+  test("explicit status: 'trash' surfaces trashed posts (dedicated view)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "live" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "gone",
+      status: "trash",
+    });
+
+    const rows = await h.client.post.list({ status: "trash" });
+    expect(rows.map((r) => r.slug)).toEqual(["gone"]);
+  });
+
+  test("status array unions across listed statuses", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "pub" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "draft" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "scheduled",
+      status: "scheduled",
+    });
+
+    const rows = await h.client.post.list({ status: ["draft", "scheduled"] });
+    expect(rows.map((r) => r.slug).sort()).toEqual(["draft", "scheduled"]);
+  });
+
+  test("subscriber asking for a status array including non-public gets empty", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "secret" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "ok" });
+
+    // Even though `published` is allowed, asking for `[published, draft]`
+    // mixes in a status the caller can't see — match WP's silent filter.
+    const rows = await h.client.post.list({
+      status: ["published", "draft"],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  test("subscriber asking for status: ['published'] is equivalent to 'published'", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "visible" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "hidden" });
+
+    const rows = await h.client.post.list({ status: ["published"] });
+    expect(rows.map((r) => r.slug)).toEqual(["visible"]);
+  });
+
+  test("authorId filters to posts by that user", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const other = await h.factory.user.create({ email: "other@example.test" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "by-me",
+    });
+    await h.factory.published.create({
+      authorId: other.id,
+      slug: "by-other",
+    });
+
+    const mine = await h.client.post.list({ authorId: h.user.id });
+    expect(mine.map((r) => r.slug)).toEqual(["by-me"]);
+
+    const theirs = await h.client.post.list({ authorId: other.id });
+    expect(theirs.map((r) => r.slug)).toEqual(["by-other"]);
+  });
+
+  test("orderBy=title&order=asc sorts alphabetically", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Charlie",
+      slug: "c",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Alpha",
+      slug: "a",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Bravo",
+      slug: "b",
+    });
+
+    const rows = await h.client.post.list({
+      orderBy: "title",
+      order: "asc",
+    });
+    expect(rows.map((r) => r.slug)).toEqual(["a", "b", "c"]);
+  });
+
+  test("orderBy=menu_order respects explicit order values", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "third",
+      menuOrder: 30,
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "first",
+      menuOrder: 10,
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "second",
+      menuOrder: 20,
+    });
+
+    const rows = await h.client.post.list({
+      orderBy: "menu_order",
+      order: "asc",
+    });
+    expect(rows.map((r) => r.slug)).toEqual(["first", "second", "third"]);
+  });
 });
 
 describe("post.get", () => {

--- a/packages/core/src/rpc/procedures/post/schemas.ts
+++ b/packages/core/src/rpc/procedures/post/schemas.ts
@@ -89,9 +89,38 @@ const termSlugSchema = v.pipe(
   v.maxLength(200),
 );
 
+// Whitelist of columns the caller is allowed to sort by. Keys are the
+// wire-level names (snake_case, matching DB columns) so the API surface
+// stays stable even if we rename the drizzle TS fields later. The handler
+// maps these to column references.
+export const POST_LIST_ORDER_COLUMNS = [
+  "updated_at",
+  "published_at",
+  "title",
+  "menu_order",
+] as const;
+export type PostListOrderColumn = (typeof POST_LIST_ORDER_COLUMNS)[number];
+
 export const postListInputSchema = v.object({
   type: v.optional(trimmedText(100)),
-  status: v.optional(userSuppliableFields.entries.status),
+  /**
+   * Status filter. Accepts a single status or a list — WP admin views
+   * like "Drafts + Pending" need arrays. When omitted, the handler
+   * excludes `trash` by default (WP's "All" semantics — trash is its
+   * own view, not part of the flat list). Pass `["trash"]` explicitly
+   * to see trashed posts.
+   */
+  status: v.optional(
+    v.union([
+      userSuppliableFields.entries.status,
+      v.pipe(v.array(userSuppliableFields.entries.status), v.minLength(1)),
+    ]),
+  ),
+  /**
+   * Filter by the post's `authorId`. Admin "Mine" filter passes the
+   * session user's id here; future UIs can surface an author dropdown.
+   */
+  authorId: v.optional(postIdSchema),
   /**
    * Filter by parent post id for hierarchical types (pages, etc.).
    * - `null` → only top-level posts (parent_id IS NULL).
@@ -121,6 +150,13 @@ export const postListInputSchema = v.object({
       v.pipe(v.array(termSlugSchema), v.maxLength(MAX_TERM_SLUGS_PER_TAXONOMY)),
     ),
   ),
+  /**
+   * Column to sort by. Whitelisted — arbitrary values are rejected so a
+   * malicious caller can't probe the schema. `id` is always applied as a
+   * stable tiebreaker by the handler, not exposed here.
+   */
+  orderBy: v.optional(v.picklist(POST_LIST_ORDER_COLUMNS), "updated_at"),
+  order: v.optional(v.picklist(["asc", "desc"] as const), "desc"),
   limit: v.optional(
     v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
     20,


### PR DESCRIPTION
## Summary

Follow-up to [#39](https://github.com/withplumix/plumix/pull/39). Addresses filter gaps surfaced by that PR's review: the default list polluted with trashed posts, no way to filter "posts by me", no column sort. Matches WP admin's `edit.php` mental model.

### Core

- **Semantic fix (breaking for internal callers)**: `status: undefined` now excludes trash — matches WP's "All" tab. Callers that want trash pass `status: "trash"` explicitly.
- `status` accepts `PostStatus | PostStatus[]` (array has `v.minLength(1)`). Covers combined views like "drafts + scheduled". Subscribers asking for a status they can't see get an empty list (WP's silent filter).
- `authorId?: number` — enables "Mine" + future author-picker UIs.
- `orderBy?: "updated_at" | "published_at" | "title" | "menu_order"` + `order?: "asc" | "desc"` — whitelisted; column resolution via a `Record<PostListOrderColumn, AnySQLiteColumn>` map, `posts.id DESC` always appended as stable tiebreaker.
- `resolveStatusClause` / `normalizeStatusInput` helpers isolate the capability + trash-exclusion + array coercion so each piece is testable.

### Admin

- Author filter chips: `All authors | Mine`. "Mine" sends `authorId: user.id` from the session.
- Sortable column headers: Title (default asc) and Updated (default desc). Clicking the active column flips; clicking a different column jumps to its sensible default. URL-synced via `?orderBy=&order=`.
- `SortableHeader` + `SortIndicator` components; `nextSortOrder()` helper flattens the "flip or default" nested-ternary pattern.
- Navigation handlers wrapped in `useCallback` so the `columns` memo has stable deps.
- Copy on the list page updated to reflect the new "All excludes trash" semantics.

## Test plan

- [x] Core: 8 new integration tests — default excludes trash, `status: "trash"` surfaces trash, status arrays union, subscriber forbidden on mixed statuses, subscriber allowed with `["published"]`, `authorId` filter, `orderBy=title&order=asc`, `orderBy=menu_order`
- [x] Admin e2e: Mine toggle URL-syncs + sends `authorId`; Title column click URL-syncs `orderBy=title&order=asc` and reaches the RPC input
- [x] `pnpm turbo run typecheck lint test` — 32/32 green
- [x] `pnpm --filter @plumix/admin exec playwright test` — 11/11 green
- [x] `pnpm knip`, `publint`, `attw` clean