### PR TITLE
fix(admin): defer initial mount until plugin chunks register

### DIFF
--- a/packages/admin/src/lib/wait-for-plugin-chunks.test.ts
+++ b/packages/admin/src/lib/wait-for-plugin-chunks.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { waitForPluginChunks } from "./wait-for-plugin-chunks.js";
+
+afterEach(() => {
+  document.head.replaceChildren();
+  document.body.replaceChildren();
+});
+
+function appendPluginScript(id: string): HTMLScriptElement {
+  const script = document.createElement("script");
+  script.type = "module";
+  script.dataset.plumixPlugin = id;
+  script.src = `/plugins/${id}.js`;
+  document.body.appendChild(script);
+  return script;
+}
+
+function settled<T>(promise: Promise<T>): Promise<"settled" | "pending"> {
+  return Promise.race([
+    promise.then(() => "settled" as const),
+    new Promise<"pending">((resolve) => {
+      setTimeout(() => resolve("pending"), 10);
+    }),
+  ]);
+}
+
+describe("waitForPluginChunks", () => {
+  test("resolves immediately when no plugin chunks are present", async () => {
+    await expect(waitForPluginChunks()).resolves.toBeUndefined();
+  });
+
+  test("ignores non-plugin script tags", async () => {
+    const other = document.createElement("script");
+    other.src = "/other.js";
+    document.body.appendChild(other);
+    await expect(waitForPluginChunks()).resolves.toBeUndefined();
+  });
+
+  test("ignores plugin <link rel=stylesheet> tags", async () => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.dataset.plumixPlugin = "media";
+    link.href = "/plugins/media.css";
+    document.head.appendChild(link);
+    await expect(waitForPluginChunks()).resolves.toBeUndefined();
+  });
+
+  test("waits until every plugin script fires load", async () => {
+    const a = appendPluginScript("media");
+    const b = appendPluginScript("menus");
+    const promise = waitForPluginChunks();
+
+    expect(await settled(promise)).toBe("pending");
+
+    a.dispatchEvent(new Event("load"));
+    expect(await settled(promise)).toBe("pending");
+
+    b.dispatchEvent(new Event("load"));
+    expect(await settled(promise)).toBe("settled");
+  });
+
+  test("treats error as settled so a broken plugin does not block the admin", async () => {
+    const broken = appendPluginScript("broken");
+    const ok = appendPluginScript("ok");
+    const promise = waitForPluginChunks();
+
+    broken.dispatchEvent(new Event("error"));
+    ok.dispatchEvent(new Event("load"));
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+});

--- a/packages/admin/src/lib/wait-for-plugin-chunks.ts
+++ b/packages/admin/src/lib/wait-for-plugin-chunks.ts
@@ -1,34 +1,27 @@
 // Plugin admin chunks register their React components at module-eval
 // time via `window.plumix.registerPluginPage(...)`. Their `<script
 // type="module" data-plumix-plugin>` tags are injected after the main
-// bundle in document order, so they evaluate AFTER `main.tsx` runs.
-// If we mounted React synchronously here, the very first route render
-// would happen with an empty registry — a direct hit on
-// `/_plumix/admin/pages/<plugin>` would land on "Plugin not loaded"
-// even though the plugin would register a tick later. Waiting for
-// every plugin script's `load`/`error` event before mounting closes
-// that race.
+// bundle in document order, so they evaluate after `main.tsx` runs.
+// Mounting React without waiting renders the first route against an
+// empty registry — a deep link to `/_plumix/admin/pages/<plugin>`
+// lands on "Plugin not loaded" with no re-render to recover.
 //
-// Safe re: listener attachment: this runs inside the main bundle's
-// module evaluation, and module scripts evaluate in document order, so
-// later plugin script tags cannot have fired their load events yet.
-// On `error` we still resolve so a single broken plugin doesn't block
-// the whole admin — that page falls back to "Plugin not loaded" while
-// the rest of the app works.
-export function waitForPluginChunks(doc: Document = document): Promise<void> {
-  const scripts = doc.querySelectorAll<HTMLScriptElement>(
+// Listener attachment is safe because this runs inside the main
+// bundle's module evaluation, and module scripts evaluate in document
+// order — later plugin tags can't have fired their load events yet.
+// `error` resolves too so a single broken plugin chunk doesn't block
+// the rest of the admin.
+export async function waitForPluginChunks(): Promise<void> {
+  const scripts = document.querySelectorAll<HTMLScriptElement>(
     "script[data-plumix-plugin]",
   );
-  if (scripts.length === 0) return Promise.resolve();
-  return Promise.all(Array.from(scripts).map(waitForScriptSettled)).then(
-    () => undefined,
-  );
+  await Promise.all(Array.from(scripts).map(waitForScriptSettled));
 }
 
 function waitForScriptSettled(script: HTMLScriptElement): Promise<void> {
   return new Promise((resolve) => {
-    const done = (): void => resolve();
-    script.addEventListener("load", done, { once: true });
-    script.addEventListener("error", done, { once: true });
+    const settle = (): void => resolve();
+    script.addEventListener("load", settle, { once: true });
+    script.addEventListener("error", settle, { once: true });
   });
 }

--- a/packages/admin/src/lib/wait-for-plugin-chunks.ts
+++ b/packages/admin/src/lib/wait-for-plugin-chunks.ts
@@ -1,0 +1,34 @@
+// Plugin admin chunks register their React components at module-eval
+// time via `window.plumix.registerPluginPage(...)`. Their `<script
+// type="module" data-plumix-plugin>` tags are injected after the main
+// bundle in document order, so they evaluate AFTER `main.tsx` runs.
+// If we mounted React synchronously here, the very first route render
+// would happen with an empty registry — a direct hit on
+// `/_plumix/admin/pages/<plugin>` would land on "Plugin not loaded"
+// even though the plugin would register a tick later. Waiting for
+// every plugin script's `load`/`error` event before mounting closes
+// that race.
+//
+// Safe re: listener attachment: this runs inside the main bundle's
+// module evaluation, and module scripts evaluate in document order, so
+// later plugin script tags cannot have fired their load events yet.
+// On `error` we still resolve so a single broken plugin doesn't block
+// the whole admin — that page falls back to "Plugin not loaded" while
+// the rest of the app works.
+export function waitForPluginChunks(doc: Document = document): Promise<void> {
+  const scripts = doc.querySelectorAll<HTMLScriptElement>(
+    "script[data-plumix-plugin]",
+  );
+  if (scripts.length === 0) return Promise.resolve();
+  return Promise.all(Array.from(scripts).map(waitForScriptSettled)).then(
+    () => undefined,
+  );
+}
+
+function waitForScriptSettled(script: HTMLScriptElement): Promise<void> {
+  return new Promise((resolve) => {
+    const done = (): void => resolve();
+    script.addEventListener("load", done, { once: true });
+    script.addEventListener("error", done, { once: true });
+  });
+}

--- a/packages/admin/src/main.tsx
+++ b/packages/admin/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
 import { bootPlumixGlobals } from "./lib/plumix-globals.js";
+import { waitForPluginChunks } from "./lib/wait-for-plugin-chunks.js";
 
 import "./styles/globals.css";
 
@@ -16,8 +17,15 @@ bootPlumixGlobals();
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Missing #root element");
 
-createRoot(rootElement).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+// Defer the initial mount until every `<script data-plumix-plugin>` tag
+// has finished evaluating. Otherwise a deep-link to a plugin route
+// (e.g. /_plumix/admin/pages/media) renders before the plugin's
+// registerPluginPage() side effect runs, and the route falls through
+// to "Plugin not loaded" with no re-render to recover.
+void waitForPluginChunks().then(() => {
+  createRoot(rootElement).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+});

--- a/packages/admin/src/main.tsx
+++ b/packages/admin/src/main.tsx
@@ -10,18 +10,15 @@ import { waitForPluginChunks } from "./lib/wait-for-plugin-chunks.js";
 
 import "./styles/globals.css";
 
-// Plugin chunks load after this script and call window.plumix.* at
-// module-eval time, so the global has to exist before they execute.
+// Plugin chunks evaluate after this script and call `window.plumix.*`
+// at module-eval time. Boot the global first so it exists when they
+// run, then defer the initial mount until every chunk has settled —
+// see `waitForPluginChunks` for why.
 bootPlumixGlobals();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Missing #root element");
 
-// Defer the initial mount until every `<script data-plumix-plugin>` tag
-// has finished evaluating. Otherwise a deep-link to a plugin route
-// (e.g. /_plumix/admin/pages/media) renders before the plugin's
-// registerPluginPage() side effect runs, and the route falls through
-// to "Plugin not loaded" with no re-render to recover.
 void waitForPluginChunks().then(() => {
   createRoot(rootElement).render(
     <StrictMode>


### PR DESCRIPTION
## Summary

Direct deep-links to plugin-registered admin pages (e.g. `/_plumix/admin/pages/media`) rendered "Plugin not loaded" even when the plugin was wired up correctly. Navigating to the dashboard first and then clicking through worked.

**Cause.** The HTML emits two `<script type="module">` tags — the main admin bundle and the plugin site-bundle (injected before `</body>`). Module scripts evaluate in document order, so by the time `main.tsx` calls `createRoot().render()` the plugin module hasn't run yet, and `getPluginPage("/media")` returns `undefined`. The plugin module then registers its component a tick later, but the registry is a plain `Map` with no subscription, so React never re-renders. Dashboard-first works only because the plugin module finishes long before the user clicks the nav link, and the route transition triggers a fresh registry lookup.

**Fix.** Defer the initial mount in [main.tsx](packages/admin/src/main.tsx) until every `<script data-plumix-plugin>` tag has fired `load` (or `error` — a single broken plugin shouldn't take down the whole admin; that page falls back to "Plugin not loaded" while the rest works). The wait helper is extracted to its own module with colocated unit tests.

Safe re: listener attachment timing: this code runs inside the main bundle's module evaluation, and module scripts evaluate in document order, so later plugin script tags can't have fired their load events yet.

## Test plan

- [x] `pnpm vitest run src/lib/wait-for-plugin-chunks.test.ts` — 5 new tests pass (no scripts, ignores non-plugin scripts, ignores `<link>` tags, waits for every plugin script, treats error as settled)
- [ ] Deploy to a worker and confirm hard-refresh on `/_plumix/admin/pages/media` renders the Media Library instead of "Plugin not loaded"
- [ ] Confirm dashboard-first navigation still works (no regression)