### PR TITLE
fix(admin): sidebar entry URLs, shadcn empty, post-create list refresh

### DIFF
--- a/packages/admin/src/components/ui/empty.tsx
+++ b/packages/admin/src/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import type { VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+import { cva } from "class-variance-authority";
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+};

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -7,12 +7,12 @@ import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
 import { Button } from "@/components/ui/button.js";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card.js";
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty.js";
 import {
   Pagination,
   PaginationContent,
@@ -548,24 +548,19 @@ function EmptyState({
   pluralLower: string;
 }): ReactNode {
   return (
-    <div
-      data-testid="content-list-empty-state"
-      className="flex flex-col items-center gap-2 py-12 text-center"
-    >
-      <Card className="max-w-sm border-dashed">
-        <CardHeader>
-          <CardTitle>No {pluralLower} yet</CardTitle>
-          <CardDescription>
-            Create your first {singularLower} to see it here.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button disabled className="w-full">
-            <Plus />
-            New {singularLower}
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
+    <Empty data-testid="content-list-empty-state" className="border">
+      <EmptyHeader>
+        <EmptyTitle>No {pluralLower} yet</EmptyTitle>
+        <EmptyDescription>
+          Create your first {singularLower} to see it here.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button disabled>
+          <Plus />
+          New {singularLower}
+        </Button>
+      </EmptyContent>
+    </Empty>
   );
 }

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -7,6 +7,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import { visibleEntryTypes } from "@/lib/manifest.js";
 import { createFileRoute, Link } from "@tanstack/react-router";
@@ -70,18 +76,15 @@ function DashboardIndex(): ReactNode {
           })}
         </div>
       ) : (
-        <Card
-          className="max-w-xl border-dashed"
-          data-testid="dashboard-empty-state"
-        >
-          <CardHeader>
-            <CardTitle>No content types yet</CardTitle>
-            <CardDescription>
+        <Empty data-testid="dashboard-empty-state" className="border">
+          <EmptyHeader>
+            <EmptyTitle>No content types yet</EmptyTitle>
+            <EmptyDescription>
               Add a plugin that registers a post type (e.g.{" "}
               <code>@plumix/plugin-blog</code>) to see it here.
-            </CardDescription>
-          </CardHeader>
-        </Card>
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       )}
     </div>
   );

