### PR TITLE
refactor(core,admin): share id param schema across RPC + router

### DIFF
--- a/packages/admin/src/components/taxonomy/term-form.tsx
+++ b/packages/admin/src/components/taxonomy/term-form.tsx
@@ -6,6 +6,8 @@ import { Label } from "@/components/ui/label.js";
 import { useForm } from "@tanstack/react-form";
 import * as v from "valibot";
 
+import { idParam } from "@plumix/core/validation";
+
 /** Normalised input shape consumed by both create + update paths. */
 interface TermFormValues {
   readonly name: string;
@@ -29,7 +31,7 @@ const termFormSchema = v.object({
     ),
   ),
   description: v.pipe(v.string(), v.trim(), v.maxLength(2000)),
-  parentId: v.nullable(v.pipe(v.number(), v.integer(), v.minValue(1))),
+  parentId: v.nullable(idParam),
 });
 
 /**

--- a/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/$id.tsx
@@ -14,41 +14,39 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import {
-  createFileRoute,
-  notFound,
-  redirect,
-  useNavigate,
-} from "@tanstack/react-router";
+import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
+import * as v from "valibot";
 
 import type { PostTypeManifestEntry } from "@plumix/core/manifest";
 import type { PostWithMeta } from "@plumix/core/schema";
+import { idPathParam } from "@plumix/core/validation";
 
 import { CONTENT_LIST_DEFAULT_SEARCH } from "./-constants.js";
 
 export const Route = createFileRoute("/_authenticated/content/$slug/$id")({
+  // Reject invalid ids as a router 404 before `beforeLoad` / `loader`
+  // fire — no RPC, no stale-id flicker through the cache.
+  params: {
+    parse: (raw) => {
+      const result = v.safeParse(idPathParam, raw.id);
+      if (!result.success) {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+        throw notFound();
+      }
+      return { slug: raw.slug, id: result.output };
+    },
+  },
   beforeLoad: ({ params }): { postType: PostTypeManifestEntry } => {
     const postType = findPostTypeBySlug(params.slug);
     if (!postType) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
       throw notFound();
     }
-    const postId = Number(params.id);
-    if (Number.isNaN(postId) || postId < 1) {
-      // Non-numeric or negative ids can't resolve — bounce back to the
-      // post-type list rather than firing an RPC with garbage.
-      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
-      throw redirect({
-        to: "/content/$slug",
-        params: { slug: params.slug },
-        search: CONTENT_LIST_DEFAULT_SEARCH,
-      });
-    }
     return { postType };
   },
   loader: ({ context, params }) =>
     context.queryClient.ensureQueryData(
-      orpc.post.get.queryOptions({ input: { id: Number(params.id) } }),
+      orpc.post.get.queryOptions({ input: { id: params.id } }),
     ),
   // Pending/error screens are per-slug so copy reflects the actual
   // type ("page", "product") instead of hardcoding "post".
@@ -82,10 +80,9 @@ function EditPostErrorScreen(): ReactNode {
 
 function EditPostRoute(): ReactNode {
   const { user, postType } = Route.useRouteContext();
-  const params = Route.useParams();
+  const { id: postId, slug } = Route.useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const postId = Number(params.id);
   const [serverError, setServerError] = useState<string | null>(null);
 
   const { data: post } = useSuspenseQuery(
@@ -191,7 +188,7 @@ function EditPostRoute(): ReactNode {
         onCancel={() => {
           void navigate({
             to: "/content/$slug",
-            params: { slug: params.slug },
+            params: { slug },
             search: CONTENT_LIST_DEFAULT_SEARCH,
           });
         }}

--- a/packages/admin/src/routes/_authenticated/content/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/index.tsx
@@ -156,7 +156,7 @@ function buildColumns({
       cell: ({ row }) => (
         <Link
           to="/content/$slug/$id"
-          params={{ slug: adminSlug, id: String(row.original.id) }}
+          params={{ slug: adminSlug, id: row.original.id }}
           data-testid={`content-list-row-${String(row.original.id)}`}
           className="hover:text-primary flex flex-col transition-colors"
         >

--- a/packages/admin/src/routes/_authenticated/content/$slug/new.tsx
+++ b/packages/admin/src/routes/_authenticated/content/$slug/new.tsx
@@ -74,7 +74,7 @@ function NewPostRoute(): ReactNode {
     onSuccess: async (created) => {
       await navigate({
         to: "/content/$slug/$id",
-        params: { slug: params.slug, id: String(created.id) },
+        params: { slug: params.slug, id: created.id },
       });
     },
     onError: (err) => {

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
@@ -31,27 +31,28 @@ import {
   useNavigate,
 } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
+import * as v from "valibot";
 
 import type { TaxonomyManifestEntry } from "@plumix/core/manifest";
+import { idPathParam } from "@plumix/core/validation";
 
 import { TAXONOMY_LIST_DEFAULT_SEARCH } from "./-constants.js";
 import { mapTermError } from "./-errors.js";
 
 export const Route = createFileRoute("/_authenticated/taxonomies/$name/$id")({
-  parseParams: (params) => ({
-    name: params.name,
-    id: Number(params.id),
-  }),
+  // Reject invalid ids as a router 404 before `beforeLoad` / `loader`
+  // fire — no RPC, no stale-id flicker through the cache.
+  params: {
+    parse: (raw) => {
+      const result = v.safeParse(idPathParam, raw.id);
+      if (!result.success) {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+        throw notFound();
+      }
+      return { name: raw.name, id: result.output };
+    },
+  },
   beforeLoad: ({ context, params }): { taxonomy: TaxonomyManifestEntry } => {
-    // `parseParams` runs `Number()` on the raw string; `Number("abc")`
-    // is NaN. Reject unparseable ids before the component mounts so
-    // the RPC never sees garbage input, and the router surfaces a
-    // proper 404 instead of a misleading "term deleted" error.
-    const id = Number(params.id);
-    if (Number.isNaN(id) || id < 1) {
-      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
-      throw notFound();
-    }
     const taxonomy = findTaxonomyByName(params.name);
     if (!taxonomy) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow

--- a/packages/admin/src/routes/_authenticated/users/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id.tsx
@@ -25,6 +25,7 @@ import {
 import {
   createFileRoute,
   Link,
+  notFound,
   redirect,
   useNavigate,
 } from "@tanstack/react-router";
@@ -32,6 +33,7 @@ import { ArrowLeft } from "lucide-react";
 import * as v from "valibot";
 
 import type { User, UserRole } from "@plumix/core/schema";
+import { idPathParam } from "@plumix/core/validation";
 
 import {
   isUserRole,
@@ -56,19 +58,25 @@ const profileFormSchema = v.object({
 });
 
 export const Route = createFileRoute("/_authenticated/users/$id")({
-  parseParams: (params) => ({ id: Number(params.id) }),
+  // Reject invalid ids as a router 404 before `beforeLoad` / `loader`
+  // fire — no RPC, no stale-id flicker through the cache.
+  params: {
+    parse: (raw) => {
+      const result = v.safeParse(idPathParam, raw.id);
+      if (!result.success) {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+        throw notFound();
+      }
+      return { id: result.output };
+    },
+  },
   // More permissive than `/users/` — a user without `user:list` can
   // still edit their OWN row, so this screen doubles as `/profile`
   // (which redirects here). Other-user edits require `user:list`; the
   // server's own `user:edit_own` / `user:edit` checks are the final
   // word, but surfacing the right screen is half the UX.
   beforeLoad: ({ context, params }) => {
-    const id = Number(params.id);
-    if (Number.isNaN(id) || id < 1) {
-      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
-      throw redirect({ to: "/users", search: USERS_LIST_DEFAULT_SEARCH });
-    }
-    const isSelf = id === context.user.id;
+    const isSelf = params.id === context.user.id;
     const canEditAny = hasCap(context.user.capabilities, "user:list");
     const canEditSelf =
       isSelf && hasCap(context.user.capabilities, "user:edit_own");
@@ -79,7 +87,7 @@ export const Route = createFileRoute("/_authenticated/users/$id")({
   },
   loader: ({ context, params }) =>
     context.queryClient.ensureQueryData(
-      orpc.user.get.queryOptions({ input: { id: Number(params.id) } }),
+      orpc.user.get.queryOptions({ input: { id: params.id } }),
     ),
   pendingComponent: () => (
     <FormEditSkeleton ariaLabel="Loading user" testId="user-edit-loading" />
@@ -91,9 +99,8 @@ export const Route = createFileRoute("/_authenticated/users/$id")({
 });
 
 function UserEditRoute(): ReactNode {
-  const { id } = Route.useParams();
+  const { id: userId } = Route.useParams();
   const { user: session } = Route.useRouteContext();
-  const userId = Number(id);
   const isSelf = userId === session.id;
 
   // Self can't self-promote, self-disable, or self-delete — the `!isSelf`

--- a/packages/core/src/rpc/procedures/auth/schemas.ts
+++ b/packages/core/src/rpc/procedures/auth/schemas.ts
@@ -1,9 +1,10 @@
 import * as v from "valibot";
 
 import { USER_ROLES } from "../../../db/schema/users.js";
+import { idParam } from "../../validation.js";
 
 const sessionUserSchema = v.object({
-  id: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  id: idParam,
   email: v.string(),
   name: v.nullable(v.string()),
   avatarUrl: v.nullable(v.string()),

--- a/packages/core/src/rpc/procedures/post/schemas.ts
+++ b/packages/core/src/rpc/procedures/post/schemas.ts
@@ -2,6 +2,7 @@ import * as v from "valibot";
 
 import { postInsertSchema } from "../../../db/schema/posts.js";
 import { slugSchema } from "../../schemas.js";
+import { idParam } from "../../validation.js";
 
 const MAX_CONTENT_BYTES = 1_000_000;
 const MAX_EXCERPT_LENGTH = 600;
@@ -11,8 +12,6 @@ const MAX_TERMS_PER_TAXONOMY = 200;
 
 const trimmedText = (max: number) =>
   v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(max));
-
-const postIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
 
 const contentSchema = v.nullable(
   v.pipe(v.string(), v.maxLength(MAX_CONTENT_BYTES)),
@@ -33,7 +32,6 @@ const userSuppliableFields = v.omit(postInsertSchema, serverControlledKeys);
 
 // taxonomy → ordered term ids. Empty array clears all assignments for that
 // taxonomy. Taxonomy keys not in the map are untouched.
-const termIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
 const postTermsSchema = v.record(
   v.pipe(
     v.string(),
@@ -42,7 +40,7 @@ const postTermsSchema = v.record(
     v.maxLength(100),
     v.regex(/^[a-zA-Z0-9_-]+$/, "taxonomy must be kebab/snake ASCII"),
   ),
-  v.pipe(v.array(termIdSchema), v.maxLength(MAX_TERMS_PER_TAXONOMY)),
+  v.pipe(v.array(idParam), v.maxLength(MAX_TERMS_PER_TAXONOMY)),
 );
 
 // Meta bag accepted by `post.create` / `post.update`. Per-key validation
@@ -82,13 +80,13 @@ export const postCreateInputSchema = v.object({
 });
 
 export const postUpdateInputSchema = v.object({
-  id: postIdSchema,
+  id: idParam,
   title: v.optional(trimmedText(300)),
   slug: v.optional(slugSchema),
   content: v.optional(contentSchema),
   excerpt: v.optional(excerptSchema),
   status: v.optional(userSuppliableFields.entries.status),
-  parentId: v.optional(v.nullable(postIdSchema)),
+  parentId: v.optional(v.nullable(idParam)),
   menuOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
   terms: v.optional(postTermsSchema),
   meta: v.optional(postMetaInputSchema),
@@ -146,14 +144,14 @@ export const postListInputSchema = v.object({
    * Filter by the post's `authorId`. Admin "Mine" filter passes the
    * session user's id here; future UIs can surface an author dropdown.
    */
