### PR TITLE
feat(core,admin): persist post meta end-to-end

### DIFF
--- a/packages/admin/.prettierignore
+++ b/packages/admin/.prettierignore
@@ -1,0 +1,6 @@
+# TanStack Router regenerates this on every dev / build run using its own
+# formatter (`quoteStyle` + `semicolons` are set in vite.config.ts). Our
+# repo-wide `@ianvs/prettier-plugin-sort-imports` reorders imports
+# differently, so a `prettier --write` is immediately clobbered on the
+# next generation. Per the generator's own file header, exclude it.
+src/routeTree.gen.ts

--- a/packages/admin/e2e/editor.spec.ts
+++ b/packages/admin/e2e/editor.spec.ts
@@ -48,6 +48,7 @@ test.describe("/content/$slug/new", () => {
               publishedAt: null,
               createdAt: new Date("2026-04-21T00:00:00Z"),
               updatedAt: new Date("2026-04-21T00:00:00Z"),
+              meta: {},
             },
             meta: [],
           }),
@@ -72,6 +73,7 @@ test.describe("/content/$slug/new", () => {
               publishedAt: null,
               createdAt: new Date("2026-04-21T00:00:00Z"),
               updatedAt: new Date("2026-04-21T00:00:00Z"),
+              meta: {},
             },
             meta: [],
           }),
@@ -177,6 +179,7 @@ test.describe("/content/$slug/$id", () => {
               publishedAt: null,
               createdAt: now,
               updatedAt: now,
+              meta: {},
             },
             meta: [],
           }),
@@ -203,6 +206,7 @@ test.describe("/content/$slug/$id", () => {
               publishedAt: null,
               createdAt: now,
               updatedAt: new Date("2026-04-21T01:00:00Z"),
+              meta: {},
             },
             meta: [],
           }),
@@ -259,5 +263,95 @@ test.describe("meta-box sidebar", () => {
     await expect(featured).not.toBeChecked();
     await featured.check();
     await expect(featured).toBeChecked();
+  });
+
+  test("submit forwards meta values on the post.create input, and hydrates them back on edit", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_META_BOXES);
+
+    const createInputs: unknown[] = [];
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/post/create")) {
+        const body = route.request().postDataJSON() as { json?: unknown };
+        createInputs.push(body.json);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 99,
+              type: "post",
+              parentId: null,
+              title: "meta post",
+              slug: "meta-post",
+              content: null,
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              menuOrder: 0,
+              publishedAt: null,
+              createdAt: new Date("2026-04-21T00:00:00Z"),
+              updatedAt: new Date("2026-04-21T00:00:00Z"),
+              meta: { meta_title: "seo title", is_featured: true },
+            },
+            meta: [],
+          }),
+        });
+      }
+      if (url.endsWith("/post/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 99,
+              type: "post",
+              parentId: null,
+              title: "meta post",
+              slug: "meta-post",
+              content: null,
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              menuOrder: 0,
+              publishedAt: null,
+              createdAt: new Date("2026-04-21T00:00:00Z"),
+              updatedAt: new Date("2026-04-21T00:00:00Z"),
+              meta: { meta_title: "seo title", is_featured: true },
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("content/posts/new");
+    await page.getByTestId("post-editor-title-input").fill("meta post");
+    await page.getByTestId("meta-box-field-meta_title-input").fill("seo title");
+    await page.getByTestId("meta-box-field-is_featured-input").check();
+    await page.getByTestId("post-editor-submit").click();
+
+    await expect
+      .poll(() => (createInputs.at(-1) as { meta?: unknown } | undefined)?.meta)
+      .toEqual({ meta_title: "seo title", is_featured: true });
+    // Route advances to the edit page after save.
+    await expect(page).toHaveURL(/content\/posts\/99/);
+    // The loaded post hydrates the meta inputs from `post.get`'s `meta` bag.
+    await expect(
+      page.getByTestId("meta-box-field-meta_title-input"),
+    ).toHaveValue("seo title");
+    await expect(
+      page.getByTestId("meta-box-field-is_featured-input"),
+    ).toBeChecked();
   });
 });

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "clean": "git clean -xdf .cache .turbo dist node_modules playwright-report test-results",
     "dev": "vite",
-    "format": "prettier --check . --ignore-path ../../.gitignore",
+    "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "lint": "eslint",
     "test": "vitest run",
     "test:e2e": "playwright test",

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -9,14 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root";
-import { Route as AuthRouteImport } from "./routes/_auth";
-import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
-import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
-import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
+import { Route as AuthRouteImport } from "./routes/_auth";
+import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
+import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
+import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
 import { Route as AuthenticatedContentSlugNewRouteImport } from "./routes/_authenticated/content/$slug/new";
-import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
+import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: "/_authenticated",

--- a/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
@@ -11,7 +11,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
 
 import type { PostTypeManifestEntry } from "@plumix/core/manifest";
-import type { Post } from "@plumix/core/schema";
+import type { PostWithMeta } from "@plumix/core/schema";
 
 import { CONTENT_LIST_DEFAULT_SEARCH } from "./index.js";
 
@@ -45,6 +45,7 @@ function EditPostRoute(): ReactNode {
         content: input.content.length > 0 ? input.content : null,
         excerpt: input.excerpt.length > 0 ? input.excerpt : null,
         status: input.status,
+        meta: input.meta,
       }),
     onMutate: () => {
       setServerError(null);
@@ -161,17 +162,18 @@ function EditPostRoute(): ReactNode {
   );
 }
 
