### PR TITLE
feat(plugins): blog + pages first-party content plugins + examples/blog fixture

### DIFF
--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -1,0 +1,4 @@
+.plumix/
+.wrangler/
+dist/
+node_modules/

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -1,0 +1,34 @@
+# plumix-blog
+
+Plumix app demoing the first-party content plugins:
+
+- **`@plumix/plugin-blog`** — `post` entry type, `category` and `tag` taxonomies
+- **`@plumix/plugin-pages`** — hierarchical `page` entry type
+
+Targets Cloudflare Workers + D1. New plugins can be wired in `plumix.config.ts` as we add them.
+
+## Develop
+
+```bash
+pnpm dev
+```
+
+Opens a local Workers dev server on `http://localhost:8787`.
+
+## Build
+
+```bash
+pnpm build
+```
+
+Emits the worker bundle to `dist/plumix_blog/`. Equivalent to `pnpm exec plumix build`.
+
+## Deploy
+
+```bash
+pnpm exec plumix migrate generate
+pnpm exec wrangler d1 create plumix_blog
+# paste the returned database_id into wrangler.jsonc
+pnpm exec plumix migrate apply --remote
+pnpm exec plumix deploy
+```

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@plumix-examples/blog",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Plumix app with the blog and pages plugins — Cloudflare + D1",
+  "license": "MIT",
+  "scripts": {
+    "build": "plumix build",
+    "clean": "git clean -xdf .plumix .wrangler dist node_modules",
+    "dev": "plumix dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@plumix/plugin-blog": "workspace:*",
+    "@plumix/plugin-pages": "workspace:*",
+    "@plumix/runtime-cloudflare": "workspace:*",
+    "plumix": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
+    "@plumix/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/blog/plumix.config.ts
+++ b/examples/blog/plumix.config.ts
@@ -1,0 +1,17 @@
+import { blog } from "@plumix/plugin-blog";
+import { pages } from "@plumix/plugin-pages";
+import { cloudflare, d1 } from "@plumix/runtime-cloudflare";
+import { auth, plumix } from "plumix";
+
+export default plumix({
+  runtime: cloudflare(),
+  database: d1({ binding: "DB", session: "auto" }),
+  auth: auth({
+    passkey: {
+      rpName: "Plumix — Blog",
+      rpId: "localhost",
+      origin: "http://localhost:8787",
+    },
+  }),
+  plugins: [blog, pages],
+});

--- a/examples/blog/tsconfig.json
+++ b/examples/blog/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@plumix/typescript-config/base.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/workers-types"]
+  },
+  "include": ["plumix.config.ts", ".plumix"]
+}

--- a/examples/blog/wrangler.jsonc
+++ b/examples/blog/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://unpkg.com/wrangler/config-schema.json",
+  "name": "plumix-blog",
+  "main": ".plumix/worker.ts",
+  "compatibility_date": "2026-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "plumix_blog",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+    },
+  ],
+  "assets": {
+    "directory": ".plumix/public",
+    "binding": "ASSETS",
+    "not_found_handling": "none",
+  },
+}

