### PR TITLE
feat(admin,core): taxonomies admin UI + manifest slice

### DIFF
--- a/examples/minimal/test/build.integration.test.ts
+++ b/examples/minimal/test/build.integration.test.ts
@@ -51,7 +51,7 @@ describe("examples/minimal — plumix build", () => {
       // so postTypes is empty but the tag must still be present.
       const adminHtml = readFileSync(adminIndexHtml, "utf8");
       expect(adminHtml).toMatch(
-        /<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\],"metaBoxes":\[\]\}<\/script>/,
+        /<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\],"taxonomies":\[\],"metaBoxes":\[\]\}<\/script>/,
       );
     },
     60_000,

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -2,7 +2,7 @@ import type { Page, Route } from "@playwright/test";
 
 import type { AuthSessionOutput } from "@plumix/core";
 import type { PlumixManifest } from "@plumix/core/manifest";
-import type { Post, User } from "@plumix/core/schema";
+import type { Post, Term, User } from "@plumix/core/schema";
 
 // The e2e webServer is just Vite — no real backend — so every /_plumix/rpc
 // call is intercepted here and answered with a deterministic fixture.
@@ -24,6 +24,11 @@ interface MockRpcHandlers {
   "/user/disable"?: User;
   "/user/enable"?: User;
   "/user/delete"?: User;
+  "/term/list"?: readonly Term[];
+  "/term/get"?: Term;
+  "/term/create"?: Term;
+  "/term/update"?: Term;
+  "/term/delete"?: Term;
 }
 
 // oRPC's StandardRPCSerializer wire format — `meta` is always present,
@@ -102,6 +107,35 @@ export const MANIFEST_WITH_POST: PlumixManifest = {
       labels: { singular: "Post", plural: "Posts" },
     },
   ],
+  taxonomies: [],
+  metaBoxes: [],
+};
+
+// Manifest with two taxonomies — one hierarchical (category), one flat
+// (tag) — shared by the taxonomy e2e specs so both code paths can be
+// exercised from a single fixture.
+export const MANIFEST_WITH_TAXONOMIES: PlumixManifest = {
+  postTypes: [
+    {
+      name: "post",
+      adminSlug: "posts",
+      label: "Posts",
+      labels: { singular: "Post", plural: "Posts" },
+    },
+  ],
+  taxonomies: [
+    {
+      name: "category",
+      label: "Categories",
+      labels: { singular: "Category" },
+      isHierarchical: true,
+    },
+    {
+      name: "tag",
+      label: "Tags",
+      labels: { singular: "Tag" },
+    },
+  ],
   metaBoxes: [],
 };
 
@@ -116,6 +150,7 @@ export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
       labels: { singular: "Post", plural: "Posts" },
     },
   ],
+  taxonomies: [],
   metaBoxes: [
     {
       id: "seo",
@@ -175,6 +210,16 @@ export const AUTHED_ADMIN: AuthSessionOutput = {
       "user:edit_own",
       "user:list",
       "user:promote",
+      // Per-taxonomy caps matching MANIFEST_WITH_TAXONOMIES. The real
+      // server derives these from `deriveTaxonomyCapabilities(name)` for
+      // every registered taxonomy; mock-land hard-codes the union of
+      // every taxonomy that any fixture uses.
+      "category:read",
+      "category:edit",
+      "category:delete",
+      "tag:read",
+      "tag:edit",
+      "tag:delete",
     ],
   },
   needsBootstrap: false,

--- a/packages/admin/e2e/taxonomies.spec.ts
+++ b/packages/admin/e2e/taxonomies.spec.ts
@@ -1,0 +1,320 @@
+import { expect, test } from "@playwright/test";
+
+import type { Term } from "@plumix/core/schema";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_TAXONOMIES,
+  mockManifest,
+  mockRpc,
+} from "./support/rpc-mock.js";
+
+function term(overrides: Partial<Term> & { id: number; name: string }): Term {
+  return {
+    taxonomy: "category",
+    slug: overrides.name.toLowerCase().replaceAll(" ", "-"),
+    description: null,
+    parentId: null,
+    ...overrides,
+  };
+}
+
+test.describe("/taxonomies/$name (hierarchical)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_TAXONOMIES);
+  });
+
+  test("renders a tree-indented list and shows the New button for caps holders", async ({
+    page,
+  }) => {
+    const fruit = term({ id: 1, name: "Fruit", taxonomy: "category" });
+    const apple = term({
+      id: 2,
+      name: "Apple",
+      taxonomy: "category",
+      parentId: 1,
+    });
+    const granny = term({
+      id: 3,
+      name: "Granny Smith",
+      taxonomy: "category",
+      parentId: 2,
+    });
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/term/list": [fruit, apple, granny],
+    });
+
+    await page.goto("taxonomies/category");
+    await expect(page.getByTestId("taxonomy-list-heading")).toHaveText(
+      "Categories",
+    );
+
+    // Tree ordering: root (Fruit) → child (Apple) → grandchild (Granny).
+    const row1 = page.getByTestId("taxonomy-list-row-1");
+    const row2 = page.getByTestId("taxonomy-list-row-2");
+    const row3 = page.getByTestId("taxonomy-list-row-3");
+    await expect(row1).toHaveAttribute("aria-level", "1");
+    await expect(row2).toHaveAttribute("aria-level", "2");
+    await expect(row3).toHaveAttribute("aria-level", "3");
+
+    // Admin has `category:edit` cap — New button is visible.
+    await expect(page.getByTestId("taxonomy-list-new-button")).toBeVisible();
+  });
+
+  test("empty state renders when the taxonomy has no terms", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/term/list": [],
+    });
+    await page.goto("taxonomies/category");
+    await expect(page.getByTestId("taxonomy-list-empty-state")).toBeVisible();
+  });
+
+  test("unregistered taxonomy name → not-found page", async ({ page }) => {
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.goto("taxonomies/unregistered");
+    // TanStack Router renders the admin's generic not-found state.
+    await expect(page.getByTestId("not-found-page")).toBeVisible();
+  });
+
+  test("subscriber without `category:read` is redirected away from the list", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": {
+        user: {
+          id: 5,
+          email: "sub@example.test",
+          name: "Sub",
+          avatarUrl: null,
+          role: "subscriber",
+          capabilities: ["post:read"],
+        },
+        needsBootstrap: false,
+      },
+    });
+    await page.goto("taxonomies/category");
+    // beforeLoad throws notFound() since the user can't read this
+    // taxonomy — the generic 404 surface handles it.
+    await expect(page.getByTestId("not-found-page")).toBeVisible();
+  });
+});
+
+test.describe("/taxonomies/$name/new", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_TAXONOMIES);
+  });
+
+  test("hierarchical: parent picker shows existing terms, derives slug from name on submit", async ({
+    page,
+  }) => {
+    const createInputs: unknown[] = [];
+    const fruit = term({ id: 1, name: "Fruit", taxonomy: "category" });
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/term/list")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: [fruit], meta: [] }),
+        });
+      }
+      if (url.endsWith("/term/create")) {
+        createInputs.push(
+          (route.request().postDataJSON() as { json?: unknown }).json,
+        );
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: term({
+              id: 42,
+              name: "Vegetables",
+              taxonomy: "category",
+              slug: "vegetables",
+            }),
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("taxonomies/category/new");
+    await expect(page.getByTestId("term-new-heading")).toContainText(
+      "New category",
+    );
+    await page.getByTestId("term-form-name-input").fill("Vegetables");
+    // Leave slug blank — should be derived from name on submit.
+    await page.getByTestId("term-form-submit").click();
+
+    await expect
+      .poll(() => (createInputs.at(-1) as { slug?: string } | undefined)?.slug)
+      .toBe("vegetables");
+    expect((createInputs.at(-1) as { name?: string } | undefined)?.name).toBe(
+      "Vegetables",
+    );
+    // Redirected back to list on success.
+    await expect(page).toHaveURL(/\/taxonomies\/category\?/);
+  });
+
+  test("flat taxonomy (tag): parent picker is hidden", async ({ page }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/term/list": [],
+    });
+    await page.goto("taxonomies/tag/new");
+    await expect(page.getByTestId("term-new-heading")).toContainText("New tag");
+    // Parent picker is hidden for flat taxonomies.
+    await expect(page.getByTestId("term-form-parent-select")).toHaveCount(0);
+  });
+
+  test("slug_taken CONFLICT surfaces a friendly message", async ({ page }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/term/list")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: [], meta: [] }),
+        });
+      }
+      if (url.endsWith("/term/create")) {
+        return route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              defined: true,
+              code: "CONFLICT",
+              status: 409,
+              message: "Resource conflict",
+              data: { reason: "slug_taken" },
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("taxonomies/category/new");
+    await page.getByTestId("term-form-name-input").fill("Dup");
+    await page.getByTestId("term-form-submit").click();
+    await expect(page.getByTestId("term-form-server-error")).toBeVisible();
+    await expect(page.getByTestId("term-form-server-error")).toContainText(
+      "slug already exists",
+    );
+  });
+});
+
+test.describe("/taxonomies/$name/$id", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_TAXONOMIES);
+  });
+
+  test("edit: parent picker excludes self and descendants (cycle prevention)", async ({
+    page,
+  }) => {
+    // Tree: Fruit (1) → Apple (2) → Granny (3). Editing Apple's parent
+    // must exclude Apple (self) and Granny (descendant) so the user
+    // can't pick a cycle the server would reject.
+    const fruit = term({ id: 1, name: "Fruit", taxonomy: "category" });
+    const apple = term({
+      id: 2,
+      name: "Apple",
+      taxonomy: "category",
+      parentId: 1,
+    });
+    const granny = term({
+      id: 3,
+      name: "Granny Smith",
+      taxonomy: "category",
+      parentId: 2,
+    });
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/term/get": apple,
+      "/term/list": [fruit, apple, granny],
+    });
+    await page.goto("taxonomies/category/2");
+    await expect(page.getByTestId("term-edit-heading")).toContainText(
+      "Edit category",
+    );
+
+    const selectOptions = await page
+      .getByTestId("term-form-parent-select")
+      .locator("option")
+      .allTextContents();
+    // Root + Fruit only; Apple (self) + Granny (descendant) excluded.
+    expect(selectOptions.some((o) => o.includes("Fruit"))).toBe(true);
+    expect(selectOptions.some((o) => o.includes("Apple"))).toBe(false);
+    expect(selectOptions.some((o) => o.includes("Granny"))).toBe(false);
+  });
+
+  test("delete flow: confirm → redirect to list", async ({ page }) => {
+    const target = term({ id: 42, name: "Stale", taxonomy: "category" });
+    const deleteInputs: unknown[] = [];
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/term/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: target, meta: [] }),
+        });
+      }
+      if (url.endsWith("/term/list")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: [target], meta: [] }),
+        });
+      }
+      if (url.endsWith("/term/delete")) {
+        deleteInputs.push(
+          (route.request().postDataJSON() as { json?: unknown }).json,
+        );
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: target, meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("taxonomies/category/42");
+    await page.getByTestId("term-edit-delete-button").click();
+    await page.getByTestId("term-delete-confirm-button").click();
+
+    await expect
+      .poll(() => (deleteInputs.at(-1) as { id?: number } | undefined)?.id)
+      .toBe(42);
+    await expect(page).toHaveURL(/\/taxonomies\/category\?/);
+  });
+});

