### PR TITLE
feat(admin,core): settings admin with page → fieldset → field schema

### DIFF
--- a/examples/minimal/test/build.integration.test.ts
+++ b/examples/minimal/test/build.integration.test.ts
@@ -48,10 +48,12 @@ describe("examples/minimal — plumix build", () => {
 
       // Manifest placeholder is replaced by the vite plugin with a
       // config-derived payload. `examples/minimal` registers no plugins,
-      // so postTypes is empty but the tag must still be present.
+      // so every manifest slice is empty but the tag must still be
+      // present — the admin bundle's `readManifest()` asserts shape on
+      // page load.
       const adminHtml = readFileSync(adminIndexHtml, "utf8");
       expect(adminHtml).toMatch(
-        /<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\],"taxonomies":\[\],"metaBoxes":\[\]\}<\/script>/,
+        /<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\],"taxonomies":\[\],"metaBoxes":\[\],"settingsGroups":\[\]\}<\/script>/,
       );
     },
     60_000,

--- a/packages/admin/e2e/settings.spec.ts
+++ b/packages/admin/e2e/settings.spec.ts
@@ -1,0 +1,197 @@
+import { expect, test } from "@playwright/test";
+
+import { expectNoAxeViolations } from "./support/axe.js";
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_SETTINGS,
+  mockManifest,
+  mockRpc,
+  mockSession,
+} from "./support/rpc-mock.js";
+
+// The settings admin surface:
+//   - /settings — the page index
+//   - /settings/$group — one page per registered group, rendering every
+//     declared fieldset as a native `<fieldset>` with `<legend>`
+// Scope: the plugin-facing contract end-to-end (group → fieldsets →
+// fields) and the option.getMany/set round-trips. Doesn't exercise
+// boolean / number / select field types — those land when we widen
+// `SettingsFieldType` beyond `text | textarea`.
+
+test.describe("/settings (group index)", () => {
+  test("admin sees a card per registered group; each links into its form", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_SETTINGS);
+    await mockSession(page, AUTHED_ADMIN);
+    await page.goto("settings");
+    await expect(page.getByTestId("settings-heading")).toBeVisible();
+    const link = page.getByTestId("settings-group-link-general");
+    await expect(link).toHaveAttribute("href", /\/settings\/general$/);
+    await expectNoAxeViolations(page);
+  });
+
+  test("empty-state card renders when no groups are registered", async ({
+    page,
+  }) => {
+    await mockSession(page, AUTHED_ADMIN);
+    await page.goto("settings");
+    await expect(page.getByTestId("settings-empty-state")).toBeVisible();
+    await expectNoAxeViolations(page);
+  });
+
+  test("non-admin without option:manage is redirected home", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_SETTINGS);
+    const adminUser = AUTHED_ADMIN.user;
+    if (!adminUser) throw new Error("AUTHED_ADMIN fixture missing user");
+    await mockSession(page, {
+      user: {
+        ...adminUser,
+        role: "editor",
+        capabilities: ["post:edit_own"],
+      },
+      needsBootstrap: false,
+    });
+    await page.goto("settings");
+    await expect(page).toHaveURL(/\/(?:$|_plumix\/admin\/$)/);
+  });
+});
+
+test.describe("/settings/$group", () => {
+  test("renders each declared fieldset with its legend + fields", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_SETTINGS);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/option/getMany": {},
+    });
+    await page.goto("settings/general");
+    await expect(page.getByTestId("settings-group-heading")).toBeVisible();
+    // Both fieldsets render with their legends.
+    await expect(
+      page.getByTestId("settings-fieldset-legend-identity"),
+    ).toHaveText("Identity");
+    await expect(
+      page.getByTestId("settings-fieldset-legend-contact"),
+    ).toHaveText("Contact");
+    // Fields inside each fieldset are reachable by the flat testid —
+    // storage keys are flat across fieldsets.
+    await expect(page.getByTestId("settings-field-site_title")).toBeVisible();
+    await expect(page.getByTestId("settings-field-admin_email")).toBeVisible();
+    await expectNoAxeViolations(page);
+  });
+
+  test("empty fetch — fields start empty (no stored values, no defaults)", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_SETTINGS);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/option/getMany": {},
+    });
+    await page.goto("settings/general");
+    await expect(page.getByTestId("settings-field-site_title")).toHaveValue("");
+    await expect(page.getByTestId("settings-field-admin_email")).toHaveValue(
+      "",
+    );
+  });
+
+  test("hydrates field values from option.getMany across fieldsets", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_SETTINGS);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/option/getMany": {
+        // Storage is flat — fieldsets don't namespace the key, only
+        // `groupName.fieldName`. Same key works across fieldsets.
+        "general.site_title": "Plumix",
+        "general.admin_email": "root@plumix.dev",
+      },
+    });
+    await page.goto("settings/general");
+    await expect(page.getByTestId("settings-field-site_title")).toHaveValue(
+      "Plumix",
+    );
+    await expect(page.getByTestId("settings-field-admin_email")).toHaveValue(
+      "root@plumix.dev",
+    );
+    await expect(
+      page.getByTestId("settings-field-site_description"),
+    ).toHaveValue("");
+  });
+
+  test("save: submit fires option.set per field; success notice renders", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_SETTINGS);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/option/getMany": {},
+      "/option/set": {
+        name: "general.site_title",
+        value: "New",
+        isAutoloaded: true,
+      },
+    });
+    await page.goto("settings/general");
+    await page.getByTestId("settings-field-site_title").fill("Plumix");
+    await page.getByTestId("settings-submit").click();
+    await expect(page.getByTestId("settings-save-notice")).toBeVisible();
+  });
+
+  test("save failure: RPC rejection surfaces the server-error alert", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_SETTINGS);
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: AUTHED_ADMIN, meta: [] }),
+        });
+      }
+      if (url.endsWith("/option/getMany")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: {}, meta: [] }),
+        });
+      }
+      if (url.endsWith("/option/set")) {
+        // oRPC's error wire format — match what the server emits so the
+        // client's error pipeline surfaces the message through to the
+        // mutation's `onError`.
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            defined: false,
+            code: "INTERNAL_SERVER_ERROR",
+            status: 500,
+            message: "Storage is unavailable",
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+    await page.goto("settings/general");
+    await page.getByTestId("settings-field-site_title").fill("Plumix");
+    await page.getByTestId("settings-submit").click();
+    await expect(page.getByTestId("settings-server-error")).toBeVisible();
+    // Success notice must NOT appear when the save errored.
+    await expect(page.getByTestId("settings-save-notice")).toHaveCount(0);
+  });
+
+  test("unregistered group surfaces the router 404", async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_SETTINGS);
+    await mockSession(page, AUTHED_ADMIN);
+    await page.goto("settings/nonexistent");
+    await expect(page.getByTestId("not-found-page")).toBeVisible();
+  });
+});

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -29,6 +29,12 @@ interface MockRpcHandlers {
   "/term/create"?: Term;
   "/term/update"?: Term;
   "/term/delete"?: Term;
+  "/option/getMany"?: Record<string, string>;
+  "/option/set"?: {
+    name: string;
+    value: string;
+    isAutoloaded: boolean;
+  };
 }
 
 // oRPC's StandardRPCSerializer wire format — `meta` is always present,
@@ -109,6 +115,7 @@ export const MANIFEST_WITH_POST: PlumixManifest = {
   ],
   taxonomies: [],
   metaBoxes: [],
+  settingsGroups: [],
 };
 
 // Manifest with two taxonomies — one hierarchical (category), one flat
@@ -137,6 +144,7 @@ export const MANIFEST_WITH_TAXONOMIES: PlumixManifest = {
     },
   ],
   metaBoxes: [],
+  settingsGroups: [],
 };
 
 // Manifest with two meta boxes — one in the right rail (`side`), one in
@@ -176,6 +184,58 @@ export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
           key: "is_featured",
           label: "Featured",
           inputType: "checkbox",