-  authorId: v.optional(postIdSchema),
+  authorId: v.optional(idParam),
   /**
    * Filter by parent post id for hierarchical types (pages, etc.).
    * - `null` → only top-level posts (parent_id IS NULL).
    * - a number → only direct children of that post.
    * - omitted → no filter, flat list across all depths.
    */
-  parentId: v.optional(v.nullable(postIdSchema)),
+  parentId: v.optional(v.nullable(idParam)),
   /**
    * Free-text search across `title`, `content`, and `excerpt`. Whitespace
    * separates terms (all AND-ed), `"quoted phrases"` stay whole, and a
@@ -190,8 +188,8 @@ export const postListInputSchema = v.object({
   offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
 });
 
-export const postGetInputSchema = v.object({ id: postIdSchema });
-export const postTrashInputSchema = v.object({ id: postIdSchema });
+export const postGetInputSchema = v.object({ id: idParam });
+export const postTrashInputSchema = v.object({ id: idParam });
 
 export type PostListInput = v.InferOutput<typeof postListInputSchema>;
 export type PostGetInput = v.InferOutput<typeof postGetInputSchema>;

--- a/packages/core/src/rpc/procedures/term/schemas.ts
+++ b/packages/core/src/rpc/procedures/term/schemas.ts
@@ -1,8 +1,7 @@
 import * as v from "valibot";
 
 import { slugSchema } from "../../schemas.js";
-
-const termIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
+import { idParam } from "../../validation.js";
 
 const taxonomySchema = v.pipe(
   v.string(),
@@ -22,7 +21,7 @@ const descriptionSchema = v.nullable(v.pipe(v.string(), v.maxLength(10_000)));
 
 export const termListInputSchema = v.object({
   taxonomy: taxonomySchema,
-  parentId: v.optional(v.nullable(termIdSchema)),
+  parentId: v.optional(v.nullable(idParam)),
   search: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200))),
   limit: v.optional(
     v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(200)),
@@ -31,25 +30,25 @@ export const termListInputSchema = v.object({
   offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
 });
 
-export const termGetInputSchema = v.object({ id: termIdSchema });
+export const termGetInputSchema = v.object({ id: idParam });
 
 export const termCreateInputSchema = v.object({
   taxonomy: taxonomySchema,
   name: nameSchema,
   slug: slugSchema,
   description: v.optional(descriptionSchema),
-  parentId: v.optional(v.nullable(termIdSchema)),
+  parentId: v.optional(v.nullable(idParam)),
 });
 
 export const termUpdateInputSchema = v.object({
-  id: termIdSchema,
+  id: idParam,
   name: v.optional(nameSchema),
   slug: v.optional(slugSchema),
   description: v.optional(descriptionSchema),
-  parentId: v.optional(v.nullable(termIdSchema)),
+  parentId: v.optional(v.nullable(idParam)),
 });
 
-export const termDeleteInputSchema = v.object({ id: termIdSchema });
+export const termDeleteInputSchema = v.object({ id: idParam });
 
 export type TermListInput = v.InferOutput<typeof termListInputSchema>;
 export type TermGetInput = v.InferOutput<typeof termGetInputSchema>;

--- a/packages/core/src/rpc/procedures/user/schemas.ts
+++ b/packages/core/src/rpc/procedures/user/schemas.ts
@@ -1,9 +1,7 @@
 import * as v from "valibot";
 
 import { USER_ROLES } from "../../../db/schema/users.js";
-import { emailField, nameField } from "../../validation.js";
-
-const userIdSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
+import { emailField, idParam, nameField } from "../../validation.js";
 
 const avatarUrlSchema = v.pipe(
   v.string(),
@@ -26,7 +24,7 @@ export const userListInputSchema = v.object({
   search: v.optional(searchSchema),
 });
 
-export const userGetInputSchema = v.object({ id: userIdSchema });
+export const userGetInputSchema = v.object({ id: idParam });
 
 export const userInviteInputSchema = v.object({
   email: emailField,
@@ -35,21 +33,21 @@ export const userInviteInputSchema = v.object({
 });
 
 export const userUpdateInputSchema = v.object({
-  id: userIdSchema,
+  id: idParam,
   email: v.optional(emailField),
   name: v.optional(v.nullable(nameField)),
   avatarUrl: v.optional(v.nullable(avatarUrlSchema)),
   role: v.optional(roleSchema),
 });
 
-export const userDisableInputSchema = v.object({ id: userIdSchema });
+export const userDisableInputSchema = v.object({ id: idParam });
 
-export const userEnableInputSchema = v.object({ id: userIdSchema });
+export const userEnableInputSchema = v.object({ id: idParam });
 
 export const userDeleteInputSchema = v.object({
-  id: userIdSchema,
+  id: idParam,
   /** Reassign this user's authored posts to the given user id before deletion. */
