### PR TITLE
refactor(admin): migrate e2e selectors to data-testid

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"e3cba8df-958c-4138-be90-d2c070ec2386","pid":62388,"acquiredAt":1776753191670}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"e3cba8df-958c-4138-be90-d2c070ec2386","pid":62388,"acquiredAt":1776753191670}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ yarn-error.log*
 # Internal planning and reference docs (not committed)
 PLAN.md
 docs/reference/
+.claude/

--- a/packages/admin/e2e/bootstrap.spec.ts
+++ b/packages/admin/e2e/bootstrap.spec.ts
@@ -9,9 +9,7 @@ test.describe("/bootstrap", () => {
   }) => {
     await mockSession(page, { user: null, needsBootstrap: true });
     await page.goto("bootstrap");
-    await expect(
-      page.getByRole("heading", { name: "Create admin account" }),
-    ).toBeVisible();
+    await expect(page.getByTestId("bootstrap-heading")).toBeVisible();
     await expectNoAxeViolations(page);
   });
 });

--- a/packages/admin/e2e/content.spec.ts
+++ b/packages/admin/e2e/content.spec.ts
@@ -45,10 +45,8 @@ test.describe("/content/$slug", () => {
     });
 
     await page.goto("content/posts?status=all&page=1");
-    await expect(page.getByRole("heading", { name: "Posts" })).toBeVisible();
-    await expect(
-      page.getByRole("region", { name: /loading posts/i }),
-    ).toBeVisible();
+    await expect(page.getByTestId("content-list-heading")).toBeVisible();
+    await expect(page.getByTestId("data-table-loading")).toBeVisible();
     await expectNoAxeViolations(page);
 
     release?.();
@@ -62,8 +60,8 @@ test.describe("/content/$slug", () => {
       "/post/list": [],
     });
     await page.goto("content/posts?status=all&page=1");
-    await expect(page.getByRole("heading", { name: "Posts" })).toBeVisible();
-    await expect(page.getByText("No posts yet")).toBeVisible();
+    await expect(page.getByTestId("content-list-heading")).toBeVisible();
+    await expect(page.getByTestId("content-list-empty-state")).toBeVisible();
     await expectNoAxeViolations(page);
   });
 
@@ -76,7 +74,7 @@ test.describe("/content/$slug", () => {
     // literal HTTP 404 since we're behind Vite's SPA dev server, so assert
     // the router's default "Not Found" marker instead.
     expect(response?.status()).toBeLessThan(500);
-    await expect(page.getByText(/not found/i).first()).toBeVisible();
+    await expect(page.getByTestId("not-found-page")).toBeVisible();
   });
 
   test("search box URL-syncs ?q= and triggers a refetch after debounce", async ({
@@ -108,9 +106,7 @@ test.describe("/content/$slug", () => {
     });
 
     await page.goto("content/posts?status=all&page=1");
-    await page
-      .getByRole("searchbox", { name: /search posts/i })
-      .fill("quantum");
+    await page.getByTestId("content-list-search-input").fill("quantum");
     await expect(page).toHaveURL(/q=quantum/);
     // The debounced commit + refetch should eventually ship `search` in
     // the RPC input. Playwright's expect.poll waits up to 5s by default,
@@ -149,7 +145,7 @@ test.describe("/content/$slug", () => {
     });
 
     await page.goto("content/posts?status=all&page=1");
-    await page.getByRole("button", { name: "Mine" }).click();
+    await page.getByTestId("author-filter-mine").click();
     await expect(page).toHaveURL(/author=mine/);
     await expect
       .poll(
@@ -186,7 +182,7 @@ test.describe("/content/$slug", () => {
     });
 
     await page.goto("content/posts?status=all&page=1");
-    await page.getByRole("button", { name: /sort by title/i }).click();
+    await page.getByTestId("content-list-sort-title").click();
     await expect(page).toHaveURL(/orderBy=title/);
     await expect(page).toHaveURL(/order=asc/);
     await expect
@@ -235,7 +231,12 @@ test.describe("/content/$slug", () => {
       ],
     });
     await page.goto("content/posts?status=all&page=1");
-    await expect(page.getByText("Hello world")).toBeVisible();
+    // Row id 1 was seeded by the mock above with title "Hello world" —
+    // asserting the row exists + its content is enough without binding
+    // to visible copy.
+    const helloRow = page.getByTestId("content-list-row-1");
+    await expect(helloRow).toBeVisible();
+    await expect(helloRow).toContainText("Hello world");
     await expectNoAxeViolations(page);
   });
 });

