### PR TITLE
feat(plugin-media): attachment-detail drawer + 4-review fix pass

### DIFF
--- a/packages/plugins/media/src/admin/MediaLibrary.tsx
+++ b/packages/plugins/media/src/admin/MediaLibrary.tsx
@@ -1,5 +1,5 @@
 import type { DragEvent, ReactNode } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useInfiniteQuery,
   useMutation,
@@ -143,7 +143,10 @@ export function MediaLibrary(): ReactNode {
       last.hasMore ? allPages.length * PAGE_SIZE : undefined,
   });
 
-  const items = list.data?.pages.flatMap((p) => p.items) ?? [];
+  const items = useMemo(
+    () => list.data?.pages.flatMap((p) => p.items) ?? [],
+    [list.data?.pages],
+  );
 
   const invalidateList = useCallback((): void => {
     void queryClient.invalidateQueries({ queryKey: MEDIA_LIST_KEY });
@@ -271,102 +274,168 @@ export function MediaLibrary(): ReactNode {
     },
   };
 
+  // Keep `selectedItem` in state, not derived from `items`. The list
+  // refetches on every mutation; deriving would make the drawer
+  // disappear silently when the row briefly drops out of the page
+  // window or while a refetch is in flight. We refresh from the list
+  // by id when a fresh copy is available, never null it from absence.
+  const [selectedItem, setSelectedItem] = useState<MediaItem | null>(null);
+  useEffect(() => {
+    if (selectedItem === null) return;
+    const fresh = items.find((it) => it.id === selectedItem.id);
+    if (fresh && fresh !== selectedItem) setSelectedItem(fresh);
+    // If the row was deleted (not in items AND list is settled), close.
+    if (!fresh && list.status === "success" && !list.isFetching) {
+      setSelectedItem(null);
+    }
+  }, [items, list.status, list.isFetching, selectedItem]);
+
+  // ESC closes the detail drawer. Depend on the boolean `open` flag
+  // (primitive) so the listener doesn't tear down/rebind on every
+  // refresh of `selectedItem`.
+  const drawerOpen = selectedItem !== null;
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") setSelectedItem(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [drawerOpen]);
+
   return (
     <div
       data-testid="media-library"
-      className="relative flex flex-col gap-6 p-8"
+      style={{
+        display: "flex",
+        gap: "1.5rem",
+        padding: "2rem",
+        position: "relative",
+        minHeight: "100%",
+      }}
       {...dropProps}
     >
-      <header className="flex items-center justify-between">
-        <h1
-          data-testid="media-library-title"
-          className="text-3xl font-semibold tracking-tight"
-        >
-          Media Library
-        </h1>
-        <UploadButton onSelect={(files) => void startUpload(files)} />
-      </header>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          gap: "1.5rem",
+          minWidth: 0,
+        }}
+      >
+        <header className="flex items-center justify-between">
+          <h1
+            data-testid="media-library-title"
+            className="text-3xl font-semibold tracking-tight"
+          >
+            Media Library
+          </h1>
+          <UploadButton onSelect={(files) => void startUpload(files)} />
+        </header>
 
-      {pending.length > 0 && <UploadProgressBar pending={pending} />}
+        {pending.length > 0 && <UploadProgressBar pending={pending} />}
 
-      {list.status === "pending" && (
-        <div data-testid="media-library-loading" className="text-sm">
-          Loading…
-        </div>
-      )}
-      {list.status === "error" && (
-        <div
-          role="alert"
-          data-testid="media-library-error"
-          className="text-destructive text-sm"
-        >
-          Failed to load media.
-        </div>
-      )}
+        {list.status === "pending" && (
+          <div data-testid="media-library-loading" className="text-sm">
+            Loading…
+          </div>
+        )}
+        {list.status === "error" && (
+          <div
+            role="alert"
+            data-testid="media-library-error"
+            className="text-destructive text-sm"
+          >
+            Failed to load media.
+          </div>
+        )}
 
-      {list.status === "success" && items.length === 0 && (
-        <Dropzone
-          onSelect={(files) => void startUpload(files)}
-          highlight={dragging}
-        />
-      )}
+        {list.status === "success" && items.length === 0 && (
+          <Dropzone
+            onSelect={(files) => void startUpload(files)}
+            highlight={dragging}
+          />
+        )}
 
