### PR TITLE
feat(admin,core): users admin — list + invite + accept-invite flow

### DIFF
--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -2,7 +2,7 @@ import type { Page, Route } from "@playwright/test";
 
 import type { AuthSessionOutput } from "@plumix/core";
 import type { PlumixManifest } from "@plumix/core/manifest";
-import type { Post } from "@plumix/core/schema";
+import type { Post, User } from "@plumix/core/schema";
 
 // The e2e webServer is just Vite — no real backend — so every /_plumix/rpc
 // call is intercepted here and answered with a deterministic fixture.
@@ -17,6 +17,8 @@ import type { Post } from "@plumix/core/schema";
 interface MockRpcHandlers {
   "/auth/session"?: AuthSessionOutput;
   "/post/list"?: readonly Post[];
+  "/user/list"?: readonly User[];
+  "/user/invite"?: { user: User; inviteToken: string };
 }
 
 // oRPC's StandardRPCSerializer wire format — `meta` is always present,

--- a/packages/admin/e2e/users.spec.ts
+++ b/packages/admin/e2e/users.spec.ts
@@ -1,0 +1,246 @@
+import { expect, test } from "@playwright/test";
+
+import type { User } from "@plumix/core/schema";
+
+import { AUTHED_ADMIN, mockRpc } from "./support/rpc-mock.js";
+
+function user(overrides: Partial<User> & { id: number; email: string }): User {
+  return {
+    name: null,
+    avatarUrl: null,
+    role: "subscriber",
+    emailVerifiedAt: new Date("2026-04-20T00:00:00Z"),
+    disabledAt: null,
+    createdAt: new Date("2026-04-20T00:00:00Z"),
+    updatedAt: new Date("2026-04-20T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+test.describe("/users", () => {
+  test("renders the admin's own row + invited users, gated by user:list", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/user/list": [
+        user({
+          id: 1,
+          email: "admin@example.test",
+          name: "Admin",
+          role: "admin",
+        }),
+        user({
+          id: 2,
+          email: "eddie@example.test",
+          name: "Eddie Editor",
+          role: "editor",
+        }),
+        user({
+          id: 3,
+          email: "sub@example.test",
+          role: "subscriber",
+          disabledAt: new Date("2026-04-20T00:00:00Z"),
+        }),
+      ],
+    });
+
+    await page.goto("users");
+    await expect(page.getByTestId("users-list-heading")).toBeVisible();
+
+    // Each user's name column is keyed by id so other columns (role,
+    // status) can be asserted relative to the row without text coupling.
+    await expect(page.getByTestId("users-list-row-1")).toBeVisible();
+    await expect(page.getByTestId("users-list-row-2")).toBeVisible();
+    await expect(page.getByTestId("users-list-row-3")).toBeVisible();
+
+    // Admin is shown as "You" — matches WP's self-marker on the user list.
+    await expect(
+      page.getByTestId("users-list-row-1").locator("text=You"),
+    ).toBeVisible();
+
+    // Invite button is visible for an admin (has `user:create`).
+    await expect(page.getByTestId("users-list-invite-button")).toBeVisible();
+  });
+
+  test("empty-state card renders when no users match the filter", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/user/list": [],
+    });
+    await page.goto("users");
+    await expect(page.getByTestId("users-list-empty-state")).toBeVisible();
+  });
+
+  test("role filter URL-syncs and triggers a refetch", async ({ page }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/user/list": [],
+    });
+    await page.goto("users");
+    await page.getByTestId("users-role-filter-editor").click();
+    await expect(page).toHaveURL(/role=editor/);
+    await expect(page).toHaveURL(/page=1/);
+  });
+
+  test("search box URL-syncs ?q= after debounce", async ({ page }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/user/list": [],
+    });
+    await page.goto("users");
+    await page.getByTestId("users-list-search-input").fill("eddie");
+    await expect(page).toHaveURL(/q=eddie/, { timeout: 2000 });
+  });
+
+  test("non-admin session without user:list is redirected to the dashboard", async ({
+    page,
+  }) => {
+    // Subscriber-shaped session — no `user:list` capability.
+    await mockRpc(page, {
+      "/auth/session": {
+        user: {
+          id: 5,
+          email: "sub@example.test",
+          name: "Sub",
+          avatarUrl: null,
+          role: "subscriber",
+          capabilities: ["post:read"],
+        },
+        needsBootstrap: false,
+      },
+    });
+    await page.goto("users");
+    // Router redirect lands on dashboard.
+    await expect(page).toHaveURL(/_plumix\/admin\/?$/);
+  });
+});
+
+test.describe("/users/new", () => {
+  test("invite happy path: email + role → success screen with copy-able URL", async ({
+    page,
+  }) => {
+    const inviteInputs: unknown[] = [];
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/invite")) {
+        const body = route.request().postDataJSON() as { json?: unknown };
+        inviteInputs.push(body.json);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              user: user({
+                id: 42,
+                email: "newbie@example.test",
+                name: null,
+                role: "editor",
+              }),
+              inviteToken: "opaque-invite-token-xyz",
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("users/new");
+    await expect(page.getByTestId("invite-heading")).toBeVisible();
+
+    await page.getByTestId("invite-email-input").fill("newbie@example.test");
+    await page.getByTestId("invite-role-select").selectOption("editor");
+    await page.getByTestId("invite-submit").click();
+
+    // Submission forwards the expected shape to user.invite.
+    await expect
+      .poll(
+        () => (inviteInputs.at(-1) as { email?: string } | undefined)?.email,
+      )
+      .toBe("newbie@example.test");
+    expect((inviteInputs.at(-1) as { role?: string } | undefined)?.role).toBe(
+      "editor",
+    );
+
+    // Success screen shows the copy-able URL with the token embedded.
+    await expect(page.getByTestId("invite-success-heading")).toBeVisible();
+    await expect(page.getByTestId("invite-url-input")).toHaveValue(
+      /accept-invite\/opaque-invite-token-xyz$/,
+    );
+  });
+
+  test("email-taken CONFLICT surfaces a friendly message from the server", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/invite")) {
+        return route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              defined: true,
+              code: "CONFLICT",
+              status: 409,
+              message: "Resource conflict",
+              data: { reason: "email_taken" },
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("users/new");
+    await page.getByTestId("invite-email-input").fill("taken@example.test");
+    await page.getByTestId("invite-submit").click();
+
+    await expect(page.getByTestId("invite-server-error")).toBeVisible();
+    await expect(page.getByTestId("invite-server-error")).toContainText(
+      "email already exists",
+    );
+  });
+
+  test("non-admin without user:create is bounced to /users", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": {
+        user: {
+          id: 6,
+          email: "ed@example.test",
+          name: "Ed",
+          avatarUrl: null,
+          role: "editor",
+          // Editor has user:list but NOT user:create.
+          capabilities: ["user:list", "post:read"],
+        },
+        needsBootstrap: false,
+      },
+      "/user/list": [],
+    });
+    await page.goto("users/new");
+    // Route's beforeLoad redirects to /users.
+    await expect(page).toHaveURL(/\/users/);
+    await expect(page.getByTestId("users-list-heading")).toBeVisible();
+  });
+});

