### PR TITLE
AI-review accepts + shadcn drift cleanup

### DIFF
--- a/packages/admin/e2e/content.spec.ts
+++ b/packages/admin/e2e/content.spec.ts
@@ -153,7 +153,8 @@ test.describe("/entries/$slug", () => {
     });
 
     await page.goto("entries/posts?status=all&page=1");
-    await page.getByTestId("author-filter").selectOption("mine");
+    await page.getByTestId("author-filter").click();
+    await page.getByTestId("author-filter-mine").click();
     await expect(page).toHaveURL(/author=mine/);
     await expect
       .poll(

--- a/packages/admin/src/components/form/search-input.tsx
+++ b/packages/admin/src/components/form/search-input.tsx
@@ -40,7 +40,7 @@ export function DebouncedSearchInput({
     <div className="relative">
       <Search
         aria-hidden
-        className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2"
+        className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2"
       />
       <Input
         type="search"
@@ -53,7 +53,7 @@ export function DebouncedSearchInput({
         onChange={(e) => {
           setValue(e.target.value);
         }}
-        className="h-9 w-64 pl-8"
+        className="h-9 w-64 pl-9"
       />
     </div>
   );

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -29,6 +29,13 @@ import {
   PaginationContent,
   PaginationItem,
 } from "@/components/ui/pagination.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select.js";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.js";
 import { hasCap } from "@/lib/caps.js";
 import { toDate } from "@/lib/dates.js";
@@ -730,9 +737,6 @@ function StatusViews({
   );
 }
 
-const SELECT_CLASS =
-  "border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-2 text-sm focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
-
 // Stable empty array reference — react-query returns a fresh `[]`
 // fallback on every render when `data` is undefined, which breaks
 // useMemo identity in `TaxonomyFilter`.
@@ -743,6 +747,12 @@ const EMPTY_TERMS: readonly Term[] = [];
 // invalidates every tick when termTaxonomies is undefined).
 const EMPTY_TAXONOMY_NAMES: readonly string[] = [];
 
+const AUTHOR_FILTER_OPTIONS: readonly { value: AuthorFilter; label: string }[] =
+  [
+    { value: "all", label: "All authors" },
+    { value: "mine", label: "Mine" },
+  ];
+
 function AuthorSelect({
   value,
   onChange,
@@ -751,18 +761,31 @@ function AuthorSelect({
   onChange: (next: AuthorFilter) => void;
 }): ReactNode {
   return (
-    <select
-      aria-label="Filter by author"
-      data-testid="author-filter"
-      className={SELECT_CLASS}
+    <Select
       value={value}
-      onChange={(e) => {
-        onChange(e.target.value as AuthorFilter);
+      onValueChange={(next) => {
+        onChange(next as AuthorFilter);
       }}
     >
-      <option value="all">All authors</option>
-      <option value="mine">Mine</option>
-    </select>
+      <SelectTrigger
+        size="sm"
+        aria-label="Filter by author"
+        data-testid="author-filter"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {AUTHOR_FILTER_OPTIONS.map((opt) => (
+          <SelectItem
+            key={opt.value}
+            value={opt.value}
+            data-testid={`author-filter-${opt.value}`}
+          >
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 

--- a/packages/plugins/media/src/serve-route.ts
+++ b/packages/plugins/media/src/serve-route.ts
@@ -49,7 +49,9 @@ export async function handleMediaServe(
     return new Response(null, { status: 404 });
   }
   const idStr = url.pathname.slice(PREFIX.length);
-  if (!/^[1-9]\d{0,15}$/.test(idStr)) {
+  // 15 digits max keeps the parsed value below Number.MAX_SAFE_INTEGER
+  // (~9.007e15) — 16 digits could round on parseInt.
+  if (!/^[1-9]\d{0,14}$/.test(idStr)) {
     return new Response(null, { status: 400 });
   }
   const id = Number.parseInt(idStr, 10);

--- a/packages/plumix/src/admin/shim-drift.test.ts
+++ b/packages/plumix/src/admin/shim-drift.test.ts
@@ -70,11 +70,17 @@ const SHIMS: readonly ShimSpec[] = [
     upstream: ReactQueryNs,
     load: () => import("./react-query.js"),
     knownGaps: new Set([
-      // Internal singletons — typing doesn't round-trip cleanly; plugin
-      // code reaches them via hooks (useIsFetching etc.) instead.
+      // Internal singletons — plugin code reaches them via hooks
+      // (useIsFetching etc.) instead.
       "focusManager",
       "notifyManager",
       "onlineManager",
+      // Public hook, but its inferred return type references
+      // `QueryErrorResetBoundaryValue` from react-query's internal
+      // `_tsup-dts-rollup.js` — re-exporting trips TS2883 in our
+      // `.d.ts` emit. Plugins that need error-boundary reset can read
+      // it via the `QueryErrorResetBoundary` component (re-exported)
+      // through context.
       "useQueryErrorResetBoundary",
       // Internal helpers + symbols — not part of the documented surface.
       "dataTagErrorSymbol",


### PR DESCRIPTION
## Summary

Four small, related fixes:

- **plugin-media**: tighten the `serve` route's id regex from `\d{0,15}` to `\d{0,14}` so a 16-digit value can't round on `Number.parseInt` past `MAX_SAFE_INTEGER`.
- **plumix**: clarify the `knownGaps` comment for `useQueryErrorResetBoundary` — it's a public hook (not an internal singleton), but its inferred return type references react-query's private `_tsup-dts-rollup.js` so re-exporting trips TS2883.
- **admin**: replace `AuthorSelect`'s hand-rolled native `<select>` (with its own Tailwind block) with shadcn `<Select>`, matching the `RoleFilter` pattern. E2e updated to click trigger + item instead of `selectOption()`.
- **admin**: shift `DebouncedSearchInput`'s icon `left-2 → left-3` and Input `pl-8 → pl-9` so the placeholder isn't flush against the magnifier.

The `components/ui/*` shadcn files (input, select, button) were spot-checked against upstream — 1:1, just with classes reordered by the Tailwind sorter.

## Test plan
- [ ] CI green
- [ ] `/entries/posts` author filter dropdown opens and switches between "All authors" / "Mine"
- [ ] Search inputs have visible gap between icon and placeholder