--- a/packages/admin/src/routes/_authenticated/settings/$page.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/$page.tsx
@@ -12,6 +12,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty.js";
 import { Form } from "@/components/ui/form.js";
 import { hasCap } from "@/lib/caps.js";
 import {
@@ -225,19 +231,19 @@ function SettingsGroupCard({
 
 function EmptyPagePlaceholder(): ReactNode {
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>No groups on this page</CardTitle>
-        <CardDescription>
+    <Empty className="border">
+      <EmptyHeader>
+        <EmptyTitle>No groups on this page</EmptyTitle>
+        <EmptyDescription>
           This settings page doesn't reference any registered groups yet.
           Plugins compose pages with{" "}
           <code className="font-mono text-xs">
             ctx.registerSettingsPage(name, {"{"} groups: [...] {"}"})
           </code>
           .
-        </CardDescription>
-      </CardHeader>
-    </Card>
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
   );
 }
 

--- a/packages/admin/src/routes/_authenticated/settings/index.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.tsx
@@ -6,6 +6,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty.js";
 import { hasCap } from "@/lib/caps.js";
 import { visibleSettingsPages } from "@/lib/manifest.js";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
@@ -38,10 +44,10 @@ function SettingsIndexRoute(): ReactNode {
         <h1 className="text-2xl font-semibold" data-testid="settings-heading">
           Settings
         </h1>
-        <Card data-testid="settings-empty-state">
-          <CardHeader>
-            <CardTitle>No settings registered yet</CardTitle>
-            <CardDescription>
+        <Empty data-testid="settings-empty-state" className="border">
+          <EmptyHeader>
+            <EmptyTitle>No settings registered yet</EmptyTitle>
+            <EmptyDescription>
               Core ships no settings by design — plugins (or your own
               plumix.config) declare pages + groups via{" "}
               <code className="font-mono text-xs">
@@ -52,9 +58,9 @@ function SettingsIndexRoute(): ReactNode {
                 ctx.registerSettingsGroup
               </code>
               . Registered pages appear here with one card per page.
-            </CardDescription>
-          </CardHeader>
-        </Card>
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       </div>
     );
   }

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/index.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/index.tsx
@@ -7,12 +7,12 @@ import { buildTermTree, flattenTree } from "@/components/taxonomy/tree.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Button } from "@/components/ui/button.js";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card.js";
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty.js";
 import {
   Pagination,
   PaginationContent,
@@ -319,33 +319,28 @@ function EmptyState({
   taxonomyName: string;
 }): ReactNode {
   return (
-    <div
-      data-testid="taxonomy-list-empty-state"
-      className="flex flex-col items-center gap-2 py-12 text-center"
-    >
-      <Card className="max-w-sm border-dashed">
-        <CardHeader>
-          <CardTitle>No {singularLower} yet</CardTitle>
-          <CardDescription>
-            Create your first {singularLower} to see it here.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {canCreate ? (
-            <Button asChild className="w-full">
-              <Link to="/taxonomies/$name/new" params={{ name: taxonomyName }}>
-                <Plus />
-                New {singularLower}
-              </Link>
-            </Button>
-          ) : (
-            <Button disabled className="w-full">
+    <Empty data-testid="taxonomy-list-empty-state" className="border">
+      <EmptyHeader>
+        <EmptyTitle>No {singularLower} yet</EmptyTitle>
+        <EmptyDescription>
+          Create your first {singularLower} to see it here.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        {canCreate ? (
+          <Button asChild>
+            <Link to="/taxonomies/$name/new" params={{ name: taxonomyName }}>
               <Plus />
               New {singularLower}
-            </Button>
-          )}
-        </CardContent>
-      </Card>
-    </div>
+            </Link>
+          </Button>
+        ) : (
+          <Button disabled>
+            <Plus />
+            New {singularLower}
+          </Button>
+        )}
+      </EmptyContent>
+    </Empty>
   );
 }

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/new.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/new.tsx
@@ -12,7 +12,7 @@ import {
 import { hasCap } from "@/lib/caps.js";
 import { findTermTaxonomyByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createFileRoute,
   Link,
@@ -55,6 +55,7 @@ export const Route = createFileRoute("/_authenticated/taxonomies/$name/new")({
 
 function NewTermRoute(): ReactNode {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { taxonomy } = Route.useRouteContext();
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -94,7 +95,13 @@ function NewTermRoute(): ReactNode {
     onMutate: () => {
       setServerError(null);
     },
-    onSuccess: () => {
+    onSuccess: async () => {
+      // Drop the cached `term.list` for this taxonomy so the list view
+      // shows the freshly created term on landing — without this the
+      // post-create navigation lands on a stale empty result.
+      await queryClient.invalidateQueries({
+        queryKey: orpc.term.list.key({ input: { taxonomy: taxonomy.name } }),
+      });
       void navigate({
         to: "/taxonomies/$name",
         params: { name: taxonomy.name },

--- a/packages/admin/src/routes/_authenticated/taxonomies/$name/new.tsx
+++ b/packages/admin/src/routes/_authenticated/taxonomies/$name/new.tsx
@@ -96,9 +96,8 @@ function NewTermRoute(): ReactNode {
       setServerError(null);
     },
     onSuccess: async () => {
-      // Drop the cached `term.list` for this taxonomy so the list view
-      // shows the freshly created term on landing — without this the
-      // post-create navigation lands on a stale empty result.
+      // Awaited because the navigate target IS the list page; without
+      // this the user lands on a 60s-stale cache before refetch.
       await queryClient.invalidateQueries({
         queryKey: orpc.term.list.key({ input: { taxonomy: taxonomy.name } }),
       });

--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -7,12 +7,12 @@ import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
 import { Button } from "@/components/ui/button.js";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card.js";
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty.js";
 import {
   Pagination,
   PaginationContent,
@@ -345,33 +345,28 @@ function RoleFilter({
 
 function EmptyState({ canInvite }: { canInvite: boolean }): ReactNode {
   return (
-    <div
-      data-testid="users-list-empty-state"
-      className="flex flex-col items-center gap-2 py-12 text-center"
-    >
-      <Card className="max-w-sm border-dashed">
-        <CardHeader>
-          <CardTitle>No users match your filter</CardTitle>
-          <CardDescription>
-            Clear the filter, or invite someone new to join.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {canInvite ? (
-            <Button asChild className="w-full">
-              <Link to="/users/new">
-                <Plus />
-                Invite user
-              </Link>
-            </Button>
-          ) : (
-            <Button disabled className="w-full">
+    <Empty data-testid="users-list-empty-state" className="border">
+      <EmptyHeader>
+        <EmptyTitle>No users match your filter</EmptyTitle>
+        <EmptyDescription>
+          Clear the filter, or invite someone new to join.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        {canInvite ? (
+          <Button asChild>
+            <Link to="/users/new">
               <Plus />
               Invite user
-            </Button>
-          )}
-        </CardContent>
-      </Card>
-    </div>
+            </Link>
+          </Button>
+        ) : (
+          <Button disabled>
+            <Plus />
+            Invite user
+          </Button>
+        )}
+      </EmptyContent>
+    </Empty>
   );
 }

--- a/packages/admin/src/routes/_editor/entries/$slug/new.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/new.tsx
@@ -6,7 +6,7 @@ import { hasCap } from "@/lib/caps.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   createFileRoute,
   notFound,
@@ -54,6 +54,7 @@ function NewPostRoute(): ReactNode {
   const { user, entryType } = Route.useRouteContext();
   const params = Route.useParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [serverError, setServerError] = useState<string | null>(null);
 
   const createPost = useMutation({
@@ -71,6 +72,12 @@ function NewPostRoute(): ReactNode {
       setServerError(null);
     },
     onSuccess: async (created) => {
+      // Drop the cached `entry.list` for this type so navigating back
+      // to the list view (now or later in the session) reflects the
+      // newly created row instead of the stale pre-create payload.
+      await queryClient.invalidateQueries({
+        queryKey: orpc.entry.list.key({ input: { type: entryType.name } }),
+      });
       await navigate({
         to: "/entries/$slug/$id",
         params: { slug: params.slug, id: created.id },

--- a/packages/admin/src/routes/_editor/entries/$slug/new.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/new.tsx
@@ -72,10 +72,9 @@ function NewPostRoute(): ReactNode {
       setServerError(null);
     },
     onSuccess: async (created) => {
-      // Drop the cached `entry.list` for this type so navigating back
-      // to the list view (now or later in the session) reflects the
-      // newly created row instead of the stale pre-create payload.
-      await queryClient.invalidateQueries({
+      // Editor doesn't read entry.list — fire-and-forget so navigation
+      // isn't blocked on a refetch nothing on this screen consumes.
+      void queryClient.invalidateQueries({
         queryKey: orpc.entry.list.key({ input: { type: entryType.name } }),
       });
       await navigate({

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -10,7 +10,7 @@ export interface EntryTypeOptions {
   readonly label: string;
   /**
    * Human-readable label variants. `plural` also drives the admin URL slug
-   * (`/content/<slugified-plural>`) unless overridden; omit it and the slug
+   * (`/entries/<slugified-plural>`) unless overridden; omit it and the slug
    * falls back to `${name}s`, which is acceptable for English-named types
    * but surfaces an "anglos" for `name: "angle"` etc. — plugins with
    * irregular plurals should set `labels.plural` explicitly.
@@ -758,7 +758,7 @@ export interface SettingsPageManifestEntry {
  * `component` is set only for plugin-rendered routes — the admin's
  * `/p/$` catch-all looks up this ref to render the page. Items that
  * point at core admin routes (`/`, `/users`, `/settings`,
- * `/content/<slug>`, etc.) leave it undefined.
+ * `/entries/<slug>`, etc.) leave it undefined.
  */
 export interface AdminNavItem {
   readonly to: string;
@@ -1006,7 +1006,7 @@ function projectAdminNav(
   for (const entry of entries) {
     if (entry.showInSidebar !== true) continue;
     groups.get("content")?.items.push({
-      to: `/content/${entry.adminSlug}`,
+      to: `/entries/${entry.adminSlug}`,
       label: entry.labels?.plural ?? entry.label,
       order: entry.priority,
       coreIcon: "content",
@@ -1234,7 +1234,7 @@ export class DuplicateAdminSlugError extends Error {
  * to `${name}s` which is English-biased but matches the common case.
  * Non-alphanumerics collapse to single dashes; leading/trailing dashes
  * are trimmed. Empty results throw — an empty slug would shadow
- * `/content/` itself in TanStack Router.
+ * `/entries/` itself in TanStack Router.
  */
 export function deriveAdminSlug(name: string, plural?: string): string {
   const source = plural ?? `${name}s`;


### PR DESCRIPTION
## Summary

- **Sidebar entry URLs**: Manifest projection now emits `/entries/<adminSlug>` instead of `/content/<adminSlug>` so sidebar links land on the actual admin route (`packages/admin/src/routes/_authenticated/entries/\$slug`). Previously every entry-type sidebar item 404'd.
- **shadcn Empty**: Vendored `components/ui/empty.tsx` and replaced the ad-hoc `Card`-as-empty-state across the admin (dashboard, settings, users, entries, taxonomies) for consistent centered layout.
- **Post-create list refresh**: `term.create` and `entry.create` now invalidate the relevant `*.list` query before navigating, so coming back to the list shows the just-created row instead of a stale empty payload that needs a manual refresh.

## Test plan

- [ ] Click each entry type in the sidebar → lands on `/entries/<slug>` and renders.
- [ ] Visit a taxonomy page with no terms; create one; redirect lands on a populated list.
- [ ] Create a new entry; navigating back to the list shows the new row without refresh.
- [ ] `pnpm --filter @plumix/admin lint && pnpm --filter @plumix/admin typecheck && pnpm --filter @plumix/admin test`.
- [ ] `pnpm --filter @plumix/core typecheck && pnpm --filter @plumix/core test`.

## Open question

Reported separately: opening `/_plumix/admin/taxonomies/<name>?page=1` directly redirects to `/_plumix/admin/` on the deployed worker. Couldn't reproduce from the codebase (the route's `beforeLoad` only throws `notFound()` and the `__root` notFoundComponent renders inline without changing the URL). Likely needs a redeploy with the latest admin bundle, or a fresh repro with the browser network tab to see whether the redirect is server-side or client-side.