+        },
+      ],
+    },
+  ],
+  settingsGroups: [],
+};
+
+// Manifest exercising the full settings hierarchy: one page (group),
+// two fieldsets, several fields across them. Covers the plugin-author
+// contract end-to-end — plugins register a page with labelled sections
+// and the admin renders `<fieldset>` / `<legend>` accessibility markup.
+export const MANIFEST_WITH_SETTINGS: PlumixManifest = {
+  postTypes: [],
+  taxonomies: [],
+  metaBoxes: [],
+  settingsGroups: [
+    {
+      name: "general",
+      label: "General",
+      description: "Basic site identity and contact details.",
+      fieldsets: [
+        {
+          name: "identity",
+          label: "Identity",
+          description: "Public-facing site identity.",
+          fields: [
+            {
+              name: "site_title",
+              label: "Site title",
+              type: "text",
+              maxLength: 200,
+            },
+            {
+              name: "site_description",
+              label: "Tagline",
+              type: "text",
+              maxLength: 300,
+            },
+          ],
+        },
+        {
+          name: "contact",
+          label: "Contact",
+          description: "Admin notifications route to this address.",
+          fields: [
+            {
+              name: "admin_email",
+              label: "Administration email",
+              type: "text",
+              maxLength: 254,
+            },
+          ],
         },
       ],
     },

--- a/packages/admin/src/components/settings/field.test.tsx
+++ b/packages/admin/src/components/settings/field.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { SettingsFieldManifestEntry } from "@plumix/core/manifest";
+
+import { SettingsField } from "./field.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function field(
+  overrides: Partial<SettingsFieldManifestEntry> = {},
+): SettingsFieldManifestEntry {
+  return {
+    name: "site_title",
+    label: "Site title",
+    type: "text",
+    ...overrides,
+  };
+}
+
+describe("SettingsField", () => {
+  test("text: renders an <input type='text'> wired to value + onChange", () => {
+    const handle = vi.fn();
+    render(
+      <SettingsField
+        field={field()}
+        value="Plumix"
+        onChange={handle}
+        testId="sf-site-title"
+      />,
+    );
+    const input = screen.getByTestId("sf-site-title");
+    expect(input).toHaveProperty("tagName", "INPUT");
+    expect(input).toHaveProperty("type", "text");
+    expect(input).toHaveProperty("value", "Plumix");
+  });
+
+  test("textarea: renders a <textarea> with value + onChange", () => {
+    render(
+      <SettingsField
+        field={field({ type: "textarea", name: "site_description" })}
+        value="A headless CMS"
+        onChange={() => {
+          // not exercised in this test
+        }}
+        testId="sf-site-desc"
+      />,
+    );
+    const el = screen.getByTestId("sf-site-desc");
+    expect(el).toHaveProperty("tagName", "TEXTAREA");
+    expect(el).toHaveProperty("value", "A headless CMS");
+  });
+
+  test("description wires via aria-describedby", () => {
+    render(
+      <SettingsField
+        field={field({ description: "Shown in the browser tab." })}
+        value=""
+        onChange={() => {
+          // not exercised in this test
+        }}
+        testId="sf-with-desc"
+      />,
+    );
+    const input = screen.getByTestId("sf-with-desc");
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const descEl = describedBy ? document.getElementById(describedBy) : null;
+    expect(descEl?.textContent).toBe("Shown in the browser tab.");
+  });
+
+  test("disabled flag propagates and blocks typing", () => {
+    render(
+      <SettingsField
+        field={field()}
+        value="x"
+        onChange={() => {
+          // not exercised
+        }}
+        disabled
+        testId="sf-disabled"
+      />,
+    );
+    expect(screen.getByTestId("sf-disabled")).toHaveProperty("disabled", true);
+  });
+
+  test("maxLength propagates to the native attribute", () => {
+    render(
+      <SettingsField
+        field={field({ maxLength: 80 })}
+        value=""
+        onChange={() => {
+          // not exercised
+        }}
+        testId="sf-maxlen"
+      />,
+    );
+    expect(screen.getByTestId("sf-maxlen")).toHaveProperty("maxLength", 80);
+  });
+});

--- a/packages/admin/src/components/settings/field.tsx
+++ b/packages/admin/src/components/settings/field.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import { Input } from "@/components/ui/input.js";
+import { Label } from "@/components/ui/label.js";
+
+import type { SettingsFieldManifestEntry } from "@plumix/core/manifest";
+
+/**
+ * Dispatcher for a single settings field. Narrow on `field.type` so the
+ * TypeScript compiler flags an unhandled case the moment we widen the
+ * `SettingsFieldType` union in core. Contrast with `MetaBoxField` which
+ * accepts a free-form `inputType: string` with a dispatcher fallback —
+ * settings are core infrastructure where widening the union is a
+ * core-team call, so the exhaustive switch is worth the rigidity.
+ *
+ * Consumers wire the field into TanStack Form via `value` + `onChange`;
+ * validation + dirty tracking happen at the form level. ARIA dance
+ * (label/input association, `aria-describedby` for `field.description`)
+ * is encapsulated here so every settings form behaves identically.
+ */
+export function SettingsField({
+  field,
+  value,
+  onChange,
+  disabled,
+  testId,
+}: {
+  readonly field: SettingsFieldManifestEntry;
+  readonly value: string;
+  readonly onChange: (next: string) => void;
+  readonly disabled?: boolean;
+  readonly testId?: string;
+}): ReactNode {
+  const inputId = `setting-${field.name}`;
+  const descriptionId = field.description ? `${inputId}-desc` : undefined;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor={inputId}>{field.label}</Label>
+      {field.type === "text" ? (
+        <Input
+          id={inputId}
+          name={field.name}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          maxLength={field.maxLength}
+          disabled={disabled}
+          aria-describedby={descriptionId}
+          data-testid={testId}
+        />
+      ) : (
+        <textarea
+          id={inputId}
+          name={field.name}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          maxLength={field.maxLength}
+          disabled={disabled}
+          aria-describedby={descriptionId}
+          data-testid={testId}
+          rows={4}
+          className="border-input bg-background focus-visible:ring-ring rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      )}
+      {field.description ? (
+        <p id={descriptionId} className="text-muted-foreground text-xs">
+          {field.description}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/admin/src/components/shell/app-sidebar.tsx
+++ b/packages/admin/src/components/shell/app-sidebar.tsx
@@ -13,9 +13,13 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar.js";
 import { hasCap } from "@/lib/caps.js";
-import { visiblePostTypes, visibleTaxonomies } from "@/lib/manifest.js";
+import {
+  visiblePostTypes,
+  visibleSettingsGroups,
+  visibleTaxonomies,
+} from "@/lib/manifest.js";
 import { Link } from "@tanstack/react-router";
-import { FileText, LayoutDashboard, Tag, Users } from "lucide-react";
+import { FileText, LayoutDashboard, Settings, Tag, Users } from "lucide-react";
 
 import type { UserIdentity } from "./user-menu.js";
 import { UserMenu } from "./user-menu.js";
@@ -69,17 +73,23 @@ function buildTaxonomyGroup(capabilities: readonly string[]): NavGroup | null {
   return { label: "Taxonomies", items };
 }
 
-// `user:list` is admin / editor-level. Subscribers and authors see their
-// own profile via `/profile` (future PR) but don't get a user-management
-// nav entry at all — matches WordPress's "Users" menu being role-gated.
+// `user:list` gates Users (admin / editor-level); Settings appears when
+// ANY settings group is visible to the caller (at minimum
+// `option:manage`, but plugins may declare tighter per-group gates).
+// The group only hides entirely when the caller has no management
+// surfaces at all.
 function buildManagementGroup(
   capabilities: readonly string[],
 ): NavGroup | null {
-  if (!hasCap(capabilities, "user:list")) return null;
-  return {
-    label: "Management",
-    items: [{ to: "/users", label: "Users", icon: Users }],
-  };
+  const items: NavItem[] = [];
+  if (hasCap(capabilities, "user:list")) {
+    items.push({ to: "/users", label: "Users", icon: Users });
+  }
+  if (visibleSettingsGroups(capabilities).length > 0) {
+    items.push({ to: "/settings", label: "Settings", icon: Settings });
+  }
+  if (items.length === 0) return null;
+  return { label: "Management", items };
 }
 
 export function AppSidebar({

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -6,11 +6,14 @@ import type {
 } from "@plumix/core/manifest";
 
 import {
+  allSettingsFields,
   findPostTypeBySlug,
+  findSettingsGroupByName,
   findTaxonomyByName,
   metaBoxesForPostType,
   readManifest,
   visiblePostTypes,
+  visibleSettingsGroups,
   visibleTaxonomies,
 } from "./manifest.js";
 
@@ -35,6 +38,7 @@ describe("readManifest", () => {
       postTypes: [],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
   });
 
@@ -48,6 +52,7 @@ describe("readManifest", () => {
       postTypes: [{ name: "post", label: "Posts" }],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
   });
 
@@ -57,6 +62,7 @@ describe("readManifest", () => {
       postTypes: [],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
   });
 
@@ -69,6 +75,7 @@ describe("readManifest", () => {
       postTypes: [],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
     expect(errSpy).toHaveBeenCalledOnce();
   });
@@ -79,6 +86,7 @@ describe("readManifest", () => {
       postTypes: [],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
   });
 
@@ -90,6 +98,7 @@ describe("readManifest", () => {
       postTypes: [],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
   });
 
@@ -118,6 +127,7 @@ describe("readManifest", () => {
           fields: [],
         },
       ],
+      settingsGroups: [],
     });
   });
 
@@ -144,6 +154,7 @@ describe("readManifest", () => {
         },
       ],
       metaBoxes: [],
+      settingsGroups: [],
     });
   });
 
