### PR TITLE
refactor(core,admin): drop span from entry meta box fields

### DIFF
--- a/packages/admin/src/components/meta-box/meta-box.tsx
+++ b/packages/admin/src/components/meta-box/meta-box.tsx
@@ -21,12 +21,10 @@ import type {
 import { MetaBoxField } from "./meta-box-field.js";
 import { metaBoxFieldColSpanClass } from "./meta-box-grid.js";
 
-// Settings groups deliberately don't pass through this component —
-// they use their own per-card save model in `SettingsGroupCard`.
-type MetaBoxCardEntry =
-  | EntryMetaBoxManifestEntry
-  | TermMetaBoxManifestEntry
-  | UserMetaBoxManifestEntry;
+// `MetaBoxCard` serves the page-width surfaces (term + user edit). The
+// entry editor rail uses `MetaBoxAccordionItem`, and settings groups
+// use their own per-card save model in `SettingsGroupCard`.
+type MetaBoxCardEntry = TermMetaBoxManifestEntry | UserMetaBoxManifestEntry;
 
 interface MetaBoxProps {
   readonly box: MetaBoxCardEntry;
@@ -36,8 +34,9 @@ interface MetaBoxProps {
 
 /**
  * Card variant — used by standalone meta-box surfaces (term + user
- * edit forms) where the box is its own card on the page. Entry-editor
- * rail uses `MetaBoxAccordionItem` instead.
+ * edit forms) where the box is its own card on the page. Honours
+ * `field.span` for multi-column layouts. Entry-editor rail uses
+ * `MetaBoxAccordionItem` instead, which is always single-column.
  *
  * Expects an ancestor `<Form>` provider — each field binds to
  * `${basePath}.${field.key}` via react-hook-form context.
@@ -72,23 +71,30 @@ export function MetaBoxCard({
   );
 }
 
+interface MetaBoxAccordionItemProps {
+  readonly box: EntryMetaBoxManifestEntry;
+  readonly basePath: string;
+  readonly disabled?: boolean;
+}
+
 /**
  * Accordion-section variant — used inside the entry editor's right
  * rail, where meta boxes stack as collapsible sections alongside
  * built-in document panels (Permalink, Status, Excerpt). Must render
  * inside an `<Accordion>` parent; `box.id` is the accordion value.
+ *
+ * Fields always occupy the full row — the rail is fixed at 256px and
+ * side-by-side layouts don't fit legibly. `EntryMetaBoxField` drops
+ * `span` from the type, and this renderer ignores it besides, so a
+ * runtime-loaded plugin can't force a squished layout.
  */
 export function MetaBoxAccordionItem({
   box,
   basePath,
   disabled = false,
-}: MetaBoxProps): ReactNode {
+}: MetaBoxAccordionItemProps): ReactNode {
   return (
-    <AccordionItem
-      value={box.id}
-      className="@container"
-      data-testid={`meta-box-${box.id}`}
-    >
+    <AccordionItem value={box.id} data-testid={`meta-box-${box.id}`}>
       <AccordionTrigger
         className="px-4 py-3 text-sm font-semibold"
         data-testid={`meta-box-heading-${box.id}`}
@@ -101,7 +107,16 @@ export function MetaBoxAccordionItem({
             {box.description}
           </p>
         ) : null}
-        <MetaBoxFieldsGrid box={box} basePath={basePath} disabled={disabled} />
+        <div className="flex flex-col gap-4">
+          {box.fields.map((field) => (
+            <MetaBoxField
+              key={field.key}
+              field={field}
+              name={`${basePath}.${field.key}`}
+              disabled={disabled}
+            />
+          ))}
+        </div>
       </AccordionContent>
     </AccordionItem>
   );

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -151,10 +151,23 @@ export interface MetaBoxBaseOptions {
 }
 
 /**
- * Meta box shown on the entry editor. Scoped by `entryTypes`. Renders
- * as a collapsible section in the editor's document rail.
+ * Field shape for entry meta boxes. Drops `span` from the shared
+ * `MetaBoxField` — the editor's document rail is a fixed 256px column,
+ * so side-by-side layouts can't fit legibly. Compile-time signal to
+ * plugin authors that spans are a page-width affordance only (term,
+ * user, settings).
  */
-export interface EntryMetaBoxOptions extends MetaBoxBaseOptions {
+export type EntryMetaBoxField = Omit<MetaBoxField, "span">;
+
+/**
+ * Meta box shown on the entry editor. Scoped by `entryTypes`. Renders
+ * as a collapsible section in the editor's document rail, which is
+ * fixed at 256px — fields always occupy the full row.
+ */
+export interface EntryMetaBoxOptions extends Omit<
+  MetaBoxBaseOptions,
+  "fields"
+> {
   /**
    * @deprecated The entry editor no longer partitions meta boxes by
    * location — every registered box renders as a collapsible section in
@@ -164,6 +177,7 @@ export interface EntryMetaBoxOptions extends MetaBoxBaseOptions {
    */
   readonly location?: "bottom" | "sidebar";
   readonly entryTypes: readonly string[];
+  readonly fields: readonly EntryMetaBoxField[];
 }
 
 /** Meta box shown on the taxonomy term edit form. Scoped by `taxonomies`. */
@@ -416,7 +430,19 @@ export interface MetaBoxBaseManifestEntry {
   readonly fields: readonly MetaBoxFieldManifestEntry[];
 }
 
-export interface EntryMetaBoxManifestEntry extends MetaBoxBaseManifestEntry {
+/**
+ * Wire-side mirror of `EntryMetaBoxField` — drops `span` from the
+ * shared `MetaBoxFieldManifestEntry`. See `EntryMetaBoxField` for why.
+ */
+export type EntryMetaBoxFieldManifestEntry = Omit<
+  MetaBoxFieldManifestEntry,
+  "span"
+>;
+
+export interface EntryMetaBoxManifestEntry extends Omit<
+  MetaBoxBaseManifestEntry,
+  "fields"
+> {
   readonly id: string;
   /**
    * @deprecated Ignored by the admin editor — all entry meta boxes
@@ -425,6 +451,7 @@ export interface EntryMetaBoxManifestEntry extends MetaBoxBaseManifestEntry {
    */
   readonly location?: "bottom" | "sidebar";
   readonly entryTypes: readonly string[];
+  readonly fields: readonly EntryMetaBoxFieldManifestEntry[];
 }
 
 export interface TermMetaBoxManifestEntry extends MetaBoxBaseManifestEntry {
@@ -829,7 +856,9 @@ function toTaxonomyEntry(tax: RegisteredTaxonomy): TaxonomyManifestEntry {
 // Allowlist for entry meta box entries — same rationale as
 // `toEntryTypeManifest`. `registeredBy` is intentionally excluded
 // (server-only debug metadata). `sanitize` on each field is stripped
-// via `toMetaBoxFieldEntry` — it's a server-side callback.
+// via `toEntryMetaBoxFieldEntry` — it's a server-side callback. `span`
+// is also stripped: the editor rail renders every entry field at full
+// width, and shipping a hint the renderer ignores just bloats the wire.
 function toEntryMetaBoxEntry(
   box: RegisteredEntryMetaBox,
 ): EntryMetaBoxManifestEntry {
@@ -851,7 +880,7 @@ function toEntryMetaBoxEntry(
     priority,
     entryTypes,
     capability,
-    fields: fields.map(toMetaBoxFieldEntry),
+    fields: fields.map(toEntryMetaBoxFieldEntry),
   };
 }
 
@@ -945,6 +974,42 @@ function toMetaBoxFieldEntry(field: MetaBoxField): MetaBoxFieldManifestEntry {
     options,
     default: defaultValue,
     span,
+  };
+}
+
+// Entry meta fields ship without `span` — see `EntryMetaBoxField`.
+function toEntryMetaBoxFieldEntry(
+  field: EntryMetaBoxField,
+): EntryMetaBoxFieldManifestEntry {
+  const {
+    key,
+    label,
+    type,
+    inputType,
+    description,
+    required,
+    placeholder,
+    maxLength,
+    min,
+    max,
+    step,
+    options,
+    default: defaultValue,
+  } = field;
+  return {
+    key,
+    label,
+    type,
+    inputType,
+    description,
+    required,
+    placeholder,
+    maxLength,
+    min,
+    max,
+    step,
+    options,
+    default: defaultValue,
   };
 }
 


### PR DESCRIPTION
## Summary

- The entry editor's right rail is fixed at 256px — a `span: 6` field collapses to ~104px after padding/gap, and container-query breakpoints never fire at that width either. Spans are a page-width affordance in practice.
- Narrow `EntryMetaBoxOptions.fields` (and its manifest mirror) to `Omit<MetaBoxField, "span">`. Plugin authors get a compile error instead of a squished layout. Term, user, and settings meta boxes keep `span` — they render at page width where side-by-side fields actually fit.
- `MetaBoxAccordionItem` now inlines a single-column stack instead of delegating to the 12-col grid helper — belt-and-suspenders for runtime-loaded plugins that slip past the type check, and it avoids a pointless `@container` on the rail where spans can't resolve anyway.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (pre-existing `useReactTable` warning unaffected)
- [x] `pnpm format` — clean
- [x] `pnpm test` — 483 unit tests pass
- [x] `pnpm test:e2e` — 50 Playwright tests pass
- [x] `pnpm knip` — no new findings
- [x] `pnpm publint` / `pnpm attw` — clean