### PR TITLE
feat(core,admin): responsive 12-column field grid inside meta boxes

### DIFF
--- a/packages/admin/src/components/meta-box/meta-box-field.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Input } from "@/components/ui/input.js";
 import { Label } from "@/components/ui/label.js";
+import { cn } from "@/lib/utils";
 
 import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 
@@ -14,15 +15,20 @@ export function MetaBoxField({
   value,
   onChange,
   disabled = false,
+  className,
 }: {
   readonly field: MetaBoxFieldManifestEntry;
   readonly value: unknown;
   readonly onChange: (next: unknown) => void;
   readonly disabled?: boolean;
+  readonly className?: string;
 }): ReactNode {
   const testIdPrefix = `meta-box-field-${field.key}`;
   return (
-    <div className="flex flex-col gap-2" data-testid={testIdPrefix}>
+    <div
+      className={cn("flex flex-col gap-2", className)}
+      data-testid={testIdPrefix}
+    >
       {field.inputType === "checkbox" ? (
         <InlineCheckbox
           field={field}

--- a/packages/admin/src/components/meta-box/meta-box-grid.test.ts
+++ b/packages/admin/src/components/meta-box/meta-box-grid.test.ts
@@ -12,9 +12,9 @@ describe("metaBoxFieldColSpanClass", () => {
   });
 
   test("responsive object emits mobile-first breakpoints in order", () => {
-    expect(
-      metaBoxFieldColSpanClass({ base: 12, sm: 6, md: 4, lg: 3 }),
-    ).toBe("col-span-12 @sm:col-span-6 @md:col-span-4 @lg:col-span-3");
+    expect(metaBoxFieldColSpanClass({ base: 12, sm: 6, md: 4, lg: 3 })).toBe(
+      "col-span-12 @sm:col-span-6 @md:col-span-4 @lg:col-span-3",
+    );
   });
 
   test("object without base falls back to full width", () => {

--- a/packages/admin/src/components/meta-box/meta-box-grid.test.ts
+++ b/packages/admin/src/components/meta-box/meta-box-grid.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+
+import { metaBoxFieldColSpanClass } from "./meta-box-grid.js";
+
+describe("metaBoxFieldColSpanClass", () => {
+  test("omitted span defaults to full width", () => {
+    expect(metaBoxFieldColSpanClass(undefined)).toBe("col-span-12");
+  });
+
+  test("plain number sets the base span", () => {
+    expect(metaBoxFieldColSpanClass(6)).toBe("col-span-6");
+  });
+
+  test("responsive object emits mobile-first breakpoints in order", () => {
+    expect(
+      metaBoxFieldColSpanClass({ base: 12, sm: 6, md: 4, lg: 3 }),
+    ).toBe("col-span-12 @sm:col-span-6 @md:col-span-4 @lg:col-span-3");
+  });
+
+  test("object without base falls back to full width", () => {
+    expect(metaBoxFieldColSpanClass({ md: 6 })).toBe(
+      "col-span-12 @md:col-span-6",
+    );
+  });
+
+  test("only sets classes for breakpoints that were provided", () => {
+    expect(metaBoxFieldColSpanClass({ base: 6, lg: 3 })).toBe(
+      "col-span-6 @lg:col-span-3",
+    );
+  });
+
+  test("clamps values outside 1..12", () => {
+    expect(metaBoxFieldColSpanClass(0)).toBe("col-span-1");
+    expect(metaBoxFieldColSpanClass(99)).toBe("col-span-12");
+    expect(metaBoxFieldColSpanClass({ base: -3, md: 200 })).toBe(
+      "col-span-1 @md:col-span-12",
+    );
+  });
+
+  test("rounds fractional spans", () => {
+    expect(metaBoxFieldColSpanClass(5.7)).toBe("col-span-6");
+  });
+
+  test("non-finite numbers fall back to full width", () => {
+    expect(metaBoxFieldColSpanClass(Number.NaN)).toBe("col-span-12");
+  });
+});

--- a/packages/admin/src/components/meta-box/meta-box-grid.ts
+++ b/packages/admin/src/components/meta-box/meta-box-grid.ts
@@ -2,11 +2,13 @@ import { cn } from "@/lib/utils";
 
 import type { MetaBoxFieldSpan } from "@plumix/core/manifest";
 
+type SpanValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
 // Literal col-span class strings for every valid span value. Tailwind v4's
 // JIT only generates classes it can see verbatim in source — building them
 // with template strings (`col-span-${n}`) would silently purge at build.
 // Keep these tables exhaustive for 1..12 at every breakpoint we expose.
-const BASE: Record<number, string> = {
+const BASE: Record<SpanValue, string> = {
   1: "col-span-1",
   2: "col-span-2",
   3: "col-span-3",
@@ -21,7 +23,7 @@ const BASE: Record<number, string> = {
   12: "col-span-12",
 };
 
-const SM: Record<number, string> = {
+const SM: Record<SpanValue, string> = {
   1: "@sm:col-span-1",
   2: "@sm:col-span-2",
   3: "@sm:col-span-3",
@@ -36,7 +38,7 @@ const SM: Record<number, string> = {
   12: "@sm:col-span-12",
 };
 
-const MD: Record<number, string> = {
+const MD: Record<SpanValue, string> = {
   1: "@md:col-span-1",
   2: "@md:col-span-2",
   3: "@md:col-span-3",
@@ -51,7 +53,7 @@ const MD: Record<number, string> = {
   12: "@md:col-span-12",
 };
 
-const LG: Record<number, string> = {
+const LG: Record<SpanValue, string> = {
   1: "@lg:col-span-1",
   2: "@lg:col-span-2",
   3: "@lg:col-span-3",
@@ -66,14 +68,14 @@ const LG: Record<number, string> = {
   12: "@lg:col-span-12",
 };
 
-const DEFAULT_BASE = 12;
+const DEFAULT_BASE: SpanValue = 12;
 
-function clamp(n: number): number {
+function clamp(n: number): SpanValue {
   if (!Number.isFinite(n)) return DEFAULT_BASE;
   const rounded = Math.round(n);
   if (rounded < 1) return 1;
   if (rounded > 12) return 12;
-  return rounded;
+  return rounded as SpanValue;
 }
 
 /**
@@ -85,11 +87,11 @@ function clamp(n: number): number {
 export function metaBoxFieldColSpanClass(
   span: MetaBoxFieldSpan | undefined,
 ): string {
-  if (typeof span === "number") return BASE[clamp(span)]!;
+  if (typeof span === "number") return BASE[clamp(span)];
   return cn(
-    BASE[clamp(span?.base ?? DEFAULT_BASE)]!,
-    span?.sm !== undefined && SM[clamp(span.sm)]!,
-    span?.md !== undefined && MD[clamp(span.md)]!,
-    span?.lg !== undefined && LG[clamp(span.lg)]!,
+    BASE[clamp(span?.base ?? DEFAULT_BASE)],
+    span?.sm !== undefined && SM[clamp(span.sm)],
+    span?.md !== undefined && MD[clamp(span.md)],
+    span?.lg !== undefined && LG[clamp(span.lg)],
   );
 }

--- a/packages/admin/src/components/meta-box/meta-box-grid.ts
+++ b/packages/admin/src/components/meta-box/meta-box-grid.ts
@@ -1,0 +1,95 @@
+import { cn } from "@/lib/utils";
+
+import type { MetaBoxFieldSpan } from "@plumix/core/manifest";
+
+// Literal col-span class strings for every valid span value. Tailwind v4's
+// JIT only generates classes it can see verbatim in source — building them
+// with template strings (`col-span-${n}`) would silently purge at build.
+// Keep these tables exhaustive for 1..12 at every breakpoint we expose.
+const BASE: Record<number, string> = {
+  1: "col-span-1",
+  2: "col-span-2",
+  3: "col-span-3",
+  4: "col-span-4",
+  5: "col-span-5",
+  6: "col-span-6",
+  7: "col-span-7",
+  8: "col-span-8",
+  9: "col-span-9",
+  10: "col-span-10",
+  11: "col-span-11",
+  12: "col-span-12",
+};
+
+const SM: Record<number, string> = {
+  1: "@sm:col-span-1",
+  2: "@sm:col-span-2",
+  3: "@sm:col-span-3",
+  4: "@sm:col-span-4",
+  5: "@sm:col-span-5",
+  6: "@sm:col-span-6",
+  7: "@sm:col-span-7",
+  8: "@sm:col-span-8",
+  9: "@sm:col-span-9",
+  10: "@sm:col-span-10",
+  11: "@sm:col-span-11",
+  12: "@sm:col-span-12",
+};
+
+const MD: Record<number, string> = {
+  1: "@md:col-span-1",
+  2: "@md:col-span-2",
+  3: "@md:col-span-3",
+  4: "@md:col-span-4",
+  5: "@md:col-span-5",
+  6: "@md:col-span-6",
+  7: "@md:col-span-7",
+  8: "@md:col-span-8",
+  9: "@md:col-span-9",
+  10: "@md:col-span-10",
+  11: "@md:col-span-11",
+  12: "@md:col-span-12",
+};
+
+const LG: Record<number, string> = {
+  1: "@lg:col-span-1",
+  2: "@lg:col-span-2",
+  3: "@lg:col-span-3",
+  4: "@lg:col-span-4",
+  5: "@lg:col-span-5",
+  6: "@lg:col-span-6",
+  7: "@lg:col-span-7",
+  8: "@lg:col-span-8",
+  9: "@lg:col-span-9",
+  10: "@lg:col-span-10",
+  11: "@lg:col-span-11",
+  12: "@lg:col-span-12",
+};
+
+const DEFAULT_BASE = 12;
+
+function clamp(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_BASE;
+  const rounded = Math.round(n);
+  if (rounded < 1) return 1;
+  if (rounded > 12) return 12;
+  return rounded;
+}
+
+/**
+ * Resolve a (possibly responsive) field span into Tailwind col-span
+ * classes. Mobile-first: `base` applies from 0+, each larger breakpoint
+ * overrides upward at the card's container width (`@sm` / `@md` / `@lg`).
+ * Out-of-range values are clamped to 1..12; omitted span is full width.
+ */
+export function metaBoxFieldColSpanClass(
+  span: MetaBoxFieldSpan | undefined,
+): string {
+  if (typeof span === "number") return BASE[clamp(span)]!;
+  return cn(
+    BASE[clamp(span?.base ?? DEFAULT_BASE)]!,
+    span?.sm !== undefined && SM[clamp(span.sm)]!,
+    span?.md !== undefined && MD[clamp(span.md)]!,
+    span?.lg !== undefined && LG[clamp(span.lg)]!,
+  );
+}

--- a/packages/admin/src/components/meta-box/meta-box.tsx
+++ b/packages/admin/src/components/meta-box/meta-box.tsx
@@ -14,6 +14,7 @@ import type {
 } from "@plumix/core/manifest";
 
 import { MetaBoxField } from "./meta-box-field.js";
+import { metaBoxFieldColSpanClass } from "./meta-box-grid.js";
 
 // Settings groups deliberately don't pass through this component —
 // they use their own per-card save model in `SettingsGroupCard`.
@@ -39,7 +40,10 @@ export function MetaBoxCard({
   readonly disabled?: boolean;
 }): ReactNode {
   return (
-    <Card data-testid={`meta-box-${box.id}`}>
+    // Container-query root so field spans resolve against the card's
+    // own width — same span renders consistently in a full-width route
+    // and a narrow sidebar, where viewport-based breakpoints would lie.
+    <Card className="@container" data-testid={`meta-box-${box.id}`}>
       <CardHeader>
         <CardTitle>
           <h2
@@ -53,7 +57,7 @@ export function MetaBoxCard({
           <CardDescription>{box.description}</CardDescription>
         ) : null}
       </CardHeader>
-      <CardContent className="flex flex-col gap-4">
+      <CardContent className="grid grid-cols-12 gap-4">
         {box.fields.map((field) => (
           <MetaBoxField
             key={field.key}
@@ -63,6 +67,7 @@ export function MetaBoxCard({
             onChange={(next) => {
               onChange(field.key, next);
             }}
+            className={metaBoxFieldColSpanClass(field.span)}
           />
         ))}
       </CardContent>

--- a/packages/admin/src/routes/_authenticated/settings/$page.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/$page.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { FormEditSkeleton } from "@/components/form/edit-skeleton.js";
 import { MetaBoxField } from "@/components/meta-box/meta-box-field.js";
+import { metaBoxFieldColSpanClass } from "@/components/meta-box/meta-box-grid.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Button } from "@/components/ui/button.js";
 import {
@@ -146,7 +147,10 @@ function SettingsGroupCard({
   });
 
   return (
-    <Card data-testid={`settings-group-card-${group.name}`}>
+    <Card
+      className="@container"
+      data-testid={`settings-group-card-${group.name}`}
+    >
       <form
         onSubmit={(event) => {
           event.preventDefault();
@@ -168,17 +172,20 @@ function SettingsGroupCard({
           ) : null}
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
-          {group.fields.map((field) => (
-            <MetaBoxField
-              key={field.key}
-              field={field}
-              value={values[field.key]}
-              disabled={save.isPending}
-              onChange={(next) => {
-                setValues((prev) => ({ ...prev, [field.key]: next }));
-              }}
-            />
-          ))}
+          <div className="grid grid-cols-12 gap-4">
+            {group.fields.map((field) => (
+              <MetaBoxField
+                key={field.key}
+                field={field}
+                value={values[field.key]}
+                disabled={save.isPending}
+                onChange={(next) => {
+                  setValues((prev) => ({ ...prev, [field.key]: next }));
+                }}
+                className={metaBoxFieldColSpanClass(field.span)}
+              />
+            ))}
+          </div>
 
           {serverError ? (
             <Alert

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -52,6 +52,24 @@ export interface MetaBoxFieldOption {
 }
 
 /**
+ * Column span for a field within its meta box's 12-column grid. A plain
+ * number applies from the smallest breakpoint up. The object form is
+ * mobile-first: `base` is the default, `sm` / `md` / `lg` override upward.
+ * Breakpoints key off the card's own width (Tailwind container queries,
+ * `@sm` / `@md` / `@lg`) so the same `span` renders consistently whether
+ * the box lands in a full-width route or a narrow sidebar. Values outside
+ * 1..12 are clamped at render time. Omitted span means full width (12).
+ */
+export type MetaBoxFieldSpan =
+  | number
+  | {
+      readonly base?: number;
+      readonly sm?: number;
+      readonly md?: number;
+      readonly lg?: number;
+    };
+
+/**
  * A field inside a meta box — the single source of truth for both the
  * admin UI renderer and the server-side storage contract. Declaring a
  * meta box is the only way to register a meta key; there is no separate
@@ -99,6 +117,11 @@ export interface MetaBoxField {
   readonly step?: number;
   /** Required for `select` and `radio`; ignored otherwise. */
   readonly options?: readonly MetaBoxFieldOption[];
+  /**
+   * Column span within the meta box's 12-column grid. Defaults to full
+   * width. See `MetaBoxFieldSpan` for the responsive object form.
+   */
+  readonly span?: MetaBoxFieldSpan;
 }
 
 /**
@@ -371,6 +394,7 @@ export interface MetaBoxFieldManifestEntry {
   readonly step?: number;
   readonly options?: readonly MetaBoxFieldOption[];
   readonly default?: unknown;
+  readonly span?: MetaBoxFieldSpan;
 }
 
 /**
@@ -893,6 +917,7 @@ function toMetaBoxFieldEntry(field: MetaBoxField): MetaBoxFieldManifestEntry {
     step,
     options,
     default: defaultValue,
+    span,
   } = field;
   return {
     key,
@@ -908,6 +933,7 @@ function toMetaBoxFieldEntry(field: MetaBoxField): MetaBoxFieldManifestEntry {
     step,
     options,
     default: defaultValue,
+    span,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds an optional `span` on `MetaBoxField` — a number or mobile-first `{ base, sm, md, lg }` — so plugins can lay fields out side by side inside a meta box without reaching into admin styles.
- Card becomes a container-query root (`@container`), so the same span renders consistently in full-width routes and narrow sidebars — breakpoints key off the card's own width, not the viewport.
- `CardContent` is a `grid grid-cols-12`; each `MetaBoxField` takes a `className` (col-span) via the new `metaBoxFieldColSpanClass` helper. Defaults to `col-span-12` so existing plugins render unchanged.
- Helper uses static literal class strings so Tailwind v4's JIT emits every `col-span-1..12` and `@sm|md|lg:col-span-N` variant — no purge surprises.
- Settings group card gets the same grid (nested so alerts/save notices stay full width).

## Test plan
- [x] `pnpm --filter @plumix/core test` (483 tests)
- [x] `pnpm --filter @plumix/admin test` (86 tests, incl. new `meta-box-grid.test.ts`)
- [x] `pnpm --filter @plumix/core typecheck` / `pnpm --filter @plumix/admin typecheck`
- [x] Verified `packages/admin/dist/assets/*.css` contains all 12 base spans + `@sm|md|lg` container-query rules
- [ ] Manual: register a meta box with mixed field spans (e.g. `{ base: 12, md: 6 }`) and confirm layout reflows at the card's own width in both a full-width route and the entry-editor sidebar