--- a/packages/admin/src/components/form/search-input.tsx
+++ b/packages/admin/src/components/form/search-input.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input.js";
+import { Search } from "lucide-react";
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+/**
+ * Debounced URL-synced search input shared by admin list screens
+ * (/content/$slug, /users, etc). Local state keeps typing instant; the
+ * debounce defers the URL commit (which triggers the RPC refetch) so
+ * every keystroke doesn't spawn a query. Parent keys this component on
+ * the URL value so external URL changes (back button, deep links) remount
+ * with the right initial value instead of needing a setState-in-effect
+ * sync.
+ */
+export function DebouncedSearchInput({
+  initialValue,
+  placeholder,
+  testId,
+  onCommit,
+}: {
+  readonly initialValue: string;
+  readonly placeholder: string;
+  readonly testId: string;
+  readonly onCommit: (next: string | undefined) => void;
+}): ReactNode {
+  const [value, setValue] = useState(initialValue);
+  useEffect(() => {
+    if (value === initialValue) return;
+    const id = setTimeout(() => {
+      onCommit(value.length === 0 ? undefined : value);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(id);
+    };
+  }, [value, initialValue, onCommit]);
+
+  return (
+    <div className="relative">
+      <Search
+        aria-hidden
+        className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2"
+      />
+      <Input
+        type="search"
+        role="searchbox"
+        value={value}
+        maxLength={200}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        data-testid={testId}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+        className="h-9 w-64 pl-8"
+      />
+    </div>
+  );
+}

--- a/packages/admin/src/components/shell/app-sidebar.tsx
+++ b/packages/admin/src/components/shell/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar.js";
+import { hasCap } from "@/lib/caps.js";
 import { visiblePostTypes } from "@/lib/manifest.js";
 import { Link } from "@tanstack/react-router";
 import { FileText, LayoutDashboard, Users } from "lucide-react";
@@ -61,7 +62,7 @@ function buildContentGroup(capabilities: readonly string[]): NavGroup | null {
 function buildManagementGroup(
   capabilities: readonly string[],
 ): NavGroup | null {
-  if (!capabilities.includes("user:list")) return null;
+  if (!hasCap(capabilities, "user:list")) return null;
   return {
     label: "Management",
     items: [{ to: "/users", label: "Users", icon: Users }],

--- a/packages/admin/src/components/shell/app-sidebar.tsx
+++ b/packages/admin/src/components/shell/app-sidebar.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/sidebar.js";
 import { visiblePostTypes } from "@/lib/manifest.js";
 import { Link } from "@tanstack/react-router";
-import { FileText, LayoutDashboard } from "lucide-react";
+import { FileText, LayoutDashboard, Users } from "lucide-react";
 
 import type { UserIdentity } from "./user-menu.js";
 import { UserMenu } from "./user-menu.js";
@@ -55,6 +55,19 @@ function buildContentGroup(capabilities: readonly string[]): NavGroup | null {
   return { label: "Content", items };
 }
 
+// `user:list` is admin / editor-level. Subscribers and authors see their
+// own profile via `/profile` (future PR) but don't get a user-management
+// nav entry at all — matches WordPress's "Users" menu being role-gated.
+function buildManagementGroup(
+  capabilities: readonly string[],
+): NavGroup | null {
+  if (!capabilities.includes("user:list")) return null;
+  return {
+    label: "Management",
+    items: [{ to: "/users", label: "Users", icon: Users }],
+  };
+}
+
 export function AppSidebar({
   user,
   capabilities,
@@ -63,9 +76,12 @@ export function AppSidebar({
   capabilities: readonly string[];
 }): ReactNode {
   const contentGroup = buildContentGroup(capabilities);
-  const groups = contentGroup
-    ? [OVERVIEW_GROUP, contentGroup]
-    : [OVERVIEW_GROUP];
+  const managementGroup = buildManagementGroup(capabilities);
+  const groups = [
+    OVERVIEW_GROUP,
+    ...(contentGroup ? [contentGroup] : []),
+    ...(managementGroup ? [managementGroup] : []),
+  ];
   return (
     <Sidebar collapsible="icon" variant="inset">
       <SidebarHeader>

--- a/packages/admin/src/lib/caps.ts
+++ b/packages/admin/src/lib/caps.ts
@@ -1,0 +1,14 @@
+/**
+ * Single grep target for every capability check in the admin. Centralising
+ * it lets us add wildcard matching (`content:*`), role shortcuts, or a
+ * session-hash-keyed cache in one place rather than threading the change
+ * through every route guard and component.
+ *
+ * Accepts the capability array directly rather than the full user object
+ * so it composes with both sources we have:
+ *   - `context.user.capabilities` (route `beforeLoad` contexts)
+ *   - `capabilities` (threaded into shell components without the user)
+ */
+export function hasCap(capabilities: readonly string[], cap: string): boolean {
+  return capabilities.includes(cap);
+}

--- a/packages/admin/src/lib/passkey-errors.ts
+++ b/packages/admin/src/lib/passkey-errors.ts
@@ -19,8 +19,11 @@ type PasskeyServerErrorCode =
   | "user_not_found"
   | "invalid_response"
   | "challenge_not_bound_to_user"
+  | "challenge_mismatch"
   | "registration_closed"
   | "email_mismatch"
+  | "invalid_token"
+  | "token_expired"
   | "invalid_input";
 
 // Browser-side failures we distinguish ourselves before/after the server call.
@@ -95,6 +98,14 @@ const MESSAGES: Record<PasskeyErrorCode, string> = {
   user_not_found: "No account found for that email.",
   registration_closed: "Sign-up is not open on this site.",
   email_mismatch: "That email doesn't match your signed-in account.",
+
+  // --- server-side: invite acceptance ---
+  invalid_token:
+    "This invite link is no longer valid. Ask your admin to send a new one.",
+  token_expired:
+    "This invite link has expired. Ask your admin to send a new one.",
+  challenge_mismatch:
+    "The passkey was created for a different invite. Please reload and try again.",
 };
 
 export function getPasskeyErrorMessage(code: string): string {

--- a/packages/admin/src/lib/passkey.test.ts
+++ b/packages/admin/src/lib/passkey.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { bufferToBase64url } from "./base64url.js";
 import { PasskeyError } from "./passkey-errors.js";
-import { registerWithPasskey, signInWithPasskey, signOut } from "./passkey.js";
+import {
+  acceptInviteWithPasskey,
+  registerWithPasskey,
+  signInWithPasskey,
+  signOut,
+} from "./passkey.js";
 
 type FetchMock = ReturnType<typeof vi.fn<typeof fetch>>;
 
@@ -232,5 +237,92 @@ describe("signOut", () => {
     expect(
       (call[1]?.headers as Record<string, string>)["x-plumix-request"],
     ).toBe("1");
+  });
+});
+
+describe("acceptInviteWithPasskey", () => {
+  test("verify POST body nests the full credential under `response` (server schema)", async () => {
+    // Critical regression guard: the server's
+    // `inviteRegisterVerifyInputSchema` is `{ token, response: credential }`
+    // — spreading the credential at the top level (earlier bug) made
+    // every accept-invite fail with `invalid_input`. Assert the shape
+    // explicitly so a future refactor can't regress.
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          options: fakeRegistrationOptions(),
+          invitee: {
+            email: "invited@example.test",
+            role: "editor",
+            name: null,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ userId: 99 }));
+    credentialsCreate.mockResolvedValue(fakeCreatedCredential());
+
+    const result = await acceptInviteWithPasskey({
+      token: "invite-token-xyz",
+      name: "Invited",
+    });
+    expect(result.userId).toBe(99);
+    expect(result.invitee.email).toBe("invited@example.test");
+
+    const optionsCall = callAt(fetchMock, 0);
+    expect(optionsCall[0]).toBe("/_plumix/auth/invite/register/options");
+    expect(JSON.parse(optionsCall[1]?.body as string)).toEqual({
+      token: "invite-token-xyz",
+      name: "Invited",
+    });
+
+    const verifyCall = callAt(fetchMock, 1);
+    expect(verifyCall[0]).toBe("/_plumix/auth/invite/register/verify");
+    const verifyBody = JSON.parse(verifyCall[1]?.body as string) as {
+      token: string;
+      response: {
+        id: string;
+        rawId: string;
+        type: string;
+        response: { clientDataJSON: string; attestationObject: string };
+      };
+      // Fields that must NOT leak to the top level — catches the
+      // regression where the credential was spread instead of nested.
+      id?: unknown;
+      rawId?: unknown;
+    };
+    expect(verifyBody.token).toBe("invite-token-xyz");
+    expect(verifyBody.id).toBeUndefined();
+    expect(verifyBody.rawId).toBeUndefined();
+    expect(verifyBody.response.id).toBe("credential-id");
+    expect(verifyBody.response.type).toBe("public-key");
+    expect(typeof verifyBody.response.response.clientDataJSON).toBe("string");
+  });
+
+  test("server 404 on invalid token → PasskeyError with invalid_token code", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: "invalid_token" }, 404),
+    );
+
+    const rejection = acceptInviteWithPasskey({ token: "bogus" });
+    await expect(rejection).rejects.toBeInstanceOf(PasskeyError);
+    await expect(rejection).rejects.toMatchObject({ code: "invalid_token" });
+    // Options call failed → credential create never fired.
+    expect(credentialsCreate).not.toHaveBeenCalled();
+  });
+
+  test("omits name from the options body when not provided", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          options: fakeRegistrationOptions(),
+          invitee: { email: "x@example.test", role: "subscriber", name: null },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ userId: 1 }));
+    credentialsCreate.mockResolvedValue(fakeCreatedCredential());
+
+    await acceptInviteWithPasskey({ token: "t" });
+    const optionsCall = callAt(fetchMock, 0);
+    expect(JSON.parse(optionsCall[1]?.body as string)).toEqual({ token: "t" });
   });
 });

--- a/packages/admin/src/lib/passkey.ts
+++ b/packages/admin/src/lib/passkey.ts
@@ -210,7 +210,7 @@ interface InviteOptionsResponse {
   readonly invitee: InviteeSummary;
 }
 