-function toEditorValues(post: Post): PostEditorValues {
+function toEditorValues(post: PostWithMeta): PostEditorValues {
   return {
     title: post.title,
     slug: post.slug,
     content: post.content ?? "",
     excerpt: post.excerpt ?? "",
     status: post.status,
-    // Meta values start empty — the `Post` row doesn't carry meta yet.
-    // The next PR wires `post.meta` persistence; today the editor renders
-    // empty boxes and submitted meta is dropped by the parent route.
-    meta: {},
+    // `post.meta` ships alongside the post row (server hydrates it from
+    // post_meta, typed against the plugin registry). Passing as-is — the
+    // editor form treats values as `unknown` and the field dispatcher
+    // handles per-type coercion on render.
+    meta: post.meta,
   };
 }
 

--- a/packages/admin/src/routes/_authenticated/content/$slug/new.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/new.tsx
@@ -65,6 +65,7 @@ function NewPostRoute(): ReactNode {
         content: input.content.length > 0 ? input.content : null,
         excerpt: input.excerpt.length > 0 ? input.excerpt : null,
         status: input.status,
+        meta: input.meta,
       }),
     onMutate: () => {
       setServerError(null);

--- a/packages/core/src/db/schema/posts.ts
+++ b/packages/core/src/db/schema/posts.ts
@@ -58,5 +58,15 @@ export const posts = sqliteTable(
 export type Post = typeof posts.$inferSelect;
 export type NewPost = typeof posts.$inferInsert;
 
+/**
+ * `Post` row plus its decoded meta bag. Returned by `post.get` /
+ * `post.create` / `post.update` so the editor can render meta boxes in
+ * one round-trip. Values are `unknown` — per-key types are driven by
+ * the plugin registry (`MetaScalarType`) and coerced on read.
+ */
+export type PostWithMeta = Post & {
+  readonly meta: Readonly<Record<string, unknown>>;
+};
+
 export const postInsertSchema = createInsertSchema(posts);
 export const postSelectSchema = createSelectSchema(posts);

--- a/packages/core/src/rpc/errors.ts
+++ b/packages/core/src/rpc/errors.ts
@@ -21,6 +21,10 @@ export const RPC_ERRORS = {
     message: "Resource conflict",
     data: v.object({
       reason: v.string(),
+      // Optional identifier the client can surface in-context. Filled by
+      // reasons that pinpoint a specific field/row (e.g. `meta_*` reasons
+      // set this to the offending meta key); omitted otherwise.
+      key: v.optional(v.string()),
     }),
   },
 } as const;

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -8,10 +8,7 @@ import type {
 import type { Term } from "../db/schema/terms.js";
 import type { User } from "../db/schema/users.js";
 import type { OptionSetInput } from "./procedures/option/schemas.js";
-import type {
-  MetaPatch,
-  PostMetaChanges,
-} from "./procedures/post/meta.js";
+import type { MetaPatch, PostMetaChanges } from "./procedures/post/meta.js";
 import type {
   PostCreateInput,
   PostListInput,

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -1,12 +1,16 @@
 import type { Option } from "../db/schema/options.js";
-import type { NewPost, Post, PostStatus } from "../db/schema/posts.js";
+import type {
+  NewPost,
+  Post,
+  PostStatus,
+  PostWithMeta,
+} from "../db/schema/posts.js";
 import type { Term } from "../db/schema/terms.js";
 import type { User } from "../db/schema/users.js";
 import type { OptionSetInput } from "./procedures/option/schemas.js";
 import type {
   MetaPatch,
   PostMetaChanges,
-  PostWithMeta,
 } from "./procedures/post/meta.js";
 import type {
   PostCreateInput,

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -3,6 +3,7 @@ import type { NewPost, Post, PostStatus } from "../db/schema/posts.js";
 import type { Term } from "../db/schema/terms.js";
 import type { User } from "../db/schema/users.js";
 import type { OptionSetInput } from "./procedures/option/schemas.js";
+import type { PostWithMeta } from "./procedures/post/meta.js";
 import type {
   PostCreateInput,
   PostListInput,
@@ -25,13 +26,13 @@ declare module "../hooks/types.js" {
     "rpc:post.list:output": (output: readonly Post[]) => readonly Post[];
 
     "rpc:post.get:input": (input: { id: number }) => typeof input;
-    "rpc:post.get:output": (output: Post) => Post;
+    "rpc:post.get:output": (output: PostWithMeta) => PostWithMeta;
 
     "rpc:post.create:input": (input: PostCreateInput) => PostCreateInput;
-    "rpc:post.create:output": (output: Post) => Post;
+    "rpc:post.create:output": (output: PostWithMeta) => PostWithMeta;
 
     "rpc:post.update:input": (input: PostUpdateInput) => PostUpdateInput;
-    "rpc:post.update:output": (output: Post) => Post;
+    "rpc:post.update:output": (output: PostWithMeta) => PostWithMeta;
 
     "rpc:post.trash:input": (input: { id: number }) => typeof input;
     "rpc:post.trash:output": (output: Post) => Post;

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -3,7 +3,11 @@ import type { NewPost, Post, PostStatus } from "../db/schema/posts.js";
 import type { Term } from "../db/schema/terms.js";
 import type { User } from "../db/schema/users.js";
 import type { OptionSetInput } from "./procedures/option/schemas.js";
-import type { PostWithMeta } from "./procedures/post/meta.js";
+import type {
+  MetaPatch,
+  PostMetaChanges,
+  PostWithMeta,
+} from "./procedures/post/meta.js";
 import type {
   PostCreateInput,
   PostListInput,
@@ -33,6 +37,34 @@ declare module "../hooks/types.js" {
 
     "rpc:post.update:input": (input: PostUpdateInput) => PostUpdateInput;
     "rpc:post.update:output": (output: PostWithMeta) => PostWithMeta;
+
+    /**
+     * Last chance to mutate or short-circuit a meta patch before it hits
+     * the DB. Runs after per-key type coercion + `MetaOptions.sanitize`,
+     * so the patch values are already normalized. Plugins can:
+     *   - reshape `upserts` / `deletes` (e.g. derive one key from another)
+     *   - return an empty patch to block the write entirely
+     *   - inject meta the caller didn't send
+     * Fires on both `post.create` and `post.update`.
+     */
+    "rpc:post.meta:write": (
+      patch: MetaPatch,
+      post: { readonly id: number; readonly type: string },
+    ) => MetaPatch | Promise<MetaPatch>;
+
+    /**
+     * Runs on the decoded meta bag right before `post.get` / `post.create`
+     * / `post.update` returns. Plugins can add derived keys, redact
+     * secrets, or replace the bag outright. The bag is keyed by the same
+     * strings as `metaKeys`; values are typed against each key's
+     * `MetaScalarType`.
+     */
+    "rpc:post.meta:read": (
+      meta: Readonly<Record<string, unknown>>,
+      post: { readonly id: number; readonly type: string },
+    ) =>
+      | Readonly<Record<string, unknown>>
+      | Promise<Readonly<Record<string, unknown>>>;
 
     "rpc:post.trash:input": (input: { id: number }) => typeof input;
     "rpc:post.trash:output": (output: Post) => Post;
@@ -86,6 +118,20 @@ declare module "../hooks/types.js" {
     [K: `${string}:transition`]: (
       post: Post,
       oldStatus: PostStatus,
+    ) => void | Promise<void>;
+
+    /**
+     * Fires after a successful meta write on any post type. Payload
+     * carries the decoded upserts + deleted keys — matches WP's
+     * `updated_post_meta` / `deleted_post_meta` / `added_post_meta`
+     * collapsed into one action. Named `meta_changed` (not `:updated`)
+     * so it doesn't collide with the `${string}:updated` post-row
+     * signature above. Plugins that care about a single CPT branch on
+     * `post.type` inside the handler.
+     */
+    "post:meta_changed": (
+      post: { readonly id: number; readonly type: string },
+      changes: PostMetaChanges,
     ) => void | Promise<void>;
   }
 }

--- a/packages/core/src/rpc/procedures/post/create.test.ts
+++ b/packages/core/src/rpc/procedures/post/create.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { eq } from "../../../db/index.js";
 import { posts } from "../../../db/schema/posts.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
 describe("post.create", () => {
@@ -233,5 +234,45 @@ describe("post.create", () => {
       parentId: parent.id,
     });
     expect(child.parentId).toBe(parent.id);
+  });
+
+  test("meta: registered keys persist and come back on the create response", async () => {
+    const plugins = createPluginRegistry();
+    plugins.metaKeys.set("meta_title", {
+      key: "meta_title",
+      type: "string",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    plugins.metaKeys.set("is_featured", {
+      key: "is_featured",
+      type: "boolean",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const created = await h.client.post.create({
+      title: "with-meta",
+      slug: "with-meta",
+      meta: { meta_title: "SEO title", is_featured: true },
+    });
+    expect(created.meta).toEqual({
+      meta_title: "SEO title",
+      is_featured: true,
+    });
+  });
+
+  test("meta: unregistered key → CONFLICT with the offending key surfaced", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.post.create({
+        title: "bad-meta",
+        slug: "bad-meta",
+        meta: { mystery: "x" },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "meta_not_registered", key: "mystery" },
+    });
   });
 });

--- a/packages/core/src/rpc/procedures/post/create.test.ts
+++ b/packages/core/src/rpc/procedures/post/create.test.ts
@@ -275,4 +275,22 @@ describe("post.create", () => {
       data: { reason: "meta_not_registered", key: "mystery" },
     });
   });
+
+  test("meta: input schema caps the map at 200 keys (DoS guard)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const oversized: Record<string, string> = {};
+    for (let i = 0; i < 201; i++) oversized[`k${i}`] = "x";
+    await expect(
+      h.client.post.create({
+        title: "too-much",
+        slug: "too-much",
+        meta: oversized,
+      }),
+    ).rejects.toMatchObject({
+      // oRPC's valibot adapter surfaces a `BAD_REQUEST` for schema failures,
+      // so we match on the code, not a CONFLICT reason — the cap is a wire
+      // validation check, not a sanitizer rejection.
+      code: "BAD_REQUEST",
+    });
+  });
 });

--- a/packages/core/src/rpc/procedures/post/create.ts
+++ b/packages/core/src/rpc/procedures/post/create.ts
@@ -9,6 +9,12 @@ import {
   loadReadableParent,
   postCapability,
 } from "./lifecycle.js";
+import {
+  applyMetaPatch,
+  loadPostMeta,
+  MetaSanitizationError,
+  sanitizeMetaInput,
+} from "./meta.js";
 import { postCreateInputSchema } from "./schemas.js";
 
 export const create = base
@@ -47,6 +53,24 @@ export const create = base
       }
     }
 
+    // Validate meta up-front so a bad key fails before the post insert —
+    // keeps the DB clean when the client sends a typo in a meta key.
+    let metaPatch;
+    try {
+      metaPatch = sanitizeMetaInput(
+        context.plugins,
+        filtered.type,
+        filtered.meta,
+      );
+    } catch (error) {
+      if (error instanceof MetaSanitizationError) {
+        throw errors.CONFLICT({
+          data: { reason: `meta_${error.reason}`, key: error.key },
+        });
+      }
+      throw error;
+    }
+
     const candidate: NewPost = {
       type: filtered.type,
       title: filtered.title,
@@ -78,10 +102,18 @@ export const create = base
       throw errors.CONFLICT({ data: { reason: "slug_taken" } });
     }
 
+    if (metaPatch) {
+      await applyMetaPatch(context, created.id, metaPatch);
+    }
+    const meta = await loadPostMeta(context.db, context.plugins, created.id);
+
     await firePostTransition(context, created, "draft");
     if (created.status === "published") {
       await firePostPublished(context, created);
     }
 
-    return context.hooks.applyFilter("rpc:post.create:output", created);
+    return context.hooks.applyFilter("rpc:post.create:output", {
+      ...created,
+      meta,
+    });
   });

--- a/packages/core/src/rpc/procedures/post/create.ts
+++ b/packages/core/src/rpc/procedures/post/create.ts
@@ -10,10 +10,11 @@ import {
   postCapability,
 } from "./lifecycle.js";
 import {
-  applyMetaPatch,
+  applyPostMetaReadFilter,
   loadPostMeta,
   MetaSanitizationError,
   sanitizeMetaInput,
+  writePostMetaWithHooks,
 } from "./meta.js";
 import { postCreateInputSchema } from "./schemas.js";
 
@@ -103,9 +104,14 @@ export const create = base
     }
 
     if (metaPatch) {
-      await applyMetaPatch(context, created.id, metaPatch);
+      await writePostMetaWithHooks(context, created, metaPatch);
     }
