### PR TITLE
ci: group dependabot by lockstep-versioned package families

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,16 +11,42 @@ updates:
       eslint:
         patterns:
           - "eslint"
-          - "eslint-*"
           - "@eslint/*"
-          - "eslint-plugin-*"
+      typescript-eslint:
+        patterns:
           - "typescript-eslint"
+          - "@typescript-eslint/*"
+      turbo:
+        patterns:
+          - "turbo"
+          - "eslint-plugin-turbo"
       commitlint:
         patterns:
           - "@commitlint/*"
       arethetypeswrong:
         patterns:
           - "@arethetypeswrong/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      tiptap:
+        patterns:
+          - "@tiptap/*"
+      orpc:
+        patterns:
+          - "@orpc/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+      fontsource:
+        patterns:
+          - "@fontsource*/*"
     ignore:
       # @types/node major version must match .nvmrc — bump manually with Node upgrades
       - dependency-name: "@types/node"


### PR DESCRIPTION
## Summary

Adds dependabot groups so packages that release with matching version numbers get squashed into a single weekly PR. Triggered by the `tailwindcss` / `@tailwindcss/vite` 4.2.3 split into two separate PRs ([#47](https://github.com/withplumix/plumix/pull/47) and [#48](https://github.com/withplumix/plumix/pull/48), both merged).

### New / retuned groups (all lockstep-versioned)

| Group | Packages | Rationale |
|---|---|---|
| `tailwind` | `tailwindcss`, `@tailwindcss/*` | all 4.2.x from tailwind monorepo |
| `vitest` | `vitest`, `@vitest/*` | all 4.1.x |
| `tiptap` | `@tiptap/*` | all 3.22.x |
| `orpc` | `@orpc/*` | all 1.13.14 |
| `react` | `react`, `react-dom` | matched majors |
| `fontsource` | `@fontsource*/*` | maintained in lockstep |
| `typescript-eslint` | `typescript-eslint`, `@typescript-eslint/*` | split out of `eslint` — own 8.x major cadence |
| `turbo` | `turbo`, `eslint-plugin-turbo` | plugin ships from the turbo monorepo |

### Retuned

- **`eslint`** tightened to `eslint` + `@eslint/*` only. Dropped `eslint-*` / `eslint-plugin-*` / `typescript-eslint` patterns: they have independent release cadences and were masking drift. `eslint-plugin-turbo` now rides the `turbo` group so a turbo bump lands as one PR, not two.

### Intentionally NOT grouped

Independent versioning — bundling would produce noisy combined PRs:

- `@tanstack/*` — mixed projects (react-query 5.x, react-router 1.x, react-table 8.x, react-form 1.x)
- `drizzle-orm` (0.45) / `drizzle-kit` (0.31) / `drizzle-valibot` (0.4)
- `@cloudflare/workers-types` (4.x) + `wrangler` (4.x) + `@cloudflare/vite-plugin` (1.x)
- `@oslojs/crypto` (1.0.1) / `encoding` (1.1.0) / `webauthn` (1.0.0)
- `@testing-library/jest-dom` (6.x) / `react` (16.x) / `user-event` (14.x)
- `@playwright/test` (1.x) + `@axe-core/playwright` (4.x)
- `vite` (8.x) + `@vitejs/plugin-react` (6.x)
- `@types/react` (19.2.14) + `@types/react-dom` (19.2.3)
- `eslint-plugin-react` / `eslint-plugin-react-hooks` / `eslint-plugin-import-x` — independent repos

### Singletons

`typescript`, `prettier`, `publint`, `knip`, `valibot`, `jsdom`, `prettier-plugin-tailwindcss`, `tw-animate-css`, `@ianvs/prettier-plugin-sort-imports`, `@types/node` (already semver-major-ignored to track `.nvmrc`), and shadcn-adjacent (`radix-ui`, `lucide-react`, `class-variance-authority`, `clsx`, `tailwind-merge`).

## Test plan

- [ ] Dependabot picks up the new group config on next Monday run
- [ ] Future `tailwindcss` / `@tailwindcss/*` bumps arrive as a single grouped PR