### PR TITLE
feat(core): oauth sign-in with PKCE + domain-gated signup

### DIFF
--- a/packages/admin/src/lib/oauth-errors.test.ts
+++ b/packages/admin/src/lib/oauth-errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import { OAUTH_ERROR_CODES } from "@plumix/core";
+
+import { getOAuthErrorMessage, OAUTH_ERROR_MESSAGES } from "./oauth-errors.js";
+
+describe("getOAuthErrorMessage", () => {
+  test("maps every server-defined error code", () => {
+    // The login page reads from this map. Adding a code in core without
+    // updating the admin map silently degrades to the fallback string —
+    // this assertion catches that drift.
+    for (const code of OAUTH_ERROR_CODES) {
+      expect(OAUTH_ERROR_MESSAGES[code]).toBeDefined();
+      expect(OAUTH_ERROR_MESSAGES[code]).toMatch(/\S/);
+    }
+  });
+
+  test("returns null for empty / undefined codes", () => {
+    expect(getOAuthErrorMessage(undefined)).toBeNull();
+    expect(getOAuthErrorMessage("")).toBeNull();
+  });
+
+  test("falls back to the generic message for unknown codes", () => {
+    const message = getOAuthErrorMessage("something_the_server_added_later");
+    expect(message).toMatch(/try again/i);
+  });
+});

--- a/packages/admin/src/lib/oauth-errors.ts
+++ b/packages/admin/src/lib/oauth-errors.ts
@@ -1,0 +1,32 @@
+import type { OAuthErrorCode } from "@plumix/core";
+
+const MESSAGES: Record<OAuthErrorCode, string> = {
+  state_invalid: "Sign-in expired or invalid. Try again.",
+  state_expired: "Sign-in expired. Try again.",
+  code_exchange_failed: "Couldn't reach the provider. Try again.",
+  profile_fetch_failed: "Couldn't read your profile. Try again.",
+  email_missing: "The provider didn't return an email address.",
+  email_unverified:
+    "The provider hasn't verified your email yet. Verify it there, then try again.",
+  domain_not_allowed:
+    "Your email domain isn't on the allowlist. Ask an administrator to add it.",
+  account_disabled: "That account is disabled.",
+  link_broken:
+    "That account can't be reached. Contact an administrator to re-link it.",
+  registration_closed:
+    "OAuth signup is unavailable until an admin has finished setup.",
+  provider_not_configured: "That provider isn't configured.",
+};
+
+const FALLBACK = "Couldn't sign in. Try again.";
+
+export function getOAuthErrorMessage(code: string | undefined): string | null {
+  if (!code) return null;
+  return Object.hasOwn(MESSAGES, code)
+    ? MESSAGES[code as OAuthErrorCode]
+    : FALLBACK;
+}
+
+// Test-only export so the unit test can assert every code in
+// `OAUTH_ERROR_CODES` is mapped (no silent fallbacks).
+export const OAUTH_ERROR_MESSAGES = MESSAGES;

--- a/packages/admin/src/routeTree.gen.ts
+++ b/packages/admin/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as AuthLoginRouteImport } from "./routes/_auth/login";
 import { Route as AuthBootstrapRouteImport } from "./routes/_auth/bootstrap";
 import { Route as AuthenticatedUsersIndexRouteImport } from "./routes/_authenticated/users/index";
 import { Route as AuthenticatedSettingsIndexRouteImport } from "./routes/_authenticated/settings/index";
+import { Route as AuthenticatedAllowedDomainsIndexRouteImport } from "./routes/_authenticated/allowed-domains/index";
 import { Route as AuthenticatedUsersCreateRouteImport } from "./routes/_authenticated/users/create";
 import { Route as AuthenticatedSettingsPageRouteImport } from "./routes/_authenticated/settings/$page";
 import { Route as AuthenticatedPagesSplatRouteImport } from "./routes/_authenticated/pages/$";
@@ -71,6 +72,12 @@ const AuthenticatedSettingsIndexRoute =
   AuthenticatedSettingsIndexRouteImport.update({
     id: "/settings/",
     path: "/settings/",
+    getParentRoute: () => AuthenticatedRoute,
+  } as any);
+const AuthenticatedAllowedDomainsIndexRoute =
+  AuthenticatedAllowedDomainsIndexRouteImport.update({
+    id: "/allowed-domains/",
+    path: "/allowed-domains/",
     getParentRoute: () => AuthenticatedRoute,
   } as any);
 const AuthenticatedUsersCreateRoute =