-    const meta = await loadPostMeta(context.db, context.plugins, created.id);
+    const loadedMeta = await loadPostMeta(
+      context.db,
+      context.plugins,
+      created.id,
+    );
+    const meta = await applyPostMetaReadFilter(context, created, loadedMeta);
 
     await firePostTransition(context, created, "draft");
     if (created.status === "published") {

--- a/packages/core/src/rpc/procedures/post/create.ts
+++ b/packages/core/src/rpc/procedures/post/create.ts
@@ -12,8 +12,7 @@ import {
 import {
   applyPostMetaReadFilter,
   loadPostMeta,
-  MetaSanitizationError,
-  sanitizeMetaInput,
+  sanitizeMetaForRpc,
   writePostMetaWithHooks,
 } from "./meta.js";
 import { postCreateInputSchema } from "./schemas.js";
@@ -56,21 +55,12 @@ export const create = base
 
     // Validate meta up-front so a bad key fails before the post insert —
     // keeps the DB clean when the client sends a typo in a meta key.
-    let metaPatch;
-    try {
-      metaPatch = sanitizeMetaInput(
-        context.plugins,
-        filtered.type,
-        filtered.meta,
-      );
-    } catch (error) {
-      if (error instanceof MetaSanitizationError) {
-        throw errors.CONFLICT({
-          data: { reason: `meta_${error.reason}`, key: error.key },
-        });
-      }
-      throw error;
-    }
+    const metaPatch = sanitizeMetaForRpc(
+      context.plugins,
+      filtered.type,
+      filtered.meta,
+      errors,
+    );
 
     const candidate: NewPost = {
       type: filtered.type,
@@ -106,11 +96,7 @@ export const create = base
     if (metaPatch) {
       await writePostMetaWithHooks(context, created, metaPatch);
     }
-    const loadedMeta = await loadPostMeta(
-      context.db,
-      context.plugins,
-      created.id,
-    );
+    const loadedMeta = await loadPostMeta(context, created.id);
     const meta = await applyPostMetaReadFilter(context, created, loadedMeta);
 
     await firePostTransition(context, created, "draft");

--- a/packages/core/src/rpc/procedures/post/get.ts
+++ b/packages/core/src/rpc/procedures/post/get.ts
@@ -3,6 +3,7 @@ import { posts } from "../../../db/schema/posts.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { postCapability } from "./lifecycle.js";
+import { loadPostMeta } from "./meta.js";
 import { postGetInputSchema } from "./schemas.js";
 
 export const get = base
@@ -35,5 +36,6 @@ export const get = base
       }
     }
 
-    return context.hooks.applyFilter("rpc:post.get:output", row);
+    const meta = await loadPostMeta(context.db, context.plugins, row.id);
+    return context.hooks.applyFilter("rpc:post.get:output", { ...row, meta });
   });

--- a/packages/core/src/rpc/procedures/post/get.ts
+++ b/packages/core/src/rpc/procedures/post/get.ts
@@ -36,7 +36,7 @@ export const get = base
       }
     }
 
-    const loaded = await loadPostMeta(context.db, context.plugins, row.id);
+    const loaded = await loadPostMeta(context, row.id);
     const meta = await applyPostMetaReadFilter(context, row, loaded);
     return context.hooks.applyFilter("rpc:post.get:output", { ...row, meta });
   });

--- a/packages/core/src/rpc/procedures/post/get.ts
+++ b/packages/core/src/rpc/procedures/post/get.ts
@@ -3,7 +3,7 @@ import { posts } from "../../../db/schema/posts.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { postCapability } from "./lifecycle.js";
-import { loadPostMeta } from "./meta.js";
+import { applyPostMetaReadFilter, loadPostMeta } from "./meta.js";
 import { postGetInputSchema } from "./schemas.js";
 
 export const get = base
@@ -36,6 +36,7 @@ export const get = base
       }
     }
 
-    const meta = await loadPostMeta(context.db, context.plugins, row.id);
+    const loaded = await loadPostMeta(context.db, context.plugins, row.id);
+    const meta = await applyPostMetaReadFilter(context, row, loaded);
     return context.hooks.applyFilter("rpc:post.get:output", { ...row, meta });
   });

--- a/packages/core/src/rpc/procedures/post/meta.test.ts
+++ b/packages/core/src/rpc/procedures/post/meta.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "vitest";
+
+import { eq } from "../../../db/index.js";
+import { postMeta } from "../../../db/schema/post_meta.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+import {
+  applyMetaPatch,
+  loadPostMeta,
+  MetaSanitizationError,
+  sanitizeMetaInput,
+} from "./meta.js";
+
+function registryWithMeta(
+  keys: Record<
+    string,
+    {
+      type: "string" | "number" | "boolean" | "json";
+      postTypes?: string[];
+      sanitize?: (value: unknown) => unknown;
+      default?: unknown;
+    }
+  >,
+) {
+  const registry = createPluginRegistry();
+  for (const [key, options] of Object.entries(keys)) {
+    registry.metaKeys.set(key, {
+      key,
+      type: options.type,
+      postTypes: options.postTypes ?? ["post"],
+      sanitize: options.sanitize,
+      default: options.default,
+      registeredBy: "test",
+    });
+  }
+  return registry;
+}
+
+describe("sanitizeMetaInput", () => {
+  test("returns null when the input map is absent (no patch to apply)", () => {
+    const registry = registryWithMeta({});
+    expect(sanitizeMetaInput(registry, "post", undefined)).toBeNull();
+  });
+
+  test("empty object produces an empty patch (valid — just nothing to do)", () => {
+    const registry = registryWithMeta({});
+    const patch = sanitizeMetaInput(registry, "post", {});
+    expect(patch).toEqual({ upserts: new Map(), deletes: [] });
+  });
+
+  test("string meta encodes as JSON so reads round-trip via JSON.parse", () => {
+    const registry = registryWithMeta({ title: { type: "string" } });
+    const patch = sanitizeMetaInput(registry, "post", { title: "Hello" });
+    expect(patch?.upserts.get("title")).toBe('"Hello"');
+  });
+
+  test("number meta rejects NaN / Infinity (they would poison JSON)", () => {
+    const registry = registryWithMeta({ count: { type: "number" } });
+    expect(() =>
+      sanitizeMetaInput(registry, "post", { count: Number.NaN }),
+    ).toThrow(MetaSanitizationError);
+    expect(() =>
+      sanitizeMetaInput(registry, "post", { count: Number.POSITIVE_INFINITY }),
+    ).toThrow(MetaSanitizationError);
+  });
+
+  test("number meta coerces numeric strings (admin may ship form-value strings)", () => {
+    const registry = registryWithMeta({ count: { type: "number" } });
+    const patch = sanitizeMetaInput(registry, "post", { count: "42" });
+    expect(patch?.upserts.get("count")).toBe("42");
+  });
+
+  test("boolean meta coerces 0/1 and 'true'/'false' for form-field compatibility", () => {
+    const registry = registryWithMeta({ featured: { type: "boolean" } });
+    expect(
+      sanitizeMetaInput(registry, "post", { featured: 1 })?.upserts.get(
+        "featured",
+      ),
+    ).toBe("true");
+    expect(
+      sanitizeMetaInput(registry, "post", { featured: "false" })?.upserts.get(
+        "featured",
+      ),
+    ).toBe("false");
+  });
+
+  test("json meta accepts nested structures, rejects non-serializable values", () => {
+    const registry = registryWithMeta({ config: { type: "json" } });
+    const patch = sanitizeMetaInput(registry, "post", {
+      config: { nested: { arr: [1, 2] } },
+    });
+    expect(patch?.upserts.get("config")).toBe('{"nested":{"arr":[1,2]}}');
+    expect(() =>
+      sanitizeMetaInput(registry, "post", { config: () => 1 }),
+    ).toThrow(MetaSanitizationError);
+  });
+
+  test("null / undefined values queue a delete rather than an upsert", () => {
+    const registry = registryWithMeta({
+      a: { type: "string" },
+      b: { type: "string" },
+    });
+    const patch = sanitizeMetaInput(registry, "post", {
+      a: null,
+      b: undefined,
+    });
+    expect([...(patch?.deletes ?? [])].sort()).toEqual(["a", "b"]);
+    expect(patch?.upserts.size).toBe(0);
+  });
+
+  test("unregistered key → NOT_REGISTERED error (protects against typos)", () => {
+    const registry = registryWithMeta({});
+    expect(() => sanitizeMetaInput(registry, "post", { mystery: "x" })).toThrow(
+      expect.objectContaining({
+        key: "mystery",
+        reason: "not_registered",
+      }),
+    );
+  });
+
+  test("key registered for a different post type → POST_TYPE_MISMATCH", () => {
+    const registry = registryWithMeta({
+      product_sku: { type: "string", postTypes: ["product"] },
+    });
+    expect(() =>
+      sanitizeMetaInput(registry, "post", { product_sku: "ABC" }),
+    ).toThrow(
+      expect.objectContaining({
+        key: "product_sku",
+        reason: "post_type_mismatch",
+      }),
+    );
+  });
+
+  test("custom sanitize fn runs after type coercion", () => {
+    const registry = registryWithMeta({
+      slug: {
+        type: "string",
+        sanitize: (value) =>
+          typeof value === "string" ? value.toLowerCase() : value,
+      },
+    });
+    const patch = sanitizeMetaInput(registry, "post", { slug: "HELLO" });
+    expect(patch?.upserts.get("slug")).toBe('"hello"');
+  });
+});
+
+describe("applyMetaPatch + loadPostMeta", () => {
+  test("upserts new rows, preserves existing keys outside the patch (partial write semantics)", async () => {
+    const plugins = registryWithMeta({
+      title: { type: "string" },
+      count: { type: "number" },
+      untouched: { type: "string" },
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const post = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "target",
+    });
+    // Seed one row that the patch should NOT touch.
+    await h.context.db
+      .insert(postMeta)
+      .values({ postId: post.id, key: "untouched", value: '"keep"' });
+
+    const patch = sanitizeMetaInput(plugins, post.type, {
+      title: "Written",
+      count: 7,
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await applyMetaPatch(h.context, post.id, patch);
+
+    const meta = await loadPostMeta(h.context.db, plugins, post.id);
+    expect(meta).toEqual({ title: "Written", count: 7, untouched: "keep" });
+  });
+
+  test("re-applying overwrites via ON CONFLICT (upsert) without duplicating rows", async () => {
+    const plugins = registryWithMeta({ title: { type: "string" } });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const post = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "upsert",
+    });
+
+    const first = sanitizeMetaInput(plugins, post.type, { title: "v1" });
+    const second = sanitizeMetaInput(plugins, post.type, { title: "v2" });
+    if (!first || !second) throw new Error("patches should not be null");
+    await applyMetaPatch(h.context, post.id, first);
+    await applyMetaPatch(h.context, post.id, second);
+
+    const rows = await h.context.db
+      .select()
+      .from(postMeta)
+      .where(eq(postMeta.postId, post.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.value).toBe('"v2"');
+  });
+
+  test("null value removes the row (caller opts out of the key)", async () => {
+    const plugins = registryWithMeta({ title: { type: "string" } });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const post = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "delete",
+    });
+
+    const set = sanitizeMetaInput(plugins, post.type, { title: "x" });
+    const clear = sanitizeMetaInput(plugins, post.type, { title: null });
+    if (!set || !clear) throw new Error("patches should not be null");
+    await applyMetaPatch(h.context, post.id, set);
+    await applyMetaPatch(h.context, post.id, clear);
+
+    const meta = await loadPostMeta(h.context.db, plugins, post.id);
+    expect(meta).toEqual({});
+  });
+});

