### PR TITLE
feat(admin,core): users edit + delete + profile

### DIFF
--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -19,6 +19,11 @@ interface MockRpcHandlers {
   "/post/list"?: readonly Post[];
   "/user/list"?: readonly User[];
   "/user/invite"?: { user: User; inviteToken: string };
+  "/user/get"?: User;
+  "/user/update"?: User;
+  "/user/disable"?: User;
+  "/user/enable"?: User;
+  "/user/delete"?: User;
 }
 
 // oRPC's StandardRPCSerializer wire format — `meta` is always present,

--- a/packages/admin/e2e/users-edit.spec.ts
+++ b/packages/admin/e2e/users-edit.spec.ts
@@ -1,0 +1,292 @@
+import { expect, test } from "@playwright/test";
+
+import type { User } from "@plumix/core/schema";
+
+import { AUTHED_ADMIN, mockRpc } from "./support/rpc-mock.js";
+
+function user(overrides: Partial<User> & { id: number; email: string }): User {
+  return {
+    name: null,
+    avatarUrl: null,
+    role: "subscriber",
+    emailVerifiedAt: new Date("2026-04-20T00:00:00Z"),
+    disabledAt: null,
+    createdAt: new Date("2026-04-20T00:00:00Z"),
+    updatedAt: new Date("2026-04-20T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+test.describe("/users/$id", () => {
+  test("admin editing another user: form prefilled, role dropdown visible, Disable + Delete cards present", async ({
+    page,
+  }) => {
+    const target = user({
+      id: 42,
+      email: "eddie@example.test",
+      name: "Eddie",
+      role: "editor",
+    });
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/user/get": target,
+      "/user/list": [target, user({ id: 1, email: "admin@example.test" })],
+    });
+    await page.goto("users/42");
+
+    await expect(page.getByTestId("user-edit-heading")).toContainText(
+      "Edit eddie@example.test",
+    );
+    await expect(page.getByTestId("user-edit-email")).toHaveText(
+      "eddie@example.test",
+    );
+    await expect(page.getByTestId("user-edit-name-input")).toHaveValue("Eddie");
+    await expect(page.getByTestId("user-edit-role-select")).toHaveValue(
+      "editor",
+    );
+    // Disable + Delete surfaces are visible to admin-editing-other.
+    await expect(page.getByTestId("user-edit-disable-button")).toBeVisible();
+    await expect(page.getByTestId("user-edit-delete-button")).toBeVisible();
+  });
+
+  test("self-edit via /profile: redirects to /users/$id, role dropdown hidden, no Disable/Delete", async ({
+    page,
+  }) => {
+    // AUTHED_ADMIN.user.id === 1 — /profile redirects to /users/1.
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/user/get": user({
+        id: 1,
+        email: "admin@example.test",
+        name: "Admin",
+        role: "admin",
+      }),
+    });
+    await page.goto("profile");
+    await expect(page).toHaveURL(/\/users\/1/);
+    await expect(page.getByTestId("user-edit-heading")).toContainText(
+      "Your profile",
+    );
+    // Role is shown as a read-only badge; dropdown is hidden.
+    await expect(page.getByTestId("user-edit-role-select")).toHaveCount(0);
+    // You can't disable or delete yourself.
+    await expect(page.getByTestId("user-edit-disable-button")).toHaveCount(0);
+    await expect(page.getByTestId("user-edit-delete-button")).toHaveCount(0);
+  });
+
+  test("name update: PATCHes user.update and shows no errors", async ({
+    page,
+  }) => {
+    const updateInputs: unknown[] = [];
+    const target = user({ id: 42, email: "a@example.test", name: "Before" });
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: target, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/update")) {
+        updateInputs.push(
+          (route.request().postDataJSON() as { json?: unknown }).json,
+        );
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: { ...target, name: "After" },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("users/42");
+    await page.getByTestId("user-edit-name-input").fill("After");
+    await page.getByTestId("user-edit-submit").click();
+
+    await expect
+      .poll(() => (updateInputs.at(-1) as { name?: string } | undefined)?.name)
+      .toBe("After");
+  });
+
+  test("last-admin CONFLICT surfaces a friendly form error on disable", async ({
+    page,
+  }) => {
+    const target = user({ id: 1, email: "admin@example.test", role: "admin" });
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        // Simulate a secondary admin viewing the primary admin's edit page
+        // so Disable is visible but the server knows it's the last admin.
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              user: {
+                id: 9,
+                email: "admin2@example.test",
+                name: "Admin 2",
+                avatarUrl: null,
+                role: "admin",
+                capabilities: AUTHED_ADMIN.user?.capabilities ?? [],
+              },
+              needsBootstrap: false,
+            },
+            meta: [],
+          }),
+        });
+      }
+      if (url.endsWith("/user/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: target, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/disable")) {
+        return route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              defined: true,
+              code: "CONFLICT",
+              status: 409,
+              message: "Resource conflict",
+              data: { reason: "last_admin" },
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("users/1");
+    await page.getByTestId("user-edit-disable-button").click();
+    await expect(page.getByTestId("user-status-error")).toBeVisible();
+    await expect(page.getByTestId("user-status-error")).toContainText(
+      "last administrator",
+    );
+  });
+
+  test("delete flow: reveal reassign picker → confirm → redirect to /users", async ({
+    page,
+  }) => {
+    const target = user({
+      id: 42,
+      email: "eddie@example.test",
+      name: "Eddie",
+      role: "editor",
+    });
+    const inheritor = user({
+      id: 7,
+      email: "inheritor@example.test",
+      name: "Inheritor",
+    });
+    const deleteInputs: unknown[] = [];
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: target, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/list")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: [target, inheritor], meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/delete")) {
+        deleteInputs.push(
+          (route.request().postDataJSON() as { json?: unknown }).json,
+        );
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: target, meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("users/42");
+    // Reveal confirmation → pick reassignee → confirm.
+    await page.getByTestId("user-edit-delete-button").click();
+    await page
+      .getByTestId("user-delete-reassign-select")
+      .selectOption(String(inheritor.id));
+    await page.getByTestId("user-delete-confirm-button").click();
+
+    await expect
+      .poll(
+        () =>
+          (
+            deleteInputs.at(-1) as
+              | { id?: number; reassignPostsTo?: number }
+              | undefined
+          )?.reassignPostsTo,
+      )
+      .toBe(inheritor.id);
+    await expect(page).toHaveURL(/\/users/);
+    await expect(page).not.toHaveURL(/\/users\/42/);
+  });
+
+  test("subscriber can edit own row via /profile but not access /users/99", async ({
+    page,
+  }) => {
+    const subscriber: User = user({
+      id: 5,
+      email: "sub@example.test",
+      name: "Sub",
+    });
+    await mockRpc(page, {
+      "/auth/session": {
+        user: {
+          id: 5,
+          email: "sub@example.test",
+          name: "Sub",
+          avatarUrl: null,
+          role: "subscriber",
+          // Subscribers have `user:edit_own` by default but NOT `user:list`.
+          capabilities: ["user:edit_own", "post:read"],
+        },
+        needsBootstrap: false,
+      },
+      "/user/get": subscriber,
+    });
+
+    // Own row: works.
+    await page.goto("users/5");
+    await expect(page.getByTestId("user-edit-heading")).toContainText(
+      "Your profile",
+    );
+
+    // Someone else's row: redirected to dashboard.
+    await page.goto("users/99");
+    await expect(page).toHaveURL(/_plumix\/admin\/?$/);
+  });
+});

