### PR TITLE
feat(core,admin): user meta boxes via the same shared primitive

### DIFF
--- a/examples/minimal/test/build.integration.test.ts
+++ b/examples/minimal/test/build.integration.test.ts
@@ -53,7 +53,7 @@ describe("examples/minimal — plumix build", () => {
       // page load.
       const adminHtml = readFileSync(adminIndexHtml, "utf8");
       expect(adminHtml).toMatch(
-        /<script id="plumix-manifest" type="application\/json">\{"entryTypes":\[\],"taxonomies":\[\],"entryMetaBoxes":\[\],"termMetaBoxes":\[\],"settingsGroups":\[\],"settingsPages":\[\]\}<\/script>/,
+        /<script id="plumix-manifest" type="application\/json">\{"entryTypes":\[\],"taxonomies":\[\],"entryMetaBoxes":\[\],"termMetaBoxes":\[\],"userMetaBoxes":\[\],"settingsGroups":\[\],"settingsPages":\[\]\}<\/script>/,
       );
     },
     60_000,

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -112,6 +112,7 @@ export const MANIFEST_WITH_POST: PlumixManifest = {
   taxonomies: [],
   entryMetaBoxes: [],
   termMetaBoxes: [],
+  userMetaBoxes: [],
   settingsGroups: [],
   settingsPages: [],
 };
@@ -143,6 +144,7 @@ export const MANIFEST_WITH_TAXONOMIES: PlumixManifest = {
   ],
   entryMetaBoxes: [],
   termMetaBoxes: [],
+  userMetaBoxes: [],
   settingsGroups: [],
   settingsPages: [],
 };
@@ -191,6 +193,7 @@ export const MANIFEST_WITH_META_BOXES: PlumixManifest = {
     },
   ],
   termMetaBoxes: [],
+  userMetaBoxes: [],
   settingsGroups: [],
   settingsPages: [],
 };
