### PR TITLE
refactor(admin): migrate edit routes to TanStack Router loaders

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -3,7 +3,7 @@
 Pre-built React SPA that ships inside the [`plumix`](../plumix) package.
 The admin compiles once into `dist/`, gets copied into `plumix/dist/admin-app/`
 at plumix build time, and the plumix Vite plugin stages it into the consumer's
-`.plumix/public/_plumix/admin/` directory so Cloudflare Workers Assets serves
+`.plumix/public/_plumix/admin/` directory so the active runtime adapter serves
 it at `/_plumix/admin/*` with no per-consumer rebuild.
 
 ## Dev workflows
@@ -12,8 +12,8 @@ Two supported loops, pick whichever matches what you're iterating on.
 
 ### Consumer-style: `plumix dev` only (single origin)
 
-Once the consumer has the `assets` binding in their wrangler config (see
-[examples/minimal/wrangler.jsonc](../../examples/minimal/wrangler.jsonc)),
+Once the consumer has wired static-asset serving for their chosen runtime
+(the example app's config shows the right binding for that runtime),
 running the backend serves admin too — no second process:
 
 ```bash
@@ -22,8 +22,9 @@ pnpm dev                              # :5173
 # open http://localhost:5173/_plumix/admin/
 ```
 
-This mode exercises the same serving path production uses (CF Assets in
-front of the worker). Best for "does my feature work end-to-end?" checks.
+This mode exercises the same serving path production uses (the runtime's
+asset layer in front of the request handler). Best for "does my feature
+work end-to-end?" checks.
 
 ### Admin-authoring: `pnpm dev` in both workspaces (two ports, HMR)
 
@@ -57,8 +58,8 @@ two-port layout as the two-terminal variant but in one shell.
 ### First-time setup
 
 Before RPC endpoints work, the dev database needs migrations applied —
-the specifics depend on the database adapter the example app uses.
-For `examples/minimal` (Cloudflare D1):
+the specifics depend on the database adapter the example app uses. From
+your example app (e.g. `examples/minimal`):
 
 ```bash
 cd examples/minimal
@@ -143,7 +144,8 @@ as noise, so add the full set you expect to use.
 
 Admin build output (`dist/`) becomes a static asset bundle inside the
 published `plumix` tarball. At consumer build time, `plumix build` copies
-those assets into the consumer's `dist/_plumix/admin/` and the runtime
-dispatcher (see `packages/core/src/runtime/dispatcher.ts`) serves them.
-Plugin-contributed admin chunks + the manifest that wires them are planned
-for a later phase — see ARCHITECTURE.md §Admin for the full design.
+those assets into the consumer's `dist/_plumix/admin/` and the active
+runtime adapter serves them (see `packages/core/src/runtime/dispatcher.ts`
+for the runtime-agnostic request pipeline). Plugin-contributed admin
+chunks + the manifest that wires them are planned for a later phase —
+see ARCHITECTURE.md §Admin for the full design.

--- a/packages/admin/src/providers/router.ts
+++ b/packages/admin/src/providers/router.ts
@@ -11,6 +11,9 @@ export function createRouter(queryClient: QueryClient) {
     routeTree,
     basepath: ADMIN_BASE_PATH,
     defaultPreload: "intent",
+    // Defer freshness to Query's own cache — avoids two competing
+    // SWR policies fighting over the same data.
+    defaultPreloadStaleTime: 0,
     scrollRestoration: true,
     context: { queryClient },
   });

--- a/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
@@ -9,8 +9,17 @@ import { Skeleton } from "@/components/ui/skeleton.js";
 import { hasCap } from "@/lib/caps.js";
 import { findPostTypeBySlug, metaBoxesForPostType } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import {
+  createFileRoute,
+  notFound,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router";
 
 import type { PostTypeManifestEntry } from "@plumix/core/manifest";
 import type { PostWithMeta } from "@plumix/core/schema";
@@ -24,19 +33,64 @@ export const Route = createFileRoute("/_authenticated/content/$slug/$id")({
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
       throw notFound();
     }
+    const postId = Number(params.id);
+    if (Number.isNaN(postId) || postId < 1) {
+      // Non-numeric or negative ids can't resolve — bounce back to the
+      // post-type list rather than firing an RPC with garbage.
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+      throw redirect({
+        to: "/content/$slug",
+        params: { slug: params.slug },
+        search: CONTENT_LIST_DEFAULT_SEARCH,
+      });
+    }
     return { postType };
   },
+  loader: ({ context, params }) =>
+    context.queryClient.ensureQueryData(
+      orpc.post.get.queryOptions({ input: { id: Number(params.id) } }),
+    ),
+  // Pending/error screens are per-slug so copy reflects the actual
+  // type ("page", "product") instead of hardcoding "post".
+  pendingComponent: EditPostPendingScreen,
+  errorComponent: EditPostErrorScreen,
   component: EditPostRoute,
 });
+
+function postTypeSingular(slug: string): string {
+  const postType = findPostTypeBySlug(slug);
+  return (
+    postType?.labels?.singular ??
+    postType?.label ??
+    "post"
+  ).toLowerCase();
+}
+
+function EditPostPendingScreen(): ReactNode {
+  const { slug } = Route.useParams();
+  return <EditorSkeleton label={`Loading ${postTypeSingular(slug)}`} />;
+}
+
+function EditPostErrorScreen(): ReactNode {
+  const { slug } = Route.useParams();
+  return (
+    <NotFoundPlaceholder
+      message={`Couldn't load that ${postTypeSingular(slug)}. It may have been deleted.`}
+    />
+  );
+}
 
 function EditPostRoute(): ReactNode {
   const { user, postType } = Route.useRouteContext();
   const params = Route.useParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const postId = Number(params.id);
   const [serverError, setServerError] = useState<string | null>(null);
 
-  const query = useQuery(orpc.post.get.queryOptions({ input: { id: postId } }));
+  const { data: post } = useSuspenseQuery(
+    orpc.post.get.queryOptions({ input: { id: postId } }),
+  );
 
   const updatePost = useMutation({
     mutationFn: (input: PostEditorValues) =>
@@ -52,8 +106,18 @@ function EditPostRoute(): ReactNode {
     onMutate: () => {
       setServerError(null);
     },
-    onSuccess: () => {
-      void query.refetch();
+    onSuccess: async () => {
+      // List variants are scoped by `type` so sibling post types
+      // don't needlessly refetch.
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.post.get.queryOptions({ input: { id: postId } })
+            .queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.post.list.key({ input: { type: postType.name } }),
+        }),
+      ]);
     },
     onError: (err) => {
       setServerError(err instanceof Error ? err.message : "Couldn't save.");
@@ -64,36 +128,11 @@ function EditPostRoute(): ReactNode {
     postType.labels?.singular ?? postType.label
   ).toLowerCase();
 
-  // Meta boxes registered for this post type, filtered by the user's
-  // capabilities. Computed unconditionally (before any early returns)
-  // to keep the hook order stable across render paths.
   const metaBoxes = useMemo(
     () => metaBoxesForPostType(postType.name, user.capabilities),
     [postType.name, user.capabilities],
   );
 
-  if (Number.isNaN(postId) || postId < 1) {
-    // Defensive: `$id` param is a string; reject anything non-numeric
-    // rather than hitting the RPC with garbage. The router could enforce
-    // this via a loader, but the dedicated check keeps the error local.
-    return (
-      <NotFoundPlaceholder message="The post id in the URL isn't a number." />
-    );
-  }
-
-  if (query.isPending) {
-    return <EditorSkeleton label={`Loading ${singularLower}`} />;
-  }
-
-  if (query.isError) {
-    return (
-      <NotFoundPlaceholder
-        message={`Couldn't load that ${singularLower}. It may have been deleted.`}
-      />
-    );
-  }
-
-  const post = query.data;
   const capNamespace = postType.capabilityType ?? postType.name;
   const canEditAny = hasCap(user.capabilities, `${capNamespace}:edit_any`);
   const canEditOwn =

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
@@ -18,7 +18,12 @@ import {
 import { hasCap } from "@/lib/caps.js";
 import { findTaxonomyByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import {
   createFileRoute,
   Link,
@@ -60,12 +65,23 @@ export const Route = createFileRoute("/_authenticated/taxonomies/$name/$id")({
     }
     return { taxonomy };
   },
+  // Siblings load inline in the component (not here) so a flaky list
+  // fetch degrades the parent-picker to empty instead of nuking the
+  // whole edit screen via errorComponent.
+  loader: ({ context, params }) =>
+    context.queryClient.ensureQueryData(
+      orpc.term.get.queryOptions({ input: { id: params.id } }),
+    ),
+  pendingComponent: () => (
+    <FormEditSkeleton ariaLabel="Loading term" testId="term-edit-loading" />
+  ),
+  errorComponent: () => (
+    <NotFoundPlaceholder message="Couldn't load that term. It may have been deleted." />
+  ),
   component: EditTermRoute,
 });
 
 function EditTermRoute(): ReactNode {
-  // NaN-guard already ran in `beforeLoad` so `termId` is a positive
-  // integer by the time the component mounts.
   const { id: termId } = Route.useParams();
   const { user, taxonomy } = Route.useRouteContext();
 
@@ -73,39 +89,25 @@ function EditTermRoute(): ReactNode {
   const canDelete = hasCap(user.capabilities, `${taxonomy.name}:delete`);
   const isHierarchical = taxonomy.isHierarchical === true;
 
-  const query = useQuery(orpc.term.get.queryOptions({ input: { id: termId } }));
-  // Pull siblings for the parent picker; only relevant for
-  // hierarchical taxonomies. Excludes this term and its descendants so
-  // the picker can't suggest a cycle the server would reject anyway.
-  const siblings = useQuery({
+  const { data: term } = useSuspenseQuery(
+    orpc.term.get.queryOptions({ input: { id: termId } }),
+  );
+  const siblingsQuery = useQuery({
     ...orpc.term.list.queryOptions({
       input: { taxonomy: taxonomy.name, limit: 200 },
     }),
     enabled: isHierarchical,
   });
+  const siblings = siblingsQuery.data ?? [];
 
-  if (query.isPending) {
-    return (
-      <FormEditSkeleton ariaLabel="Loading term" testId="term-edit-loading" />
-    );
-  }
-  if (query.isError) {
-    return (
-      <NotFoundPlaceholder message="Couldn't load that term. It may have been deleted." />
-    );
-  }
-
-  const term = query.data;
   // Always seed the exclusion with the term's own id so self-selection
-  // is blocked even before siblings load (otherwise the dropdown is
-  // briefly un-filtered and a fast click could round-trip to the
-  // server's `parent_cycle` CONFLICT). Descendants are added in once
-  // the siblings query lands.
+  // is blocked regardless of subtree resolution — client-side mirror
+  // of the server's `parent_cycle` guard.
   const excludeIds = isHierarchical
-    ? new Set<number>([term.id, ...descendantIds(siblings.data ?? [], term.id)])
+    ? new Set<number>([term.id, ...descendantIds(siblings, term.id)])
     : new Set<number>();
   const parentOptions = isHierarchical
-    ? parentPickerOptions(siblings.data ?? [], excludeIds)
+    ? parentPickerOptions(siblings, excludeIds)
     : [];
 
   return (
@@ -119,9 +121,6 @@ function EditTermRoute(): ReactNode {
       parentOptions={parentOptions}
       canEdit={canEdit}
       canDelete={canDelete}
-      onRefetch={() => {
-        void query.refetch();
-      }}
     />
   );
 }
@@ -133,7 +132,6 @@ function EditTermContent({
   parentOptions,
   canEdit,
   canDelete,
-  onRefetch,
 }: {
   readonly taxonomy: TaxonomyManifestEntry;
   readonly term: {
@@ -150,9 +148,9 @@ function EditTermContent({
   }[];
   readonly canEdit: boolean;
   readonly canDelete: boolean;
-  readonly onRefetch: () => void;
 }): ReactNode {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [serverError, setServerError] = useState<string | null>(null);
 
   const updateTerm = useMutation({
@@ -172,8 +170,20 @@ function EditTermContent({
     onMutate: () => {
       setServerError(null);
     },
-    onSuccess: () => {
-      onRefetch();
+    onSuccess: async () => {
+      // List variants are scoped by `taxonomy` so sibling taxonomies
+      // don't needlessly refetch.
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.term.get.queryOptions({ input: { id: term.id } })
+            .queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.term.list.key({
+            input: { taxonomy: taxonomy.name },
+          }),
+        }),
+      ]);
     },
     onError: (err) => {
       setServerError(
@@ -257,6 +267,7 @@ function DeleteCard({
   readonly termName: string;
 }): ReactNode {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [confirming, setConfirming] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -265,7 +276,14 @@ function DeleteCard({
     onMutate: () => {
       setServerError(null);
     },
-    onSuccess: () => {
+    onSuccess: async () => {
+      // Evict cached list entries before navigating back — otherwise
+      // the list route shows the deleted row within its staleTime
+      // window. Scoped by taxonomy so sibling taxonomies don't
+      // needlessly refetch.
+      await queryClient.invalidateQueries({
+        queryKey: orpc.term.list.key({ input: { taxonomy: taxonomyName } }),
+      });
       void navigate({
         to: "/taxonomies/$name",
         params: { name: taxonomyName },

--- a/packages/admin/src/routes/_authenticated/users/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id.tsx
@@ -16,7 +16,12 @@ import { Label } from "@/components/ui/label.js";
 import { hasCap } from "@/lib/caps.js";
 import { orpc } from "@/lib/orpc.js";
 import { useForm } from "@tanstack/react-form";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import {
   createFileRoute,
   Link,
@@ -72,6 +77,16 @@ export const Route = createFileRoute("/_authenticated/users/$id")({
       throw redirect({ to: "/" });
     }
   },
+  loader: ({ context, params }) =>
+    context.queryClient.ensureQueryData(
+      orpc.user.get.queryOptions({ input: { id: Number(params.id) } }),
+    ),
+  pendingComponent: () => (
+    <FormEditSkeleton ariaLabel="Loading user" testId="user-edit-loading" />
+  ),
+  errorComponent: () => (
+    <NotFoundPlaceholder message="Couldn't load that user. They may have been deleted." />
+  ),
   component: UserEditRoute,
 });
 
@@ -97,20 +112,9 @@ function UserEditRoute(): ReactNode {
     ? hasCap(session.capabilities, "user:edit_own")
     : hasCap(session.capabilities, "user:edit");
 
-  const query = useQuery(orpc.user.get.queryOptions({ input: { id: userId } }));
-
-  if (query.isPending) {
-    return (
-      <FormEditSkeleton ariaLabel="Loading user" testId="user-edit-loading" />
-    );
-  }
-  if (query.isError) {
-    return (
-      <NotFoundPlaceholder message="Couldn't load that user. They may have been deleted." />
-    );
-  }
-
-  const target = query.data;
+  const { data: target } = useSuspenseQuery(
+    orpc.user.get.queryOptions({ input: { id: userId } }),
+  );
   return (
     <UserEditForm
       // Remount after each save so TanStack Form re-reads `defaultValues`
@@ -126,9 +130,6 @@ function UserEditRoute(): ReactNode {
       canSave={canSave}
       canDisable={canDisable}
       canDelete={canDelete}
-      onRefetch={() => {
-        void query.refetch();
-      }}
     />
   );
 }
@@ -140,7 +141,6 @@ function UserEditForm({
   canSave,
   canDisable,
   canDelete,
-  onRefetch,
 }: {
   target: User;
   isSelf: boolean;
@@ -148,9 +148,9 @@ function UserEditForm({
   canSave: boolean;
   canDisable: boolean;
   canDelete: boolean;
-  onRefetch: () => void;
 }): ReactNode {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [serverError, setServerError] = useState<string | null>(null);
 
   const updateUser = useMutation({
@@ -168,8 +168,14 @@ function UserEditForm({
     onMutate: () => {
       setServerError(null);
     },
-    onSuccess: () => {
-      onRefetch();
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.user.get.queryOptions({ input: { id: target.id } })
+            .queryKey,
+        }),
+        queryClient.invalidateQueries({ queryKey: orpc.user.list.key() }),
+      ]);
     },
     onError: (err) => {
       setServerError(
@@ -339,19 +345,14 @@ function UserEditForm({
         </CardContent>
       </Card>
 
-      {canDisable ? <StatusCard target={target} onChanged={onRefetch} /> : null}
+      {canDisable ? <StatusCard target={target} /> : null}
       {canDelete ? <DeleteCard target={target} /> : null}
     </div>
   );
 }
 
-function StatusCard({
-  target,
-  onChanged,
-}: {
-  target: User;
-  onChanged: () => void;
-}): ReactNode {
+function StatusCard({ target }: { target: User }): ReactNode {
+  const queryClient = useQueryClient();
   const [serverError, setServerError] = useState<string | null>(null);
   const isDisabled = target.disabledAt != null;
 
@@ -363,8 +364,14 @@ function StatusCard({
     onMutate: () => {
       setServerError(null);
     },
-    onSuccess: () => {
-      onChanged();
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.user.get.queryOptions({ input: { id: target.id } })
+            .queryKey,
+        }),
+        queryClient.invalidateQueries({ queryKey: orpc.user.list.key() }),
+      ]);
     },
     onError: (err) => {
       setServerError(
@@ -424,6 +431,7 @@ function toggleButtonLabel(isDisabled: boolean, isPending: boolean): string {
 
 function DeleteCard({ target }: { target: User }): ReactNode {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [confirming, setConfirming] = useState(false);
   const [reassignTo, setReassignTo] = useState<number | null>(null);
   const [serverError, setServerError] = useState<string | null>(null);
@@ -449,7 +457,13 @@ function DeleteCard({ target }: { target: User }): ReactNode {
     onMutate: () => {
       setServerError(null);
     },
-    onSuccess: () => {
+    onSuccess: async () => {
+      // Purge the now-deleted row from the list cache before we land
+      // there — otherwise the destination renders stale within the
+      // list's staleTime window.
+      await queryClient.invalidateQueries({
+        queryKey: orpc.user.list.key(),
+      });
       void navigate({ to: "/users", search: USERS_LIST_DEFAULT_SEARCH });
     },
     onError: (err) => {


### PR DESCRIPTION
## Summary

- Three edit routes (`users/$id`, `taxonomies/$name/$id`, `content/$slug/$id`) move from inline `useQuery` to the canonical `beforeLoad + loader + useSuspenseQuery + pendingComponent + errorComponent` pattern. The component reads synchronously; router owns pending/error boundaries.
- Router-level `defaultPreload: 'intent'` + `defaultPreloadStaleTime: 0` — hovering a row in the list preloads the target route's data in the background; clicks land on a rendered screen. Freshness is deferred to TanStack Query alone (one SWR policy, not two).
- Mutation `onSuccess` handlers now use `queryClient.invalidateQueries` with oRPC's partial `.key({ input: { scope } })` helpers. Scoped to the relevant post type or taxonomy so sibling subscribers (other post types, other taxonomies) don't refetch. Covers the specific detail key plus all list-view variants (pagination, filters, search).
- Admin README stripped of runtime-specific references (Cloudflare, wrangler, D1) so the doc stays neutral as more runtime adapters land.

Applied find-bugs, code-review, and code-simplifier sentry skills; findings folded in (Promise.all sibling risk, list-key mismatch, hardcoded "post" copy, over-invalidation scope).

## Test plan

- [x] `pnpm typecheck` — 15/15
- [x] `pnpm lint` — 12/12 (pre-existing data-table warning only)
- [x] `pnpm test` — 13/13 (including examples/minimal build integration)
- [x] `pnpm format`
- [x] `pnpm -F @plumix/admin test:e2e` — 41/41 Playwright + axe