### PR TITLE
feat(core,admin): term meta boxes + collapse meta registration to one primitive

### DIFF
--- a/examples/minimal/test/build.integration.test.ts
+++ b/examples/minimal/test/build.integration.test.ts
@@ -53,7 +53,7 @@ describe("examples/minimal — plumix build", () => {
       // page load.
       const adminHtml = readFileSync(adminIndexHtml, "utf8");
       expect(adminHtml).toMatch(
-        /<script id="plumix-manifest" type="application\/json">\{"entryTypes":\[\],"taxonomies":\[\],"metaBoxes":\[\],"settingsGroups":\[\],"settingsPages":\[\]\}<\/script>/,
+        /<script id="plumix-manifest" type="application\/json">\{"entryTypes":\[\],"taxonomies":\[\],"entryMetaBoxes":\[\],"termMetaBoxes":\[\],"settingsGroups":\[\],"settingsPages":\[\]\}<\/script>/,
       );
     },
     60_000,

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -110,7 +110,7 @@ export const MANIFEST_WITH_POST: PlumixManifest = {
     },
   ],
   taxonomies: [],
-  metaBoxes: [],
+  entryMetaBoxes: [], termMetaBoxes: [],
   settingsGroups: [],
   settingsPages: [],
 };
@@ -140,7 +140,7 @@ export const MANIFEST_WITH_TAXONOMIES: PlumixManifest = {
       labels: { singular: "Tag" },
     },
   ],
-  metaBoxes: [],
+  entryMetaBoxes: [], termMetaBoxes: [],
   settingsGroups: [],
   settingsPages: [],
 };
@@ -157,7 +157,7 @@ export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
     },
   ],
   taxonomies: [],
-  metaBoxes: [
+  entryMetaBoxes: [
     {
       id: "seo",
       label: "SEO",
@@ -167,6 +167,7 @@ export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
         {
           key: "meta_title",
           label: "Meta title",
+          type: "string",
           inputType: "text",
           maxLength: 60,
         },
@@ -181,11 +182,13 @@ export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
         {
           key: "is_featured",
           label: "Featured",
+          type: "boolean",
           inputType: "checkbox",
         },
       ],
     },
   ],
+  termMetaBoxes: [],
   settingsGroups: [],
   settingsPages: [],
 };
@@ -198,7 +201,7 @@ export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
 export const MANIFEST_WITH_SETTINGS: PlumixManifest = {
   entryTypes: [],
   taxonomies: [],
-  metaBoxes: [],
+  entryMetaBoxes: [], termMetaBoxes: [],
   settingsGroups: [
     {
       name: "identity",

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -110,7 +110,8 @@ export const MANIFEST_WITH_POST: PlumixManifest = {
     },
   ],
   taxonomies: [],
-  entryMetaBoxes: [], termMetaBoxes: [],
+  entryMetaBoxes: [],
+  termMetaBoxes: [],
   settingsGroups: [],
   settingsPages: [],
 };
@@ -140,7 +141,8 @@ export const MANIFEST_WITH_TAXONOMIES: PlumixManifest = {
       labels: { singular: "Tag" },
     },
   ],
-  entryMetaBoxes: [], termMetaBoxes: [],
+  entryMetaBoxes: [],
+  termMetaBoxes: [],
   settingsGroups: [],
   settingsPages: [],
 };
