### PR TITLE
ci: split dependabot dev-tooling group and skip labeler for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,19 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     groups:
-      dev-tooling:
+      eslint:
         patterns:
-          - "eslint*"
+          - "eslint"
+          - "eslint-*"
           - "@eslint/*"
-          - "prettier"
-          - "typescript-eslint"
-          - "turbo"
-          - "publint"
-          - "@arethetypeswrong/*"
-          - "@commitlint/*"
           - "eslint-plugin-*"
+          - "typescript-eslint"
+      commitlint:
+        patterns:
+          - "@commitlint/*"
+      arethetypeswrong:
+        patterns:
+          - "@arethetypeswrong/*"
     ignore:
       # @types/node major version must match .nvmrc — bump manually with Node upgrades
       - dependency-name: "@types/node"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   label:
     name: Label PR
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v6


### PR DESCRIPTION
## Summary
- Break the catch-all `dev-tooling` group into narrower per-provider groups: `eslint` (eslint ecosystem + typescript-eslint), `commitlint`, `arethetypeswrong`. Everything else in the old group (prettier, turbo, publint) falls back to individual PRs — they don't share release cycles.
- Skip the Label PR job when the actor is `dependabot[bot]`. Nothing in `.github/labeler.yml` targets dependabot branches, so the run was a no-op.

## Test plan
- [ ] Next Monday's dependabot run opens separate `eslint`, `commitlint`, `arethetypeswrong` group PRs instead of one mixed dev-tooling PR.
- [ ] New dependabot PRs no longer run the Label PR check.