-  reassignPostsTo: v.optional(userIdSchema),
+  reassignPostsTo: v.optional(idParam),
 });
 
 export type UserListInput = v.InferOutput<typeof userListInputSchema>;

--- a/packages/core/src/rpc/validation.test.ts
+++ b/packages/core/src/rpc/validation.test.ts
@@ -1,0 +1,85 @@
+import * as v from "valibot";
+import { describe, expect, test } from "vitest";
+
+import { idParam, idPathParam } from "./validation.js";
+
+describe("idParam", () => {
+  test("accepts positive integers", () => {
+    expect(v.parse(idParam, 1)).toBe(1);
+    expect(v.parse(idParam, 42)).toBe(42);
+    expect(v.parse(idParam, 999_999)).toBe(999_999);
+  });
+
+  test("rejects zero, negatives, floats, and NaN", () => {
+    expect(() => v.parse(idParam, 0)).toThrow();
+    expect(() => v.parse(idParam, -1)).toThrow();
+    expect(() => v.parse(idParam, 1.5)).toThrow();
+    expect(() => v.parse(idParam, Number.NaN)).toThrow();
+    expect(() => v.parse(idParam, Infinity)).toThrow();
+  });
+
+  test("rejects unsafe-integer-valued numbers (precision loss risk)", () => {
+    // 1e21 passes v.integer() because the number IS integer-valued,
+    // but it's beyond MAX_SAFE_INTEGER and loses precision in cache
+    // keys / SQLite row-id comparisons.
+    expect(() => v.parse(idParam, 1e21)).toThrow();
+    expect(() => v.parse(idParam, Number.MAX_SAFE_INTEGER + 1)).toThrow();
+  });
+
+  test("rejects non-numbers", () => {
+    expect(() => v.parse(idParam, "1")).toThrow();
+    expect(() => v.parse(idParam, null)).toThrow();
+    expect(() => v.parse(idParam, undefined)).toThrow();
+  });
+});
+
+describe("idPathParam", () => {
+  test("coerces numeric strings to positive integers", () => {
+    expect(v.parse(idPathParam, "1")).toBe(1);
+    expect(v.parse(idPathParam, "42")).toBe(42);
+  });
+
+  test("rejects non-numeric strings", () => {
+    expect(() => v.parse(idPathParam, "abc")).toThrow();
+    expect(() => v.parse(idPathParam, "")).toThrow();
+    expect(() => v.parse(idPathParam, "1.5")).toThrow();
+  });
+
+  test("rejects zero and negatives even when parseable", () => {
+    expect(() => v.parse(idPathParam, "0")).toThrow();
+    expect(() => v.parse(idPathParam, "-5")).toThrow();
+  });
+
+  test("rejects unicode-digit strings (ASCII-only by design)", () => {
+    // Some browsers encode `〡` / `١` / `１` intact in URLs; the ASCII-
+    // only `/^[1-9]\d*$/` rejects them so the schema stays portable
+    // and unambiguous across locales.
+    expect(() => v.parse(idPathParam, "１")).toThrow();
+    expect(() => v.parse(idPathParam, "١")).toThrow();
+  });
+
+  test("rejects null bytes and digit runs that exceed MAX_SAFE_INTEGER", () => {
+    expect(() => v.parse(idPathParam, "1\0")).toThrow();
+    // Regex passes, but the coerced number loses precision beyond
+    // MAX_SAFE_INTEGER — idParam's maxValue check catches this.
+    expect(() => v.parse(idPathParam, "9".repeat(20))).toThrow();
+  });
+
+  test("rejects Number() coercion quirks that would otherwise pass", () => {
+    // `Number()` coerces these to valid integers (0x1F→31, 5e2→500,
+    // +5→5, " 42 "→42). The regex gate in `idPathParam` rejects
+    // them up front so the route surfaces a clean 404 instead of
+    // firing an RPC with a surprising id.
+    expect(() => v.parse(idPathParam, "0x1F")).toThrow();
+    expect(() => v.parse(idPathParam, "5e2")).toThrow();
+    expect(() => v.parse(idPathParam, "+5")).toThrow();
+    expect(() => v.parse(idPathParam, " 42 ")).toThrow();
+    expect(() => v.parse(idPathParam, "01")).toThrow();
+    expect(() => v.parse(idPathParam, "1\n")).toThrow();
+  });
+
+  test("rejects non-strings — URL params are always strings", () => {
+    expect(() => v.parse(idPathParam, 1)).toThrow();
+    expect(() => v.parse(idPathParam, null)).toThrow();
+  });
+});

