### PR TITLE
feat(core): plugin provides phase + extend{Plugin,Theme}Context APIs

### DIFF
--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -38,7 +38,86 @@ import { DEFAULT_REWRITE_RULE_PRIORITY } from "../route/compile.js";
 import { MAX_PLUGIN_ID_LENGTH, PLUGIN_ID_RE } from "./define.js";
 import { CORE_RPC_NAMESPACES, DuplicateRegistrationError } from "./manifest.js";
 
-export interface PluginSetupContext {
+/**
+ * One entry in either extension registry — the value the plugin
+ * provided plus the plugin id for diagnostics. Same shape for plugin
+ * and theme contexts, so we name it once.
+ */
+export interface ContextExtensionEntry {
+  readonly value: unknown;
+  readonly pluginId: string;
+}
+
+/**
+ * Augmentable map of values that plugins register via
+ * `ctx.extendPluginContext(key, value)` in their `provides` phase. Other
+ * plugins consume these in their `setup` callback as `ctx[key](...)`.
+ *
+ * Plugins augment to type their own keys:
+ *
+ * ```ts
+ * declare module "plumix/plugin" {
+ *   interface PluginContextExtensions {
+ *     registerMenuItemType(type: string, opts: MenuItemTypeOpts): void;
+ *   }
+ * }
+ * ```
+ *
+ * Calling `extendPluginContext` for a key that's not in this interface
+ * is a type error — keeps the `ctx` surface authoritative.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface PluginContextExtensions {}
+
+/**
+ * Same model as `PluginContextExtensions` but for the `ctx` passed to
+ * `defineTheme` callbacks. Themes don't ship in week 1; the registry is
+ * collected anyway so plugins can declare extensions before the theme
+ * runtime lands without a follow-up shape change.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ThemeContextExtensions {}
+
+/**
+ * `ctx` passed to a plugin's `provides` callback. Phase 1 — runs before
+ * any plugin's `setup`. The only methods here are the two extension
+ * registrars: `provides` is deliberately narrow so plugins can't reach
+ * for hooks / RPC / admin during this phase (those land in `setup`).
+ */
+export interface PluginProvidesContext {
+  readonly id: string;
+
+  /**
+   * Add a method or value to the `PluginSetupContext` that every
+   * plugin's `setup` callback (including this plugin's own) sees.
+   * Augment `PluginContextExtensions` to type the key. Two plugins
+   * extending the same key throws at install time — config order is
+   * not load-bearing.
+   */
+  extendPluginContext<TKey extends keyof PluginContextExtensions>(
+    key: TKey,
+    value: PluginContextExtensions[TKey],
+  ): void;
+
+  /**
+   * Same as `extendPluginContext` but targets the `ThemeContext` that
+   * `defineTheme` callbacks receive. Themes aren't wired in week 1 —
+   * the registry is collected for forward-compat so plugin extensions
+   * declared today work the moment themes land.
+   */
+  extendThemeContext<TKey extends keyof ThemeContextExtensions>(
+    key: TKey,
+    value: ThemeContextExtensions[TKey],
+  ): void;
+}
+
+/**
+ * Built-in members of the plugin setup context. Constructed by
+ * `createPluginSetupContext` and unaffected by plugin module
+ * augmentation — the augmentation lives on `PluginContextExtensions`
+ * and is intersected at the public `PluginSetupContext` boundary.
+ */
+export interface PluginSetupContextBase {
   readonly id: string;
 
   /** Subscribe to an existing (core or other-plugin) filter. */
@@ -159,16 +238,85 @@ export interface PluginSetupContext {
   registerFieldType(options: FieldTypeOptions): void;
 }
 
+/**
+ * What plugin authors actually consume in their `setup` callback —
+ * built-ins plus every extension declared by another plugin's
+ * `provides` phase. Plugin module augmentation against
+ * `PluginContextExtensions` extends this surface automatically.
+ */
+export type PluginSetupContext = PluginSetupContextBase &
+  PluginContextExtensions;
+
 interface CreatePluginContextArgs {
   readonly pluginId: string;
   readonly hooks: HookRegistry;
   readonly registry: MutablePluginRegistry;
+  /**
+   * Key/value pairs collected from every plugin's `provides` phase.
+   * Spread onto the returned context after the built-in methods so a
+   * plugin can't shadow `addFilter` / `registerEntryType` / etc. — that
+   * collision is also detected at registration time, but defending here
+   * keeps the contract local.
+   */
+  readonly extensions?: ReadonlyMap<string, unknown>;
+}
+
+interface CreateProvidesContextArgs {
+  readonly pluginId: string;
+  readonly pluginExtensions: Map<string, ContextExtensionEntry>;
+  readonly themeExtensions: Map<string, ContextExtensionEntry>;
+}
+
+/**
+ * Build the narrow `ctx` passed to a plugin's `provides` callback. The
+ * two extension maps are shared across all plugins so collisions can be
+ * detected globally (first writer logs the plugin id; second writer
+ * throws with both ids in the message).
+ */
+export function createPluginProvidesContext({
+  pluginId,
+  pluginExtensions,
+  themeExtensions,
+}: CreateProvidesContextArgs): PluginProvidesContext {
+  const stash = (
+    target: Map<string, ContextExtensionEntry>,
+    kind: "Plugin" | "Theme",
+    key: string,
+    value: unknown,
+  ): void => {
+    if (typeof key !== "string" || key.length === 0) {
+      throw new Error(
+        `Plugin "${pluginId}" called extend${kind}Context with an ` +
+          `invalid key — must be a non-empty string.`,
+      );
+    }
+    const existing = target.get(key);
+    if (existing) {
+      throw new Error(
+        `Plugin "${pluginId}" extended the ${kind.toLowerCase()} context ` +
+          `with "${key}", but "${existing.pluginId}" already registered it. ` +
+          `Each extension key has exactly one provider — rename one or ` +
+          `consolidate the providing plugin.`,
+      );
+    }
+    target.set(key, { value, pluginId });
+  };
+  return {
+    id: pluginId,
+    extendPluginContext: (key, value) => {
+      stash(pluginExtensions, "Plugin", key, value);
+    },
+    extendThemeContext: (key, value) => {
+      stash(themeExtensions, "Theme", key, value);
+    },
+  };
 }
 
 export function createPluginSetupContext({
   pluginId,
   hooks,
   registry,
+  extensions,
 }: CreatePluginContextArgs): PluginSetupContext {
   // Pooling caps by capabilityType is safe when minRoles agree; if one
   // type applies a `capabilities` override and another doesn't, silent
@@ -193,7 +341,7 @@ export function createPluginSetupContext({
     }
   };
 
-  return {
+  const ctx: PluginSetupContextBase = {
     id: pluginId,
 
     addFilter: (name, fn, options) => {
@@ -429,6 +577,25 @@ export function createPluginSetupContext({
       });
     },
   };
+
+  if (extensions && extensions.size > 0) {
+    // Extensions go on a `Record<string, unknown>` view of the context
+    // before the cast — `PluginSetupContext` doesn't index by string but
+    // its augmentations do.
+    const target = ctx as unknown as Record<string, unknown>;
+    for (const [key, value] of extensions) {
+      if (key in target) {
+        throw new Error(
+          `Plugin context extension key "${key}" collides with a built-in ` +
+            `PluginSetupContext member. Rename the extension to avoid ` +
+            `shadowing core registration APIs.`,
+        );
+      }
+      target[key] = value;
+    }
+  }
+
+  return ctx as PluginSetupContext;
 }
 
 // Three meta-box registrations (entry/term/user) only differ in their

--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -1,13 +1,24 @@
-import type { PluginSetupContext } from "./context.js";
+import type { PluginProvidesContext, PluginSetupContext } from "./context.js";
 
 export type PluginSetup<TConfig> = (
   ctx: PluginSetupContext,
   config: TConfig,
 ) => void | Promise<void>;
 
+export type PluginProvides = (
+  ctx: PluginProvidesContext,
+) => void | Promise<void>;
+
 export interface PluginDescriptor<TConfig = undefined> {
   readonly id: string;
   readonly version?: string;
+  /**
+   * Phase 1 — runs before any plugin's `setup`. Use to declare
+   * `extendPluginContext` / `extendThemeContext` registrations that
+   * other plugins (or themes) consume during their `setup`. Most
+   * plugins don't need this.
+   */
+  readonly provides?: PluginProvides;
   readonly setup: PluginSetup<TConfig>;
   readonly schema?: Record<string, unknown>;
   readonly schemaModule?: string;
@@ -26,6 +37,16 @@ export interface DefinePluginOptions {
   readonly adminChunk?: string;
   readonly adminCss?: string;
   readonly adminPeerVersion?: string;
+}
+
+/**
+ * Options-form input — `setup` is required, `provides` is optional, plus
+ * everything in `DefinePluginOptions`. Mirrors the architecture's
+ * `definePlugin(id, { provides, setup, ... })` shape.
+ */
+export interface DefinePluginInput<TConfig> extends DefinePluginOptions {
+  readonly provides?: PluginProvides;
+  readonly setup: PluginSetup<TConfig>;
 }
 
 // URL- and SQL-identifier-safe — plugin ids become path segments,
@@ -52,16 +73,45 @@ export function definePlugin<TConfig = undefined>(
   id: string,
   setup: PluginSetup<TConfig>,
   options?: DefinePluginOptions,
+): PluginDescriptor<TConfig>;
+export function definePlugin<TConfig = undefined>(
+  id: string,
+  input: DefinePluginInput<TConfig>,
+): PluginDescriptor<TConfig>;
+export function definePlugin<TConfig = undefined>(
+  id: string,
+  setupOrInput: PluginSetup<TConfig> | DefinePluginInput<TConfig>,
+  legacyOptions?: DefinePluginOptions,
 ): PluginDescriptor<TConfig> {
   assertValidPluginId(id);
+  if (typeof setupOrInput === "function") {
+    return {
+      id,
+      version: legacyOptions?.version,
+      setup: setupOrInput,
+      schema: legacyOptions?.schema,
+      schemaModule: legacyOptions?.schemaModule,
+      adminChunk: legacyOptions?.adminChunk,
+      adminCss: legacyOptions?.adminCss,
+      adminPeerVersion: legacyOptions?.adminPeerVersion,
+    };
+  }
+  if (legacyOptions !== undefined) {
+    throw new Error(
+      `definePlugin("${id}", input) — pass options inside the input ` +
+        `object (\`setup\`, \`provides\`, \`schema\`, ...) instead of the ` +
+        `legacy third argument.`,
+    );
+  }
   return {
     id,
-    version: options?.version,
-    setup,
-    schema: options?.schema,
-    schemaModule: options?.schemaModule,
-    adminChunk: options?.adminChunk,
-    adminCss: options?.adminCss,
-    adminPeerVersion: options?.adminPeerVersion,
+    version: setupOrInput.version,
+    provides: setupOrInput.provides,
+    setup: setupOrInput.setup,
+    schema: setupOrInput.schema,
+    schemaModule: setupOrInput.schemaModule,
+    adminChunk: setupOrInput.adminChunk,
+    adminCss: setupOrInput.adminCss,
+    adminPeerVersion: setupOrInput.adminPeerVersion,
   };
 }

--- a/packages/core/src/plugin/provides.test.ts
+++ b/packages/core/src/plugin/provides.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry } from "../hooks/registry.js";
+import { definePlugin } from "./define.js";
+import { installPlugins } from "./register.js";
+
+declare module "./context.js" {
+  interface PluginContextExtensions {
+    registerMenuItemType(type: string, opts: { readonly label: string }): void;
+    media: {
+      url(key: string): string;
+    };
+  }
+  interface ThemeContextExtensions {
+    registerMenuLocation(id: string, opts: { readonly label: string }): void;
+  }
+}
+
+describe("provides phase", () => {
+  test("setup ctx sees extensions registered by another plugin's provides", async () => {
+    const recorded: { type: string; label: string }[] = [];
+
+    const menus = definePlugin("menus", {
+      provides: (ctx) => {
+        ctx.extendPluginContext("registerMenuItemType", (type, opts) => {
+          recorded.push({ type, label: opts.label });
+        });
+      },
+      setup: () => undefined,
+    });
+
+    const cart = definePlugin("cart", (ctx) => {
+      ctx.registerMenuItemType("cart-link", { label: "Cart" });
+    });
+
+    await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [menus, cart],
+    });
+    expect(recorded).toEqual([{ type: "cart-link", label: "Cart" }]);
+  });
+
+  test("config order doesn't matter — consumer registered before provider still sees the extension", async () => {
+    const recorded: string[] = [];
+
+    const menus = definePlugin("menus", {
+      provides: (ctx) => {
+        ctx.extendPluginContext("registerMenuItemType", (type) => {
+          recorded.push(type);
+        });
+      },
+      setup: () => undefined,
+    });
+
+    const cart = definePlugin("cart", (ctx) => {
+      ctx.registerMenuItemType("cart-link", { label: "Cart" });
+    });
+
+    // Cart appears first in the array — its setup must still see the
+    // menus extension because all `provides` run before any `setup`.
+    await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [cart, menus],
+    });
+    expect(recorded).toEqual(["cart-link"]);
+  });
+
+  test("non-function extension values are returned as-is", async () => {
+    let captured: ((key: string) => string) | undefined;
+
+    const media = definePlugin("media", {
+      provides: (ctx) => {
+        ctx.extendPluginContext("media", {
+          url: (key: string) => `https://cdn.example/${key}`,
+        });
+      },
+      setup: () => undefined,
+    });
+
+    const consumer = definePlugin("consumer", (ctx) => {
+      // Wrap so the bound-method check stays happy and the captured
+      // closure resolves `url` against the same `ctx.media` instance.
+      captured = (key) => ctx.media.url(key);
+    });
+
+    await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [media, consumer],
+    });
+    expect(captured?.("logo.png")).toBe("https://cdn.example/logo.png");
+  });
+
+  test("two plugins extending the same plugin-context key throw with both ids", async () => {
+    const a = definePlugin("a", {
+      provides: (ctx) => {
+        ctx.extendPluginContext("registerMenuItemType", () => undefined);
+      },
+      setup: () => undefined,
+    });
+    const b = definePlugin("b", {
+      provides: (ctx) => {
+        ctx.extendPluginContext("registerMenuItemType", () => undefined);
+      },
+      setup: () => undefined,
+    });
+
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [a, b] }),
+    ).rejects.toThrow(
+      /Plugin "b" extended.*"registerMenuItemType".*"a" already registered/s,
+    );
+  });
+
+  test("extending with a key that shadows a built-in registrar throws", async () => {
+    const evil = definePlugin("evil", {
+      provides: (ctx) => {
+        // Cast through unknown — TS protects callers via
+        // PluginContextExtensions, this test simulates a plugin
+        // bypassing types.
+        (
+          ctx.extendPluginContext as unknown as (
+            key: string,
+            value: unknown,
+          ) => void
+        )("addFilter", () => undefined);
+      },
+      setup: () => undefined,
+    });
+
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [evil] }),
+    ).rejects.toThrow(
+      /"addFilter" collides with a built-in PluginSetupContext/,
+    );
+  });
+
+  test("theme extensions are collected and surfaced on the install result", async () => {
+    const menus = definePlugin("menus", {
+      provides: (ctx) => {
+        ctx.extendThemeContext("registerMenuLocation", (id, opts) => ({
+          id,
+          opts,
+        }));
+      },
+      setup: () => undefined,
+    });
+
+    const result = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [menus],
+    });
+
+    const entry = result.themeExtensions.get("registerMenuLocation");
+    expect(entry?.pluginId).toBe("menus");
+    expect(typeof entry?.value).toBe("function");
+  });
+
+  test("two plugins extending the same theme-context key throw with both ids", async () => {
+    const a = definePlugin("a", {
+      provides: (ctx) => {
+        ctx.extendThemeContext("registerMenuLocation", () => undefined);
+      },
+      setup: () => undefined,
+    });
+    const b = definePlugin("b", {
+      provides: (ctx) => {
+        ctx.extendThemeContext("registerMenuLocation", () => undefined);
+      },
+      setup: () => undefined,
+    });
+
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [a, b] }),
+    ).rejects.toThrow(
+      /Plugin "b" extended.*"registerMenuLocation".*"a" already registered/s,
+    );
+  });
+
+  test("plugin without provides still installs (back-compat)", async () => {
+    const plain = definePlugin("plain", (ctx) => {
+      ctx.registerCapability("plain:cap", "admin");
+    });
+
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [plain],
+    });
+    expect(registry.capabilities.get("plain:cap")?.minRole).toBe("admin");
+  });
+
+  test("passing legacy 3rd-arg options alongside the options-form throws", () => {
+    // Bypass overload resolution — the call shape isn't reachable from
+    // either typed overload, so we drop into the runtime guard.
+    const callRaw = definePlugin as unknown as (...args: unknown[]) => unknown;
+    expect(() =>
+      callRaw("y", { setup: () => undefined }, { version: "1.0.0" }),
+    ).toThrow(/pass options inside the input object/);
+  });
+
+  test("async provides callback is awaited before any setup runs", async () => {
+    const order: string[] = [];
+
+    const menus = definePlugin("menus", {
+      provides: async (ctx) => {
+        await Promise.resolve();
+        order.push("menus:provides");
+        ctx.extendPluginContext("registerMenuItemType", () => {
+          order.push("cart:registerMenuItemType");
+        });
+      },
+      setup: () => {
+        order.push("menus:setup");
+      },
+    });
+
+    const cart = definePlugin("cart", (ctx) => {
+      order.push("cart:setup");
+      ctx.registerMenuItemType("link", { label: "L" });
+    });
+
+    await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [menus, cart],
+    });
+    expect(order).toEqual([
+      "menus:provides",
+      "menus:setup",
+      "cart:setup",
+      "cart:registerMenuItemType",
+    ]);
+  });
+
+  test("a plugin extending the same key twice in its own provides throws", async () => {
+    const dupe = definePlugin("dupe", {
+      provides: (ctx) => {
+        ctx.extendPluginContext("registerMenuItemType", () => undefined);
+        ctx.extendPluginContext("registerMenuItemType", () => undefined);
+      },
+      setup: () => undefined,
+    });
+
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [dupe] }),
+    ).rejects.toThrow(
+      /Plugin "dupe" extended.*"registerMenuItemType".*"dupe" already registered/s,
+    );
+  });
+
+  test("a plugin's own setup can call extensions it provided", async () => {
+    const recorded: string[] = [];
+
+    const selfConsumer = definePlugin("self", {
+      provides: (ctx) => {
+        ctx.extendPluginContext("registerMenuItemType", (type) => {
+          recorded.push(type);
+        });
+      },
+      setup: (ctx) => {
+        ctx.registerMenuItemType("self-link", { label: "Self" });
+      },
+    });
+
+    await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [selfConsumer],
+    });
+    expect(recorded).toEqual(["self-link"]);
+  });
+});

