### PR TITLE
feat(admin,core): parent-page picker in the entry editor

### DIFF
--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -57,7 +57,6 @@ import { slugify } from "@plumix/core/slugify";
 import { idParam } from "@plumix/core/validation";
 
 import type { ParentPickerOption } from "./entry-tree.js";
-
 import { TiptapEditor } from "./tiptap-editor.js";
 
 // Stable empty fallbacks — react-query returns a fresh `[]` for

--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -54,6 +54,9 @@ import type {
 } from "@plumix/core/manifest";
 import type { EntryStatus, Term } from "@plumix/core/schema";
 import { slugify } from "@plumix/core/slugify";
+import { idParam } from "@plumix/core/validation";
+
+import type { ParentPickerOption } from "./entry-tree.js";
 
 import { TiptapEditor } from "./tiptap-editor.js";
 
@@ -98,6 +101,9 @@ const postEditorSchema = v.object({
    * plugin-added taxonomy doesn't require a schema update.
    */
   terms: v.record(v.string(), v.array(v.number())),
+  /** `null` means root. Hidden for non-hierarchical types — the field
+   *  stays at `null` and the route's mutation skips it. */
+  parentId: v.nullable(idParam),
 });
 
 export type PostEditorValues = v.InferOutput<typeof postEditorSchema>;
