### PR TITLE
feat(admin,core): assign categories/tags inside the entry editor

### DIFF
--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -360,10 +360,11 @@ function TitleField({ disabled }: { readonly disabled: boolean }): ReactNode {
               required
               autoComplete="off"
               disabled={disabled}
+              placeholder="Title"
               data-testid="post-editor-title-input"
               className={cn(
                 "h-auto border-0 bg-transparent px-0 text-3xl font-semibold shadow-none dark:bg-transparent",
-                "placeholder:text-muted-foreground/60",
+                "placeholder:text-muted-foreground/40",
                 "focus-visible:border-0 focus-visible:ring-0",
               )}
               {...field}

--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -1,6 +1,7 @@
 import type { JSONContent } from "@tiptap/react";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { MultiSelect } from "@/components/form/multi-select.js";
 import { MetaBoxAccordionItem } from "@/components/meta-box/meta-box.js";
 import {
   Accordion,
@@ -37,18 +38,30 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar.js";
+import { orpc } from "@/lib/orpc.js";
+import { buildEditorTermOptions } from "@/lib/terms.js";
 import { cn } from "@/lib/utils";
 import { valibotResolver } from "@hookform/resolvers/valibot";
+import { useQuery } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 import { useForm, useFormContext, useWatch } from "react-hook-form";
 import * as v from "valibot";
 
-import type { EntryMetaBoxManifestEntry } from "@plumix/core/manifest";
-import type { EntryStatus } from "@plumix/core/schema";
+import type {
+  EntryMetaBoxManifestEntry,
+  TermTaxonomyManifestEntry,
+} from "@plumix/core/manifest";
+import type { EntryStatus, Term } from "@plumix/core/schema";
 import { slugify } from "@plumix/core/slugify";
 
 import { TiptapEditor } from "./tiptap-editor.js";
+
+// Stable empty fallbacks — react-query returns a fresh `[]` for
+// `data` while loading, which would invalidate `useMemo` deps every
+// render if we used `?? []` inline.
+const EMPTY_TERMS: readonly Term[] = [];
+const EMPTY_NUMBER_IDS: readonly number[] = [];
 
 // Matches the server's `slugSchema` — lowercase ASCII alphanumerics
 // separated by single dashes. Keeping a local copy so the admin form
@@ -78,6 +91,13 @@ const postEditorSchema = v.object({
    * and can ignore it.
    */
   meta: v.record(v.string(), v.unknown()),
+  /**
+   * Term assignments per taxonomy: `{ category: [3, 7], tag: [12] }`.
+   * Caller filters this against the entry-type's registered
+   * taxonomies on submit; arbitrary keys are tolerated here so a
+   * plugin-added taxonomy doesn't require a schema update.
+   */
+  terms: v.record(v.string(), v.array(v.number())),
 });
 
 export type PostEditorValues = v.InferOutput<typeof postEditorSchema>;
@@ -119,6 +139,10 @@ interface PostEditorFormProps {
    * Excerpt cards — `box.location` is ignored.
    */
   readonly metaBoxes: readonly EntryMetaBoxManifestEntry[];
+  /** Taxonomies registered for this entry type. One Accordion section
+   *  is rendered per taxonomy, with a Combobox-based multi-select
+   *  populated from `term.list`. */
+  readonly taxonomies: readonly TermTaxonomyManifestEntry[];
   /** Caption shown next to the back button — e.g. `"New post"` or
    *  `"Edit post"`. The editor itself is the page, so there's no
    *  separate `<h1>` above it. */
@@ -136,6 +160,7 @@ export function PostEditorForm({
   availableStatuses,
   supports,
   metaBoxes,
+  taxonomies,
   headline,
   submitLabel,
   isSubmitting,
@@ -193,6 +218,7 @@ export function PostEditorForm({
     ...(showSlug ? ["permalink"] : []),
     "status",
     ...(showExcerpt ? ["excerpt"] : []),
+    ...taxonomies.map((tax) => `taxonomy:${tax.name}`),
     ...metaBoxes.map((box) => box.id),
   ];
 
@@ -299,6 +325,13 @@ export function PostEditorForm({
                 {showExcerpt ? (
                   <ExcerptSection disabled={isSubmitting} />
                 ) : null}
+                {taxonomies.map((tax) => (
+                  <TaxonomySection
+                    key={tax.name}
+                    taxonomy={tax}
+                    disabled={isSubmitting}
+                  />
+                ))}
                 {metaBoxes.map((box) => (
                   <MetaBoxAccordionItem
                     key={box.id}
@@ -552,4 +585,62 @@ function ExcerptSection({
 
 function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function TaxonomySection({
+  taxonomy,
+  disabled,
+}: {
+  readonly taxonomy: TermTaxonomyManifestEntry;
+  readonly disabled: boolean;
+}): ReactNode {
+  const { control } = useFormContext<PostEditorValues>();
+  const termsQuery = useQuery(
+    orpc.term.list.queryOptions({
+      input: { taxonomy: taxonomy.name, limit: 200 },
+    }),
+  );
+  const isHierarchical = taxonomy.isHierarchical === true;
+  const options = useMemo(
+    () =>
+      buildEditorTermOptions(termsQuery.data ?? EMPTY_TERMS, isHierarchical),
+    [termsQuery.data, isHierarchical],
+  );
+
+  const pluralLower = taxonomy.label.toLowerCase();
+  return (
+    <RailSection value={`taxonomy:${taxonomy.name}`} title={taxonomy.label}>
+      <FormField
+        control={control}
+        name={`terms.${taxonomy.name}`}
+        render={({ field }) => {
+          // rhf returns whatever's at `terms.<taxonomy>`; default to []
+          // when the form was initialised without this taxonomy.
+          const ids =
+            (field.value as readonly number[] | undefined) ?? EMPTY_NUMBER_IDS;
+          return (
+            <FormItem>
+              <FormLabel className="sr-only">{taxonomy.label}</FormLabel>
+              <FormControl>
+                <MultiSelect
+                  options={options}
+                  value={ids.map(String)}
+                  onChange={(next) => {
+                    field.onChange(next.map(Number));
+                  }}
+                  placeholder={`Add ${pluralLower}…`}
+                  searchPlaceholder={`Search ${pluralLower}…`}
+                  emptyText={`No ${pluralLower} match.`}
+                  testId={`post-editor-taxonomy-${taxonomy.name}`}
+                  disabled={disabled}
+                  className="w-full"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          );
+        }}
+      />
+    </RailSection>
+  );
 }

--- a/packages/admin/src/components/shell/shell-header.tsx
+++ b/packages/admin/src/components/shell/shell-header.tsx
@@ -1,3 +1,4 @@
+import type { Crumb } from "@/lib/breadcrumbs.js";
 import type { ReactNode } from "react";
 import { Fragment } from "react";
 import {
@@ -10,9 +11,9 @@ import {
 import { Separator } from "@/components/ui/separator.js";
 import { SidebarTrigger } from "@/components/ui/sidebar.js";
 import { pathToCrumbs } from "@/lib/breadcrumbs.js";
-import { useRouterState } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
 
-function useBreadcrumbs(): readonly string[] {
+function useBreadcrumbs(): readonly Crumb[] {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
@@ -30,13 +31,20 @@ export function ShellHeader(): ReactNode {
           {crumbs.map((crumb, index) => {
             const isLast = index === crumbs.length - 1;
             return (
-              <Fragment key={`${String(index)}-${crumb}`}>
+              <Fragment key={`${String(index)}-${crumb.label}`}>
                 {index > 0 ? <BreadcrumbSeparator /> : null}
                 <BreadcrumbItem>
                   {isLast ? (
-                    <BreadcrumbPage>{crumb}</BreadcrumbPage>
+                    <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                  ) : crumb.to !== undefined ? (
+                    <Link
+                      to={crumb.to}
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {crumb.label}
+                    </Link>
                   ) : (
-                    <span className="text-muted-foreground">{crumb}</span>
+                    <span className="text-muted-foreground">{crumb.label}</span>
                   )}
                 </BreadcrumbItem>
               </Fragment>

--- a/packages/admin/src/lib/breadcrumbs.test.ts
+++ b/packages/admin/src/lib/breadcrumbs.test.ts
@@ -45,63 +45,80 @@ afterEach(() => {
 
 describe("pathToCrumbs", () => {
   test("dashboard", () => {
-    expect(pathToCrumbs("/")).toEqual(["Dashboard"]);
-    expect(pathToCrumbs("")).toEqual(["Dashboard"]);
+    expect(pathToCrumbs("/")).toEqual([{ label: "Dashboard" }]);
+    expect(pathToCrumbs("")).toEqual([{ label: "Dashboard" }]);
   });
 
-  test("entries list resolves the plural label from manifest", () => {
-    expect(pathToCrumbs("/entries/posts")).toEqual(["Entries", "Posts"]);
-    expect(pathToCrumbs("/entries/pages")).toEqual(["Entries", "Pages"]);
-  });
-
-  test("entries create + edit append the action segment", () => {
-    expect(pathToCrumbs("/entries/posts/create")).toEqual([
-      "Entries",
-      "Posts",
-      "Create",
+  test("entries list resolves the plural label from manifest (no link on leaf)", () => {
+    expect(pathToCrumbs("/entries/posts")).toEqual([
+      { label: "Entries" },
+      { label: "Posts" },
     ]);
+  });
+
+  test("entries create: list crumb is a link, action crumb is leaf", () => {
+    expect(pathToCrumbs("/entries/posts/create")).toEqual([
+      { label: "Entries" },
+      { label: "Posts", to: "/entries/posts" },
+      { label: "Create" },
+    ]);
+  });
+
+  test("entries edit: list crumb is a link, edit crumb is leaf", () => {
     expect(pathToCrumbs("/entries/posts/42/edit")).toEqual([
-      "Entries",
-      "Posts",
-      "Edit",
+      { label: "Entries" },
+      { label: "Posts", to: "/entries/posts" },
+      { label: "Edit" },
     ]);
   });
 
   test("entries with unknown slug falls back to the raw segment", () => {
-    expect(pathToCrumbs("/entries/widgets")).toEqual(["Entries", "widgets"]);
+    expect(pathToCrumbs("/entries/widgets")).toEqual([
+      { label: "Entries" },
+      { label: "widgets" },
+    ]);
   });
 
-  test("terms list + create + edit use the taxonomy label and singular", () => {
-    expect(pathToCrumbs("/terms/category")).toEqual(["Terms", "Categories"]);
+  test("terms create: taxonomy crumb is a link", () => {
     expect(pathToCrumbs("/terms/category/create")).toEqual([
-      "Terms",
-      "Categories",
-      "Create category",
-    ]);
-    expect(pathToCrumbs("/terms/category/7/edit")).toEqual([
-      "Terms",
-      "Categories",
-      "Edit category",
+      { label: "Terms" },
+      { label: "Categories", to: "/terms/category" },
+      { label: "Create category" },
     ]);
   });
 
-  test("users list + create + edit", () => {
-    expect(pathToCrumbs("/users")).toEqual(["Users"]);
-    expect(pathToCrumbs("/users/create")).toEqual(["Users", "Add new"]);
-    expect(pathToCrumbs("/users/3/edit")).toEqual(["Users", "Edit user"]);
+  test("terms edit: taxonomy crumb is a link, action uses singular label", () => {
+    expect(pathToCrumbs("/terms/category/7/edit")).toEqual([
+      { label: "Terms" },
+      { label: "Categories", to: "/terms/category" },
+      { label: "Edit category" },
+    ]);
+  });
+
+  test("users edit: list crumb is a link", () => {
+    expect(pathToCrumbs("/users/3/edit")).toEqual([
+      { label: "Users", to: "/users" },
+      { label: "Edit user" },
+    ]);
   });
 
   test("settings list + page", () => {
-    expect(pathToCrumbs("/settings")).toEqual(["Settings"]);
-    expect(pathToCrumbs("/settings/general")).toEqual(["Settings", "General"]);
+    expect(pathToCrumbs("/settings")).toEqual([{ label: "Settings" }]);
+    expect(pathToCrumbs("/settings/general")).toEqual([
+      { label: "Settings", to: "/settings" },
+      { label: "General" },
+    ]);
   });
 
   test("profile + plugin pages", () => {
-    expect(pathToCrumbs("/profile")).toEqual(["Profile"]);
-    expect(pathToCrumbs("/pages/menus")).toEqual(["Pages", "menus"]);
+    expect(pathToCrumbs("/profile")).toEqual([{ label: "Profile" }]);
+    expect(pathToCrumbs("/pages/menus")).toEqual([
+      { label: "Pages" },
+      { label: "menus" },
+    ]);
   });
 
   test("unknown top-level segment falls back to Admin", () => {
-    expect(pathToCrumbs("/whatever")).toEqual(["Admin"]);
+    expect(pathToCrumbs("/whatever")).toEqual([{ label: "Admin" }]);
   });
 });

--- a/packages/admin/src/lib/breadcrumbs.ts
+++ b/packages/admin/src/lib/breadcrumbs.ts
@@ -4,16 +4,25 @@ import {
   findTermTaxonomyByName,
 } from "./manifest.js";
 
+export interface Crumb {
+  readonly label: string;
+  /** Absolute admin path for non-leaf crumbs that link to a real list
+   *  page. Omitted for group labels (no list route exists) and for
+   *  the leaf crumb. */
+  readonly to?: string;
+}
+
 /**
  * Pathname → breadcrumb trail. Resolves entry-type / taxonomy / settings
- * labels via the manifest so dynamic segments match the sidebar. Used by
- * both the shell header (visual breadcrumbs) and the document-title
- * effect on the root route.
+ * labels via the manifest so dynamic segments match the sidebar. Used
+ * by both the shell header (visual breadcrumbs, with non-leaf crumbs
+ * rendered as Links) and the document-title effect on the root route
+ * (which only reads the leaf label).
  */
-export function pathToCrumbs(pathname: string): readonly string[] {
-  if (pathname === "/") return ["Dashboard"];
+export function pathToCrumbs(pathname: string): readonly Crumb[] {
+  if (pathname === "/") return [{ label: "Dashboard" }];
   const parts = pathname.split("/").filter((p) => p.length > 0);
-  if (parts.length === 0) return ["Dashboard"];
+  if (parts.length === 0) return [{ label: "Dashboard" }];
 
   switch (parts[0]) {
     case "entries":
@@ -25,45 +34,58 @@ export function pathToCrumbs(pathname: string): readonly string[] {
     case "settings":
       return settingsCrumbs(parts);
     case "profile":
-      return ["Profile"];
+      return [{ label: "Profile" }];
     case "pages":
-      return ["Pages", ...parts.slice(1)];
+      return [
+        { label: "Pages" },
+        ...parts.slice(1).map((label) => ({ label })),
+      ];
     default:
-      return ["Admin"];
+      return [{ label: "Admin" }];
   }
 }
 
-function entriesCrumbs(parts: readonly string[]): readonly string[] {
+function entriesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const slug = parts[1];
-  if (slug === undefined) return ["Entries"];
+  if (slug === undefined) return [{ label: "Entries" }];
   const entry = findEntryTypeBySlug(slug);
   const label = entry?.labels?.plural ?? entry?.label ?? slug;
-  if (parts[2] === "create") return ["Entries", label, "Create"];
-  if (parts[3] === "edit") return ["Entries", label, "Edit"];
-  return ["Entries", label];
+  const list: Crumb = { label, to: `/entries/${slug}` };
+  if (parts[2] === "create")
+    return [{ label: "Entries" }, list, { label: "Create" }];
+  if (parts[3] === "edit")
+    return [{ label: "Entries" }, list, { label: "Edit" }];
+  return [{ label: "Entries" }, { ...list, to: undefined }];
 }
 
-function taxonomiesCrumbs(parts: readonly string[]): readonly string[] {
+function taxonomiesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const name = parts[1];
-  if (name === undefined) return ["Terms"];
+  if (name === undefined) return [{ label: "Terms" }];
   const tax = findTermTaxonomyByName(name);
   const label = tax?.label ?? name;
   const singular = (tax?.labels?.singular ?? label).toLowerCase();
-  if (parts[2] === "create") return ["Terms", label, `Create ${singular}`];
-  if (parts[3] === "edit") return ["Terms", label, `Edit ${singular}`];
-  return ["Terms", label];
+  const list: Crumb = { label, to: `/terms/${name}` };
+  if (parts[2] === "create")
+    return [{ label: "Terms" }, list, { label: `Create ${singular}` }];
+  if (parts[3] === "edit")
+    return [{ label: "Terms" }, list, { label: `Edit ${singular}` }];
+  return [{ label: "Terms" }, { ...list, to: undefined }];
 }
 
-function usersCrumbs(parts: readonly string[]): readonly string[] {
-  if (parts[1] === undefined) return ["Users"];
-  if (parts[1] === "create") return ["Users", "Add new"];
-  if (parts[2] === "edit") return ["Users", "Edit user"];
-  return ["Users"];
+function usersCrumbs(parts: readonly string[]): readonly Crumb[] {
+  if (parts[1] === undefined) return [{ label: "Users" }];
+  const usersList: Crumb = { label: "Users", to: "/users" };
+  if (parts[1] === "create") return [usersList, { label: "Add new" }];
+  if (parts[2] === "edit") return [usersList, { label: "Edit user" }];
+  return [{ label: "Users" }];
 }
 
-function settingsCrumbs(parts: readonly string[]): readonly string[] {
+function settingsCrumbs(parts: readonly string[]): readonly Crumb[] {
   const name = parts[1];
-  if (name === undefined) return ["Settings"];
+  if (name === undefined) return [{ label: "Settings" }];
   const page = findSettingsPageByName(name);
-  return ["Settings", page?.label ?? name];
+  return [
+    { label: "Settings", to: "/settings" },
+    { label: page?.label ?? name },
+  ];
 }

--- a/packages/admin/src/lib/terms.ts
+++ b/packages/admin/src/lib/terms.ts
@@ -1,0 +1,73 @@
+import type { MultiSelectOption } from "@/components/form/multi-select.js";
+import { buildTermTree, flattenTree } from "@/components/taxonomy/tree.js";
+
+import type { Term } from "@plumix/core/schema";
+
+/**
+ * Narrow a term-id bag (`{ category: [3, 7], tag: [12] }`) to the set
+ * of taxonomies registered against the current entry type. Stale keys
+ * from a previous entry-type or a hand-edited URL don't make it to
+ * `entry.create`/`entry.update` — the server would reject them, but
+ * filtering up-front gives a cleaner contract.
+ *
+ * Empty arrays are dropped; an empty result returns `undefined` so
+ * callers can spread it conditionally without sending an empty `terms`
+ * field to the server.
+ */
+export function filterTermsForEntryType(
+  bag: Record<string, readonly number[]>,
+  allowed: readonly string[] | undefined,
+): Record<string, number[]> | undefined {
+  if (!allowed || allowed.length === 0) return undefined;
+  const allow = new Set(allowed);
+  const out: Record<string, number[]> = {};
+  for (const [taxonomy, ids] of Object.entries(bag)) {
+    if (allow.has(taxonomy) && ids.length > 0) {
+      out[taxonomy] = [...ids];
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * `MultiSelectOption[]` for the editor's term picker — values are
+ * stringified term ids because the form persists assignments by id.
+ * Hierarchical taxonomies render with depth-indented options; flat
+ * taxonomies sort alphabetically.
+ */
+export function buildEditorTermOptions(
+  terms: readonly Term[],
+  isHierarchical: boolean,
+): MultiSelectOption[] {
+  if (!isHierarchical) {
+    return terms
+      .map((term) => ({ value: String(term.id), label: term.name, depth: 0 }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }
+  return flattenTree(buildTermTree(terms)).map(({ term, depth }) => ({
+    value: String(term.id),
+    label: term.name,
+    depth,
+  }));
+}
+
+/**
+ * Like `buildEditorTermOptions`, but values are slugs because the
+ * entries-list term filter uses URL search params and slugs are the
+ * stable wire identifier for `entry.list.termTaxonomies`.
+ */
+export function buildFilterTermOptions(
+  terms: readonly Term[],
+  isHierarchical: boolean,
+): MultiSelectOption[] {
+  if (!isHierarchical) {
+    return terms
+      .map((term) => ({ value: term.slug, label: term.name, depth: 0 }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }
+  return flattenTree(buildTermTree(terms)).map(({ term, depth }) => ({
+    value: term.slug,
+    label: term.name,
+    depth,
+  }));
+}

--- a/packages/admin/src/routes/__root.tsx
+++ b/packages/admin/src/routes/__root.tsx
@@ -38,7 +38,7 @@ function useDocumentTitle(): void {
   useEffect(() => {
     const crumbs = pathToCrumbs(pathname);
     const leaf = crumbs[crumbs.length - 1];
-    document.title = leaf ? `${leaf} · ${TITLE_BRAND}` : TITLE_BRAND;
+    document.title = leaf ? `${leaf.label} · ${TITLE_BRAND}` : TITLE_BRAND;
   }, [pathname]);
 }
 

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -1,11 +1,9 @@
-import type { MultiSelectOption } from "@/components/form/multi-select.js";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { DataTable } from "@/components/data-table/data-table.js";
 import { MultiSelect } from "@/components/form/multi-select.js";
 import { DebouncedSearchInput } from "@/components/form/search-input.js";
-import { buildTermTree, flattenTree } from "@/components/taxonomy/tree.js";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -36,6 +34,7 @@ import { hasCap } from "@/lib/caps.js";
 import { toDate } from "@/lib/dates.js";
 import { findEntryTypeBySlug, findTermTaxonomyByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { buildFilterTermOptions } from "@/lib/terms.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -783,19 +782,11 @@ function TaxonomyFilter({
     }),
   );
   const isHierarchical = taxonomy?.isHierarchical === true;
-  const options = useMemo<MultiSelectOption[]>(() => {
-    const terms: readonly Term[] = termsQuery.data ?? EMPTY_TERMS;
-    if (!isHierarchical) {
-      return terms
-        .map((term) => ({ value: term.slug, label: term.name, depth: 0 }))
-        .sort((a, b) => a.label.localeCompare(b.label));
-    }
-    return flattenTree(buildTermTree(terms)).map(({ term, depth }) => ({
-      value: term.slug,
-      label: term.name,
-      depth,
-    }));
-  }, [termsQuery.data, isHierarchical]);
+  const options = useMemo(
+    () =>
+      buildFilterTermOptions(termsQuery.data ?? EMPTY_TERMS, isHierarchical),
+    [termsQuery.data, isHierarchical],
+  );
 
   const pluralLower = (taxonomy?.label ?? taxonomyName).toLowerCase();
   return (

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -11,12 +11,13 @@ import {
   Empty,
   EmptyDescription,
   EmptyHeader,
+  EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import { visibleEntryTypes } from "@/lib/manifest.js";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRight, FileText } from "lucide-react";
+import { ArrowRight, FileText, Puzzle } from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated/")({
   component: DashboardIndex,
@@ -79,6 +80,9 @@ function DashboardIndex(): ReactNode {
         <Card className="max-w-xl" data-testid="dashboard-empty-state">
           <Empty>
             <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Puzzle />
+              </EmptyMedia>
               <EmptyTitle>No content types yet</EmptyTitle>
               <EmptyDescription>
                 Add a plugin that registers a post type (e.g.{" "}

--- a/packages/admin/src/routes/_authenticated/settings/index.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.tsx
@@ -10,11 +10,13 @@ import {
   Empty,
   EmptyDescription,
   EmptyHeader,
+  EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty.js";
 import { hasCap } from "@/lib/caps.js";
 import { visibleSettingsPages } from "@/lib/manifest.js";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { Settings as SettingsIcon } from "lucide-react";
 
 function pageSummary(groupCount: number): string {
   return `${groupCount} ${groupCount === 1 ? "group" : "groups"}`;
@@ -47,6 +49,9 @@ function SettingsIndexRoute(): ReactNode {
         <Card data-testid="settings-empty-state">
           <Empty>
             <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <SettingsIcon />
+              </EmptyMedia>
               <EmptyTitle>No settings registered yet</EmptyTitle>
               <EmptyDescription>
                 Core ships no settings by design — plugins (or your own

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -8,8 +8,13 @@ import {
 import { Skeleton } from "@/components/ui/skeleton.js";
 import { hasCap } from "@/lib/caps.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
-import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
+import {
+  entryMetaBoxesForType,
+  findEntryTypeBySlug,
+  visibleTermTaxonomies,
+} from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { filterTermsForEntryType } from "@/lib/terms.js";
 import {
   useMutation,
   useQueryClient,
@@ -98,6 +103,7 @@ function EditPostRoute(): ReactNode {
         excerpt: input.excerpt.length > 0 ? input.excerpt : null,
         status: input.status,
         meta: input.meta,
+        terms: filterTermsForEntryType(input.terms, entryType.termTaxonomies),
       }),
     onMutate: () => {
       setServerError(null);
@@ -128,6 +134,12 @@ function EditPostRoute(): ReactNode {
     () => entryMetaBoxesForType(entryType.name, user.capabilities),
     [entryType.name, user.capabilities],
   );
+  const taxonomies = useMemo(() => {
+    const allowed = new Set(entryType.termTaxonomies ?? []);
+    return visibleTermTaxonomies(user.capabilities).filter((t) =>
+      allowed.has(t.name),
+    );
+  }, [entryType.termTaxonomies, user.capabilities]);
 
   const capNamespace = `entry:${entryType.capabilityType ?? entryType.name}`;
   const canEditAny = hasCap(user.capabilities, `${capNamespace}:edit_any`);
@@ -161,6 +173,7 @@ function EditPostRoute(): ReactNode {
       availableStatuses={POST_EDITOR_STATUSES}
       supports={entryType.supports}
       metaBoxes={metaBoxes}
+      taxonomies={taxonomies}
       headline={`Edit ${singularLower}`}
       submitLabel="Save"
       // For the edit path, the post-save remount (keyed on
@@ -184,7 +197,9 @@ function EditPostRoute(): ReactNode {
   );
 }
 
-function toEditorValues(post: Entry): PostEditorValues {
+function toEditorValues(
+  post: Entry & { terms?: Record<string, readonly number[]> },
+): PostEditorValues {
   return {
     title: post.title,
     slug: post.slug,
@@ -192,6 +207,9 @@ function toEditorValues(post: Entry): PostEditorValues {
     excerpt: post.excerpt ?? "",
     status: post.status,
     meta: post.meta,
+    terms: Object.fromEntries(
+      Object.entries(post.terms ?? {}).map(([k, v]) => [k, [...v]]),
+    ),
   };
 }
 

--- a/packages/admin/src/routes/_editor/entries/$slug/create.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/create.tsx
@@ -4,8 +4,13 @@ import { useMemo, useState } from "react";
 import { PostEditorForm } from "@/components/editor/entry-editor-form.js";
 import { hasCap } from "@/lib/caps.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
-import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
+import {
+  entryMetaBoxesForType,
+  findEntryTypeBySlug,
+  visibleTermTaxonomies,
+} from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { filterTermsForEntryType } from "@/lib/terms.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -67,6 +72,7 @@ function NewPostRoute(): ReactNode {
         excerpt: input.excerpt.length > 0 ? input.excerpt : null,
         status: input.status,
         meta: input.meta,
+        terms: filterTermsForEntryType(input.terms, entryType.termTaxonomies),
       }),
     onMutate: () => {
       setServerError(null);
@@ -94,6 +100,7 @@ function NewPostRoute(): ReactNode {
     excerpt: "",
     status: "draft",
     meta: {},
+    terms: {},
   };
 
   // Meta boxes registered for this post type, filtered by the user's
@@ -103,6 +110,14 @@ function NewPostRoute(): ReactNode {
     () => entryMetaBoxesForType(entryType.name, user.capabilities),
     [entryType.name, user.capabilities],
   );
+  // Taxonomies registered against this entry type AND visible to the
+  // viewer. The form renders one rail section per taxonomy.
+  const taxonomies = useMemo(() => {
+    const allowed = new Set(entryType.termTaxonomies ?? []);
+    return visibleTermTaxonomies(user.capabilities).filter((t) =>
+      allowed.has(t.name),
+    );
+  }, [entryType.termTaxonomies, user.capabilities]);
 
   const singularLower = (
     entryType.labels?.singular ?? entryType.label
@@ -115,6 +130,7 @@ function NewPostRoute(): ReactNode {
       availableStatuses={NEW_POST_STATUSES}
       supports={entryType.supports}
       metaBoxes={metaBoxes}
+      taxonomies={taxonomies}
       headline={`New ${singularLower}`}
       submitLabel="Create"
       // Stay "busy" through `isSuccess` too — TanStack Query flips

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -24,13 +24,19 @@ import type {
   UserUpdateInput,
 } from "./procedures/user/schemas.js";
 
+// `entry.get` enriches the row with the assigned term ids per
+// taxonomy. Plugins editing the output filter receive this shape.
+type EntryWithTerms = Entry & {
+  readonly terms: Record<string, readonly number[]>;
+};
+
 declare module "../hooks/types.js" {
   interface FilterRegistry {
     "rpc:entry.list:input": (input: EntryListInput) => EntryListInput;
     "rpc:entry.list:output": (output: readonly Entry[]) => readonly Entry[];
 
     "rpc:entry.get:input": (input: { id: number }) => typeof input;
-    "rpc:entry.get:output": (output: Entry) => Entry;
+    "rpc:entry.get:output": (output: EntryWithTerms) => EntryWithTerms;
 
     "rpc:entry.create:input": (input: EntryCreateInput) => EntryCreateInput;
     "rpc:entry.create:output": (output: Entry) => Entry;

--- a/packages/core/src/rpc/procedures/entry/create.ts
+++ b/packages/core/src/rpc/procedures/entry/create.ts
@@ -17,6 +17,7 @@ import {
   writeEntryMeta,
 } from "./meta.js";
 import { entryCreateInputSchema } from "./schemas.js";
+import { applyTermPatch, assertTermsPatchValid } from "./terms.js";
 
 export const create = base
   .use(authenticated)
@@ -65,6 +66,25 @@ export const create = base
       errors,
     );
 
+    // Same up-front validation: a bad term reference shouldn't leave a
+    // half-created entry behind.
+    const termsPatch = filtered.terms;
+    if (termsPatch !== undefined) {
+      await assertTermsPatchValid(context, termsPatch, {
+        taxonomyNotFound: (taxonomy) => {
+          throw errors.NOT_FOUND({
+            data: { kind: "termTaxonomy", id: taxonomy },
+          });
+        },
+        forbidden: (capability) => {
+          throw errors.FORBIDDEN({ data: { capability } });
+        },
+        termTaxonomyMismatch: () => {
+          throw errors.CONFLICT({ data: { reason: "term_taxonomy_mismatch" } });
+        },
+      });
+    }
+
     const candidate: NewEntry = {
       type: filtered.type,
       title: filtered.title,
@@ -94,6 +114,10 @@ export const create = base
 
     if (!created) {
       throw errors.CONFLICT({ data: { reason: "slug_taken" } });
+    }
+
+    if (termsPatch !== undefined) {
+      await applyTermPatch(context, created.id, termsPatch);
     }
 
     let meta: Record<string, unknown>;

--- a/packages/core/src/rpc/procedures/entry/get.ts
+++ b/packages/core/src/rpc/procedures/entry/get.ts
@@ -5,6 +5,7 @@ import { base } from "../../base.js";
 import { entryCapability } from "./lifecycle.js";
 import { decodeMetaBag } from "./meta.js";
 import { entryGetInputSchema } from "./schemas.js";
+import { loadEntryTerms } from "./terms.js";
 
 export const get = base
   .use(authenticated)
@@ -37,5 +38,10 @@ export const get = base
     }
 
     const meta = decodeMetaBag(context.plugins, row, row.meta);
-    return context.hooks.applyFilter("rpc:entry.get:output", { ...row, meta });
+    const terms = await loadEntryTerms(context, row.id);
+    return context.hooks.applyFilter("rpc:entry.get:output", {
+      ...row,
+      meta,
+      terms,
+    });
   });

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -78,6 +78,7 @@ export const entryCreateInputSchema = v.object({
   excerpt: v.optional(excerptSchema),
   status: v.optional(userSuppliableFields.entries.status, "draft"),
   menuOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+  terms: v.optional(postTermsSchema),
   meta: v.optional(entryMetaInputSchema),
 });
 

--- a/packages/core/src/rpc/procedures/entry/terms.ts
+++ b/packages/core/src/rpc/procedures/entry/terms.ts
@@ -1,0 +1,135 @@
+import type { AppContext } from "../../../context/app.js";
+import { and, eq, inArray } from "../../../db/index.js";
+import { entryTerm } from "../../../db/schema/entry_term.js";
+import { terms } from "../../../db/schema/terms.js";
+
+// Errors a `terms` patch can raise. Helpers receive callable throwers
+// so the orpc-typed `errors` map at the handler call-site doesn't have
+// to leak its concrete shape into shared code.
+interface TermPatchThrowers {
+  taxonomyNotFound(taxonomy: string): never;
+  forbidden(capability: string): never;
+  termTaxonomyMismatch(): never;
+}
+
+/**
+ * Validate a `terms` patch from an entry create/update payload:
+ * - every taxonomy must be registered with core
+ * - the caller must hold `term:<taxonomy>:assign` for each taxonomy
+ *   that appears in the patch
+ * - each (taxonomy, termId) pair must reference an existing term in
+ *   that taxonomy (catches cross-taxonomy id reuse and stale ids)
+ *
+ * Pure validation — no writes happen here. Callers run this before
+ * inserting the entry row so a bad patch fails up-front rather than
+ * leaving an orphaned entry behind.
+ */
+export async function assertTermsPatchValid(
+  context: AppContext,
+  termsPatch: Record<string, readonly number[]>,
+  throwers: TermPatchThrowers,
+): Promise<void> {
+  for (const taxonomy of Object.keys(termsPatch)) {
+    if (!context.plugins.termTaxonomies.has(taxonomy)) {
+      throwers.taxonomyNotFound(taxonomy);
+    }
+    if (!context.auth.can(`term:${taxonomy}:assign`)) {
+      throwers.forbidden(`term:${taxonomy}:assign`);
+    }
+  }
+  for (const [taxonomy, termIds] of Object.entries(termsPatch)) {
+    const unique = Array.from(new Set(termIds));
+    if (unique.length === 0) continue;
+    const rows = await context.db
+      .select({ id: terms.id })
+      .from(terms)
+      .where(and(eq(terms.taxonomy, taxonomy), inArray(terms.id, unique)));
+    if (rows.length !== unique.length) {
+      throwers.termTaxonomyMismatch();
+    }
+  }
+}
+
+/**
+ * Replace `entry_term` rows for every (entryId, taxonomy) pair in the
+ * patch. Each taxonomy is rewritten independently — taxonomies absent
+ * from the patch keep their existing assignments. An empty array
+ * clears the taxonomy's assignments without touching the others.
+ */
+export async function applyTermPatch(
+  context: AppContext,
+  entryId: number,
+  termsPatch: Record<string, readonly number[]>,
+): Promise<void> {
+  for (const [taxonomy, termIds] of Object.entries(termsPatch)) {
+    const unique = Array.from(new Set(termIds));
+    // Scope the delete to rows whose term belongs to this taxonomy — saves a
+    // per-term round-trip and avoids accidentally wiping another taxonomy's
+    // rows in the same entry_term table.
+    const existingAssignments = await context.db
+      .select({ termId: entryTerm.termId })
+      .from(entryTerm)
+      .innerJoin(terms, eq(entryTerm.termId, terms.id))
+      .where(and(eq(entryTerm.entryId, entryId), eq(terms.taxonomy, taxonomy)));
+    if (existingAssignments.length > 0) {
+      const ids = existingAssignments.map((r) => r.termId);
+      await context.db
+        .delete(entryTerm)
+        .where(
+          and(eq(entryTerm.entryId, entryId), inArray(entryTerm.termId, ids)),
+        );
+    }
+
+    if (unique.length > 0) {
+      // onConflictDoNothing handles the race where a concurrent write beat us
+      // to inserting the same (entryId, termId) row — the desired end state
+      // (row exists) is reached regardless of which request inserted it.
+      await context.db
+        .insert(entryTerm)
+        .values(
+          unique.map((termId, index) => ({
+            entryId,
+            termId,
+            sortOrder: index,
+          })),
+        )
+        .onConflictDoNothing({
+          target: [entryTerm.entryId, entryTerm.termId],
+        });
+    }
+  }
+}
+
+/**
+ * Load the assigned term ids per taxonomy for an entry, shaped for
+ * the wire as `{ [taxonomy]: number[] }`. Empty taxonomies are
+ * omitted; ordering matches the `entry_term.sortOrder` the editor
+ * persisted.
+ */
+export async function loadEntryTerms(
+  context: AppContext,
+  entryId: number,
+): Promise<Record<string, number[]>> {
+  const rows = await context.db
+    .select({
+      taxonomy: terms.taxonomy,
+      termId: entryTerm.termId,
+      sortOrder: entryTerm.sortOrder,
+    })
+    .from(entryTerm)
+    .innerJoin(terms, eq(entryTerm.termId, terms.id))
+    .where(eq(entryTerm.entryId, entryId));
+
+  const grouped: Record<string, { termId: number; sortOrder: number }[]> = {};
+  for (const row of rows) {
+    const bucket = (grouped[row.taxonomy] ??= []);
+    bucket.push({ termId: row.termId, sortOrder: row.sortOrder });
+  }
+
+  const out: Record<string, number[]> = {};
+  for (const [taxonomy, items] of Object.entries(grouped)) {
+    items.sort((a, b) => a.sortOrder - b.sortOrder);
+    out[taxonomy] = items.map((i) => i.termId);
+  }
+  return out;
+}

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -1,15 +1,6 @@
-import type { AppContext } from "../../../context/app.js";
 import type { NewEntry } from "../../../db/schema/entries.js";
-import {
-  and,
-  eq,
-  inArray,
-  isUniqueConstraintError,
-  ne,
-} from "../../../db/index.js";
+import { and, eq, isUniqueConstraintError, ne } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
-import { entryTerm } from "../../../db/schema/entry_term.js";
-import { terms } from "../../../db/schema/terms.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { isEmptyMetaPatch } from "../../meta/core.js";
@@ -31,6 +22,7 @@ import {
   writeEntryMeta,
 } from "./meta.js";
 import { entryUpdateInputSchema } from "./schemas.js";
+import { applyTermPatch, assertTermsPatchValid } from "./terms.js";
 
 export const update = base
   .use(authenticated)
@@ -111,28 +103,19 @@ export const update = base
       errors,
     );
     if (termsPatch !== undefined) {
-      for (const taxonomy of Object.keys(termsPatch)) {
-        if (!context.plugins.termTaxonomies.has(taxonomy)) {
+      await assertTermsPatchValid(context, termsPatch, {
+        taxonomyNotFound: (taxonomy) => {
           throw errors.NOT_FOUND({
             data: { kind: "termTaxonomy", id: taxonomy },
           });
-        }
-        const assignCap = `term:${taxonomy}:assign`;
-        if (!context.auth.can(assignCap)) {
-          throw errors.FORBIDDEN({ data: { capability: assignCap } });
-        }
-      }
-      for (const [taxonomy, termIds] of Object.entries(termsPatch)) {
-        const unique = Array.from(new Set(termIds));
-        if (unique.length === 0) continue;
-        const rows = await context.db
-          .select({ id: terms.id })
-          .from(terms)
-          .where(and(eq(terms.taxonomy, taxonomy), inArray(terms.id, unique)));
-        if (rows.length !== unique.length) {
+        },
+        forbidden: (capability) => {
+          throw errors.FORBIDDEN({ data: { capability } });
+        },
+        termTaxonomyMismatch: () => {
           throw errors.CONFLICT({ data: { reason: "term_taxonomy_mismatch" } });
-        }
-      }
+        },
+      });
     }
 
     const patch: Partial<NewEntry> = stripUndefined(changes);
@@ -232,50 +215,3 @@ export const update = base
       meta,
     });
   });
-
-/** Replace post_term rows for every (entryId, taxonomy) pair in the patch. */
-async function applyTermPatch(
-  context: AppContext,
-  entryId: number,
-  termsPatch: Record<string, readonly number[]>,
-): Promise<void> {
-  for (const [taxonomy, termIds] of Object.entries(termsPatch)) {
-    const unique = Array.from(new Set(termIds));
-    // Scope the delete to rows whose term belongs to this taxonomy — saves
-    // a per-term round-trip and avoids accidentally wiping another taxonomy's
-    // rows in the same post_term table.
-    const existingAssignments = await context.db
-      .select({ termId: entryTerm.termId })
-      .from(entryTerm)
-      .innerJoin(terms, eq(entryTerm.termId, terms.id))
-      .where(and(eq(entryTerm.entryId, entryId), eq(terms.taxonomy, taxonomy)));
-    if (existingAssignments.length > 0) {
-      const ids = existingAssignments.map((r) => r.termId);
-      await context.db
-        .delete(entryTerm)
-        .where(
-          and(eq(entryTerm.entryId, entryId), inArray(entryTerm.termId, ids)),
-        );
-    }
-
-    if (unique.length > 0) {
-      // onConflictDoNothing handles the race where a concurrent update
-      // beat us to inserting the same (entryId, termId) row — the desired
-      // end state (row exists) is reached regardless of which request
-      // inserted it. Without this, the second request would bubble a PK
-      // violation up as a 500.
-      await context.db
-        .insert(entryTerm)
-        .values(
-          unique.map((termId, index) => ({
-            entryId,
-            termId,
-            sortOrder: index,
-          })),
-        )
-        .onConflictDoNothing({
-          target: [entryTerm.entryId, entryTerm.termId],
-        });
-    }
-  }
-}


### PR DESCRIPTION
## Summary

End-to-end taxonomy assignment in the entry editor. Plugins that declare \`termTaxonomies\` on an entry type now get a Combobox-based picker per taxonomy in the editor's right rail.

### Server

- \`entry.create\` accepts \`terms: { [taxonomy]: number[] }\` (already on \`entry.update\`). Up-front validation: every taxonomy must be registered, the caller must hold \`term:<name>:assign\`, and each \`(taxonomy, termId)\` pair must point at a real term in that taxonomy — fails before the entry is inserted so we never leave an orphaned row.
- \`entry.get\` enriches the response with a \`terms\` map of assigned ids per taxonomy, ordered by \`entry_term.sortOrder\`.
- Validation + insert + load logic lives in \`packages/core/src/rpc/procedures/entry/terms.ts\` and is reused from \`update.ts\`, \`create.ts\`, and \`get.ts\` — no duplication.
- Hook signature for \`rpc:entry.get:output\` widened to \`EntryWithTerms\` so plugin filters can decorate or redact term assignments alongside the row.

### Admin

- Editor form schema gains \`terms: Record<string, number[]>\`. New \`TaxonomySection\` rail component renders one shadcn-Combobox multi-select per taxonomy registered against the entry type, with typeahead search. Term list comes from \`term.list\`; hierarchical taxonomies render with depth-indented options, flat taxonomies sort alphabetically.
- Create / edit routes thread \`taxonomies\` and term assignments through the form; submit narrows the bag to the entry type's registered taxonomies before sending so a stale URL/state can't smuggle in unrelated taxonomies.

Bundles closed PR #82's work too: clickable breadcrumbs (Crumb[] with optional \`to\`, non-leaf crumbs render as Links), editor title placeholder restoration (\`"Title"\`), and empty-state icons on Settings + Dashboard.

## Test plan

- [x] admin: lint ✓ · typecheck ✓ · 96 unit tests ✓ · format ✓
- [x] core: typecheck ✓ · 615 unit tests ✓ · format ✓
- [x] knip exit 0 ✓
- [x] 53 playwright e2e ✓ in 12.5s

## Out of scope (named follow-ups)

- Empty-state icons across the remaining list-page empties (entries, users, terms, settings/$page).
- Editor title hover/focus underline so the field signals editability after the user clears the placeholder.
- Users-list row click + Edit/Trash hover actions for parity with entries.
- Deployed-build redirect to \`/admin/\` on direct deep-link URLs — needs a browser network tab to triage.