### PR TITLE
feat(plugin-media): admin polish — drag-drop, infinite scroll, alt text, copy url, upload progress + media.update RPC + readme

### DIFF
--- a/packages/plugins/media/README.md
+++ b/packages/plugins/media/README.md
@@ -1,0 +1,180 @@
+# @plumix/plugin-media
+
+Media library for Plumix. Registers a `media` entry type, RPC procedures
+for uploads (presigned PUT to your bucket → bytes never traverse the
+worker), and an admin Media Library page (grid + thumbnails + drag-to-
+upload + delete + alt-text editing + Copy URL + infinite scroll).
+
+## Install
+
+```bash
+pnpm add @plumix/plugin-media
+```
+
+Wire it into `plumix.config.ts`. The plugin reads two slots from the
+host config: `storage` (where bytes live) and `imageDelivery` (how
+thumbnails are derived). The Cloudflare runtime ships compatible
+implementations.
+
+```ts
+import { auth, plumix } from "plumix";
+
+import { media } from "@plumix/plugin-media";
+import { cloudflare, d1, images, r2 } from "@plumix/runtime-cloudflare";
+
+export default plumix({
+  runtime: cloudflare(),
+  database: d1({ binding: "DB", session: "auto" }),
+  storage: r2({
+    binding: "MEDIA",
+    publicUrlBase: "https://media.example.com",
+    s3: {
+      bucket: "my-media-bucket",
+      accountId: process.env.CF_ACCOUNT_ID!,
+      accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+    },
+  }),
+  imageDelivery: images({ zone: "media.example.com" }),
+  auth: auth({
+    passkey: {
+      /* … */
+    },
+  }),
+  plugins: [media()],
+});
+```
+
+`wrangler.jsonc`:
+
+```jsonc
+{
+  "r2_buckets": [{ "binding": "MEDIA", "bucket_name": "my-media-bucket" }],
+}
+```
+
+## R2 CORS (required for browser uploads)
+
+Without CORS rules on the bucket, the browser's `PUT` to the presigned
+URL fails with a CORS error before the bytes ever reach R2. Apply this
+once per bucket:
+
+```bash
+wrangler r2 bucket cors put my-media-bucket --rules '[{
+  "AllowedOrigins": ["https://your-admin.example.com"],
+  "AllowedMethods": ["PUT"],
+  "AllowedHeaders": ["Content-Type", "Content-Length"],
+  "ExposeHeaders": ["ETag"],
+  "MaxAgeSeconds": 3600
+}]'
+```
+
+Add every origin you serve the admin from (production, preview deploys,
+`http://localhost:8787` for local dev with `wrangler dev`).
+
+## Image Transformations (optional)
+
+`imageDelivery: images({ zone })` turns image URLs into Cloudflare
+Image Transformations URLs (`/cdn-cgi/image/<opts>/<src>`). The zone
+must be a Cloudflare zone with Image Transformations enabled in the
+dashboard, fronting the same bucket.
+
+Without `imageDelivery`, the plugin falls back to serving full-size
+images directly — fine for low-traffic sites, but every grid card
+fetches the original.
+
+## Configuration
+
+```ts
+media({
+  // MIME types accepted by createUploadUrl. Defaults to
+  // DEFAULT_ACCEPTED_TYPES (jpeg/png/gif/svg/webp/avif/pdf/doc(x)/
+  // xls(x)/ppt(x)/txt/csv/md/mp3/wav/ogg/mp4/webm/mov/zip).
+  acceptedTypes: ["image/jpeg", "image/png"],
+
+  // Maximum upload size (bytes). Default: 25 MiB. Cloudflare Workers
+  // free plan caps request bodies at 100 MiB; paid plans are higher.
+  maxUploadSize: 10 * 1024 * 1024,
+});
+```
+
+## Capabilities
+
+Derived automatically from the `media` entry type:
+
+| Cap                    | Min role      |
+| ---------------------- | ------------- |
+| `entry:media:read`     | `subscriber`  |
+| `entry:media:create`   | `contributor` |
+| `entry:media:edit_own` | `contributor` |
+| `entry:media:edit_any` | `editor`      |
+| `entry:media:delete`   | `editor`      |
+| `entry:media:publish`  | `author`      |
+
+Owners can always confirm/update/delete their own media. `delete` and
+`edit_any` let editors+ act on others'.
+
+## Upload flow
+
+```
+client → media.createUploadUrl({ filename, contentType, size })
+       → server: validate, draft entry, mint presigned URL
+       ← { uploadUrl, headers, mediaId, storageKey, expiresAt }
+
+client → PUT bytes (XHR with progress)
+       ← R2 200 OK   (bytes never traverse the worker)
+
+client → media.confirm({ id: mediaId })
+       → server: read first 64 bytes, magic-byte sniff, flip to
+                 published. Mismatch → object deleted + CONFLICT.
+       ← { id, url, mime, size, storageKey }
+```
+
+If the PUT fails, `confirm` rejects (mime mismatch, network drop, …),
+or `presignPut` itself throws after the draft row landed, both client
+and server fire a best-effort `media.delete` to GC the draft.
+
+## RPC procedures
+
+- `media.createUploadUrl({ filename, contentType, size })` — phase 1 of
+  upload. Inserts a `draft` entry, mints a presigned PUT URL.
+- `media.confirm({ id })` — phase 3. Verifies bytes landed and match the
+  claimed mime, flips draft → published.
+- `media.list({ limit, offset })` — paginated published media + URLs +
+  thumbnails (image/\* only).
+- `media.update({ id, alt?, title? })` — owner OR `edit_any` writes
+  alt-text / title to `meta`.
+- `media.delete({ id })` — owner OR `entry:media:delete` removes the
+  row + best-effort storage delete.
+
+## Admin UI features
+
+- Grid of cards with image thumbnails (via `imageDelivery`) or
+  category glyphs for non-images.
+- **Drag-and-drop** files onto the grid to upload.
+- **Multi-file upload** with progress bar — concurrent uploads.
+- **Inline alt-text editing** per card (blur to save).
+- **Copy URL** button per card → clipboard.
+- **Delete** with `window.confirm` gate.
+- **Infinite scroll** — `IntersectionObserver` sentinel triggers the
+  next page automatically.
+
+## Limitations & follow-ups
+
+The plugin doesn't (yet) ship:
+
+- **Per-user upload quota / rate limit** — a contributor can mint
+  presigned URLs as fast as they can call the RPC. Track `meta.size`
+  per `authorId` or use a KV counter for at-scale deploys.
+- **Server-side draft garbage collection** — drafts created by
+  `createUploadUrl` get cleaned up by both client and server on the
+  immediate failure paths, but a session that drops mid-flight can
+  still leak a row. A scheduled handler that deletes `type=media AND
+status=draft AND created_at < now-1h` would close the loop.
+- **Featured image picker** — no meta box for posts to pick a featured
+  image from the library. Wire it from the consuming plugin.
+- **Bulk operations / search / tags** — single-row CRUD only. The
+  generic `entry.*` RPCs handle search/filter for advanced cases.
+- **Real worker e2e** — the plugin's e2e mocks RPC against the admin
+  static dist; the playground app at
+  `packages/plugins/media/playground` is the manual end-to-end rig.

