### PR TITLE
fix(admin): breadcrumbs as links, editor title placeholder, empty-state icons

### DIFF
--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -360,10 +360,11 @@ function TitleField({ disabled }: { readonly disabled: boolean }): ReactNode {
               required
               autoComplete="off"
               disabled={disabled}
+              placeholder="Title"
               data-testid="post-editor-title-input"
               className={cn(
                 "h-auto border-0 bg-transparent px-0 text-3xl font-semibold shadow-none dark:bg-transparent",
-                "placeholder:text-muted-foreground/60",
+                "placeholder:text-muted-foreground/40",
                 "focus-visible:border-0 focus-visible:ring-0",
               )}
               {...field}

--- a/packages/admin/src/components/shell/shell-header.tsx
+++ b/packages/admin/src/components/shell/shell-header.tsx
@@ -1,3 +1,4 @@
+import type { Crumb } from "@/lib/breadcrumbs.js";
 import type { ReactNode } from "react";
 import { Fragment } from "react";
 import {
@@ -10,9 +11,9 @@ import {
 import { Separator } from "@/components/ui/separator.js";
 import { SidebarTrigger } from "@/components/ui/sidebar.js";
 import { pathToCrumbs } from "@/lib/breadcrumbs.js";
-import { useRouterState } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
 
-function useBreadcrumbs(): readonly string[] {
+function useBreadcrumbs(): readonly Crumb[] {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
@@ -30,13 +31,20 @@ export function ShellHeader(): ReactNode {
           {crumbs.map((crumb, index) => {
             const isLast = index === crumbs.length - 1;
             return (
-              <Fragment key={`${String(index)}-${crumb}`}>
+              <Fragment key={`${String(index)}-${crumb.label}`}>
                 {index > 0 ? <BreadcrumbSeparator /> : null}
                 <BreadcrumbItem>
                   {isLast ? (
-                    <BreadcrumbPage>{crumb}</BreadcrumbPage>
+                    <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                  ) : crumb.to !== undefined ? (
+                    <Link
+                      to={crumb.to}
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {crumb.label}
+                    </Link>
                   ) : (
-                    <span className="text-muted-foreground">{crumb}</span>
+                    <span className="text-muted-foreground">{crumb.label}</span>
                   )}
                 </BreadcrumbItem>
               </Fragment>

--- a/packages/admin/src/lib/breadcrumbs.test.ts
+++ b/packages/admin/src/lib/breadcrumbs.test.ts
@@ -45,63 +45,80 @@ afterEach(() => {
 
 describe("pathToCrumbs", () => {
   test("dashboard", () => {
-    expect(pathToCrumbs("/")).toEqual(["Dashboard"]);
-    expect(pathToCrumbs("")).toEqual(["Dashboard"]);
+    expect(pathToCrumbs("/")).toEqual([{ label: "Dashboard" }]);
+    expect(pathToCrumbs("")).toEqual([{ label: "Dashboard" }]);
   });
 
-  test("entries list resolves the plural label from manifest", () => {
-    expect(pathToCrumbs("/entries/posts")).toEqual(["Entries", "Posts"]);
-    expect(pathToCrumbs("/entries/pages")).toEqual(["Entries", "Pages"]);
-  });
-
-  test("entries create + edit append the action segment", () => {
-    expect(pathToCrumbs("/entries/posts/create")).toEqual([
-      "Entries",
-      "Posts",
-      "Create",
+  test("entries list resolves the plural label from manifest (no link on leaf)", () => {
+    expect(pathToCrumbs("/entries/posts")).toEqual([
+      { label: "Entries" },
+      { label: "Posts" },
     ]);
+  });
+
+  test("entries create: list crumb is a link, action crumb is leaf", () => {
+    expect(pathToCrumbs("/entries/posts/create")).toEqual([
+      { label: "Entries" },
+      { label: "Posts", to: "/entries/posts" },
+      { label: "Create" },
+    ]);
+  });
+
+  test("entries edit: list crumb is a link, edit crumb is leaf", () => {
     expect(pathToCrumbs("/entries/posts/42/edit")).toEqual([
-      "Entries",
-      "Posts",
-      "Edit",
+      { label: "Entries" },
+      { label: "Posts", to: "/entries/posts" },
+      { label: "Edit" },
     ]);
   });
 
   test("entries with unknown slug falls back to the raw segment", () => {
-    expect(pathToCrumbs("/entries/widgets")).toEqual(["Entries", "widgets"]);
+    expect(pathToCrumbs("/entries/widgets")).toEqual([
+      { label: "Entries" },
+      { label: "widgets" },
+    ]);
   });
 
-  test("terms list + create + edit use the taxonomy label and singular", () => {
-    expect(pathToCrumbs("/terms/category")).toEqual(["Terms", "Categories"]);
+  test("terms create: taxonomy crumb is a link", () => {
     expect(pathToCrumbs("/terms/category/create")).toEqual([
-      "Terms",
-      "Categories",
-      "Create category",
-    ]);
-    expect(pathToCrumbs("/terms/category/7/edit")).toEqual([
-      "Terms",
-      "Categories",
-      "Edit category",
+      { label: "Terms" },
+      { label: "Categories", to: "/terms/category" },
+      { label: "Create category" },
     ]);
   });
 
-  test("users list + create + edit", () => {
-    expect(pathToCrumbs("/users")).toEqual(["Users"]);
-    expect(pathToCrumbs("/users/create")).toEqual(["Users", "Add new"]);
-    expect(pathToCrumbs("/users/3/edit")).toEqual(["Users", "Edit user"]);
+  test("terms edit: taxonomy crumb is a link, action uses singular label", () => {
+    expect(pathToCrumbs("/terms/category/7/edit")).toEqual([
+      { label: "Terms" },
+      { label: "Categories", to: "/terms/category" },
+      { label: "Edit category" },
+    ]);
+  });
+
+  test("users edit: list crumb is a link", () => {
+    expect(pathToCrumbs("/users/3/edit")).toEqual([
+      { label: "Users", to: "/users" },
+      { label: "Edit user" },
+    ]);
   });
 
   test("settings list + page", () => {
-    expect(pathToCrumbs("/settings")).toEqual(["Settings"]);
-    expect(pathToCrumbs("/settings/general")).toEqual(["Settings", "General"]);
+    expect(pathToCrumbs("/settings")).toEqual([{ label: "Settings" }]);
+    expect(pathToCrumbs("/settings/general")).toEqual([
+      { label: "Settings", to: "/settings" },
+      { label: "General" },
+    ]);
   });
 
   test("profile + plugin pages", () => {
-    expect(pathToCrumbs("/profile")).toEqual(["Profile"]);
-    expect(pathToCrumbs("/pages/menus")).toEqual(["Pages", "menus"]);
+    expect(pathToCrumbs("/profile")).toEqual([{ label: "Profile" }]);
+    expect(pathToCrumbs("/pages/menus")).toEqual([
+      { label: "Pages" },
+      { label: "menus" },
+    ]);
   });
 
   test("unknown top-level segment falls back to Admin", () => {
-    expect(pathToCrumbs("/whatever")).toEqual(["Admin"]);
+    expect(pathToCrumbs("/whatever")).toEqual([{ label: "Admin" }]);
   });
 });

--- a/packages/admin/src/lib/breadcrumbs.ts
+++ b/packages/admin/src/lib/breadcrumbs.ts
@@ -4,16 +4,25 @@ import {
   findTermTaxonomyByName,
 } from "./manifest.js";
 
+export interface Crumb {
+  readonly label: string;
+  /** Absolute admin path for non-leaf crumbs that link to a real list
+   *  page. Omitted for group labels (no list route exists) and for
+   *  the leaf crumb. */
+  readonly to?: string;
+}
+
 /**
  * Pathname → breadcrumb trail. Resolves entry-type / taxonomy / settings
- * labels via the manifest so dynamic segments match the sidebar. Used by
- * both the shell header (visual breadcrumbs) and the document-title
- * effect on the root route.
+ * labels via the manifest so dynamic segments match the sidebar. Used
+ * by both the shell header (visual breadcrumbs, with non-leaf crumbs
+ * rendered as Links) and the document-title effect on the root route
+ * (which only reads the leaf label).
  */
-export function pathToCrumbs(pathname: string): readonly string[] {
-  if (pathname === "/") return ["Dashboard"];
+export function pathToCrumbs(pathname: string): readonly Crumb[] {
+  if (pathname === "/") return [{ label: "Dashboard" }];
   const parts = pathname.split("/").filter((p) => p.length > 0);
-  if (parts.length === 0) return ["Dashboard"];
+  if (parts.length === 0) return [{ label: "Dashboard" }];
 
   switch (parts[0]) {
     case "entries":
@@ -25,45 +34,58 @@ export function pathToCrumbs(pathname: string): readonly string[] {
     case "settings":
       return settingsCrumbs(parts);
     case "profile":
-      return ["Profile"];
+      return [{ label: "Profile" }];
     case "pages":
-      return ["Pages", ...parts.slice(1)];
+      return [
+        { label: "Pages" },
+        ...parts.slice(1).map((label) => ({ label })),
+      ];
     default:
-      return ["Admin"];
+      return [{ label: "Admin" }];
   }
 }
 
-function entriesCrumbs(parts: readonly string[]): readonly string[] {
+function entriesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const slug = parts[1];
-  if (slug === undefined) return ["Entries"];
+  if (slug === undefined) return [{ label: "Entries" }];
   const entry = findEntryTypeBySlug(slug);
   const label = entry?.labels?.plural ?? entry?.label ?? slug;
-  if (parts[2] === "create") return ["Entries", label, "Create"];
-  if (parts[3] === "edit") return ["Entries", label, "Edit"];
-  return ["Entries", label];
+  const list: Crumb = { label, to: `/entries/${slug}` };
+  if (parts[2] === "create")
+    return [{ label: "Entries" }, list, { label: "Create" }];
+  if (parts[3] === "edit")
+    return [{ label: "Entries" }, list, { label: "Edit" }];
+  return [{ label: "Entries" }, { ...list, to: undefined }];
 }
 
-function taxonomiesCrumbs(parts: readonly string[]): readonly string[] {
+function taxonomiesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const name = parts[1];
-  if (name === undefined) return ["Terms"];
+  if (name === undefined) return [{ label: "Terms" }];
   const tax = findTermTaxonomyByName(name);
   const label = tax?.label ?? name;
   const singular = (tax?.labels?.singular ?? label).toLowerCase();
-  if (parts[2] === "create") return ["Terms", label, `Create ${singular}`];
-  if (parts[3] === "edit") return ["Terms", label, `Edit ${singular}`];
-  return ["Terms", label];
+  const list: Crumb = { label, to: `/terms/${name}` };
+  if (parts[2] === "create")
+    return [{ label: "Terms" }, list, { label: `Create ${singular}` }];
+  if (parts[3] === "edit")
+    return [{ label: "Terms" }, list, { label: `Edit ${singular}` }];
+  return [{ label: "Terms" }, { ...list, to: undefined }];
 }
 
-function usersCrumbs(parts: readonly string[]): readonly string[] {
-  if (parts[1] === undefined) return ["Users"];
-  if (parts[1] === "create") return ["Users", "Add new"];
-  if (parts[2] === "edit") return ["Users", "Edit user"];
-  return ["Users"];
+function usersCrumbs(parts: readonly string[]): readonly Crumb[] {
+  if (parts[1] === undefined) return [{ label: "Users" }];
+  const usersList: Crumb = { label: "Users", to: "/users" };
+  if (parts[1] === "create") return [usersList, { label: "Add new" }];
+  if (parts[2] === "edit") return [usersList, { label: "Edit user" }];
+  return [{ label: "Users" }];
 }
 
-function settingsCrumbs(parts: readonly string[]): readonly string[] {
+function settingsCrumbs(parts: readonly string[]): readonly Crumb[] {
   const name = parts[1];
-  if (name === undefined) return ["Settings"];
+  if (name === undefined) return [{ label: "Settings" }];
   const page = findSettingsPageByName(name);
-  return ["Settings", page?.label ?? name];
+  return [
+    { label: "Settings", to: "/settings" },
+    { label: page?.label ?? name },
+  ];
 }

--- a/packages/admin/src/routes/__root.tsx
+++ b/packages/admin/src/routes/__root.tsx
@@ -38,7 +38,7 @@ function useDocumentTitle(): void {
   useEffect(() => {
     const crumbs = pathToCrumbs(pathname);
     const leaf = crumbs[crumbs.length - 1];
-    document.title = leaf ? `${leaf} · ${TITLE_BRAND}` : TITLE_BRAND;
+    document.title = leaf ? `${leaf.label} · ${TITLE_BRAND}` : TITLE_BRAND;
   }, [pathname]);
 }
 

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -11,12 +11,13 @@ import {
   Empty,
   EmptyDescription,
   EmptyHeader,
+  EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import { visibleEntryTypes } from "@/lib/manifest.js";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRight, FileText } from "lucide-react";
+import { ArrowRight, FileText, Puzzle } from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated/")({
   component: DashboardIndex,
@@ -79,6 +80,9 @@ function DashboardIndex(): ReactNode {
         <Card className="max-w-xl" data-testid="dashboard-empty-state">
           <Empty>
             <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Puzzle />
+              </EmptyMedia>
               <EmptyTitle>No content types yet</EmptyTitle>
               <EmptyDescription>
                 Add a plugin that registers a post type (e.g.{" "}

--- a/packages/admin/src/routes/_authenticated/settings/index.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.tsx
@@ -10,11 +10,13 @@ import {
   Empty,
   EmptyDescription,
   EmptyHeader,
+  EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty.js";
 import { hasCap } from "@/lib/caps.js";
 import { visibleSettingsPages } from "@/lib/manifest.js";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { Settings as SettingsIcon } from "lucide-react";
 
 function pageSummary(groupCount: number): string {
   return `${groupCount} ${groupCount === 1 ? "group" : "groups"}`;
@@ -47,6 +49,9 @@ function SettingsIndexRoute(): ReactNode {
         <Card data-testid="settings-empty-state">
           <Empty>
             <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <SettingsIcon />
+              </EmptyMedia>
               <EmptyTitle>No settings registered yet</EmptyTitle>
               <EmptyDescription>
                 Core ships no settings by design — plugins (or your own


### PR DESCRIPTION
## Summary

Three small visual fixes from the deployed-build review.

- **Editor title was invisible** — placeholder `Title` restored so an empty field has a visible affordance. The earlier placeholder strip was too aggressive; it was meant to remove the slug field's noisy placeholder but caught the title too.
- **Breadcrumbs are now clickable** — `pathToCrumbs` returns `Crumb[] = { label, to? }` instead of plain strings. Shell header renders non-leaf crumbs with a real `to` as TanStack Router `<Link>`s; group labels (Entries / Terms) and the leaf stay as text. Tests updated.
- **Empty-state icons** — Settings + Dashboard empty states wear an `<EmptyMedia variant="icon">` so they read as designed surfaces, not unfinished pages.

## CI gauntlet (locally)

- admin: lint ✓ · typecheck ✓ · 96 unit ✓ · format ✓
- core: 615 unit ✓
- knip exit 0 ✓
- 53 e2e ✓ (12.4s)

## Out of scope (real follow-ups still open)

- Categories/tags picker inside the entry editor — needs server change to `entry.get` + `entry.create` plus rail UI. Substantial; warrants its own PR.
- Users list rows clickable + Edit/Trash actions (parity with entries).
- The `/_plumix/admin/entries/pages?...` redirect-to-`/admin/` reported on the deployed build. Couldn't reproduce from code; needs DevTools network info to determine if it's a server 302 or a client-side redirect (likely an auth-cookie issue).