@@ -145,6 +152,7 @@ export interface FileRoutesByFullPath {
   "/pages/$": typeof AuthenticatedPagesSplatRoute;
   "/settings/$page": typeof AuthenticatedSettingsPageRoute;
   "/users/create": typeof AuthenticatedUsersCreateRoute;
+  "/allowed-domains/": typeof AuthenticatedAllowedDomainsIndexRoute;
   "/settings/": typeof AuthenticatedSettingsIndexRoute;
   "/users/": typeof AuthenticatedUsersIndexRoute;
   "/terms/$name/create": typeof AuthenticatedTermsNameCreateRoute;
@@ -164,6 +172,7 @@ export interface FileRoutesByTo {
   "/pages/$": typeof AuthenticatedPagesSplatRoute;
   "/settings/$page": typeof AuthenticatedSettingsPageRoute;
   "/users/create": typeof AuthenticatedUsersCreateRoute;
+  "/allowed-domains": typeof AuthenticatedAllowedDomainsIndexRoute;
   "/settings": typeof AuthenticatedSettingsIndexRoute;
   "/users": typeof AuthenticatedUsersIndexRoute;
   "/terms/$name/create": typeof AuthenticatedTermsNameCreateRoute;
@@ -187,6 +196,7 @@ export interface FileRoutesById {
   "/_authenticated/pages/$": typeof AuthenticatedPagesSplatRoute;
   "/_authenticated/settings/$page": typeof AuthenticatedSettingsPageRoute;
   "/_authenticated/users/create": typeof AuthenticatedUsersCreateRoute;
+  "/_authenticated/allowed-domains/": typeof AuthenticatedAllowedDomainsIndexRoute;
   "/_authenticated/settings/": typeof AuthenticatedSettingsIndexRoute;
   "/_authenticated/users/": typeof AuthenticatedUsersIndexRoute;
   "/_authenticated/terms/$name/create": typeof AuthenticatedTermsNameCreateRoute;
@@ -208,6 +218,7 @@ export interface FileRouteTypes {
     | "/pages/$"
     | "/settings/$page"
     | "/users/create"
+    | "/allowed-domains/"
     | "/settings/"
     | "/users/"
     | "/terms/$name/create"
@@ -227,6 +238,7 @@ export interface FileRouteTypes {
     | "/pages/$"
     | "/settings/$page"
     | "/users/create"
+    | "/allowed-domains"
     | "/settings"
     | "/users"
     | "/terms/$name/create"
@@ -249,6 +261,7 @@ export interface FileRouteTypes {
     | "/_authenticated/pages/$"
     | "/_authenticated/settings/$page"
     | "/_authenticated/users/create"
+    | "/_authenticated/allowed-domains/"
     | "/_authenticated/settings/"
     | "/_authenticated/users/"
     | "/_authenticated/terms/$name/create"
@@ -329,6 +342,13 @@ declare module "@tanstack/react-router" {
       path: "/settings";
       fullPath: "/settings/";
       preLoaderRoute: typeof AuthenticatedSettingsIndexRouteImport;
+      parentRoute: typeof AuthenticatedRoute;
+    };
+    "/_authenticated/allowed-domains/": {
+      id: "/_authenticated/allowed-domains/";
+      path: "/allowed-domains";
+      fullPath: "/allowed-domains/";
+      preLoaderRoute: typeof AuthenticatedAllowedDomainsIndexRouteImport;
       parentRoute: typeof AuthenticatedRoute;
     };
     "/_authenticated/users/create": {
@@ -431,6 +451,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedPagesSplatRoute: typeof AuthenticatedPagesSplatRoute;
   AuthenticatedSettingsPageRoute: typeof AuthenticatedSettingsPageRoute;
   AuthenticatedUsersCreateRoute: typeof AuthenticatedUsersCreateRoute;
+  AuthenticatedAllowedDomainsIndexRoute: typeof AuthenticatedAllowedDomainsIndexRoute;
   AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute;
   AuthenticatedUsersIndexRoute: typeof AuthenticatedUsersIndexRoute;
   AuthenticatedTermsNameCreateRoute: typeof AuthenticatedTermsNameCreateRoute;
@@ -446,6 +467,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedPagesSplatRoute: AuthenticatedPagesSplatRoute,
   AuthenticatedSettingsPageRoute: AuthenticatedSettingsPageRoute,
   AuthenticatedUsersCreateRoute: AuthenticatedUsersCreateRoute,
+  AuthenticatedAllowedDomainsIndexRoute: AuthenticatedAllowedDomainsIndexRoute,
   AuthenticatedSettingsIndexRoute: AuthenticatedSettingsIndexRoute,
   AuthenticatedUsersIndexRoute: AuthenticatedUsersIndexRoute,
   AuthenticatedTermsNameCreateRoute: AuthenticatedTermsNameCreateRoute,

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -18,17 +18,46 @@ import {
   FormMessage,
 } from "@/components/ui/form.js";
 import { Input } from "@/components/ui/input.js";
+import { Separator } from "@/components/ui/separator.js";
+import { orpc } from "@/lib/orpc.js";
 import { getPasskeyErrorMessage, PasskeyError } from "@/lib/passkey-errors.js";
 import { signInWithPasskey } from "@/lib/passkey.js";
 import { SESSION_QUERY_KEY, sessionQueryOptions } from "@/lib/session.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
+import * as v from "valibot";
 
 import { loginSchema } from "./-schemas.js";
 
+const PROVIDER_LABEL: Record<string, string> = {
+  github: "GitHub",
+  google: "Google",
+};
+
+const OAUTH_ERROR_MESSAGE: Record<string, string> = {
+  state_invalid: "Sign-in expired or invalid. Try again.",
+  state_expired: "Sign-in expired. Try again.",
+  code_exchange_failed: "Couldn't reach the provider. Try again.",
+  profile_fetch_failed: "Couldn't read your profile. Try again.",
+  email_missing: "The provider didn't return an email address.",
+  email_unverified:
+    "The provider hasn't verified your email yet. Verify it there, then try again.",
+  domain_not_allowed:
+    "Your email domain isn't on the allowlist. Ask an administrator to add it.",
+  account_disabled: "That account is disabled.",
+  registration_closed:
+    "OAuth signup is unavailable until an admin has finished setup.",
+  provider_not_configured: "That provider isn't configured.",
+};
+
+const loginSearchSchema = v.object({
+  oauth_error: v.optional(v.string()),
+});
+
 export const Route = createFileRoute("/_auth/login")({
+  validateSearch: loginSearchSchema,
   beforeLoad: async ({ context }) => {
     const session = await context.queryClient.ensureQueryData(
       sessionQueryOptions(),
@@ -43,7 +72,10 @@ export const Route = createFileRoute("/_auth/login")({
 
 function LoginRoute(): ReactNode {
   const router = useRouter();
+  const search = Route.useSearch();
   const [errorCode, setErrorCode] = useState<string | null>(null);
+
+  const providers = useQuery(orpc.auth.oauthProviders.queryOptions());
 
   const signIn = useMutation({
     mutationFn: (input: { email?: string }) => signInWithPasskey(input.email),
@@ -68,6 +100,11 @@ function LoginRoute(): ReactNode {
   const onSubmit = form.handleSubmit(({ email }) => {
     signIn.mutate({ email: email || undefined });
   });
+
+  const oauthErrorCode = search.oauth_error;
+  const oauthErrorMessage = oauthErrorCode
+    ? (OAUTH_ERROR_MESSAGE[oauthErrorCode] ?? "Couldn't sign in. Try again.")
+    : null;
 
   return (
     <Card>
@@ -102,10 +139,16 @@ function LoginRoute(): ReactNode {
             />
 
             {errorCode ? (
-              <Alert variant="destructive">
+              <Alert variant="destructive" data-testid="login-passkey-error">
                 <AlertDescription>
                   {getPasskeyErrorMessage(errorCode)}
                 </AlertDescription>
+              </Alert>
+            ) : null}
+
+            {oauthErrorMessage ? (
+              <Alert variant="destructive" data-testid="login-oauth-error">
+                <AlertDescription>{oauthErrorMessage}</AlertDescription>
               </Alert>
             ) : null}
 
@@ -114,6 +157,33 @@ function LoginRoute(): ReactNode {
             </Button>
           </form>
         </Form>
+
+        {providers.data && providers.data.length > 0 ? (
+          <div
+            className="mt-6 flex flex-col gap-3"
+            data-testid="login-oauth-providers"
+          >
+            <div className="flex items-center gap-2">
+              <Separator className="flex-1" />
+              <span className="text-muted-foreground text-xs tracking-wide uppercase">
+                or
+              </span>
+              <Separator className="flex-1" />
+            </div>
+            {providers.data.map((provider) => (
+              <Button
+                key={provider}
+                asChild
+                variant="outline"
+                data-testid={`login-oauth-${provider}`}
+              >
+                <a href={`/_plumix/auth/oauth/${provider}/start`}>
+                  Continue with {PROVIDER_LABEL[provider] ?? provider}
+                </a>
+              </Button>
+            ))}
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/form.js";
 import { Input } from "@/components/ui/input.js";
 import { Separator } from "@/components/ui/separator.js";
+import { getOAuthErrorMessage } from "@/lib/oauth-errors.js";
 import { orpc } from "@/lib/orpc.js";
 import { getPasskeyErrorMessage, PasskeyError } from "@/lib/passkey-errors.js";
 import { signInWithPasskey } from "@/lib/passkey.js";
@@ -34,22 +35,6 @@ import { loginSchema } from "./-schemas.js";
 const PROVIDER_LABEL: Record<string, string> = {
   github: "GitHub",
   google: "Google",
-};
-
-const OAUTH_ERROR_MESSAGE: Record<string, string> = {
-  state_invalid: "Sign-in expired or invalid. Try again.",
-  state_expired: "Sign-in expired. Try again.",
-  code_exchange_failed: "Couldn't reach the provider. Try again.",
-  profile_fetch_failed: "Couldn't read your profile. Try again.",
-  email_missing: "The provider didn't return an email address.",
-  email_unverified:
-    "The provider hasn't verified your email yet. Verify it there, then try again.",
-  domain_not_allowed:
-    "Your email domain isn't on the allowlist. Ask an administrator to add it.",
-  account_disabled: "That account is disabled.",
-  registration_closed:
-    "OAuth signup is unavailable until an admin has finished setup.",
-  provider_not_configured: "That provider isn't configured.",
 };
 
 const loginSearchSchema = v.object({
@@ -101,10 +86,7 @@ function LoginRoute(): ReactNode {
     signIn.mutate({ email: email || undefined });
   });
 
-  const oauthErrorCode = search.oauth_error;
-  const oauthErrorMessage = oauthErrorCode
-    ? (OAUTH_ERROR_MESSAGE[oauthErrorCode] ?? "Couldn't sign in. Try again.")
-    : null;
+  const oauthErrorMessage = getOAuthErrorMessage(search.oauth_error);
 
   return (
     <Card>

--- a/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
+++ b/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
@@ -1,0 +1,356 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form.js";
+import { Input } from "@/components/ui/input.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select.js";
+import { Toggle } from "@/components/ui/toggle.js";
+import { hasCap } from "@/lib/caps.js";
+import { orpc } from "@/lib/orpc.js";
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { Trash2 } from "lucide-react";
+import { useForm } from "react-hook-form";
+import * as v from "valibot";
+
+import type { AllowedDomain, UserRole } from "@plumix/core/schema";
+
+const USER_ROLES = [
+  "subscriber",
+  "contributor",
+  "author",
+  "editor",
+  "admin",
+] as const satisfies readonly UserRole[];
+
+const ROLE_LABEL: Record<UserRole, string> = {
+  subscriber: "Subscriber",
+  contributor: "Contributor",
+  author: "Author",
+  editor: "Editor",
+  admin: "Administrator",
+};
+
+// Mirrors the server schema in
+// packages/core/src/rpc/procedures/auth/allowed-domains/schemas.ts.
+const DOMAIN_REGEX =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/;
+
+const createFormSchema = v.object({
+  domain: v.pipe(
+    v.string(),
+    v.trim(),
+    v.toLowerCase(),
+    v.regex(DOMAIN_REGEX, "Enter a valid hostname (e.g. example.com)."),
+  ),
+  defaultRole: v.picklist(USER_ROLES),
+});
+
+export const Route = createFileRoute("/_authenticated/allowed-domains/")({
+  beforeLoad: ({ context }) => {
+    if (!hasCap(context.user.capabilities, "settings:manage")) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
+      throw redirect({ to: "/" });
+    }
+  },
+  component: AllowedDomainsRoute,
+});
+
+function AllowedDomainsRoute(): ReactNode {
+  const queryClient = useQueryClient();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const list = useQuery(
+    orpc.auth.allowedDomains.list.queryOptions({ input: {} }),
+  );
+
+  const invalidateList = (): Promise<void> =>
+    queryClient.invalidateQueries({
+      queryKey: orpc.auth.allowedDomains.list.key(),
+    });
+
+  const create = useMutation({
+    mutationFn: (input: { domain: string; defaultRole: UserRole }) =>
+      orpc.auth.allowedDomains.create.call(input),
+    onMutate: () => setServerError(null),
+    onSuccess: async () => {
+      await invalidateList();
+      form.reset({ domain: "", defaultRole: "subscriber" });
+    },
+    onError: (err) => setServerError(mapError(err)),
+  });
+
+  const update = useMutation({
+    mutationFn: (input: {
+      domain: string;
+      defaultRole?: UserRole;
+      isEnabled?: boolean;
+    }) => orpc.auth.allowedDomains.update.call(input),
+    onSuccess: () => invalidateList(),
+  });
+
+  const remove = useMutation({
+    mutationFn: (input: { domain: string }) =>
+      orpc.auth.allowedDomains.delete.call(input),
+    onSuccess: () => invalidateList(),
+  });
+
+  const form = useForm({
+    resolver: valibotResolver(createFormSchema),
+    defaultValues: { domain: "", defaultRole: "subscriber" as UserRole },
+    mode: "onBlur",
+  });
+
+  const onSubmit = form.handleSubmit((value) => {
+    create.mutate({ domain: value.domain, defaultRole: value.defaultRole });
+  });
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+      <header className="flex flex-col gap-1">
+        <h1
+          className="text-2xl font-semibold"
+          data-testid="allowed-domains-heading"
+        >
+          Allowed domains
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Email domains permitted to sign up via OAuth. New OAuth accounts are
+          created with the role set here. Disabled rows reject signup but
+          preserve their role mapping.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h2 className="text-base font-semibold">Add domain</h2>
+          </CardTitle>
+          <CardDescription>
+            Use the bare domain — no protocol, no path.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form
+              className="flex flex-col gap-4 sm:flex-row sm:items-end"
+              onSubmit={onSubmit}
+            >
+              <FormField
+                control={form.control}
+                name="domain"
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <FormLabel>Domain</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        placeholder="example.com"
+                        autoComplete="off"
+                        spellCheck={false}
+                        data-testid="allowed-domains-domain-input"
+                        disabled={create.isPending}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="defaultRole"
+                render={({ field }) => (
+                  <FormItem className="sm:w-48">
+                    <FormLabel>Default role</FormLabel>
+                    <FormControl>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        disabled={create.isPending}
+                      >
+                        <SelectTrigger data-testid="allowed-domains-role-select">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {USER_ROLES.map((role) => (
+                            <SelectItem key={role} value={role}>
+                              {ROLE_LABEL[role]}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button
+                type="submit"
+                disabled={create.isPending}
+                data-testid="allowed-domains-add-button"
+              >
+                {create.isPending ? "Adding…" : "Add"}
+              </Button>
+            </form>
+          </Form>
+          {serverError ? (
+            <Alert
+              variant="destructive"
+              className="mt-4"
+              data-testid="allowed-domains-error"
+            >
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h2 className="text-base font-semibold">Configured domains</h2>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {list.isLoading ? (
+            <p
+              className="text-muted-foreground text-sm"
+              data-testid="allowed-domains-loading"
+            >
+              Loading…
+            </p>
+          ) : (list.data ?? []).length === 0 ? (
+            <p
+              className="text-muted-foreground text-sm"
+              data-testid="allowed-domains-empty"
+            >
+              No domains configured. OAuth signup is closed until at least one
+              enabled domain is added.
+            </p>
+          ) : (
+            <ul
+              className="flex flex-col gap-2"
+              data-testid="allowed-domains-list"
+            >
+              {(list.data ?? []).map((row) => (
+                <DomainRow
+                  key={row.domain}
+                  row={row}
+                  onToggle={(isEnabled) => {
+                    update.mutate({ domain: row.domain, isEnabled });
+                  }}
+                  onChangeRole={(defaultRole) => {
+                    update.mutate({ domain: row.domain, defaultRole });
+                  }}
+                  onDelete={() => {
+                    remove.mutate({ domain: row.domain });
+                  }}
+                  busy={update.isPending || remove.isPending}
+                />
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DomainRow({
+  row,
+  onToggle,
+  onChangeRole,
+  onDelete,
+  busy,
+}: {
+  row: AllowedDomain;
+  onToggle: (isEnabled: boolean) => void;
+  onChangeRole: (role: UserRole) => void;
+  onDelete: () => void;
+  busy: boolean;
+}): ReactNode {
+  return (
+    <li
+      className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center sm:gap-4"
+      data-testid={`allowed-domains-row-${row.domain}`}
+    >
+      <span className="flex-1 font-mono text-sm">{row.domain}</span>
+      <div className="flex items-center gap-2">
+        <Select
+          value={row.defaultRole}
+          onValueChange={(value) => onChangeRole(value as UserRole)}
+          disabled={busy}
+        >
+          <SelectTrigger
+            className="w-44"
+            data-testid={`allowed-domains-row-role-${row.domain}`}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {USER_ROLES.map((role) => (
+              <SelectItem key={role} value={role}>
+                {ROLE_LABEL[role]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Toggle
+          variant="outline"
+          size="sm"
+          pressed={row.isEnabled}
+          onPressedChange={onToggle}
+          disabled={busy}
+          data-testid={`allowed-domains-row-toggle-${row.domain}`}
+        >
+          {row.isEnabled ? "Enabled" : "Disabled"}
+        </Toggle>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onDelete}
+          disabled={busy}
+          aria-label={`Delete ${row.domain}`}
+          data-testid={`allowed-domains-row-delete-${row.domain}`}
+        >
+          <Trash2 className="size-4" />
+        </Button>
+      </div>
+    </li>
+  );
+}
+
+function mapError(err: unknown): string {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data?: { reason?: string } }).data;
+    if (data?.reason === "domain_exists") {
+      return "That domain is already configured.";
+    }
+  }
+  if (err instanceof Error) return err.message;
+  return "Couldn't save the domain. Try again.";
+}

--- a/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
+++ b/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
@@ -292,6 +292,7 @@ function DomainRow({
   onDelete: () => void;
   busy: boolean;
 }): ReactNode {
+  const [confirming, setConfirming] = useState(false);
   return (
     <li
       className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center sm:gap-4"
@@ -328,17 +329,45 @@ function DomainRow({
         >
           {row.isEnabled ? "Enabled" : "Disabled"}
         </Toggle>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          onClick={onDelete}
-          disabled={busy}
-          aria-label={`Delete ${row.domain}`}
-          data-testid={`allowed-domains-row-delete-${row.domain}`}
-        >
-          <Trash2 className="size-4" />
-        </Button>
+        {confirming ? (
+          <>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => {
+                setConfirming(false);
+                onDelete();
+              }}
+              disabled={busy}
+              data-testid={`allowed-domains-row-delete-confirm-${row.domain}`}
+            >
+              Confirm delete
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setConfirming(false)}
+              disabled={busy}
+              data-testid={`allowed-domains-row-delete-cancel-${row.domain}`}
+            >
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => setConfirming(true)}
+            disabled={busy}
+            aria-label={`Delete ${row.domain}`}
+            data-testid={`allowed-domains-row-delete-${row.domain}`}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        )}
       </div>
     </li>
   );

--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -1,17 +1,24 @@
 import * as v from "valibot";
 
+import type { OAuthProvidersConfig } from "./oauth/types.js";
 import type { PasskeyConfig } from "./passkey/config.js";
 import type { SessionPolicy } from "./sessions.js";
+
+export interface PlumixOAuthConfig {
+  readonly providers: OAuthProvidersConfig;
+}
 
 export interface PlumixAuthInput {
   readonly passkey: PasskeyConfig;
   readonly sessions?: SessionPolicy;
+  readonly oauth?: PlumixOAuthConfig;
 }
 
 export interface PlumixAuthConfig {
   readonly kind: "plumix";
   readonly passkey: PasskeyConfig;
   readonly sessions?: SessionPolicy;
+  readonly oauth?: PlumixOAuthConfig;
 }
 
 export interface PlumixConfigIssue {
@@ -59,9 +66,35 @@ const sessionPolicySchema = v.pipe(
   ),
 );
 
+const oauthClientSchema = v.object({
+  clientId: v.pipe(
+    v.string(),
+    v.nonEmpty("clientId must be a non-empty string"),
+  ),
+  clientSecret: v.pipe(
+    v.string(),
+    v.nonEmpty("clientSecret must be a non-empty string"),
+  ),
+});
+
+const oauthSchema = v.pipe(
+  v.object({
+    providers: v.object({
+      github: v.optional(oauthClientSchema),
+      google: v.optional(oauthClientSchema),
+    }),
+  }),
+  v.check(
+    (cfg) =>
+      cfg.providers.github !== undefined || cfg.providers.google !== undefined,
+    "oauth.providers must declare at least one provider",
+  ),
+);
+
 const authInputSchema = v.object({
   passkey: passkeySchema,
   sessions: v.optional(sessionPolicySchema),
+  oauth: v.optional(oauthSchema),
 });
 
 function toIssues(
@@ -86,5 +119,6 @@ export function auth(input: PlumixAuthInput): PlumixAuthConfig {
     kind: "plumix",
     passkey: input.passkey,
     sessions: input.sessions,
+    oauth: input.oauth,
   };
 }

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -2,6 +2,7 @@ export * from "./bootstrap.js";
 export * from "./config.js";
 export * from "./cookies.js";
 export * from "./csrf.js";
+export * from "./oauth/index.js";
 export * from "./passkey/index.js";
 export * from "./rbac.js";
 export * from "./sessions.js";

--- a/packages/core/src/auth/oauth/consumer.ts
+++ b/packages/core/src/auth/oauth/consumer.ts
@@ -10,14 +10,14 @@ import { computeS256Challenge, generateCodeVerifier } from "./pkce.js";
 import { fetchPrimaryEmail, getProvider } from "./providers/index.js";
 import { issueOAuthState } from "./state.js";
 
-export interface BuildAuthorizeUrlInput {
+interface BuildAuthorizeUrlInput {
   readonly db: Db;
   readonly provider: OAuthProviderKey;
   readonly client: OAuthClientConfig;
   readonly redirectUri: string;
 }
 
-export interface BuiltAuthorizeUrl {
+interface BuiltAuthorizeUrl {
   readonly url: string;
   readonly state: string;
 }
@@ -57,7 +57,7 @@ export async function buildAuthorizeUrl(
   return { url: url.toString(), state };
 }
 
-export interface ExchangeAndFetchInput {
+interface ExchangeAndFetchInput {
   readonly provider: OAuthProviderKey;
   readonly client: OAuthClientConfig;
   readonly code: string;

--- a/packages/core/src/auth/oauth/consumer.ts
+++ b/packages/core/src/auth/oauth/consumer.ts
@@ -1,0 +1,184 @@
+import type { Db } from "../../context/app.js";
+import type {
+  OAuthClientConfig,
+  OAuthProfile,
+  OAuthProvider,
+  OAuthProviderKey,
+} from "./types.js";
+import { OAuthError } from "./errors.js";
+import { computeS256Challenge, generateCodeVerifier } from "./pkce.js";
+import { fetchPrimaryEmail, getProvider } from "./providers/index.js";
+import { issueOAuthState } from "./state.js";
+
+export interface BuildAuthorizeUrlInput {
+  readonly db: Db;
+  readonly provider: OAuthProviderKey;
+  readonly client: OAuthClientConfig;
+  readonly redirectUri: string;
+}
+
+export interface BuiltAuthorizeUrl {
+  readonly url: string;
+  readonly state: string;
+}
+
+/**
+ * Mint a PKCE verifier + state, persist them under `oauth_state`, and return
+ * the authorize URL. State is what the provider echoes back; it's the only
+ * way the callback ties the response to a verifier we can replay.
+ */
+export async function buildAuthorizeUrl(
+  input: BuildAuthorizeUrlInput,
+): Promise<BuiltAuthorizeUrl> {
+  const provider = getProvider(input.provider);
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await computeS256Challenge(codeVerifier);
+
+  const { state } = await issueOAuthState(input.db, {
+    provider: input.provider,
+    codeVerifier,
+  });
+
+  const url = new URL(provider.authorizeUrl);
+  url.searchParams.set("client_id", input.client.clientId);
+  url.searchParams.set("redirect_uri", input.redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", provider.scopes.join(" "));
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  // Google requires this to surface email_verified on the userinfo endpoint
+  // for accounts that aren't currently signed in. Harmless for GitHub.
+  if (input.provider === "google") {
+    url.searchParams.set("access_type", "offline");
+    url.searchParams.set("prompt", "consent");
+  }
+
+  return { url: url.toString(), state };
+}
+
+export interface ExchangeAndFetchInput {
+  readonly provider: OAuthProviderKey;
+  readonly client: OAuthClientConfig;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly codeVerifier: string;
+}
+
+interface TokenResponse {
+  readonly access_token: string;
+  readonly id_token?: string;
+  readonly token_type?: string;
+}
+
+/**
+ * Exchange the authorization code for tokens, then fetch the user's profile.
+ * Returns a normalised OAuthProfile or throws OAuthError on any step
+ * failure — the route layer maps codes to user-facing messages.
+ */
+export async function exchangeAndFetchProfile(
+  input: ExchangeAndFetchInput,
+): Promise<OAuthProfile> {
+  const provider = getProvider(input.provider);
+  const tokens = await exchangeCode(provider, input);
+  const profile = await fetchProfile(provider, tokens.access_token);
+
+  let { email, emailVerified } = profile;
+  if (input.provider === "github" && !email) {
+    const primary = await fetchPrimaryEmail(tokens.access_token);
+    if (primary) {
+      email = primary.email;
+      emailVerified = primary.verified;
+    }
+  }
+
+  if (!email) {
+    throw new OAuthError("email_missing");
+  }
+
+  return {
+    providerAccountId: profile.providerAccountId,
+    email: email.toLowerCase(),
+    emailVerified,
+    name: profile.name,
+    avatarUrl: profile.avatarUrl,
+  };
+}
+
+async function exchangeCode(
+  provider: OAuthProvider,
+  input: ExchangeAndFetchInput,
+): Promise<TokenResponse> {
+  // RFC 6749 §2.3.1 / Copenhagen Book: client credentials go in the
+  // Authorization header (HTTP Basic). client_id stays in the body for
+  // providers (like Google) whose docs require it on the form too —
+  // harmless when also present in the header.
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: input.code,
+    redirect_uri: input.redirectUri,
+    client_id: input.client.clientId,
+    code_verifier: input.codeVerifier,
+  });
+  const basic = btoa(`${input.client.clientId}:${input.client.clientSecret}`);
+
+  let response: Response;
+  try {
+    response = await fetch(provider.tokenUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${basic}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body,
+    });
+  } catch {
+    throw new OAuthError("code_exchange_failed", "network error");
+  }
+
+  if (!response.ok) {
+    throw new OAuthError("code_exchange_failed", `status ${response.status}`);
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    throw new OAuthError("code_exchange_failed", "non-json response");
+  }
+
+  if (
+    !json ||
+    typeof json !== "object" ||
+    !("access_token" in json) ||
+    typeof json.access_token !== "string"
+  ) {
+    throw new OAuthError("code_exchange_failed", "missing access_token");
+  }
+  return json as TokenResponse;
+}
+
+async function fetchProfile(
+  provider: OAuthProvider,
+  accessToken: string,
+): Promise<ReturnType<OAuthProvider["parseProfile"]>> {
+  let response: Response;
+  try {
+    response = await fetch(provider.userInfoUrl, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+        "User-Agent": "plumix",
+      },
+    });
+  } catch {
+    throw new OAuthError("profile_fetch_failed", "network error");
+  }
+
+  if (!response.ok) {
+    throw new OAuthError("profile_fetch_failed", `status ${response.status}`);
+  }
+  const raw: unknown = await response.json();
+  return provider.parseProfile(raw);
+}

--- a/packages/core/src/auth/oauth/errors.ts
+++ b/packages/core/src/auth/oauth/errors.ts
@@ -1,0 +1,24 @@
+export const OAUTH_ERROR_CODES = [
+  "provider_not_configured",
+  "state_invalid",
+  "state_expired",
+  "code_exchange_failed",
+  "profile_fetch_failed",
+  "email_missing",
+  "email_unverified",
+  "domain_not_allowed",
+  "account_disabled",
+  "registration_closed",
+] as const;
+
+export type OAuthErrorCode = (typeof OAUTH_ERROR_CODES)[number];
+
+export class OAuthError extends Error {
+  readonly code: OAuthErrorCode;
+
+  constructor(code: OAuthErrorCode, message?: string) {
+    super(message ?? code);
+    this.name = "OAuthError";
+    this.code = code;
+  }
+}

--- a/packages/core/src/auth/oauth/errors.ts
+++ b/packages/core/src/auth/oauth/errors.ts
@@ -8,6 +8,7 @@ export const OAUTH_ERROR_CODES = [
   "email_unverified",
   "domain_not_allowed",
   "account_disabled",
+  "link_broken",
   "registration_closed",
 ] as const;
 

--- a/packages/core/src/auth/oauth/index.ts
+++ b/packages/core/src/auth/oauth/index.ts
@@ -1,0 +1,43 @@
+export { buildAuthorizeUrl, exchangeAndFetchProfile } from "./consumer.js";
+export type {
+  BuildAuthorizeUrlInput,
+  BuiltAuthorizeUrl,
+  ExchangeAndFetchInput,
+} from "./consumer.js";
+
+export { OAUTH_ERROR_CODES, OAuthError } from "./errors.js";
+export type { OAuthErrorCode } from "./errors.js";
+
+export { computeS256Challenge, generateCodeVerifier } from "./pkce.js";
+
+export {
+  handleOAuthCallback,
+  handleOAuthStart,
+  parseOAuthPath,
+} from "./routes.js";
+
+export { resolveOAuthUser } from "./signup.js";
+export type { ResolveOAuthUserInput, ResolvedOAuthUser } from "./signup.js";
+
+export {
+  consumeOAuthState,
+  issueOAuthState,
+  OAUTH_STATE_TTL_SECONDS,
+} from "./state.js";
+export type { IssuedOAuthState, OAuthStatePayload } from "./state.js";
+
+export { OAUTH_PROVIDER_KEYS } from "./types.js";
+export type {
+  OAuthClientConfig,
+  OAuthProfile,
+  OAuthProvider,
+  OAuthProviderKey,
+  OAuthProvidersConfig,
+} from "./types.js";
+
+export {
+  fetchPrimaryEmail,
+  getProvider,
+  github,
+  google,
+} from "./providers/index.js";

--- a/packages/core/src/auth/oauth/index.ts
+++ b/packages/core/src/auth/oauth/index.ts
@@ -1,30 +1,14 @@
-export { buildAuthorizeUrl, exchangeAndFetchProfile } from "./consumer.js";
-export type {
-  BuildAuthorizeUrlInput,
-  BuiltAuthorizeUrl,
-  ExchangeAndFetchInput,
-} from "./consumer.js";
+// Public OAuth surface. Internals (PKCE primitives, state store, provider
+// singletons, GitHub email helper, the `consumer` exchange/fetch helpers,
+// the path parser) are intentionally NOT re-exported — they're only used
+// by the dispatcher + tests, which import them by file path. Keeping the
+// barrel narrow prevents accidental load-bearing dependencies on internal
+// helpers ahead of the 0.1.0 freeze.
 
 export { OAUTH_ERROR_CODES, OAuthError } from "./errors.js";
 export type { OAuthErrorCode } from "./errors.js";
 
-export { computeS256Challenge, generateCodeVerifier } from "./pkce.js";
-
-export {
-  handleOAuthCallback,
-  handleOAuthStart,
-  parseOAuthPath,
-} from "./routes.js";
-
-export { resolveOAuthUser } from "./signup.js";
-export type { ResolveOAuthUserInput, ResolvedOAuthUser } from "./signup.js";
-
-export {
-  consumeOAuthState,
-  issueOAuthState,
-  OAUTH_STATE_TTL_SECONDS,
-} from "./state.js";
-export type { IssuedOAuthState, OAuthStatePayload } from "./state.js";
+export { handleOAuthCallback, handleOAuthStart } from "./routes.js";
 
 export { OAUTH_PROVIDER_KEYS } from "./types.js";
 export type {
@@ -34,10 +18,3 @@ export type {
   OAuthProviderKey,
   OAuthProvidersConfig,
 } from "./types.js";
-
-export {
-  fetchPrimaryEmail,
-  getProvider,
-  github,
-  google,
-} from "./providers/index.js";

--- a/packages/core/src/auth/oauth/pkce.test.ts
+++ b/packages/core/src/auth/oauth/pkce.test.ts
@@ -1,0 +1,42 @@
+import { encodeBase64urlNoPadding } from "@oslojs/encoding";
+import { describe, expect, test } from "vitest";
+
+import { computeS256Challenge, generateCodeVerifier } from "./pkce.js";
+
+describe("PKCE helpers", () => {
+  test("generates a 43-char base64url verifier (32 bytes, no padding)", () => {
+    const verifier = generateCodeVerifier();
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 32 bytes → 43 chars in base64url-no-pad (ceil(32 * 4 / 3) = 43).
+    expect(verifier).toHaveLength(43);
+  });
+
+  test("verifiers are unique across calls", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 32; i++) seen.add(generateCodeVerifier());
+    expect(seen.size).toBe(32);
+  });
+
+  test("S256 challenge equals base64url(SHA-256(verifier))", async () => {
+    const verifier = "test-verifier-12345";
+    const expected = encodeBase64urlNoPadding(
+      new Uint8Array(
+        await crypto.subtle.digest(
+          "SHA-256",
+          new TextEncoder().encode(verifier),
+        ),
+      ),
+    );
+    const challenge = await computeS256Challenge(verifier);
+    expect(challenge).toBe(expected);
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(challenge).toHaveLength(43);
+  });
+
+  test("S256 challenge is deterministic for the same verifier", async () => {
+    const v = generateCodeVerifier();
+    const a = await computeS256Challenge(v);
+    const b = await computeS256Challenge(v);
+    expect(a).toBe(b);
+  });
+});

--- a/packages/core/src/auth/oauth/pkce.ts
+++ b/packages/core/src/auth/oauth/pkce.ts
@@ -1,0 +1,18 @@
+import { encodeBase64urlNoPadding } from "@oslojs/encoding";
+
+const VERIFIER_BYTES = 32;
+const ENCODER = new TextEncoder();
+
+export function generateCodeVerifier(): string {
+  const bytes = new Uint8Array(VERIFIER_BYTES);
+  crypto.getRandomValues(bytes);
+  return encodeBase64urlNoPadding(bytes);
+}
+
+export async function computeS256Challenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    ENCODER.encode(verifier),
+  );
+  return encodeBase64urlNoPadding(new Uint8Array(digest));
+}

--- a/packages/core/src/auth/oauth/providers/github.ts
+++ b/packages/core/src/auth/oauth/providers/github.ts
@@ -1,0 +1,59 @@
+import type { OAuthProvider } from "../types.js";
+
+interface GitHubProfile {
+  readonly id: number;
+  readonly login: string;
+  readonly name: string | null;
+  readonly email: string | null;
+  readonly avatar_url: string | null;
+}
+
+interface GitHubEmail {
+  readonly email: string;
+  readonly primary: boolean;
+  readonly verified: boolean;
+}
+
+export const github: OAuthProvider = {
+  key: "github",
+  authorizeUrl: "https://github.com/login/oauth/authorize",
+  tokenUrl: "https://github.com/login/oauth/access_token",
+  userInfoUrl: "https://api.github.com/user",
+  scopes: ["read:user", "user:email"],
+  parseProfile(raw) {
+    const p = raw as GitHubProfile;
+    return {
+      providerAccountId: String(p.id),
+      // GitHub's /user only exposes `email` when the user has marked one
+      // public, and GitHub only allows publicising verified addresses —
+      // so if `email` is non-null here, treat it as verified.
+      email: p.email,
+      emailVerified: p.email !== null,
+      name: p.name ?? p.login,
+      avatarUrl: p.avatar_url,
+    };
+  },
+};
+
+export interface PrimaryEmail {
+  readonly email: string;
+  readonly verified: boolean;
+}
+
+export async function fetchPrimaryEmail(
+  accessToken: string,
+): Promise<PrimaryEmail | null> {
+  const response = await fetch("https://api.github.com/user/emails", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "plumix",
+    },
+  });
+  if (!response.ok) return null;
+  const list = (await response.json()) as readonly GitHubEmail[];
+  const primary = list.find((e) => e.primary) ?? list[0];
+  if (!primary) return null;
+  return { email: primary.email, verified: primary.verified };
+}

--- a/packages/core/src/auth/oauth/providers/github.ts
+++ b/packages/core/src/auth/oauth/providers/github.ts
@@ -35,7 +35,7 @@ export const github: OAuthProvider = {
   },
 };
 
-export interface PrimaryEmail {
+interface PrimaryEmail {
   readonly email: string;
   readonly verified: boolean;
 }

--- a/packages/core/src/auth/oauth/providers/google.ts
+++ b/packages/core/src/auth/oauth/providers/google.ts
@@ -1,0 +1,27 @@
+import type { OAuthProvider } from "../types.js";
+
+interface GoogleProfile {
+  readonly sub: string;
+  readonly email: string;
+  readonly email_verified: boolean;
+  readonly name: string | null;
+  readonly picture: string | null;
+}
+
+export const google: OAuthProvider = {
+  key: "google",
+  authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenUrl: "https://oauth2.googleapis.com/token",
+  userInfoUrl: "https://openidconnect.googleapis.com/v1/userinfo",
+  scopes: ["openid", "email", "profile"],
+  parseProfile(raw) {
+    const p = raw as GoogleProfile;
+    return {
+      providerAccountId: p.sub,
+      email: p.email,
+      emailVerified: Boolean(p.email_verified),
+      name: p.name,
+      avatarUrl: p.picture,
+    };
+  },
+};

--- a/packages/core/src/auth/oauth/providers/index.ts
+++ b/packages/core/src/auth/oauth/providers/index.ts
@@ -1,0 +1,14 @@
+import type { OAuthProvider, OAuthProviderKey } from "../types.js";
+import { fetchPrimaryEmail, github } from "./github.js";
+import { google } from "./google.js";
+
+export { github, google, fetchPrimaryEmail };
+
+export function getProvider(key: OAuthProviderKey): OAuthProvider {
+  switch (key) {
+    case "github":
+      return github;
+    case "google":
+      return google;
+  }
+}

--- a/packages/core/src/auth/oauth/routes.test.ts
+++ b/packages/core/src/auth/oauth/routes.test.ts
@@ -1,0 +1,422 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { eq } from "../../db/index.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
+import { sessions } from "../../db/schema/sessions.js";
+import { users } from "../../db/schema/users.js";
+import { createDispatcherHarness } from "../../test/dispatcher.js";
+import { issueOAuthState } from "./state.js";
+
+const TEST_OAUTH = {
+  github: { clientId: "gh-client", clientSecret: "gh-secret" },
+  google: { clientId: "gg-client", clientSecret: "gg-secret" },
+} as const;
+
+interface StubResponse {
+  readonly status?: number;
+  readonly body: unknown;
+}
+
+type Stub = StubResponse | ((url: string, init?: RequestInit) => StubResponse);
+
+const fetchMock =
+  vi.fn<(url: string, init?: RequestInit) => Promise<Response>>();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function answer(routes: Record<string, Stub>): void {
+  fetchMock.mockImplementation((url, init) => {
+    for (const [pattern, stub] of Object.entries(routes)) {
+      if (url.startsWith(pattern)) {
+        const result = typeof stub === "function" ? stub(url, init) : stub;
+        return Promise.resolve(
+          new Response(JSON.stringify(result.body), {
+            status: result.status ?? 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+    }
+    return Promise.reject(new Error(`unstubbed fetch: ${url}`));
+  });
+}
+
+function get(
+  h: Awaited<ReturnType<typeof createDispatcherHarness>>,
+  path: string,
+): Promise<Response> {
+  return h.dispatch(new Request(`https://cms.example${path}`));
+}
+
+describe("oauth start route", () => {
+  test("redirects to bootstrap when no users exist", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/oauth/github/start"),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/_plumix/admin/bootstrap");
+  });
+
+  test("redirects to provider authorize URL with PKCE + state", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/oauth/github/start"),
+    );
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    if (!location) throw new Error("missing location header");
+
+    const url = new URL(location);
+    expect(url.origin).toBe("https://github.com");
+    expect(url.pathname).toBe("/login/oauth/authorize");
+    expect(url.searchParams.get("client_id")).toBe("gh-client");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(url.searchParams.get("state")).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://cms.example/_plumix/auth/oauth/github/callback",
+    );
+
+    // State token landed in auth_tokens.
+    const rows = await h.db.select().from(authTokens);
+    expect(rows.some((r) => r.type === "oauth_state")).toBe(true);
+  });
+
+  test("redirects to login with error when provider isn't configured", async () => {
+    const h = await createDispatcherHarness();
+    await h.seedUser("admin");
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/oauth/github/start"),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "/_plumix/admin/login?oauth_error=provider_not_configured",
+    );
+  });
+
+  test("returns 405 on POST", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/oauth/github/start", {
+        method: "POST",
+        headers: { "x-plumix-request": "1" },
+      }),
+    );
+    expect(response.status).toBe(405);
+  });
+
+  test("returns 404 on unknown provider", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/oauth/twitter/start"),
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("oauth callback route", () => {
+  async function seedState(
+    h: Awaited<ReturnType<typeof createDispatcherHarness>>,
+    provider: "github" | "google",
+    codeVerifier: string,
+  ): Promise<string> {
+    const { state } = await issueOAuthState(h.db, { provider, codeVerifier });
+    return state;
+  }
+
+  test("rejects callback when state is missing", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const response = await get(
+      h,
+      "/_plumix/auth/oauth/github/callback?code=abc",
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=state_invalid",
+    );
+  });
+
+  test("rejects callback when state is unknown", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const response = await get(
+      h,
+      "/_plumix/auth/oauth/github/callback?code=abc&state=nope",
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=state_expired",
+    );
+  });
+
+  test("rejects callback when state was issued for a different provider", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const state = await seedState(h, "google", "verifier");
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=state_invalid",
+    );
+  });
+
+  test("forwards a provider error param to the login page", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const response = await get(
+      h,
+      "/_plumix/auth/oauth/github/callback?error=access_denied",
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=state_invalid",
+    );
+  });
+
+  test("token exchange uses HTTP Basic Authorization for client credentials (RFC 6749 / Copenhagen Book)", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    await h.factory.allowedDomain.create({
+      domain: "example.com",
+      defaultRole: "subscriber",
+      isEnabled: true,
+    });
+    const state = await seedState(h, "github", "v-basic");
+    const tokenCalls: { authorization: string | null; body: string | null }[] =
+      [];
+    fetchMock.mockImplementation((url, init) => {
+      if (url.startsWith("https://github.com/login/oauth/access_token")) {
+        const headers = new Headers(init?.headers);
+        const bodyText =
+          typeof init?.body === "string"
+            ? init.body
+            : init?.body instanceof URLSearchParams
+              ? init.body.toString()
+              : null;
+        tokenCalls.push({
+          authorization: headers.get("authorization"),
+          body: bodyText,
+        });
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "tk" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+      if (url.startsWith("https://api.github.com/user")) {
+        const body = url.endsWith("/emails")
+          ? [{ email: "x@example.com", primary: true, verified: true }]
+          : {
+              id: 1,
+              login: "x",
+              name: null,
+              email: null,
+              avatar_url: null,
+            };
+        return Promise.resolve(
+          new Response(JSON.stringify(body), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+      return Promise.reject(new Error(`unstubbed fetch: ${url}`));
+    });
+
+    await get(h, `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`);
+
+    expect(tokenCalls).toHaveLength(1);
+    const expectedBasic = `Basic ${btoa("gh-client:gh-secret")}`;
+    expect(tokenCalls[0]?.authorization).toBe(expectedBasic);
+    // client_secret must NOT also appear in the body — keeps it out of
+    // server access logs that record request bodies.
+    expect(tokenCalls[0]?.body ?? "").not.toContain("client_secret");
+  });
+
+  test("happy path — links to existing user, mints session, sets cookie, redirects to admin", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const seeded = await h.seedUser("editor");
+    // Force the email so the verified-email link path is exercised.
+    await h.db
+      .update(users)
+      .set({ email: "alice@example.com" })
+      .where(eq(users.id, seeded.id));
+
+    const state = await seedState(h, "github", "v-1");
+
+    answer({
+      "https://github.com/login/oauth/access_token": {
+        body: { access_token: "tk", token_type: "bearer" },
+      },
+      "https://api.github.com/user": {
+        body: {
+          id: 9001,
+          login: "alice",
+          name: "Alice",
+          email: "alice@example.com",
+          avatar_url: "https://example.com/a.png",
+        },
+      },
+      "https://api.github.com/user/emails": {
+        body: [{ email: "alice@example.com", primary: true, verified: true }],
+      },
+    });
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/_plumix/admin");
+    expect(response.headers.get("set-cookie")).toContain("plumix_session=");
+
+    const link = await h.db
+      .select()
+      .from(oauthAccounts)
+      .where(eq(oauthAccounts.providerAccountId, "9001"));
+    expect(link).toHaveLength(1);
+    expect(link[0]?.userId).toBe(seeded.id);
+
+    const sessionRows = await h.db.select().from(sessions);
+    expect(sessionRows).toHaveLength(1);
+    expect(sessionRows[0]?.userId).toBe(seeded.id);
+  });
+
+  test("domain-gated signup creates a user with the domain's default role", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    await h.factory.allowedDomain.create({
+      domain: "example.com",
+      defaultRole: "author",
+      isEnabled: true,
+    });
+
+    const state = await seedState(h, "google", "v-2");
+
+    answer({
+      "https://oauth2.googleapis.com/token": {
+        body: { access_token: "tk", id_token: "id", token_type: "bearer" },
+      },
+      "https://openidconnect.googleapis.com/v1/userinfo": {
+        body: {
+          sub: "google-42",
+          email: "newcomer@example.com",
+          email_verified: true,
+          name: "New Comer",
+          picture: "https://example.com/pic.png",
+        },
+      },
+    });
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/google/callback?code=abc&state=${state}`,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/_plumix/admin");
+
+    const created = await h.db.query.users.findFirst({
+      where: eq(users.email, "newcomer@example.com"),
+    });
+    expect(created?.role).toBe("author");
+  });
+
+  test("unknown domain redirects to login with domain_not_allowed", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+
+    const state = await seedState(h, "google", "v-3");
+
+    answer({
+      "https://oauth2.googleapis.com/token": {
+        body: { access_token: "tk", token_type: "bearer" },
+      },
+      "https://openidconnect.googleapis.com/v1/userinfo": {
+        body: {
+          sub: "g-1",
+          email: "stranger@notallowed.com",
+          email_verified: true,
+          name: "Stranger",
+          picture: null,
+        },
+      },
+    });
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/google/callback?code=abc&state=${state}`,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=domain_not_allowed",
+    );
+    // No session, no user.
+    expect(await h.db.$count(sessions)).toBe(0);
+    const stranger = await h.db.query.users.findFirst({
+      where: eq(users.email, "stranger@notallowed.com"),
+    });
+    expect(stranger).toBeUndefined();
+  });
+
+  test("token exchange failure redirects to login with code_exchange_failed", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+
+    const state = await seedState(h, "github", "v-x");
+
+    answer({
+      "https://github.com/login/oauth/access_token": {
+        status: 500,
+        body: { error: "server_error" },
+      },
+    });
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=code_exchange_failed",
+    );
+  });
+
+  test("state is consumed even when the provider call fails (no replay)", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    const state = await seedState(h, "github", "v-y");
+
+    answer({
+      "https://github.com/login/oauth/access_token": {
+        status: 500,
+        body: {},
+      },
+    });
+
+    await get(h, `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`);
+    // Second use of the same state must fail at state lookup.
+    answer({
+      "https://github.com/login/oauth/access_token": { body: {} },
+    });
+    const replay = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`,
+    );
+    expect(replay.headers.get("location")).toContain(
+      "oauth_error=state_expired",
+    );
+  });
+});

--- a/packages/core/src/auth/oauth/routes.test.ts
+++ b/packages/core/src/auth/oauth/routes.test.ts
@@ -33,8 +33,14 @@ afterEach(() => {
 });
 
 function answer(routes: Record<string, Stub>): void {
+  // Match longest-prefix first so a specific pattern like
+  // `https://api.github.com/user/emails` wins over the parent
+  // `https://api.github.com/user`.
+  const patterns = Object.entries(routes).sort(
+    ([a], [b]) => b.length - a.length,
+  );
   fetchMock.mockImplementation((url, init) => {
-    for (const [pattern, stub] of Object.entries(routes)) {
+    for (const [pattern, stub] of patterns) {
       if (url.startsWith(pattern)) {
         const result = typeof stub === "function" ? stub(url, init) : stub;
         return Promise.resolve(
@@ -391,6 +397,157 @@ describe("oauth callback route", () => {
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toContain(
       "oauth_error=code_exchange_failed",
+    );
+  });
+
+  test("github email fallback — provisions a user from /user/emails when /user.email is null", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    await h.factory.allowedDomain.create({
+      domain: "example.com",
+      defaultRole: "subscriber",
+      isEnabled: true,
+    });
+    const state = await seedState(h, "github", "v-fallback");
+
+    answer({
+      "https://github.com/login/oauth/access_token": {
+        body: { access_token: "tk", token_type: "bearer" },
+      },
+      "https://api.github.com/user": {
+        body: {
+          id: 4242,
+          login: "newcomer",
+          name: "New Comer",
+          email: null,
+          avatar_url: null,
+        },
+      },
+      "https://api.github.com/user/emails": {
+        body: [
+          { email: "newcomer@example.com", primary: true, verified: true },
+        ],
+      },
+    });
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/_plumix/admin");
+
+    const created = await h.db.query.users.findFirst({
+      where: eq(users.email, "newcomer@example.com"),
+    });
+    expect(created?.role).toBe("subscriber");
+    expect(created?.emailVerifiedAt).not.toBeNull();
+  });
+
+  test("github email fallback rejects when the primary is unverified", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    await h.factory.allowedDomain.create({
+      domain: "example.com",
+      defaultRole: "subscriber",
+      isEnabled: true,
+    });
+    const state = await seedState(h, "github", "v-fallback-unverified");
+
+    answer({
+      "https://github.com/login/oauth/access_token": {
+        body: { access_token: "tk", token_type: "bearer" },
+      },
+      "https://api.github.com/user": {
+        body: {
+          id: 4243,
+          login: "u",
+          name: null,
+          email: null,
+          avatar_url: null,
+        },
+      },
+      "https://api.github.com/user/emails": {
+        body: [{ email: "u@example.com", primary: true, verified: false }],
+      },
+    });
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`,
+    );
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=email_unverified",
+    );
+  });
+
+  test("malformed userinfo body (missing fields) rejects with email_missing", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    const state = await seedState(h, "google", "v-malformed");
+
+    answer({
+      "https://oauth2.googleapis.com/token": {
+        body: { access_token: "tk", token_type: "bearer" },
+      },
+      "https://openidconnect.googleapis.com/v1/userinfo": {
+        body: { sub: "g-malformed" },
+      },
+    });
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/google/callback?code=abc&state=${state}`,
+    );
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=email_missing",
+    );
+  });
+
+  test("oversized code is rejected before any provider call", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    const state = await seedState(h, "github", "v-oversize");
+    const huge = "x".repeat(8192);
+
+    fetchMock.mockImplementation(() =>
+      Promise.reject(new Error("provider must not be called")),
+    );
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?code=${huge}&state=${state}`,
+    );
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=state_invalid",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("provider-error callback consumes the state row", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    const state = await seedState(h, "github", "v-canceled");
+
+    const response = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?error=access_denied&state=${state}`,
+    );
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=state_invalid",
+    );
+
+    // The state row must be gone — replaying with the same value can't
+    // reach the code-exchange path.
+    answer({
+      "https://github.com/login/oauth/access_token": { body: {} },
+    });
+    const replay = await get(
+      h,
+      `/_plumix/auth/oauth/github/callback?code=abc&state=${state}`,
+    );
+    expect(replay.headers.get("location")).toContain(
+      "oauth_error=state_expired",
     );
   });
 

--- a/packages/core/src/auth/oauth/routes.ts
+++ b/packages/core/src/auth/oauth/routes.ts
@@ -15,6 +15,11 @@ const ADMIN_PATH = "/_plumix/admin";
 const LOGIN_PATH = "/_plumix/admin/login";
 const BOOTSTRAP_PATH = "/_plumix/admin/bootstrap";
 
+// Defensive bound on `code` from the provider's redirect. GitHub's codes
+// are ~20 chars; Google's a few hundred. 4 KiB is generous for any current
+// provider while bounding URL/body amplification on a malformed callback.
+const MAX_CODE_LENGTH = 4096;
+
 interface OAuthRouteParams {
   readonly provider: OAuthProviderKey;
 }
@@ -59,7 +64,7 @@ export async function handleOAuthStart(
     return redirectTo(BOOTSTRAP_PATH);
   }
 
-  const redirectUri = oauthCallbackUrl(ctx.request, provider);
+  const redirectUri = oauthCallbackUrl(app, provider);
 
   try {
     const { url } = await buildAuthorizeUrl({
@@ -84,23 +89,25 @@ export async function handleOAuthCallback(
   if (!client) return loginError("provider_not_configured");
 
   const url = new URL(ctx.request.url);
+  const state = url.searchParams.get("state");
+
   // Provider-side denial (user clicked Cancel, scope rejected, etc.)
-  // arrives as `?error=...`. Treat as state_invalid for messaging since
-  // the original state is now unreachable; we're also discarding any
-  // pending row by deleting it on consume below if it exists.
+  // arrives as `?error=...`. The state row would otherwise sit until TTL;
+  // consume it here so the slot is freed immediately.
   if (url.searchParams.has("error")) {
+    if (state) await consumeOAuthState(ctx.db, state);
     return loginError("state_invalid");
   }
 
   const code = url.searchParams.get("code");
-  const state = url.searchParams.get("state");
   if (!code || !state) return loginError("state_invalid");
+  if (code.length > MAX_CODE_LENGTH) return loginError("state_invalid");
 
   const stored = await consumeOAuthState(ctx.db, state);
   if (!stored) return loginError("state_expired");
   if (stored.provider !== provider) return loginError("state_invalid");
 
-  const redirectUri = oauthCallbackUrl(ctx.request, provider);
+  const redirectUri = oauthCallbackUrl(app, provider);
 
   try {
     const profile = await exchangeAndFetchProfile({
@@ -148,12 +155,13 @@ function pickClient(
   return oauth.providers[provider] ?? null;
 }
 
-function oauthCallbackUrl(
-  request: Request,
-  provider: OAuthProviderKey,
-): string {
-  const url = new URL(request.url);
-  return `${url.origin}/_plumix/auth/oauth/${provider}/callback`;
+// `app.origin` is the canonical site origin from passkey config — pinning
+// the callback URL there means the value the provider sees at authorize
+// time is identical at token-exchange time even if a load balancer or
+// custom adapter rewrites Host on the way in. (Cloudflare Workers binds
+// `request.url` to the connection hostname, but other adapters may not.)
+function oauthCallbackUrl(app: PlumixApp, provider: OAuthProviderKey): string {
+  return `${app.origin}/_plumix/auth/oauth/${provider}/callback`;
 }
 
 function redirectTo(

--- a/packages/core/src/auth/oauth/routes.ts
+++ b/packages/core/src/auth/oauth/routes.ts
@@ -1,0 +1,172 @@
+import type { AppContext } from "../../context/app.js";
+import type { PlumixApp } from "../../runtime/app.js";
+import type { OAuthErrorCode } from "./errors.js";
+import type { OAuthClientConfig, OAuthProviderKey } from "./types.js";
+import { users } from "../../db/schema/users.js";
+import { buildSessionCookie, isSecureRequest } from "../cookies.js";
+import { createSession } from "../sessions.js";
+import { buildAuthorizeUrl, exchangeAndFetchProfile } from "./consumer.js";
+import { OAuthError } from "./errors.js";
+import { resolveOAuthUser } from "./signup.js";
+import { consumeOAuthState } from "./state.js";
+import { OAUTH_PROVIDER_KEYS } from "./types.js";
+
+const ADMIN_PATH = "/_plumix/admin";
+const LOGIN_PATH = "/_plumix/admin/login";
+const BOOTSTRAP_PATH = "/_plumix/admin/bootstrap";
+
+interface OAuthRouteParams {
+  readonly provider: OAuthProviderKey;
+}
+
+/**
+ * Match `/_plumix/auth/oauth/<provider>/(start|callback)`. Returns the
+ * provider + tail or null if the path doesn't match the OAuth shape.
+ */
+export function parseOAuthPath(
+  pathname: string,
+): { params: OAuthRouteParams; tail: "start" | "callback" } | null {
+  const prefix = "/_plumix/auth/oauth/";
+  if (!pathname.startsWith(prefix)) return null;
+  const rest = pathname.slice(prefix.length);
+  const slash = rest.indexOf("/");
+  if (slash < 0) return null;
+  const provider = rest.slice(0, slash);
+  const tail = rest.slice(slash + 1);
+  if (!isProviderKey(provider)) return null;
+  if (tail !== "start" && tail !== "callback") return null;
+  return { params: { provider }, tail };
+}
+
+function isProviderKey(value: string): value is OAuthProviderKey {
+  return (OAUTH_PROVIDER_KEYS as readonly string[]).includes(value);
+}
+
+export async function handleOAuthStart(
+  ctx: AppContext,
+  app: PlumixApp,
+  provider: OAuthProviderKey,
+): Promise<Response> {
+  const client = pickClient(app, provider);
+  if (!client) return loginError("provider_not_configured");
+
+  // Block OAuth on a fresh deploy. Bootstrap is passkey-only; an OAuth
+  // signup before any user exists would either fail with a confusing
+  // domain_not_allowed (no rows) or — if domains were pre-seeded — mint
+  // a non-admin who can't actually do anything. Send to /bootstrap.
+  const userCount = await ctx.db.$count(users);
+  if (userCount === 0) {
+    return redirectTo(BOOTSTRAP_PATH);
+  }
+
+  const redirectUri = oauthCallbackUrl(ctx.request, provider);
+
+  try {
+    const { url } = await buildAuthorizeUrl({
+      db: ctx.db,
+      provider,
+      client,
+      redirectUri,
+    });
+    return redirectTo(url);
+  } catch (error) {
+    ctx.logger.error("oauth_start_failed", { error, provider });
+    return loginError("code_exchange_failed");
+  }
+}
+
+export async function handleOAuthCallback(
+  ctx: AppContext,
+  app: PlumixApp,
+  provider: OAuthProviderKey,
+): Promise<Response> {
+  const client = pickClient(app, provider);
+  if (!client) return loginError("provider_not_configured");
+
+  const url = new URL(ctx.request.url);
+  // Provider-side denial (user clicked Cancel, scope rejected, etc.)
+  // arrives as `?error=...`. Treat as state_invalid for messaging since
+  // the original state is now unreachable; we're also discarding any
+  // pending row by deleting it on consume below if it exists.
+  if (url.searchParams.has("error")) {
+    return loginError("state_invalid");
+  }
+
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  if (!code || !state) return loginError("state_invalid");
+
+  const stored = await consumeOAuthState(ctx.db, state);
+  if (!stored) return loginError("state_expired");
+  if (stored.provider !== provider) return loginError("state_invalid");
+
+  const redirectUri = oauthCallbackUrl(ctx.request, provider);
+
+  try {
+    const profile = await exchangeAndFetchProfile({
+      provider,
+      client,
+      code,
+      redirectUri,
+      codeVerifier: stored.codeVerifier,
+    });
+
+    const { user } = await resolveOAuthUser(ctx.db, { provider, profile });
+
+    const { token } = await createSession(
+      ctx.db,
+      { userId: user.id },
+      app.sessionPolicy,
+    );
+
+    const cookie = buildSessionCookie(token, {
+      maxAgeSeconds: app.sessionPolicy.maxAgeSeconds,
+      secure: isSecureRequest(ctx.request),
+      sameSite: "Lax",
+    });
+
+    return redirectTo(ADMIN_PATH, { "set-cookie": cookie });
+  } catch (error) {
+    if (error instanceof OAuthError) {
+      ctx.logger.warn("oauth_callback_rejected", {
+        provider,
+        code: error.code,
+      });
+      return loginError(error.code);
+    }
+    ctx.logger.error("oauth_callback_failed", { error, provider });
+    return loginError("code_exchange_failed");
+  }
+}
+
+function pickClient(
+  app: PlumixApp,
+  provider: OAuthProviderKey,
+): OAuthClientConfig | null {
+  const oauth = app.config.auth.oauth;
+  if (!oauth) return null;
+  return oauth.providers[provider] ?? null;
+}
+
+function oauthCallbackUrl(
+  request: Request,
+  provider: OAuthProviderKey,
+): string {
+  const url = new URL(request.url);
+  return `${url.origin}/_plumix/auth/oauth/${provider}/callback`;
+}
+
+function redirectTo(
+  location: string,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  const headers = new Headers({ Location: location, ...extraHeaders });
+  return new Response(null, { status: 302, headers });
+}
+
+function loginError(code: OAuthErrorCode): Response {
+  const params = new URLSearchParams({ oauth_error: code });
+  // Relative location — keeps the same scheme/host/port the browser
+  // already used to reach us, no need to know the canonical origin.
+  return redirectTo(`${LOGIN_PATH}?${params.toString()}`);
+}

--- a/packages/core/src/auth/oauth/signup.test.ts
+++ b/packages/core/src/auth/oauth/signup.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "vitest";
+
+import { eq } from "../../db/index.js";
+import { allowedDomains } from "../../db/schema/allowed_domains.js";
+import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
+import { users } from "../../db/schema/users.js";
+import { allowedDomainFactory, userFactory } from "../../test/factories.js";
+import { createTestDb } from "../../test/harness.js";
+import { OAuthError } from "./errors.js";
+import { resolveOAuthUser } from "./signup.js";
+
+const PROFILE = {
+  providerAccountId: "gh-123",
+  email: "alice@example.com",
+  emailVerified: true,
+  name: "Alice",
+  avatarUrl: "https://example.com/a.png",
+} as const;
+
+describe("resolveOAuthUser — link existing oauth account", () => {
+  test("returns the linked user without creating anything", async () => {
+    const db = await createTestDb();
+    const seeded = await userFactory.transient({ db }).create({
+      email: PROFILE.email,
+      role: "editor",
+    });
+    await db.insert(oauthAccounts).values({
+      provider: "github",
+      providerAccountId: PROFILE.providerAccountId,
+      userId: seeded.id,
+    });
+
+    const result = await resolveOAuthUser(db, {
+      provider: "github",
+      profile: PROFILE,
+    });
+    expect(result.user.id).toBe(seeded.id);
+    expect(result.created).toBe(false);
+    expect(result.linked).toBe(false);
+  });
+
+  test("rejects when the linked user is disabled", async () => {
+    const db = await createTestDb();
+    const seeded = await userFactory.transient({ db }).create({
+      email: PROFILE.email,
+      role: "editor",
+      disabledAt: new Date(),
+    });
+    await db.insert(oauthAccounts).values({
+      provider: "github",
+      providerAccountId: PROFILE.providerAccountId,
+      userId: seeded.id,
+    });
+
+    await expect(
+      resolveOAuthUser(db, { provider: "github", profile: PROFILE }),
+    ).rejects.toMatchObject({ code: "account_disabled" });
+  });
+});
+
+describe("resolveOAuthUser — link by email (existing user, no oauth row)", () => {
+  test("verified-email match writes the oauth_accounts row and returns the user", async () => {
+    const db = await createTestDb();
+    const seeded = await userFactory.transient({ db }).create({
+      email: PROFILE.email,
+      role: "author",
+    });
+
+    const result = await resolveOAuthUser(db, {
+      provider: "github",
+      profile: PROFILE,
+    });
+    expect(result.user.id).toBe(seeded.id);
+    expect(result.linked).toBe(true);
+    expect(result.created).toBe(false);
+
+    const link = await db.query.oauthAccounts.findFirst({
+      where: eq(oauthAccounts.providerAccountId, PROFILE.providerAccountId),
+    });
+    expect(link?.userId).toBe(seeded.id);
+  });
+
+  test("unverified email is refused (no link, no signup)", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({
+      email: PROFILE.email,
+      role: "author",
+    });
+
+    await expect(
+      resolveOAuthUser(db, {
+        provider: "github",
+        profile: { ...PROFILE, emailVerified: false },
+      }),
+    ).rejects.toMatchObject({ code: "email_unverified" });
+  });
+
+  test("rejects when the existing user is disabled", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({
+      email: PROFILE.email,
+      role: "author",
+      disabledAt: new Date(),
+    });
+    await expect(
+      resolveOAuthUser(db, { provider: "github", profile: PROFILE }),
+    ).rejects.toMatchObject({ code: "account_disabled" });
+  });
+});
+
+describe("resolveOAuthUser — domain-gated signup", () => {
+  test("allowed + enabled domain provisions a new user with the domain's role", async () => {
+    const db = await createTestDb();
+    // System needs at least one user so we never bootstrap an admin via OAuth.
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "contributor",
+      isEnabled: true,
+    });
+
+    const result = await resolveOAuthUser(db, {
+      provider: "github",
+      profile: PROFILE,
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.user.email).toBe(PROFILE.email);
+    expect(result.user.role).toBe("contributor");
+    expect(result.user.emailVerifiedAt).not.toBeNull();
+
+    const link = await db.query.oauthAccounts.findFirst({
+      where: eq(oauthAccounts.providerAccountId, PROFILE.providerAccountId),
+    });
+    expect(link?.userId).toBe(result.user.id);
+  });
+
+  test("disabled domain row rejects with domain_not_allowed", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await db.insert(allowedDomains).values({
+      domain: "example.com",
+      defaultRole: "contributor",
+      isEnabled: false,
+    });
+    await expect(
+      resolveOAuthUser(db, { provider: "github", profile: PROFILE }),
+    ).rejects.toMatchObject({ code: "domain_not_allowed" });
+  });
+
+  test("missing domain row rejects with domain_not_allowed", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await expect(
+      resolveOAuthUser(db, { provider: "github", profile: PROFILE }),
+    ).rejects.toMatchObject({ code: "domain_not_allowed" });
+  });
+
+  test("unverified email blocks signup even when domain is allowed", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "contributor",
+      isEnabled: true,
+    });
+    await expect(
+      resolveOAuthUser(db, {
+        provider: "github",
+        profile: { ...PROFILE, emailVerified: false },
+      }),
+    ).rejects.toMatchObject({ code: "email_unverified" });
+  });
+
+  test("zero-user system refuses OAuth signup so bootstrap stays passkey-only", async () => {
+    const db = await createTestDb();
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "admin",
+      isEnabled: true,
+    });
+    await expect(
+      resolveOAuthUser(db, { provider: "github", profile: PROFILE }),
+    ).rejects.toMatchObject({ code: "registration_closed" });
+    expect(await db.$count(users)).toBe(0);
+  });
+});
+
+describe("resolveOAuthUser — error type", () => {
+  test("throws OAuthError instances for all reject paths", async () => {
+    const db = await createTestDb();
+    await expect(
+      resolveOAuthUser(db, {
+        provider: "github",
+        profile: { ...PROFILE, emailVerified: false },
+      }),
+    ).rejects.toBeInstanceOf(OAuthError);
+  });
+});

--- a/packages/core/src/auth/oauth/signup.test.ts
+++ b/packages/core/src/auth/oauth/signup.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { eq } from "../../db/index.js";
+import { eq, sql } from "../../db/index.js";
 import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
 import { users } from "../../db/schema/users.js";
@@ -16,6 +16,30 @@ const PROFILE = {
   name: "Alice",
   avatarUrl: "https://example.com/a.png",
 } as const;
+
+describe("resolveOAuthUser — dangling oauth_accounts row", () => {
+  test("missing user behind an oauth_accounts row throws link_broken", async () => {
+    const db = await createTestDb();
+    // SQLite enforces FKs in our test harness; produce a dangling row by
+    // disabling enforcement just long enough to insert a forward-reference
+    // to a userId that doesn't exist. Mirrors the production-data shape we
+    // care about: a row that the cascade should have deleted but didn't.
+    await db.run(sql`PRAGMA foreign_keys = OFF`);
+    await db.insert(oauthAccounts).values({
+      provider: "github",
+      providerAccountId: "ghost-1",
+      userId: 9999,
+    });
+    await db.run(sql`PRAGMA foreign_keys = ON`);
+
+    await expect(
+      resolveOAuthUser(db, {
+        provider: "github",
+        profile: { ...PROFILE, providerAccountId: "ghost-1" },
+      }),
+    ).rejects.toMatchObject({ code: "link_broken" });
+  });
+});
 
 describe("resolveOAuthUser — link existing oauth account", () => {
   test("returns the linked user without creating anything", async () => {
@@ -195,5 +219,69 @@ describe("resolveOAuthUser — error type", () => {
         profile: { ...PROFILE, emailVerified: false },
       }),
     ).rejects.toBeInstanceOf(OAuthError);
+  });
+});
+
+describe("resolveOAuthUser — race on concurrent inserts", () => {
+  test("two callbacks for the same new email both resolve without throwing 500", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "subscriber",
+      isEnabled: true,
+    });
+
+    const [a, b] = await Promise.all([
+      resolveOAuthUser(db, {
+        provider: "github",
+        profile: { ...PROFILE, providerAccountId: "race-1" },
+      }),
+      resolveOAuthUser(db, {
+        provider: "github",
+        // Identical email but a *different* providerAccountId — both
+        // would normally try to insert a new user row keyed by that
+        // email. The unique-constraint retry pattern lets the loser
+        // fall through to the email-link branch on attempt #2.
+        profile: { ...PROFILE, providerAccountId: "race-2" },
+      }),
+    ]);
+
+    // Both calls return the same user (one created it, the other linked).
+    expect(a.user.id).toBe(b.user.id);
+    expect(a.user.email).toBe(PROFILE.email);
+    // Exactly one user row, two oauth_accounts rows.
+    const usersForEmail = await db.query.users.findMany({
+      where: eq(users.email, PROFILE.email),
+    });
+    expect(usersForEmail).toHaveLength(1);
+    const userId = usersForEmail[0]?.id;
+    if (userId === undefined) throw new Error("user not created");
+    const linksForUser = await db.query.oauthAccounts.findMany({
+      where: eq(oauthAccounts.userId, userId),
+    });
+    expect(linksForUser).toHaveLength(2);
+  });
+
+  test("two callbacks for the same provider account map to the same user", async () => {
+    const db = await createTestDb();
+    const seeded = await userFactory.transient({ db }).create({
+      email: PROFILE.email,
+      role: "editor",
+    });
+
+    const [a, b] = await Promise.all([
+      resolveOAuthUser(db, { provider: "github", profile: PROFILE }),
+      resolveOAuthUser(db, { provider: "github", profile: PROFILE }),
+    ]);
+
+    expect(a.user.id).toBe(seeded.id);
+    expect(b.user.id).toBe(seeded.id);
+    // Composite PK on (provider, providerAccountId) means the second
+    // insert raced — exactly one row must exist.
+    const links = await db.query.oauthAccounts.findMany({
+      where: eq(oauthAccounts.providerAccountId, PROFILE.providerAccountId),
+    });
+    expect(links).toHaveLength(1);
   });
 });

--- a/packages/core/src/auth/oauth/signup.ts
+++ b/packages/core/src/auth/oauth/signup.ts
@@ -7,12 +7,12 @@ import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
 import { users } from "../../db/schema/users.js";
 import { OAuthError } from "./errors.js";
 
-export interface ResolveOAuthUserInput {
+interface ResolveOAuthUserInput {
   readonly provider: OAuthProviderKey;
   readonly profile: OAuthProfile;
 }
 
-export interface ResolvedOAuthUser {
+interface ResolvedOAuthUser {
   readonly user: User;
   /** True when this call provisioned a new user row. */
   readonly created: boolean;

--- a/packages/core/src/auth/oauth/signup.ts
+++ b/packages/core/src/auth/oauth/signup.ts
@@ -1,7 +1,7 @@
 import type { Db } from "../../context/app.js";
 import type { User, UserRole } from "../../db/schema/users.js";
 import type { OAuthProfile, OAuthProviderKey } from "./types.js";
-import { and, eq } from "../../db/index.js";
+import { and, eq, isUniqueConstraintError } from "../../db/index.js";
 import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
 import { users } from "../../db/schema/users.js";
@@ -32,8 +32,26 @@ export interface ResolvedOAuthUser {
  *      provision a new user with the domain's `defaultRole`. Otherwise
  *      reject — bootstrap remains passkey-only, so we never create an
  *      admin via OAuth here even on a fresh deploy.
+ *
+ * Concurrent callbacks for the same email or the same `(provider,
+ * providerAccountId)` race on the underlying UNIQUE constraints. We retry
+ * the whole resolution exactly once on a unique-violation: by then the
+ * winner's row is durable, and the second attempt falls into branch 1 or
+ * 2 deterministically.
  */
 export async function resolveOAuthUser(
+  db: Db,
+  input: ResolveOAuthUserInput,
+): Promise<ResolvedOAuthUser> {
+  try {
+    return await resolveOnce(db, input);
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    return resolveOnce(db, input);
+  }
+}
+
+async function resolveOnce(
   db: Db,
   input: ResolveOAuthUserInput,
 ): Promise<ResolvedOAuthUser> {
@@ -49,12 +67,11 @@ export async function resolveOAuthUser(
     const linked = await db.query.users.findFirst({
       where: eq(users.id, existingLink.userId),
     });
-    if (!linked) {
-      // The OAuth row is dangling — likely raced with a user delete that
-      // didn't cascade. Treat as a hard error rather than silently
-      // re-provisioning a new admin under the same provider id.
-      throw new OAuthError("account_disabled");
-    }
+    // A dangling oauth_accounts row means the cascade-on-delete didn't
+    // fire (FK enforcement off, or hand-rolled SQL). Surface a distinct
+    // code so the friendly-message map can say "support" rather than
+    // "your account is disabled" — the row is gone, not paused.
+    if (!linked) throw new OAuthError("link_broken");
     if (linked.disabledAt) throw new OAuthError("account_disabled");
     return { user: linked, created: false, linked: false };
   }

--- a/packages/core/src/auth/oauth/signup.ts
+++ b/packages/core/src/auth/oauth/signup.ts
@@ -1,0 +1,128 @@
+import type { Db } from "../../context/app.js";
+import type { User, UserRole } from "../../db/schema/users.js";
+import type { OAuthProfile, OAuthProviderKey } from "./types.js";
+import { and, eq } from "../../db/index.js";
+import { allowedDomains } from "../../db/schema/allowed_domains.js";
+import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
+import { users } from "../../db/schema/users.js";
+import { OAuthError } from "./errors.js";
+
+export interface ResolveOAuthUserInput {
+  readonly provider: OAuthProviderKey;
+  readonly profile: OAuthProfile;
+}
+
+export interface ResolvedOAuthUser {
+  readonly user: User;
+  /** True when this call provisioned a new user row. */
+  readonly created: boolean;
+  /** True when this call linked an existing user to the OAuth account. */
+  readonly linked: boolean;
+}
+
+/**
+ * Decide who an OAuth callback maps to:
+ *   1. If `oauth_accounts(provider, providerAccountId)` already points to a
+ *      user, that's the answer (modulo disabled check). Pure sign-in.
+ *   2. Else if a user exists with the same email AND the provider verified
+ *      that email, link the OAuth account into the existing user row.
+ *      Refusing the unverified case prevents takeover via a third-party
+ *      account that controls the email string but not the inbox.
+ *   3. Else look up `allowed_domains` for the email's domain. If enabled,
+ *      provision a new user with the domain's `defaultRole`. Otherwise
+ *      reject — bootstrap remains passkey-only, so we never create an
+ *      admin via OAuth here even on a fresh deploy.
+ */
+export async function resolveOAuthUser(
+  db: Db,
+  input: ResolveOAuthUserInput,
+): Promise<ResolvedOAuthUser> {
+  const { provider, profile } = input;
+
+  const existingLink = await db.query.oauthAccounts.findFirst({
+    where: and(
+      eq(oauthAccounts.provider, provider),
+      eq(oauthAccounts.providerAccountId, profile.providerAccountId),
+    ),
+  });
+  if (existingLink) {
+    const linked = await db.query.users.findFirst({
+      where: eq(users.id, existingLink.userId),
+    });
+    if (!linked) {
+      // The OAuth row is dangling — likely raced with a user delete that
+      // didn't cascade. Treat as a hard error rather than silently
+      // re-provisioning a new admin under the same provider id.
+      throw new OAuthError("account_disabled");
+    }
+    if (linked.disabledAt) throw new OAuthError("account_disabled");
+    return { user: linked, created: false, linked: false };
+  }
+
+  const existingByEmail = await db.query.users.findFirst({
+    where: eq(users.email, profile.email),
+  });
+  if (existingByEmail) {
+    if (!profile.emailVerified) {
+      // Provider didn't assert verification of this email. Auto-linking
+      // here would let an attacker who registers $victim@gmail.com on a
+      // throwaway provider take over the local account.
+      throw new OAuthError("email_unverified");
+    }
+    if (existingByEmail.disabledAt) throw new OAuthError("account_disabled");
+    await db.insert(oauthAccounts).values({
+      provider,
+      providerAccountId: profile.providerAccountId,
+      userId: existingByEmail.id,
+    });
+    return { user: existingByEmail, created: false, linked: true };
+  }
+
+  if (!profile.emailVerified) {
+    throw new OAuthError("email_unverified");
+  }
+
+  const domain = extractDomain(profile.email);
+  if (!domain) throw new OAuthError("domain_not_allowed");
+
+  const allowed = await db.query.allowedDomains.findFirst({
+    where: eq(allowedDomains.domain, domain),
+  });
+  if (!allowed?.isEnabled) {
+    throw new OAuthError("domain_not_allowed");
+  }
+
+  // Bootstrap path is passkey-only. Refuse OAuth signup when the system
+  // has no users — otherwise a misconfigured `allowed_domains` row would
+  // mint an admin via a third-party provider. This is a soft rail; the
+  // route layer also pre-checks user count to render a friendlier flow.
+  const userCount = await db.$count(users);
+  if (userCount === 0) throw new OAuthError("registration_closed");
+
+  const role: UserRole = allowed.defaultRole;
+  const [user] = await db
+    .insert(users)
+    .values({
+      email: profile.email,
+      name: profile.name,
+      avatarUrl: profile.avatarUrl,
+      role,
+      emailVerifiedAt: new Date(),
+    })
+    .returning();
+  if (!user) throw new Error("resolveOAuthUser: insert returned no row");
+
+  await db.insert(oauthAccounts).values({
+    provider,
+    providerAccountId: profile.providerAccountId,
+    userId: user.id,
+  });
+
+  return { user, created: true, linked: false };
+}
+
+function extractDomain(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at < 0 || at === email.length - 1) return null;
+  return email.slice(at + 1).toLowerCase();
+}

--- a/packages/core/src/auth/oauth/state.test.ts
+++ b/packages/core/src/auth/oauth/state.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+
+import { eq } from "../../db/index.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { createTestDb } from "../../test/harness.js";
+import { hashToken } from "../tokens.js";
+import { consumeOAuthState, issueOAuthState } from "./state.js";
+
+describe("oauth state store", () => {
+  test("issues a base64url state and persists the hash, never the raw value", async () => {
+    const db = await createTestDb();
+    const { state, expiresAt } = await issueOAuthState(db, {
+      provider: "github",
+      codeVerifier: "v-1",
+    });
+
+    expect(state).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+
+    const hash = await hashToken(state);
+    const row = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, hash),
+    });
+    expect(row?.type).toBe("oauth_state");
+    // Raw state must not appear in the row's primary key.
+    const rawRow = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, state),
+    });
+    expect(rawRow).toBeUndefined();
+  });
+
+  test("consume returns the payload and deletes the row (single-use)", async () => {
+    const db = await createTestDb();
+    const { state } = await issueOAuthState(db, {
+      provider: "google",
+      codeVerifier: "abc",
+    });
+
+    const first = await consumeOAuthState(db, state);
+    expect(first).toEqual({ provider: "google", codeVerifier: "abc" });
+
+    const replay = await consumeOAuthState(db, state);
+    expect(replay).toBeNull();
+  });
+
+  test("consume rejects an unknown state without throwing", async () => {
+    const db = await createTestDb();
+    expect(
+      await consumeOAuthState(db, "definitely-not-a-real-token"),
+    ).toBeNull();
+  });
+
+  test("consume rejects an expired state and removes the row", async () => {
+    const db = await createTestDb();
+    const { state } = await issueOAuthState(
+      db,
+      { provider: "github", codeVerifier: "v" },
+      -1, // already expired
+    );
+
+    expect(await consumeOAuthState(db, state)).toBeNull();
+    const hash = await hashToken(state);
+    const row = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, hash),
+    });
+    expect(row).toBeUndefined();
+  });
+
+  test("consume ignores rows of a different type", async () => {
+    const db = await createTestDb();
+    const raw = "not-an-oauth-token";
+    const hash = await hashToken(raw);
+    // An invite-typed row stored under the same hash an oauth_state would
+    // hash to — consumer must return null and leave the row alone.
+    await db.insert(authTokens).values({
+      hash,
+      type: "invite",
+      email: "x@y.z",
+      role: "subscriber",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect(await consumeOAuthState(db, raw)).toBeNull();
+    const row = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, hash),
+    });
+    expect(row?.type).toBe("invite");
+  });
+});

--- a/packages/core/src/auth/oauth/state.ts
+++ b/packages/core/src/auth/oauth/state.ts
@@ -1,6 +1,6 @@
 import type { Db } from "../../context/app.js";
 import type { OAuthProviderKey } from "./types.js";
-import { eq } from "../../db/index.js";
+import { and, eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { generateToken, hashToken } from "../tokens.js";
 
@@ -44,15 +44,19 @@ export async function consumeOAuthState(
   state: string,
 ): Promise<OAuthStatePayload | null> {
   const hash = await hashToken(state);
-  const row = await db.query.authTokens.findFirst({
-    where: eq(authTokens.hash, hash),
-  });
-  if (row?.type !== "oauth_state") return null;
 
-  // Single-use regardless of expiry: a replay should never succeed even if
-  // the row hasn't been pruned. Delete first, then evaluate validity.
-  await db.delete(authTokens).where(eq(authTokens.hash, hash));
+  // Atomic compare-and-delete: `DELETE … RETURNING` returns at most one
+  // row to whichever caller wins the SQLite write. A concurrent second
+  // consume sees an empty result, never the same payload twice. Scope the
+  // DELETE by `type = 'oauth_state'` so a hash collision with another
+  // token type (invite, magic_link, …) doesn't accidentally consume that
+  // row when the oauth row was never present.
+  const [row] = await db
+    .delete(authTokens)
+    .where(and(eq(authTokens.hash, hash), eq(authTokens.type, "oauth_state")))
+    .returning();
 
+  if (!row) return null;
   if (row.expiresAt.getTime() < Date.now()) return null;
 
   const payload = row.payload as Partial<OAuthStatePayload> | null;

--- a/packages/core/src/auth/oauth/state.ts
+++ b/packages/core/src/auth/oauth/state.ts
@@ -6,12 +6,12 @@ import { generateToken, hashToken } from "../tokens.js";
 
 export const OAUTH_STATE_TTL_SECONDS = 10 * 60;
 
-export interface OAuthStatePayload {
+interface OAuthStatePayload {
   readonly provider: OAuthProviderKey;
   readonly codeVerifier: string;
 }
 
-export interface IssuedOAuthState {
+interface IssuedOAuthState {
   /** Raw state token to send to the provider via the URL. Never persisted. */
   readonly state: string;
   readonly expiresAt: Date;

--- a/packages/core/src/auth/oauth/state.ts
+++ b/packages/core/src/auth/oauth/state.ts
@@ -1,0 +1,69 @@
+import type { Db } from "../../context/app.js";
+import type { OAuthProviderKey } from "./types.js";
+import { eq } from "../../db/index.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { generateToken, hashToken } from "../tokens.js";
+
+export const OAUTH_STATE_TTL_SECONDS = 10 * 60;
+
+export interface OAuthStatePayload {
+  readonly provider: OAuthProviderKey;
+  readonly codeVerifier: string;
+}
+
+export interface IssuedOAuthState {
+  /** Raw state token to send to the provider via the URL. Never persisted. */
+  readonly state: string;
+  readonly expiresAt: Date;
+}
+
+/**
+ * Store oauth_state in `auth_tokens` keyed by SHA-256(state). The raw token
+ * lives only in the URL round-trip; a DB snapshot leak yields hashes, not
+ * forgeable states. Single-use semantics enforced by `consumeOAuthState`.
+ */
+export async function issueOAuthState(
+  db: Db,
+  payload: OAuthStatePayload,
+  ttlSeconds: number = OAUTH_STATE_TTL_SECONDS,
+): Promise<IssuedOAuthState> {
+  const state = generateToken();
+  const hash = await hashToken(state);
+  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+  await db.insert(authTokens).values({
+    hash,
+    type: "oauth_state",
+    payload: { ...payload },
+    expiresAt,
+  });
+  return { state, expiresAt };
+}
+
+export async function consumeOAuthState(
+  db: Db,
+  state: string,
+): Promise<OAuthStatePayload | null> {
+  const hash = await hashToken(state);
+  const row = await db.query.authTokens.findFirst({
+    where: eq(authTokens.hash, hash),
+  });
+  if (row?.type !== "oauth_state") return null;
+
+  // Single-use regardless of expiry: a replay should never succeed even if
+  // the row hasn't been pruned. Delete first, then evaluate validity.
+  await db.delete(authTokens).where(eq(authTokens.hash, hash));
+
+  if (row.expiresAt.getTime() < Date.now()) return null;
+
+  const payload = row.payload as Partial<OAuthStatePayload> | null;
+  if (
+    typeof payload?.provider !== "string" ||
+    typeof payload.codeVerifier !== "string"
+  ) {
+    return null;
+  }
+  return {
+    provider: payload.provider,
+    codeVerifier: payload.codeVerifier,
+  };
+}

--- a/packages/core/src/auth/oauth/types.ts
+++ b/packages/core/src/auth/oauth/types.ts
@@ -1,0 +1,45 @@
+export const OAUTH_PROVIDER_KEYS = ["github", "google"] as const;
+
+export type OAuthProviderKey = (typeof OAUTH_PROVIDER_KEYS)[number];
+
+export interface OAuthClientConfig {
+  readonly clientId: string;
+  readonly clientSecret: string;
+}
+
+export interface OAuthProvidersConfig {
+  readonly github?: OAuthClientConfig;
+  readonly google?: OAuthClientConfig;
+}
+
+export interface OAuthProfile {
+  /** Provider-side stable user id. */
+  readonly providerAccountId: string;
+  readonly email: string;
+  /**
+   * Whether the provider asserts the email is verified. We refuse to
+   * auto-link an OAuth identity to an existing local user unless the
+   * provider has confirmed the address — without this any attacker who
+   * controls the provider account could claim someone else's email.
+   */
+  readonly emailVerified: boolean;
+  readonly name: string | null;
+  readonly avatarUrl: string | null;
+}
+
+export interface OAuthProvider {
+  readonly key: OAuthProviderKey;
+  readonly authorizeUrl: string;
+  readonly tokenUrl: string;
+  readonly userInfoUrl: string;
+  readonly scopes: readonly string[];
+  /**
+   * Translate the provider's profile JSON into the shared shape. Some
+   * providers (GitHub) need a follow-up call to resolve the email — that
+   * happens in the consumer, not here.
+   */
+  parseProfile(raw: unknown): Omit<OAuthProfile, "email" | "emailVerified"> & {
+    email: string | null;
+    emailVerified: boolean;
+  };
+}

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -1,5 +1,6 @@
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
+import type { OAuthProviderKey } from "../auth/oauth/types.js";
 import type { KnownCapability } from "../auth/rbac.js";
 import type * as coreSchema from "../db/schema/index.js";
 import type { UserRole } from "../db/schema/users.js";
@@ -52,6 +53,13 @@ export interface AppContext<
   readonly logger: Logger;
   readonly auth: AuthNamespace;
   /**
+   * OAuth provider keys configured on this app. Empty when the deploy is
+   * passkey-only. Read by the login screen (via auth.oauthProviders RPC)
+   * to render provider buttons; the actual client_id/client_secret never
+   * leave the app config.
+   */
+  readonly oauthProviders: readonly OAuthProviderKey[];
+  /**
    * Extend work past the returned Response. Runtime adapters bind this
    * to their platform primitive (CF Workers: `ExecutionContext.waitUntil`).
    * Default: fire-and-forget — handlers must tolerate the promise being
@@ -99,6 +107,7 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly assets?: AssetsBinding;
   readonly storage?: ConnectedObjectStorage;
   readonly imageDelivery?: ImageDelivery;
+  readonly oauthProviders?: readonly OAuthProviderKey[];
 }
 
 const dropPromise: AfterResponse = () => undefined;
@@ -124,6 +133,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     assets: args.assets,
     storage: args.storage,
     imageDelivery: args.imageDelivery,
+    oauthProviders: args.oauthProviders ?? [],
   };
 }
 
@@ -138,6 +148,7 @@ export function withUser<TSchema extends Record<string, unknown>>(
     auth: {
       can: (capability) => resolver.hasCapability(user.role, capability),
     },
+    oauthProviders: ctx.oauthProviders,
   };
 }
 

--- a/packages/core/src/db/schema/auth_tokens.ts
+++ b/packages/core/src/db/schema/auth_tokens.ts
@@ -10,6 +10,7 @@ export const AUTH_TOKEN_TYPES = [
   "email_verification",
   "password_reset",
   "invite",
+  "oauth_state",
 ] as const;
 
 export type AuthTokenType = (typeof AUTH_TOKEN_TYPES)[number];
@@ -23,6 +24,10 @@ export const authTokens = sqliteTable(
     type: t.text({ enum: AUTH_TOKEN_TYPES }).notNull(),
     role: t.text({ enum: USER_ROLES }),
     invitedBy: t.integer().references(() => users.id, { onDelete: "set null" }),
+    // Free-form per-type payload. Today only `oauth_state` populates this
+    // (PKCE verifier + provider key + return path); kept nullable so the
+    // existing token types keep their narrow column footprint.
+    payload: t.text({ mode: "json" }).$type<Record<string, unknown>>(),
     expiresAt: t.integer({ mode: "timestamp" }).notNull(),
     createdAt: t
       .integer({ mode: "timestamp" })

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -30,12 +30,16 @@ describe("buildManifest", () => {
     expect(manifest.blocks).toEqual([]);
     expect(manifest.fieldTypes).toEqual([]);
     // Overview always carries Dashboard; Management carries Users +
-    // Settings. Capability filtering happens admin-side at render
-    // time — the projection ships every item.
+    // Allowed domains + Settings. Capability filtering happens admin-side
+    // at render time — the projection ships every item.
     const overview = manifest.adminNav.find((g) => g.id === "overview");
     expect(overview?.items.map((i) => i.to)).toEqual(["/"]);
     const management = manifest.adminNav.find((g) => g.id === "management");
-    expect(management?.items.map((i) => i.to)).toEqual(["/users", "/settings"]);
+    expect(management?.items.map((i) => i.to)).toEqual([
+      "/users",
+      "/allowed-domains",
+      "/settings",
+    ]);
   });
 
   test("projects registered settings groups, fields use the shared MetaBoxField shape", async () => {

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -992,6 +992,16 @@ const CORE_NAV_ITEMS: readonly { groupId: string; item: AdminNavItem }[] = [
   {
     groupId: "management",
     item: {
+      to: "/allowed-domains",
+      label: "Allowed domains",
+      coreIcon: "users",
+      order: 150,
+      capability: "settings:manage",
+    },
+  },
+  {
+    groupId: "management",
+    item: {
       to: "/settings",
       label: "Settings",
       coreIcon: "settings",

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/create.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/create.ts
@@ -1,0 +1,35 @@
+import { isUniqueConstraintError } from "../../../../db/index.js";
+import { allowedDomains } from "../../../../db/schema/allowed_domains.js";
+import { authenticated } from "../../../authenticated.js";
+import { base } from "../../../base.js";
+import { allowedDomainsCreateInputSchema } from "./schemas.js";
+
+const CAPABILITY = "settings:manage";
+
+export const create = base
+  .use(authenticated)
+  .input(allowedDomainsCreateInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+    try {
+      const [row] = await context.db
+        .insert(allowedDomains)
+        .values({
+          domain: input.domain,
+          defaultRole: input.defaultRole,
+          isEnabled: input.isEnabled,
+        })
+        .returning();
+      if (!row) {
+        throw errors.CONFLICT({ data: { reason: "insert_failed" } });
+      }
+      return row;
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw errors.CONFLICT({ data: { reason: "domain_exists" } });
+      }
+      throw error;
+    }
+  });

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/create.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/create.ts
@@ -22,9 +22,8 @@ export const create = base
           isEnabled: input.isEnabled,
         })
         .returning();
-      if (!row) {
-        throw errors.CONFLICT({ data: { reason: "insert_failed" } });
-      }
+      if (!row)
+        throw new Error("allowedDomains.create: insert returned no row");
       return row;
     } catch (error) {
       if (isUniqueConstraintError(error)) {

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/delete.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/delete.ts
@@ -1,0 +1,26 @@
+import { eq } from "../../../../db/index.js";
+import { allowedDomains } from "../../../../db/schema/allowed_domains.js";
+import { authenticated } from "../../../authenticated.js";
+import { base } from "../../../base.js";
+import { allowedDomainsDeleteInputSchema } from "./schemas.js";
+
+const CAPABILITY = "settings:manage";
+
+export const del = base
+  .use(authenticated)
+  .input(allowedDomainsDeleteInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+    const [row] = await context.db
+      .delete(allowedDomains)
+      .where(eq(allowedDomains.domain, input.domain))
+      .returning();
+    if (!row) {
+      throw errors.NOT_FOUND({
+        data: { kind: "allowed_domain", id: input.domain },
+      });
+    }
+    return row;
+  });

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/index.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/index.ts
@@ -9,5 +9,3 @@ export const allowedDomainsRouter = {
   update,
   delete: del,
 } as const;
-
-export type AllowedDomainsRouter = typeof allowedDomainsRouter;

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/index.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/index.ts
@@ -1,0 +1,13 @@
+import { create } from "./create.js";
+import { del } from "./delete.js";
+import { list } from "./list.js";
+import { update } from "./update.js";
+
+export const allowedDomainsRouter = {
+  list,
+  create,
+  update,
+  delete: del,
+} as const;
+
+export type AllowedDomainsRouter = typeof allowedDomainsRouter;

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/list.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/list.ts
@@ -1,0 +1,20 @@
+import { asc } from "../../../../db/index.js";
+import { allowedDomains } from "../../../../db/schema/allowed_domains.js";
+import { authenticated } from "../../../authenticated.js";
+import { base } from "../../../base.js";
+import { allowedDomainsListInputSchema } from "./schemas.js";
+
+const CAPABILITY = "settings:manage";
+
+export const list = base
+  .use(authenticated)
+  .input(allowedDomainsListInputSchema)
+  .handler(async ({ context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+    return context.db
+      .select()
+      .from(allowedDomains)
+      .orderBy(asc(allowedDomains.domain));
+  });

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/schemas.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/schemas.ts
@@ -1,0 +1,36 @@
+import * as v from "valibot";
+
+import { USER_ROLES } from "../../../../db/schema/users.js";
+
+// RFC 1035-ish domain shape: labels of [a-z0-9] (with internal hyphens),
+// 1–63 chars per label, total <= 253. We don't accept punycode-encoded
+// names directly — callers should normalise to ASCII before sending.
+const DOMAIN_REGEX =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/;
+
+const domainSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.toLowerCase(),
+  v.regex(DOMAIN_REGEX, "domain must be a valid hostname"),
+);
+
+const roleSchema = v.picklist(USER_ROLES);
+
+export const allowedDomainsListInputSchema = v.optional(v.object({}), {});
+
+export const allowedDomainsCreateInputSchema = v.object({
+  domain: domainSchema,
+  defaultRole: v.optional(roleSchema, "subscriber"),
+  isEnabled: v.optional(v.boolean(), true),
+});
+
+export const allowedDomainsUpdateInputSchema = v.object({
+  domain: domainSchema,
+  defaultRole: v.optional(roleSchema),
+  isEnabled: v.optional(v.boolean()),
+});
+
+export const allowedDomainsDeleteInputSchema = v.object({
+  domain: domainSchema,
+});

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/update.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/update.ts
@@ -14,10 +14,10 @@ export const update = base
       throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
     }
 
-    const patch: Partial<{
-      defaultRole: typeof input.defaultRole;
-      isEnabled: boolean;
-    }> = {};
+    const patch: {
+      defaultRole?: typeof input.defaultRole;
+      isEnabled?: boolean;
+    } = {};
     if (input.defaultRole !== undefined) patch.defaultRole = input.defaultRole;
     if (input.isEnabled !== undefined) patch.isEnabled = input.isEnabled;
     if (Object.keys(patch).length === 0) {

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/update.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/update.ts
@@ -1,0 +1,38 @@
+import { eq } from "../../../../db/index.js";
+import { allowedDomains } from "../../../../db/schema/allowed_domains.js";
+import { authenticated } from "../../../authenticated.js";
+import { base } from "../../../base.js";
+import { allowedDomainsUpdateInputSchema } from "./schemas.js";
+
+const CAPABILITY = "settings:manage";
+
+export const update = base
+  .use(authenticated)
+  .input(allowedDomainsUpdateInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: CAPABILITY } });
+    }
+
+    const patch: Partial<{
+      defaultRole: typeof input.defaultRole;
+      isEnabled: boolean;
+    }> = {};
+    if (input.defaultRole !== undefined) patch.defaultRole = input.defaultRole;
+    if (input.isEnabled !== undefined) patch.isEnabled = input.isEnabled;
+    if (Object.keys(patch).length === 0) {
+      throw errors.CONFLICT({ data: { reason: "empty_patch" } });
+    }
+
+    const [row] = await context.db
+      .update(allowedDomains)
+      .set(patch)
+      .where(eq(allowedDomains.domain, input.domain))
+      .returning();
+    if (!row) {
+      throw errors.NOT_FOUND({
+        data: { kind: "allowed_domain", id: input.domain },
+      });
+    }
+    return row;
+  });

--- a/packages/core/src/rpc/procedures/auth/auth.test.ts
+++ b/packages/core/src/rpc/procedures/auth/auth.test.ts
@@ -97,3 +97,106 @@ describe("auth.session", () => {
     expect(populatedResult).toEqual({ user: null, needsBootstrap: false });
   });
 });
+
+describe("auth.oauthProviders", () => {
+  test("empty by default — passkey-only deploy", async () => {
+    const h = await createRpcHarness();
+    const result = await h.client.auth.oauthProviders({});
+    expect(result).toEqual([]);
+  });
+
+  test("returns enabled provider keys", async () => {
+    const h = await createRpcHarness({ oauthProviders: ["github"] });
+    const result = await h.client.auth.oauthProviders({});
+    expect(result).toEqual(["github"]);
+  });
+
+  test("returns multiple providers in declared order", async () => {
+    const h = await createRpcHarness({ oauthProviders: ["github", "google"] });
+    const result = await h.client.auth.oauthProviders({});
+    expect(result).toEqual(["github", "google"]);
+  });
+});
+
+describe("auth.allowedDomains", () => {
+  test("list rejects an unauthenticated caller", async () => {
+    const h = await createRpcHarness();
+    await expect(h.client.auth.allowedDomains.list({})).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  test("list rejects a non-admin caller", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await expect(h.client.auth.allowedDomains.list({})).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  test("admin can create, update, delete a domain", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+
+    const created = await h.client.auth.allowedDomains.create({
+      domain: "example.com",
+      defaultRole: "author",
+    });
+    expect(created).toMatchObject({
+      domain: "example.com",
+      defaultRole: "author",
+      isEnabled: true,
+    });
+
+    const list = await h.client.auth.allowedDomains.list({});
+    expect(list).toHaveLength(1);
+
+    const updated = await h.client.auth.allowedDomains.update({
+      domain: "example.com",
+      isEnabled: false,
+    });
+    expect(updated.isEnabled).toBe(false);
+
+    const removed = await h.client.auth.allowedDomains.delete({
+      domain: "example.com",
+    });
+    expect(removed.domain).toBe("example.com");
+
+    const after = await h.client.auth.allowedDomains.list({});
+    expect(after).toEqual([]);
+  });
+
+  test("create rejects a duplicate domain with CONFLICT/domain_exists", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.auth.allowedDomains.create({ domain: "example.com" });
+    await expect(
+      h.client.auth.allowedDomains.create({ domain: "example.com" }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "domain_exists" },
+    });
+  });
+
+  test("update rejects an unknown domain with NOT_FOUND", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.auth.allowedDomains.update({
+        domain: "nope.example",
+        isEnabled: true,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("update rejects an empty patch", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await h.client.auth.allowedDomains.create({ domain: "example.com" });
+    await expect(
+      h.client.auth.allowedDomains.update({ domain: "example.com" }),
+    ).rejects.toMatchObject({ data: { reason: "empty_patch" } });
+  });
+
+  test("create rejects a malformed domain at the input layer", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      h.client.auth.allowedDomains.create({ domain: "not a domain" }),
+    ).rejects.toBeDefined();
+  });
+});

--- a/packages/core/src/rpc/procedures/auth/index.ts
+++ b/packages/core/src/rpc/procedures/auth/index.ts
@@ -1,7 +1,11 @@
+import { allowedDomainsRouter } from "./allowed-domains/index.js";
+import { oauthProviders } from "./oauth-providers.js";
 import { session } from "./session.js";
 
 export const authRouter = {
   session,
+  oauthProviders,
+  allowedDomains: allowedDomainsRouter,
 } as const;
 
 export type AuthRouter = typeof authRouter;

--- a/packages/core/src/rpc/procedures/auth/oauth-providers.ts
+++ b/packages/core/src/rpc/procedures/auth/oauth-providers.ts
@@ -1,0 +1,9 @@
+import type { OAuthProviderKey } from "../../../auth/oauth/types.js";
+import { base } from "../../base.js";
+
+// Public — used by the login screen to render provider buttons. Driven
+// purely by config (resolved at app build time); no DB call. Returning
+// `[]` means "passkey-only", which the admin already knows how to render.
+export const oauthProviders = base.handler(
+  ({ context }): readonly OAuthProviderKey[] => context.oauthProviders,
+);

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -1,5 +1,6 @@
 import { RPCHandler } from "@orpc/server/fetch";
 
+import type { OAuthProviderKey } from "../auth/oauth/types.js";
 import type { ResolvedPasskeyConfig } from "../auth/passkey/config.js";
 import type { CapabilityResolver } from "../auth/rbac.js";
 import type { SessionPolicy } from "../auth/sessions.js";
@@ -7,6 +8,7 @@ import type { PlumixConfig } from "../config.js";
 import type { AppContext } from "../context/app.js";
 import type { PluginRegistry, RegisteredRawRoute } from "../plugin/manifest.js";
 import type { RouteRule } from "../route/intent.js";
+import { OAUTH_PROVIDER_KEYS } from "../auth/oauth/types.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
@@ -31,6 +33,8 @@ export interface PlumixApp {
   readonly origin: string;
   readonly passkey: ResolvedPasskeyConfig;
   readonly sessionPolicy: SessionPolicy;
+  /** Provider keys with credentials configured. Empty when oauth() wasn't passed. */
+  readonly oauthProviders: readonly OAuthProviderKey[];
   readonly schema: Record<string, unknown>;
   /**
    * Sorted route map compiled once at `buildApp` from the plugin registry.
@@ -83,6 +87,10 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   }
 
   const passkey = resolvePasskeyConfig(config.auth.passkey);
+  const oauth = config.auth.oauth;
+  const oauthProviders = oauth
+    ? OAUTH_PROVIDER_KEYS.filter((key) => oauth.providers[key])
+    : [];
   return {
     config,
     hooks,
@@ -91,6 +99,7 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     origin: passkey.origin,
     passkey,
     sessionPolicy: config.auth.sessions ?? DEFAULT_SESSION_POLICY,
+    oauthProviders,
     schema,
     routeMap: compileRouteMap(registry),
     rawRoutes: registry.rawRoutes,

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -4,6 +4,11 @@ import type { PlumixApp } from "./app.js";
 import { readSessionCookie } from "../auth/cookies.js";
 import { hasCsrfHeader, hasMatchingOrigin } from "../auth/csrf.js";
 import {
+  handleOAuthCallback,
+  handleOAuthStart,
+  parseOAuthPath,
+} from "../auth/oauth/routes.js";
+import {
   handleInviteRegisterOptions,
   handleInviteRegisterVerify,
   handlePasskeyLoginOptions,
@@ -97,6 +102,18 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   if (authHandler) {
     if (ctx.request.method !== "POST") return methodNotAllowed(["POST"]);
     return authHandler(ctx, app);
+  }
+
+  // OAuth endpoints are top-level GET navigations from the browser, so they
+  // can't carry the X-Plumix-Request header. The CSRF gate already lets
+  // safe methods through, and the state token is the per-request CSRF
+  // anchor for the callback. Match the path *and* enforce GET here.
+  const oauth = parseOAuthPath(pathname);
+  if (oauth) {
+    if (ctx.request.method !== "GET") return methodNotAllowed(["GET"]);
+    return oauth.tail === "start"
+      ? handleOAuthStart(ctx, app, oauth.params.provider)
+      : handleOAuthCallback(ctx, app, oauth.params.provider);
   }
 
   if (pathname === ADMIN_PREFIX || pathname.startsWith(`${ADMIN_PREFIX}/`)) {

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -1,3 +1,4 @@
+import type { OAuthProvidersConfig } from "../auth/oauth/types.js";
 import type { AnyPluginDescriptor } from "../config.js";
 import type { AppContext } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
@@ -70,6 +71,12 @@ export interface CreateDispatcherHarnessOptions {
    * `memoryStorage().connect({})` for a working in-memory backend.
    */
   readonly storage?: ConnectedObjectStorage;
+  /**
+   * OAuth provider credentials to expose on `app.config.auth.oauth`. Tests
+   * exercising the OAuth start/callback routes pass dummy clientId/secret
+   * here; passkey-only deployments leave it undefined.
+   */
+  readonly oauth?: OAuthProvidersConfig;
 }
 
 export interface DispatcherHarness {
@@ -143,6 +150,7 @@ function withRequest(
     assets,
     storage,
     imageDelivery: app.config.imageDelivery,
+    oauthProviders: app.oauthProviders,
   });
 }
 
@@ -160,6 +168,7 @@ export async function createDispatcherHarness(
         rpId: "cms.example",
         origin: "https://cms.example",
       },
+      oauth: options.oauth ? { providers: options.oauth } : undefined,
     }),
     plugins: options.plugins,
     imageDelivery: options.imageDelivery,

--- a/packages/core/src/test/rpc.ts
+++ b/packages/core/src/test/rpc.ts
@@ -1,6 +1,7 @@
 import type { RouterClient } from "@orpc/server";
 import { createRouterClient } from "@orpc/server";
 
+import type { OAuthProviderKey } from "../auth/oauth/types.js";
 import type { AppContext, Db } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
 import type { HookExecutor, HookRegistry } from "../hooks/registry.js";
@@ -36,6 +37,12 @@ export interface BaseRpcHarnessOptions {
    * Empty object by default; override for tests that need specific bindings.
    */
   readonly env?: PlumixEnv;
+  /**
+   * Provider keys the harness should report on `ctx.oauthProviders`. Pass
+   * `["github"]` etc. when exercising the auth.oauthProviders procedure;
+   * default `[]` matches a passkey-only deploy.
+   */
+  readonly oauthProviders?: readonly OAuthProviderKey[];
 }
 
 export interface AuthenticatedHarnessOptions extends BaseRpcHarnessOptions {
@@ -85,6 +92,7 @@ function buildContext(
   hooks: HookExecutor,
   plugins: PluginRegistry,
   request: Request,
+  oauthProviders: readonly OAuthProviderKey[],
 ): AppContext {
   return createAppContext({
     db,
@@ -93,6 +101,7 @@ function buildContext(
     hooks,
     plugins,
     logger: silentLogger,
+    oauthProviders,
   });
 }
 
@@ -118,8 +127,16 @@ function assemble<TUser extends User | null>(
   plugins: PluginRegistry,
   request: Request,
   user: TUser,
+  oauthProviders: readonly OAuthProviderKey[],
 ): RpcHarnessBase<TUser> {
-  const context = buildContext(db, env, hooks, plugins, request);
+  const context = buildContext(
+    db,
+    env,
+    hooks,
+    plugins,
+    request,
+    oauthProviders,
+  );
   const client = createRouterClient(appRouter, { context });
 
   const harness: RpcHarnessBase<TUser> = {
@@ -139,7 +156,7 @@ function assemble<TUser extends User | null>(
           ? await userFactory.transient({ db }).create({ role: userOrRole })
           : userOrRole;
       const req = await authenticatedRequest(db, targetUser.id);
-      return assemble(db, env, hooks, plugins, req, targetUser);
+      return assemble(db, env, hooks, plugins, req, targetUser, oauthProviders);
     },
   };
   return harness;
@@ -158,15 +175,24 @@ export async function createRpcHarness(
   const hooks = options.hooks ?? new HookRegistryImpl();
   const plugins = options.plugins ?? createPluginRegistry();
   const env = options.env ?? {};
+  const oauthProviders = options.oauthProviders ?? [];
 
   if (!options.request && options.authAs) {
     const user = await userFactory
       .transient({ db })
       .create({ role: options.authAs });
     const request = await authenticatedRequest(db, user.id);
-    return assemble(db, env, hooks, plugins, request, user);
+    return assemble(db, env, hooks, plugins, request, user, oauthProviders);
   }
 
   const request = options.request ?? unauthenticatedRequest();
-  return assemble<User | null>(db, env, hooks, plugins, request, null);
+  return assemble<User | null>(
+    db,
+    env,
+    hooks,
+    plugins,
+    request,
+    null,
+    oauthProviders,
+  );
 }

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -212,6 +212,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
         assets: readAssetsBinding(env),
         storage,
         imageDelivery: app.config.imageDelivery,
+        oauthProviders: app.oauthProviders,
       });
       const response = await requestStore.run(appCtx, () => dispatcher(appCtx));
       return finalize(response);


### PR DESCRIPTION
Adds GitHub + Google OAuth as a sign-in / sign-up path alongside the
existing passkey flow. The `oauth_accounts` and `allowed_domains`
tables already shipped in the schema with no logic behind them; this
PR fills in the rest.

## Why now

Phase 11 admin work needs an answer to "how do new contributors join
the CMS?". Passkey-only requires every user to be invited by an
existing admin. OAuth + an allowed-domains allowlist gives small
teams a self-service signup story (domain-gated, no email
verification round-trip on the server side) without giving up the
hard rails on the bootstrap path.

Reference implementation: emdash-cms's auth flow. Decisions diverge
where plumix's existing patterns dictate (state stored in
`auth_tokens` rather than a new `auth_challenges` table, since
plumix already conflates challenges with tokens via `webauthn_challenge`).

## Trust model — alignment with the Copenhagen Book

Pilcrow's [Copenhagen Book](https://thecopenhagenbook.com/) is the
explicit reference for the OAuth, session, and token primitives, and
plumix already pulls Oslo libs (`@oslojs/crypto`, `@oslojs/encoding`)
from the same author. Concrete alignment:

- **State**: 192-bit cryptographically random, hashed (SHA-256) in
  `auth_tokens` keyed by `type='oauth_state'`, single-use via atomic
  `DELETE … RETURNING`, 10-minute TTL.
- **PKCE**: 256-bit verifier per request, S256 challenge mandatory
  for both providers.
- **Token exchange**: client credentials sent via HTTP Basic
  Authorization (RFC 6749 §2.3.1 / Copenhagen recommendation), not
  the request body — keeps `client_secret` out of any access log
  that records bodies.
- **Account-link gate**: requires the provider to assert
  `email_verified` before linking an OAuth identity to an existing
  local user with the same email. Without that an attacker who
  controls a throwaway third-party account whose email string
  matches a victim's could take the local row over.

## Bootstrap stays passkey-only

The first-user-becomes-admin flow remains passkey-only. The
`/oauth/<provider>/start` route 302s to `/admin/bootstrap` when the
system has zero users; `resolveOAuthUser` refuses provisioning under
the same condition as a soft rail. A misconfigured `allowed_domains`
row can never mint an admin via OAuth as a result.

## Surface added

- **Schema**: `auth_tokens.type` enum gains `oauth_state`; new
  nullable JSON `payload` column carries the PKCE verifier and
  provider key for that row only.
- **Module**: `packages/core/src/auth/oauth/` with state store, PKCE
  helpers, provider definitions (GitHub, Google), code-exchange
  consumer, signup resolver (link existing / domain-gated), HTTP
  start + callback handlers, and a typed `OAuthError` /
  `OAUTH_ERROR_CODES` set the admin maps to friendly copy.
- **RPC**: `auth.oauthProviders` (public; lists enabled keys for the
  login screen) and `auth.allowedDomains.{list,create,update,delete}`
  (admin-only, gated by `settings:manage`).
- **Config**: `auth({ oauth: { providers: { github?, google? } } })`
  is additive — passkey config unchanged. At least one provider key
  required when the `oauth` block is present (catches typos).
- **Admin UI**: provider buttons on `/login` (one per enabled
  provider, links to the start route — browser handles the redirect,
  no JS-level state to round-trip), and `/allowed-domains` for
  managing the signup allowlist (CRUD with confirm-then-delete).

## Out of scope

Magic links, email verification mailer, API tokens, scopes-based
authorization, and multi-origin passkey config are each their own
follow-up PR. emdash exposes them in the same package but landing
them all here would balloon the surface and the review.

Rate limiting is intentionally not on that list: it's a deployment
concern (Cloudflare WAF, edge rules, fronting CDN), not a CMS
responsibility. The OAuth callback isn't a more attractive target
than the existing passkey routes; both rely on the deploy layer.

## Reviewer notes

- Internal audit (find-bugs / security-review / code-review /
  code-simplifier) ran on the first two commits; the `fix(*)`
  commits (3 + 4) close out every must-fix from those passes.
- Each commit is independently CI-clean (`pnpm test && pnpm lint &&
  pnpm typecheck && pnpm format`).
- The provider abstraction is small: one new file under
  `oauth/providers/`, one entry in `OAUTH_PROVIDER_KEYS`, one entry
  each in the config schema and `PROVIDER_LABEL` map. No deeper
  changes for a third provider.