### PR TITLE
refactor(core): align wire-format naming pre-0.1.0

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -64,7 +64,6 @@ const config: KnipConfig = {
         "src/test/playwright.ts",
         "src/theme/index.ts",
         "src/vite/index.ts",
-        "bin/plumix.mjs",
       ],
       // - drizzle-kit is invoked by consumers as a CLI hint, not imported.
       // - @plumix/admin is consumed via filesystem copy (scripts/copy-admin.mjs).
@@ -86,15 +85,6 @@ const config: KnipConfig = {
         // .tsx extension swap; list explicitly.
         "e2e/fixtures/runtime-proof-plugin/src/MediaLibrary.tsx",
       ],
-    },
-    // The `./commands` subpath export points at `dist/commands/index.js` —
-    // knip's default entry discovery only reads `exports` paths and
-    // doesn't map them back to source files, so the whole `src/commands`
-    // tree plus its deps (`@cloudflare/vite-plugin`, `plumix`) read as
-    // unused. Explicit entries pin the source location. `plumix` is a
-    // workspace sibling used transitively via `emitPlumixSources`.
-    "packages/runtimes/cloudflare": {
-      entry: ["src/index.ts", "src/commands/index.ts"],
     },
     // The admin chunk is loaded by the plumix vite plugin at consumer
     // build time via `adminEntry` — knip can't follow that runtime path.

