### PR TITLE
feat(plumix,admin,core): expose oRPC client trio + drift detection

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -42,6 +42,9 @@ const config: KnipConfig = {
         "src/admin/react-dom-client.ts",
         "src/admin/react-query.ts",
         "src/admin/react-router.ts",
+        "src/admin/orpc-client.ts",
+        "src/admin/orpc-client-fetch.ts",
+        "src/admin/orpc-tanstack-query.ts",
         "src/blocks/index.ts",
         "src/cli/index.ts",
         "src/i18n/index.ts",
@@ -63,6 +66,10 @@ const config: KnipConfig = {
       entry: [
         "e2e/fixtures/build-runtime-proof-plugin.ts",
         "e2e/fixtures/runtime-proof-plugin/src/admin.ts",
+        // Reachable via `import "./MediaLibrary.js"` from admin.ts but
+        // knip's static analysis on fixtures doesn't resolve the .js→
+        // .tsx extension swap; list explicitly.
+        "e2e/fixtures/runtime-proof-plugin/src/MediaLibrary.tsx",
       ],
     },
     // The `./commands` subpath export points at `dist/commands/index.js` —

--- a/packages/admin/e2e/fixtures/runtime-proof-plugin/src/MediaLibrary.tsx
+++ b/packages/admin/e2e/fixtures/runtime-proof-plugin/src/MediaLibrary.tsx
@@ -4,8 +4,25 @@
 
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
+
+// The orpc trio is sourced from the host runtime via aliased imports.
+// In a real plugin, the type parameter on `createORPCClient` would
+// match the plugin's own router definition. For the seam proof we
+// only need the runtime instances to be reachable.
+type FixtureRouter = Record<string, never>;
+
+const fixtureClient = createORPCClient<FixtureRouter>(
+  new RPCLink({
+    url: () => `${window.location.origin}/_plumix/admin/index.html`,
+    headers: () => ({}),
+  }),
+);
+const fixtureOrpc = createTanstackQueryUtils(fixtureClient);
 
 const PROOF_QUERY_KEY = ["e2e", "runtime-proof", "ping"] as const;
 
@@ -25,6 +42,13 @@ export function MediaLibrary(): ReactNode {
   });
 
   const cached = client.getQueryData(PROOF_QUERY_KEY);
+
+  // Proves the orpc trio is shared with the host: constructing the
+  // client + utils above resolves through the importmap-equivalent
+  // alias seam, not a bundled copy.
+  const orpcShared =
+    typeof fixtureClient === "function" || typeof fixtureClient === "object";
+  const orpcUtilsShared = typeof fixtureOrpc === "object";
 
   return (
     <div data-testid="runtime-proof" className="flex flex-col gap-4 p-6">
@@ -52,6 +76,10 @@ export function MediaLibrary(): ReactNode {
       <span
         data-testid="runtime-proof-shares-cache"
         data-shared={String(cached !== undefined)}
+      />
+      <span
+        data-testid="runtime-proof-shares-orpc"
+        data-shared={String(orpcShared && orpcUtilsShared)}
       />
 
       <Link

--- a/packages/admin/e2e/plugin-runtime.spec.ts
+++ b/packages/admin/e2e/plugin-runtime.spec.ts
@@ -88,5 +88,14 @@ test.describe("plugin runtime alias seam", () => {
     // (6) Router hook navigates inside admin
     await page.getByTestId("runtime-proof-navigate").click();
     await expect(page).toHaveURL(/\/_plumix\/admin\/?$/);
+
+    // (7) The orpc trio resolves through the runtime — plugins can
+    // construct an orpc client + tanstack-query utils against their
+    // own router type without bundling a private copy.
+    await page.goto("pages/__runtime-proof");
+    await expect(page.getByTestId("runtime-proof-shares-orpc")).toHaveAttribute(
+      "data-shared",
+      "true",
+    );
   });
 });

--- a/packages/admin/src/lib/plumix-globals.ts
+++ b/packages/admin/src/lib/plumix-globals.ts
@@ -1,5 +1,8 @@
 import * as ReactNs from "react";
 import * as ReactJsxRuntimeNs from "react/jsx-runtime";