--- a/packages/admin/src/components/form/edit-skeleton.tsx
+++ b/packages/admin/src/components/form/edit-skeleton.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
+
+/**
+ * Shared "form-shaped loading state" for the admin's edit routes
+ * (users/$id, taxonomies/$name/$id, and future settings screens).
+ * Renders a content-shaped shimmer instead of a plain "Loading…"
+ * string so the form doesn't pop in with a visible reflow once the
+ * query resolves.
+ *
+ * `role="status"` + `aria-live` announces loading to assistive tech
+ * via the `ariaLabel` prop; sighted users get the visual shimmer.
+ * Each consumer picks its own `testId` so e2e can wait for the right
+ * loading state without false positives across routes.
+ */
+export function FormEditSkeleton({
+  ariaLabel,
+  testId,
+}: {
+  readonly ariaLabel: string;
+  readonly testId: string;
+}): ReactNode {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className="mx-auto flex w-full max-w-xl flex-col gap-4"
+    >
+      <Skeleton className="h-4 w-24" />
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/admin/src/components/shell/app-sidebar.tsx
+++ b/packages/admin/src/components/shell/app-sidebar.tsx
@@ -13,9 +13,9 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar.js";
 import { hasCap } from "@/lib/caps.js";
-import { visiblePostTypes } from "@/lib/manifest.js";
+import { visiblePostTypes, visibleTaxonomies } from "@/lib/manifest.js";
 import { Link } from "@tanstack/react-router";
-import { FileText, LayoutDashboard, Users } from "lucide-react";
+import { FileText, LayoutDashboard, Tag, Users } from "lucide-react";
 
 import type { UserIdentity } from "./user-menu.js";
 import { UserMenu } from "./user-menu.js";
@@ -56,6 +56,19 @@ function buildContentGroup(capabilities: readonly string[]): NavGroup | null {
   return { label: "Content", items };
 }
 
+// Core registers no taxonomies — a bare install hides the "Taxonomies"
+// group entirely. The blog plugin (Phase 12) is the first consumer;
+// other plugins bring their own (product categories, doc sections, …).
+function buildTaxonomyGroup(capabilities: readonly string[]): NavGroup | null {
+  const items = visibleTaxonomies(capabilities).map<NavItem>((tax) => ({
+    to: `/taxonomies/${tax.name}`,
+    label: tax.label,
+    icon: Tag,
+  }));
+  if (items.length === 0) return null;
+  return { label: "Taxonomies", items };
+}
+
 // `user:list` is admin / editor-level. Subscribers and authors see their
 // own profile via `/profile` (future PR) but don't get a user-management
 // nav entry at all — matches WordPress's "Users" menu being role-gated.
@@ -77,10 +90,12 @@ export function AppSidebar({
   capabilities: readonly string[];
 }): ReactNode {
   const contentGroup = buildContentGroup(capabilities);
+  const taxonomyGroup = buildTaxonomyGroup(capabilities);
   const managementGroup = buildManagementGroup(capabilities);
   const groups = [
     OVERVIEW_GROUP,
     ...(contentGroup ? [contentGroup] : []),
+    ...(taxonomyGroup ? [taxonomyGroup] : []),
     ...(managementGroup ? [managementGroup] : []),
   ];
   return (

--- a/packages/admin/src/components/taxonomy/term-form.tsx
+++ b/packages/admin/src/components/taxonomy/term-form.tsx
@@ -7,7 +7,7 @@ import { useForm } from "@tanstack/react-form";
 import * as v from "valibot";
 
 /** Normalised input shape consumed by both create + update paths. */
-export interface TermFormValues {
+interface TermFormValues {
   readonly name: string;
   readonly slug: string;
   readonly description: string;
@@ -45,7 +45,7 @@ const termFormSchema = v.object({
  * itself and its descendants — client-side cycle prevention that's
  * kinder than a round-trip to a CONFLICT.
  */
-export interface ParentOption {
+interface ParentOption {
   readonly id: number;
   readonly label: string;
 }

--- a/packages/admin/src/components/taxonomy/term-form.tsx
+++ b/packages/admin/src/components/taxonomy/term-form.tsx
@@ -1,0 +1,210 @@
+import type { ReactNode } from "react";
+import { FormField } from "@/components/form/field.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import { Label } from "@/components/ui/label.js";
+import { useForm } from "@tanstack/react-form";
+import * as v from "valibot";
+
+/** Normalised input shape consumed by both create + update paths. */
+export interface TermFormValues {
+  readonly name: string;
+  readonly slug: string;
+  readonly description: string;
+  readonly parentId: number | null;
+}
+
+// Client-side shape mirrors `termCreateInputSchema` / `termUpdateInputSchema`
+// on the server. Slug is optional at the form level — the server derives
+// it from the name if omitted (see `term.create` handler).
+const termFormSchema = v.object({
+  name: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(200)),
+  slug: v.pipe(
+    v.string(),
+    v.trim(),
+    v.maxLength(200),
+    v.regex(
+      /^[a-z0-9-]*$/,
+      "Slug may only contain lowercase letters, digits, and hyphens.",
+    ),
+  ),
+  description: v.pipe(v.string(), v.trim(), v.maxLength(2000)),
+  parentId: v.nullable(v.pipe(v.number(), v.integer(), v.minValue(1))),
+});
+
+/**
+ * Form component shared by `/taxonomies/$name/new` and
+ * `/taxonomies/$name/$id` — the only differences between create and
+ * edit are the mutation target + the default values, both injected by
+ * the parent route. The `submitLabel` prop lets callers say "Create" vs
+ * "Save changes" without the form knowing which mode it's in.
+ *
+ * `parentOptions` is a pre-flattened list with depth-indented labels
+ * (see `parentPickerOptions` in `./tree.ts`) so the select visibly
+ * conveys nesting. Editing a term? Pass a list that excludes the term
+ * itself and its descendants — client-side cycle prevention that's
+ * kinder than a round-trip to a CONFLICT.
+ */
+export interface ParentOption {
+  readonly id: number;
+  readonly label: string;
+}
+
+export function TermForm({
+  initialValues,
+  isHierarchical,
+  parentOptions,
+  isSubmitting,
+  serverError,
+  submitLabel,
+  onSubmit,
+  onCancel,
+}: {
+  readonly initialValues: TermFormValues;
+  readonly isHierarchical: boolean;
+  readonly parentOptions: readonly ParentOption[];
+  readonly isSubmitting: boolean;
+  readonly serverError: string | null;
+  readonly submitLabel: string;
+  readonly onSubmit: (values: TermFormValues) => void;
+  readonly onCancel: () => void;
+}): ReactNode {
+  const form = useForm({
+    defaultValues: initialValues,
+    validators: {
+      onSubmit: ({ value }) => {
+        const result = v.safeParse(termFormSchema, value);
+        return result.success ? undefined : result.issues[0].message;
+      },
+    },
+    onSubmit: ({ value }) => {
+      onSubmit(value);
+    },
+  });
+
+  return (
+    <form
+      className="flex flex-col gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void form.handleSubmit();
+      }}
+    >
+      <form.Field name="name">
+        {(field) => (
+          <FormField
+            field={field}
+            label="Name"
+            type="text"
+            required
+            disabled={isSubmitting}
+            data-testid="term-form-name-input"
+          />
+        )}
+      </form.Field>
+
+      <form.Field name="slug">
+        {(field) => (
+          <FormField
+            field={field}
+            label={
+              <>
+                Slug <span className="text-muted-foreground">(optional)</span>
+              </>
+            }
+            type="text"
+            autoComplete="off"
+            disabled={isSubmitting}
+            data-testid="term-form-slug-input"
+            placeholder="derived-from-name-if-blank"
+          />
+        )}
+      </form.Field>
+
+      <form.Field name="description">
+        {(field) => (
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="term-description">
+              Description{" "}
+              <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <textarea
+              id="term-description"
+              name="description"
+              value={field.state.value}
+              onChange={(e) => {
+                field.handleChange(e.target.value);
+              }}
+              disabled={isSubmitting}
+              rows={3}
+              data-testid="term-form-description-input"
+              className="border-input bg-background focus-visible:ring-ring flex min-h-20 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </div>
+        )}
+      </form.Field>
+
+      {isHierarchical ? (
+        <form.Field name="parentId">
+          {(field) => (
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="term-parent">
+                Parent <span className="text-muted-foreground">(optional)</span>
+              </Label>
+              <select
+                id="term-parent"
+                name="parentId"
+                value={
+                  field.state.value == null ? "" : String(field.state.value)
+                }
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  field.handleChange(raw === "" ? null : Number(raw));
+                }}
+                disabled={isSubmitting}
+                data-testid="term-form-parent-select"
+                className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">— root —</option>
+                {parentOptions.map((opt) => (
+                  <option key={opt.id} value={String(opt.id)}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </form.Field>
+      ) : null}
+
+      {serverError ? (
+        <Alert variant="destructive" data-testid="term-form-server-error">
+          <AlertDescription>{serverError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+        <form.Subscribe selector={(state) => state.canSubmit}>
+          {(canSubmit) => (
+            <Button
+              type="submit"
+              disabled={!canSubmit || isSubmitting}
+              data-testid="term-form-submit"
+            >
+              {isSubmitting ? "Saving…" : submitLabel}
+            </Button>
+          )}
+        </form.Subscribe>
+      </div>
+    </form>
+  );
+}

--- a/packages/admin/src/components/taxonomy/tree.test.ts
+++ b/packages/admin/src/components/taxonomy/tree.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "vitest";
+
+import type { Term } from "@plumix/core/schema";
+
+import {
+  buildTermTree,
+  descendantIds,
+  flattenTree,
+  parentPickerOptions,
+} from "./tree.js";
+
+function term(overrides: Partial<Term> & { id: number; name: string }): Term {
+  return {
+    taxonomy: "category",
+    slug: overrides.name.toLowerCase().replaceAll(" ", "-"),
+    description: null,
+    parentId: null,
+    ...overrides,
+  };
+}
+
+describe("buildTermTree", () => {
+  test("empty input yields an empty forest", () => {
+    expect(buildTermTree([])).toEqual([]);
+  });
+
+  test("roots are terms with null parentId", () => {
+    const tree = buildTermTree([
+      term({ id: 1, name: "Food" }),
+      term({ id: 2, name: "Drink" }),
+    ]);
+    expect(tree.map((n) => n.term.id)).toEqual([2, 1]); // alpha: Drink, Food
+    expect(tree[0]?.children).toEqual([]);
+  });
+
+  test("sorts siblings alphabetically (matches server ORDER BY name)", () => {
+    const tree = buildTermTree([
+      term({ id: 1, name: "Zeta" }),
+      term({ id: 2, name: "Alpha" }),
+      term({ id: 3, name: "Mu" }),
+    ]);
+    expect(tree.map((n) => n.term.name)).toEqual(["Alpha", "Mu", "Zeta"]);
+  });
+
+  test("nests children under their parent", () => {
+    const tree = buildTermTree([
+      term({ id: 1, name: "Food" }),
+      term({ id: 2, name: "Fruit", parentId: 1 }),
+      term({ id: 3, name: "Apple", parentId: 2 }),
+    ]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.term.name).toBe("Food");
+    expect(tree[0]?.children).toHaveLength(1);
+    expect(tree[0]?.children[0]?.term.name).toBe("Fruit");
+    expect(tree[0]?.children[0]?.children[0]?.term.name).toBe("Apple");
+  });
+
+  test("orphan promotion: parentId pointing outside the set → rendered at root", () => {
+    // Real-world cause: a taxonomy with >200 terms where the edit-page
+    // siblings query paginates out a term's actual parent. Better to
+    // still render the orphan at root than drop it silently.
+    const tree = buildTermTree([
+      term({ id: 5, name: "Orphan", parentId: 999 }),
+    ]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.term.id).toBe(5);
+  });
+});
+
+describe("flattenTree", () => {
+  test("DFS preserves tree order and carries depth", () => {
+    const tree = buildTermTree([
+      term({ id: 1, name: "Food" }),
+      term({ id: 2, name: "Fruit", parentId: 1 }),
+      term({ id: 3, name: "Apple", parentId: 2 }),
+      term({ id: 4, name: "Vegetable", parentId: 1 }),
+    ]);
+    const flat = flattenTree(tree);
+    expect(flat.map((n) => [n.term.name, n.depth])).toEqual([
+      ["Food", 0],
+      ["Fruit", 1],
+      ["Apple", 2],
+      ["Vegetable", 1],
+    ]);
+  });
+});
+
+describe("descendantIds", () => {
+  test("includes the root itself plus every descendant", () => {
+    const terms: Term[] = [
+      term({ id: 1, name: "Food" }),
+      term({ id: 2, name: "Fruit", parentId: 1 }),
+      term({ id: 3, name: "Apple", parentId: 2 }),
+      term({ id: 4, name: "Vegetable", parentId: 1 }),
+    ];
+    expect([...descendantIds(terms, 1)].sort()).toEqual([1, 2, 3, 4]);
+    expect([...descendantIds(terms, 2)].sort()).toEqual([2, 3]);
+    expect([...descendantIds(terms, 3)].sort()).toEqual([3]);
+  });
+
+  test("rootId not in the tree → empty set (caller must backstop)", () => {
+    // This is the gap the `$id.tsx` edit route works around by
+    // always seeding `excludeIds` with the term's own id. This test
+    // locks in the `descendantIds` behaviour so a future "helpful"
+    // refactor doesn't quietly change the contract.
+    const terms: Term[] = [term({ id: 1, name: "Food" })];
+    expect(descendantIds(terms, 999)).toEqual(new Set());
+  });
+
+  test("empty input is safe", () => {
+    expect(descendantIds([], 1)).toEqual(new Set());
+  });
+});
+
+describe("parentPickerOptions", () => {
+  test("returns all terms with depth-prefixed labels", () => {
+    const terms: Term[] = [
+      term({ id: 1, name: "Food" }),
+      term({ id: 2, name: "Fruit", parentId: 1 }),
+      term({ id: 3, name: "Apple", parentId: 2 }),
+    ];
+    expect(parentPickerOptions(terms)).toEqual([
+      { id: 1, label: "Food" },
+      { id: 2, label: "— Fruit" },
+      { id: 3, label: "— — Apple" },
+    ]);
+  });
+
+  test("respects the exclude set (self + descendants for cycle prevention)", () => {
+    const terms: Term[] = [
+      term({ id: 1, name: "Food" }),
+      term({ id: 2, name: "Fruit", parentId: 1 }),
+      term({ id: 3, name: "Apple", parentId: 2 }),
+      term({ id: 4, name: "Vegetable", parentId: 1 }),
+    ];
+    // Editing "Fruit" (id=2): exclude itself + Apple (descendant) so
+    // the picker can't suggest a parent change that creates a cycle.
+    const exclude = new Set([2, 3]);
+    const ids = parentPickerOptions(terms, exclude).map((o) => o.id);
+    expect(ids).toEqual([1, 4]);
+  });
+});

--- a/packages/admin/src/components/taxonomy/tree.ts
+++ b/packages/admin/src/components/taxonomy/tree.ts
@@ -15,7 +15,7 @@ import type { Term } from "@plumix/core/schema";
  * enough rows (via a large limit) before calling these helpers.
  */
 
-export interface TermNode {
+interface TermNode {
   readonly term: Term;
   readonly children: readonly TermNode[];
 }
@@ -53,7 +53,7 @@ export function buildTermTree(terms: readonly Term[]): readonly TermNode[] {
   return build(null);
 }
 
-export interface FlatTermNode {
+interface FlatTermNode {
   readonly term: Term;
   readonly depth: number;
 }

--- a/packages/admin/src/components/taxonomy/tree.ts
+++ b/packages/admin/src/components/taxonomy/tree.ts
@@ -1,0 +1,129 @@
+import type { Term } from "@plumix/core/schema";
+
+/**
+ * Hierarchical-taxonomy helpers. WordPress renders hierarchical term
+ * admin as a flat list with parent-id badges; we build an actual tree
+ * so the UI shows the structure at a glance (indent in the list,
+ * breadcrumb in the parent picker) and client-side cycle prevention is
+ * possible.
+ *
+ * These are pure utilities — no React, no I/O. The list route passes
+ * in whatever page `term.list` returned; the tree only reflects
+ * whatever's in that payload. Orphans (children whose parent isn't in
+ * the set) are promoted to roots so they still render rather than
+ * vanishing silently. Callers that need the full tree should fetch
+ * enough rows (via a large limit) before calling these helpers.
+ */
+
+export interface TermNode {
+  readonly term: Term;
+  readonly children: readonly TermNode[];
+}
+
+/**
+ * Build a forest from a flat `Term[]`. Roots are terms with
+ * `parentId == null` OR whose parent isn't present in the input (see
+ * orphan-promotion note above).
+ */
+export function buildTermTree(terms: readonly Term[]): readonly TermNode[] {
+  const byId = new Map<number, Term>();
+  for (const t of terms) byId.set(t.id, t);
+
+  const childMap = new Map<number | null, Term[]>();
+  for (const t of terms) {
+    // Orphan promotion: treat "parent not in the set" as root-level.
+    const parentKey =
+      t.parentId != null && byId.has(t.parentId) ? t.parentId : null;
+    const bucket = childMap.get(parentKey) ?? [];
+    bucket.push(t);
+    childMap.set(parentKey, bucket);
+  }
+
+  // Sort each bucket alphabetically — matches the server's
+  // `ORDER BY name ASC` for root-level terms and keeps siblings
+  // predictable.
+  for (const bucket of childMap.values()) {
+    bucket.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  function build(parentId: number | null): TermNode[] {
+    const bucket = childMap.get(parentId) ?? [];
+    return bucket.map((t) => ({ term: t, children: build(t.id) }));
+  }
+  return build(null);
+}
+
+export interface FlatTermNode {
+  readonly term: Term;
+  readonly depth: number;
+}
+
+/** DFS flatten, preserving order — for rendering an indented list. */
+export function flattenTree(
+  tree: readonly TermNode[],
+  depth = 0,
+): readonly FlatTermNode[] {
+  const out: FlatTermNode[] = [];
+  for (const node of tree) {
+    out.push({ term: node.term, depth });
+    out.push(...flattenTree(node.children, depth + 1));
+  }
+  return out;
+}
+
+/**
+ * Collect the ids of `root` + every descendant. Used to exclude a term
+ * and its subtree from the parent-picker in the edit form — setting
+ * your parent to yourself or one of your descendants creates a cycle
+ * the server would reject anyway, but surfacing the constraint in the
+ * picker is kinder than a round-trip to a CONFLICT.
+ */
+export function descendantIds(
+  terms: readonly Term[],
+  rootId: number,
+): ReadonlySet<number> {
+  const tree = buildTermTree(terms);
+  const ids = new Set<number>();
+  function visit(nodes: readonly TermNode[]): void {
+    for (const node of nodes) {
+      ids.add(node.term.id);
+      visit(node.children);
+    }
+  }
+  function findAndVisit(nodes: readonly TermNode[]): boolean {
+    for (const node of nodes) {
+      if (node.term.id === rootId) {
+        ids.add(node.term.id);
+        visit(node.children);
+        return true;
+      }
+      if (findAndVisit(node.children)) return true;
+    }
+    return false;
+  }
+  findAndVisit(tree);
+  return ids;
+}
+
+/**
+ * Build labelled options for a `<select>` parent-picker: the term's
+ * name prefixed with depth indentation (`— — Name`) so nesting is
+ * visible in the flat `<option>` list. WordPress does something
+ * similar but uses `&nbsp;` spaces which don't copy cleanly; we use
+ * em-dashes which render identically across browsers and transcribe
+ * sensibly for screen readers.
+ */
+export function parentPickerOptions(
+  terms: readonly Term[],
+  exclude: ReadonlySet<number> = new Set(),
+): readonly { readonly id: number; readonly label: string }[] {
+  return flattenTree(buildTermTree(terms))
+    .filter((entry) => !exclude.has(entry.term.id))
+    .map((entry) => ({
+      id: entry.term.id,
+      label:
+        entry.depth === 0
+          ? entry.term.name
+          : `${"— ".repeat(entry.depth)}${entry.term.name}`,
+    }));
+}

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -7,9 +7,11 @@ import type {
 
 import {
   findPostTypeBySlug,
+  findTaxonomyByName,
   metaBoxesForPostType,
   readManifest,
   visiblePostTypes,
+  visibleTaxonomies,
 } from "./manifest.js";
 
 function withManifestScript(json: string): Document {
@@ -29,7 +31,11 @@ describe("readManifest", () => {
 
   test("returns empty manifest when the script tag is absent", () => {
     const doc = document.implementation.createHTMLDocument("test");
-    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
+    expect(readManifest(doc)).toEqual({
+      postTypes: [],
+      taxonomies: [],
+      metaBoxes: [],
+    });
   });
 
   test("parses the injected JSON payload", () => {
@@ -40,13 +46,18 @@ describe("readManifest", () => {
     );
     expect(readManifest(doc)).toEqual({
       postTypes: [{ name: "post", label: "Posts" }],
+      taxonomies: [],
       metaBoxes: [],
     });
   });
 
   test("empty payload falls back to empty manifest", () => {
     const doc = withManifestScript("");
-    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
+    expect(readManifest(doc)).toEqual({
+      postTypes: [],
+      taxonomies: [],
+      metaBoxes: [],
+    });
   });
 
   test("malformed JSON logs and falls back without throwing", () => {
@@ -54,20 +65,32 @@ describe("readManifest", () => {
       // swallow expected error log
     });
     const doc = withManifestScript("{not-json");
-    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
+    expect(readManifest(doc)).toEqual({
+      postTypes: [],
+      taxonomies: [],
+      metaBoxes: [],
+    });
     expect(errSpy).toHaveBeenCalledOnce();
   });
 
   test("non-array postTypes coerces to empty array", () => {
     const doc = withManifestScript(JSON.stringify({ postTypes: "oops" }));
-    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
+    expect(readManifest(doc)).toEqual({
+      postTypes: [],
+      taxonomies: [],
+      metaBoxes: [],
+    });
   });
 
   test("non-array metaBoxes coerces to empty array", () => {
     const doc = withManifestScript(
       JSON.stringify({ postTypes: [], metaBoxes: "oops" }),
     );
-    expect(readManifest(doc)).toEqual({ postTypes: [], metaBoxes: [] });
+    expect(readManifest(doc)).toEqual({
+      postTypes: [],
+      taxonomies: [],
+      metaBoxes: [],
+    });
   });
 
   test("parses the injected JSON payload with metaBoxes", () => {
@@ -86,6 +109,7 @@ describe("readManifest", () => {
     );
     expect(readManifest(doc)).toEqual({
       postTypes: [],
+      taxonomies: [],
       metaBoxes: [
         {
           id: "seo",
@@ -96,6 +120,39 @@ describe("readManifest", () => {
       ],
     });
   });
+
+  test("parses the injected JSON payload with taxonomies", () => {
+    const doc = withManifestScript(
+      JSON.stringify({
+        postTypes: [],
+        taxonomies: [
+          {
+            name: "category",
+            label: "Categories",
+            isHierarchical: true,
+          },
+        ],
+      }),
+    );
+    expect(readManifest(doc)).toEqual({
+      postTypes: [],
+      taxonomies: [
+        {
+          name: "category",
+          label: "Categories",
+          isHierarchical: true,
+        },
+      ],
+      metaBoxes: [],
+    });
+  });
+
+  test("non-array taxonomies coerces to empty array", () => {
+    const doc = withManifestScript(
+      JSON.stringify({ postTypes: [], taxonomies: "not-an-array" }),
+    );
+    expect(readManifest(doc).taxonomies).toEqual([]);
+  });
 });
 
 describe("findPostTypeBySlug", () => {
@@ -104,6 +161,7 @@ describe("findPostTypeBySlug", () => {
       { name: "post", adminSlug: "posts", label: "Posts" },
       { name: "product", adminSlug: "products", label: "Products" },
     ],
+    taxonomies: [],
     metaBoxes: [],
   };
 
@@ -133,6 +191,7 @@ describe("visiblePostTypes", () => {
         capabilityType: "post",
       },
     ],
+    taxonomies: [],
     metaBoxes: [],
   };
 
@@ -163,6 +222,7 @@ describe("metaBoxesForPostType", () => {
 
   test("returns boxes applicable to the post type, honours priority order", () => {
     const source: PlumixManifest = {
+      taxonomies: [],
       postTypes: [],
       metaBoxes: [
         box("a", { priority: "low" }),
@@ -176,6 +236,7 @@ describe("metaBoxesForPostType", () => {
 
   test("insertion order is the tiebreaker among boxes at the same priority", () => {
     const source: PlumixManifest = {
+      taxonomies: [],
       postTypes: [],
       metaBoxes: [
         box("first", { priority: "high" }),
@@ -188,6 +249,7 @@ describe("metaBoxesForPostType", () => {
 
   test("drops boxes whose `postTypes` doesn't include the target", () => {
     const source: PlumixManifest = {
+      taxonomies: [],
       postTypes: [],
       metaBoxes: [
         box("seo", { postTypes: ["post"] }),
@@ -200,6 +262,7 @@ describe("metaBoxesForPostType", () => {
 
   test("drops boxes gated by a capability the user lacks", () => {
     const source: PlumixManifest = {
+      taxonomies: [],
       postTypes: [],
       metaBoxes: [
         box("public"),
@@ -218,7 +281,52 @@ describe("metaBoxesForPostType", () => {
   });
 
   test("returns empty when no meta boxes are registered", () => {
-    const source: PlumixManifest = { postTypes: [], metaBoxes: [] };
+    const source: PlumixManifest = {
+      postTypes: [],
+      taxonomies: [],
+      metaBoxes: [],
+    };
     expect(metaBoxesForPostType("post", [], source)).toEqual([]);
+  });
+});
+
+describe("findTaxonomyByName", () => {
+  const source: PlumixManifest = {
+    postTypes: [],
+    taxonomies: [
+      { name: "category", label: "Categories", isHierarchical: true },
+      { name: "tag", label: "Tags" },
+    ],
+    metaBoxes: [],
+  };
+
+  test("returns the matching taxonomy", () => {
+    expect(findTaxonomyByName("tag", source)?.label).toBe("Tags");
+  });
+
+  test("returns undefined when no taxonomy matches", () => {
+    expect(findTaxonomyByName("mystery", source)).toBeUndefined();
+  });
+});
+
+describe("visibleTaxonomies", () => {
+  const source: PlumixManifest = {
+    postTypes: [],
+    taxonomies: [
+      { name: "category", label: "Categories" },
+      { name: "tag", label: "Tags" },
+      { name: "internal", label: "Internal" },
+    ],
+    metaBoxes: [],
+  };
+
+  test("filters by per-taxonomy :read capability", () => {
+    const caps = ["category:read", "tag:read"];
+    const visible = visibleTaxonomies(caps, source).map((t) => t.name);
+    expect(visible).toEqual(["category", "tag"]);
+  });
+
+  test("returns empty when the caller has no taxonomy :read caps", () => {
+    expect(visibleTaxonomies(["post:edit_own"], source)).toEqual([]);
   });
 });

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -2,6 +2,7 @@ import type {
   MetaBoxManifestEntry,
   PlumixManifest,
   PostTypeManifestEntry,
+  TaxonomyManifestEntry,
 } from "@plumix/core/manifest";
 import { emptyManifest, MANIFEST_SCRIPT_ID } from "@plumix/core/manifest";
 
@@ -31,9 +32,11 @@ export function readManifest(doc: Document = document): PlumixManifest {
 function normalize(value: unknown): PlumixManifest {
   if (!value || typeof value !== "object") return emptyManifest();
   const postTypes = (value as { postTypes?: unknown }).postTypes;
+  const taxonomies = (value as { taxonomies?: unknown }).taxonomies;
   const metaBoxes = (value as { metaBoxes?: unknown }).metaBoxes;
   return {
     postTypes: Array.isArray(postTypes) ? postTypes : [],
+    taxonomies: Array.isArray(taxonomies) ? taxonomies : [],
     metaBoxes: Array.isArray(metaBoxes) ? metaBoxes : [],
   };
 }
@@ -79,6 +82,32 @@ export function visiblePostTypes(
     const cap = `${pt.capabilityType ?? pt.name}:edit_own`;
     return caps.has(cap);
   });
+}
+
+/**
+ * Look up a registered taxonomy by its name (the `/taxonomies/$name`
+ * route param). Returns `undefined` when the name doesn't match — the
+ * route component should render a 404-style not-found state.
+ */
+export function findTaxonomyByName(
+  name: string,
+  source: PlumixManifest = manifest,
+): TaxonomyManifestEntry | undefined {
+  return source.taxonomies.find((tax) => tax.name === name);
+}
+
+/**
+ * Sidebar gate: which taxonomies should show up in the admin nav for a
+ * user with the given capability set. Gates on `${taxonomy}:read` —
+ * subscribers and above can see a taxonomy if they can read it; edit /
+ * delete are gated separately per action inside the route.
+ */
+export function visibleTaxonomies(
+  capabilities: readonly string[],
+  source: PlumixManifest = manifest,
+): readonly TaxonomyManifestEntry[] {
+  const caps = new Set(capabilities);
+  return source.taxonomies.filter((tax) => caps.has(`${tax.name}:read`));
 }
 
 // Ordering for meta-box `priority`. Boxes render top-down in the editor

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -19,7 +19,10 @@ import { Route as AuthenticatedUsersIndexRouteImport } from "./routes/_authentic
 import { Route as AuthenticatedUsersNewRouteImport } from "./routes/_authenticated/users/new";
 import { Route as AuthenticatedUsersIdRouteImport } from "./routes/_authenticated/users/$id";
 import { Route as AuthAcceptInviteTokenRouteImport } from "./routes/_auth/accept-invite/$token";
+import { Route as AuthenticatedTaxonomiesNameIndexRouteImport } from "./routes/_authenticated/taxonomies/$name/index";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
+import { Route as AuthenticatedTaxonomiesNameNewRouteImport } from "./routes/_authenticated/taxonomies/$name/new";
+import { Route as AuthenticatedTaxonomiesNameIdRouteImport } from "./routes/_authenticated/taxonomies/$name/$id";
 import { Route as AuthenticatedContentSlugNewRouteImport } from "./routes/_authenticated/content/$slug/new";
 import { Route as AuthenticatedContentSlugIdRouteImport } from "./routes/_authenticated/content/$slug/$id";
 
@@ -71,10 +74,28 @@ const AuthAcceptInviteTokenRoute = AuthAcceptInviteTokenRouteImport.update({
   path: "/accept-invite/$token",
   getParentRoute: () => AuthRoute,
 } as any);
+const AuthenticatedTaxonomiesNameIndexRoute =
+  AuthenticatedTaxonomiesNameIndexRouteImport.update({
+    id: "/taxonomies/$name/",
+    path: "/taxonomies/$name/",
+    getParentRoute: () => AuthenticatedRoute,
+  } as any);
 const AuthenticatedContentSlugIndexRoute =
   AuthenticatedContentSlugIndexRouteImport.update({
     id: "/content/$slug/",
     path: "/content/$slug/",
+    getParentRoute: () => AuthenticatedRoute,
+  } as any);
+const AuthenticatedTaxonomiesNameNewRoute =
+  AuthenticatedTaxonomiesNameNewRouteImport.update({
+    id: "/taxonomies/$name/new",
+    path: "/taxonomies/$name/new",
+    getParentRoute: () => AuthenticatedRoute,
+  } as any);
+const AuthenticatedTaxonomiesNameIdRoute =
+  AuthenticatedTaxonomiesNameIdRouteImport.update({
+    id: "/taxonomies/$name/$id",
+    path: "/taxonomies/$name/$id",
     getParentRoute: () => AuthenticatedRoute,
   } as any);
 const AuthenticatedContentSlugNewRoute =
@@ -101,7 +122,10 @@ export interface FileRoutesByFullPath {
   "/users/": typeof AuthenticatedUsersIndexRoute;
   "/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
+  "/taxonomies/$name/$id": typeof AuthenticatedTaxonomiesNameIdRoute;
+  "/taxonomies/$name/new": typeof AuthenticatedTaxonomiesNameNewRoute;
   "/content/$slug/": typeof AuthenticatedContentSlugIndexRoute;
+  "/taxonomies/$name/": typeof AuthenticatedTaxonomiesNameIndexRoute;
 }
 export interface FileRoutesByTo {
   "/": typeof AuthenticatedIndexRoute;
@@ -114,7 +138,10 @@ export interface FileRoutesByTo {
   "/users": typeof AuthenticatedUsersIndexRoute;
   "/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
+  "/taxonomies/$name/$id": typeof AuthenticatedTaxonomiesNameIdRoute;
+  "/taxonomies/$name/new": typeof AuthenticatedTaxonomiesNameNewRoute;
   "/content/$slug": typeof AuthenticatedContentSlugIndexRoute;
+  "/taxonomies/$name": typeof AuthenticatedTaxonomiesNameIndexRoute;
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
@@ -130,7 +157,10 @@ export interface FileRoutesById {
   "/_authenticated/users/": typeof AuthenticatedUsersIndexRoute;
   "/_authenticated/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/_authenticated/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
+  "/_authenticated/taxonomies/$name/$id": typeof AuthenticatedTaxonomiesNameIdRoute;
+  "/_authenticated/taxonomies/$name/new": typeof AuthenticatedTaxonomiesNameNewRoute;
   "/_authenticated/content/$slug/": typeof AuthenticatedContentSlugIndexRoute;
+  "/_authenticated/taxonomies/$name/": typeof AuthenticatedTaxonomiesNameIndexRoute;
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
@@ -145,7 +175,10 @@ export interface FileRouteTypes {
     | "/users/"
     | "/content/$slug/$id"
     | "/content/$slug/new"
-    | "/content/$slug/";
+    | "/taxonomies/$name/$id"
+    | "/taxonomies/$name/new"
+    | "/content/$slug/"
+    | "/taxonomies/$name/";
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/"
@@ -158,7 +191,10 @@ export interface FileRouteTypes {
     | "/users"
     | "/content/$slug/$id"
     | "/content/$slug/new"
-    | "/content/$slug";
+    | "/taxonomies/$name/$id"
+    | "/taxonomies/$name/new"
+    | "/content/$slug"
+    | "/taxonomies/$name";
   id:
     | "__root__"
     | "/_auth"
@@ -173,7 +209,10 @@ export interface FileRouteTypes {
     | "/_authenticated/users/"
     | "/_authenticated/content/$slug/$id"
     | "/_authenticated/content/$slug/new"
-    | "/_authenticated/content/$slug/";
+    | "/_authenticated/taxonomies/$name/$id"
+    | "/_authenticated/taxonomies/$name/new"
+    | "/_authenticated/content/$slug/"
+    | "/_authenticated/taxonomies/$name/";
   fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
@@ -253,11 +292,32 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AuthAcceptInviteTokenRouteImport;
       parentRoute: typeof AuthRoute;
     };
+    "/_authenticated/taxonomies/$name/": {
+      id: "/_authenticated/taxonomies/$name/";
+      path: "/taxonomies/$name";
+      fullPath: "/taxonomies/$name/";
+      preLoaderRoute: typeof AuthenticatedTaxonomiesNameIndexRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
     "/_authenticated/content/$slug/": {
       id: "/_authenticated/content/$slug/";
       path: "/content/$slug";
       fullPath: "/content/$slug/";
       preLoaderRoute: typeof AuthenticatedContentSlugIndexRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
+    "/_authenticated/taxonomies/$name/new": {
+      id: "/_authenticated/taxonomies/$name/new";
+      path: "/taxonomies/$name/new";
+      fullPath: "/taxonomies/$name/new";
+      preLoaderRoute: typeof AuthenticatedTaxonomiesNameNewRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
+    "/_authenticated/taxonomies/$name/$id": {
+      id: "/_authenticated/taxonomies/$name/$id";
+      path: "/taxonomies/$name/$id";
+      fullPath: "/taxonomies/$name/$id";
+      preLoaderRoute: typeof AuthenticatedTaxonomiesNameIdRouteImport;
       parentRoute: typeof AuthenticatedRoute;
     };
     "/_authenticated/content/$slug/new": {
@@ -299,7 +359,10 @@ interface AuthenticatedRouteChildren {
   AuthenticatedUsersIndexRoute: typeof AuthenticatedUsersIndexRoute;
   AuthenticatedContentSlugIdRoute: typeof AuthenticatedContentSlugIdRoute;
   AuthenticatedContentSlugNewRoute: typeof AuthenticatedContentSlugNewRoute;
+  AuthenticatedTaxonomiesNameIdRoute: typeof AuthenticatedTaxonomiesNameIdRoute;
+  AuthenticatedTaxonomiesNameNewRoute: typeof AuthenticatedTaxonomiesNameNewRoute;
   AuthenticatedContentSlugIndexRoute: typeof AuthenticatedContentSlugIndexRoute;
+  AuthenticatedTaxonomiesNameIndexRoute: typeof AuthenticatedTaxonomiesNameIndexRoute;
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
@@ -310,7 +373,10 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedUsersIndexRoute: AuthenticatedUsersIndexRoute,
   AuthenticatedContentSlugIdRoute: AuthenticatedContentSlugIdRoute,
   AuthenticatedContentSlugNewRoute: AuthenticatedContentSlugNewRoute,
+  AuthenticatedTaxonomiesNameIdRoute: AuthenticatedTaxonomiesNameIdRoute,
+  AuthenticatedTaxonomiesNameNewRoute: AuthenticatedTaxonomiesNameNewRoute,
   AuthenticatedContentSlugIndexRoute: AuthenticatedContentSlugIndexRoute,
+  AuthenticatedTaxonomiesNameIndexRoute: AuthenticatedTaxonomiesNameIndexRoute,
 };
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
@@ -1,0 +1,366 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { TermForm } from "@/components/taxonomy/term-form.js";
+import {
+  descendantIds,
+  parentPickerOptions,
+} from "@/components/taxonomy/tree.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
+import { hasCap } from "@/lib/caps.js";
+import { findTaxonomyByName } from "@/lib/manifest.js";
+import { orpc } from "@/lib/orpc.js";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  useNavigate,
+} from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+
+import type { TaxonomyManifestEntry } from "@plumix/core/manifest";
+
+import { TAXONOMY_LIST_DEFAULT_SEARCH } from "./-constants.js";
+import { mapTermError } from "./new.js";
+
+export const Route = createFileRoute("/_authenticated/taxonomies/$name/$id")({
+  parseParams: (params) => ({
+    name: params.name,
+    id: Number(params.id),
+  }),
+  beforeLoad: ({ context, params }): { taxonomy: TaxonomyManifestEntry } => {
+    const taxonomy = findTaxonomyByName(params.name);
+    if (!taxonomy) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
+    // Minimum bar is `:read`; edit/delete actions gate separately
+    // below so a read-only user can still land on the screen.
+    if (!hasCap(context.user.capabilities, `${taxonomy.name}:read`)) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
+    return { taxonomy };
+  },
+  component: EditTermRoute,
+});
+
+function EditTermRoute(): ReactNode {
+  const { id } = Route.useParams();
+  const { user, taxonomy } = Route.useRouteContext();
+  const termId = Number(id);
+
+  const canEdit = hasCap(user.capabilities, `${taxonomy.name}:edit`);
+  const canDelete = hasCap(user.capabilities, `${taxonomy.name}:delete`);
+  const isHierarchical = taxonomy.isHierarchical === true;
+
+  const query = useQuery(orpc.term.get.queryOptions({ input: { id: termId } }));
+  // Pull siblings for the parent picker; only relevant for
+  // hierarchical taxonomies. Excludes this term and its descendants so
+  // the picker can't suggest a cycle the server would reject anyway.
+  const siblings = useQuery({
+    ...orpc.term.list.queryOptions({
+      input: { taxonomy: taxonomy.name, limit: 200 },
+    }),
+    enabled: isHierarchical,
+  });
+
+  if (query.isPending) return <EditSkeleton />;
+  if (query.isError) {
+    return (
+      <NotFoundPlaceholder message="Couldn't load that term. It may have been deleted." />
+    );
+  }
+
+  const term = query.data;
+  const excludeIds = isHierarchical
+    ? descendantIds(siblings.data ?? [], term.id)
+    : new Set<number>();
+  const parentOptions = isHierarchical
+    ? parentPickerOptions(siblings.data ?? [], excludeIds)
+    : [];
+
+  return (
+    <EditTermContent
+      // Keep the form fresh after a save — same pattern as the
+      // user/post edit screens.
+      key={term.id}
+      taxonomy={taxonomy}
+      term={term}
+      isHierarchical={isHierarchical}
+      parentOptions={parentOptions}
+      canEdit={canEdit}
+      canDelete={canDelete}
+      onRefetch={() => {
+        void query.refetch();
+      }}
+    />
+  );
+}
+
+function EditTermContent({
+  taxonomy,
+  term,
+  isHierarchical,
+  parentOptions,
+  canEdit,
+  canDelete,
+  onRefetch,
+}: {
+  readonly taxonomy: TaxonomyManifestEntry;
+  readonly term: {
+    readonly id: number;
+    readonly name: string;
+    readonly slug: string;
+    readonly description: string | null;
+    readonly parentId: number | null;
+  };
+  readonly isHierarchical: boolean;
+  readonly parentOptions: readonly {
+    readonly id: number;
+    readonly label: string;
+  }[];
+  readonly canEdit: boolean;
+  readonly canDelete: boolean;
+  readonly onRefetch: () => void;
+}): ReactNode {
+  const navigate = useNavigate();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const updateTerm = useMutation({
+    mutationFn: (values: {
+      name: string;
+      slug: string;
+      description: string;
+      parentId: number | null;
+    }) =>
+      orpc.term.update.call({
+        id: term.id,
+        name: values.name,
+        slug: values.slug.length > 0 ? values.slug : undefined,
+        description: values.description.length > 0 ? values.description : null,
+        parentId: values.parentId,
+      }),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: () => {
+      onRefetch();
+    },
+    onError: (err) => {
+      setServerError(
+        mapTermError(err, "Couldn't save the changes. Try again."),
+      );
+    },
+  });
+
+  const singularLower = (
+    taxonomy.labels?.singular ?? taxonomy.label
+  ).toLowerCase();
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
+      <Link
+        to="/taxonomies/$name"
+        params={{ name: taxonomy.name }}
+        search={TAXONOMY_LIST_DEFAULT_SEARCH}
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
+        data-testid="term-edit-back-link"
+      >
+        <ArrowLeft className="size-4" />
+        Back to {taxonomy.label.toLowerCase()}
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h1 data-testid="term-edit-heading">Edit {singularLower}</h1>
+          </CardTitle>
+          <CardDescription>
+            {term.name}
+            {isHierarchical ? " — descendants can't be picked as parent." : ""}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <TermForm
+            initialValues={{
+              name: term.name,
+              slug: term.slug,
+              description: term.description ?? "",
+              parentId: term.parentId,
+            }}
+            isHierarchical={isHierarchical}
+            parentOptions={parentOptions}
+            isSubmitting={updateTerm.isPending || !canEdit}
+            serverError={serverError}
+            submitLabel="Save changes"
+            onSubmit={(values) => {
+              updateTerm.mutate(values);
+            }}
+            onCancel={() => {
+              void navigate({
+                to: "/taxonomies/$name",
+                params: { name: taxonomy.name },
+                search: TAXONOMY_LIST_DEFAULT_SEARCH,
+              });
+            }}
+          />
+        </CardContent>
+      </Card>
+
+      {canDelete ? (
+        <DeleteCard
+          taxonomyName={taxonomy.name}
+          termId={term.id}
+          termName={term.name}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function DeleteCard({
+  taxonomyName,
+  termId,
+  termName,
+}: {
+  readonly taxonomyName: string;
+  readonly termId: number;
+  readonly termName: string;
+}): ReactNode {
+  const navigate = useNavigate();
+  const [confirming, setConfirming] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const deleteTerm = useMutation({
+    mutationFn: () => orpc.term.delete.call({ id: termId }),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: () => {
+      void navigate({
+        to: "/taxonomies/$name",
+        params: { name: taxonomyName },
+        search: TAXONOMY_LIST_DEFAULT_SEARCH,
+      });
+    },
+    onError: (err) => {
+      setServerError(mapTermError(err, "Couldn't delete the term. Try again."));
+    },
+  });
+
+  if (!confirming) {
+    return (
+      <Card className="border-destructive/50">
+        <CardHeader>
+          <CardTitle className="text-destructive">Delete term</CardTitle>
+          <CardDescription>
+            Removes this term and unassigns it from any posts that use it.
+            Descendants are promoted to root level (their posts keep their other
+            term assignments).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              setConfirming(true);
+            }}
+            data-testid="term-edit-delete-button"
+          >
+            Delete term
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-destructive">
+      <CardHeader>
+        <CardTitle className="text-destructive">
+          Confirm delete: {termName}
+        </CardTitle>
+        <CardDescription>
+          Post assignments to this term are removed. If the term has children,
+          they become root-level automatically.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {serverError ? (
+          <Alert variant="destructive" data-testid="term-delete-error">
+            <AlertDescription>{serverError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setConfirming(false);
+              setServerError(null);
+            }}
+            disabled={deleteTerm.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => {
+              deleteTerm.mutate();
+            }}
+            disabled={deleteTerm.isPending}
+            data-testid="term-delete-confirm-button"
+          >
+            {deleteTerm.isPending ? "Deleting…" : "Delete forever"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EditSkeleton(): ReactNode {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading term"
+      data-testid="term-edit-loading"
+      className="mx-auto flex w-full max-w-xl flex-col gap-4"
+    >
+      <Skeleton className="h-4 w-24" />
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function NotFoundPlaceholder({ message }: { message: string }): ReactNode {
+  return (
+    <div className="flex flex-col gap-2">
+      <h1 className="text-2xl font-semibold">Not found</h1>
+      <p className="text-muted-foreground text-sm">{message}</p>
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { FormEditSkeleton } from "@/components/form/edit-skeleton.js";
 import { TermForm } from "@/components/taxonomy/term-form.js";
 import {
   descendantIds,
@@ -14,7 +15,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
-import { Skeleton } from "@/components/ui/skeleton.js";
 import { hasCap } from "@/lib/caps.js";
 import { findTaxonomyByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
@@ -30,7 +30,7 @@ import { ArrowLeft } from "lucide-react";
 import type { TaxonomyManifestEntry } from "@plumix/core/manifest";
 
 import { TAXONOMY_LIST_DEFAULT_SEARCH } from "./-constants.js";
-import { mapTermError } from "./new.js";
+import { mapTermError } from "./-errors.js";
 
 export const Route = createFileRoute("/_authenticated/taxonomies/$name/$id")({
   parseParams: (params) => ({
@@ -38,6 +38,15 @@ export const Route = createFileRoute("/_authenticated/taxonomies/$name/$id")({
     id: Number(params.id),
   }),
   beforeLoad: ({ context, params }): { taxonomy: TaxonomyManifestEntry } => {
+    // `parseParams` runs `Number()` on the raw string; `Number("abc")`
+    // is NaN. Reject unparseable ids before the component mounts so
+    // the RPC never sees garbage input, and the router surfaces a
+    // proper 404 instead of a misleading "term deleted" error.
+    const id = Number(params.id);
+    if (Number.isNaN(id) || id < 1) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
     const taxonomy = findTaxonomyByName(params.name);
     if (!taxonomy) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
@@ -55,9 +64,10 @@ export const Route = createFileRoute("/_authenticated/taxonomies/$name/$id")({
 });
 
 function EditTermRoute(): ReactNode {
-  const { id } = Route.useParams();
+  // NaN-guard already ran in `beforeLoad` so `termId` is a positive
+  // integer by the time the component mounts.
+  const { id: termId } = Route.useParams();
   const { user, taxonomy } = Route.useRouteContext();
-  const termId = Number(id);
 
   const canEdit = hasCap(user.capabilities, `${taxonomy.name}:edit`);
   const canDelete = hasCap(user.capabilities, `${taxonomy.name}:delete`);
@@ -74,7 +84,11 @@ function EditTermRoute(): ReactNode {
     enabled: isHierarchical,
   });
 
-  if (query.isPending) return <EditSkeleton />;
+  if (query.isPending) {
+    return (
+      <FormEditSkeleton ariaLabel="Loading term" testId="term-edit-loading" />
+    );
+  }
   if (query.isError) {
     return (
       <NotFoundPlaceholder message="Couldn't load that term. It may have been deleted." />
@@ -82,8 +96,13 @@ function EditTermRoute(): ReactNode {
   }
 
   const term = query.data;
+  // Always seed the exclusion with the term's own id so self-selection
+  // is blocked even before siblings load (otherwise the dropdown is
+  // briefly un-filtered and a fast click could round-trip to the
+  // server's `parent_cycle` CONFLICT). Descendants are added in once
+  // the siblings query lands.
   const excludeIds = isHierarchical
-    ? descendantIds(siblings.data ?? [], term.id)
+    ? new Set<number>([term.id, ...descendantIds(siblings.data ?? [], term.id)])
     : new Set<number>();
   const parentOptions = isHierarchical
     ? parentPickerOptions(siblings.data ?? [], excludeIds)
@@ -328,31 +347,6 @@ function DeleteCard({
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-function EditSkeleton(): ReactNode {
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      aria-label="Loading term"
-      data-testid="term-edit-loading"
-      className="mx-auto flex w-full max-w-xl flex-col gap-4"
-    >
-      <Skeleton className="h-4 w-24" />
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-48" />
-          <Skeleton className="h-4 w-72" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-20 w-full" />
-        </CardContent>
-      </Card>
-    </div>
   );
 }
 

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/-constants.ts
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/-constants.ts
@@ -1,0 +1,9 @@
+// Default search-param set for `/taxonomies/$name`. Sibling routes
+// (`/taxonomies/$name/new`, `/taxonomies/$name/$id`) link back to the
+// list with this constant rather than re-declaring the defaults. Kept
+// in `-constants.ts` so cross-route imports don't drag the list-route
+// module into the sibling chunks (same pattern as `users/-constants.ts`
+// and `content/$slug/-constants.ts`).
+export const TAXONOMY_LIST_DEFAULT_SEARCH = {
+  page: 1,
+} as const;

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/-errors.ts
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/-errors.ts
@@ -1,0 +1,33 @@
+// Shared CONFLICT → friendly-copy translation for `term.*` mutations.
+// Lives here (not in `new.tsx` or `$id.tsx`) so neither route needs to
+// import from the other — the direction "$id depends on new" was a
+// smell, and the `-` prefix keeps TanStack Router from treating this
+// as a route file.
+//
+// Server surfaces these reasons: `slug_taken`, `parent_mismatch`,
+// `parent_is_self`, `parent_cycle`, `insert_failed`, `update_failed`.
+// Unknown reasons fall through to the error's own message, then the
+// caller-provided `fallback` copy.
+
+export function mapTermError(err: unknown, fallback: string): string {
+  const reason = extractReason(err);
+  if (reason === "slug_taken") {
+    return "A term with that slug already exists in this taxonomy.";
+  }
+  if (reason === "parent_mismatch") {
+    return "The selected parent belongs to a different taxonomy.";
+  }
+  if (reason === "parent_is_self" || reason === "parent_cycle") {
+    return "A term can't be its own ancestor — pick a different parent.";
+  }
+  if (err instanceof Error) return err.message;
+  return fallback;
+}
+
+function extractReason(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data?: { reason?: string } }).data;
+    return data?.reason;
+  }
+  return undefined;
+}

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/index.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/index.tsx
@@ -1,0 +1,348 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import type { ReactNode } from "react";
+import { useCallback, useMemo } from "react";
+import { DataTable } from "@/components/data-table/data-table.js";
+import { DebouncedSearchInput } from "@/components/form/search-input.js";
+import { buildTermTree, flattenTree } from "@/components/taxonomy/tree.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+} from "@/components/ui/pagination.js";
+import { hasCap } from "@/lib/caps.js";
+import { findTaxonomyByName } from "@/lib/manifest.js";
+import { orpc } from "@/lib/orpc.js";
+import { useQuery } from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  useNavigate,
+} from "@tanstack/react-router";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import * as v from "valibot";
+
+import type { TaxonomyManifestEntry } from "@plumix/core/manifest";
+import type { Term } from "@plumix/core/schema";
+
+// Flat (non-hierarchical) lists paginate conventionally. Hierarchical
+// lists fetch a larger page so the tree renders as a coherent unit; the
+// server's `term.list` caps at 200. Deployments with >200 terms will
+// want a proper tree-aware paginator (root-level pagination + expand on
+// demand) — deferred until someone has that problem.
+const FLAT_PAGE_SIZE = 50;
+const TREE_PAGE_SIZE = 200;
+
+const searchSchema = v.object({
+  page: v.optional(
+    v.fallback(v.pipe(v.number(), v.integer(), v.minValue(1)), 1),
+    1,
+  ),
+  q: v.optional(
+    v.fallback(
+      v.pipe(
+        v.string(),
+        v.trim(),
+        v.maxLength(200),
+        v.transform((value) => (value.length === 0 ? undefined : value)),
+      ),
+      undefined,
+    ),
+  ),
+});
+
+export const Route = createFileRoute("/_authenticated/taxonomies/$name/")({
+  validateSearch: (search) => v.parse(searchSchema, search),
+  // Resolve the manifest entry in `beforeLoad` so the component never
+  // has to handle a missing taxonomy — unregistered names bubble up to
+  // the router's 404 state.
+  beforeLoad: ({ context, params }): { taxonomy: TaxonomyManifestEntry } => {
+    const taxonomy = findTaxonomyByName(params.name);
+    if (!taxonomy) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
+    // Server's `term.list` requires `${name}:read`. Check here too so
+    // users land on a friendly redirect rather than a 403 from the RPC.
+    if (!hasCap(context.user.capabilities, `${taxonomy.name}:read`)) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
+    return { taxonomy };
+  },
+  component: TaxonomyListRoute,
+});
+
+// Row shape for the list table — `displayDepth` is the tree indent for
+// hierarchical taxonomies (always 0 for flat ones). Keyed on the term
+// so react-table can key rows cleanly even when the same term appears
+// on different pages.
+interface TermRow {
+  readonly term: Term;
+  readonly displayDepth: number;
+}
+
+function TaxonomyListRoute(): ReactNode {
+  const search = Route.useSearch();
+  const { user, taxonomy } = Route.useRouteContext();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const isHierarchical = taxonomy.isHierarchical === true;
+  const pageSize = isHierarchical ? TREE_PAGE_SIZE : FLAT_PAGE_SIZE;
+
+  const query = useQuery(
+    orpc.term.list.queryOptions({
+      input: {
+        taxonomy: taxonomy.name,
+        limit: pageSize,
+        offset: (search.page - 1) * pageSize,
+        ...(search.q ? { search: search.q } : {}),
+      },
+    }),
+  );
+
+  const setPage = useCallback(
+    (page: number): void => {
+      void navigate({ search: (prev) => ({ ...prev, page }) });
+    },
+    [navigate],
+  );
+  const setSearch = useCallback(
+    (q: string | undefined): void => {
+      void navigate({ search: (prev) => ({ ...prev, q, page: 1 }) });
+    },
+    [navigate],
+  );
+
+  // `query.data` is `Term[] | undefined`; depending on the identity of
+  // `rawRows` directly in the tree memo below would make it re-run on
+  // every render when data is undefined (fresh `[]` each time). Tie the
+  // memo to the query itself — react-query gives us referential
+  // stability on `data` across renders within the same request state.
+  const rawRows = query.data;
+
+  // Hierarchical taxonomies render as a tree: flatten-with-depth so
+  // each row carries its indent level. Non-hierarchical just keeps the
+  // server-provided order. Searching in a hierarchical taxonomy
+  // temporarily collapses to flat-list mode so search results aren't
+  // hidden inside collapsed parents that didn't match — matches the
+  // WP behaviour where category search flattens.
+  const rows: readonly TermRow[] = useMemo(() => {
+    const data = rawRows ?? [];
+    if (!isHierarchical || search.q) {
+      return data.map((t) => ({ term: t, displayDepth: 0 }));
+    }
+    const tree = buildTermTree(data);
+    return flattenTree(tree).map((n) => ({
+      term: n.term,
+      displayDepth: n.depth,
+    }));
+  }, [rawRows, isHierarchical, search.q]);
+
+  const canPrev = search.page > 1;
+  // Heuristic "next page exists": full page came back.
+  const canNext = (rawRows?.length ?? 0) === pageSize;
+
+  const canEdit = hasCap(user.capabilities, `${taxonomy.name}:edit`);
+  const singularLower = (
+    taxonomy.labels?.singular ?? taxonomy.label
+  ).toLowerCase();
+  const pluralLower = taxonomy.label.toLowerCase();
+
+  const columns = useMemo<ColumnDef<TermRow>[]>(() => {
+    return [
+      {
+        accessorKey: "name",
+        header: "Name",
+        cell: ({ row }) => {
+          const term = row.original.term;
+          // `--taxonomy-indent` drives the left padding so the depth
+          // visual is purely CSS — accessible to screen readers via the
+          // `aria-level` below.
+          const style = {
+            paddingLeft: `${row.original.displayDepth * 1.5}rem`,
+          };
+          return (
+            <Link
+              to="/taxonomies/$name/$id"
+              params={{ name: taxonomy.name, id: term.id }}
+              data-testid={`taxonomy-list-row-${String(term.id)}`}
+              aria-level={row.original.displayDepth + 1}
+              className="hover:text-primary flex flex-col transition-colors"
+              style={style}
+            >
+              <span className="font-medium">{term.name}</span>
+              <span className="text-muted-foreground font-mono text-xs">
+                {term.slug}
+              </span>
+            </Link>
+          );
+        },
+      },
+      {
+        accessorKey: "description",
+        header: "Description",
+        cell: ({ row }) => (
+          <span className="text-muted-foreground line-clamp-1 text-sm">
+            {row.original.term.description ?? ""}
+          </span>
+        ),
+      },
+    ];
+  }, [taxonomy.name]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1
+            data-testid="taxonomy-list-heading"
+            className="text-2xl font-semibold capitalize"
+          >
+            {taxonomy.label}
+          </h1>
+          {taxonomy.description ? (
+            <p className="text-muted-foreground text-sm">
+              {taxonomy.description}
+            </p>
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              Manage {pluralLower} for this site.
+            </p>
+          )}
+        </div>
+        {canEdit ? (
+          <Button asChild>
+            <Link
+              to="/taxonomies/$name/new"
+              params={{ name: taxonomy.name }}
+              data-testid="taxonomy-list-new-button"
+            >
+              <Plus />
+              New {singularLower}
+            </Link>
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <DebouncedSearchInput
+          key={search.q ?? ""}
+          initialValue={search.q ?? ""}
+          placeholder={`Search ${pluralLower}…`}
+          testId="taxonomy-list-search-input"
+          onCommit={setSearch}
+        />
+      </div>
+
+      {query.isError ? (
+        <Alert variant="destructive">
+          <AlertDescription>
+            {query.error instanceof Error
+              ? query.error.message
+              : `Couldn't load ${pluralLower}. Try again.`}
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <DataTable<TermRow>
+          columns={columns}
+          data={rows}
+          isLoading={query.isPending}
+          loadingLabel={`Loading ${pluralLower}`}
+          emptyState={
+            <EmptyState
+              singularLower={singularLower}
+              canCreate={canEdit}
+              taxonomyName={taxonomy.name}
+            />
+          }
+        />
+      )}
+
+      <Pagination className="justify-between">
+        <span className="text-muted-foreground text-sm">
+          Page {search.page}
+        </span>
+        <PaginationContent>
+          <PaginationItem>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!canPrev || query.isPending}
+              onClick={() => {
+                setPage(search.page - 1);
+              }}
+              aria-label="Go to previous page"
+            >
+              <ChevronLeft />
+              <span className="hidden sm:inline">Previous</span>
+            </Button>
+          </PaginationItem>
+          <PaginationItem>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!canNext || query.isPending}
+              onClick={() => {
+                setPage(search.page + 1);
+              }}
+              aria-label="Go to next page"
+            >
+              <span className="hidden sm:inline">Next</span>
+              <ChevronRight />
+            </Button>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}
+
+function EmptyState({
+  singularLower,
+  canCreate,
+  taxonomyName,
+}: {
+  singularLower: string;
+  canCreate: boolean;
+  taxonomyName: string;
+}): ReactNode {
+  return (
+    <div
+      data-testid="taxonomy-list-empty-state"
+      className="flex flex-col items-center gap-2 py-12 text-center"
+    >
+      <Card className="max-w-sm border-dashed">
+        <CardHeader>
+          <CardTitle>No {singularLower} yet</CardTitle>
+          <CardDescription>
+            Create your first {singularLower} to see it here.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {canCreate ? (
+            <Button asChild className="w-full">
+              <Link to="/taxonomies/$name/new" params={{ name: taxonomyName }}>
+                <Plus />
+                New {singularLower}
+              </Link>
+            </Button>
+          ) : (
+            <Button disabled className="w-full">
+              <Plus />
+              New {singularLower}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/new.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/new.tsx
@@ -26,6 +26,7 @@ import { ArrowLeft } from "lucide-react";
 import type { TaxonomyManifestEntry } from "@plumix/core/manifest";
 
 import { TAXONOMY_LIST_DEFAULT_SEARCH } from "./-constants.js";
+import { mapTermError } from "./-errors.js";
 
 export const Route = createFileRoute("/_authenticated/taxonomies/$name/new")({
   beforeLoad: ({ context, params }): { taxonomy: TaxonomyManifestEntry } => {
@@ -159,34 +160,3 @@ function NewTermRoute(): ReactNode {
     </div>
   );
 }
-
-// CONFLICT → friendly copy. `term.*` surfaces these reasons:
-// `slug_taken` / `parent_mismatch` / `parent_is_self` / `parent_cycle` /
-// `insert_failed` / `update_failed`. Unknown reasons fall through to the
-// error's own message then the caller-provided `fallback`.
-function mapTermError(err: unknown, fallback: string): string {
-  const reason = extractReason(err);
-  if (reason === "slug_taken") {
-    return "A term with that slug already exists in this taxonomy.";
-  }
-  if (reason === "parent_mismatch") {
-    return "The selected parent belongs to a different taxonomy.";
-  }
-  if (reason === "parent_is_self" || reason === "parent_cycle") {
-    return "A term can't be its own ancestor — pick a different parent.";
-  }
-  if (err instanceof Error) return err.message;
-  return fallback;
-}
-
-function extractReason(err: unknown): string | undefined {
-  if (err && typeof err === "object" && "data" in err) {
-    const data = (err as { data?: { reason?: string } }).data;
-    return data?.reason;
-  }
-  return undefined;
-}
-
-// Export so the edit route can reuse the exact same copy — single
-// source of truth for server-reason → user-facing string.
-export { mapTermError };

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/new.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/new.tsx
@@ -1,0 +1,192 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { slugify } from "@/components/editor/slugify.js";
+import { TermForm } from "@/components/taxonomy/term-form.js";
+import { parentPickerOptions } from "@/components/taxonomy/tree.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { hasCap } from "@/lib/caps.js";
+import { findTaxonomyByName } from "@/lib/manifest.js";
+import { orpc } from "@/lib/orpc.js";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+
+import type { TaxonomyManifestEntry } from "@plumix/core/manifest";
+
+import { TAXONOMY_LIST_DEFAULT_SEARCH } from "./-constants.js";
+
+export const Route = createFileRoute("/_authenticated/taxonomies/$name/new")({
+  beforeLoad: ({ context, params }): { taxonomy: TaxonomyManifestEntry } => {
+    const taxonomy = findTaxonomyByName(params.name);
+    if (!taxonomy) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
+    // `term.create` requires `${name}:edit` — gate the route too so a
+    // caller without edit doesn't land on a form that will 403 on save.
+    if (!hasCap(context.user.capabilities, `${taxonomy.name}:edit`)) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw redirect({
+        to: "/taxonomies/$name",
+        params: { name: params.name },
+        search: TAXONOMY_LIST_DEFAULT_SEARCH,
+      });
+    }
+    return { taxonomy };
+  },
+  component: NewTermRoute,
+});
+
+function NewTermRoute(): ReactNode {
+  const navigate = useNavigate();
+  const { taxonomy } = Route.useRouteContext();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  // For hierarchical taxonomies we pull the existing term set so the
+  // parent picker can render a depth-indented list. Skipped for flat
+  // taxonomies — no parent, no query.
+  const isHierarchical = taxonomy.isHierarchical === true;
+  const parents = useQuery({
+    ...orpc.term.list.queryOptions({
+      input: { taxonomy: taxonomy.name, limit: 200 },
+    }),
+    enabled: isHierarchical,
+  });
+  const parentOptions = isHierarchical
+    ? parentPickerOptions(parents.data ?? [])
+    : [];
+
+  const createTerm = useMutation({
+    mutationFn: (values: {
+      name: string;
+      slug: string;
+      description: string;
+      parentId: number | null;
+    }) =>
+      orpc.term.create.call({
+        taxonomy: taxonomy.name,
+        name: values.name,
+        // Server requires a slug on create; derive from the name if
+        // the user left it blank. Matches the post editor's auto-slug
+        // behaviour (same `slugify` helper).
+        slug: values.slug.length > 0 ? values.slug : slugify(values.name),
+        ...(values.description.length > 0
+          ? { description: values.description }
+          : {}),
+        ...(values.parentId != null ? { parentId: values.parentId } : {}),
+      }),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: () => {
+      void navigate({
+        to: "/taxonomies/$name",
+        params: { name: taxonomy.name },
+        search: TAXONOMY_LIST_DEFAULT_SEARCH,
+      });
+    },
+    onError: (err) => {
+      setServerError(mapTermError(err, "Couldn't create the term. Try again."));
+    },
+  });
+
+  const singularLower = (
+    taxonomy.labels?.singular ?? taxonomy.label
+  ).toLowerCase();
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
+      <Link
+        to="/taxonomies/$name"
+        params={{ name: taxonomy.name }}
+        search={TAXONOMY_LIST_DEFAULT_SEARCH}
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
+        data-testid="term-new-back-link"
+      >
+        <ArrowLeft className="size-4" />
+        Back to {taxonomy.label.toLowerCase()}
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h1 data-testid="term-new-heading">New {singularLower}</h1>
+          </CardTitle>
+          <CardDescription>
+            {isHierarchical
+              ? "Pick a parent to nest this term, or leave empty for a root-level term."
+              : `Add a new ${singularLower} for grouping content.`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <TermForm
+            initialValues={{
+              name: "",
+              slug: "",
+              description: "",
+              parentId: null,
+            }}
+            isHierarchical={isHierarchical}
+            parentOptions={parentOptions}
+            isSubmitting={createTerm.isPending}
+            serverError={serverError}
+            submitLabel={`Create ${singularLower}`}
+            onSubmit={(values) => {
+              createTerm.mutate(values);
+            }}
+            onCancel={() => {
+              void navigate({
+                to: "/taxonomies/$name",
+                params: { name: taxonomy.name },
+                search: TAXONOMY_LIST_DEFAULT_SEARCH,
+              });
+            }}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// CONFLICT → friendly copy. `term.*` surfaces these reasons:
+// `slug_taken` / `parent_mismatch` / `parent_is_self` / `parent_cycle` /
+// `insert_failed` / `update_failed`. Unknown reasons fall through to the
+// error's own message then the caller-provided `fallback`.
+function mapTermError(err: unknown, fallback: string): string {
+  const reason = extractReason(err);
+  if (reason === "slug_taken") {
+    return "A term with that slug already exists in this taxonomy.";
+  }
+  if (reason === "parent_mismatch") {
+    return "The selected parent belongs to a different taxonomy.";
+  }
+  if (reason === "parent_is_self" || reason === "parent_cycle") {
+    return "A term can't be its own ancestor — pick a different parent.";
+  }
+  if (err instanceof Error) return err.message;
+  return fallback;
+}
+
+function extractReason(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data?: { reason?: string } }).data;
+    return data?.reason;
+  }
+  return undefined;
+}
+
+// Export so the edit route can reuse the exact same copy — single
+// source of truth for server-reason → user-facing string.
+export { mapTermError };

--- a/packages/admin/src/routes/_authenticated/users/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { FormEditSkeleton } from "@/components/form/edit-skeleton.js";
 import { FormField } from "@/components/form/field.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
@@ -12,7 +13,6 @@ import {
   CardTitle,
 } from "@/components/ui/card.js";
 import { Label } from "@/components/ui/label.js";
-import { Skeleton } from "@/components/ui/skeleton.js";
 import { hasCap } from "@/lib/caps.js";
 import { orpc } from "@/lib/orpc.js";
 import { useForm } from "@tanstack/react-form";
@@ -100,7 +100,9 @@ function UserEditRoute(): ReactNode {
   const query = useQuery(orpc.user.get.queryOptions({ input: { id: userId } }));
 
   if (query.isPending) {
-    return <UserEditSkeleton />;
+    return (
+      <FormEditSkeleton ariaLabel="Loading user" testId="user-edit-loading" />
+    );
   }
   if (query.isError) {
     return (
@@ -602,31 +604,6 @@ const DELETE_ERROR_MESSAGES: Partial<Record<string, string>> = {
     "This user has authored posts. Pick someone to reassign them to above.",
   reassign_to_self: "Can't reassign to the user being deleted.",
 };
-
-function UserEditSkeleton(): ReactNode {
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      aria-label="Loading user"
-      data-testid="user-edit-loading"
-      className="mx-auto flex w-full max-w-xl flex-col gap-4"
-    >
-      <Skeleton className="h-4 w-24" />
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-48" />
-          <Skeleton className="h-4 w-72" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-10 w-full" />
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
 
 function NotFoundPlaceholder({ message }: { message: string }): ReactNode {
   return (

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -155,6 +155,55 @@ describe("buildManifest", () => {
 
     expect(buildManifest(registry).metaBoxes).toEqual([]);
   });
+
+  test("projects registered taxonomies, dropping server-only fields", async () => {
+    const hooks = new HookRegistry();
+    const blog = definePlugin("blog", (ctx) => {
+      ctx.registerTaxonomy("category", {
+        label: "Categories",
+        labels: { singular: "Category" },
+        description: "Top-level organisation for blog posts.",
+        isHierarchical: true,
+        postTypes: ["post"],
+        // Server-only / public-site-only fields that should NOT ship to
+        // the admin manifest — asserted below.
+        isPublic: true,
+        isInQuickEdit: true,
+        hasAdminColumn: true,
+        rewrite: { slug: "category" },
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [blog] });
+
+    const manifest = buildManifest(registry);
+    expect(manifest.taxonomies).toEqual([
+      {
+        name: "category",
+        label: "Categories",
+        labels: { singular: "Category" },
+        description: "Top-level organisation for blog posts.",
+        isHierarchical: true,
+        postTypes: ["post"],
+      },
+    ]);
+    // Operational flags + `registeredBy` stay server-side.
+    const entry = manifest.taxonomies[0] as unknown as Record<string, unknown>;
+    expect(entry.registeredBy).toBeUndefined();
+    expect(entry.isPublic).toBeUndefined();
+    expect(entry.isInQuickEdit).toBeUndefined();
+    expect(entry.hasAdminColumn).toBeUndefined();
+    expect(entry.rewrite).toBeUndefined();
+  });
+
+  test("empty taxonomy registry yields an empty taxonomies array", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("blog", (ctx) => {
+      ctx.registerPostType("post", { label: "Posts" });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).taxonomies).toEqual([]);
+  });
 });
 
 describe("deriveAdminSlug", () => {
@@ -177,12 +226,13 @@ describe("serializeManifestScript", () => {
   test("emits a json script tag with the expected id", () => {
     const tag = serializeManifestScript({
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      taxonomies: [],
       metaBoxes: [],
     });
     expect(tag).toContain(`id="${MANIFEST_SCRIPT_ID}"`);
     expect(tag).toContain(`type="application/json"`);
     expect(tag).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"metaBoxes":[]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[]}`,
     );
   });
 
@@ -191,6 +241,7 @@ describe("serializeManifestScript", () => {
       postTypes: [
         { name: "post", adminSlug: "posts", label: "</script><b>x</b>" },
       ],
+      taxonomies: [],
       metaBoxes: [],
     });
     expect(tag).not.toContain("</script><b>");
@@ -200,6 +251,7 @@ describe("serializeManifestScript", () => {
   test("round-trips through JSON.parse after unescaping the slash", () => {
     const manifest = {
       postTypes: [{ name: "post", adminSlug: "posts", label: "x</y>" }],
+      taxonomies: [],
       metaBoxes: [],
     };
     const tag = serializeManifestScript(manifest);
@@ -222,17 +274,21 @@ describe("injectManifestIntoHtml", () => {
   test("replaces the placeholder with the serialised manifest", () => {
     const out = injectManifestIntoHtml(TEMPLATE, {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      taxonomies: [],
       metaBoxes: [],
     });
     expect(out).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"metaBoxes":[]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[]}`,
     );
-    expect(out).not.toContain(`{"postTypes":[],"metaBoxes":[]}`);
+    expect(out).not.toContain(
+      `{"postTypes":[],"taxonomies":[],"metaBoxes":[]}`,
+    );
   });
 
   test("is idempotent when the manifest is already injected", () => {
     const manifest = {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      taxonomies: [],
       metaBoxes: [],
     };
     const once = injectManifestIntoHtml(TEMPLATE, manifest);
@@ -256,10 +312,11 @@ describe("injectManifestIntoHtml", () => {
     const html = `<SCRIPT ID="plumix-manifest" TYPE="application/json">{"postTypes":[]}</SCRIPT>`;
     const out = injectManifestIntoHtml(html, {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      taxonomies: [],
       metaBoxes: [],
     });
     expect(out).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"metaBoxes":[]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[]}`,
     );
   });
 
@@ -269,10 +326,11 @@ describe("injectManifestIntoHtml", () => {
     </script>`;
     const out = injectManifestIntoHtml(html, {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
+      taxonomies: [],
       metaBoxes: [],
     });
     expect(out).toMatch(
-      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"metaBoxes":\[\]\}<\/script>$/,
+      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"taxonomies":\[\],"metaBoxes":\[\]\}<\/script>$/,
     );
   });
 });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -221,8 +221,26 @@ export interface MetaBoxManifestEntry {
   readonly fields: readonly MetaBoxFieldManifestEntry[];
 }
 
+/**
+ * Shape serialised for taxonomies in the manifest. Strict allowlist
+ * projection of `RegisteredTaxonomy` — drops `registeredBy` (server-only
+ * debug metadata) and server-only operational flags (`isInQuickEdit`,
+ * `hasAdminColumn`, `rewrite`) that don't affect the admin UI today.
+ * `postTypes` is kept so future admin surfaces (term-picker on post
+ * editor) can filter by post type without a second round-trip.
+ */
+export interface TaxonomyManifestEntry {
+  readonly name: string;
+  readonly label: string;
+  readonly labels?: { readonly singular?: string };
+  readonly description?: string;
+  readonly isHierarchical?: boolean;
+  readonly postTypes?: readonly string[];
+}
+
 export interface PlumixManifest {
   readonly postTypes: readonly PostTypeManifestEntry[];
+  readonly taxonomies: readonly TaxonomyManifestEntry[];
   readonly metaBoxes: readonly MetaBoxManifestEntry[];
 }
 
@@ -230,7 +248,7 @@ export interface PlumixManifest {
 export const MANIFEST_SCRIPT_ID = "plumix-manifest";
 
 export function emptyManifest(): PlumixManifest {
-  return { postTypes: [], metaBoxes: [] };
+  return { postTypes: [], taxonomies: [], metaBoxes: [] };
 }
 
 /**
@@ -252,8 +270,11 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
     return ap - bp;
   });
   assertUniqueAdminSlugs(entries);
+  const taxonomies = Array.from(registry.taxonomies.values()).map(
+    toTaxonomyEntry,
+  );
   const metaBoxes = Array.from(registry.metaBoxes.values()).map(toMetaBoxEntry);
-  return { postTypes: entries, metaBoxes };
+  return { postTypes: entries, taxonomies, metaBoxes };
 }
 
 function assertUniqueAdminSlugs(
@@ -359,6 +380,23 @@ function toPostTypeEntry(pt: RegisteredPostType): PostTypeManifestEntry {
     capabilityType,
     menuPosition,
     menuIcon,
+  };
+}
+
+// Allowlist for taxonomy entries — same rationale as `toPostTypeEntry`.
+// `registeredBy` excluded; `isPublic` / `isInQuickEdit` / `hasAdminColumn`
+// / `rewrite` are server-/public-site-only and don't affect the admin
+// surface, so they're intentionally dropped from the wire contract until
+// a concrete admin need arises.
+function toTaxonomyEntry(tax: RegisteredTaxonomy): TaxonomyManifestEntry {
+  const { name, label, labels, description, isHierarchical, postTypes } = tax;
+  return {
+    name,
+    label,
+    labels,
+    description,
+    isHierarchical,
+    postTypes,
   };
 }
 


### PR DESCRIPTION
## Summary

Plugin-driven `/taxonomies/\$name` surface so registered taxonomies get an admin screen with zero per-plugin UI code. Taxonomies are "better than WP" on the hierarchy front:

- **Tree list view** — actual depth-indented rendering (CSS padding + `aria-level`) for hierarchical taxonomies instead of WP's flat list with parent-id badges. Larger page size (200 vs 50 for flat) so the tree is a coherent unit.
- **Search flattens** — hierarchical search collapses the tree to a flat match list so results aren't hidden inside parents that didn't match (matches WP's behaviour).
- **Cycle prevention in the UI** — editing a term? The parent picker excludes the term's own subtree, so the user can't even *try* to set a cycle the server would reject with `parent_cycle`.
- **Depth-indented parent picker** — `— Apple`, `— — Granny Smith` prefixes make nesting visible in a flat `<select>`.

## Scope

- **Core** — `TaxonomyManifestEntry` type + allowlist projection + `PlumixManifest.taxonomies` slice; `buildManifest` / `emptyManifest` / reader / serializer all updated in lockstep. Same pattern as #44's metaBoxes slice.
- **Admin routes** — list at `/taxonomies/\$name`, create at `.../new`, edit at `.../\$id` (includes inline delete confirmation). Auto-slug derivation from name reuses the post editor's `slugify` helper.
- **Admin helpers** — `findTaxonomyByName`, `visibleTaxonomies(caps)` gated on `\${name}:read`.
- **Sidebar** — capability-gated "Taxonomies" group that hides entirely on a bare install (core registers no taxonomies; the blog plugin in Phase 12 will be the first consumer).
- **Shared pieces** — `TermForm` (mutation-agnostic, shared by new + edit), `tree.ts` (pure helpers: `buildTermTree`, `flattenTree`, `descendantIds`, `parentPickerOptions`), `-constants.ts` for the default search params.
- **Error mapping** — `mapTermError` surfaces `slug_taken` / `parent_mismatch` / `parent_cycle` / `parent_is_self` CONFLICTs as friendly copy.

## Test plan

- [x] 4 core unit tests: taxonomy projection drops server-only fields, empty-registry yields empty array.
- [x] 2 admin unit tests: `findTaxonomyByName`, `visibleTaxonomies` cap filtering.
- [x] 9 new e2e tests: tree-indented list, empty state, unregistered taxonomy → 404, subscriber redirect, hierarchical form with slug derivation, flat-taxonomy hides parent picker, `slug_taken` CONFLICT surfacing, edit-parent-picker excludes self+descendants, delete flow → redirect.
- [x] 43 workspace tasks + 50 admin e2e + 389 core tests all green locally.
- [ ] Manual check with a real taxonomy plugin (follow-up — `examples/minimal` has no taxonomies registered, will be exercised by blog in Phase 12).