@@ -143,6 +149,12 @@ interface PostEditorFormProps {
    *  is rendered per taxonomy, with a Combobox-based multi-select
    *  populated from `term.list`. */
   readonly taxonomies: readonly TermTaxonomyManifestEntry[];
+  /** When true, render the Parent rail section. Pages are hierarchical;
+   *  posts are not. */
+  readonly isHierarchical: boolean;
+  /** Depth-indented options. Edit route excludes self+descendants for
+   *  cycle prevention. Ignored when `isHierarchical` is false. */
+  readonly parentOptions: readonly ParentPickerOption[];
   /** Caption shown next to the back button — e.g. `"New post"` or
    *  `"Edit post"`. The editor itself is the page, so there's no
    *  separate `<h1>` above it. */
@@ -161,6 +173,8 @@ export function PostEditorForm({
   supports,
   metaBoxes,
   taxonomies,
+  isHierarchical,
+  parentOptions,
   headline,
   submitLabel,
   isSubmitting,
@@ -217,6 +231,7 @@ export function PostEditorForm({
   const openSections = [
     ...(showSlug ? ["permalink"] : []),
     "status",
+    ...(isHierarchical ? ["parent"] : []),
     ...(showExcerpt ? ["excerpt"] : []),
     ...taxonomies.map((tax) => `taxonomy:${tax.name}`),
     ...metaBoxes.map((box) => box.id),
@@ -322,6 +337,12 @@ export function PostEditorForm({
                   availableStatuses={availableStatuses}
                   disabled={isSubmitting}
                 />
+                {isHierarchical ? (
+                  <ParentSection
+                    parentOptions={parentOptions}
+                    disabled={isSubmitting}
+                  />
+                ) : null}
                 {showExcerpt ? (
                   <ExcerptSection disabled={isSubmitting} />
                 ) : null}
@@ -539,6 +560,50 @@ function StatusSection({
                 {availableStatuses.map((status) => (
                   <option key={status} value={status} className="capitalize">
                     {capitalize(status)}
+                  </option>
+                ))}
+              </select>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </RailSection>
+  );
+}
+
+function ParentSection({
+  parentOptions,
+  disabled,
+}: {
+  readonly parentOptions: readonly ParentPickerOption[];
+  readonly disabled: boolean;
+}): ReactNode {
+  const { control } = useFormContext<PostEditorValues>();
+  return (
+    <RailSection value="parent" title="Parent">
+      <FormField
+        control={control}
+        name="parentId"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="sr-only">Parent</FormLabel>
+            <FormControl>
+              <select
+                value={field.value == null ? "" : String(field.value)}
+                onBlur={field.onBlur}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  field.onChange(raw === "" ? null : Number(raw));
+                }}
+                disabled={disabled}
+                data-testid="post-editor-parent-select"
+                className="border-input bg-background focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">— root —</option>
+                {parentOptions.map((opt) => (
+                  <option key={opt.id} value={String(opt.id)}>
+                    {opt.label}
                   </option>
                 ))}
               </select>

--- a/packages/admin/src/components/editor/entry-tree.test.ts
+++ b/packages/admin/src/components/editor/entry-tree.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+
+import type { Entry } from "@plumix/core/schema";
+
+import {
+  buildEntryTree,
+  descendantIds,
+  flattenTree,
+  parentPickerOptions,
+} from "./entry-tree.js";
+
+function entry(
+  overrides: Partial<Entry> & { id: number; title: string },
+): Entry {
+  const now = new Date(0);
+  return {
+    type: "page",
+    parentId: null,
+    slug: overrides.title.toLowerCase().replaceAll(" ", "-"),
+    content: null,
+    excerpt: null,
+    status: "published",
+    authorId: 1,
+    menuOrder: 0,
+    meta: {},
+    publishedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("buildEntryTree", () => {
+  test("empty input yields an empty forest", () => {
+    expect(buildEntryTree([])).toEqual([]);
+  });
+
+  test("roots are entries with null parentId, sorted by title", () => {
+    const tree = buildEntryTree([
+      entry({ id: 1, title: "About" }),
+      entry({ id: 2, title: "Contact" }),
+    ]);
+    expect(tree.map((n) => n.entry.title)).toEqual(["About", "Contact"]);
+  });
+
+  test("nests children under their parent", () => {
+    const tree = buildEntryTree([
+      entry({ id: 1, title: "About" }),
+      entry({ id: 2, title: "Team", parentId: 1 }),
+      entry({ id: 3, title: "Eng", parentId: 2 }),
+    ]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.entry.title).toBe("About");
+    expect(tree[0]?.children[0]?.entry.title).toBe("Team");
+    expect(tree[0]?.children[0]?.children[0]?.entry.title).toBe("Eng");
+  });
+
+  test("orphan promotion: parentId pointing outside the set → rendered at root", () => {
+    const tree = buildEntryTree([
+      entry({ id: 5, title: "Orphan", parentId: 999 }),
+    ]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.entry.id).toBe(5);
+  });
+
+  test("untitled entries don't crash and still appear in the tree", () => {
+    const tree = buildEntryTree([
+      entry({ id: 1, title: "" }),
+      entry({ id: 2, title: "About" }),
+    ]);
+    expect(tree).toHaveLength(2);
+    expect(tree.map((n) => n.entry.id).sort()).toEqual([1, 2]);
+  });
+});
+
+describe("flattenTree", () => {
+  test("DFS preserves order and carries depth", () => {
+    const tree = buildEntryTree([
+      entry({ id: 1, title: "About" }),
+      entry({ id: 2, title: "Team", parentId: 1 }),
+      entry({ id: 3, title: "Eng", parentId: 2 }),
+      entry({ id: 4, title: "Press", parentId: 1 }),
+    ]);
+    const flat = flattenTree(tree);
+    expect(flat.map((n) => [n.entry.title, n.depth])).toEqual([
+      ["About", 0],
+      ["Press", 1],
+      ["Team", 1],
+      ["Eng", 2],
+    ]);
+  });
+});
+
+describe("descendantIds", () => {
+  test("includes the root itself plus every descendant", () => {
+    const entries: Entry[] = [
+      entry({ id: 1, title: "About" }),
+      entry({ id: 2, title: "Team", parentId: 1 }),
+      entry({ id: 3, title: "Eng", parentId: 2 }),
+      entry({ id: 4, title: "Press", parentId: 1 }),
+    ];
+    expect([...descendantIds(entries, 1)].sort()).toEqual([1, 2, 3, 4]);
+    expect([...descendantIds(entries, 2)].sort()).toEqual([2, 3]);
+    expect([...descendantIds(entries, 3)].sort()).toEqual([3]);
+  });
+
+  test("rootId not in the tree → empty set (caller must backstop with self id)", () => {
+    expect(descendantIds([entry({ id: 1, title: "About" })], 999)).toEqual(
+      new Set(),
+    );
+  });
+
+  test("empty input is safe", () => {
+    expect(descendantIds([], 1)).toEqual(new Set());
+  });
+});
+
+describe("parentPickerOptions", () => {
+  test("returns all entries with depth-prefixed labels", () => {
+    const entries: Entry[] = [
+      entry({ id: 1, title: "About" }),
+      entry({ id: 2, title: "Team", parentId: 1 }),
+      entry({ id: 3, title: "Eng", parentId: 2 }),
+    ];
+    expect(parentPickerOptions(entries)).toEqual([
+      { id: 1, label: "About" },
+      { id: 2, label: "— Team" },
+      { id: 3, label: "— — Eng" },
+    ]);
+  });
+
+  test("respects the exclude set (self + descendants for cycle prevention)", () => {
+    const entries: Entry[] = [
+      entry({ id: 1, title: "About" }),
+      entry({ id: 2, title: "Team", parentId: 1 }),
+      entry({ id: 3, title: "Eng", parentId: 2 }),
+      entry({ id: 4, title: "Press", parentId: 1 }),
+    ];
+    const ids = parentPickerOptions(entries, new Set([2, 3])).map((o) => o.id);
+    expect(ids).toEqual([1, 4]);
+  });
+
+  test("falls back to a placeholder label when the title is empty", () => {
+    const entries: Entry[] = [entry({ id: 1, title: "" })];
+    expect(parentPickerOptions(entries)).toEqual([
+      { id: 1, label: "(no title)" },
+    ]);
+  });
+});

--- a/packages/admin/src/components/editor/entry-tree.ts
+++ b/packages/admin/src/components/editor/entry-tree.ts
@@ -1,0 +1,103 @@
+import type { Entry } from "@plumix/core/schema";
+
+interface EntryNode {
+  readonly entry: Entry;
+  readonly children: readonly EntryNode[];
+}
+
+const UNTITLED_PLACEHOLDER = "(no title)";
+
+function entryLabel(entry: Entry): string {
+  const trimmed = entry.title.trim();
+  return trimmed.length > 0 ? trimmed : UNTITLED_PLACEHOLDER;
+}
+
+// Orphans (children whose parent isn't in the input set) get promoted
+// to roots so a paginated `entry.list` page never silently drops rows.
+export function buildEntryTree(entries: readonly Entry[]): readonly EntryNode[] {
+  const byId = new Map<number, Entry>();
+  for (const e of entries) byId.set(e.id, e);
+
+  const childMap = new Map<number | null, Entry[]>();
+  for (const e of entries) {
+    const parentKey =
+      e.parentId != null && byId.has(e.parentId) ? e.parentId : null;
+    const bucket = childMap.get(parentKey) ?? [];
+    bucket.push(e);
+    childMap.set(parentKey, bucket);
+  }
+
+  for (const bucket of childMap.values()) {
+    bucket.sort((a, b) => entryLabel(a).localeCompare(entryLabel(b)));
+  }
+
+  function build(parentId: number | null): EntryNode[] {
+    const bucket = childMap.get(parentId) ?? [];
+    return bucket.map((e) => ({ entry: e, children: build(e.id) }));
+  }
+  return build(null);
+}
+
+interface FlatEntryNode {
+  readonly entry: Entry;
+  readonly depth: number;
+}
+
+export function flattenTree(
+  tree: readonly EntryNode[],
+  depth = 0,
+): readonly FlatEntryNode[] {
+  const out: FlatEntryNode[] = [];
+  for (const node of tree) {
+    out.push({ entry: node.entry, depth });
+    out.push(...flattenTree(node.children, depth + 1));
+  }
+  return out;
+}
+
+export function descendantIds(
+  entries: readonly Entry[],
+  rootId: number,
+): ReadonlySet<number> {
+  const tree = buildEntryTree(entries);
+  const ids = new Set<number>();
+  function visit(nodes: readonly EntryNode[]): void {
+    for (const node of nodes) {
+      ids.add(node.entry.id);
+      visit(node.children);
+    }
+  }
+  function findAndVisit(nodes: readonly EntryNode[]): boolean {
+    for (const node of nodes) {
+      if (node.entry.id === rootId) {
+        ids.add(node.entry.id);
+        visit(node.children);
+        return true;
+      }
+      if (findAndVisit(node.children)) return true;
+    }
+    return false;
+  }
+  findAndVisit(tree);
+  return ids;
+}
+
+export interface ParentPickerOption {
+  readonly id: number;
+  readonly label: string;
+}
+
+export function parentPickerOptions(
+  entries: readonly Entry[],
+  exclude: ReadonlySet<number> = new Set(),
+): readonly ParentPickerOption[] {
+  return flattenTree(buildEntryTree(entries))
+    .filter((entry) => !exclude.has(entry.entry.id))
+    .map((entry) => ({
+      id: entry.entry.id,
+      label:
+        entry.depth === 0
+          ? entryLabel(entry.entry)
+          : `${"— ".repeat(entry.depth)}${entryLabel(entry.entry)}`,
+    }));
+}

--- a/packages/admin/src/components/editor/entry-tree.ts
+++ b/packages/admin/src/components/editor/entry-tree.ts
@@ -14,7 +14,9 @@ function entryLabel(entry: Entry): string {
 
 // Orphans (children whose parent isn't in the input set) get promoted
 // to roots so a paginated `entry.list` page never silently drops rows.
-export function buildEntryTree(entries: readonly Entry[]): readonly EntryNode[] {
+export function buildEntryTree(
+  entries: readonly Entry[],
+): readonly EntryNode[] {
   const byId = new Map<number, Entry>();
   for (const e of entries) byId.set(e.id, e);
 

--- a/packages/admin/src/components/editor/use-parent-options.ts
+++ b/packages/admin/src/components/editor/use-parent-options.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { orpc } from "@/lib/orpc.js";
+import { useQuery } from "@tanstack/react-query";
+
+import type { Entry } from "@plumix/core/schema";
+
+import type { ParentPickerOption } from "./entry-tree.js";
+import { descendantIds, parentPickerOptions } from "./entry-tree.js";
+
+const EMPTY_ENTRIES: readonly Entry[] = [];
+const PARENT_PICKER_LIMIT = 100;
+
+// On edit, `excludeSelfId` removes the entry + its descendants so the
+// picker can't propose a cycle. Skipped on create. The DB allows
+// arbitrarily deep parent chains; the 100-row cap is the same one the
+// list view uses, and is enough for typical sites — sites with more
+// pages will need a search/typeahead picker, tracked separately.
+export function useParentOptions({
+  entryTypeName,
+  isHierarchical,
+  excludeSelfId,
+}: {
+  readonly entryTypeName: string;
+  readonly isHierarchical: boolean;
+  readonly excludeSelfId?: number;
+}): readonly ParentPickerOption[] {
+  const query = useQuery({
+    ...orpc.entry.list.queryOptions({
+      input: { type: entryTypeName, limit: PARENT_PICKER_LIMIT },
+    }),
+    enabled: isHierarchical,
+  });
+  return useMemo(() => {
+    if (!isHierarchical) return [];
+    const all = query.data ?? EMPTY_ENTRIES;
+    if (excludeSelfId === undefined) return parentPickerOptions(all);
+    // Backstop the descendant set with the self id — `descendantIds`
+    // returns empty when the entry isn't on the fetched page.
+    const exclude = new Set<number>(descendantIds(all, excludeSelfId));
+    exclude.add(excludeSelfId);
+    return parentPickerOptions(all, exclude);
+  }, [isHierarchical, query.data, excludeSelfId]);
+}

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -5,6 +5,7 @@ import {
   POST_EDITOR_STATUSES,
   PostEditorForm,
 } from "@/components/editor/entry-editor-form.js";
+import { useParentOptions } from "@/components/editor/use-parent-options.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import { hasCap } from "@/lib/caps.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
@@ -93,6 +94,8 @@ function EditPostRoute(): ReactNode {
     orpc.entry.get.queryOptions({ input: { id: entryId } }),
   );
 
+  const isHierarchical = entryType.isHierarchical === true;
+
   const updatePost = useMutation({
     mutationFn: (input: PostEditorValues) =>
       orpc.entry.update.call({
@@ -104,6 +107,7 @@ function EditPostRoute(): ReactNode {
         status: input.status,
         meta: input.meta,
         terms: filterTermsForEntryType(input.terms, entryType.termTaxonomies),
+        ...(isHierarchical ? { parentId: input.parentId } : {}),
       }),
     onMutate: () => {
       setServerError(null);
@@ -141,6 +145,12 @@ function EditPostRoute(): ReactNode {
     );
   }, [entryType.termTaxonomies, user.capabilities]);
 
+  const parentOptions = useParentOptions({
+    entryTypeName: entryType.name,
+    isHierarchical,
+    excludeSelfId: entryId,
+  });
+
   const capNamespace = `entry:${entryType.capabilityType ?? entryType.name}`;
   const canEditAny = hasCap(user.capabilities, `${capNamespace}:edit_any`);
   const canEditOwn =
@@ -174,6 +184,8 @@ function EditPostRoute(): ReactNode {
       supports={entryType.supports}
       metaBoxes={metaBoxes}
       taxonomies={taxonomies}
+      isHierarchical={isHierarchical}
+      parentOptions={parentOptions}
       headline={`Edit ${singularLower}`}
       submitLabel="Save"
       // For the edit path, the post-save remount (keyed on
@@ -210,6 +222,7 @@ function toEditorValues(
     terms: Object.fromEntries(
       Object.entries(post.terms ?? {}).map(([k, v]) => [k, [...v]]),
     ),
+    parentId: post.parentId,
   };
 }
 

--- a/packages/admin/src/routes/_editor/entries/$slug/create.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/create.tsx
@@ -2,6 +2,7 @@ import type { PostEditorValues } from "@/components/editor/entry-editor-form.js"
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { PostEditorForm } from "@/components/editor/entry-editor-form.js";
+import { useParentOptions } from "@/components/editor/use-parent-options.js";
 import { hasCap } from "@/lib/caps.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import {
@@ -62,6 +63,8 @@ function NewPostRoute(): ReactNode {
   const queryClient = useQueryClient();
   const [serverError, setServerError] = useState<string | null>(null);
 
+  const isHierarchical = entryType.isHierarchical === true;
+
   const createPost = useMutation({
     mutationFn: (input: PostEditorValues) =>
       orpc.entry.create.call({
@@ -73,6 +76,7 @@ function NewPostRoute(): ReactNode {
         status: input.status,
         meta: input.meta,
         terms: filterTermsForEntryType(input.terms, entryType.termTaxonomies),
+        ...(isHierarchical ? { parentId: input.parentId } : {}),
       }),
     onMutate: () => {
       setServerError(null);
@@ -101,7 +105,13 @@ function NewPostRoute(): ReactNode {
     status: "draft",
     meta: {},
     terms: {},
+    parentId: null,
   };
+
+  const parentOptions = useParentOptions({
+    entryTypeName: entryType.name,
+    isHierarchical,
+  });
 
   // Meta boxes registered for this post type, filtered by the user's
   // capabilities. Memo keyed on `user.capabilities` avoids refiltering
@@ -131,6 +141,8 @@ function NewPostRoute(): ReactNode {
       supports={entryType.supports}
       metaBoxes={metaBoxes}
       taxonomies={taxonomies}
+      isHierarchical={isHierarchical}
+      parentOptions={parentOptions}
       headline={`New ${singularLower}`}
       submitLabel="Create"
       // Stay "busy" through `isSuccess` too — TanStack Query flips

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -77,6 +77,7 @@ export const entryCreateInputSchema = v.object({
   content: v.optional(contentSchema),
   excerpt: v.optional(excerptSchema),
   status: v.optional(userSuppliableFields.entries.status, "draft"),
+  parentId: v.optional(v.nullable(idParam)),
   menuOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
   terms: v.optional(postTermsSchema),
   meta: v.optional(entryMetaInputSchema),


### PR DESCRIPTION
## Summary

Hierarchical entry types (e.g. **pages**) now expose a **Parent** select in the editor's right rail, alongside Permalink / Status / Excerpt — WP/Gutenberg parity. Non-hierarchical types (posts) keep the form unchanged.

The picker fetches up to 100 entries via `entry.list` and renders them with depth-indented labels (`— — Team`). On edit, the entry's own id and its descendants are excluded from the options to prevent obvious cycles client-side (the server also rejects them).

`entryCreateInputSchema` already accepted `parentId` via the spread of `userSuppliableFields`; promoting it to an explicit field mirrors `entryUpdateInputSchema` and pins the validator to `idParam`.

## What changed

- `entry-tree.ts` + tests — flatten/sort/exclude helpers (mirrors `taxonomy/tree.ts`, but labels by `title` and handles untitled entries)
- `use-parent-options` hook — fetch + memoize, used by both create and edit routes
- `PostEditorForm` — new `parentId` schema field, `ParentSection` rail, gated on `isHierarchical`
- `entry.create` schema — explicit `parentId: v.optional(v.nullable(idParam))`

Out of scope (follow-ups if needed):
- Picker is capped at 100 entries — a typeahead/searchable picker for sites with deeper trees
- "New child" action from the list view (pre-fills the parent on create)

## Test plan

- [x] `pnpm --filter @plumix/admin test` — 116 pass (incl. 12 new for `entry-tree`)
- [x] `pnpm --filter @plumix/core test` — 615 pass
- [x] `pnpm turbo run typecheck lint` — green
- [ ] Manual: create `/about`, then create a child page with parent = "About", verify it persists and shows on the edit form
- [ ] Manual: editing a page, confirm the parent dropdown excludes itself and its descendants
- [ ] Manual: the Parent section does not render for posts (non-hierarchical)