--- a/packages/admin/e2e/users.spec.ts
+++ b/packages/admin/e2e/users.spec.ts
@@ -436,9 +436,9 @@ test.describe("/users/$id/edit", () => {
         () =>
           (
             deleteInputs.at(-1) as
-              | { id?: number; reassignPostsTo?: number }
+              | { id?: number; reassignTo?: number }
               | undefined
-          )?.reassignPostsTo,
+          )?.reassignTo,
       )
       .toBe(inheritor.id);
     await expect(page).toHaveURL(/\/users/);

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -361,7 +361,7 @@ function ContentListRoute(): ReactNode {
   const rows: readonly Entry[] = query.data ?? [];
   const canPrev = search.page > 1;
   // Heuristic "next exists": a full page came back. Imprecise when total is an
-  // exact multiple of PAGE_SIZE — the user sees an extra empty page. `post.list`
+  // exact multiple of PAGE_SIZE — the user sees an extra empty page. `entry.list`
   // doesn't expose a total count today; accept the edge case until it does.
   const canNext = rows.length === PAGE_SIZE;
 

--- a/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
@@ -514,7 +514,7 @@ function DeleteCard({ target }: { target: User }): ReactNode {
     mutationFn: () =>
       orpc.user.delete.call({
         id: target.id,
-        ...(reassignTo != null ? { reassignPostsTo: reassignTo } : {}),
+        ...(reassignTo != null ? { reassignTo } : {}),
       }),
     onMutate: () => {
       setServerError(null);
@@ -676,7 +676,7 @@ const STATUS_ERROR_MESSAGES: Partial<Record<string, string>> = {
 const DELETE_ERROR_MESSAGES: Partial<Record<string, string>> = {
   last_admin:
     "Can't delete the last administrator. Promote someone else first.",
-  has_posts:
+  has_entries:
     "This user has authored entries. Pick someone to reassign them to above.",
   reassign_to_self: "Can't reassign to the user being deleted.",
 };

--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -150,7 +150,7 @@ function UsersListRoute(): ReactNode {
   const rows: readonly User[] = query.data ?? [];
   const canPrev = search.page > 1;
   // Heuristic "next page exists": full page came back. `user.list` doesn't
-  // return a total, same tradeoff as `post.list` — accept the occasional
+  // return a total, same tradeoff as `entry.list` — accept the occasional
   // empty-next-page when total is an exact multiple of PAGE_SIZE.
   const canNext = rows.length === PAGE_SIZE;
 

--- a/packages/core/src/auth/rbac.ts
+++ b/packages/core/src/auth/rbac.ts
@@ -199,8 +199,8 @@ export function capabilitiesForRole(
   plugins: PluginRegistry,
 ): readonly string[] {
   const level = roleLevel(role);
-  // Set — a plugin registering a post type with `capabilityType: 'post'`
-  // duplicates the derived `post:read` etc. caps into `plugins.capabilities`
+  // Set — a plugin registering an entry type with `capabilityType: 'post'`
+  // duplicates the derived `entry:post:read` etc. caps into `plugins.capabilities`
   // on top of the entries already present in CORE_CAPABILITIES. Dedupe so
   // the wire payload doesn't carry `["entry:post:read", "entry:post:read", ...]`.
   const granted = new Set<string>();

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -247,7 +247,7 @@ declare module "../hooks/types.js" {
     /**
      * Fires after a successful `term.update` row-columns write. Payload
      * carries the post-write row and the pre-write row for diffing —
-     * parallel to `post:updated` / `user:updated`.
+     * parallel to `entry:updated` / `user:updated`.
      *
      * Only fires when the row columns changed. A meta-only update does
      * NOT fire `term:updated`; subscribe to `term:meta_changed` for

--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -189,7 +189,7 @@ describe("entry.create", () => {
       }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
-      data: { kind: "post", id: secret.id },
+      data: { kind: "entry", id: secret.id },
     });
   });
 
@@ -217,7 +217,7 @@ describe("entry.create", () => {
       }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
-      data: { kind: "post", id: page.id },
+      data: { kind: "entry", id: page.id },
     });
   });
 

--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -55,7 +55,7 @@ describe("entry.create", () => {
     });
   });
 
-  test("post:before_save cannot overwrite authorId at create", async () => {
+  test("entry:before_save cannot overwrite authorId at create", async () => {
     const h = await createRpcHarness({ authAs: "author" });
     const other = await h.factory.admin.create({
       email: "other@example.test",
@@ -107,7 +107,7 @@ describe("entry.create", () => {
     expect(created.title).toBe("[pinned] orig");
   });
 
-  test("post:before_save filter runs before the insert", async () => {
+  test("entry:before_save filter runs before the insert", async () => {
     const h = await createRpcHarness({ authAs: "author" });
     h.hooks.addFilter("entry:before_save", (post) => ({
       ...post,
@@ -121,7 +121,7 @@ describe("entry.create", () => {
     expect(created.excerpt).toBe("[auto] t");
   });
 
-  test("post:published fires once when status is published, never on drafts", async () => {
+  test("entry:published fires once when status is published, never on drafts", async () => {
     const h = await createRpcHarness({ authAs: "author" });
     const onPublish = h.spyAction("entry:published");
 

--- a/packages/core/src/rpc/procedures/entry/create.ts
+++ b/packages/core/src/rpc/procedures/entry/create.ts
@@ -61,7 +61,7 @@ export const create = base
 
     assertContentWithinByteCap(filtered.content, errors);
 
-    // Validate meta up-front so a bad key fails before the post insert —
+    // Validate meta up-front so a bad key fails before the entry insert —
     // keeps the DB clean when the client sends a typo in a meta key.
     const metaPatch = sanitizeMetaForRpc(
       context.plugins,

--- a/packages/core/src/rpc/procedures/entry/create.ts
+++ b/packages/core/src/rpc/procedures/entry/create.ts
@@ -54,7 +54,7 @@ export const create = base
       );
       if (!parent) {
         throw errors.NOT_FOUND({
-          data: { kind: "post", id: filtered.parentId },
+          data: { kind: "entry", id: filtered.parentId },
         });
       }
     }

--- a/packages/core/src/rpc/procedures/entry/get.ts
+++ b/packages/core/src/rpc/procedures/entry/get.ts
@@ -20,11 +20,11 @@ export const get = base
       where: eq(entries.id, filtered.id),
     });
     if (!row) {
-      throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
     }
 
     if (!context.auth.can(entryCapability(row.type, "read"))) {
-      throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
     }
 
     if (row.status !== "published") {
@@ -33,7 +33,7 @@ export const get = base
         row.authorId === context.user.id &&
         context.auth.can(entryCapability(row.type, "edit_own"));
       if (!canSeeAny && !ownsAndCanEdit) {
-        throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+        throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
       }
     }
 

--- a/packages/core/src/rpc/procedures/entry/list.ts
+++ b/packages/core/src/rpc/procedures/entry/list.ts
@@ -69,7 +69,7 @@ export const list = base
         filtered.termTaxonomies,
       )) {
         if (slugs.length === 0) continue;
-        // Correlated subquery: post.id must appear in `post_term` joined
+        // Correlated subquery: entries.id must appear in `entry_term` joined
         // to `terms` filtered by this termTaxonomy + listed slugs. One clause
         // per termTaxonomy; multiple clauses AND together — matching WP's
         // default `tax_query` relation.

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -45,7 +45,7 @@ const postTermsSchema = v.record(
   v.pipe(v.array(idParam), v.maxLength(MAX_TERMS_PER_TAXONOMY)),
 );
 
-// Meta bag accepted by `post.create` / `post.update`. Per-key validation
+// Meta bag accepted by `entry.create` / `entry.update`. Per-key validation
 // happens in the handler against the plugin-registered `MetaScalarType`
 // — here we only enforce the outer shape + a defensive cap on the
 // number of keys per request so a malformed client can't ship a 10k-key
@@ -97,7 +97,7 @@ export const entryUpdateInputSchema = v.object({
 });
 
 // Upper bound on the term-slug list per termTaxonomy clause. Mirrors the
-// per-termTaxonomy guard on `post.update` — admin UIs don't reasonably issue
+// per-termTaxonomy guard on `entry.update` — admin UIs don't reasonably issue
 // queries beyond this, and the cap protects the generated `IN (?, ?, …)`
 // subquery from pathological input lengths.
 const MAX_TERM_SLUGS_PER_TAXONOMY = 50;
@@ -145,7 +145,7 @@ export const entryListInputSchema = v.object({
     ]),
   ),
   /**
-   * Filter by the post's `authorId`. Admin "Mine" filter passes the
+   * Filter by the entry's `authorId`. Admin "Mine" filter passes the
    * session user's id here; future UIs can surface an author dropdown.
    */
   authorId: v.optional(idParam),

--- a/packages/core/src/rpc/procedures/entry/trash.ts
+++ b/packages/core/src/rpc/procedures/entry/trash.ts
@@ -18,7 +18,7 @@ export const trash = base
       where: eq(entries.id, filtered.id),
     });
     if (!existing) {
-      throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
     }
 
     const deleteCapability = entryCapability(existing.type, "delete");

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -234,7 +234,7 @@ describe("entry.update", () => {
       h.client.entry.update({ id: own.id, parentId: secret.id }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
-      data: { kind: "post", id: secret.id },
+      data: { kind: "entry", id: secret.id },
     });
   });
 

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -138,7 +138,7 @@ describe("entry.update", () => {
     });
   });
 
-  test("empty patch is a no-op and does not fire post:updated", async () => {
+  test("empty patch is a no-op and does not fire entry:updated", async () => {
     const h = await createRpcHarness({ authAs: "author" });
     const own = await h.factory.draft.create({
       authorId: h.user.id,
@@ -158,7 +158,7 @@ describe("entry.update", () => {
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 
-  test("concurrent publish transitions: post:published fires exactly once", async () => {
+  test("concurrent publish transitions: entry:published fires exactly once", async () => {
     const h = await createRpcHarness({ authAs: "author" });
     const own = await h.factory.draft.create({
       authorId: h.user.id,
@@ -176,7 +176,7 @@ describe("entry.update", () => {
     onPublish.assertCalledOnce();
   });
 
-  test("post:before_save cannot overwrite immutable fields", async () => {
+  test("entry:before_save cannot overwrite immutable fields", async () => {
     const h = await createRpcHarness({ authAs: "author" });
     const impostor = await h.factory.admin.create({
       email: "impostor@example.test",
@@ -357,7 +357,7 @@ describe("entry.update", () => {
     expect(reloaded.title).toBe("p3");
   });
 
-  test("rpc:entry.update:input can inject derived meta before sanitization; post:meta_changed fires with the final bag", async () => {
+  test("rpc:entry.update:input can inject derived meta before sanitization; entry:meta_changed fires with the final bag", async () => {
     const plugins = createPluginRegistry();
     plugins.entryMetaBoxes.set("test-derived", {
       id: "test-derived",

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -67,7 +67,7 @@ function assertCanPublishTransition(
 }
 
 // Reparenting: caller may only point at entries they can see, and the
-// parent must share the current post's type. Undistinguished 404 on
+// parent must share the current entry's type. Undistinguished 404 on
 // any failure — don't leak whether the parent exists. Also walk the
 // chain upward to reject cycles of any depth (self-parent, A→B→A, …) —
 // admin UI tree renders will infinite-loop on any cycle in the DB.

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -142,7 +142,7 @@ export const update = base
       where: eq(entries.id, filtered.id),
     });
     if (!existing) {
-      throw errors.NOT_FOUND({ data: { kind: "post", id: filtered.id } });
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
     }
 
     const accessGuards: AccessGuards = {
@@ -165,7 +165,7 @@ export const update = base
         filtered.parentId,
         {
           notFound: (parentId) => {
-            throw errors.NOT_FOUND({ data: { kind: "post", id: parentId } });
+            throw errors.NOT_FOUND({ data: { kind: "entry", id: parentId } });
           },
           cycle: () => {
             throw errors.CONFLICT({ data: { reason: "parent_cycle" } });

--- a/packages/core/src/rpc/procedures/term/delete.ts
+++ b/packages/core/src/rpc/procedures/term/delete.ts
@@ -21,7 +21,7 @@ export const del = base
       throw errors.FORBIDDEN({ data: { capability: deleteCap } });
     }
 
-    // post_term cascades via the FK; children terms get parentId = null via
+    // entry_term cascades via the FK; children terms get parentId = null via
     // the terms.parentId self-reference `onDelete: set null`.
     const [deleted] = await context.db
       .delete(terms)

--- a/packages/core/src/rpc/procedures/term/get.ts
+++ b/packages/core/src/rpc/procedures/term/get.ts
@@ -19,7 +19,7 @@ export const get = base
 
     const readCap = taxonomyCapability(row.taxonomy, "read");
     if (!context.auth.can(readCap)) {
-      // Hide existence — mirror post.get's "no oracle" rule.
+      // Hide existence — mirror entry.get's "no oracle" rule.
       throw errors.NOT_FOUND({ data: { kind: "term", id: input.id } });
     }
 

--- a/packages/core/src/rpc/procedures/user/delete.ts
+++ b/packages/core/src/rpc/procedures/user/delete.ts
@@ -28,26 +28,26 @@ export const del = base
       .select({ value: count() })
       .from(entries)
       .where(eq(entries.authorId, existing.id));
-    const postCount = countRow?.value ?? 0;
+    const entryCount = countRow?.value ?? 0;
 
-    if (postCount > 0) {
-      if (input.reassignPostsTo === undefined) {
-        throw errors.CONFLICT({ data: { reason: "has_posts" } });
+    if (entryCount > 0) {
+      if (input.reassignTo === undefined) {
+        throw errors.CONFLICT({ data: { reason: "has_entries" } });
       }
-      if (input.reassignPostsTo === existing.id) {
+      if (input.reassignTo === existing.id) {
         throw errors.CONFLICT({ data: { reason: "reassign_to_self" } });
       }
       const target = await context.db.query.users.findFirst({
-        where: eq(users.id, input.reassignPostsTo),
+        where: eq(users.id, input.reassignTo),
       });
       if (!target) {
         throw errors.NOT_FOUND({
-          data: { kind: "user", id: input.reassignPostsTo },
+          data: { kind: "user", id: input.reassignTo },
         });
       }
       await context.db
         .update(entries)
-        .set({ authorId: input.reassignPostsTo })
+        .set({ authorId: input.reassignTo })
         .where(eq(entries.authorId, existing.id));
     }
 
@@ -75,7 +75,7 @@ export const del = base
     // had no entries (no reassignment happened); otherwise carries the id
     // we migrated entries to so audit-log plugins can reconstruct the move.
     await context.hooks.doAction("user:deleted", deleted, {
-      reassignedTo: postCount > 0 ? (input.reassignPostsTo ?? null) : null,
+      reassignedTo: entryCount > 0 ? (input.reassignTo ?? null) : null,
     });
 
     return context.hooks.applyFilter("rpc:user.delete:output", deleted);

--- a/packages/core/src/rpc/procedures/user/schemas.ts
+++ b/packages/core/src/rpc/procedures/user/schemas.ts
@@ -69,7 +69,7 @@ export const userEnableInputSchema = v.object({ id: idParam });
 export const userDeleteInputSchema = v.object({
   id: idParam,
   /** Reassign this user's authored entries to the given user id before deletion. */
-  reassignPostsTo: v.optional(idParam),
+  reassignTo: v.optional(idParam),
 });
 
 export type UserListInput = v.InferOutput<typeof userListInputSchema>;

--- a/packages/core/src/rpc/procedures/user/user.test.ts
+++ b/packages/core/src/rpc/procedures/user/user.test.ts
@@ -270,18 +270,18 @@ describe("user.delete", () => {
     await expect(h.client.user.delete({ id: author.id })).rejects.toMatchObject(
       {
         code: "CONFLICT",
-        data: { reason: "has_posts" },
+        data: { reason: "has_entries" },
       },
     );
   });
 
-  test("reassigns entries when reassignPostsTo is provided", async () => {
+  test("reassigns entries when reassignTo is provided", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
     const author = await h.factory.author.create();
     const heir = await h.factory.author.create();
     const post = await h.factory.entry.create({ authorId: author.id });
 
-    await h.client.user.delete({ id: author.id, reassignPostsTo: heir.id });
+    await h.client.user.delete({ id: author.id, reassignTo: heir.id });
 
     const moved = await h.context.db.query.entries.findFirst({
       where: eq(entries.id, post.id),
@@ -395,7 +395,7 @@ describe("user lifecycle action hooks", () => {
     const spy = h.spyAction("user:deleted");
     await h.client.user.delete({
       id: author.id,
-      reassignPostsTo: inheritor.id,
+      reassignTo: inheritor.id,
     });
     spy.assertCalledOnce();
     expect(spy.lastArgs?.[1]).toEqual({ reassignedTo: inheritor.id });

--- a/packages/core/src/test/factories.ts
+++ b/packages/core/src/test/factories.ts
@@ -193,7 +193,7 @@ export const settingFactory = Factory.define<NewSetting, DbTransient, Setting>(
   },
 );
 
-// post_term join row. Caller passes entryId + termId; sortOrder defaults to 0.
+// entry_term join row. Caller passes entryId + termId; sortOrder defaults to 0.
 export const entryTermFactory = Factory.define<
   NewEntryTerm,
   DbTransient,

--- a/packages/core/src/test/match.test.ts
+++ b/packages/core/src/test/match.test.ts
@@ -55,8 +55,8 @@ describe("partialMatch", () => {
   test("nested partial match", () => {
     expect(
       partialMatch(
-        { code: "NOT_FOUND", data: { kind: "post", id: 5, extra: true } },
-        { code: "NOT_FOUND", data: { kind: "post", id: 5 } },
+        { code: "NOT_FOUND", data: { kind: "entry", id: 5, extra: true } },
+        { code: "NOT_FOUND", data: { kind: "entry", id: 5 } },
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary

Pre-0.1.0 audit found two wire-format strings still using stale \"post\" terminology that predates the `EntryType` rename. Renaming these after 0.1.0 publish would be a breaking change for every client switching on them.

- **`user.delete` input field:** `reassignPostsTo` → `reassignTo` (procedure namespace covers the prefix per the established RPC field-naming convention)
- **`user.delete` error code:** `has_posts` → `has_entries` (resource is \"entries\" internally; user-facing admin error message text is unchanged)
- **`entry.*` `NOT_FOUND` payloads:** `kind: \"post\"` → `kind: \"entry\"` (matches procedure namespace + db schema name; `user` / `term` kinds were already correct)

Internal var rename `postCount` → `entryCount` in `delete.ts` follows from the wire rename. Tests + admin error-message map updated in lockstep. No admin code switches on the old `kind: \"post\"` string, so no UI fallout.

## Test plan

- [x] `pnpm turbo run build test --force --filter=@plumix/core --filter=@plumix/admin` — 638 core tests + 4 task suites pass
- [x] `pnpm turbo run typecheck lint --force` — 30/30 tasks pass (one pre-existing TanStack Table memoization warning unchanged)
- [ ] Manual smoke of /users/\$id delete-with-reassign in admin (CI Playwright will catch this)