### PR TITLE
feat(admin,core): meta-box sidebar with schema-driven field dispatcher

### DIFF
--- a/packages/admin/e2e/editor.spec.ts
+++ b/packages/admin/e2e/editor.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { expectNoAxeViolations } from "./support/axe.js";
 import {
   AUTHED_ADMIN,
+  MANIFEST_WITH_META_BOXES,
   MANIFEST_WITH_POST,
   mockManifest,
   mockRpc,
@@ -231,5 +232,32 @@ test.describe("/content/$slug/$id", () => {
       )
       .toBe("Edited title");
     expect((updateInputs.at(-1) as { id?: number } | undefined)?.id).toBe(7);
+  });
+});
+
+test.describe("meta-box sidebar", () => {
+  test("renders side + normal boxes, fields are typable", async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_META_BOXES);
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.goto("content/posts/new");
+
+    // Both boxes render — one in the side rail, one in the main column.
+    await expect(page.getByTestId("meta-box-seo")).toBeVisible();
+    await expect(page.getByTestId("meta-box-featured")).toBeVisible();
+    // Side rail container picks up only side-context boxes.
+    const sideRail = page.getByTestId("meta-boxes-side");
+    await expect(sideRail.getByTestId("meta-box-featured")).toBeVisible();
+    await expect(sideRail.getByTestId("meta-box-seo")).toHaveCount(0);
+
+    // Text field in the normal box accepts input.
+    const metaTitle = page.getByTestId("meta-box-field-meta_title-input");
+    await metaTitle.fill("Hello meta");
+    await expect(metaTitle).toHaveValue("Hello meta");
+
+    // Checkbox in the side box toggles.
+    const featured = page.getByTestId("meta-box-field-is_featured-input");
+    await expect(featured).not.toBeChecked();
+    await featured.check();
+    await expect(featured).toBeChecked();
   });
 });

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -98,6 +98,48 @@ export const MANIFEST_WITH_POST: PlumixManifest = {
   metaBoxes: [],
 };
 
+// Manifest with two meta boxes — one in the right rail (`side`), one in
+// the main column (`normal`) — used by editor e2e to cover both slots.
+export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
+  postTypes: [
+    {
+      name: "post",
+      adminSlug: "posts",
+      label: "Posts",
+      labels: { singular: "Post", plural: "Posts" },
+    },
+  ],
+  metaBoxes: [
+    {
+      id: "seo",
+      label: "SEO",
+      context: "normal",
+      postTypes: ["post"],
+      fields: [
+        {
+          key: "meta_title",
+          label: "Meta title",
+          inputType: "text",
+          maxLength: 60,
+        },
+      ],
+    },
+    {
+      id: "featured",
+      label: "Featured",
+      context: "side",
+      postTypes: ["post"],
+      fields: [
+        {
+          key: "is_featured",
+          label: "Featured",
+          inputType: "checkbox",
+        },
+      ],
+    },
+  ],
+};
+
 // Fixture: an authed admin session. Reused across every spec that needs a
 // logged-in user — specs override individual fields via spread if they need
 // something specific. Capabilities list covers the gates the admin UI

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -47,6 +47,8 @@
     "@tanstack/react-router-devtools": "^1.166.13",
     "@tanstack/router-plugin": "^1.167.22",
     "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",

--- a/packages/admin/src/components/editor/post-editor-form.tsx
+++ b/packages/admin/src/components/editor/post-editor-form.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
+import { MetaBox } from "@/components/meta-box/meta-box.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Button } from "@/components/ui/button.js";
 import { Input } from "@/components/ui/input.js";
@@ -8,6 +9,7 @@ import { useForm, useStore } from "@tanstack/react-form";
 import { useBlocker } from "@tanstack/react-router";
 import * as v from "valibot";
 
+import type { MetaBoxManifestEntry } from "@plumix/core/manifest";
 import type { PostStatus } from "@plumix/core/schema";
 
 import { slugify } from "./slugify.js";
@@ -33,6 +35,14 @@ const postEditorSchema = v.object({
   content: v.optional(v.string(), ""),
   excerpt: v.optional(v.pipe(v.string(), v.maxLength(600)), ""),
   status: v.picklist(["draft", "published", "scheduled", "trash"] as const),
+  /**
+   * Meta-box values — one entry per `MetaBoxFieldManifestEntry.key` the
+   * editor renders. The form carries them as opaque `unknown` values and
+   * leaves per-field type-shaping to the dispatcher. Server persistence
+   * lands in a follow-up PR; today callers receive `meta` in `onSubmit`
+   * and can ignore it.
+   */
+  meta: v.record(v.string(), v.unknown()),
 });
 
 export type PostEditorValues = v.InferOutput<typeof postEditorSchema>;