--- a/packages/core/src/rpc/validation.ts
+++ b/packages/core/src/rpc/validation.ts
@@ -22,3 +22,31 @@ export const nameField = v.pipe(
   v.trim(),
   v.maxLength(200, "Name is too long."),
 );
+
+/**
+ * Canonical row-id shape for RPC inputs. MAX_SAFE_INTEGER cap rejects
+ * integer-valued numbers like `1e21` that pass `v.integer()` but lose
+ * precision in cache keys and DB comparisons.
+ */
+export const idParam = v.pipe(
+  v.number(),
+  v.integer(),
+  v.minValue(1),
+  v.maxValue(Number.MAX_SAFE_INTEGER),
+);
+
+/**
+ * String-to-int coercer for URL path params. The regex is tighter than
+ * `Number()` — it rejects hex (`"0x1F"`), exponential (`"5e2"`), signed,
+ * whitespace-wrapped, leading-zero, and empty strings, all of which
+ * `Number()` would otherwise coerce to a valid positive int.
+ */
+export const idPathParam = v.pipe(
+  v.string(),
+  v.regex(/^[1-9]\d*$/, "id must be a positive decimal integer"),
+  v.transform((s) => Number(s)),
+  v.number(),
+  v.integer(),
+  v.minValue(1),
+  v.maxValue(Number.MAX_SAFE_INTEGER),
+);