-      {list.status === "success" && items.length > 0 && (
-        <div
-          data-testid="media-library-grid"
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
-            gap: "1rem",
-          }}
-        >
-          {items.map((item) => (
-            <MediaCard
-              key={item.id}
-              item={item}
-              onDelete={() => {
-                if (
-                  typeof window !== "undefined" &&
-                  window.confirm(`Delete ${item.title}?`)
-                ) {
-                  remove.mutate(item.id);
-                }
-              }}
-              onAltChange={(alt) => update.mutate({ id: item.id, alt })}
-              deleting={remove.isPending && remove.variables === item.id}
-            />
-          ))}
-        </div>
-      )}
+        {list.status === "success" && items.length > 0 && (
+          <div
+            data-testid="media-library-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
+              gap: "1rem",
+            }}
+          >
+            {items.map((item) => (
+              <MediaCard
+                key={item.id}
+                item={item}
+                selected={selectedItem?.id === item.id}
+                onOpen={() => setSelectedItem(item)}
+                onDelete={() => {
+                  if (
+                    typeof window !== "undefined" &&
+                    window.confirm(`Delete ${item.title}?`)
+                  ) {
+                    if (selectedItem?.id === item.id) setSelectedItem(null);
+                    remove.mutate(item.id);
+                  }
+                }}
+                onAltChange={(alt) => update.mutate({ id: item.id, alt })}
+                deleting={remove.isPending && remove.variables === item.id}
+              />
+            ))}
+          </div>
+        )}
 
-      <div ref={sentinelRef} data-testid="media-library-sentinel" />
+        <div ref={sentinelRef} data-testid="media-library-sentinel" />
 
-      {list.isFetchingNextPage && (
-        <div
-          data-testid="media-library-loading-more"
-          className="text-muted-foreground text-center text-sm"
-        >
-          Loading more…
-        </div>
-      )}
+        {list.isFetchingNextPage && (
+          <div
+            data-testid="media-library-loading-more"
+            className="text-muted-foreground text-center text-sm"
+          >
+            Loading more…
+          </div>
+        )}
 
