### PR TITLE
feat(core,admin): public route map + tiptap JSON content pipeline

### DIFF
--- a/packages/admin/e2e/content.spec.ts
+++ b/packages/admin/e2e/content.spec.ts
@@ -279,7 +279,8 @@ test.describe("/content/$slug/new", () => {
               parentId: null,
               title: "Hello world",
               slug: "hello-world",
-              content: "<p>body</p>",
+              content:
+                '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"body"}]}]}',
               excerpt: null,
               status: "draft",
               authorId: 1,
@@ -304,7 +305,8 @@ test.describe("/content/$slug/new", () => {
               parentId: null,
               title: "Hello world",
               slug: "hello-world",
-              content: "<p>body</p>",
+              content:
+                '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"body"}]}]}',
               excerpt: null,
               status: "draft",
               authorId: 1,
@@ -410,7 +412,8 @@ test.describe("/content/$slug/$id", () => {
               parentId: null,
               title: "Original title",
               slug: "original",
-              content: "<p>Original body</p>",
+              content:
+                '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Original body"}]}]}',
               excerpt: null,
               status: "draft",
               authorId: 1,
@@ -437,7 +440,8 @@ test.describe("/content/$slug/$id", () => {
               parentId: null,
               title: "Edited title",
               slug: "original",
-              content: "<p>Original body</p>",
+              content:
+                '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Original body"}]}]}',
               excerpt: null,
               status: "draft",
               authorId: 1,

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -1,3 +1,4 @@
+import type { Content } from "@tiptap/react";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button.js";
@@ -14,11 +15,11 @@ import {
   ListOrdered,
 } from "lucide-react";
 
-// Minimal Tiptap editor with the toolbar WP admins expect for a "light"
-// content surface. Content is stored and round-tripped as HTML via the
-// parent form — Tiptap serialises to HTML by default, which is what the
-// `posts.content` column holds today. A future PR may swap to ProseMirror
-// JSON for richer block support; keeping HTML here avoids a migration.
+// Minimal Tiptap editor. Content round-trips as a JSON-encoded ProseMirror
+// document — the public resolver walks the JSON against a node-type
+// allowlist, which is the trust boundary that keeps `<script>` and other
+// untrusted HTML out of public pages even if a contributor bypasses the
+// editor via the RPC.
 export function TiptapEditor({
   value,
   onChange,
@@ -26,7 +27,7 @@ export function TiptapEditor({
   ariaLabel,
 }: {
   readonly value: string;
-  readonly onChange: (html: string) => void;
+  readonly onChange: (json: string) => void;
   readonly disabled?: boolean;
   readonly ariaLabel?: string;
 }): ReactNode {
@@ -35,10 +36,8 @@ export function TiptapEditor({
       // StarterKit v3 bundles Link; keep it configured here so the toolbar
       // button's behaviour (openOnClick off so admins can freely edit,
       // safe rel attrs on user-entered hrefs) is explicit. Whitelist URL
-      // schemes — without this a contributor could paste `javascript:…`
-      // into the prompt and the HTML would execute when another admin
-      // rendered the post. Defense-in-depth inside the admin trust
-      // boundary; matches WP's kses Link filter.
+      // schemes — defense-in-depth inside the admin; the public walker
+      // re-checks on render.
       StarterKit.configure({
         heading: { levels: [2, 3] },
         link: {
@@ -51,7 +50,7 @@ export function TiptapEditor({
         },
       }),
     ],
-    content: value,
+    content: parseContent(value),
     editable: !disabled,
     editorProps: {
       attributes: {
@@ -63,17 +62,17 @@ export function TiptapEditor({
       },
     },
     onUpdate: ({ editor: e }) => {
-      onChange(e.getHTML());
+      onChange(JSON.stringify(e.getJSON()));
     },
   });
 
   // Sync external value changes (e.g., loading an existing post) into the
   // editor without a render-time setContent — that'd fight the user's
-  // cursor. Only updates when the incoming HTML genuinely differs from
-  // the editor's current content.
+  // cursor. Only updates when the incoming JSON genuinely differs.
   useEffect(() => {
-    if (editor.getHTML() === value) return;
-    editor.commands.setContent(value);
+    const current = JSON.stringify(editor.getJSON());
+    if (current === value) return;
+    editor.commands.setContent(parseContent(value));
   }, [editor, value]);
 
   useEffect(() => {
@@ -201,6 +200,17 @@ function Toolbar({
 const SAFE_URL_RE = /^(https?:|mailto:|\/|#)/i;
 function isSafeUrl(href: string): boolean {
   return SAFE_URL_RE.test(href.trim());
+}
+
+// Empty or malformed payloads render as an empty doc rather than crash
+// the editor — matches Tiptap's own tolerance for `null` on setContent.
+function parseContent(value: string): Content {
+  if (value === "") return null;
+  try {
+    return JSON.parse(value) as Content;
+  } catch {
+    return null;
+  }
 }
 
 function ToolbarButton({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./db/index.js";
 export * from "./db/schema/index.js";
 export * from "./hooks/index.js";
 export * from "./plugin/index.js";
+export type { RouteIntent, RouteRule } from "./route/intent.js";
 export * from "./rpc/index.js";
 export type * from "./runtime/adapter.js";
 export { buildApp } from "./runtime/app.js";

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -11,6 +11,7 @@ import type {
   FilterRest,
   HookOptions,
 } from "../hooks/types.js";
+import type { RouteIntent } from "../route/intent.js";
 import type {
   MetaBoxOptions,
   MetaOptions,
@@ -24,6 +25,7 @@ import {
   derivePostTypeCapabilities,
   deriveTaxonomyCapabilities,
 } from "../auth/rbac.js";
+import { DEFAULT_REWRITE_RULE_PRIORITY } from "../route/compile.js";
 import { DuplicateRegistrationError } from "./manifest.js";
 
 export interface PluginSetupContext {
@@ -84,6 +86,18 @@ export interface PluginSetupContext {
    * flat across fieldsets).
    */
   registerSettingsFieldset(groupName: string, fieldset: SettingsFieldset): void;
+
+  /**
+   * Declare a public URL → `RouteIntent` mapping. Lands in the compiled
+   * route map at `buildApp`; `URLPattern` pathname syntax (e.g. `/:slug`,
+   * `/docs/:category/:slug`). `priority` defaults to 10 — lower wins,
+   * auto-generated archive/single rules from `registerPostType` sit at 50.
+   */
+  addRewriteRule(
+    pattern: string,
+    intent: RouteIntent,
+    options?: { readonly priority?: number },
+  ): void;
 }
 
 interface CreatePluginContextArgs {
@@ -195,6 +209,15 @@ export function createPluginSetupContext({
       registry.settingsGroups.set(name, {
         ...options,
         name,
+        registeredBy: pluginId,
+      });
+    },
+
+    addRewriteRule: (pattern, intent, options) => {
+      registry.rewriteRules.push({
+        pattern,
+        intent,
+        priority: options?.priority ?? DEFAULT_REWRITE_RULE_PRIORITY,
         registeredBy: pluginId,
       });
     },

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1,4 +1,5 @@
 import type { UserRole } from "../db/schema/users.js";
+import type { RouteIntent } from "../route/intent.js";
 
 export interface PostTypeOptions {
   readonly label: string;
@@ -191,6 +192,13 @@ export interface RegisteredCapability {
   readonly registeredBy: string | null;
 }
 
+export interface RegisteredRewriteRule {
+  readonly pattern: string;
+  readonly intent: RouteIntent;
+  readonly priority: number;
+  readonly registeredBy: string | null;
+}
+
 export interface PluginRegistry {
   readonly postTypes: ReadonlyMap<string, RegisteredPostType>;
   readonly taxonomies: ReadonlyMap<string, RegisteredTaxonomy>;
@@ -198,6 +206,7 @@ export interface PluginRegistry {
   readonly metaBoxes: ReadonlyMap<string, RegisteredMetaBox>;
   readonly capabilities: ReadonlyMap<string, RegisteredCapability>;
   readonly settingsGroups: ReadonlyMap<string, RegisteredSettingsGroup>;
+  readonly rewriteRules: readonly RegisteredRewriteRule[];
 }
 
 export interface MutablePluginRegistry extends PluginRegistry {
@@ -207,6 +216,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly metaBoxes: Map<string, RegisteredMetaBox>;
   readonly capabilities: Map<string, RegisteredCapability>;
   readonly settingsGroups: Map<string, RegisteredSettingsGroup>;
+  readonly rewriteRules: RegisteredRewriteRule[];
 }
 
 export function createPluginRegistry(): MutablePluginRegistry {
@@ -217,6 +227,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     metaBoxes: new Map(),
     capabilities: new Map(),
     settingsGroups: new Map(),
+    rewriteRules: [],
   };
 }
 

--- a/packages/core/src/route/compile.test.ts
+++ b/packages/core/src/route/compile.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "vitest";
+
+import { definePlugin } from "../plugin/define.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { installPlugins } from "../plugin/register.js";
+import { HookRegistry } from "../hooks/registry.js";
+import { compileRouteMap } from "./compile.js";
+
+async function buildRegistry(plugins: ReturnType<typeof definePlugin>[]) {
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  await installPlugins({ hooks, plugins, registry });
+  return registry;
+}
+
+describe("compileRouteMap", () => {
+  test("auto-generates /{type}/:slug from a registered post type", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerPostType("post", { label: "Posts", isPublic: true });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    expect(map).toHaveLength(1);
+    expect(map[0]?.rawPattern).toBe("/post/:slug");
+    expect(map[0]?.intent).toEqual({ kind: "single", postType: "post" });
+    expect(map[0]?.priority).toBe(50);
+  });
+
+  test("honors rewrite.slug for both single and archive patterns", async () => {
+    const registry = await buildRegistry([
+      definePlugin("shop", (ctx) => {
+        ctx.registerPostType("product", {
+          label: "Products",
+          isPublic: true,
+          hasArchive: true,
+          rewrite: { slug: "shop" },
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    expect(patterns).toEqual(["/shop", "/shop/:slug"]);
+    expect(map[0]?.intent).toEqual({ kind: "archive", postType: "product" });
+    expect(map[1]?.intent).toEqual({ kind: "single", postType: "product" });
+  });
+
+  test("hasArchive: string overrides the auto archive slug", async () => {
+    const registry = await buildRegistry([
+      definePlugin("catalog", (ctx) => {
+        ctx.registerPostType("product", {
+          label: "Products",
+          isPublic: true,
+          hasArchive: "store",
+          rewrite: { slug: "p" },
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    expect(map.map((r) => r.rawPattern)).toEqual(["/store", "/p/:slug"]);
+  });
+
+  test("skips private post types entirely", async () => {
+    const registry = await buildRegistry([
+      definePlugin("internal", (ctx) => {
+        ctx.registerPostType("nav_menu_item", {
+          label: "Menu items",
+          isPublic: false,
+        });
+      }),
+    ]);
+    expect(compileRouteMap(registry)).toHaveLength(0);
+  });
+
+  test("addRewriteRule lands ahead of auto rules via default priority", async () => {
+    const registry = await buildRegistry([
+      definePlugin("docs", (ctx) => {
+        ctx.registerPostType("doc", {
+          label: "Docs",
+          isPublic: true,
+          rewrite: { slug: "docs" },
+        });
+        ctx.addRewriteRule("/docs/:category/:slug", {
+          kind: "single",
+          postType: "doc",
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    expect(map[0]?.rawPattern).toBe("/docs/:category/:slug");
+    expect(map[0]?.priority).toBe(10);
+    expect(map[1]?.rawPattern).toBe("/docs/:slug");
+  });
+
+  test("duplicate explicit pattern within one plugin throws at compile", async () => {
+    const registry = await buildRegistry([
+      definePlugin("a", (ctx) => {
+        ctx.addRewriteRule("/cart", { kind: "single", postType: "x" });
+        ctx.addRewriteRule("/cart", { kind: "single", postType: "x" });
+      }),
+    ]);
+    expect(() => compileRouteMap(registry)).toThrow(
+      /registered twice.*"a".*"a"/,
+    );
+  });
+
+  test("pattern collision between auto and explicit rules throws at compile, naming both owners", async () => {
+    const registry = await buildRegistry([
+      definePlugin("conflict", (ctx) => {
+        ctx.registerPostType("post", { label: "Posts", isPublic: true });
+        ctx.addRewriteRule("/post/:slug", {
+          kind: "single",
+          postType: "post",
+        });
+      }),
+    ]);
+    expect(() => compileRouteMap(registry)).toThrow(
+      /registered twice.*"conflict".*"conflict"/,
+    );
+  });
+
+  test("cross-plugin collisions name both plugin ids", async () => {
+    const registry = await buildRegistry([
+      definePlugin("plugin-a", (ctx) => {
+        ctx.addRewriteRule("/x", { kind: "single", postType: "a" });
+      }),
+      definePlugin("plugin-b", (ctx) => {
+        ctx.addRewriteRule("/x", { kind: "single", postType: "b" });
+      }),
+    ]);
+    expect(() => compileRouteMap(registry)).toThrow(
+      /"plugin-a".*"plugin-b"/,
+    );
+  });
+
+  test("stable sort preserves registration order on equal priorities", async () => {
+    const registry = await buildRegistry([
+      definePlugin("a", (ctx) => {
+        ctx.addRewriteRule("/a", { kind: "single", postType: "x" });
+        ctx.addRewriteRule("/b", { kind: "single", postType: "x" });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    expect(map.map((r) => r.rawPattern)).toEqual(["/a", "/b"]);
+  });
+
+  test("isPublic defaults to true — omitting it still generates routes", async () => {
+    const registry = await buildRegistry([
+      definePlugin("default", (ctx) => {
+        ctx.registerPostType("article", { label: "Articles" });
+      }),
+    ]);
+    expect(compileRouteMap(registry).map((r) => r.rawPattern)).toEqual([
+      "/article/:slug",
+    ]);
+  });
+
+  test("cross-plugin priority: explicit plugin rule beats another plugin's auto rule", async () => {
+    const registry = await buildRegistry([
+      definePlugin("core-blog", (ctx) => {
+        ctx.registerPostType("post", { label: "Posts", isPublic: true });
+      }),
+      definePlugin("overrider", (ctx) => {
+        ctx.addRewriteRule(
+          "/post/featured",
+          { kind: "archive", postType: "post" },
+          { priority: 5 },
+        );
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    expect(map[0]?.rawPattern).toBe("/post/featured");
+    expect(map[0]?.priority).toBe(5);
+  });
+
+  test("hasArchive: string rejects multi-segment or non-kebab input", async () => {
+    const bad = await buildRegistry([
+      definePlugin("x", (ctx) => {
+        ctx.registerPostType("product", {
+          label: "Products",
+          isPublic: true,
+          hasArchive: "foo/bar",
+        });
+      }),
+    ]);
+    expect(() => compileRouteMap(bad)).toThrow(/invalid hasArchive/);
+
+    const dots = await buildRegistry([
+      definePlugin("y", (ctx) => {
+        ctx.registerPostType("product", {
+          label: "Products",
+          isPublic: true,
+          hasArchive: "../admin",
+        });
+      }),
+    ]);
+    expect(() => compileRouteMap(dots)).toThrow(/invalid hasArchive/);
+  });
+});

--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -1,0 +1,111 @@
+import type {
+  PluginRegistry,
+  RegisteredPostType,
+} from "../plugin/manifest.js";
+import type { RouteRule } from "./intent.js";
+
+export const AUTO_ROUTE_PRIORITY = 50;
+export const DEFAULT_REWRITE_RULE_PRIORITY = 10;
+
+interface CompiledRule extends RouteRule {
+  readonly registeredBy: string | null;
+}
+
+/**
+ * Compile the route map from the plugin registry. Auto-generates single +
+ * archive rules for each public post type, appends explicit
+ * `addRewriteRule` entries, sorts ascending by priority. Identical raw
+ * patterns throw — the error names both offending plugins.
+ */
+export function compileRouteMap(registry: PluginRegistry): readonly RouteRule[] {
+  const rules: CompiledRule[] = [];
+
+  for (const postType of registry.postTypes.values()) {
+    if (postType.isPublic === false) continue;
+    for (const rule of autoRulesForPostType(postType)) rules.push(rule);
+  }
+
+  for (const registered of registry.rewriteRules) {
+    rules.push({
+      pattern: new URLPattern({ pathname: registered.pattern }),
+      rawPattern: registered.pattern,
+      intent: registered.intent,
+      priority: registered.priority,
+      registeredBy: registered.registeredBy,
+    });
+  }
+
+  assertUniquePatterns(rules);
+  rules.sort((a, b) => a.priority - b.priority);
+  return rules;
+}
+
+function autoRulesForPostType(postType: RegisteredPostType): CompiledRule[] {
+  const baseSlug = postType.rewrite?.slug ?? postType.name;
+  const archiveSlug = archiveSlugFor(postType, baseSlug);
+  const rules: CompiledRule[] = [];
+
+  if (archiveSlug !== null) {
+    const pattern = `/${archiveSlug}`;
+    rules.push({
+      pattern: new URLPattern({ pathname: pattern }),
+      rawPattern: pattern,
+      intent: { kind: "archive", postType: postType.name },
+      priority: AUTO_ROUTE_PRIORITY,
+      registeredBy: postType.registeredBy,
+    });
+  }
+
+  const singlePattern = baseSlug === "" ? "/:slug" : `/${baseSlug}/:slug`;
+  rules.push({
+    pattern: new URLPattern({ pathname: singlePattern }),
+    rawPattern: singlePattern,
+    intent: { kind: "single", postType: postType.name },
+    priority: AUTO_ROUTE_PRIORITY,
+    registeredBy: postType.registeredBy,
+  });
+
+  return rules;
+}
+
+// Archive slugs need to be a single path segment — slashes would let a
+// plugin silently shadow other routes. Empty is reserved (would match
+// `front-page`).
+const ARCHIVE_SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function archiveSlugFor(
+  postType: RegisteredPostType,
+  baseSlug: string,
+): string | null {
+  const { hasArchive } = postType;
+  if (!hasArchive) return null;
+  if (typeof hasArchive === "string") {
+    if (!ARCHIVE_SLUG_RE.test(hasArchive)) {
+      throw new Error(
+        `Post type "${postType.name}" has invalid hasArchive "${hasArchive}" — ` +
+          `expected a single lowercase kebab-case path segment.`,
+      );
+    }
+    return hasArchive;
+  }
+  if (baseSlug === "") return null;
+  return baseSlug;
+}
+
+function assertUniquePatterns(rules: readonly CompiledRule[]): void {
+  const first = new Map<string, string | null>();
+  for (const rule of rules) {
+    const existing = first.get(rule.rawPattern);
+    if (existing !== undefined) {
+      throw new Error(
+        `Rewrite rule "${rule.rawPattern}" is registered twice ` +
+          `(by ${formatOwner(existing)} and ${formatOwner(rule.registeredBy)}).`,
+      );
+    }
+    first.set(rule.rawPattern, rule.registeredBy);
+  }
+}
+
+function formatOwner(plugin: string | null): string {
+  return plugin === null ? "core" : `plugin "${plugin}"`;
+}

--- a/packages/core/src/route/intent.ts
+++ b/packages/core/src/route/intent.ts
@@ -1,0 +1,21 @@
+/**
+ * Discriminated union describing what a matched URL represents. Resolved
+ * into a Response by the public-route resolver. Kept narrow for now — the
+ * arch doc specs `taxonomy` / `search` / `front-page` / `handler` /
+ * `redirect`; those land when a plugin actually needs them.
+ */
+export type RouteIntent =
+  | { readonly kind: "single"; readonly postType: string }
+  | { readonly kind: "archive"; readonly postType: string };
+
+/**
+ * Compiled rule. `priority` preserves arch-doc ordering semantics — lower
+ * number wins. Explicit `addRewriteRule` defaults to 10; auto-generated
+ * rules from `hasArchive` / `rewrite.slug` land at 50.
+ */
+export interface RouteRule {
+  readonly pattern: URLPattern;
+  readonly rawPattern: string;
+  readonly intent: RouteIntent;
+  readonly priority: number;
+}

--- a/packages/core/src/route/match.test.ts
+++ b/packages/core/src/route/match.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import type { RouteRule } from "./intent.js";
+import { matchRoute } from "./match.js";
+
+function rule(pathname: string, priority = 50): RouteRule {
+  return {
+    pattern: new URLPattern({ pathname }),
+    rawPattern: pathname,
+    intent: { kind: "single", postType: "post" },
+    priority,
+  };
+}
+
+describe("matchRoute", () => {
+  test("returns null when no rule matches", () => {
+    const rules = [rule("/posts/:slug")];
+    expect(matchRoute(new URL("https://cms.example/other"), rules)).toBeNull();
+  });
+
+  test("extracts named params", () => {
+    const rules = [rule("/docs/:category/:slug")];
+    const result = matchRoute(
+      new URL("https://cms.example/docs/guides/setup"),
+      rules,
+    );
+    expect(result?.params).toEqual({ category: "guides", slug: "setup" });
+  });
+
+  test("first match wins — iteration order is the caller's responsibility", () => {
+    const rules = [rule("/a/:slug"), rule("/a/:slug")];
+    const result = matchRoute(new URL("https://cms.example/a/hello"), rules);
+    expect(result?.intent).toEqual({ kind: "single", postType: "post" });
+  });
+});

--- a/packages/core/src/route/match.ts
+++ b/packages/core/src/route/match.ts
@@ -1,0 +1,28 @@
+import type { RouteIntent, RouteRule } from "./intent.js";
+
+export interface RouteMatch {
+  readonly intent: RouteIntent;
+  readonly params: Record<string, string>;
+}
+
+export function matchRoute(
+  url: URL,
+  rules: readonly RouteRule[],
+): RouteMatch | null {
+  for (const rule of rules) {
+    const result = rule.pattern.exec({ pathname: url.pathname });
+    if (result === null) continue;
+    return { intent: rule.intent, params: extractParams(result.pathname) };
+  }
+  return null;
+}
+
+function extractParams(
+  pathname: URLPatternComponentResult,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(pathname.groups)) {
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
+}

--- a/packages/core/src/route/render/document.test.ts
+++ b/packages/core/src/route/render/document.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { renderDefaultDocument } from "./document.js";
+
+describe("renderDefaultDocument", () => {
+  test("renders a doctyped html document with the escaped title in <title>", () => {
+    const html = renderDefaultDocument({
+      title: "Hello & goodbye",
+      bodyHtml: "<p>hi</p>",
+    });
+    expect(html.startsWith("<!doctype html>")).toBe(true);
+    expect(html).toContain("<title>Hello &amp; goodbye</title>");
+    expect(html).toContain("<body><p>hi</p></body>");
+  });
+
+  test("passes bodyHtml through without re-escaping (caller's responsibility)", () => {
+    const html = renderDefaultDocument({
+      title: "t",
+      bodyHtml: "<article>keep me</article>",
+    });
+    expect(html).toContain("<article>keep me</article>");
+  });
+});

--- a/packages/core/src/route/render/document.ts
+++ b/packages/core/src/route/render/document.ts
@@ -1,0 +1,25 @@
+/**
+ * Minimal default document. No theme, no CSS, no head metadata beyond what
+ * a browser needs to render the bytes as HTML — this is the "ugly but
+ * working" walking-skeleton layout. Themes replace this entirely.
+ */
+export function renderDefaultDocument(args: {
+  readonly title: string;
+  readonly bodyHtml: string;
+}): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>${escapeHtml(args.title)}</title></head><body>${args.bodyHtml}</body></html>`;
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// Attribute-context escape: `href="..."` / `alt="..."` etc. Additionally
+// escapes the quote characters that would let untrusted input break out of
+// the attribute.
+export function escapeAttr(value: string): string {
+  return escapeHtml(value).replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}

--- a/packages/core/src/route/render/tiptap.test.ts
+++ b/packages/core/src/route/render/tiptap.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+
+import { renderTiptapContent } from "./tiptap.js";
+
+function doc(...content: unknown[]) {
+  return { type: "doc", content };
+}
+
+function p(...content: unknown[]) {
+  return { type: "paragraph", content };
+}
+
+function t(text: string, marks?: readonly { type: string; attrs?: unknown }[]) {
+  return marks ? { type: "text", text, marks } : { type: "text", text };
+}
+
+describe("renderTiptapContent — JSON input", () => {
+  test("empty / null / undefined inputs produce empty output", () => {
+    expect(renderTiptapContent(null)).toBe("");
+    expect(renderTiptapContent(undefined)).toBe("");
+    expect(renderTiptapContent("")).toBe("");
+    expect(renderTiptapContent("   ")).toBe("");
+  });
+
+  test("accepts JSON-encoded string or raw object equivalently", () => {
+    const obj = doc(p(t("Hello.")));
+    const expected = "<p>Hello.</p>";
+    expect(renderTiptapContent(obj)).toBe(expected);
+    expect(renderTiptapContent(JSON.stringify(obj))).toBe(expected);
+  });
+
+  test("unparseable JSON string renders empty (never throws)", () => {
+    expect(renderTiptapContent("<p>legacy html</p>")).toBe("");
+    expect(renderTiptapContent("{not-json")).toBe("");
+    expect(renderTiptapContent("42")).toBe("");
+  });
+
+  test("unknown node types render empty — allowlist only", () => {
+    expect(renderTiptapContent(doc({ type: "mystery" }))).toBe("");
+  });
+
+  test("script tags in text are escaped", () => {
+    expect(renderTiptapContent(doc(p(t("<script>alert(1)</script>"))))).toBe(
+      "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>",
+    );
+  });
+
+  test("clamps heading levels to 1..6", () => {
+    const h = (level: number) => ({
+      type: "heading",
+      attrs: { level },
+      content: [t("x")],
+    });
+    expect(renderTiptapContent(h(1))).toBe("<h1>x</h1>");
+    expect(renderTiptapContent(h(99))).toBe("<h6>x</h6>");
+    expect(renderTiptapContent(h(-3))).toBe("<h1>x</h1>");
+    expect(renderTiptapContent({ type: "heading", content: [t("x")] })).toBe(
+      "<h2>x</h2>",
+    );
+  });
+
+  test("applies marks inside-out so outer marks wrap inner ones", () => {
+    expect(
+      renderTiptapContent(
+        doc(p(t("x", [{ type: "italic" }, { type: "bold" }]))),
+      ),
+    ).toBe("<p><em><strong>x</strong></em></p>");
+  });
+
+  test("link mark admits http/https/mailto/tel/relative, blocks javascript:", () => {
+    const link = (href: string) =>
+      renderTiptapContent(
+        doc(p(t("x", [{ type: "link", attrs: { href } }]))),
+      );
+    expect(link("https://example.com")).toBe(
+      '<p><a href="https://example.com" rel="noopener noreferrer nofollow">x</a></p>',
+    );
+    expect(link("mailto:a@b.c")).toBe(
+      '<p><a href="mailto:a@b.c" rel="noopener noreferrer nofollow">x</a></p>',
+    );
+    expect(link("/relative")).toBe(
+      '<p><a href="/relative" rel="noopener noreferrer nofollow">x</a></p>',
+    );
+    expect(link("javascript:alert(1)")).toBe("<p>x</p>");
+    expect(link("data:text/html,hi")).toBe("<p>x</p>");
+  });
+
+  test("link href is attr-escaped to prevent attribute breakout", () => {
+    const rendered = renderTiptapContent(
+      doc(p(t("x", [{ type: "link", attrs: { href: 'https://a/"evil' } }]))),
+    );
+    expect(rendered).toContain('href="https://a/&quot;evil"');
+    expect(rendered).not.toContain('"evil"');
+  });
+
+  test("code block escapes inner text", () => {
+    expect(renderTiptapContent({ type: "codeBlock", content: [t("<div>")] }))
+      .toBe("<pre><code>&lt;div&gt;</code></pre>");
+  });
+
+  test("lists, blockquote, hr, br render", () => {
+    expect(
+      renderTiptapContent({
+        type: "bulletList",
+        content: [{ type: "listItem", content: [p(t("a"))] }],
+      }),
+    ).toBe("<ul><li><p>a</p></li></ul>");
+    expect(
+      renderTiptapContent({
+        type: "orderedList",
+        content: [{ type: "listItem", content: [p(t("b"))] }],
+      }),
+    ).toBe("<ol><li><p>b</p></li></ol>");
+    expect(renderTiptapContent({ type: "blockquote", content: [p(t("c"))] }))
+      .toBe("<blockquote><p>c</p></blockquote>");
+    expect(renderTiptapContent({ type: "horizontalRule" })).toBe("<hr />");
+    expect(renderTiptapContent({ type: "hardBreak" })).toBe("<br />");
+  });
+});

--- a/packages/core/src/route/render/tiptap.ts
+++ b/packages/core/src/route/render/tiptap.ts
@@ -1,0 +1,142 @@
+import { escapeAttr, escapeHtml } from "./document.js";
+
+/**
+ * Tiptap / ProseMirror JSON → HTML walker. Accepts the JSON-encoded string
+ * persisted in `posts.content` (or the parsed object) and renders it
+ * against an allowlist of node and mark types. Unknown types render empty
+ * — the walker is the trust boundary that keeps public HTML free of
+ * injection regardless of what reaches the column.
+ */
+export function renderTiptapContent(input: unknown): string {
+  if (input === null || input === undefined) return "";
+  if (typeof input === "string") {
+    if (input.trim() === "") return "";
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(input);
+    } catch {
+      return "";
+    }
+    return renderNode(parsed);
+  }
+  return renderNode(input);
+}
+
+interface TiptapMark {
+  readonly type?: string;
+  readonly attrs?: Readonly<Record<string, unknown>>;
+}
+
+interface TiptapNode {
+  readonly type?: string;
+  readonly text?: string;
+  readonly attrs?: Readonly<Record<string, unknown>>;
+  readonly marks?: readonly TiptapMark[];
+  readonly content?: readonly unknown[];
+}
+
+function renderNode(value: unknown): string {
+  if (value === null || typeof value !== "object") return "";
+  const node = value as TiptapNode;
+  switch (node.type) {
+    case "doc":
+      return renderChildren(node.content);
+    case "paragraph":
+      return `<p>${renderChildren(node.content)}</p>`;
+    case "heading": {
+      const level = clampHeadingLevel(node.attrs?.level);
+      return `<h${level}>${renderChildren(node.content)}</h${level}>`;
+    }
+    case "bulletList":
+      return `<ul>${renderChildren(node.content)}</ul>`;
+    case "orderedList":
+      return `<ol>${renderChildren(node.content)}</ol>`;
+    case "listItem":
+      return `<li>${renderChildren(node.content)}</li>`;
+    case "blockquote":
+      return `<blockquote>${renderChildren(node.content)}</blockquote>`;
+    case "codeBlock":
+      return `<pre><code>${escapeHtml(collectText(node.content))}</code></pre>`;
+    case "horizontalRule":
+      return "<hr />";
+    case "hardBreak":
+      return "<br />";
+    case "text":
+      return applyMarks(escapeHtml(node.text ?? ""), node.marks);
+    default:
+      return "";
+  }
+}
+
+function renderChildren(content: readonly unknown[] | undefined): string {
+  if (!content) return "";
+  let out = "";
+  for (const child of content) out += renderNode(child);
+  return out;
+}
+
+function applyMarks(
+  text: string,
+  marks: readonly TiptapMark[] | undefined,
+): string {
+  if (!marks || marks.length === 0) return text;
+  let out = text;
+  // Marks are stored outside-in; wrap inside-out so the innermost tag is
+  // the first mark in the array.
+  for (let i = marks.length - 1; i >= 0; i -= 1) {
+    const mark = marks[i];
+    switch (mark?.type) {
+      case "bold":
+        out = `<strong>${out}</strong>`;
+        break;
+      case "italic":
+        out = `<em>${out}</em>`;
+        break;
+      case "code":
+        out = `<code>${out}</code>`;
+        break;
+      case "strike":
+        out = `<s>${out}</s>`;
+        break;
+      case "link": {
+        const href = sanitizeHref(mark.attrs?.href);
+        if (href === null) break;
+        out = `<a href="${escapeAttr(href)}" rel="noopener noreferrer nofollow">${out}</a>`;
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+function collectText(content: readonly unknown[] | undefined): string {
+  if (!content) return "";
+  let out = "";
+  for (const child of content) {
+    if (child && typeof child === "object") {
+      const node = child as TiptapNode;
+      if (typeof node.text === "string") out += node.text;
+      else if (node.content) out += collectText(node.content);
+    }
+  }
+  return out;
+}
+
+function clampHeadingLevel(level: unknown): 1 | 2 | 3 | 4 | 5 | 6 {
+  if (typeof level !== "number") return 2;
+  if (level < 1) return 1;
+  if (level > 6) return 6;
+  return Math.trunc(level) as 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+// Mirrors the admin editor's link allowlist. Blocks javascript:, data:,
+// vbscript:, file: and their variants; passes relative paths and
+// `#fragment`.
+const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|#|\?|\.\.?\/)/i;
+
+function sanitizeHref(href: unknown): string | null {
+  if (typeof href !== "string") return null;
+  const trimmed = href.trim();
+  if (trimmed === "") return null;
+  return SAFE_HREF.test(trimmed) ? trimmed : null;
+}

--- a/packages/core/src/route/resolve.test.ts
+++ b/packages/core/src/route/resolve.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "vitest";
+
+import { definePlugin } from "../plugin/define.js";
+import { createDispatcherHarness } from "../test/dispatcher.js";
+
+const blogPlugin = definePlugin("blog", (ctx) => {
+  ctx.registerPostType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+});
+
+const shopPlugin = definePlugin("shop", (ctx) => {
+  ctx.registerPostType("product", {
+    label: "Products",
+    isPublic: true,
+    hasArchive: true,
+    rewrite: { slug: "shop" },
+  });
+});
+
+const TIPTAP_BODY = {
+  type: "doc",
+  content: [
+    { type: "paragraph", content: [{ type: "text", text: "Body." }] },
+  ],
+};
+
+describe("resolvePublicRoute — single", () => {
+  test("renders title + walked content for a published post", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.post.create({
+      type: "post",
+      slug: "hello",
+      title: "Hello & <world>",
+      content: JSON.stringify(TIPTAP_BODY),
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post/hello"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<title>Hello &amp; &lt;world&gt;</title>");
+    expect(body).toContain("<h1>Hello &amp; &lt;world&gt;</h1>");
+    expect(body).toContain("<p>Body.</p>");
+  });
+
+  test("draft with a matching slug returns 404 (status gate)", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.post.create({
+      type: "post",
+      slug: "secret",
+      title: "Secret",
+      content: null,
+      status: "draft",
+      authorId: author.id,
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post/secret"));
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("public-post-not-found");
+  });
+
+  test("trashed post returns 404", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.post.create({
+      type: "post",
+      slug: "gone",
+      title: "Gone",
+      content: null,
+      status: "trash",
+      authorId: author.id,
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post/gone"));
+    expect(response.status).toBe(404);
+  });
+
+  test("legacy HTML content renders empty (walker rejects non-JSON)", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.post.create({
+      type: "post",
+      slug: "legacy",
+      title: "Legacy",
+      content: "<p>old html</p>",
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post/legacy"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<h1>Legacy</h1>");
+    expect(body).not.toContain("<p>old html</p>");
+  });
+});
+
+describe("resolvePublicRoute — archive", () => {
+  test("lists published posts with hrefs honoring rewrite.slug", async () => {
+    const h = await createDispatcherHarness({ plugins: [shopPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.post.create({
+      type: "product",
+      slug: "widget",
+      title: "Widget",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-04-20"),
+    });
+    await h.factory.post.create({
+      type: "product",
+      slug: "gadget",
+      title: "Gadget",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-04-21"),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/shop"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<title>Products</title>");
+    expect(body).toContain('<a href="/shop/gadget">Gadget</a>');
+    expect(body).toContain('<a href="/shop/widget">Widget</a>');
+    // Most recent first
+    expect(body.indexOf("Gadget")).toBeLessThan(body.indexOf("Widget"));
+  });
+
+  test("archive with no published posts renders the empty-state copy", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<h1>Posts</h1>");
+    expect(body).toContain("No posts yet.");
+  });
+
+  test("drafts do not appear in the archive", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.post.create({
+      type: "post",
+      slug: "draft-one",
+      title: "Draft One",
+      content: null,
+      status: "draft",
+      authorId: author.id,
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain("No posts yet.");
+    expect(body).not.toContain("Draft One");
+  });
+
+  test("archive title falls back label → postType when labels.plural is absent", async () => {
+    const plugin = definePlugin("docs", (ctx) => {
+      ctx.registerPostType("doc", { label: "Docs", isPublic: true, hasArchive: true });
+    });
+    const h = await createDispatcherHarness({ plugins: [plugin] });
+    const response = await h.dispatch(new Request("https://cms.example/doc"));
+    const body = await response.text();
+    expect(body).toContain("<title>Docs</title>");
+  });
+});

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -1,0 +1,83 @@
+import type { AppContext } from "../context/app.js";
+import type { Post } from "../db/schema/posts.js";
+import type { RouteIntent } from "./intent.js";
+import type { RouteMatch } from "./match.js";
+import { and, desc, eq } from "../db/index.js";
+import { posts } from "../db/schema/posts.js";
+import { notFound } from "../runtime/http.js";
+import {
+  escapeAttr,
+  escapeHtml,
+  renderDefaultDocument,
+} from "./render/document.js";
+import { renderTiptapContent } from "./render/tiptap.js";
+
+const ARCHIVE_LIMIT = 20;
+
+export async function resolvePublicRoute(
+  ctx: AppContext,
+  match: RouteMatch,
+): Promise<Response> {
+  switch (match.intent.kind) {
+    case "single":
+      return resolveSingle(ctx, match.intent, match.params);
+    case "archive":
+      return resolveArchive(ctx, match.intent);
+  }
+}
+
+async function resolveSingle(
+  ctx: AppContext,
+  intent: Extract<RouteIntent, { kind: "single" }>,
+  params: Record<string, string>,
+): Promise<Response> {
+  const slug = params.slug;
+  if (typeof slug !== "string" || slug === "") {
+    return notFound("public-route-slug-missing");
+  }
+
+  const row = await ctx.db.query.posts.findFirst({
+    where: and(
+      eq(posts.type, intent.postType),
+      eq(posts.slug, slug),
+      eq(posts.status, "published"),
+    ),
+  });
+  if (!row) return notFound("public-post-not-found");
+
+  const body = `<article><h1>${escapeHtml(row.title)}</h1>${renderTiptapContent(row.content)}</article>`;
+  return htmlResponse(row.title, body);
+}
+
+async function resolveArchive(
+  ctx: AppContext,
+  intent: Extract<RouteIntent, { kind: "archive" }>,
+): Promise<Response> {
+  const rows = await ctx.db
+    .select()
+    .from(posts)
+    .where(and(eq(posts.type, intent.postType), eq(posts.status, "published")))
+    .orderBy(desc(posts.publishedAt), desc(posts.id))
+    .limit(ARCHIVE_LIMIT);
+
+  const registered = ctx.plugins.postTypes.get(intent.postType);
+  const title =
+    registered?.labels?.plural ?? registered?.label ?? intent.postType;
+  const baseSlug = registered?.rewrite?.slug ?? intent.postType;
+  const body =
+    rows.length === 0
+      ? `<h1>${escapeHtml(title)}</h1><p>No posts yet.</p>`
+      : `<h1>${escapeHtml(title)}</h1><ul>${rows.map((row) => renderArchiveItem(row, baseSlug)).join("")}</ul>`;
+  return htmlResponse(title, body);
+}
+
+function renderArchiveItem(row: Post, baseSlug: string): string {
+  const href = baseSlug === "" ? `/${row.slug}` : `/${baseSlug}/${row.slug}`;
+  return `<li><a href="${escapeAttr(href)}">${escapeHtml(row.title)}</a></li>`;
+}
+
+function htmlResponse(title: string, bodyHtml: string): Response {
+  return new Response(renderDefaultDocument({ title, bodyHtml }), {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -5,11 +5,13 @@ import type { SessionPolicy } from "../auth/sessions.js";
 import type { PlumixConfig } from "../config.js";
 import type { AppContext } from "../context/app.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
+import type { RouteRule } from "../route/intent.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
 import * as coreSchema from "../db/schema/index.js";
 import { HookRegistry } from "../hooks/registry.js";
 import { installPlugins } from "../plugin/register.js";
+import { compileRouteMap } from "../route/compile.js";
 import { appRouter } from "../rpc/router.js";
 
 export interface PlumixApp {
@@ -27,6 +29,12 @@ export interface PlumixApp {
   readonly passkey: ResolvedPasskeyConfig;
   readonly sessionPolicy: SessionPolicy;
   readonly schema: Record<string, unknown>;
+  /**
+   * Sorted route map compiled once at `buildApp` from the plugin registry.
+   * Module-scoped module-less equivalent: CF Worker isolates reuse this
+   * across requests without re-derivation.
+   */
+  readonly routeMap: readonly RouteRule[];
 }
 
 export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
@@ -60,5 +68,6 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     passkey,
     sessionPolicy: config.auth.sessions ?? DEFAULT_SESSION_POLICY,
     schema,
+    routeMap: compileRouteMap(registry),
   };
 }

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "vitest";
 
+import { definePlugin } from "../plugin/define.js";
 import { createDispatcherHarness, plumixRequest } from "../test/dispatcher.js";
 
 describe("dispatcher — routing", () => {
-  test("public / returns the SSR placeholder", async () => {
+  test("public / 404s when no plugin claims it", async () => {
     const h = await createDispatcherHarness();
     const response = await h.dispatch(new Request("https://cms.example/"));
-    expect(response.status).toBe(200);
-    expect(await response.text()).toBe("<h1>Plumix</h1>");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe(
+      "public-route-not-found",
+    );
   });
 
   test("/_plumix/admin returns 404 with admin-not-available when no assets binding is configured", async () => {
@@ -245,6 +248,64 @@ describe("dispatcher — auth routes", () => {
 });
 
 describe("dispatcher — error boundary", () => {
+  test("public GET resolves a plugin-registered single-post route", async () => {
+    const blog = definePlugin("test-blog", (ctx) => {
+      ctx.registerPostType("post", { label: "Posts", isPublic: true });
+    });
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const author = await h.seedUser("admin");
+    await h.factory.post.create({
+      type: "post",
+      slug: "hello-world",
+      title: "Hello World",
+      content: JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "First post." }],
+          },
+        ],
+      }),
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/hello-world"),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    const body = await response.text();
+    expect(body).toContain("<h1>Hello World</h1>");
+    expect(body).toContain("<p>First post.</p>");
+  });
+
+  test("public GET 404s for an unknown slug", async () => {
+    const blog = definePlugin("test-blog", (ctx) => {
+      ctx.registerPostType("post", { label: "Posts", isPublic: true });
+    });
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/nope"),
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe(
+      "public-post-not-found",
+    );
+  });
+
+  test("public POST returns 405 (public routes are GET/HEAD-only in PR 1)", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      new Request("https://cms.example/anything", { method: "POST" }),
+    );
+    expect(response.status).toBe(405);
+  });
+
   test("unhandled handler exceptions return 500 JSON (no raw throw)", async () => {
     const h = await createDispatcherHarness();
     h.app.hooks.addFilter("rpc:post.list:input", () => {

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -10,6 +10,8 @@ import {
   handlePasskeyRegisterVerify,
   handleSignout,
 } from "../auth/passkey/routes.js";
+import { matchRoute } from "../route/match.js";
+import { resolvePublicRoute } from "../route/resolve.js";
 import { forbidden, jsonResponse, methodNotAllowed, notFound } from "./http.js";
 
 const RPC_PREFIX = "/_plumix/rpc";
@@ -50,7 +52,8 @@ export function createPlumixDispatcher(app: PlumixApp): PlumixDispatcher {
 }
 
 async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
-  const { pathname } = new URL(ctx.request.url);
+  const url = new URL(ctx.request.url);
+  const { pathname } = url;
 
   if (pathname.startsWith(PLUMIX_PREFIX)) {
     if (!hasCsrfHeader(ctx.request)) {
@@ -93,9 +96,13 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
     return notFound("unknown-plumix-route");
   }
 
-  return new Response("<h1>Plumix</h1>", {
-    headers: { "content-type": "text/html; charset=utf-8" },
-  });
+  if (ctx.request.method !== "GET" && ctx.request.method !== "HEAD") {
+    return methodNotAllowed(["GET", "HEAD"]);
+  }
+
+  const match = matchRoute(url, app.routeMap);
+  if (match === null) return notFound("public-route-not-found");
+  return resolvePublicRoute(ctx, match);
 }
 
 async function serveAdmin(ctx: AppContext): Promise<Response> {

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -1,4 +1,5 @@
 import type { AppContext } from "../context/app.js";
+import type { AnyPluginDescriptor } from "../config.js";
 import type { User, UserRole } from "../db/schema/users.js";
 import type {
   ActionArgs,
@@ -49,6 +50,11 @@ export interface CreateDispatcherHarnessOptions {
    * when exercising the dispatcher's /_plumix/admin/* SPA fallback.
    */
   readonly assets?: AssetsBinding;
+  /**
+   * Plugins to install into the test app. Use when exercising public
+   * routes, manifest projection, or plugin-registered hooks.
+   */
+  readonly plugins?: readonly AnyPluginDescriptor[];
 }
 
 export interface DispatcherHarness {
@@ -137,6 +143,7 @@ export async function createDispatcherHarness(
         origin: "https://cms.example",
       },
     }),
+    plugins: options.plugins,
   });
   const app = await buildApp(config);
   const dispatcher = createPlumixDispatcher(app);

--- a/packages/runtimes/cloudflare/src/adapter.test.ts
+++ b/packages/runtimes/cloudflare/src/adapter.test.ts
@@ -53,8 +53,10 @@ async function invoke(
 describe("cloudflare adapter — buildFetchHandler", () => {
   test("routes the public / request through the dispatcher", async () => {
     const response = await invoke(new Request("https://cms.example/"), {});
-    expect(response.status).toBe(200);
-    expect(await response.text()).toBe("<h1>Plumix</h1>");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe(
+      "public-route-not-found",
+    );
   });
 
   test("ALS is entered for each request and cleaned up afterwards", async () => {
@@ -82,7 +84,7 @@ describe("cloudflare adapter — buildFetchHandler", () => {
 
   test("tolerates a test-time executionCtx without waitUntil (after falls back to a no-op)", async () => {
     const response = await invoke(new Request("https://cms.example/"), {});
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(404);
   });
 
   test("passes the env + request through to the database adapter", async () => {
@@ -119,8 +121,8 @@ describe("cloudflare adapter — buildFetchHandler", () => {
       ),
     ]);
 
-    expect(a.status).toBe(200);
-    expect(b.status).toBe(200);
+    expect(a.status).toBe(404);
+    expect(b.status).toBe(404);
   });
 
   test("rejects /_plumix/* non-safe method without CSRF header (403)", async () => {
@@ -202,7 +204,7 @@ describe("cloudflare adapter — connectRequest", () => {
       {},
       adapter,
     );
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(404);
     expect(connectCalls.count).toBe(0);
   });
 
@@ -277,7 +279,7 @@ describe("cloudflare adapter — connectRequest", () => {
       {},
       adapter,
     );
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(404);
     expect(connectCalled).toBe(1);
   });
 
@@ -400,12 +402,12 @@ describe("cloudflare adapter — binding validation", () => {
       { DB: { fake: true } },
       adapterWithBindings,
     );
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(404);
   });
 
   test("adapter without requiredBindings is unaffected (opt-in behaviour)", async () => {
     const response = await invoke(new Request("https://cms.example/"), {});
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(404);
   });
 
   test("validation is memoised — runs once per Worker isolate", async () => {


### PR DESCRIPTION
## Summary

- `ctx.addRewriteRule(pattern, intent, options?)` plugin API + `RouteIntent` union (`single | archive`). `compileRouteMap` builds a sorted `URLPattern` array at `buildApp` time; dispatcher matches public URLs via `URLPattern.exec()`. Collision detection names both offending plugins; `hasArchive: string` validated to a single kebab-case segment.
- Content pipeline migrated from HTML to Tiptap JSON. Admin editor round-trips via `getJSON()` / `JSON.parse(value)`; public renderer walks the JSON against a node-type allowlist (paragraph / heading / lists / blockquote / codeBlock / marks / link). Unknown nodes render empty — arbitrary HTML submitted through the RPC cannot reach public pages. The walker is the trust boundary.
- Default HTML document shell + `escapeAttr` helper for attribute-context output. 22 new unit tests across `route/{compile,match,resolve}` and `render/{tiptap,document}`; dispatcher integration tests extended with a plugin-registered public route. Core suite: 457 tests passing.

## Deviations from architecture.md

- `RouteIntent` omits match-time fields (slug/page); those come from URLPattern params at resolve time.
- Route map compiled at `buildApp` rather than emitted by the Vite plugin as `dist/_plumix/routes.js`. Semantically identical inside a worker isolate.
- Hand-rolled Tiptap walker instead of `@tiptap/html` (pulls ~200kB of `@tiptap/core` + ProseMirror schema into every worker bundle).

## Out of scope — follow-ups

- `ctx.addRouteHandler`, other intent kinds (`taxonomy` / `search` / `front-page` / `handler` / `redirect`).
- Hierarchical `parentId` URL walking — lands with the pages plugin.
- `permalinks` structure tags (`%year%`, `%postname%`, …), `route:before_resolve` filter, rate limiting.
- URL reversal primitive — archive `<li>` hrefs currently reconstruct from `rewrite.slug` directly, which would go stale if a plugin overrides the auto-route with `addRewriteRule`.

## Breaking

- `/` no longer returns the `<h1>Plumix</h1>` placeholder; unmatched public paths return 404 with `x-plumix-hint: public-route-not-found`. Public routes are GET/HEAD-only (405 on other methods).
- `posts.content` format changed from HTML to Tiptap JSON. Pre-1.0, no migration script — dev databases reset; no production dogfood installs.

## Test plan

- [x] `pnpm turbo run typecheck lint test build` — 32/32 green
- [x] core: 457 tests passing (22 new across route module + walker)
- [x] cloudflare adapter tests updated for the new 404 default
- [x] admin e2e content specs updated for JSON content payloads