### PR DESCRIPTION
## Summary

- Adds `idParam` + `idPathParam` to `@plumix/core/validation` — canonical positive-integer row id (server) and regex-gated string-to-int coercer (admin URL path params).
- Every RPC input field that takes a row id (`user.*`, `post.*`, `term.*`, auth session probe, post→term relations) now imports `idParam` instead of inlining `v.pipe(v.number(), v.integer(), v.minValue(1))`. Also adds a `MAX_SAFE_INTEGER` cap that rejects `1e21`-shaped numbers that pass `v.integer()` but lose precision in cache keys + SQLite comparisons.
- Three admin edit routes (`users/$id`, `taxonomies/$name/$id`, `content/$slug/$id`) swap their manual `beforeLoad` NaN guards for the router-native `params.parse` + `throw notFound()` pattern. Invalid ids surface the router's 404 page before `beforeLoad` / `loader` run — no RPC, no stale-id flicker. Idiomatic TanStack Router shape for path-param validation.
- `idPathParam` is tighter than a plain `Number()` coerce: `/^[1-9]\d*$/` rejects hex (`"0x1F"`), exponential (`"5e2"`), signed (`"+5"`), whitespace-wrapped, leading-zero, unicode-digit (`"١"`/`"１"`), and null-byte strings.
- Admin term-form's `parentId` now imports `idParam` for consistency.

Sentry skills applied: find-bugs (caught the Number() coercion quirks, MAX_SAFE_INTEGER gap, and a missed `termIdSchema` in post/schemas.ts), code-review (ok with minor nits — folded in `auth/schemas.ts` + `term-form.tsx` consistency, plus 3 more test cases), code-simplifier (trimmed redundant JSDoc + comments).

## Test plan

- [x] `pnpm typecheck` — 15/15
- [x] `pnpm lint` — 12/12 (pre-existing data-table warning only)
- [x] `pnpm test` — 13/13 (includes 12 new validation tests)
- [x] `pnpm format`
- [x] `pnpm -F @plumix/admin test:e2e` — 41/41 Playwright + axe