--- a/packages/core/src/plugin/register.ts
+++ b/packages/core/src/plugin/register.ts
@@ -1,13 +1,24 @@
 import type { AnyPluginDescriptor } from "../config.js";
 import type { HookRegistry } from "../hooks/registry.js";
+import type { ContextExtensionEntry } from "./context.js";
 import type { MutablePluginRegistry, PluginRegistry } from "./manifest.js";
-import { createPluginSetupContext } from "./context.js";
+import {
+  createPluginProvidesContext,
+  createPluginSetupContext,
+} from "./context.js";
 import { assertValidPluginId } from "./define.js";
 import { createPluginRegistry } from "./manifest.js";
 
 export interface PluginInstallResult {
   readonly hooks: HookRegistry;
   readonly registry: PluginRegistry;
+  /**
+   * Theme-context extensions collected from every plugin's `provides`
+   * phase. Themes don't ship in week 1; the runtime stores these so the
+   * `defineTheme` consumer can read them once themes land. Entries
+   * carry the providing plugin id for diagnostics.
+   */
+  readonly themeExtensions: ReadonlyMap<string, ContextExtensionEntry>;
 }
 
 interface InstallPluginsArgs {
@@ -33,13 +44,40 @@ export async function installPlugins({
     }
     seenIds.add(descriptor.id);
   }
+
+  // Phase 1 — collect context extensions. Maps are shared across every
+  // plugin's provides ctx so collisions surface globally with both
+  // providing plugin ids in the error message.
+  const pluginExtensions = new Map<string, ContextExtensionEntry>();
+  const themeExtensions = new Map<string, ContextExtensionEntry>();
+  for (const descriptor of plugins) {
+    if (!descriptor.provides) continue;
+    const providesCtx = createPluginProvidesContext({
+      pluginId: descriptor.id,
+      pluginExtensions,
+      themeExtensions,
+    });
+    await descriptor.provides(providesCtx);
+  }
+
+  // Build the merged extensions view passed to every setup ctx — the
+  // shape `createPluginSetupContext` consumes is `key → value`, the
+  // pluginId attribution stays on the source map.
+  const mergedPluginExtensions = new Map<string, unknown>();
+  for (const [key, entry] of pluginExtensions) {
+    mergedPluginExtensions.set(key, entry.value);
+  }
+
+  // Phase 2 — run setup with the merged context.
   for (const descriptor of plugins) {
     const ctx = createPluginSetupContext({
       pluginId: descriptor.id,
       hooks,
       registry,
+      extensions: mergedPluginExtensions,
     });
     await descriptor.setup(ctx, undefined);
   }
-  return { hooks, registry };
+
+  return { hooks, registry, themeExtensions };
 }


