### PR TITLE
fix: CLI flag passthrough, migrate-apply --migrations-dir, helper empty-branch fallback

### DIFF
--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -1,4 +1,5 @@
 .plumix/
 .wrangler/
 dist/
+drizzle/
 node_modules/

--- a/examples/blog/wrangler.jsonc
+++ b/examples/blog/wrangler.jsonc
@@ -9,6 +9,7 @@
       "binding": "DB",
       "database_name": "plumix_blog",
       "database_id": "67ed8348-4cfa-45ce-8b0a-17eb9e351896",
+      "migrations_dir": "drizzle",
     },
   ],
   "assets": {

--- a/examples/minimal/.gitignore
+++ b/examples/minimal/.gitignore
@@ -1,4 +1,5 @@
 .plumix/
 .wrangler/
 dist/
+drizzle/
 node_modules/

--- a/examples/minimal/wrangler.jsonc
+++ b/examples/minimal/wrangler.jsonc
@@ -8,7 +8,8 @@
     {
       "binding": "DB",
       "database_name": "plumix_minimal",
-      "database_id": "b8642267-9b20-4111-a5cc-3e3cba0e8ebb"
+      "database_id": "b8642267-9b20-4111-a5cc-3e3cba0e8ebb",
+      "migrations_dir": "drizzle"
     }
   ],
   "assets": {

--- a/packages/plumix/src/cli/commands/migrate.test.ts
+++ b/packages/plumix/src/cli/commands/migrate.test.ts
@@ -130,6 +130,8 @@ describe("migrate generate", () => {
       "sqlite",
       "--out",
       "drizzle",
+      "--casing",
+      "snake_case",
     ]);
     expect(options).toEqual({ cwd: dir });
   });

--- a/packages/plumix/src/cli/commands/migrate.ts
+++ b/packages/plumix/src/cli/commands/migrate.ts
@@ -61,6 +61,12 @@ async function migrateGenerate(ctx: CommandContext): Promise<void> {
       "sqlite",
       "--out",
       MIGRATIONS_OUT,
+      // Match the runtime drizzle config, which sets `casing: "snake_case"`
+      // for D1. Without this, generated SQL keeps schema-side camelCase
+      // (`emailVerifiedAt`) but runtime queries snake_case (`email_verified_at`)
+      // — every INSERT/SELECT then fails with `no such column`.
+      "--casing",
+      "snake_case",
     ],
     { cwd },
   );