--- a/examples/blog/wrangler.jsonc
+++ b/examples/blog/wrangler.jsonc
@@ -8,7 +8,7 @@
     {
       "binding": "DB",
       "database_name": "plumix_blog",
-      "database_id": "00000000-0000-0000-0000-000000000000",
+      "database_id": "67ed8348-4cfa-45ce-8b0a-17eb9e351896",
     },
   ],
   "assets": {

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -13,10 +13,10 @@ Opens a local Workers dev server (via `@cloudflare/vite-plugin`) on `http://loca
 ## Build
 
 ```bash
-pnpm exec plumix build
+pnpm build
 ```
 
-Emits the worker bundle to `dist/plumix_minimal/`.
+Emits the worker bundle to `dist/plumix_minimal/`. Equivalent to `pnpm exec plumix build`.
 
 ## Deploy
 

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -6,6 +6,7 @@
   "description": "Smallest buildable Plumix app — Cloudflare + D1",
   "license": "MIT",
   "scripts": {
+    "build": "plumix build",
     "clean": "git clean -xdf .plumix .wrangler dist node_modules",
     "dev": "plumix dev",
     "test": "vitest run",

--- a/examples/minimal/wrangler.jsonc
+++ b/examples/minimal/wrangler.jsonc
@@ -8,7 +8,7 @@
     {
       "binding": "DB",
       "database_name": "plumix_minimal",
-      "database_id": "00000000-0000-0000-0000-000000000000"
+      "database_id": "b8642267-9b20-4111-a5cc-3e3cba0e8ebb"
     }
   ],
   "assets": {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,6 +12,14 @@ const config: KnipConfig = {
     "tooling/typescript": {
       entry: ["*.json"],
     },
+    // plumix.config.ts is the consumer's entry — knip can't infer it
+    // from package.json's exports because examples don't publish.
+    "examples/blog": {
+      entry: ["plumix.config.ts"],
+    },
+    "examples/minimal": {
+      entry: ["plumix.config.ts"],
+    },
     // @plumix/core is a dependency but has no real imports yet (empty skeleton).
     // Remove these once packages have actual code importing from core.
     "packages/blocks": {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -17,9 +17,6 @@ const config: KnipConfig = {
     "packages/blocks": {
       ignoreDependencies: ["@plumix/core"],
     },
-    "packages/plugins/pages": {
-      ignoreDependencies: ["@plumix/core"],
-    },
     // - drizzle-kit is invoked by consumers as a CLI hint, not imported.
     // - @plumix/admin is consumed via filesystem copy (scripts/copy-admin.mjs)
     //   at build time, not as a TypeScript import.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -17,9 +17,6 @@ const config: KnipConfig = {
     "packages/blocks": {
       ignoreDependencies: ["@plumix/core"],
     },
-    "packages/plugins/blog": {
-      ignoreDependencies: ["@plumix/core"],
-    },
     "packages/plugins/pages": {
       ignoreDependencies: ["@plumix/core"],
     },

--- a/packages/plugins/blog/package.json
+++ b/packages/plugins/blog/package.json
@@ -38,11 +38,12 @@
   },
   "scripts": {
     "attw": "attw --pack . --profile esm-only",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../../.gitignore",
     "lint": "eslint",
     "publint": "publint",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
@@ -53,10 +54,13 @@
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
+    "@plumix/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "prettier": "@plumix/prettier-config"
 }

--- a/packages/plugins/blog/src/index.test.ts
+++ b/packages/plugins/blog/src/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry, installPlugins } from "@plumix/core";
+
+import { blog } from "./index.js";
+
+async function install() {
+  return installPlugins({ hooks: new HookRegistry(), plugins: [blog] });
+}
+
+describe("@plumix/plugin-blog", () => {
+  test("registers the post entry type with attribution", async () => {
+    const { registry } = await install();
+    const post = registry.entryTypes.get("post");
+    expect(post).toBeDefined();
+    expect(post?.label).toBe("Posts");
+    expect(post?.isPublic).toBe(true);
+    expect(post?.hasArchive).toBe(true);
+    expect(post?.termTaxonomies).toEqual(["category", "tag"]);
+    expect(post?.registeredBy).toBe("blog");
+  });
+
+  test("registers category as a hierarchical taxonomy with admin column", async () => {
+    const { registry } = await install();
+    const category = registry.termTaxonomies.get("category");
+    expect(category?.isHierarchical).toBe(true);
+    expect(category?.hasAdminColumn).toBe(true);
+    expect(category?.entryTypes).toEqual(["post"]);
+    expect(category?.rewrite).toEqual({
+      slug: "category",
+      isHierarchical: true,
+    });
+  });
+
+  test("registers tag as a flat taxonomy", async () => {
+    const { registry } = await install();
+    const tag = registry.termTaxonomies.get("tag");
+    expect(tag?.isHierarchical).toBe(false);
+    expect(tag?.rewrite).toEqual({ slug: "tag" });
+  });
+
+  test("derives post:* capabilities from the entry type", async () => {
+    const { registry } = await install();
+    expect(registry.capabilities.get("entry:post:create")?.minRole).toBe(
+      "contributor",
+    );
+    expect(registry.capabilities.get("entry:post:publish")?.minRole).toBe(
+      "author",
+    );
+    expect(registry.capabilities.get("entry:post:edit_any")?.minRole).toBe(
+      "editor",
+    );
+  });
+
+  test("derives term:category:* and term:tag:* capabilities", async () => {
+    const { registry } = await install();
+    expect(registry.capabilities.get("term:category:assign")?.minRole).toBe(
+      "contributor",
+    );
+    expect(registry.capabilities.get("term:category:manage")?.minRole).toBe(
+      "editor",
+    );
+    expect(registry.capabilities.get("term:tag:assign")?.minRole).toBe(
+      "contributor",
+    );
+  });
+});

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -1,1 +1,36 @@
-export {};
+import { definePlugin } from "@plumix/core";
+
+export const blog = definePlugin("blog", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    labels: { singular: "Post", plural: "Posts" },
+    description: "Standard blog posts",
+    supports: ["title", "editor", "excerpt"],
+    termTaxonomies: ["category", "tag"],
+    isHierarchical: false,
+    isPublic: true,
+    hasArchive: true,
+    capabilityType: "post",
+    menuIcon: "file-text",
+  });
+
+  ctx.registerTermTaxonomy("category", {
+    label: "Categories",
+    labels: { singular: "Category" },
+    isHierarchical: true,
+    entryTypes: ["post"],
+    isPublic: true,
+    hasAdminColumn: true,
+    rewrite: { slug: "category", isHierarchical: true },
+  });
+
+  ctx.registerTermTaxonomy("tag", {
+    label: "Tags",
+    labels: { singular: "Tag" },
+    isHierarchical: false,
+    entryTypes: ["post"],
+    isPublic: true,
+    hasAdminColumn: true,
+    rewrite: { slug: "tag" },
+  });
+});

--- a/packages/plugins/blog/tsconfig.build.json
+++ b/packages/plugins/blog/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "stripInternal": true
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/blog/vitest.config.ts
+++ b/packages/plugins/blog/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config";
+
+import { baseConfig } from "@plumix/vitest-config/base";
+
+export default defineConfig(baseConfig);

--- a/packages/plugins/pages/package.json
+++ b/packages/plugins/pages/package.json
@@ -38,11 +38,12 @@
   },
   "scripts": {
     "attw": "attw --pack . --profile esm-only",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../../.gitignore",
     "lint": "eslint",
     "publint": "publint",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
@@ -53,10 +54,13 @@
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
+    "@plumix/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "prettier": "@plumix/prettier-config"
 }

--- a/packages/plugins/pages/src/index.test.ts
+++ b/packages/plugins/pages/src/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry, installPlugins } from "@plumix/core";
+
+import { pages } from "./index.js";
+
+async function install() {
+  return installPlugins({ hooks: new HookRegistry(), plugins: [pages] });
+}
+
+describe("@plumix/plugin-pages", () => {
+  test("registers the page entry type with attribution", async () => {
+    const { registry } = await install();
+    const page = registry.entryTypes.get("page");
+    expect(page).toBeDefined();
+    expect(page?.label).toBe("Pages");
+    expect(page?.isHierarchical).toBe(true);
+    expect(page?.isPublic).toBe(true);
+    expect(page?.hasArchive).toBe(false);
+    expect(page?.registeredBy).toBe("pages");
+  });
+
+  test("registers no taxonomies", async () => {
+    const { registry } = await install();
+    expect(registry.termTaxonomies.size).toBe(0);
+  });
+
+  test("derives page:* capabilities from the entry type", async () => {
+    const { registry } = await install();
+    expect(registry.capabilities.get("entry:page:create")?.minRole).toBe(
+      "contributor",
+    );
+    expect(registry.capabilities.get("entry:page:publish")?.minRole).toBe(
+      "author",
+    );
+    expect(registry.capabilities.get("entry:page:edit_any")?.minRole).toBe(
+      "editor",
+    );
+  });
+});

--- a/packages/plugins/pages/src/index.ts
+++ b/packages/plugins/pages/src/index.ts
@@ -1,1 +1,15 @@
-export {};
+import { definePlugin } from "@plumix/core";
+
+export const pages = definePlugin("pages", (ctx) => {
+  ctx.registerEntryType("page", {
+    label: "Pages",
+    labels: { singular: "Page", plural: "Pages" },
+    description: "Hierarchical static pages",
+    supports: ["title", "editor", "excerpt"],
+    isHierarchical: true,
+    isPublic: true,
+    hasArchive: false,
+    capabilityType: "page",
+    menuIcon: "layout",
+  });
+});

--- a/packages/plugins/pages/tsconfig.build.json
+++ b/packages/plugins/pages/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "stripInternal": true
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/pages/vitest.config.ts
+++ b/packages/plugins/pages/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config";
+
+import { baseConfig } from "@plumix/vitest-config/base";
+
+export default defineConfig(baseConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,12 @@ importers:
       '@plumix/typescript-config':
         specifier: workspace:*
         version: link:../../../tooling/typescript
+      '@plumix/vitest-config':
+        specifier: workspace:*
+        version: link:../../../tooling/vitest
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: 'catalog:'
         version: 10.2.1(jiti@2.6.1)
@@ -449,6 +455,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plumix:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,12 @@ importers:
       '@plumix/typescript-config':
         specifier: workspace:*
         version: link:../../../tooling/typescript
+      '@plumix/vitest-config':
+        specifier: workspace:*
+        version: link:../../../tooling/vitest
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: 'catalog:'
         version: 10.2.1(jiti@2.6.1)
@@ -409,6 +415,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugins/pages:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,34 @@ importers:
         specifier: ^2.9.6
         version: 2.9.6
 
+  examples/blog:
+    dependencies:
+      '@plumix/plugin-blog':
+        specifier: workspace:*
+        version: link:../../packages/plugins/blog
+      '@plumix/plugin-pages':
+        specifier: workspace:*
+        version: link:../../packages/plugins/pages
+      '@plumix/runtime-cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/runtimes/cloudflare
+      plumix:
+        specifier: workspace:*
+        version: link:../../packages/plumix
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260421.1
+      '@plumix/typescript-config':
+        specifier: workspace:*
+        version: link:../../tooling/typescript
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   examples/minimal:
     dependencies:
       '@plumix/runtime-cloudflare':


### PR DESCRIPTION
First real first-party plugins, plus a workspace example that exercises them end-to-end. Three commits:

1. **\`feat(plugin-blog): post entry type + category/tag taxonomies\`** — registers \`post\` (title/editor/excerpt, hasArchive: true), \`category\` (hierarchical), and \`tag\` (flat) using the existing \`registerEntryType\` / \`registerTermTaxonomy\` primitives. Public routes auto-generate via the route compiler from \`hasArchive\` + entry type name; no plugin-side route wiring needed. Capability set derives from \`capabilityType: 'post'\`. Adds the test/build tooling the empty scaffold was missing (vitest config + tsconfig.build.json that strips test files from dist). 5 unit tests.
2. **\`feat(plugin-pages): page entry type (hierarchical, no taxonomies)\`** — companion to plugin-blog. Single hierarchical \`page\` entry type, no taxonomies, no archive (pages live at canonical URLs, not behind a date/category index). Capability namespace is \`page\` so admin role mappings can scope edit/publish independently from posts. Mirrors the same test/build tooling. 3 unit tests.
3. **\`feat(examples): blog — fixture exercising blog + pages plugins\`** — new workspace example mirroring \`examples/minimal\`'s shape (Cloudflare + D1 runtime), but with both plugins wired into \`plumix.config.ts\`. Sister fixture so \`examples/minimal\` stays focused on the bare-runtime smoke path; this one's the plugin-stack smoke path and is where additional first-party plugins (menus, media, …) will land as they ship.

## Why this shape

Blog and pages were the obvious first plugins to write because they're the smallest possible exercise of the plugin surface — pure declarative registration, no \`provides\`, no extension APIs, no data API beyond what core's generic \`entry.*\` RPC already provides. If these don't feel right to write, neither will the more complex menus/media that come next.

Both plugins are dogfooding the public surface — same \`definePlugin\` callback shorthand any third-party plugin author would use, no internal APIs.

## Out of scope

- Public-route resolution for hierarchical pages (e.g. \`/about/team/leadership\` walking the \`parent_id\` chain). The route compiler currently auto-generates \`/page/:slug\` only; nested resolution is a follow-up to the resolver (PLAN Phase 12 noted this lives in core's routing engine, not the plugin).
- Taxonomy archive routes (\`/category/:slug\`). Taxonomies declare \`rewrite.slug\` as metadata but the route compiler only auto-routes entry types today. Same future-resolver work.
- Admin templates beyond what core's manifest projection already exposes.

## Tests

- 5 unit tests on plugin-blog (registration shape, capabilities)
- 3 unit tests on plugin-pages (registration shape, capabilities)
- 2 tests on examples/blog: config smoke + a real \`plumix build\` integration that asserts the embedded admin manifest carries both entry types + both taxonomies with the expected hierarchical / termTaxonomy wiring

All 45 turbo tasks (lint, typecheck, test, publint, attw) green locally.