### PR DESCRIPTION
Add the two-phase plugin init from [ARCHITECTURE.md §2060–2117](docs/reference/ARCHITECTURE.md) so plugins can expose APIs that other plugins (and, later, themes) consume in their `setup` ctx. This is the foundational primitive blocking [PLAN.md Phase 11.5](PLAN.md) — without it, the menus + media spike acceptance tests can't be written without core changes.

## Why now

[Phase 11.5](PLAN.md) frames its acceptance as: a developer can write `@plumix/plugin-menus` and `@plumix/plugin-media` as pure plugin packages with zero changes to `@plumix/core` or `@plumix/admin`. Both spikes need a way for one plugin to expose APIs to another (`menus` → `registerMenuItemType` for cart/auth plugins; `media` → `ctx.media.url(...)` for the image block). Architecture spec'd the shape; this lands the runtime + types.

## What changes

**Two-phase install in `installPlugins`:**

1. `provides` — every plugin's optional `provides` callback runs first with a narrow `PluginProvidesContext` that only exposes `extendPluginContext` / `extendThemeContext`. Extensions accumulate into call-local maps shared across all providers so collisions surface globally with both plugin ids in the error.
2. `setup` — every plugin's `setup` runs with the merged extensions spread onto the existing `PluginSetupContext`. Config order doesn't matter: a consumer registered before the provider in `plumix.config.ts` still sees the extension because all `provides` land before any `setup`.

