### PR TITLE
feat(core,admin): manifest metaBoxes slice

### DIFF
--- a/examples/minimal/test/build.integration.test.ts
+++ b/examples/minimal/test/build.integration.test.ts
@@ -51,7 +51,7 @@ describe("examples/minimal — plumix build", () => {
       // so postTypes is empty but the tag must still be present.
       const adminHtml = readFileSync(adminIndexHtml, "utf8");
       expect(adminHtml).toMatch(
-        /<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\]\}<\/script>/,
+        /<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\],"metaBoxes":\[\]\}<\/script>/,
       );
     },
     60_000,

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -38,8 +38,18 @@ const config: KnipConfig = {
         "src/test/index.ts",
         "src/theme/index.ts",
         "src/vite/index.ts",
+        "bin/plumix.mjs",
       ],
       ignoreDependencies: ["drizzle-kit", "@plumix/admin"],
+    },
+    // The `./commands` subpath export points at `dist/commands/index.js` —
+    // knip's default entry discovery only reads `exports` paths and
+    // doesn't map them back to source files, so the whole `src/commands`
+    // tree plus its deps (`@cloudflare/vite-plugin`, `plumix`) read as
+    // unused. Explicit entries pin the source location. `plumix` is a
+    // workspace sibling used transitively via `emitPlumixSources`.
+    "packages/runtimes/cloudflare": {
+      entry: ["src/index.ts", "src/commands/index.ts"],
     },
   },
 };

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -95,6 +95,7 @@ export const MANIFEST_WITH_POST: PlumixManifest = {
       labels: { singular: "Post", plural: "Posts" },
     },
   ],
+  metaBoxes: [],
 };
 
 // Fixture: an authed admin session. Reused across every spec that needs a

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import type { PlumixManifest } from "@plumix/core/manifest";
+import type {
+  MetaBoxManifestEntry,
+  PlumixManifest,
+} from "@plumix/core/manifest";
 
 import {
   findPostTypeBySlug,
+  metaBoxesForPostType,
   readManifest,
   visiblePostTypes,
 } from "./manifest.js";