@@ -163,6 +174,7 @@ describe("findPostTypeBySlug", () => {
     ],
     taxonomies: [],
     metaBoxes: [],
+    settingsGroups: [],
   };
 
   test("returns the matching entry", () => {
@@ -193,6 +205,7 @@ describe("visiblePostTypes", () => {
     ],
     taxonomies: [],
     metaBoxes: [],
+    settingsGroups: [],
   };
 
   test("filters by `${capabilityType}:edit_own`; unset capabilityType uses name", () => {
@@ -229,6 +242,7 @@ describe("metaBoxesForPostType", () => {
         box("b", { priority: "high" }),
         box("c"), // default
       ],
+      settingsGroups: [],
     };
     const ids = metaBoxesForPostType("post", [], source).map((b) => b.id);
     expect(ids).toEqual(["b", "c", "a"]);
@@ -242,6 +256,7 @@ describe("metaBoxesForPostType", () => {
         box("first", { priority: "high" }),
         box("second", { priority: "high" }),
       ],
+      settingsGroups: [],
     };
     const ids = metaBoxesForPostType("post", [], source).map((b) => b.id);
     expect(ids).toEqual(["first", "second"]);
@@ -255,6 +270,7 @@ describe("metaBoxesForPostType", () => {
         box("seo", { postTypes: ["post"] }),
         box("shop", { postTypes: ["product"] }),
       ],
+      settingsGroups: [],
     };
     const ids = metaBoxesForPostType("post", [], source).map((b) => b.id);
     expect(ids).toEqual(["seo"]);
@@ -268,6 +284,7 @@ describe("metaBoxesForPostType", () => {
         box("public"),
         box("privileged", { capability: "post:edit_any" }),
       ],
+      settingsGroups: [],
     };
     const withoutCap = metaBoxesForPostType("post", [], source).map(
       (b) => b.id,
@@ -285,6 +302,7 @@ describe("metaBoxesForPostType", () => {
       postTypes: [],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     };
     expect(metaBoxesForPostType("post", [], source)).toEqual([]);
   });
@@ -298,6 +316,7 @@ describe("findTaxonomyByName", () => {
       { name: "tag", label: "Tags" },
     ],
     metaBoxes: [],
+    settingsGroups: [],
   };
 
   test("returns the matching taxonomy", () => {
@@ -318,6 +337,7 @@ describe("visibleTaxonomies", () => {
       { name: "internal", label: "Internal" },
     ],
     metaBoxes: [],
+    settingsGroups: [],
   };
 
   test("filters by per-taxonomy :read capability", () => {
@@ -328,5 +348,70 @@ describe("visibleTaxonomies", () => {
 
   test("returns empty when the caller has no taxonomy :read caps", () => {
     expect(visibleTaxonomies(["post:edit_own"], source)).toEqual([]);
+  });
+});
+
+describe("findSettingsGroupByName + visibleSettingsGroups + allSettingsFields", () => {
+  const source: PlumixManifest = {
+    postTypes: [],
+    taxonomies: [],
+    metaBoxes: [],
+    settingsGroups: [
+      {
+        name: "general",
+        label: "General",
+        fieldsets: [
+          {
+            name: "identity",
+            fields: [
+              { name: "site_title", label: "Site title", type: "text" },
+              { name: "site_description", label: "Tagline", type: "text" },
+            ],
+          },
+          {
+            name: "contact",
+            fields: [
+              { name: "admin_email", label: "Admin email", type: "text" },
+            ],
+          },
+        ],
+      },
+      {
+        name: "billing",
+        label: "Billing",
+        fieldsets: [],
+      },
+    ],
+  };
+
+  test("findSettingsGroupByName returns the matching group", () => {
+    expect(findSettingsGroupByName("general", source)?.label).toBe("General");
+  });
+
+  test("findSettingsGroupByName returns undefined when missing", () => {
+    expect(findSettingsGroupByName("mystery", source)).toBeUndefined();
+  });
+
+  test("visibleSettingsGroups returns every group when caller has option:manage", () => {
+    const visible = visibleSettingsGroups(["option:manage"], source).map(
+      (g) => g.name,
+    );
+    expect(visible).toEqual(["general", "billing"]);
+  });
+
+  test("visibleSettingsGroups returns empty when caller lacks option:manage", () => {
+    expect(visibleSettingsGroups(["post:edit_own"], source)).toEqual([]);
+    expect(visibleSettingsGroups([], source)).toEqual([]);
+  });
+
+  test("allSettingsFields flattens fieldsets in declared order", () => {
+    const general = findSettingsGroupByName("general", source);
+    expect(general).toBeDefined();
+    if (!general) return;
+    expect(allSettingsFields(general).map((f) => f.name)).toEqual([
+      "site_title",
+      "site_description",
+      "admin_email",
+    ]);
   });
 });

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -2,6 +2,8 @@ import type {
   MetaBoxManifestEntry,
   PlumixManifest,
   PostTypeManifestEntry,
+  SettingsFieldManifestEntry,
+  SettingsGroupManifestEntry,
   TaxonomyManifestEntry,
 } from "@plumix/core/manifest";
 import { emptyManifest, MANIFEST_SCRIPT_ID } from "@plumix/core/manifest";
@@ -34,10 +36,12 @@ function normalize(value: unknown): PlumixManifest {
   const postTypes = (value as { postTypes?: unknown }).postTypes;
   const taxonomies = (value as { taxonomies?: unknown }).taxonomies;
   const metaBoxes = (value as { metaBoxes?: unknown }).metaBoxes;
+  const settingsGroups = (value as { settingsGroups?: unknown }).settingsGroups;
   return {
     postTypes: Array.isArray(postTypes) ? postTypes : [],
     taxonomies: Array.isArray(taxonomies) ? taxonomies : [],
     metaBoxes: Array.isArray(metaBoxes) ? metaBoxes : [],
+    settingsGroups: Array.isArray(settingsGroups) ? settingsGroups : [],
   };
 }
 
@@ -148,4 +152,44 @@ export function metaBoxesForPostType(
       const bp = META_BOX_PRIORITY_WEIGHT[b.priority ?? "default"];
       return ap - bp;
     });
+}
+
+/**
+ * Look up a registered settings group by its name (the `/settings/$group`
+ * route param). Returns `undefined` when the name doesn't match — the
+ * route surfaces a 404-style not-found state in that case.
+ */
+export function findSettingsGroupByName(
+  name: string,
+  source: PlumixManifest = manifest,
+): SettingsGroupManifestEntry | undefined {
+  return source.settingsGroups.find((g) => g.name === name);
+}
+
+/**
+ * Sidebar + list-route gate: which settings groups should render for a
+ * user with the given capability set. Gate is `option:manage` across
+ * the board — matches the server's `option.*` RPC gate. Per-group
+ * capability overrides are a future feature (needs server-side
+ * plumbing to tighten / loosen the RPC check accordingly); shipping
+ * without them keeps the surface honest.
+ */
+export function visibleSettingsGroups(
+  capabilities: readonly string[],
+  source: PlumixManifest = manifest,
+): readonly SettingsGroupManifestEntry[] {
+  if (!capabilities.includes("option:manage")) return [];
+  return source.settingsGroups;
+}
+
+/**
+ * Flatten a group's fieldsets into a single array of every field — the
+ * shape the loader wants when it builds the `option.getMany` input.
+ * Fieldsets are UI-only; storage keys stay flat (`${group}.${field}`)
+ * so this collapse is lossless for the persistence layer.
+ */
+export function allSettingsFields(
+  group: SettingsGroupManifestEntry,
+): readonly SettingsFieldManifestEntry[] {
+  return group.fieldsets.flatMap((fs) => fs.fields);
 }

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -16,8 +16,10 @@ import { Route as AuthenticatedProfileRouteImport } from "./routes/_authenticate
 import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
 import { Route as AuthenticatedUsersIndexRouteImport } from "./routes/_authenticated/users/index";
+import { Route as AuthenticatedSettingsIndexRouteImport } from "./routes/_authenticated/settings/index";
 import { Route as AuthenticatedUsersNewRouteImport } from "./routes/_authenticated/users/new";
 import { Route as AuthenticatedUsersIdRouteImport } from "./routes/_authenticated/users/$id";
+import { Route as AuthenticatedSettingsGroupRouteImport } from "./routes/_authenticated/settings/$group";
 import { Route as AuthAcceptInviteTokenRouteImport } from "./routes/_auth/accept-invite/$token";
 import { Route as AuthenticatedTaxonomiesNameIndexRouteImport } from "./routes/_authenticated/taxonomies/$name/index";
 import { Route as AuthenticatedContentSlugIndexRouteImport } from "./routes/_authenticated/content/$slug/index";
@@ -59,6 +61,12 @@ const AuthenticatedUsersIndexRoute = AuthenticatedUsersIndexRouteImport.update({
   path: "/users/",
   getParentRoute: () => AuthenticatedRoute,
 } as any);
+const AuthenticatedSettingsIndexRoute =
+  AuthenticatedSettingsIndexRouteImport.update({
+    id: "/settings/",
+    path: "/settings/",
+    getParentRoute: () => AuthenticatedRoute,
+  } as any);
 const AuthenticatedUsersNewRoute = AuthenticatedUsersNewRouteImport.update({
   id: "/users/new",
   path: "/users/new",
@@ -69,6 +77,12 @@ const AuthenticatedUsersIdRoute = AuthenticatedUsersIdRouteImport.update({
   path: "/users/$id",
   getParentRoute: () => AuthenticatedRoute,
 } as any);
+const AuthenticatedSettingsGroupRoute =
+  AuthenticatedSettingsGroupRouteImport.update({
+    id: "/settings/$group",
+    path: "/settings/$group",
+    getParentRoute: () => AuthenticatedRoute,
+  } as any);
 const AuthAcceptInviteTokenRoute = AuthAcceptInviteTokenRouteImport.update({
   id: "/accept-invite/$token",
   path: "/accept-invite/$token",
@@ -117,8 +131,10 @@ export interface FileRoutesByFullPath {
   "/login": typeof AuthLoginRoute;
   "/profile": typeof AuthenticatedProfileRoute;
   "/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/settings/$group": typeof AuthenticatedSettingsGroupRoute;
   "/users/$id": typeof AuthenticatedUsersIdRoute;
   "/users/new": typeof AuthenticatedUsersNewRoute;
+  "/settings/": typeof AuthenticatedSettingsIndexRoute;
   "/users/": typeof AuthenticatedUsersIndexRoute;
   "/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
@@ -133,8 +149,10 @@ export interface FileRoutesByTo {
   "/login": typeof AuthLoginRoute;
   "/profile": typeof AuthenticatedProfileRoute;
   "/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/settings/$group": typeof AuthenticatedSettingsGroupRoute;
   "/users/$id": typeof AuthenticatedUsersIdRoute;
   "/users/new": typeof AuthenticatedUsersNewRoute;
+  "/settings": typeof AuthenticatedSettingsIndexRoute;
   "/users": typeof AuthenticatedUsersIndexRoute;
   "/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
@@ -152,8 +170,10 @@ export interface FileRoutesById {
   "/_authenticated/profile": typeof AuthenticatedProfileRoute;
   "/_authenticated/": typeof AuthenticatedIndexRoute;
   "/_auth/accept-invite/$token": typeof AuthAcceptInviteTokenRoute;
+  "/_authenticated/settings/$group": typeof AuthenticatedSettingsGroupRoute;
   "/_authenticated/users/$id": typeof AuthenticatedUsersIdRoute;
   "/_authenticated/users/new": typeof AuthenticatedUsersNewRoute;
+  "/_authenticated/settings/": typeof AuthenticatedSettingsIndexRoute;
   "/_authenticated/users/": typeof AuthenticatedUsersIndexRoute;
   "/_authenticated/content/$slug/$id": typeof AuthenticatedContentSlugIdRoute;
   "/_authenticated/content/$slug/new": typeof AuthenticatedContentSlugNewRoute;
@@ -170,8 +190,10 @@ export interface FileRouteTypes {
     | "/login"
     | "/profile"
     | "/accept-invite/$token"
+    | "/settings/$group"
     | "/users/$id"
     | "/users/new"
+    | "/settings/"
     | "/users/"
     | "/content/$slug/$id"
     | "/content/$slug/new"
@@ -186,8 +208,10 @@ export interface FileRouteTypes {
     | "/login"
     | "/profile"
     | "/accept-invite/$token"
+    | "/settings/$group"
     | "/users/$id"
     | "/users/new"
+    | "/settings"
     | "/users"
     | "/content/$slug/$id"
     | "/content/$slug/new"
@@ -204,8 +228,10 @@ export interface FileRouteTypes {
     | "/_authenticated/profile"
     | "/_authenticated/"
     | "/_auth/accept-invite/$token"
+    | "/_authenticated/settings/$group"
     | "/_authenticated/users/$id"
     | "/_authenticated/users/new"
+    | "/_authenticated/settings/"
     | "/_authenticated/users/"
     | "/_authenticated/content/$slug/$id"
     | "/_authenticated/content/$slug/new"
@@ -271,6 +297,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AuthenticatedUsersIndexRouteImport;
       parentRoute: typeof AuthenticatedRoute;
     };
+    "/_authenticated/settings/": {
+      id: "/_authenticated/settings/";
+      path: "/settings";
+      fullPath: "/settings/";
+      preLoaderRoute: typeof AuthenticatedSettingsIndexRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
     "/_authenticated/users/new": {
       id: "/_authenticated/users/new";
       path: "/users/new";
@@ -283,6 +316,13 @@ declare module "@tanstack/react-router" {
       path: "/users/$id";
       fullPath: "/users/$id";
       preLoaderRoute: typeof AuthenticatedUsersIdRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
+    "/_authenticated/settings/$group": {
+      id: "/_authenticated/settings/$group";
+      path: "/settings/$group";
+      fullPath: "/settings/$group";
+      preLoaderRoute: typeof AuthenticatedSettingsGroupRouteImport;
       parentRoute: typeof AuthenticatedRoute;
     };
     "/_auth/accept-invite/$token": {
@@ -354,8 +394,10 @@ const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren);
 interface AuthenticatedRouteChildren {
   AuthenticatedProfileRoute: typeof AuthenticatedProfileRoute;
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute;
+  AuthenticatedSettingsGroupRoute: typeof AuthenticatedSettingsGroupRoute;
   AuthenticatedUsersIdRoute: typeof AuthenticatedUsersIdRoute;
   AuthenticatedUsersNewRoute: typeof AuthenticatedUsersNewRoute;
+  AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute;
   AuthenticatedUsersIndexRoute: typeof AuthenticatedUsersIndexRoute;
   AuthenticatedContentSlugIdRoute: typeof AuthenticatedContentSlugIdRoute;
   AuthenticatedContentSlugNewRoute: typeof AuthenticatedContentSlugNewRoute;
@@ -368,8 +410,10 @@ interface AuthenticatedRouteChildren {
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedProfileRoute: AuthenticatedProfileRoute,
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
+  AuthenticatedSettingsGroupRoute: AuthenticatedSettingsGroupRoute,
   AuthenticatedUsersIdRoute: AuthenticatedUsersIdRoute,
   AuthenticatedUsersNewRoute: AuthenticatedUsersNewRoute,
+  AuthenticatedSettingsIndexRoute: AuthenticatedSettingsIndexRoute,
   AuthenticatedUsersIndexRoute: AuthenticatedUsersIndexRoute,
   AuthenticatedContentSlugIdRoute: AuthenticatedContentSlugIdRoute,
   AuthenticatedContentSlugNewRoute: AuthenticatedContentSlugNewRoute,

--- a/packages/admin/src/routes/_authenticated/settings/$group.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/$group.tsx
@@ -1,0 +1,299 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { FormEditSkeleton } from "@/components/form/edit-skeleton.js";
+import { SettingsField } from "@/components/settings/field.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { hasCap } from "@/lib/caps.js";
+import { allSettingsFields, findSettingsGroupByName } from "@/lib/manifest.js";
+import { orpc } from "@/lib/orpc.js";
+import { useForm } from "@tanstack/react-form";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  useNavigate,
+} from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+
+import type { SettingsGroupManifestEntry } from "@plumix/core/manifest";
+
+// Storage keys are flat: `${groupName}.${fieldName}`. Fieldsets are a
+// UI-only grouping — they don't namespace the key — so field names
+// must be unique across the whole group (enforced at registration).
+function optionKey(groupName: string, fieldName: string): string {
+  return `${groupName}.${fieldName}`;
+}
+
+export const Route = createFileRoute("/_authenticated/settings/$group")({
+  beforeLoad: ({ context, params }): { group: SettingsGroupManifestEntry } => {
+    const group = findSettingsGroupByName(params.group);
+    if (!group) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
+    // `option:manage` matches the RPC gate; keeping the route + server
+    // checks in lockstep means no "route opens, RPC 403s" footgun.
+    if (!hasCap(context.user.capabilities, "option:manage")) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+      throw notFound();
+    }
+    return { group };
+  },
+  // Bulk-fetch every field key in one round-trip — `option.getMany` is
+  // the shape the settings form wants (one request, missing keys absent
+  // from the map and the form falls back to each field's `default`).
+  // The group reference comes from `beforeLoad`'s returned context so we
+  // avoid a second manifest lookup.
+  loader: ({ context, params }) => {
+    const names = allSettingsFields(context.group).map((f) =>
+      optionKey(params.group, f.name),
+    );
+    if (names.length === 0) return Promise.resolve({});
+    return context.queryClient.ensureQueryData(
+      orpc.option.getMany.queryOptions({ input: { names } }),
+    );
+  },
+  pendingComponent: () => (
+    <FormEditSkeleton
+      ariaLabel="Loading settings"
+      testId="settings-group-loading"
+    />
+  ),
+  errorComponent: () => (
+    <NotFoundPlaceholder message="Couldn't load these settings. Try again." />
+  ),
+  component: SettingsGroupRoute,
+});
+
+function SettingsGroupRoute(): ReactNode {
+  const { group } = Route.useRouteContext();
+  const { group: groupName } = Route.useParams();
+  const fields = allSettingsFields(group);
+  if (fields.length === 0) {
+    return <EmptyGroupPlaceholder group={group} />;
+  }
+  return <SettingsGroupForm group={group} groupName={groupName} />;
+}
+
+function SettingsGroupForm({
+  group,
+  groupName,
+}: {
+  readonly group: SettingsGroupManifestEntry;
+  readonly groupName: string;
+}): ReactNode {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [saveNotice, setSaveNotice] = useState<string | null>(null);
+
+  const flat = allSettingsFields(group);
+  const names = flat.map((f) => optionKey(groupName, f.name));
+  const { data: stored } = useSuspenseQuery(
+    orpc.option.getMany.queryOptions({ input: { names } }),
+  );
+
+  // Initial form state: stored value when present, field default when not.
+  const defaultValues: Record<string, string> = Object.fromEntries(
+    flat.map((f) => [
+      f.name,
+      stored[optionKey(groupName, f.name)] ?? f.default ?? "",
+    ]),
+  );
+
+  const save = useMutation({
+    mutationFn: async (values: Record<string, string>) => {
+      // Persist one key per field. Concurrent calls are fine — option
+      // rows don't inter-reference, and `option.set` is an upsert.
+      // `isAutoloaded` flows from each field's manifest declaration
+      // (defaults to true server-side when omitted) so settings stay
+      // on the autoload fast path unless the plugin author opts out.
+      await Promise.all(
+        flat.map((field) =>
+          orpc.option.set.call({
+            name: optionKey(groupName, field.name),
+            value: values[field.name] ?? "",
+            isAutoloaded: field.autoload,
+          }),
+        ),
+      );
+    },
+    onMutate: () => {
+      setServerError(null);
+      setSaveNotice(null);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: orpc.option.getMany.queryOptions({ input: { names } })
+          .queryKey,
+      });
+      setSaveNotice("Saved.");
+    },
+    onError: (err) => {
+      setServerError(
+        err instanceof Error ? err.message : "Couldn't save settings.",
+      );
+    },
+  });
+
+  const form = useForm({
+    defaultValues,
+    onSubmit: ({ value }) => {
+      save.mutate(value);
+    },
+  });
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+      <Link
+        to="/settings"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
+        data-testid="settings-back-link"
+      >
+        <ArrowLeft className="size-4" />
+        Back to settings
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h1 data-testid="settings-group-heading">{group.label}</h1>
+          </CardTitle>
+          {group.description ? (
+            <CardDescription>{group.description}</CardDescription>
+          ) : null}
+        </CardHeader>
+        <CardContent>
+          <form
+            className="flex flex-col gap-6"
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void form.handleSubmit();
+            }}
+          >
+            {group.fieldsets.map((fs) => (
+              <fieldset
+                key={fs.name}
+                className="flex flex-col gap-4 border-0 p-0"
+                data-testid={`settings-fieldset-${fs.name}`}
+              >
+                {fs.label ? (
+                  <legend
+                    className="mb-1 text-sm font-semibold"
+                    data-testid={`settings-fieldset-legend-${fs.name}`}
+                  >
+                    {fs.label}
+                  </legend>
+                ) : null}
+                {fs.description ? (
+                  <p className="text-muted-foreground -mt-2 text-xs">
+                    {fs.description}
+                  </p>
+                ) : null}
+                {fs.fields.map((field) => (
+                  <form.Field key={field.name} name={field.name}>
+                    {(f) => (
+                      <SettingsField
+                        field={field}
+                        value={f.state.value}
+                        onChange={f.handleChange}
+                        disabled={save.isPending}
+                        testId={`settings-field-${field.name}`}
+                      />
+                    )}
+                  </form.Field>
+                ))}
+              </fieldset>
+            ))}
+
+            {serverError ? (
+              <Alert variant="destructive" data-testid="settings-server-error">
+                <AlertDescription>{serverError}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            {saveNotice ? (
+              <Alert data-testid="settings-save-notice">
+                <AlertDescription>{saveNotice}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  void navigate({ to: "/settings" });
+                }}
+                disabled={save.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={save.isPending}
+                data-testid="settings-submit"
+              >
+                {save.isPending ? "Saving…" : "Save changes"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function EmptyGroupPlaceholder({
+  group,
+}: {
+  readonly group: SettingsGroupManifestEntry;
+}): ReactNode {
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+      <Link
+        to="/settings"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
+      >
+        <ArrowLeft className="size-4" />
+        Back to settings
+      </Link>
+      <Card>
+        <CardHeader>
+          <CardTitle>{group.label}</CardTitle>
+          <CardDescription>
+            This group has no fieldsets with fields yet. Plugins contribute
+            sections via{" "}
+            <code className="font-mono text-xs">
+              ctx.registerSettingsFieldset(...)
+            </code>
+            .
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+}
+
+function NotFoundPlaceholder({ message }: { message: string }): ReactNode {
+  return (
+    <div className="flex flex-col gap-2">
+      <h1 className="text-2xl font-semibold">Not found</h1>
+      <p className="text-muted-foreground text-sm">{message}</p>
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_authenticated/settings/index.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { hasCap } from "@/lib/caps.js";
+import { allSettingsFields, visibleSettingsGroups } from "@/lib/manifest.js";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+
+function groupSummary(fieldsetCount: number, fieldCount: number): string {
+  const fs = `${fieldsetCount} ${fieldsetCount === 1 ? "fieldset" : "fieldsets"}`;
+  const fl = `${fieldCount} ${fieldCount === 1 ? "field" : "fields"}`;
+  return `${fs} · ${fl}`;
+}
+
+export const Route = createFileRoute("/_authenticated/settings/")({
+  // The settings surface is admin-only at the floor — `option:manage` is
+  // the server's gate for every `option.*` RPC. Plugins may declare a
+  // tighter per-group capability; those are filtered by
+  // `visibleSettingsGroups` further down rather than rejected here.
+  beforeLoad: ({ context }) => {
+    if (!hasCap(context.user.capabilities, "option:manage")) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+      throw redirect({ to: "/" });
+    }
+  },
+  component: SettingsIndexRoute,
+});
+
+function SettingsIndexRoute(): ReactNode {
+  const { user } = Route.useRouteContext();
+  const groups = visibleSettingsGroups(user.capabilities);
+
+  if (groups.length === 0) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+        <h1 className="text-2xl font-semibold" data-testid="settings-heading">
+          Settings
+        </h1>
+        <Card data-testid="settings-empty-state">
+          <CardHeader>
+            <CardTitle>No settings registered yet</CardTitle>
+            <CardDescription>
+              Core ships no settings by design — plugins (or your own
+              plumix.config) declare groups via{" "}
+              <code className="font-mono text-xs">
+                ctx.registerSettingsGroup(name, {"{"} fieldsets: [...] {"}"})
+              </code>
+              . Registered groups appear here with one card per group.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+      <h1 className="text-2xl font-semibold" data-testid="settings-heading">
+        Settings
+      </h1>
+      <div className="grid gap-3" data-testid="settings-group-list">
+        {groups.map((group) => (
+          <Link
+            key={group.name}
+            to="/settings/$group"
+            params={{ group: group.name }}
+            className="block"
+            data-testid={`settings-group-link-${group.name}`}
+          >
+            <Card className="hover:border-primary transition-colors">
+              <CardHeader>
+                <CardTitle>
+                  <h2 className="text-base font-semibold">{group.label}</h2>
+                </CardTitle>
+                {group.description ? (
+                  <CardDescription>{group.description}</CardDescription>
+                ) : null}
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground text-xs">
+                  {groupSummary(
+                    group.fieldsets.length,
+                    allSettingsFields(group).length,
+                  )}
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -16,6 +16,8 @@ import type {
   MetaOptions,
   MutablePluginRegistry,
   PostTypeOptions,
+  SettingsFieldset,
+  SettingsGroupOptions,
   TaxonomyOptions,
 } from "./manifest.js";
 import {
@@ -63,6 +65,25 @@ export interface PluginSetupContext {
   registerMeta(key: string, options: MetaOptions): void;
   registerMetaBox(id: string, options: MetaBoxOptions): void;
   registerCapability(name: string, minRole: UserRole): void;
+
+  /**
+   * Declare a top-level settings group — its own `/settings/$name`
+   * admin page, populated by the group's fieldsets. Throws
+   * `DuplicateRegistrationError` if another plugin already registered
+   * the same name; use `registerSettingsFieldset` to append a section
+   * to an existing group.
+   */
+  registerSettingsGroup(name: string, options: SettingsGroupOptions): void;
+
+  /**
+   * Append a fieldset (WP's `add_settings_section` analogue) to an
+   * existing settings group. Throws if the group isn't registered yet
+   * (plugin install order matters), if the fieldset name collides
+   * with one already on the group, or if any field inside it collides
+   * with a field name anywhere else in the group (storage keys are
+   * flat across fieldsets).
+   */
+  registerSettingsFieldset(groupName: string, fieldset: SettingsFieldset): void;
 }
 
 interface CreatePluginContextArgs {
@@ -157,7 +178,117 @@ export function createPluginSetupContext({
         registeredBy: pluginId,
       });
     },
+
+    registerSettingsGroup: (name, options) => {
+      assertValidIdentifier("settings group", name);
+      if (registry.settingsGroups.has(name)) {
+        throw new DuplicateRegistrationError("settings group", name);
+      }
+      for (const fs of options.fieldsets)
+        assertValidIdentifier("settings fieldset", fs.name);
+      for (const fs of options.fieldsets) {
+        for (const field of fs.fields)
+          assertValidIdentifier("settings field", field.name);
+      }
+      assertUniqueFieldNamesAcrossFieldsets(name, options.fieldsets);
+      assertGroupFieldCountWithinBounds(name, options.fieldsets);
+      registry.settingsGroups.set(name, {
+        ...options,
+        name,
+        registeredBy: pluginId,
+      });
+    },
+
+    registerSettingsFieldset: (groupName, fieldset) => {
+      const existing = registry.settingsGroups.get(groupName);
+      if (existing === undefined) {
+        throw new Error(
+          `Cannot add fieldset to settings group "${groupName}" — it hasn't been registered yet. ` +
+            `Ensure the plugin that calls \`registerSettingsGroup\` runs before this one.`,
+        );
+      }
+      assertValidIdentifier("settings fieldset", fieldset.name);
+      for (const field of fieldset.fields)
+        assertValidIdentifier("settings field", field.name);
+      if (existing.fieldsets.some((fs) => fs.name === fieldset.name)) {
+        throw new DuplicateRegistrationError(
+          "settings fieldset",
+          `${groupName}.${fieldset.name}`,
+        );
+      }
+      const next = [...existing.fieldsets, fieldset];
+      assertUniqueFieldNamesAcrossFieldsets(groupName, next);
+      assertGroupFieldCountWithinBounds(groupName, next);
+      registry.settingsGroups.set(groupName, {
+        ...existing,
+        fieldsets: next,
+      });
+    },
   };
+}
+
+// Keep group / fieldset / field names portable: ASCII identifier that
+// starts with a letter, then letters/digits/underscores. This is
+// tighter than `optionNameSchema`'s regex (which allows `.`/`-`) on
+// purpose — dots in names would collide with the flat storage-key
+// convention (`${group}.${field}`), and hyphens make testids and
+// URL params awkward.
+const SETTINGS_NAME_RE = /^[a-z][a-z0-9_]*$/;
+
+function assertValidIdentifier(kind: string, name: string): void {
+  if (!SETTINGS_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid ${kind} name "${name}" — expected lowercase ASCII ` +
+        `[a-z][a-z0-9_]* so storage keys, testids, and URLs stay portable.`,
+    );
+  }
+}
+
+// Storage keys are flat (`${groupName}.${fieldName}`), so two fieldsets
+// within the same group can't declare the same field name — they'd
+// collide on disk. Enforced at registration time so plugin authors
+// fail fast rather than quietly overwriting each other's values.
+function assertUniqueFieldNamesAcrossFieldsets(
+  groupName: string,
+  fieldsets: readonly {
+    readonly fields: readonly { readonly name: string }[];
+  }[],
+): void {
+  const seen = new Set<string>();
+  for (const fs of fieldsets) {
+    for (const field of fs.fields) {
+      if (seen.has(field.name)) {
+        throw new DuplicateRegistrationError(
+          "settings field",
+          `${groupName}.${field.name}`,
+        );
+      }
+      seen.add(field.name);
+    }
+  }
+}
+
+// Mirror the RPC's `option.getMany` 200-name cap so a plugin that
+// over-registers fails at registration time rather than at route-load
+// time with a generic error. If a real CMS ever needs >200 fields in
+// one group, bump both limits together — the admin loader would need
+// to chunk the fetch to stay under the server cap.
+const MAX_FIELDS_PER_SETTINGS_GROUP = 200;
+
+function assertGroupFieldCountWithinBounds(
+  groupName: string,
+  fieldsets: readonly {
+    readonly fields: readonly { readonly name: string }[];
+  }[],
+): void {
+  const total = fieldsets.reduce((sum, fs) => sum + fs.fields.length, 0);
+  if (total > MAX_FIELDS_PER_SETTINGS_GROUP) {
+    throw new Error(
+      `Settings group "${groupName}" has ${total} fields; ` +
+        `the admin loader caps a single group at ${MAX_FIELDS_PER_SETTINGS_GROUP}. ` +
+        `Split into multiple groups or chunk the loader.`,
+    );
+  }
 }
 
 // Re-exported from our local FilterRest helper so the type used by hook wrapper

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -20,6 +20,250 @@ describe("buildManifest", () => {
     expect(manifest).toEqual(emptyManifest());
   });
 
+  test("projects registered settings groups, dropping server-only fields", async () => {
+    const hooks = new HookRegistry();
+    const corePlugin = definePlugin("core", (ctx) => {
+      ctx.registerSettingsGroup("general", {
+        label: "General",
+        description: "Basic site identity.",
+        fieldsets: [
+          {
+            name: "identity",
+            label: "Identity",
+            description: "Public-facing site identity.",
+            fields: [
+              {
+                name: "site_title",
+                label: "Site title",
+                type: "text",
+                default: "My Site",
+                autoload: true,
+              },
+              {
+                name: "site_description",
+                label: "Tagline",
+                type: "text",
+              },
+            ],
+          },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({
+      hooks,
+      plugins: [corePlugin],
+    });
+    const manifest = buildManifest(registry);
+    expect(manifest.settingsGroups).toEqual([
+      {
+        name: "general",
+        label: "General",
+        description: "Basic site identity.",
+        fieldsets: [
+          {
+            name: "identity",
+            label: "Identity",
+            description: "Public-facing site identity.",
+            fields: [
+              {
+                name: "site_title",
+                label: "Site title",
+                type: "text",
+                default: "My Site",
+                description: undefined,
+                placeholder: undefined,
+                maxLength: undefined,
+                autoload: true,
+              },
+              {
+                name: "site_description",
+                label: "Tagline",
+                type: "text",
+                default: undefined,
+                description: undefined,
+                placeholder: undefined,
+                maxLength: undefined,
+                autoload: undefined,
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("second plugin appends a fieldset to an existing group", async () => {
+    const hooks = new HookRegistry();
+    const corePlugin = definePlugin("core", (ctx) => {
+      ctx.registerSettingsGroup("general", {
+        label: "General",
+        fieldsets: [
+          {
+            name: "identity",
+            fields: [{ name: "site_title", label: "Site title", type: "text" }],
+          },
+        ],
+      });
+    });
+    const seoPlugin = definePlugin("seo", (ctx) => {
+      ctx.registerSettingsFieldset("general", {
+        name: "seo",
+        label: "SEO",
+        fields: [
+          {
+            name: "meta_description",
+            label: "Meta description",
+            type: "textarea",
+          },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({
+      hooks,
+      plugins: [corePlugin, seoPlugin],
+    });
+    const manifest = buildManifest(registry);
+    expect(manifest.settingsGroups[0]?.fieldsets.map((fs) => fs.name)).toEqual([
+      "identity",
+      "seo",
+    ]);
+  });
+
+  test("rejects duplicate settings group registration", async () => {
+    const hooks = new HookRegistry();
+    const pluginA = definePlugin("a", (ctx) => {
+      ctx.registerSettingsGroup("general", { label: "General", fieldsets: [] });
+    });
+    const pluginB = definePlugin("b", (ctx) => {
+      ctx.registerSettingsGroup("general", {
+        label: "Also General",
+        fieldsets: [],
+      });
+    });
+    await expect(
+      installPlugins({ hooks, plugins: [pluginA, pluginB] }),
+    ).rejects.toThrow(/settings group "general"/);
+  });
+
+  test("rejects adding a fieldset to a non-existent group", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("orphan", (ctx) => {
+      ctx.registerSettingsFieldset("nonexistent", {
+        name: "x",
+        fields: [{ name: "a", label: "A", type: "text" }],
+      });
+    });
+    await expect(installPlugins({ hooks, plugins: [plugin] })).rejects.toThrow(
+      /hasn't been registered yet/,
+    );
+  });
+
+  test("rejects a fieldset whose name collides with an existing one", async () => {
+    const hooks = new HookRegistry();
+    const corePlugin = definePlugin("core", (ctx) => {
+      ctx.registerSettingsGroup("general", {
+        label: "General",
+        fieldsets: [{ name: "identity", fields: [] }],
+      });
+    });
+    const dupe = definePlugin("dupe", (ctx) => {
+      ctx.registerSettingsFieldset("general", {
+        name: "identity",
+        fields: [{ name: "x", label: "X", type: "text" }],
+      });
+    });
+    await expect(
+      installPlugins({ hooks, plugins: [corePlugin, dupe] }),
+    ).rejects.toThrow(/settings fieldset "general\.identity"/);
+  });
+
+  test("rejects invalid group / fieldset / field names (must be snake_case ASCII)", async () => {
+    const hooks = new HookRegistry();
+    const badGroup = definePlugin("a", (ctx) => {
+      ctx.registerSettingsGroup("Foo-Bar", {
+        label: "x",
+        fieldsets: [],
+      });
+    });
+    await expect(
+      installPlugins({ hooks, plugins: [badGroup] }),
+    ).rejects.toThrow(/Invalid settings group name "Foo-Bar"/);
+
+    const badField = definePlugin("b", (ctx) => {
+      ctx.registerSettingsGroup("good", {
+        label: "x",
+        fieldsets: [
+          {
+            name: "section",
+            fields: [{ name: "bad.name", label: "X", type: "text" }],
+          },
+        ],
+      });
+    });
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [badField] }),
+    ).rejects.toThrow(/Invalid settings field name "bad\.name"/);
+
+    const badFieldset = definePlugin("c", (ctx) => {
+      ctx.registerSettingsGroup("good", { label: "x", fieldsets: [] });
+      ctx.registerSettingsFieldset("good", {
+        name: "Bad-Section",
+        fields: [],
+      });
+    });
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [badFieldset] }),
+    ).rejects.toThrow(/Invalid settings fieldset name "Bad-Section"/);
+  });
+
+  test("rejects a group that exceeds the 200-field cap", async () => {
+    const hooks = new HookRegistry();
+    const tooMany = definePlugin("big", (ctx) => {
+      ctx.registerSettingsGroup("big", {
+        label: "x",
+        fieldsets: [
+          {
+            name: "section",
+            fields: Array.from({ length: 201 }, (_, i) => ({
+              name: `f${i}`,
+              label: `Field ${i}`,
+              type: "text" as const,
+            })),
+          },
+        ],
+      });
+    });
+    await expect(installPlugins({ hooks, plugins: [tooMany] })).rejects.toThrow(
+      /has 201 fields; the admin loader caps a single group at 200/,
+    );
+  });
+
+  test("rejects a field that collides across fieldsets in the same group", async () => {
+    const hooks = new HookRegistry();
+    const corePlugin = definePlugin("core", (ctx) => {
+      ctx.registerSettingsGroup("general", {
+        label: "General",
+        fieldsets: [
+          {
+            name: "identity",
+            fields: [{ name: "site_title", label: "Site title", type: "text" }],
+          },
+        ],
+      });
+    });
+    const dupe = definePlugin("dupe", (ctx) => {
+      ctx.registerSettingsFieldset("general", {
+        name: "seo",
+        fields: [
+          { name: "site_title", label: "Different label", type: "text" },
+        ],
+      });
+    });
+    await expect(
+      installPlugins({ hooks, plugins: [corePlugin, dupe] }),
+    ).rejects.toThrow(/settings field "general\.site_title"/);
+  });
+
   test("projects registered post types, dropping server-only fields", async () => {
     const hooks = new HookRegistry();
     const blog = definePlugin("blog", (ctx) => {
@@ -228,11 +472,12 @@ describe("serializeManifestScript", () => {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
     expect(tag).toContain(`id="${MANIFEST_SCRIPT_ID}"`);
     expect(tag).toContain(`type="application/json"`);
     expect(tag).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[],"settingsGroups":[]}`,
     );
   });
 
@@ -243,6 +488,7 @@ describe("serializeManifestScript", () => {
       ],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
     expect(tag).not.toContain("</script><b>");
     expect(tag).toMatch(/<\\\/script>/);
@@ -253,6 +499,7 @@ describe("serializeManifestScript", () => {
       postTypes: [{ name: "post", adminSlug: "posts", label: "x</y>" }],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     };
     const tag = serializeManifestScript(manifest);
     const prefix = `<script id="${MANIFEST_SCRIPT_ID}" type="application/json">`;
@@ -276,12 +523,13 @@ describe("injectManifestIntoHtml", () => {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
     expect(out).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[],"settingsGroups":[]}`,
     );
     expect(out).not.toContain(
-      `{"postTypes":[],"taxonomies":[],"metaBoxes":[]}`,
+      `{"postTypes":[],"taxonomies":[],"metaBoxes":[],"settingsGroups":[]}`,
     );
   });
 
@@ -290,6 +538,7 @@ describe("injectManifestIntoHtml", () => {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     };
     const once = injectManifestIntoHtml(TEMPLATE, manifest);
     const twice = injectManifestIntoHtml(once, manifest);
@@ -314,9 +563,10 @@ describe("injectManifestIntoHtml", () => {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
     expect(out).toContain(
-      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[]}`,
+      `{"postTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[],"settingsGroups":[]}`,
     );
   });
 
@@ -328,9 +578,10 @@ describe("injectManifestIntoHtml", () => {
       postTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
       metaBoxes: [],
+      settingsGroups: [],
     });
     expect(out).toMatch(
-      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"taxonomies":\[\],"metaBoxes":\[\]\}<\/script>$/,
+      /^<script id="plumix-manifest" type="application\/json">\{"postTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"taxonomies":\[\],"metaBoxes":\[\],"settingsGroups":\[\]\}<\/script>$/,
     );
   });
 });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -95,6 +95,71 @@ export interface MetaBoxOptions {
   readonly fields: readonly MetaBoxField[];
 }
 
+/**
+ * Narrow discriminator for settings-form fields. Mirrors the subset of
+ * `MetaBoxField.inputType` values that the settings admin's field
+ * dispatcher renders today — `text` (single-line) and `textarea`
+ * (multi-line). Extending this is cheap: add a new literal, then teach
+ * the admin's `SettingsField` dispatcher to render it. Keeping the
+ * union narrow (vs free-form string like meta boxes) trades plugin
+ * extensibility for an exhaustive type-check in the dispatcher.
+ */
+export type SettingsFieldType = "text" | "textarea";
+
+export interface SettingsField {
+  readonly name: string;
+  readonly label: string;
+  readonly type: SettingsFieldType;
+  /**
+   * Initial value rendered when the option row hasn't been saved yet.
+   * Admin forms fall back to this on first render if `option.getMany`
+   * returns no row for `${groupName}.${fieldName}`.
+   */
+  readonly default?: string;
+  readonly description?: string;
+  readonly placeholder?: string;
+  /** Text-shaped inputs. Enforced on the client; server re-validates. */
+  readonly maxLength?: number;
+  /**
+   * Whether the option row should load on every request via the
+   * autoload prefetch (equivalent to WP's `register_setting` `autoload`
+   * arg). Defaults to `true` when omitted — matches `option.set`'s
+   * default and WP convention. Flip to `false` for rarely-touched
+   * settings (seed keys, one-off tokens) to keep the autoload set tight.
+   *
+   * **The manifest is authoritative**: every form save re-sends this
+   * flag alongside the value. Out-of-band toggles to the underlying
+   * `options` row (scripts, other admin tools) get overwritten on the
+   * next save. If you need per-install autoload overrides, treat the
+   * manifest declaration as the source of truth or expose it as a
+   * separate option the user can toggle.
+   */
+  readonly autoload?: boolean;
+}
+
+/**
+ * A visual cluster of related fields inside a settings group — mirrors
+ * WordPress's `add_settings_section`. Fieldsets are UI-only; storage
+ * keys stay flat (`${groupName}.${fieldName}`), so field names must be
+ * unique across the whole group regardless of fieldset. Admin renders
+ * each fieldset inside a native `<fieldset>` with `<legend>` for
+ * accessibility; a fieldset with no `label` elides the legend and
+ * renders its fields inline — handy for groups that have only one
+ * implicit "default" fieldset.
+ */
+export interface SettingsFieldset {
+  readonly name: string;
+  readonly label?: string;
+  readonly description?: string;
+  readonly fields: readonly SettingsField[];
+}
+
+export interface SettingsGroupOptions {
+  readonly label: string;
+  readonly description?: string;
+  readonly fieldsets: readonly SettingsFieldset[];
+}
+
 export interface RegisteredPostType extends PostTypeOptions {
   readonly name: string;
   readonly registeredBy: string | null;
@@ -115,6 +180,11 @@ export interface RegisteredMetaBox extends MetaBoxOptions {
   readonly registeredBy: string | null;
 }
 
+export interface RegisteredSettingsGroup extends SettingsGroupOptions {
+  readonly name: string;
+  readonly registeredBy: string | null;
+}
+
 export interface RegisteredCapability {
   readonly name: string;
   readonly minRole: UserRole;
@@ -127,6 +197,7 @@ export interface PluginRegistry {
   readonly metaKeys: ReadonlyMap<string, RegisteredMeta>;
   readonly metaBoxes: ReadonlyMap<string, RegisteredMetaBox>;
   readonly capabilities: ReadonlyMap<string, RegisteredCapability>;
+  readonly settingsGroups: ReadonlyMap<string, RegisteredSettingsGroup>;
 }
 
 export interface MutablePluginRegistry extends PluginRegistry {
@@ -135,6 +206,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly metaKeys: Map<string, RegisteredMeta>;
   readonly metaBoxes: Map<string, RegisteredMetaBox>;
   readonly capabilities: Map<string, RegisteredCapability>;
+  readonly settingsGroups: Map<string, RegisteredSettingsGroup>;
 }
 
 export function createPluginRegistry(): MutablePluginRegistry {
@@ -144,6 +216,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     metaKeys: new Map(),
     metaBoxes: new Map(),
     capabilities: new Map(),
+    settingsGroups: new Map(),
   };
 }
 
@@ -238,17 +311,55 @@ export interface TaxonomyManifestEntry {
   readonly postTypes?: readonly string[];
 }
 
+/**
+ * Client-safe projection of a settings field. Mirrors `SettingsField`
+ * today — kept separate so the manifest boundary can diverge (e.g.,
+ * strip server-only validators / sanitisers) without rippling through
+ * plugin registration code.
+ */
+export interface SettingsFieldManifestEntry {
+  readonly name: string;
+  readonly label: string;
+  readonly type: SettingsFieldType;
+  readonly default?: string;
+  readonly description?: string;
+  readonly placeholder?: string;
+  readonly maxLength?: number;
+  readonly autoload?: boolean;
+}
+
+export interface SettingsFieldsetManifestEntry {
+  readonly name: string;
+  readonly label?: string;
+  readonly description?: string;
+  readonly fields: readonly SettingsFieldManifestEntry[];
+}
+
+/**
+ * Shape serialised for settings groups in the manifest. Same allowlist
+ * rationale as the other entry projections — `registeredBy` stays
+ * server-only; field internals project via `SettingsFieldManifestEntry`
+ * so they can diverge independently.
+ */
+export interface SettingsGroupManifestEntry {
+  readonly name: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly fieldsets: readonly SettingsFieldsetManifestEntry[];
+}
+
 export interface PlumixManifest {
   readonly postTypes: readonly PostTypeManifestEntry[];
   readonly taxonomies: readonly TaxonomyManifestEntry[];
   readonly metaBoxes: readonly MetaBoxManifestEntry[];
+  readonly settingsGroups: readonly SettingsGroupManifestEntry[];
 }
 
 /** Script tag id that carries the JSON-encoded manifest in the admin HTML. */
 export const MANIFEST_SCRIPT_ID = "plumix-manifest";
 
 export function emptyManifest(): PlumixManifest {
-  return { postTypes: [], taxonomies: [], metaBoxes: [] };
+  return { postTypes: [], taxonomies: [], metaBoxes: [], settingsGroups: [] };
 }
 
 /**
@@ -274,7 +385,10 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
     toTaxonomyEntry,
   );
   const metaBoxes = Array.from(registry.metaBoxes.values()).map(toMetaBoxEntry);
-  return { postTypes: entries, taxonomies, metaBoxes };
+  const settingsGroups = Array.from(registry.settingsGroups.values()).map(
+    toSettingsGroupEntry,
+  );
+  return { postTypes: entries, taxonomies, metaBoxes, settingsGroups };
 }
 
 function assertUniqueAdminSlugs(
@@ -414,6 +528,57 @@ function toMetaBoxEntry(box: RegisteredMetaBox): MetaBoxManifestEntry {
     postTypes,
     capability,
     fields: fields.map(toMetaBoxFieldEntry),
+  };
+}
+
+// Allowlist for settings group entries — same rationale as the other
+// `to*Entry` projections. `registeredBy` is server-only debug metadata.
+function toSettingsGroupEntry(
+  group: RegisteredSettingsGroup,
+): SettingsGroupManifestEntry {
+  const { name, label, description, fieldsets } = group;
+  return {
+    name,
+    label,
+    description,
+    fieldsets: fieldsets.map(toSettingsFieldsetEntry),
+  };
+}
+
+function toSettingsFieldsetEntry(
+  fieldset: SettingsFieldset,
+): SettingsFieldsetManifestEntry {
+  const { name, label, description, fields } = fieldset;
+  return {
+    name,
+    label,
+    description,
+    fields: fields.map(toSettingsFieldEntry),
+  };
+}
+
+function toSettingsFieldEntry(
+  field: SettingsField,
+): SettingsFieldManifestEntry {
+  const {
+    name,
+    label,
+    type,
+    default: defaultValue,
+    description,
+    placeholder,
+    maxLength,
+    autoload,
+  } = field;
+  return {
+    name,
+    label,
+    type,
+    default: defaultValue,
+    description,
+    placeholder,
+    maxLength,
+    autoload,
   };
 }
 

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -105,6 +105,9 @@ declare module "../hooks/types.js" {
 
     "rpc:option.list:output": (output: readonly Option[]) => readonly Option[];
     "rpc:option.get:output": (output: Option) => Option;
+    "rpc:option.getMany:output": (
+      output: Record<string, string>,
+    ) => Record<string, string>;
     "rpc:option.set:input": (input: OptionSetInput) => OptionSetInput;
     "rpc:option.set:output": (output: Option) => Option;
     "rpc:option.delete:output": (output: Option) => Option;

--- a/packages/core/src/rpc/procedures/option/get-many.ts
+++ b/packages/core/src/rpc/procedures/option/get-many.ts
@@ -1,0 +1,33 @@
+import { inArray } from "../../../db/index.js";
+import { options } from "../../../db/schema/options.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { optionGetManyInputSchema } from "./schemas.js";
+
+const CAPABILITY = "option:manage";
+
+/**
+ * Fetch multiple options in one round-trip — the shape the settings
+ * form's loader wants (one request to hydrate every field in a group).
+ * Returns a keyed map rather than an array; missing names simply don't
+ * appear, mirroring `option.get`'s NOT_FOUND semantics without the
+ * per-miss throw. Callers fall back to the field's `default` when a
+ * name is absent.
+ */
+export const getMany = base
+  .use(authenticated)
+  .input(optionGetManyInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+
+    const rows = await context.db
+      .select()
+      .from(options)
+      .where(inArray(options.name, input.names));
+
+    const result: Record<string, string> = {};
+    for (const row of rows) result[row.name] = row.value;
+    return context.hooks.applyFilter("rpc:option.getMany:output", result);
+  });

--- a/packages/core/src/rpc/procedures/option/index.ts
+++ b/packages/core/src/rpc/procedures/option/index.ts
@@ -1,4 +1,5 @@
 import { del } from "./delete.js";
+import { getMany } from "./get-many.js";
 import { get } from "./get.js";
 import { list } from "./list.js";
 import { set } from "./set.js";
@@ -6,6 +7,7 @@ import { set } from "./set.js";
 export const optionRouter = {
   list,
   get,
+  getMany,
   set,
   delete: del,
 } as const;

--- a/packages/core/src/rpc/procedures/option/option.test.ts
+++ b/packages/core/src/rpc/procedures/option/option.test.ts
@@ -90,6 +90,49 @@ describe("option.get", () => {
   });
 });
 
+describe("option.getMany", () => {
+  test("admin fetches a keyed map for existing names; missing names omitted", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.option.set({ name: "general.site_title", value: "Plumix" });
+    await h.client.option.set({
+      name: "general.site_description",
+      value: "Headless CMS",
+    });
+    const map = await h.client.option.getMany({
+      names: [
+        "general.site_title",
+        "general.site_description",
+        "general.admin_email",
+      ],
+    });
+    expect(map).toEqual({
+      "general.site_title": "Plumix",
+      "general.site_description": "Headless CMS",
+    });
+  });
+
+  test("returns an empty object when no names match", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const map = await h.client.option.getMany({ names: ["nope.one"] });
+    expect(map).toEqual({});
+  });
+
+  test("editor cannot use getMany (reads gated by option:manage)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await expect(
+      h.client.option.getMany({ names: ["anything"] }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "option:manage" },
+    });
+  });
+
+  test("rejects empty names array at the schema layer", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(h.client.option.getMany({ names: [] })).rejects.toThrow();
+  });
+});
+
 describe("option.list", () => {
   test("admin lists all options by default, sorted by name", async () => {
     const h = await createRpcHarness({ authAs: "admin" });

--- a/packages/core/src/rpc/procedures/option/schemas.ts
+++ b/packages/core/src/rpc/procedures/option/schemas.ts
@@ -45,7 +45,20 @@ export const optionSetInputSchema = v.object({
 
 export const optionDeleteInputSchema = v.object({ name: optionNameSchema });
 
+// Bulk fetch used by the settings form loader — one round-trip instead
+// of N. 200-name cap is generous (the largest plausible settings group
+// won't come close); a hard ceiling blocks accidental fan-out from
+// callers that iterate on untrusted input.
+export const optionGetManyInputSchema = v.object({
+  names: v.pipe(
+    v.array(optionNameSchema),
+    v.minLength(1, "provide at least one option name"),
+    v.maxLength(200, "too many option names (max 200)"),
+  ),
+});
+
 export type OptionListInput = v.InferOutput<typeof optionListInputSchema>;
 export type OptionGetInput = v.InferOutput<typeof optionGetInputSchema>;
+export type OptionGetManyInput = v.InferOutput<typeof optionGetManyInputSchema>;
 export type OptionSetInput = v.InferOutput<typeof optionSetInputSchema>;
 export type OptionDeleteInput = v.InferOutput<typeof optionDeleteInputSchema>;

--- a/packages/core/src/rpc/procedures/option/schemas.ts
+++ b/packages/core/src/rpc/procedures/option/schemas.ts
@@ -59,6 +59,5 @@ export const optionGetManyInputSchema = v.object({
 
 export type OptionListInput = v.InferOutput<typeof optionListInputSchema>;
 export type OptionGetInput = v.InferOutput<typeof optionGetInputSchema>;
-export type OptionGetManyInput = v.InferOutput<typeof optionGetManyInputSchema>;
 export type OptionSetInput = v.InferOutput<typeof optionSetInputSchema>;
 export type OptionDeleteInput = v.InferOutput<typeof optionDeleteInputSchema>;


### PR DESCRIPTION
## Summary

Adds the admin settings surface. Core ships **no default settings** by design — matches Plumix's existing posture (zero post types / taxonomies / meta boxes out of the box; plugins declare everything). Plugins register groups via the new manifest API.

Hierarchy mirrors WordPress's Settings API: **group (page) → fieldsets (sections) → fields**.

### Plugin API

Two new methods on `PluginSetupContext`:

- **`registerSettingsGroup(name, { label, description?, fieldsets })`** — creates a `/settings/$name` admin page. Dup throws.
- **`registerSettingsFieldset(groupName, { name, label?, description?, fields })`** — appends a section (WP's `add_settings_section`) to an existing group. Missing group, dup fieldset, or dup field name anywhere in the group throws.

Fields: `{ name, label, type: "text"|"textarea", default?, description?, placeholder?, maxLength?, autoload? }`. Narrow union on `type` (contrast with `MetaBoxField`'s free-form `inputType`) — settings are core infrastructure, widening the union is a core-team call. `autoload` flows to `option.set`'s `isAutoloaded`, matching WP's `register_setting` `autoload` arg.

### Constraints enforced at registration

- Identifier regex `/^[a-z][a-z0-9_]*$/` on group/fieldset/field names — keeps storage keys, testids, and URLs portable.
- 200-field cap per group, matching `option.getMany`'s server-side limit.
- Storage keys stay flat (`${group}.${field}`) — fieldsets are UI-only, so field names must be unique across the whole group.

### New RPC

`option.getMany({ names })` returns `Record<string, string>` for bulk-hydrating the form in one round-trip. `option:manage` gated.

### Admin

- `/settings` — group index with empty-state copy that teaches the registration API.
- `/settings/$group` — form rendering each fieldset in a native `<fieldset>`/`<legend>` for a11y; save posts one `option.set` per field via `Promise.all`.
- Sidebar: Settings entry under Management, gated by `visibleSettingsGroups(caps).length > 0`.

### Sentry skills applied

- **find-bugs** — caught three real issues:
  - Route/RPC capability gap → removed the per-group capability override entirely; `option:manage` is the sole gate.
  - Dotted-name collision surface → added identifier regex.
  - Unbounded field count → added 200-field cap matching the RPC.
- **code-review** — approved with nits folded in: loader threads `group` from `beforeLoad` context (single lookup), `inArray` spread removed, field dispatcher comment explains the narrow-union contrast, save-failure e2e added.
- **code-simplifier** — collapsed the `isAutoloaded` conditional spread to a direct assignment (absent and `undefined` are equivalent here).

## Test plan

- [x] `pnpm typecheck` — 15/15
- [x] `pnpm lint` — 12/12 (pre-existing data-table warning only)
- [x] `pnpm test` — 13/13 (+14 new core tests, +5 new admin manifest tests, +5 new SettingsField dispatcher tests)
- [x] `pnpm format`
- [x] `pnpm -F @plumix/admin test:e2e` — 49/49 Playwright + axe (9 new settings specs: index, empty state, admin gate, fieldset rendering, empty hydration, stored hydration, save success, save failure, 404)