-      {/* Page-wide drop overlay — visible whenever a drag is active and
-          the populated grid is rendered (the empty state has its own
-          built-in highlight via the Dropzone component). */}
-      {dragging && items.length > 0 && (
-        <div
-          data-testid="media-library-drop-overlay"
-          aria-hidden="true"
-          style={{
-            position: "absolute",
-            top: "1rem",
-            right: "1rem",
-            bottom: "1rem",
-            left: "1rem",
-            border: "2px dashed var(--primary, #888)",
-            background: "rgba(127,127,127,0.05)",
-            borderRadius: "0.5rem",
-            pointerEvents: "none",
+        {/* Page-wide drop overlay — visible whenever a drag is active and
+            the populated grid is rendered (the empty state has its own
+            built-in highlight via the Dropzone component). */}
+        {dragging && items.length > 0 && (
+          <div
+            data-testid="media-library-drop-overlay"
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              top: "1rem",
+              right: "1rem",
+              bottom: "1rem",
+              left: "1rem",
+              border: "2px dashed var(--primary, #888)",
+              background: "rgba(127,127,127,0.05)",
+              borderRadius: "0.5rem",
+              pointerEvents: "none",
+            }}
+          />
+        )}
+      </div>
+
+      {selectedItem && (
+        <MediaDetailDrawer
+          item={selectedItem}
+          onClose={() => setSelectedItem(null)}
+          onAltChange={(alt) => update.mutate({ id: selectedItem.id, alt })}
+          onDelete={() => {
+            if (
+              typeof window !== "undefined" &&
+              window.confirm(`Delete ${selectedItem.title}?`)
+            ) {
+              const id = selectedItem.id;
+              setSelectedItem(null);
+              remove.mutate(id);
+            }
           }}
         />
       )}
@@ -612,11 +681,15 @@ function UploadProgressBar({
 
 function MediaCard({
   item,
+  selected,
+  onOpen,
   onDelete,
   onAltChange,
   deleting,
 }: {
   item: MediaItem;
+  selected: boolean;
+  onOpen: () => void;
   onDelete: () => void;
   onAltChange: (alt: string) => void;
   deleting: boolean;
@@ -638,7 +711,23 @@ function MediaCard({
   return (
     <article
       data-testid={`media-card-${String(item.id)}`}
+      data-selected={selected ? "true" : undefined}
       className="bg-card group relative flex flex-col gap-2 rounded border p-3"
+      style={{
+        outline: selected ? "2px solid var(--primary, #fff)" : undefined,
+        outlineOffset: selected ? "2px" : undefined,
+        cursor: "pointer",
+      }}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={`Open details for ${item.title}`}
     >
       <div
         style={{
@@ -647,6 +736,7 @@ function MediaCard({
           overflow: "hidden",
           borderRadius: "0.25rem",
           background: "var(--muted, rgba(127,127,127,0.1))",
+          display: "block",
         }}
       >
         {isImage ? (
@@ -655,7 +745,12 @@ function MediaCard({
             src={item.thumbnailUrl}
             alt={item.alt ?? item.title}
             loading="lazy"
-            className="h-full w-full object-cover"
+            style={{
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+              display: "block",
+            }}
           />
         ) : (
           <FileGlyph mime={item.mime} />
@@ -671,11 +766,25 @@ function MediaCard({
       <div className="text-muted-foreground text-xs">
         {item.mime} · {formatSize(item.size)}
       </div>
-      <div className="absolute top-2 right-2 flex gap-1 opacity-0 transition group-hover:opacity-100">
+      <div
+        style={{
+          position: "absolute",
+          top: "0.5rem",
+          right: "0.5rem",
+          display: "flex",
+          gap: "0.25rem",
+          opacity: 0,
+          transition: "opacity 120ms",
+        }}
+        className="group-hover:opacity-100"
+      >
         <button
           type="button"
           data-testid={`media-card-${String(item.id)}-copy`}
-          onClick={() => void copyUrl()}
+          onClick={(e) => {
+            e.stopPropagation();
+            void copyUrl();
+          }}
           className="bg-card hover:bg-muted rounded border px-2 py-0.5 text-xs"
         >
           {copied ? "Copied" : "Copy URL"}
@@ -684,7 +793,10 @@ function MediaCard({
           type="button"
           data-testid={`media-card-${String(item.id)}-delete`}
           disabled={deleting}
-          onClick={onDelete}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
           className="bg-card hover:bg-destructive hover:text-destructive-foreground rounded border px-2 py-0.5 text-xs disabled:opacity-50"
         >
           {deleting ? "Deleting…" : "Delete"}
@@ -694,13 +806,261 @@ function MediaCard({
   );
 }
 
+function MediaDetailDrawer({
+  item,
+  onClose,
+  onAltChange,
+  onDelete,
+}: {
+  item: MediaItem;
+  onClose: () => void;
+  onAltChange: (alt: string) => void;
+  onDelete: () => void;
+}): ReactNode {
+  const [copied, setCopied] = useState(false);
+  const isImage = item.mime.startsWith("image/");
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(item.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* user can copy from the visible URL */
+    }
+  }, [item.url]);
+
+  return (
+    <aside
+      data-testid="media-detail-drawer"
+      style={{
+        width: "320px",
+        flexShrink: 0,
+        position: "sticky",
+        top: "2rem",
+        alignSelf: "flex-start",
+        maxHeight: "calc(100vh - 4rem)",
+        overflowY: "auto",
+        border: "1px solid var(--border, rgba(255,255,255,0.1))",
+        borderRadius: "0.5rem",
+        background: "var(--card, rgba(255,255,255,0.02))",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0.75rem 1rem",
+          borderBottom: "1px solid var(--border, rgba(255,255,255,0.1))",
+        }}
+      >
+        <span
+          style={{ fontSize: "0.75rem", letterSpacing: "0.05em", opacity: 0.7 }}
+        >
+          ASSET DETAILS
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close details"
+          data-testid="media-detail-close"
+          style={{
+            all: "unset",
+            cursor: "pointer",
+            padding: "0.125rem 0.375rem",
+            borderRadius: "0.25rem",
+            fontSize: "1rem",
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      <div
+        style={{
+          aspectRatio: "1 / 1",
+          width: "100%",
+          background: "var(--muted, rgba(127,127,127,0.1))",
+          overflow: "hidden",
+        }}
+      >
+        {isImage ? (
+          <img
+            src={item.thumbnailUrl}
+            alt={item.alt ?? item.title}
+            style={{ width: "100%", height: "100%", objectFit: "contain" }}
+          />
+        ) : (
+          <FileGlyph mime={item.mime} />
+        )}
+      </div>
+
+      <div
+        style={{
+          padding: "1rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+        }}
+      >
+        <div>
+          <h2
+            style={{
+              fontSize: "1rem",
+              fontWeight: 600,
+              margin: 0,
+              wordBreak: "break-all",
+            }}
+          >
+            {item.title}
+          </h2>
+        </div>
+
+        <DetailField label="ASSET TYPE" value={item.mime} />
+        <DetailField label="FILE SIZE" value={formatSize(item.size)} />
+
+        <div>
+          <DetailLabel>ALT TEXT</DetailLabel>
+          <AltEditor
+            cardId={item.id}
+            testIdPrefix="media-detail"
+            value={item.alt ?? ""}
+            placeholder={
+              isImage ? "Describe this image…" : "Add a description…"
+            }
+            onSave={onAltChange}
+          />
+        </div>
+
+        <div>
+          <DetailLabel>URL</DetailLabel>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.5rem",
+            }}
+          >
+            <code
+              style={{
+                fontSize: "0.7rem",
+                flex: 1,
+                wordBreak: "break-all",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                opacity: 0.85,
+              }}
+              title={item.url}
+            >
+              {item.url}
+            </code>
+            <button
+              type="button"
+              onClick={() => void copy()}
+              data-testid="media-detail-copy"
+              className="bg-card hover:bg-muted rounded border px-2 py-0.5 text-xs"
+              style={{ flexShrink: 0 }}
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            gap: "0.5rem",
+            paddingTop: "0.5rem",
+            borderTop: "1px solid var(--border, rgba(255,255,255,0.1))",
+          }}
+        >
+          <a
+            // Always go through the worker serve route with
+            // ?attachment=1 — the HTML `download` attribute is ignored
+            // cross-origin (e.g. when `publicUrlBase` is configured),
+            // but the route always sends `Content-Disposition:
+            // attachment` for this query param, so downloads work
+            // regardless of which mode `item.url` is in.
+            href={`/_plumix/media/serve/${String(item.id)}?attachment=1`}
+            download={item.title}
+            data-testid="media-detail-download"
+            className="bg-card hover:bg-muted rounded border text-xs"
+            style={{
+              flex: 1,
+              padding: "0.5rem 0.75rem",
+              textAlign: "center",
+              textDecoration: "none",
+              color: "inherit",
+            }}
+          >
+            Download
+          </a>
+          <button
+            type="button"
+            data-testid="media-detail-delete"
+            onClick={onDelete}
+            className="hover:bg-destructive hover:text-destructive-foreground rounded border text-xs"
+            style={{
+              flex: 1,
+              padding: "0.5rem 0.75rem",
+              cursor: "pointer",
+              background: "transparent",
+              color: "inherit",
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function DetailLabel({ children }: { children: ReactNode }): ReactNode {
+  return (
+    <div
+      style={{
+        fontSize: "0.7rem",
+        letterSpacing: "0.05em",
+        opacity: 0.6,
+        marginBottom: "0.25rem",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function DetailField({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): ReactNode {
+  return (
+    <div>
+      <DetailLabel>{label}</DetailLabel>
+      <div style={{ fontSize: "0.875rem", wordBreak: "break-word" }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
 function AltEditor({
   cardId,
+  testIdPrefix = "media-card",
   value,
   placeholder,
   onSave,
 }: {
   cardId: number;
+  testIdPrefix?: string;
   value: string;
   placeholder: string;
   onSave: (alt: string) => void;
@@ -715,7 +1075,7 @@ function AltEditor({
   }, [value]);
   return (
     <input
-      data-testid={`media-card-${String(cardId)}-alt`}
+      data-testid={`${testIdPrefix}-${String(cardId)}-alt`}
       type="text"
       value={draft}
       placeholder={placeholder}

--- a/packages/plugins/media/src/index.test.ts
+++ b/packages/plugins/media/src/index.test.ts
@@ -386,6 +386,36 @@ describe("@plumix/plugin-media — media.confirm", () => {
     expect(confirm.error?.data?.reason).toBe("object_not_found");
   });
 
+  test("rejects an upload that exceeds meta.size with PAYLOAD_TOO_LARGE (413)", async () => {
+    // Bytes are not signed into the SigV4 query, so `meta.size` is
+    // just the client's claim. confirm must verify via head() that
+    // the actually-stored object isn't oversized — otherwise an
+    // attacker who got a presigned URL could PUT arbitrary size.
+    const storage = memoryStorage().connect({});
+    const h = await createDispatcherHarness({ plugins: [media()], storage });
+    const user = await h.seedUser("contributor");
+    const created = await rpcDispatch<CreateUploadUrlOutput>(
+      h,
+      "media/createUploadUrl",
+      { filename: "big.png", contentType: "image/png", size: 8 },
+      user.id,
+    );
+    if (!created.output) throw new Error("expected createUploadUrl output");
+    // Stuff 64 bytes of valid PNG header into a slot that claimed 8.
+    await storage.put(created.output.storageKey, PNG_1X1_BYTES, {
+      contentType: "image/png",
+    });
+    const confirm = await rpcDispatch(
+      h,
+      "media/confirm",
+      { id: created.output.mediaId },
+      user.id,
+    );
+    expect(confirm.status).toBe(413);
+    // Object should be deleted (defense-in-depth, no junk in bucket).
+    expect(await storage.head(created.output.storageKey)).toBeNull();
+  });
+
   test("returns FORBIDDEN for a different user's draft", async () => {
     const storage = memoryStorage().connect({});
     const h = await createDispatcherHarness({ plugins: [media()], storage });
@@ -406,6 +436,31 @@ describe("@plumix/plugin-media — media.confirm", () => {
       "media/confirm",
       { id: mediaId },
       other.id,
+    );
+    expect(confirm.status).toBe(403);
+  });
+
+  test("editors with entry:media:edit_any cannot confirm someone else's draft (owner-only)", async () => {
+    // Confirm finalizes someone else's pending upload — `edit_any` is
+    // for editing existing assets, not for taking over a half-baked
+    // draft. Even editor-tier users get 403 when they didn't author
+    // the draft.
+    const storage = memoryStorage().connect({});
+    const h = await createDispatcherHarness({ plugins: [media()], storage });
+    const owner = await h.seedUser("contributor");
+    const editor = await h.seedUser("editor");
+    const created = await rpcDispatch<CreateUploadUrlOutput>(
+      h,
+      "media/createUploadUrl",
+      { filename: "x.png", contentType: "image/png", size: 5 },
+      owner.id,
+    );
+    if (!created.output) throw new Error("expected createUploadUrl output");
+    const confirm = await rpcDispatch<ConfirmOutput>(
+      h,
+      "media/confirm",
+      { id: created.output.mediaId },
+      editor.id,
     );
     expect(confirm.status).toBe(403);
   });

--- a/packages/plugins/media/src/magic-bytes.ts
+++ b/packages/plugins/media/src/magic-bytes.ts
@@ -79,7 +79,11 @@ const isPlainText: Matcher = (b) => {
 const isISOBMFF: Matcher = sigAt(4, 0x66, 0x74, 0x79, 0x70);
 
 // PKZIP local-file header — also matches DOCX/XLSX/PPTX (they're zip
-// archives) and odt/ods/odp.
+// archives) and odt/ods/odp. We sniff "is this a zip container", NOT
+// "is this the right Office subtype". A `.docx` claimed as xlsx still
+// passes — verifying via the OOXML `[Content_Types].xml` is out of
+// scope; the inline-safe allowlist excludes all of these so the
+// serve route force-downloads regardless of subtype.
 const isZipContainer: Matcher = startsWith(0x50, 0x4b, 0x03, 0x04);
 
 // OLE2 compound document — legacy Office (.doc/.xls/.ppt).

--- a/packages/plugins/media/src/rpc.ts
+++ b/packages/plugins/media/src/rpc.ts
@@ -214,10 +214,13 @@ export function createMediaRouter(
         .limit(1);
       if (row?.type !== MEDIA_ENTRY_TYPE) throw notFound();
 
-      const isOwner = row.authorId === context.user.id;
-      if (!isOwner && !context.auth.can("entry:media:edit_any")) {
+      // Confirm is owner-only — `entry:media:edit_any` is for editing
+      // existing assets, not finalizing someone else's drafts. A
+      // non-owner shouldn't be able to publish another user's
+      // half-completed upload.
+      if (row.authorId !== context.user.id) {
         throw errors.FORBIDDEN({
-          data: { capability: "entry:media:edit_any" },
+          data: { capability: "entry:media:create" },
         });
       }
 
@@ -231,14 +234,23 @@ export function createMediaRouter(
         throw errors.CONFLICT({ data: { reason: "storage_not_configured" } });
       }
 
-      // Verify the presigned PUT actually landed AND defend against MIME
-      // confusion in one round-trip: a ranged read returns null if the
-      // object is missing, otherwise hands us the first bytes to check
-      // against the claimed content-type. The bucket stores whatever the
-      // upload signed, so if a client claimed `image/png` but uploaded
-      // arbitrary bytes, we'd serve them as PNG forever. Delete on
-      // mismatch so an attacker can't force-leave junk in the bucket
-      // between a forged claim and our detection.
+      // Size check — bytes are not signed into the SigV4 query, so
+      // `meta.size` is just the client's claim at draft creation. Use
+      // head() to verify the actually-stored bytes don't exceed it.
+      const head = await storage.head(meta.storageKey);
+      if (!head) {
+        throw errors.CONFLICT({ data: { reason: "object_not_found" } });
+      }
+      if (head.size > meta.size) {
+        await storage.delete(meta.storageKey);
+        throw errors.PAYLOAD_TOO_LARGE({
+          data: { limit: meta.size, received: head.size },
+        });
+      }
+
+      // Verify the bytes match the claimed mime via magic-byte sniff.
+      // Delete on mismatch so an attacker can't force-leave junk in
+      // the bucket between a forged claim and our detection.
       const sampleObj = await storage.get(meta.storageKey, {
         range: { offset: 0, length: MAGIC_BYTE_SAMPLE_SIZE },
       });

--- a/packages/plugins/media/src/serve-route.ts
+++ b/packages/plugins/media/src/serve-route.ts
@@ -84,18 +84,32 @@ export async function handleMediaServe(
     });
   }
 
+  // `?attachment=1` forces a download regardless of mime. The admin's
+  // Download button uses this so the response carries the attachment
+  // disposition even when `publicUrlBase` would otherwise route around
+  // the worker (HTML `<a download>` is silently ignored cross-origin
+  // without a matching `Content-Disposition` header).
+  const forceAttachment = url.searchParams.get("attachment") === "1";
+  const inline = !forceAttachment && INLINE_SAFE_MIMES.has(meta.mime);
+
   const headers = new Headers();
   headers.set("content-type", meta.mime);
   headers.set("content-length", String(obj.size));
   headers.set("cache-control", cacheControl());
   headers.set("x-content-type-options", "nosniff");
   if (obj.etag) headers.set("etag", obj.etag);
-  if (!INLINE_SAFE_MIMES.has(meta.mime)) {
-    const filename = sanitizeFilename(row.title);
-    headers.set("content-disposition", `attachment; filename="${filename}"`);
-  }
+  if (!inline)
+    headers.set("content-disposition", contentDisposition(row.title));
 
   return new Response(obj.body, { status: 200, headers });
+}
+
+function contentDisposition(title: string): string {
+  // RFC 6266: ASCII fallback in `filename="..."` plus a UTF-8
+  // `filename*=UTF-8''...` so non-Latin titles aren't mangled.
+  const ascii = sanitizeFilename(title);
+  const utf8 = encodeURIComponent(title);
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${utf8}`;
 }
 
 function cacheControl(): string {


### PR DESCRIPTION
## Summary

Adds the WordPress-style attachment-detail drawer (right-rail, updates as cards are clicked) and addresses convergent findings from four parallel reviews (find-bugs / code-review / code-simplifier / sentry:senpai) on the whole plugin.

## What's in

**New: MediaDetailDrawer** — preview, title, mime, size, alt-text editor, URL with copy, download, delete. ESC + × to close. Survives list refetches.

**Critical fixes from review consensus:**
- Selection state owns the item (was: derived from `items.find(...)`, drawer disappeared on refetch)
- `confirm` is owner-only (was: `entry:media:edit_any` could finalize someone else's draft)
- `confirm` verifies actual size via `head()` (was: `meta.size` was the client's claim, no server check)
- Cross-origin downloads route through `/_plumix/media/serve/<id>?attachment=1` (was: `<a download>` silently ignored cross-origin)
- Drawer preview uses thumbnail (was: full-resolution refetch on every drawer open)

**UX / a11y:**
- Card thumbnail click target is the article (role=button + tabIndex + Enter/Space) — fixes the giant-cloud-icon rendering bug from the previous wrapper-button approach
- ESC handler depends on a primitive boolean — no listener thrash on refetch
- AltEditor `testIdPrefix` so drawer/card don't collide on data-testid
- Card actions stopPropagation
- useMemo for flattened items

## Tests

70 tests in plugin (up from 67):
- `confirm` rejects editor-tier non-owners (owner-only enforcement)
- `confirm` rejects oversized objects (413, object deleted)
- All existing serve-route, upload-route, RPC tests passing

54 turbo tasks green.

## Deferred to follow-up PRs

- MediaLibrary.tsx file split (~1100 lines, six components in one file)
- `window.confirm` → AlertDialog (needs admin component imports via shared-runtime importmap)
- Drawer component tests (need jsdom + @testing-library/react in plugin's vitest config)
- Caption / description / uploadedBy / dimensions (incremental WP-parity)
- Server-side draft GC cron
- Per-file upload error rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)