### PR TITLE
fix(plumix): make plugin chunk URLs absolute (fixes "Plugin not loaded" deep-links)

### DIFF
--- a/packages/plumix/src/vite/admin-plugin-bundle.test.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.test.ts
@@ -173,7 +173,12 @@ describe("assemblePluginAdminBundle", () => {
       projectRoot: workspace,
     });
 
-    expect(result?.cssUrl).toBe("./plugins/site-bundle.css");
+    // Both URLs must be absolute — relative `./plugins/...` would 404
+    // when the SPA serves index.html for a deep-link like
+    // `/_plumix/admin/pages/<plugin>` and the browser resolves the
+    // src against the current URL.
+    expect(result?.chunkUrl).toBe("/_plumix/admin/plugins/site-bundle.js");
+    expect(result?.cssUrl).toBe("/_plumix/admin/plugins/site-bundle.css");
     const css = await readFile(
       resolve(adminDest, "plugins/site-bundle.css"),
       "utf8",

--- a/packages/plumix/src/vite/admin-plugin-bundle.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.ts
@@ -20,6 +20,15 @@ import {
 // `plumix/admin/<lib>` shims that read from `window.plumix.runtime.*`
 // — single React instance across host + plugin.
 
+// Plugin chunk URLs MUST be absolute (not `./plugins/...`). The SPA's
+// index.html is served for every deep-link, so a relative `src`
+// resolves against the current URL — `/_plumix/admin/pages/media`
+// would fetch `/_plumix/admin/pages/plugins/site-bundle.js` and 404,
+// leaving the plugin registry empty and rendering "Plugin not loaded"
+// on direct deep-links. Same prefix the dispatcher and admin Vite
+// config hardcode.
+export const ADMIN_URL_PREFIX = "/_plumix/admin";
+
 interface AssembledBundle {
   readonly chunkUrl: string;
   readonly cssUrl?: string;
@@ -127,8 +136,8 @@ export async function assemblePluginAdminBundle({
   });
 
   return {
-    chunkUrl: "./plugins/site-bundle.js",
-    cssUrl: cssUrl ? "./plugins/site-bundle.css" : undefined,
+    chunkUrl: `${ADMIN_URL_PREFIX}/plugins/site-bundle.js`,
+    cssUrl: cssUrl ? `${ADMIN_URL_PREFIX}/plugins/site-bundle.css` : undefined,
   };
 }
 

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -27,7 +27,10 @@ import {
 } from "@plumix/core";
 
 import { loadConfig } from "../cli/load-config.js";
-import { assemblePluginAdminBundle } from "./admin-plugin-bundle.js";
+import {
+  ADMIN_URL_PREFIX,
+  assemblePluginAdminBundle,
+} from "./admin-plugin-bundle.js";
 
 // `import.meta.url` for this module lives at plumix/dist/vite/index.js in
 // consumer installs, so the pre-compiled admin artifact is a sibling at
@@ -254,14 +257,14 @@ async function stagePluginChunks(
           projectRoot,
         );
         cssCopy = copyFile(cssSource, resolve(pluginsDir, `${plugin.id}.css`));
-        cssUrl = `./plugins/${plugin.id}.css`;
+        cssUrl = `${ADMIN_URL_PREFIX}/plugins/${plugin.id}.css`;
       }
       const pending: Promise<void>[] = [chunkCopy];
       if (cssCopy) pending.push(cssCopy);
       await Promise.all(pending);
       return {
         pluginId: plugin.id,
-        chunkUrl: `./plugins/${plugin.id}.js`,
+        chunkUrl: `${ADMIN_URL_PREFIX}/plugins/${plugin.id}.js`,
         cssUrl,
       };
     }),