-export interface InviteAcceptSuccess extends VerifySuccess {
+interface InviteAcceptSuccess extends VerifySuccess {
   readonly invitee: InviteeSummary;
 }
 

--- a/packages/admin/src/lib/passkey.ts
+++ b/packages/admin/src/lib/passkey.ts
@@ -196,6 +196,60 @@ export async function registerWithPasskey(input: {
   );
 }
 
+// Server pairs the registration options with a compact `invitee` preview
+// so the accept-invite screen can confirm the target email / role before
+// the user taps their passkey.
+interface InviteeSummary {
+  readonly email: string;
+  readonly role: string;
+  readonly name: string | null;
+}
+
+interface InviteOptionsResponse {
+  readonly options: ServerRegistrationOptions;
+  readonly invitee: InviteeSummary;
+}
+
+export interface InviteAcceptSuccess extends VerifySuccess {
+  readonly invitee: InviteeSummary;
+}
+
+/**
+ * Two-step invite acceptance: fetch passkey-registration options keyed to
+ * the invite token, prompt the authenticator, then POST the attestation
+ * back for verification. A successful verify creates the user session
+ * (cookie set by the server) and consumes the token — a second attempt
+ * with the same token returns `invalid_token`.
+ */
+export async function acceptInviteWithPasskey(input: {
+  token: string;
+  name?: string;
+}): Promise<InviteAcceptSuccess> {
+  const { options, invitee } = await postJson<InviteOptionsResponse>(
+    "/_plumix/auth/invite/register/options",
+    {
+      token: input.token,
+      ...(input.name ? { name: input.name } : {}),
+    },
+  );
+
+  const credential = await callCredentialsApi(() =>
+    navigator.credentials.create({
+      publicKey: decodeRegistrationOptions(options),
+    }),
+  );
+
+  const verified = await postJson<VerifySuccess>(
+    "/_plumix/auth/invite/register/verify",
+    {
+      token: input.token,
+      ...(encodeRegistrationCredential(credential) as object),
+    },
+  );
+
+  return { ...verified, invitee };
+}
+
 export async function signInWithPasskey(
   email?: string,
 ): Promise<VerifySuccess> {

--- a/packages/admin/src/lib/passkey.ts
+++ b/packages/admin/src/lib/passkey.ts
@@ -239,11 +239,15 @@ export async function acceptInviteWithPasskey(input: {
     }),
   );
 
+  // Invite-verify nests the credential under `response` (see
+  // `inviteRegisterVerifyInputSchema` server-side). This differs from the
+  // non-invite `passkey/register/verify` endpoint which takes the
+  // credential at the top level.
   const verified = await postJson<VerifySuccess>(
     "/_plumix/auth/invite/register/verify",
     {
       token: input.token,
-      ...(encodeRegistrationCredential(credential) as object),
+      response: encodeRegistrationCredential(credential),
     },
   );
 

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -14,6 +14,9 @@ import { Route as AuthRouteImport } from "./routes/_auth";
 import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
 import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
+import { Route as AuthenticatedUsersIndexRouteImport } from "./routes/_authenticated/users/index";
+import { Route as AuthenticatedUsersNewRouteImport } from "./routes/_authenticated/users/new";
+import { Route as AuthAcceptInviteTokenRouteImport } from "./routes/_auth/accept-invite/$token";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
 import { Route as AuthenticatedContentSlugNewRouteImport } from "./routes/_authenticated/content/$slug/new";
 import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
@@ -41,6 +44,21 @@ const AuthBootstrapRoute = AuthBootstrapRouteImport.update({
   path: "/bootstrap",
   getParentRoute: () => AuthRoute,
 } as any);
+const AuthenticatedUsersIndexRoute = AuthenticatedUsersIndexRouteImport.update({
+  id: "/users/",
+  path: "/users/",
+  getParentRoute: () => AuthenticatedRoute,
+} as any);
+const AuthenticatedUsersNewRoute = AuthenticatedUsersNewRouteImport.update({
+  id: "/users/new",
+  path: "/users/new",
+  getParentRoute: () => AuthenticatedRoute,
+} as any);
+const AuthAcceptInviteTokenRoute = AuthAcceptInviteTokenRouteImport.update({
+  id: "/accept-invite/$token",
+  path: "/accept-invite/$token",
+  getParentRoute: () => AuthRoute,
+} as any);
 const AuthenticatedContentSlugIndexRoute =
   AuthenticatedContentSlugIndexRouteImport.update({
     id: "/content/$slug/",
@@ -64,6 +82,9 @@ export interface FileRoutesByFullPath {
   "/": typeof AuthenticatedIndexRoute;
   "/bootstrap": typeof AuthBootstrapRoute;
   "/login": typeof AuthLoginRoute;
+  "/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/users/new": typeof AuthenticatedUsersNewRoute;
+  "/users/": typeof AuthenticatedUsersIndexRoute;
   "/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
   "/content/$slug/": typeof AuthenticatedContentSlugIndexRoute;
@@ -72,6 +93,9 @@ export interface FileRoutesByTo {
   "/": typeof AuthenticatedIndexRoute;
   "/bootstrap": typeof AuthBootstrapRoute;
   "/login": typeof AuthLoginRoute;
+  "/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/users/new": typeof AuthenticatedUsersNewRoute;
+  "/users": typeof AuthenticatedUsersIndexRoute;
   "/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
   "/content/$slug": typeof AuthenticatedContentSlugIndexRoute;
@@ -83,6 +107,9 @@ export interface FileRoutesById {
   "/_auth/bootstrap": typeof AuthBootstrapRoute;
   "/_auth/login": typeof AuthLoginRoute;
   "/_authenticated/": typeof AuthenticatedIndexRoute;
+  "/_auth/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/_authenticated/users/new": typeof AuthenticatedUsersNewRoute;
+  "/_authenticated/users/": typeof AuthenticatedUsersIndexRoute;
   "/_authenticated/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/_authenticated/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
   "/_authenticated/content/$slug/": typeof AuthenticatedContentSlugIndexRoute;
@@ -93,6 +120,9 @@ export interface FileRouteTypes {
     | "/"
     | "/bootstrap"
     | "/login"
+    | "/accept-invite/$token"
+    | "/users/new"
+    | "/users/"
     | "/content/$slug/$id"
     | "/content/$slug/new"
     | "/content/$slug/";
@@ -101,6 +131,9 @@ export interface FileRouteTypes {
     | "/"
     | "/bootstrap"
     | "/login"
+    | "/accept-invite/$token"
+    | "/users/new"
+    | "/users"
     | "/content/$slug/$id"
     | "/content/$slug/new"
     | "/content/$slug";
@@ -111,6 +144,9 @@ export interface FileRouteTypes {
     | "/_auth/bootstrap"
     | "/_auth/login"
     | "/_authenticated/"
+    | "/_auth/accept-invite/$token"
+    | "/_authenticated/users/new"
+    | "/_authenticated/users/"
     | "/_authenticated/content/$slug/$id"
     | "/_authenticated/content/$slug/new"
     | "/_authenticated/content/$slug/";
@@ -158,6 +194,27 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AuthBootstrapRouteImport;
       parentRoute: typeof AuthRoute;
     };
+    "/_authenticated/users/": {
+      id: "/_authenticated/users/";
+      path: "/users";
+      fullPath: "/users/";
+      preLoaderRoute: typeof AuthenticatedUsersIndexRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
+    "/_authenticated/users/new": {
+      id: "/_authenticated/users/new";
+      path: "/users/new";
+      fullPath: "/users/new";
+      preLoaderRoute: typeof AuthenticatedUsersNewRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
+    "/_auth/accept-invite/$token": {
+      id: "/_auth/accept-invite/$token";
+      path: "/accept-invite/$token";
+      fullPath: "/accept-invite/$token";
+      preLoaderRoute: typeof AuthAcceptInviteTokenRouteImport;
+      parentRoute: typeof AuthRoute;
+    };
     "/_authenticated/content/$slug/": {
       id: "/_authenticated/content/$slug/";
       path: "/content/$slug";
@@ -185,17 +242,21 @@ declare module "@tanstack/react-router" {
 interface AuthRouteChildren {
   AuthBootstrapRoute: typeof AuthBootstrapRoute;
   AuthLoginRoute: typeof AuthLoginRoute;
+  AuthAcceptInviteTokenRoute: typeof AuthAcceptInviteTokenRoute;
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
   AuthBootstrapRoute: AuthBootstrapRoute,
   AuthLoginRoute: AuthLoginRoute,
+  AuthAcceptInviteTokenRoute: AuthAcceptInviteTokenRoute,
 };
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren);
 
 interface AuthenticatedRouteChildren {
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute;
+  AuthenticatedUsersNewRoute: typeof AuthenticatedUsersNewRoute;
+  AuthenticatedUsersIndexRoute: typeof AuthenticatedUsersIndexRoute;
   AuthenticatedContentSlugIdRoute: typeof AuthenticatedContentSlugIdRoute;
   AuthenticatedContentSlugNewRoute: typeof AuthenticatedContentSlugNewRoute;
   AuthenticatedContentSlugIndexRoute: typeof AuthenticatedContentSlugIndexRoute;
@@ -203,6 +264,8 @@ interface AuthenticatedRouteChildren {
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
+  AuthenticatedUsersNewRoute: AuthenticatedUsersNewRoute,
+  AuthenticatedUsersIndexRoute: AuthenticatedUsersIndexRoute,
   AuthenticatedContentSlugIdRoute: AuthenticatedContentSlugIdRoute,
   AuthenticatedContentSlugNewRoute: AuthenticatedContentSlugNewRoute,
   AuthenticatedContentSlugIndexRoute: AuthenticatedContentSlugIndexRoute,

--- a/packages/admin/src/routes/_auth/accept-invite/$token.tsx
+++ b/packages/admin/src/routes/_auth/accept-invite/$token.tsx
@@ -1,0 +1,130 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { FormField } from "@/components/form/field.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { getPasskeyErrorMessage, PasskeyError } from "@/lib/passkey-errors.js";
+import { acceptInviteWithPasskey } from "@/lib/passkey.js";
+import { SESSION_QUERY_KEY, sessionQueryOptions } from "@/lib/session.js";
+import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
+
+// The invite flow lands unauthenticated users here — any existing session
+// is a red flag (you don't accept an invite while already signed in, and
+// the token would bind a *different* user to your current browser). Kick
+// them to the dashboard; if they want to switch accounts they can sign
+// out first.
+export const Route = createFileRoute("/_auth/accept-invite/$token")({
+  beforeLoad: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(
+      sessionQueryOptions(),
+    );
+    if (session.user) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+      throw redirect({ to: "/" });
+    }
+  },
+  component: AcceptInviteRoute,
+});
+
+function AcceptInviteRoute(): ReactNode {
+  const { token } = Route.useParams();
+  const router = useRouter();
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+
+  const accept = useMutation({
+    mutationFn: (input: { name?: string }) =>
+      acceptInviteWithPasskey({
+        token,
+        ...(input.name ? { name: input.name } : {}),
+      }),
+    onMutate: () => {
+      setErrorCode(null);
+    },
+    onSuccess: async () => {
+      // Session cookie is set by the verify endpoint. Invalidate the
+      // session query so the router's `_authenticated` guard sees the
+      // new identity on the next navigation, then land on the dashboard.
+      await router.options.context.queryClient.invalidateQueries({
+        queryKey: SESSION_QUERY_KEY,
+      });
+      await router.navigate({ to: "/" });
+    },
+    onError: (err) => {
+      setErrorCode(err instanceof PasskeyError ? err.code : "unknown");
+    },
+  });
+
+  const form = useForm({
+    defaultValues: { name: "" },
+    onSubmit: ({ value }) => {
+      accept.mutate({ name: value.name || undefined });
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <h1 data-testid="accept-invite-heading">Accept your invite</h1>
+        </CardTitle>
+        <CardDescription>
+          Set up a passkey to finish creating your account. Your browser or
+          device will guide you through the prompt.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
+          <form.Field name="name">
+            {(field) => (
+              <FormField
+                field={field}
+                label={
+                  <>
+                    Name{" "}
+                    <span className="text-muted-foreground">(optional)</span>
+                  </>
+                }
+                type="text"
+                autoComplete="name"
+                disabled={accept.isPending}
+                data-testid="accept-invite-name-input"
+              />
+            )}
+          </form.Field>
+
+          {errorCode ? (
+            <Alert variant="destructive" data-testid="accept-invite-error">
+              <AlertDescription>
+                {getPasskeyErrorMessage(errorCode)}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Button
+            type="submit"
+            disabled={accept.isPending}
+            data-testid="accept-invite-submit"
+          >
+            {accept.isPending ? "Setting up…" : "Create passkey"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
@@ -5,6 +5,8 @@ import {
   POST_EDITOR_STATUSES,
   PostEditorForm,
 } from "@/components/editor/post-editor-form.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
+import { hasCap } from "@/lib/caps.js";
 import { findPostTypeBySlug, metaBoxesForPostType } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -13,7 +15,7 @@ import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
 import type { PostTypeManifestEntry } from "@plumix/core/manifest";
 import type { PostWithMeta } from "@plumix/core/schema";
 
-import { CONTENT_LIST_DEFAULT_SEARCH } from "./index.js";
+import { CONTENT_LIST_DEFAULT_SEARCH } from "./-constants.js";
 
 export const Route = createFileRoute("/_authenticated/content/$slug/$id")({
   beforeLoad: ({ params }): { postType: PostTypeManifestEntry } => {
@@ -80,7 +82,7 @@ function EditPostRoute(): ReactNode {
   }
 
   if (query.isPending) {
-    return <LoadingPlaceholder label={`Loading ${singularLower}`} />;
+    return <EditorSkeleton label={`Loading ${singularLower}`} />;
   }
 
   if (query.isError) {
@@ -92,14 +94,11 @@ function EditPostRoute(): ReactNode {
   }
 
   const post = query.data;
-  const canEditAny = user.capabilities.includes(
-    `${postType.capabilityType ?? postType.name}:edit_any`,
-  );
+  const capNamespace = postType.capabilityType ?? postType.name;
+  const canEditAny = hasCap(user.capabilities, `${capNamespace}:edit_any`);
   const canEditOwn =
     post.authorId === user.id &&
-    user.capabilities.includes(
-      `${postType.capabilityType ?? postType.name}:edit_own`,
-    );
+    hasCap(user.capabilities, `${capNamespace}:edit_own`);
   if (!canEditAny && !canEditOwn) {
     return (
       <NotFoundPlaceholder
@@ -177,14 +176,35 @@ function toEditorValues(post: PostWithMeta): PostEditorValues {
   };
 }
 
-function LoadingPlaceholder({ label }: { label: string }): ReactNode {
+// Content-shaped skeleton while the existing post fetches: heading +
+// title field + slug field + body block + side rail. Keeps layout stable
+// so the form doesn't pop in with a visible reflow once the query
+// resolves. `role=status` + `aria-live` announces the loading state to
+// screen readers; sighted users get the visual shimmer.
+function EditorSkeleton({ label }: { label: string }): ReactNode {
   return (
     <div
       role="status"
       aria-live="polite"
-      className="text-muted-foreground text-sm"
+      aria-label={label}
+      data-testid="post-editor-loading"
+      className="flex max-w-6xl flex-col gap-6"
     >
-      {label}…
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+      <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+        <aside className="flex flex-col gap-4">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </aside>
+      </div>
     </div>
   );
 }

--- a/packages/admin/src/routes/_authenticated/content/$slug/-constants.ts
+++ b/packages/admin/src/routes/_authenticated/content/$slug/-constants.ts
@@ -1,0 +1,14 @@
+// Default search-param set for `/content/$slug`. Every field in this
+// route's `searchSchema` has a `v.fallback`, but TanStack Router's typed
+// `Link` / `redirect` calls demand all non-optional fields at the call
+// site. Keeping the defaults here (rather than in the route file) means
+// sibling routes — `/content/$slug/new`, `/content/$slug/$id` — can
+// import the constant without dragging the list-route's module into
+// their chunk via a cross-route import.
+export const CONTENT_LIST_DEFAULT_SEARCH = {
+  status: "all",
+  page: 1,
+  author: "all",
+  orderBy: "updated_at",
+  order: "desc",
+} as const;

--- a/packages/admin/src/routes/_authenticated/content/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/index.tsx
@@ -1,7 +1,8 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { DataTable } from "@/components/data-table/data-table.js";
+import { DebouncedSearchInput } from "@/components/form/search-input.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
 import { Button } from "@/components/ui/button.js";
@@ -12,12 +13,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
-import { Input } from "@/components/ui/input.js";
 import {
   Pagination,
   PaginationContent,
   PaginationItem,
 } from "@/components/ui/pagination.js";
+import { hasCap } from "@/lib/caps.js";
 import { toDate } from "@/lib/dates.js";
 import { findPostTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
@@ -35,7 +36,6 @@ import {
   ChevronLeft,
   ChevronRight,
   Plus,
-  Search,
 } from "lucide-react";
 import * as v from "valibot";
 
@@ -75,20 +75,6 @@ type Order = (typeof ORDER_VALUES)[number];
 
 const AUTHOR_VALUES = ["all", "mine"] as const;
 type AuthorFilter = (typeof AUTHOR_VALUES)[number];
-
-// Default search-param values for `/content/$slug` — every field in
-// `searchSchema` has a `v.fallback` default, but TanStack Router's typed
-// `Link`/`redirect` calls demand all non-optional fields spelled out at
-// the call site. Exporting this constant lets sibling routes link back
-// to the list without redeclaring the defaults (keeps the set of
-// required fields a single source of truth).
-export const CONTENT_LIST_DEFAULT_SEARCH = {
-  status: "all",
-  page: 1,
-  author: "all",
-  orderBy: "updated_at",
-  order: "desc",
-} as const;
 
 const searchSchema = v.object({
   page: v.optional(
@@ -320,7 +306,7 @@ function ContentListRoute(): ReactNode {
   // button — the new-post route also redirects on `beforeLoad` but we
   // shouldn't surface the button at all.
   const createCapability = `${postType.capabilityType ?? postType.name}:create`;
-  const canCreate = user.capabilities.includes(createCapability);
+  const canCreate = hasCap(user.capabilities, createCapability);
 
   const columns = useMemo(
     () =>
@@ -365,13 +351,14 @@ function ContentListRoute(): ReactNode {
       <div className="flex flex-wrap items-center gap-2">
         <StatusFilter value={search.status} onChange={setStatus} />
         <AuthorFilter value={search.author} onChange={setAuthor} />
-        <SearchInput
+        <DebouncedSearchInput
           // Keyed on the URL value so external navigations (back button,
           // links) remount the input with fresh local state instead of
           // desynchronising from the URL.
           key={search.q ?? ""}
           initialValue={search.q ?? ""}
           placeholder={`Search ${pluralLower}…`}
+          testId="content-list-search-input"
           onCommit={setSearch}
         />
       </div>
@@ -523,55 +510,6 @@ function AuthorFilter({
           {opt === "all" ? "All authors" : "Mine"}
         </Button>
       ))}
-    </div>
-  );
-}
-
-const SEARCH_DEBOUNCE_MS = 250;
-
-function SearchInput({
-  initialValue,
-  placeholder,
-  onCommit,
-}: {
-  initialValue: string;
-  placeholder: string;
-  onCommit: (next: string | undefined) => void;
-}): ReactNode {
-  // Local state so typing feels immediate; commit to the URL (which
-  // triggers the RPC refetch) after a debounce. Parent keys this
-  // component on the URL value so external URL changes remount the
-  // input rather than needing a setState-in-effect sync.
-  const [value, setValue] = useState(initialValue);
-  useEffect(() => {
-    if (value === initialValue) return;
-    const id = setTimeout(() => {
-      onCommit(value.length === 0 ? undefined : value);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => {
-      clearTimeout(id);
-    };
-  }, [value, initialValue, onCommit]);
-
-  return (
-    <div className="relative">
-      <Search
-        aria-hidden
-        className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2"
-      />
-      <Input
-        type="search"
-        role="searchbox"
-        value={value}
-        maxLength={200}
-        placeholder={placeholder}
-        aria-label={placeholder}
-        data-testid="content-list-search-input"
-        onChange={(e) => {
-          setValue(e.target.value);
-        }}
-        className="h-9 w-64 pl-8"
-      />
     </div>
   );
 }

--- a/packages/admin/src/routes/_authenticated/content/$slug/new.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/new.tsx
@@ -2,6 +2,7 @@ import type { PostEditorValues } from "@/components/editor/post-editor-form.js";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { PostEditorForm } from "@/components/editor/post-editor-form.js";
+import { hasCap } from "@/lib/caps.js";
 import { findPostTypeBySlug, metaBoxesForPostType } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useMutation } from "@tanstack/react-query";
@@ -15,7 +16,7 @@ import {
 import type { PostTypeManifestEntry } from "@plumix/core/manifest";
 import type { PostStatus } from "@plumix/core/schema";
 
-import { CONTENT_LIST_DEFAULT_SEARCH } from "./index.js";
+import { CONTENT_LIST_DEFAULT_SEARCH } from "./-constants.js";
 
 // Statuses the new-post dropdown should expose. `trash` is omitted — you
 // don't create a post straight into the trash bin; the list view has a
@@ -37,7 +38,7 @@ export const Route = createFileRoute("/_authenticated/content/$slug/new")({
     // alone isn't enough — that permission is about editing your own
     // existing posts, not spawning new ones.
     const capability = `${postType.capabilityType ?? postType.name}:create`;
-    if (!context.user.capabilities.includes(capability)) {
+    if (!hasCap(context.user.capabilities, capability)) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
       throw redirect({
         to: "/content/$slug",

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -11,7 +11,7 @@ import { visiblePostTypes } from "@/lib/manifest.js";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, FileText } from "lucide-react";
 
-import { CONTENT_LIST_DEFAULT_SEARCH } from "./content/$slug/index.js";
+import { CONTENT_LIST_DEFAULT_SEARCH } from "./content/$slug/-constants.js";
 
 export const Route = createFileRoute("/_authenticated/")({
   component: DashboardIndex,

--- a/packages/admin/src/routes/_authenticated/users/-constants.ts
+++ b/packages/admin/src/routes/_authenticated/users/-constants.ts
@@ -1,3 +1,5 @@
+import type { UserRole } from "@plumix/core/schema";
+
 // Default search-param set for `/users`. Every field in this route's
 // `searchSchema` has a `v.fallback`, but TanStack Router's typed `Link`
 // / `redirect` calls demand all non-optional fields at the call site.
@@ -9,3 +11,19 @@ export const USERS_LIST_DEFAULT_SEARCH = {
   page: 1,
   role: "all",
 } as const;
+
+// Mirrors `USER_ROLES` from core's schema; kept local so the valibot
+// picklist stays tree-shakeable (importing the core runtime symbol
+// would pull drizzle into the admin bundle). The `UserRole` type
+// import keeps the two in lockstep — a drift breaks compilation.
+export const USER_ROLES: readonly UserRole[] = [
+  "subscriber",
+  "contributor",
+  "author",
+  "editor",
+  "admin",
+];
+
+export function isUserRole(value: string): value is UserRole {
+  return (USER_ROLES as readonly string[]).includes(value);
+}

--- a/packages/admin/src/routes/_authenticated/users/-constants.ts
+++ b/packages/admin/src/routes/_authenticated/users/-constants.ts
@@ -1,0 +1,11 @@
+// Default search-param set for `/users`. Every field in this route's
+// `searchSchema` has a `v.fallback`, but TanStack Router's typed `Link`
+// / `redirect` calls demand all non-optional fields at the call site.
+// Keeping the defaults here (rather than in the route file) means
+// sibling routes — `/users/new`, the future `/users/$id` — can import
+// the constant without dragging the list-route's module into their
+// chunk via a cross-route import.
+export const USERS_LIST_DEFAULT_SEARCH = {
+  page: 1,
+  role: "all",
+} as const;

--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -1,0 +1,436 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { DataTable } from "@/components/data-table/data-table.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Badge } from "@/components/ui/badge.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Input } from "@/components/ui/input.js";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+} from "@/components/ui/pagination.js";
+import { toDate } from "@/lib/dates.js";
+import { orpc } from "@/lib/orpc.js";
+import { useQuery } from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Search,
+  UserPlus,
+} from "lucide-react";
+import * as v from "valibot";
+
+import type { User, UserRole } from "@plumix/core/schema";
+
+const PAGE_SIZE = 20;
+
+// Mirrors `USER_ROLES` from core's schema; kept local as a runtime array so
+// the valibot picklist stays tree-shakeable (importing the core runtime
+// symbol would pull drizzle into the admin bundle). The `UserRole` type
+// import above keeps the two in lockstep — a drift would break
+// compilation.
+const USER_ROLES: readonly UserRole[] = [
+  "subscriber",
+  "contributor",
+  "author",
+  "editor",
+  "admin",
+];
+const ROLE_FILTER_VALUES = ["all", ...USER_ROLES] as const;
+type RoleFilter = (typeof ROLE_FILTER_VALUES)[number];
+
+const searchSchema = v.object({
+  page: v.optional(
+    v.fallback(v.pipe(v.number(), v.integer(), v.minValue(1)), 1),
+    1,
+  ),
+  role: v.optional(v.fallback(v.picklist(ROLE_FILTER_VALUES), "all"), "all"),
+  // Empty string coerces to `undefined` so `?q=` doesn't linger in the URL.
+  q: v.optional(
+    v.fallback(
+      v.pipe(
+        v.string(),
+        v.trim(),
+        v.maxLength(200),
+        v.transform((value) => (value.length === 0 ? undefined : value)),
+      ),
+      undefined,
+    ),
+  ),
+});
+
+// Reused from sibling routes that link back to this list.
+export const USERS_LIST_DEFAULT_SEARCH = {
+  page: 1,
+  role: "all",
+} as const;
+
+// Admin / editor = strong; author / contributor = neutral; subscriber =
+// muted; disabled overrides everything to destructive to signal the
+// blocked state at a glance (matches WordPress's greyed-out disabled
+// user row).
+const ROLE_VARIANT: Record<UserRole, "default" | "secondary" | "outline"> = {
+  admin: "default",
+  editor: "default",
+  author: "secondary",
+  contributor: "secondary",
+  subscriber: "outline",
+};
+
+const ROLE_LABEL: Record<UserRole, string> = {
+  admin: "Administrator",
+  editor: "Editor",
+  author: "Author",
+  contributor: "Contributor",
+  subscriber: "Subscriber",
+};
+
+const ROLE_FILTER_OPTIONS: { value: RoleFilter; label: string }[] = [
+  { value: "all", label: "All roles" },
+  ...USER_ROLES.map((role) => ({ value: role, label: ROLE_LABEL[role] })),
+];
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+});
+
+export const Route = createFileRoute("/_authenticated/users/")({
+  validateSearch: (search) => v.parse(searchSchema, search),
+  // Route-level capability gate. Without `user:list` there's nothing to
+  // show and the RPC would 403 — redirect back to the dashboard so the
+  // user doesn't land on a forbidden screen.
+  beforeLoad: ({ context }) => {
+    if (!context.user.capabilities.includes("user:list")) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+      throw redirect({ to: "/" });
+    }
+  },
+  component: UsersListRoute,
+});
+
+function UsersListRoute(): ReactNode {
+  const search = Route.useSearch();
+  const { user } = Route.useRouteContext();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const query = useQuery(
+    orpc.user.list.queryOptions({
+      input: {
+        limit: PAGE_SIZE,
+        offset: (search.page - 1) * PAGE_SIZE,
+        ...(search.role !== "all" ? { role: search.role } : {}),
+        ...(search.q ? { search: search.q } : {}),
+      },
+    }),
+  );
+
+  const setRole = useCallback(
+    (role: RoleFilter): void => {
+      void navigate({ search: (prev) => ({ ...prev, role, page: 1 }) });
+    },
+    [navigate],
+  );
+  const setPage = useCallback(
+    (page: number): void => {
+      void navigate({ search: (prev) => ({ ...prev, page }) });
+    },
+    [navigate],
+  );
+  const setSearch = useCallback(
+    (q: string | undefined): void => {
+      void navigate({ search: (prev) => ({ ...prev, q, page: 1 }) });
+    },
+    [navigate],
+  );
+
+  const rows: readonly User[] = query.data ?? [];
+  const canPrev = search.page > 1;
+  // Heuristic "next page exists": full page came back. `user.list` doesn't
+  // return a total, same tradeoff as `post.list` — accept the occasional
+  // empty-next-page when total is an exact multiple of PAGE_SIZE.
+  const canNext = rows.length === PAGE_SIZE;
+
+  // `user:create` is admin-only; editors see the list but don't get the
+  // "Invite user" button. The route behind it also redirects on
+  // `beforeLoad` for defense-in-depth.
+  const canInvite = user.capabilities.includes("user:create");
+
+  const columns = useMemo(
+    () => buildColumns({ currentUserId: user.id }),
+    [user.id],
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1
+            data-testid="users-list-heading"
+            className="text-2xl font-semibold"
+          >
+            Users
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Manage people with access to this site. Invite new users via email —
+            they'll enrol their passkey from the link you share.
+          </p>
+        </div>
+        {canInvite ? (
+          <Button asChild>
+            <Link to="/users/new" data-testid="users-list-invite-button">
+              <UserPlus />
+              Invite user
+            </Link>
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <RoleFilter value={search.role} onChange={setRole} />
+        <SearchInput
+          key={search.q ?? ""}
+          initialValue={search.q ?? ""}
+          onCommit={setSearch}
+        />
+      </div>
+
+      {query.isError ? (
+        <Alert variant="destructive">
+          <AlertDescription>
+            {query.error instanceof Error
+              ? query.error.message
+              : "Couldn't load users. Try again."}
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <DataTable<User>
+          columns={columns}
+          data={rows}
+          isLoading={query.isPending}
+          loadingLabel="Loading users"
+          emptyState={<EmptyState canInvite={canInvite} />}
+        />
+      )}
+
+      <Pagination className="justify-between">
+        <span className="text-muted-foreground text-sm">
+          Page {search.page}
+        </span>
+        <PaginationContent>
+          <PaginationItem>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!canPrev || query.isPending}
+              onClick={() => {
+                setPage(search.page - 1);
+              }}
+              aria-label="Go to previous page"
+            >
+              <ChevronLeft />
+              <span className="hidden sm:inline">Previous</span>
+            </Button>
+          </PaginationItem>
+          <PaginationItem>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!canNext || query.isPending}
+              onClick={() => {
+                setPage(search.page + 1);
+              }}
+              aria-label="Go to next page"
+            >
+              <span className="hidden sm:inline">Next</span>
+              <ChevronRight />
+            </Button>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}
+
+function buildColumns({
+  currentUserId,
+}: {
+  currentUserId: number;
+}): ColumnDef<User>[] {
+  return [
+    {
+      accessorKey: "name",
+      header: "User",
+      cell: ({ row }) => {
+        const u = row.original;
+        const isSelf = u.id === currentUserId;
+        return (
+          <div
+            className="flex flex-col"
+            data-testid={`users-list-row-${String(u.id)}`}
+          >
+            <span className="flex items-center gap-2 font-medium">
+              {u.name ?? (
+                <span className="text-muted-foreground italic">(no name)</span>
+              )}
+              {isSelf ? (
+                <Badge variant="outline" className="text-xs">
+                  You
+                </Badge>
+              ) : null}
+            </span>
+            <span className="text-muted-foreground text-xs">{u.email}</span>
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "role",
+      header: "Role",
+      cell: ({ row }) => (
+        <Badge variant={ROLE_VARIANT[row.original.role]} className="capitalize">
+          {ROLE_LABEL[row.original.role]}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: "disabledAt",
+      header: "Status",
+      cell: ({ row }) => {
+        const disabled = row.original.disabledAt != null;
+        return (
+          <Badge variant={disabled ? "destructive" : "secondary"}>
+            {disabled ? "Disabled" : "Active"}
+          </Badge>
+        );
+      },
+    },
+    {
+      accessorKey: "createdAt",
+      header: "Joined",
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-sm">
+          {dateFormatter.format(toDate(row.original.createdAt))}
+        </span>
+      ),
+    },
+  ];
+}
+
+function RoleFilter({
+  value,
+  onChange,
+}: {
+  value: RoleFilter;
+  onChange: (next: RoleFilter) => void;
+}): ReactNode {
+  return (
+    <div role="group" aria-label="Filter by role" className="flex gap-1">
+      {ROLE_FILTER_OPTIONS.map((opt) => (
+        <Button
+          key={opt.value}
+          variant={value === opt.value ? "default" : "outline"}
+          size="sm"
+          onClick={() => {
+            onChange(opt.value);
+          }}
+          aria-pressed={value === opt.value}
+          data-testid={`users-role-filter-${opt.value}`}
+        >
+          {opt.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+function SearchInput({
+  initialValue,
+  onCommit,
+}: {
+  initialValue: string;
+  onCommit: (next: string | undefined) => void;
+}): ReactNode {
+  const [value, setValue] = useState(initialValue);
+  useEffect(() => {
+    if (value === initialValue) return;
+    const id = setTimeout(() => {
+      onCommit(value.length === 0 ? undefined : value);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(id);
+    };
+  }, [value, initialValue, onCommit]);
+
+  return (
+    <div className="relative">
+      <Search
+        aria-hidden
+        className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2"
+      />
+      <Input
+        type="search"
+        role="searchbox"
+        value={value}
+        maxLength={200}
+        placeholder="Search by email…"
+        aria-label="Search users by email"
+        data-testid="users-list-search-input"
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+        className="h-9 w-64 pl-8"
+      />
+    </div>
+  );
+}
+
+function EmptyState({ canInvite }: { canInvite: boolean }): ReactNode {
+  return (
+    <div
+      data-testid="users-list-empty-state"
+      className="flex flex-col items-center gap-2 py-12 text-center"
+    >
+      <Card className="max-w-sm border-dashed">
+        <CardHeader>
+          <CardTitle>No users match your filter</CardTitle>
+          <CardDescription>
+            Clear the filter, or invite someone new to join.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {canInvite ? (
+            <Button asChild className="w-full">
+              <Link to="/users/new">
+                <Plus />
+                Invite user
+              </Link>
+            </Button>
+          ) : (
+            <Button disabled className="w-full">
+              <Plus />
+              Invite user
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -1,7 +1,8 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { DataTable } from "@/components/data-table/data-table.js";
+import { DebouncedSearchInput } from "@/components/form/search-input.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
 import { Button } from "@/components/ui/button.js";
@@ -12,12 +13,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
-import { Input } from "@/components/ui/input.js";
 import {
   Pagination,
   PaginationContent,
   PaginationItem,
 } from "@/components/ui/pagination.js";
+import { hasCap } from "@/lib/caps.js";
 import { toDate } from "@/lib/dates.js";
 import { orpc } from "@/lib/orpc.js";
 import { useQuery } from "@tanstack/react-query";
@@ -27,13 +28,7 @@ import {
   redirect,
   useNavigate,
 } from "@tanstack/react-router";
-import {
-  ChevronLeft,
-  ChevronRight,
-  Plus,
-  Search,
-  UserPlus,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus, UserPlus } from "lucide-react";
 import * as v from "valibot";
 
 import type { User, UserRole } from "@plumix/core/schema";
@@ -75,12 +70,6 @@ const searchSchema = v.object({
   ),
 });
 
-// Reused from sibling routes that link back to this list.
-export const USERS_LIST_DEFAULT_SEARCH = {
-  page: 1,
-  role: "all",
-} as const;
-
 // Admin / editor = strong; author / contributor = neutral; subscriber =
 // muted; disabled overrides everything to destructive to signal the
 // blocked state at a glance (matches WordPress's greyed-out disabled
@@ -116,7 +105,7 @@ export const Route = createFileRoute("/_authenticated/users/")({
   // show and the RPC would 403 — redirect back to the dashboard so the
   // user doesn't land on a forbidden screen.
   beforeLoad: ({ context }) => {
-    if (!context.user.capabilities.includes("user:list")) {
+    if (!hasCap(context.user.capabilities, "user:list")) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
       throw redirect({ to: "/" });
     }
@@ -169,7 +158,7 @@ function UsersListRoute(): ReactNode {
   // `user:create` is admin-only; editors see the list but don't get the
   // "Invite user" button. The route behind it also redirects on
   // `beforeLoad` for defense-in-depth.
-  const canInvite = user.capabilities.includes("user:create");
+  const canInvite = hasCap(user.capabilities, "user:create");
 
   const columns = useMemo(
     () => buildColumns({ currentUserId: user.id }),
@@ -203,9 +192,14 @@ function UsersListRoute(): ReactNode {
 
       <div className="flex flex-wrap items-center gap-2">
         <RoleFilter value={search.role} onChange={setRole} />
-        <SearchInput
+        <DebouncedSearchInput
+          // Keyed on the URL value so external navigations (back button,
+          // links) remount the input with fresh local state instead of
+          // desynchronising from the URL.
           key={search.q ?? ""}
           initialValue={search.q ?? ""}
+          placeholder="Search by email…"
+          testId="users-list-search-input"
           onCommit={setSearch}
         />
       </div>
@@ -355,49 +349,6 @@ function RoleFilter({
           {opt.label}
         </Button>
       ))}
-    </div>
-  );
-}
-
-const SEARCH_DEBOUNCE_MS = 250;
-
-function SearchInput({
-  initialValue,
-  onCommit,
-}: {
-  initialValue: string;
-  onCommit: (next: string | undefined) => void;
-}): ReactNode {
-  const [value, setValue] = useState(initialValue);
-  useEffect(() => {
-    if (value === initialValue) return;
-    const id = setTimeout(() => {
-      onCommit(value.length === 0 ? undefined : value);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => {
-      clearTimeout(id);
-    };
-  }, [value, initialValue, onCommit]);
-
-  return (
-    <div className="relative">
-      <Search
-        aria-hidden
-        className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2"
-      />
-      <Input
-        type="search"
-        role="searchbox"
-        value={value}
-        maxLength={200}
-        placeholder="Search by email…"
-        aria-label="Search users by email"
-        data-testid="users-list-search-input"
-        onChange={(e) => {
-          setValue(e.target.value);
-        }}
-        className="h-9 w-64 pl-8"
-      />
     </div>
   );
 }

--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -33,20 +33,10 @@ import * as v from "valibot";
 
 import type { User, UserRole } from "@plumix/core/schema";
 
+import { USER_ROLES } from "./-constants.js";
+
 const PAGE_SIZE = 20;
 
-// Mirrors `USER_ROLES` from core's schema; kept local as a runtime array so
-// the valibot picklist stays tree-shakeable (importing the core runtime
-// symbol would pull drizzle into the admin bundle). The `UserRole` type
-// import above keeps the two in lockstep — a drift would break
-// compilation.
-const USER_ROLES: readonly UserRole[] = [
-  "subscriber",
-  "contributor",
-  "author",
-  "editor",
-  "admin",
-];
 const ROLE_FILTER_VALUES = ["all", ...USER_ROLES] as const;
 type RoleFilter = (typeof ROLE_FILTER_VALUES)[number];
 

--- a/packages/admin/src/routes/_authenticated/users/new.tsx
+++ b/packages/admin/src/routes/_authenticated/users/new.tsx
@@ -27,22 +27,15 @@ import * as v from "valibot";
 
 import type { User, UserRole } from "@plumix/core/schema";
 
-import { USERS_LIST_DEFAULT_SEARCH } from "./-constants.js";
+import {
+  isUserRole,
+  USER_ROLES,
+  USERS_LIST_DEFAULT_SEARCH,
+} from "./-constants.js";
 
-// Mirrors `USER_ROLES` from core — kept local so the valibot picklist
-// stays tree-shakeable. `UserRole` type import keeps it in lockstep.
-const USER_ROLES: readonly UserRole[] = [
-  "subscriber",
-  "contributor",
-  "author",
-  "editor",
-  "admin",
-];
-
-function isUserRole(value: string): value is UserRole {
-  return (USER_ROLES as readonly string[]).includes(value);
-}
-
+// Long-form labels for the invite-flow dropdown — users picking a role
+// for someone else want the trade-offs spelled out. The list view uses
+// the short form (just the noun) since a badge has no room for copy.
 const ROLE_LABEL: Record<UserRole, string> = {
   admin: "Administrator — full control",
   editor: "Editor — publish + edit any post",
@@ -286,16 +279,10 @@ function InviteUserRoute(): ReactNode {
   );
 }
 
-// Build the shareable URL for the invite. Absolute so the admin can copy
-// and paste into an email client without post-processing. Relies on the
-// SPA being served at `ADMIN_BASE_PATH` — the accept-invite route under
-// `/_auth/accept-invite/$token` consumes the token query when opened.
+// Absolute URL so the admin can copy-paste into an email client without
+// post-processing. Admin is SPA-only so `window` is always defined here
+// (jsdom covers the test path).
 function buildInviteUrl(token: string): string {
-  if (typeof window === "undefined") {
-    // SSR / Node test harness — fall back to a path-only URL. The admin
-    // is client-rendered in practice so this branch is a safety net.
-    return `${ADMIN_BASE_PATH}/accept-invite/${token}`;
-  }
   return `${window.location.origin}${ADMIN_BASE_PATH}/accept-invite/${token}`;
 }
 
@@ -330,8 +317,6 @@ function InviteSuccess({
     try {
       await navigator.clipboard.writeText(inviteUrl);
       setCopied(true);
-      // Two seconds is the shortest interval where a "Copied!" label
-      // registers as intentional feedback rather than a flicker.
       setTimeout(() => {
         setCopied(false);
       }, 2000);

--- a/packages/admin/src/routes/_authenticated/users/new.tsx
+++ b/packages/admin/src/routes/_authenticated/users/new.tsx
@@ -1,0 +1,403 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { FormField } from "@/components/form/field.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Label } from "@/components/ui/label.js";
+import { ADMIN_BASE_PATH } from "@/lib/constants.js";
+import { orpc } from "@/lib/orpc.js";
+import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router";
+import { ArrowLeft, Check, Copy } from "lucide-react";
+import * as v from "valibot";
+
+import type { User, UserRole } from "@plumix/core/schema";
+
+import { USERS_LIST_DEFAULT_SEARCH } from "./index.js";
+
+// Mirrors `USER_ROLES` from core — kept local so the valibot picklist
+// stays tree-shakeable. `UserRole` type import keeps it in lockstep.
+const USER_ROLES: readonly UserRole[] = [
+  "subscriber",
+  "contributor",
+  "author",
+  "editor",
+  "admin",
+];
+
+const ROLE_LABEL: Record<UserRole, string> = {
+  admin: "Administrator — full control",
+  editor: "Editor — publish + edit any post",
+  author: "Author — publish own posts",
+  contributor: "Contributor — draft, no publish",
+  subscriber: "Subscriber — read only",
+};
+
+// Client-side validation mirrors `userInviteInputSchema` on the server so
+// the user gets instant feedback; the server remains the authoritative
+// gate.
+const inviteFormSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.trim(),
+    v.email("Enter a valid email address"),
+    v.maxLength(255),
+  ),
+  name: v.pipe(v.string(), v.trim(), v.maxLength(100)),
+  role: v.picklist(USER_ROLES),
+});
+
+export const Route = createFileRoute("/_authenticated/users/new")({
+  beforeLoad: ({ context }) => {
+    // `user:create` is admin-only. Defense in depth — the sidebar button
+    // is already gated on this cap but someone following a direct link
+    // shouldn't land on a forbidden form.
+    if (!context.user.capabilities.includes("user:create")) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+      throw redirect({ to: "/users", search: USERS_LIST_DEFAULT_SEARCH });
+    }
+  },
+  component: InviteUserRoute,
+});
+
+// State machine. We render one of three views: the form, a submitting
+// spinner (implicit via the form's isSubmitting), or the success screen
+// with the shareable URL. `success` is a discriminated payload so React
+// doesn't have to juggle two separate optional pieces of state.
+type ViewState =
+  | { status: "idle" }
+  | { status: "success"; user: User; inviteUrl: string };
+
+function InviteUserRoute(): ReactNode {
+  const navigate = useNavigate();
+  const [view, setView] = useState<ViewState>({ status: "idle" });
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const inviteUser = useMutation({
+    mutationFn: (input: { email: string; name: string; role: UserRole }) =>
+      orpc.user.invite.call({
+        email: input.email,
+        role: input.role,
+        ...(input.name.length > 0 ? { name: input.name } : {}),
+      }),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: (result) => {
+      setView({
+        status: "success",
+        user: result.user,
+        inviteUrl: buildInviteUrl(result.inviteToken),
+      });
+    },
+    onError: (err) => {
+      setServerError(mapInviteError(err));
+    },
+  });
+
+  const form = useForm({
+    defaultValues: { email: "", name: "", role: "subscriber" as UserRole },
+    validators: {
+      onSubmit: ({ value }) => {
+        const result = v.safeParse(inviteFormSchema, value);
+        return result.success ? undefined : result.issues[0].message;
+      },
+    },
+    onSubmit: ({ value }) => {
+      inviteUser.mutate(value);
+    },
+  });
+
+  if (view.status === "success") {
+    return (
+      <InviteSuccess
+        user={view.user}
+        inviteUrl={view.inviteUrl}
+        onInviteAnother={() => {
+          setView({ status: "idle" });
+          setServerError(null);
+          form.reset();
+        }}
+        onBackToList={() => {
+          void navigate({ to: "/users", search: USERS_LIST_DEFAULT_SEARCH });
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
+      <Link
+        to="/users"
+        search={USERS_LIST_DEFAULT_SEARCH}
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
+        data-testid="invite-back-link"
+      >
+        <ArrowLeft className="size-4" />
+        Back to users
+      </Link>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h1 data-testid="invite-heading">Invite user</h1>
+          </CardTitle>
+          <CardDescription>
+            They'll enrol a passkey the first time they open the invite link. No
+            password required.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void form.handleSubmit();
+            }}
+          >
+            <form.Field
+              name="email"
+              validators={{
+                onBlur: ({ value }) => {
+                  const result = v.safeParse(
+                    inviteFormSchema.entries.email,
+                    value,
+                  );
+                  return result.success ? undefined : result.issues[0].message;
+                },
+              }}
+            >
+              {(field) => (
+                <FormField
+                  field={field}
+                  label="Email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  disabled={inviteUser.isPending}
+                  data-testid="invite-email-input"
+                />
+              )}
+            </form.Field>
+
+            <form.Field name="name">
+              {(field) => (
+                <FormField
+                  field={field}
+                  label={
+                    <>
+                      Name{" "}
+                      <span className="text-muted-foreground">(optional)</span>
+                    </>
+                  }
+                  type="text"
+                  autoComplete="name"
+                  disabled={inviteUser.isPending}
+                  data-testid="invite-name-input"
+                />
+              )}
+            </form.Field>
+
+            <form.Field name="role">
+              {(field) => (
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="role">Role</Label>
+                  <select
+                    id="role"
+                    name="role"
+                    value={field.state.value}
+                    onChange={(e) => {
+                      field.handleChange(e.target.value as UserRole);
+                    }}
+                    disabled={inviteUser.isPending}
+                    data-testid="invite-role-select"
+                    className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {USER_ROLES.map((role) => (
+                      <option key={role} value={role}>
+                        {ROLE_LABEL[role]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+            </form.Field>
+
+            {serverError ? (
+              <Alert variant="destructive" data-testid="invite-server-error">
+                <AlertDescription>{serverError}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  void navigate({
+                    to: "/users",
+                    search: USERS_LIST_DEFAULT_SEARCH,
+                  });
+                }}
+                disabled={inviteUser.isPending}
+              >
+                Cancel
+              </Button>
+              <form.Subscribe selector={(state) => state.canSubmit}>
+                {(canSubmit) => (
+                  <Button
+                    type="submit"
+                    disabled={!canSubmit || inviteUser.isPending}
+                    data-testid="invite-submit"
+                  >
+                    {inviteUser.isPending ? "Inviting…" : "Send invite"}
+                  </Button>
+                )}
+              </form.Subscribe>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// Build the shareable URL for the invite. Absolute so the admin can copy
+// and paste into an email client without post-processing. Relies on the
+// SPA being served at `ADMIN_BASE_PATH` — the accept-invite route under
+// `/_auth/accept-invite/$token` consumes the token query when opened.
+function buildInviteUrl(token: string): string {
+  if (typeof window === "undefined") {
+    // SSR / Node test harness — fall back to a path-only URL. The admin
+    // is client-rendered in practice so this branch is a safety net.
+    return `${ADMIN_BASE_PATH}/accept-invite/${token}`;
+  }
+  return `${window.location.origin}${ADMIN_BASE_PATH}/accept-invite/${token}`;
+}
+
+// Surface server-side errors with a human-friendly message where we can.
+// The RPC layer throws with `.data.reason` on CONFLICT — everything else
+// falls through as a generic "try again".
+function mapInviteError(err: unknown): string {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data?: { reason?: string } }).data;
+    if (data?.reason === "email_taken") {
+      return "A user with that email already exists.";
+    }
+  }
+  if (err instanceof Error) return err.message;
+  return "Couldn't send invite. Try again.";
+}
+
+function InviteSuccess({
+  user,
+  inviteUrl,
+  onInviteAnother,
+  onBackToList,
+}: {
+  user: User;
+  inviteUrl: string;
+  onInviteAnother: () => void;
+  onBackToList: () => void;
+}): ReactNode {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      // Two seconds is the shortest interval where a "Copied!" label
+      // registers as intentional feedback rather than a flicker.
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch {
+      // Clipboard API can be denied in some contexts (non-HTTPS, iframes).
+      // Fall back silently — the URL is still visible + selectable.
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h1 data-testid="invite-success-heading">Invite ready</h1>
+          </CardTitle>
+          <CardDescription>
+            Share the link below with {user.email}. They'll enrol a passkey the
+            first time they open it. Link expires in 7 days.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="invite-url">Invite link</Label>
+            <div className="flex gap-2">
+              <input
+                id="invite-url"
+                readOnly
+                value={inviteUrl}
+                onFocus={(e) => {
+                  e.currentTarget.select();
+                }}
+                data-testid="invite-url-input"
+                className="border-input bg-muted text-muted-foreground flex h-9 w-full rounded-md border px-3 py-1 font-mono text-sm focus-visible:outline-none"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  void copy();
+                }}
+                data-testid="invite-copy-button"
+                aria-label="Copy invite link"
+              >
+                {copied ? (
+                  <>
+                    <Check />
+                    <span>Copied</span>
+                  </>
+                ) : (
+                  <>
+                    <Copy />
+                    <span>Copy</span>
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onInviteAnother}
+              data-testid="invite-another-button"
+            >
+              Invite another
+            </Button>
+            <Button
+              type="button"
+              onClick={onBackToList}
+              data-testid="invite-done-button"
+            >
+              Back to users
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_authenticated/users/new.tsx
+++ b/packages/admin/src/routes/_authenticated/users/new.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@/components/ui/card.js";
 import { Label } from "@/components/ui/label.js";
+import { hasCap } from "@/lib/caps.js";
 import { ADMIN_BASE_PATH } from "@/lib/constants.js";
 import { orpc } from "@/lib/orpc.js";
 import { useForm } from "@tanstack/react-form";
@@ -26,7 +27,7 @@ import * as v from "valibot";
 
 import type { User, UserRole } from "@plumix/core/schema";
 
-import { USERS_LIST_DEFAULT_SEARCH } from "./index.js";
+import { USERS_LIST_DEFAULT_SEARCH } from "./-constants.js";
 
 // Mirrors `USER_ROLES` from core — kept local so the valibot picklist
 // stays tree-shakeable. `UserRole` type import keeps it in lockstep.
@@ -37,6 +38,10 @@ const USER_ROLES: readonly UserRole[] = [
   "editor",
   "admin",
 ];
+
+function isUserRole(value: string): value is UserRole {
+  return (USER_ROLES as readonly string[]).includes(value);
+}
 
 const ROLE_LABEL: Record<UserRole, string> = {
   admin: "Administrator — full control",
@@ -65,7 +70,7 @@ export const Route = createFileRoute("/_authenticated/users/new")({
     // `user:create` is admin-only. Defense in depth — the sidebar button
     // is already gated on this cap but someone following a direct link
     // shouldn't land on a forbidden form.
-    if (!context.user.capabilities.includes("user:create")) {
+    if (!hasCap(context.user.capabilities, "user:create")) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
       throw redirect({ to: "/users", search: USERS_LIST_DEFAULT_SEARCH });
     }
@@ -73,10 +78,11 @@ export const Route = createFileRoute("/_authenticated/users/new")({
   component: InviteUserRoute,
 });
 
-// State machine. We render one of three views: the form, a submitting
-// spinner (implicit via the form's isSubmitting), or the success screen
-// with the shareable URL. `success` is a discriminated payload so React
-// doesn't have to juggle two separate optional pieces of state.
+// We render one of two views: the form (idle) or the success screen with
+// the shareable URL. The submitting state is tracked separately via
+// `inviteUser.isPending`, not by this union. Discriminated union here so
+// the success payload (user + url) correlates with the status without
+// nullable juggling.
 type ViewState =
   | { status: "idle" }
   | { status: "success"; user: User; inviteUrl: string };
@@ -220,7 +226,12 @@ function InviteUserRoute(): ReactNode {
                     name="role"
                     value={field.state.value}
                     onChange={(e) => {
-                      field.handleChange(e.target.value as UserRole);
+                      // `<option>` values come from `USER_ROLES`, but the
+                      // DOM types `e.target.value` as a bare string. Guard
+                      // via `includes` so a future refactor that adds a
+                      // raw option can't silently slip a bad role past TS.
+                      const next = e.target.value;
+                      if (isUserRole(next)) field.handleChange(next);
                     }}
                     disabled={inviteUser.isPending}
                     data-testid="invite-role-select"
@@ -325,8 +336,14 @@ function InviteSuccess({
         setCopied(false);
       }, 2000);
     } catch {
-      // Clipboard API can be denied in some contexts (non-HTTPS, iframes).
-      // Fall back silently — the URL is still visible + selectable.
+      // Clipboard API is gated in non-HTTPS / iframed / Permissions-Policy
+      // contexts. Select the input so the user can fall back to ⌘-C /
+      // Ctrl-C — better than a dead button that looks like it worked.
+      const input = document.getElementById("invite-url");
+      if (input instanceof HTMLInputElement) {
+        input.focus();
+        input.select();
+      }
     }
   };
 

--- a/packages/core/src/auth/passkey/routes.ts
+++ b/packages/core/src/auth/passkey/routes.ts
@@ -431,6 +431,11 @@ export async function handleInviteRegisterVerify(
       { userId: user.id },
       app.sessionPolicy,
     );
+    // User is fully enrolled (credential persisted, token consumed,
+    // session created). Fire after the session exists so handlers that
+    // hit the DB can rely on the user being in a stable post-invite
+    // state — matches WP's `user_register` firing post-save.
+    await ctx.hooks.doAction("user:registered", user);
     return jsonResponse(
       { userId: user.id },
       {

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -134,6 +134,31 @@ declare module "../hooks/types.js" {
       post: { readonly id: number; readonly type: string },
       changes: PostMetaChanges,
     ) => void | Promise<void>;
+
+    /**
+     * Fires after `user.invite` persists the pending user + token. Main
+     * consumer is an email-delivery plugin composing the invite link
+     * from `inviteToken`. Payload matches WP's `user_register` plus
+     * invite-specific fields — plugins listening on both `user:invited`
+     * and `user:registered` can tell "invite sent" from "invite taken".
+     */
+    "user:invited": (
+      user: User,
+      context: {
+        readonly inviteToken: string;
+        readonly invitedBy: number;
+        readonly expiresAt: Date;
+      },
+    ) => void | Promise<void>;
+
+    /**
+     * Fires after a user completes invite acceptance (passkey persisted,
+     * invite token consumed, session created). Parallel to WordPress's
+     * `user_register` when the user comes online for the first time.
+     * Use this (not `user:invited`) for onboarding flows like welcome
+     * emails or default-content seeding.
+     */
+    "user:registered": (user: User) => void | Promise<void>;
   }
 }
 

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -141,6 +141,13 @@ declare module "../hooks/types.js" {
      * from `inviteToken`. Payload matches WP's `user_register` plus
      * invite-specific fields — plugins listening on both `user:invited`
      * and `user:registered` can tell "invite sent" from "invite taken".
+     *
+     * SECURITY: `inviteToken` is the raw plaintext (the DB stores only a
+     * hash). Treat it as a credential — do NOT log it, persist it
+     * outside the consuming plugin's scope, or forward it to analytics /
+     * error-tracking services. A leaked token grants anyone the ability
+     * to complete registration as the invited user until it's consumed
+     * or expires (7 days).
      */
     "user:invited": (
       user: User,

--- a/packages/core/src/rpc/procedures/user/invite.ts
+++ b/packages/core/src/rpc/procedures/user/invite.ts
@@ -55,6 +55,16 @@ export const invite = base
       expiresAt,
     });
 
+    // Fires before the output filter so plugins observing invites see the
+    // raw created user + token — e.g. an email-delivery plugin needs the
+    // token here to compose the invite URL. Parallel to WordPress's
+    // `user_register` action hook.
+    await context.hooks.doAction("user:invited", created, {
+      inviteToken: token,
+      invitedBy: context.user.id,
+      expiresAt,
+    });
+
     const output = { user: created, inviteToken: token };
     return context.hooks.applyFilter("rpc:user.invite:output", output);
   });

--- a/packages/core/src/rpc/procedures/user/user.test.ts
+++ b/packages/core/src/rpc/procedures/user/user.test.ts
@@ -103,6 +103,21 @@ describe("user.invite", () => {
       data: { reason: "email_taken" },
     });
   });
+
+  test("fires user:invited with the token + invitedBy for plugins to hook (e.g. email delivery)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const onInvited = h.spyAction("user:invited");
+    const { user, inviteToken } = await h.client.user.invite({
+      email: "plugin@example.test",
+      role: "subscriber",
+    });
+    onInvited.assertCalledOnce();
+    const [userArg, ctxArg] = onInvited.lastArgs ?? [];
+    expect(userArg?.id).toBe(user.id);
+    expect(ctxArg?.inviteToken).toBe(inviteToken);
+    expect(ctxArg?.invitedBy).toBe(h.user.id);
+    expect(ctxArg?.expiresAt).toBeInstanceOf(Date);
+  });
 });
 
 describe("user.update", () => {


### PR DESCRIPTION
## Summary

End-to-end invite lifecycle from the admin UI, on top of the Phase-9/10 server plumbing:

- **`/users`** — list view backed by `user.list`. Name/email + role badge + status + join date. URL-synced role filter, debounced email search, pagination. Gated on `user:list`; sidebar "Management → Users" hides when missing.
- **`/users/new`** — invite form (email + name + role). Success screen shows a copy-able `/accept-invite/{token}` URL with "Invite another" + "Back to users" actions. CONFLICT mapping surfaces `email_taken` as a friendly message. Gated on `user:create` (admin-only).
- **`/_auth/accept-invite/$token`** — unauthenticated passkey-enrollment page consuming Phase-10 `/options` + `/verify` endpoints. Session cookie set by the server; we invalidate the session query and land on the dashboard. Existing sessions redirect to `/` — you can't accept an invite while already signed in as someone else.

## Notes

- **WP-parity extension surface** — new server-side action hooks so plugins can observe invite lifecycle: `user:invited` fires after `user.invite` with `{ inviteToken, invitedBy, expiresAt }` (primary consumer: email-delivery plugin); `user:registered` fires after accept-invite completes (onboarding / welcome-email plugins). Mirrors WordPress's `user_register` semantics.
- **Admin behavior matches WP's Users screen** where it makes sense: self-row is marked "You", role filter row across the top, empty state prompts to invite. Passkey-only auth replaces WP's password flow — invite UX is closer to Emdash's shareable-link model.
- Cap-based route guards on both `/users` and `/users/new` (dashboard and list redirects respectively) provide defense in depth against the sidebar being bypassed via direct URL.

## Test plan

- [x] 8 e2e tests covering: list render + self-marker + invite button visibility, empty state, role-filter URL-sync, debounced search URL-sync, `user:list`-less session redirect, invite happy path with `post.invite` payload assertion + success URL format, `email_taken` CONFLICT surfacing, `user:create`-less session redirect on `/users/new`.
- [x] 1 core unit test — `user:invited` action fires with the full context payload.
- [x] Existing 17 editor + content e2e still pass.
- [x] All 32 workspace tasks pass (typecheck + lint + test + format + knip).
- [ ] Manual check against a real passkey-supporting browser (follow-up in PR 2 when edit/delete ship alongside).