### PR TITLE
ci(plugin-media-playground): kill turbo task-graph race on typecheck

### DIFF
--- a/packages/plugins/media/playground/tsconfig.json
+++ b/packages/plugins/media/playground/tsconfig.json
@@ -1,7 +1,25 @@
 {
   "extends": "@plumix/typescript-config/base.json",
   "compilerOptions": {
-    "types": ["node", "@cloudflare/workers-types"]
+    "types": ["node", "@cloudflare/workers-types"],
+    // Resolve the workspace packages directly from `src/` rather than
+    // their built `dist/`. Otherwise the playground's typecheck
+    // depends on `^build` for every workspace dep, and turbo's task
+    // scheduler races: when an upstream package's typecheck is
+    // cache-hit but its build is cache-miss, the playground's
+    // typecheck can run before `dist/` exists, producing
+    // `Cannot find module '@plumix/runtime-cloudflare'` even though
+    // the dependency is correctly declared. Pointing TS at `src/`
+    // sidesteps the race entirely — this is a dogfooding rig, not a
+    // published package, so the layered-through-dist behavior of
+    // real consumers isn't what we're verifying here.
+    "paths": {
+      "plumix": ["../../../plumix/src/index.ts"],
+      "@plumix/plugin-media": ["../src/index.ts"],
+      "@plumix/runtime-cloudflare": [
+        "../../../runtimes/cloudflare/src/index.ts"
+      ]
+    }
   },
   "include": ["plumix.config.ts", ".plumix"]
 }


### PR DESCRIPTION
## What

Add tsconfig `paths` to the playground so its typecheck resolves `plumix`, `@plumix/plugin-media`, and `@plumix/runtime-cloudflare` from their `src/` directly — not via `dist/*.d.ts`.

## Why

Main's CI failed once already after #91 merged with:
```
plumix.config.ts:10:8 - error TS2307: Cannot find module '@plumix/runtime-cloudflare'
```

Re-running fixed it, but the cause is a turbo task-graph race that can re-fire any time. When `runtime-cloudflare:typecheck` is cache-hit but its `build` is cache-miss, turbo's scheduler can run downstream typechecks before `dist/` is written to disk. This breaks the playground's typecheck only — other consumers of `runtime-cloudflare` happened to have warm caches in the failing run.

Pointing the playground's TS resolver at `src/` removes the dependency on `dist/` for typecheck purposes. It's a dogfooding rig, not a published package, so we don't lose meaningful validation by skipping the layered-through-dist path.

## Test plan

Reproduced the failure mode locally:
```
rm -rf packages/{runtimes/cloudflare,plumix,plugins/media}/{dist,.cache}
pnpm --filter @plumix/plugin-media-playground typecheck
```
- Without this change → `Cannot find module '@plumix/runtime-cloudflare'`
- With this change → typecheck passes

Full pipeline (54 turbo tasks: typecheck/lint/test/format) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)