--- a/packages/admin/e2e/dashboard.spec.ts
+++ b/packages/admin/e2e/dashboard.spec.ts
@@ -15,10 +15,11 @@ test.describe("/ (dashboard)", () => {
     await mockManifest(page, MANIFEST_WITH_POST);
     await mockSession(page, AUTHED_ADMIN);
     await page.goto("");
-    await expect(page.getByRole("heading", { name: /welcome/i })).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /browse posts/i }),
-    ).toHaveAttribute("href", /\/content\/posts/);
+    await expect(page.getByTestId("dashboard-welcome-heading")).toBeVisible();
+    await expect(page.getByTestId("dashboard-tile-post-link")).toHaveAttribute(
+      "href",
+      /\/content\/posts/,
+    );
     await expectNoAxeViolations(page);
   });
 
@@ -27,7 +28,7 @@ test.describe("/ (dashboard)", () => {
   }) => {
     await mockSession(page, AUTHED_ADMIN);
     await page.goto("");
-    await expect(page.getByText("No content types yet")).toBeVisible();
+    await expect(page.getByTestId("dashboard-empty-state")).toBeVisible();
     await expectNoAxeViolations(page);
   });
 });

--- a/packages/admin/e2e/login.spec.ts
+++ b/packages/admin/e2e/login.spec.ts
@@ -9,7 +9,7 @@ test.describe("/login", () => {
   }) => {
     await mockSession(page, { user: null, needsBootstrap: false });
     await page.goto("login");
-    await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
+    await expect(page.getByTestId("login-heading")).toBeVisible();
     await expectNoAxeViolations(page);
   });
 });

