### PR TITLE
fix(admin): editor back button, sidebar header alignment, empty-state CTA

### DIFF
--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -155,15 +155,23 @@ export function PostEditorForm({
     form.setValue("slug", slugify(titleValue));
   }, [form, slugLocked, titleValue]);
 
-  // TanStack Router blocker: prompt before navigation (sidebar click,
-  // back button, etc.) if the form is dirty and not currently saving.
-  // `isSubmitting` guard avoids the prompt firing on the redirect that
-  // follows a successful save.
-  useBlocker({
+  // Block in-app navigation while dirty so the user gets a chance to
+  // confirm. `withResolver: true` is load-bearing: with `false`, a
+  // dirty form would silently swallow back-button / link clicks.
+  // `isSubmitting` guard avoids prompting on the post-save redirect.
+  const blocker = useBlocker({
     shouldBlockFn: () => !isSubmitting && isDirty,
-    withResolver: false,
+    withResolver: true,
     disabled: isSubmitting,
   });
+  useEffect(() => {
+    if (blocker.status !== "blocked") return;
+    if (window.confirm("Discard unsaved changes?")) {
+      blocker.proceed();
+    } else {
+      blocker.reset();
+    }
+  }, [blocker]);
 
   const handleSubmit = form.handleSubmit((value) => {
     onSubmit(value);
@@ -265,7 +273,7 @@ export function PostEditorForm({
             collapsible="offcanvas"
             data-testid="meta-boxes-sidebar"
           >
-            <SidebarHeader className="border-b px-4 py-3 text-sm font-semibold">
+            <SidebarHeader className="flex h-14 shrink-0 flex-row items-center border-b px-4 text-sm font-semibold">
               Document
             </SidebarHeader>
             <SidebarContent>

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -381,6 +381,8 @@ function ContentListRoute(): ReactNode {
             <EmptyState
               singularLower={singularLower}
               pluralLower={pluralLower}
+              canCreate={canCreate}
+              entryTypeSlug={entryType.adminSlug}
             />
           }
         />
@@ -543,9 +545,13 @@ function StatusFilter({
 function EmptyState({
   singularLower,
   pluralLower,
+  canCreate,
+  entryTypeSlug,
 }: {
   singularLower: string;
   pluralLower: string;
+  canCreate: boolean;
+  entryTypeSlug: string;
 }): ReactNode {
   return (
     <Empty data-testid="content-list-empty-state" className="border">
@@ -556,10 +562,19 @@ function EmptyState({
         </EmptyDescription>
       </EmptyHeader>
       <EmptyContent>
-        <Button disabled>
-          <Plus />
-          New {singularLower}
-        </Button>
+        {canCreate ? (
+          <Button asChild>
+            <Link to="/entries/$slug/new" params={{ slug: entryTypeSlug }}>
+              <Plus />
+              New {singularLower}
+            </Link>
+          </Button>
+        ) : (
+          <Button disabled>
+            <Plus />
+            New {singularLower}
+          </Button>
+        )}
       </EmptyContent>
     </Empty>
   );


### PR DESCRIPTION
## Summary

Three small admin fixes spotted while exercising the editor.

- **Editor back button**: switched `useBlocker` from `withResolver: false` to `withResolver: true` and added a `window.confirm` resolver. With `false`, a dirty form silently swallowed back-button / link clicks because TanStack Router's blocker treats a `true` return as a hard block with no UI affordance. The user now sees a discard prompt and can either proceed or stay.
- **Editor right-rail alignment**: the \`Document\` header was \`py-3\` (variable height), the main editor header was \`h-14\` — their bottom borders sat on different baselines. Pinned the rail header to \`h-14 flex items-center\` so the borders line up.
- **Entries empty-state CTA**: the \`+ New <singular>\` button on the entries list empty state was hardcoded \`disabled\`, even when the viewer had the create capability and the top-bar \`+ New\` worked. Wired \`canCreate\` + \`entryTypeSlug\` through the \`EmptyState\` so it renders a working \`<Link>\` for capable users (mirroring the taxonomies empty state).

## Out of scope

- The user also asked for category/tag assignment in the post editor. That requires UI for term-pickers per registered taxonomy plus extending \`entry.get\` to return current assignments — substantial enough to warrant its own PR.
- The \`/_plumix/admin/taxonomies/<name>?page=1\` direct-URL redirect-to-\`/\` reported on the prior PR is still unconfirmed; needs browser network-tab repro to know whether it's server-side or client-side.

## Test plan

- [ ] Open the entry editor, click back without changes → list opens immediately, no prompt.
- [ ] Open the editor, type into the title, click back → confirm prompt; "Cancel" stays put, "OK" navigates.
- [ ] Right-rail \`Document\` header sits flush with the main editor header.
- [ ] Visit \`/entries/<slug>\` with no entries as a user with create capability — \`+ New <singular>\` in the empty state navigates to the create route.

\`pnpm --filter @plumix/admin lint && pnpm --filter @plumix/admin typecheck && pnpm --filter @plumix/admin test\` all green.