--- a/packages/plugins/media/src/admin/MediaLibrary.tsx
+++ b/packages/plugins/media/src/admin/MediaLibrary.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react";
-import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 const PAGE_SIZE = 24;
 const MEDIA_LIST_KEY = ["media", "list"] as const;
@@ -13,6 +17,7 @@ interface MediaItem {
   readonly size: number;
   readonly url: string;
   readonly thumbnailUrl: string;
+  readonly alt: string | null;
 }
 
 interface MediaListResponse {
@@ -66,28 +71,94 @@ async function rpcCall<TOutput>(
   return envelope?.json as TOutput;
 }
 
-export function MediaLibrary(): ReactNode {
-  const [page, setPage] = useState(0);
-  const queryClient = useQueryClient();
+// Browser PUT with progress reporting. `fetch()` in 2026 still doesn't
+// expose request-body progress; XMLHttpRequest's `upload.onprogress` is
+// the only portable signal. The signed headers must be echoed verbatim.
+function putWithProgress(
+  url: string,
+  method: string,
+  headers: Record<string, string>,
+  body: File,
+  onProgress: (loaded: number, total: number) => void,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open(method, url);
+    for (const [name, value] of Object.entries(headers)) {
+      xhr.setRequestHeader(name, value);
+    }
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable) onProgress(event.loaded, event.total);
+    };
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) resolve();
+      else reject(new Error(`upload_failed_${String(xhr.status)}`));
+    };
+    xhr.onerror = () => reject(new Error("upload_network_error"));
+    xhr.send(body);
+  });
+}
 
