### PR TITLE
feat(core): magic-link sign-in + open OAuth providers for extension

### DIFF
--- a/examples/blog/plumix.config.ts
+++ b/examples/blog/plumix.config.ts
@@ -8,7 +8,7 @@ import {
   images,
   r2,
 } from "@plumix/runtime-cloudflare";
-import { auth, plumix } from "plumix";
+import { auth, consoleMailer, plumix } from "plumix";
 
 // Derives `rpId` + `origin` from the Workers Builds env (`WORKERS_CI`,
 // `WORKERS_CI_BRANCH`): production deploys → `<worker>.<account>.workers.dev`,
@@ -46,6 +46,30 @@ export default plumix({
       rpName: "Plumix — Blog",
       rpId,
       origin,
+    },
+    // Magic-link sign-in / signup. The default `consoleMailer()` logs
+    // the message instead of sending — fine for dev / `wrangler tail`,
+    // not fine for production. Swap in your own factory for Resend /
+    // Postmark / SES / SMTP — the `Mailer` interface is one method:
+    //
+    //   const mailer = {
+    //     async send(message) {
+    //       await fetch("https://api.resend.com/emails", {
+    //         method: "POST",
+    //         headers: {
+    //           Authorization: `Bearer ${env.RESEND_API_KEY}`,
+    //           "Content-Type": "application/json",
+    //         },
+    //         body: JSON.stringify({
+    //           from: "noreply@plumix.test",
+    //           ...message,
+    //         }),
+    //       });
+    //     },
+    //   };
+    magicLink: {
+      siteName: "Plumix — Blog",
+      mailer: consoleMailer(),
     },
   }),
   plugins: [blog, pages, media()],

--- a/examples/blog/plumix.config.ts
+++ b/examples/blog/plumix.config.ts
@@ -41,36 +41,39 @@ export default plumix({
   imageDelivery: process.env.MEDIA_PUBLIC_URL_BASE
     ? images({ zone: process.env.MEDIA_PUBLIC_URL_BASE })
     : undefined,
+  // Outbound email transport. Top-level so every feature that sends
+  // mail (magic-link today; future invite-email, notifications, plugin
+  // emails) reuses the same instance — operators wire one transport,
+  // it's available repo-wide via `ctx.mailer`. The default
+  // `consoleMailer()` logs the message; production swaps in any
+  // `Mailer` (one method):
+  //
+  //   const mailer = {
+  //     async send(message) {
+  //       await fetch("https://api.resend.com/emails", {
+  //         method: "POST",
+  //         headers: {
+  //           Authorization: `Bearer ${env.RESEND_API_KEY}`,
+  //           "Content-Type": "application/json",
+  //         },
+  //         body: JSON.stringify({
+  //           from: "noreply@plumix.test",
+  //           ...message,
+  //         }),
+  //       });
+  //     },
+  //   };
+  mailer: consoleMailer(),
   auth: auth({
     passkey: {
       rpName: "Plumix — Blog",
       rpId,
       origin,
     },
-    // Magic-link sign-in / signup. The default `consoleMailer()` logs
-    // the message instead of sending — fine for dev / `wrangler tail`,
-    // not fine for production. Swap in your own factory for Resend /
-    // Postmark / SES / SMTP — the `Mailer` interface is one method:
-    //
-    //   const mailer = {
-    //     async send(message) {
-    //       await fetch("https://api.resend.com/emails", {
-    //         method: "POST",
-    //         headers: {
-    //           Authorization: `Bearer ${env.RESEND_API_KEY}`,
-    //           "Content-Type": "application/json",
-    //         },
-    //         body: JSON.stringify({
-    //           from: "noreply@plumix.test",
-    //           ...message,
-    //         }),
-    //       });
-    //     },
-    //   };
-    magicLink: {
-      siteName: "Plumix — Blog",
-      mailer: consoleMailer(),
-    },
+    // Magic-link sign-in + signup (allowed-domain gated). The transport
+    // is the top-level `mailer` above; siteName is the user-visible
+    // string in the email subject + body.
+    magicLink: { siteName: "Plumix — Blog" },
   }),
   plugins: [blog, pages, media()],
 });

--- a/packages/admin/src/lib/magic-link-errors.test.ts
+++ b/packages/admin/src/lib/magic-link-errors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+import { MAGIC_LINK_ERROR_CODES } from "@plumix/core";
+
+import {
+  getMagicLinkErrorMessage,
+  MAGIC_LINK_ERROR_MESSAGES,
+} from "./magic-link-errors.js";
+
+describe("getMagicLinkErrorMessage", () => {
+  test("maps every server-defined error code", () => {
+    // Adding a code in core without updating this map silently degrades
+    // to the fallback string. Catch the drift here.
+    for (const code of MAGIC_LINK_ERROR_CODES) {
+      expect(MAGIC_LINK_ERROR_MESSAGES[code]).toBeDefined();
+      expect(MAGIC_LINK_ERROR_MESSAGES[code]).toMatch(/\S/);
+    }
+  });
+
+  test("returns null for empty / undefined codes", () => {
+    expect(getMagicLinkErrorMessage(undefined)).toBeNull();
+    expect(getMagicLinkErrorMessage("")).toBeNull();
+  });
+
+  test("falls back to the generic message for unknown codes", () => {
+    const message = getMagicLinkErrorMessage("server_added_a_new_code");
+    expect(message).toMatch(/try again/i);
+  });
+});

--- a/packages/admin/src/lib/magic-link-errors.ts
+++ b/packages/admin/src/lib/magic-link-errors.ts
@@ -1,0 +1,25 @@
+import type { MagicLinkErrorCode } from "@plumix/core";
+
+const MESSAGES: Record<MagicLinkErrorCode, string> = {
+  missing_token:
+    "That sign-in link is missing its token. Request a new one and try again.",
+  token_invalid:
+    "That sign-in link isn't valid. It may have already been used. Request a new one.",
+  token_expired: "That sign-in link expired. Request a new one.",
+  account_disabled: "That account is disabled.",
+};
+
+const FALLBACK = "Couldn't sign in. Try again.";
+
+export function getMagicLinkErrorMessage(
+  code: string | undefined,
+): string | null {
+  if (!code) return null;
+  return Object.hasOwn(MESSAGES, code)
+    ? MESSAGES[code as MagicLinkErrorCode]
+    : FALLBACK;
+}
+
+// Test-only export so the unit test can assert every code in
+// `MAGIC_LINK_ERROR_CODES` is mapped (no silent fallbacks).
+export const MAGIC_LINK_ERROR_MESSAGES = MESSAGES;

--- a/packages/admin/src/lib/magic-link-errors.ts
+++ b/packages/admin/src/lib/magic-link-errors.ts
@@ -7,6 +7,10 @@ const MESSAGES: Record<MagicLinkErrorCode, string> = {
     "That sign-in link isn't valid. It may have already been used. Request a new one.",
   token_expired: "That sign-in link expired. Request a new one.",
   account_disabled: "That account is disabled.",
+  domain_not_allowed:
+    "Your email domain isn't on the allowlist anymore. Ask an administrator to add it.",
+  registration_closed:
+    "Self-signup is unavailable until an administrator has finished setup.",
 };
 
 const FALLBACK = "Couldn't sign in. Try again.";

--- a/packages/admin/src/lib/magic-link.ts
+++ b/packages/admin/src/lib/magic-link.ts
@@ -45,3 +45,16 @@ export class MagicLinkRequestError extends Error {
     this.code = code;
   }
 }
+
+const REQUEST_ERROR_MESSAGES: Record<MagicLinkRequestErrorCode, string> = {
+  not_configured: "Magic-link sign-in isn't configured on this site.",
+  invalid_input: "Enter a valid email address.",
+  network: "Couldn't send the link. Try again.",
+};
+
+export function getMagicLinkRequestErrorMessage(error: unknown): string {
+  if (error instanceof MagicLinkRequestError) {
+    return REQUEST_ERROR_MESSAGES[error.code];
+  }
+  return REQUEST_ERROR_MESSAGES.network;
+}