@@ -55,6 +65,13 @@ interface PostEditorFormProps {
    * URL. */
   readonly slugLocked: boolean;
   readonly availableStatuses: readonly PostStatus[];
+  /**
+   * Meta boxes applicable to the post type being edited, already
+   * filtered by capability and sorted by priority. The form splits them
+   * into side / normal / advanced columns internally based on
+   * `entry.context`.
+   */
+  readonly metaBoxes: readonly MetaBoxManifestEntry[];
   readonly submitLabel: string;
   readonly isSubmitting: boolean;
   readonly serverError?: string | null;
@@ -66,6 +83,7 @@ export function PostEditorForm({
   initialValues,
   slugLocked: initialSlugLocked,
   availableStatuses,
+  metaBoxes,
   submitLabel,
   isSubmitting,
   serverError,
@@ -111,6 +129,20 @@ export function PostEditorForm({
     disabled: isSubmitting,
   });
 
+  // `side` floats right of the main editor column; `normal` stacks below
+  // the primary fields; `advanced` drops to the bottom of the main column
+  // — matching WP's admin layout slots.
+  const { side, normal, advanced } = partitionBoxesByContext(metaBoxes);
+
+  // Single subscription to the form's `meta` field powers all three
+  // regions — each box reads from `metaValues` and writes via the shared
+  // `onMetaChange`. Sharing the subscription avoids triple-re-renders on
+  // every keystroke.
+  const metaValues = useStore(form.store, (state) => state.values.meta);
+  const onMetaChange = (key: string, next: unknown): void => {
+    form.setFieldValue("meta", { ...metaValues, [key]: next });
+  };
+
   return (
     <form
       className="flex flex-col gap-6"
@@ -121,102 +153,132 @@ export function PostEditorForm({
         void form.handleSubmit();
       }}
     >
-      <form.Field name="title">
-        {(field) => (
-          <TextFieldRow
-            field={field}
-            label="Title"
-            required
-            disabled={isSubmitting}
-            testId="post-editor-title-input"
-          />
-        )}
-      </form.Field>
-
-      <form.Field name="slug">
-        {(field) => (
-          <TextFieldRow
-            field={field}
-            label="Slug"
-            required
-            disabled={isSubmitting}
-            testId="post-editor-slug-input"
-            onChangeValue={(next) => {
-              // Any direct edit to the slug input locks out the
-              // title-driven auto-derivation for the rest of this
-              // editor session.
-              setSlugLocked(true);
-              field.handleChange(next);
-            }}
-          />
-        )}
-      </form.Field>
-
-      <form.Field name="content">
-        {(field) => (
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="post-editor-content">Content</Label>
-            <div id="post-editor-content">
-              <TiptapEditor
-                value={field.state.value}
-                onChange={(html) => {
-                  field.handleChange(html);
-                }}
+      <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="flex flex-col gap-6">
+          <form.Field name="title">
+            {(field) => (
+              <TextFieldRow
+                field={field}
+                label="Title"
+                required
                 disabled={isSubmitting}
-                ariaLabel="Post content"
+                testId="post-editor-title-input"
               />
-            </div>
-          </div>
-        )}
-      </form.Field>
+            )}
+          </form.Field>
 
-      <form.Field name="excerpt">
-        {(field) => (
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="post-editor-excerpt">
-              Excerpt <span className="text-muted-foreground">(optional)</span>
-            </Label>
-            <textarea
-              id="post-editor-excerpt"
-              name="excerpt"
-              value={field.state.value}
-              maxLength={600}
-              rows={3}
-              disabled={isSubmitting}
-              onBlur={field.handleBlur}
-              onChange={(e) => {
-                field.handleChange(e.target.value);
-              }}
-              className="border-input bg-background focus-visible:ring-ring flex min-h-20 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            />
-          </div>
-        )}
-      </form.Field>
+          <form.Field name="slug">
+            {(field) => (
+              <TextFieldRow
+                field={field}
+                label="Slug"
+                required
+                disabled={isSubmitting}
+                testId="post-editor-slug-input"
+                onChangeValue={(next) => {
+                  // Any direct edit to the slug input locks out the
+                  // title-driven auto-derivation for the rest of this
+                  // editor session.
+                  setSlugLocked(true);
+                  field.handleChange(next);
+                }}
+              />
+            )}
+          </form.Field>
 
-      <form.Field name="status">
-        {(field) => (
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="post-editor-status">Status</Label>
-            <select
-              id="post-editor-status"
-              name="status"
-              value={field.state.value}
-              disabled={isSubmitting}
-              onBlur={field.handleBlur}
-              onChange={(e) => {
-                field.handleChange(e.target.value as PostStatus);
-              }}
-              className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {availableStatuses.map((status) => (
-                <option key={status} value={status} className="capitalize">
-                  {capitalize(status)}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
-      </form.Field>
+          <form.Field name="content">
+            {(field) => (
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="post-editor-content">Content</Label>
+                <div id="post-editor-content">
+                  <TiptapEditor
+                    value={field.state.value}
+                    onChange={(html) => {
+                      field.handleChange(html);
+                    }}
+                    disabled={isSubmitting}
+                    ariaLabel="Post content"
+                  />
+                </div>
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="excerpt">
+            {(field) => (
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="post-editor-excerpt">
+                  Excerpt{" "}
+                  <span className="text-muted-foreground">(optional)</span>
+                </Label>
+                <textarea
+                  id="post-editor-excerpt"
+                  name="excerpt"
+                  value={field.state.value}
+                  maxLength={600}
+                  rows={3}
+                  disabled={isSubmitting}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => {
+                    field.handleChange(e.target.value);
+                  }}
+                  className="border-input bg-background focus-visible:ring-ring flex min-h-20 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                />
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="status">
+            {(field) => (
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="post-editor-status">Status</Label>
+                <select
+                  id="post-editor-status"
+                  name="status"
+                  value={field.state.value}
+                  disabled={isSubmitting}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => {
+                    field.handleChange(e.target.value as PostStatus);
+                  }}
+                  className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {availableStatuses.map((status) => (
+                    <option key={status} value={status} className="capitalize">
+                      {capitalize(status)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </form.Field>
+
+          <MetaBoxRegion
+            boxes={normal}
+            testId="meta-boxes-normal"
+            values={metaValues}
+            onChange={onMetaChange}
+            disabled={isSubmitting}
+          />
+          <MetaBoxRegion
+            boxes={advanced}
+            testId="meta-boxes-advanced"
+            values={metaValues}
+            onChange={onMetaChange}
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <aside className="flex flex-col gap-4" data-testid="meta-boxes-side">
+          <MetaBoxRegion
+            boxes={side}
+            testId="meta-boxes-side-boxes"
+            values={metaValues}
+            onChange={onMetaChange}
+            disabled={isSubmitting}
+          />
+        </aside>
+      </div>
 
       {serverError ? (
         <Alert variant="destructive">
@@ -252,6 +314,56 @@ export function PostEditorForm({
 
 function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+// Bucket boxes by context. Undefined `context` is treated as "normal"
+// (matches WP's default); unknown values fall through to the main
+// column so a plugin-specific `context` doesn't vanish into nowhere.
+function partitionBoxesByContext(boxes: readonly MetaBoxManifestEntry[]): {
+  side: readonly MetaBoxManifestEntry[];
+  normal: readonly MetaBoxManifestEntry[];
+  advanced: readonly MetaBoxManifestEntry[];
+} {
+  const side: MetaBoxManifestEntry[] = [];
+  const normal: MetaBoxManifestEntry[] = [];
+  const advanced: MetaBoxManifestEntry[] = [];
+  for (const box of boxes) {
+    if (box.context === "side") side.push(box);
+    else if (box.context === "advanced") advanced.push(box);
+    else normal.push(box);
+  }
+  return { side, normal, advanced };
+}
+
+// Render a stack of boxes against a shared meta bag. Nothing renders
+// when the bucket is empty so the layout stays tight.
+function MetaBoxRegion({
+  boxes,
+  testId,
+  values,
+  onChange,
+  disabled,
+}: {
+  readonly boxes: readonly MetaBoxManifestEntry[];
+  readonly testId: string;
+  readonly values: Readonly<Record<string, unknown>>;
+  readonly onChange: (key: string, next: unknown) => void;
+  readonly disabled: boolean;
+}): ReactNode {
+  if (boxes.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-4" data-testid={testId}>
+      {boxes.map((box) => (
+        <MetaBox
+          key={box.id}
+          box={box}
+          values={values}
+          disabled={disabled}
+          onChange={onChange}
+        />
+      ))}
+    </div>
+  );
 }
 
 // Lightweight field row for the editor's text inputs. FormField (used on

--- a/packages/admin/src/components/meta-box/meta-box-field.test.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.test.tsx
@@ -1,0 +1,261 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
+
+import { MetaBoxField } from "./meta-box-field.js";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function field(
+  overrides: Partial<MetaBoxFieldManifestEntry> & {
+    inputType: string;
+  },
+): MetaBoxFieldManifestEntry {
+  return {
+    key: "k",
+    label: "Label",
+    ...overrides,
+  };
+}
+
+// Stateful wrapper so controlled-input tests behave like a real form —
+// onChange calls flow back through to the component's `value` prop.
+function StatefulField({
+  fieldDef,
+  initial,
+  onChangeSpy,
+}: {
+  fieldDef: MetaBoxFieldManifestEntry;
+  initial: unknown;
+  onChangeSpy: (next: unknown) => void;
+}): ReactNode {
+  const [value, setValue] = useState<unknown>(initial);
+  return (
+    <MetaBoxField
+      field={fieldDef}
+      value={value}
+      onChange={(next) => {
+        onChangeSpy(next);
+        setValue(next);
+      }}
+    />
+  );
+}
+
+describe("MetaBoxField dispatcher", () => {
+  test("text: renders an <input type=text>, forwards value + onChange", async () => {
+    const onChange = vi.fn();
+    render(
+      <MetaBoxField
+        field={field({ inputType: "text", placeholder: "Type here" })}
+        value=""
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByTestId("meta-box-field-k-input");
+    expect(input.tagName).toBe("INPUT");
+    expect(input).toHaveAttribute("type", "text");
+    expect(input).toHaveAttribute("placeholder", "Type here");
+
+    await userEvent.type(input, "ab");
+    expect(onChange).toHaveBeenCalledWith("a");
+    expect(onChange).toHaveBeenCalledWith("b");
+  });
+
+  test("textarea: renders a <textarea>, honours maxLength + rows", () => {
+    render(
+      <MetaBoxField
+        field={field({ inputType: "textarea", maxLength: 50 })}
+        value="existing"
+        onChange={vi.fn()}
+      />,
+    );
+    const el = screen.getByTestId("meta-box-field-k-input");
+    expect(el.tagName).toBe("TEXTAREA");
+    expect(el).toHaveAttribute("maxLength", "50");
+    expect(el).toHaveValue("existing");
+  });
+
+  test("number: coerces empty string to null, numeric to Number", async () => {
+    const onChange = vi.fn();
+    render(
+      <StatefulField
+        fieldDef={field({ inputType: "number", min: 0, max: 100 })}
+        initial={42}
+        onChangeSpy={onChange}
+      />,
+    );
+    const input = screen.getByTestId("meta-box-field-k-input");
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveAttribute("min", "0");
+    expect(input).toHaveAttribute("max", "100");
+
+    await userEvent.clear(input);
+    expect(onChange).toHaveBeenLastCalledWith(null);
+
+    await userEvent.type(input, "7");
+    expect(onChange).toHaveBeenLastCalledWith(7);
+  });
+
+  test("number: partial input like '-' does not propagate NaN", async () => {
+    const onChange = vi.fn();
+    render(
+      <StatefulField
+        fieldDef={field({ inputType: "number" })}
+        initial={null}
+        onChangeSpy={onChange}
+      />,
+    );
+    const input = screen.getByTestId("meta-box-field-k-input");
+    // Typing "-" on an empty number input is valid partial state in most
+    // browsers but Number("-") is NaN; the component must drop it on the
+    // floor so NaN never lands in form state.
+    await userEvent.type(input, "-");
+    for (const call of onChange.mock.calls) {
+      expect(Number.isNaN(call[0])).toBe(false);
+    }
+  });
+
+  test("email / url: emit the matching native HTML5 input type", () => {
+    const { rerender } = render(
+      <MetaBoxField
+        field={field({ inputType: "email" })}
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("meta-box-field-k-input")).toHaveAttribute(
+      "type",
+      "email",
+    );
+
+    rerender(
+      <MetaBoxField
+        field={field({ inputType: "url" })}
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("meta-box-field-k-input")).toHaveAttribute(
+      "type",
+      "url",
+    );
+  });
+
+  test("select: renders options, selection fires onChange with the value", async () => {
+    const onChange = vi.fn();
+    render(
+      <MetaBoxField
+        field={field({
+          inputType: "select",
+          options: [
+            { value: "a", label: "Alpha" },
+            { value: "b", label: "Bravo" },
+          ],
+        })}
+        value="a"
+        onChange={onChange}
+      />,
+    );
+    const select = screen.getByTestId("meta-box-field-k-input");
+    expect(select.tagName).toBe("SELECT");
+    expect(select).toHaveValue("a");
+
+    await userEvent.selectOptions(select, "b");
+    expect(onChange).toHaveBeenCalledWith("b");
+  });
+
+  test("radio: renders one input per option, click fires onChange", async () => {
+    const onChange = vi.fn();
+    render(
+      <MetaBoxField
+        field={field({
+          inputType: "radio",
+          options: [
+            { value: "a", label: "Alpha" },
+            { value: "b", label: "Bravo" },
+          ],
+        })}
+        value="a"
+        onChange={onChange}
+      />,
+    );
+    const bravo = screen.getByTestId("meta-box-field-k-input-b");
+    expect(bravo).toHaveAttribute("type", "radio");
+
+    await userEvent.click(bravo);
+    expect(onChange).toHaveBeenCalledWith("b");
+  });
+
+  test("checkbox: renders as inline label, toggles emit the checked boolean", async () => {
+    const onChange = vi.fn();
+    render(
+      <MetaBoxField
+        field={field({ inputType: "checkbox", label: "Featured" })}
+        value={false}
+        onChange={onChange}
+      />,
+    );
+    const box = screen.getByTestId("meta-box-field-k-input");
+    expect(box).toHaveAttribute("type", "checkbox");
+
+    await userEvent.click(box);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test("unknown inputType: falls back to text input + logs a dev warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {
+      // silence expected warning
+    });
+    render(
+      <MetaBoxField
+        field={field({ inputType: "mystery" })}
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+    const input = screen.getByTestId("meta-box-field-k-input");
+    expect(input.tagName).toBe("INPUT");
+    expect(input).toHaveAttribute("type", "text");
+    expect(warn).toHaveBeenCalledOnce();
+    const firstCall = warn.mock.calls[0];
+    expect(firstCall?.[0]).toContain("unknown meta-box field inputType");
+  });
+
+  test("description renders under the field and is referenced by aria-describedby", () => {
+    render(
+      <MetaBoxField
+        field={field({
+          inputType: "text",
+          description: "Help text",
+        })}
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+    const input = screen.getByTestId("meta-box-field-k-input");
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const desc = screen.getByTestId("meta-box-field-k-description");
+    expect(desc).toHaveAttribute("id", describedBy);
+    expect(desc).toHaveTextContent("Help text");
+  });
+
+  test("required flag propagates to the native input", () => {
+    render(
+      <MetaBoxField
+        field={field({ inputType: "text", required: true })}
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("meta-box-field-k-input")).toBeRequired();
+  });
+});

--- a/packages/admin/src/components/meta-box/meta-box-field.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.tsx
@@ -1,0 +1,294 @@
+import type { ReactNode } from "react";
+import { Input } from "@/components/ui/input.js";
+import { Label } from "@/components/ui/label.js";
+
+import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
+
+// Schema-driven field renderer. One dispatcher branch per built-in
+// `inputType`; unknown types fall back to a plain text input with a
+// dev-mode warning so a plugin-specific type doesn't crash the editor.
+// Custom React renderers (plugin chunks) are a future extension seam —
+// they'll slot in ahead of the built-in switch when chunk splitting lands.
+export function MetaBoxField({
+  field,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  readonly field: MetaBoxFieldManifestEntry;
+  readonly value: unknown;
+  readonly onChange: (next: unknown) => void;
+  readonly disabled?: boolean;
+}): ReactNode {
+  const testIdPrefix = `meta-box-field-${field.key}`;
+  return (
+    <div className="flex flex-col gap-2" data-testid={testIdPrefix}>
+      {field.inputType === "checkbox" ? (
+        <InlineCheckbox
+          field={field}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          testId={`${testIdPrefix}-input`}
+        />
+      ) : (
+        <>
+          <Label id={labelId(field)} htmlFor={inputId(field)}>
+            {field.label}
+            <RequiredMarker show={field.required} />
+          </Label>
+          <FieldInput
+            field={field}
+            value={value}
+            onChange={onChange}
+            disabled={disabled}
+            testId={`${testIdPrefix}-input`}
+          />
+        </>
+      )}
+      {field.description ? (
+        <p
+          id={descriptionId(field)}
+          className="text-muted-foreground text-xs"
+          data-testid={`${testIdPrefix}-description`}
+        >
+          {field.description}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function RequiredMarker({ show }: { show: boolean | undefined }): ReactNode {
+  if (!show) return null;
+  return (
+    <span aria-hidden className="text-destructive ml-0.5">
+      *
+    </span>
+  );
+}
+
+// Base classes shared by <textarea> and <select> — mirror the shadcn
+// <Input> look (same border, ring, disabled states) so all three line up
+// visually in a dense sidebar.
+const CONTROL_BASE_CLASS =
+  "border-input bg-background focus-visible:ring-ring rounded-md border text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+
+function inputId(field: MetaBoxFieldManifestEntry): string {
+  return `meta-${field.key}`;
+}
+
+function labelId(field: MetaBoxFieldManifestEntry): string {
+  return `meta-${field.key}-label`;
+}
+
+function descriptionId(field: MetaBoxFieldManifestEntry): string {
+  return `meta-${field.key}-description`;
+}
+
+// Dispatcher for everything except `checkbox`, which renders its label
+// inline and doesn't share this label/input/description shell.
+function FieldInput({
+  field,
+  value,
+  onChange,
+  disabled,
+  testId,
+}: {
+  readonly field: MetaBoxFieldManifestEntry;
+  readonly value: unknown;
+  readonly onChange: (next: unknown) => void;
+  readonly disabled: boolean;
+  readonly testId: string;
+}): ReactNode {
+  const common = {
+    id: inputId(field),
+    name: field.key,
+    required: field.required,
+    disabled,
+    "aria-describedby": field.description ? descriptionId(field) : undefined,
+    "data-testid": testId,
+  } as const;
+
+  if (field.inputType === "textarea") {
+    return (
+      <textarea
+        {...common}
+        value={asString(value)}
+        maxLength={field.maxLength}
+        placeholder={field.placeholder}
+        rows={3}
+        onChange={(e) => {
+          onChange(e.target.value);
+        }}
+        className={`${CONTROL_BASE_CLASS} flex min-h-20 w-full px-3 py-2`}
+      />
+    );
+  }
+
+  if (field.inputType === "number") {
+    return (
+      <Input
+        {...common}
+        type="number"
+        value={asNumberInputValue(value)}
+        placeholder={field.placeholder}
+        min={field.min}
+        max={field.max}
+        step={field.step ?? 1}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === "") {
+            onChange(null);
+            return;
+          }
+          // Native `<input type=number>` accepts partial input ("-", "1e")
+          // which parses to NaN; guard so we never propagate NaN into the
+          // form's meta bag. User can keep typing — once the input is a
+          // complete number the `isFinite` check passes.
+          const parsed = Number(raw);
+          if (Number.isFinite(parsed)) onChange(parsed);
+        }}
+      />
+    );
+  }
+
+  if (field.inputType === "select") {
+    return (
+      <select
+        {...common}
+        value={asString(value)}
+        onChange={(e) => {
+          onChange(e.target.value);
+        }}
+        className={`${CONTROL_BASE_CLASS} h-9 px-3 py-1`}
+      >
+        {(field.options ?? []).map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  if (field.inputType === "radio") {
+    return (
+      <div
+        role="radiogroup"
+        aria-labelledby={labelId(field)}
+        aria-describedby={field.description ? descriptionId(field) : undefined}
+        className="flex flex-col gap-1"
+        data-testid={testId}
+      >
+        {(field.options ?? []).map((opt) => (
+          <label
+            key={opt.value}
+            className="inline-flex items-center gap-2 text-sm"
+          >
+            <input
+              type="radio"
+              name={field.key}
+              value={opt.value}
+              checked={asString(value) === opt.value}
+              required={field.required}
+              disabled={disabled}
+              onChange={() => {
+                onChange(opt.value);
+              }}
+              data-testid={`${testId}-${opt.value}`}
+            />
+            {opt.label}
+          </label>
+        ))}
+      </div>
+    );
+  }
+
+  if (
+    field.inputType !== "text" &&
+    field.inputType !== "email" &&
+    field.inputType !== "url"
+  ) {
+    // Forward-compat fallback: unknown inputType renders as a plain text
+    // input so a plugin-specific type doesn't crash the editor. Warn once
+    // per render so the plugin author sees the mismatch in dev tools.
+    // A future `customRenderers` seam will hook in here before the fallback.
+    console.warn(
+      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/select/radio/checkbox).`,
+    );
+  }
+
+  // Shared shape for `text` / `email` / `url` / unknown fallback.
+  const htmlType =
+    field.inputType === "email" || field.inputType === "url"
+      ? field.inputType
+      : "text";
+  return (
+    <Input
+      {...common}
+      type={htmlType}
+      value={asString(value)}
+      placeholder={field.placeholder}
+      maxLength={field.maxLength}
+      onChange={(e) => {
+        onChange(e.target.value);
+      }}
+    />
+  );
+}
+
+function InlineCheckbox({
+  field,
+  value,
+  onChange,
+  disabled,
+  testId,
+}: {
+  readonly field: MetaBoxFieldManifestEntry;
+  readonly value: unknown;
+  readonly onChange: (next: unknown) => void;
+  readonly disabled: boolean;
+  readonly testId: string;
+}): ReactNode {
+  return (
+    <label className="inline-flex items-center gap-2 text-sm">
+      <input
+        type="checkbox"
+        id={inputId(field)}
+        name={field.key}
+        checked={value === true}
+        required={field.required}
+        disabled={disabled}
+        aria-describedby={field.description ? descriptionId(field) : undefined}
+        onChange={(e) => {
+          onChange(e.target.checked);
+        }}
+        data-testid={testId}
+      />
+      {field.label}
+      <RequiredMarker show={field.required} />
+    </label>
+  );
+}
+
+// Tolerant coercion for inputs that display strings. Meta values arrive
+// as `unknown` because the registry isn't per-type-generic yet; each
+// input keeps the display-string stable regardless of what the server
+// sent. `null` / `undefined` become empty strings.
+function asString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+// `<input type="number">` needs an empty string (not `0`) to render an
+// empty field, and a number-or-string for a valued field. Non-numeric
+// input drops to empty rather than rendering "NaN".
+function asNumberInputValue(value: unknown): number | string {
+  if (typeof value === "number" && !Number.isNaN(value)) return value;
+  return "";
+}

--- a/packages/admin/src/components/meta-box/meta-box.tsx
+++ b/packages/admin/src/components/meta-box/meta-box.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+
+import type { MetaBoxManifestEntry } from "@plumix/core/manifest";
+
+import { MetaBoxField } from "./meta-box-field.js";
+
+// Single meta-box renderer — uniform shape regardless of the registered
+// `context` ("side" / "normal" / "advanced"). Parent layout decides
+// placement; this component just renders the box itself.
+export function MetaBox({
+  box,
+  values,
+  onChange,
+  disabled = false,
+}: {
+  readonly box: MetaBoxManifestEntry;
+  readonly values: Readonly<Record<string, unknown>>;
+  readonly onChange: (key: string, value: unknown) => void;
+  readonly disabled?: boolean;
+}): ReactNode {
+  return (
+    <Card data-testid={`meta-box-${box.id}`}>
+      <CardHeader>
+        <CardTitle>{box.label}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {box.fields.map((field) => (
+          <MetaBoxField
+            key={field.key}
+            field={field}
+            value={values[field.key]}
+            disabled={disabled}
+            onChange={(next) => {
+              onChange(field.key, next);
+            }}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -9,14 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root";
-import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
 import { Route as AuthRouteImport } from "./routes/_auth";
-import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
-import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
+import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
+import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
+import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
 import { Route as AuthenticatedContentSlugNewRouteImport } from "./routes/_authenticated/content/$slug/new";
-import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
+import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: "/_authenticated",

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -9,14 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root";
-import { Route as AuthRouteImport } from "./routes/_auth";
-import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
-import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
-import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
+import { Route as AuthRouteImport } from "./routes/_auth";
+import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
+import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
+import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
 import { Route as AuthenticatedContentSlugNewRouteImport } from "./routes/_authenticated/content/$slug/new";
-import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
+import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: "/_authenticated",

--- a/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
@@ -1,11 +1,11 @@
 import type { PostEditorValues } from "@/components/editor/post-editor-form.js";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   POST_EDITOR_STATUSES,
   PostEditorForm,
 } from "@/components/editor/post-editor-form.js";
-import { findPostTypeBySlug } from "@/lib/manifest.js";
+import { findPostTypeBySlug, metaBoxesForPostType } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
@@ -61,6 +61,14 @@ function EditPostRoute(): ReactNode {
     postType.labels?.singular ?? postType.label
   ).toLowerCase();
 
+  // Meta boxes registered for this post type, filtered by the user's
+  // capabilities. Computed unconditionally (before any early returns)
+  // to keep the hook order stable across render paths.
+  const metaBoxes = useMemo(
+    () => metaBoxesForPostType(postType.name, user.capabilities),
+    [postType.name, user.capabilities],
+  );
+
   if (Number.isNaN(postId) || postId < 1) {
     // Defensive: `$id` param is a string; reject anything non-numeric
     // rather than hitting the RPC with garbage. The router could enforce
@@ -102,7 +110,7 @@ function EditPostRoute(): ReactNode {
   const initialValues: PostEditorValues = toEditorValues(post);
 
   return (
-    <div className="flex max-w-3xl flex-col gap-6">
+    <div className="flex max-w-6xl flex-col gap-6">
       <div>
         <h1
           className="text-2xl font-semibold"
@@ -129,6 +137,7 @@ function EditPostRoute(): ReactNode {
         initialValues={initialValues}
         slugLocked
         availableStatuses={POST_EDITOR_STATUSES}
+        metaBoxes={metaBoxes}
         submitLabel="Save"
         // For the edit path, the post-save remount (keyed on
         // `updatedAt`) resets the form's isDirty to false — so the
@@ -159,6 +168,10 @@ function toEditorValues(post: Post): PostEditorValues {
     content: post.content ?? "",
     excerpt: post.excerpt ?? "",
     status: post.status,
+    // Meta values start empty — the `Post` row doesn't carry meta yet.
+    // The next PR wires `post.meta` persistence; today the editor renders
+    // empty boxes and submitted meta is dropped by the parent route.
+    meta: {},
   };
 }
 

--- a/packages/admin/src/routes/_authenticated/content/$slug/new.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/new.tsx
@@ -1,8 +1,8 @@
 import type { PostEditorValues } from "@/components/editor/post-editor-form.js";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { PostEditorForm } from "@/components/editor/post-editor-form.js";
-import { findPostTypeBySlug } from "@/lib/manifest.js";
+import { findPostTypeBySlug, metaBoxesForPostType } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useMutation } from "@tanstack/react-query";
 import {
@@ -51,7 +51,7 @@ export const Route = createFileRoute("/_authenticated/content/$slug/new")({
 });
 
 function NewPostRoute(): ReactNode {
-  const { postType } = Route.useRouteContext();
+  const { user, postType } = Route.useRouteContext();
   const params = Route.useParams();
   const navigate = useNavigate();
   const [serverError, setServerError] = useState<string | null>(null);
@@ -86,14 +86,23 @@ function NewPostRoute(): ReactNode {
     content: "",
     excerpt: "",
     status: "draft",
+    meta: {},
   };
+
+  // Meta boxes registered for this post type, filtered by the user's
+  // capabilities. Memo keyed on `user.capabilities` avoids refiltering
+  // every render while keeping the helper out of the component body.
+  const metaBoxes = useMemo(
+    () => metaBoxesForPostType(postType.name, user.capabilities),
+    [postType.name, user.capabilities],
+  );
 
   const singularLower = (
     postType.labels?.singular ?? postType.label
   ).toLowerCase();
 
   return (
-    <div className="flex max-w-3xl flex-col gap-6">
+    <div className="flex max-w-6xl flex-col gap-6">
       <div>
         <h1
           className="text-2xl font-semibold"
@@ -106,6 +115,7 @@ function NewPostRoute(): ReactNode {
         initialValues={initialValues}
         slugLocked={false}
         availableStatuses={NEW_POST_STATUSES}
+        metaBoxes={metaBoxes}
         submitLabel="Create"
         // Stay "busy" through `isSuccess` too — TanStack Query flips
         // `isPending` to false BEFORE `onSuccess` calls navigate(), which

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -52,11 +52,38 @@ export interface MetaOptions {
   readonly sanitize?: (value: unknown) => unknown;
 }
 
+export interface MetaBoxFieldOption {
+  readonly value: string;
+  readonly label: string;
+}
+
 export interface MetaBoxField {
   readonly key: string;
   readonly label: string;
+  /**
+   * Drives the admin sidebar's input renderer. Built-in dispatcher
+   * handles `text` / `textarea` / `number` / `email` / `url` /
+   * `select` / `radio` / `checkbox`. Plugins may use custom values —
+   * the renderer falls back to `<input type="text">` for unknown
+   * types with a dev-mode console warning.
+   */
   readonly inputType: string;
+  /** Optional help text rendered under the label on every input type. */
+  readonly description?: string;
+  /** Renders `required` on the native input; server validation is separate. */
+  readonly required?: boolean;
+  /** Text-shaped inputs (`text` / `textarea` / `email` / `url` / `number`). */
+  readonly placeholder?: string;
+  /** Text-shaped inputs — `text` / `textarea` / `email` / `url`. */
   readonly maxLength?: number;
+  /** `number` input only. */
+  readonly min?: number;
+  /** `number` input only. */
+  readonly max?: number;
+  /** `number` input only; defaults to 1 (integer) when omitted. */
+  readonly step?: number;
+  /** Required for `select` and `radio`; ignored otherwise. */
+  readonly options?: readonly MetaBoxFieldOption[];
 }
 
 export interface MetaBoxOptions {
@@ -160,14 +187,21 @@ export interface PostTypeManifestEntry {
 
 /**
  * Client-safe field descriptor inside a meta box. Mirrors `MetaBoxField`
- * exactly today — kept as a separate type so the manifest boundary can
- * diverge (e.g., omit server-only `sanitize` callbacks) when needed.
+ * today — kept as a separate type so the manifest boundary can diverge
+ * (e.g., omit server-only `sanitize` callbacks) when needed.
  */
 export interface MetaBoxFieldManifestEntry {
   readonly key: string;
   readonly label: string;
   readonly inputType: string;
+  readonly description?: string;
+  readonly required?: boolean;
+  readonly placeholder?: string;
   readonly maxLength?: number;
+  readonly min?: number;
+  readonly max?: number;
+  readonly step?: number;
+  readonly options?: readonly MetaBoxFieldOption[];
 }
 
 /**
@@ -346,8 +380,32 @@ function toMetaBoxEntry(box: RegisteredMetaBox): MetaBoxManifestEntry {
 }
 
 function toMetaBoxFieldEntry(field: MetaBoxField): MetaBoxFieldManifestEntry {
-  const { key, label, inputType, maxLength } = field;
-  return { key, label, inputType, maxLength };
+  const {
+    key,
+    label,
+    inputType,
+    description,
+    required,
+    placeholder,
+    maxLength,
+    min,
+    max,
+    step,
+    options,
+  } = field;
+  return {
+    key,
+    label,
+    inputType,
+    description,
+    required,
+    placeholder,
+    maxLength,
+    min,
+    max,
+    step,
+    options,
+  };
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,12 @@ importers:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -746,6 +752,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -3223,9 +3233,34 @@ packages:
     engines: {node: '>=20.19'}
     hasBin: true
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tiptap/core@3.22.4':
     resolution: {integrity: sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==}
@@ -3408,6 +3443,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -3693,6 +3731,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
@@ -3710,6 +3752,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -3995,6 +4040,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
     engines: {node: '>=8'}
@@ -4013,6 +4062,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
@@ -4900,6 +4952,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -5208,6 +5264,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
@@ -5286,6 +5346,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -6163,6 +6226,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -8313,6 +8378,17 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.161.7': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
   '@testing-library/jest-dom@6.9.1':
     dependencies:
       '@adobe/css-tools': 4.4.4
@@ -8321,6 +8397,20 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tiptap/core@3.22.4(@tiptap/pm@3.22.4)':
     dependencies:
@@ -8515,6 +8605,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -8803,6 +8895,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansis@4.2.0: {}
 
   any-promise@1.3.0: {}
@@ -8817,6 +8911,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -9140,6 +9238,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.0.2: {}
 
   detect-libc@2.1.2: {}
@@ -9151,6 +9251,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
 
@@ -10104,6 +10206,8 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -10397,6 +10501,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   promise-limit@2.7.0: {}
 
   prop-types@15.8.1:
@@ -10556,6 +10666,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary

- Admin editor now renders plugin-registered meta boxes in a side rail + main column, driven entirely by the manifest — no per-plugin React code needed for the built-in types.
- `MetaBoxField` dispatcher covers `text`, `textarea`, `number`, `email`, `url`, `select`, `radio`, `checkbox`; unknown `inputType` falls through to a text input with a dev-mode `console.warn` so a plugin-specific type never crashes the editor.
- Meta state lives in the form's `meta` record, so isDirty tracking and the navigation blocker cover meta changes the same way they already cover title/body.

## Notes

- Core `MetaBoxField` schema extended with `placeholder`, `description`, `required`, `min`, `max`, `step`, `maxLength`, `options[]` — kept the existing manifest projection shape.
- `<input type=number>` guards against partial input like `-` or `1e` (those parse to `NaN`) — empty strings propagate as `null`, partial strings are swallowed until the value becomes a finite number.
- Radio groups use `aria-labelledby` pointing at the field's `<Label>` (which carries the required marker) rather than `htmlFor`, since the radio group has no single focusable input.
- Custom React renderers (plugin chunks) are deferred — the switch branches leave a clear seam to slot them in later.

## Test plan

- [x] 11 RTL unit tests for the dispatcher (one per input type + description + required + NaN-guard)
- [x] E2E covers two-box manifest: side + normal contexts render, text input typable, checkbox togglable
- [x] Existing editor e2e (new post, edit post, slug locking, axe) still green
- [x] 32/32 turbo tasks pass (typecheck + lint + test) across workspace