**`definePlugin` options-form overload:**

```ts
definePlugin('menus', {
  provides: (ctx) => {
    ctx.extendPluginContext('registerMenuItemType', (type, opts) => { ... })
  },
  setup: (ctx) => { /* existing registration APIs */ },
})
```

The existing `definePlugin(id, callback)` shorthand stays unchanged — every current call site (12 in tests, none in published packages) keeps working.

**Module-augmentation pattern** (mirrors `FilterRegistry` / `ActionRegistry` from `hooks/types.ts`):

```ts
declare module 'plumix/plugin' {
  interface PluginContextExtensions {
    registerMenuItemType(type: string, opts: MenuItemTypeOpts): void
  }
}
```

`PluginSetupContext = PluginSetupContextBase & PluginContextExtensions` keeps the construction site type-safe while plugin augmentation flows through to the consumer ctx automatically.

## Lifecycle hooks deliberately not included

Discussed `onActivate` / `onUpgrade` / `onDeactivate` / `onUninstall` and decided against — they're WP's solution to WP's problem (a CMS that owns plugin discovery via filesystem scanning). In a build-time-bundled, declarative-config CMS:

- Schema diffs flow through drizzle-kit migrations (already shipped Phase 4)
- Default option values via `registerOption({ default })` (Phase 11.5 #7)
- One-shot ops (R2 GC, reindex, cleanup orphans) via plugin-shipped CLI subcommands (existing `commandsModule` pattern from Phase 5)
- Cleanup on removal via `DROP TABLE` migrations + a CLI command run *before* removing the plugin

A runtime hook that fires on cold boot is strictly worse: race-prone across concurrent worker boots, hidden side effect, no audit trail. Every state change in plumix happens at a known time the operator triggered.

## Theme extensions surfaced for forward-compat

Themes don't ship in week 1, but `PluginInstallResult.themeExtensions` is collected and returned anyway so plugin extensions declared today work the moment `defineTheme` lands — no follow-up shape change.

## Risk

Low. Build-time only, no DB / auth / request handling. All 599 pre-existing core tests pass unchanged; 12 new tests cover the new surface (sync + async `provides`, ordering independence, intra-plugin double-extend, plugin's own `setup` consuming its own extension, both collision paths, built-in shadowing rejection, back-compat callback shorthand).

`find-bugs`, `code-review`, and `code-simplifier` skill passes ran clean — no blockers, only one minor refinement (extracted shared `ContextExtensionEntry` type) applied.

## What's next in Phase 11.5

This unblocks the core/admin primitive items in [PLAN.md](PLAN.md). Remaining 11.5 items still ahead: `registerOption` + Settings UI, public `ctx.route` primitive (needed by blog/pages), the manifest slice for plugin-declared admin pages, and the eventual Bucket C build pipeline ADRs.