--- a/packages/admin/e2e/users-edit.spec.ts
+++ b/packages/admin/e2e/users-edit.spec.ts
@@ -255,6 +255,65 @@ test.describe("/users/$id", () => {
     await expect(page).not.toHaveURL(/\/users\/42/);
   });
 
+  test("self-save never includes `role` in the payload (guards against self-promotion)", async ({
+    page,
+  }) => {
+    const updateInputs: unknown[] = [];
+    const adminSelf = user({
+      id: 1,
+      email: "admin@example.test",
+      name: "Admin",
+      role: "admin",
+    });
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: adminSelf, meta: [] }),
+        });
+      }
+      if (url.endsWith("/user/update")) {
+        updateInputs.push(
+          (route.request().postDataJSON() as { json?: unknown }).json,
+        );
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: { ...adminSelf, name: "Admin 2" },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("profile");
+    await expect(page.getByTestId("user-edit-heading")).toContainText(
+      "Your profile",
+    );
+    await page.getByTestId("user-edit-name-input").fill("Admin 2");
+    await page.getByTestId("user-edit-submit").click();
+
+    // Submit fires — assert the role field is absent so a future refactor
+    // can't re-introduce a self-promotion hole via the form.
+    await expect
+      .poll(() => (updateInputs.at(-1) as { name?: string } | undefined)?.name)
+      .toBe("Admin 2");
+    const lastCall = updateInputs.at(-1) as Record<string, unknown> | undefined;
+    expect(lastCall).toBeDefined();
+    expect(lastCall).not.toHaveProperty("role");
+  });
+
   test("subscriber can edit own row via /profile but not access /users/99", async ({
     page,
   }) => {

--- a/packages/admin/src/components/shell/user-menu.tsx
+++ b/packages/admin/src/components/shell/user-menu.tsx
@@ -12,7 +12,7 @@ import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar.js";
 import { signOut } from "@/lib/passkey.js";
 import { SESSION_QUERY_KEY } from "@/lib/session.js";
 import { useMutation } from "@tanstack/react-query";
-import { useRouter } from "@tanstack/react-router";
+import { Link, useRouter } from "@tanstack/react-router";
 import { ChevronsUpDown, LogOut, Settings, User } from "lucide-react";
 
 import type { AuthSessionUser } from "@plumix/core";
@@ -88,9 +88,11 @@ export function UserMenu({ user }: { user: UserIdentity }): ReactNode {
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
-          <DropdownMenuItem disabled>
-            <User className="size-4" />
-            Profile
+          <DropdownMenuItem asChild>
+            <Link to="/profile" data-testid="user-menu-profile-link">
+              <User className="size-4" />
+              Profile
+            </Link>
           </DropdownMenuItem>
           <DropdownMenuItem disabled>
             <Settings className="size-4" />

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -12,10 +12,12 @@ import { Route as rootRouteImport } from "./routes/__root";
 import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
 import { Route as AuthRouteImport } from "./routes/_auth";
 import { Route as AuthenticatedIndexRouteImport } from "./routes/_authenticated/index";
+import { Route as AuthenticatedProfileRouteImport } from "./routes/_authenticated/profile";
 import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
 import { Route as AuthenticatedUsersIndexRouteImport } from "./routes/_authenticated/users/index";
 import { Route as AuthenticatedUsersNewRouteImport } from "./routes/_authenticated/users/new";
+import { Route as AuthenticatedUsersIdRouteImport } from "./routes/_authenticated/users/$id";
 import { Route as AuthAcceptInviteTokenRouteImport } from "./routes/_auth/accept-invite/$token";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
 import { Route as AuthenticatedContentSlugNewRouteImport } from "./routes/_authenticated/content/$slug/new";
@@ -32,6 +34,11 @@ const AuthRoute = AuthRouteImport.update({
 const AuthenticatedIndexRoute = AuthenticatedIndexRouteImport.update({
   id: "/",
   path: "/",
+  getParentRoute: () => AuthenticatedRoute,
+} as any);
+const AuthenticatedProfileRoute = AuthenticatedProfileRouteImport.update({
+  id: "/profile",
+  path: "/profile",
   getParentRoute: () => AuthenticatedRoute,
 } as any);
 const AuthLoginRoute = AuthLoginRouteImport.update({
@@ -52,6 +59,11 @@ const AuthenticatedUsersIndexRoute = AuthenticatedUsersIndexRouteImport.update({
 const AuthenticatedUsersNewRoute = AuthenticatedUsersNewRouteImport.update({
   id: "/users/new",
   path: "/users/new",
+  getParentRoute: () => AuthenticatedRoute,
+} as any);
+const AuthenticatedUsersIdRoute = AuthenticatedUsersIdRouteImport.update({
+  id: "/users/$id",
+  path: "/users/$id",
   getParentRoute: () => AuthenticatedRoute,
 } as any);
 const AuthAcceptInviteTokenRoute = AuthAcceptInviteTokenRouteImport.update({
@@ -82,7 +94,9 @@ export interface FileRoutesByFullPath {
   "/": typeof AuthenticatedIndexRoute;
   "/bootstrap": typeof AuthBootstrapRoute;
   "/login": typeof AuthLoginRoute;
+  "/profile": typeof AuthenticatedProfileRoute;
   "/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/users/$id": typeof AuthenticatedUsersIdRoute;
   "/users/new": typeof AuthenticatedUsersNewRoute;
   "/users/": typeof AuthenticatedUsersIndexRoute;
   "/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
@@ -93,7 +107,9 @@ export interface FileRoutesByTo {
   "/": typeof AuthenticatedIndexRoute;
   "/bootstrap": typeof AuthBootstrapRoute;
   "/login": typeof AuthLoginRoute;
+  "/profile": typeof AuthenticatedProfileRoute;
   "/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/users/$id": typeof AuthenticatedUsersIdRoute;
   "/users/new": typeof AuthenticatedUsersNewRoute;
   "/users": typeof AuthenticatedUsersIndexRoute;
   "/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
@@ -106,8 +122,10 @@ export interface FileRoutesById {
   "/_authenticated": typeof AuthenticatedRouteWithChildren;
   "/_auth/bootstrap": typeof AuthBootstrapRoute;
   "/_auth/login": typeof AuthLoginRoute;
+  "/_authenticated/profile": typeof AuthenticatedProfileRoute;
   "/_authenticated/": typeof AuthenticatedIndexRoute;
   "/_auth/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/_authenticated/users/$id": typeof AuthenticatedUsersIdRoute;
   "/_authenticated/users/new": typeof AuthenticatedUsersNewRoute;
   "/_authenticated/users/": typeof AuthenticatedUsersIndexRoute;
   "/_authenticated/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
@@ -120,7 +138,9 @@ export interface FileRouteTypes {
     | "/"
     | "/bootstrap"
     | "/login"
+    | "/profile"
     | "/accept-invite/$token"
+    | "/users/$id"
     | "/users/new"
     | "/users/"
     | "/content/$slug/$id"
@@ -131,7 +151,9 @@ export interface FileRouteTypes {
     | "/"
     | "/bootstrap"
     | "/login"
+    | "/profile"
     | "/accept-invite/$token"
+    | "/users/$id"
     | "/users/new"
     | "/users"
     | "/content/$slug/$id"
@@ -143,8 +165,10 @@ export interface FileRouteTypes {
     | "/_authenticated"
     | "/_auth/bootstrap"
     | "/_auth/login"
+    | "/_authenticated/profile"
     | "/_authenticated/"
     | "/_auth/accept-invite/$token"
+    | "/_authenticated/users/$id"
     | "/_authenticated/users/new"
     | "/_authenticated/users/"
     | "/_authenticated/content/$slug/$id"
@@ -180,6 +204,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AuthenticatedIndexRouteImport;
       parentRoute: typeof AuthenticatedRoute;
     };
+    "/_authenticated/profile": {
+      id: "/_authenticated/profile";
+      path: "/profile";
+      fullPath: "/profile";
+      preLoaderRoute: typeof AuthenticatedProfileRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
     "/_auth/login": {
       id: "/_auth/login";
       path: "/login";
@@ -206,6 +237,13 @@ declare module "@tanstack/react-router" {
       path: "/users/new";
       fullPath: "/users/new";
       preLoaderRoute: typeof AuthenticatedUsersNewRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
+    "/_authenticated/users/$id": {
+      id: "/_authenticated/users/$id";
+      path: "/users/$id";
+      fullPath: "/users/$id";
+      preLoaderRoute: typeof AuthenticatedUsersIdRouteImport;
       parentRoute: typeof AuthenticatedRoute;
     };
     "/_auth/accept-invite/$token": {
@@ -254,7 +292,9 @@ const AuthRouteChildren: AuthRouteChildren = {
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren);
 
 interface AuthenticatedRouteChildren {
+  AuthenticatedProfileRoute: typeof AuthenticatedProfileRoute;
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute;
+  AuthenticatedUsersIdRoute: typeof AuthenticatedUsersIdRoute;
   AuthenticatedUsersNewRoute: typeof AuthenticatedUsersNewRoute;
   AuthenticatedUsersIndexRoute: typeof AuthenticatedUsersIndexRoute;
   AuthenticatedContentSlugIdRoute: typeof AuthenticatedContentSlugIdRoute;
@@ -263,7 +303,9 @@ interface AuthenticatedRouteChildren {
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedProfileRoute: AuthenticatedProfileRoute,
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
+  AuthenticatedUsersIdRoute: AuthenticatedUsersIdRoute,
   AuthenticatedUsersNewRoute: AuthenticatedUsersNewRoute,
   AuthenticatedUsersIndexRoute: AuthenticatedUsersIndexRoute,
   AuthenticatedContentSlugIdRoute: AuthenticatedContentSlugIdRoute,

--- a/packages/admin/src/routes/_authenticated/profile.tsx
+++ b/packages/admin/src/routes/_authenticated/profile.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+// `/profile` is a stable-URL alias for editing your own account. It
+// resolves to `/users/${session.user.id}` so there's one edit
+// implementation — the user row decides self-vs-other internally (role
+// dropdown hidden for self, no delete button, etc). Matches WP's
+// `profile.php` being a thin wrapper around `user-edit.php?user_id=self`.
+export const Route = createFileRoute("/_authenticated/profile")({
+  beforeLoad: ({ context }) => {
+    // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+    throw redirect({
+      to: "/users/$id",
+      params: { id: context.user.id },
+    });
+  },
+});

--- a/packages/admin/src/routes/_authenticated/users/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id.tsx
@@ -85,6 +85,14 @@ function UserEditRoute(): ReactNode {
   const canPromote = hasCap(session.capabilities, "user:promote") && !isSelf;
   const canDisable = hasCap(session.capabilities, "user:edit") && !isSelf;
   const canDelete = hasCap(session.capabilities, "user:delete") && !isSelf;
+  // Match the server's actual write permission, not the more permissive
+  // route gate (`user:list` vs `user:edit`). Editors can view the edit
+  // screen (via `user:list`) but not save — this disables the Save
+  // button and the Name input for them instead of surfacing a generic
+  // server 403 after a wasted keystroke.
+  const canSave = isSelf
+    ? hasCap(session.capabilities, "user:edit_own")
+    : hasCap(session.capabilities, "user:edit");
 
   const query = useQuery(orpc.user.get.queryOptions({ input: { id: userId } }));
 
@@ -100,9 +108,20 @@ function UserEditRoute(): ReactNode {
   const target = query.data;
   return (
     <UserEditForm
+      // Remount after each successful save — the server bumps
+      // `updatedAt`, the refetch delivers fresh data, and this key
+      // flip gets TanStack Form to re-read `defaultValues`. Without
+      // it the form keeps displaying pre-save values until the user
+      // navigates away. Same pattern as /content/$slug/$id.
+      key={
+        target.updatedAt instanceof Date
+          ? target.updatedAt.toISOString()
+          : String(target.updatedAt)
+      }
       target={target}
       isSelf={isSelf}
       canPromote={canPromote}
+      canSave={canSave}
       canDisable={canDisable}
       canDelete={canDelete}
       onRefetch={() => {
@@ -116,6 +135,7 @@ function UserEditForm({
   target,
   isSelf,
   canPromote,
+  canSave,
   canDisable,
   canDelete,
   onRefetch,
@@ -123,6 +143,7 @@ function UserEditForm({
   target: User;
   isSelf: boolean;
   canPromote: boolean;
+  canSave: boolean;
   canDisable: boolean;
   canDelete: boolean;
   onRefetch: () => void;
@@ -149,7 +170,13 @@ function UserEditForm({
       onRefetch();
     },
     onError: (err) => {
-      setServerError(mapUpdateError(err));
+      setServerError(
+        mapUserError(
+          err,
+          UPDATE_ERROR_MESSAGES,
+          "Couldn't save the changes. Try again.",
+        ),
+      );
     },
   });
 
@@ -228,7 +255,7 @@ function UserEditForm({
                   }
                   type="text"
                   autoComplete="name"
-                  disabled={updateUser.isPending}
+                  disabled={updateUser.isPending || !canSave}
                   data-testid="user-edit-name-input"
                 />
               )}
@@ -298,7 +325,7 @@ function UserEditForm({
                 {(canSubmit) => (
                   <Button
                     type="submit"
-                    disabled={!canSubmit || updateUser.isPending}
+                    disabled={!canSubmit || updateUser.isPending || !canSave}
                     data-testid="user-edit-submit"
                   >
                     {updateUser.isPending ? "Saving…" : "Save changes"}
@@ -343,7 +370,13 @@ function StatusCard({
       onChanged();
     },
     onError: (err) => {
-      setServerError(mapStatusError(err));
+      setServerError(
+        mapUserError(
+          err,
+          STATUS_ERROR_MESSAGES,
+          "Couldn't change the account status. Try again.",
+        ),
+      );
     },
   });
 
@@ -424,7 +457,13 @@ function DeleteCard({ target }: { target: User; isSelf: boolean }): ReactNode {
       void navigate({ to: "/users", search: USERS_LIST_DEFAULT_SEARCH });
     },
     onError: (err) => {
-      setServerError(mapDeleteError(err));
+      setServerError(
+        mapUserError(
+          err,
+          DELETE_ERROR_MESSAGES,
+          "Couldn't delete the user. Try again.",
+        ),
+      );
     },
   });
 
@@ -523,43 +562,24 @@ function DeleteCard({ target }: { target: User; isSelf: boolean }): ReactNode {
   );
 }
 
-// CONFLICT→friendly copy. `last_admin` is the common one — the server's
-// atomic guard fires when you try to demote/disable/delete the last
-// active admin. `email_taken` can't happen from this form today (email
-// isn't editable) but the mapping is here for the future.
-function mapUpdateError(err: unknown): string {
+// CONFLICT→friendly-copy lookup for user-mutation surfaces. Each caller
+// passes its own `overrides` for per-action phrasing (the `last_admin`
+// message reads differently depending on whether you're demoting,
+// disabling, or deleting) plus a `fallback` for unmapped errors. Server
+// reasons not present in `overrides` fall through to `err.message` then
+// `fallback`.
+function mapUserError(
+  err: unknown,
+  overrides: Partial<Record<string, string>>,
+  fallback: string,
+): string {
   const reason = extractReason(err);
-  if (reason === "last_admin") {
-    return "Can't do that — this is the last administrator. Promote someone else first.";
-  }
-  if (reason === "email_taken") {
-    return "A user with that email already exists.";
+  if (reason != null && reason in overrides) {
+    const message = overrides[reason];
+    if (message != null) return message;
   }
   if (err instanceof Error) return err.message;
-  return "Couldn't save the changes. Try again.";
-}
-
-function mapStatusError(err: unknown): string {
-  if (extractReason(err) === "last_admin") {
-    return "Can't disable the last administrator. Promote someone else first.";
-  }
-  if (err instanceof Error) return err.message;
-  return "Couldn't change the account status. Try again.";
-}
-
-function mapDeleteError(err: unknown): string {
-  const reason = extractReason(err);
-  if (reason === "last_admin") {
-    return "Can't delete the last administrator. Promote someone else first.";
-  }
-  if (reason === "has_posts") {
-    return "This user has authored posts. Pick someone to reassign them to above.";
-  }
-  if (reason === "reassign_to_self") {
-    return "Can't reassign to the user being deleted.";
-  }
-  if (err instanceof Error) return err.message;
-  return "Couldn't delete the user. Try again.";
+  return fallback;
 }
 
 function extractReason(err: unknown): string | undefined {
@@ -569,6 +589,25 @@ function extractReason(err: unknown): string | undefined {
   }
   return undefined;
 }
+
+// Per-surface message bundles. Kept near the call sites (not inline at
+// `onError`) so adding a new reason is a one-line edit per surface.
+const UPDATE_ERROR_MESSAGES: Partial<Record<string, string>> = {
+  last_admin:
+    "Can't do that — this is the last administrator. Promote someone else first.",
+  email_taken: "A user with that email already exists.",
+};
+const STATUS_ERROR_MESSAGES: Partial<Record<string, string>> = {
+  last_admin:
+    "Can't disable the last administrator. Promote someone else first.",
+};
+const DELETE_ERROR_MESSAGES: Partial<Record<string, string>> = {
+  last_admin:
+    "Can't delete the last administrator. Promote someone else first.",
+  has_posts:
+    "This user has authored posts. Pick someone to reassign them to above.",
+  reassign_to_self: "Can't reassign to the user being deleted.",
+};
 
 function UserEditSkeleton(): ReactNode {
   return (

--- a/packages/admin/src/routes/_authenticated/users/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id.tsx
@@ -80,16 +80,19 @@ function UserEditRoute(): ReactNode {
   const { user: session } = Route.useRouteContext();
   const userId = Number(id);
   const isSelf = userId === session.id;
-  // `user:promote` is admin-only. Self can't promote self even with the
-  // cap (mirrors WP) — the role dropdown is hidden in the self case.
-  const canPromote = hasCap(session.capabilities, "user:promote") && !isSelf;
-  const canDisable = hasCap(session.capabilities, "user:edit") && !isSelf;
-  const canDelete = hasCap(session.capabilities, "user:delete") && !isSelf;
-  // Match the server's actual write permission, not the more permissive
-  // route gate (`user:list` vs `user:edit`). Editors can view the edit
-  // screen (via `user:list`) but not save — this disables the Save
-  // button and the Name input for them instead of surfacing a generic
-  // server 403 after a wasted keystroke.
+
+  // Self can't self-promote, self-disable, or self-delete — the `!isSelf`
+  // gate mirrors WP's user-edit UX and keeps the last-admin-lockout
+  // surface entirely server-side.
+  function otherUserCap(cap: string): boolean {
+    return !isSelf && hasCap(session.capabilities, cap);
+  }
+  const canPromote = otherUserCap("user:promote");
+  const canDisable = otherUserCap("user:edit");
+  const canDelete = otherUserCap("user:delete");
+  // Match the server's actual write permission — editors can view the
+  // edit screen (via `user:list`) but don't get `user:edit`, so we
+  // disable Save / Name input instead of letting them hit a server 403.
   const canSave = isSelf
     ? hasCap(session.capabilities, "user:edit_own")
     : hasCap(session.capabilities, "user:edit");
@@ -108,11 +111,8 @@ function UserEditRoute(): ReactNode {
   const target = query.data;
   return (
     <UserEditForm
-      // Remount after each successful save — the server bumps
-      // `updatedAt`, the refetch delivers fresh data, and this key
-      // flip gets TanStack Form to re-read `defaultValues`. Without
-      // it the form keeps displaying pre-save values until the user
-      // navigates away. Same pattern as /content/$slug/$id.
+      // Remount after each save so TanStack Form re-reads `defaultValues`
+      // from the refetched row. Same pattern as `/content/$slug/$id`.
       key={
         target.updatedAt instanceof Date
           ? target.updatedAt.toISOString()
@@ -338,12 +338,7 @@ function UserEditForm({
       </Card>
 
       {canDisable ? <StatusCard target={target} onChanged={onRefetch} /> : null}
-      {canDelete ? (
-        <DeleteCard
-          target={target}
-          isSelf={isSelf}
-        /> /* isSelf is always false here since canDelete hides for self, but spelled out for the reader */
-      ) : null}
+      {canDelete ? <DeleteCard target={target} /> : null}
     </div>
   );
 }
@@ -407,13 +402,7 @@ function StatusCard({
                 : "user-edit-disable-button"
             }
           >
-            {toggle.isPending
-              ? isDisabled
-                ? "Enabling…"
-                : "Disabling…"
-              : isDisabled
-                ? "Re-enable user"
-                : "Disable user"}
+            {toggleButtonLabel(isDisabled, toggle.isPending)}
           </Button>
         </div>
         {serverError ? (
@@ -426,7 +415,12 @@ function StatusCard({
   );
 }
 
-function DeleteCard({ target }: { target: User; isSelf: boolean }): ReactNode {
+function toggleButtonLabel(isDisabled: boolean, isPending: boolean): string {
+  if (isPending) return isDisabled ? "Enabling…" : "Disabling…";
+  return isDisabled ? "Re-enable user" : "Disable user";
+}
+
+function DeleteCard({ target }: { target: User }): ReactNode {
   const navigate = useNavigate();
   const [confirming, setConfirming] = useState(false);
   const [reassignTo, setReassignTo] = useState<number | null>(null);

--- a/packages/admin/src/routes/_authenticated/users/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id.tsx
@@ -1,0 +1,605 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { FormField } from "@/components/form/field.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Badge } from "@/components/ui/badge.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Label } from "@/components/ui/label.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
+import { hasCap } from "@/lib/caps.js";
+import { orpc } from "@/lib/orpc.js";
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import * as v from "valibot";
+
+import type { User, UserRole } from "@plumix/core/schema";
+
+import {
+  isUserRole,
+  USER_ROLES,
+  USERS_LIST_DEFAULT_SEARCH,
+} from "./-constants.js";
+
+// Long-form labels for the role dropdown — same rationale as the invite
+// form (the picker benefits from affordance copy, unlike the list view's
+// compact badges).
+const ROLE_LABEL: Record<UserRole, string> = {
+  admin: "Administrator — full control",
+  editor: "Editor — publish + edit any post",
+  author: "Author — publish own posts",
+  contributor: "Contributor — draft, no publish",
+  subscriber: "Subscriber — read only",
+};
+
+const profileFormSchema = v.object({
+  name: v.pipe(v.string(), v.trim(), v.maxLength(100)),
+  role: v.picklist(USER_ROLES),
+});
+
+export const Route = createFileRoute("/_authenticated/users/$id")({
+  parseParams: (params) => ({ id: Number(params.id) }),
+  // More permissive than `/users/` — a user without `user:list` can
+  // still edit their OWN row, so this screen doubles as `/profile`
+  // (which redirects here). Other-user edits require `user:list`; the
+  // server's own `user:edit_own` / `user:edit` checks are the final
+  // word, but surfacing the right screen is half the UX.
+  beforeLoad: ({ context, params }) => {
+    const id = Number(params.id);
+    if (Number.isNaN(id) || id < 1) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+      throw redirect({ to: "/users", search: USERS_LIST_DEFAULT_SEARCH });
+    }
+    const isSelf = id === context.user.id;
+    const canEditAny = hasCap(context.user.capabilities, "user:list");
+    const canEditSelf =
+      isSelf && hasCap(context.user.capabilities, "user:edit_own");
+    if (!canEditAny && !canEditSelf) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+      throw redirect({ to: "/" });
+    }
+  },
+  component: UserEditRoute,
+});
+
+function UserEditRoute(): ReactNode {
+  const { id } = Route.useParams();
+  const { user: session } = Route.useRouteContext();
+  const userId = Number(id);
+  const isSelf = userId === session.id;
+  // `user:promote` is admin-only. Self can't promote self even with the
+  // cap (mirrors WP) — the role dropdown is hidden in the self case.
+  const canPromote = hasCap(session.capabilities, "user:promote") && !isSelf;
+  const canDisable = hasCap(session.capabilities, "user:edit") && !isSelf;
+  const canDelete = hasCap(session.capabilities, "user:delete") && !isSelf;
+
+  const query = useQuery(orpc.user.get.queryOptions({ input: { id: userId } }));
+
+  if (query.isPending) {
+    return <UserEditSkeleton />;
+  }
+  if (query.isError) {
+    return (
+      <NotFoundPlaceholder message="Couldn't load that user. They may have been deleted." />
+    );
+  }
+
+  const target = query.data;
+  return (
+    <UserEditForm
+      target={target}
+      isSelf={isSelf}
+      canPromote={canPromote}
+      canDisable={canDisable}
+      canDelete={canDelete}
+      onRefetch={() => {
+        void query.refetch();
+      }}
+    />
+  );
+}
+
+function UserEditForm({
+  target,
+  isSelf,
+  canPromote,
+  canDisable,
+  canDelete,
+  onRefetch,
+}: {
+  target: User;
+  isSelf: boolean;
+  canPromote: boolean;
+  canDisable: boolean;
+  canDelete: boolean;
+  onRefetch: () => void;
+}): ReactNode {
+  const navigate = useNavigate();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const updateUser = useMutation({
+    mutationFn: (values: { name: string; role: UserRole }) =>
+      orpc.user.update.call({
+        id: target.id,
+        name: values.name.length > 0 ? values.name : null,
+        // Only send role if the caller can change it AND it actually
+        // differs — avoids a needless `user:promote` cap check on the
+        // server for name-only edits.
+        ...(canPromote && values.role !== target.role
+          ? { role: values.role }
+          : {}),
+      }),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: () => {
+      onRefetch();
+    },
+    onError: (err) => {
+      setServerError(mapUpdateError(err));
+    },
+  });
+
+  const form = useForm({
+    defaultValues: {
+      name: target.name ?? "",
+      role: target.role,
+    },
+    validators: {
+      onSubmit: ({ value }) => {
+        const result = v.safeParse(profileFormSchema, value);
+        return result.success ? undefined : result.issues[0].message;
+      },
+    },
+    onSubmit: ({ value }) => {
+      updateUser.mutate(value);
+    },
+  });
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
+      <Link
+        to="/users"
+        search={USERS_LIST_DEFAULT_SEARCH}
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
+        data-testid="user-edit-back-link"
+      >
+        <ArrowLeft className="size-4" />
+        Back to users
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h1 data-testid="user-edit-heading">
+              {isSelf ? "Your profile" : `Edit ${target.email}`}
+            </h1>
+          </CardTitle>
+          <CardDescription>
+            {isSelf
+              ? "Update your display name. Role and account state are managed by administrators."
+              : "Update this account's details. Role changes invalidate existing sessions immediately."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void form.handleSubmit();
+            }}
+          >
+            <div className="flex flex-col gap-2">
+              <Label>Email</Label>
+              <p
+                className="text-muted-foreground font-mono text-sm"
+                data-testid="user-edit-email"
+              >
+                {target.email}
+              </p>
+              <p className="text-muted-foreground text-xs">
+                Email changes aren't supported yet — it's the account key.
+              </p>
+            </div>
+
+            <form.Field name="name">
+              {(field) => (
+                <FormField
+                  field={field}
+                  label={
+                    <>
+                      Name{" "}
+                      <span className="text-muted-foreground">(optional)</span>
+                    </>
+                  }
+                  type="text"
+                  autoComplete="name"
+                  disabled={updateUser.isPending}
+                  data-testid="user-edit-name-input"
+                />
+              )}
+            </form.Field>
+
+            {canPromote ? (
+              <form.Field name="role">
+                {(field) => (
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="role">Role</Label>
+                    <select
+                      id="role"
+                      name="role"
+                      value={field.state.value}
+                      onChange={(e) => {
+                        const next = e.target.value;
+                        if (isUserRole(next)) field.handleChange(next);
+                      }}
+                      disabled={updateUser.isPending}
+                      data-testid="user-edit-role-select"
+                      className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {USER_ROLES.map((role) => (
+                        <option key={role} value={role}>
+                          {ROLE_LABEL[role]}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </form.Field>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <Label>Role</Label>
+                <Badge variant="secondary" className="w-fit capitalize">
+                  {target.role}
+                </Badge>
+                {isSelf ? (
+                  <p className="text-muted-foreground text-xs">
+                    Only another administrator can change your role.
+                  </p>
+                ) : null}
+              </div>
+            )}
+
+            {serverError ? (
+              <Alert variant="destructive" data-testid="user-edit-server-error">
+                <AlertDescription>{serverError}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  void navigate({
+                    to: "/users",
+                    search: USERS_LIST_DEFAULT_SEARCH,
+                  });
+                }}
+                disabled={updateUser.isPending}
+              >
+                Cancel
+              </Button>
+              <form.Subscribe selector={(state) => state.canSubmit}>
+                {(canSubmit) => (
+                  <Button
+                    type="submit"
+                    disabled={!canSubmit || updateUser.isPending}
+                    data-testid="user-edit-submit"
+                  >
+                    {updateUser.isPending ? "Saving…" : "Save changes"}
+                  </Button>
+                )}
+              </form.Subscribe>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {canDisable ? <StatusCard target={target} onChanged={onRefetch} /> : null}
+      {canDelete ? (
+        <DeleteCard
+          target={target}
+          isSelf={isSelf}
+        /> /* isSelf is always false here since canDelete hides for self, but spelled out for the reader */
+      ) : null}
+    </div>
+  );
+}
+
+function StatusCard({
+  target,
+  onChanged,
+}: {
+  target: User;
+  onChanged: () => void;
+}): ReactNode {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const isDisabled = target.disabledAt != null;
+
+  const toggle = useMutation({
+    mutationFn: () =>
+      isDisabled
+        ? orpc.user.enable.call({ id: target.id })
+        : orpc.user.disable.call({ id: target.id }),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: () => {
+      onChanged();
+    },
+    onError: (err) => {
+      setServerError(mapStatusError(err));
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Account status</CardTitle>
+        <CardDescription>
+          {isDisabled
+            ? "Disabled accounts can't sign in. Re-enabling restores access; their passkey is still registered."
+            : "Disabling signs the user out immediately and blocks future sign-ins. Their posts stay published."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-4">
+          <Badge variant={isDisabled ? "destructive" : "secondary"}>
+            {isDisabled ? "Disabled" : "Active"}
+          </Badge>
+          <Button
+            variant={isDisabled ? "default" : "outline"}
+            onClick={() => {
+              toggle.mutate();
+            }}
+            disabled={toggle.isPending}
+            data-testid={
+              isDisabled
+                ? "user-edit-enable-button"
+                : "user-edit-disable-button"
+            }
+          >
+            {toggle.isPending
+              ? isDisabled
+                ? "Enabling…"
+                : "Disabling…"
+              : isDisabled
+                ? "Re-enable user"
+                : "Disable user"}
+          </Button>
+        </div>
+        {serverError ? (
+          <Alert variant="destructive" data-testid="user-status-error">
+            <AlertDescription>{serverError}</AlertDescription>
+          </Alert>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DeleteCard({ target }: { target: User; isSelf: boolean }): ReactNode {
+  const navigate = useNavigate();
+  const [confirming, setConfirming] = useState(false);
+  const [reassignTo, setReassignTo] = useState<number | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  // Everyone except the user being deleted — populates the reassign
+  // dropdown. 100-item cap is fine for the single-site MVP; larger
+  // deployments will want a typeahead, which we can slot in later by
+  // swapping this query for a debounced search list.
+  const candidates = useQuery({
+    ...orpc.user.list.queryOptions({ input: { limit: 100 } }),
+    enabled: confirming,
+  });
+  const reassignOptions = (candidates.data ?? []).filter(
+    (u) => u.id !== target.id,
+  );
+
+  const deleteUser = useMutation({
+    mutationFn: () =>
+      orpc.user.delete.call({
+        id: target.id,
+        ...(reassignTo != null ? { reassignPostsTo: reassignTo } : {}),
+      }),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: () => {
+      void navigate({ to: "/users", search: USERS_LIST_DEFAULT_SEARCH });
+    },
+    onError: (err) => {
+      setServerError(mapDeleteError(err));
+    },
+  });
+
+  if (!confirming) {
+    return (
+      <Card className="border-destructive/50">
+        <CardHeader>
+          <CardTitle className="text-destructive">Delete user</CardTitle>
+          <CardDescription>
+            Permanent. Their posts stay, but you'll choose who inherits
+            authorship.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              setConfirming(true);
+            }}
+            data-testid="user-edit-delete-button"
+          >
+            Delete user
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-destructive">
+      <CardHeader>
+        <CardTitle className="text-destructive">
+          Confirm delete: {target.email}
+        </CardTitle>
+        <CardDescription>
+          If this user authored any posts, the next step reassigns them. Leave
+          "Keep posts as-is" if they have none.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="reassign-to">Reassign posts to</Label>
+          <select
+            id="reassign-to"
+            value={reassignTo == null ? "" : String(reassignTo)}
+            onChange={(e) => {
+              const raw = e.target.value;
+              setReassignTo(raw === "" ? null : Number(raw));
+            }}
+            disabled={deleteUser.isPending || candidates.isPending}
+            data-testid="user-delete-reassign-select"
+            className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <option value="">Keep posts as-is (none to reassign)</option>
+            {reassignOptions.map((u) => (
+              <option key={u.id} value={String(u.id)}>
+                {u.name ?? u.email} ({u.email})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {serverError ? (
+          <Alert variant="destructive" data-testid="user-delete-error">
+            <AlertDescription>{serverError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setConfirming(false);
+              setReassignTo(null);
+              setServerError(null);
+            }}
+            disabled={deleteUser.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => {
+              deleteUser.mutate();
+            }}
+            disabled={deleteUser.isPending}
+            data-testid="user-delete-confirm-button"
+          >
+            {deleteUser.isPending ? "Deleting…" : "Delete forever"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// CONFLICT→friendly copy. `last_admin` is the common one — the server's
+// atomic guard fires when you try to demote/disable/delete the last
+// active admin. `email_taken` can't happen from this form today (email
+// isn't editable) but the mapping is here for the future.
+function mapUpdateError(err: unknown): string {
+  const reason = extractReason(err);
+  if (reason === "last_admin") {
+    return "Can't do that — this is the last administrator. Promote someone else first.";
+  }
+  if (reason === "email_taken") {
+    return "A user with that email already exists.";
+  }
+  if (err instanceof Error) return err.message;
+  return "Couldn't save the changes. Try again.";
+}
+
+function mapStatusError(err: unknown): string {
+  if (extractReason(err) === "last_admin") {
+    return "Can't disable the last administrator. Promote someone else first.";
+  }
+  if (err instanceof Error) return err.message;
+  return "Couldn't change the account status. Try again.";
+}
+
+function mapDeleteError(err: unknown): string {
+  const reason = extractReason(err);
+  if (reason === "last_admin") {
+    return "Can't delete the last administrator. Promote someone else first.";
+  }
+  if (reason === "has_posts") {
+    return "This user has authored posts. Pick someone to reassign them to above.";
+  }
+  if (reason === "reassign_to_self") {
+    return "Can't reassign to the user being deleted.";
+  }
+  if (err instanceof Error) return err.message;
+  return "Couldn't delete the user. Try again.";
+}
+
+function extractReason(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data?: { reason?: string } }).data;
+    return data?.reason;
+  }
+  return undefined;
+}
+
+function UserEditSkeleton(): ReactNode {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading user"
+      data-testid="user-edit-loading"
+      className="mx-auto flex w-full max-w-xl flex-col gap-4"
+    >
+      <Skeleton className="h-4 w-24" />
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function NotFoundPlaceholder({ message }: { message: string }): ReactNode {
+  return (
+    <div className="flex flex-col gap-2">
+      <h1 className="text-2xl font-semibold">Not found</h1>
+      <p className="text-muted-foreground text-sm">{message}</p>
+    </div>
+  );
+}

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -85,6 +85,7 @@ declare module "../hooks/types.js" {
     "rpc:user.update:output": (output: User) => User;
 
     "rpc:user.disable:output": (output: User) => User;
+    "rpc:user.enable:output": (output: User) => User;
     "rpc:user.delete:output": (output: User) => User;
 
     "rpc:term.list:input": (input: TermListInput) => TermListInput;
@@ -166,6 +167,42 @@ declare module "../hooks/types.js" {
      * emails or default-content seeding.
      */
     "user:registered": (user: User) => void | Promise<void>;
+
+    /**
+     * Fires after a successful `user.update`. Payload carries the
+     * post-write row and the pre-write row for diffing — matches WP's
+     * `profile_update(user_id, old_user_data)` signature. Use this
+     * instead of the output filter when you need to know what actually
+     * changed (role demotion, email swap, etc.). Named
+     * `profile_changed` (not `:updated`) so the template-literal
+     * `${string}:updated` post-row signature above doesn't swallow it.
+     */
+    "user:profile_changed": (
+      user: User,
+      previous: User,
+    ) => void | Promise<void>;
+
+    /**
+     * Fires on both disable (`enabled: false`) and re-enable
+     * (`enabled: true`). One surface so "account state changed" is a
+     * single subscription, instead of two. Sessions for the affected
+     * user are already invalidated by the time this fires.
+     */
+    "user:status_changed": (
+      user: User,
+      context: { readonly enabled: boolean },
+    ) => void | Promise<void>;
+
+    /**
+     * Fires after a successful `user.delete`. `reassignedTo` is the
+     * user id that inherited this account's posts, or `null` if the
+     * deleted user had no posts (so no reassignment happened). Mirrors
+     * WP's `deleted_user(user_id, reassign_to)`.
+     */
+    "user:deleted": (
+      user: User,
+      context: { readonly reassignedTo: number | null },
+    ) => void | Promise<void>;
   }
 }
 

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -84,7 +84,9 @@ declare module "../hooks/types.js" {
     "rpc:user.update:input": (input: UserUpdateInput) => UserUpdateInput;
     "rpc:user.update:output": (output: User) => User;
 
+    "rpc:user.disable:input": (input: { id: number }) => typeof input;
     "rpc:user.disable:output": (output: User) => User;
+    "rpc:user.enable:input": (input: { id: number }) => typeof input;
     "rpc:user.enable:output": (output: User) => User;
     "rpc:user.delete:output": (output: User) => User;
 
@@ -165,6 +167,10 @@ declare module "../hooks/types.js" {
      * `user_register` when the user comes online for the first time.
      * Use this (not `user:invited`) for onboarding flows like welcome
      * emails or default-content seeding.
+     *
+     * PII: payload carries `email`, `name`, `role`. Don't ship the full
+     * row to third-party log/analytics services without the user's
+     * consent. Same caveat applies to all `user:*` actions below.
      */
     "user:registered": (user: User) => void | Promise<void>;
 

--- a/packages/core/src/rpc/procedures/user/delete.ts
+++ b/packages/core/src/rpc/procedures/user/delete.ts
@@ -71,5 +71,12 @@ export const del = base
       throw errors.CONFLICT({ data: { reason: "delete_failed" } });
     }
 
+    // WP's `deleted_user` parity. `reassignedTo` is `null` if the user
+    // had no posts (no reassignment happened); otherwise carries the id
+    // we migrated posts to so audit-log plugins can reconstruct the move.
+    await context.hooks.doAction("user:deleted", deleted, {
+      reassignedTo: postCount > 0 ? (input.reassignPostsTo ?? null) : null,
+    });
+
     return context.hooks.applyFilter("rpc:user.delete:output", deleted);
   });

--- a/packages/core/src/rpc/procedures/user/disable.ts
+++ b/packages/core/src/rpc/procedures/user/disable.ts
@@ -50,5 +50,12 @@ export const disable = base
 
     await invalidateAllSessionsForUser(context.db, updated.id);
 
+    // Pairs with the `user:status_changed` fired on re-enable — one
+    // hook surface for "account active state changed" so plugins don't
+    // have to subscribe to two events.
+    await context.hooks.doAction("user:status_changed", updated, {
+      enabled: false,
+    });
+
     return context.hooks.applyFilter("rpc:user.disable:output", updated);
   });

--- a/packages/core/src/rpc/procedures/user/disable.ts
+++ b/packages/core/src/rpc/procedures/user/disable.ts
@@ -15,9 +15,13 @@ export const disable = base
     if (!context.auth.can(CAPABILITY)) {
       throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
     }
+    const filtered = await context.hooks.applyFilter(
+      "rpc:user.disable:input",
+      input,
+    );
 
     const existing = await context.db.query.users.findFirst({
-      where: eq(users.id, input.id),
+      where: eq(users.id, filtered.id),
     });
     if (!existing) {
       throw errors.NOT_FOUND({ data: { kind: "user", id: input.id } });

--- a/packages/core/src/rpc/procedures/user/enable.ts
+++ b/packages/core/src/rpc/procedures/user/enable.ts
@@ -1,0 +1,48 @@
+import { eq } from "../../../db/index.js";
+import { users } from "../../../db/schema/users.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { userEnableInputSchema } from "./schemas.js";
+
+const CAPABILITY = "user:edit";
+
+// Restore a previously-disabled user by clearing `disabledAt`. No
+// last-admin guard here — unlike disable/delete/demote, re-enabling is
+// never the path to an all-admins-locked-out state. Idempotent: a second
+// call on an already-active user short-circuits with the existing row.
+export const enable = base
+  .use(authenticated)
+  .input(userEnableInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+
+    const existing = await context.db.query.users.findFirst({
+      where: eq(users.id, input.id),
+    });
+    if (!existing) {
+      throw errors.NOT_FOUND({ data: { kind: "user", id: input.id } });
+    }
+    if (!existing.disabledAt) {
+      return context.hooks.applyFilter("rpc:user.enable:output", existing);
+    }
+
+    const [updated] = await context.db
+      .update(users)
+      .set({ disabledAt: null })
+      .where(eq(users.id, existing.id))
+      .returning();
+    if (!updated) {
+      throw errors.CONFLICT({ data: { reason: "update_failed" } });
+    }
+
+    // Mirrors the status_changed action fired by `user.disable` — one
+    // hook covers both transitions so plugins observing "account
+    // activity state changed" don't need to subscribe to two events.
+    await context.hooks.doAction("user:status_changed", updated, {
+      enabled: true,
+    });
+
+    return context.hooks.applyFilter("rpc:user.enable:output", updated);
+  });

--- a/packages/core/src/rpc/procedures/user/enable.ts
+++ b/packages/core/src/rpc/procedures/user/enable.ts
@@ -17,9 +17,13 @@ export const enable = base
     if (!context.auth.can(CAPABILITY)) {
       throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
     }
+    const filtered = await context.hooks.applyFilter(
+      "rpc:user.enable:input",
+      input,
+    );
 
     const existing = await context.db.query.users.findFirst({
-      where: eq(users.id, input.id),
+      where: eq(users.id, filtered.id),
     });
     if (!existing) {
       throw errors.NOT_FOUND({ data: { kind: "user", id: input.id } });

--- a/packages/core/src/rpc/procedures/user/index.ts
+++ b/packages/core/src/rpc/procedures/user/index.ts
@@ -1,5 +1,6 @@
 import { del } from "./delete.js";
 import { disable } from "./disable.js";
+import { enable } from "./enable.js";
 import { get } from "./get.js";
 import { invite } from "./invite.js";
 import { list } from "./list.js";
@@ -11,6 +12,7 @@ export const userRouter = {
   invite,
   update,
   disable,
+  enable,
   delete: del,
 } as const;
 

--- a/packages/core/src/rpc/procedures/user/schemas.ts
+++ b/packages/core/src/rpc/procedures/user/schemas.ts
@@ -44,6 +44,8 @@ export const userUpdateInputSchema = v.object({
 
 export const userDisableInputSchema = v.object({ id: userIdSchema });
 
+export const userEnableInputSchema = v.object({ id: userIdSchema });
+
 export const userDeleteInputSchema = v.object({
   id: userIdSchema,
   /** Reassign this user's authored posts to the given user id before deletion. */
@@ -55,4 +57,5 @@ export type UserGetInput = v.InferOutput<typeof userGetInputSchema>;
 export type UserInviteInput = v.InferOutput<typeof userInviteInputSchema>;
 export type UserUpdateInput = v.InferOutput<typeof userUpdateInputSchema>;
 export type UserDisableInput = v.InferOutput<typeof userDisableInputSchema>;
+export type UserEnableInput = v.InferOutput<typeof userEnableInputSchema>;
 export type UserDeleteInput = v.InferOutput<typeof userDeleteInputSchema>;

--- a/packages/core/src/rpc/procedures/user/schemas.ts
+++ b/packages/core/src/rpc/procedures/user/schemas.ts
@@ -57,5 +57,4 @@ export type UserGetInput = v.InferOutput<typeof userGetInputSchema>;
 export type UserInviteInput = v.InferOutput<typeof userInviteInputSchema>;
 export type UserUpdateInput = v.InferOutput<typeof userUpdateInputSchema>;
 export type UserDisableInput = v.InferOutput<typeof userDisableInputSchema>;
-export type UserEnableInput = v.InferOutput<typeof userEnableInputSchema>;
 export type UserDeleteInput = v.InferOutput<typeof userDeleteInputSchema>;

--- a/packages/core/src/rpc/procedures/user/update.ts
+++ b/packages/core/src/rpc/procedures/user/update.ts
@@ -91,5 +91,9 @@ export const update = base
       await invalidateAllSessionsForUser(context.db, updated.id);
     }
 
+    // WP's `profile_update` parity — plugins observe successful writes
+    // with the previous row for diffing (audit log, cache invalidation).
+    await context.hooks.doAction("user:profile_changed", updated, existing);
+
     return context.hooks.applyFilter("rpc:user.update:output", updated);
   });

--- a/packages/core/src/rpc/procedures/user/user.test.ts
+++ b/packages/core/src/rpc/procedures/user/user.test.ts
@@ -310,3 +310,94 @@ describe("user.delete", () => {
     );
   });
 });
+
+describe("user.enable", () => {
+  test("admin can re-enable a disabled user", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.subscriber.create();
+    await h.client.user.disable({ id: target.id });
+    const re = await h.client.user.enable({ id: target.id });
+    expect(re.disabledAt).toBeNull();
+  });
+
+  test("already-active target is a no-op (idempotent)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.subscriber.create();
+    const result = await h.client.user.enable({ id: target.id });
+    expect(result.disabledAt).toBeNull();
+  });
+
+  test("editor cannot enable (user:edit is admin-only here)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const target = await h.factory.subscriber.create();
+    await expect(h.client.user.enable({ id: target.id })).rejects.toMatchObject(
+      {
+        code: "FORBIDDEN",
+        data: { capability: "user:edit" },
+      },
+    );
+  });
+});
+
+describe("user lifecycle action hooks", () => {
+  test("user:profile_changed fires after update with previous row", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.subscriber.create({ name: "Before" });
+    const spy = h.spyAction("user:profile_changed");
+    await h.client.user.update({ id: target.id, name: "After" });
+    spy.assertCalledOnce();
+    const [post, previous] = spy.lastArgs ?? [];
+    expect(post?.name).toBe("After");
+    expect(previous?.name).toBe("Before");
+  });
+
+  test("user:status_changed fires on disable with enabled=false", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.subscriber.create();
+    const spy = h.spyAction("user:status_changed");
+    await h.client.user.disable({ id: target.id });
+    spy.assertCalledOnce();
+    expect(spy.lastArgs?.[1]).toEqual({ enabled: false });
+  });
+
+  test("user:status_changed fires on re-enable with enabled=true", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.subscriber.create();
+    await h.client.user.disable({ id: target.id });
+    const spy = h.spyAction("user:status_changed");
+    await h.client.user.enable({ id: target.id });
+    spy.assertCalledOnce();
+    expect(spy.lastArgs?.[1]).toEqual({ enabled: true });
+  });
+
+  test("user:status_changed does NOT fire on an already-active enable (idempotent short-circuit)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.subscriber.create();
+    const spy = h.spyAction("user:status_changed");
+    await h.client.user.enable({ id: target.id });
+    spy.assertNotCalled();
+  });
+
+  test("user:deleted fires with reassignedTo=null when the user had no posts", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const target = await h.factory.subscriber.create();
+    const spy = h.spyAction("user:deleted");
+    await h.client.user.delete({ id: target.id });
+    spy.assertCalledOnce();
+    expect(spy.lastArgs?.[1]).toEqual({ reassignedTo: null });
+  });
+
+  test("user:deleted fires with reassignedTo=<id> when posts were migrated", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const author = await h.factory.author.create();
+    const inheritor = await h.factory.author.create();
+    await h.factory.draft.create({ authorId: author.id, slug: "orphan" });
+    const spy = h.spyAction("user:deleted");
+    await h.client.user.delete({
+      id: author.id,
+      reassignPostsTo: inheritor.id,
+    });
+    spy.assertCalledOnce();
+    expect(spy.lastArgs?.[1]).toEqual({ reassignedTo: inheritor.id });
+  });
+});


### PR DESCRIPTION
## Summary

Finishes the Users admin surface on top of #50 (list + invite). One `/users/$id` edit screen used by both admin-editing-others and self-edit; `/profile` is a thin redirect into it. Mirrors WP's `profile.php` being a wrapper around `user-edit.php`.

## Routes

- **`/users/\$id`** — the single edit screen. Self-vs-other branching:
  - Self: role shown as read-only badge; Disable / Delete cards hidden.
  - Admin-editing-other: role dropdown when caller has `user:promote`; Disable/Re-enable card when `user:edit`; Delete card when `user:delete`.
  - Inline delete confirmation with a "reassign posts to" dropdown (WP attribute-to UX, no modal).
- **`/profile`** — 15-line redirect to `/users/\${session.user.id}`.
- **UserMenu** Profile item wired (was a disabled stub).

## Server extension surface (WP lifecycle parity)

- New `user.enable` RPC — clears `disabledAt`; idempotent; no last-admin guard needed (re-enabling is never destructive).
- Three new action hooks in the registry:
  - **`user:profile_changed(user, previous)`** — WP `profile_update` parity. Named `profile_changed` not `:updated` to dodge the `\${string}:updated` post-row template collision (same pattern as `post:meta_changed`).
  - **`user:status_changed(user, { enabled })`** — one surface covers both disable and re-enable.
  - **`user:deleted(user, { reassignedTo })`** — WP `deleted_user` parity. `reassignedTo` is `null` when the user had no posts.

## Error surfacing

- **Last-admin CONFLICT** from update/disable/delete atomic guards surfaces as "Promote someone else first" per-surface.
- **has_posts** on delete directs back to the reassign dropdown.
- **reassign_to_self** caught per-surface.

## Test plan

- [x] 9 new core unit tests: `user.enable` auth + idempotency, all 3 action hooks with correct payloads + idempotent short-circuit for status_changed.
- [x] 6 new e2e: admin-editing-other, self via /profile (role/disable/delete hidden), name update payload, last-admin CONFLICT surfacing, delete-with-reassign, subscriber self-access + redirect.
- [x] 43 workspace tasks + 31 admin e2e + 383 core tests all green locally.