--- a/packages/core/src/rpc/procedures/post/meta.test.ts
+++ b/packages/core/src/rpc/procedures/post/meta.test.ts
@@ -48,10 +48,10 @@ describe("sanitizeMetaInput", () => {
     expect(patch).toEqual({ upserts: new Map(), deletes: [] });
   });
 
-  test("string meta encodes as JSON so reads round-trip via JSON.parse", () => {
+  test("string meta passes through as a decoded string in the patch", () => {
     const registry = registryWithMeta({ title: { type: "string" } });
     const patch = sanitizeMetaInput(registry, "post", { title: "Hello" });
-    expect(patch?.upserts.get("title")).toBe('"Hello"');
+    expect(patch?.upserts.get("title")).toBe("Hello");
   });
 
   test("number meta rejects NaN / Infinity (they would poison JSON)", () => {
@@ -67,21 +67,32 @@ describe("sanitizeMetaInput", () => {
   test("number meta coerces numeric strings (admin may ship form-value strings)", () => {
     const registry = registryWithMeta({ count: { type: "number" } });
     const patch = sanitizeMetaInput(registry, "post", { count: "42" });
-    expect(patch?.upserts.get("count")).toBe("42");
+    expect(patch?.upserts.get("count")).toBe(42);
   });
 
-  test("boolean meta coerces 0/1 and 'true'/'false' for form-field compatibility", () => {
+  test("number meta rejects empty string (would silently coerce to 0 via Number(''))", () => {
+    const registry = registryWithMeta({ count: { type: "number" } });
+    expect(() => sanitizeMetaInput(registry, "post", { count: "" })).toThrow(
+      MetaSanitizationError,
+    );
+    expect(() => sanitizeMetaInput(registry, "post", { count: "   " })).toThrow(
+      MetaSanitizationError,
+    );
+  });
+
+  test("boolean meta accepts every common truthy/falsy form callers send", () => {
     const registry = registryWithMeta({ featured: { type: "boolean" } });
-    expect(
-      sanitizeMetaInput(registry, "post", { featured: 1 })?.upserts.get(
-        "featured",
-      ),
-    ).toBe("true");
-    expect(
-      sanitizeMetaInput(registry, "post", { featured: "false" })?.upserts.get(
-        "featured",
-      ),
-    ).toBe("false");
+    for (const truthy of [true, 1, "1", "true"]) {
+      const patch = sanitizeMetaInput(registry, "post", { featured: truthy });
+      expect(patch?.upserts.get("featured")).toBe(true);
+    }
+    for (const falsy of [false, 0, "0", "false"]) {
+      const patch = sanitizeMetaInput(registry, "post", { featured: falsy });
+      expect(patch?.upserts.get("featured")).toBe(false);
+    }
+    expect(() =>
+      sanitizeMetaInput(registry, "post", { featured: "yes" }),
+    ).toThrow(MetaSanitizationError);
   });
 
   test("json meta accepts nested structures, rejects non-serializable values", () => {
@@ -89,10 +100,21 @@ describe("sanitizeMetaInput", () => {
     const patch = sanitizeMetaInput(registry, "post", {
       config: { nested: { arr: [1, 2] } },
     });
-    expect(patch?.upserts.get("config")).toBe('{"nested":{"arr":[1,2]}}');
+    expect(patch?.upserts.get("config")).toEqual({ nested: { arr: [1, 2] } });
     expect(() =>
       sanitizeMetaInput(registry, "post", { config: () => 1 }),
     ).toThrow(MetaSanitizationError);
+  });
+
+  test("value exceeding the encoded-byte cap is rejected (DoS guard)", () => {
+    const registry = registryWithMeta({ blob: { type: "string" } });
+    // 256KiB cap + one extra char → just over. The encoded form adds two
+    // quote bytes around a raw string; we use 260k chars to comfortably
+    // exceed even the bare-length cap.
+    const tooBig = "x".repeat(260 * 1024);
+    expect(() => sanitizeMetaInput(registry, "post", { blob: tooBig })).toThrow(
+      expect.objectContaining({ reason: "value_too_large" }),
+    );
   });
 
   test("null / undefined values queue a delete rather than an upsert", () => {
@@ -141,7 +163,7 @@ describe("sanitizeMetaInput", () => {
       },
     });
     const patch = sanitizeMetaInput(registry, "post", { slug: "HELLO" });
-    expect(patch?.upserts.get("slug")).toBe('"hello"');
+    expect(patch?.upserts.get("slug")).toBe("hello");
   });
 });
 
@@ -211,5 +233,22 @@ describe("applyMetaPatch + loadPostMeta", () => {
 
     const meta = await loadPostMeta(h.context.db, plugins, post.id);
     expect(meta).toEqual({});
+  });
+
+  test("reads gracefully recover when a row has a non-JSON value (legacy writer)", async () => {
+    const plugins = registryWithMeta({ title: { type: "string" } });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const post = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "legacy",
+    });
+    // Simulate a row written before we settled on JSON encoding — raw
+    // string without surrounding quotes, so JSON.parse would throw.
+    await h.context.db
+      .insert(postMeta)
+      .values({ postId: post.id, key: "title", value: "raw-legacy" });
+
+    const meta = await loadPostMeta(h.context.db, plugins, post.id);
+    expect(meta).toEqual({ title: "raw-legacy" });
   });
 });

--- a/packages/core/src/rpc/procedures/post/meta.test.ts
+++ b/packages/core/src/rpc/procedures/post/meta.test.ts
@@ -191,7 +191,7 @@ describe("applyMetaPatch + loadPostMeta", () => {
     if (!patch) throw new Error("patch should not be null");
     await applyMetaPatch(h.context, post.id, patch);
 
-    const meta = await loadPostMeta(h.context.db, plugins, post.id);
+    const meta = await loadPostMeta(h.context, post.id);
     expect(meta).toEqual({ title: "Written", count: 7, untouched: "keep" });
   });
 
@@ -231,7 +231,7 @@ describe("applyMetaPatch + loadPostMeta", () => {
     await applyMetaPatch(h.context, post.id, set);
     await applyMetaPatch(h.context, post.id, clear);
 
-    const meta = await loadPostMeta(h.context.db, plugins, post.id);
+    const meta = await loadPostMeta(h.context, post.id);
     expect(meta).toEqual({});
   });
 
@@ -248,7 +248,7 @@ describe("applyMetaPatch + loadPostMeta", () => {
       .insert(postMeta)
       .values({ postId: post.id, key: "title", value: "raw-legacy" });
 
-    const meta = await loadPostMeta(h.context.db, plugins, post.id);
+    const meta = await loadPostMeta(h.context, post.id);
     expect(meta).toEqual({ title: "raw-legacy" });
   });
 });

--- a/packages/core/src/rpc/procedures/post/meta.ts
+++ b/packages/core/src/rpc/procedures/post/meta.ts
@@ -1,6 +1,6 @@
 import { sql } from "drizzle-orm";
 
-import type { AppContext, Db } from "../../../context/app.js";
+import type { AppContext } from "../../../context/app.js";
 import type {
   MetaScalarType,
   PluginRegistry,
@@ -8,8 +8,6 @@ import type {
 } from "../../../plugin/manifest.js";
 import { and, eq, inArray } from "../../../db/index.js";
 import { postMeta } from "../../../db/schema/post_meta.js";
-
-export type { PostWithMeta } from "../../../db/schema/posts.js";
 
 // The unfortunate truth about post meta is that the store is a single TEXT
 // column: we can only round-trip values via JSON. That's fine for what we
@@ -100,6 +98,43 @@ export class MetaSanitizationError extends Error {
     super(`meta key "${key}" failed sanitization: ${reason}`);
     this.key = key;
     this.reason = reason;
+  }
+}
+
+/**
+ * Minimum shape of the oRPC `errors` object needed to surface a
+ * `MetaSanitizationError` as a CONFLICT. Declared structurally so this
+ * helper doesn't have to import oRPC types — the handler passes its
+ * `errors` in and TS matches on shape.
+ */
+interface RpcErrorsForMeta {
+  CONFLICT: (args: {
+    data: { reason: string; key?: string };
+  }) => Error;
+}
+
+/**
+ * Thin wrapper around `sanitizeMetaInput` that translates a thrown
+ * `MetaSanitizationError` into the RPC handler's CONFLICT envelope.
+ * Keeps the per-handler call site to one line and localizes the
+ * `meta_${reason}` naming convention here instead of copy-pasting it
+ * into create.ts / update.ts.
+ */
+export function sanitizeMetaForRpc(
+  registry: PluginRegistry,
+  postType: string,
+  input: PostMetaMap | undefined,
+  errors: RpcErrorsForMeta,
+): MetaPatch | null {
+  try {
+    return sanitizeMetaInput(registry, postType, input);
+  } catch (error) {
+    if (error instanceof MetaSanitizationError) {
+      throw errors.CONFLICT({
+        data: { reason: `meta_${error.reason}`, key: error.key },
+      });
+    }
+    throw error;
   }
 }
 
@@ -232,17 +267,16 @@ function coerceOnRead(type: MetaScalarType, value: unknown): unknown {
  * `post.update` to populate the output envelope.
  */
 export async function loadPostMeta(
-  db: Db,
-  registry: PluginRegistry,
+  context: AppContext,
   postId: number,
 ): Promise<PostMetaMap> {
-  const rows = await db
+  const rows = await context.db
     .select({ key: postMeta.key, value: postMeta.value })
     .from(postMeta)
     .where(eq(postMeta.postId, postId));
   const out: PostMetaMap = {};
   for (const row of rows) {
-    out[row.key] = decodeMetaValue(registry, row.key, row.value);
+    out[row.key] = decodeMetaValue(context.plugins, row.key, row.value);
   }
   return out;
 }

--- a/packages/core/src/rpc/procedures/post/meta.ts
+++ b/packages/core/src/rpc/procedures/post/meta.ts
@@ -1,0 +1,251 @@
+import { sql } from "drizzle-orm";
+
+import type { AppContext, Db } from "../../../context/app.js";
+import type {
+  MetaScalarType,
+  PluginRegistry,
+  RegisteredMeta,
+} from "../../../plugin/manifest.js";
+import { and, eq, inArray } from "../../../db/index.js";
+import { postMeta } from "../../../db/schema/post_meta.js";
+
+export type { PostWithMeta } from "../../../db/schema/posts.js";
+
+// The unfortunate truth about post meta is that the store is a single TEXT
+// column: we can only round-trip values via JSON. That's fine for what we
+// support today (`string` / `number` / `boolean` / `json`) but we pay for
+// it with an encode/decode pair and an allowlist of types the registry is
+// willing to hydrate on read.
+
+type PostMetaMap = Record<string, unknown>;
+
+/**
+ * Validation outcome for a meta patch before we touch the DB. We split
+ * `upserts` (key → encoded JSON string) from `deletes` so the handler can
+ * issue a single upsert statement and a single delete-by-keys statement.
+ */
+interface MetaPatch {
+  readonly upserts: ReadonlyMap<string, string>;
+  readonly deletes: readonly string[];
+}
+
+/**
+ * Validate an incoming meta map against the plugin registry and produce a
+ * DB-ready patch. Unregistered keys, keys registered for a different
+ * post type, and type-coercion failures all throw so the caller can
+ * surface them as 4xx before any write. `null` values are deletion
+ * requests; everything else is coerced + encoded.
+ */
+export function sanitizeMetaInput(
+  registry: PluginRegistry,
+  postType: string,
+  input: PostMetaMap | undefined,
+): MetaPatch | null {
+  if (input === undefined) return null;
+  const upserts = new Map<string, string>();
+  const deletes: string[] = [];
+  for (const [key, rawValue] of Object.entries(input)) {
+    const definition = registry.metaKeys.get(key);
+    if (!definition) {
+      throw new MetaSanitizationError(key, "not_registered");
+    }
+    if (!definition.postTypes.includes(postType)) {
+      throw new MetaSanitizationError(key, "post_type_mismatch");
+    }
+    if (rawValue === null || rawValue === undefined) {
+      deletes.push(key);
+      continue;
+    }
+    const coerced = coerceToType(definition, rawValue);
+    const sanitized = definition.sanitize
+      ? definition.sanitize(coerced)
+      : coerced;
+    upserts.set(key, encodeMetaValue(sanitized));
+  }
+  return { upserts, deletes };
+}
+
+/**
+ * Reason codes are part of the RPC error `data.reason` surface — admin
+ * UIs and plugin tests match on these strings, so treat them as a
+ * public contract.
+ */
+type MetaSanitizationReason =
+  | "not_registered"
+  | "post_type_mismatch"
+  | "invalid_value";
+
+export class MetaSanitizationError extends Error {
+  readonly key: string;
+  readonly reason: MetaSanitizationReason;
+  constructor(key: string, reason: MetaSanitizationReason) {
+    super(`meta key "${key}" failed sanitization: ${reason}`);
+    this.key = key;
+    this.reason = reason;
+  }
+}
+
+function coerceToType(definition: RegisteredMeta, value: unknown): unknown {
+  switch (definition.type) {
+    case "string":
+      return coerceString(definition.key, value);
+    case "number":
+      return coerceNumber(definition.key, value);
+    case "boolean":
+      return coerceBoolean(definition.key, value);
+    case "json":
+      return coerceJson(definition.key, value);
+  }
+}
+
+function coerceString(key: string, value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value === "boolean") return String(value);
+  throw new MetaSanitizationError(key, "invalid_value");
+}
+
+function coerceNumber(key: string, value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  if (typeof value === "boolean") return value ? 1 : 0;
+  throw new MetaSanitizationError(key, "invalid_value");
+}
+
+function coerceBoolean(key: string, value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (value === "true" || value === 1) return true;
+  if (value === "false" || value === 0) return false;
+  throw new MetaSanitizationError(key, "invalid_value");
+}
+
+function coerceJson(key: string, value: unknown): unknown {
+  // json keys take anything round-trippable through JSON.stringify — we
+  // reject values that throw (BigInt) or silently drop (functions,
+  // Symbols) so reads don't hand back `undefined` for something a plugin
+  // thought it stored. TS types JSON.stringify as always-string, but at
+  // runtime it returns `undefined` for un-serializable inputs — hence
+  // the cast.
+  try {
+    const encoded = JSON.stringify(value) as string | undefined;
+    if (encoded === undefined) {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+    return JSON.parse(encoded);
+  } catch {
+    throw new MetaSanitizationError(key, "invalid_value");
+  }
+}
+
+function encodeMetaValue(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * Decode one row's stored value against its registered type. Unregistered
+ * keys fall through as raw strings — the row exists in the DB but the
+ * plugin that wrote it is no longer installed; we don't pretend to know
+ * its shape.
+ */
+function decodeMetaValue(
+  registry: PluginRegistry,
+  key: string,
+  raw: string,
+): unknown {
+  const definition = registry.metaKeys.get(key);
+  if (!definition) {
+    // Best-effort parse so plugin authors can still see the data during
+    // migration; fall back to the raw string if it was stored before we
+    // settled on JSON encoding.
+    return tryParseJson(raw, raw);
+  }
+  const parsed = tryParseJson(raw, raw);
+  return coerceOnRead(definition.type, parsed);
+}
+
+function tryParseJson(raw: string, fallback: unknown): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function coerceOnRead(type: MetaScalarType, value: unknown): unknown {
+  // Reads are forgiving — the row was validated on write but a schema
+  // change (e.g. a plugin flipping `number` → `string`) shouldn't 500 the
+  // editor. We coerce when we can and fall through to the raw value
+  // otherwise.
+  switch (type) {
+    case "string":
+      return typeof value === "string" ? value : String(value);
+    case "number":
+      return typeof value === "number" ? value : Number(value);
+    case "boolean":
+      return typeof value === "boolean" ? value : Boolean(value);
+    case "json":
+      return value;
+  }
+}
+
+/**
+ * Load the full meta bag for a single post. Returns an empty object when
+ * the post has no meta rows. Used by `post.get` / `post.create` /
+ * `post.update` to populate the output envelope.
+ */
+export async function loadPostMeta(
+  db: Db,
+  registry: PluginRegistry,
+  postId: number,
+): Promise<PostMetaMap> {
+  const rows = await db
+    .select({ key: postMeta.key, value: postMeta.value })
+    .from(postMeta)
+    .where(eq(postMeta.postId, postId));
+  const out: PostMetaMap = {};
+  for (const row of rows) {
+    out[row.key] = decodeMetaValue(registry, row.key, row.value);
+  }
+  return out;
+}
+
+/**
+ * Apply a validated patch to the meta store. Partial semantics: keys not
+ * mentioned in the patch are untouched. Deletes run first so a caller
+ * that clears and re-sets the same key in one request behaves
+ * predictably. Follows `applyTermPatch`'s "no transaction" pattern —
+ * SQLite's D1 binding doesn't expose nested transactions cleanly, and
+ * the existing terms path already accepts the same tradeoff.
+ */
+export async function applyMetaPatch(
+  context: AppContext,
+  postId: number,
+  patch: MetaPatch,
+): Promise<void> {
+  if (patch.deletes.length > 0) {
+    await context.db
+      .delete(postMeta)
+      .where(
+        and(eq(postMeta.postId, postId), inArray(postMeta.key, patch.deletes)),
+      );
+  }
+  if (patch.upserts.size === 0) return;
+  const rows = Array.from(patch.upserts, ([key, value]) => ({
+    postId,
+    key,
+    value,
+  }));
+  // `excluded.value` is SQLite's idiomatic "use the incoming INSERT row's
+  // value" in an ON CONFLICT clause — the upsert target is the unique
+  // (postId, key) index.
+  await context.db
+    .insert(postMeta)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: [postMeta.postId, postMeta.key],
+      set: { value: sql`excluded.value` },
+    });
+}

--- a/packages/core/src/rpc/procedures/post/meta.ts
+++ b/packages/core/src/rpc/procedures/post/meta.ts
@@ -108,9 +108,7 @@ export class MetaSanitizationError extends Error {
  * `errors` in and TS matches on shape.
  */
 interface RpcErrorsForMeta {
-  CONFLICT: (args: {
-    data: { reason: string; key?: string };
-  }) => Error;
+  CONFLICT: (args: { data: { reason: string; key?: string } }) => Error;
 }
 
 /**

--- a/packages/core/src/rpc/procedures/post/meta.ts
+++ b/packages/core/src/rpc/procedures/post/meta.ts
@@ -17,15 +17,28 @@ export type { PostWithMeta } from "../../../db/schema/posts.js";
 // it with an encode/decode pair and an allowlist of types the registry is
 // willing to hydrate on read.
 
+/**
+ * Hard cap on the JSON-encoded size of a single meta value, in bytes.
+ * 256KiB fits any realistic plugin-shaped JSON config while bounding the
+ * damage an adversarial writer can do — WordPress's TEXT column tops out
+ * around 64KiB, so this is already more generous than the incumbent.
+ * Enforced in `coerceToType` rather than the valibot schema so plugin
+ * authors can calibrate per key via a custom `sanitize` if they need
+ * tighter bounds.
+ */
+const MAX_META_VALUE_BYTES = 256 * 1024;
+
 type PostMetaMap = Record<string, unknown>;
 
 /**
- * Validation outcome for a meta patch before we touch the DB. We split
- * `upserts` (key → encoded JSON string) from `deletes` so the handler can
- * issue a single upsert statement and a single delete-by-keys statement.
+ * Validated meta patch produced by `sanitizeMetaInput`. Values in
+ * `upserts` are the *decoded* post-sanitization objects — the `MetaPatch`
+ * is what filter hooks see, so keeping decoded values here means a
+ * plugin doesn't have to double-parse. `applyMetaPatch` JSON-encodes at
+ * the last moment, before the INSERT.
  */
-interface MetaPatch {
-  readonly upserts: ReadonlyMap<string, string>;
+export interface MetaPatch {
+  readonly upserts: ReadonlyMap<string, unknown>;
   readonly deletes: readonly string[];
 }
 
@@ -33,8 +46,8 @@ interface MetaPatch {
  * Validate an incoming meta map against the plugin registry and produce a
  * DB-ready patch. Unregistered keys, keys registered for a different
  * post type, and type-coercion failures all throw so the caller can
- * surface them as 4xx before any write. `null` values are deletion
- * requests; everything else is coerced + encoded.
+ * surface them as 4xx before any write. `null` / `undefined` values are
+ * deletion requests; everything else is coerced + sanitized.
  */
 export function sanitizeMetaInput(
   registry: PluginRegistry,
@@ -42,7 +55,7 @@ export function sanitizeMetaInput(
   input: PostMetaMap | undefined,
 ): MetaPatch | null {
   if (input === undefined) return null;
-  const upserts = new Map<string, string>();
+  const upserts = new Map<string, unknown>();
   const deletes: string[] = [];
   for (const [key, rawValue] of Object.entries(input)) {
     const definition = registry.metaKeys.get(key);
@@ -60,7 +73,11 @@ export function sanitizeMetaInput(
     const sanitized = definition.sanitize
       ? definition.sanitize(coerced)
       : coerced;
-    upserts.set(key, encodeMetaValue(sanitized));
+    // Encoded-size check guards the DB against a 10MB-in-one-request abuse
+    // path. Re-encoding in applyMetaPatch is cheap so we accept the double
+    // stringify rather than threading the encoded string through the patch.
+    assertEncodedSize(key, sanitized);
+    upserts.set(key, sanitized);
   }
   return { upserts, deletes };
 }
@@ -73,7 +90,8 @@ export function sanitizeMetaInput(
 type MetaSanitizationReason =
   | "not_registered"
   | "post_type_mismatch"
-  | "invalid_value";
+  | "invalid_value"
+  | "value_too_large";
 
 export class MetaSanitizationError extends Error {
   readonly key: string;
@@ -108,8 +126,14 @@ function coerceString(key: string, value: unknown): string {
 function coerceNumber(key: string, value: unknown): number {
   if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string") {
-    const n = Number(value);
-    if (Number.isFinite(n)) return n;
+    // Empty string comes from cleared form inputs; the admin dispatcher
+    // already sends `null` for those, but a direct RPC caller might send
+    // "" — reject here so we don't silently coerce to 0 (`Number("") === 0`).
+    if (value.trim() === "") {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
   }
   if (typeof value === "boolean") return value ? 1 : 0;
   throw new MetaSanitizationError(key, "invalid_value");
@@ -117,8 +141,12 @@ function coerceNumber(key: string, value: unknown): number {
 
 function coerceBoolean(key: string, value: unknown): boolean {
   if (typeof value === "boolean") return value;
-  if (value === "true" || value === 1) return true;
-  if (value === "false" || value === 0) return false;
+  // Accept the common truthy/falsy forms from form-encoded and query-string
+  // callers — 0/1 (numeric or stringified) and "true"/"false". Anything else
+  // is rejected so `"yes"` / `"off"` don't silently become booleans of
+  // surprising polarity.
+  if (value === 1 || value === "1" || value === "true") return true;
+  if (value === 0 || value === "0" || value === "false") return false;
   throw new MetaSanitizationError(key, "invalid_value");
 }
 
@@ -140,8 +168,15 @@ function coerceJson(key: string, value: unknown): unknown {
   }
 }
 
-function encodeMetaValue(value: unknown): string {
-  return JSON.stringify(value);
+function assertEncodedSize(key: string, value: unknown): void {
+  const encoded = JSON.stringify(value) as string | undefined;
+  if (encoded === undefined) return; // already caught in coerceJson
+  // `TextEncoder.encode(...).length` is the canonical UTF-8 byte length;
+  // avoids a `Buffer` dependency (which we don't have in workers anyway).
+  const byteLength = new TextEncoder().encode(encoded).length;
+  if (byteLength > MAX_META_VALUE_BYTES) {
+    throw new MetaSanitizationError(key, "value_too_large");
+  }
 }
 
 /**
@@ -213,6 +248,17 @@ export async function loadPostMeta(
 }
 
 /**
+ * True when the patch would result in any DB writes. Handlers use this to
+ * skip the short-circuit that's optimized for "no post change, no term
+ * change, no meta change" requests.
+ */
+export function isEmptyMetaPatch(patch: MetaPatch | null): boolean {
+  return (
+    patch === null || (patch.upserts.size === 0 && patch.deletes.length === 0)
+  );
+}
+
+/**
  * Apply a validated patch to the meta store. Partial semantics: keys not
  * mentioned in the patch are untouched. Deletes run first so a caller
  * that clears and re-sets the same key in one request behaves
@@ -236,7 +282,7 @@ export async function applyMetaPatch(
   const rows = Array.from(patch.upserts, ([key, value]) => ({
     postId,
     key,
-    value,
+    value: JSON.stringify(value),
   }));
   // `excluded.value` is SQLite's idiomatic "use the incoming INSERT row's
   // value" in an ON CONFLICT clause — the upsert target is the unique
@@ -248,4 +294,57 @@ export async function applyMetaPatch(
       target: [postMeta.postId, postMeta.key],
       set: { value: sql`excluded.value` },
     });
+}
+
+/**
+ * Fire the extension surface around a meta write: `rpc:post.meta:write`
+ * lets plugins mutate or short-circuit a patch before it hits the DB;
+ * `post.meta:updated` (with the CPT-scoped variant) fires after the write
+ * so auditors / cache-invalidators can react. Kept in one place so the
+ * create + update handlers stay thin.
+ */
+export async function writePostMetaWithHooks(
+  context: AppContext,
+  post: { id: number; type: string },
+  patch: MetaPatch,
+): Promise<void> {
+  const filtered = await context.hooks.applyFilter(
+    "rpc:post.meta:write",
+    patch,
+    post,
+  );
+  if (isEmptyMetaPatch(filtered)) return;
+  await applyMetaPatch(context, post.id, filtered);
+
+  const changes: PostMetaChanges = {
+    set: Object.fromEntries(filtered.upserts),
+    removed: [...filtered.deletes],
+  };
+  await context.hooks.doAction("post:meta_changed", post, changes);
+}
+
+/**
+ * Payload for `post.meta:updated` (and CPT-scoped variant). `set` is the
+ * decoded key → value map of upserts; `removed` is the list of cleared
+ * keys. Plugins that need the old values should subscribe to the write
+ * filter and snapshot themselves — the action is strictly "what just
+ * happened".
+ */
+export interface PostMetaChanges {
+  readonly set: Readonly<Record<string, unknown>>;
+  readonly removed: readonly string[];
+}
+
+/**
+ * Run the `rpc:post.meta:read` filter on a freshly-loaded meta bag.
+ * Plugins can decorate (add derived keys), redact (drop secrets), or
+ * replace the bag entirely — it's the post-read equivalent of the write
+ * filter.
+ */
+export async function applyPostMetaReadFilter(
+  context: AppContext,
+  post: { id: number; type: string },
+  meta: PostMetaMap,
+): Promise<PostMetaMap> {
+  return context.hooks.applyFilter("rpc:post.meta:read", meta, post);
 }

--- a/packages/core/src/rpc/procedures/post/read.test.ts
+++ b/packages/core/src/rpc/procedures/post/read.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "vitest";
 
+import { postMeta } from "../../../db/schema/post_meta.js";
 import { postTerm } from "../../../db/schema/post_term.js";
 import { terms } from "../../../db/schema/terms.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
 async function seedTerm(
@@ -526,5 +528,38 @@ describe("post.get", () => {
     });
     const got = await h.client.post.get({ id: theirs.id });
     expect(got.id).toBe(theirs.id);
+  });
+
+  test("response includes a `meta` bag — empty object when the post has no rows", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const post = await h.factory.published.create({ authorId: h.user.id });
+    const got = await h.client.post.get({ id: post.id });
+    expect(got.meta).toEqual({});
+  });
+
+  test("response hydrates meta rows, typed against the plugin registry", async () => {
+    const plugins = createPluginRegistry();
+    plugins.metaKeys.set("meta_title", {
+      key: "meta_title",
+      type: "string",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    plugins.metaKeys.set("is_featured", {
+      key: "is_featured",
+      type: "boolean",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const post = await h.factory.published.create({ authorId: h.user.id });
+    // Write directly to the DB (bypassing the RPC sanitizer) to prove the
+    // reader decodes what the writer laid down.
+    await h.context.db.insert(postMeta).values([
+      { postId: post.id, key: "meta_title", value: '"Seeded"' },
+      { postId: post.id, key: "is_featured", value: "true" },
+    ]);
+    const got = await h.client.post.get({ id: post.id });
+    expect(got.meta).toEqual({ meta_title: "Seeded", is_featured: true });
   });
 });

--- a/packages/core/src/rpc/procedures/post/schemas.ts
+++ b/packages/core/src/rpc/procedures/post/schemas.ts
@@ -45,6 +45,30 @@ const postTermsSchema = v.record(
   v.pipe(v.array(termIdSchema), v.maxLength(MAX_TERMS_PER_TAXONOMY)),
 );
 
+// Meta bag accepted by `post.create` / `post.update`. Per-key validation
+// happens in the handler against the plugin-registered `MetaScalarType`
+// — here we only enforce the outer shape + a defensive cap on the
+// number of keys per request so a malformed client can't ship a 10k-key
+// object at us. Values stay `unknown` because the registry drives their
+// shape.
+const MAX_META_KEYS_PER_REQUEST = 200;
+
+const metaKeySchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(200),
+  v.regex(/^[a-zA-Z0-9_:-]+$/, "meta key must be alphanumeric/_/:/-"),
+);
+
+const postMetaInputSchema = v.pipe(
+  v.record(metaKeySchema, v.unknown()),
+  v.check(
+    (val) => Object.keys(val).length <= MAX_META_KEYS_PER_REQUEST,
+    `meta accepts at most ${MAX_META_KEYS_PER_REQUEST} keys per request`,
+  ),
+);
+
 export const postCreateInputSchema = v.object({
   ...userSuppliableFields.entries,
   type: v.optional(trimmedText(100), "post"),
@@ -54,6 +78,7 @@ export const postCreateInputSchema = v.object({
   excerpt: v.optional(excerptSchema),
   status: v.optional(userSuppliableFields.entries.status, "draft"),
   menuOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+  meta: v.optional(postMetaInputSchema),
 });
 
 export const postUpdateInputSchema = v.object({
@@ -66,6 +91,7 @@ export const postUpdateInputSchema = v.object({
   parentId: v.optional(v.nullable(postIdSchema)),
   menuOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
   terms: v.optional(postTermsSchema),
+  meta: v.optional(postMetaInputSchema),
 });
 
 // Upper bound on the term-slug list per taxonomy clause. Mirrors the

--- a/packages/core/src/rpc/procedures/post/update.test.ts
+++ b/packages/core/src/rpc/procedures/post/update.test.ts
@@ -350,4 +350,78 @@ describe("post.update", () => {
     const reloaded = await h.client.post.get({ id: post.id });
     expect(reloaded.title).toBe("p3");
   });
+
+  test("meta hooks: rpc:post.meta:write can rewrite a patch; post.meta:updated fires with the final bag", async () => {
+    const plugins = createPluginRegistry();
+    plugins.metaKeys.set("title", {
+      key: "title",
+      type: "string",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    plugins.metaKeys.set("title_lc", {
+      key: "title_lc",
+      type: "string",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    // Plugin that mirrors `title` into `title_lc` on every write — a
+    // realistic use of the write filter (derived / normalized field).
+    h.hooks.addFilter("rpc:post.meta:write", (patch) => {
+      const title = patch.upserts.get("title");
+      if (typeof title !== "string") return patch;
+      const upserts = new Map(patch.upserts);
+      upserts.set("title_lc", title.toLowerCase());
+      return { ...patch, upserts };
+    });
+    const onUpdated = h.spyAction("post:meta_changed");
+
+    const post = await h.client.post.create({ title: "p", slug: "p" });
+    await h.client.post.update({
+      id: post.id,
+      meta: { title: "SHOUTING" },
+    });
+
+    const reloaded = await h.client.post.get({ id: post.id });
+    expect(reloaded.meta).toEqual({
+      title: "SHOUTING",
+      title_lc: "shouting",
+    });
+    // Create had no meta → write filter / action didn't fire for it.
+    // The update is the only meta-bearing call, so the action fired once
+    // with the filter's augmented changes.
+    onUpdated.assertCalledOnce();
+    expect(onUpdated.lastArgs?.[1]).toEqual({
+      set: { title: "SHOUTING", title_lc: "shouting" },
+      removed: [],
+    });
+  });
+
+  test("meta hooks: rpc:post.meta:read can decorate the bag without touching storage", async () => {
+    const plugins = createPluginRegistry();
+    plugins.metaKeys.set("title", {
+      key: "title",
+      type: "string",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    h.hooks.addFilter("rpc:post.meta:read", (meta) => ({
+      ...meta,
+      _derived: "always-there",
+    }));
+
+    const post = await h.client.post.create({
+      title: "p",
+      slug: "p",
+      meta: { title: "stored" },
+    });
+    expect(post.meta).toEqual({ title: "stored", _derived: "always-there" });
+    const refetched = await h.client.post.get({ id: post.id });
+    expect(refetched.meta).toEqual({
+      title: "stored",
+      _derived: "always-there",
+    });
+  });
 });

--- a/packages/core/src/rpc/procedures/post/update.test.ts
+++ b/packages/core/src/rpc/procedures/post/update.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { posts } from "../../../db/schema/posts.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
 describe("post.update", () => {
@@ -272,5 +273,81 @@ describe("post.update", () => {
       code: "CONFLICT",
       data: { reason: "parent_cycle" },
     });
+  });
+
+  test("meta: partial write leaves keys outside the patch untouched", async () => {
+    const plugins = createPluginRegistry();
+    plugins.metaKeys.set("meta_title", {
+      key: "meta_title",
+      type: "string",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    plugins.metaKeys.set("is_featured", {
+      key: "is_featured",
+      type: "boolean",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const post = await h.client.post.create({
+      title: "p",
+      slug: "p",
+      meta: { meta_title: "seed title", is_featured: false },
+    });
+
+    const updated = await h.client.post.update({
+      id: post.id,
+      meta: { is_featured: true },
+    });
+    expect(updated.meta).toEqual({
+      meta_title: "seed title",
+      is_featured: true,
+    });
+  });
+
+  test("meta: null value clears a key without touching the others", async () => {
+    const plugins = createPluginRegistry();
+    plugins.metaKeys.set("meta_title", {
+      key: "meta_title",
+      type: "string",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    plugins.metaKeys.set("is_featured", {
+      key: "is_featured",
+      type: "boolean",
+      postTypes: ["post"],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const post = await h.client.post.create({
+      title: "p2",
+      slug: "p2",
+      meta: { meta_title: "keep", is_featured: true },
+    });
+
+    const updated = await h.client.post.update({
+      id: post.id,
+      meta: { is_featured: null },
+    });
+    expect(updated.meta).toEqual({ meta_title: "keep" });
+  });
+
+  test("meta: bad key → CONFLICT, and the post row is untouched (validated pre-write)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const post = await h.client.post.create({ title: "p3", slug: "p3" });
+    await expect(
+      h.client.post.update({
+        id: post.id,
+        title: "new-title",
+        meta: { bogus: "x" },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "meta_not_registered", key: "bogus" },
+    });
+    const reloaded = await h.client.post.get({ id: post.id });
+    expect(reloaded.title).toBe("p3");
   });
 });

--- a/packages/core/src/rpc/procedures/post/update.ts
+++ b/packages/core/src/rpc/procedures/post/update.ts
@@ -22,6 +22,12 @@ import {
   postCapability,
   wouldCreateParentCycle,
 } from "./lifecycle.js";
+import {
+  applyMetaPatch,
+  loadPostMeta,
+  MetaSanitizationError,
+  sanitizeMetaInput,
+} from "./meta.js";
 import { postUpdateInputSchema } from "./schemas.js";
 
 export const update = base
@@ -85,9 +91,26 @@ export const update = base
       }
     }
 
-    // `terms` isn't a posts.* column — split it out and validate up front so
-    // a bad taxonomy or cap error fails fast, before any write happens.
-    const { id: _id, terms: termsPatch, ...changes } = filtered;
+    // `terms` and `meta` aren't posts.* columns — split them out and
+    // validate up front so a bad taxonomy/cap/meta key fails fast,
+    // before any write happens.
+    const {
+      id: _id,
+      terms: termsPatch,
+      meta: metaInput,
+      ...changes
+    } = filtered;
+    let metaPatch;
+    try {
+      metaPatch = sanitizeMetaInput(context.plugins, existing.type, metaInput);
+    } catch (error) {
+      if (error instanceof MetaSanitizationError) {
+        throw errors.CONFLICT({
+          data: { reason: `meta_${error.reason}`, key: error.key },
+        });
+      }
+      throw error;
+    }
     if (termsPatch !== undefined) {
       for (const taxonomy of Object.keys(termsPatch)) {
         if (!context.plugins.taxonomies.has(taxonomy)) {
@@ -116,9 +139,18 @@ export const update = base
       patch.publishedAt = new Date();
     }
 
-    // Nothing to write anywhere? Short-circuit without firing hooks.
-    if (Object.keys(patch).length === 0 && termsPatch === undefined) {
-      return context.hooks.applyFilter("rpc:post.update:output", existing);
+    // Nothing to write anywhere? Short-circuit without firing hooks, but
+    // still return the current meta so callers get a consistent shape.
+    if (
+      Object.keys(patch).length === 0 &&
+      termsPatch === undefined &&
+      metaPatch === null
+    ) {
+      const meta = await loadPostMeta(context.db, context.plugins, existing.id);
+      return context.hooks.applyFilter("rpc:post.update:output", {
+        ...existing,
+        meta,
+      });
     }
 
     let updated = existing;
@@ -174,6 +206,11 @@ export const update = base
       await applyTermPatch(context, updated.id, termsPatch);
     }
 
+    if (metaPatch) {
+      await applyMetaPatch(context, updated.id, metaPatch);
+    }
+    const meta = await loadPostMeta(context.db, context.plugins, updated.id);
+
     if (postColumnsWritten) {
       await firePostUpdated(context, updated, existing);
       await firePostTransition(context, updated, existing.status);
@@ -182,7 +219,10 @@ export const update = base
       }
     }
 
-    return context.hooks.applyFilter("rpc:post.update:output", updated);
+    return context.hooks.applyFilter("rpc:post.update:output", {
+      ...updated,
+      meta,
+    });
   });
 
 /** Replace post_term rows for every (postId, taxonomy) pair in the patch. */

--- a/packages/core/src/rpc/procedures/post/update.ts
+++ b/packages/core/src/rpc/procedures/post/update.ts
@@ -26,8 +26,7 @@ import {
   applyPostMetaReadFilter,
   isEmptyMetaPatch,
   loadPostMeta,
-  MetaSanitizationError,
-  sanitizeMetaInput,
+  sanitizeMetaForRpc,
   writePostMetaWithHooks,
 } from "./meta.js";
 import { postUpdateInputSchema } from "./schemas.js";
@@ -102,17 +101,12 @@ export const update = base
       meta: metaInput,
       ...changes
     } = filtered;
-    let metaPatch;
-    try {
-      metaPatch = sanitizeMetaInput(context.plugins, existing.type, metaInput);
-    } catch (error) {
-      if (error instanceof MetaSanitizationError) {
-        throw errors.CONFLICT({
-          data: { reason: `meta_${error.reason}`, key: error.key },
-        });
-      }
-      throw error;
-    }
+    const metaPatch = sanitizeMetaForRpc(
+      context.plugins,
+      existing.type,
+      metaInput,
+      errors,
+    );
     if (termsPatch !== undefined) {
       for (const taxonomy of Object.keys(termsPatch)) {
         if (!context.plugins.taxonomies.has(taxonomy)) {
@@ -150,11 +144,7 @@ export const update = base
       termsPatch === undefined &&
       isEmptyMetaPatch(metaPatch)
     ) {
-      const loaded = await loadPostMeta(
-        context.db,
-        context.plugins,
-        existing.id,
-      );
+      const loaded = await loadPostMeta(context, existing.id);
       const meta = await applyPostMetaReadFilter(context, existing, loaded);
       return context.hooks.applyFilter("rpc:post.update:output", {
         ...existing,
@@ -215,10 +205,12 @@ export const update = base
       await applyTermPatch(context, updated.id, termsPatch);
     }
 
-    if (metaPatch && !isEmptyMetaPatch(metaPatch)) {
+    // `writePostMetaWithHooks` is a no-op on an empty patch, so the null
+    // check here is the only gate we need — no separate empty-patch check.
+    if (metaPatch) {
       await writePostMetaWithHooks(context, updated, metaPatch);
     }
-    const loaded = await loadPostMeta(context.db, context.plugins, updated.id);
+    const loaded = await loadPostMeta(context, updated.id);
     const meta = await applyPostMetaReadFilter(context, updated, loaded);
 
     if (postColumnsWritten) {

--- a/packages/core/src/rpc/procedures/post/update.ts
+++ b/packages/core/src/rpc/procedures/post/update.ts
@@ -23,10 +23,12 @@ import {
   wouldCreateParentCycle,
 } from "./lifecycle.js";
 import {
-  applyMetaPatch,
+  applyPostMetaReadFilter,
+  isEmptyMetaPatch,
   loadPostMeta,
   MetaSanitizationError,
   sanitizeMetaInput,
+  writePostMetaWithHooks,
 } from "./meta.js";
 import { postUpdateInputSchema } from "./schemas.js";
 
@@ -140,13 +142,20 @@ export const update = base
     }
 
     // Nothing to write anywhere? Short-circuit without firing hooks, but
-    // still return the current meta so callers get a consistent shape.
+    // still return the current meta so callers get a consistent shape. An
+    // empty meta map from the client (e.g. admin always sending `meta: {}`)
+    // counts as no-op on the meta side too.
     if (
       Object.keys(patch).length === 0 &&
       termsPatch === undefined &&
-      metaPatch === null
+      isEmptyMetaPatch(metaPatch)
     ) {
-      const meta = await loadPostMeta(context.db, context.plugins, existing.id);
+      const loaded = await loadPostMeta(
+        context.db,
+        context.plugins,
+        existing.id,
+      );
+      const meta = await applyPostMetaReadFilter(context, existing, loaded);
       return context.hooks.applyFilter("rpc:post.update:output", {
         ...existing,
         meta,
@@ -206,10 +215,11 @@ export const update = base
       await applyTermPatch(context, updated.id, termsPatch);
     }
 
-    if (metaPatch) {
-      await applyMetaPatch(context, updated.id, metaPatch);
+    if (metaPatch && !isEmptyMetaPatch(metaPatch)) {
+      await writePostMetaWithHooks(context, updated, metaPatch);
     }
-    const meta = await loadPostMeta(context.db, context.plugins, updated.id);
+    const loaded = await loadPostMeta(context.db, context.plugins, updated.id);
+    const meta = await applyPostMetaReadFilter(context, updated, loaded);
 
     if (postColumnsWritten) {
       await firePostUpdated(context, updated, existing);


### PR DESCRIPTION
## Summary

- `post.create` / `post.update` now accept a `meta: Record<string, unknown>` field and write it to `post_meta` after validating each key against `context.plugins.metaKeys` (`registerMeta` registry) — coerced by registered `MetaScalarType`, run through any per-key `sanitize`, upserted via SQLite `ON CONFLICT (postId, key) DO UPDATE SET value = excluded.value`. `null` values queue a DELETE so clients can clear keys cleanly.
- `post.get` returns the row plus a decoded `meta` bag so the editor hydrates in one round-trip. `PostWithMeta` lives on `@plumix/core/schema`.
- Admin routes (`new.tsx`, `$id.tsx`) forward `values.meta` into the mutation and seed `toEditorValues` from `post.meta`. The meta-box UI shipped in #45 was dropping values on submit; it now round-trips.

## Notes

- **Validation placement:** meta keys fail fast *before* the post insert / update, same pattern as `terms`. A typo in a meta key won't leave the post row in an inconsistent state.
- **Error shape:** CONFLICT gains an optional `key` field; `meta_not_registered`, `meta_post_type_mismatch`, `meta_invalid_value` reasons point the client at the offending key.
- **Storage format:** values are JSON-encoded (so numbers / booleans / nested JSON all round-trip). Reads decode and coerce to the registered type; unknown keys fall through as raw strings so a plugin-removed key's data stays legible during migration.
- **Per-request cap:** 200 meta keys per create/update. Above reasonable UI limits but bounds the upsert payload.

## Test plan

- [x] 14 unit tests in `meta.test.ts` — coercion per `MetaScalarType`, null/undefined → delete, unregistered key / wrong post type / non-serializable values → error, `applyMetaPatch` upsert + partial-write + delete semantics
- [x] 5 RPC integration tests across `create.test.ts` / `update.test.ts` / `read.test.ts` — create with meta, partial update, null clears a key, bad key raises CONFLICT + leaves post row untouched, `post.get` hydrates rows written directly to the DB
- [x] E2E (`editor.spec.ts`) fills a text + checkbox meta field, asserts the `post.create` input carries them, and the subsequent edit-page load hydrates them back
- [x] All 32 workspace tasks pass (typecheck + lint + test + format)