--- a/packages/plumix/test/vite-plugin-chunks.test.ts
+++ b/packages/plumix/test/vite-plugin-chunks.test.ts
@@ -217,8 +217,8 @@ describe("plugin-host acceptance — end-to-end primitive coverage", () => {
     // when the plugin shape shifts.
     const expectedBlock = [
       "<!-- plumix:plugin-chunks -->",
-      '<link rel="stylesheet" data-plumix-plugin="hello-world" href="./plugins/hello-world.css">',
-      '<script type="module" data-plumix-plugin="hello-world" src="./plugins/hello-world.js"></script>',
+      '<link rel="stylesheet" data-plumix-plugin="hello-world" href="/_plumix/admin/plugins/hello-world.css">',
+      '<script type="module" data-plumix-plugin="hello-world" src="/_plumix/admin/plugins/hello-world.js"></script>',
       "<!-- /plumix:plugin-chunks -->",
     ].join("\n");
     html = html.replace("</body>", `${expectedBlock}\n</body>`);
@@ -228,10 +228,10 @@ describe("plugin-host acceptance — end-to-end primitive coverage", () => {
     const roundTrip = await readFile(destHtml, "utf8");
 
     expect(roundTrip).toContain(
-      '<link rel="stylesheet" data-plumix-plugin="hello-world" href="./plugins/hello-world.css">',
+      '<link rel="stylesheet" data-plumix-plugin="hello-world" href="/_plumix/admin/plugins/hello-world.css">',
     );
     expect(roundTrip).toContain(
-      '<script type="module" data-plumix-plugin="hello-world" src="./plugins/hello-world.js"></script>',
+      '<script type="module" data-plumix-plugin="hello-world" src="/_plumix/admin/plugins/hello-world.js"></script>',
     );
     // Manifest still present alongside the plugin block.
     expect(roundTrip).toContain('<script id="plumix-manifest"');


### PR DESCRIPTION
## Summary

Direct deep-link to a plugin route (e.g. `/_plumix/admin/pages/media`) still showed "Plugin not loaded" after #97, even though the script-execution-order race was closed.

**Cause.** The vite plugin emitted **relative** `<script>` and `<link>` URLs for staged plugin chunks: `./plugins/<id>.js`. Browsers resolve a relative `src` against the current URL, but the SPA's `index.html` is served for every deep-link, so:

| Page URL | Resolved chunk URL | |
|---|---|---|
| `/_plumix/admin/` | `/_plumix/admin/plugins/site-bundle.js` | 200 |
| `/_plumix/admin/pages/media` | `/_plumix/admin/pages/plugins/site-bundle.js` | **404** |

The plugin chunk 404'd, the registry stayed empty, the route fell through to "Plugin not loaded". From the dashboard the chunk loaded fine, registered, and was already in the registry by the time the user clicked the Media Library nav item.

[#97](https://github.com/withplumix/plumix/pull/97)'s defer-mount fix actually masked this — the `error`-as-settled path let the broken script count as done and React mounted on an empty registry. (That fix is still needed for the in-document-order race; it just couldn't paper over a 404.)

**Fix.** Switch all four chunk-URL emit sites to absolute paths under `/_plumix/admin/`:
- assembled `site-bundle.js` + `site-bundle.css` (the Tailwind sidecar from #108) in [admin-plugin-bundle.ts](packages/plumix/src/vite/admin-plugin-bundle.ts)
- per-plugin `<id>.js` + `<id>.css` for legacy `adminChunk` plugins in [vite/index.ts](packages/plumix/src/vite/index.ts)

A single `ADMIN_URL_PREFIX = "/_plumix/admin"` constant is exported from `admin-plugin-bundle.ts` and used by both. The same prefix is hardcoded in the dispatcher and admin Vite config; consolidating to one shared source-of-truth across packages would be a follow-up.

## Test plan

- [x] `pnpm --filter plumix test src/vite/admin-plugin-bundle.test.ts` — Tailwind sidecar test now asserts both `chunkUrl` and `cssUrl` resolve to `/_plumix/admin/plugins/...`
- [x] `pnpm --filter plumix test test/vite-plugin-chunks.test.ts` — round-trip HTML test updated to expect absolute URLs in the injected `<script>` and `<link>` tags
- [ ] Deploy to a worker, hard-refresh on `/_plumix/admin/pages/media`, confirm Media Library renders
- [ ] Confirm dashboard-first navigation still works (no regression)

## Notes

- Two pre-existing test failures in `test/vite-plugin-chunks.test.ts` and `src/vite/admin-plugin-bundle.test.ts` (`auto-emits register* calls...`) — both failing on clean main, fallout from [#108](https://github.com/withplumix/plumix/pull/108)'s `PluginComponentRef: { package, export } → string` breaking change. Out of scope for this PR.