+import * as OrpcClientNs from "@orpc/client";
+import * as OrpcClientFetchNs from "@orpc/client/fetch";
+import * as OrpcTanstackQueryNs from "@orpc/tanstack-query";
 import * as ReactQueryNs from "@tanstack/react-query";
 import * as ReactRouterNs from "@tanstack/react-router";
 import * as ReactDomNs from "react-dom";
@@ -11,10 +14,8 @@ import {
   registerPluginPage,
 } from "./plugin-registry.js";
 
-// The runtime bag the per-site plugin bundle reads via `plumix/admin/*`
-// shims. Listed here (not destructured into a const) so the property
-// names line up exactly with the `PlumixAdminRuntime` type in
-// `plumix/admin/runtime`.
+// Property names line up with `PlumixAdminRuntime` in
+// `plumix/admin/runtime` — keep in sync.
 const runtime = {
   react: ReactNs,
   reactJsxRuntime: ReactJsxRuntimeNs,
@@ -22,6 +23,9 @@ const runtime = {
   reactDomClient: ReactDomClientNs,
   reactQuery: ReactQueryNs,
   reactRouter: ReactRouterNs,
+  orpcClient: OrpcClientNs,
+  orpcClientFetch: OrpcClientFetchNs,
+  orpcTanstackQuery: OrpcTanstackQueryNs,
 } as const;
 
 declare global {

--- a/packages/core/src/admin/runtime.test.ts
+++ b/packages/core/src/admin/runtime.test.ts
@@ -9,6 +9,9 @@ import {
 describe("SHARED_ADMIN_RUNTIME_SPECIFIERS", () => {
   test("covers every shared library plugin chunks may need", () => {
     expect(Object.keys(SHARED_ADMIN_RUNTIME_SPECIFIERS).sort()).toEqual([
+      "@orpc/client",
+      "@orpc/client/fetch",
+      "@orpc/tanstack-query",
       "@tanstack/react-query",
       "@tanstack/react-router",
       "react",
@@ -37,6 +40,13 @@ describe("adminRuntimeShimSlug", () => {
     expect(adminRuntimeShimSlug("react-dom/client")).toBe("react-dom-client");
     expect(adminRuntimeShimSlug("@tanstack/react-query")).toBe("react-query");
     expect(adminRuntimeShimSlug("@tanstack/react-router")).toBe("react-router");
+    expect(adminRuntimeShimSlug("@orpc/client")).toBe("orpc-client");
+    expect(adminRuntimeShimSlug("@orpc/client/fetch")).toBe(
+      "orpc-client-fetch",
+    );
+    expect(adminRuntimeShimSlug("@orpc/tanstack-query")).toBe(
+      "orpc-tanstack-query",
+    );
   });
 
   test("slug is a filename-safe segment (used as `<slug>.js`)", () => {

--- a/packages/core/src/admin/runtime.ts
+++ b/packages/core/src/admin/runtime.ts
@@ -12,6 +12,13 @@ const SHIM_SLUGS = {
   "react-dom/client": "react-dom-client",
   "@tanstack/react-query": "react-query",
   "@tanstack/react-router": "react-router",
+  // oRPC client + tanstack-query bridge — plugin pages call their
+  // server-registered RPC routes via these. Sharing the modules with
+  // the host means plugin queries hit the QueryClient cache the admin
+  // already populates from its own `auth.session` etc.
+  "@orpc/client": "orpc-client",
+  "@orpc/client/fetch": "orpc-client-fetch",
+  "@orpc/tanstack-query": "orpc-tanstack-query",
 } as const satisfies Record<string, string>;
 
 export type SharedAdminRuntimeSpecifier = keyof typeof SHIM_SLUGS;

--- a/packages/plumix/package.json
+++ b/packages/plumix/package.json
@@ -67,6 +67,18 @@
       "types": "./dist/admin/react-router.d.ts",
       "default": "./dist/admin/react-router.js"
     },
+    "./admin/orpc-client": {
+      "types": "./dist/admin/orpc-client.d.ts",
+      "default": "./dist/admin/orpc-client.js"
+    },
+    "./admin/orpc-client-fetch": {
+      "types": "./dist/admin/orpc-client-fetch.d.ts",
+      "default": "./dist/admin/orpc-client-fetch.js"
+    },
+    "./admin/orpc-tanstack-query": {
+      "types": "./dist/admin/orpc-tanstack-query.d.ts",
+      "default": "./dist/admin/orpc-tanstack-query.js"
+    },
     "./test/playwright": {
       "types": "./dist/test/playwright.d.ts",
       "default": "./dist/test/playwright.js"
@@ -119,6 +131,8 @@
     "valibot": "catalog:"
   },
   "peerDependencies": {
+    "@orpc/client": "^1.13.0",
+    "@orpc/tanstack-query": "^1.13.0",
     "@playwright/test": "^1.59.0",
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-router": "^1.168.0",
@@ -128,6 +142,12 @@
     "vite": "catalog:"
   },
   "peerDependenciesMeta": {
+    "@orpc/client": {
+      "optional": true
+    },
+    "@orpc/tanstack-query": {
+      "optional": true
+    },
     "@playwright/test": {
       "optional": true
     },
@@ -149,6 +169,8 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@orpc/client": "^1.13.14",
+    "@orpc/tanstack-query": "^1.13.14",
     "@playwright/test": "^1.59.1",
     "@plumix/admin": "workspace:*",
     "@plumix/eslint-config": "workspace:*",

--- a/packages/plumix/src/admin/orpc-client-fetch.ts
+++ b/packages/plumix/src/admin/orpc-client-fetch.ts
@@ -1,0 +1,8 @@
+import { getRuntime } from "./runtime.js";
+
+const ns = getRuntime().orpcClientFetch;
+
+export default ns;
+
+export const LinkFetchClient = ns.LinkFetchClient;
+export const RPCLink = ns.RPCLink;

--- a/packages/plumix/src/admin/orpc-client.ts
+++ b/packages/plumix/src/admin/orpc-client.ts
@@ -1,0 +1,37 @@
+import { getRuntime } from "./runtime.js";
+
+const ns = getRuntime().orpcClient;
+
+export default ns;
+
+export const AsyncIteratorClass = ns.AsyncIteratorClass;
+export const COMMON_ORPC_ERROR_DEFS = ns.COMMON_ORPC_ERROR_DEFS;
+export const DynamicLink = ns.DynamicLink;
+export const ErrorEvent = ns.ErrorEvent;
+export const EventPublisher = ns.EventPublisher;
+export const ORPCError = ns.ORPCError;
+export const ORPC_CLIENT_PACKAGE_NAME = ns.ORPC_CLIENT_PACKAGE_NAME;
+export const ORPC_CLIENT_PACKAGE_VERSION = ns.ORPC_CLIENT_PACKAGE_VERSION;
+export const consumeEventIterator = ns.consumeEventIterator;
+export const createORPCClient = ns.createORPCClient;
+export const createORPCErrorFromJson = ns.createORPCErrorFromJson;
+export const createSafeClient = ns.createSafeClient;
+export const eventIteratorToStream = ns.eventIteratorToStream;
+export const eventIteratorToUnproxiedDataStream =
+  ns.eventIteratorToUnproxiedDataStream;
+export const fallbackORPCErrorMessage = ns.fallbackORPCErrorMessage;
+export const fallbackORPCErrorStatus = ns.fallbackORPCErrorStatus;
+export const getEventMeta = ns.getEventMeta;
+export const isDefinedError = ns.isDefinedError;
+export const isORPCErrorJson = ns.isORPCErrorJson;
+export const isORPCErrorStatus = ns.isORPCErrorStatus;
+export const mapEventIterator = ns.mapEventIterator;
+export const onError = ns.onError;
+export const onFinish = ns.onFinish;
+export const onStart = ns.onStart;
+export const onSuccess = ns.onSuccess;
+export const resolveFriendlyClientOptions = ns.resolveFriendlyClientOptions;
+export const safe = ns.safe;
+export const streamToEventIterator = ns.streamToEventIterator;
+export const toORPCError = ns.toORPCError;
+export const withEventMeta = ns.withEventMeta;

--- a/packages/plumix/src/admin/orpc-tanstack-query.ts
+++ b/packages/plumix/src/admin/orpc-tanstack-query.ts
@@ -1,0 +1,14 @@
+import { getRuntime } from "./runtime.js";
+
+const ns = getRuntime().orpcTanstackQuery;
+
+export default ns;
+
+export const OPERATION_CONTEXT_SYMBOL = ns.OPERATION_CONTEXT_SYMBOL;
+export const TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL =
+  ns.TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL;
+export const createGeneralUtils = ns.createGeneralUtils;
+export const createProcedureUtils = ns.createProcedureUtils;
+export const createRouterUtils = ns.createRouterUtils;
+export const createTanstackQueryUtils = ns.createTanstackQueryUtils;
+export const generateOperationKey = ns.generateOperationKey;

--- a/packages/plumix/src/admin/react-query.ts
+++ b/packages/plumix/src/admin/react-query.ts
@@ -27,11 +27,24 @@ export const useSuspenseInfiniteQuery = ns.useSuspenseInfiniteQuery;
 
 export const queryOptions = ns.queryOptions;
 export const infiniteQueryOptions = ns.infiniteQueryOptions;
+export const mutationOptions = ns.mutationOptions;
 export const hydrate = ns.hydrate;
 export const dehydrate = ns.dehydrate;
 export const matchQuery = ns.matchQuery;
 export const matchMutation = ns.matchMutation;
 export const replaceEqualDeep = ns.replaceEqualDeep;
 export const hashKey = ns.hashKey;
+export const keepPreviousData = ns.keepPreviousData;
 export const isCancelledError = ns.isCancelledError;
 export const skipToken = ns.skipToken;
+export const usePrefetchQuery = ns.usePrefetchQuery;
+export const usePrefetchInfiniteQuery = ns.usePrefetchInfiniteQuery;
+
+export const CancelledError = ns.CancelledError;
+export const Query = ns.Query;
+export const Mutation = ns.Mutation;
+export const QueryObserver = ns.QueryObserver;
+export const InfiniteQueryObserver = ns.InfiniteQueryObserver;
+export const QueriesObserver = ns.QueriesObserver;
+export const MutationObserver = ns.MutationObserver;
+export const QueryClientContext = ns.QueryClientContext;

--- a/packages/plumix/src/admin/react.ts
+++ b/packages/plumix/src/admin/react.ts
@@ -4,6 +4,7 @@ const ns = getRuntime().react;
 
 export default ns;
 
+export const Activity = ns.Activity;
 export const Children = ns.Children;
 export const Component = ns.Component;
 export const Fragment = ns.Fragment;
@@ -11,7 +12,10 @@ export const Profiler = ns.Profiler;
 export const PureComponent = ns.PureComponent;
 export const StrictMode = ns.StrictMode;
 export const Suspense = ns.Suspense;
+export const act = ns.act;
 export const cache = ns.cache;
+export const cacheSignal = ns.cacheSignal;
+export const captureOwnerStack = ns.captureOwnerStack;
 export const cloneElement = ns.cloneElement;
 export const createContext = ns.createContext;
 export const createElement = ns.createElement;
@@ -28,6 +32,7 @@ export const useContext = ns.useContext;
 export const useDebugValue = ns.useDebugValue;
 export const useDeferredValue = ns.useDeferredValue;
 export const useEffect = ns.useEffect;
+export const useEffectEvent = ns.useEffectEvent;
 export const useId = ns.useId;
 export const useImperativeHandle = ns.useImperativeHandle;
 export const useInsertionEffect = ns.useInsertionEffect;

--- a/packages/plumix/src/admin/runtime.ts
+++ b/packages/plumix/src/admin/runtime.ts
@@ -3,6 +3,9 @@
 // to `runtime`). This module is just the runtime slice plugin chunks
 // see, plus the throw if it's missing.
 
+import type * as OrpcClientNs from "@orpc/client";
+import type * as OrpcClientFetchNs from "@orpc/client/fetch";
+import type * as OrpcTanstackQueryNs from "@orpc/tanstack-query";
 import type * as ReactQueryNs from "@tanstack/react-query";
 import type * as ReactRouterNs from "@tanstack/react-router";
 import type * as ReactNs from "react";
@@ -17,6 +20,9 @@ export interface PlumixAdminRuntime {
   readonly reactDomClient: typeof ReactDomClientNs;
   readonly reactQuery: typeof ReactQueryNs;
   readonly reactRouter: typeof ReactRouterNs;
+  readonly orpcClient: typeof OrpcClientNs;
+  readonly orpcClientFetch: typeof OrpcClientFetchNs;
+  readonly orpcTanstackQuery: typeof OrpcTanstackQueryNs;
 }
 
 export interface PlumixGlobal {

--- a/packages/plumix/src/admin/shim-drift.test.ts
+++ b/packages/plumix/src/admin/shim-drift.test.ts
@@ -1,0 +1,264 @@
+import * as ReactNs from "react";
+import * as ReactJsxRuntimeNs from "react/jsx-runtime";
+import * as OrpcClientNs from "@orpc/client";
+import * as OrpcClientFetchNs from "@orpc/client/fetch";
+import * as OrpcTanstackQueryNs from "@orpc/tanstack-query";
+import * as ReactQueryNs from "@tanstack/react-query";
+import * as ReactRouterNs from "@tanstack/react-router";
+import * as ReactDomNs from "react-dom";
+import * as ReactDomClientNs from "react-dom/client";
+import { beforeAll, describe, expect, test } from "vitest";
+
+// Drift detection: when an upstream package adds a new public export,
+// our shim should re-export it. This test fails CI when a shim falls
+// behind upstream — at which point either add the missing export to
+// the shim or extend `KNOWN_GAPS` below with a justification.
+
+beforeAll(() => {
+  (globalThis as { plumix?: unknown }).plumix = {
+    runtime: {
+      react: ReactNs,
+      reactJsxRuntime: ReactJsxRuntimeNs,
+      reactDom: ReactDomNs,
+      reactDomClient: ReactDomClientNs,
+      reactQuery: ReactQueryNs,
+      reactRouter: ReactRouterNs,
+      orpcClient: OrpcClientNs,
+      orpcClientFetch: OrpcClientFetchNs,
+      orpcTanstackQuery: OrpcTanstackQueryNs,
+    },
+  };
+});
+
+interface ShimSpec {
+  readonly name: string;
+  readonly upstream: Readonly<Record<string, unknown>>;
+  readonly load: () => Promise<Readonly<Record<string, unknown>>>;
+  readonly knownGaps?: ReadonlySet<string>;
+}
+
+// Names we deliberately don't re-export. Reasons:
+//   - `module.exports` / `default` — namespace artefacts, not real exports
+//   - `unstable_*` — explicit opt-out so plugin authors don't depend on
+//     APIs that may break between minor versions
+const SHIMS: readonly ShimSpec[] = [
+  {
+    name: "react",
+    upstream: ReactNs,
+    load: () => import("./react.js"),
+  },
+  {
+    name: "react/jsx-runtime",
+    upstream: ReactJsxRuntimeNs,
+    load: () => import("./react-jsx-runtime.js"),
+  },
+  {
+    name: "react-dom",
+    upstream: ReactDomNs,
+    load: () => import("./react-dom.js"),
+  },
+  {
+    name: "react-dom/client",
+    upstream: ReactDomClientNs,
+    load: () => import("./react-dom-client.js"),
+    // `version` leaks at runtime but isn't in @types/react-dom — skip
+    // until the types include it.
+    knownGaps: new Set(["version"]),
+  },
+  {
+    name: "@tanstack/react-query",
+    upstream: ReactQueryNs,
+    load: () => import("./react-query.js"),
+    knownGaps: new Set([
+      // Internal singletons — typing doesn't round-trip cleanly; plugin
+      // code reaches them via hooks (useIsFetching etc.) instead.
+      "focusManager",
+      "notifyManager",
+      "onlineManager",
+      "useQueryErrorResetBoundary",
+      // Internal helpers + symbols — not part of the documented surface.
+      "dataTagErrorSymbol",
+      "dataTagSymbol",
+      "defaultScheduler",
+      "defaultShouldDehydrateMutation",
+      "defaultShouldDehydrateQuery",
+      "environmentManager",
+      "isServer",
+      "noop",
+      "partialMatchKey",
+      "shouldThrowError",
+      "timeoutManager",
+      "unsetMarker",
+      // Experimental — explicit opt-out so plugin authors don't depend
+      // on APIs the upstream may break between minors.
+      "experimental_streamedQuery",
+    ]),
+  },
+  {
+    name: "@tanstack/react-router",
+    upstream: ReactRouterNs,
+    load: () => import("./react-router.js"),
+    // Plugin pages mount inside admin's router via the catch-all
+    // route — they don't construct routers, history, or file routes
+    // themselves. Skip the advanced/internal helpers; revisit when a
+    // plugin actually needs one (the failing test reminds us).
+    knownGaps: new Set([
+      "Asset",
+      "Await",
+      "Asyncify",
+      "Block",
+      "CatchBoundary",
+      "CatchNotFound",
+      "ClientOnly",
+      "DEFAULT_PROTOCOL_ALLOWLIST",
+      "DefaultGlobalNotFound",
+      "DefaultNotFoundComponent",
+      "ErrorComponent",
+      "FileRoute",
+      "FileRouteLoader",
+      "HeadContent",
+      "LazyRoute",
+      "Match",
+      "MatchRoute",
+      "Matches",
+      "NotFoundError",
+      "NotFoundRoute",
+      "PathParamError",
+      "RootRoute",
+      "Route",
+      "RouteApi",
+      "Router",
+      "RouterContextProvider",
+      "ScriptOnce",
+      "Scripts",
+      "SearchParamError",
+      "Transitioner",
+      "asyncBuildLocation",
+      "cleanPath",
+      "composeRewrites",
+      "createBrowserHistory",
+      "createControlledPromise",
+      "createFileRoute",
+      "createHashHistory",
+      "createHistory",
+      "createLazyFileRoute",
+      "createLazyRoute",
+      "createLink",
+      "createMemoryHistory",
+      "createRootRoute",
+      "createRootRouteWithContext",
+      "createRoute",
+      "createRouteMask",
+      "createRouter",
+      "createRouterConfig",
+      "createSerializationAdapter",
+      "decode",
+      "deepEqual",
+      "defaultDeserializeError",
+      "defaultParseSearch",
+      "defaultSerializeError",
+      "defaultStringifySearch",
+      "defaultTransformer",
+      "defer",
+      "encode",
+      "escapeJSON",
+      "exactPathTest",
+      "fileRouteRoutes",
+      "functionalUpdate",
+      "getInitialRouterMetadata",
+      "getLocationChangeInfo",
+      "getMatchedRoutes",
+      "getRouteApi",
+      "isMatch",
+      "isModuleNotFoundError",
+      "isPlainArray",
+      "isPlainObject",
+      "isResolvedRedirect",
+      "joinPaths",
+      "lazyFn",
+      "lazyRouteComponent",
+      "linkOptions",
+      "matchByPath",
+      "matchPathname",
+      "parsePathname",
+      "parseSearchWith",
+      "pick",
+      "preloadWarning",
+      "processRouteTree",
+      "removeBasepath",
+      "removeTrailingSlash",
+      "replaceEqualDeep",
+      "resolvePath",
+      "retainSearchParams",
+      "rootRouteId",
+      "rootRouteWithContext",
+      "shallow",
+      "stringifySearchWith",
+      "stripSearchParams",
+      "trimPath",
+      "trimPathLeft",
+      "trimPathRight",
+      "useAwaited",
+      "useElementScrollRestoration",
+      "useHydrated",
+      "useLayoutEffect",
+      "useMatchRoute",
+      "useTags",
+      "warning",
+    ]),
+  },
+  {
+    name: "@orpc/client",
+    upstream: OrpcClientNs,
+    load: () => import("./orpc-client.js"),
+  },
+  {
+    name: "@orpc/client/fetch",
+    upstream: OrpcClientFetchNs,
+    load: () => import("./orpc-client-fetch.js"),
+  },
+  {
+    name: "@orpc/tanstack-query",
+    upstream: OrpcTanstackQueryNs,
+    load: () => import("./orpc-tanstack-query.js"),
+    knownGaps: new Set([
+      // Stream handling — adds future-flag risk; opt-in by name when
+      // a plugin actually wants it.
+      "experimental_serializableStreamedQuery",
+    ]),
+  },
+];
+
+const ALWAYS_SKIPPED_KEYS = new Set([
+  "default",
+  "module.exports",
+  "__esModule",
+]);
+
+function publicKeysOf(
+  ns: Readonly<Record<string, unknown>>,
+): readonly string[] {
+  return Object.keys(ns)
+    .filter((k) => !ALWAYS_SKIPPED_KEYS.has(k))
+    .filter((k) => !k.startsWith("_"))
+    .filter((k) => !k.startsWith("unstable_"))
+    .sort();
+}
+
+describe("shim drift vs upstream packages", () => {
+  test.each(SHIMS)(
+    "$name shim re-exports every public upstream value",
+    async ({ name, upstream, load, knownGaps }) => {
+      const shim = await load();
+      const expected = publicKeysOf(upstream).filter((k) => !knownGaps?.has(k));
+      const actual = publicKeysOf(shim);
+      const missing = expected.filter((k) => !actual.includes(k));
+      expect(
+        missing,
+        `Shim "${name}" is missing upstream exports: ${missing.join(", ")}. ` +
+          `Add them to packages/plumix/src/admin/<shim>.ts, or extend ` +
+          `KNOWN_GAPS in shim-drift.test.ts with a justification.`,
+      ).toEqual([]);
+    },
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,6 +523,12 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.2
+      '@orpc/client':
+        specifier: ^1.13.14
+        version: 1.13.14
+      '@orpc/tanstack-query':
+        specifier: ^1.13.14
+        version: 1.13.14(@orpc/client@1.13.14)(@tanstack/query-core@5.99.2)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1


### PR DESCRIPTION
## Why

The build-time alias seam from #86 already shares React, react-dom, tanstack react-query/react-router with plugin chunks. To call its server-registered RPC procedures from the admin page, a plugin also needs the oRPC client trio (`@orpc/client`, `@orpc/client/fetch`, `@orpc/tanstack-query`). Without sharing them, every plugin would bundle its own ~30 KB copies and split the QueryClient cache.

## What's new

- **Three new shim sub-exports** — `plumix/admin/orpc-client`, `plumix/admin/orpc-client-fetch`, `plumix/admin/orpc-tanstack-query` — backed by `window.plumix.runtime.orpc{Client,ClientFetch,TanstackQuery}`.
- **Alias contract extended** in `@plumix/core/admin/runtime` so plumix's vite plugin rewrites bare imports automatically; plugin authors write `import { createORPCClient } from \"@orpc/client\"` as normal.
- **Wired into `bootPlumixGlobals()`** so the runtime bag is populated synchronously before render.
- **Declared as optional peer deps** on plumix.

## Drift detection (also lands here)

The drift test from PR #86 never made the squash. Adding it now:

- `shim-drift.test.ts` introspects every shared upstream package and asserts each shim re-exports every public named export. **Fails CI when React/tanstack/orpc add a new hook** — we either add the export to the shim or extend `KNOWN_GAPS` with a justification.
- The drift test surfaced **real gaps** in the existing react/react-query shims that PR #86 missed: `Activity`, `act`, `cacheSignal`, `captureOwnerStack`, `useEffectEvent`, `mutationOptions`, `keepPreviousData`, `usePrefetchQuery`, `usePrefetchInfiniteQuery`, plus the `*Observer` / `Query` / `Mutation` classes — all now re-exported.

## E2E proof

`plugin-runtime.spec.ts` extended with **assertion (7)**: the fixture plugin imports the orpc trio + constructs a typed client + tanstack-query utils. Page renders `data-shared=\"true\"` only if all three runtime namespaces resolved through the alias seam. Spec passes locally.

## Plugin author DX (e.g. media plugin)

```ts
import { createORPCClient } from \"@orpc/client\";
import { RPCLink } from \"@orpc/client/fetch\";
import { createTanstackQueryUtils } from \"@orpc/tanstack-query\";
import { useQuery } from \"@tanstack/react-query\";
import type { MediaRouter } from \"@example/media-plugin/rpc\";

const orpc = createTanstackQueryUtils(
  createORPCClient<MediaRouter>(
    new RPCLink({
      url: () => \`\${window.location.origin}/_plumix/rpc\`,
      headers: () => ({ \"x-plumix-request\": \"1\" }),
    }),
  ),
);

const { data } = useQuery(orpc.media.list.queryOptions({ input: {} }));
```

Cache shares with admin queries automatically — oRPC's queryKey is path+input, identical across client instances.

## Test plan

- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r test` — 37 plumix tests pass (3 new orpc drift tests; existing react/react-query/react-router drift tests pass after backfilling missing exports)
- [x] `pnpm -r lint` — clean
- [x] `pnpm knip` — clean (only pre-existing shadcn surface hints)
- [x] `pnpm --filter @plumix/admin test:e2e` — all 54 specs pass including the extended runtime-proof
- [ ] Manual: build a tiny plugin off this branch with one RPC procedure, confirm the round-trip