--- a/packages/admin/src/components/data-table/data-table.tsx
+++ b/packages/admin/src/components/data-table/data-table.tsx
@@ -50,6 +50,7 @@ export function DataTable<TData>({
       aria-busy={isLoading || undefined}
       role={isLoading ? "region" : undefined}
       aria-label={isLoading ? loadingLabel : undefined}
+      data-testid={isLoading ? "data-table-loading" : "data-table"}
     >
       <Table>
         <TableHeader>

--- a/packages/admin/src/routes/__root.tsx
+++ b/packages/admin/src/routes/__root.tsx
@@ -24,7 +24,10 @@ function RootLayout(): ReactNode {
 
 function NotFound(): ReactNode {
   return (
-    <div className="flex h-screen flex-col items-center justify-center gap-2 p-6 text-center">
+    <div
+      data-testid="not-found-page"
+      className="flex h-screen flex-col items-center justify-center gap-2 p-6 text-center"
+    >
       <h1 className="text-2xl font-semibold">Not found</h1>
       <p className="text-muted-foreground text-sm">
         The page you're looking for doesn't exist or the resource isn't

--- a/packages/admin/src/routes/_auth/bootstrap.tsx
+++ b/packages/admin/src/routes/_auth/bootstrap.tsx
@@ -74,7 +74,7 @@ function BootstrapRoute(): ReactNode {
     <Card>
       <CardHeader>
         <CardTitle>
-          <h1>Create admin account</h1>
+          <h1 data-testid="bootstrap-heading">Create admin account</h1>
         </CardTitle>
         <CardDescription>
           Set up your site — this email becomes the admin account.

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -68,7 +68,7 @@ function LoginRoute(): ReactNode {
     <Card>
       <CardHeader>
         <CardTitle>
-          <h1>Sign in</h1>
+          <h1 data-testid="login-heading">Sign in</h1>
         </CardTitle>
         <CardDescription>
           Use a passkey registered with this site.

--- a/packages/admin/src/routes/_authenticated/content/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/index.tsx
@@ -171,6 +171,7 @@ function buildColumns({
         <Link
           to="/content/$slug/$id"
           params={{ slug: adminSlug, id: String(row.original.id) }}
+          data-testid={`content-list-row-${String(row.original.id)}`}
           className="hover:text-primary flex flex-col transition-colors"
         >
           <span className="font-medium">
@@ -336,7 +337,12 @@ function ContentListRoute(): ReactNode {
     <div className="flex flex-col gap-6">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">{pluralLabel}</h1>
+          <h1
+            data-testid="content-list-heading"
+            className="text-2xl font-semibold"
+          >
+            {pluralLabel}
+          </h1>
           <p className="text-muted-foreground text-sm">
             Manage {pluralLower}. "All" shows drafts, scheduled, and published
             items; trashed items live in their own view.
@@ -344,7 +350,11 @@ function ContentListRoute(): ReactNode {
         </div>
         {canCreate ? (
           <Button asChild>
-            <Link to="/content/$slug/new" params={{ slug: postType.adminSlug }}>
+            <Link
+              to="/content/$slug/new"
+              params={{ slug: postType.adminSlug }}
+              data-testid="content-list-new-button"
+            >
               <Plus />
               New {singularLower}
             </Link>
@@ -478,6 +488,7 @@ function SortableHeader({
       onClick={() => {
         onSort(column, defaultDirection);
       }}
+      data-testid={`content-list-sort-${column}`}
       className="hover:text-foreground -ml-2 inline-flex items-center gap-1 rounded px-2 py-1 text-left font-medium transition-colors"
       aria-label={`Sort by ${label} (${nextDirection})`}
       aria-pressed={isActive}
@@ -506,6 +517,7 @@ function AuthorFilter({
             onChange(opt);
           }}
           aria-pressed={value === opt}
+          data-testid={`author-filter-${opt}`}
           className="capitalize"
         >
           {opt === "all" ? "All authors" : "Mine"}
@@ -554,6 +566,7 @@ function SearchInput({
         maxLength={200}
         placeholder={placeholder}
         aria-label={placeholder}
+        data-testid="content-list-search-input"
         onChange={(e) => {
           setValue(e.target.value);
         }}
@@ -597,7 +610,10 @@ function EmptyState({
   pluralLower: string;
 }): ReactNode {
   return (
-    <div className="flex flex-col items-center gap-2 py-12 text-center">
+    <div
+      data-testid="content-list-empty-state"
+      className="flex flex-col items-center gap-2 py-12 text-center"
+    >
       <Card className="max-w-sm border-dashed">
         <CardHeader>
           <CardTitle>No {pluralLower} yet</CardTitle>

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -25,7 +25,12 @@ function DashboardIndex(): ReactNode {
   return (
     <div className="flex flex-col gap-6">
       <div>
-        <h1 className="text-2xl font-semibold">Welcome, {greeting}</h1>
+        <h1
+          data-testid="dashboard-welcome-heading"
+          className="text-2xl font-semibold"
+        >
+          Welcome, {greeting}
+        </h1>
         <p className="text-muted-foreground text-sm">
           What would you like to work on today?
         </p>
@@ -37,7 +42,7 @@ function DashboardIndex(): ReactNode {
             const label = pt.labels?.plural ?? pt.label;
             const labelLower = label.toLowerCase();
             return (
-              <Card key={pt.name}>
+              <Card key={pt.name} data-testid={`dashboard-tile-${pt.name}`}>
                 <CardHeader>
                   <div className="bg-primary/10 text-primary mb-2 flex size-10 items-center justify-center rounded-md">
                     <FileText className="size-5" aria-hidden />
@@ -54,6 +59,7 @@ function DashboardIndex(): ReactNode {
                       to="/content/$slug"
                       params={{ slug: pt.adminSlug }}
                       search={CONTENT_LIST_DEFAULT_SEARCH}
+                      data-testid={`dashboard-tile-${pt.name}-link`}
                     >
                       Browse {labelLower}
                       <ArrowRight />
@@ -65,7 +71,10 @@ function DashboardIndex(): ReactNode {
           })}
         </div>
       ) : (
-        <Card className="max-w-xl border-dashed">
+        <Card
+          className="max-w-xl border-dashed"
+          data-testid="dashboard-empty-state"
+        >
           <CardHeader>
             <CardTitle>No content types yet</CardTitle>
             <CardDescription>


### PR DESCRIPTION
## Summary

Project convention (saved to memory 2026-04-21): all test-element targeting uses `data-testid` attributes — never role / text / label queries. Editor e2e in [#41](https://github.com/withplumix/plumix/pull/41) already ships the pattern; this PR retroactively migrates the four pre-convention spec files.

### Why

Role/text selectors are fragile under copy changes, i18n, a11y-tree shuffles. `data-testid` decouples test intent from rendering detail — a heading rename doesn't break the test.

### What changed

**Components — testids added:**
- `bootstrap.tsx`, `login.tsx` — h1 testids
- `_authenticated/index.tsx` (dashboard) — welcome heading + per-post-type tile/link testids + empty state
- `_authenticated/content/$slug/index.tsx` — list heading, "New" button, sort headers (`content-list-sort-${column}`), author filter chips, search input, per-row Link (`content-list-row-${id}`), empty state
- `data-table/data-table.tsx` — root exposes `data-table-loading` / `data-table` testid pair
- `__root.tsx` — not-found page wrapper testid so 404 assertions don't match incidental "not found" text elsewhere

**Specs — rewritten to `page.getByTestId(...)`:**
- `bootstrap.spec.ts`, `login.spec.ts` — heading check only
- `dashboard.spec.ts` — welcome + tile link + empty state
- `content.spec.ts` — all six selectors (heading, loading region, empty state, search, author filter, sort header, row content)

Row-content assertions use `toContainText` on a testid-targeted row instead of `getByText`.

### Untouched

- `components/ui/*` (vendored shadcn primitives stay as-shipped per the other memory).
- `editor.spec.ts` already uses testids — no changes.

### Gitignore

- Added `.claude/` to `.gitignore`. The scheduled-task harness wrote a lock file that slipped into the first commit; staging catch-all `git add -A` picked it up. Follow-up commit removes + ignores.

## Test plan

- [x] `pnpm --filter @plumix/admin exec playwright test` — 15/15 green
- [x] `pnpm turbo run typecheck lint test` — 32/32 green
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean
- [x] Grep confirms zero `getByRole` / `getByText` / `getByLabel` remain across `e2e/*.spec.ts`