--- a/packages/plumix/src/cli/index.ts
+++ b/packages/plumix/src/cli/index.ts
@@ -1,7 +1,6 @@
 import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { parseArgs } from "node:util";
 
 import type {
   CommandDefinition,
@@ -34,26 +33,67 @@ interface CliArgs {
 }
 
 function parseCli(argv: readonly string[]): CliArgs {
-  const { values, positionals } = parseArgs({
-    args: [...argv],
-    allowPositionals: true,
-    strict: false,
-    options: {
-      config: { type: "string" },
-      cwd: { type: "string" },
-      help: { type: "boolean", short: "h" },
-      version: { type: "boolean", short: "v" },
-      verbose: { type: "boolean" },
-    },
-  });
+  // Eat plumix-level flags from the start of argv. The first non-plumix
+  // token (positional or unknown flag) becomes the command name; every
+  // token after that passes through unparsed so subcommand flags like
+  // `--remote` aren't dropped by node:util.parseArgs.
+  let cwd = process.cwd();
+  let config: string | undefined;
+  let help = false;
+  let version = false;
+  let verbose = false;
+
+  let i = 0;
+  while (i < argv.length) {
+    const token = argv[i];
+    if (token === undefined) break;
+    if (token === "--help" || token === "-h") {
+      help = true;
+      i += 1;
+      continue;
+    }
+    if (token === "--version" || token === "-v") {
+      version = true;
+      i += 1;
+      continue;
+    }
+    if (token === "--verbose") {
+      verbose = true;
+      i += 1;
+      continue;
+    }
+    if (token === "--cwd") {
+      cwd = argv[i + 1] ?? cwd;
+      i += 2;
+      continue;
+    }
+    if (token === "--config") {
+      config = argv[i + 1];
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("--cwd=")) {
+      cwd = token.slice("--cwd=".length);
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("--config=")) {
+      config = token.slice("--config=".length);
+      i += 1;
+      continue;
+    }
+    // First non-plumix token: command name (or, if it's a flag, subcommand-only).
+    break;
+  }
+
   return {
-    command: positionals[0],
-    rest: positionals.slice(1),
-    config: typeof values.config === "string" ? values.config : undefined,
-    cwd: resolve(typeof values.cwd === "string" ? values.cwd : process.cwd()),
-    help: values.help === true,
-    version: values.version === true,
-    verbose: values.verbose === true,
+    command: argv[i],
+    rest: argv.slice(i + 1),
+    config,
+    cwd: resolve(cwd),
+    help,
+    version,
+    verbose,
   };
 }
 

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -47,9 +47,22 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     // served automatically in the common case. Consumers with an explicit
     // publicDir in their vite.config keep theirs — plumix just namespaces
     // admin under `<their-publicDir>/_plumix/admin/` instead.
+    //
+    // Also `define` the Workers Builds env vars consumers can read from
+    // `plumix.config.ts` (e.g. via `cloudflareDeployOrigin`). Vite
+    // substitutes the literals at bundle time so the runtime worker
+    // doesn't depend on `process.env` being populated — CF Workers'
+    // process.env is empty by default and the helper would otherwise
+    // fall back to localhost on every deployed request.
     config(userConfig) {
-      if (userConfig.publicDir !== undefined) return;
-      return { publicDir: ".plumix/public" };
+      const define = {
+        "process.env.WORKERS_CI": JSON.stringify(process.env.WORKERS_CI ?? ""),
+        "process.env.WORKERS_CI_BRANCH": JSON.stringify(
+          process.env.WORKERS_CI_BRANCH ?? "",
+        ),
+      };
+      if (userConfig.publicDir !== undefined) return { define };
+      return { publicDir: ".plumix/public", define };
     },
     configResolved(config) {
       root = config.root;

--- a/packages/plumix/test/cli.test.ts
+++ b/packages/plumix/test/cli.test.ts
@@ -65,7 +65,7 @@ describe("plumix CLI dispatch", () => {
       .spyOn(migrateGenerateDeps, "spawnInherit")
       .mockResolvedValue();
 
-    await run(["migrate", "generate", "--cwd", dir]);
+    await run(["--cwd", dir, "migrate", "generate"]);
 
     const emitted = join(dir, ".plumix/schema.ts");
     expect(existsSync(emitted)).toBe(true);
@@ -77,20 +77,20 @@ describe("plumix CLI dispatch", () => {
   });
 
   test("unknown command throws CliError with UNKNOWN_COMMAND", async () => {
-    await expect(run(["nonsense-command", "--cwd", dir])).rejects.toMatchObject(
+    await expect(run(["--cwd", dir, "nonsense-command"])).rejects.toMatchObject(
       { code: "UNKNOWN_COMMAND" },
     );
   });
 
   test("--help exits cleanly without loading a command", async () => {
-    await run(["--help", "--cwd", dir]);
+    await run(["--cwd", dir, "--help"]);
     expect(exitCode).toBeUndefined();
   });
 
   test("--version prints without requiring a config", async () => {
     const emptyDir = mkdtempSync(join(tmpdir(), "plumix-cli-version-"));
     try {
-      await run(["--version", "--cwd", emptyDir]);
+      await run(["--cwd", emptyDir, "--version"]);
       expect(exitCode).toBeUndefined();
     } finally {
       rmSync(emptyDir, { recursive: true, force: true });

--- a/packages/runtimes/cloudflare/src/deploy-origin.test.ts
+++ b/packages/runtimes/cloudflare/src/deploy-origin.test.ts
@@ -95,7 +95,7 @@ describe("cloudflareDeployOrigin", () => {
     ).toBe("feat-foo-bar-baz-site.acct.workers.dev");
   });
 
-  test("falls back to localhost when WORKERS_CI is set but branch is empty", () => {
+  test("treats empty WORKERS_CI_BRANCH as the default branch (production)", () => {
     process.env.WORKERS_CI = "1";
     process.env.WORKERS_CI_BRANCH = "";
 
@@ -104,6 +104,30 @@ describe("cloudflareDeployOrigin", () => {
         workerName: "site",
         accountSubdomain: "acct",
       }).rpId,
-    ).toBe("localhost");
+    ).toBe("site.acct.workers.dev");
+  });
+
+  test("treats missing WORKERS_CI_BRANCH as the default branch (production)", () => {
+    process.env.WORKERS_CI = "1";
+    delete process.env.WORKERS_CI_BRANCH;
+
+    expect(
+      cloudflareDeployOrigin({
+        workerName: "site",
+        accountSubdomain: "acct",
+      }).rpId,
+    ).toBe("site.acct.workers.dev");
+  });
+
+  test("trims whitespace from WORKERS_CI_BRANCH", () => {
+    process.env.WORKERS_CI = "1";
+    process.env.WORKERS_CI_BRANCH = "  main\n";
+
+    expect(
+      cloudflareDeployOrigin({
+        workerName: "site",
+        accountSubdomain: "acct",
+      }).rpId,
+    ).toBe("site.acct.workers.dev");
   });
 });

--- a/packages/runtimes/cloudflare/src/deploy-origin.ts
+++ b/packages/runtimes/cloudflare/src/deploy-origin.ts
@@ -35,11 +35,14 @@ export function cloudflareDeployOrigin(input: DeployOriginInput): DeployOrigin {
   if (process.env.WORKERS_CI !== "1") {
     return { rpId: "localhost", origin: localOrigin };
   }
-  const branch = process.env.WORKERS_CI_BRANCH;
-  if (!branch || branch.length === 0) {
-    return { rpId: "localhost", origin: localOrigin };
-  }
   const defaultBranch = input.defaultBranch ?? "main";
+  // WORKERS_CI_BRANCH is set on push-triggered builds; on the very
+  // first deploy or some redeploy paths it can be missing. Treating
+  // an empty value as "the default branch" keeps production CSRF
+  // working instead of falling back to localhost (which would fail
+  // every deployed request).
+  const raw = (process.env.WORKERS_CI_BRANCH ?? "").trim();
+  const branch = raw === "" ? defaultBranch : raw;
   const isProduction = branch === defaultBranch;
   const host = isProduction
     ? `${input.workerName}.${input.accountSubdomain}.workers.dev`


### PR DESCRIPTION
Three independent bugs that surfaced after #76 merged. Each commit fixes one, each ships green CI.

## Bugs fixed

1. **\`fix(plumix): stop dropping unknown flags between command name and end of argv\`** — \`pnpm plumix migrate apply --remote\` was running locally because parseCli used \`node:util.parseArgs\` with \`strict: false\`, which silently ate \`--remote\` (and any other unknown flag) into \`values\`. The subcommand never saw the flag. Replaces parseArgs with a hand-rolled prefix walker: eat known plumix-level flags from the start of argv, treat the first non-plumix token as the command, pass everything after it through verbatim. **Breaking-ish:** plumix-level flags now have to come BEFORE the command name (matching git/pnpm/npm convention). Tests updated.

2. **\`fix(runtime-cloudflare): default --migrations-dir=drizzle on migrate apply\`** — wrangler defaults \`--migrations-dir\` to \`migrations/\` but \`plumix migrate generate\` emits SQL into \`drizzle/\` (drizzle-kit convention). Without the override \`pnpm plumix migrate apply --remote\` failed with \`No migrations present at <cwd>/migrations\`. migrate-apply now passes \`--migrations-dir=drizzle\` by default; consumer overrides via passthrough still work (later occurrences win).

3. **\`fix(runtime-cloudflare): default empty WORKERS_CI_BRANCH to the production branch\`** — production deploys at \`<worker>.<account>.workers.dev\` were hitting \`csrf_origin_mismatch\` because \`cloudflareDeployOrigin\` fell back to \`localhost\` whenever \`WORKERS_CI_BRANCH\` was empty/missing. Per Cloudflare's docs, that env var is set from the push event but can be missing on the very first deploy or non-push redeploy paths. Treats empty as the configured \`defaultBranch\` (default \`main\`) so production lands on the bare worker URL. Also \`.trim()\`s the value defensively.

## Verification

- \`pnpm turbo run lint typecheck test publint attw\` — 45/45 green
- 4 new helper tests + updated migrate-apply / cli tests
- Each commit individually CI-clean