--- a/packages/admin/src/lib/magic-link.ts
+++ b/packages/admin/src/lib/magic-link.ts
@@ -1,0 +1,47 @@
+// Client wrapper for the magic-link request endpoint. Not an oRPC
+// procedure (the verify side is a top-level GET navigation, and the
+// always-success response shape is intentionally hand-rolled rather
+// than typed through oRPC).
+
+interface MagicLinkRequestResponse {
+  readonly ok: boolean;
+  readonly message: string;
+}
+
+export async function requestMagicLink(
+  email: string,
+): Promise<MagicLinkRequestResponse> {
+  const response = await fetch("/_plumix/auth/magic-link/request", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-plumix-request": "1",
+    },
+    body: JSON.stringify({ email }),
+    credentials: "same-origin",
+  });
+
+  if (response.status === 503) {
+    throw new MagicLinkRequestError("not_configured");
+  }
+  if (response.status === 400) {
+    throw new MagicLinkRequestError("invalid_input");
+  }
+  if (!response.ok) {
+    throw new MagicLinkRequestError("network");
+  }
+
+  return (await response.json()) as MagicLinkRequestResponse;
+}
+
+type MagicLinkRequestErrorCode = "not_configured" | "invalid_input" | "network";
+
+export class MagicLinkRequestError extends Error {
+  readonly code: MagicLinkRequestErrorCode;
+
+  constructor(code: MagicLinkRequestErrorCode, message?: string) {
+    super(message ?? code);
+    this.name = "MagicLinkRequestError";
+    this.code = code;
+  }
+}

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -20,7 +20,10 @@ import {
 import { Input } from "@/components/ui/input.js";
 import { Separator } from "@/components/ui/separator.js";
 import { getMagicLinkErrorMessage } from "@/lib/magic-link-errors.js";
-import { MagicLinkRequestError, requestMagicLink } from "@/lib/magic-link.js";
+import {
+  getMagicLinkRequestErrorMessage,
+  requestMagicLink,
+} from "@/lib/magic-link.js";
 import { getOAuthErrorMessage } from "@/lib/oauth-errors.js";
 import { orpc } from "@/lib/orpc.js";
 import { getPasskeyErrorMessage, PasskeyError } from "@/lib/passkey-errors.js";
@@ -83,19 +86,7 @@ function LoginRoute(): ReactNode {
       setMagicLinkSent(false);
     },
     onSuccess: () => setMagicLinkSent(true),
-    onError: (err) => {
-      if (err instanceof MagicLinkRequestError) {
-        setMagicLinkError(
-          err.code === "not_configured"
-            ? "Magic-link sign-in isn't configured on this site."
-            : err.code === "invalid_input"
-              ? "Enter a valid email address."
-              : "Couldn't send the link. Try again.",
-        );
-        return;
-      }
-      setMagicLinkError("Couldn't send the link. Try again.");
-    },
+    onError: (err) => setMagicLinkError(getMagicLinkRequestErrorMessage(err)),
   });
 
   const form = useForm({

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/components/ui/form.js";
 import { Input } from "@/components/ui/input.js";
 import { Separator } from "@/components/ui/separator.js";
+import { getMagicLinkErrorMessage } from "@/lib/magic-link-errors.js";
+import { MagicLinkRequestError, requestMagicLink } from "@/lib/magic-link.js";
 import { getOAuthErrorMessage } from "@/lib/oauth-errors.js";
 import { orpc } from "@/lib/orpc.js";
 import { getPasskeyErrorMessage, PasskeyError } from "@/lib/passkey-errors.js";
@@ -34,6 +36,7 @@ import { loginSchema } from "./-schemas.js";
 
 const loginSearchSchema = v.object({
   oauth_error: v.optional(v.string()),
+  magic_link_error: v.optional(v.string()),
 });
 
 export const Route = createFileRoute("/_auth/login")({
@@ -53,13 +56,15 @@ export const Route = createFileRoute("/_auth/login")({
 function LoginRoute(): ReactNode {
   const router = useRouter();
   const search = Route.useSearch();
-  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [passkeyError, setPasskeyError] = useState<string | null>(null);
+  const [magicLinkSent, setMagicLinkSent] = useState(false);
+  const [magicLinkError, setMagicLinkError] = useState<string | null>(null);
 
   const providers = useQuery(orpc.auth.oauthProviders.queryOptions());
 
   const signIn = useMutation({
     mutationFn: (input: { email?: string }) => signInWithPasskey(input.email),
-    onMutate: () => setErrorCode(null),
+    onMutate: () => setPasskeyError(null),
     onSuccess: async () => {
       await router.options.context.queryClient.invalidateQueries({
         queryKey: SESSION_QUERY_KEY,
@@ -67,7 +72,29 @@ function LoginRoute(): ReactNode {
       await router.navigate({ to: "/" });
     },
     onError: (err) => {
-      setErrorCode(err instanceof PasskeyError ? err.code : "unknown");
+      setPasskeyError(err instanceof PasskeyError ? err.code : "unknown");
+    },
+  });
+
+  const magicLink = useMutation({
+    mutationFn: (input: { email: string }) => requestMagicLink(input.email),
+    onMutate: () => {
+      setMagicLinkError(null);
+      setMagicLinkSent(false);
+    },
+    onSuccess: () => setMagicLinkSent(true),
+    onError: (err) => {
+      if (err instanceof MagicLinkRequestError) {
+        setMagicLinkError(
+          err.code === "not_configured"
+            ? "Magic-link sign-in isn't configured on this site."
+            : err.code === "invalid_input"
+              ? "Enter a valid email address."
+              : "Couldn't send the link. Try again.",
+        );
+        return;
+      }
+      setMagicLinkError("Couldn't send the link. Try again.");
     },
   });
 
@@ -77,11 +104,47 @@ function LoginRoute(): ReactNode {
     mode: "onChange",
   });
 
-  const onSubmit = form.handleSubmit(({ email }) => {
+  const onPasskeySubmit = form.handleSubmit(({ email }) => {
     signIn.mutate({ email: email || undefined });
   });
 
+  const onMagicLinkClick = (): void => {
+    const email = form.getValues("email").trim();
+    if (!email) {
+      setMagicLinkError("Enter your email above first.");
+      return;
+    }
+    magicLink.mutate({ email });
+  };
+
   const oauthErrorMessage = getOAuthErrorMessage(search.oauth_error);
+  const magicLinkUrlError = getMagicLinkErrorMessage(search.magic_link_error);
+
+  if (magicLinkSent) {
+    return (
+      <Card data-testid="login-magic-link-sent">
+        <CardHeader>
+          <CardTitle>
+            <h1 data-testid="login-heading">Check your email</h1>
+          </CardTitle>
+          <CardDescription>
+            If an account exists for this email, we sent a sign-in link. The
+            link expires in 15 minutes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setMagicLinkSent(false)}
+            data-testid="login-magic-link-back"
+          >
+            Back
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card>
@@ -90,12 +153,12 @@ function LoginRoute(): ReactNode {
           <h1 data-testid="login-heading">Sign in</h1>
         </CardTitle>
         <CardDescription>
-          Use a passkey registered with this site.
+          Use a passkey, get a one-time email link, or continue with a provider.
         </CardDescription>
       </CardHeader>
       <CardContent>
         <Form {...form}>
-          <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+          <form className="flex flex-col gap-4" onSubmit={onPasskeySubmit}>
             <FormField
               control={form.control}
               name="email"
@@ -106,7 +169,8 @@ function LoginRoute(): ReactNode {
                     <Input
                       type="email"
                       autoComplete="username webauthn"
-                      disabled={signIn.isPending}
+                      disabled={signIn.isPending || magicLink.isPending}
+                      data-testid="login-email-input"
                       {...field}
                     />
                   </FormControl>
@@ -115,10 +179,10 @@ function LoginRoute(): ReactNode {
               )}
             />
 
-            {errorCode ? (
+            {passkeyError ? (
               <Alert variant="destructive" data-testid="login-passkey-error">
                 <AlertDescription>
-                  {getPasskeyErrorMessage(errorCode)}
+                  {getPasskeyErrorMessage(passkeyError)}
                 </AlertDescription>
               </Alert>
             ) : null}
@@ -129,9 +193,41 @@ function LoginRoute(): ReactNode {
               </Alert>
             ) : null}
 
-            <Button type="submit" disabled={signIn.isPending}>
-              {signIn.isPending ? "Signing in…" : "Sign in with passkey"}
-            </Button>
+            {magicLinkUrlError ? (
+              <Alert
+                variant="destructive"
+                data-testid="login-magic-link-url-error"
+              >
+                <AlertDescription>{magicLinkUrlError}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            {magicLinkError ? (
+              <Alert variant="destructive" data-testid="login-magic-link-error">
+                <AlertDescription>{magicLinkError}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                type="submit"
+                className="flex-1"
+                disabled={signIn.isPending || magicLink.isPending}
+                data-testid="login-passkey-submit"
+              >
+                {signIn.isPending ? "Signing in…" : "Sign in with passkey"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1"
+                onClick={onMagicLinkClick}
+                disabled={signIn.isPending || magicLink.isPending}
+                data-testid="login-magic-link-submit"
+              >
+                {magicLink.isPending ? "Sending…" : "Email me a link"}
+              </Button>
+            </div>
           </form>
         </Form>
 

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -32,11 +32,6 @@ import * as v from "valibot";
 
 import { loginSchema } from "./-schemas.js";
 
-const PROVIDER_LABEL: Record<string, string> = {
-  github: "GitHub",
-  google: "Google",
-};
-
 const loginSearchSchema = v.object({
   oauth_error: v.optional(v.string()),
 });
@@ -152,15 +147,15 @@ function LoginRoute(): ReactNode {
               </span>
               <Separator className="flex-1" />
             </div>
-            {providers.data.map((provider) => (
+            {providers.data.map(({ key, label }) => (
               <Button
-                key={provider}
+                key={key}
                 asChild
                 variant="outline"
-                data-testid={`login-oauth-${provider}`}
+                data-testid={`login-oauth-${key}`}
               >
-                <a href={`/_plumix/auth/oauth/${provider}/start`}>
-                  Continue with {PROVIDER_LABEL[provider] ?? provider}
+                <a href={`/_plumix/auth/oauth/${key}/start`}>
+                  Continue with {label}
                 </a>
               </Button>
             ))}

--- a/packages/core/src/auth/config.test.ts
+++ b/packages/core/src/auth/config.test.ts
@@ -186,12 +186,10 @@ describe("auth() — oauth schema", () => {
 });
 
 describe("auth() — magicLink schema", () => {
-  const stubMailer = { send: () => Promise.resolve() };
-
   test("accepts a minimal valid magicLink config", () => {
     const config = auth({
       passkey: validPasskey,
-      magicLink: { mailer: stubMailer, siteName: "Plumix" },
+      magicLink: { siteName: "Plumix" },
     });
     expect(config.magicLink?.siteName).toBe("Plumix");
   });
@@ -199,9 +197,7 @@ describe("auth() — magicLink schema", () => {
   test("rejects a missing siteName", () => {
     const error = rejected({
       passkey: validPasskey,
-      magicLink: {
-        mailer: stubMailer,
-      } as unknown as PlumixAuthInput["magicLink"],
+      magicLink: {} as unknown as PlumixAuthInput["magicLink"],
     });
     expect(error.issues[0]?.path).toContain("magicLink.siteName");
   });
@@ -209,26 +205,15 @@ describe("auth() — magicLink schema", () => {
   test("rejects a siteName with newline (CR/LF defense)", () => {
     const error = rejected({
       passkey: validPasskey,
-      magicLink: { mailer: stubMailer, siteName: "bad\r\nSubject: x" },
+      magicLink: { siteName: "bad\r\nSubject: x" },
     });
     expect(error.issues[0]?.message).toMatch(/newlines/);
-  });
-
-  test("rejects a mailer without a send method", () => {
-    const error = rejected({
-      passkey: validPasskey,
-      magicLink: {
-        mailer: {} as unknown as { send: () => Promise<void> },
-        siteName: "Plumix",
-      },
-    });
-    expect(error.issues[0]?.message).toMatch(/mailer/);
   });
 
   test("rejects ttlSeconds below 60", () => {
     const error = rejected({
       passkey: validPasskey,
-      magicLink: { mailer: stubMailer, siteName: "Plumix", ttlSeconds: 30 },
+      magicLink: { siteName: "Plumix", ttlSeconds: 30 },
     });
     expect(error.issues[0]?.message).toMatch(/ttlSeconds/);
   });
@@ -236,7 +221,7 @@ describe("auth() — magicLink schema", () => {
   test("rejects ttlSeconds above 3600", () => {
     const error = rejected({
       passkey: validPasskey,
-      magicLink: { mailer: stubMailer, siteName: "Plumix", ttlSeconds: 7200 },
+      magicLink: { siteName: "Plumix", ttlSeconds: 7200 },
     });
     expect(error.issues[0]?.message).toMatch(/ttlSeconds/);
   });

--- a/packages/core/src/auth/config.test.ts
+++ b/packages/core/src/auth/config.test.ts
@@ -120,3 +120,124 @@ describe("auth()", () => {
     expect(paths).toContain("passkey.rpName");
   });
 });
+
+describe("auth() — oauth schema", () => {
+  const stubProvider = {
+    label: "Stub",
+    authorizeUrl: "https://example.com/authorize",
+    tokenUrl: "https://example.com/token",
+    userInfoUrl: "https://example.com/userinfo",
+    scopes: ["openid"],
+    client: { clientId: "id", clientSecret: "secret" },
+    parseProfile: () => ({
+      providerAccountId: "x",
+      email: null,
+      emailVerified: false,
+      name: null,
+      avatarUrl: null,
+    }),
+  };
+
+  test("accepts a single configured provider", () => {
+    const config = auth({
+      passkey: validPasskey,
+      oauth: { providers: { acme: stubProvider } },
+    });
+    expect(config.oauth?.providers.acme).toBeDefined();
+  });
+
+  test("rejects an empty providers map", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      oauth: { providers: {} },
+    });
+    expect(error.issues[0]?.message).toMatch(/at least one provider/);
+  });
+
+  test("rejects a provider key with invalid characters", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      oauth: { providers: { "Bad-Key!": stubProvider } },
+    });
+    expect(error.issues[0]?.message).toMatch(/lowercase alphanum/);
+  });
+
+  test("rejects a provider with non-URL authorizeUrl", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      oauth: {
+        providers: { acme: { ...stubProvider, authorizeUrl: "not-a-url" } },
+      },
+    });
+    expect(error.issues[0]?.message).toMatch(/authorizeUrl/);
+  });
+
+  test("rejects a provider missing the parseProfile function", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      oauth: {
+        providers: {
+          acme: { ...stubProvider, parseProfile: "not-a-function" },
+        },
+      } as unknown as PlumixAuthInput["oauth"],
+    });
+    expect(error.issues[0]?.message).toMatch(/parseProfile/);
+  });
+});
+
+describe("auth() — magicLink schema", () => {
+  const stubMailer = { send: () => Promise.resolve() };
+
+  test("accepts a minimal valid magicLink config", () => {
+    const config = auth({
+      passkey: validPasskey,
+      magicLink: { mailer: stubMailer, siteName: "Plumix" },
+    });
+    expect(config.magicLink?.siteName).toBe("Plumix");
+  });
+
+  test("rejects a missing siteName", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      magicLink: {
+        mailer: stubMailer,
+      } as unknown as PlumixAuthInput["magicLink"],
+    });
+    expect(error.issues[0]?.path).toContain("magicLink.siteName");
+  });
+
+  test("rejects a siteName with newline (CR/LF defense)", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      magicLink: { mailer: stubMailer, siteName: "bad\r\nSubject: x" },
+    });
+    expect(error.issues[0]?.message).toMatch(/newlines/);
+  });
+
+  test("rejects a mailer without a send method", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      magicLink: {
+        mailer: {} as unknown as { send: () => Promise<void> },
+        siteName: "Plumix",
+      },
+    });
+    expect(error.issues[0]?.message).toMatch(/mailer/);
+  });
+
+  test("rejects ttlSeconds below 60", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      magicLink: { mailer: stubMailer, siteName: "Plumix", ttlSeconds: 30 },
+    });
+    expect(error.issues[0]?.message).toMatch(/ttlSeconds/);
+  });
+
+  test("rejects ttlSeconds above 3600", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      magicLink: { mailer: stubMailer, siteName: "Plumix", ttlSeconds: 7200 },
+    });
+    expect(error.issues[0]?.message).toMatch(/ttlSeconds/);
+  });
+});

--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -1,17 +1,11 @@
 import * as v from "valibot";
 
-import type { Mailer } from "./mailer/types.js";
 import type { OAuthProviderClient } from "./oauth/types.js";
 import type { PasskeyConfig } from "./passkey/config.js";
 import type { SessionPolicy } from "./sessions.js";
 import { OAUTH_PROVIDER_KEY_PATTERN } from "./oauth/types.js";
 
 export interface PlumixMagicLinkConfig {
-  /**
-   * Required when magic-link sign-in is enabled. Implementations must
-   * conform to the `Mailer` interface; ship `consoleMailer()` for dev.
-   */
-  readonly mailer: Mailer;
   /**
    * Site name shown in the email subject + body ("Sign in to {siteName}").
    * Required so the operator picks the user-visible string explicitly —
@@ -163,17 +157,6 @@ const oauthSchema = v.pipe(
 );
 
 const magicLinkSchema = v.object({
-  mailer: v.pipe(
-    v.unknown(),
-    v.check(
-      (val) =>
-        typeof val === "object" &&
-        val !== null &&
-        "send" in val &&
-        typeof val.send === "function",
-      "magicLink.mailer must implement `send(message)`",
-    ),
-  ),
   siteName: v.pipe(
     v.string(),
     v.nonEmpty("siteName must be non-empty"),

--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -1,9 +1,28 @@
 import * as v from "valibot";
 
+import type { Mailer } from "./mailer/types.js";
 import type { OAuthProviderClient } from "./oauth/types.js";
 import type { PasskeyConfig } from "./passkey/config.js";
 import type { SessionPolicy } from "./sessions.js";
 import { OAUTH_PROVIDER_KEY_PATTERN } from "./oauth/types.js";
+
+export interface PlumixMagicLinkConfig {
+  /**
+   * Required when magic-link sign-in is enabled. Implementations must
+   * conform to the `Mailer` interface; ship `consoleMailer()` for dev.
+   */
+  readonly mailer: Mailer;
+  /**
+   * Site name shown in the email subject + body ("Sign in to {siteName}").
+   * Defaults to `passkey.rpName` when omitted.
+   */
+  readonly siteName?: string;
+  /**
+   * Token lifetime in seconds. Defaults to 15 minutes (900) — the
+   * Copenhagen Book / emdash convention. Lower for paranoid deploys.
+   */
+  readonly ttlSeconds?: number;
+}
 
 export interface PlumixOAuthConfig {
   /**
@@ -21,6 +40,7 @@ export interface PlumixAuthInput {
   readonly passkey: PasskeyConfig;
   readonly sessions?: SessionPolicy;
   readonly oauth?: PlumixOAuthConfig;
+  readonly magicLink?: PlumixMagicLinkConfig;
 }
 
 export interface PlumixAuthConfig {
@@ -28,6 +48,7 @@ export interface PlumixAuthConfig {
   readonly passkey: PasskeyConfig;
   readonly sessions?: SessionPolicy;
   readonly oauth?: PlumixOAuthConfig;
+  readonly magicLink?: PlumixMagicLinkConfig;
 }
 
 export interface PlumixConfigIssue {
@@ -139,10 +160,36 @@ const oauthSchema = v.pipe(
   ),
 );
 
+const magicLinkSchema = v.object({
+  mailer: v.pipe(
+    v.unknown(),
+    v.check(
+      (val) =>
+        typeof val === "object" &&
+        val !== null &&
+        "send" in val &&
+        typeof val.send === "function",
+      "magicLink.mailer must implement `send(message)`",
+    ),
+  ),
+  siteName: v.optional(
+    v.pipe(v.string(), v.nonEmpty("siteName must be non-empty")),
+  ),
+  ttlSeconds: v.optional(
+    v.pipe(
+      v.number(),
+      v.integer("ttlSeconds must be an integer"),
+      v.minValue(60, "ttlSeconds must be ≥ 60"),
+      v.maxValue(60 * 60, "ttlSeconds must be ≤ 3600"),
+    ),
+  ),
+});
+
 const authInputSchema = v.object({
   passkey: passkeySchema,
   sessions: v.optional(sessionPolicySchema),
   oauth: v.optional(oauthSchema),
+  magicLink: v.optional(magicLinkSchema),
 });
 
 function toIssues(
@@ -168,5 +215,6 @@ export function auth(input: PlumixAuthInput): PlumixAuthConfig {
     passkey: input.passkey,
     sessions: input.sessions,
     oauth: input.oauth,
+    magicLink: input.magicLink,
   };
 }

--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -1,11 +1,20 @@
 import * as v from "valibot";
 
-import type { OAuthProvidersConfig } from "./oauth/types.js";
+import type { OAuthProviderClient } from "./oauth/types.js";
 import type { PasskeyConfig } from "./passkey/config.js";
 import type { SessionPolicy } from "./sessions.js";
+import { OAUTH_PROVIDER_KEY_PATTERN } from "./oauth/types.js";
 
 export interface PlumixOAuthConfig {
-  readonly providers: OAuthProvidersConfig;
+  /**
+   * Map of provider keys → configured provider clients. The map key
+   * doubles as the URL path segment (`/_plumix/auth/oauth/<key>/start`)
+   * and the value of `oauth_accounts.provider` for any user that signs
+   * in via this provider. Pass instances from `github(creds)` /
+   * `google(creds)` (built-ins) or from your own factory implementing
+   * `OAuthProviderClient` for provider parity.
+   */
+  readonly providers: Readonly<Record<string, OAuthProviderClient>>;
 }
 
 export interface PlumixAuthInput {
@@ -66,27 +75,66 @@ const sessionPolicySchema = v.pipe(
   ),
 );
 
-const oauthClientSchema = v.object({
-  clientId: v.pipe(
-    v.string(),
-    v.nonEmpty("clientId must be a non-empty string"),
+// Provider clients are user-supplied factory output — we shape-check the
+// minimum required fields so a malformed entry surfaces at config time
+// rather than at the first sign-in attempt. Anything beyond these (the
+// `parseProfile` impl, optional hooks) is the provider author's contract.
+const oauthProviderClientSchema = v.object({
+  label: v.pipe(v.string(), v.nonEmpty("provider label must be non-empty")),
+  authorizeUrl: v.pipe(v.string(), v.url("authorizeUrl must be a valid URL")),
+  tokenUrl: v.pipe(v.string(), v.url("tokenUrl must be a valid URL")),
+  userInfoUrl: v.pipe(v.string(), v.url("userInfoUrl must be a valid URL")),
+  scopes: v.array(v.string()),
+  client: v.object({
+    clientId: v.pipe(v.string(), v.nonEmpty("clientId must be non-empty")),
+    clientSecret: v.pipe(
+      v.string(),
+      v.nonEmpty("clientSecret must be non-empty"),
+    ),
+  }),
+  parseProfile: v.pipe(
+    v.unknown(),
+    v.check(
+      (val) => typeof val === "function",
+      "parseProfile must be a function",
+    ),
   ),
-  clientSecret: v.pipe(
-    v.string(),
-    v.nonEmpty("clientSecret must be a non-empty string"),
+  // optional hooks — present-or-absent, no shape check beyond function
+  decorateAuthorizeUrl: v.optional(
+    v.pipe(
+      v.unknown(),
+      v.check(
+        (val) => typeof val === "function",
+        "decorateAuthorizeUrl must be a function",
+      ),
+    ),
+  ),
+  fetchVerifiedEmail: v.optional(
+    v.pipe(
+      v.unknown(),
+      v.check(
+        (val) => typeof val === "function",
+        "fetchVerifiedEmail must be a function",
+      ),
+    ),
   ),
 });
 
 const oauthSchema = v.pipe(
   v.object({
-    providers: v.object({
-      github: v.optional(oauthClientSchema),
-      google: v.optional(oauthClientSchema),
-    }),
+    providers: v.record(
+      v.pipe(
+        v.string(),
+        v.regex(
+          OAUTH_PROVIDER_KEY_PATTERN,
+          "oauth.providers key must be lowercase alphanum + dash/underscore (1-32 chars)",
+        ),
+      ),
+      oauthProviderClientSchema,
+    ),
   }),
   v.check(
-    (cfg) =>
-      cfg.providers.github !== undefined || cfg.providers.google !== undefined,
+    (cfg) => Object.keys(cfg.providers).length > 0,
     "oauth.providers must declare at least one provider",
   ),
 );

--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -14,9 +14,11 @@ export interface PlumixMagicLinkConfig {
   readonly mailer: Mailer;
   /**
    * Site name shown in the email subject + body ("Sign in to {siteName}").
-   * Defaults to `passkey.rpName` when omitted.
+   * Required so the operator picks the user-visible string explicitly —
+   * the alternative (silently falling back to `passkey.rpName`) couples
+   * config blocks in a non-obvious way.
    */
-  readonly siteName?: string;
+  readonly siteName: string;
   /**
    * Token lifetime in seconds. Defaults to 15 minutes (900) — the
    * Copenhagen Book / emdash convention. Lower for paranoid deploys.
@@ -172,8 +174,14 @@ const magicLinkSchema = v.object({
       "magicLink.mailer must implement `send(message)`",
     ),
   ),
-  siteName: v.optional(
-    v.pipe(v.string(), v.nonEmpty("siteName must be non-empty")),
+  siteName: v.pipe(
+    v.string(),
+    v.nonEmpty("siteName must be non-empty"),
+    // Defense-in-depth: siteName flows into the email Subject header. Today
+    // it's operator config (not request input) so safe, but if a future
+    // settings UI ever lets it become user-input, blocking CR/LF here
+    // prevents header injection at the boundary.
+    v.regex(/^[^\r\n]+$/, "siteName must not contain newlines"),
   ),
   ttlSeconds: v.optional(
     v.pipe(

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -2,6 +2,7 @@ export * from "./bootstrap.js";
 export * from "./config.js";
 export * from "./cookies.js";
 export * from "./csrf.js";
+export * from "./magic-link/index.js";
 export * from "./mailer/index.js";
 export * from "./oauth/index.js";
 export * from "./passkey/index.js";

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -2,6 +2,7 @@ export * from "./bootstrap.js";
 export * from "./config.js";
 export * from "./cookies.js";
 export * from "./csrf.js";
+export * from "./mailer/index.js";
 export * from "./oauth/index.js";
 export * from "./passkey/index.js";
 export * from "./rbac.js";

--- a/packages/core/src/auth/magic-link/errors.ts
+++ b/packages/core/src/auth/magic-link/errors.ts
@@ -3,6 +3,11 @@ export const MAGIC_LINK_ERROR_CODES = [
   "token_invalid",
   "token_expired",
   "account_disabled",
+  // Signup-only — the click-the-link path provisioned a user, but the
+  // domain's allowlist row is no longer enabled at verify time, or the
+  // system is in zero-user state (bootstrap is passkey-only).
+  "domain_not_allowed",
+  "registration_closed",
 ] as const;
 
 export type MagicLinkErrorCode = (typeof MAGIC_LINK_ERROR_CODES)[number];

--- a/packages/core/src/auth/magic-link/errors.ts
+++ b/packages/core/src/auth/magic-link/errors.ts
@@ -1,0 +1,18 @@
+export const MAGIC_LINK_ERROR_CODES = [
+  "missing_token",
+  "token_invalid",
+  "token_expired",
+  "account_disabled",
+] as const;
+
+export type MagicLinkErrorCode = (typeof MAGIC_LINK_ERROR_CODES)[number];
+
+export class MagicLinkError extends Error {
+  readonly code: MagicLinkErrorCode;
+
+  constructor(code: MagicLinkErrorCode, message?: string) {
+    super(message ?? code);
+    this.name = "MagicLinkError";
+    this.code = code;
+  }
+}

--- a/packages/core/src/auth/magic-link/index.ts
+++ b/packages/core/src/auth/magic-link/index.ts
@@ -1,0 +1,8 @@
+// Public magic-link surface. Mirrors the OAuth barrel: errors + route
+// handlers leave the package; the request/verify implementations are
+// internal (the dispatcher imports them by file path).
+
+export { MAGIC_LINK_ERROR_CODES, MagicLinkError } from "./errors.js";
+export type { MagicLinkErrorCode } from "./errors.js";
+
+export { handleMagicLinkRequest, handleMagicLinkVerify } from "./routes.js";

--- a/packages/core/src/auth/magic-link/request.test.ts
+++ b/packages/core/src/auth/magic-link/request.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import type { Mailer } from "../mailer/types.js";
 import { eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
-import { userFactory } from "../../test/factories.js";
+import { allowedDomainFactory, userFactory } from "../../test/factories.js";
 import { createTestDb } from "../../test/harness.js";
 import { hashToken } from "../tokens.js";
 import { requestMagicLink } from "./request.js";
@@ -51,7 +51,9 @@ describe("requestMagicLink", () => {
     expect(message?.text).toContain(
       "https://cms.example/_plumix/auth/magic-link/verify?token=",
     );
-    expect(message?.html).toContain("Test Site");
+    // Plumix doesn't ship HTML — operators template in their own mailer
+    // wrapper if they want it. The text body alone is the contract.
+    expect(message?.html).toBeUndefined();
 
     // The DB row exists, keyed by SHA-256(token), pointing at the user.
     // Recover the token from the URL and verify hash storage.
@@ -118,6 +120,95 @@ describe("requestMagicLink", () => {
     });
 
     expect(sent).toHaveLength(1);
+  });
+
+  test("signup: allowed domain → token issued with userId=null + email sent", async () => {
+    const db = await createTestDb();
+    // Need at least one user so the bootstrap rail is satisfied.
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "subscriber",
+      isEnabled: true,
+    });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "newcomer@example.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test",
+    });
+
+    expect(sent).toHaveLength(1);
+    const tokenMatch = /token=([A-Za-z0-9_-]+)/.exec(sent[0]?.text ?? "");
+    const tokenInUrl = tokenMatch?.[1];
+    if (!tokenInUrl) throw new Error("expected token in email URL");
+    const hash = await hashToken(tokenInUrl);
+    const row = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, hash),
+    });
+    expect(row?.type).toBe("magic_link");
+    expect(row?.userId).toBeNull();
+    expect(row?.email).toBe("newcomer@example.com");
+  });
+
+  test("signup: disabled allowed-domains row silently no-ops", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "subscriber",
+      isEnabled: false,
+    });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "newcomer@example.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test",
+    });
+
+    expect(sent).toHaveLength(0);
+    const tokens = await db.select().from(authTokens);
+    expect(tokens).toHaveLength(0);
+  });
+
+  test("signup: missing allowed-domains row silently no-ops", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "stranger@unknown.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test",
+    });
+
+    expect(sent).toHaveLength(0);
+  });
+
+  test("signup: zero-user system refuses signup (bootstrap is passkey-only)", async () => {
+    const db = await createTestDb();
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "admin",
+      isEnabled: true,
+    });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "first@example.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test",
+    });
+
+    expect(sent).toHaveLength(0);
+    const tokens = await db.select().from(authTokens);
+    expect(tokens).toHaveLength(0);
   });
 
   test("swallows mailer errors so the response shape never leaks success", async () => {

--- a/packages/core/src/auth/magic-link/request.test.ts
+++ b/packages/core/src/auth/magic-link/request.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Mailer } from "../mailer/types.js";
+import { eq } from "../../db/index.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { userFactory } from "../../test/factories.js";
+import { createTestDb } from "../../test/harness.js";
+import { hashToken } from "../tokens.js";
+import { requestMagicLink } from "./request.js";
+
+interface CapturedSend {
+  readonly to: string;
+  readonly subject: string;
+  readonly text: string;
+  readonly html?: string;
+}
+
+function captureMailer(): { mailer: Mailer; sent: CapturedSend[] } {
+  const sent: CapturedSend[] = [];
+  return {
+    sent,
+    mailer: {
+      send(message) {
+        sent.push({ ...message });
+        return Promise.resolve();
+      },
+    },
+  };
+}
+
+describe("requestMagicLink", () => {
+  test("issues a token + sends email when the user exists", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "alice@example.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test Site",
+    });
+
+    expect(sent).toHaveLength(1);
+    const [message] = sent;
+    expect(message?.to).toBe("alice@example.com");
+    expect(message?.subject).toContain("Test Site");
+    expect(message?.text).toContain(
+      "https://cms.example/_plumix/auth/magic-link/verify?token=",
+    );
+    expect(message?.html).toContain("Test Site");
+
+    // The DB row exists, keyed by SHA-256(token), pointing at the user.
+    // Recover the token from the URL and verify hash storage.
+    const tokenMatch = /token=([A-Za-z0-9_-]+)/.exec(message?.text ?? "");
+    const tokenInUrl = tokenMatch?.[1];
+    if (!tokenInUrl) throw new Error("expected token in email URL");
+    const hash = await hashToken(tokenInUrl);
+    const row = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, hash),
+    });
+    expect(row?.type).toBe("magic_link");
+    expect(row?.userId).toBe(user.id);
+    expect(row?.email).toBe("alice@example.com");
+  });
+
+  test("silently no-ops when the email is unregistered", async () => {
+    const db = await createTestDb();
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "stranger@example.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test",
+    });
+
+    expect(sent).toHaveLength(0);
+    const all = await db.select().from(authTokens);
+    expect(all).toHaveLength(0);
+  });
+
+  test("silently no-ops when the user is disabled", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({
+      email: "blocked@example.com",
+      role: "editor",
+      disabledAt: new Date(),
+    });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "blocked@example.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test",
+    });
+
+    expect(sent).toHaveLength(0);
+  });
+
+  test("normalises email to lowercase before lookup", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "  Alice@Example.com  ",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test",
+    });
+
+    expect(sent).toHaveLength(1);
+  });
+
+  test("swallows mailer errors so the response shape never leaks success", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+    const mailer: Mailer = {
+      send: vi.fn().mockRejectedValue(new Error("smtp down")),
+    };
+
+    await expect(
+      requestMagicLink(db, {
+        email: "alice@example.com",
+        origin: "https://cms.example",
+        mailer,
+        siteName: "Test",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/auth/magic-link/request.ts
+++ b/packages/core/src/auth/magic-link/request.ts
@@ -1,0 +1,126 @@
+import type { Db } from "../../context/app.js";
+import type { Mailer } from "../mailer/types.js";
+import { eq } from "../../db/index.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { users } from "../../db/schema/users.js";
+import { generateToken, hashToken } from "../tokens.js";
+
+const MAGIC_LINK_TTL_SECONDS = 15 * 60;
+
+// Artificial delay range when the recipient is unknown — adds enough
+// jitter that response timing alone can't tell a registered email apart
+// from an unregistered one. The 100-250ms band approximates the cost
+// of token generation + the mailer round-trip on the happy path.
+const TIMING_DELAY_MIN_MS = 100;
+const TIMING_DELAY_RANGE_MS = 150;
+
+interface RequestMagicLinkInput {
+  readonly email: string;
+  /** `${origin}/_plumix/admin/magic-link?token=…` will be sent to the user. */
+  readonly origin: string;
+  readonly mailer: Mailer;
+  readonly siteName: string;
+  readonly ttlSeconds?: number;
+}
+
+/**
+ * Issue a magic-link if (and only if) a user with this email exists.
+ * Always behaves identically from the caller's perspective regardless of
+ * whether the recipient is registered — the route layer turns this into
+ * an "If an account exists, we sent you a link" response. Per Copenhagen
+ * Book / emdash: don't reveal email existence via response timing or
+ * shape; honour that here at the function boundary.
+ *
+ * Errors from the mailer are swallowed (logged at the route layer if
+ * the caller wires logging in). The function never throws; it returns
+ * normally regardless of outcome. Sign-in only — does not provision new
+ * users; an unknown email is a silent no-op.
+ */
+export async function requestMagicLink(
+  db: Db,
+  input: RequestMagicLinkInput,
+): Promise<void> {
+  const email = input.email.trim().toLowerCase();
+  const ttlSeconds = input.ttlSeconds ?? MAGIC_LINK_TTL_SECONDS;
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.email, email),
+  });
+
+  if (!user || user.disabledAt) {
+    await timingDelay();
+    return;
+  }
+
+  const token = generateToken();
+  const hash = await hashToken(token);
+  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+  await db.insert(authTokens).values({
+    hash,
+    userId: user.id,
+    email: user.email,
+    type: "magic_link",
+    expiresAt,
+  });
+
+  const verifyUrl = new URL("/_plumix/auth/magic-link/verify", input.origin);
+  verifyUrl.searchParams.set("token", token);
+
+  try {
+    await input.mailer.send({
+      to: user.email,
+      subject: `Sign in to ${input.siteName}`,
+      text: composeText(input.siteName, verifyUrl.toString()),
+      html: composeHtml(input.siteName, verifyUrl.toString()),
+    });
+  } catch {
+    // Swallow — we already issued the token (next attempt will replace
+    // it). Surfacing the failure to the caller would leak that the
+    // recipient is registered. Route layer logs from its own catch.
+  }
+}
+
+function composeText(siteName: string, url: string): string {
+  return [
+    `Sign in to ${siteName} by opening this link:`,
+    "",
+    url,
+    "",
+    `The link expires in ${MAGIC_LINK_TTL_SECONDS / 60} minutes.`,
+    "",
+    "If you didn't request this, you can ignore this email.",
+  ].join("\n");
+}
+
+function composeHtml(siteName: string, url: string): string {
+  const safeName = escapeHtml(siteName);
+  // The URL is server-generated (origin from app.origin + token from our
+  // crypto-random generator), so it's already HTML-safe. Still, route it
+  // through escapeHtml for defense-in-depth.
+  const safeUrl = escapeHtml(url);
+  return `<!doctype html>
+<html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;line-height:1.5;color:#333;max-width:600px;margin:0 auto;padding:24px">
+<h1 style="font-size:20px;margin:0 0 16px">Sign in to ${safeName}</h1>
+<p>Click the button below to sign in:</p>
+<p style="margin:24px 0">
+  <a href="${safeUrl}" style="background:#0f172a;color:#fff;padding:12px 20px;text-decoration:none;border-radius:6px;display:inline-block">Sign in</a>
+</p>
+<p style="color:#666;font-size:14px">The link expires in ${MAGIC_LINK_TTL_SECONDS / 60} minutes.</p>
+<p style="color:#666;font-size:14px">If you didn't request this, you can ignore this email.</p>
+</body></html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function timingDelay(): Promise<void> {
+  const ms = TIMING_DELAY_MIN_MS + Math.random() * TIMING_DELAY_RANGE_MS;
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/core/src/auth/magic-link/request.ts
+++ b/packages/core/src/auth/magic-link/request.ts
@@ -1,10 +1,14 @@
-import type { Db } from "../../context/app.js";
+import type { Db, Logger } from "../../context/app.js";
 import type { Mailer } from "../mailer/types.js";
 import { eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { users } from "../../db/schema/users.js";
 import { generateToken, hashToken } from "../tokens.js";
 
+// 15-minute default — the Copenhagen Book / emdash convention for
+// passwordless sign-in tokens. Long enough to survive normal email
+// delivery, short enough that a stolen / leaked link is mostly stale.
+// Operators can lower via `auth.magicLink.ttlSeconds` (60–3600).
 const MAGIC_LINK_TTL_SECONDS = 15 * 60;
 
 // Artificial delay range when the recipient is unknown — adds enough
@@ -21,6 +25,13 @@ interface RequestMagicLinkInput {
   readonly mailer: Mailer;
   readonly siteName: string;
   readonly ttlSeconds?: number;
+  /**
+   * Optional logger for swallowed mailer errors. The function never
+   * throws (so the response can stay shape-identical on every code
+   * path), but a transport failure is still operator-visible signal —
+   * route this through the request logger when one is available.
+   */
+  readonly logger?: Pick<Logger, "warn">;
 }
 
 /**
@@ -74,10 +85,11 @@ export async function requestMagicLink(
       text: composeText(input.siteName, verifyUrl.toString()),
       html: composeHtml(input.siteName, verifyUrl.toString()),
     });
-  } catch {
-    // Swallow — we already issued the token (next attempt will replace
-    // it). Surfacing the failure to the caller would leak that the
-    // recipient is registered. Route layer logs from its own catch.
+  } catch (error) {
+    // Swallow toward the caller — surfacing this would leak that the
+    // recipient is registered. Log it server-side so the operator sees
+    // the failure (otherwise broken mail config would be silent).
+    input.logger?.warn("magic_link_mailer_failed", { error });
   }
 }
 

--- a/packages/core/src/auth/magic-link/request.ts
+++ b/packages/core/src/auth/magic-link/request.ts
@@ -1,6 +1,7 @@
 import type { Db, Logger } from "../../context/app.js";
 import type { Mailer } from "../mailer/types.js";
 import { eq } from "../../db/index.js";
+import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { users } from "../../db/schema/users.js";
 import { generateToken, hashToken } from "../tokens.js";
@@ -35,17 +36,25 @@ interface RequestMagicLinkInput {
 }
 
 /**
- * Issue a magic-link if (and only if) a user with this email exists.
- * Always behaves identically from the caller's perspective regardless of
- * whether the recipient is registered — the route layer turns this into
- * an "If an account exists, we sent you a link" response. Per Copenhagen
- * Book / emdash: don't reveal email existence via response timing or
- * shape; honour that here at the function boundary.
+ * Issue a magic-link for sign-in or domain-gated signup.
  *
- * Errors from the mailer are swallowed (logged at the route layer if
- * the caller wires logging in). The function never throws; it returns
- * normally regardless of outcome. Sign-in only — does not provision new
- * users; an unknown email is a silent no-op.
+ *   sign-in (existing user)        → token row carries `userId = user.id`.
+ *   signup (allowed-domain match)  → token row carries `userId = null`,
+ *                                    role omitted (resolved at verify).
+ *   neither                        → silent no-op + timing delay.
+ *
+ * Always behaves identically from the caller's perspective regardless of
+ * which branch fired — the route layer turns this into an "If an
+ * account exists or self-signup is open, we sent you a link" response.
+ * Per Copenhagen Book / emdash: don't reveal email existence via
+ * response timing or shape; honour that here at the function boundary.
+ *
+ * Bootstrap rail: signup is refused when the system has zero users
+ * (matches OAuth — first-admin must enrol via passkey).
+ *
+ * Errors from the mailer are swallowed (logged via input.logger when
+ * present). The function never throws; it returns normally regardless
+ * of outcome.
  */
 export async function requestMagicLink(
   db: Db,
@@ -58,19 +67,63 @@ export async function requestMagicLink(
     where: eq(users.email, email),
   });
 
-  if (!user || user.disabledAt) {
+  // Sign-in path — existing active user.
+  if (user && !user.disabledAt) {
+    await issueAndSend(db, input, ttlSeconds, {
+      userId: user.id,
+      email: user.email,
+    });
+    return;
+  }
+  if (user?.disabledAt) {
+    // Disabled user: no signup attempt, silent no-op + jitter.
     await timingDelay();
     return;
   }
 
+  // Signup path — no user yet. Gate on allowed_domains + non-zero
+  // user count so the bootstrap-via-passkey rule holds.
+  const domain = extractDomain(email);
+  if (!domain) {
+    await timingDelay();
+    return;
+  }
+  const allowed = await db.query.allowedDomains.findFirst({
+    where: eq(allowedDomains.domain, domain),
+  });
+  if (!allowed?.isEnabled) {
+    await timingDelay();
+    return;
+  }
+  const userCount = await db.$count(users);
+  if (userCount === 0) {
+    // Refuse signup before bootstrap completes. Same rail OAuth uses.
+    await timingDelay();
+    return;
+  }
+
+  await issueAndSend(db, input, ttlSeconds, { userId: null, email });
+}
+
+interface IssueAndSendInput {
+  readonly userId: number | null;
+  readonly email: string;
+}
+
+async function issueAndSend(
+  db: Db,
+  input: RequestMagicLinkInput,
+  ttlSeconds: number,
+  target: IssueAndSendInput,
+): Promise<void> {
   const token = generateToken();
   const hash = await hashToken(token);
   const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
 
   await db.insert(authTokens).values({
     hash,
-    userId: user.id,
-    email: user.email,
+    userId: target.userId,
+    email: target.email,
     type: "magic_link",
     expiresAt,
   });
@@ -79,11 +132,13 @@ export async function requestMagicLink(
   verifyUrl.searchParams.set("token", token);
 
   try {
+    // Plain-text body only. Branded HTML / template rendering is the
+    // operator's call — they wrap their `Mailer` adapter and template
+    // however they like. Plumix is not in the email-design business.
     await input.mailer.send({
-      to: user.email,
+      to: target.email,
       subject: `Sign in to ${input.siteName}`,
-      text: composeText(input.siteName, verifyUrl.toString()),
-      html: composeHtml(input.siteName, verifyUrl.toString()),
+      text: composeText(input.siteName, verifyUrl.toString(), ttlSeconds),
     });
   } catch (error) {
     // Swallow toward the caller — surfacing this would leak that the
@@ -93,43 +148,26 @@ export async function requestMagicLink(
   }
 }
 
-function composeText(siteName: string, url: string): string {
+function extractDomain(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at < 0 || at === email.length - 1) return null;
+  return email.slice(at + 1).toLowerCase();
+}
+
+function composeText(
+  siteName: string,
+  url: string,
+  ttlSeconds: number,
+): string {
   return [
     `Sign in to ${siteName} by opening this link:`,
     "",
     url,
     "",
-    `The link expires in ${MAGIC_LINK_TTL_SECONDS / 60} minutes.`,
+    `The link expires in ${Math.round(ttlSeconds / 60)} minutes.`,
     "",
     "If you didn't request this, you can ignore this email.",
   ].join("\n");
-}
-
-function composeHtml(siteName: string, url: string): string {
-  const safeName = escapeHtml(siteName);
-  // The URL is server-generated (origin from app.origin + token from our
-  // crypto-random generator), so it's already HTML-safe. Still, route it
-  // through escapeHtml for defense-in-depth.
-  const safeUrl = escapeHtml(url);
-  return `<!doctype html>
-<html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;line-height:1.5;color:#333;max-width:600px;margin:0 auto;padding:24px">
-<h1 style="font-size:20px;margin:0 0 16px">Sign in to ${safeName}</h1>
-<p>Click the button below to sign in:</p>
-<p style="margin:24px 0">
-  <a href="${safeUrl}" style="background:#0f172a;color:#fff;padding:12px 20px;text-decoration:none;border-radius:6px;display:inline-block">Sign in</a>
-</p>
-<p style="color:#666;font-size:14px">The link expires in ${MAGIC_LINK_TTL_SECONDS / 60} minutes.</p>
-<p style="color:#666;font-size:14px">If you didn't request this, you can ignore this email.</p>
-</body></html>`;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 function timingDelay(): Promise<void> {

--- a/packages/core/src/auth/magic-link/routes.test.ts
+++ b/packages/core/src/auth/magic-link/routes.test.ts
@@ -56,7 +56,8 @@ describe("magic-link request route", () => {
   test("returns 200 with generic message and sends mail when user exists", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     await h.factory.user.create({
       email: "alice@example.com",
@@ -81,7 +82,8 @@ describe("magic-link request route", () => {
   test("returns the same shape when user does not exist (no enumeration)", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
 
     const response = await h.dispatch(
@@ -99,7 +101,8 @@ describe("magic-link request route", () => {
   test("rejects malformed input with 400", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
 
     const response = await h.dispatch(
@@ -113,7 +116,8 @@ describe("magic-link request route", () => {
   test("rejects missing CSRF header", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
 
     const response = await h.dispatch(
@@ -149,7 +153,8 @@ describe("magic-link verify route", () => {
   test("missing token redirects with magic_link_error=missing_token", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const response = await h.dispatch(
       getRequest("/_plumix/auth/magic-link/verify"),
@@ -163,7 +168,8 @@ describe("magic-link verify route", () => {
   test("happy path mints session, sets cookie, redirects to admin", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const user = await h.factory.user.create({
       email: "alice@example.com",
@@ -186,7 +192,8 @@ describe("magic-link verify route", () => {
   test("rejects an unknown token with token_invalid", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
 
     const response = await h.dispatch(
@@ -201,7 +208,8 @@ describe("magic-link verify route", () => {
   test("rejects an expired token with token_expired", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const user = await h.factory.user.create({ role: "editor" });
     const token = await seedToken(h, user.id, user.email, -1);
@@ -217,7 +225,8 @@ describe("magic-link verify route", () => {
   test("rejects when the linked user is disabled", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const user = await h.factory.user.create({
       role: "editor",
@@ -236,7 +245,8 @@ describe("magic-link verify route", () => {
   test("oversized token is rejected as token_invalid", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const huge = "x".repeat(512);
 
@@ -251,7 +261,8 @@ describe("magic-link verify route", () => {
   test("replay of a single-use token fails on second use", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const user = await h.factory.user.create({
       email: "alice@example.com",
@@ -280,7 +291,8 @@ describe("magic-link verify route", () => {
     // create a new session when the user signs in" rule.
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const user = await h.factory.user.create({
       email: "alice@example.com",
@@ -313,7 +325,8 @@ describe("magic-link verify route", () => {
   test("end-to-end signup: request → verify provisions user with the domain's role", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     await h.factory.user.create({ role: "admin" });
     await h.factory.allowedDomain.create({
@@ -360,7 +373,8 @@ describe("magic-link verify route", () => {
   test("signup verify rejects with domain_not_allowed if admin disables the domain mid-flight", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     await h.factory.user.create({ role: "admin" });
     const allowed = await h.factory.allowedDomain.create({
@@ -400,7 +414,8 @@ describe("magic-link verify route", () => {
   test("returns 405 on POST", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const response = await h.dispatch(
       new Request("https://cms.example/_plumix/auth/magic-link/verify", {
@@ -418,7 +433,8 @@ describe("magic-link verify route", () => {
     // covered above; this test is the explicit "unknown error" symbol.
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { siteName: "Plumix Test" }, mailer,
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
     });
     const verifySpy = vi
       .spyOn(console, "info")

--- a/packages/core/src/auth/magic-link/routes.test.ts
+++ b/packages/core/src/auth/magic-link/routes.test.ts
@@ -53,7 +53,9 @@ describe("magic-link request route", () => {
 
   test("returns 200 with generic message and sends mail when user exists", async () => {
     const { mailer, sent } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     await h.factory.user.create({
       email: "alice@example.com",
       role: "editor",
@@ -76,7 +78,9 @@ describe("magic-link request route", () => {
 
   test("returns the same shape when user does not exist (no enumeration)", async () => {
     const { mailer, sent } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
 
     const response = await h.dispatch(
       postRequest("/_plumix/auth/magic-link/request", {
@@ -92,7 +96,9 @@ describe("magic-link request route", () => {
 
   test("rejects malformed input with 400", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
 
     const response = await h.dispatch(
       postRequest("/_plumix/auth/magic-link/request", {
@@ -104,7 +110,9 @@ describe("magic-link request route", () => {
 
   test("rejects missing CSRF header", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
 
     const response = await h.dispatch(
       new Request("https://cms.example/_plumix/auth/magic-link/request", {
@@ -138,7 +146,9 @@ describe("magic-link verify route", () => {
 
   test("missing token redirects with magic_link_error=missing_token", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     const response = await h.dispatch(
       getRequest("/_plumix/auth/magic-link/verify"),
     );
@@ -150,7 +160,9 @@ describe("magic-link verify route", () => {
 
   test("happy path mints session, sets cookie, redirects to admin", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     const user = await h.factory.user.create({
       email: "alice@example.com",
       role: "editor",
@@ -171,7 +183,9 @@ describe("magic-link verify route", () => {
 
   test("rejects an unknown token with token_invalid", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
 
     const response = await h.dispatch(
       getRequest("/_plumix/auth/magic-link/verify?token=not-a-real-token"),
@@ -184,7 +198,9 @@ describe("magic-link verify route", () => {
 
   test("rejects an expired token with token_expired", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     const user = await h.factory.user.create({ role: "editor" });
     const token = await seedToken(h, user.id, user.email, -1);
 
@@ -198,7 +214,9 @@ describe("magic-link verify route", () => {
 
   test("rejects when the linked user is disabled", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     const user = await h.factory.user.create({
       role: "editor",
       disabledAt: new Date(),
@@ -215,7 +233,9 @@ describe("magic-link verify route", () => {
 
   test("oversized token is rejected as token_invalid", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     const huge = "x".repeat(512);
 
     const response = await h.dispatch(
@@ -228,7 +248,9 @@ describe("magic-link verify route", () => {
 
   test("replay of a single-use token fails on second use", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     const user = await h.factory.user.create({
       email: "alice@example.com",
       role: "editor",
@@ -248,9 +270,49 @@ describe("magic-link verify route", () => {
     );
   });
 
+  test("signed-in user clicking a magic-link mints a fresh session", async () => {
+    // Already-authenticated browser clicks the email link. The verify
+    // route mints a NEW session row and overwrites the cookie. The old
+    // row stays in the DB until its own TTL — that matches every other
+    // sign-in path (passkey, oauth) and the Copenhagen Book "always
+    // create a new session when the user signs in" rule.
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
+    const user = await h.factory.user.create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+    const existingSessioned = await h.authenticateRequest(
+      getRequest("/_plumix/auth/magic-link/verify"),
+      user.id,
+    );
+    const beforeCount = (await h.db.select().from(sessions)).length;
+    expect(beforeCount).toBe(1);
+
+    const token = await seedToken(h, user.id, "alice@example.com");
+    const cookie = existingSessioned.headers.get("cookie");
+    const response = await h.dispatch(
+      new Request(
+        `https://cms.example/_plumix/auth/magic-link/verify?token=${token}`,
+        { headers: cookie ? { cookie } : undefined },
+      ),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/_plumix/admin");
+
+    const sessionRows = await h.db.select().from(sessions);
+    expect(sessionRows).toHaveLength(2);
+    // Both belong to the same user.
+    for (const row of sessionRows) expect(row.userId).toBe(user.id);
+  });
+
   test("returns 405 on POST", async () => {
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     const response = await h.dispatch(
       new Request("https://cms.example/_plumix/auth/magic-link/verify", {
         method: "POST",
@@ -266,7 +328,9 @@ describe("magic-link verify route", () => {
     // "not found" branch which surfaces as token_invalid. Already
     // covered above; this test is the explicit "unknown error" symbol.
     const { mailer } = captureMailer();
-    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
     const verifySpy = vi
       .spyOn(console, "info")
       .mockImplementation(() => undefined);

--- a/packages/core/src/auth/magic-link/routes.test.ts
+++ b/packages/core/src/auth/magic-link/routes.test.ts
@@ -56,7 +56,7 @@ describe("magic-link request route", () => {
   test("returns 200 with generic message and sends mail when user exists", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     await h.factory.user.create({
       email: "alice@example.com",
@@ -81,7 +81,7 @@ describe("magic-link request route", () => {
   test("returns the same shape when user does not exist (no enumeration)", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
 
     const response = await h.dispatch(
@@ -99,7 +99,7 @@ describe("magic-link request route", () => {
   test("rejects malformed input with 400", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
 
     const response = await h.dispatch(
@@ -113,7 +113,7 @@ describe("magic-link request route", () => {
   test("rejects missing CSRF header", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
 
     const response = await h.dispatch(
@@ -149,7 +149,7 @@ describe("magic-link verify route", () => {
   test("missing token redirects with magic_link_error=missing_token", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const response = await h.dispatch(
       getRequest("/_plumix/auth/magic-link/verify"),
@@ -163,7 +163,7 @@ describe("magic-link verify route", () => {
   test("happy path mints session, sets cookie, redirects to admin", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const user = await h.factory.user.create({
       email: "alice@example.com",
@@ -186,7 +186,7 @@ describe("magic-link verify route", () => {
   test("rejects an unknown token with token_invalid", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
 
     const response = await h.dispatch(
@@ -201,7 +201,7 @@ describe("magic-link verify route", () => {
   test("rejects an expired token with token_expired", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const user = await h.factory.user.create({ role: "editor" });
     const token = await seedToken(h, user.id, user.email, -1);
@@ -217,7 +217,7 @@ describe("magic-link verify route", () => {
   test("rejects when the linked user is disabled", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const user = await h.factory.user.create({
       role: "editor",
@@ -236,7 +236,7 @@ describe("magic-link verify route", () => {
   test("oversized token is rejected as token_invalid", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const huge = "x".repeat(512);
 
@@ -251,7 +251,7 @@ describe("magic-link verify route", () => {
   test("replay of a single-use token fails on second use", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const user = await h.factory.user.create({
       email: "alice@example.com",
@@ -280,7 +280,7 @@ describe("magic-link verify route", () => {
     // create a new session when the user signs in" rule.
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const user = await h.factory.user.create({
       email: "alice@example.com",
@@ -313,7 +313,7 @@ describe("magic-link verify route", () => {
   test("end-to-end signup: request → verify provisions user with the domain's role", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     await h.factory.user.create({ role: "admin" });
     await h.factory.allowedDomain.create({
@@ -360,7 +360,7 @@ describe("magic-link verify route", () => {
   test("signup verify rejects with domain_not_allowed if admin disables the domain mid-flight", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     await h.factory.user.create({ role: "admin" });
     const allowed = await h.factory.allowedDomain.create({
@@ -400,7 +400,7 @@ describe("magic-link verify route", () => {
   test("returns 405 on POST", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const response = await h.dispatch(
       new Request("https://cms.example/_plumix/auth/magic-link/verify", {
@@ -418,7 +418,7 @@ describe("magic-link verify route", () => {
     // covered above; this test is the explicit "unknown error" symbol.
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
-      magicLink: { mailer, siteName: "Plumix Test" },
+      magicLink: { siteName: "Plumix Test" }, mailer,
     });
     const verifySpy = vi
       .spyOn(console, "info")

--- a/packages/core/src/auth/magic-link/routes.test.ts
+++ b/packages/core/src/auth/magic-link/routes.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test, vi } from "vitest";
 
 import type { Mailer } from "../mailer/types.js";
 import { eq } from "../../db/index.js";
+import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { sessions } from "../../db/schema/sessions.js";
+import { users } from "../../db/schema/users.js";
 import { createDispatcherHarness } from "../../test/dispatcher.js";
 import { generateToken, hashToken } from "../tokens.js";
 
@@ -306,6 +308,93 @@ describe("magic-link verify route", () => {
     expect(sessionRows).toHaveLength(2);
     // Both belong to the same user.
     for (const row of sessionRows) expect(row.userId).toBe(user.id);
+  });
+
+  test("end-to-end signup: request → verify provisions user with the domain's role", async () => {
+    const { mailer, sent } = captureMailer();
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
+    await h.factory.user.create({ role: "admin" });
+    await h.factory.allowedDomain.create({
+      domain: "example.com",
+      defaultRole: "contributor",
+      isEnabled: true,
+    });
+
+    // Step 1: request the link.
+    const requestResp = await h.dispatch(
+      postRequest("/_plumix/auth/magic-link/request", {
+        email: "newcomer@example.com",
+      }),
+    );
+    expect(requestResp.status).toBe(200);
+    expect(sent).toHaveLength(1);
+
+    // Step 2: parse the token from the emailed URL and click it.
+    const tokenMatch = /token=([A-Za-z0-9_-]+)/.exec(sent[0]?.text ?? "");
+    const token = tokenMatch?.[1];
+    if (!token) throw new Error("expected token in email");
+
+    const verifyResp = await h.dispatch(
+      getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
+    );
+    expect(verifyResp.status).toBe(302);
+    expect(verifyResp.headers.get("location")).toBe("/_plumix/admin");
+    expect(verifyResp.headers.get("set-cookie")).toContain("plumix_session=");
+
+    // The user was provisioned with the right role + email-verified mark.
+    const created = await h.db.query.users.findFirst({
+      where: eq(users.email, "newcomer@example.com"),
+    });
+    expect(created?.role).toBe("contributor");
+    expect(created?.emailVerifiedAt).not.toBeNull();
+    // A session was minted for them.
+    const sessionRows = await h.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.userId, created?.id ?? 0));
+    expect(sessionRows).toHaveLength(1);
+  });
+
+  test("signup verify rejects with domain_not_allowed if admin disables the domain mid-flight", async () => {
+    const { mailer, sent } = captureMailer();
+    const h = await createDispatcherHarness({
+      magicLink: { mailer, siteName: "Plumix Test" },
+    });
+    await h.factory.user.create({ role: "admin" });
+    const allowed = await h.factory.allowedDomain.create({
+      domain: "example.com",
+      defaultRole: "contributor",
+      isEnabled: true,
+    });
+
+    // Request issues a signup token while the domain is enabled.
+    await h.dispatch(
+      postRequest("/_plumix/auth/magic-link/request", {
+        email: "newcomer@example.com",
+      }),
+    );
+    const tokenMatch = /token=([A-Za-z0-9_-]+)/.exec(sent[0]?.text ?? "");
+    const token = tokenMatch?.[1];
+    if (!token) throw new Error("expected token in email");
+
+    // Admin disables the domain before the user clicks.
+    await h.db
+      .update(allowedDomains)
+      .set({ isEnabled: false })
+      .where(eq(allowedDomains.domain, allowed.domain));
+
+    const verifyResp = await h.dispatch(
+      getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
+    );
+    expect(verifyResp.headers.get("location")).toContain(
+      "magic_link_error=domain_not_allowed",
+    );
+    const created = await h.db.query.users.findFirst({
+      where: eq(users.email, "newcomer@example.com"),
+    });
+    expect(created).toBeUndefined();
   });
 
   test("returns 405 on POST", async () => {

--- a/packages/core/src/auth/magic-link/routes.test.ts
+++ b/packages/core/src/auth/magic-link/routes.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Mailer } from "../mailer/types.js";
+import { eq } from "../../db/index.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { sessions } from "../../db/schema/sessions.js";
+import { createDispatcherHarness } from "../../test/dispatcher.js";
+import { generateToken, hashToken } from "../tokens.js";
+
+interface CapturedSend {
+  readonly to: string;
+  readonly subject: string;
+  readonly text: string;
+  readonly html?: string;
+}
+
+function captureMailer(): { mailer: Mailer; sent: CapturedSend[] } {
+  const sent: CapturedSend[] = [];
+  return {
+    sent,
+    mailer: {
+      send(message) {
+        sent.push({ ...message });
+        return Promise.resolve();
+      },
+    },
+  };
+}
+
+function postRequest(path: string, body: unknown): Request {
+  return new Request(`https://cms.example${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-plumix-request": "1",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function getRequest(path: string): Request {
+  return new Request(`https://cms.example${path}`);
+}
+
+describe("magic-link request route", () => {
+  test("returns 503 when magic-link is not configured", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      postRequest("/_plumix/auth/magic-link/request", { email: "x@y.z" }),
+    );
+    expect(response.status).toBe(503);
+  });
+
+  test("returns 200 with generic message and sends mail when user exists", async () => {
+    const { mailer, sent } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    await h.factory.user.create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+
+    const response = await h.dispatch(
+      postRequest("/_plumix/auth/magic-link/request", {
+        email: "alice@example.com",
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; message: string };
+    expect(body.ok).toBe(true);
+    expect(body.message).toMatch(/account exists/i);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.text).toContain(
+      "https://cms.example/_plumix/auth/magic-link/verify?token=",
+    );
+  });
+
+  test("returns the same shape when user does not exist (no enumeration)", async () => {
+    const { mailer, sent } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+
+    const response = await h.dispatch(
+      postRequest("/_plumix/auth/magic-link/request", {
+        email: "stranger@example.com",
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; message: string };
+    expect(body.ok).toBe(true);
+    expect(body.message).toMatch(/account exists/i);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("rejects malformed input with 400", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+
+    const response = await h.dispatch(
+      postRequest("/_plumix/auth/magic-link/request", {
+        email: "not-an-email",
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("rejects missing CSRF header", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/magic-link/request", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "x@y.z" }),
+      }),
+    );
+    expect(response.status).toBe(403);
+  });
+});
+
+describe("magic-link verify route", () => {
+  async function seedToken(
+    h: Awaited<ReturnType<typeof createDispatcherHarness>>,
+    userId: number,
+    email: string,
+    ttlSeconds: number = 15 * 60,
+  ): Promise<string> {
+    const token = generateToken();
+    const hash = await hashToken(token);
+    await h.db.insert(authTokens).values({
+      hash,
+      userId,
+      email,
+      type: "magic_link",
+      expiresAt: new Date(Date.now() + ttlSeconds * 1000),
+    });
+    return token;
+  }
+
+  test("missing token redirects with magic_link_error=missing_token", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const response = await h.dispatch(
+      getRequest("/_plumix/auth/magic-link/verify"),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "magic_link_error=missing_token",
+    );
+  });
+
+  test("happy path mints session, sets cookie, redirects to admin", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const user = await h.factory.user.create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+    const token = await seedToken(h, user.id, "alice@example.com");
+
+    const response = await h.dispatch(
+      getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/_plumix/admin");
+    expect(response.headers.get("set-cookie")).toContain("plumix_session=");
+
+    const sessionRows = await h.db.select().from(sessions);
+    expect(sessionRows).toHaveLength(1);
+    expect(sessionRows[0]?.userId).toBe(user.id);
+  });
+
+  test("rejects an unknown token with token_invalid", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+
+    const response = await h.dispatch(
+      getRequest("/_plumix/auth/magic-link/verify?token=not-a-real-token"),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "magic_link_error=token_invalid",
+    );
+  });
+
+  test("rejects an expired token with token_expired", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const user = await h.factory.user.create({ role: "editor" });
+    const token = await seedToken(h, user.id, user.email, -1);
+
+    const response = await h.dispatch(
+      getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
+    );
+    expect(response.headers.get("location")).toContain(
+      "magic_link_error=token_expired",
+    );
+  });
+
+  test("rejects when the linked user is disabled", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const user = await h.factory.user.create({
+      role: "editor",
+      disabledAt: new Date(),
+    });
+    const token = await seedToken(h, user.id, user.email);
+
+    const response = await h.dispatch(
+      getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
+    );
+    expect(response.headers.get("location")).toContain(
+      "magic_link_error=account_disabled",
+    );
+  });
+
+  test("oversized token is rejected as token_invalid", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const huge = "x".repeat(512);
+
+    const response = await h.dispatch(
+      getRequest(`/_plumix/auth/magic-link/verify?token=${huge}`),
+    );
+    expect(response.headers.get("location")).toContain(
+      "magic_link_error=token_invalid",
+    );
+  });
+
+  test("replay of a single-use token fails on second use", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const user = await h.factory.user.create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+    const token = await seedToken(h, user.id, "alice@example.com");
+
+    const first = await h.dispatch(
+      getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
+    );
+    expect(first.headers.get("location")).toBe("/_plumix/admin");
+
+    const replay = await h.dispatch(
+      getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
+    );
+    expect(replay.headers.get("location")).toContain(
+      "magic_link_error=token_invalid",
+    );
+  });
+
+  test("returns 405 on POST", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/magic-link/verify", {
+        method: "POST",
+        headers: { "x-plumix-request": "1" },
+      }),
+    );
+    expect(response.status).toBe(405);
+  });
+
+  test("logs and surfaces a generic token_invalid for unexpected errors", async () => {
+    // Spy on the request schema parser by passing a token that's neither
+    // missing nor in DB nor oversized — it just hits the standard
+    // "not found" branch which surfaces as token_invalid. Already
+    // covered above; this test is the explicit "unknown error" symbol.
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({ magicLink: { mailer } });
+    const verifySpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+    try {
+      await h.dispatch(getRequest("/_plumix/auth/magic-link/verify?token=zzz"));
+    } finally {
+      verifySpy.mockRestore();
+    }
+    const remaining = await h.db
+      .select()
+      .from(authTokens)
+      .where(eq(authTokens.type, "magic_link"));
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/packages/core/src/auth/magic-link/routes.ts
+++ b/packages/core/src/auth/magic-link/routes.ts
@@ -1,0 +1,138 @@
+import * as v from "valibot";
+
+import type { AppContext } from "../../context/app.js";
+import type { PlumixApp } from "../../runtime/app.js";
+import type { MagicLinkErrorCode } from "./errors.js";
+import { jsonResponse } from "../../runtime/http.js";
+import { buildSessionCookie, isSecureRequest } from "../cookies.js";
+import { createSession } from "../sessions.js";
+import { MagicLinkError } from "./errors.js";
+import { requestMagicLink } from "./request.js";
+import { verifyMagicLink } from "./verify.js";
+
+const ADMIN_PATH = "/_plumix/admin";
+const LOGIN_PATH = "/_plumix/admin/login";
+
+// Defensive bound on the inbound `token` query param. Our generator
+// emits 192-bit base64url (32 chars); 256 chars is generous for
+// future-proofing while bounding malformed-callback amplification.
+const MAX_TOKEN_LENGTH = 256;
+
+const requestInputSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.trim(),
+    v.toLowerCase(),
+    v.email(),
+    v.maxLength(255),
+  ),
+});
+
+/**
+ * POST /_plumix/auth/magic-link/request — JSON body `{ email }`.
+ *
+ * Always responds with 200 and a generic "If an account exists…"
+ * message regardless of whether the recipient is registered. The
+ * dispatcher's CSRF gate fires before this handler (custom header +
+ * Origin check); we don't need additional CSRF here.
+ */
+export async function handleMagicLinkRequest(
+  ctx: AppContext,
+  app: PlumixApp,
+): Promise<Response> {
+  if (!app.config.auth.magicLink) {
+    return jsonResponse(
+      { error: "magic_link_not_configured" },
+      { status: 503 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await ctx.request.json();
+  } catch {
+    return invalidInput();
+  }
+  const parsed = v.safeParse(requestInputSchema, body);
+  if (!parsed.success) return invalidInput();
+
+  try {
+    await requestMagicLink(ctx.db, {
+      email: parsed.output.email,
+      origin: app.origin,
+      mailer: app.config.auth.magicLink.mailer,
+      siteName: app.config.auth.magicLink.siteName ?? app.passkey.rpName,
+      ttlSeconds: app.config.auth.magicLink.ttlSeconds,
+    });
+  } catch (error) {
+    // requestMagicLink swallows mailer errors internally; anything that
+    // reaches here is a programming error (DB failure, etc.). Log but
+    // still respond identically to keep the always-success contract.
+    ctx.logger.error("magic_link_request_failed", { error });
+  }
+
+  return jsonResponse({
+    ok: true,
+    message: "If an account exists for this email, we sent a sign-in link.",
+  });
+}
+
+/**
+ * GET /_plumix/auth/magic-link/verify?token=…
+ *
+ * Top-level navigation from the user's email client; consumes the
+ * single-use token, mints a session, redirects to /admin. Errors
+ * redirect to /admin/login with a typed `magic_link_error=<code>`.
+ */
+export async function handleMagicLinkVerify(
+  ctx: AppContext,
+  app: PlumixApp,
+): Promise<Response> {
+  if (!app.config.auth.magicLink) {
+    return loginError("token_invalid");
+  }
+
+  const url = new URL(ctx.request.url);
+  const token = url.searchParams.get("token");
+  if (!token) return loginError("missing_token");
+  if (token.length > MAX_TOKEN_LENGTH) return loginError("token_invalid");
+
+  try {
+    const user = await verifyMagicLink(ctx.db, token);
+    const { token: sessionToken } = await createSession(
+      ctx.db,
+      { userId: user.id },
+      app.sessionPolicy,
+    );
+    const cookie = buildSessionCookie(sessionToken, {
+      maxAgeSeconds: app.sessionPolicy.maxAgeSeconds,
+      secure: isSecureRequest(ctx.request),
+      sameSite: "Lax",
+    });
+    return redirectTo(ADMIN_PATH, { "set-cookie": cookie });
+  } catch (error) {
+    if (error instanceof MagicLinkError) {
+      ctx.logger.warn("magic_link_verify_rejected", { code: error.code });
+      return loginError(error.code);
+    }
+    ctx.logger.error("magic_link_verify_failed", { error });
+    return loginError("token_invalid");
+  }
+}
+
+function invalidInput(): Response {
+  return jsonResponse({ error: "invalid_input" }, { status: 400 });
+}
+
+function redirectTo(
+  location: string,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  const headers = new Headers({ Location: location, ...extraHeaders });
+  return new Response(null, { status: 302, headers });
+}
+
+function loginError(code: MagicLinkErrorCode): Response {
+  const params = new URLSearchParams({ magic_link_error: code });
+  return redirectTo(`${LOGIN_PATH}?${params.toString()}`);
+}

--- a/packages/core/src/auth/magic-link/routes.ts
+++ b/packages/core/src/auth/magic-link/routes.ts
@@ -40,6 +40,9 @@ export async function handleMagicLinkRequest(
   ctx: AppContext,
   app: PlumixApp,
 ): Promise<Response> {
+  // 503 distinguishes "plumix doesn't have magic-link wired up" (operator
+  // omission, should fail loudly) from "this email isn't registered"
+  // (always-success contract, intentionally silent). Don't fold them.
   if (!app.config.auth.magicLink) {
     return jsonResponse(
       { error: "magic_link_not_configured" },
@@ -61,13 +64,17 @@ export async function handleMagicLinkRequest(
       email: parsed.output.email,
       origin: app.origin,
       mailer: app.config.auth.magicLink.mailer,
-      siteName: app.config.auth.magicLink.siteName ?? app.passkey.rpName,
+      siteName: app.config.auth.magicLink.siteName,
       ttlSeconds: app.config.auth.magicLink.ttlSeconds,
+      logger: ctx.logger,
     });
   } catch (error) {
     // requestMagicLink swallows mailer errors internally; anything that
-    // reaches here is a programming error (DB failure, etc.). Log but
-    // still respond identically to keep the always-success contract.
+    // reaches here is a programming error (DB outage, etc.). The
+    // always-success contract is non-negotiable — distinguishing
+    // success from "DB blew up while looking up your email" would let
+    // an attacker fingerprint the registered set via response codes.
+    // Log server-side; respond identically.
     ctx.logger.error("magic_link_request_failed", { error });
   }
 

--- a/packages/core/src/auth/magic-link/routes.ts
+++ b/packages/core/src/auth/magic-link/routes.ts
@@ -43,7 +43,10 @@ export async function handleMagicLinkRequest(
   // 503 distinguishes "plumix doesn't have magic-link wired up" (operator
   // omission, should fail loudly) from "this email isn't registered"
   // (always-success contract, intentionally silent). Don't fold them.
-  if (!app.config.auth.magicLink) {
+  // The cross-field check in `plumix()` prevents `magicLink` from being
+  // configured without a top-level mailer, so `ctx.mailer` is reliably
+  // present here when `magicLink` is. Belt + braces: re-check both.
+  if (!app.config.auth.magicLink || !ctx.mailer) {
     return jsonResponse(
       { error: "magic_link_not_configured" },
       { status: 503 },
@@ -63,7 +66,7 @@ export async function handleMagicLinkRequest(
     await requestMagicLink(ctx.db, {
       email: parsed.output.email,
       origin: app.origin,
-      mailer: app.config.auth.magicLink.mailer,
+      mailer: ctx.mailer,
       siteName: app.config.auth.magicLink.siteName,
       ttlSeconds: app.config.auth.magicLink.ttlSeconds,
       logger: ctx.logger,

--- a/packages/core/src/auth/magic-link/verify.test.ts
+++ b/packages/core/src/auth/magic-link/verify.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+
+import { eq } from "../../db/index.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { userFactory } from "../../test/factories.js";
+import { createTestDb } from "../../test/harness.js";
+import { generateToken, hashToken } from "../tokens.js";
+import { MagicLinkError } from "./errors.js";
+import { verifyMagicLink } from "./verify.js";
+
+async function seedToken(
+  db: Awaited<ReturnType<typeof createTestDb>>,
+  userId: number,
+  email: string,
+  ttlSeconds: number = 15 * 60,
+): Promise<string> {
+  const token = generateToken();
+  const hash = await hashToken(token);
+  await db.insert(authTokens).values({
+    hash,
+    userId,
+    email,
+    type: "magic_link",
+    expiresAt: new Date(Date.now() + ttlSeconds * 1000),
+  });
+  return token;
+}
+
+describe("verifyMagicLink", () => {
+  test("returns the user and deletes the row on success", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+    const token = await seedToken(db, user.id, "alice@example.com");
+
+    const result = await verifyMagicLink(db, token);
+    expect(result.id).toBe(user.id);
+
+    // Row gone — replay rejects.
+    const remaining = await db.select().from(authTokens);
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("rejects an unknown token with token_invalid", async () => {
+    const db = await createTestDb();
+    await expect(
+      verifyMagicLink(db, "definitely-not-a-token"),
+    ).rejects.toMatchObject({ code: "token_invalid" });
+  });
+
+  test("rejects an expired token with token_expired (and removes the row)", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({
+      role: "editor",
+      email: "x@y.z",
+    });
+    const token = await seedToken(db, user.id, "x@y.z", -1);
+
+    await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
+      code: "token_expired",
+    });
+
+    const remaining = await db.select().from(authTokens);
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("rejects when the linked user is disabled", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({
+      role: "editor",
+      email: "x@y.z",
+      disabledAt: new Date(),
+    });
+    const token = await seedToken(db, user.id, "x@y.z");
+
+    await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
+      code: "account_disabled",
+    });
+  });
+
+  test("ignores tokens of a different type stored under the same hash", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
+    // Insert an invite-typed row whose hash matches what verifyMagicLink
+    // would compute for a chosen raw token. Verify that we don't accept
+    // it as a magic-link.
+    const raw = generateToken();
+    const hash = await hashToken(raw);
+    await db.insert(authTokens).values({
+      hash,
+      userId: user.id,
+      email: user.email,
+      type: "invite",
+      role: "subscriber",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await expect(verifyMagicLink(db, raw)).rejects.toMatchObject({
+      code: "token_invalid",
+    });
+
+    // The invite row is untouched.
+    const row = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, hash),
+    });
+    expect(row?.type).toBe("invite");
+  });
+
+  test("throws MagicLinkError instances for all reject paths", async () => {
+    const db = await createTestDb();
+    await expect(verifyMagicLink(db, "x")).rejects.toBeInstanceOf(
+      MagicLinkError,
+    );
+  });
+});

--- a/packages/core/src/auth/magic-link/verify.test.ts
+++ b/packages/core/src/auth/magic-link/verify.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "vitest";
 
 import { eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
-import { userFactory } from "../../test/factories.js";
+import { users } from "../../db/schema/users.js";
+import { allowedDomainFactory, userFactory } from "../../test/factories.js";
 import { createTestDb } from "../../test/harness.js";
 import { generateToken, hashToken } from "../tokens.js";
 import { MagicLinkError } from "./errors.js";
@@ -10,7 +11,7 @@ import { verifyMagicLink } from "./verify.js";
 
 async function seedToken(
   db: Awaited<ReturnType<typeof createTestDb>>,
-  userId: number,
+  userId: number | null,
   email: string,
   ttlSeconds: number = 15 * 60,
 ): Promise<string> {
@@ -113,5 +114,112 @@ describe("verifyMagicLink", () => {
     await expect(verifyMagicLink(db, "x")).rejects.toBeInstanceOf(
       MagicLinkError,
     );
+  });
+});
+
+describe("verifyMagicLink — signup branch (userId null)", () => {
+  test("provisions a user with the domain's defaultRole + emailVerifiedAt set", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "author",
+      isEnabled: true,
+    });
+    const token = await seedToken(db, null, "newcomer@example.com");
+
+    const result = await verifyMagicLink(db, token);
+    expect(result.email).toBe("newcomer@example.com");
+    expect(result.role).toBe("author");
+    expect(result.emailVerifiedAt).not.toBeNull();
+
+    // The token row is gone (single-use).
+    const remaining = await db.select().from(authTokens);
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("rejects with domain_not_allowed when the domain was disabled mid-flight", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    // Domain was enabled at request time (token issued), then admin
+    // disabled it before the user clicked.
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "author",
+      isEnabled: false,
+    });
+    const token = await seedToken(db, null, "newcomer@example.com");
+
+    await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
+      code: "domain_not_allowed",
+    });
+    // No user was provisioned.
+    const created = await db.query.users.findFirst({
+      where: eq(users.email, "newcomer@example.com"),
+    });
+    expect(created).toBeUndefined();
+  });
+
+  test("rejects with domain_not_allowed when the allowed-domains row was removed mid-flight", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    const token = await seedToken(db, null, "newcomer@example.com");
+    // No allowed_domains row at all — domain was deleted between request
+    // and verify, or the row never existed (defensive: token was hand-
+    // rolled).
+
+    await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
+      code: "domain_not_allowed",
+    });
+  });
+
+  test("rejects with registration_closed when the system has zero users at verify time", async () => {
+    const db = await createTestDb();
+    await allowedDomainFactory.transient({ db }).create({
+      domain: "example.com",
+      defaultRole: "admin",
+      isEnabled: true,
+    });
+    // Hand-rolled signup token — the request path would refuse to
+    // issue this when zero users exist, but a hand-rolled DB state or
+    // a now-deleted-admin race could surface it.
+    const token = await seedToken(db, null, "newcomer@example.com");
+
+    await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
+      code: "registration_closed",
+    });
+  });
+
+  test("falls through to sign-in if a user with this email exists at verify time", async () => {
+    // Race: two paths created the same user during the 15-min window —
+    // OAuth signup completed while the magic-link signup token was
+    // pending. The link click should sign the user into the now-
+    // existing row, not refuse and not duplicate.
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    const raced = await userFactory.transient({ db }).create({
+      email: "newcomer@example.com",
+      role: "subscriber",
+    });
+    const token = await seedToken(db, null, "newcomer@example.com");
+
+    const result = await verifyMagicLink(db, token);
+    expect(result.id).toBe(raced.id);
+    expect(result.role).toBe("subscriber");
+  });
+
+  test("rejects when the raced existing user is disabled", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({ role: "admin" });
+    await userFactory.transient({ db }).create({
+      email: "newcomer@example.com",
+      role: "subscriber",
+      disabledAt: new Date(),
+    });
+    const token = await seedToken(db, null, "newcomer@example.com");
+
+    await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
+      code: "account_disabled",
+    });
   });
 });

--- a/packages/core/src/auth/magic-link/verify.ts
+++ b/packages/core/src/auth/magic-link/verify.ts
@@ -1,17 +1,29 @@
 import type { Db } from "../../context/app.js";
 import type { User } from "../../db/schema/users.js";
-import { and, eq } from "../../db/index.js";
+import { and, eq, isUniqueConstraintError } from "../../db/index.js";
+import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { users } from "../../db/schema/users.js";
+import { provisionUser } from "../bootstrap.js";
 import { hashToken } from "../tokens.js";
 import { MagicLinkError } from "./errors.js";
 
 /**
- * Consume a magic-link token and return the matching user. Atomic
- * compare-and-delete via `DELETE … RETURNING` — a concurrent second
- * verify of the same token sees an empty result, never the same row
- * twice. Scoped by `type='magic_link'` so a hash collision with another
- * token type can't accidentally consume that row.
+ * Consume a magic-link token and return the matching user.
+ *
+ *   userId set in the token row → sign-in (existing user).
+ *   userId null in the token row → signup. Re-check `allowed_domains`
+ *     at this moment (admin could have disabled the domain after
+ *     issuance), refuse if zero users (bootstrap rail), then provision.
+ *
+ * Atomic compare-and-delete via `DELETE … RETURNING` — a concurrent
+ * second verify of the same token sees an empty result, never the same
+ * row twice. Scoped by `type='magic_link'` so a hash collision with
+ * another token type can't accidentally consume that row.
+ *
+ * The link click implicitly verifies that the user has access to the
+ * email's inbox — no separate emailVerified gate is needed (unlike the
+ * OAuth path, where the provider's verified-email claim is the gate).
  */
 export async function verifyMagicLink(db: Db, rawToken: string): Promise<User> {
   const hash = await hashToken(rawToken);
@@ -25,16 +37,81 @@ export async function verifyMagicLink(db: Db, rawToken: string): Promise<User> {
   if (row.expiresAt.getTime() < Date.now()) {
     throw new MagicLinkError("token_expired");
   }
-  if (row.userId === null) {
+  if (row.email === null) {
     // Defensive: every magic_link row written by `requestMagicLink`
-    // sets userId. A null here means hand-rolled DB state.
+    // sets email. A null here means hand-rolled DB state.
     throw new MagicLinkError("token_invalid");
   }
 
+  if (row.userId !== null) {
+    return resolveExistingUser(db, row.userId);
+  }
+  return resolveSignup(db, row.email);
+}
+
+async function resolveExistingUser(db: Db, userId: number): Promise<User> {
   const user = await db.query.users.findFirst({
-    where: eq(users.id, row.userId),
+    where: eq(users.id, userId),
   });
   if (!user) throw new MagicLinkError("token_invalid");
   if (user.disabledAt) throw new MagicLinkError("account_disabled");
   return user;
+}
+
+async function resolveSignup(db: Db, email: string): Promise<User> {
+  // The token was issued because no user existed and the domain was
+  // allowed. Anything could have changed in the meantime — re-check
+  // every gate at the verify boundary.
+
+  // Race vs another sign-in path (passkey, oauth) creating the same
+  // email. Treat that as a successful sign-in for the existing user —
+  // the click verifies the email, which is at least as strong as
+  // OAuth's email-verified link path.
+  const existing = await db.query.users.findFirst({
+    where: eq(users.email, email),
+  });
+  if (existing) {
+    if (existing.disabledAt) throw new MagicLinkError("account_disabled");
+    return existing;
+  }
+
+  const userCount = await db.$count(users);
+  if (userCount === 0) {
+    throw new MagicLinkError("registration_closed");
+  }
+
+  const domain = extractDomain(email);
+  if (!domain) throw new MagicLinkError("token_invalid");
+  const allowed = await db.query.allowedDomains.findFirst({
+    where: eq(allowedDomains.domain, domain),
+  });
+  if (!allowed?.isEnabled) {
+    throw new MagicLinkError("domain_not_allowed");
+  }
+
+  try {
+    const { user } = await provisionUser(db, {
+      email,
+      defaultRole: allowed.defaultRole,
+      emailVerified: true,
+    });
+    return user;
+  } catch (error) {
+    // Race: another path created a user with this email between the
+    // existing-user check above and this insert. Re-resolve and treat
+    // as sign-in.
+    if (!isUniqueConstraintError(error)) throw error;
+    const raced = await db.query.users.findFirst({
+      where: eq(users.email, email),
+    });
+    if (!raced) throw error;
+    if (raced.disabledAt) throw new MagicLinkError("account_disabled");
+    return raced;
+  }
+}
+
+function extractDomain(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at < 0 || at === email.length - 1) return null;
+  return email.slice(at + 1).toLowerCase();
 }

--- a/packages/core/src/auth/magic-link/verify.ts
+++ b/packages/core/src/auth/magic-link/verify.ts
@@ -1,0 +1,40 @@
+import type { Db } from "../../context/app.js";
+import type { User } from "../../db/schema/users.js";
+import { and, eq } from "../../db/index.js";
+import { authTokens } from "../../db/schema/auth_tokens.js";
+import { users } from "../../db/schema/users.js";
+import { hashToken } from "../tokens.js";
+import { MagicLinkError } from "./errors.js";
+
+/**
+ * Consume a magic-link token and return the matching user. Atomic
+ * compare-and-delete via `DELETE … RETURNING` — a concurrent second
+ * verify of the same token sees an empty result, never the same row
+ * twice. Scoped by `type='magic_link'` so a hash collision with another
+ * token type can't accidentally consume that row.
+ */
+export async function verifyMagicLink(db: Db, rawToken: string): Promise<User> {
+  const hash = await hashToken(rawToken);
+
+  const [row] = await db
+    .delete(authTokens)
+    .where(and(eq(authTokens.hash, hash), eq(authTokens.type, "magic_link")))
+    .returning();
+
+  if (!row) throw new MagicLinkError("token_invalid");
+  if (row.expiresAt.getTime() < Date.now()) {
+    throw new MagicLinkError("token_expired");
+  }
+  if (row.userId === null) {
+    // Defensive: every magic_link row written by `requestMagicLink`
+    // sets userId. A null here means hand-rolled DB state.
+    throw new MagicLinkError("token_invalid");
+  }
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, row.userId),
+  });
+  if (!user) throw new MagicLinkError("token_invalid");
+  if (user.disabledAt) throw new MagicLinkError("account_disabled");
+  return user;
+}

--- a/packages/core/src/auth/mailer/console.test.ts
+++ b/packages/core/src/auth/mailer/console.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { EmailMessage } from "./types.js";
+import { consoleMailer } from "./console.js";
+
+type LoggerCall = readonly [tag: string, meta: EmailMessage];
+
+describe("consoleMailer", () => {
+  test("logs the message at info level and resolves", async () => {
+    const info = vi.fn();
+    const mailer = consoleMailer({ logger: { info } });
+
+    await mailer.send({
+      to: "alice@example.com",
+      subject: "hi",
+      text: "hello",
+    });
+
+    expect(info).toHaveBeenCalledOnce();
+    const call = info.mock.calls[0] as LoggerCall | undefined;
+    if (!call) throw new Error("logger not called");
+    const [tag, meta] = call;
+    expect(tag).toBe("[mailer:console]");
+    expect(meta).toMatchObject({
+      to: "alice@example.com",
+      subject: "hi",
+      text: "hello",
+    });
+    expect(meta).not.toHaveProperty("html");
+  });
+
+  test("includes html when provided", async () => {
+    const info = vi.fn();
+    const mailer = consoleMailer({ logger: { info } });
+
+    await mailer.send({
+      to: "alice@example.com",
+      subject: "hi",
+      text: "hello",
+      html: "<p>hello</p>",
+    });
+
+    const call = info.mock.calls[0] as LoggerCall | undefined;
+    if (!call) throw new Error("logger not called");
+    expect(call[1]).toMatchObject({ html: "<p>hello</p>" });
+  });
+
+  test("defaults to console when no logger is passed", async () => {
+    const spy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    try {
+      await consoleMailer().send({
+        to: "x@y.z",
+        subject: "s",
+        text: "t",
+      });
+      expect(spy).toHaveBeenCalledOnce();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/auth/mailer/console.ts
+++ b/packages/core/src/auth/mailer/console.ts
@@ -1,0 +1,35 @@
+import type { Logger } from "../../context/app.js";
+import type { EmailMessage, Mailer } from "./types.js";
+
+interface ConsoleMailerOptions {
+  /**
+   * Logger to write the message through. Defaults to `console`. Pass
+   * the request `Logger` from a route handler when you want the
+   * message to appear with the rest of that request's structured logs.
+   */
+  readonly logger?: Pick<Logger, "info">;
+}
+
+/**
+ * Dev-only mailer that logs each outgoing message instead of sending.
+ * Intended for local development and tests — there's no hidden network
+ * call and no rate-limit. Production deploys should pass a real
+ * `Mailer` (Resend, Postmark, SES, SMTP, …).
+ *
+ * The full message body is dumped at `info` level so the operator can
+ * copy the magic-link URL out of the logs during local sign-in.
+ */
+export function consoleMailer(options: ConsoleMailerOptions = {}): Mailer {
+  const logger = options.logger ?? console;
+  return {
+    send(message: EmailMessage): Promise<void> {
+      logger.info("[mailer:console]", {
+        to: message.to,
+        subject: message.subject,
+        text: message.text,
+        ...(message.html === undefined ? {} : { html: message.html }),
+      });
+      return Promise.resolve();
+    },
+  };
+}

--- a/packages/core/src/auth/mailer/index.ts
+++ b/packages/core/src/auth/mailer/index.ts
@@ -1,0 +1,2 @@
+export { consoleMailer } from "./console.js";
+export type { EmailMessage, Mailer } from "./types.js";

--- a/packages/core/src/auth/mailer/types.ts
+++ b/packages/core/src/auth/mailer/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Outbound email message — the payload `Mailer.send` is invoked with.
+ * Plain text required; HTML optional. Subject + recipient are the two
+ * routing-relevant fields.
+ */
+export interface EmailMessage {
+  readonly to: string;
+  readonly subject: string;
+  readonly text: string;
+  readonly html?: string;
+}
+
+/**
+ * Pluggable outbound-email transport. Plumix needs this exactly when
+ * an auth feature wants to send mail (magic-link today; email-verify,
+ * invite-email, password-reset later). Implementations can wrap any
+ * provider — Resend, Postmark, SES, SMTP, a queue. Core never knows.
+ *
+ * The contract is one method, fail-fast: throw on send failure so the
+ * caller can react (the magic-link flow swallows + logs to avoid
+ * leaking whether the recipient is registered).
+ */
+export interface Mailer {
+  send(message: EmailMessage): Promise<void>;
+}

--- a/packages/core/src/auth/oauth/consumer.ts
+++ b/packages/core/src/auth/oauth/consumer.ts
@@ -1,19 +1,13 @@
 import type { Db } from "../../context/app.js";
-import type {
-  OAuthClientConfig,
-  OAuthProfile,
-  OAuthProvider,
-  OAuthProviderKey,
-} from "./types.js";
+import type { OAuthProfile, OAuthProviderClient } from "./types.js";
 import { OAuthError } from "./errors.js";
 import { computeS256Challenge, generateCodeVerifier } from "./pkce.js";
-import { fetchPrimaryEmail, getProvider } from "./providers/index.js";
 import { issueOAuthState } from "./state.js";
 
 interface BuildAuthorizeUrlInput {
   readonly db: Db;
-  readonly provider: OAuthProviderKey;
-  readonly client: OAuthClientConfig;
+  readonly providerKey: string;
+  readonly provider: OAuthProviderClient;
   readonly redirectUri: string;
 }
 
@@ -23,43 +17,37 @@ interface BuiltAuthorizeUrl {
 }
 
 /**
- * Mint a PKCE verifier + state, persist them under `oauth_state`, and return
- * the authorize URL. State is what the provider echoes back; it's the only
- * way the callback ties the response to a verifier we can replay.
+ * Mint a PKCE verifier + state, persist them under `oauth_state`, and
+ * return the authorize URL. State is what the provider echoes back; it's
+ * the only way the callback ties the response to a verifier we can replay.
  */
 export async function buildAuthorizeUrl(
   input: BuildAuthorizeUrlInput,
 ): Promise<BuiltAuthorizeUrl> {
-  const provider = getProvider(input.provider);
+  const { provider } = input;
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await computeS256Challenge(codeVerifier);
 
   const { state } = await issueOAuthState(input.db, {
-    provider: input.provider,
+    provider: input.providerKey,
     codeVerifier,
   });
 
   const url = new URL(provider.authorizeUrl);
-  url.searchParams.set("client_id", input.client.clientId);
+  url.searchParams.set("client_id", provider.client.clientId);
   url.searchParams.set("redirect_uri", input.redirectUri);
   url.searchParams.set("response_type", "code");
   url.searchParams.set("scope", provider.scopes.join(" "));
   url.searchParams.set("state", state);
   url.searchParams.set("code_challenge", codeChallenge);
   url.searchParams.set("code_challenge_method", "S256");
-  // Google requires this to surface email_verified on the userinfo endpoint
-  // for accounts that aren't currently signed in. Harmless for GitHub.
-  if (input.provider === "google") {
-    url.searchParams.set("access_type", "offline");
-    url.searchParams.set("prompt", "consent");
-  }
+  provider.decorateAuthorizeUrl?.(url);
 
   return { url: url.toString(), state };
 }
 
 interface ExchangeAndFetchInput {
-  readonly provider: OAuthProviderKey;
-  readonly client: OAuthClientConfig;
+  readonly provider: OAuthProviderClient;
   readonly code: string;
   readonly redirectUri: string;
   readonly codeVerifier: string;
@@ -72,23 +60,23 @@ interface TokenResponse {
 }
 
 /**
- * Exchange the authorization code for tokens, then fetch the user's profile.
- * Returns a normalised OAuthProfile or throws OAuthError on any step
- * failure — the route layer maps codes to user-facing messages.
+ * Exchange the authorization code for tokens, then fetch the user's
+ * profile. Returns a normalised OAuthProfile or throws OAuthError on any
+ * step failure — the route layer maps codes to user-facing messages.
  */
 export async function exchangeAndFetchProfile(
   input: ExchangeAndFetchInput,
 ): Promise<OAuthProfile> {
-  const provider = getProvider(input.provider);
-  const tokens = await exchangeCode(provider, input);
+  const { provider } = input;
+  const tokens = await exchangeCode(input);
   const profile = await fetchProfile(provider, tokens.access_token);
 
   let { email, emailVerified } = profile;
-  if (input.provider === "github" && !email) {
-    const primary = await fetchPrimaryEmail(tokens.access_token);
-    if (primary) {
-      email = primary.email;
-      emailVerified = primary.verified;
+  if (!email && provider.fetchVerifiedEmail) {
+    const fallback = await provider.fetchVerifiedEmail(tokens.access_token);
+    if (fallback) {
+      email = fallback.email;
+      emailVerified = fallback.verified;
     }
   }
 
@@ -106,9 +94,9 @@ export async function exchangeAndFetchProfile(
 }
 
 async function exchangeCode(
-  provider: OAuthProvider,
   input: ExchangeAndFetchInput,
 ): Promise<TokenResponse> {
+  const { provider } = input;
   // RFC 6749 §2.3.1 / Copenhagen Book: client credentials go in the
   // Authorization header (HTTP Basic). client_id stays in the body for
   // providers (like Google) whose docs require it on the form too —
@@ -117,10 +105,12 @@ async function exchangeCode(
     grant_type: "authorization_code",
     code: input.code,
     redirect_uri: input.redirectUri,
-    client_id: input.client.clientId,
+    client_id: provider.client.clientId,
     code_verifier: input.codeVerifier,
   });
-  const basic = btoa(`${input.client.clientId}:${input.client.clientSecret}`);
+  const basic = btoa(
+    `${provider.client.clientId}:${provider.client.clientSecret}`,
+  );
 
   let response: Response;
   try {
@@ -160,9 +150,9 @@ async function exchangeCode(
 }
 
 async function fetchProfile(
-  provider: OAuthProvider,
+  provider: OAuthProviderClient,
   accessToken: string,
-): Promise<ReturnType<OAuthProvider["parseProfile"]>> {
+): Promise<ReturnType<OAuthProviderClient["parseProfile"]>> {
   let response: Response;
   try {
     response = await fetch(provider.userInfoUrl, {

--- a/packages/core/src/auth/oauth/index.ts
+++ b/packages/core/src/auth/oauth/index.ts
@@ -1,20 +1,32 @@
-// Public OAuth surface. Internals (PKCE primitives, state store, provider
-// singletons, GitHub email helper, the `consumer` exchange/fetch helpers,
-// the path parser) are intentionally NOT re-exported — they're only used
-// by the dispatcher + tests, which import them by file path. Keeping the
-// barrel narrow prevents accidental load-bearing dependencies on internal
-// helpers ahead of the 0.1.0 freeze.
+// Public OAuth surface.
+//
+// Built-in provider factories (`github`, `google`) ship from this barrel
+// alongside the public types so a user wiring up `auth({ oauth: ... })`
+// has everything from one import:
+//
+//   import { auth, github, google } from "@plumix/core";
+//
+// User-defined providers live in user code — they implement
+// `OAuthProviderClient` (often via a factory matching the
+// `OAuthProviderFactory` signature) and pass the result into the same
+// `oauth.providers` map. Adding a third built-in or a custom provider
+// follows the same path; no privileged registry, no const enum.
+//
+// Internals (PKCE, state store, consumer, signup, route handlers, the
+// path parser) are imported directly by the dispatcher and tests; they
+// don't leave the package.
 
 export { OAUTH_ERROR_CODES, OAuthError } from "./errors.js";
 export type { OAuthErrorCode } from "./errors.js";
 
 export { handleOAuthCallback, handleOAuthStart } from "./routes.js";
 
-export { OAUTH_PROVIDER_KEYS } from "./types.js";
+export { github, google } from "./providers/index.js";
+
+export { OAUTH_PROVIDER_KEY_PATTERN } from "./types.js";
 export type {
   OAuthClientConfig,
   OAuthProfile,
-  OAuthProvider,
-  OAuthProviderKey,
-  OAuthProvidersConfig,
+  OAuthProviderClient,
+  OAuthProviderFactory,
 } from "./types.js";

--- a/packages/core/src/auth/oauth/providers/github.ts
+++ b/packages/core/src/auth/oauth/providers/github.ts
@@ -1,4 +1,8 @@
-import type { OAuthProvider } from "../types.js";
+import type {
+  OAuthClientConfig,
+  OAuthProviderClient,
+  OAuthProviderFactory,
+} from "../types.js";
 
 interface GitHubProfile {
   readonly id: number;
@@ -14,12 +18,15 @@ interface GitHubEmail {
   readonly verified: boolean;
 }
 
-export const github: OAuthProvider = {
-  key: "github",
+export const github: OAuthProviderFactory = (
+  client: OAuthClientConfig,
+): OAuthProviderClient => ({
+  label: "GitHub",
   authorizeUrl: "https://github.com/login/oauth/authorize",
   tokenUrl: "https://github.com/login/oauth/access_token",
   userInfoUrl: "https://api.github.com/user",
   scopes: ["read:user", "user:email"],
+  client,
   parseProfile(raw) {
     const p = raw as GitHubProfile;
     return {
@@ -33,27 +40,19 @@ export const github: OAuthProvider = {
       avatarUrl: p.avatar_url,
     };
   },
-};
-
-interface PrimaryEmail {
-  readonly email: string;
-  readonly verified: boolean;
-}
-
-export async function fetchPrimaryEmail(
-  accessToken: string,
-): Promise<PrimaryEmail | null> {
-  const response = await fetch("https://api.github.com/user/emails", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "plumix",
-    },
-  });
-  if (!response.ok) return null;
-  const list = (await response.json()) as readonly GitHubEmail[];
-  const primary = list.find((e) => e.primary) ?? list[0];
-  if (!primary) return null;
-  return { email: primary.email, verified: primary.verified };
-}
+  async fetchVerifiedEmail(accessToken) {
+    const response = await fetch("https://api.github.com/user/emails", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "plumix",
+      },
+    });
+    if (!response.ok) return null;
+    const list = (await response.json()) as readonly GitHubEmail[];
+    const primary = list.find((e) => e.primary) ?? list[0];
+    if (!primary) return null;
+    return { email: primary.email, verified: primary.verified };
+  },
+});

--- a/packages/core/src/auth/oauth/providers/google.ts
+++ b/packages/core/src/auth/oauth/providers/google.ts
@@ -1,4 +1,8 @@
-import type { OAuthProvider } from "../types.js";
+import type {
+  OAuthClientConfig,
+  OAuthProviderClient,
+  OAuthProviderFactory,
+} from "../types.js";
 
 interface GoogleProfile {
   readonly sub: string;
@@ -8,12 +12,15 @@ interface GoogleProfile {
   readonly picture: string | null;
 }
 
-export const google: OAuthProvider = {
-  key: "google",
+export const google: OAuthProviderFactory = (
+  client: OAuthClientConfig,
+): OAuthProviderClient => ({
+  label: "Google",
   authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenUrl: "https://oauth2.googleapis.com/token",
   userInfoUrl: "https://openidconnect.googleapis.com/v1/userinfo",
   scopes: ["openid", "email", "profile"],
+  client,
   parseProfile(raw) {
     const p = raw as GoogleProfile;
     return {
@@ -24,4 +31,11 @@ export const google: OAuthProvider = {
       avatarUrl: p.picture,
     };
   },
-};
+  decorateAuthorizeUrl(url) {
+    // Google needs `access_type=offline` + `prompt=consent` to surface
+    // `email_verified` on the userinfo endpoint for accounts that
+    // aren't currently signed in. Harmless for repeat sign-ins.
+    url.searchParams.set("access_type", "offline");
+    url.searchParams.set("prompt", "consent");
+  },
+});

--- a/packages/core/src/auth/oauth/providers/index.ts
+++ b/packages/core/src/auth/oauth/providers/index.ts
@@ -1,14 +1,2 @@
-import type { OAuthProvider, OAuthProviderKey } from "../types.js";
-import { fetchPrimaryEmail, github } from "./github.js";
-import { google } from "./google.js";
-
-export { github, google, fetchPrimaryEmail };
-
-export function getProvider(key: OAuthProviderKey): OAuthProvider {
-  switch (key) {
-    case "github":
-      return github;
-    case "google":
-      return google;
-  }
-}
+export { github } from "./github.js";
+export { google } from "./google.js";

--- a/packages/core/src/auth/oauth/routes.test.ts
+++ b/packages/core/src/auth/oauth/routes.test.ts
@@ -143,6 +143,22 @@ describe("oauth start route", () => {
     );
     expect(response.status).toBe(404);
   });
+
+  test("rejects `constructor` (prototype-chain key) as not configured", async () => {
+    // The path regex accepts `constructor` (lowercase letters only), but
+    // a direct `providers[key]` lookup would walk the prototype chain
+    // and return `Object`. `Object.hasOwn` keeps the lookup confined to
+    // the operator's config map.
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    await h.seedUser("admin");
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/oauth/constructor/start"),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=provider_not_configured",
+    );
+  });
 });
 
 describe("oauth callback route", () => {

--- a/packages/core/src/auth/oauth/routes.test.ts
+++ b/packages/core/src/auth/oauth/routes.test.ts
@@ -6,11 +6,13 @@ import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
 import { sessions } from "../../db/schema/sessions.js";
 import { users } from "../../db/schema/users.js";
 import { createDispatcherHarness } from "../../test/dispatcher.js";
+import { github } from "./providers/github.js";
+import { google } from "./providers/google.js";
 import { issueOAuthState } from "./state.js";
 
 const TEST_OAUTH = {
-  github: { clientId: "gh-client", clientSecret: "gh-secret" },
-  google: { clientId: "gg-client", clientSecret: "gg-secret" },
+  github: github({ clientId: "gh-client", clientSecret: "gh-secret" }),
+  google: google({ clientId: "gg-client", clientSecret: "gg-secret" }),
 } as const;
 
 interface StubResponse {
@@ -123,10 +125,21 @@ describe("oauth start route", () => {
     expect(response.status).toBe(405);
   });
 
-  test("returns 404 on unknown provider", async () => {
+  test("redirects to login with provider_not_configured for an unknown key", async () => {
     const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
     const response = await h.dispatch(
       new Request("https://cms.example/_plumix/auth/oauth/twitter/start"),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "oauth_error=provider_not_configured",
+    );
+  });
+
+  test("returns 404 on a malformed provider key (uppercase / specials)", async () => {
+    const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/oauth/Bad-Key!/start"),
     );
     expect(response.status).toBe(404);
   });

--- a/packages/core/src/auth/oauth/routes.ts
+++ b/packages/core/src/auth/oauth/routes.ts
@@ -1,7 +1,7 @@
 import type { AppContext } from "../../context/app.js";
 import type { PlumixApp } from "../../runtime/app.js";
 import type { OAuthErrorCode } from "./errors.js";
-import type { OAuthClientConfig, OAuthProviderKey } from "./types.js";
+import type { OAuthProviderClient } from "./types.js";
 import { users } from "../../db/schema/users.js";
 import { buildSessionCookie, isSecureRequest } from "../cookies.js";
 import { createSession } from "../sessions.js";
@@ -9,24 +9,27 @@ import { buildAuthorizeUrl, exchangeAndFetchProfile } from "./consumer.js";
 import { OAuthError } from "./errors.js";
 import { resolveOAuthUser } from "./signup.js";
 import { consumeOAuthState } from "./state.js";
-import { OAUTH_PROVIDER_KEYS } from "./types.js";
+import { OAUTH_PROVIDER_KEY_PATTERN } from "./types.js";
 
 const ADMIN_PATH = "/_plumix/admin";
 const LOGIN_PATH = "/_plumix/admin/login";
 const BOOTSTRAP_PATH = "/_plumix/admin/bootstrap";
 
 // Defensive bound on `code` from the provider's redirect. GitHub's codes
-// are ~20 chars; Google's a few hundred. 4 KiB is generous for any current
-// provider while bounding URL/body amplification on a malformed callback.
+// are ~20 chars; Google's a few hundred. 4 KiB is generous for any
+// current provider while bounding URL/body amplification on a malformed
+// callback.
 const MAX_CODE_LENGTH = 4096;
 
 interface OAuthRouteParams {
-  readonly provider: OAuthProviderKey;
+  readonly providerKey: string;
 }
 
 /**
- * Match `/_plumix/auth/oauth/<provider>/(start|callback)`. Returns the
- * provider + tail or null if the path doesn't match the OAuth shape.
+ * Match `/_plumix/auth/oauth/<key>/(start|callback)`. The shape check
+ * (alphanum + `_-`) happens here; existence check ("is this a configured
+ * provider?") happens in the handler. A path that doesn't match the
+ * shape returns null → 404 from the dispatcher.
  */
 export function parseOAuthPath(
   pathname: string,
@@ -36,24 +39,20 @@ export function parseOAuthPath(
   const rest = pathname.slice(prefix.length);
   const slash = rest.indexOf("/");
   if (slash < 0) return null;
-  const provider = rest.slice(0, slash);
+  const providerKey = rest.slice(0, slash);
   const tail = rest.slice(slash + 1);
-  if (!isProviderKey(provider)) return null;
+  if (!OAUTH_PROVIDER_KEY_PATTERN.test(providerKey)) return null;
   if (tail !== "start" && tail !== "callback") return null;
-  return { params: { provider }, tail };
-}
-
-function isProviderKey(value: string): value is OAuthProviderKey {
-  return (OAUTH_PROVIDER_KEYS as readonly string[]).includes(value);
+  return { params: { providerKey }, tail };
 }
 
 export async function handleOAuthStart(
   ctx: AppContext,
   app: PlumixApp,
-  provider: OAuthProviderKey,
+  providerKey: string,
 ): Promise<Response> {
-  const client = pickClient(app, provider);
-  if (!client) return loginError("provider_not_configured");
+  const provider = pickProvider(app, providerKey);
+  if (!provider) return loginError("provider_not_configured");
 
   // Block OAuth on a fresh deploy. Bootstrap is passkey-only; an OAuth
   // signup before any user exists would either fail with a confusing
@@ -64,18 +63,18 @@ export async function handleOAuthStart(
     return redirectTo(BOOTSTRAP_PATH);
   }
 
-  const redirectUri = oauthCallbackUrl(app, provider);
+  const redirectUri = oauthCallbackUrl(app, providerKey);
 
   try {
     const { url } = await buildAuthorizeUrl({
       db: ctx.db,
+      providerKey,
       provider,
-      client,
       redirectUri,
     });
     return redirectTo(url);
   } catch (error) {
-    ctx.logger.error("oauth_start_failed", { error, provider });
+    ctx.logger.error("oauth_start_failed", { error, provider: providerKey });
     return loginError("code_exchange_failed");
   }
 }
@@ -83,17 +82,17 @@ export async function handleOAuthStart(
 export async function handleOAuthCallback(
   ctx: AppContext,
   app: PlumixApp,
-  provider: OAuthProviderKey,
+  providerKey: string,
 ): Promise<Response> {
-  const client = pickClient(app, provider);
-  if (!client) return loginError("provider_not_configured");
+  const provider = pickProvider(app, providerKey);
+  if (!provider) return loginError("provider_not_configured");
 
   const url = new URL(ctx.request.url);
   const state = url.searchParams.get("state");
 
   // Provider-side denial (user clicked Cancel, scope rejected, etc.)
-  // arrives as `?error=...`. The state row would otherwise sit until TTL;
-  // consume it here so the slot is freed immediately.
+  // arrives as `?error=...`. The state row would otherwise sit until
+  // TTL; consume it here so the slot is freed immediately.
   if (url.searchParams.has("error")) {
     if (state) await consumeOAuthState(ctx.db, state);
     return loginError("state_invalid");
@@ -105,20 +104,22 @@ export async function handleOAuthCallback(
 
   const stored = await consumeOAuthState(ctx.db, state);
   if (!stored) return loginError("state_expired");
-  if (stored.provider !== provider) return loginError("state_invalid");
+  if (stored.provider !== providerKey) return loginError("state_invalid");
 
-  const redirectUri = oauthCallbackUrl(app, provider);
+  const redirectUri = oauthCallbackUrl(app, providerKey);
 
   try {
     const profile = await exchangeAndFetchProfile({
       provider,
-      client,
       code,
       redirectUri,
       codeVerifier: stored.codeVerifier,
     });
 
-    const { user } = await resolveOAuthUser(ctx.db, { provider, profile });
+    const { user } = await resolveOAuthUser(ctx.db, {
+      provider: providerKey,
+      profile,
+    });
 
     const { token } = await createSession(
       ctx.db,
@@ -136,23 +137,18 @@ export async function handleOAuthCallback(
   } catch (error) {
     if (error instanceof OAuthError) {
       ctx.logger.warn("oauth_callback_rejected", {
-        provider,
+        provider: providerKey,
         code: error.code,
       });
       return loginError(error.code);
     }
-    ctx.logger.error("oauth_callback_failed", { error, provider });
+    ctx.logger.error("oauth_callback_failed", { error, provider: providerKey });
     return loginError("code_exchange_failed");
   }
 }
 
-function pickClient(
-  app: PlumixApp,
-  provider: OAuthProviderKey,
-): OAuthClientConfig | null {
-  const oauth = app.config.auth.oauth;
-  if (!oauth) return null;
-  return oauth.providers[provider] ?? null;
+function pickProvider(app: PlumixApp, key: string): OAuthProviderClient | null {
+  return app.config.auth.oauth?.providers[key] ?? null;
 }
 
 // `app.origin` is the canonical site origin from passkey config — pinning
@@ -160,8 +156,8 @@ function pickClient(
 // time is identical at token-exchange time even if a load balancer or
 // custom adapter rewrites Host on the way in. (Cloudflare Workers binds
 // `request.url` to the connection hostname, but other adapters may not.)
-function oauthCallbackUrl(app: PlumixApp, provider: OAuthProviderKey): string {
-  return `${app.origin}/_plumix/auth/oauth/${provider}/callback`;
+function oauthCallbackUrl(app: PlumixApp, providerKey: string): string {
+  return `${app.origin}/_plumix/auth/oauth/${providerKey}/callback`;
 }
 
 function redirectTo(

--- a/packages/core/src/auth/oauth/routes.ts
+++ b/packages/core/src/auth/oauth/routes.ts
@@ -148,7 +148,14 @@ export async function handleOAuthCallback(
 }
 
 function pickProvider(app: PlumixApp, key: string): OAuthProviderClient | null {
-  return app.config.auth.oauth?.providers[key] ?? null;
+  // `OAUTH_PROVIDER_KEY_PATTERN` rejects most prototype-chain keys at the
+  // path layer (`__proto__`, `hasOwnProperty`, …), but `constructor`
+  // matches the regex. `Object.hasOwn` keeps the lookup confined to the
+  // operator's `auth.oauth.providers` object instead of walking the
+  // prototype chain.
+  const providers = app.config.auth.oauth?.providers;
+  if (!providers || !Object.hasOwn(providers, key)) return null;
+  return providers[key] ?? null;
 }
 
 // `app.origin` is the canonical site origin from passkey config — pinning

--- a/packages/core/src/auth/oauth/signup.ts
+++ b/packages/core/src/auth/oauth/signup.ts
@@ -1,6 +1,6 @@
 import type { Db } from "../../context/app.js";
 import type { User, UserRole } from "../../db/schema/users.js";
-import type { OAuthProfile, OAuthProviderKey } from "./types.js";
+import type { OAuthProfile } from "./types.js";
 import { and, eq, isUniqueConstraintError } from "../../db/index.js";
 import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
@@ -8,7 +8,7 @@ import { users } from "../../db/schema/users.js";
 import { OAuthError } from "./errors.js";
 
 interface ResolveOAuthUserInput {
-  readonly provider: OAuthProviderKey;
+  readonly provider: string;
   readonly profile: OAuthProfile;
 }
 

--- a/packages/core/src/auth/oauth/state.ts
+++ b/packages/core/src/auth/oauth/state.ts
@@ -1,5 +1,4 @@
 import type { Db } from "../../context/app.js";
-import type { OAuthProviderKey } from "./types.js";
 import { and, eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { generateToken, hashToken } from "../tokens.js";
@@ -7,7 +6,7 @@ import { generateToken, hashToken } from "../tokens.js";
 export const OAUTH_STATE_TTL_SECONDS = 10 * 60;
 
 interface OAuthStatePayload {
-  readonly provider: OAuthProviderKey;
+  readonly provider: string;
   readonly codeVerifier: string;
 }
 

--- a/packages/core/src/auth/oauth/state.ts
+++ b/packages/core/src/auth/oauth/state.ts
@@ -3,7 +3,7 @@ import { and, eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { generateToken, hashToken } from "../tokens.js";
 
-export const OAUTH_STATE_TTL_SECONDS = 10 * 60;
+const OAUTH_STATE_TTL_SECONDS = 10 * 60;
 
 interface OAuthStatePayload {
   readonly provider: string;

--- a/packages/core/src/auth/oauth/types.ts
+++ b/packages/core/src/auth/oauth/types.ts
@@ -1,15 +1,6 @@
-export const OAUTH_PROVIDER_KEYS = ["github", "google"] as const;
-
-export type OAuthProviderKey = (typeof OAUTH_PROVIDER_KEYS)[number];
-
 export interface OAuthClientConfig {
   readonly clientId: string;
   readonly clientSecret: string;
-}
-
-export interface OAuthProvidersConfig {
-  readonly github?: OAuthClientConfig;
-  readonly google?: OAuthClientConfig;
 }
 
 export interface OAuthProfile {
@@ -27,19 +18,65 @@ export interface OAuthProfile {
   readonly avatarUrl: string | null;
 }
 
-export interface OAuthProvider {
-  readonly key: OAuthProviderKey;
+/**
+ * Concrete, configured provider — what `auth({ oauth: { providers } })`
+ * accepts. Built-ins (`github`, `google`) ship as factories that return
+ * this shape; user-defined providers implement the same interface in
+ * their own code and hand an instance to the same config slot. There's
+ * no privileged registry — provider keys come from the user's config
+ * map, and routes / admin UI / signup all read keys at runtime.
+ */
+export interface OAuthProviderClient {
+  /**
+   * Human-readable name shown on the login screen ("GitHub", "Google",
+   * "Acme SSO"). Travels with the provider definition so adding a new
+   * provider is one file, not "edit core + edit admin".
+   */
+  readonly label: string;
   readonly authorizeUrl: string;
   readonly tokenUrl: string;
   readonly userInfoUrl: string;
   readonly scopes: readonly string[];
+  readonly client: OAuthClientConfig;
+
   /**
-   * Translate the provider's profile JSON into the shared shape. Some
-   * providers (GitHub) need a follow-up call to resolve the email — that
-   * happens in the consumer, not here.
+   * Translate the provider's userinfo JSON into a partial OAuthProfile.
+   * Returning `email: null` is fine — the consumer will call
+   * `fetchVerifiedEmail` (if defined) to resolve the missing address.
    */
   parseProfile(raw: unknown): Omit<OAuthProfile, "email" | "emailVerified"> & {
     email: string | null;
     emailVerified: boolean;
   };
+
+  /**
+   * Provider-specific authorize-URL params (Google's `access_type=offline`,
+   * etc.). Called after the standard OAuth params are set; the provider
+   * may add or override searchParams freely.
+   */
+  decorateAuthorizeUrl?(url: URL): void;
+
+  /**
+   * Resolve a verified primary email when `parseProfile` returned
+   * `email: null`. GitHub needs this — its `/user` endpoint omits
+   * email unless made public, but `/user/emails` always carries it.
+   * Returning null here surfaces as `email_missing` to the user.
+   */
+  fetchVerifiedEmail?(
+    accessToken: string,
+  ): Promise<{ email: string; verified: boolean } | null>;
 }
+
+/**
+ * Convenience alias for provider factories. Built-ins follow this shape;
+ * users can write their own factories the same way.
+ */
+export type OAuthProviderFactory = (
+  client: OAuthClientConfig,
+) => OAuthProviderClient;
+
+// Provider keys (the map keys in `auth.oauth.providers`) flow through the
+// URL path and into the `oauth_accounts.provider` column. Constrain the
+// shape to URL-path-safe identifiers so a typo can't smuggle special
+// characters into routing or storage.
+export const OAUTH_PROVIDER_KEY_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/;

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -56,3 +56,38 @@ test("plumix() leaves imageDelivery undefined when not provided", () => {
   const config = plumix({ runtime, database, auth: authConfig });
   expect(config.imageDelivery).toBeUndefined();
 });
+
+test("plumix() preserves the top-level mailer slot", () => {
+  const mailer = { send: () => Promise.resolve() };
+  const config = plumix({ runtime, database, auth: authConfig, mailer });
+  expect(config.mailer).toBe(mailer);
+});
+
+test("plumix() requires mailer when auth.magicLink is configured", () => {
+  const authWithMagicLink = auth({
+    passkey: {
+      rpName: "mock",
+      rpId: "cms.example",
+      origin: "https://cms.example",
+    },
+    magicLink: { siteName: "mock" },
+  });
+  expect(() => plumix({ runtime, database, auth: authWithMagicLink })).toThrow(
+    /magicLink.*requires.*mailer/,
+  );
+});
+
+test("plumix() accepts auth.magicLink when paired with a top-level mailer", () => {
+  const authWithMagicLink = auth({
+    passkey: {
+      rpName: "mock",
+      rpId: "cms.example",
+      origin: "https://cms.example",
+    },
+    magicLink: { siteName: "mock" },
+  });
+  const mailer = { send: () => Promise.resolve() };
+  expect(() =>
+    plumix({ runtime, database, auth: authWithMagicLink, mailer }),
+  ).not.toThrow();
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,4 +1,5 @@
 import type { PlumixAuthConfig } from "./auth/config.js";
+import type { Mailer } from "./auth/mailer/types.js";
 import type { PluginDescriptor } from "./plugin/define.js";
 import type { RuntimeAdapter } from "./runtime/adapter.js";
 import type {
@@ -26,6 +27,16 @@ export interface PlumixConfigInput {
   readonly storage?: ObjectStorage;
   readonly imageDelivery?: ImageDelivery;
   readonly kv?: KV;
+  /**
+   * Outbound email transport. Implementations conform to the `Mailer`
+   * interface from `@plumix/core` — one method, swap in any provider
+   * (Resend, Postmark, SES, SMTP). Shared by every feature that sends
+   * mail (magic-link today; future invite-email, password-reset,
+   * plugin-defined notifications), so plugin authors and operators
+   * configure the transport once at the top level. `consoleMailer()`
+   * is the dev default.
+   */
+  readonly mailer?: Mailer;
   readonly themes?: readonly Theme[];
   readonly plugins?: readonly AnyPluginDescriptor[];
 }
@@ -37,11 +48,21 @@ export interface PlumixConfig {
   readonly storage?: ObjectStorage;
   readonly imageDelivery?: ImageDelivery;
   readonly kv?: KV;
+  readonly mailer?: Mailer;
   readonly themes: readonly Theme[];
   readonly plugins: readonly AnyPluginDescriptor[];
 }
 
 export function plumix(config: PlumixConfigInput): PlumixConfig {
+  // Cross-field invariant: features that require email (magic-link
+  // today) need a configured mailer at the top level. Surface this at
+  // app build time rather than letting it crash on the first request.
+  if (config.auth.magicLink && !config.mailer) {
+    throw new Error(
+      "plumix(): `auth.magicLink` requires a top-level `mailer` " +
+        "(use `consoleMailer()` for dev or pass your own `Mailer`).",
+    );
+  }
   return {
     runtime: config.runtime,
     database: config.database,
@@ -49,6 +70,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
     storage: config.storage,
     imageDelivery: config.imageDelivery,
     kv: config.kv,
+    mailer: config.mailer,
     themes: config.themes ?? [],
     plugins: config.plugins ?? [],
   };

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -1,5 +1,6 @@
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
+import type { Mailer } from "../auth/mailer/types.js";
 import type { KnownCapability } from "../auth/rbac.js";
 import type * as coreSchema from "../db/schema/index.js";
 import type { UserRole } from "../db/schema/users.js";
@@ -87,6 +88,15 @@ export interface AppContext<
    * procedures don't use it today.
    */
   readonly imageDelivery?: ImageDelivery;
+  /**
+   * Configured outbound email transport. Present when the operator
+   * passed `mailer:` at the top of `plumix({...})`. Magic-link reads
+   * this; future invite-email / password-reset / plugin-defined
+   * notifications read the same instance — operators configure once,
+   * every feature reuses. Plugin handlers should null-check and
+   * degrade if mail is optional for their feature.
+   */
+  readonly mailer?: Mailer;
 }
 
 export type AuthenticatedAppContext<
@@ -107,6 +117,7 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly assets?: AssetsBinding;
   readonly storage?: ConnectedObjectStorage;
   readonly imageDelivery?: ImageDelivery;
+  readonly mailer?: Mailer;
   readonly oauthProviders?: readonly OAuthProviderSummary[];
 }
 
@@ -133,6 +144,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     assets: args.assets,
     storage: args.storage,
     imageDelivery: args.imageDelivery,
+    mailer: args.mailer,
     oauthProviders: args.oauthProviders ?? [],
   };
 }

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -1,11 +1,11 @@
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
-import type { OAuthProviderKey } from "../auth/oauth/types.js";
 import type { KnownCapability } from "../auth/rbac.js";
 import type * as coreSchema from "../db/schema/index.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { HookExecutor } from "../hooks/registry.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
+import type { OAuthProviderSummary } from "../runtime/app.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
 import type {
   AssetsBinding,
@@ -53,12 +53,12 @@ export interface AppContext<
   readonly logger: Logger;
   readonly auth: AuthNamespace;
   /**
-   * OAuth provider keys configured on this app. Empty when the deploy is
-   * passkey-only. Read by the login screen (via auth.oauthProviders RPC)
-   * to render provider buttons; the actual client_id/client_secret never
-   * leave the app config.
+   * Configured OAuth providers — `{ key, label }` per entry. Empty when
+   * the deploy is passkey-only. Read by the login screen (via the
+   * `auth.oauthProviders` RPC) to render provider buttons; client
+   * credentials never reach this surface.
    */
-  readonly oauthProviders: readonly OAuthProviderKey[];
+  readonly oauthProviders: readonly OAuthProviderSummary[];
   /**
    * Extend work past the returned Response. Runtime adapters bind this
    * to their platform primitive (CF Workers: `ExecutionContext.waitUntil`).
@@ -107,7 +107,7 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly assets?: AssetsBinding;
   readonly storage?: ConnectedObjectStorage;
   readonly imageDelivery?: ImageDelivery;
-  readonly oauthProviders?: readonly OAuthProviderKey[];
+  readonly oauthProviders?: readonly OAuthProviderSummary[];
 }
 
 const dropPromise: AfterResponse = () => undefined;

--- a/packages/core/src/rpc/procedures/auth/auth.test.ts
+++ b/packages/core/src/rpc/procedures/auth/auth.test.ts
@@ -105,16 +105,26 @@ describe("auth.oauthProviders", () => {
     expect(result).toEqual([]);
   });
 
-  test("returns enabled provider keys", async () => {
-    const h = await createRpcHarness({ oauthProviders: ["github"] });
+  test("returns key + label per configured provider", async () => {
+    const h = await createRpcHarness({
+      oauthProviders: [{ key: "github", label: "GitHub" }],
+    });
     const result = await h.client.auth.oauthProviders({});
-    expect(result).toEqual(["github"]);
+    expect(result).toEqual([{ key: "github", label: "GitHub" }]);
   });
 
   test("returns multiple providers in declared order", async () => {
-    const h = await createRpcHarness({ oauthProviders: ["github", "google"] });
+    const h = await createRpcHarness({
+      oauthProviders: [
+        { key: "github", label: "GitHub" },
+        { key: "google", label: "Google" },
+      ],
+    });
     const result = await h.client.auth.oauthProviders({});
-    expect(result).toEqual(["github", "google"]);
+    expect(result).toEqual([
+      { key: "github", label: "GitHub" },
+      { key: "google", label: "Google" },
+    ]);
   });
 });
 

--- a/packages/core/src/rpc/procedures/auth/oauth-providers.ts
+++ b/packages/core/src/rpc/procedures/auth/oauth-providers.ts
@@ -1,9 +1,11 @@
-import type { OAuthProviderKey } from "../../../auth/oauth/types.js";
+import type { OAuthProviderSummary } from "../../../runtime/app.js";
 import { base } from "../../base.js";
 
 // Public — used by the login screen to render provider buttons. Driven
 // purely by config (resolved at app build time); no DB call. Returning
-// `[]` means "passkey-only", which the admin already knows how to render.
+// `[]` means "passkey-only", which the admin already knows how to
+// render. Each entry carries `key` (URL path segment) and `label`
+// (human-readable) so the admin doesn't need a separate lookup table.
 export const oauthProviders = base.handler(
-  ({ context }): readonly OAuthProviderKey[] => context.oauthProviders,
+  ({ context }): readonly OAuthProviderSummary[] => context.oauthProviders,
 );

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -1,6 +1,5 @@
 import { RPCHandler } from "@orpc/server/fetch";
 
-import type { OAuthProviderKey } from "../auth/oauth/types.js";
 import type { ResolvedPasskeyConfig } from "../auth/passkey/config.js";
 import type { CapabilityResolver } from "../auth/rbac.js";
 import type { SessionPolicy } from "../auth/sessions.js";
@@ -8,7 +7,6 @@ import type { PlumixConfig } from "../config.js";
 import type { AppContext } from "../context/app.js";
 import type { PluginRegistry, RegisteredRawRoute } from "../plugin/manifest.js";
 import type { RouteRule } from "../route/intent.js";
-import { OAUTH_PROVIDER_KEYS } from "../auth/oauth/types.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
@@ -18,6 +16,13 @@ import { CORE_RPC_NAMESPACES } from "../plugin/manifest.js";
 import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
 import { appRouter } from "../rpc/router.js";
+
+export interface OAuthProviderSummary {
+  /** Map key in `auth.oauth.providers`; the URL path segment. */
+  readonly key: string;
+  /** Human-readable name for the login button ("GitHub", "Google", …). */
+  readonly label: string;
+}
 
 export interface PlumixApp {
   readonly config: PlumixConfig;
@@ -33,8 +38,13 @@ export interface PlumixApp {
   readonly origin: string;
   readonly passkey: ResolvedPasskeyConfig;
   readonly sessionPolicy: SessionPolicy;
-  /** Provider keys with credentials configured. Empty when oauth() wasn't passed. */
-  readonly oauthProviders: readonly OAuthProviderKey[];
+  /**
+   * Public summary of configured OAuth providers — `{ key, label }` per
+   * entry, derived from the user's `oauth.providers` map at app build
+   * time. The login screen reads this verbatim through the
+   * `auth.oauthProviders` RPC; secrets never leave config.
+   */
+  readonly oauthProviders: readonly OAuthProviderSummary[];
   readonly schema: Record<string, unknown>;
   /**
    * Sorted route map compiled once at `buildApp` from the plugin registry.
@@ -88,8 +98,11 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
 
   const passkey = resolvePasskeyConfig(config.auth.passkey);
   const oauth = config.auth.oauth;
-  const oauthProviders = oauth
-    ? OAUTH_PROVIDER_KEYS.filter((key) => oauth.providers[key])
+  const oauthProviders: OAuthProviderSummary[] = oauth
+    ? Object.entries(oauth.providers).map(([key, provider]) => ({
+        key,
+        label: provider.label,
+      }))
     : [];
   return {
     config,

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -4,6 +4,10 @@ import type { PlumixApp } from "./app.js";
 import { readSessionCookie } from "../auth/cookies.js";
 import { hasCsrfHeader, hasMatchingOrigin } from "../auth/csrf.js";
 import {
+  handleMagicLinkRequest,
+  handleMagicLinkVerify,
+} from "../auth/magic-link/routes.js";
+import {
   handleOAuthCallback,
   handleOAuthStart,
   parseOAuthPath,
@@ -41,8 +45,11 @@ const POST_AUTH_ROUTES = new Map<string, RouteHandler>([
   ["/_plumix/auth/passkey/login/verify", handlePasskeyLoginVerify],
   ["/_plumix/auth/invite/register/options", handleInviteRegisterOptions],
   ["/_plumix/auth/invite/register/verify", handleInviteRegisterVerify],
+  ["/_plumix/auth/magic-link/request", handleMagicLinkRequest],
   ["/_plumix/auth/signout", (ctx) => handleSignout(ctx)],
 ]);
+
+const MAGIC_LINK_VERIFY_PATH = "/_plumix/auth/magic-link/verify";
 
 export type PlumixDispatcher = (ctx: AppContext) => Promise<Response>;
 
@@ -114,6 +121,14 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
     return oauth.tail === "start"
       ? handleOAuthStart(ctx, app, oauth.params.providerKey)
       : handleOAuthCallback(ctx, app, oauth.params.providerKey);
+  }
+
+  // Magic-link verify is the same shape — top-level GET from the user's
+  // mail client. The 192-bit single-use token in `?token=…` is the
+  // per-request CSRF anchor.
+  if (pathname === MAGIC_LINK_VERIFY_PATH) {
+    if (ctx.request.method !== "GET") return methodNotAllowed(["GET"]);
+    return handleMagicLinkVerify(ctx, app);
   }
 
   if (pathname === ADMIN_PREFIX || pathname.startsWith(`${ADMIN_PREFIX}/`)) {

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -112,8 +112,8 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   if (oauth) {
     if (ctx.request.method !== "GET") return methodNotAllowed(["GET"]);
     return oauth.tail === "start"
-      ? handleOAuthStart(ctx, app, oauth.params.provider)
-      : handleOAuthCallback(ctx, app, oauth.params.provider);
+      ? handleOAuthStart(ctx, app, oauth.params.providerKey)
+      : handleOAuthCallback(ctx, app, oauth.params.providerKey);
   }
 
   if (pathname === ADMIN_PREFIX || pathname.startsWith(`${ADMIN_PREFIX}/`)) {

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -1,3 +1,4 @@
+import type { PlumixMagicLinkConfig } from "../auth/config.js";
 import type { OAuthProviderClient } from "../auth/oauth/types.js";
 import type { AnyPluginDescriptor } from "../config.js";
 import type { AppContext } from "../context/app.js";
@@ -77,6 +78,12 @@ export interface CreateDispatcherHarnessOptions {
    * google(...) }`. Passkey-only deployments leave undefined.
    */
   readonly oauth?: Readonly<Record<string, OAuthProviderClient>>;
+  /**
+   * Magic-link config for tests exercising the request/verify routes.
+   * The `mailer` field is required; pass `consoleMailer({ logger })` or
+   * a mock to assert sends.
+   */
+  readonly magicLink?: PlumixMagicLinkConfig;
 }
 
 export interface DispatcherHarness {
@@ -169,6 +176,7 @@ export async function createDispatcherHarness(
         origin: "https://cms.example",
       },
       oauth: options.oauth ? { providers: options.oauth } : undefined,
+      magicLink: options.magicLink,
     }),
     plugins: options.plugins,
     imageDelivery: options.imageDelivery,

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -1,4 +1,5 @@
 import type { PlumixMagicLinkConfig } from "../auth/config.js";
+import type { Mailer } from "../auth/mailer/types.js";
 import type { OAuthProviderClient } from "../auth/oauth/types.js";
 import type { AnyPluginDescriptor } from "../config.js";
 import type { AppContext } from "../context/app.js";
@@ -80,10 +81,15 @@ export interface CreateDispatcherHarnessOptions {
   readonly oauth?: Readonly<Record<string, OAuthProviderClient>>;
   /**
    * Magic-link config for tests exercising the request/verify routes.
-   * The `mailer` field is required; pass `consoleMailer({ logger })` or
-   * a mock to assert sends.
+   * Pair with `mailer` at the top level (the request route requires
+   * both — same cross-field invariant `plumix()` enforces).
    */
   readonly magicLink?: PlumixMagicLinkConfig;
+  /**
+   * Top-level outbound email transport. Tests that exercise magic-link
+   * pass a capturing `Mailer` here so they can assert what was sent.
+   */
+  readonly mailer?: Mailer;
 }
 
 export interface DispatcherHarness {
@@ -157,6 +163,7 @@ function withRequest(
     assets,
     storage,
     imageDelivery: app.config.imageDelivery,
+    mailer: app.config.mailer,
     oauthProviders: app.oauthProviders,
   });
 }
@@ -180,6 +187,7 @@ export async function createDispatcherHarness(
     }),
     plugins: options.plugins,
     imageDelivery: options.imageDelivery,
+    mailer: options.mailer,
   });
   const app = await buildApp(config);
   const dispatcher = createPlumixDispatcher(app);

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -1,4 +1,4 @@
-import type { OAuthProvidersConfig } from "../auth/oauth/types.js";
+import type { OAuthProviderClient } from "../auth/oauth/types.js";
 import type { AnyPluginDescriptor } from "../config.js";
 import type { AppContext } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
@@ -72,11 +72,11 @@ export interface CreateDispatcherHarnessOptions {
    */
   readonly storage?: ConnectedObjectStorage;
   /**
-   * OAuth provider credentials to expose on `app.config.auth.oauth`. Tests
-   * exercising the OAuth start/callback routes pass dummy clientId/secret
-   * here; passkey-only deployments leave it undefined.
+   * Configured OAuth providers for tests exercising the start/callback
+   * routes. Pass `{ github: github({ clientId, clientSecret }), google:
+   * google(...) }`. Passkey-only deployments leave undefined.
    */
-  readonly oauth?: OAuthProvidersConfig;
+  readonly oauth?: Readonly<Record<string, OAuthProviderClient>>;
 }
 
 export interface DispatcherHarness {

--- a/packages/core/src/test/rpc.ts
+++ b/packages/core/src/test/rpc.ts
@@ -1,7 +1,6 @@
 import type { RouterClient } from "@orpc/server";
 import { createRouterClient } from "@orpc/server";
 
-import type { OAuthProviderKey } from "../auth/oauth/types.js";
 import type { AppContext, Db } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
 import type { HookExecutor, HookRegistry } from "../hooks/registry.js";
@@ -13,6 +12,7 @@ import type {
   FilterRest,
 } from "../hooks/types.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
+import type { OAuthProviderSummary } from "../runtime/app.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
 import type { Factories } from "./factories.js";
 import type { ActionSpy, FilterSpy } from "./spies.js";
@@ -42,7 +42,7 @@ export interface BaseRpcHarnessOptions {
    * `["github"]` etc. when exercising the auth.oauthProviders procedure;
    * default `[]` matches a passkey-only deploy.
    */
-  readonly oauthProviders?: readonly OAuthProviderKey[];
+  readonly oauthProviders?: readonly OAuthProviderSummary[];
 }
 
 export interface AuthenticatedHarnessOptions extends BaseRpcHarnessOptions {
@@ -92,7 +92,7 @@ function buildContext(
   hooks: HookExecutor,
   plugins: PluginRegistry,
   request: Request,
-  oauthProviders: readonly OAuthProviderKey[],
+  oauthProviders: readonly OAuthProviderSummary[],
 ): AppContext {
   return createAppContext({
     db,
@@ -127,7 +127,7 @@ function assemble<TUser extends User | null>(
   plugins: PluginRegistry,
   request: Request,
   user: TUser,
-  oauthProviders: readonly OAuthProviderKey[],
+  oauthProviders: readonly OAuthProviderSummary[],
 ): RpcHarnessBase<TUser> {
   const context = buildContext(
     db,

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -212,6 +212,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
         assets: readAssetsBinding(env),
         storage,
         imageDelivery: app.config.imageDelivery,
+        mailer: app.config.mailer,
         oauthProviders: app.oauthProviders,
       });
       const response = await requestStore.run(appCtx, () => dispatcher(appCtx));


### PR DESCRIPTION
Two intertwined themes shipped together because they share design DNA.

## OCP applied to OAuth providers

Replaces the const-enum + switch-case + per-provider config-schema
with a uniform contract: providers are factories that return an
\`OAuthProviderClient\` instance. Built-ins (\`github\`, \`google\`)
ship as factories from \`@plumix/core\`; user code can implement the
same interface and pass instances to the same \`oauth.providers\` map.
No privileged registry. Provider keys come from runtime config (the
map keys); the admin label travels with the factory output.

\`\`\`ts
import { auth, github, google } from "@plumix/core";

auth({
  oauth: {
    providers: {
      github: github({ clientId, clientSecret }),
      google: google({ clientId, clientSecret }),
      // microsoft: microsoftFactory({ … })  ← user-defined, zero core change
    }
  }
})
\`\`\`

Provider-specific quirks live on the factory output as optional
hooks: \`decorateAuthorizeUrl\` (Google's \`access_type=offline\`) and
\`fetchVerifiedEmail\` (GitHub's \`/user/emails\` fallback).

The \`auth.oauthProviders\` RPC return type changes from
\`Array<key>\` to \`Array<{key, label}>\`. The admin's hard-coded
\`PROVIDER_LABEL\` map is gone — adding a built-in or a user-defined
provider no longer requires editing admin code.

## Mailer as shared infrastructure

\`Mailer\` is one method, top-level config (alongside \`storage\` and
\`imageDelivery\`), and exposed via \`ctx.mailer\`:

\`\`\`ts
plumix({
  runtime: cloudflare(),
  database: d1({...}),
  storage: r2({...}),
  imageDelivery: images({...}),
  mailer: consoleMailer(),   // ← shared by every feature
  auth: auth({
    passkey: { ... },
    magicLink: { siteName: "Plumix — Blog" },   // no mailer here
  }),
})
\`\`\`

The transport is shared by every feature that sends mail — magic-link
today, future invite-email / password-reset / plugin-defined
notifications all read \`ctx.mailer\`. Operators wire one transport.
Plugin authors don't have to reach into \`auth.magicLink.mailer\`
(coupling) or build their own slot (DX pain).

Cross-field invariant: \`plumix()\` throws if \`auth.magicLink\` is
set without a top-level \`mailer\`. Surfaces the misconfig loudly
at build time rather than at the first sign-in request.

Plumix never imports a transport package; the \`Mailer\` interface is
one method, operators write the factory. \`consoleMailer({ logger })\`
ships as the dev default — magic-link URL appears in
\`wrangler tail\`. The blog example shows the Resend recipe inline as
a comment.

**Plumix is not in the email-design business.** The body sent to the
mailer is plain text only — operators template / brand HTML in their
own \`Mailer\` adapter when they want it.

## Magic-link sign-in **and** signup

Sign-in (existing user) and signup (allowed-domain match) are peers
of the OAuth flow. Token row in \`auth_tokens\` is keyed by SHA-256
hash, type-discriminated, atomic delete-and-return.

| request side                            | token row              |
|-----------------------------------------|------------------------|
| user exists + active                    | \`{ userId, email }\`  |
| user disabled                           | silent no-op + jitter  |
| no user, \`allowed_domains\` enabled    | \`{ userId: null, email }\` |
| no user, no allowed-domain match        | silent no-op + jitter  |
| no user, allowed but zero users         | silent no-op (bootstrap is passkey-only) |

| verify side                             | outcome                |
|-----------------------------------------|------------------------|
| sign-in token, user active              | mint session, → /admin |
| signup token, allowed-domain still on   | provision user with \`defaultRole\` + \`emailVerifiedAt\`, mint session |
| signup token, domain disabled mid-flight| → \`magic_link_error=domain_not_allowed\` |
| signup token, raced into existing user  | sign in idempotently   |
| signup token, system at zero users      | → \`magic_link_error=registration_closed\` |
| missing / expired / replayed token      | typed error → /admin/login |

Copenhagen Book / RFC alignment:

- 192-bit cryptographically random token, SHA-256 hashed before DB
  storage. Raw token only travels in the email URL.
- 15-minute default TTL (configurable 60s–3600s).
- Atomic compare-and-delete via \`DELETE … RETURNING\` scoped by
  \`type='magic_link'\` — replays past TTL fail at the consume step;
  hash collision with another token type can't accidentally consume
  the wrong row.
- **Always-success response shape.** Unknown email or disabled user
  returns the same \`{ ok: true, message: \"If an account exists or
  self-signup is open, we sent a sign-in link.\" }\` payload as a
  successful send.
- **Timing-attack resistance.** Branches that don't issue a token add
  100–250ms jitter so response time alone can't fingerprint
  registered emails.
- **Mailer error logging without leak.** Failed sends are logged via
  the request logger (operator visibility) but the request still
  returns success — surfacing the failure would leak that the
  recipient is registered.
- **Fresh session on every sign-in.** No session-fixation surface.

## Audit pass

\`find-bugs\` / \`security-review\` / \`code-review\` /
\`code-simplifier\` ran via the actual Sentry skills before opening;
every must-fix landed in the \`fix(*)\` commits ahead of the signup
commit:

- \`pickProvider\` hardening via \`Object.hasOwn\`
- \`magicLink.siteName\` is required, with a CR/LF guard
- mailer error logging from inside \`requestMagicLink\`
- 11 schema-validation tests for \`oauth\` + \`magicLink\` config
- signed-in-user-clicks-magic-link test
- \`login.tsx\` error mapping moved to a Record lookup
- cross-field validation test for \`mailer\` ↔ \`magicLink\`

## Scope discipline

Inside this PR (every "what's left for magic-link?" item closed):
sign-in, signup, mailer abstraction, console default, allowed-domain
gate, bootstrap rail, race handling, admin form, error mapping,
example app wiring, cross-feature mailer reuse via \`ctx.mailer\`.

Out of scope (truly orthogonal):

- Passkey credential management UI (rename / delete) — different
  feature, different surface.
- AT Protocol provider — the factory contract makes it trivial; will
  ship when there's a concrete consumer.
- Per-email rate limiting — deployment concern (Cloudflare WAF / CDN).