### PR TITLE
fix(admin): list polish, multi-select term filters, modal confirms

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -27,6 +27,7 @@
     "@tiptap/starter-kit": "^3.22.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^1.8.0",
     "radix-ui": "^1.4.3",
     "react": "catalog:",

--- a/packages/admin/src/components/data-table/data-table.tsx
+++ b/packages/admin/src/components/data-table/data-table.tsx
@@ -16,11 +16,23 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table.js";
+import { cn } from "@/lib/utils.js";
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+
+// Per-column alignment + className passthrough. Column defs opt in via
+// `meta: { className: "text-right" }`; both the header cell and every
+// body cell pick up the class so alignment stays in sync.
+declare module "@tanstack/react-table" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    className?: string;
+  }
+}
+type RowData = unknown;
 
 export function DataTable<TData>({
   columns,
@@ -57,7 +69,11 @@ export function DataTable<TData>({
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id} colSpan={header.colSpan}>
+                <TableHead
+                  key={header.id}
+                  colSpan={header.colSpan}
+                  className={cn(header.column.columnDef.meta?.className)}
+                >
                   {header.isPlaceholder
                     ? null
                     : flexRender(
@@ -80,7 +96,10 @@ export function DataTable<TData>({
                 className="group/row"
               >
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
+                  <TableCell
+                    key={cell.id}
+                    className={cn(cell.column.columnDef.meta?.className)}
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}

--- a/packages/admin/src/components/form/multi-select.tsx
+++ b/packages/admin/src/components/form/multi-select.tsx
@@ -1,0 +1,135 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command.js";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover.js";
+import { cn } from "@/lib/utils.js";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+export interface MultiSelectOption {
+  readonly value: string;
+  readonly label: string;
+  /** Indent depth — used to render hierarchical taxonomy term lists. */
+  readonly depth?: number;
+}
+
+export function MultiSelect({
+  options,
+  value,
+  onChange,
+  placeholder = "Select…",
+  searchPlaceholder = "Search…",
+  emptyText = "No matches.",
+  className,
+  testId,
+  disabled = false,
+}: {
+  readonly options: readonly MultiSelectOption[];
+  readonly value: readonly string[];
+  readonly onChange: (next: readonly string[]) => void;
+  readonly placeholder?: string;
+  readonly searchPlaceholder?: string;
+  readonly emptyText?: string;
+  readonly className?: string;
+  readonly testId?: string;
+  readonly disabled?: boolean;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+  const selected = new Set(value);
+  const triggerLabel =
+    value.length === 0
+      ? placeholder
+      : value.length === 1
+        ? (options.find((o) => o.value === value[0])?.label ?? value[0])
+        : `${String(value.length)} selected`;
+
+  const toggle = (optValue: string): void => {
+    if (selected.has(optValue)) {
+      onChange(value.filter((v) => v !== optValue));
+    } else {
+      onChange([...value, optValue]);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          data-testid={testId}
+          className={cn(
+            "justify-between gap-2 font-normal",
+            value.length === 0 && "text-muted-foreground",
+            className,
+          )}
+        >
+          <span className="truncate">{triggerLabel}</span>
+          {value.length > 1 ? (
+            <Badge variant="secondary" className="ml-1">
+              {value.length}
+            </Badge>
+          ) : null}
+          <ChevronsUpDown className="ml-auto opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {options.map((opt) => {
+                const checked = selected.has(opt.value);
+                return (
+                  <CommandItem
+                    key={opt.value}
+                    value={`${opt.label} ${opt.value}`}
+                    onSelect={() => {
+                      toggle(opt.value);
+                    }}
+                    data-testid={
+                      testId ? `${testId}-option-${opt.value}` : undefined
+                    }
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 size-4",
+                        checked ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    <span
+                      style={
+                        opt.depth && opt.depth > 0
+                          ? { paddingLeft: `${String(opt.depth * 12)}px` }
+                          : undefined
+                      }
+                    >
+                      {opt.label}
+                    </span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/admin/src/components/ui/command.tsx
+++ b/packages/admin/src/components/ui/command.tsx
@@ -1,0 +1,181 @@
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/packages/admin/src/components/ui/dialog.tsx
+++ b/packages/admin/src/components/ui/dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { XIcon } from "lucide-react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/packages/admin/src/components/ui/popover.tsx
+++ b/packages/admin/src/components/ui/popover.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+};

--- a/packages/admin/src/components/ui/toggle-group.tsx
+++ b/packages/admin/src/components/ui/toggle-group.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+import { toggleVariants } from "@/components/ui/toggle";
+import { cn } from "@/lib/utils";
+import { type VariantProps } from "class-variance-authority";
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/packages/admin/src/components/ui/toggle.tsx
+++ b/packages/admin/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+import type { VariantProps } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { cva } from "class-variance-authority";
+import { Toggle as TogglePrimitive } from "radix-ui";
+
+const toggleVariants = cva(
+  "hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border-input hover:bg-accent hover:text-accent-foreground border bg-transparent shadow-xs",
+      },
+      size: {
+        default: "h-9 min-w-9 px-2",
+        sm: "h-8 min-w-8 px-1.5",
+        lg: "h-10 min-w-10 px-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/packages/admin/src/lib/breadcrumbs.test.ts
+++ b/packages/admin/src/lib/breadcrumbs.test.ts
@@ -72,17 +72,14 @@ describe("pathToCrumbs", () => {
   });
 
   test("terms list + create + edit use the taxonomy label and singular", () => {
-    expect(pathToCrumbs("/terms/category")).toEqual([
-      "Taxonomies",
-      "Categories",
-    ]);
+    expect(pathToCrumbs("/terms/category")).toEqual(["Terms", "Categories"]);
     expect(pathToCrumbs("/terms/category/create")).toEqual([
-      "Taxonomies",
+      "Terms",
       "Categories",
       "Create category",
     ]);
     expect(pathToCrumbs("/terms/category/7/edit")).toEqual([
-      "Taxonomies",
+      "Terms",
       "Categories",
       "Edit category",
     ]);

--- a/packages/admin/src/lib/breadcrumbs.ts
+++ b/packages/admin/src/lib/breadcrumbs.ts
@@ -45,13 +45,13 @@ function entriesCrumbs(parts: readonly string[]): readonly string[] {
 
 function taxonomiesCrumbs(parts: readonly string[]): readonly string[] {
   const name = parts[1];
-  if (name === undefined) return ["Taxonomies"];
+  if (name === undefined) return ["Terms"];
   const tax = findTermTaxonomyByName(name);
   const label = tax?.label ?? name;
   const singular = (tax?.labels?.singular ?? label).toLowerCase();
-  if (parts[2] === "create") return ["Taxonomies", label, `Create ${singular}`];
-  if (parts[3] === "edit") return ["Taxonomies", label, `Edit ${singular}`];
-  return ["Taxonomies", label];
+  if (parts[2] === "create") return ["Terms", label, `Create ${singular}`];
+  if (parts[3] === "edit") return ["Terms", label, `Edit ${singular}`];
+  return ["Terms", label];
 }
 
 function usersCrumbs(parts: readonly string[]): readonly string[] {

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -1,7 +1,9 @@
+import type { MultiSelectOption } from "@/components/form/multi-select.js";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
-import { Fragment, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { DataTable } from "@/components/data-table/data-table.js";
+import { MultiSelect } from "@/components/form/multi-select.js";
 import { DebouncedSearchInput } from "@/components/form/search-input.js";
 import { buildTermTree, flattenTree } from "@/components/taxonomy/tree.js";
 import {
@@ -29,6 +31,7 @@ import {
   PaginationContent,
   PaginationItem,
 } from "@/components/ui/pagination.js";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.js";
 import { hasCap } from "@/lib/caps.js";
 import { toDate } from "@/lib/dates.js";
 import { findEntryTypeBySlug, findTermTaxonomyByName } from "@/lib/manifest.js";
@@ -198,6 +201,7 @@ function buildColumns({
     },
     {
       accessorKey: "updatedAt",
+      meta: { className: "text-right" },
       header: () => (
         <SortableHeader
           label="Updated"
@@ -206,6 +210,7 @@ function buildColumns({
           activeOrderBy={activeOrderBy}
           activeOrder={activeOrder}
           onSort={onSort}
+          align="right"
         />
       ),
       cell: ({ row }) => (
@@ -241,14 +246,19 @@ function ContentListRoute(): ReactNode {
 
   const taxonomyNames = entryType.termTaxonomies ?? EMPTY_TAXONOMY_NAMES;
   // Memoised so `entry.list`'s queryOptions input has a stable
-  // identity across renders — without this the queryOptions object
-  // is re-allocated each tick even when search hasn't changed.
+  // identity across renders. Comma-separated URL values
+  // (`?category=foo,bar`) split into the slug array the server
+  // expects for multi-term filtering.
   const termFilters = useMemo(() => {
     const out: Record<string, string[]> = {};
     for (const name of taxonomyNames) {
       const raw = (search as Record<string, unknown>)[name];
       if (typeof raw === "string" && raw.length > 0) {
-        out[name] = [raw];
+        const slugs = raw
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+        if (slugs.length > 0) out[name] = slugs;
       }
     }
     return out;
@@ -300,15 +310,15 @@ function ContentListRoute(): ReactNode {
     [navigate],
   );
   const setTermFilter = useCallback(
-    (taxonomy: string, slug: string | undefined): void => {
+    (taxonomy: string, slugs: readonly string[]): void => {
       void navigate({
         search: (prev) => {
           const next: Record<string, unknown> = {
             ...(prev as Record<string, unknown>),
             page: 1,
           };
-          if (slug !== undefined && slug.length > 0) {
-            next[taxonomy] = slug;
+          if (slugs.length > 0) {
+            next[taxonomy] = slugs.join(",");
           } else {
             delete next[taxonomy];
           }
@@ -439,9 +449,9 @@ function ContentListRoute(): ReactNode {
           <TaxonomyFilter
             key={name}
             taxonomyName={name}
-            value={termFilters[name]?.[0]}
-            onChange={(slug) => {
-              setTermFilter(name, slug);
+            value={termFilters[name] ?? EMPTY_TAXONOMY_NAMES}
+            onChange={(slugs) => {
+              setTermFilter(name, slugs);
             }}
           />
         ))}
@@ -477,6 +487,8 @@ function ContentListRoute(): ReactNode {
             <EmptyState
               singularLower={singularLower}
               pluralLower={pluralLower}
+              canCreate={canCreate}
+              entryTypeSlug={entryType.adminSlug}
             />
           }
         />
@@ -586,6 +598,7 @@ function SortableHeader({
   activeOrderBy,
   activeOrder,
   onSort,
+  align = "left",
 }: {
   label: string;
   column: OrderBy;
@@ -593,6 +606,7 @@ function SortableHeader({
   activeOrderBy: OrderBy;
   activeOrder: Order;
   onSort: (column: OrderBy, defaultDirection: Order) => void;
+  align?: "left" | "right";
 }): ReactNode {
   const isActive = activeOrderBy === column;
   const nextDirection = nextSortOrder(isActive, activeOrder, defaultDirection);
@@ -603,7 +617,10 @@ function SortableHeader({
         onSort(column, defaultDirection);
       }}
       data-testid={`content-list-sort-${column}`}
-      className="hover:text-foreground -ml-2 inline-flex items-center gap-1 rounded px-2 py-1 text-left font-medium transition-colors"
+      className={cn(
+        "hover:text-foreground inline-flex items-center gap-1 rounded px-2 py-1 font-medium transition-colors",
+        align === "right" ? "-mr-2 text-right" : "-ml-2 text-left",
+      )}
       aria-label={`Sort by ${label} (${nextDirection})`}
       aria-pressed={isActive}
     >
@@ -680,9 +697,7 @@ function TitleCell({
   );
 }
 
-// WP-style status views: inline text-link strip with `|` separators.
-// Active view gets bold + foreground colour; siblings sit in muted
-// colour and reveal on hover.
+// Pill-style status filter (shadcn ToggleGroup, single-select).
 function StatusViews({
   value,
   onChange,
@@ -691,37 +706,28 @@ function StatusViews({
   onChange: (next: StatusFilter) => void;
 }): ReactNode {
   return (
-    <div
-      role="group"
+    <ToggleGroup
+      type="single"
+      variant="outline"
+      value={value}
+      onValueChange={(next) => {
+        // ToggleGroup emits "" when the user toggles off the active
+        // item; pin to "all" so the filter never lands in an invalid
+        // empty state.
+        onChange((next || "all") as StatusFilter);
+      }}
       aria-label="Filter by status"
-      className="flex flex-wrap items-center gap-2 text-sm"
     >
-      {STATUS_FILTER_OPTIONS.map((opt, idx) => (
-        <Fragment key={opt.value}>
-          {idx > 0 ? (
-            <span aria-hidden className="text-muted-foreground/50">
-              |
-            </span>
-          ) : null}
-          <button
-            type="button"
-            onClick={() => {
-              onChange(opt.value);
-            }}
-            aria-pressed={value === opt.value}
-            data-testid={`status-view-${opt.value}`}
-            className={cn(
-              "transition-colors",
-              value === opt.value
-                ? "text-foreground font-semibold"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            {opt.label}
-          </button>
-        </Fragment>
+      {STATUS_FILTER_OPTIONS.map((opt) => (
+        <ToggleGroupItem
+          key={opt.value}
+          value={opt.value}
+          data-testid={`status-view-${opt.value}`}
+        >
+          {opt.label}
+        </ToggleGroupItem>
       ))}
-    </div>
+    </ToggleGroup>
   );
 }
 
@@ -767,8 +773,8 @@ function TaxonomyFilter({
   onChange,
 }: {
   taxonomyName: string;
-  value: string | undefined;
-  onChange: (slug: string | undefined) => void;
+  value: readonly string[];
+  onChange: (slugs: readonly string[]) => void;
 }): ReactNode {
   const taxonomy = findTermTaxonomyByName(taxonomyName);
   const termsQuery = useQuery(
@@ -777,44 +783,44 @@ function TaxonomyFilter({
     }),
   );
   const isHierarchical = taxonomy?.isHierarchical === true;
-  const items = useMemo(() => {
+  const options = useMemo<MultiSelectOption[]>(() => {
     const terms: readonly Term[] = termsQuery.data ?? EMPTY_TERMS;
     if (!isHierarchical) {
       return terms
-        .map((term) => ({ term, depth: 0 }))
-        .sort((a, b) => a.term.name.localeCompare(b.term.name));
+        .map((term) => ({ value: term.slug, label: term.name, depth: 0 }))
+        .sort((a, b) => a.label.localeCompare(b.label));
     }
-    return flattenTree(buildTermTree(terms));
+    return flattenTree(buildTermTree(terms)).map(({ term, depth }) => ({
+      value: term.slug,
+      label: term.name,
+      depth,
+    }));
   }, [termsQuery.data, isHierarchical]);
 
   const pluralLower = (taxonomy?.label ?? taxonomyName).toLowerCase();
   return (
-    <select
-      aria-label={`Filter by ${pluralLower}`}
-      data-testid={`taxonomy-filter-${taxonomyName}`}
-      className={SELECT_CLASS}
-      value={value ?? ""}
-      onChange={(e) => {
-        const next = e.target.value;
-        onChange(next.length === 0 ? undefined : next);
-      }}
-    >
-      <option value="">All {pluralLower}</option>
-      {items.map(({ term, depth }) => (
-        <option key={term.id} value={term.slug}>
-          {depth === 0 ? term.name : `${"— ".repeat(depth)}${term.name}`}
-        </option>
-      ))}
-    </select>
+    <MultiSelect
+      options={options}
+      value={value}
+      onChange={onChange}
+      placeholder={`All ${pluralLower}`}
+      searchPlaceholder={`Search ${pluralLower}…`}
+      emptyText={`No ${pluralLower} match.`}
+      testId={`taxonomy-filter-${taxonomyName}`}
+    />
   );
 }
 
 function EmptyState({
   singularLower,
   pluralLower,
+  canCreate,
+  entryTypeSlug,
 }: {
   singularLower: string;
   pluralLower: string;
+  canCreate: boolean;
+  entryTypeSlug: string;
 }): ReactNode {
   return (
     <Empty data-testid="content-list-empty-state" className="border">
@@ -825,10 +831,19 @@ function EmptyState({
         </EmptyDescription>
       </EmptyHeader>
       <EmptyContent>
-        <Button disabled>
-          <Plus />
-          New {singularLower}
-        </Button>
+        {canCreate ? (
+          <Button asChild>
+            <Link to="/entries/$slug/create" params={{ slug: entryTypeSlug }}>
+              <Plus />
+              New {singularLower}
+            </Link>
+          </Button>
+        ) : (
+          <Button disabled>
+            <Plus />
+            New {singularLower}
+          </Button>
+        )}
       </EmptyContent>
     </Empty>
   );

--- a/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
@@ -6,6 +6,16 @@ import {
   descendantIds,
   parentPickerOptions,
 } from "@/components/taxonomy/tree.js";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Button } from "@/components/ui/button.js";
 import {
@@ -319,8 +329,8 @@ function DeleteCard({
     },
   });
 
-  if (!confirming) {
-    return (
+  return (
+    <>
       <Card className="border-destructive/50">
         <CardHeader>
           <CardTitle className="text-destructive">Delete term</CardTitle>
@@ -342,53 +352,48 @@ function DeleteCard({
           </Button>
         </CardContent>
       </Card>
-    );
-  }
 
-  return (
-    <Card className="border-destructive">
-      <CardHeader>
-        <CardTitle className="text-destructive">
-          Confirm delete: {termName}
-        </CardTitle>
-        <CardDescription>
-          Entry assignments to this term are removed. If the term has children,
-          they become root-level automatically.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-3">
-        {serverError ? (
-          <Alert variant="destructive" data-testid="term-delete-error">
-            <AlertDescription>{serverError}</AlertDescription>
-          </Alert>
-        ) : null}
-
-        <div className="flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              setConfirming(false);
-              setServerError(null);
-            }}
-            disabled={deleteTerm.isPending}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            onClick={() => {
-              deleteTerm.mutate();
-            }}
-            disabled={deleteTerm.isPending}
-            data-testid="term-delete-confirm-button"
-          >
-            {deleteTerm.isPending ? "Deleting…" : "Delete forever"}
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+      <AlertDialog
+        open={confirming}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirming(false);
+            setServerError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {termName}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Entry assignments to this term are removed. If the term has
+              children, they become root-level automatically.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {serverError ? (
+            <Alert variant="destructive" data-testid="term-delete-error">
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteTerm.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="term-delete-confirm-button"
+              disabled={deleteTerm.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={(e) => {
+                e.preventDefault();
+                deleteTerm.mutate();
+              }}
+            >
+              {deleteTerm.isPending ? "Deleting…" : "Delete forever"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 

--- a/packages/admin/src/routes/_authenticated/terms/$name/index.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/index.tsx
@@ -21,7 +21,6 @@ import {
 import { hasCap } from "@/lib/caps.js";
 import { findTermTaxonomyByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
-import { cn } from "@/lib/utils.js";
 import { useQuery } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -175,15 +174,22 @@ function TaxonomyListRoute(): ReactNode {
               params={{ name: taxonomy.name, id: term.id }}
               data-testid={`taxonomy-list-row-${String(term.id)}`}
               aria-level={depth + 1}
-              className="hover:text-primary flex items-start gap-2 transition-colors"
+              className="hover:text-primary flex min-w-0 flex-col transition-colors"
             >
-              <TreeIndent depth={depth} />
-              <div className="flex min-w-0 flex-col">
-                <span className="font-medium">{term.name}</span>
-                <span className="text-muted-foreground font-mono text-xs">
-                  {term.slug}
-                </span>
-              </div>
+              <span className="font-medium">
+                {depth > 0 ? (
+                  <span
+                    aria-hidden
+                    className="text-muted-foreground/60 mr-1 font-normal select-none"
+                  >
+                    {"— ".repeat(depth)}
+                  </span>
+                ) : null}
+                {term.name}
+              </span>
+              <span className="text-muted-foreground font-mono text-xs">
+                {term.slug}
+              </span>
             </Link>
           );
         },
@@ -191,11 +197,21 @@ function TaxonomyListRoute(): ReactNode {
       {
         accessorKey: "description",
         header: "Description",
-        cell: ({ row }) => (
-          <span className="text-muted-foreground line-clamp-1 text-sm">
-            {row.original.term.description ?? ""}
-          </span>
-        ),
+        cell: ({ row }) => {
+          const value = row.original.term.description;
+          if (value === null || value.length === 0) {
+            return (
+              <span aria-hidden className="text-muted-foreground/50">
+                —
+              </span>
+            );
+          }
+          return (
+            <span className="text-muted-foreground line-clamp-1 text-sm">
+              {value}
+            </span>
+          );
+        },
       },
     ];
   }, [taxonomy.name]);
@@ -301,37 +317,6 @@ function TaxonomyListRoute(): ReactNode {
           </PaginationItem>
         </PaginationContent>
       </Pagination>
-    </div>
-  );
-}
-
-// Tree-line connector for hierarchical term rows. Renders one column per
-// ancestor; the column for the immediate parent draws a corner glyph,
-// shallower columns draw a vertical guide so successive rows visually
-// chain. Pure CSS (border-l + border-b on a small div) so it renders
-// uniformly regardless of row height.
-function TreeIndent({ depth }: { depth: number }): ReactNode {
-  if (depth === 0) return null;
-  return (
-    <div
-      aria-hidden
-      className="text-muted-foreground/40 flex shrink-0 self-stretch"
-    >
-      {Array.from({ length: depth }).map((_, i) => (
-        <div
-          key={i}
-          className={cn(
-            "relative w-5",
-            i < depth - 1
-              ? "before:absolute before:inset-y-0 before:left-2 before:border-l before:border-current/30"
-              : null,
-          )}
-        >
-          {i === depth - 1 ? (
-            <div className="absolute top-0 bottom-1/2 left-2 rounded-bl-md border-b border-l border-current/40" />
-          ) : null}
-        </div>
-      ))}
     </div>
   );
 }

--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -311,6 +311,7 @@ function buildColumns({
     },
     {
       accessorKey: "createdAt",
+      meta: { className: "text-right" },
       header: "Created",
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">

--- a/packages/runtimes/cloudflare/src/deploy-origin.ts
+++ b/packages/runtimes/cloudflare/src/deploy-origin.ts
@@ -55,9 +55,26 @@ export function cloudflareDeployOrigin(input: DeployOriginInput): DeployOrigin {
 // covers the cases the user is likely to push (slashes from feat/x,
 // underscores from snake_case, etc.) and lines up with the URLs
 // Workers Builds generates in practice.
+//
+// Hand-rolled single-pass to dodge CodeQL's `js/polynomial-redos` —
+// the `replace(/^-+|-+$/g, "")` trim is technically polynomial when
+// fed pathological dash runs, even though the upstream input is a
+// short branch name.
 function sanitizeBranch(branch: string): string {
-  return branch
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  let result = "";
+  let pendingDash = false;
+  for (let i = 0; i < branch.length; i++) {
+    const c = branch.charCodeAt(i);
+    const lower = c >= 65 && c <= 90 ? c + 32 : c; // ASCII upper → lower
+    const isAlphaNum =
+      (lower >= 97 && lower <= 122) || (lower >= 48 && lower <= 57);
+    if (isAlphaNum) {
+      if (pendingDash && result.length > 0) result += "-";
+      result += String.fromCharCode(lower);
+      pendingDash = false;
+    } else {
+      pendingDash = true;
+    }
+  }
+  return result;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -3962,6 +3965,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -9167,6 +9176,18 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

A second wave of admin polish that builds on #80, addressing feedback from a deployed-build review.

- **Status filter**: now a shadcn ToggleGroup (pill segmented control). Tabs were semantically wrong here — Axe caught the dangling aria-controls.
- **Per-taxonomy filters → multi-select with search**. Vendored shadcn Popover + Command, built a reusable \`<MultiSelect>\` primitive, wired it for each registered taxonomy. URL state is now \`?category=a,b\` (comma-separated slugs).
- **Date columns right-aligned**. Added \`meta.className\` passthrough on the DataTable; \`updatedAt\` (entries) and \`createdAt\` (users) opt in. \`SortableHeader\` gets an \`align\` prop so the button hugs the right edge.
- **Term delete confirm → shadcn AlertDialog**. Drops the inline Card-based confirm.
- **Hierarchical term list**: tree-line connectors didn't render cleanly; replaced with WP em-dash prefixes (\`— Child\`, \`— — Grandchild\`).
- **Empty term description**: shows \`—\` instead of blank — WP edit-tags convention.
- **Entries empty-state CTA**: re-wires \`canCreate\` + \`entryTypeSlug\` (the wiring was lost in #80's squash) so the "+ New <singular>" button works for capable users.
- **Breadcrumb label**: \`Taxonomies\` → \`Terms\` so the URL segment, breadcrumb, and routes all agree.

## Test plan

- [x] admin: lint + typecheck + 96 unit tests + format
- [x] core: typecheck + 615 unit tests + format
- [x] knip exit 0
- [x] 53 playwright e2e tests pass locally (12.9s)

Open question reported during review but not in this PR's scope: editor title field reads as plain text without obvious affordance — needs its own treatment.