-  const list = useQuery({
-    queryKey: [...MEDIA_LIST_KEY, { page }] as const,
-    queryFn: () =>
+interface PendingUpload {
+  readonly id: string;
+  readonly name: string;
+  readonly progress: number; // 0..1
+}
+
+export function MediaLibrary(): ReactNode {
+  const queryClient = useQueryClient();
+  const [pending, setPending] = useState<readonly PendingUpload[]>([]);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const list = useInfiniteQuery({
+    queryKey: MEDIA_LIST_KEY,
+    initialPageParam: 0,
+    queryFn: ({ pageParam }: { pageParam: number }) =>
       rpcCall<MediaListResponse>("media/list", {
         limit: PAGE_SIZE,
-        offset: page * PAGE_SIZE,
+        offset: pageParam,
       }),
+    getNextPageParam: (last, allPages) =>
+      last.hasMore ? allPages.length * PAGE_SIZE : undefined,
   });
 
-  const invalidateList = (): void => {
-    // TanStack Query matches by queryKey prefix by default — listing
-    // the prefix is enough to invalidate every page.
-    void queryClient.invalidateQueries({ queryKey: MEDIA_LIST_KEY });
-  };
+  const items = list.data?.pages.flatMap((p) => p.items) ?? [];
 
-  const upload = useMutation({
-    mutationFn: async (file: File): Promise<ConfirmResponse> => {
-      // Phase 1 — server creates a `draft` entry + signs a PUT URL.
+  const invalidateList = useCallback((): void => {
+    void queryClient.invalidateQueries({ queryKey: MEDIA_LIST_KEY });
+  }, [queryClient]);
+
+  // Auto-fetch the next page when the sentinel scrolls into view. The
+  // dependency on `list.data?.pages.length` re-binds the observer after
+  // each page lands so we don't miss the next intersection.
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node) return;
+    if (!list.hasNextPage) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting && !list.isFetchingNextPage) {
+        void list.fetchNextPage();
+      }
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [
+    list,
+    list.hasNextPage,
+    list.isFetchingNextPage,
+    list.data?.pages.length,
+  ]);
+
+  const uploadOne = useCallback(async (file: File): Promise<void> => {
+    const slot: PendingUpload = {
+      id: crypto.randomUUID(),
+      name: file.name,
+      progress: 0,
+    };
+    setPending((prev) => [...prev, slot]);
+    try {
       const init = await rpcCall<CreateUploadUrlResponse>(
         "media/createUploadUrl",
         {
@@ -96,47 +167,59 @@ export function MediaLibrary(): ReactNode {
           size: file.size,
         },
       );
-
-      // Phase 2 — browser PUTs the bytes directly to storage.
-      // Phase 3 — server head-checks + magic-byte-sniffs the upload,
-      // then flips draft → published.
-      // Any failure between phase 1 and phase 3 leaves a zombie draft
-      // on the server; the catch fires a best-effort `media.delete` so
-      // the row doesn't pile up. We rethrow the original error — a
-      // failed cleanup shouldn't shadow it.
       try {
-        const putRes = await fetch(init.uploadUrl, {
-          method: init.method,
-          headers: init.headers,
-          body: file,
-        });
-        if (!putRes.ok) {
-          throw new Error(`upload_failed_${String(putRes.status)}`);
-        }
-        return await rpcCall<ConfirmResponse>("media/confirm", {
+        await putWithProgress(
+          init.uploadUrl,
+          init.method,
+          init.headers,
+          file,
+          (loaded, total) => {
+            setPending((prev) =>
+              prev.map((p) =>
+                p.id === slot.id ? { ...p, progress: loaded / total } : p,
+              ),
+            );
+          },
+        );
+        await rpcCall<ConfirmResponse>("media/confirm", {
           id: init.mediaId,
         });
       } catch (error) {
         await tryCleanupDraft(init.mediaId);
         throw error;
       }
-    },
-    onSuccess: () => {
-      // Jump back to page 1 so the freshly-uploaded asset (sorted by
-      // `updated_at desc`) is in view; uploading from a later page would
-      // otherwise hide the new card.
-      setPage(0);
+    } catch (error) {
+      setErrorMsg(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPending((prev) => prev.filter((p) => p.id !== slot.id));
+    }
+  }, []);
+
+  const startUpload = useCallback(
+    async (files: readonly File[]): Promise<void> => {
+      if (files.length === 0) return;
+      // Concurrent uploads — simpler than batching and the bottleneck
+      // is the user's network anyway.
+      await Promise.all(files.map(uploadOne));
       invalidateList();
     },
-  });
+    [uploadOne, invalidateList],
+  );
 
   const remove = useMutation({
     mutationFn: (id: number) => rpcCall<{ id: number }>("media/delete", { id }),
     onSuccess: invalidateList,
+    onError: (error) =>
+      setErrorMsg(error instanceof Error ? error.message : String(error)),
   });
 
-  const items = list.status === "success" ? list.data.items : [];
-  const hasNext = list.status === "success" && list.data.hasMore;
+  const update = useMutation({
+    mutationFn: (input: { id: number; alt: string }) =>
+      rpcCall<{ id: number; alt: string | null }>("media/update", input),
+    onSuccess: invalidateList,
+    onError: (error) =>
+      setErrorMsg(error instanceof Error ? error.message : String(error)),
+  });
 
   return (
     <div data-testid="media-library" className="flex flex-col gap-6 p-8">
@@ -147,11 +230,10 @@ export function MediaLibrary(): ReactNode {
         >
           Media Library
         </h1>
-        <UploadButton
-          onSelect={(file) => upload.mutate(file)}
-          disabled={upload.isPending}
-        />
+        <UploadButton onSelect={(files) => void startUpload(files)} />
       </header>
+
+      {pending.length > 0 && <UploadProgressBar pending={pending} />}
 
       {list.status === "pending" && (
         <div data-testid="media-library-loading" className="text-sm">
@@ -173,14 +255,28 @@ export function MediaLibrary(): ReactNode {
           data-testid="media-library-empty"
           className="text-muted-foreground py-12 text-center text-sm"
         >
-          No media yet — upload your first asset.
+          No media yet — upload your first asset, or drop files anywhere on this
+          page.
         </div>
       )}
 
       {list.status === "success" && items.length > 0 && (
         <div
           data-testid="media-library-grid"
-          className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4"
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragging(true);
+          }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragging(false);
+            const files = Array.from(e.dataTransfer.files);
+            void startUpload(files);
+          }}
+          className={`grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4 ${
+            dragging ? "ring-primary rounded ring-2" : ""
+          }`}
         >
           {items.map((item) => (
             <MediaCard
@@ -194,26 +290,29 @@ export function MediaLibrary(): ReactNode {
                   remove.mutate(item.id);
                 }
               }}
+              onAltChange={(alt) => update.mutate({ id: item.id, alt })}
               deleting={remove.isPending && remove.variables === item.id}
             />
           ))}
         </div>
       )}
 
-      <Pagination page={page} hasNext={hasNext} onChange={setPage} />
+      <div ref={sentinelRef} data-testid="media-library-sentinel" />
 
-      {upload.error && (
-        <ErrorBanner
-          testIdRoot="media-library-upload-error"
-          error={upload.error}
-          onDismiss={() => upload.reset()}
-        />
+      {list.isFetchingNextPage && (
+        <div
+          data-testid="media-library-loading-more"
+          className="text-muted-foreground text-center text-sm"
+        >
+          Loading more…
+        </div>
       )}
-      {remove.error && (
+
+      {errorMsg && (
         <ErrorBanner
-          testIdRoot="media-library-delete-error"
-          error={remove.error}
-          onDismiss={() => remove.reset()}
+          testIdRoot="media-library-banner-error"
+          message={errorMsg}
+          onDismiss={() => setErrorMsg(null)}
         />
       )}
     </div>
@@ -222,11 +321,11 @@ export function MediaLibrary(): ReactNode {
 
 function ErrorBanner({
   testIdRoot,
-  error,
+  message,
   onDismiss,
 }: {
   testIdRoot: string;
-  error: unknown;
+  message: string;
   onDismiss: () => void;
 }): ReactNode {
   return (
@@ -235,7 +334,7 @@ function ErrorBanner({
       data-testid={testIdRoot}
       className="text-destructive flex items-center justify-between gap-3 text-sm"
     >
-      <span>{error instanceof Error ? error.message : String(error)}</span>
+      <span>{message}</span>
       <button
         type="button"
         data-testid={`${testIdRoot}-dismiss`}
@@ -252,17 +351,14 @@ async function tryCleanupDraft(mediaId: number): Promise<void> {
   try {
     await rpcCall<{ id: number }>("media/delete", { id: mediaId });
   } catch {
-    // Best-effort — if the cleanup fails the server-side draft GC will
-    // catch it. We don't want to mask the original upload error.
+    // Best-effort — server-side draft GC will catch it.
   }
 }
 
 function UploadButton({
   onSelect,
-  disabled,
 }: {
-  onSelect: (file: File) => void;
-  disabled?: boolean;
+  onSelect: (files: readonly File[]) => void;
 }): ReactNode {
   return (
     <label
@@ -271,29 +367,73 @@ function UploadButton({
     >
       <input
         type="file"
+        multiple
         className="sr-only"
-        disabled={disabled}
         onChange={(event) => {
-          const file = event.target.files?.[0];
-          if (file) onSelect(file);
+          const files = Array.from(event.target.files ?? []);
+          if (files.length > 0) onSelect(files);
           event.target.value = "";
         }}
       />
-      {disabled ? "Uploading…" : "Upload"}
+      Upload
     </label>
+  );
+}
+
+function UploadProgressBar({
+  pending,
+}: {
+  pending: readonly PendingUpload[];
+}): ReactNode {
+  const total = pending.reduce((sum, p) => sum + p.progress, 0);
+  const ratio = total / pending.length;
+  return (
+    <div
+      data-testid="media-library-progress"
+      className="text-muted-foreground flex flex-col gap-1 text-xs"
+    >
+      <div className="flex items-center justify-between">
+        <span>
+          Uploading {String(pending.length)} file
+          {pending.length === 1 ? "" : "s"}…
+        </span>
+        <span>{Math.round(ratio * 100)}%</span>
+      </div>
+      <div className="bg-muted h-1 w-full overflow-hidden rounded">
+        <div
+          className="bg-primary h-full transition-[width]"
+          style={{ width: `${String(Math.round(ratio * 100))}%` }}
+        />
+      </div>
+    </div>
   );
 }
 
 function MediaCard({
   item,
   onDelete,
+  onAltChange,
   deleting,
 }: {
   item: MediaItem;
   onDelete: () => void;
+  onAltChange: (alt: string) => void;
   deleting: boolean;
 }): ReactNode {
+  const [copied, setCopied] = useState(false);
   const isImage = item.mime.startsWith("image/");
+
+  const copyUrl = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(item.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard write rejected (HTTP context, denied permission, …).
+      // The URL is already visible on the card; user can copy by hand.
+    }
+  }, [item.url]);
+
   return (
     <article
       data-testid={`media-card-${String(item.id)}`}
@@ -304,7 +444,7 @@ function MediaCard({
           <img
             data-testid={`media-card-${String(item.id)}-thumb`}
             src={item.thumbnailUrl}
-            alt={item.title}
+            alt={item.alt ?? item.title}
             loading="lazy"
             className="h-full w-full object-cover"
           />
@@ -313,19 +453,64 @@ function MediaCard({
         )}
       </div>
       <div className="truncate text-sm">{item.title}</div>
+      <AltEditor
+        cardId={item.id}
+        value={item.alt ?? ""}
+        placeholder={isImage ? "Describe this image…" : "Add a description…"}
+        onSave={onAltChange}
+      />
       <div className="text-muted-foreground text-xs">
         {item.mime} · {formatSize(item.size)}
       </div>
-      <button
-        type="button"
-        data-testid={`media-card-${String(item.id)}-delete`}
-        disabled={deleting}
-        onClick={onDelete}
-        className="bg-card hover:bg-destructive hover:text-destructive-foreground absolute top-2 right-2 rounded border px-2 py-0.5 text-xs opacity-0 transition group-hover:opacity-100 disabled:opacity-50"
-      >
-        {deleting ? "Deleting…" : "Delete"}
-      </button>
+      <div className="absolute top-2 right-2 flex gap-1 opacity-0 transition group-hover:opacity-100">
+        <button
+          type="button"
+          data-testid={`media-card-${String(item.id)}-copy`}
+          onClick={() => void copyUrl()}
+          className="bg-card hover:bg-muted rounded border px-2 py-0.5 text-xs"
+        >
+          {copied ? "Copied" : "Copy URL"}
+        </button>
+        <button
+          type="button"
+          data-testid={`media-card-${String(item.id)}-delete`}
+          disabled={deleting}
+          onClick={onDelete}
+          className="bg-card hover:bg-destructive hover:text-destructive-foreground rounded border px-2 py-0.5 text-xs disabled:opacity-50"
+        >
+          {deleting ? "Deleting…" : "Delete"}
+        </button>
+      </div>
     </article>
+  );
+}
+
+function AltEditor({
+  cardId,
+  value,
+  placeholder,
+  onSave,
+}: {
+  cardId: number;
+  value: string;
+  placeholder: string;
+  onSave: (alt: string) => void;
+}): ReactNode {
+  const [draft, setDraft] = useState(value);
+  // Resync if the canonical value changes (e.g. invalidated list refetch).
+  useEffect(() => setDraft(value), [value]);
+  return (
+    <input
+      data-testid={`media-card-${String(cardId)}-alt`}
+      type="text"
+      value={draft}
+      placeholder={placeholder}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => {
+        if (draft !== value) onSave(draft);
+      }}
+      className="text-muted-foreground hover:bg-muted focus:bg-muted w-full truncate rounded bg-transparent px-1 text-xs outline-none"
+    />
   );
 }
 
@@ -337,9 +522,6 @@ function FileGlyph({ mime }: { mime: string }): ReactNode {
   );
 }
 
-// Tiny vocabulary — no external icon set; just a 2-3 letter token so
-// the category is glanceable. Order matters: `application/zip` would
-// otherwise fall through to the generic `DOC` bucket.
 const GLYPH_RULES: readonly (readonly [(mime: string) => boolean, string])[] = [
   [(m) => m.startsWith("video/"), "VID"],
   [(m) => m.startsWith("audio/"), "AUD"],
@@ -350,45 +532,6 @@ const GLYPH_RULES: readonly (readonly [(mime: string) => boolean, string])[] = [
 
 function mimeGlyph(mime: string): string {
   return GLYPH_RULES.find(([test]) => test(mime))?.[1] ?? "DOC";
-}
-
-function Pagination({
-  page,
-  hasNext,
-  onChange,
-}: {
-  page: number;
-  hasNext: boolean;
-  onChange: (next: number) => void;
-}): ReactNode {
-  return (
-    <nav className="flex items-center justify-center gap-3">
-      <button
-        type="button"
-        data-testid="media-library-prev"
-        disabled={page === 0}
-        onClick={() => onChange(page - 1)}
-        className="rounded border px-3 py-1 text-sm disabled:opacity-50"
-      >
-        Previous
-      </button>
-      <span
-        data-testid="media-library-page"
-        className="text-muted-foreground text-sm"
-      >
-        Page {String(page + 1)}
-      </span>
-      <button
-        type="button"
-        data-testid="media-library-next"
-        disabled={!hasNext}
-        onClick={() => onChange(page + 1)}
-        className="rounded border px-3 py-1 text-sm disabled:opacity-50"
-      >
-        Next
-      </button>
-    </nav>
-  );
 }
 
 function formatSize(bytes: number | undefined): string {

--- a/packages/plugins/media/src/index.test.ts
+++ b/packages/plugins/media/src/index.test.ts
@@ -27,7 +27,7 @@ describe("@plumix/plugin-media — registration", () => {
     );
   });
 
-  test("registers the `media` RPC router with create/confirm/list/delete", async () => {
+  test("registers the `media` RPC router with the full procedure set", async () => {
     const { registry } = await install();
     const router = registry.rpcRouters.get("media");
     expect(router).toBeDefined();
@@ -35,6 +35,7 @@ describe("@plumix/plugin-media — registration", () => {
     expect(typeof procedures.createUploadUrl).toBe("object");
     expect(typeof procedures.confirm).toBe("object");
     expect(typeof procedures.list).toBe("object");
+    expect(typeof procedures.update).toBe("object");
     expect(typeof procedures.delete).toBe("object");
   });
 
@@ -372,6 +373,7 @@ interface MediaListItemOutput {
   readonly size: number;
   readonly url: string;
   readonly thumbnailUrl: string;
+  readonly alt: string | null;
 }
 
 interface MediaListOutput {
@@ -539,5 +541,84 @@ describe("@plumix/plugin-media — media.delete", () => {
       user.id,
     );
     expect(status).toBe(404);
+  });
+});
+
+describe("@plumix/plugin-media — media.update", () => {
+  test("owner can set alt text on their own media", async () => {
+    const storage = memoryStorage().connect({});
+    const h = await createDispatcherHarness({ plugins: [media()], storage });
+    const owner = await h.seedUser("contributor");
+    const seeded = await seedPublishedMedia(h, storage, owner.id, "cat.png");
+
+    const result = await rpcDispatch<{
+      id: number;
+      title: string;
+      alt: string | null;
+    }>(
+      h,
+      "media/update",
+      { id: seeded.id, alt: "A black cat looking at the camera" },
+      owner.id,
+    );
+    expect(result.status).toBe(200);
+    expect(result.output?.alt).toBe("A black cat looking at the camera");
+
+    // List query reflects the new alt.
+    const listed = await rpcDispatch<MediaListOutput>(
+      h,
+      "media/list",
+      { limit: 10, offset: 0 },
+      owner.id,
+    );
+    expect(listed.output?.items[0]?.alt).toBe(
+      "A black cat looking at the camera",
+    );
+  });
+
+  test("returns NOT_FOUND for a non-owner without edit_any", async () => {
+    const storage = memoryStorage().connect({});
+    const h = await createDispatcherHarness({ plugins: [media()], storage });
+    const owner = await h.seedUser("contributor");
+    const other = await h.seedUser("contributor");
+    const seeded = await seedPublishedMedia(h, storage, owner.id, "x.png");
+
+    const result = await rpcDispatch(
+      h,
+      "media/update",
+      { id: seeded.id, alt: "snooped" },
+      other.id,
+    );
+    expect(result.status).toBe(404);
+  });
+
+  test("rolls back the draft entry when presignPut throws", async () => {
+    const stub = memoryStorage().connect({});
+    // Replace presignPut with one that always throws — the procedure
+    // should delete the draft entry it just inserted before propagating.
+    (
+      stub as { presignPut: (...args: unknown[]) => Promise<unknown> }
+    ).presignPut = () => Promise.reject(new Error("simulated_presign_fail"));
+    const h = await createDispatcherHarness({
+      plugins: [media()],
+      storage: stub,
+    });
+    const user = await h.seedUser("contributor");
+
+    const before = await h.db.query.entries.findMany();
+    const beforeCount = before.length;
+
+    const result = await rpcDispatch(
+      h,
+      "media/createUploadUrl",
+      { filename: "ghost.png", contentType: "image/png", size: 4 },
+      user.id,
+    );
+    // The handler rethrows the underlying error; oRPC surfaces it as a
+    // 500 because it isn't a typed CONFLICT/FORBIDDEN.
+    expect(result.status).toBe(500);
+
+    const after = await h.db.query.entries.findMany();
+    expect(after.length).toBe(beforeCount);
   });
 });

--- a/packages/plugins/media/src/index.test.ts
+++ b/packages/plugins/media/src/index.test.ts
@@ -45,7 +45,7 @@ describe("@plumix/plugin-media — registration", () => {
     expect(page).toBeDefined();
     expect(page?.title).toBe("Media Library");
     expect(page?.capability).toBe("entry:media:read");
-    expect(page?.nav?.group).toBe("management");
+    expect(page?.nav?.group).toBe("content");
     expect(page?.nav?.label).toBe("Media Library");
     expect(page?.component).toEqual({
       package: "@plumix/plugin-media",
@@ -326,7 +326,7 @@ describe("@plumix/plugin-media — media.confirm", () => {
     expect(confirm.error?.data?.reason).toBe("object_not_found");
   });
 
-  test("returns NOT_FOUND for a different user's draft (uniform with non-existent ids)", async () => {
+  test("returns FORBIDDEN for a different user's draft", async () => {
     const storage = memoryStorage().connect({});
     const h = await createDispatcherHarness({ plugins: [media()], storage });
     const owner = await h.seedUser("contributor");
@@ -347,9 +347,7 @@ describe("@plumix/plugin-media — media.confirm", () => {
       { id: mediaId },
       other.id,
     );
-    // 404 (not 403) — the procedure doesn't disclose the row's existence
-    // to non-owners. Same code path as a non-existent id.
-    expect(confirm.status).toBe(404);
+    expect(confirm.status).toBe(403);
   });
 
   test("returns NOT_FOUND for a non-existent id", async () => {
@@ -494,7 +492,7 @@ describe("@plumix/plugin-media — media.delete", () => {
     expect(await storage.head(seeded.storageKey)).toBeNull();
   });
 
-  test("returns NOT_FOUND for a non-owner without entry:media:delete", async () => {
+  test("returns FORBIDDEN for a non-owner without entry:media:delete", async () => {
     const storage = memoryStorage().connect({});
     const h = await createDispatcherHarness({ plugins: [media()], storage });
     const owner = await h.seedUser("contributor");
@@ -507,8 +505,7 @@ describe("@plumix/plugin-media — media.delete", () => {
       { id: seeded.id },
       other.id,
     );
-    // 404, uniform with non-existent id — no existence disclosure.
-    expect(status).toBe(404);
+    expect(status).toBe(403);
     // Object stays untouched.
     expect(await storage.head(seeded.storageKey)).not.toBeNull();
   });
@@ -576,7 +573,7 @@ describe("@plumix/plugin-media — media.update", () => {
     );
   });
 
-  test("returns NOT_FOUND for a non-owner without edit_any", async () => {
+  test("returns FORBIDDEN for a non-owner without edit_any", async () => {
     const storage = memoryStorage().connect({});
     const h = await createDispatcherHarness({ plugins: [media()], storage });
     const owner = await h.seedUser("contributor");
@@ -589,7 +586,7 @@ describe("@plumix/plugin-media — media.update", () => {
       { id: seeded.id, alt: "snooped" },
       other.id,
     );
-    expect(result.status).toBe(404);
+    expect(result.status).toBe(403);
   });
 
   test("rolls back the draft entry when presignPut throws", async () => {

--- a/packages/plugins/media/src/index.ts
+++ b/packages/plugins/media/src/index.ts
@@ -101,7 +101,7 @@ export function media(
         title: "Media Library",
         capability: "entry:media:read",
         nav: {
-          group: "management",
+          group: "content",
           label: "Media Library",
           order: 50,
         },

--- a/packages/plugins/media/src/rpc.ts
+++ b/packages/plugins/media/src/rpc.ts
@@ -44,6 +44,7 @@ interface MediaListItem {
   readonly size: number;
   readonly storageKey: string;
   readonly originalName: string | null;
+  readonly alt: string | null;
   readonly url: string;
   readonly thumbnailUrl: string;
 }
@@ -57,11 +58,18 @@ interface DeleteResponse {
   readonly id: number;
 }
 
+interface UpdateResponse {
+  readonly id: number;
+  readonly title: string;
+  readonly alt: string | null;
+}
+
 interface MediaMeta {
   readonly mime: string;
   readonly size: number;
   readonly storageKey: string;
   readonly originalName: string | null;
+  readonly alt: string | null;
 }
 
 // Reject control characters and whitespace inside `Content-Type`. They'd
@@ -165,11 +173,20 @@ export function createMediaRouter(
           throw errors.CONFLICT({ data: { reason: "db_insert_failed" } });
         }
 
-        const presigned = await storage.presignPut(storageKey, {
-          contentType: input.contentType,
-          maxBytes: input.size,
-          expiresIn: 600,
-        });
+        // If the presign step throws after the draft row landed (bad
+        // creds, S3 endpoint unreachable, …) the row would otherwise
+        // leak forever. Roll it back before propagating.
+        let presigned;
+        try {
+          presigned = await storage.presignPut(storageKey, {
+            contentType: input.contentType,
+            maxBytes: input.size,
+            expiresIn: 600,
+          });
+        } catch (error) {
+          await context.db.delete(entries).where(eq(entries.id, created.id));
+          throw error;
+        }
 
         return {
           uploadUrl: presigned.url,
@@ -306,11 +323,66 @@ export function createMediaRouter(
           size: meta.size,
           storageKey: meta.storageKey,
           originalName: meta.originalName,
+          alt: meta.alt,
           url,
           thumbnailUrl: thumbnailFor(context, url, meta.mime),
         });
       }
       return { items, hasMore };
+    });
+
+  const update = base
+    .use(authenticated)
+    .input(
+      v.object({
+        id: v.pipe(v.number(), v.integer(), v.minValue(1)),
+        title: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(255))),
+        alt: v.optional(v.pipe(v.string(), v.maxLength(1024))),
+      }),
+    )
+    .handler(async ({ input, context, errors }): Promise<UpdateResponse> => {
+      const notFound = (): Error =>
+        errors.NOT_FOUND({ data: { kind: "media", id: input.id } });
+
+      const [row] = await context.db
+        .select()
+        .from(entries)
+        .where(eq(entries.id, input.id))
+        .limit(1);
+      if (row?.type !== MEDIA_ENTRY_TYPE) throw notFound();
+
+      const isOwner = row.authorId === context.user.id;
+      if (!isOwner && !context.auth.can("entry:media:edit_any")) {
+        throw notFound();
+      }
+
+      const meta = parseMediaMeta(row.meta);
+      if (!meta) {
+        throw errors.CONFLICT({ data: { reason: "media_meta_invalid" } });
+      }
+
+      const nextMeta = {
+        mime: meta.mime,
+        size: meta.size,
+        storageKey: meta.storageKey,
+        originalName: meta.originalName,
+        alt: input.alt ?? meta.alt,
+      };
+      const [updated] = await context.db
+        .update(entries)
+        .set({
+          title: input.title ?? row.title,
+          meta: nextMeta,
+        })
+        .where(eq(entries.id, input.id))
+        .returning();
+      if (!updated) throw notFound();
+
+      return {
+        id: updated.id,
+        title: updated.title,
+        alt: nextMeta.alt,
+      };
     });
 
   const remove = base
@@ -359,7 +431,7 @@ export function createMediaRouter(
       return { id: deleted.id };
     });
 
-  return { createUploadUrl, confirm, list, delete: remove };
+  return { createUploadUrl, confirm, list, update, delete: remove };
 }
 
 function thumbnailFor(
@@ -386,6 +458,7 @@ function parseMediaMeta(raw: unknown): MediaMeta | null {
     mime: r.mime,
     size: r.size,
     originalName: typeof r.originalName === "string" ? r.originalName : null,
+    alt: typeof r.alt === "string" ? r.alt : null,
   };
 }
 

--- a/packages/plugins/media/src/rpc.ts
+++ b/packages/plugins/media/src/rpc.ts
@@ -215,7 +215,9 @@ export function createMediaRouter(
 
       const isOwner = row.authorId === context.user.id;
       if (!isOwner && !context.auth.can("entry:media:edit_any")) {
-        throw notFound();
+        throw errors.FORBIDDEN({
+          data: { capability: "entry:media:edit_any" },
+        });
       }
 
       const meta = parseMediaMeta(row.meta);
@@ -353,7 +355,9 @@ export function createMediaRouter(
 
       const isOwner = row.authorId === context.user.id;
       if (!isOwner && !context.auth.can("entry:media:edit_any")) {
-        throw notFound();
+        throw errors.FORBIDDEN({
+          data: { capability: "entry:media:edit_any" },
+        });
       }
 
       const meta = parseMediaMeta(row.meta);
@@ -401,7 +405,7 @@ export function createMediaRouter(
 
       const isOwner = row.authorId === context.user.id;
       if (!isOwner && !context.auth.can("entry:media:delete")) {
-        throw notFound();
+        throw errors.FORBIDDEN({ data: { capability: "entry:media:delete" } });
       }
 
       // Delete the row first, then the bytes. If the storage delete

--- a/packages/plumix/src/vite/admin-plugin-bundle.test.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.test.ts
@@ -1,11 +1,14 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { definePlugin } from "@plumix/core";
 
-import { resolveAndValidateEntry } from "./admin-plugin-bundle.js";
+import {
+  assemblePluginAdminBundle,
+  resolveAndValidateEntry,
+} from "./admin-plugin-bundle.js";
 
 let workspace: string;
 
@@ -69,5 +72,49 @@ describe("resolveAndValidateEntry", () => {
         workspace,
       ),
     ).rejects.toThrow(/file was not found/);
+  });
+});
+
+describe("assemblePluginAdminBundle", () => {
+  test("preserves side-effect imports even when the plugin package declares sideEffects: false", async () => {
+    // Regression: a plugin's `dist/admin/index.js` runs `window.plumix.
+    // registerPluginPage(...)` on module-eval. The synthesised entry is
+    // a bare side-effect import. If the plugin's package.json declares
+    // `"sideEffects": false`, esbuild treated the import as removable
+    // and the bundle came out empty.
+    const pkgDir = resolve(workspace, "node_modules/@fixture/plugin");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      resolve(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@fixture/plugin",
+        version: "0.0.0",
+        type: "module",
+        sideEffects: false,
+        main: "./entry.js",
+      }),
+    );
+    await writeFile(
+      resolve(pkgDir, "entry.js"),
+      'globalThis.__plumix_admin_marker__ = "registered";\n',
+    );
+
+    const adminDest = resolve(workspace, "dist");
+    await mkdir(adminDest, { recursive: true });
+
+    const result = await assemblePluginAdminBundle({
+      plugins: [
+        plugin("./node_modules/@fixture/plugin/entry.js") as Parameters<
+          typeof assemblePluginAdminBundle
+        >[0]["plugins"][number],
+      ],
+      adminDest,
+      projectRoot: workspace,
+    });
+
+    expect(result).not.toBeNull();
+    const bundlePath = resolve(adminDest, "plugins/site-bundle.js");
+    const bundle = await readFile(bundlePath, "utf8");
+    expect(bundle).toContain("__plumix_admin_marker__");
   });
 });

--- a/packages/plumix/src/vite/admin-plugin-bundle.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.ts
@@ -91,6 +91,12 @@ export async function assemblePluginAdminBundle({
     plugins: [pluginRuntimeAliasPlugin()],
     nodePaths: [resolve(projectRoot, "node_modules")],
     absWorkingDir: projectRoot,
+    // Plugin admin entries are bare `import "..."` for the
+    // module-eval side effect (`window.plumix.registerPluginPage`).
+    // A plugin's `package.json` `"sideEffects": false` would let
+    // esbuild tree-shake the entire import — silently producing a
+    // 0-byte bundle. Ignore those annotations for this build.
+    ignoreAnnotations: true,
   });
 
   return { chunkUrl: "./plugins/site-bundle.js" };


### PR DESCRIPTION
## Why

Round-2 polish on top of #88/#89. Closes the admin-UX gaps the v1 shipped without and makes the plugin actually usable end-to-end for a real blog: upload → see thumbnail → drag in more → copy URL → set alt → paste into a post body.

## Server-side

- **`media.update({ id, alt?, title? })`** — new RPC. Owner OR `entry:media:edit_any` writes alt-text / title into `meta`. Returns `{ id, title, alt }`.
- **Worker-side rollback if `presignPut` throws** — `createUploadUrl` now wraps the presign step. If R2 / SigV4 / DNS goes wrong after the draft row landed, the row is deleted before the error propagates. Without this, a transient R2 outage leaks a draft per attempt.

## Admin Media Library

- **Drag-and-drop** files onto the grid — `onDrop` extracts files and fires the same `startUpload` path. Visual ring around the grid while dragging.
- **Multi-file upload with progress bar** — switched the PUT from `fetch()` to `XMLHttpRequest` so we can wire `xhr.upload.onprogress`. Per-file slot in a `pending` array; the bar shows aggregate progress + file count.
- **Inline alt-text editor** per card — blur to save. Calls `media.update`. Resyncs when the canonical value changes after a list invalidation.
- **Copy URL** button per card — `navigator.clipboard.writeText(url)` with a transient "Copied" indicator.
- **Infinite scroll** — replaces the v1 Prev/Next pagination. `useInfiniteQuery` + `IntersectionObserver` on a sentinel under the grid. Originally requested in the very first design pass and finally lands.
- **Single error banner** — collapsed the per-mutation banners into one `errorMsg` state shared by upload/delete/update.

## Tests

New cases in [packages/plugins/media/src/index.test.ts](packages/plugins/media/src/index.test.ts):
- `media.update` happy path (owner sets alt, list reflects it).
- `media.update` non-owner returns NOT_FOUND (uniform with non-existent id).
- `media.createUploadUrl` rolls back the draft entry when `presignPut` rejects — verifies the new server-side cleanup path.

48 plugin-media tests / 9 cloudflare runtime test files / 4 e2e specs all green.

## README

[packages/plugins/media/README.md](packages/plugins/media/README.md) — install, full wiring example, the **R2 CORS rules** consumers must apply (this was previously undocumented and silently broke browser uploads), capability table, RPC surface, admin UI feature list, deferred follow-ups.

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm -r test` — 7 packages green; 48 plugin-media tests
- [x] `pnpm -r lint` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm publint` + `pnpm attw` — clean
- [x] `pnpm --filter @plumix/plugin-media test:e2e` — 4/4 specs pass

## Stats

4 files changed, +605 / −128.

## Still deferred

- Per-user upload quota / rate limit
- Server-side draft-GC cron (client + server now clean up immediate failures; only mid-session drops still leak)
- Featured-image picker meta box for posts
- Bulk operations / search / tags
- Real worker-driven e2e (replace mocked RPC with `wrangler dev` + DB seed)
- `adminEntry` Node-resolution mechanism (replace the `node_modules/...` path string)