@@ -25,7 +29,7 @@ describe("readManifest", () => {
 
   test("returns empty manifest when the script tag is absent", () => {
     const doc = document.implementation.createHTMLDocument("test");
-    expect(readManifest(doc)).toEqual({ postTypes: [] });
+    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
   });
 
   test("parses the injected JSON payload", () => {
@@ -36,12 +40,13 @@ describe("readManifest", () => {
     );
     expect(readManifest(doc)).toEqual({
       postTypes: [{ name: "post", label: "Posts" }],
+      metaBoxes: [],
     });
   });
 
   test("empty payload falls back to empty manifest", () => {
     const doc = withManifestScript("");
-    expect(readManifest(doc)).toEqual({ postTypes: [] });
+    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
   });
 
   test("malformed JSON logs and falls back without throwing", () => {
@@ -49,13 +54,13 @@ describe("readManifest", () => {
       // swallow expected error log
     });
     const doc = withManifestScript("{not-json");
-    expect(readManifest(doc)).toEqual({ postTypes: [] });
+    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
     expect(errSpy).toHaveBeenCalledOnce();
   });
 
   test("non-array postTypes coerces to empty array", () => {
     const doc = withManifestScript(JSON.stringify({ postTypes: "oops" }));
-    expect(readManifest(doc)).toEqual({ postTypes: [] });
+    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
   });
 });
 
@@ -65,6 +70,7 @@ describe("findPostTypeBySlug", () => {
       { name: "post", adminSlug: "posts", label: "Posts" },
       { name: "product", adminSlug: "products", label: "Products" },
     ],
+    metaBoxes: [],
   };
 
   test("returns the matching entry", () => {
@@ -93,6 +99,7 @@ describe("visiblePostTypes", () => {
         capabilityType: "post",
       },
     ],
+    metaBoxes: [],
   };
 
   test("filters by `${capabilityType}:edit_own`; unset capabilityType uses name", () => {
@@ -105,5 +112,79 @@ describe("visiblePostTypes", () => {
 
   test("returns empty when no capabilities match", () => {
     expect(visiblePostTypes([], source)).toEqual([]);
+  });
+});
+
+describe("metaBoxesForPostType", () => {
+  const box = (
+    id: string,
+    overrides: Partial<MetaBoxManifestEntry> = {},
+  ): MetaBoxManifestEntry => ({
+    id,
+    label: id,
+    postTypes: ["post"],
+    fields: [],
+    ...overrides,
+  });
+
+  test("returns boxes applicable to the post type, honours priority order", () => {
+    const source: PlumixManifest = {
+      postTypes: [],
+      metaBoxes: [
+        box("a", { priority: "low" }),
+        box("b", { priority: "high" }),
+        box("c"), // default
+      ],
+    };
+    const ids = metaBoxesForPostType("post", [], source).map((b) => b.id);
+    expect(ids).toEqual(["b", "c", "a"]);
+  });
+
+  test("insertion order is the tiebreaker among boxes at the same priority", () => {
+    const source: PlumixManifest = {
+      postTypes: [],
+      metaBoxes: [
+        box("first", { priority: "high" }),
+        box("second", { priority: "high" }),
+      ],
+    };
+    const ids = metaBoxesForPostType("post", [], source).map((b) => b.id);
+    expect(ids).toEqual(["first", "second"]);
+  });
+
+  test("drops boxes whose `postTypes` doesn't include the target", () => {
+    const source: PlumixManifest = {
+      postTypes: [],
+      metaBoxes: [
+        box("seo", { postTypes: ["post"] }),
+        box("shop", { postTypes: ["product"] }),
+      ],
+    };
+    const ids = metaBoxesForPostType("post", [], source).map((b) => b.id);
+    expect(ids).toEqual(["seo"]);
+  });
+
+  test("drops boxes gated by a capability the user lacks", () => {
+    const source: PlumixManifest = {
+      postTypes: [],
+      metaBoxes: [
+        box("public"),
+        box("privileged", { capability: "post:edit_any" }),
+      ],
+    };
+    const withoutCap = metaBoxesForPostType("post", [], source).map(
+      (b) => b.id,
+    );
+    expect(withoutCap).toEqual(["public"]);
+
+    const withCap = metaBoxesForPostType("post", ["post:edit_any"], source).map(
+      (b) => b.id,
+    );
+    expect(withCap).toEqual(["public", "privileged"]);
+  });
+
+  test("returns empty when no meta boxes are registered", () => {
+    const source: PlumixManifest = { postTypes: [], metaBoxes: [] };
+    expect(metaBoxesForPostType("post", [], source)).toEqual([]);
   });
 });

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -62,6 +62,40 @@ describe("readManifest", () => {
     const doc = withManifestScript(JSON.stringify({ postTypes: "oops" }));
     expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
   });
+
+  test("non-array metaBoxes coerces to empty array", () => {
+    const doc = withManifestScript(
+      JSON.stringify({ postTypes: [], metaBoxes: "oops" }),
+    );
+    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
+  });
+
+  test("parses the injected JSON payload with metaBoxes", () => {
+    const doc = withManifestScript(
+      JSON.stringify({
+        postTypes: [],
+        metaBoxes: [
+          {
+            id: "seo",
+            label: "SEO",
+            postTypes: ["post"],
+            fields: [],
+          },
+        ],
+      }),
+    );
+    expect(readManifest(doc)).toEqual({
+      postTypes: [],
+      metaBoxes: [
+        {
+          id: "seo",
+          label: "SEO",
+          postTypes: ["post"],
+          fields: [],
+        },
+      ],
+    });
+  });
 });
 
 describe("findPostTypeBySlug", () => {

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -1,4 +1,5 @@
 import type {
+  MetaBoxManifestEntry,
   PlumixManifest,
   PostTypeManifestEntry,
 } from "@plumix/core/manifest";
@@ -30,7 +31,11 @@ export function readManifest(doc: Document = document): PlumixManifest {
 function normalize(value: unknown): PlumixManifest {
   if (!value || typeof value !== "object") return emptyManifest();
   const postTypes = (value as { postTypes?: unknown }).postTypes;
-  return { postTypes: Array.isArray(postTypes) ? postTypes : [] };
+  const metaBoxes = (value as { metaBoxes?: unknown }).metaBoxes;
+  return {
+    postTypes: Array.isArray(postTypes) ? postTypes : [],
+    metaBoxes: Array.isArray(metaBoxes) ? metaBoxes : [],
+  };
 }
 
 /**
@@ -73,5 +78,41 @@ export function visiblePostTypes(
   return source.postTypes.filter((pt) => {
     const cap = `${pt.capabilityType ?? pt.name}:edit_own`;
     return caps.has(cap);
+  });
+}
+
+// Ordering for meta-box `priority`. Boxes render top-down in the editor
+// sidebar; "high" pins above the fold, "low" drops to the bottom. Registry
+// insertion order breaks ties (Array.prototype.sort is stable per ES2019).
+const META_BOX_PRIORITY_WEIGHT: Record<
+  NonNullable<MetaBoxManifestEntry["priority"]>,
+  number
+> = {
+  high: 0,
+  default: 1,
+  low: 2,
+};
+
+/**
+ * Resolve the set of meta boxes the editor should render for a given
+ * post type, honouring each box's optional capability gate. Returned in
+ * render order: by `priority` (high → default → low; undefined treated
+ * as "default"), with registration order as the stable tiebreaker.
+ */
+export function metaBoxesForPostType(
+  postTypeName: string,
+  capabilities: readonly string[],
+  source: PlumixManifest = manifest,
+): readonly MetaBoxManifestEntry[] {
+  const caps = new Set(capabilities);
+  const applicable = source.metaBoxes.filter((box) => {
+    if (!box.postTypes.includes(postTypeName)) return false;
+    if (box.capability !== undefined && !caps.has(box.capability)) return false;
+    return true;
+  });
+  return [...applicable].sort((a, b) => {
+    const ap = META_BOX_PRIORITY_WEIGHT[a.priority ?? "default"];
+    const bp = META_BOX_PRIORITY_WEIGHT[b.priority ?? "default"];
+    return ap - bp;
   });
 }

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -105,14 +105,18 @@ export function metaBoxesForPostType(
   source: PlumixManifest = manifest,
 ): readonly MetaBoxManifestEntry[] {
   const caps = new Set(capabilities);
-  const applicable = source.metaBoxes.filter((box) => {
-    if (!box.postTypes.includes(postTypeName)) return false;
-    if (box.capability !== undefined && !caps.has(box.capability)) return false;
-    return true;
-  });
-  return [...applicable].sort((a, b) => {
-    const ap = META_BOX_PRIORITY_WEIGHT[a.priority ?? "default"];
-    const bp = META_BOX_PRIORITY_WEIGHT[b.priority ?? "default"];
-    return ap - bp;
-  });
+  // `.filter()` already returns a fresh array, so subsequent `.sort()` is
+  // safe to do in place — no need to copy again.
+  return source.metaBoxes
+    .filter((box) => {
+      if (!box.postTypes.includes(postTypeName)) return false;
+      if (box.capability !== undefined && !caps.has(box.capability))
+        return false;
+      return true;
+    })
+    .sort((a, b) => {
+      const ap = META_BOX_PRIORITY_WEIGHT[a.priority ?? "default"];
+      const bp = META_BOX_PRIORITY_WEIGHT[b.priority ?? "default"];
+      return ap - bp;
+    });
 }

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -9,14 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root";
-import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
 import { Route as AuthRouteImport } from "./routes/_auth";
-import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
-import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
+import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
+import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
+import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
 import { Route as AuthenticatedContentSlugNewRouteImport } from "./routes/_authenticated/content/$slug/new";
-import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
+import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: "/_authenticated",

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -9,14 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root";
-import { Route as AuthRouteImport } from "./routes/_auth";
-import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
-import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
-import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
+import { Route as AuthRouteImport } from "./routes/_auth";
+import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
+import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
+import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
 import { Route as AuthenticatedContentSlugNewRouteImport } from "./routes/_authenticated/content/$slug/new";
-import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
+import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: "/_authenticated",

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -98,6 +98,63 @@ describe("buildManifest", () => {
     const names = buildManifest(registry).postTypes.map((pt) => pt.name);
     expect(names).toEqual(["early", "late", "unpositioned"]);
   });
+
+  test("projects registered meta boxes, dropping server-only fields", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("seo", (ctx) => {
+      ctx.registerPostType("post", { label: "Posts" });
+      ctx.registerMetaBox("seo-meta", {
+        label: "SEO",
+        context: "side",
+        priority: "high",
+        postTypes: ["post"],
+        capability: "post:edit_any",
+        fields: [
+          {
+            key: "title",
+            label: "Meta title",
+            inputType: "text",
+            maxLength: 60,
+          },
+          { key: "desc", label: "Meta description", inputType: "textarea" },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    const manifest = buildManifest(registry);
+    expect(manifest.metaBoxes).toEqual([
+      {
+        id: "seo-meta",
+        label: "SEO",
+        context: "side",
+        priority: "high",
+        postTypes: ["post"],
+        capability: "post:edit_any",
+        fields: [
+          {
+            key: "title",
+            label: "Meta title",
+            inputType: "text",
+            maxLength: 60,
+          },
+          { key: "desc", label: "Meta description", inputType: "textarea" },
+        ],
+      },
+    ]);
+    const entry = manifest.metaBoxes[0] as unknown as Record<string, unknown>;
+    expect(entry.registeredBy).toBeUndefined();
+  });
+
+  test("empty meta-box registry yields an empty metaBoxes array", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("blog", (ctx) => {
+      ctx.registerPostType("post", { label: "Posts" });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).metaBoxes).toEqual([]);
+  });
 });
 
 describe("deriveAdminSlug", () => {
@@ -120,11 +177,12 @@ describe("serializeManifestScript", () => {
   test("emits a json script tag with the expected id", () => {
     const tag = serializeManifestScript({
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      metaBoxes: [],
     });
     expect(tag).toContain(`id="${MANIFEST_SCRIPT_ID}"`);
     expect(tag).toContain(`type="application/json"`);
     expect(tag).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"metaBoxes":[]}`,
     );
   });
 
@@ -133,6 +191,7 @@ describe("serializeManifestScript", () => {
       postTypes: [
         { name: "post", adminSlug: "posts", label: "</script><b>x</b>" },
       ],
+      metaBoxes: [],
     });
     expect(tag).not.toContain("</script><b>");
     expect(tag).toMatch(/<\\\/script>/);
@@ -141,6 +200,7 @@ describe("serializeManifestScript", () => {
   test("round-trips through JSON.parse after unescaping the slash", () => {
     const manifest = {
       postTypes: [{ name: "post", adminSlug: "posts", label: "x</y>" }],
+      metaBoxes: [],
     };
     const tag = serializeManifestScript(manifest);
     const prefix = `<script id="${MANIFEST_SCRIPT_ID}" type="application/json">`;
@@ -162,16 +222,18 @@ describe("injectManifestIntoHtml", () => {
   test("replaces the placeholder with the serialised manifest", () => {
     const out = injectManifestIntoHtml(TEMPLATE, {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      metaBoxes: [],
     });
     expect(out).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"metaBoxes":[]}`,
     );
-    expect(out).not.toContain(`{"postTypes":[]}`);
+    expect(out).not.toContain(`{"postTypes":[],"metaBoxes":[]}`);
   });
 
   test("is idempotent when the manifest is already injected", () => {
     const manifest = {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      metaBoxes: [],
     };
     const once = injectManifestIntoHtml(TEMPLATE, manifest);
     const twice = injectManifestIntoHtml(once, manifest);
@@ -194,9 +256,10 @@ describe("injectManifestIntoHtml", () => {
     const html = `<SCRIPT ID="plumix-manifest" TYPE="application/json">{"postTypes":[]}</SCRIPT>`;
     const out = injectManifestIntoHtml(html, {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      metaBoxes: [],
     });
     expect(out).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"metaBoxes":[]}`,
     );
   });
 
@@ -206,9 +269,10 @@ describe("injectManifestIntoHtml", () => {
     </script>`;
     const out = injectManifestIntoHtml(html, {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      metaBoxes: [],
     });
     expect(out).toMatch(
-      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\]\}<\/script>$/,
+      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"metaBoxes":\[\]\}<\/script>$/,
     );
   });
 });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -158,15 +158,45 @@ export interface PostTypeManifestEntry {
   readonly menuIcon?: string;
 }
 
+/**
+ * Client-safe field descriptor inside a meta box. Mirrors `MetaBoxField`
+ * exactly today — kept as a separate type so the manifest boundary can
+ * diverge (e.g., omit server-only `sanitize` callbacks) when needed.
+ */
+export interface MetaBoxFieldManifestEntry {
+  readonly key: string;
+  readonly label: string;
+  readonly inputType: string;
+  readonly maxLength?: number;
+}
+
+/**
+ * Shape serialised for meta boxes in the manifest. Strict allowlist
+ * projection of `RegisteredMetaBox`; drops `registeredBy` (server-only
+ * debug metadata). `fields` is projected via
+ * `MetaBoxFieldManifestEntry` so the field-level contract is independent
+ * of the registration type.
+ */
+export interface MetaBoxManifestEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly context?: "side" | "normal" | "advanced";
+  readonly priority?: "high" | "default" | "low";
+  readonly postTypes: readonly string[];
+  readonly capability?: string;
+  readonly fields: readonly MetaBoxFieldManifestEntry[];
+}
+
 export interface PlumixManifest {
   readonly postTypes: readonly PostTypeManifestEntry[];
+  readonly metaBoxes: readonly MetaBoxManifestEntry[];
 }
 
 /** Script tag id that carries the JSON-encoded manifest in the admin HTML. */
 export const MANIFEST_SCRIPT_ID = "plumix-manifest";
 
 export function emptyManifest(): PlumixManifest {
-  return { postTypes: [] };
+  return { postTypes: [], metaBoxes: [] };
 }
 
 /**
@@ -188,7 +218,8 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
     return ap - bp;
   });
   assertUniqueAdminSlugs(entries);
-  return { postTypes: entries };
+  const metaBoxes = Array.from(registry.metaBoxes.values()).map(toMetaBoxEntry);
+  return { postTypes: entries, metaBoxes };
 }
 
 function assertUniqueAdminSlugs(
@@ -295,6 +326,28 @@ function toPostTypeEntry(pt: RegisteredPostType): PostTypeManifestEntry {
     menuPosition,
     menuIcon,
   };
+}
+
+// Allowlist for meta box entries — same rationale as `toPostTypeEntry`.
+// `registeredBy` is intentionally excluded (server-only debug metadata).
+// `fields` is projected per entry so field-level internals could diverge
+// from the registration type without altering the wire contract.
+function toMetaBoxEntry(box: RegisteredMetaBox): MetaBoxManifestEntry {
+  const { id, label, context, priority, postTypes, capability, fields } = box;
+  return {
+    id,
+    label,
+    context,
+    priority,
+    postTypes,
+    capability,
+    fields: fields.map(toMetaBoxFieldEntry),
+  };
+}
+
+function toMetaBoxFieldEntry(field: MetaBoxField): MetaBoxFieldManifestEntry {
+  const { key, label, inputType, maxLength } = field;
+  return { key, label, inputType, maxLength };
 }
 
 /**


### PR DESCRIPTION
## Summary

Extends the plugin manifest with meta-box descriptors so the editor sidebar has something to render against in a follow-up PR. Sized as a tight manifest-only change — no RPC changes, no UI yet.

Follow-up from the `postTypes` manifest slice ([#29](https://github.com/withplumix/plumix/pull/29)) — same pattern, same guarantees (strict allowlist projection, drops server-only fields, deterministic serialisation).

### Core

- New `MetaBoxManifestEntry` + `MetaBoxFieldManifestEntry` types at `@plumix/core/manifest`. Both are strict allowlist projections; `registeredBy` dropped.
- `PlumixManifest.metaBoxes: readonly MetaBoxManifestEntry[]` — required field, empty array when nothing's registered. `emptyManifest()` and `buildManifest()` updated in lockstep.
- `toMetaBoxEntry` / `toMetaBoxFieldEntry` private projection helpers mirror the `toPostTypeEntry` destructure-return pattern.
- Separate field-entry type so future field-level internals (`sanitize` callbacks, type-specific validators) can diverge from the wire contract without renames cascading through the admin.

### Admin

- `readManifest` normalises the new `metaBoxes` array with the same `Array.isArray` coercion already used for `postTypes`.
- `metaBoxesForPostType(postTypeName, capabilities, source?)` — filters by post type, honours the optional `capability` gate, sorts by `priority` (high → default → low) with registration order as the stable tiebreaker.

### Not in scope

- Editor sidebar renderer — next PR.
- `post.update.meta` field to persist values — next PR (per the memory, it'll be `meta`, not `postMeta`, since the procedure namespace covers the prefix).
- Chunk-splitting meta-box React components — week 2+.

### Bonus

`knip.config.ts` cleanup — pre-existing issue where knip flagged `packages/runtimes/cloudflare/src/commands/*` as unused files (subpath export `./commands` points at `dist/commands/index.js`, knip's default discovery didn't map back to source). Added explicit `entry` paths for that workspace and `bin/plumix.mjs` for the plumix workspace.

## Test plan

- [x] Core: two new `buildManifest` tests — meta-box projection drops `registeredBy` + preserves allowlisted fields, empty-registry case
- [x] Admin: five `metaBoxesForPostType` tests — priority order, insertion tiebreaker, post-type filter, capability gate (present + absent), empty-boxes short-circuit
- [x] Existing tests updated for the new required `metaBoxes` field on `PlumixManifest`
- [x] `examples/minimal` build-integration regex updated for the new wire payload `{"postTypes":[],"metaBoxes":[]}`
- [x] `pnpm turbo run typecheck lint test` — 32/32 green
- [x] `pnpm --filter @plumix/admin exec playwright test` — 15/15 green
- [x] `pnpm knip` — clean (bonus fixes flushed out the pre-existing false positives)
- [x] `publint` / `attw` clean on `@plumix/core` subpaths