@@ -201,7 +203,8 @@ export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
 export const MANIFEST_WITH_SETTINGS: PlumixManifest = {
   entryTypes: [],
   taxonomies: [],
-  entryMetaBoxes: [], termMetaBoxes: [],
+  entryMetaBoxes: [],
+  termMetaBoxes: [],
   settingsGroups: [
     {
       name: "identity",

--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -10,7 +10,7 @@ import { useForm, useStore } from "@tanstack/react-form";
 import { useBlocker } from "@tanstack/react-router";
 import * as v from "valibot";
 
-import type { MetaBoxManifestEntry } from "@plumix/core/manifest";
+import type { EntryMetaBoxManifestEntry } from "@plumix/core/manifest";
 import type { EntryStatus } from "@plumix/core/schema";
 import { slugify } from "@plumix/core/slugify";
 
@@ -72,7 +72,7 @@ interface PostEditorFormProps {
    * into side / normal / advanced columns internally based on
    * `entry.context`.
    */
-  readonly metaBoxes: readonly MetaBoxManifestEntry[];
+  readonly metaBoxes: readonly EntryMetaBoxManifestEntry[];
   readonly submitLabel: string;
   readonly isSubmitting: boolean;
   readonly serverError?: string | null;
@@ -320,14 +320,14 @@ function capitalize(value: string): string {
 // Bucket boxes by context. Undefined `context` is treated as "normal"
 // (matches WP's default); unknown values fall through to the main
 // column so a plugin-specific `context` doesn't vanish into nowhere.
-function partitionBoxesByContext(boxes: readonly MetaBoxManifestEntry[]): {
-  side: readonly MetaBoxManifestEntry[];
-  normal: readonly MetaBoxManifestEntry[];
-  advanced: readonly MetaBoxManifestEntry[];
+function partitionBoxesByContext(boxes: readonly EntryMetaBoxManifestEntry[]): {
+  side: readonly EntryMetaBoxManifestEntry[];
+  normal: readonly EntryMetaBoxManifestEntry[];
+  advanced: readonly EntryMetaBoxManifestEntry[];
 } {
-  const side: MetaBoxManifestEntry[] = [];
-  const normal: MetaBoxManifestEntry[] = [];
-  const advanced: MetaBoxManifestEntry[] = [];
+  const side: EntryMetaBoxManifestEntry[] = [];
+  const normal: EntryMetaBoxManifestEntry[] = [];
+  const advanced: EntryMetaBoxManifestEntry[] = [];
   for (const box of boxes) {
     if (box.context === "side") side.push(box);
     else if (box.context === "advanced") advanced.push(box);
@@ -345,7 +345,7 @@ function MetaBoxRegion({
   onChange,
   disabled,
 }: {
-  readonly boxes: readonly MetaBoxManifestEntry[];
+  readonly boxes: readonly EntryMetaBoxManifestEntry[];
   readonly testId: string;
   readonly values: Readonly<Record<string, unknown>>;
   readonly onChange: (key: string, next: unknown) => void;

--- a/packages/admin/src/components/meta-box/meta-box-field.test.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.test.tsx
@@ -21,6 +21,7 @@ function field(
   return {
     key: "k",
     label: "Label",
+    type: "string",
     ...overrides,
   };
 }

--- a/packages/admin/src/components/meta-box/meta-box.tsx
+++ b/packages/admin/src/components/meta-box/meta-box.tsx
@@ -6,7 +6,7 @@ import {
   CardTitle,
 } from "@/components/ui/card.js";
 
-import type { MetaBoxManifestEntry } from "@plumix/core/manifest";
+import type { EntryMetaBoxManifestEntry } from "@plumix/core/manifest";
 
 import { MetaBoxField } from "./meta-box-field.js";
 
@@ -19,7 +19,7 @@ export function MetaBox({
   onChange,
   disabled = false,
 }: {
-  readonly box: MetaBoxManifestEntry;
+  readonly box: EntryMetaBoxManifestEntry;
   readonly values: Readonly<Record<string, unknown>>;
   readonly onChange: (key: string, value: unknown) => void;
   readonly disabled?: boolean;

--- a/packages/admin/src/components/meta-box/term-meta-box-card.tsx
+++ b/packages/admin/src/components/meta-box/term-meta-box-card.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { orpc } from "@/lib/orpc.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { TermMetaBoxManifestEntry } from "@plumix/core/manifest";
+
+import { MetaBoxField } from "./meta-box-field.js";
+
+/**
+ * One shadcn `<Card>` for a registered term meta box. Each card is an
+ * independent form — its Save button fires `term.update` with just
+ * that box's fields as the meta patch, same per-card atomic save model
+ * as settings pages.
+ */
+export function TermMetaBoxCard({
+  box,
+  term,
+  taxonomyName,
+  disabled = false,
+}: {
+  readonly box: TermMetaBoxManifestEntry;
+  readonly term: {
+    readonly id: number;
+    readonly meta?: Readonly<Record<string, unknown>>;
+  };
+  readonly taxonomyName: string;
+  readonly disabled?: boolean;
+}): ReactNode {
+  const queryClient = useQueryClient();
+  const stored = term.meta ?? {};
+  const initial: Record<string, unknown> = {};
+  for (const field of box.fields) {
+    initial[field.key] = stored[field.key] ?? field.default;
+  }
+  const [values, setValues] = useState<Record<string, unknown>>(initial);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [saveNotice, setSaveNotice] = useState<string | null>(null);
+
+  const save = useMutation({
+    mutationFn: (next: Record<string, unknown>) =>
+      orpc.term.update.call({ id: term.id, meta: next }),
+    onMutate: () => {
+      setServerError(null);
+      setSaveNotice(null);
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.term.get.queryOptions({ input: { id: term.id } })
+            .queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.term.list.key({ input: { taxonomy: taxonomyName } }),
+        }),
+      ]);
+      setSaveNotice("Saved.");
+    },
+    onError: (err) => {
+      setServerError(
+        err instanceof Error ? err.message : "Couldn't save these fields.",
+      );
+    },
+  });
+
+  return (
+    <Card data-testid={`term-meta-box-${box.id}`}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          save.mutate(values);
+        }}
+      >
+        <CardHeader>
+          <CardTitle>
+            <h2
+              className="text-lg font-semibold"
+              data-testid={`term-meta-box-heading-${box.id}`}
+            >
+              {box.label}
+            </h2>
+          </CardTitle>
+          {box.description ? (
+            <CardDescription>{box.description}</CardDescription>
+          ) : null}
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {box.fields.map((field) => (
+            <MetaBoxField
+              key={field.key}
+              field={field}
+              value={values[field.key]}
+              disabled={disabled || save.isPending}
+              onChange={(next) => {
+                setValues((prev) => ({ ...prev, [field.key]: next }));
+              }}
+            />
+          ))}
+
+          {serverError ? (
+            <Alert
+              variant="destructive"
+              data-testid={`term-meta-box-error-${box.id}`}
+            >
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {saveNotice ? (
+            <Alert data-testid={`term-meta-box-notice-${box.id}`}>
+              <AlertDescription>{saveNotice}</AlertDescription>
+            </Alert>
+          ) : null}
+        </CardContent>
+        <div className="flex justify-end px-6 pb-6">
+          <Button
+            type="submit"
+            disabled={disabled || save.isPending}
+            data-testid={`term-meta-box-submit-${box.id}`}
+          >
+            {save.isPending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/packages/admin/src/components/meta-box/term-meta-box-card.tsx
+++ b/packages/admin/src/components/meta-box/term-meta-box-card.tsx
@@ -16,6 +16,18 @@ import type { TermMetaBoxManifestEntry } from "@plumix/core/manifest";
 
 import { MetaBoxField } from "./meta-box-field.js";
 
+function seedFromTerm(
+  fields: TermMetaBoxManifestEntry["fields"],
+  meta: Readonly<Record<string, unknown>> | null | undefined,
+): Record<string, unknown> {
+  const bag = meta ?? {};
+  const seed: Record<string, unknown> = {};
+  for (const field of fields) {
+    seed[field.key] = bag[field.key] ?? field.default;
+  }
+  return seed;
+}
+
 /**
  * One shadcn `<Card>` for a registered term meta box. Each card is an
  * independent form — its Save button fires `term.update` with just
@@ -37,12 +49,9 @@ export function TermMetaBoxCard({
   readonly disabled?: boolean;
 }): ReactNode {
   const queryClient = useQueryClient();
-  const stored = term.meta ?? {};
-  const initial: Record<string, unknown> = {};
-  for (const field of box.fields) {
-    initial[field.key] = stored[field.key] ?? field.default;
-  }
-  const [values, setValues] = useState<Record<string, unknown>>(initial);
+  const [values, setValues] = useState<Record<string, unknown>>(() =>
+    seedFromTerm(box.fields, term.meta),
+  );
   const [serverError, setServerError] = useState<string | null>(null);
   const [saveNotice, setSaveNotice] = useState<string | null>(null);
 
@@ -53,7 +62,11 @@ export function TermMetaBoxCard({
       setServerError(null);
       setSaveNotice(null);
     },
-    onSuccess: async () => {
+    onSuccess: async (data) => {
+      // Re-seed from the server's authoritative post-sanitize bag so
+      // the form reflects any trimming / coercion the server applied
+      // (see `coerceOnRead` / plugin sanitize hooks).
+      setValues(seedFromTerm(box.fields, data.meta));
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: orpc.term.get.queryOptions({ input: { id: term.id } })
@@ -110,6 +123,7 @@ export function TermMetaBoxCard({
           {serverError ? (
             <Alert
               variant="destructive"
+              role="alert"
               data-testid={`term-meta-box-error-${box.id}`}
             >
               <AlertDescription>{serverError}</AlertDescription>
@@ -117,7 +131,10 @@ export function TermMetaBoxCard({
           ) : null}
 
           {saveNotice ? (
-            <Alert data-testid={`term-meta-box-notice-${box.id}`}>
+            <Alert
+              aria-live="polite"
+              data-testid={`term-meta-box-notice-${box.id}`}
+            >
               <AlertDescription>{saveNotice}</AlertDescription>
             </Alert>
           ) : null}

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import type {
-  MetaBoxManifestEntry,
+  EntryMetaBoxManifestEntry,
   PlumixManifest,
   SettingsPageManifestEntry,
 } from "@plumix/core/manifest";
@@ -12,7 +12,7 @@ import {
   findSettingsPageByName,
   findTaxonomyByName,
   groupsForSettingsPage,
-  metaBoxesForEntryType,
+  entryMetaBoxesForType,
   readManifest,
   visibleEntryTypes,
   visibleSettingsPages,
@@ -39,7 +39,7 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -54,7 +54,7 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [{ name: "post", label: "Posts" }],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -65,7 +65,7 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -79,7 +79,7 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -91,7 +91,7 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -104,7 +104,7 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -114,7 +114,7 @@ describe("readManifest", () => {
     const doc = withManifestScript(
       JSON.stringify({
         entryTypes: [],
-        metaBoxes: [
+        entryMetaBoxes: [
           {
             id: "seo",
             label: "SEO",
@@ -127,7 +127,7 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      metaBoxes: [
+      entryMetaBoxes: [
         {
           id: "seo",
           label: "SEO",
@@ -135,6 +135,7 @@ describe("readManifest", () => {
           fields: [],
         },
       ],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -162,7 +163,7 @@ describe("readManifest", () => {
           isHierarchical: true,
         },
       ],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -183,7 +184,7 @@ describe("findEntryTypeBySlug", () => {
       { name: "product", adminSlug: "products", label: "Products" },
     ],
     taxonomies: [],
-    metaBoxes: [],
+    entryMetaBoxes: [], termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -215,7 +216,7 @@ describe("visibleEntryTypes", () => {
       },
     ],
     taxonomies: [],
-    metaBoxes: [],
+    entryMetaBoxes: [], termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -233,11 +234,11 @@ describe("visibleEntryTypes", () => {
   });
 });
 
-describe("metaBoxesForEntryType", () => {
+describe("entryMetaBoxesForType", () => {
   const box = (
     id: string,
-    overrides: Partial<MetaBoxManifestEntry> = {},
-  ): MetaBoxManifestEntry => ({
+    overrides: Partial<EntryMetaBoxManifestEntry> = {},
+  ): EntryMetaBoxManifestEntry => ({
     id,
     label: id,
     entryTypes: ["post"],
@@ -249,15 +250,16 @@ describe("metaBoxesForEntryType", () => {
     const source: PlumixManifest = {
       taxonomies: [],
       entryTypes: [],
-      metaBoxes: [
+      entryMetaBoxes: [
         box("a", { priority: "low" }),
         box("b", { priority: "high" }),
         box("c"), // default
       ],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
-    const ids = metaBoxesForEntryType("post", [], source).map((b) => b.id);
+    const ids = entryMetaBoxesForType("post", [], source).map((b) => b.id);
     expect(ids).toEqual(["b", "c", "a"]);
   });
 
@@ -265,14 +267,15 @@ describe("metaBoxesForEntryType", () => {
     const source: PlumixManifest = {
       taxonomies: [],
       entryTypes: [],
-      metaBoxes: [
+      entryMetaBoxes: [
         box("first", { priority: "high" }),
         box("second", { priority: "high" }),
       ],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
-    const ids = metaBoxesForEntryType("post", [], source).map((b) => b.id);
+    const ids = entryMetaBoxesForType("post", [], source).map((b) => b.id);
     expect(ids).toEqual(["first", "second"]);
   });
 
@@ -280,14 +283,15 @@ describe("metaBoxesForEntryType", () => {
     const source: PlumixManifest = {
       taxonomies: [],
       entryTypes: [],
-      metaBoxes: [
+      entryMetaBoxes: [
         box("seo", { entryTypes: ["post"] }),
         box("shop", { entryTypes: ["product"] }),
       ],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
-    const ids = metaBoxesForEntryType("post", [], source).map((b) => b.id);
+    const ids = entryMetaBoxesForType("post", [], source).map((b) => b.id);
     expect(ids).toEqual(["seo"]);
   });
 
@@ -295,19 +299,20 @@ describe("metaBoxesForEntryType", () => {
     const source: PlumixManifest = {
       taxonomies: [],
       entryTypes: [],
-      metaBoxes: [
+      entryMetaBoxes: [
         box("public"),
         box("privileged", { capability: "post:edit_any" }),
       ],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
-    const withoutCap = metaBoxesForEntryType("post", [], source).map(
+    const withoutCap = entryMetaBoxesForType("post", [], source).map(
       (b) => b.id,
     );
     expect(withoutCap).toEqual(["public"]);
 
-    const withCap = metaBoxesForEntryType(
+    const withCap = entryMetaBoxesForType(
       "post",
       ["post:edit_any"],
       source,
@@ -319,11 +324,11 @@ describe("metaBoxesForEntryType", () => {
     const source: PlumixManifest = {
       entryTypes: [],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
-    expect(metaBoxesForEntryType("post", [], source)).toEqual([]);
+    expect(entryMetaBoxesForType("post", [], source)).toEqual([]);
   });
 });
 
@@ -334,7 +339,7 @@ describe("findTaxonomyByName", () => {
       { name: "category", label: "Categories", isHierarchical: true },
       { name: "tag", label: "Tags" },
     ],
-    metaBoxes: [],
+    entryMetaBoxes: [], termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -356,7 +361,7 @@ describe("visibleTaxonomies", () => {
       { name: "tag", label: "Tags" },
       { name: "internal", label: "Internal" },
     ],
-    metaBoxes: [],
+    entryMetaBoxes: [], termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -376,7 +381,7 @@ describe("findSettingsPageByName + visibleSettingsPages + findSettingsGroupByNam
   const source: PlumixManifest = {
     entryTypes: [],
     taxonomies: [],
-    metaBoxes: [],
+    entryMetaBoxes: [], termMetaBoxes: [],
     settingsGroups: [
       {
         name: "identity",

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -7,12 +7,12 @@ import type {
 } from "@plumix/core/manifest";
 
 import {
+  entryMetaBoxesForType,
   findEntryTypeBySlug,
   findSettingsGroupByName,
   findSettingsPageByName,
   findTaxonomyByName,
   groupsForSettingsPage,
-  entryMetaBoxesForType,
   readManifest,
   visibleEntryTypes,
   visibleSettingsPages,
@@ -39,7 +39,8 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -54,7 +55,8 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [{ name: "post", label: "Posts" }],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -65,7 +67,8 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -79,7 +82,8 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -91,7 +95,8 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -104,7 +109,8 @@ describe("readManifest", () => {
     expect(readManifest(doc)).toEqual({
       entryTypes: [],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -163,7 +169,8 @@ describe("readManifest", () => {
           isHierarchical: true,
         },
       ],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -184,7 +191,8 @@ describe("findEntryTypeBySlug", () => {
       { name: "product", adminSlug: "products", label: "Products" },
     ],
     taxonomies: [],
-    entryMetaBoxes: [], termMetaBoxes: [],
+    entryMetaBoxes: [],
+    termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -216,7 +224,8 @@ describe("visibleEntryTypes", () => {
       },
     ],
     taxonomies: [],
-    entryMetaBoxes: [], termMetaBoxes: [],
+    entryMetaBoxes: [],
+    termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -324,7 +333,8 @@ describe("entryMetaBoxesForType", () => {
     const source: PlumixManifest = {
       entryTypes: [],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -339,7 +349,8 @@ describe("findTaxonomyByName", () => {
       { name: "category", label: "Categories", isHierarchical: true },
       { name: "tag", label: "Tags" },
     ],
-    entryMetaBoxes: [], termMetaBoxes: [],
+    entryMetaBoxes: [],
+    termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -361,7 +372,8 @@ describe("visibleTaxonomies", () => {
       { name: "tag", label: "Tags" },
       { name: "internal", label: "Internal" },
     ],
-    entryMetaBoxes: [], termMetaBoxes: [],
+    entryMetaBoxes: [],
+    termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -381,7 +393,8 @@ describe("findSettingsPageByName + visibleSettingsPages + findSettingsGroupByNam
   const source: PlumixManifest = {
     entryTypes: [],
     taxonomies: [],
-    entryMetaBoxes: [], termMetaBoxes: [],
+    entryMetaBoxes: [],
+    termMetaBoxes: [],
     settingsGroups: [
       {
         name: "identity",

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -1,10 +1,11 @@
 import type {
+  EntryMetaBoxManifestEntry,
   EntryTypeManifestEntry,
-  MetaBoxManifestEntry,
   PlumixManifest,
   SettingsGroupManifestEntry,
   SettingsPageManifestEntry,
   TaxonomyManifestEntry,
+  TermMetaBoxManifestEntry,
 } from "@plumix/core/manifest";
 import { emptyManifest, MANIFEST_SCRIPT_ID } from "@plumix/core/manifest";
 
@@ -35,13 +36,16 @@ function normalize(value: unknown): PlumixManifest {
   if (!value || typeof value !== "object") return emptyManifest();
   const entryTypes = (value as { entryTypes?: unknown }).entryTypes;
   const taxonomies = (value as { taxonomies?: unknown }).taxonomies;
-  const metaBoxes = (value as { metaBoxes?: unknown }).metaBoxes;
+  const entryMetaBoxes = (value as { entryMetaBoxes?: unknown })
+    .entryMetaBoxes;
+  const termMetaBoxes = (value as { termMetaBoxes?: unknown }).termMetaBoxes;
   const settingsGroups = (value as { settingsGroups?: unknown }).settingsGroups;
   const settingsPages = (value as { settingsPages?: unknown }).settingsPages;
   return {
     entryTypes: Array.isArray(entryTypes) ? entryTypes : [],
     taxonomies: Array.isArray(taxonomies) ? taxonomies : [],
-    metaBoxes: Array.isArray(metaBoxes) ? metaBoxes : [],
+    entryMetaBoxes: Array.isArray(entryMetaBoxes) ? entryMetaBoxes : [],
+    termMetaBoxes: Array.isArray(termMetaBoxes) ? termMetaBoxes : [],
     settingsGroups: Array.isArray(settingsGroups) ? settingsGroups : [],
     settingsPages: Array.isArray(settingsPages) ? settingsPages : [],
   };
@@ -116,11 +120,12 @@ export function visibleTaxonomies(
   return source.taxonomies.filter((tax) => caps.has(`${tax.name}:read`));
 }
 
-// Ordering for meta-box `priority`. Boxes render top-down in the editor
-// sidebar; "high" pins above the fold, "low" drops to the bottom. Registry
-// insertion order breaks ties (Array.prototype.sort is stable per ES2019).
+// Ordering for entry meta-box `priority`. Boxes render top-down in the
+// editor sidebar; "high" pins above the fold, "low" drops to the
+// bottom. Registry insertion order breaks ties (Array.prototype.sort is
+// stable per ES2019).
 const META_BOX_PRIORITY_WEIGHT: Record<
-  NonNullable<MetaBoxManifestEntry["priority"]>,
+  NonNullable<EntryMetaBoxManifestEntry["priority"]>,
   number
 > = {
   high: 0,
@@ -129,20 +134,19 @@ const META_BOX_PRIORITY_WEIGHT: Record<
 };
 
 /**
- * Resolve the set of meta boxes the editor should render for a given
- * entry type, honouring each box's optional capability gate. Returned in
- * render order: by `priority` (high → default → low; undefined treated
- * as "default"), with registration order as the stable tiebreaker.
+ * Resolve the set of entry meta boxes the editor should render for a
+ * given entry type, honouring each box's optional capability gate.
+ * Returned in render order: by `priority` (high → default → low;
+ * undefined treated as "default"), with registration order as the
+ * stable tiebreaker.
  */
-export function metaBoxesForEntryType(
+export function entryMetaBoxesForType(
   entryTypeName: string,
   capabilities: readonly string[],
   source: PlumixManifest = manifest,
-): readonly MetaBoxManifestEntry[] {
+): readonly EntryMetaBoxManifestEntry[] {
   const caps = new Set(capabilities);
-  // `.filter()` already returns a fresh array, so subsequent `.sort()` is
-  // safe to do in place — no need to copy again.
-  return source.metaBoxes
+  return source.entryMetaBoxes
     .filter((box) => {
       if (!box.entryTypes.includes(entryTypeName)) return false;
       if (box.capability !== undefined && !caps.has(box.capability))
@@ -154,6 +158,25 @@ export function metaBoxesForEntryType(
       const bp = META_BOX_PRIORITY_WEIGHT[b.priority ?? "default"];
       return ap - bp;
     });
+}
+
+/**
+ * Resolve the term meta boxes rendered on the edit form for a given
+ * taxonomy. Same capability gate + registration-order shape as
+ * `entryMetaBoxesForType`; no `priority` tier because term forms
+ * render boxes stacked without a sidebar split.
+ */
+export function termMetaBoxesForTaxonomy(
+  taxonomyName: string,
+  capabilities: readonly string[],
+  source: PlumixManifest = manifest,
+): readonly TermMetaBoxManifestEntry[] {
+  const caps = new Set(capabilities);
+  return source.termMetaBoxes.filter((box) => {
+    if (!box.taxonomies.includes(taxonomyName)) return false;
+    if (box.capability !== undefined && !caps.has(box.capability)) return false;
+    return true;
+  });
 }
 
 /**

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -36,8 +36,7 @@ function normalize(value: unknown): PlumixManifest {
   if (!value || typeof value !== "object") return emptyManifest();
   const entryTypes = (value as { entryTypes?: unknown }).entryTypes;
   const taxonomies = (value as { taxonomies?: unknown }).taxonomies;
-  const entryMetaBoxes = (value as { entryMetaBoxes?: unknown })
-    .entryMetaBoxes;
+  const entryMetaBoxes = (value as { entryMetaBoxes?: unknown }).entryMetaBoxes;
   const termMetaBoxes = (value as { termMetaBoxes?: unknown }).termMetaBoxes;
   const settingsGroups = (value as { settingsGroups?: unknown }).settingsGroups;
   const settingsPages = (value as { settingsPages?: unknown }).settingsPages;

--- a/packages/admin/src/routes/_authenticated/entries/$slug/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/$id.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/editor/entry-editor-form.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import { hasCap } from "@/lib/caps.js";
-import { findEntryTypeBySlug, entryMetaBoxesForType } from "@/lib/manifest.js";
+import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import {
   useMutation,

--- a/packages/admin/src/routes/_authenticated/entries/$slug/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/$id.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/editor/entry-editor-form.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import { hasCap } from "@/lib/caps.js";
-import { findEntryTypeBySlug, metaBoxesForEntryType } from "@/lib/manifest.js";
+import { findEntryTypeBySlug, entryMetaBoxesForType } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import {
   useMutation,
@@ -126,7 +126,7 @@ function EditPostRoute(): ReactNode {
   ).toLowerCase();
 
   const metaBoxes = useMemo(
-    () => metaBoxesForEntryType(entryType.name, user.capabilities),
+    () => entryMetaBoxesForType(entryType.name, user.capabilities),
     [entryType.name, user.capabilities],
   );
 

--- a/packages/admin/src/routes/_authenticated/entries/$slug/new.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/new.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { PostEditorForm } from "@/components/editor/entry-editor-form.js";
 import { hasCap } from "@/lib/caps.js";
-import { findEntryTypeBySlug, entryMetaBoxesForType } from "@/lib/manifest.js";
+import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useMutation } from "@tanstack/react-query";
 import {

--- a/packages/admin/src/routes/_authenticated/entries/$slug/new.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/new.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { PostEditorForm } from "@/components/editor/entry-editor-form.js";
 import { hasCap } from "@/lib/caps.js";
-import { findEntryTypeBySlug, metaBoxesForEntryType } from "@/lib/manifest.js";
+import { findEntryTypeBySlug, entryMetaBoxesForType } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useMutation } from "@tanstack/react-query";
 import {
@@ -95,7 +95,7 @@ function NewPostRoute(): ReactNode {
   // capabilities. Memo keyed on `user.capabilities` avoids refiltering
   // every render while keeping the helper out of the component body.
   const metaBoxes = useMemo(
-    () => metaBoxesForEntryType(entryType.name, user.capabilities),
+    () => entryMetaBoxesForType(entryType.name, user.capabilities),
     [entryType.name, user.capabilities],
   );
 

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/$id.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { FormEditSkeleton } from "@/components/form/edit-skeleton.js";
+import { TermMetaBoxCard } from "@/components/meta-box/term-meta-box-card.js";
 import { TermForm } from "@/components/taxonomy/term-form.js";
 import {
   descendantIds,
@@ -16,7 +17,10 @@ import {
   CardTitle,
 } from "@/components/ui/card.js";
 import { hasCap } from "@/lib/caps.js";
-import { findTaxonomyByName } from "@/lib/manifest.js";
+import {
+  findTaxonomyByName,
+  termMetaBoxesForTaxonomy,
+} from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import {
   useMutation,
@@ -141,6 +145,7 @@ function EditTermContent({
     readonly slug: string;
     readonly description: string | null;
     readonly parentId: number | null;
+    readonly meta?: Readonly<Record<string, unknown>>;
   };
   readonly isHierarchical: boolean;
   readonly parentOptions: readonly {
@@ -196,6 +201,11 @@ function EditTermContent({
   const singularLower = (
     taxonomy.labels?.singular ?? taxonomy.label
   ).toLowerCase();
+  // Plugin-registered meta boxes for this taxonomy. Each one renders
+  // as an independent card with its own save button, parallel to the
+  // settings-page card-per-group model.
+  const { user } = Route.useRouteContext();
+  const metaBoxes = termMetaBoxesForTaxonomy(taxonomy.name, user.capabilities);
 
   return (
     <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
@@ -246,6 +256,16 @@ function EditTermContent({
           />
         </CardContent>
       </Card>
+
+      {metaBoxes.map((box) => (
+        <TermMetaBoxCard
+          key={box.id}
+          box={box}
+          term={term}
+          taxonomyName={taxonomy.name}
+          disabled={!canEdit}
+        />
+      ))}
 
       {canDelete ? (
         <DeleteCard

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -13,13 +13,13 @@ import type {
 } from "../hooks/types.js";
 import type { RouteIntent } from "../route/intent.js";
 import type {
+  EntryMetaBoxOptions,
   EntryTypeOptions,
-  MetaBoxOptions,
-  MetaOptions,
   MutablePluginRegistry,
   SettingsGroupOptions,
   SettingsPageOptions,
   TaxonomyOptions,
+  TermMetaBoxOptions,
 } from "./manifest.js";
 import {
   deriveEntryTypeCapabilities,
@@ -64,8 +64,22 @@ export interface PluginSetupContext {
 
   registerEntryType(name: string, options: EntryTypeOptions): void;
   registerTaxonomy(name: string, options: TaxonomyOptions): void;
-  registerMeta(key: string, options: MetaOptions): void;
-  registerMetaBox(id: string, options: MetaBoxOptions): void;
+  /**
+   * Declare a meta box on the entry editor sidebar. The fields inside
+   * the box drive both the admin input rendering and the server-side
+   * storage schema (type + sanitize) — there is no separate
+   * `registerMeta` step. Throws `DuplicateRegistrationError` on id
+   * collision; `buildManifest` rejects two boxes writing to the same
+   * `(entryType, field.key)` pair.
+   */
+  registerEntryMetaBox(id: string, options: EntryMetaBoxOptions): void;
+  /**
+   * Same model as `registerEntryMetaBox`, but scoped to taxonomies and
+   * rendered on the term edit form as one stacked shadcn `<Card>` per
+   * box. `registerTermMeta` is not a separate step — the box's fields
+   * are the meta key contract.
+   */
+  registerTermMetaBox(id: string, options: TermMetaBoxOptions): void;
   registerCapability(name: string, minRole: UserRole): void;
 
   /**
@@ -172,16 +186,26 @@ export function createPluginSetupContext({
       addDerivedCaps(deriveTaxonomyCapabilities(name));
     },
 
-    registerMeta: (key, options) => {
-      if (registry.metaKeys.has(key))
-        throw new DuplicateRegistrationError("meta key", key);
-      registry.metaKeys.set(key, { ...options, key, registeredBy: pluginId });
+    registerEntryMetaBox: (id, options) => {
+      if (registry.entryMetaBoxes.has(id)) {
+        throw new DuplicateRegistrationError("entry meta box", id);
+      }
+      registry.entryMetaBoxes.set(id, {
+        ...options,
+        id,
+        registeredBy: pluginId,
+      });
     },
 
-    registerMetaBox: (id, options) => {
-      if (registry.metaBoxes.has(id))
-        throw new DuplicateRegistrationError("meta box", id);
-      registry.metaBoxes.set(id, { ...options, id, registeredBy: pluginId });
+    registerTermMetaBox: (id, options) => {
+      if (registry.termMetaBoxes.has(id)) {
+        throw new DuplicateRegistrationError("term meta box", id);
+      }
+      registry.termMetaBoxes.set(id, {
+        ...options,
+        id,
+        registeredBy: pluginId,
+      });
     },
 
     registerCapability: (name, minRole) => {

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -15,6 +15,7 @@ import type { RouteIntent } from "../route/intent.js";
 import type {
   EntryMetaBoxOptions,
   EntryTypeOptions,
+  MetaBoxField,
   MutablePluginRegistry,
   SettingsGroupOptions,
   SettingsPageOptions,
@@ -190,6 +191,7 @@ export function createPluginSetupContext({
       if (registry.entryMetaBoxes.has(id)) {
         throw new DuplicateRegistrationError("entry meta box", id);
       }
+      assertMetaBoxFields("entry meta box", id, options.fields);
       registry.entryMetaBoxes.set(id, {
         ...options,
         id,
@@ -201,6 +203,7 @@ export function createPluginSetupContext({
       if (registry.termMetaBoxes.has(id)) {
         throw new DuplicateRegistrationError("term meta box", id);
       }
+      assertMetaBoxFields("term meta box", id, options.fields);
       registry.termMetaBoxes.set(id, {
         ...options,
         id,
@@ -306,6 +309,33 @@ function assertUniqueFieldNames(
       );
     }
     seen.add(field.name);
+  }
+}
+
+// Must match the RPC input-schema regex for meta keys — any key that
+// doesn't match is dead code (the write path rejects it), so catch it
+// at registration instead of letting the admin discover it later.
+const META_FIELD_KEY_RE = /^[a-zA-Z0-9_:-]+$/;
+
+function assertMetaBoxFields(
+  kind: string,
+  id: string,
+  fields: readonly MetaBoxField[],
+): void {
+  const seen = new Set<string>();
+  for (const field of fields) {
+    if (!META_FIELD_KEY_RE.test(field.key)) {
+      throw new Error(
+        `${kind} "${id}" declares field with invalid key "${field.key}" — ` +
+          `meta keys must match ${META_FIELD_KEY_RE}.`,
+      );
+    }
+    if (seen.has(field.key)) {
+      throw new Error(
+        `${kind} "${id}" declares field "${field.key}" more than once.`,
+      );
+    }
+    seen.add(field.key);
   }
 }
 

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -305,12 +305,13 @@ describe("buildManifest", () => {
     expect(names).toEqual(["early", "late", "unpositioned"]);
   });
 
-  test("projects registered meta boxes, dropping server-only fields", async () => {
+  test("projects registered entry meta boxes, dropping server-only fields", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("seo", (ctx) => {
       ctx.registerEntryType("post", { label: "Posts" });
-      ctx.registerMetaBox("seo-meta", {
+      ctx.registerEntryMetaBox("seo-meta", {
         label: "SEO",
+        description: "Meta title + description for search snippets.",
         context: "side",
         priority: "high",
         entryTypes: ["post"],
@@ -319,47 +320,133 @@ describe("buildManifest", () => {
           {
             key: "title",
             label: "Meta title",
+            type: "string",
             inputType: "text",
             maxLength: 60,
           },
-          { key: "desc", label: "Meta description", inputType: "textarea" },
+          {
+            key: "desc",
+            label: "Meta description",
+            type: "string",
+            inputType: "textarea",
+          },
         ],
       });
     });
     const { registry } = await installPlugins({ hooks, plugins: [plugin] });
 
     const manifest = buildManifest(registry);
-    expect(manifest.metaBoxes).toEqual([
+    expect(manifest.entryMetaBoxes).toHaveLength(1);
+    const [box] = manifest.entryMetaBoxes;
+    expect(box).toMatchObject({
+      id: "seo-meta",
+      label: "SEO",
+      description: "Meta title + description for search snippets.",
+      context: "side",
+      priority: "high",
+      entryTypes: ["post"],
+      capability: "post:edit_any",
+    });
+    expect(box?.fields).toEqual([
       {
-        id: "seo-meta",
-        label: "SEO",
-        context: "side",
-        priority: "high",
-        entryTypes: ["post"],
-        capability: "post:edit_any",
-        fields: [
-          {
-            key: "title",
-            label: "Meta title",
-            inputType: "text",
-            maxLength: 60,
-          },
-          { key: "desc", label: "Meta description", inputType: "textarea" },
-        ],
+        key: "title",
+        label: "Meta title",
+        type: "string",
+        inputType: "text",
+        description: undefined,
+        required: undefined,
+        placeholder: undefined,
+        maxLength: 60,
+        min: undefined,
+        max: undefined,
+        step: undefined,
+        options: undefined,
+        default: undefined,
+      },
+      {
+        key: "desc",
+        label: "Meta description",
+        type: "string",
+        inputType: "textarea",
+        description: undefined,
+        required: undefined,
+        placeholder: undefined,
+        maxLength: undefined,
+        min: undefined,
+        max: undefined,
+        step: undefined,
+        options: undefined,
+        default: undefined,
       },
     ]);
-    const entry = manifest.metaBoxes[0] as unknown as Record<string, unknown>;
+    const entry = box as unknown as Record<string, unknown>;
     expect(entry.registeredBy).toBeUndefined();
   });
 
-  test("empty meta-box registry yields an empty metaBoxes array", async () => {
+  test("projects registered term meta boxes, keyed by taxonomy", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("branding", (ctx) => {
+      ctx.registerTaxonomy("category", { label: "Categories" });
+      ctx.registerTermMetaBox("category-branding", {
+        label: "Branding",
+        description: "Optional icon + accent colour.",
+        taxonomies: ["category"],
+        fields: [
+          {
+            key: "icon_url",
+            label: "Icon URL",
+            type: "string",
+            inputType: "url",
+          },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    const manifest = buildManifest(registry);
+    expect(manifest.termMetaBoxes).toHaveLength(1);
+    expect(manifest.termMetaBoxes[0]).toMatchObject({
+      id: "category-branding",
+      label: "Branding",
+      taxonomies: ["category"],
+    });
+  });
+
+  test("rejects two entry boxes declaring the same field key on the same entry type", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("dupe", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts" });
+      ctx.registerEntryMetaBox("box-a", {
+        label: "A",
+        entryTypes: ["post"],
+        fields: [
+          { key: "title", label: "Title", type: "string", inputType: "text" },
+        ],
+      });
+      ctx.registerEntryMetaBox("box-b", {
+        label: "B",
+        entryTypes: ["post"],
+        fields: [
+          { key: "title", label: "Title", type: "string", inputType: "text" },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(() => buildManifest(registry)).toThrow(
+      /Meta field "title" is declared by entry meta boxes "box-a" and "box-b" on the same scope "post"/,
+    );
+  });
+
+  test("empty meta-box registry yields empty entry + term meta box arrays", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("blog", (ctx) => {
       ctx.registerEntryType("post", { label: "Posts" });
     });
     const { registry } = await installPlugins({ hooks, plugins: [plugin] });
 
-    expect(buildManifest(registry).metaBoxes).toEqual([]);
+    const manifest = buildManifest(registry);
+    expect(manifest.entryMetaBoxes).toEqual([]);
+    expect(manifest.termMetaBoxes).toEqual([]);
   });
 
   test("projects registered taxonomies, dropping server-only fields", async () => {
@@ -433,14 +520,14 @@ describe("serializeManifestScript", () => {
     const tag = serializeManifestScript({
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
     expect(tag).toContain(`id="${MANIFEST_SCRIPT_ID}"`);
     expect(tag).toContain(`type="application/json"`);
     expect(tag).toContain(
-      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
+      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
     );
   });
 
@@ -450,7 +537,7 @@ describe("serializeManifestScript", () => {
         { name: "post", adminSlug: "posts", label: "</script><b>x</b>" },
       ],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -462,7 +549,7 @@ describe("serializeManifestScript", () => {
     const manifest = {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "x</y>" }],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -487,15 +574,15 @@ describe("injectManifestIntoHtml", () => {
     const out = injectManifestIntoHtml(TEMPLATE, {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
     expect(out).toContain(
-      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
+      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
     );
     expect(out).not.toContain(
-      `{"entryTypes":[],"taxonomies":[],"metaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
+      `{"entryTypes":[],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
     );
   });
 
@@ -503,7 +590,7 @@ describe("injectManifestIntoHtml", () => {
     const manifest = {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -529,12 +616,12 @@ describe("injectManifestIntoHtml", () => {
     const out = injectManifestIntoHtml(html, {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
     expect(out).toContain(
-      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"metaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
+      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
     );
   });
 
@@ -545,12 +632,12 @@ describe("injectManifestIntoHtml", () => {
     const out = injectManifestIntoHtml(html, {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      metaBoxes: [],
+      entryMetaBoxes: [], termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
     expect(out).toMatch(
-      /^<script id="plumix-manifest" type="application\/json">\{"entryTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"taxonomies":\[\],"metaBoxes":\[\],"settingsGroups":\[\],"settingsPages":\[\]}<\/script>$/,
+      /^<script id="plumix-manifest" type="application\/json">\{"entryTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"taxonomies":\[\],"entryMetaBoxes":\[\],"termMetaBoxes":\[\],"settingsGroups":\[\],"settingsPages":\[\]}<\/script>$/,
     );
   });
 });

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -437,6 +437,64 @@ describe("buildManifest", () => {
     );
   });
 
+  test("rejects two term boxes declaring the same field key on the same taxonomy", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("dupe-term", (ctx) => {
+      ctx.registerTaxonomy("category", { label: "Categories" });
+      ctx.registerTermMetaBox("t-a", {
+        label: "A",
+        taxonomies: ["category"],
+        fields: [
+          { key: "icon", label: "Icon", type: "string", inputType: "text" },
+        ],
+      });
+      ctx.registerTermMetaBox("t-b", {
+        label: "B",
+        taxonomies: ["category"],
+        fields: [
+          { key: "icon", label: "Icon", type: "string", inputType: "text" },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(() => buildManifest(registry)).toThrow(
+      /Meta field "icon" is declared by term meta boxes "t-a" and "t-b" on the same scope "category"/,
+    );
+  });
+
+  test("rejects a term meta box scoped to an unregistered taxonomy", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("unknown-scope", (ctx) => {
+      // No `registerTaxonomy("catagory")` — the typo below is dead code.
+      ctx.registerTermMetaBox("branding", {
+        label: "Branding",
+        taxonomies: ["catagory"],
+        fields: [
+          { key: "icon", label: "Icon", type: "string", inputType: "text" },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(() => buildManifest(registry)).toThrow(
+      /term meta box "branding" references taxonomy "catagory" which hasn't been registered/,
+    );
+  });
+
+  test("rejects an entry meta box scoped to an unregistered entry type", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("unknown-scope", (ctx) => {
+      ctx.registerEntryMetaBox("seo", {
+        label: "SEO",
+        entryTypes: ["pots"],
+        fields: [{ key: "og", label: "OG", type: "string", inputType: "text" }],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(() => buildManifest(registry)).toThrow(
+      /entry meta box "seo" references entry type "pots" which hasn't been registered/,
+    );
+  });
+
   test("empty meta-box registry yields empty entry + term meta box arrays", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("blog", (ctx) => {
@@ -520,7 +578,8 @@ describe("serializeManifestScript", () => {
     const tag = serializeManifestScript({
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -537,7 +596,8 @@ describe("serializeManifestScript", () => {
         { name: "post", adminSlug: "posts", label: "</script><b>x</b>" },
       ],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -549,7 +609,8 @@ describe("serializeManifestScript", () => {
     const manifest = {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "x</y>" }],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -574,7 +635,8 @@ describe("injectManifestIntoHtml", () => {
     const out = injectManifestIntoHtml(TEMPLATE, {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -590,7 +652,8 @@ describe("injectManifestIntoHtml", () => {
     const manifest = {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -616,7 +679,8 @@ describe("injectManifestIntoHtml", () => {
     const out = injectManifestIntoHtml(html, {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -632,7 +696,8 @@ describe("injectManifestIntoHtml", () => {
     const out = injectManifestIntoHtml(html, {
       entryTypes: [{ name: "post", adminSlug: "posts", label: "Posts" }],
       taxonomies: [],
-      entryMetaBoxes: [], termMetaBoxes: [],
+      entryMetaBoxes: [],
+      termMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -46,21 +46,27 @@ export interface TaxonomyOptions {
 
 export type MetaScalarType = "string" | "number" | "boolean" | "json";
 
-export interface MetaOptions {
-  readonly type: MetaScalarType;
-  readonly default?: unknown;
-  readonly entryTypes: readonly string[];
-  readonly sanitize?: (value: unknown) => unknown;
-}
-
 export interface MetaBoxFieldOption {
   readonly value: string;
   readonly label: string;
 }
 
+/**
+ * A field inside a meta box — the single source of truth for both the
+ * admin UI renderer and the server-side storage contract. Declaring a
+ * meta box is the only way to register a meta key; there is no separate
+ * `registerMeta` step.
+ */
 export interface MetaBoxField {
   readonly key: string;
   readonly label: string;
+  /**
+   * Storage type. Drives server-side sanitization on write and
+   * coercion on read (`entry.meta` / `term.meta` columns store JSON,
+   * but the type informs the expected shape). `json` accepts any
+   * JSON-serialisable value.
+   */
+  readonly type: MetaScalarType;
   /**
    * Drives the admin sidebar's input renderer. Built-in dispatcher
    * handles `text` / `textarea` / `number` / `email` / `url` /
@@ -69,6 +75,14 @@ export interface MetaBoxField {
    * types with a dev-mode console warning.
    */
   readonly inputType: string;
+  /**
+   * Applied after type coercion, before persistence. Returning a
+   * sanitized value replaces the caller's input — ideal for trimming,
+   * whitelisting, or normalising shape.
+   */
+  readonly sanitize?: (value: unknown) => unknown;
+  /** Default surfaced in the admin form when the key has no saved value. */
+  readonly default?: unknown;
   /** Optional help text rendered under the label on every input type. */
   readonly description?: string;
   /** Renders `required` on the native input; server validation is separate. */
@@ -87,11 +101,30 @@ export interface MetaBoxField {
   readonly options?: readonly MetaBoxFieldOption[];
 }
 
-export interface MetaBoxOptions {
+/**
+ * Meta box shown on the entry editor. Rendered alongside the post in
+ * `/entries/<type>/<id>`; the `context` hint controls which column the
+ * box lands in.
+ */
+export interface EntryMetaBoxOptions {
   readonly label: string;
+  readonly description?: string;
   readonly context?: "side" | "normal" | "advanced";
   readonly priority?: "high" | "default" | "low";
   readonly entryTypes: readonly string[];
+  readonly capability?: string;
+  readonly fields: readonly MetaBoxField[];
+}
+
+/**
+ * Meta box shown on the taxonomy term edit form. Rendered as one
+ * shadcn `<Card>` with its own save button — same card-per-box model
+ * as settings groups. Scoped by `taxonomies`.
+ */
+export interface TermMetaBoxOptions {
+  readonly label: string;
+  readonly description?: string;
+  readonly taxonomies: readonly string[];
   readonly capability?: string;
   readonly fields: readonly MetaBoxField[];
 }
@@ -164,12 +197,12 @@ export interface RegisteredTaxonomy extends TaxonomyOptions {
   readonly registeredBy: string | null;
 }
 
-export interface RegisteredMeta extends MetaOptions {
-  readonly key: string;
+export interface RegisteredEntryMetaBox extends EntryMetaBoxOptions {
+  readonly id: string;
   readonly registeredBy: string | null;
 }
 
-export interface RegisteredMetaBox extends MetaBoxOptions {
+export interface RegisteredTermMetaBox extends TermMetaBoxOptions {
   readonly id: string;
   readonly registeredBy: string | null;
 }
@@ -200,8 +233,8 @@ export interface RegisteredRewriteRule {
 export interface PluginRegistry {
   readonly entryTypes: ReadonlyMap<string, RegisteredEntryType>;
   readonly taxonomies: ReadonlyMap<string, RegisteredTaxonomy>;
-  readonly metaKeys: ReadonlyMap<string, RegisteredMeta>;
-  readonly metaBoxes: ReadonlyMap<string, RegisteredMetaBox>;
+  readonly entryMetaBoxes: ReadonlyMap<string, RegisteredEntryMetaBox>;
+  readonly termMetaBoxes: ReadonlyMap<string, RegisteredTermMetaBox>;
   readonly capabilities: ReadonlyMap<string, RegisteredCapability>;
   readonly settingsGroups: ReadonlyMap<string, RegisteredSettingsGroup>;
   readonly settingsPages: ReadonlyMap<string, RegisteredSettingsPage>;
@@ -211,8 +244,8 @@ export interface PluginRegistry {
 export interface MutablePluginRegistry extends PluginRegistry {
   readonly entryTypes: Map<string, RegisteredEntryType>;
   readonly taxonomies: Map<string, RegisteredTaxonomy>;
-  readonly metaKeys: Map<string, RegisteredMeta>;
-  readonly metaBoxes: Map<string, RegisteredMetaBox>;
+  readonly entryMetaBoxes: Map<string, RegisteredEntryMetaBox>;
+  readonly termMetaBoxes: Map<string, RegisteredTermMetaBox>;
   readonly capabilities: Map<string, RegisteredCapability>;
   readonly settingsGroups: Map<string, RegisteredSettingsGroup>;
   readonly settingsPages: Map<string, RegisteredSettingsPage>;
@@ -223,13 +256,49 @@ export function createPluginRegistry(): MutablePluginRegistry {
   return {
     entryTypes: new Map(),
     taxonomies: new Map(),
-    metaKeys: new Map(),
-    metaBoxes: new Map(),
+    entryMetaBoxes: new Map(),
+    termMetaBoxes: new Map(),
     capabilities: new Map(),
     settingsGroups: new Map(),
     settingsPages: new Map(),
     rewriteRules: [],
   };
+}
+
+/**
+ * Look up the `MetaBoxField` declaration for a meta key within the
+ * entry meta surface, scoped to a given entry type. Returns the first
+ * matching field across all registered entry meta boxes — key
+ * uniqueness per (entryType, key) is enforced at registration time,
+ * so "first match" is the only match.
+ */
+export function findEntryMetaField(
+  registry: PluginRegistry,
+  entryType: string,
+  key: string,
+): MetaBoxField | undefined {
+  for (const box of registry.entryMetaBoxes.values()) {
+    if (!box.entryTypes.includes(entryType)) continue;
+    const field = box.fields.find((f) => f.key === key);
+    if (field) return field;
+  }
+  return undefined;
+}
+
+/**
+ * Like `findEntryMetaField`, but for term meta. Scoped by taxonomy.
+ */
+export function findTermMetaField(
+  registry: PluginRegistry,
+  taxonomy: string,
+  key: string,
+): MetaBoxField | undefined {
+  for (const box of registry.termMetaBoxes.values()) {
+    if (!box.taxonomies.includes(taxonomy)) continue;
+    const field = box.fields.find((f) => f.key === key);
+    if (field) return field;
+  }
+  return undefined;
 }
 
 export class DuplicateRegistrationError extends Error {
@@ -272,12 +341,13 @@ export interface EntryTypeManifestEntry {
 
 /**
  * Client-safe field descriptor inside a meta box. Mirrors `MetaBoxField`
- * today — kept as a separate type so the manifest boundary can diverge
- * (e.g., omit server-only `sanitize` callbacks) when needed.
+ * minus the server-only `sanitize` callback and `default` value (the
+ * admin receives the default server-side and injects it into the form).
  */
 export interface MetaBoxFieldManifestEntry {
   readonly key: string;
   readonly label: string;
+  readonly type: MetaScalarType;
   readonly inputType: string;
   readonly description?: string;
   readonly required?: boolean;
@@ -287,21 +357,35 @@ export interface MetaBoxFieldManifestEntry {
   readonly max?: number;
   readonly step?: number;
   readonly options?: readonly MetaBoxFieldOption[];
+  readonly default?: unknown;
 }
 
 /**
- * Shape serialised for meta boxes in the manifest. Strict allowlist
- * projection of `RegisteredMetaBox`; drops `registeredBy` (server-only
- * debug metadata). `fields` is projected via
- * `MetaBoxFieldManifestEntry` so the field-level contract is independent
- * of the registration type.
+ * Shape serialised for entry meta boxes (post editor sidebar). Strict
+ * allowlist projection of `RegisteredEntryMetaBox`; drops
+ * `registeredBy` (server-only debug metadata).
  */
-export interface MetaBoxManifestEntry {
+export interface EntryMetaBoxManifestEntry {
   readonly id: string;
   readonly label: string;
+  readonly description?: string;
   readonly context?: "side" | "normal" | "advanced";
   readonly priority?: "high" | "default" | "low";
   readonly entryTypes: readonly string[];
+  readonly capability?: string;
+  readonly fields: readonly MetaBoxFieldManifestEntry[];
+}
+
+/**
+ * Shape serialised for term meta boxes (taxonomy edit form). Same
+ * field-level shape as `EntryMetaBoxManifestEntry`; `context` /
+ * `priority` don't apply because term forms render stacked cards.
+ */
+export interface TermMetaBoxManifestEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly taxonomies: readonly string[];
   readonly capability?: string;
   readonly fields: readonly MetaBoxFieldManifestEntry[];
 }
@@ -367,7 +451,8 @@ export interface SettingsPageManifestEntry {
 export interface PlumixManifest {
   readonly entryTypes: readonly EntryTypeManifestEntry[];
   readonly taxonomies: readonly TaxonomyManifestEntry[];
-  readonly metaBoxes: readonly MetaBoxManifestEntry[];
+  readonly entryMetaBoxes: readonly EntryMetaBoxManifestEntry[];
+  readonly termMetaBoxes: readonly TermMetaBoxManifestEntry[];
   readonly settingsGroups: readonly SettingsGroupManifestEntry[];
   readonly settingsPages: readonly SettingsPageManifestEntry[];
 }
@@ -379,7 +464,8 @@ export function emptyManifest(): PlumixManifest {
   return {
     entryTypes: [],
     taxonomies: [],
-    metaBoxes: [],
+    entryMetaBoxes: [],
+    termMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -409,7 +495,14 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
   const taxonomies = Array.from(registry.taxonomies.values()).map(
     toTaxonomyEntry,
   );
-  const metaBoxes = Array.from(registry.metaBoxes.values()).map(toMetaBoxEntry);
+  const entryMetaBoxes = Array.from(registry.entryMetaBoxes.values()).map(
+    toEntryMetaBoxEntry,
+  );
+  const termMetaBoxes = Array.from(registry.termMetaBoxes.values()).map(
+    toTermMetaBoxEntry,
+  );
+  assertUniqueFieldKeysPerScope(entryMetaBoxes, "entry");
+  assertUniqueFieldKeysPerScope(termMetaBoxes, "term");
   const settingsGroups = Array.from(registry.settingsGroups.values()).map(
     toSettingsGroupEntry,
   );
@@ -424,10 +517,46 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
   return {
     entryTypes: entries,
     taxonomies,
-    metaBoxes,
+    entryMetaBoxes,
+    termMetaBoxes,
     settingsGroups,
     settingsPages,
   };
+}
+
+/**
+ * Two meta boxes on the same `(scope, field.key)` pair would silently
+ * write to the same storage key — a plugin-author footgun. Fail loudly
+ * at manifest-build time. `scope` is the entry type (for entry boxes)
+ * or taxonomy (for term boxes).
+ */
+function assertUniqueFieldKeysPerScope(
+  boxes: readonly (
+    | EntryMetaBoxManifestEntry
+    | TermMetaBoxManifestEntry
+  )[],
+  kind: "entry" | "term",
+): void {
+  const seen = new Map<string, string>();
+  for (const box of boxes) {
+    const scopes =
+      "entryTypes" in box ? box.entryTypes : box.taxonomies;
+    for (const scope of scopes) {
+      for (const field of box.fields) {
+        const scopedKey = `${scope}:${field.key}`;
+        const existing = seen.get(scopedKey);
+        if (existing !== undefined && existing !== box.id) {
+          throw new Error(
+            `Meta field "${field.key}" is declared by ${kind} meta ` +
+              `boxes "${existing}" and "${box.id}" on the same scope ` +
+              `"${scope}". Each key may appear in at most one box ` +
+              `per scope.`,
+          );
+        }
+        seen.set(scopedKey, box.id);
+      }
+    }
+  }
 }
 
 // Surfacing a clear error at manifest-build time beats a runtime
@@ -574,18 +703,46 @@ function toTaxonomyEntry(tax: RegisteredTaxonomy): TaxonomyManifestEntry {
   };
 }
 
-// Allowlist for meta box entries — same rationale as `toEntryTypeManifest`.
-// `registeredBy` is intentionally excluded (server-only debug metadata).
-// `fields` is projected per entry so field-level internals could diverge
-// from the registration type without altering the wire contract.
-function toMetaBoxEntry(box: RegisteredMetaBox): MetaBoxManifestEntry {
-  const { id, label, context, priority, entryTypes, capability, fields } = box;
-  return {
+// Allowlist for entry meta box entries — same rationale as
+// `toEntryTypeManifest`. `registeredBy` is intentionally excluded
+// (server-only debug metadata). `sanitize` on each field is stripped
+// via `toMetaBoxFieldEntry` — it's a server-side callback.
+function toEntryMetaBoxEntry(
+  box: RegisteredEntryMetaBox,
+): EntryMetaBoxManifestEntry {
+  const {
     id,
     label,
+    description,
     context,
     priority,
     entryTypes,
+    capability,
+    fields,
+  } = box;
+  return {
+    id,
+    label,
+    description,
+    context,
+    priority,
+    entryTypes,
+    capability,
+    fields: fields.map(toMetaBoxFieldEntry),
+  };
+}
+
+// Term meta boxes are always stacked top-to-bottom on the taxonomy
+// edit form — no `context` / `priority` hints apply.
+function toTermMetaBoxEntry(
+  box: RegisteredTermMetaBox,
+): TermMetaBoxManifestEntry {
+  const { id, label, description, taxonomies, capability, fields } = box;
+  return {
+    id,
+    label,
+    description,
+    taxonomies,
     capability,
     fields: fields.map(toMetaBoxFieldEntry),
   };
@@ -639,6 +796,7 @@ function toMetaBoxFieldEntry(field: MetaBoxField): MetaBoxFieldManifestEntry {
   const {
     key,
     label,
+    type,
     inputType,
     description,
     required,
@@ -648,10 +806,12 @@ function toMetaBoxFieldEntry(field: MetaBoxField): MetaBoxFieldManifestEntry {
     max,
     step,
     options,
+    default: defaultValue,
   } = field;
   return {
     key,
     label,
+    type,
     inputType,
     description,
     required,
@@ -661,6 +821,7 @@ function toMetaBoxFieldEntry(field: MetaBoxField): MetaBoxFieldManifestEntry {
     max,
     step,
     options,
+    default: defaultValue,
   };
 }
 

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -105,6 +105,12 @@ export interface MetaBoxField {
  * Meta box shown on the entry editor. Rendered alongside the post in
  * `/entries/<type>/<id>`; the `context` hint controls which column the
  * box lands in.
+ *
+ * `capability` is a UI-only filter: the admin hides boxes the current
+ * user lacks the capability for, but the server enforces only the
+ * entity-level cap (`<entryType>:edit*`). Do NOT use it to gate
+ * secrets — any user who can edit the entry can write any registered
+ * meta key via the raw RPC.
  */
 export interface EntryMetaBoxOptions {
   readonly label: string;
@@ -120,6 +126,9 @@ export interface EntryMetaBoxOptions {
  * Meta box shown on the taxonomy term edit form. Rendered as one
  * shadcn `<Card>` with its own save button — same card-per-box model
  * as settings groups. Scoped by `taxonomies`.
+ *
+ * `capability` is a UI-only filter; see `EntryMetaBoxOptions` for the
+ * caveat. The server gates term meta writes on `<taxonomy>:edit`.
  */
 export interface TermMetaBoxOptions {
   readonly label: string;
@@ -501,6 +510,20 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
   const termMetaBoxes = Array.from(registry.termMetaBoxes.values()).map(
     toTermMetaBoxEntry,
   );
+  assertMetaBoxScopesExist(
+    entryMetaBoxes,
+    (box) => box.entryTypes,
+    new Set(entries.map((e) => e.name)),
+    "entry meta box",
+    "entry type",
+  );
+  assertMetaBoxScopesExist(
+    termMetaBoxes,
+    (box) => box.taxonomies,
+    new Set(taxonomies.map((t) => t.name)),
+    "term meta box",
+    "taxonomy",
+  );
   assertUniqueFieldKeysPerScope(entryMetaBoxes, "entry");
   assertUniqueFieldKeysPerScope(termMetaBoxes, "term");
   const settingsGroups = Array.from(registry.settingsGroups.values()).map(
@@ -531,16 +554,12 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
  * or taxonomy (for term boxes).
  */
 function assertUniqueFieldKeysPerScope(
-  boxes: readonly (
-    | EntryMetaBoxManifestEntry
-    | TermMetaBoxManifestEntry
-  )[],
+  boxes: readonly (EntryMetaBoxManifestEntry | TermMetaBoxManifestEntry)[],
   kind: "entry" | "term",
 ): void {
   const seen = new Map<string, string>();
   for (const box of boxes) {
-    const scopes =
-      "entryTypes" in box ? box.entryTypes : box.taxonomies;
+    const scopes = "entryTypes" in box ? box.entryTypes : box.taxonomies;
     for (const scope of scopes) {
       for (const field of box.fields) {
         const scopedKey = `${scope}:${field.key}`;
@@ -554,6 +573,30 @@ function assertUniqueFieldKeysPerScope(
           );
         }
         seen.set(scopedKey, box.id);
+      }
+    }
+  }
+}
+
+// A meta box referencing an unregistered scope ("catagory" typo, a
+// taxonomy removed behind the plugin's back, etc.) is dead code — the
+// box never renders and never writes. Fail at manifest build so the
+// plugin author sees it on boot, not at first admin click. Matches the
+// settings-page→group reference check.
+function assertMetaBoxScopesExist<TBox extends { readonly id: string }>(
+  boxes: readonly TBox[],
+  getScopes: (box: TBox) => readonly string[],
+  known: ReadonlySet<string>,
+  boxKind: string,
+  scopeKind: string,
+): void {
+  for (const box of boxes) {
+    for (const scope of getScopes(box)) {
+      if (!known.has(scope)) {
+        throw new Error(
+          `${boxKind} "${box.id}" references ${scopeKind} "${scope}" ` +
+            `which hasn't been registered.`,
+        );
       }
     }
   }

--- a/packages/core/src/plugin/register.test.ts
+++ b/packages/core/src/plugin/register.test.ts
@@ -155,4 +155,62 @@ describe("installPlugins", () => {
       registeredBy: "seo",
     });
   });
+
+  test("registerTermMetaBox rejects a duplicate id across plugins", async () => {
+    const hooks = new HookRegistry();
+    const first = definePlugin("a", (ctx) => {
+      ctx.registerTermMetaBox("branding", {
+        label: "A",
+        taxonomies: ["category"],
+        fields: [
+          { key: "icon", label: "Icon", type: "string", inputType: "text" },
+        ],
+      });
+    });
+    const second = definePlugin("b", (ctx) => {
+      ctx.registerTermMetaBox("branding", {
+        label: "B",
+        taxonomies: ["category"],
+        fields: [
+          { key: "icon", label: "Icon", type: "string", inputType: "text" },
+        ],
+      });
+    });
+    await expect(
+      installPlugins({ hooks, plugins: [first, second] }),
+    ).rejects.toBeInstanceOf(DuplicateRegistrationError);
+  });
+
+  test("registerEntryMetaBox rejects an invalid field key at registration time", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("bad", (ctx) => {
+      ctx.registerEntryMetaBox("seo", {
+        label: "SEO",
+        entryTypes: ["post"],
+        fields: [
+          { key: "bad key!", label: "Bad", type: "string", inputType: "text" },
+        ],
+      });
+    });
+    await expect(installPlugins({ hooks, plugins: [plugin] })).rejects.toThrow(
+      /invalid key "bad key!"/,
+    );
+  });
+
+  test("registerTermMetaBox rejects a duplicate field key within the same box", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("dupe", (ctx) => {
+      ctx.registerTermMetaBox("branding", {
+        label: "Branding",
+        taxonomies: ["category"],
+        fields: [
+          { key: "icon", label: "Icon", type: "string", inputType: "text" },
+          { key: "icon", label: "Icon 2", type: "string", inputType: "text" },
+        ],
+      });
+    });
+    await expect(installPlugins({ hooks, plugins: [plugin] })).rejects.toThrow(
+      /declares field "icon" more than once/,
+    );
+  });
 });

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -2,7 +2,6 @@ import type { Entry, EntryStatus, NewEntry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
 import type { User } from "../db/schema/users.js";
 import type { EntryMetaChanges } from "./procedures/entry/meta.js";
-import type { TermMetaChanges } from "./procedures/term/meta.js";
 import type {
   EntryCreateInput,
   EntryListInput,
@@ -12,6 +11,7 @@ import type {
   SettingsGetInput,
   SettingsUpsertInput,
 } from "./procedures/settings/schemas.js";
+import type { TermMetaChanges } from "./procedures/term/meta.js";
 import type {
   TermCreateInput,
   TermListInput,
@@ -219,9 +219,16 @@ declare module "../hooks/types.js" {
     "term:created": (term: Term) => void | Promise<void>;
 
     /**
-     * Fires after a successful `term.update`. Payload carries the
-     * post-write row and the pre-write row for diffing — parallel to
-     * `post:updated` / `user:updated`.
+     * Fires after a successful `term.update` row-columns write. Payload
+     * carries the post-write row and the pre-write row for diffing —
+     * parallel to `post:updated` / `user:updated`.
+     *
+     * Only fires when the row columns changed. A meta-only update does
+     * NOT fire `term:updated`; subscribe to `term:meta_changed` for
+     * that. The `term.meta` here reflects the row read right after the
+     * column write and may lag a meta write that happens in the same
+     * RPC call — use `term:meta_changed` for the authoritative meta
+     * diff.
      */
     "term:updated": (term: Term, previous: Term) => void | Promise<void>;
 

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -2,6 +2,7 @@ import type { Entry, EntryStatus, NewEntry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
 import type { User } from "../db/schema/users.js";
 import type { EntryMetaChanges } from "./procedures/entry/meta.js";
+import type { TermMetaChanges } from "./procedures/term/meta.js";
 import type {
   EntryCreateInput,
   EntryListInput,
@@ -226,6 +227,17 @@ declare module "../hooks/types.js" {
 
     /** Fires after `term.delete` removes a term row. */
     "term:deleted": (term: Term) => void | Promise<void>;
+
+    /**
+     * Fires after a successful meta write via `term.create` /
+     * `term.update`. Payload carries the decoded upserts + deleted
+     * keys — same shape as `entry:meta_changed` so plugins adopt one
+     * pattern across bags.
+     */
+    "term:meta_changed": (
+      term: { readonly id: number; readonly taxonomy: string },
+      changes: TermMetaChanges,
+    ) => void | Promise<void>;
 
     /**
      * Fires after a successful `settings.upsert`. Payload carries the

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -18,7 +18,7 @@ import { eq } from "../../db/index.js";
  *  plugin config while bounding adversarial payloads. */
 const MAX_META_VALUE_BYTES = 256 * 1024;
 
-export type MetaMap = Record<string, unknown>;
+type MetaMap = Record<string, unknown>;
 
 /**
  * Validated meta patch produced by `sanitizeMetaInput`. Values in
@@ -37,9 +37,8 @@ export interface MetaPatch {
  * UIs and plugin tests match on these strings, so treat them as a
  * public contract.
  */
-export type MetaSanitizationReason =
+type MetaSanitizationReason =
   | "not_registered"
-  | "scope_mismatch"
   | "invalid_value"
   | "value_too_large";
 
@@ -59,7 +58,7 @@ export class MetaSanitizationError extends Error {
  * helper doesn't have to import oRPC types — the handler passes its
  * `errors` in and TS matches on shape.
  */
-export interface RpcErrorsForMeta {
+interface RpcErrorsForMeta {
   CONFLICT: (args: { data: { reason: string; key?: string } }) => Error;
 }
 
@@ -159,9 +158,7 @@ export function isEmptyMetaPatch(patch: MetaPatch | null): boolean {
  * caller clearing + re-setting the same key in one request behaves
  * predictably.
  */
-export async function applyMetaPatch<
-  TTable extends { meta: SQLiteColumn },
->(
+export async function applyMetaPatch<TTable extends { meta: SQLiteColumn }>(
   ctx: AppContext,
   table: TTable,
   idColumn: SQLiteColumn,
@@ -292,14 +289,21 @@ function coerceOnRead(type: MetaScalarType, value: unknown): unknown {
   // Reads are forgiving — the row was validated on write but a
   // schema change (e.g. a plugin flipping `number` → `string`)
   // shouldn't 500 the editor. We coerce when we can and fall through
-  // to the raw value otherwise.
+  // to the raw value otherwise. For booleans, mirror the write-side
+  // accepted tokens instead of `Boolean(value)` — the latter would
+  // flip `"false"` → `true`, silently inverting rows persisted via
+  // `type: "json"` before a plugin tightened the field to `boolean`.
   switch (type) {
     case "string":
       return typeof value === "string" ? value : String(value);
     case "number":
       return typeof value === "number" ? value : Number(value);
-    case "boolean":
-      return typeof value === "boolean" ? value : Boolean(value);
+    case "boolean": {
+      if (typeof value === "boolean") return value;
+      if (value === 1 || value === "1" || value === "true") return true;
+      if (value === 0 || value === "0" || value === "false") return false;
+      return value;
+    }
     case "json":
       return value;
   }
@@ -308,8 +312,15 @@ function coerceOnRead(type: MetaScalarType, value: unknown): unknown {
 // SQLite's JSON path `$.label` only accepts `[A-Za-z0-9_]` in unquoted
 // labels, but valid meta keys may include `-` or `:` (see the input
 // schema regex). The double-quoted label form `$."foo-bar"` handles
-// them; interpolation is safe because keys are pre-validated to
-// exclude `"` and `\`.
+// them; the RPC input schema already rejects `"` and `\`, but belt-and-
+// braces matters here because non-RPC callers (tests, hook listeners,
+// future surfaces) could bypass that schema and trigger SQL injection
+// via a crafted path.
 function metaJsonPath(key: string): string {
+  if (/["\\]/.test(key)) {
+    throw new Error(
+      `meta key "${key}" contains characters forbidden in a JSON path`,
+    );
+  }
   return `$."${key}"`;
 }

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -1,0 +1,315 @@
+import type { SQL } from "drizzle-orm";
+import type { SQLiteColumn } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+
+import type { AppContext } from "../../context/app.js";
+import type { MetaBoxField, MetaScalarType } from "../../plugin/manifest.js";
+import { eq } from "../../db/index.js";
+
+// Shared meta plumbing for every entity that stores a `meta` JSON
+// column (entries, terms, and — eventually — users). The storage
+// contract: writes merge into the bag via SQLite `json_set` /
+// `json_remove`; reads come back already-parsed via drizzle's
+// `mode: "json"`. Per-entity specializations in `procedures/{entry,
+// term}/meta.ts` thread the right table + action name through these
+// helpers.
+
+/** Per-value byte cap after JSON encoding. 256 KiB fits any realistic
+ *  plugin config while bounding adversarial payloads. */
+const MAX_META_VALUE_BYTES = 256 * 1024;
+
+export type MetaMap = Record<string, unknown>;
+
+/**
+ * Validated meta patch produced by `sanitizeMetaInput`. Values in
+ * `upserts` are the *decoded* post-sanitization objects — filter hooks
+ * see this shape, so keeping decoded values here means a plugin
+ * doesn't have to double-parse. `applyMetaPatch` JSON-encodes at the
+ * last moment, before the UPDATE.
+ */
+export interface MetaPatch {
+  readonly upserts: ReadonlyMap<string, unknown>;
+  readonly deletes: readonly string[];
+}
+
+/**
+ * Reason codes are part of the RPC error `data.reason` surface — admin
+ * UIs and plugin tests match on these strings, so treat them as a
+ * public contract.
+ */
+export type MetaSanitizationReason =
+  | "not_registered"
+  | "scope_mismatch"
+  | "invalid_value"
+  | "value_too_large";
+
+export class MetaSanitizationError extends Error {
+  readonly key: string;
+  readonly reason: MetaSanitizationReason;
+  constructor(key: string, reason: MetaSanitizationReason) {
+    super(`meta key "${key}" failed sanitization: ${reason}`);
+    this.key = key;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Minimum shape of the oRPC `errors` object needed to surface a
+ * `MetaSanitizationError` as a CONFLICT. Declared structurally so this
+ * helper doesn't have to import oRPC types — the handler passes its
+ * `errors` in and TS matches on shape.
+ */
+export interface RpcErrorsForMeta {
+  CONFLICT: (args: { data: { reason: string; key?: string } }) => Error;
+}
+
+/**
+ * Standard payload for `<entity>:meta_changed` actions. `set` is the
+ * decoded key → value map of upserts; `removed` is the list of
+ * cleared keys.
+ */
+export interface MetaChanges {
+  readonly set: Readonly<Record<string, unknown>>;
+  readonly removed: readonly string[];
+}
+
+/**
+ * Validate an incoming meta map against a field-lookup fn produced by
+ * the caller (entry vs term differ only in which registry they walk).
+ * Unregistered keys and type-coercion failures throw so the caller can
+ * surface them as 4xx before any write. `null` / `undefined` values
+ * are deletion requests; everything else is coerced + sanitized.
+ */
+export function sanitizeMetaInput(
+  findField: (key: string) => MetaBoxField | undefined,
+  input: MetaMap | undefined,
+): MetaPatch | null {
+  if (input === undefined) return null;
+  const upserts = new Map<string, unknown>();
+  const deletes: string[] = [];
+  for (const [key, rawValue] of Object.entries(input)) {
+    const field = findField(key);
+    if (!field) {
+      throw new MetaSanitizationError(key, "not_registered");
+    }
+    if (rawValue === null || rawValue === undefined) {
+      deletes.push(key);
+      continue;
+    }
+    const coerced = coerceToType(field.type, key, rawValue);
+    const sanitized = field.sanitize ? field.sanitize(coerced) : coerced;
+    assertEncodedSize(key, sanitized);
+    upserts.set(key, sanitized);
+  }
+  return { upserts, deletes };
+}
+
+/**
+ * Thin wrapper that translates a thrown `MetaSanitizationError` into
+ * the RPC handler's CONFLICT envelope.
+ */
+export function sanitizeMetaForRpc(
+  findField: (key: string) => MetaBoxField | undefined,
+  input: MetaMap | undefined,
+  errors: RpcErrorsForMeta,
+): MetaPatch | null {
+  try {
+    return sanitizeMetaInput(findField, input);
+  } catch (error) {
+    if (error instanceof MetaSanitizationError) {
+      throw errors.CONFLICT({
+        data: { reason: `meta_${error.reason}`, key: error.key },
+      });
+    }
+    throw error;
+  }
+}
+
+/**
+ * Decode a raw meta bag (as returned by drizzle's JSON-mode column)
+ * into the plugin-typed shape RPC consumers expect. Unregistered keys
+ * pass through untouched — the row exists in the DB but the plugin
+ * that wrote it is no longer installed; we don't pretend to know its
+ * shape.
+ */
+export function decodeMetaBag(
+  findField: (key: string) => MetaBoxField | undefined,
+  raw: Readonly<Record<string, unknown>> | null | undefined,
+): MetaMap {
+  if (!raw) return {};
+  const out: MetaMap = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const field = findField(key);
+    out[key] = field ? coerceOnRead(field.type, value) : value;
+  }
+  return out;
+}
+
+export function isEmptyMetaPatch(patch: MetaPatch | null): boolean {
+  return (
+    patch === null || (patch.upserts.size === 0 && patch.deletes.length === 0)
+  );
+}
+
+/**
+ * Merge a validated patch into the given `meta` JSON column for the
+ * row identified by `idColumn = id`. Uses SQLite `json_set` /
+ * `json_remove` so concurrent updaters touching disjoint keys don't
+ * clobber each other at the row level. Deletes nest inside sets so a
+ * caller clearing + re-setting the same key in one request behaves
+ * predictably.
+ */
+export async function applyMetaPatch<
+  TTable extends { meta: SQLiteColumn },
+>(
+  ctx: AppContext,
+  table: TTable,
+  idColumn: SQLiteColumn,
+  id: number,
+  patch: MetaPatch,
+): Promise<void> {
+  if (isEmptyMetaPatch(patch)) return;
+
+  let expr: SQL = sql`${table.meta}`;
+  if (patch.deletes.length > 0) {
+    const paths = patch.deletes.map((k) => sql`${metaJsonPath(k)}`);
+    expr = sql`json_remove(${expr}, ${sql.join(paths, sql`, `)})`;
+  }
+  if (patch.upserts.size > 0) {
+    const pairs = Array.from(
+      patch.upserts,
+      ([key, value]) =>
+        sql`${metaJsonPath(key)}, json(${JSON.stringify(value)})`,
+    );
+    expr = sql`json_set(${expr}, ${sql.join(pairs, sql`, `)})`;
+  }
+
+  await ctx.db
+    // drizzle's `update(table)` wants an `AnyTable` shape; our generic
+    // constraint only pins `meta`, so the update helper accepts any
+    // sqlite table via structural matching. Cast keeps the helper
+    // reusable across tables without widening the public types.
+    .update(table as never)
+    .set({ meta: expr })
+    .where(eq(idColumn, id));
+}
+
+/**
+ * Load + decode the full meta bag for a single row. Returns empty
+ * when the row is missing (deleted mid-flight) or has no saved meta.
+ */
+export async function loadMeta<TTable extends { meta: SQLiteColumn }>(
+  ctx: AppContext,
+  table: TTable,
+  idColumn: SQLiteColumn,
+  id: number,
+  findField: (key: string) => MetaBoxField | undefined,
+): Promise<MetaMap> {
+  const [row] = (await ctx.db
+    .select({ meta: table.meta })
+    .from(table as never)
+    .where(eq(idColumn, id))) as { meta: unknown }[];
+  return decodeMetaBag(findField, row?.meta as MetaMap | undefined);
+}
+
+// --- internals below ---------------------------------------------------
+
+function coerceToType(
+  type: MetaScalarType,
+  key: string,
+  value: unknown,
+): unknown {
+  switch (type) {
+    case "string":
+      return coerceString(key, value);
+    case "number":
+      return coerceNumber(key, value);
+    case "boolean":
+      return coerceBoolean(key, value);
+    case "json":
+      return coerceJson(key, value);
+  }
+}
+
+function coerceString(key: string, value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value === "boolean") return String(value);
+  throw new MetaSanitizationError(key, "invalid_value");
+}
+
+function coerceNumber(key: string, value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    // Empty string comes from cleared form inputs; the admin dispatcher
+    // already sends `null` for those, but a direct RPC caller might send
+    // "" — reject here so we don't silently coerce to 0 (`Number("") === 0`).
+    if (value.trim() === "") {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  if (typeof value === "boolean") return value ? 1 : 0;
+  throw new MetaSanitizationError(key, "invalid_value");
+}
+
+function coerceBoolean(key: string, value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (value === 1 || value === "1" || value === "true") return true;
+  if (value === 0 || value === "0" || value === "false") return false;
+  throw new MetaSanitizationError(key, "invalid_value");
+}
+
+function coerceJson(key: string, value: unknown): unknown {
+  // json keys take anything round-trippable through JSON.stringify —
+  // we reject values that throw (BigInt) or silently drop (functions,
+  // Symbols) so reads don't hand back `undefined` for something a
+  // plugin thought it stored. TS types JSON.stringify as always-
+  // string, but at runtime it returns `undefined` for unserializable
+  // inputs — hence the cast.
+  try {
+    const encoded = JSON.stringify(value) as string | undefined;
+    if (encoded === undefined) {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+    return JSON.parse(encoded);
+  } catch {
+    throw new MetaSanitizationError(key, "invalid_value");
+  }
+}
+
+function assertEncodedSize(key: string, value: unknown): void {
+  const encoded = JSON.stringify(value) as string | undefined;
+  if (encoded === undefined) return; // already caught in coerceJson
+  const byteLength = new TextEncoder().encode(encoded).length;
+  if (byteLength > MAX_META_VALUE_BYTES) {
+    throw new MetaSanitizationError(key, "value_too_large");
+  }
+}
+
+function coerceOnRead(type: MetaScalarType, value: unknown): unknown {
+  // Reads are forgiving — the row was validated on write but a
+  // schema change (e.g. a plugin flipping `number` → `string`)
+  // shouldn't 500 the editor. We coerce when we can and fall through
+  // to the raw value otherwise.
+  switch (type) {
+    case "string":
+      return typeof value === "string" ? value : String(value);
+    case "number":
+      return typeof value === "number" ? value : Number(value);
+    case "boolean":
+      return typeof value === "boolean" ? value : Boolean(value);
+    case "json":
+      return value;
+  }
+}
+
+// SQLite's JSON path `$.label` only accepts `[A-Za-z0-9_]` in unquoted
+// labels, but valid meta keys may include `-` or `:` (see the input
+// schema regex). The double-quoted label form `$."foo-bar"` handles
+// them; interpolation is safe because keys are pre-validated to
+// exclude `"` and `\`.
+function metaJsonPath(key: string): string {
+  return `$."${key}"`;
+}

--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -238,16 +238,14 @@ describe("entry.create", () => {
 
   test("meta: registered keys persist and come back on the create response", async () => {
     const plugins = createPluginRegistry();
-    plugins.metaKeys.set("meta_title", {
-      key: "meta_title",
-      type: "string",
+    plugins.entryMetaBoxes.set("test-seo", {
+      id: "test-seo",
+      label: "SEO",
       entryTypes: ["post"],
-      registeredBy: "test",
-    });
-    plugins.metaKeys.set("is_featured", {
-      key: "is_featured",
-      type: "boolean",
-      entryTypes: ["post"],
+      fields: [
+        { key: "meta_title", label: "Meta title", type: "string", inputType: "text" },
+        { key: "is_featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+      ],
       registeredBy: "test",
     });
     const h = await createRpcHarness({ authAs: "admin", plugins });

--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -243,8 +243,18 @@ describe("entry.create", () => {
       label: "SEO",
       entryTypes: ["post"],
       fields: [
-        { key: "meta_title", label: "Meta title", type: "string", inputType: "text" },
-        { key: "is_featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+        {
+          key: "meta_title",
+          label: "Meta title",
+          type: "string",
+          inputType: "text",
+        },
+        {
+          key: "is_featured",
+          label: "Featured",
+          type: "boolean",
+          inputType: "checkbox",
+        },
       ],
       registeredBy: "test",
     });

--- a/packages/core/src/rpc/procedures/entry/create.ts
+++ b/packages/core/src/rpc/procedures/entry/create.ts
@@ -99,11 +99,11 @@ export const create = base
     let meta: Record<string, unknown>;
     if (metaPatch) {
       await writeEntryMeta(context, created, metaPatch);
-      meta = await loadEntryMeta(context, created.id);
+      meta = await loadEntryMeta(context, created);
     } else {
       // No write path — `created.meta` is the default `{}`. Decode inline
       // to save the round trip.
-      meta = decodeMetaBag(context.plugins, created.meta);
+      meta = decodeMetaBag(context.plugins, created, created.meta);
     }
 
     await fireEntryTransition(context, created, "draft");

--- a/packages/core/src/rpc/procedures/entry/get.ts
+++ b/packages/core/src/rpc/procedures/entry/get.ts
@@ -36,6 +36,6 @@ export const get = base
       }
     }
 
-    const meta = decodeMetaBag(context.plugins, row.meta);
+    const meta = decodeMetaBag(context.plugins, row, row.meta);
     return context.hooks.applyFilter("rpc:entry.get:output", { ...row, meta });
   });

--- a/packages/core/src/rpc/procedures/entry/meta.test.ts
+++ b/packages/core/src/rpc/procedures/entry/meta.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, test } from "vitest";
+
 import type {
   MetaBoxField,
   MutablePluginRegistry,
 } from "../../../plugin/manifest.js";
-import { describe, expect, test } from "vitest";
-
 import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
 import {
@@ -62,7 +62,9 @@ function findField(registry: MutablePluginRegistry, entryType: string) {
 describe("sanitizeMetaInput", () => {
   test("returns null when the input map is absent (no patch to apply)", () => {
     const registry = registryWithMeta({});
-    expect(sanitizeMetaInput(findField(registry, "post"), undefined)).toBeNull();
+    expect(
+      sanitizeMetaInput(findField(registry, "post"), undefined),
+    ).toBeNull();
   });
 
   test("empty object produces an empty patch (valid — just nothing to do)", () => {
@@ -330,5 +332,25 @@ describe("applyMetaPatch + loadEntryMeta", () => {
     await applyMetaPatch(h.context, entries, entries.id, post.id, patch);
 
     expect(await loadEntryMeta(h.context, post)).toEqual({ title: "new" });
+  });
+
+  // Regression: `Boolean("false") === true` would silently flip rows
+  // written via `type: "json"` before a plugin tightened the field to
+  // `boolean`. `coerceOnRead` mirrors the write-side token set instead.
+  test("coerceOnRead maps legacy string booleans to their real values", async () => {
+    const plugins = registryWithMeta({ featured: { type: "boolean" } });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const post = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "legacy-bool",
+    });
+    // Seed the row as if a prior schema version stored the string "false"
+    // directly — bypass sanitize by writing to the column ourselves.
+    await h.context.db
+      .update(entries)
+      .set({ meta: { featured: "false" } })
+      .where(eq(entries.id, post.id));
+
+    expect(await loadEntryMeta(h.context, post)).toEqual({ featured: false });
   });
 });

--- a/packages/core/src/rpc/procedures/entry/meta.test.ts
+++ b/packages/core/src/rpc/procedures/entry/meta.test.ts
@@ -1,120 +1,150 @@
+import type {
+  MetaBoxField,
+  MutablePluginRegistry,
+} from "../../../plugin/manifest.js";
 import { describe, expect, test } from "vitest";
 
 import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
-import { createPluginRegistry } from "../../../plugin/manifest.js";
+import {
+  createPluginRegistry,
+  findEntryMetaField,
+} from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 import {
   applyMetaPatch,
-  loadEntryMeta,
   MetaSanitizationError,
   sanitizeMetaInput,
-} from "./meta.js";
+} from "../../meta/core.js";
+import { loadEntryMeta } from "./meta.js";
+
+// Each test declares its meta fields via this helper — one 1-field box
+// per key so the `entryTypes` scope can differ per key (useful for
+// scope-mismatch assertions).
+interface TestMetaSpec {
+  readonly type: "string" | "number" | "boolean" | "json";
+  readonly entryTypes?: readonly string[];
+  readonly sanitize?: (value: unknown) => unknown;
+  readonly default?: unknown;
+}
 
 function registryWithMeta(
-  keys: Record<
-    string,
-    {
-      type: "string" | "number" | "boolean" | "json";
-      entryTypes?: string[];
-      sanitize?: (value: unknown) => unknown;
-      default?: unknown;
-    }
-  >,
-) {
+  keys: Record<string, TestMetaSpec>,
+): MutablePluginRegistry {
   const registry = createPluginRegistry();
-  for (const [key, options] of Object.entries(keys)) {
-    registry.metaKeys.set(key, {
+  let boxIndex = 0;
+  for (const [key, spec] of Object.entries(keys)) {
+    const id = `test-box-${boxIndex++}`;
+    const field: MetaBoxField = {
       key,
-      type: options.type,
-      entryTypes: options.entryTypes ?? ["post"],
-      sanitize: options.sanitize,
-      default: options.default,
+      label: key,
+      type: spec.type,
+      inputType: spec.type === "boolean" ? "checkbox" : "text",
+      sanitize: spec.sanitize,
+      default: spec.default,
+    };
+    registry.entryMetaBoxes.set(id, {
+      id,
+      label: "Test",
+      entryTypes: spec.entryTypes ?? ["post"],
+      fields: [field],
       registeredBy: "test",
     });
   }
   return registry;
 }
 
+function findField(registry: MutablePluginRegistry, entryType: string) {
+  return (key: string): MetaBoxField | undefined =>
+    findEntryMetaField(registry, entryType, key);
+}
+
 describe("sanitizeMetaInput", () => {
   test("returns null when the input map is absent (no patch to apply)", () => {
     const registry = registryWithMeta({});
-    expect(sanitizeMetaInput(registry, "post", undefined)).toBeNull();
+    expect(sanitizeMetaInput(findField(registry, "post"), undefined)).toBeNull();
   });
 
   test("empty object produces an empty patch (valid — just nothing to do)", () => {
     const registry = registryWithMeta({});
-    const patch = sanitizeMetaInput(registry, "post", {});
+    const patch = sanitizeMetaInput(findField(registry, "post"), {});
     expect(patch).toEqual({ upserts: new Map(), deletes: [] });
   });
 
   test("string meta passes through as a decoded string in the patch", () => {
     const registry = registryWithMeta({ title: { type: "string" } });
-    const patch = sanitizeMetaInput(registry, "post", { title: "Hello" });
+    const patch = sanitizeMetaInput(findField(registry, "post"), {
+      title: "Hello",
+    });
     expect(patch?.upserts.get("title")).toBe("Hello");
   });
 
   test("number meta rejects NaN / Infinity (they would poison JSON)", () => {
     const registry = registryWithMeta({ count: { type: "number" } });
     expect(() =>
-      sanitizeMetaInput(registry, "post", { count: Number.NaN }),
+      sanitizeMetaInput(findField(registry, "post"), { count: Number.NaN }),
     ).toThrow(MetaSanitizationError);
     expect(() =>
-      sanitizeMetaInput(registry, "post", { count: Number.POSITIVE_INFINITY }),
+      sanitizeMetaInput(findField(registry, "post"), {
+        count: Number.POSITIVE_INFINITY,
+      }),
     ).toThrow(MetaSanitizationError);
   });
 
   test("number meta coerces numeric strings (admin may ship form-value strings)", () => {
     const registry = registryWithMeta({ count: { type: "number" } });
-    const patch = sanitizeMetaInput(registry, "post", { count: "42" });
+    const patch = sanitizeMetaInput(findField(registry, "post"), {
+      count: "42",
+    });
     expect(patch?.upserts.get("count")).toBe(42);
   });
 
   test("number meta rejects empty string (would silently coerce to 0 via Number(''))", () => {
     const registry = registryWithMeta({ count: { type: "number" } });
-    expect(() => sanitizeMetaInput(registry, "post", { count: "" })).toThrow(
-      MetaSanitizationError,
-    );
-    expect(() => sanitizeMetaInput(registry, "post", { count: "   " })).toThrow(
-      MetaSanitizationError,
-    );
+    expect(() =>
+      sanitizeMetaInput(findField(registry, "post"), { count: "" }),
+    ).toThrow(MetaSanitizationError);
+    expect(() =>
+      sanitizeMetaInput(findField(registry, "post"), { count: "   " }),
+    ).toThrow(MetaSanitizationError);
   });
 
   test("boolean meta accepts every common truthy/falsy form callers send", () => {
     const registry = registryWithMeta({ featured: { type: "boolean" } });
     for (const truthy of [true, 1, "1", "true"]) {
-      const patch = sanitizeMetaInput(registry, "post", { featured: truthy });
+      const patch = sanitizeMetaInput(findField(registry, "post"), {
+        featured: truthy,
+      });
       expect(patch?.upserts.get("featured")).toBe(true);
     }
     for (const falsy of [false, 0, "0", "false"]) {
-      const patch = sanitizeMetaInput(registry, "post", { featured: falsy });
+      const patch = sanitizeMetaInput(findField(registry, "post"), {
+        featured: falsy,
+      });
       expect(patch?.upserts.get("featured")).toBe(false);
     }
     expect(() =>
-      sanitizeMetaInput(registry, "post", { featured: "yes" }),
+      sanitizeMetaInput(findField(registry, "post"), { featured: "yes" }),
     ).toThrow(MetaSanitizationError);
   });
 
   test("json meta accepts nested structures, rejects non-serializable values", () => {
     const registry = registryWithMeta({ config: { type: "json" } });
-    const patch = sanitizeMetaInput(registry, "post", {
+    const patch = sanitizeMetaInput(findField(registry, "post"), {
       config: { nested: { arr: [1, 2] } },
     });
     expect(patch?.upserts.get("config")).toEqual({ nested: { arr: [1, 2] } });
     expect(() =>
-      sanitizeMetaInput(registry, "post", { config: () => 1 }),
+      sanitizeMetaInput(findField(registry, "post"), { config: () => 1 }),
     ).toThrow(MetaSanitizationError);
   });
 
   test("value exceeding the encoded-byte cap is rejected (DoS guard)", () => {
     const registry = registryWithMeta({ blob: { type: "string" } });
-    // 256KiB cap + one extra char → just over. The encoded form adds two
-    // quote bytes around a raw string; we use 260k chars to comfortably
-    // exceed even the bare-length cap.
     const tooBig = "x".repeat(260 * 1024);
-    expect(() => sanitizeMetaInput(registry, "post", { blob: tooBig })).toThrow(
-      expect.objectContaining({ reason: "value_too_large" }),
-    );
+    expect(() =>
+      sanitizeMetaInput(findField(registry, "post"), { blob: tooBig }),
+    ).toThrow(expect.objectContaining({ reason: "value_too_large" }));
   });
 
   test("null / undefined values queue a delete rather than an upsert", () => {
@@ -122,7 +152,7 @@ describe("sanitizeMetaInput", () => {
       a: { type: "string" },
       b: { type: "string" },
     });
-    const patch = sanitizeMetaInput(registry, "post", {
+    const patch = sanitizeMetaInput(findField(registry, "post"), {
       a: null,
       b: undefined,
     });
@@ -132,7 +162,9 @@ describe("sanitizeMetaInput", () => {
 
   test("unregistered key → NOT_REGISTERED error (protects against typos)", () => {
     const registry = registryWithMeta({});
-    expect(() => sanitizeMetaInput(registry, "post", { mystery: "x" })).toThrow(
+    expect(() =>
+      sanitizeMetaInput(findField(registry, "post"), { mystery: "x" }),
+    ).toThrow(
       expect.objectContaining({
         key: "mystery",
         reason: "not_registered",
@@ -140,16 +172,20 @@ describe("sanitizeMetaInput", () => {
     );
   });
 
-  test("key registered for a different post type → POST_TYPE_MISMATCH", () => {
+  test("key registered for a different entry type is NOT_REGISTERED when queried for the other scope", () => {
+    // Scope enforcement is now a property of the field-finder (the
+    // caller passes a scope-specific finder), so a key visible for
+    // `product` simply isn't visible for `post` — identical to "never
+    // registered" from the caller's perspective.
     const registry = registryWithMeta({
       product_sku: { type: "string", entryTypes: ["product"] },
     });
     expect(() =>
-      sanitizeMetaInput(registry, "post", { product_sku: "ABC" }),
+      sanitizeMetaInput(findField(registry, "post"), { product_sku: "ABC" }),
     ).toThrow(
       expect.objectContaining({
         key: "product_sku",
-        reason: "post_type_mismatch",
+        reason: "not_registered",
       }),
     );
   });
@@ -162,7 +198,9 @@ describe("sanitizeMetaInput", () => {
           typeof value === "string" ? value.toLowerCase() : value,
       },
     });
-    const patch = sanitizeMetaInput(registry, "post", { slug: "HELLO" });
+    const patch = sanitizeMetaInput(findField(registry, "post"), {
+      slug: "HELLO",
+    });
     expect(patch?.upserts.get("slug")).toBe("hello");
   });
 });
@@ -179,21 +217,23 @@ describe("applyMetaPatch + loadEntryMeta", () => {
       authorId: h.user.id,
       slug: "target",
     });
-    // Seed one key that the patch should NOT touch.
     await h.context.db
       .update(entries)
       .set({ meta: { untouched: "keep" } })
       .where(eq(entries.id, post.id));
 
-    const patch = sanitizeMetaInput(plugins, post.type, {
+    const patch = sanitizeMetaInput(findField(plugins, post.type), {
       title: "Written",
       count: 7,
     });
     if (!patch) throw new Error("patch should not be null");
-    await applyMetaPatch(h.context, post.id, patch);
+    await applyMetaPatch(h.context, entries, entries.id, post.id, patch);
 
-    const meta = await loadEntryMeta(h.context, post.id);
-    expect(meta).toEqual({ title: "Written", count: 7, untouched: "keep" });
+    expect(await loadEntryMeta(h.context, post)).toEqual({
+      title: "Written",
+      count: 7,
+      untouched: "keep",
+    });
   });
 
   test("re-applying overwrites without leaving stale values behind", async () => {
@@ -204,14 +244,17 @@ describe("applyMetaPatch + loadEntryMeta", () => {
       slug: "upsert",
     });
 
-    const first = sanitizeMetaInput(plugins, post.type, { title: "v1" });
-    const second = sanitizeMetaInput(plugins, post.type, { title: "v2" });
+    const first = sanitizeMetaInput(findField(plugins, post.type), {
+      title: "v1",
+    });
+    const second = sanitizeMetaInput(findField(plugins, post.type), {
+      title: "v2",
+    });
     if (!first || !second) throw new Error("patches should not be null");
-    await applyMetaPatch(h.context, post.id, first);
-    await applyMetaPatch(h.context, post.id, second);
+    await applyMetaPatch(h.context, entries, entries.id, post.id, first);
+    await applyMetaPatch(h.context, entries, entries.id, post.id, second);
 
-    const meta = await loadEntryMeta(h.context, post.id);
-    expect(meta).toEqual({ title: "v2" });
+    expect(await loadEntryMeta(h.context, post)).toEqual({ title: "v2" });
   });
 
   test("null value removes the key (caller opts out)", async () => {
@@ -222,20 +265,20 @@ describe("applyMetaPatch + loadEntryMeta", () => {
       slug: "delete",
     });
 
-    const set = sanitizeMetaInput(plugins, post.type, { title: "x" });
-    const clear = sanitizeMetaInput(plugins, post.type, { title: null });
+    const set = sanitizeMetaInput(findField(plugins, post.type), {
+      title: "x",
+    });
+    const clear = sanitizeMetaInput(findField(plugins, post.type), {
+      title: null,
+    });
     if (!set || !clear) throw new Error("patches should not be null");
-    await applyMetaPatch(h.context, post.id, set);
-    await applyMetaPatch(h.context, post.id, clear);
+    await applyMetaPatch(h.context, entries, entries.id, post.id, set);
+    await applyMetaPatch(h.context, entries, entries.id, post.id, clear);
 
-    const meta = await loadEntryMeta(h.context, post.id);
-    expect(meta).toEqual({});
+    expect(await loadEntryMeta(h.context, post)).toEqual({});
   });
 
   test("handles keys containing `-` / `:` that aren't JS-identifier-safe", async () => {
-    // `$.some-key` fails to parse as a SQLite json path (label must be
-    // alphanumeric/underscore); applyMetaPatch uses the double-quoted
-    // `$."key"` form so hyphens + colons round-trip.
     const plugins = registryWithMeta({
       "og:title": { type: "string" },
       "seo-description": { type: "string" },
@@ -246,27 +289,25 @@ describe("applyMetaPatch + loadEntryMeta", () => {
       slug: "path-escapes",
     });
 
-    const patch = sanitizeMetaInput(plugins, post.type, {
+    const patch = sanitizeMetaInput(findField(plugins, post.type), {
       "og:title": "Hello",
       "seo-description": "A page",
     });
     if (!patch) throw new Error("patch should not be null");
-    await applyMetaPatch(h.context, post.id, patch);
+    await applyMetaPatch(h.context, entries, entries.id, post.id, patch);
 
-    const meta = await loadEntryMeta(h.context, post.id);
-    expect(meta).toEqual({
+    expect(await loadEntryMeta(h.context, post)).toEqual({
       "og:title": "Hello",
       "seo-description": "A page",
     });
 
-    // Delete path uses the same escape — cover it too.
-    const clear = sanitizeMetaInput(plugins, post.type, {
+    const clear = sanitizeMetaInput(findField(plugins, post.type), {
       "og:title": null,
       "seo-description": null,
     });
     if (!clear) throw new Error("clear patch should not be null");
-    await applyMetaPatch(h.context, post.id, clear);
-    expect(await loadEntryMeta(h.context, post.id)).toEqual({});
+    await applyMetaPatch(h.context, entries, entries.id, post.id, clear);
+    expect(await loadEntryMeta(h.context, post)).toEqual({});
   });
 
   test("delete + upsert of the same key in one patch lands as the upsert", async () => {
@@ -276,19 +317,18 @@ describe("applyMetaPatch + loadEntryMeta", () => {
       authorId: h.user.id,
       slug: "delete-then-set",
     });
-    const seed = sanitizeMetaInput(plugins, post.type, { title: "old" });
+    const seed = sanitizeMetaInput(findField(plugins, post.type), {
+      title: "old",
+    });
     if (!seed) throw new Error("seed should not be null");
-    await applyMetaPatch(h.context, post.id, seed);
+    await applyMetaPatch(h.context, entries, entries.id, post.id, seed);
 
-    // Manually build a patch that both deletes and sets the same key —
-    // exercises the `json_set(json_remove(...))` composition order.
     const patch = {
       deletes: ["title"] as const,
       upserts: new Map([["title", "new"]]),
     };
-    await applyMetaPatch(h.context, post.id, patch);
+    await applyMetaPatch(h.context, entries, entries.id, post.id, patch);
 
-    const meta = await loadEntryMeta(h.context, post.id);
-    expect(meta).toEqual({ title: "new" });
+    expect(await loadEntryMeta(h.context, post)).toEqual({ title: "new" });
   });
 });

--- a/packages/core/src/rpc/procedures/entry/meta.ts
+++ b/packages/core/src/rpc/procedures/entry/meta.ts
@@ -1,8 +1,6 @@
 import type { AppContext } from "../../../context/app.js";
-import type {
-  MetaBoxField,
-  PluginRegistry,
-} from "../../../plugin/manifest.js";
+import type { PluginRegistry } from "../../../plugin/manifest.js";
+import type { MetaPatch } from "../../meta/core.js";
 import { entries } from "../../../db/schema/entries.js";
 import { findEntryMetaField } from "../../../plugin/manifest.js";
 import {
@@ -13,13 +11,7 @@ import {
   sanitizeMetaForRpc as sanitizeMetaForRpcCore,
 } from "../../meta/core.js";
 
-// Re-exports for handlers that use these names from this module.
-export { isEmptyMetaPatch } from "../../meta/core.js";
-export type {
-  MetaChanges as EntryMetaChanges,
-  MetaPatch,
-  RpcErrorsForMeta,
-} from "../../meta/core.js";
+export type { MetaChanges as EntryMetaChanges } from "../../meta/core.js";
 
 /** RPC-facing sanitizer for an entry's meta input, scoped by entry type. */
 export function sanitizeMetaForRpc(
@@ -27,7 +19,7 @@ export function sanitizeMetaForRpc(
   entryType: string,
   input: Record<string, unknown> | undefined,
   errors: Parameters<typeof sanitizeMetaForRpcCore>[2],
-) {
+): MetaPatch | null {
   return sanitizeMetaForRpcCore(
     (key) => findEntryMetaField(registry, entryType, key),
     input,
@@ -40,9 +32,10 @@ export function decodeMetaBag(
   entry: { readonly type: string },
   raw: Readonly<Record<string, unknown>> | null | undefined,
 ): Record<string, unknown> {
-  const finder = (key: string): MetaBoxField | undefined =>
-    findEntryMetaField(registry, entry.type, key);
-  return decodeMetaBagCore(finder, raw);
+  return decodeMetaBagCore(
+    (key) => findEntryMetaField(registry, entry.type, key),
+    raw,
+  );
 }
 
 export async function loadEntryMeta(

--- a/packages/core/src/rpc/procedures/entry/meta.ts
+++ b/packages/core/src/rpc/procedures/entry/meta.ts
@@ -1,336 +1,73 @@
-import type { SQL } from "drizzle-orm";
-import { sql } from "drizzle-orm";
-
 import type { AppContext } from "../../../context/app.js";
 import type {
-  MetaScalarType,
+  MetaBoxField,
   PluginRegistry,
-  RegisteredMeta,
 } from "../../../plugin/manifest.js";
-import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
+import { findEntryMetaField } from "../../../plugin/manifest.js";
+import {
+  applyMetaPatch,
+  decodeMetaBag as decodeMetaBagCore,
+  isEmptyMetaPatch,
+  loadMeta,
+  sanitizeMetaForRpc as sanitizeMetaForRpcCore,
+} from "../../meta/core.js";
 
-// Entry meta lives in a single JSON column (`entries.meta`). Writes merge
-// into the existing bag via SQLite's `json_set` / `json_remove` so
-// concurrent updaters touching disjoint keys don't clobber each other at
-// the row level; reads come back already-parsed thanks to drizzle's
-// `mode: "json"`.
+// Re-exports for handlers that use these names from this module.
+export { isEmptyMetaPatch } from "../../meta/core.js";
+export type {
+  MetaChanges as EntryMetaChanges,
+  MetaPatch,
+  RpcErrorsForMeta,
+} from "../../meta/core.js";
 
-/**
- * Hard cap on the JSON-encoded size of a single meta value, in bytes.
- * 256KiB fits any realistic plugin-shaped JSON config while bounding the
- * damage an adversarial writer can do. Enforced in `coerceToType` rather
- * than the valibot schema so plugin authors can calibrate per key via a
- * custom `sanitize` if they need tighter bounds.
- */
-const MAX_META_VALUE_BYTES = 256 * 1024;
-
-type EntryMetaMap = Record<string, unknown>;
-
-/**
- * Validated meta patch produced by `sanitizeMetaInput`. Values in
- * `upserts` are the *decoded* post-sanitization objects — the `MetaPatch`
- * is what filter hooks see, so keeping decoded values here means a
- * plugin doesn't have to double-parse. `applyMetaPatch` JSON-encodes at
- * the last moment, before the UPDATE.
- */
-interface MetaPatch {
-  readonly upserts: ReadonlyMap<string, unknown>;
-  readonly deletes: readonly string[];
-}
-
-/**
- * Validate an incoming meta map against the plugin registry and produce a
- * DB-ready patch. Unregistered keys, keys registered for a different
- * post type, and type-coercion failures all throw so the caller can
- * surface them as 4xx before any write. `null` / `undefined` values are
- * deletion requests; everything else is coerced + sanitized.
- */
-export function sanitizeMetaInput(
-  registry: PluginRegistry,
-  entryType: string,
-  input: EntryMetaMap | undefined,
-): MetaPatch | null {
-  if (input === undefined) return null;
-  const upserts = new Map<string, unknown>();
-  const deletes: string[] = [];
-  for (const [key, rawValue] of Object.entries(input)) {
-    const definition = registry.metaKeys.get(key);
-    if (!definition) {
-      throw new MetaSanitizationError(key, "not_registered");
-    }
-    if (!definition.entryTypes.includes(entryType)) {
-      throw new MetaSanitizationError(key, "post_type_mismatch");
-    }
-    if (rawValue === null || rawValue === undefined) {
-      deletes.push(key);
-      continue;
-    }
-    const coerced = coerceToType(definition, rawValue);
-    const sanitized = definition.sanitize
-      ? definition.sanitize(coerced)
-      : coerced;
-    assertEncodedSize(key, sanitized);
-    upserts.set(key, sanitized);
-  }
-  return { upserts, deletes };
-}
-
-/**
- * Reason codes are part of the RPC error `data.reason` surface — admin
- * UIs and plugin tests match on these strings, so treat them as a
- * public contract.
- */
-type MetaSanitizationReason =
-  | "not_registered"
-  | "post_type_mismatch"
-  | "invalid_value"
-  | "value_too_large";
-
-export class MetaSanitizationError extends Error {
-  readonly key: string;
-  readonly reason: MetaSanitizationReason;
-  constructor(key: string, reason: MetaSanitizationReason) {
-    super(`meta key "${key}" failed sanitization: ${reason}`);
-    this.key = key;
-    this.reason = reason;
-  }
-}
-
-/**
- * Minimum shape of the oRPC `errors` object needed to surface a
- * `MetaSanitizationError` as a CONFLICT. Declared structurally so this
- * helper doesn't have to import oRPC types — the handler passes its
- * `errors` in and TS matches on shape.
- */
-interface RpcErrorsForMeta {
-  CONFLICT: (args: { data: { reason: string; key?: string } }) => Error;
-}
-
-/**
- * Thin wrapper around `sanitizeMetaInput` that translates a thrown
- * `MetaSanitizationError` into the RPC handler's CONFLICT envelope.
- */
+/** RPC-facing sanitizer for an entry's meta input, scoped by entry type. */
 export function sanitizeMetaForRpc(
   registry: PluginRegistry,
   entryType: string,
-  input: EntryMetaMap | undefined,
-  errors: RpcErrorsForMeta,
-): MetaPatch | null {
-  try {
-    return sanitizeMetaInput(registry, entryType, input);
-  } catch (error) {
-    if (error instanceof MetaSanitizationError) {
-      throw errors.CONFLICT({
-        data: { reason: `meta_${error.reason}`, key: error.key },
-      });
-    }
-    throw error;
-  }
+  input: Record<string, unknown> | undefined,
+  errors: Parameters<typeof sanitizeMetaForRpcCore>[2],
+) {
+  return sanitizeMetaForRpcCore(
+    (key) => findEntryMetaField(registry, entryType, key),
+    input,
+    errors,
+  );
 }
 
-function coerceToType(definition: RegisteredMeta, value: unknown): unknown {
-  switch (definition.type) {
-    case "string":
-      return coerceString(definition.key, value);
-    case "number":
-      return coerceNumber(definition.key, value);
-    case "boolean":
-      return coerceBoolean(definition.key, value);
-    case "json":
-      return coerceJson(definition.key, value);
-  }
-}
-
-function coerceString(key: string, value: unknown): string {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" && Number.isFinite(value)) return String(value);
-  if (typeof value === "boolean") return String(value);
-  throw new MetaSanitizationError(key, "invalid_value");
-}
-
-function coerceNumber(key: string, value: unknown): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    // Empty string comes from cleared form inputs; the admin dispatcher
-    // already sends `null` for those, but a direct RPC caller might send
-    // "" — reject here so we don't silently coerce to 0 (`Number("") === 0`).
-    if (value.trim() === "") {
-      throw new MetaSanitizationError(key, "invalid_value");
-    }
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  if (typeof value === "boolean") return value ? 1 : 0;
-  throw new MetaSanitizationError(key, "invalid_value");
-}
-
-function coerceBoolean(key: string, value: unknown): boolean {
-  if (typeof value === "boolean") return value;
-  if (value === 1 || value === "1" || value === "true") return true;
-  if (value === 0 || value === "0" || value === "false") return false;
-  throw new MetaSanitizationError(key, "invalid_value");
-}
-
-function coerceJson(key: string, value: unknown): unknown {
-  // json keys take anything round-trippable through JSON.stringify — we
-  // reject values that throw (BigInt) or silently drop (functions,
-  // Symbols) so reads don't hand back `undefined` for something a plugin
-  // thought it stored. TS types JSON.stringify as always-string, but at
-  // runtime it returns `undefined` for un-serializable inputs — hence
-  // the cast.
-  try {
-    const encoded = JSON.stringify(value) as string | undefined;
-    if (encoded === undefined) {
-      throw new MetaSanitizationError(key, "invalid_value");
-    }
-    return JSON.parse(encoded);
-  } catch {
-    throw new MetaSanitizationError(key, "invalid_value");
-  }
-}
-
-function assertEncodedSize(key: string, value: unknown): void {
-  const encoded = JSON.stringify(value) as string | undefined;
-  if (encoded === undefined) return; // already caught in coerceJson
-  const byteLength = new TextEncoder().encode(encoded).length;
-  if (byteLength > MAX_META_VALUE_BYTES) {
-    throw new MetaSanitizationError(key, "value_too_large");
-  }
-}
-
-/**
- * Decode a raw meta bag (as returned by drizzle's JSON-mode column) into
- * the plugin-typed shape RPC consumers expect. Unregistered keys pass
- * through untouched — the row exists in the DB but the plugin that wrote
- * it is no longer installed; we don't pretend to know its shape.
- */
 export function decodeMetaBag(
   registry: PluginRegistry,
+  entry: { readonly type: string },
   raw: Readonly<Record<string, unknown>> | null | undefined,
-): EntryMetaMap {
-  if (!raw) return {};
-  const out: EntryMetaMap = {};
-  for (const [key, value] of Object.entries(raw)) {
-    const definition = registry.metaKeys.get(key);
-    out[key] = definition ? coerceOnRead(definition.type, value) : value;
-  }
-  return out;
+): Record<string, unknown> {
+  const finder = (key: string): MetaBoxField | undefined =>
+    findEntryMetaField(registry, entry.type, key);
+  return decodeMetaBagCore(finder, raw);
 }
 
-function coerceOnRead(type: MetaScalarType, value: unknown): unknown {
-  // Reads are forgiving — the row was validated on write but a schema
-  // change (e.g. a plugin flipping `number` → `string`) shouldn't 500 the
-  // editor. We coerce when we can and fall through to the raw value
-  // otherwise.
-  switch (type) {
-    case "string":
-      return typeof value === "string" ? value : String(value);
-    case "number":
-      return typeof value === "number" ? value : Number(value);
-    case "boolean":
-      return typeof value === "boolean" ? value : Boolean(value);
-    case "json":
-      return value;
-  }
-}
-
-/**
- * Load the full meta bag for a single post. Returns an empty object when
- * the post has no meta (fresh row) or has been deleted. Used by
- * `post.create` / `post.update` to read back the post-write state.
- */
 export async function loadEntryMeta(
-  context: AppContext,
-  entryId: number,
-): Promise<EntryMetaMap> {
-  const [row] = await context.db
-    .select({ meta: entries.meta })
-    .from(entries)
-    .where(eq(entries.id, entryId));
-  return decodeMetaBag(context.plugins, row?.meta);
-}
-
-/**
- * True when the patch is a no-op (null, or zero upserts + zero deletes).
- * `post.update` uses this as part of the "nothing to write anywhere"
- * short-circuit — when this, `termsPatch`, and the column patch are all
- * empty, the handler skips the writes and returns the existing row.
- */
-export function isEmptyMetaPatch(patch: MetaPatch | null): boolean {
-  return (
-    patch === null || (patch.upserts.size === 0 && patch.deletes.length === 0)
+  ctx: AppContext,
+  entry: { readonly id: number; readonly type: string },
+): Promise<Record<string, unknown>> {
+  return loadMeta(ctx, entries, entries.id, entry.id, (key) =>
+    findEntryMetaField(ctx.plugins, entry.type, key),
   );
 }
 
 /**
- * Merge a validated patch into `entries.meta` via `json_set` /
- * `json_remove`. Deletes nest inside sets so a caller that clears and
- * re-sets the same key in one request behaves predictably. Partial
- * semantics: keys not mentioned in the patch are untouched.
- */
-export async function applyMetaPatch(
-  context: AppContext,
-  entryId: number,
-  patch: MetaPatch,
-): Promise<void> {
-  if (patch.upserts.size === 0 && patch.deletes.length === 0) return;
-
-  let expr: SQL = sql`${entries.meta}`;
-  if (patch.deletes.length > 0) {
-    const paths = patch.deletes.map((k) => sql`${metaJsonPath(k)}`);
-    expr = sql`json_remove(${expr}, ${sql.join(paths, sql`, `)})`;
-  }
-  if (patch.upserts.size > 0) {
-    const pairs = Array.from(
-      patch.upserts,
-      ([key, value]) =>
-        sql`${metaJsonPath(key)}, json(${JSON.stringify(value)})`,
-    );
-    expr = sql`json_set(${expr}, ${sql.join(pairs, sql`, `)})`;
-  }
-
-  await context.db
-    .update(entries)
-    .set({ meta: expr })
-    .where(eq(entries.id, entryId));
-}
-
-// SQLite's JSON path `$.label` only accepts `[A-Za-z0-9_]` in unquoted
-// labels, but valid meta keys may include `-` or `:` (see the input
-// schema regex). The double-quoted label form `$."foo-bar"` handles
-// them; interpolation is safe because keys are pre-validated to exclude
-// `"` and `\`.
-function metaJsonPath(key: string): string {
-  return `$."${key}"`;
-}
-
-/**
- * Apply a meta patch and fire `post:meta_changed` so auditors /
- * cache-invalidators can react. Plugins that need to mutate the patch
- * should subscribe to `rpc:entry.{create,update}:input` instead —
- * mutating `input.meta` there feeds the sanitizer + writer downstream.
+ * Apply a meta patch to `entries.meta` and fire `entry:meta_changed`.
+ * Plugins that need to mutate the patch subscribe to
+ * `rpc:entry.{create,update}:input` and mutate `input.meta` there.
  */
 export async function writeEntryMeta(
-  context: AppContext,
-  post: { id: number; type: string },
-  patch: MetaPatch,
+  ctx: AppContext,
+  entry: { readonly id: number; readonly type: string },
+  patch: Parameters<typeof applyMetaPatch>[4],
 ): Promise<void> {
   if (isEmptyMetaPatch(patch)) return;
-  await applyMetaPatch(context, post.id, patch);
-
-  const changes: EntryMetaChanges = {
+  await applyMetaPatch(ctx, entries, entries.id, entry.id, patch);
+  await ctx.hooks.doAction("entry:meta_changed", entry, {
     set: Object.fromEntries(patch.upserts),
     removed: [...patch.deletes],
-  };
-  await context.hooks.doAction("entry:meta_changed", post, changes);
-}
-
-/**
- * Payload for `post:meta_changed`. `set` is the decoded key → value map
- * of upserts; `removed` is the list of cleared keys.
- */
-export interface EntryMetaChanges {
-  readonly set: Readonly<Record<string, unknown>>;
-  readonly removed: readonly string[];
+  });
 }

--- a/packages/core/src/rpc/procedures/entry/read.test.ts
+++ b/packages/core/src/rpc/procedures/entry/read.test.ts
@@ -561,16 +561,14 @@ describe("entry.get", () => {
 
   test("response hydrates the meta bag, typed against the plugin registry", async () => {
     const plugins = createPluginRegistry();
-    plugins.metaKeys.set("meta_title", {
-      key: "meta_title",
-      type: "string",
+    plugins.entryMetaBoxes.set("test-seo", {
+      id: "test-seo",
+      label: "SEO",
       entryTypes: ["post"],
-      registeredBy: "test",
-    });
-    plugins.metaKeys.set("is_featured", {
-      key: "is_featured",
-      type: "boolean",
-      entryTypes: ["post"],
+      fields: [
+        { key: "meta_title", label: "Meta title", type: "string", inputType: "text" },
+        { key: "is_featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+      ],
       registeredBy: "test",
     });
     const h = await createRpcHarness({ authAs: "admin", plugins });

--- a/packages/core/src/rpc/procedures/entry/read.test.ts
+++ b/packages/core/src/rpc/procedures/entry/read.test.ts
@@ -566,8 +566,18 @@ describe("entry.get", () => {
       label: "SEO",
       entryTypes: ["post"],
       fields: [
-        { key: "meta_title", label: "Meta title", type: "string", inputType: "text" },
-        { key: "is_featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+        {
+          key: "meta_title",
+          label: "Meta title",
+          type: "string",
+          inputType: "text",
+        },
+        {
+          key: "is_featured",
+          label: "Featured",
+          type: "boolean",
+          inputType: "checkbox",
+        },
       ],
       registeredBy: "test",
     });

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -277,16 +277,14 @@ describe("entry.update", () => {
 
   test("meta: partial write leaves keys outside the patch untouched", async () => {
     const plugins = createPluginRegistry();
-    plugins.metaKeys.set("meta_title", {
-      key: "meta_title",
-      type: "string",
+    plugins.entryMetaBoxes.set("test-seo", {
+      id: "test-seo",
+      label: "SEO",
       entryTypes: ["post"],
-      registeredBy: "test",
-    });
-    plugins.metaKeys.set("is_featured", {
-      key: "is_featured",
-      type: "boolean",
-      entryTypes: ["post"],
+      fields: [
+        { key: "meta_title", label: "Meta title", type: "string", inputType: "text" },
+        { key: "is_featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+      ],
       registeredBy: "test",
     });
     const h = await createRpcHarness({ authAs: "admin", plugins });
@@ -308,16 +306,14 @@ describe("entry.update", () => {
 
   test("meta: null value clears a key without touching the others", async () => {
     const plugins = createPluginRegistry();
-    plugins.metaKeys.set("meta_title", {
-      key: "meta_title",
-      type: "string",
+    plugins.entryMetaBoxes.set("test-seo", {
+      id: "test-seo",
+      label: "SEO",
       entryTypes: ["post"],
-      registeredBy: "test",
-    });
-    plugins.metaKeys.set("is_featured", {
-      key: "is_featured",
-      type: "boolean",
-      entryTypes: ["post"],
+      fields: [
+        { key: "meta_title", label: "Meta title", type: "string", inputType: "text" },
+        { key: "is_featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+      ],
       registeredBy: "test",
     });
     const h = await createRpcHarness({ authAs: "admin", plugins });
@@ -353,16 +349,14 @@ describe("entry.update", () => {
 
   test("rpc:entry.update:input can inject derived meta before sanitization; post:meta_changed fires with the final bag", async () => {
     const plugins = createPluginRegistry();
-    plugins.metaKeys.set("title", {
-      key: "title",
-      type: "string",
+    plugins.entryMetaBoxes.set("test-derived", {
+      id: "test-derived",
+      label: "Derived",
       entryTypes: ["post"],
-      registeredBy: "test",
-    });
-    plugins.metaKeys.set("title_lc", {
-      key: "title_lc",
-      type: "string",
-      entryTypes: ["post"],
+      fields: [
+        { key: "title", label: "Title", type: "string", inputType: "text" },
+        { key: "title_lc", label: "Title (lowercase)", type: "string", inputType: "text" },
+      ],
       registeredBy: "test",
     });
     const h = await createRpcHarness({ authAs: "admin", plugins });
@@ -399,10 +393,13 @@ describe("entry.update", () => {
 
   test("rpc:entry.get:output can decorate the returned meta bag without touching storage", async () => {
     const plugins = createPluginRegistry();
-    plugins.metaKeys.set("title", {
-      key: "title",
-      type: "string",
+    plugins.entryMetaBoxes.set("test-title", {
+      id: "test-title",
+      label: "Title",
       entryTypes: ["post"],
+      fields: [
+        { key: "title", label: "Title", type: "string", inputType: "text" },
+      ],
       registeredBy: "test",
     });
     const h = await createRpcHarness({ authAs: "admin", plugins });

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -282,8 +282,18 @@ describe("entry.update", () => {
       label: "SEO",
       entryTypes: ["post"],
       fields: [
-        { key: "meta_title", label: "Meta title", type: "string", inputType: "text" },
-        { key: "is_featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+        {
+          key: "meta_title",
+          label: "Meta title",
+          type: "string",
+          inputType: "text",
+        },
+        {
+          key: "is_featured",
+          label: "Featured",
+          type: "boolean",
+          inputType: "checkbox",
+        },
       ],
       registeredBy: "test",
     });
@@ -311,8 +321,18 @@ describe("entry.update", () => {
       label: "SEO",
       entryTypes: ["post"],
       fields: [
-        { key: "meta_title", label: "Meta title", type: "string", inputType: "text" },
-        { key: "is_featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+        {
+          key: "meta_title",
+          label: "Meta title",
+          type: "string",
+          inputType: "text",
+        },
+        {
+          key: "is_featured",
+          label: "Featured",
+          type: "boolean",
+          inputType: "checkbox",
+        },
       ],
       registeredBy: "test",
     });
@@ -355,7 +375,12 @@ describe("entry.update", () => {
       entryTypes: ["post"],
       fields: [
         { key: "title", label: "Title", type: "string", inputType: "text" },
-        { key: "title_lc", label: "Title (lowercase)", type: "string", inputType: "text" },
+        {
+          key: "title_lc",
+          label: "Title (lowercase)",
+          type: "string",
+          inputType: "text",
+        },
       ],
       registeredBy: "test",
     });

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -147,7 +147,7 @@ export const update = base
       termsPatch === undefined &&
       isEmptyMetaPatch(metaPatch)
     ) {
-      const meta = decodeMetaBag(context.plugins, existing.meta);
+      const meta = decodeMetaBag(context.plugins, existing, existing.meta);
       return context.hooks.applyFilter("rpc:entry.update:output", {
         ...existing,
         meta,
@@ -212,9 +212,9 @@ export const update = base
     let meta: Record<string, unknown>;
     if (metaPatch) {
       await writeEntryMeta(context, updated, metaPatch);
-      meta = await loadEntryMeta(context, updated.id);
+      meta = await loadEntryMeta(context, updated);
     } else {
-      meta = decodeMetaBag(context.plugins, updated.meta);
+      meta = decodeMetaBag(context.plugins, updated, updated.meta);
     }
 
     if (postColumnsWritten) {

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -12,6 +12,7 @@ import { entryTerm } from "../../../db/schema/entry_term.js";
 import { terms } from "../../../db/schema/terms.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
+import { isEmptyMetaPatch } from "../../meta/core.js";
 import { assertContentWithinByteCap } from "./content.js";
 import { stripUndefined } from "./helpers.js";
 import {
@@ -25,7 +26,6 @@ import {
 } from "./lifecycle.js";
 import {
   decodeMetaBag,
-  isEmptyMetaPatch,
   loadEntryMeta,
   sanitizeMetaForRpc,
   writeEntryMeta,

--- a/packages/core/src/rpc/procedures/term/create.ts
+++ b/packages/core/src/rpc/procedures/term/create.ts
@@ -3,6 +3,12 @@ import { terms } from "../../../db/schema/terms.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { taxonomyCapability } from "./helpers.js";
+import {
+  decodeMetaBag,
+  loadTermMeta,
+  sanitizeMetaForRpc,
+  writeTermMeta,
+} from "./meta.js";
 import { termCreateInputSchema } from "./schemas.js";
 
 export const create = base
@@ -37,6 +43,15 @@ export const create = base
       }
     }
 
+    // Validate meta up-front so a bad key fails before the term insert —
+    // keeps the DB clean when the client sends a typo in a meta key.
+    const metaPatch = sanitizeMetaForRpc(
+      context.plugins,
+      filtered.taxonomy,
+      filtered.meta,
+      errors,
+    );
+
     let created;
     try {
       [created] = await context.db
@@ -59,6 +74,17 @@ export const create = base
       throw errors.CONFLICT({ data: { reason: "insert_failed" } });
     }
 
+    let meta: Record<string, unknown>;
+    if (metaPatch) {
+      await writeTermMeta(context, created, metaPatch);
+      meta = await loadTermMeta(context, created);
+    } else {
+      meta = decodeMetaBag(context.plugins, created.taxonomy, created.meta);
+    }
+
     await context.hooks.doAction("term:created", created);
-    return context.hooks.applyFilter("rpc:term.create:output", created);
+    return context.hooks.applyFilter("rpc:term.create:output", {
+      ...created,
+      meta,
+    });
   });

--- a/packages/core/src/rpc/procedures/term/get.ts
+++ b/packages/core/src/rpc/procedures/term/get.ts
@@ -3,6 +3,7 @@ import { terms } from "../../../db/schema/terms.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { taxonomyCapability } from "./helpers.js";
+import { decodeMetaBag } from "./meta.js";
 import { termGetInputSchema } from "./schemas.js";
 
 export const get = base
@@ -22,5 +23,9 @@ export const get = base
       throw errors.NOT_FOUND({ data: { kind: "term", id: input.id } });
     }
 
-    return context.hooks.applyFilter("rpc:term.get:output", row);
+    const meta = decodeMetaBag(context.plugins, row.taxonomy, row.meta);
+    return context.hooks.applyFilter("rpc:term.get:output", {
+      ...row,
+      meta,
+    });
   });

--- a/packages/core/src/rpc/procedures/term/meta.test.ts
+++ b/packages/core/src/rpc/procedures/term/meta.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "vitest";
+
+import type {
+  MetaBoxField,
+  MutablePluginRegistry,
+} from "../../../plugin/manifest.js";
+import type { UserRole } from "../../../db/schema/users.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+function taxonomyRegistry(): MutablePluginRegistry {
+  const registry = createPluginRegistry();
+  registry.taxonomies.set("category", {
+    name: "category",
+    label: "Categories",
+    registeredBy: "test",
+  });
+  const caps: Record<string, UserRole> = {
+    "category:read": "subscriber",
+    "category:assign": "contributor",
+    "category:edit": "editor",
+    "category:delete": "editor",
+  };
+  for (const [name, minRole] of Object.entries(caps)) {
+    registry.capabilities.set(name, { name, minRole, registeredBy: "test" });
+  }
+  return registry;
+}
+
+function registerTermMetaFields(
+  plugins: MutablePluginRegistry,
+  taxonomy: string,
+  fields: MetaBoxField[],
+): void {
+  plugins.termMetaBoxes.set(`test-${taxonomy}`, {
+    id: `test-${taxonomy}`,
+    label: "Test",
+    taxonomies: [taxonomy],
+    fields,
+    registeredBy: "test",
+  });
+}
+
+describe("term meta: registration + round-trip via term.update", () => {
+  test("registered meta keys persist through term.create + term.get", async () => {
+    const plugins = taxonomyRegistry();
+    registerTermMetaFields(plugins, "category", [
+      { key: "icon_url", label: "Icon URL", type: "string", inputType: "url" },
+      { key: "featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    const created = await h.client.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+      meta: { icon_url: "https://example.test/news.svg", featured: true },
+    });
+    expect(created.meta).toEqual({
+      icon_url: "https://example.test/news.svg",
+      featured: true,
+    });
+
+    const reloaded = await h.client.term.get({ id: created.id });
+    expect(reloaded.meta).toEqual({
+      icon_url: "https://example.test/news.svg",
+      featured: true,
+    });
+  });
+
+  test("unregistered meta key is rejected with CONFLICT", async () => {
+    const plugins = taxonomyRegistry();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    await expect(
+      h.client.term.create({
+        taxonomy: "category",
+        name: "News",
+        slug: "news",
+        meta: { mystery: "x" },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "meta_not_registered", key: "mystery" },
+    });
+  });
+
+  test("term.update partial patch + null-delete semantics match entry.meta", async () => {
+    const plugins = taxonomyRegistry();
+    registerTermMetaFields(plugins, "category", [
+      { key: "icon_url", label: "Icon URL", type: "string", inputType: "url" },
+      { key: "featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    const created = await h.client.term.create({
+      taxonomy: "category",
+      name: "Tech",
+      slug: "tech",
+      meta: { icon_url: "https://example.test/tech.svg", featured: false },
+    });
+
+    // Partial patch: only `featured` is touched; `icon_url` survives.
+    const afterFlip = await h.client.term.update({
+      id: created.id,
+      meta: { featured: true },
+    });
+    expect(afterFlip.meta).toEqual({
+      icon_url: "https://example.test/tech.svg",
+      featured: true,
+    });
+
+    // Null deletes the key.
+    const afterClear = await h.client.term.update({
+      id: created.id,
+      meta: { icon_url: null },
+    });
+    expect(afterClear.meta).toEqual({ featured: true });
+  });
+
+  test("term:meta_changed fires with the upsert + delete diff", async () => {
+    const plugins = taxonomyRegistry();
+    registerTermMetaFields(plugins, "category", [
+      { key: "icon_url", label: "Icon URL", type: "string", inputType: "url" },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    const created = await h.client.term.create({
+      taxonomy: "category",
+      name: "Travel",
+      slug: "travel",
+    });
+    const spy = h.spyAction("term:meta_changed");
+
+    await h.client.term.update({
+      id: created.id,
+      meta: { icon_url: "https://example.test/travel.svg" },
+    });
+    await h.client.term.update({
+      id: created.id,
+      meta: { icon_url: null },
+    });
+
+    expect(spy.calls).toHaveLength(2);
+    expect(spy.calls[0]?.args[1]).toEqual({
+      set: { icon_url: "https://example.test/travel.svg" },
+      removed: [],
+    });
+    expect(spy.calls[1]?.args[1]).toEqual({
+      set: {},
+      removed: ["icon_url"],
+    });
+  });
+});

--- a/packages/core/src/rpc/procedures/term/meta.test.ts
+++ b/packages/core/src/rpc/procedures/term/meta.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "vitest";
 
+import type { UserRole } from "../../../db/schema/users.js";
 import type {
   MetaBoxField,
   MutablePluginRegistry,
 } from "../../../plugin/manifest.js";
-import type { UserRole } from "../../../db/schema/users.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
@@ -46,7 +46,12 @@ describe("term meta: registration + round-trip via term.update", () => {
     const plugins = taxonomyRegistry();
     registerTermMetaFields(plugins, "category", [
       { key: "icon_url", label: "Icon URL", type: "string", inputType: "url" },
-      { key: "featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+      {
+        key: "featured",
+        label: "Featured",
+        type: "boolean",
+        inputType: "checkbox",
+      },
     ]);
     const h = await createRpcHarness({ authAs: "admin", plugins });
 
@@ -89,7 +94,12 @@ describe("term meta: registration + round-trip via term.update", () => {
     const plugins = taxonomyRegistry();
     registerTermMetaFields(plugins, "category", [
       { key: "icon_url", label: "Icon URL", type: "string", inputType: "url" },
-      { key: "featured", label: "Featured", type: "boolean", inputType: "checkbox" },
+      {
+        key: "featured",
+        label: "Featured",
+        type: "boolean",
+        inputType: "checkbox",
+      },
     ]);
     const h = await createRpcHarness({ authAs: "admin", plugins });
 
@@ -116,6 +126,57 @@ describe("term meta: registration + round-trip via term.update", () => {
       meta: { icon_url: null },
     });
     expect(afterClear.meta).toEqual({ featured: true });
+  });
+
+  test("key registered on a different taxonomy → meta_not_registered for the other scope", async () => {
+    const plugins = taxonomyRegistry();
+    plugins.taxonomies.set("tag", {
+      name: "tag",
+      label: "Tags",
+      registeredBy: "test",
+    });
+    const tagCaps: Record<string, UserRole> = {
+      "tag:read": "subscriber",
+      "tag:edit": "editor",
+    };
+    for (const [name, minRole] of Object.entries(tagCaps)) {
+      plugins.capabilities.set(name, { name, minRole, registeredBy: "test" });
+    }
+    registerTermMetaFields(plugins, "tag", [
+      { key: "color", label: "Color", type: "string", inputType: "text" },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    await expect(
+      h.client.term.create({
+        taxonomy: "category",
+        name: "News",
+        slug: "news",
+        meta: { color: "red" },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "meta_not_registered", key: "color" },
+    });
+  });
+
+  test("term.update with an empty meta patch does not fire term:meta_changed", async () => {
+    const plugins = taxonomyRegistry();
+    registerTermMetaFields(plugins, "category", [
+      { key: "icon_url", label: "Icon URL", type: "string", inputType: "url" },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    const created = await h.client.term.create({
+      taxonomy: "category",
+      name: "Travel",
+      slug: "travel",
+    });
+    const spy = h.spyAction("term:meta_changed");
+
+    await h.client.term.update({ id: created.id, meta: {} });
+
+    expect(spy.calls).toHaveLength(0);
   });
 
   test("term:meta_changed fires with the upsert + delete diff", async () => {

--- a/packages/core/src/rpc/procedures/term/meta.ts
+++ b/packages/core/src/rpc/procedures/term/meta.ts
@@ -1,8 +1,6 @@
 import type { AppContext } from "../../../context/app.js";
-import type {
-  MetaBoxField,
-  PluginRegistry,
-} from "../../../plugin/manifest.js";
+import type { PluginRegistry } from "../../../plugin/manifest.js";
+import type { MetaPatch } from "../../meta/core.js";
 import { terms } from "../../../db/schema/terms.js";
 import { findTermMetaField } from "../../../plugin/manifest.js";
 import {
@@ -21,7 +19,7 @@ export function sanitizeMetaForRpc(
   taxonomy: string,
   input: Record<string, unknown> | undefined,
   errors: Parameters<typeof sanitizeMetaForRpcCore>[2],
-) {
+): MetaPatch | null {
   return sanitizeMetaForRpcCore(
     (key) => findTermMetaField(registry, taxonomy, key),
     input,
@@ -33,10 +31,11 @@ export function decodeMetaBag(
   registry: PluginRegistry,
   taxonomy: string,
   raw: Readonly<Record<string, unknown>> | null | undefined,
-) {
-  const finder = (key: string): MetaBoxField | undefined =>
-    findTermMetaField(registry, taxonomy, key);
-  return decodeMetaBagCore(finder, raw);
+): Record<string, unknown> {
+  return decodeMetaBagCore(
+    (key) => findTermMetaField(registry, taxonomy, key),
+    raw,
+  );
 }
 
 export async function loadTermMeta(

--- a/packages/core/src/rpc/procedures/term/meta.ts
+++ b/packages/core/src/rpc/procedures/term/meta.ts
@@ -1,0 +1,67 @@
+import type { AppContext } from "../../../context/app.js";
+import type {
+  MetaBoxField,
+  PluginRegistry,
+} from "../../../plugin/manifest.js";
+import { terms } from "../../../db/schema/terms.js";
+import { findTermMetaField } from "../../../plugin/manifest.js";
+import {
+  applyMetaPatch,
+  decodeMetaBag as decodeMetaBagCore,
+  isEmptyMetaPatch,
+  loadMeta,
+  sanitizeMetaForRpc as sanitizeMetaForRpcCore,
+} from "../../meta/core.js";
+
+export type { MetaChanges as TermMetaChanges } from "../../meta/core.js";
+
+/** RPC-facing sanitizer for a term's meta input, scoped by taxonomy. */
+export function sanitizeMetaForRpc(
+  registry: PluginRegistry,
+  taxonomy: string,
+  input: Record<string, unknown> | undefined,
+  errors: Parameters<typeof sanitizeMetaForRpcCore>[2],
+) {
+  return sanitizeMetaForRpcCore(
+    (key) => findTermMetaField(registry, taxonomy, key),
+    input,
+    errors,
+  );
+}
+
+export function decodeMetaBag(
+  registry: PluginRegistry,
+  taxonomy: string,
+  raw: Readonly<Record<string, unknown>> | null | undefined,
+) {
+  const finder = (key: string): MetaBoxField | undefined =>
+    findTermMetaField(registry, taxonomy, key);
+  return decodeMetaBagCore(finder, raw);
+}
+
+export async function loadTermMeta(
+  ctx: AppContext,
+  term: { readonly id: number; readonly taxonomy: string },
+): Promise<Record<string, unknown>> {
+  return loadMeta(ctx, terms, terms.id, term.id, (key) =>
+    findTermMetaField(ctx.plugins, term.taxonomy, key),
+  );
+}
+
+/**
+ * Apply a meta patch to `terms.meta` and fire `term:meta_changed`.
+ * Plugins that need to mutate the patch should subscribe to
+ * `rpc:term.{create,update}:input` and mutate `input.meta` there.
+ */
+export async function writeTermMeta(
+  ctx: AppContext,
+  term: { readonly id: number; readonly taxonomy: string },
+  patch: Parameters<typeof applyMetaPatch>[4],
+): Promise<void> {
+  if (isEmptyMetaPatch(patch)) return;
+  await applyMetaPatch(ctx, terms, terms.id, term.id, patch);
+  await ctx.hooks.doAction("term:meta_changed", term, {
+    set: Object.fromEntries(patch.upserts),
+    removed: [...patch.deletes],
+  });
+}

--- a/packages/core/src/rpc/procedures/term/schemas.ts
+++ b/packages/core/src/rpc/procedures/term/schemas.ts
@@ -19,6 +19,27 @@ const nameSchema = v.pipe(
 
 const descriptionSchema = v.nullable(v.pipe(v.string(), v.maxLength(10_000)));
 
+// Meta bag accepted by `term.create` / `term.update`. Per-key
+// validation runs against the term meta box registry in the handler;
+// the outer shape cap mirrors `entry.meta`.
+const MAX_META_KEYS_PER_REQUEST = 200;
+
+const metaKeySchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(200),
+  v.regex(/^[a-zA-Z0-9_:-]+$/, "meta key must be alphanumeric/_/:/-"),
+);
+
+const termMetaInputSchema = v.pipe(
+  v.record(metaKeySchema, v.unknown()),
+  v.check(
+    (val) => Object.keys(val).length <= MAX_META_KEYS_PER_REQUEST,
+    `meta accepts at most ${MAX_META_KEYS_PER_REQUEST} keys per request`,
+  ),
+);
+
 export const termListInputSchema = v.object({
   taxonomy: taxonomySchema,
   parentId: v.optional(v.nullable(idParam)),
@@ -38,6 +59,7 @@ export const termCreateInputSchema = v.object({
   slug: slugSchema,
   description: v.optional(descriptionSchema),
   parentId: v.optional(v.nullable(idParam)),
+  meta: v.optional(termMetaInputSchema),
 });
 
 export const termUpdateInputSchema = v.object({
@@ -46,6 +68,7 @@ export const termUpdateInputSchema = v.object({
   slug: v.optional(slugSchema),
   description: v.optional(descriptionSchema),
   parentId: v.optional(v.nullable(idParam)),
+  meta: v.optional(termMetaInputSchema),
 });
 
 export const termDeleteInputSchema = v.object({ id: idParam });

--- a/packages/core/src/rpc/procedures/term/update.ts
+++ b/packages/core/src/rpc/procedures/term/update.ts
@@ -1,9 +1,9 @@
 import type { NewTerm } from "../../../db/schema/terms.js";
 import { and, eq, isUniqueConstraintError } from "../../../db/index.js";
 import { terms } from "../../../db/schema/terms.js";
-import { isEmptyMetaPatch } from "../../meta/core.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
+import { isEmptyMetaPatch } from "../../meta/core.js";
 import { stripUndefined } from "../entry/helpers.js";
 import { parentWouldCreateCycle, taxonomyCapability } from "./helpers.js";
 import {

--- a/packages/core/src/rpc/procedures/term/update.ts
+++ b/packages/core/src/rpc/procedures/term/update.ts
@@ -1,10 +1,17 @@
 import type { NewTerm } from "../../../db/schema/terms.js";
 import { and, eq, isUniqueConstraintError } from "../../../db/index.js";
 import { terms } from "../../../db/schema/terms.js";
+import { isEmptyMetaPatch } from "../../meta/core.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { stripUndefined } from "../entry/helpers.js";
 import { parentWouldCreateCycle, taxonomyCapability } from "./helpers.js";
+import {
+  decodeMetaBag,
+  loadTermMeta,
+  sanitizeMetaForRpc,
+  writeTermMeta,
+} from "./meta.js";
 import { termUpdateInputSchema } from "./schemas.js";
 
 export const update = base
@@ -52,29 +59,65 @@ export const update = base
       }
     }
 
-    const { id: _id, ...changes } = filtered;
+    const { id: _id, meta: metaInput, ...changes } = filtered;
+    const metaPatch = sanitizeMetaForRpc(
+      context.plugins,
+      existing.taxonomy,
+      metaInput,
+      errors,
+    );
+
     const patch: Partial<NewTerm> = stripUndefined(changes);
-    if (Object.keys(patch).length === 0) {
-      return context.hooks.applyFilter("rpc:term.update:output", existing);
+
+    // Nothing to write anywhere? Return the existing row with its
+    // decoded meta for a consistent response shape.
+    if (Object.keys(patch).length === 0 && isEmptyMetaPatch(metaPatch)) {
+      const meta = decodeMetaBag(
+        context.plugins,
+        existing.taxonomy,
+        existing.meta,
+      );
+      return context.hooks.applyFilter("rpc:term.update:output", {
+        ...existing,
+        meta,
+      });
     }
 
-    let updated;
-    try {
-      [updated] = await context.db
-        .update(terms)
-        .set(patch)
-        .where(eq(terms.id, existing.id))
-        .returning();
-    } catch (error) {
-      if (isUniqueConstraintError(error)) {
-        throw errors.CONFLICT({ data: { reason: "slug_taken" } });
+    let updated = existing;
+    let rowWritten = false;
+    if (Object.keys(patch).length > 0) {
+      try {
+        const [row] = await context.db
+          .update(terms)
+          .set(patch)
+          .where(eq(terms.id, existing.id))
+          .returning();
+        if (!row) {
+          throw errors.CONFLICT({ data: { reason: "update_failed" } });
+        }
+        updated = row;
+        rowWritten = true;
+      } catch (error) {
+        if (isUniqueConstraintError(error)) {
+          throw errors.CONFLICT({ data: { reason: "slug_taken" } });
+        }
+        throw error;
       }
-      throw error;
-    }
-    if (!updated) {
-      throw errors.CONFLICT({ data: { reason: "update_failed" } });
     }
 
-    await context.hooks.doAction("term:updated", updated, existing);
-    return context.hooks.applyFilter("rpc:term.update:output", updated);
+    let meta: Record<string, unknown>;
+    if (metaPatch) {
+      await writeTermMeta(context, updated, metaPatch);
+      meta = await loadTermMeta(context, updated);
+    } else {
+      meta = decodeMetaBag(context.plugins, updated.taxonomy, updated.meta);
+    }
+
+    if (rowWritten) {
+      await context.hooks.doAction("term:updated", updated, existing);
+    }
+    return context.hooks.applyFilter("rpc:term.update:output", {
+      ...updated,
+      meta,
+    });
   });


### PR DESCRIPTION
## Summary

- Drop the split `registerMeta` + `registerMetaBox` API — each meta field now carries its own `type` + optional `sanitize` inline, so there's one primitive (`registerEntryMetaBox` / `registerTermMetaBox`) instead of two that have to line up.
- Term meta boxes: `meta` flows through `term.create` / `term.update` / `term.get`, fires `term:meta_changed`, admin renders card-per-box on the taxonomy edit screen (each card an independent form with its own save).
- Shared meta plumbing (sanitize, apply, load, decode) extracted to `rpc/meta/core.ts` parameterised by a find-field fn + drizzle table ref, so entry/term meta don't duplicate the JSON-column glue.
- `buildManifest` asserts `(scope, field.key)` uniqueness so a plugin author can't silently shadow another box's key on the same entry type / taxonomy.

## Test plan
- [ ] `pnpm turbo run typecheck lint test` passes across all 32 workspace tasks
- [ ] `term.create` / `term.update` with registered keys round-trips through `term.get` (new suite in `rpc/procedures/term/meta.test.ts`)
- [ ] Unregistered term meta key is rejected `CONFLICT { reason: "meta_not_registered" }`
- [ ] Null value on `term.update` deletes the key, partial patch preserves other keys
- [ ] `term:meta_changed` fires with `{ set, removed }` diff
- [ ] Entry meta test suite still green after rewrite for the new single-primitive API
- [ ] `examples/minimal` build still emits an admin manifest with `entryMetaBoxes` + `termMetaBoxes` slots