@@ -205,6 +208,7 @@ export const MANIFEST_WITH_SETTINGS: PlumixManifest = {
   taxonomies: [],
   entryMetaBoxes: [],
   termMetaBoxes: [],
+  userMetaBoxes: [],
   settingsGroups: [
     {
       name: "identity",

--- a/packages/admin/src/components/meta-box/user-meta-box-card.tsx
+++ b/packages/admin/src/components/meta-box/user-meta-box-card.tsx
@@ -1,0 +1,152 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { orpc } from "@/lib/orpc.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { UserMetaBoxManifestEntry } from "@plumix/core/manifest";
+
+import { MetaBoxField } from "./meta-box-field.js";
+
+function seedFromUser(
+  fields: UserMetaBoxManifestEntry["fields"],
+  meta: Readonly<Record<string, unknown>> | null | undefined,
+): Record<string, unknown> {
+  const bag = meta ?? {};
+  const seed: Record<string, unknown> = {};
+  for (const field of fields) {
+    seed[field.key] = bag[field.key] ?? field.default;
+  }
+  return seed;
+}
+
+/**
+ * One shadcn `<Card>` for a registered user meta box. Each card is an
+ * independent form — its Save button fires `user.update` with just
+ * that box's fields as the meta patch, same per-card atomic save model
+ * as term meta boxes and settings pages.
+ */
+export function UserMetaBoxCard({
+  box,
+  user,
+  disabled = false,
+}: {
+  readonly box: UserMetaBoxManifestEntry;
+  readonly user: {
+    readonly id: number;
+    readonly meta?: Readonly<Record<string, unknown>>;
+  };
+  readonly disabled?: boolean;
+}): ReactNode {
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<Record<string, unknown>>(() =>
+    seedFromUser(box.fields, user.meta),
+  );
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [saveNotice, setSaveNotice] = useState<string | null>(null);
+
+  const save = useMutation({
+    mutationFn: (next: Record<string, unknown>) =>
+      orpc.user.update.call({ id: user.id, meta: next }),
+    onMutate: () => {
+      setServerError(null);
+      setSaveNotice(null);
+    },
+    onSuccess: async (data) => {
+      // Re-seed from the server's post-sanitize bag so the form
+      // reflects any trimming / coercion the server applied (plugin
+      // sanitize hooks, `coerceOnRead`, etc.).
+      setValues(seedFromUser(box.fields, data.meta));
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.user.get.queryOptions({ input: { id: user.id } })
+            .queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.user.list.key(),
+        }),
+      ]);
+      setSaveNotice("Saved.");
+    },
+    onError: (err) => {
+      setServerError(
+        err instanceof Error ? err.message : "Couldn't save these fields.",
+      );
+    },
+  });
+
+  return (
+    <Card data-testid={`user-meta-box-${box.id}`}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          save.mutate(values);
+        }}
+      >
+        <CardHeader>
+          <CardTitle>
+            <h2
+              className="text-lg font-semibold"
+              data-testid={`user-meta-box-heading-${box.id}`}
+            >
+              {box.label}
+            </h2>
+          </CardTitle>
+          {box.description ? (
+            <CardDescription>{box.description}</CardDescription>
+          ) : null}
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {box.fields.map((field) => (
+            <MetaBoxField
+              key={field.key}
+              field={field}
+              value={values[field.key]}
+              disabled={disabled || save.isPending}
+              onChange={(next) => {
+                setValues((prev) => ({ ...prev, [field.key]: next }));
+              }}
+            />
+          ))}
+
+          {serverError ? (
+            <Alert
+              variant="destructive"
+              role="alert"
+              data-testid={`user-meta-box-error-${box.id}`}
+            >
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {saveNotice ? (
+            <Alert
+              aria-live="polite"
+              data-testid={`user-meta-box-notice-${box.id}`}
+            >
+              <AlertDescription>{saveNotice}</AlertDescription>
+            </Alert>
+          ) : null}
+        </CardContent>
+        <div className="flex justify-end px-6 pb-6">
+          <Button
+            type="submit"
+            disabled={disabled || save.isPending}
+            data-testid={`user-meta-box-submit-${box.id}`}
+          >
+            {save.isPending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -4,6 +4,7 @@ import type {
   EntryMetaBoxManifestEntry,
   PlumixManifest,
   SettingsPageManifestEntry,
+  UserMetaBoxManifestEntry,
 } from "@plumix/core/manifest";
 
 import {
@@ -17,6 +18,7 @@ import {
   visibleEntryTypes,
   visibleSettingsPages,
   visibleTaxonomies,
+  visibleUserMetaBoxes,
 } from "./manifest.js";
 
 function withManifestScript(json: string): Document {
@@ -354,6 +356,56 @@ describe("entryMetaBoxesForType", () => {
       settingsPages: [],
     };
     expect(entryMetaBoxesForType("post", [], source)).toEqual([]);
+  });
+});
+
+describe("visibleUserMetaBoxes", () => {
+  function userBox(
+    id: string,
+    overrides: Partial<UserMetaBoxManifestEntry> = {},
+  ): UserMetaBoxManifestEntry {
+    return {
+      id,
+      label: id,
+      fields: [],
+      ...overrides,
+    };
+  }
+
+  const source: PlumixManifest = {
+    entryTypes: [],
+    taxonomies: [],
+    entryMetaBoxes: [],
+    termMetaBoxes: [],
+    userMetaBoxes: [
+      userBox("public"),
+      userBox("privileged", { capability: "user:edit" }),
+    ],
+    settingsGroups: [],
+    settingsPages: [],
+  };
+
+  test("an undefined-capability box is visible regardless of viewer caps", () => {
+    const ids = visibleUserMetaBoxes([], source).map((b) => b.id);
+    expect(ids).toContain("public");
+  });
+
+  test("drops boxes gated by a capability the viewer lacks", () => {
+    const ids = visibleUserMetaBoxes([], source).map((b) => b.id);
+    expect(ids).toEqual(["public"]);
+  });
+
+  test("keeps capability-gated boxes when the viewer has the cap", () => {
+    const ids = visibleUserMetaBoxes(["user:edit"], source).map((b) => b.id);
+    expect(ids).toEqual(["public", "privileged"]);
+  });
+
+  test("returns empty when no user meta boxes are registered", () => {
+    const empty: PlumixManifest = {
+      ...source,
+      userMetaBoxes: [],
+    };
+    expect(visibleUserMetaBoxes(["user:edit"], empty)).toEqual([]);
   });
 });
 

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -41,6 +41,7 @@ describe("readManifest", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -57,6 +58,7 @@ describe("readManifest", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -69,6 +71,7 @@ describe("readManifest", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -84,6 +87,7 @@ describe("readManifest", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -97,6 +101,7 @@ describe("readManifest", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -111,6 +116,7 @@ describe("readManifest", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -142,6 +148,7 @@ describe("readManifest", () => {
         },
       ],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -171,6 +178,7 @@ describe("readManifest", () => {
       ],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -193,6 +201,7 @@ describe("findEntryTypeBySlug", () => {
     taxonomies: [],
     entryMetaBoxes: [],
     termMetaBoxes: [],
+    userMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -226,6 +235,7 @@ describe("visibleEntryTypes", () => {
     taxonomies: [],
     entryMetaBoxes: [],
     termMetaBoxes: [],
+    userMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -265,6 +275,7 @@ describe("entryMetaBoxesForType", () => {
         box("c"), // default
       ],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -281,6 +292,7 @@ describe("entryMetaBoxesForType", () => {
         box("second", { priority: "high" }),
       ],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -297,6 +309,7 @@ describe("entryMetaBoxesForType", () => {
         box("shop", { entryTypes: ["product"] }),
       ],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -313,6 +326,7 @@ describe("entryMetaBoxesForType", () => {
         box("privileged", { capability: "post:edit_any" }),
       ],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -335,6 +349,7 @@ describe("entryMetaBoxesForType", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -351,6 +366,7 @@ describe("findTaxonomyByName", () => {
     ],
     entryMetaBoxes: [],
     termMetaBoxes: [],
+    userMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -374,6 +390,7 @@ describe("visibleTaxonomies", () => {
     ],
     entryMetaBoxes: [],
     termMetaBoxes: [],
+    userMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -395,6 +412,7 @@ describe("findSettingsPageByName + visibleSettingsPages + findSettingsGroupByNam
     taxonomies: [],
     entryMetaBoxes: [],
     termMetaBoxes: [],
+    userMetaBoxes: [],
     settingsGroups: [
       {
         name: "identity",

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -185,8 +185,12 @@ export function termMetaBoxesForTaxonomy(
  * Resolve the user meta boxes rendered on the user edit form. User
  * meta is a flat keyspace — no scope argument; capability alone gates
  * visibility. Registration order is preserved.
+ *
+ * Named to match `visibleEntryTypes` / `visibleTaxonomies` — unlike
+ * `entryMetaBoxesForType` / `termMetaBoxesForTaxonomy`, user meta has
+ * no scope to filter on.
  */
-export function userMetaBoxes(
+export function visibleUserMetaBoxes(
   capabilities: readonly string[],
   source: PlumixManifest = manifest,
 ): readonly UserMetaBoxManifestEntry[] {

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -6,6 +6,7 @@ import type {
   SettingsPageManifestEntry,
   TaxonomyManifestEntry,
   TermMetaBoxManifestEntry,
+  UserMetaBoxManifestEntry,
 } from "@plumix/core/manifest";
 import { emptyManifest, MANIFEST_SCRIPT_ID } from "@plumix/core/manifest";
 
@@ -38,6 +39,7 @@ function normalize(value: unknown): PlumixManifest {
   const taxonomies = (value as { taxonomies?: unknown }).taxonomies;
   const entryMetaBoxes = (value as { entryMetaBoxes?: unknown }).entryMetaBoxes;
   const termMetaBoxes = (value as { termMetaBoxes?: unknown }).termMetaBoxes;
+  const userMetaBoxes = (value as { userMetaBoxes?: unknown }).userMetaBoxes;
   const settingsGroups = (value as { settingsGroups?: unknown }).settingsGroups;
   const settingsPages = (value as { settingsPages?: unknown }).settingsPages;
   return {
@@ -45,6 +47,7 @@ function normalize(value: unknown): PlumixManifest {
     taxonomies: Array.isArray(taxonomies) ? taxonomies : [],
     entryMetaBoxes: Array.isArray(entryMetaBoxes) ? entryMetaBoxes : [],
     termMetaBoxes: Array.isArray(termMetaBoxes) ? termMetaBoxes : [],
+    userMetaBoxes: Array.isArray(userMetaBoxes) ? userMetaBoxes : [],
     settingsGroups: Array.isArray(settingsGroups) ? settingsGroups : [],
     settingsPages: Array.isArray(settingsPages) ? settingsPages : [],
   };
@@ -176,6 +179,21 @@ export function termMetaBoxesForTaxonomy(
     if (box.capability !== undefined && !caps.has(box.capability)) return false;
     return true;
   });
+}
+
+/**
+ * Resolve the user meta boxes rendered on the user edit form. User
+ * meta is a flat keyspace — no scope argument; capability alone gates
+ * visibility. Registration order is preserved.
+ */
+export function userMetaBoxes(
+  capabilities: readonly string[],
+  source: PlumixManifest = manifest,
+): readonly UserMetaBoxManifestEntry[] {
+  const caps = new Set(capabilities);
+  return source.userMetaBoxes.filter(
+    (box) => box.capability === undefined || caps.has(box.capability),
+  );
 }
 
 /**

--- a/packages/admin/src/routes/_authenticated/users/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { FormEditSkeleton } from "@/components/form/edit-skeleton.js";
 import { FormField } from "@/components/form/field.js";
+import { UserMetaBoxCard } from "@/components/meta-box/user-meta-box-card.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
 import { Button } from "@/components/ui/button.js";
@@ -14,6 +15,7 @@ import {
 } from "@/components/ui/card.js";
 import { Label } from "@/components/ui/label.js";
 import { hasCap } from "@/lib/caps.js";
+import { userMetaBoxes } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useForm } from "@tanstack/react-form";
 import {
@@ -32,6 +34,7 @@ import {
 import { ArrowLeft } from "lucide-react";
 import * as v from "valibot";
 
+import type { UserMetaBoxManifestEntry } from "@plumix/core/manifest";
 import type { User, UserRole } from "@plumix/core/schema";
 import { idPathParam } from "@plumix/core/validation";
 
@@ -122,6 +125,7 @@ function UserEditRoute(): ReactNode {
   const { data: target } = useSuspenseQuery(
     orpc.user.get.queryOptions({ input: { id: userId } }),
   );
+  const metaBoxes = userMetaBoxes(session.capabilities);
   return (
     <UserEditForm
       // Remount after each save so TanStack Form re-reads `defaultValues`
@@ -137,6 +141,7 @@ function UserEditRoute(): ReactNode {
       canSave={canSave}
       canDisable={canDisable}
       canDelete={canDelete}
+      metaBoxes={metaBoxes}
     />
   );
 }
@@ -148,6 +153,7 @@ function UserEditForm({
   canSave,
   canDisable,
   canDelete,
+  metaBoxes,
 }: {
   target: User;
   isSelf: boolean;
@@ -155,6 +161,7 @@ function UserEditForm({
   canSave: boolean;
   canDisable: boolean;
   canDelete: boolean;
+  metaBoxes: readonly UserMetaBoxManifestEntry[];
 }): ReactNode {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -351,6 +358,15 @@ function UserEditForm({
           </form>
         </CardContent>
       </Card>
+
+      {metaBoxes.map((box) => (
+        <UserMetaBoxCard
+          key={box.id}
+          box={box}
+          user={target}
+          disabled={!canSave}
+        />
+      ))}
 
       {canDisable ? <StatusCard target={target} /> : null}
       {canDelete ? <DeleteCard target={target} /> : null}

--- a/packages/admin/src/routes/_authenticated/users/$id.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/card.js";
 import { Label } from "@/components/ui/label.js";
 import { hasCap } from "@/lib/caps.js";
-import { userMetaBoxes } from "@/lib/manifest.js";
+import { visibleUserMetaBoxes } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useForm } from "@tanstack/react-form";
 import {
@@ -125,7 +125,7 @@ function UserEditRoute(): ReactNode {
   const { data: target } = useSuspenseQuery(
     orpc.user.get.queryOptions({ input: { id: userId } }),
   );
-  const metaBoxes = userMetaBoxes(session.capabilities);
+  const metaBoxes = visibleUserMetaBoxes(session.capabilities);
   return (
     <UserEditForm
       // Remount after each save so TanStack Form re-reads `defaultValues`

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -21,6 +21,7 @@ import type {
   SettingsPageOptions,
   TaxonomyOptions,
   TermMetaBoxOptions,
+  UserMetaBoxOptions,
 } from "./manifest.js";
 import {
   deriveEntryTypeCapabilities,
@@ -81,6 +82,14 @@ export interface PluginSetupContext {
    * are the meta key contract.
    */
   registerTermMetaBox(id: string, options: TermMetaBoxOptions): void;
+
+  /**
+   * Same model as `registerEntryMetaBox`, but rendered on the user
+   * edit form. Users have a flat meta keyspace (no scope property) —
+   * all registered boxes target every user; use `capability` to gate
+   * which boxes the viewer sees.
+   */
+  registerUserMetaBox(id: string, options: UserMetaBoxOptions): void;
   registerCapability(name: string, minRole: UserRole): void;
 
   /**
@@ -205,6 +214,18 @@ export function createPluginSetupContext({
       }
       assertMetaBoxFields("term meta box", id, options.fields);
       registry.termMetaBoxes.set(id, {
+        ...options,
+        id,
+        registeredBy: pluginId,
+      });
+    },
+
+    registerUserMetaBox: (id, options) => {
+      if (registry.userMetaBoxes.has(id)) {
+        throw new DuplicateRegistrationError("user meta box", id);
+      }
+      assertMetaBoxFields("user meta box", id, options.fields);
+      registry.userMetaBoxes.set(id, {
         ...options,
         id,
         registeredBy: pluginId,

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -495,7 +495,51 @@ describe("buildManifest", () => {
     );
   });
 
-  test("empty meta-box registry yields empty entry + term meta box arrays", async () => {
+  test("rejects two user meta boxes declaring the same field key", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("dupe-user", (ctx) => {
+      ctx.registerUserMetaBox("u-a", {
+        label: "A",
+        fields: [
+          { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+        ],
+      });
+      ctx.registerUserMetaBox("u-b", {
+        label: "B",
+        fields: [
+          { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    expect(() => buildManifest(registry)).toThrow(
+      /Meta field "bio" is declared by user meta boxes "u-a" and "u-b" on the same scope "user"/,
+    );
+  });
+
+  test("projects a registered user meta box into the manifest", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("profile", (ctx) => {
+      ctx.registerUserMetaBox("profile", {
+        label: "Profile",
+        description: "Author bio + socials.",
+        fields: [
+          { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    const manifest = buildManifest(registry);
+    expect(manifest.userMetaBoxes).toHaveLength(1);
+    expect(manifest.userMetaBoxes[0]).toMatchObject({
+      id: "profile",
+      label: "Profile",
+      description: "Author bio + socials.",
+    });
+  });
+
+  test("empty meta-box registry yields empty entry + term + user meta box arrays", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("blog", (ctx) => {
       ctx.registerEntryType("post", { label: "Posts" });
@@ -505,6 +549,7 @@ describe("buildManifest", () => {
     const manifest = buildManifest(registry);
     expect(manifest.entryMetaBoxes).toEqual([]);
     expect(manifest.termMetaBoxes).toEqual([]);
+    expect(manifest.userMetaBoxes).toEqual([]);
   });
 
   test("projects registered taxonomies, dropping server-only fields", async () => {
@@ -580,13 +625,14 @@ describe("serializeManifestScript", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
     expect(tag).toContain(`id="${MANIFEST_SCRIPT_ID}"`);
     expect(tag).toContain(`type="application/json"`);
     expect(tag).toContain(
-      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
+      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"userMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
     );
   });
 
@@ -598,6 +644,7 @@ describe("serializeManifestScript", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
@@ -611,6 +658,7 @@ describe("serializeManifestScript", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -637,14 +685,15 @@ describe("injectManifestIntoHtml", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
     expect(out).toContain(
-      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
+      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"userMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
     );
     expect(out).not.toContain(
-      `{"entryTypes":[],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
+      `{"entryTypes":[],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"userMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
     );
   });
 
@@ -654,6 +703,7 @@ describe("injectManifestIntoHtml", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     };
@@ -681,11 +731,12 @@ describe("injectManifestIntoHtml", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
     expect(out).toContain(
-      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
+      `{"entryTypes":[{"name":"post","adminSlug":"posts","label":"Posts"}],"taxonomies":[],"entryMetaBoxes":[],"termMetaBoxes":[],"userMetaBoxes":[],"settingsGroups":[],"settingsPages":[]}`,
     );
   });
 
@@ -698,11 +749,12 @@ describe("injectManifestIntoHtml", () => {
       taxonomies: [],
       entryMetaBoxes: [],
       termMetaBoxes: [],
+      userMetaBoxes: [],
       settingsGroups: [],
       settingsPages: [],
     });
     expect(out).toMatch(
-      /^<script id="plumix-manifest" type="application\/json">\{"entryTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"taxonomies":\[\],"entryMetaBoxes":\[\],"termMetaBoxes":\[\],"settingsGroups":\[\],"settingsPages":\[\]}<\/script>$/,
+      /^<script id="plumix-manifest" type="application\/json">\{"entryTypes":\[\{"name":"post","adminSlug":"posts","label":"Posts"\}\],"taxonomies":\[\],"entryMetaBoxes":\[\],"termMetaBoxes":\[\],"userMetaBoxes":\[\],"settingsGroups":\[\],"settingsPages":\[\]}<\/script>$/,
     );
   });
 });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -139,6 +139,25 @@ export interface TermMetaBoxOptions {
 }
 
 /**
+ * Meta box shown on the user edit form. Rendered as stacked shadcn
+ * `<Card>`s with independent save buttons — same card-per-box model as
+ * term boxes and settings groups. User meta is a flat keyspace (no
+ * scope analogue to entry types or taxonomies), so every registered
+ * box targets every user; use `capability` to gate which boxes the
+ * viewer sees.
+ *
+ * `capability` is a UI-only filter; see `EntryMetaBoxOptions` for the
+ * caveat. The server gates user meta writes on `user:edit` /
+ * `user:edit_own` (same check as the rest of `user.update`).
+ */
+export interface UserMetaBoxOptions {
+  readonly label: string;
+  readonly description?: string;
+  readonly capability?: string;
+  readonly fields: readonly MetaBoxField[];
+}
+
+/**
  * Narrow discriminator for settings-form fields. Mirrors the subset of
  * `MetaBoxField.inputType` values that the settings admin's field
  * dispatcher renders today — `text` (single-line) and `textarea`
@@ -216,6 +235,11 @@ export interface RegisteredTermMetaBox extends TermMetaBoxOptions {
   readonly registeredBy: string | null;
 }
 
+export interface RegisteredUserMetaBox extends UserMetaBoxOptions {
+  readonly id: string;
+  readonly registeredBy: string | null;
+}
+
 export interface RegisteredSettingsGroup extends SettingsGroupOptions {
   readonly name: string;
   readonly registeredBy: string | null;
@@ -244,6 +268,7 @@ export interface PluginRegistry {
   readonly taxonomies: ReadonlyMap<string, RegisteredTaxonomy>;
   readonly entryMetaBoxes: ReadonlyMap<string, RegisteredEntryMetaBox>;
   readonly termMetaBoxes: ReadonlyMap<string, RegisteredTermMetaBox>;
+  readonly userMetaBoxes: ReadonlyMap<string, RegisteredUserMetaBox>;
   readonly capabilities: ReadonlyMap<string, RegisteredCapability>;
   readonly settingsGroups: ReadonlyMap<string, RegisteredSettingsGroup>;
   readonly settingsPages: ReadonlyMap<string, RegisteredSettingsPage>;
@@ -255,6 +280,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly taxonomies: Map<string, RegisteredTaxonomy>;
   readonly entryMetaBoxes: Map<string, RegisteredEntryMetaBox>;
   readonly termMetaBoxes: Map<string, RegisteredTermMetaBox>;
+  readonly userMetaBoxes: Map<string, RegisteredUserMetaBox>;
   readonly capabilities: Map<string, RegisteredCapability>;
   readonly settingsGroups: Map<string, RegisteredSettingsGroup>;
   readonly settingsPages: Map<string, RegisteredSettingsPage>;
@@ -267,6 +293,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     taxonomies: new Map(),
     entryMetaBoxes: new Map(),
     termMetaBoxes: new Map(),
+    userMetaBoxes: new Map(),
     capabilities: new Map(),
     settingsGroups: new Map(),
     settingsPages: new Map(),
@@ -304,6 +331,23 @@ export function findTermMetaField(
 ): MetaBoxField | undefined {
   for (const box of registry.termMetaBoxes.values()) {
     if (!box.taxonomies.includes(taxonomy)) continue;
+    const field = box.fields.find((f) => f.key === key);
+    if (field) return field;
+  }
+  return undefined;
+}
+
+/**
+ * Like `findEntryMetaField`, but for user meta. Users have a flat
+ * keyspace (no entry-type / taxonomy analogue), so no scope argument —
+ * key uniqueness across all user meta boxes is enforced at manifest-
+ * build time.
+ */
+export function findUserMetaField(
+  registry: PluginRegistry,
+  key: string,
+): MetaBoxField | undefined {
+  for (const box of registry.userMetaBoxes.values()) {
     const field = box.fields.find((f) => f.key === key);
     if (field) return field;
   }
@@ -400,6 +444,18 @@ export interface TermMetaBoxManifestEntry {
 }
 
 /**
+ * Shape serialised for user meta boxes (user edit form). No scope
+ * property — user meta boxes target the single user-entity surface.
+ */
+export interface UserMetaBoxManifestEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly capability?: string;
+  readonly fields: readonly MetaBoxFieldManifestEntry[];
+}
+
+/**
  * Shape serialised for taxonomies in the manifest. Strict allowlist
  * projection of `RegisteredTaxonomy` — drops `registeredBy` (server-only
  * debug metadata) and server-only operational flags (`isInQuickEdit`,
@@ -462,6 +518,7 @@ export interface PlumixManifest {
   readonly taxonomies: readonly TaxonomyManifestEntry[];
   readonly entryMetaBoxes: readonly EntryMetaBoxManifestEntry[];
   readonly termMetaBoxes: readonly TermMetaBoxManifestEntry[];
+  readonly userMetaBoxes: readonly UserMetaBoxManifestEntry[];
   readonly settingsGroups: readonly SettingsGroupManifestEntry[];
   readonly settingsPages: readonly SettingsPageManifestEntry[];
 }
@@ -475,6 +532,7 @@ export function emptyManifest(): PlumixManifest {
     taxonomies: [],
     entryMetaBoxes: [],
     termMetaBoxes: [],
+    userMetaBoxes: [],
     settingsGroups: [],
     settingsPages: [],
   };
@@ -510,6 +568,9 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
   const termMetaBoxes = Array.from(registry.termMetaBoxes.values()).map(
     toTermMetaBoxEntry,
   );
+  const userMetaBoxes = Array.from(registry.userMetaBoxes.values()).map(
+    toUserMetaBoxEntry,
+  );
   assertMetaBoxScopesExist(
     entryMetaBoxes,
     (box) => box.entryTypes,
@@ -524,8 +585,15 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
     "term meta box",
     "taxonomy",
   );
-  assertUniqueFieldKeysPerScope(entryMetaBoxes, "entry");
-  assertUniqueFieldKeysPerScope(termMetaBoxes, "term");
+  assertUniqueFieldKeysPerScope(
+    entryMetaBoxes,
+    (box) => box.entryTypes,
+    "entry",
+  );
+  assertUniqueFieldKeysPerScope(termMetaBoxes, (box) => box.taxonomies, "term");
+  // User meta is a flat keyspace — one synthetic "user" scope keeps
+  // the shared helper honest without inventing a second code path.
+  assertUniqueFieldKeysPerScope(userMetaBoxes, () => ["user"], "user");
   const settingsGroups = Array.from(registry.settingsGroups.values()).map(
     toSettingsGroupEntry,
   );
@@ -542,6 +610,7 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
     taxonomies,
     entryMetaBoxes,
     termMetaBoxes,
+    userMetaBoxes,
     settingsGroups,
     settingsPages,
   };
@@ -551,16 +620,22 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
  * Two meta boxes on the same `(scope, field.key)` pair would silently
  * write to the same storage key — a plugin-author footgun. Fail loudly
  * at manifest-build time. `scope` is the entry type (for entry boxes)
- * or taxonomy (for term boxes).
+ * or taxonomy (for term boxes); user boxes collapse to one synthetic
+ * scope because the user keyspace is flat.
  */
-function assertUniqueFieldKeysPerScope(
-  boxes: readonly (EntryMetaBoxManifestEntry | TermMetaBoxManifestEntry)[],
-  kind: "entry" | "term",
+function assertUniqueFieldKeysPerScope<
+  TBox extends {
+    readonly id: string;
+    readonly fields: readonly MetaBoxFieldManifestEntry[];
+  },
+>(
+  boxes: readonly TBox[],
+  getScopes: (box: TBox) => readonly string[],
+  kind: "entry" | "term" | "user",
 ): void {
   const seen = new Map<string, string>();
   for (const box of boxes) {
-    const scopes = "entryTypes" in box ? box.entryTypes : box.taxonomies;
-    for (const scope of scopes) {
+    for (const scope of getScopes(box)) {
       for (const field of box.fields) {
         const scopedKey = `${scope}:${field.key}`;
         const existing = seen.get(scopedKey);
@@ -786,6 +861,20 @@ function toTermMetaBoxEntry(
     label,
     description,
     taxonomies,
+    capability,
+    fields: fields.map(toMetaBoxFieldEntry),
+  };
+}
+
+// User meta boxes are stacked like term boxes — no scope / context.
+function toUserMetaBoxEntry(
+  box: RegisteredUserMetaBox,
+): UserMetaBoxManifestEntry {
+  const { id, label, description, capability, fields } = box;
+  return {
+    id,
+    label,
+    description,
     capability,
     fields: fields.map(toMetaBoxFieldEntry),
   };

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -149,6 +149,9 @@ export interface TermMetaBoxOptions {
  * `capability` is a UI-only filter; see `EntryMetaBoxOptions` for the
  * caveat. The server gates user meta writes on `user:edit` /
  * `user:edit_own` (same check as the rest of `user.update`).
+ *
+ * `MetaBoxField.sanitize` runs server-side only — the manifest wire
+ * contract strips callbacks before shipping to the admin bundle.
  */
 export interface UserMetaBoxOptions {
   readonly label: string;
@@ -593,7 +596,7 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
   assertUniqueFieldKeysPerScope(termMetaBoxes, (box) => box.taxonomies, "term");
   // User meta is a flat keyspace — one synthetic "user" scope keeps
   // the shared helper honest without inventing a second code path.
-  assertUniqueFieldKeysPerScope(userMetaBoxes, () => ["user"], "user");
+  assertUniqueFieldKeysPerScope(userMetaBoxes, getUserScope, "user");
   const settingsGroups = Array.from(registry.settingsGroups.values()).map(
     toSettingsGroupEntry,
   );
@@ -615,6 +618,12 @@ export function buildManifest(registry: PluginRegistry): PlumixManifest {
     settingsPages,
   };
 }
+
+// Synthetic flat-keyspace scope for user meta. Hoisted so the
+// `assertUniqueFieldKeysPerScope` callback doesn't re-allocate per
+// buildManifest call.
+const USER_SCOPE = ["user"] as const;
+const getUserScope = (): readonly string[] => USER_SCOPE;
 
 /**
  * Two meta boxes on the same `(scope, field.key)` pair would silently

--- a/packages/core/src/plugin/register.test.ts
+++ b/packages/core/src/plugin/register.test.ts
@@ -213,4 +213,63 @@ describe("installPlugins", () => {
       /declares field "icon" more than once/,
     );
   });
+
+  test("registerUserMetaBox rejects a duplicate id across plugins", async () => {
+    const hooks = new HookRegistry();
+    const first = definePlugin("a", (ctx) => {
+      ctx.registerUserMetaBox("profile", {
+        label: "A",
+        fields: [
+          { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+        ],
+      });
+    });
+    const second = definePlugin("b", (ctx) => {
+      ctx.registerUserMetaBox("profile", {
+        label: "B",
+        fields: [
+          { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+        ],
+      });
+    });
+    await expect(
+      installPlugins({ hooks, plugins: [first, second] }),
+    ).rejects.toBeInstanceOf(DuplicateRegistrationError);
+  });
+
+  test("registerUserMetaBox rejects an invalid field key at registration time", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("bad", (ctx) => {
+      ctx.registerUserMetaBox("profile", {
+        label: "Profile",
+        fields: [
+          {
+            key: "bad key!",
+            label: "Bad",
+            type: "string",
+            inputType: "text",
+          },
+        ],
+      });
+    });
+    await expect(installPlugins({ hooks, plugins: [plugin] })).rejects.toThrow(
+      /invalid key "bad key!"/,
+    );
+  });
+
+  test("registerUserMetaBox rejects a duplicate field key within the same box", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("dupe", (ctx) => {
+      ctx.registerUserMetaBox("profile", {
+        label: "Profile",
+        fields: [
+          { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+          { key: "bio", label: "Bio 2", type: "string", inputType: "textarea" },
+        ],
+      });
+    });
+    await expect(installPlugins({ hooks, plugins: [plugin] })).rejects.toThrow(
+      /declares field "bio" more than once/,
+    );
+  });
 });

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -194,9 +194,11 @@ declare module "../hooks/types.js" {
      *
      * Only fires when row columns changed. A meta-only update does NOT
      * fire `user:updated`; subscribe to `user:meta_changed` for that.
-     * The `user.meta` here reflects the row read right after the column
-     * write and may lag a meta write that happens in the same RPC call —
-     * use `user:meta_changed` for the authoritative meta diff.
+     * The `user.meta` on the payload is the row's `.returning()` value
+     * captured *before* the meta write — so when the same RPC writes
+     * both row columns and meta, `user.meta` here is deterministically
+     * stale. Always subscribe to `user:meta_changed` for the
+     * authoritative meta diff.
      */
     "user:updated": (user: User, previous: User) => void | Promise<void>;
 

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -17,6 +17,7 @@ import type {
   TermListInput,
   TermUpdateInput,
 } from "./procedures/term/schemas.js";
+import type { UserMetaChanges } from "./procedures/user/meta.js";
 import type {
   UserInviteInput,
   UserListInput,
@@ -185,13 +186,30 @@ declare module "../hooks/types.js" {
     "user:registered": (user: User) => void | Promise<void>;
 
     /**
-     * Fires after a successful `user.update`. Payload carries the
-     * post-write row and the pre-write row for diffing — matches WP's
-     * `profile_update(user_id, old_user_data)` signature. Use this
-     * instead of the output filter when you need to know what actually
-     * changed (role demotion, email swap, etc.).
+     * Fires after a successful `user.update` row-columns write. Payload
+     * carries the post-write row and the pre-write row for diffing —
+     * matches WP's `profile_update(user_id, old_user_data)` signature.
+     * Use this instead of the output filter when you need to know what
+     * actually changed (role demotion, email swap, etc.).
+     *
+     * Only fires when row columns changed. A meta-only update does NOT
+     * fire `user:updated`; subscribe to `user:meta_changed` for that.
+     * The `user.meta` here reflects the row read right after the column
+     * write and may lag a meta write that happens in the same RPC call —
+     * use `user:meta_changed` for the authoritative meta diff.
      */
     "user:updated": (user: User, previous: User) => void | Promise<void>;
+
+    /**
+     * Fires after a successful meta write via `user.update`. Payload
+     * carries the decoded upserts + deleted keys — same shape as
+     * `entry:meta_changed` / `term:meta_changed` so plugins adopt one
+     * pattern across bags.
+     */
+    "user:meta_changed": (
+      user: { readonly id: number },
+      changes: UserMetaChanges,
+    ) => void | Promise<void>;
 
     /**
      * Fires on both disable (`enabled: false`) and re-enable

--- a/packages/core/src/rpc/procedures/user/get.ts
+++ b/packages/core/src/rpc/procedures/user/get.ts
@@ -2,6 +2,7 @@ import { eq } from "../../../db/index.js";
 import { users } from "../../../db/schema/users.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
+import { decodeMetaBag } from "./meta.js";
 import { userGetInputSchema } from "./schemas.js";
 
 // Listing gates access to arbitrary user records; self-lookup is always
@@ -23,5 +24,6 @@ export const get = base
     if (!row) {
       throw errors.NOT_FOUND({ data: { kind: "user", id: input.id } });
     }
-    return context.hooks.applyFilter("rpc:user.get:output", row);
+    const meta = decodeMetaBag(context.plugins, row.meta);
+    return context.hooks.applyFilter("rpc:user.get:output", { ...row, meta });
   });

--- a/packages/core/src/rpc/procedures/user/meta.test.ts
+++ b/packages/core/src/rpc/procedures/user/meta.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+
+import type {
+  MetaBoxField,
+  MutablePluginRegistry,
+} from "../../../plugin/manifest.js";
+import { eq } from "../../../db/index.js";
+import { users } from "../../../db/schema/users.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+import { loadUserMeta } from "./meta.js";
+
+function registerUserFields(
+  plugins: MutablePluginRegistry,
+  fields: MetaBoxField[],
+  id = "test-user-box",
+): void {
+  plugins.userMetaBoxes.set(id, {
+    id,
+    label: "Test",
+    fields,
+    registeredBy: "test",
+  });
+}
+
+describe("user meta: registration + round-trip via user.update", () => {
+  test("registered meta keys persist through user.update + user.get", async () => {
+    const plugins = createPluginRegistry();
+    registerUserFields(plugins, [
+      { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+      {
+        key: "newsletter",
+        label: "Newsletter",
+        type: "boolean",
+        inputType: "checkbox",
+      },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    const updated = await h.client.user.update({
+      id: h.user.id,
+      meta: { bio: "Hi there", newsletter: true },
+    });
+    expect(updated.meta).toEqual({ bio: "Hi there", newsletter: true });
+
+    const reloaded = await h.client.user.get({ id: h.user.id });
+    expect(reloaded.meta).toEqual({ bio: "Hi there", newsletter: true });
+  });
+
+  test("unregistered meta key is rejected with CONFLICT", async () => {
+    const plugins = createPluginRegistry();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    await expect(
+      h.client.user.update({
+        id: h.user.id,
+        meta: { mystery: "x" },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "meta_not_registered", key: "mystery" },
+    });
+  });
+
+  test("user.update partial patch + null-delete semantics match term.meta", async () => {
+    const plugins = createPluginRegistry();
+    registerUserFields(plugins, [
+      { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+      {
+        key: "newsletter",
+        label: "Newsletter",
+        type: "boolean",
+        inputType: "checkbox",
+      },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+
+    await h.client.user.update({
+      id: h.user.id,
+      meta: { bio: "hello", newsletter: false },
+    });
+
+    // Partial patch: only `newsletter` is touched; `bio` survives.
+    const afterFlip = await h.client.user.update({
+      id: h.user.id,
+      meta: { newsletter: true },
+    });
+    expect(afterFlip.meta).toEqual({ bio: "hello", newsletter: true });
+
+    // Null deletes the key.
+    const afterClear = await h.client.user.update({
+      id: h.user.id,
+      meta: { bio: null },
+    });
+    expect(afterClear.meta).toEqual({ newsletter: true });
+  });
+
+  test("user:meta_changed fires with the upsert + delete diff", async () => {
+    const plugins = createPluginRegistry();
+    registerUserFields(plugins, [
+      { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const spy = h.spyAction("user:meta_changed");
+
+    await h.client.user.update({ id: h.user.id, meta: { bio: "hello" } });
+    await h.client.user.update({ id: h.user.id, meta: { bio: null } });
+
+    expect(spy.calls).toHaveLength(2);
+    expect(spy.calls[0]?.args[1]).toEqual({
+      set: { bio: "hello" },
+      removed: [],
+    });
+    expect(spy.calls[1]?.args[1]).toEqual({ set: {}, removed: ["bio"] });
+  });
+
+  test("user.update with an empty meta patch does not fire user:meta_changed", async () => {
+    const plugins = createPluginRegistry();
+    registerUserFields(plugins, [
+      { key: "bio", label: "Bio", type: "string", inputType: "textarea" },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const spy = h.spyAction("user:meta_changed");
+
+    await h.client.user.update({ id: h.user.id, meta: {} });
+
+    expect(spy.calls).toHaveLength(0);
+  });
+
+  // Regression: `Boolean("false") === true` would silently flip rows
+  // written via `type: "json"` before a plugin tightened the field to
+  // `boolean`. `coerceOnRead` mirrors the write-side token set instead.
+  test("coerceOnRead maps legacy string booleans to their real values", async () => {
+    const plugins = createPluginRegistry();
+    registerUserFields(plugins, [
+      {
+        key: "newsletter",
+        label: "Newsletter",
+        type: "boolean",
+        inputType: "checkbox",
+      },
+    ]);
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    // Seed as if a prior schema version stored the string "false"
+    // directly — bypass sanitize by writing to the column ourselves.
+    await h.context.db
+      .update(users)
+      .set({ meta: { newsletter: "false" } })
+      .where(eq(users.id, h.user.id));
+
+    expect(await loadUserMeta(h.context, { id: h.user.id })).toEqual({
+      newsletter: false,
+    });
+  });
+});

--- a/packages/core/src/rpc/procedures/user/meta.ts
+++ b/packages/core/src/rpc/procedures/user/meta.ts
@@ -1,0 +1,62 @@
+import type { AppContext } from "../../../context/app.js";
+import type { PluginRegistry } from "../../../plugin/manifest.js";
+import type { MetaPatch } from "../../meta/core.js";
+import { users } from "../../../db/schema/users.js";
+import { findUserMetaField } from "../../../plugin/manifest.js";
+import {
+  applyMetaPatch,
+  decodeMetaBag as decodeMetaBagCore,
+  isEmptyMetaPatch,
+  loadMeta,
+  sanitizeMetaForRpc as sanitizeMetaForRpcCore,
+} from "../../meta/core.js";
+
+export type { MetaChanges as UserMetaChanges } from "../../meta/core.js";
+
+/** RPC-facing sanitizer for a user's meta input. User meta is a flat
+ *  keyspace — no scope argument. */
+export function sanitizeMetaForRpc(
+  registry: PluginRegistry,
+  input: Record<string, unknown> | undefined,
+  errors: Parameters<typeof sanitizeMetaForRpcCore>[2],
+): MetaPatch | null {
+  return sanitizeMetaForRpcCore(
+    (key) => findUserMetaField(registry, key),
+    input,
+    errors,
+  );
+}
+
+export function decodeMetaBag(
+  registry: PluginRegistry,
+  raw: Readonly<Record<string, unknown>> | null | undefined,
+): Record<string, unknown> {
+  return decodeMetaBagCore((key) => findUserMetaField(registry, key), raw);
+}
+
+export async function loadUserMeta(
+  ctx: AppContext,
+  user: { readonly id: number },
+): Promise<Record<string, unknown>> {
+  return loadMeta(ctx, users, users.id, user.id, (key) =>
+    findUserMetaField(ctx.plugins, key),
+  );
+}
+
+/**
+ * Apply a meta patch to `users.meta` and fire `user:meta_changed`.
+ * Plugins that need to mutate the patch subscribe to
+ * `rpc:user.update:input` and mutate `input.meta` there.
+ */
+export async function writeUserMeta(
+  ctx: AppContext,
+  user: { readonly id: number },
+  patch: Parameters<typeof applyMetaPatch>[4],
+): Promise<void> {
+  if (isEmptyMetaPatch(patch)) return;
+  await applyMetaPatch(ctx, users, users.id, user.id, patch);
+  await ctx.hooks.doAction("user:meta_changed", user, {
+    set: Object.fromEntries(patch.upserts),
+    removed: [...patch.deletes],
+  });
+}

--- a/packages/core/src/rpc/procedures/user/meta.ts
+++ b/packages/core/src/rpc/procedures/user/meta.ts
@@ -51,7 +51,7 @@ export async function loadUserMeta(
 export async function writeUserMeta(
   ctx: AppContext,
   user: { readonly id: number },
-  patch: Parameters<typeof applyMetaPatch>[4],
+  patch: MetaPatch,
 ): Promise<void> {
   if (isEmptyMetaPatch(patch)) return;
   await applyMetaPatch(ctx, users, users.id, user.id, patch);

--- a/packages/core/src/rpc/procedures/user/schemas.ts
+++ b/packages/core/src/rpc/procedures/user/schemas.ts
@@ -14,6 +14,27 @@ const roleSchema = v.picklist(USER_ROLES);
 
 const searchSchema = v.pipe(v.string(), v.trim(), v.maxLength(200));
 
+// Meta bag accepted by `user.update`. Per-key validation runs against
+// the user meta box registry in the handler; the outer shape cap
+// mirrors `entry.meta` / `term.meta`.
+const MAX_META_KEYS_PER_REQUEST = 200;
+
+const metaKeySchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.maxLength(200),
+  v.regex(/^[a-zA-Z0-9_:-]+$/, "meta key must be alphanumeric/_/:/-"),
+);
+
+const userMetaInputSchema = v.pipe(
+  v.record(metaKeySchema, v.unknown()),
+  v.check(
+    (val) => Object.keys(val).length <= MAX_META_KEYS_PER_REQUEST,
+    `meta accepts at most ${MAX_META_KEYS_PER_REQUEST} keys per request`,
+  ),
+);
+
 export const userListInputSchema = v.object({
   limit: v.optional(
     v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
@@ -38,6 +59,7 @@ export const userUpdateInputSchema = v.object({
   name: v.optional(v.nullable(nameField)),
   avatarUrl: v.optional(v.nullable(avatarUrlSchema)),
   role: v.optional(roleSchema),
+  meta: v.optional(userMetaInputSchema),
 });
 
 export const userDisableInputSchema = v.object({ id: idParam });

--- a/packages/core/src/rpc/procedures/user/update.ts
+++ b/packages/core/src/rpc/procedures/user/update.ts
@@ -4,8 +4,15 @@ import { and, eq, isUniqueConstraintError } from "../../../db/index.js";
 import { users } from "../../../db/schema/users.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
+import { isEmptyMetaPatch } from "../../meta/core.js";
 import { stripUndefined } from "../entry/helpers.js";
 import { otherActiveAdminExists } from "./helpers.js";
+import {
+  decodeMetaBag,
+  loadUserMeta,
+  sanitizeMetaForRpc,
+  writeUserMeta,
+} from "./meta.js";
 import { userUpdateInputSchema } from "./schemas.js";
 
 const EDIT_OWN_CAPABILITY = "user:edit_own";
@@ -47,10 +54,20 @@ export const update = base
     const demotingAdmin =
       wantsRoleChange && existing.role === "admin" && filtered.role !== "admin";
 
-    const { id: _id, ...changes } = filtered;
+    // `meta` isn't a users.* column — split it out and validate up
+    // front so a bad key fails before any write.
+    const { id: _id, meta: metaInput, ...changes } = filtered;
+    const metaPatch = sanitizeMetaForRpc(context.plugins, metaInput, errors);
     const patch: Partial<NewUser> = stripUndefined(changes);
-    if (Object.keys(patch).length === 0) {
-      return context.hooks.applyFilter("rpc:user.update:output", existing);
+
+    // Nothing to write anywhere? Return the existing row with its
+    // decoded meta for a consistent response shape.
+    if (Object.keys(patch).length === 0 && isEmptyMetaPatch(metaPatch)) {
+      const meta = decodeMetaBag(context.plugins, existing.meta);
+      return context.hooks.applyFilter("rpc:user.update:output", {
+        ...existing,
+        meta,
+      });
     }
 
     // Last-admin guard inlined into the UPDATE WHERE clause: the row only
@@ -64,24 +81,38 @@ export const update = base
         )
       : eq(users.id, existing.id);
 
-    let updated;
-    try {
-      [updated] = await context.db
-        .update(users)
-        .set(patch)
-        .where(whereClause)
-        .returning();
-    } catch (error) {
-      if (isUniqueConstraintError(error)) {
-        throw errors.CONFLICT({ data: { reason: "email_taken" } });
+    let updated = existing;
+    let rowWritten = false;
+    if (Object.keys(patch).length > 0) {
+      let row;
+      try {
+        [row] = await context.db
+          .update(users)
+          .set(patch)
+          .where(whereClause)
+          .returning();
+      } catch (error) {
+        if (isUniqueConstraintError(error)) {
+          throw errors.CONFLICT({ data: { reason: "email_taken" } });
+        }
+        throw error;
       }
-      throw error;
+      if (!row) {
+        if (demotingAdmin) {
+          throw errors.CONFLICT({ data: { reason: "last_admin" } });
+        }
+        throw errors.CONFLICT({ data: { reason: "update_failed" } });
+      }
+      updated = row;
+      rowWritten = true;
     }
-    if (!updated) {
-      if (demotingAdmin) {
-        throw errors.CONFLICT({ data: { reason: "last_admin" } });
-      }
-      throw errors.CONFLICT({ data: { reason: "update_failed" } });
+
+    let meta: Record<string, unknown>;
+    if (metaPatch) {
+      await writeUserMeta(context, updated, metaPatch);
+      meta = await loadUserMeta(context, updated);
+    } else {
+      meta = decodeMetaBag(context.plugins, updated.meta);
     }
 
     // Any role change → existing sessions carry a cached role via AppContext
@@ -91,9 +122,15 @@ export const update = base
       await invalidateAllSessionsForUser(context.db, updated.id);
     }
 
-    // WP's `profile_update` parity — plugins observe successful writes
-    // with the previous row for diffing (audit log, cache invalidation).
-    await context.hooks.doAction("user:updated", updated, existing);
+    // WP's `profile_update` parity — plugins observe successful row writes
+    // with the previous row for diffing. Skipped on meta-only saves —
+    // subscribe to `user:meta_changed` for that surface.
+    if (rowWritten) {
+      await context.hooks.doAction("user:updated", updated, existing);
+    }
 
-    return context.hooks.applyFilter("rpc:user.update:output", updated);
+    return context.hooks.applyFilter("rpc:user.update:output", {
+      ...updated,
+      meta,
+    });
   });

--- a/packages/core/src/rpc/procedures/user/update.ts
+++ b/packages/core/src/rpc/procedures/user/update.ts
@@ -107,8 +107,11 @@ export const update = base
       rowWritten = true;
     }
 
+    // Match the early-return's empty-patch gate — an explicit `meta: {}`
+    // from the client produces a non-null but empty `MetaPatch`, and a
+    // plain `loadUserMeta` re-read for that case is just a wasted SELECT.
     let meta: Record<string, unknown>;
-    if (metaPatch) {
+    if (metaPatch !== null && !isEmptyMetaPatch(metaPatch)) {
       await writeUserMeta(context, updated, metaPatch);
       meta = await loadUserMeta(context, updated);
     } else {


### PR DESCRIPTION
## Summary

- New `registerUserMetaBox` primitive on the plugin API, paralleling `registerEntryMetaBox` / `registerTermMetaBox`. Users are a flat keyspace (no entry-type / taxonomy analogue), so `UserMetaBoxOptions` has no scope property; `capability` gates viewer visibility only.
- `user.update` accepts `meta`, `user.get` returns it decoded, and a new `user:meta_changed` action fires with the `{ set, removed }` diff — same shape as the entry + term surfaces.
- Admin user edit route stacks `UserMetaBoxCard` instances between the profile card and the account-status / delete cards. Per-card atomic save via `user.update({ meta })`, re-seeds from the server's post-sanitize bag on success, `aria-live` on the notice + `role="alert"` on errors — hardening lessons from PR #65 carried over.
- Shared meta plumbing (`rpc/meta/core.ts`) unchanged — already parameterised by a find-field fn + drizzle table. The `assertUniqueFieldKeysPerScope` helper now takes a `getScopes` fn; users pass a single synthetic `"user"` scope so duplicate-key checks stay honest.

## Test plan
- [ ] `pnpm turbo run typecheck lint test` — 32 workspace tasks pass
- [ ] `pnpm knip` clean; `pnpm format` clean
- [ ] `user.update` + `user.get` round-trip registered keys
- [ ] Unregistered user meta key → `CONFLICT { reason: "meta_not_registered" }`
- [ ] Null deletes the key; partial patch preserves siblings
- [ ] `user:meta_changed` fires with the upsert + delete diff, no-fires on empty patch
- [ ] Register-time: invalid key / duplicate id / intra-box duplicate all reject loudly
- [ ] `buildManifest` rejects two user boxes declaring the same field key
- [ ] Legacy string-boolean read regression — `"false"` no longer flips to `true`