### PR TITLE
feat(core,admin): passkey management + sign out other devices on profile

### DIFF
--- a/packages/admin/src/components/profile/passkeys-card.tsx
+++ b/packages/admin/src/components/profile/passkeys-card.tsx
@@ -22,22 +22,33 @@ import {
 } from "@/components/ui/card.js";
 import { Input } from "@/components/ui/input.js";
 import { Label } from "@/components/ui/label.js";
+import { toDate } from "@/lib/dates.js";
+import { extractCode, extractReason } from "@/lib/orpc-errors.js";
 import { orpc } from "@/lib/orpc.js";
 import { PasskeyError } from "@/lib/passkey-errors.js";
 import { registerWithPasskey } from "@/lib/passkey.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-interface PasskeySummary {
+// Wire shape from `auth.credentials.list`. Mirrors the columns the RPC
+// handler picks — keep in sync if the projection there changes. Dates
+// arrive as ISO strings or Date depending on cache state, so the
+// display sites coerce via `toDate`.
+interface PasskeyWire {
   readonly id: string;
   readonly name: string | null;
-  readonly deviceType: "single_device" | "multi_device";
   readonly isBackedUp: boolean;
   readonly transports: readonly string[] | null;
-  readonly createdAt: Date;
-  readonly lastUsedAt: Date;
+  readonly createdAt: Date | string;
+  readonly lastUsedAt: Date | string;
 }
 
 interface PasskeysCardProps {
+  /**
+   * The viewer's email — required by `registerWithPasskey` for the
+   * add-device WebAuthn challenge. The server enforces
+   * `authed.email === input.email` so passing `target.email` from a
+   * self-edit screen is the contract.
+   */
   readonly userEmail: string;
 }
 
@@ -89,7 +100,7 @@ export function PasskeysCard({ userEmail }: PasskeysCardProps): ReactNode {
             {list.data.map((cred) => (
               <PasskeyRow
                 key={cred.id}
-                cred={normaliseCred(cred)}
+                cred={cred}
                 isLast={list.data.length === 1}
                 onChanged={invalidateList}
               />
@@ -129,12 +140,14 @@ export function PasskeysCard({ userEmail }: PasskeysCardProps): ReactNode {
 }
 
 interface PasskeyRowProps {
-  readonly cred: PasskeySummary;
+  readonly cred: PasskeyWire;
   readonly isLast: boolean;
   readonly onChanged: () => Promise<void> | void;
 }
 
 function PasskeyRow({ cred, isLast, onChanged }: PasskeyRowProps): ReactNode {
+  const createdAt = toDate(cred.createdAt);
+  const lastUsedAt = toDate(cred.lastUsedAt);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(cred.name ?? "");
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -251,9 +264,9 @@ function PasskeyRow({ cred, isLast, onChanged }: PasskeyRowProps): ReactNode {
                 {cred.isBackedUp ? (
                   <Badge variant="secondary">Synced</Badge>
                 ) : null}
-                <span>Added {formatDate(cred.createdAt)}</span>
-                {cred.lastUsedAt.getTime() !== cred.createdAt.getTime() ? (
-                  <span>Last used {formatDate(cred.lastUsedAt)}</span>
+                <span>Added {formatDate(createdAt)}</span>
+                {lastUsedAt.getTime() !== createdAt.getTime() ? (
+                  <span>Last used {formatDate(lastUsedAt)}</span>
                 ) : null}
               </div>
             </>
@@ -351,68 +364,33 @@ function formatDate(date: Date): string {
   }).format(date);
 }
 
-function formatTransport(cred: PasskeySummary): string | null {
+function formatTransport(cred: PasskeyWire): string | null {
   const transports = cred.transports;
   if (!transports || transports.length === 0) return null;
   // Map WebAuthn transport tokens to readable copy. "internal" = platform
-  // authenticator (Touch ID / Windows Hello); the others are roaming.
+  // authenticator (Touch ID / Windows Hello); "hybrid" = QR-paired phone
+  // ceremony; everything else (`usb`, `nfc`, `ble`) is some flavour of
+  // hardware security key — collapse to one bucket rather than expose
+  // raw transport tokens to end users.
   if (transports.includes("internal")) return "This device";
   if (transports.includes("hybrid")) return "Cross-device";
-  if (transports.includes("usb")) return "Security key";
-  return transports[0] ?? null;
-}
-
-// The list query infers wire types from the RPC handler — coerce createdAt /
-// lastUsedAt to Date for display logic. The wire form is ISO strings (oRPC
-// preserves Dates via valibot serialisers but TanStack Query may surface
-// them as either depending on cache state).
-function normaliseCred(raw: {
-  readonly id: string;
-  readonly name: string | null;
-  readonly deviceType: "single_device" | "multi_device";
-  readonly isBackedUp: boolean;
-  readonly transports: readonly string[] | null;
-  readonly createdAt: Date | string;
-  readonly lastUsedAt: Date | string;
-}): PasskeySummary {
-  return {
-    id: raw.id,
-    name: raw.name,
-    deviceType: raw.deviceType,
-    isBackedUp: raw.isBackedUp,
-    transports: raw.transports,
-    createdAt:
-      raw.createdAt instanceof Date ? raw.createdAt : new Date(raw.createdAt),
-    lastUsedAt:
-      raw.lastUsedAt instanceof Date
-        ? raw.lastUsedAt
-        : new Date(raw.lastUsedAt),
-  };
+  return "Security key";
 }
 
 function formatRenameError(err: unknown): string {
-  if (err && typeof err === "object" && "code" in err) {
-    const code = (err as { code?: string }).code;
-    if (code === "NOT_FOUND") {
-      return "This passkey no longer exists. Refresh the list.";
-    }
+  if (extractCode(err) === "NOT_FOUND") {
+    return "This passkey no longer exists. Refresh the list.";
   }
   if (err instanceof Error) return err.message;
   return "Couldn't rename the passkey. Try again.";
 }
 
 function formatDeleteError(err: unknown): string {
-  if (err && typeof err === "object" && "data" in err) {
-    const data = (err as { data?: { reason?: string } }).data;
-    if (data?.reason === "last_credential") {
-      return "You can't delete your last passkey. Add another one first.";
-    }
+  if (extractReason(err) === "last_credential") {
+    return "You can't delete your last passkey. Add another one first.";
   }
-  if (err && typeof err === "object" && "code" in err) {
-    const code = (err as { code?: string }).code;
-    if (code === "NOT_FOUND") {
-      return "This passkey no longer exists. Refresh the list.";
-    }
+  if (extractCode(err) === "NOT_FOUND") {
+    return "This passkey no longer exists. Refresh the list.";
   }
   if (err instanceof Error) return err.message;
   return "Couldn't delete the passkey. Try again.";
@@ -436,9 +414,9 @@ function formatPasskeyEnrollError(err: unknown): string {
         return "Network error. Check your connection and try again.";
       case "email_mismatch":
         return "Couldn't enrol — re-sign-in and try again.";
-      default:
-        return "Couldn't enrol the passkey. Try again.";
     }
+    // Unknown PasskeyError code → fall through to err.message below for
+    // a slightly more informative message than a generic fallback.
   }
   if (err instanceof Error) return err.message;
   return "Couldn't enrol the passkey. Try again.";

--- a/packages/admin/src/components/profile/passkeys-card.tsx
+++ b/packages/admin/src/components/profile/passkeys-card.tsx
@@ -1,0 +1,445 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Badge } from "@/components/ui/badge.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Input } from "@/components/ui/input.js";
+import { Label } from "@/components/ui/label.js";
+import { orpc } from "@/lib/orpc.js";
+import { PasskeyError } from "@/lib/passkey-errors.js";
+import { registerWithPasskey } from "@/lib/passkey.js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+interface PasskeySummary {
+  readonly id: string;
+  readonly name: string | null;
+  readonly deviceType: "single_device" | "multi_device";
+  readonly isBackedUp: boolean;
+  readonly transports: readonly string[] | null;
+  readonly createdAt: Date;
+  readonly lastUsedAt: Date;
+}
+
+interface PasskeysCardProps {
+  readonly userEmail: string;
+}
+
+export function PasskeysCard({ userEmail }: PasskeysCardProps): ReactNode {
+  const queryClient = useQueryClient();
+  const [enrollError, setEnrollError] = useState<string | null>(null);
+
+  const list = useQuery(orpc.auth.credentials.list.queryOptions({ input: {} }));
+
+  const invalidateList = (): Promise<void> =>
+    queryClient.invalidateQueries({
+      queryKey: orpc.auth.credentials.list.key(),
+    });
+
+  const enroll = useMutation({
+    mutationFn: () => registerWithPasskey({ email: userEmail }),
+    onMutate: () => {
+      setEnrollError(null);
+    },
+    onSuccess: () => invalidateList(),
+    onError: (err) => {
+      setEnrollError(formatPasskeyEnrollError(err));
+    },
+  });
+
+  return (
+    <Card data-testid="profile-passkeys-card">
+      <CardHeader>
+        <CardTitle>Passkeys</CardTitle>
+        <CardDescription>
+          Devices that can sign in to this account. Add a new one before
+          deleting an old one — at least one passkey must remain.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {list.isPending ? (
+          <p className="text-muted-foreground text-sm">Loading…</p>
+        ) : list.error ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Couldn't load your passkeys. Refresh and try again.
+            </AlertDescription>
+          </Alert>
+        ) : list.data.length > 0 ? (
+          <ul
+            className="divide-border divide-y"
+            data-testid="profile-passkeys-list"
+          >
+            {list.data.map((cred) => (
+              <PasskeyRow
+                key={cred.id}
+                cred={normaliseCred(cred)}
+                isLast={list.data.length === 1}
+                onChanged={invalidateList}
+              />
+            ))}
+          </ul>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            No passkeys registered. Add one to enable sign-in.
+          </p>
+        )}
+
+        {enrollError ? (
+          <Alert
+            variant="destructive"
+            data-testid="profile-passkeys-enroll-error"
+          >
+            <AlertDescription>{enrollError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              enroll.mutate();
+            }}
+            disabled={enroll.isPending}
+            data-testid="profile-passkeys-enroll-button"
+          >
+            {enroll.isPending ? "Adding…" : "Add passkey"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface PasskeyRowProps {
+  readonly cred: PasskeySummary;
+  readonly isLast: boolean;
+  readonly onChanged: () => Promise<void> | void;
+}
+
+function PasskeyRow({ cred, isLast, onChanged }: PasskeyRowProps): ReactNode {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(cred.name ?? "");
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const rename = useMutation({
+    mutationFn: (name: string) =>
+      orpc.auth.credentials.rename.call({ id: cred.id, name }),
+    onMutate: () => {
+      setRenameError(null);
+    },
+    onSuccess: async () => {
+      setEditing(false);
+      await onChanged();
+    },
+    onError: (err) => {
+      setRenameError(formatRenameError(err));
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: () => orpc.auth.credentials.delete.call({ id: cred.id }),
+    onMutate: () => {
+      setDeleteError(null);
+    },
+    onSuccess: async () => {
+      setConfirmingDelete(false);
+      await onChanged();
+    },
+    onError: (err) => {
+      setDeleteError(formatDeleteError(err));
+    },
+  });
+
+  const displayName = cred.name ?? "Unnamed passkey";
+  const transportLabel = formatTransport(cred);
+
+  return (
+    <li className="flex flex-col gap-2 py-3" data-testid="profile-passkey-row">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          {editing ? (
+            <form
+              className="flex flex-col gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const trimmed = draft.trim();
+                if (trimmed.length === 0) {
+                  setRenameError("Name can't be empty.");
+                  return;
+                }
+                rename.mutate(trimmed);
+              }}
+            >
+              <Label
+                htmlFor={`passkey-name-${cred.id}`}
+                className="text-muted-foreground text-xs"
+              >
+                Rename passkey
+              </Label>
+              <Input
+                id={`passkey-name-${cred.id}`}
+                value={draft}
+                maxLength={64}
+                onChange={(e) => {
+                  setDraft(e.target.value);
+                }}
+                data-testid="profile-passkey-rename-input"
+                autoFocus
+              />
+              {renameError ? (
+                <Alert
+                  variant="destructive"
+                  data-testid="profile-passkey-rename-error"
+                >
+                  <AlertDescription>{renameError}</AlertDescription>
+                </Alert>
+              ) : null}
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setEditing(false);
+                    setDraft(cred.name ?? "");
+                    setRenameError(null);
+                  }}
+                  disabled={rename.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={rename.isPending}
+                  data-testid="profile-passkey-rename-submit"
+                >
+                  {rename.isPending ? "Saving…" : "Save"}
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <>
+              <p
+                className="text-sm font-medium"
+                data-testid="profile-passkey-name"
+              >
+                {displayName}
+              </p>
+              <div className="text-muted-foreground flex flex-wrap gap-2 text-xs">
+                {transportLabel ? <span>{transportLabel}</span> : null}
+                {cred.isBackedUp ? (
+                  <Badge variant="secondary">Synced</Badge>
+                ) : null}
+                <span>Added {formatDate(cred.createdAt)}</span>
+                {cred.lastUsedAt.getTime() !== cred.createdAt.getTime() ? (
+                  <span>Last used {formatDate(cred.lastUsedAt)}</span>
+                ) : null}
+              </div>
+            </>
+          )}
+        </div>
+        {!editing ? (
+          <div className="flex shrink-0 gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setEditing(true);
+                setDraft(cred.name ?? "");
+              }}
+              data-testid="profile-passkey-rename-button"
+            >
+              Rename
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              onClick={() => {
+                setConfirmingDelete(true);
+              }}
+              disabled={isLast}
+              title={
+                isLast
+                  ? "You can't delete your last passkey. Add another one first."
+                  : undefined
+              }
+              data-testid="profile-passkey-delete-button"
+            >
+              Delete
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      <AlertDialog
+        open={confirmingDelete}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmingDelete(false);
+            setDeleteError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this passkey?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The device that registered &quot;{displayName}&quot; will no
+              longer be able to sign in. You can re-enrol it later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {deleteError ? (
+            <Alert
+              variant="destructive"
+              data-testid="profile-passkey-delete-error"
+            >
+              <AlertDescription>{deleteError}</AlertDescription>
+            </Alert>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={remove.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="profile-passkey-delete-confirm"
+              disabled={remove.isPending}
+              onClick={(e) => {
+                e.preventDefault();
+                remove.mutate();
+              }}
+            >
+              {remove.isPending ? "Deleting…" : "Delete passkey"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </li>
+  );
+}
+
+// Server returns ISO strings for timestamps; date-format helper centralises
+// the consistent short form across this card.
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+function formatTransport(cred: PasskeySummary): string | null {
+  const transports = cred.transports;
+  if (!transports || transports.length === 0) return null;
+  // Map WebAuthn transport tokens to readable copy. "internal" = platform
+  // authenticator (Touch ID / Windows Hello); the others are roaming.
+  if (transports.includes("internal")) return "This device";
+  if (transports.includes("hybrid")) return "Cross-device";
+  if (transports.includes("usb")) return "Security key";
+  return transports[0] ?? null;
+}
+
+// The list query infers wire types from the RPC handler — coerce createdAt /
+// lastUsedAt to Date for display logic. The wire form is ISO strings (oRPC
+// preserves Dates via valibot serialisers but TanStack Query may surface
+// them as either depending on cache state).
+function normaliseCred(raw: {
+  readonly id: string;
+  readonly name: string | null;
+  readonly deviceType: "single_device" | "multi_device";
+  readonly isBackedUp: boolean;
+  readonly transports: readonly string[] | null;
+  readonly createdAt: Date | string;
+  readonly lastUsedAt: Date | string;
+}): PasskeySummary {
+  return {
+    id: raw.id,
+    name: raw.name,
+    deviceType: raw.deviceType,
+    isBackedUp: raw.isBackedUp,
+    transports: raw.transports,
+    createdAt:
+      raw.createdAt instanceof Date ? raw.createdAt : new Date(raw.createdAt),
+    lastUsedAt:
+      raw.lastUsedAt instanceof Date
+        ? raw.lastUsedAt
+        : new Date(raw.lastUsedAt),
+  };
+}
+
+function formatRenameError(err: unknown): string {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code?: string }).code;
+    if (code === "NOT_FOUND") {
+      return "This passkey no longer exists. Refresh the list.";
+    }
+  }
+  if (err instanceof Error) return err.message;
+  return "Couldn't rename the passkey. Try again.";
+}
+
+function formatDeleteError(err: unknown): string {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data?: { reason?: string } }).data;
+    if (data?.reason === "last_credential") {
+      return "You can't delete your last passkey. Add another one first.";
+    }
+  }
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code?: string }).code;
+    if (code === "NOT_FOUND") {
+      return "This passkey no longer exists. Refresh the list.";
+    }
+  }
+  if (err instanceof Error) return err.message;
+  return "Couldn't delete the passkey. Try again.";
+}
+
+// Surface-specific copy for `registerWithPasskey` failures during add-
+// device. Mirrors the login screen's PasskeyError → friendly-message
+// table but tuned to the "you're already signed in, adding a device"
+// flow (no `registration_closed` because authed users always pass that
+// check).
+function formatPasskeyEnrollError(err: unknown): string {
+  if (err instanceof PasskeyError) {
+    switch (err.code) {
+      case "user_cancelled":
+        return "Cancelled. Tap Add passkey when you're ready.";
+      case "credential_already_registered":
+        return "That passkey is already registered on this account.";
+      case "no_authenticator":
+        return "This device doesn't support passkeys.";
+      case "network_error":
+        return "Network error. Check your connection and try again.";
+      case "email_mismatch":
+        return "Couldn't enrol — re-sign-in and try again.";
+      default:
+        return "Couldn't enrol the passkey. Try again.";
+    }
+  }
+  if (err instanceof Error) return err.message;
+  return "Couldn't enrol the passkey. Try again.";
+}

--- a/packages/admin/src/components/profile/sessions-card.tsx
+++ b/packages/admin/src/components/profile/sessions-card.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { orpc } from "@/lib/orpc.js";
+import { useMutation } from "@tanstack/react-query";
+
+export function SessionsCard(): ReactNode {
+  const [feedback, setFeedback] = useState<
+    { kind: "ok"; revoked: number } | { kind: "error"; message: string } | null
+  >(null);
+
+  const revokeOthers = useMutation({
+    mutationFn: () => orpc.auth.sessions.revokeOthers.call({}),
+    onMutate: () => {
+      setFeedback(null);
+    },
+    onSuccess: (result) => {
+      setFeedback({ kind: "ok", revoked: result.revoked });
+    },
+    onError: (err) => {
+      setFeedback({
+        kind: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : "Couldn't revoke sessions. Try again.",
+      });
+    },
+  });
+
+  return (
+    <Card data-testid="profile-sessions-card">
+      <CardHeader>
+        <CardTitle>Active sessions</CardTitle>
+        <CardDescription>
+          Sign out everywhere except this browser. Use this if you suspect a
+          device has been lost or your session was used somewhere unexpected.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {feedback?.kind === "ok" ? (
+          <Alert data-testid="profile-sessions-feedback">
+            <AlertDescription>
+              {feedback.revoked === 0
+                ? "No other sessions to sign out."
+                : feedback.revoked === 1
+                  ? "Signed out 1 other session."
+                  : `Signed out ${feedback.revoked} other sessions.`}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+        {feedback?.kind === "error" ? (
+          <Alert variant="destructive" data-testid="profile-sessions-error">
+            <AlertDescription>{feedback.message}</AlertDescription>
+          </Alert>
+        ) : null}
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              revokeOthers.mutate();
+            }}
+            disabled={revokeOthers.isPending}
+            data-testid="profile-sessions-revoke-button"
+          >
+            {revokeOthers.isPending ? "Signing out…" : "Sign out other devices"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/admin/src/lib/orpc-errors.ts
+++ b/packages/admin/src/lib/orpc-errors.ts
@@ -1,0 +1,19 @@
+// Shape-checking helpers for oRPC client errors. The wire form is
+// `{ code: "NOT_FOUND" | "CONFLICT" | ..., data?: { reason?: string } }`
+// — three identical inline copies were drifting across the admin
+// surfaces (users edit, terms edit, profile passkeys); centralise so
+// new error-mapping call sites pick the same shape.
+
+export function extractCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "code" in err) {
+    return (err as { code?: string }).code;
+  }
+  return undefined;
+}
+
+export function extractReason(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "data" in err) {
+    return (err as { data?: { reason?: string } }).data?.reason;
+  }
+  return undefined;
+}

--- a/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { FormEditSkeleton } from "@/components/form/edit-skeleton.js";
 import { MetaBoxCard } from "@/components/meta-box/meta-box.js";
+import { PasskeysCard } from "@/components/profile/passkeys-card.js";
+import { SessionsCard } from "@/components/profile/sessions-card.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
 import { Button } from "@/components/ui/button.js";
@@ -415,6 +417,14 @@ function UserEditForm({
 
       {canDisable ? <StatusCard target={target} /> : null}
       {canDelete ? <DeleteCard target={target} /> : null}
+
+      {/* Self-service auth surface — only the user themselves manages
+          their own credentials and signs out their other devices.
+          Cross-user passkey/session management is intentionally not
+          available, even to admins, since both surfaces are second-
+          factor security primitives. */}
+      {isSelf ? <PasskeysCard userEmail={target.email} /> : null}
+      {isSelf ? <SessionsCard /> : null}
     </div>
   );
 }

--- a/packages/core/src/rpc/procedures/auth/auth.test.ts
+++ b/packages/core/src/rpc/procedures/auth/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 
+import type { RequestAuthenticator } from "../../../auth/authenticator.js";
 import { SESSION_COOKIE_NAME } from "../../../auth/cookies.js";
 import { createSession } from "../../../auth/sessions.js";
 import { eq } from "../../../db/index.js";
@@ -7,6 +8,8 @@ import { sessions } from "../../../db/schema/sessions.js";
 import { HookRegistry } from "../../../hooks/registry.js";
 import { definePlugin } from "../../../plugin/define.js";
 import { installPlugins } from "../../../plugin/register.js";
+import { userFactory } from "../../../test/factories.js";
+import { createTestDb } from "../../../test/harness.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
 describe("auth.session", () => {
@@ -463,5 +466,75 @@ describe("auth.sessions.revokeOthers", () => {
     const h = await createRpcHarness({ authAs: "editor" });
     const result = await h.client.auth.sessions.revokeOthers({});
     expect(result.revoked).toBe(0);
+  });
+
+  test("returns revoked: 0 when the request has no plumix session cookie (cfAccess / external IdP)", async () => {
+    // Simulate the cfAccess case via a custom authenticator: the user
+    // is authed without ever minting a plumix `sessions` row. The
+    // proc should no-op cleanly even if there are *other* sessions
+    // for this user (left over from a prior session-cookie auth).
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({ role: "editor" });
+    await createSession(db, { userId: user.id });
+    await createSession(db, { userId: user.id });
+
+    const headerAuth: RequestAuthenticator = {
+      authenticate: () => Promise.resolve(user),
+    };
+    // Build a request *without* the session cookie — the cfAccess case.
+    const request = new Request("https://cms.example/_plumix/rpc", {
+      method: "POST",
+    });
+    const h = await createRpcHarness({
+      request,
+      authenticator: headerAuth,
+    });
+    const result = await h.client.auth.sessions.revokeOthers({});
+    expect(result.revoked).toBe(0);
+
+    // Existing rows are untouched.
+    const remaining = await db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.userId, user.id));
+    expect(remaining).toHaveLength(2);
+  });
+});
+
+describe("auth.credentials.delete — race safety", () => {
+  test("two concurrent deletes can't both leave the user with zero credentials", async () => {
+    // The TOCTOU window between count + delete is closed by folding
+    // the count check into the DELETE's WHERE via a subquery (per-
+    // statement isolation in SQLite). With exactly two credentials
+    // and two concurrent delete calls, exactly one must succeed.
+    const h = await createRpcHarness({ authAs: "editor" });
+    const cred1 = await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "A",
+    });
+    const cred2 = await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([4, 5, 6]),
+      name: "B",
+    });
+
+    const results = await Promise.allSettled([
+      h.client.auth.credentials.delete({ id: cred1.id }),
+      h.client.auth.credentials.delete({ id: cred2.id }),
+    ]);
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // The losing call must be a CONFLICT/last_credential — not
+    // NOT_FOUND or anything else.
+    expect(rejected[0]!.reason).toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "last_credential" },
+    });
+
+    const after = await h.client.auth.credentials.list({});
+    expect(after).toHaveLength(1);
   });
 });

--- a/packages/core/src/rpc/procedures/auth/auth.test.ts
+++ b/packages/core/src/rpc/procedures/auth/auth.test.ts
@@ -529,7 +529,9 @@ describe("auth.credentials.delete — race safety", () => {
     expect(rejected).toHaveLength(1);
     // The losing call must be a CONFLICT/last_credential — not
     // NOT_FOUND or anything else.
-    expect(rejected[0]!.reason).toMatchObject({
+    const losing = rejected[0];
+    if (!losing) throw new Error("expected a rejected result");
+    expect(losing.reason).toMatchObject({
       code: "CONFLICT",
       data: { reason: "last_credential" },
     });

--- a/packages/core/src/rpc/procedures/auth/auth.test.ts
+++ b/packages/core/src/rpc/procedures/auth/auth.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 
 import { SESSION_COOKIE_NAME } from "../../../auth/cookies.js";
+import { createSession } from "../../../auth/sessions.js";
+import { eq } from "../../../db/index.js";
+import { sessions } from "../../../db/schema/sessions.js";
 import { HookRegistry } from "../../../hooks/registry.js";
 import { definePlugin } from "../../../plugin/define.js";
 import { installPlugins } from "../../../plugin/register.js";
@@ -239,5 +242,226 @@ describe("auth.allowedDomains", () => {
     await expect(
       h.client.auth.allowedDomains.create({ domain: "not a domain" }),
     ).rejects.toBeDefined();
+  });
+});
+
+describe("auth.credentials", () => {
+  test("list rejects an unauthenticated caller", async () => {
+    const h = await createRpcHarness();
+    await expect(h.client.auth.credentials.list({})).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  test("list returns only the current user's credentials", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const otherUser = await h.factory.user.create({
+      email: "other@cms.example",
+    });
+
+    await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "MacBook",
+    });
+    await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([4, 5, 6]),
+      name: "iPhone",
+    });
+    await h.factory.credential.create({
+      userId: otherUser.id,
+      publicKey: Buffer.from([7, 8, 9]),
+      name: "Other's key",
+    });
+
+    const result = await h.client.auth.credentials.list({});
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.name).sort()).toEqual(
+      ["MacBook", "iPhone"].sort(),
+    );
+  });
+
+  test("list omits the publicKey blob from the wire payload", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "Phone",
+    });
+    const result = await h.client.auth.credentials.list({});
+    expect(result[0]).not.toHaveProperty("publicKey");
+  });
+
+  test("rename updates the user's own credential", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const cred = await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "Old name",
+    });
+
+    const renamed = await h.client.auth.credentials.rename({
+      id: cred.id,
+      name: "New name",
+    });
+    expect(renamed.name).toBe("New name");
+  });
+
+  test("rename refuses cross-user attempts with NOT_FOUND (no oracle)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const otherUser = await h.factory.user.create({
+      email: "other@cms.example",
+    });
+    const otherCred = await h.factory.credential.create({
+      userId: otherUser.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "Not yours",
+    });
+
+    await expect(
+      h.client.auth.credentials.rename({ id: otherCred.id, name: "x" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("rename rejects empty / oversized names", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const cred = await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "ok",
+    });
+
+    await expect(
+      h.client.auth.credentials.rename({ id: cred.id, name: "" }),
+    ).rejects.toBeDefined();
+    await expect(
+      h.client.auth.credentials.rename({ id: cred.id, name: "x".repeat(65) }),
+    ).rejects.toBeDefined();
+    await expect(
+      h.client.auth.credentials.rename({
+        id: cred.id,
+        name: "name\r\ninjection",
+      }),
+    ).rejects.toBeDefined();
+  });
+
+  test("delete removes a credential when the user has more than one", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const cred1 = await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "Old",
+    });
+    await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([4, 5, 6]),
+      name: "New",
+    });
+
+    const result = await h.client.auth.credentials.delete({ id: cred1.id });
+    expect(result.id).toBe(cred1.id);
+
+    const after = await h.client.auth.credentials.list({});
+    expect(after).toHaveLength(1);
+    expect(after[0]?.name).toBe("New");
+  });
+
+  test("delete refuses to remove the user's last credential", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const cred = await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "Only",
+    });
+
+    await expect(
+      h.client.auth.credentials.delete({ id: cred.id }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "last_credential" },
+    });
+
+    // The credential is still there.
+    const after = await h.client.auth.credentials.list({});
+    expect(after).toHaveLength(1);
+  });
+
+  test("delete refuses cross-user attempts with NOT_FOUND", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    // Caller has 2 credentials so the at-least-one guard would pass
+    // for them; the cross-user attempt must still be NOT_FOUND.
+    await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([1, 2, 3]),
+      name: "Mine 1",
+    });
+    await h.factory.credential.create({
+      userId: h.user.id,
+      publicKey: Buffer.from([4, 5, 6]),
+      name: "Mine 2",
+    });
+    const otherUser = await h.factory.user.create({
+      email: "other@cms.example",
+    });
+    const otherCred = await h.factory.credential.create({
+      userId: otherUser.id,
+      publicKey: Buffer.from([7, 8, 9]),
+      name: "Theirs",
+    });
+
+    await expect(
+      h.client.auth.credentials.delete({ id: otherCred.id }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("auth.sessions.revokeOthers", () => {
+  test("rejects an unauthenticated caller", async () => {
+    const h = await createRpcHarness();
+    await expect(h.client.auth.sessions.revokeOthers({})).rejects.toMatchObject(
+      { code: "UNAUTHORIZED" },
+    );
+  });
+
+  test("deletes other sessions for the user but preserves the current one", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    // Mint two extra sessions for the current user (devices) — the
+    // harness's authed request already minted one (the "current" one).
+    await createSession(h.db, { userId: h.user.id });
+    await createSession(h.db, { userId: h.user.id });
+
+    const result = await h.client.auth.sessions.revokeOthers({});
+    expect(result.revoked).toBe(2);
+
+    // One row remains: the current session.
+    const remaining = await h.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.userId, h.user.id));
+    expect(remaining).toHaveLength(1);
+  });
+
+  test("doesn't touch other users' sessions", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const otherUser = await h.factory.user.create({
+      email: "other@cms.example",
+    });
+    await createSession(h.db, { userId: otherUser.id });
+    await createSession(h.db, { userId: otherUser.id });
+
+    await h.client.auth.sessions.revokeOthers({});
+
+    const otherSessions = await h.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.userId, otherUser.id));
+    expect(otherSessions).toHaveLength(2);
+  });
+
+  test("returns revoked: 0 when there are no other sessions", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const result = await h.client.auth.sessions.revokeOthers({});
+    expect(result.revoked).toBe(0);
   });
 });

--- a/packages/core/src/rpc/procedures/auth/credentials/delete.ts
+++ b/packages/core/src/rpc/procedures/auth/credentials/delete.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "../../../../db/index.js";
+import { and, eq, sql } from "../../../../db/index.js";
 import { credentials } from "../../../../db/schema/credentials.js";
 import { authenticated } from "../../../authenticated.js";
 import { base } from "../../../base.js";
@@ -10,29 +10,39 @@ import { credentialsDeleteInputSchema } from "./schemas.js";
 // admin intervention (re-issue invite). The user can still rotate by
 // enrolling the new device first (`/passkey/register/options` add-
 // device flow), then deleting the old one.
+//
+// Race-safety: the count check is folded into the DELETE's WHERE via a
+// subquery so the entire decision happens inside one SQLite statement
+// (per-statement isolation = atomic). Two concurrent deletes can no
+// longer both observe `count = 2` and both succeed; the second one
+// sees `count = 1` after the first commits and is denied.
 export const del = base
   .use(authenticated)
   .input(credentialsDeleteInputSchema)
   .handler(async ({ input, context, errors }) => {
-    const owned = await context.db.$count(
-      credentials,
-      eq(credentials.userId, context.user.id),
-    );
-    if (owned <= 1) {
-      throw errors.CONFLICT({ data: { reason: "last_credential" } });
-    }
-
+    const userId = context.user.id;
     const [row] = await context.db
       .delete(credentials)
       .where(
         and(
           eq(credentials.id, input.id),
-          eq(credentials.userId, context.user.id),
+          eq(credentials.userId, userId),
+          sql`(SELECT COUNT(*) FROM ${credentials} WHERE ${credentials.userId} = ${userId}) > 1`,
         ),
       )
       .returning({ id: credentials.id });
-    if (!row) {
+    if (row) return row;
+
+    // No row deleted — disambiguate the two failure modes so the
+    // client gets the right error code. NOT_FOUND if the target
+    // doesn't exist (or belongs to another user); CONFLICT if it
+    // does exist but the guard refused.
+    const [target] = await context.db
+      .select({ id: credentials.id })
+      .from(credentials)
+      .where(and(eq(credentials.id, input.id), eq(credentials.userId, userId)));
+    if (!target) {
       throw errors.NOT_FOUND({ data: { kind: "credential", id: input.id } });
     }
-    return row;
+    throw errors.CONFLICT({ data: { reason: "last_credential" } });
   });

--- a/packages/core/src/rpc/procedures/auth/credentials/delete.ts
+++ b/packages/core/src/rpc/procedures/auth/credentials/delete.ts
@@ -1,0 +1,38 @@
+import { and, eq } from "../../../../db/index.js";
+import { credentials } from "../../../../db/schema/credentials.js";
+import { authenticated } from "../../../authenticated.js";
+import { base } from "../../../base.js";
+import { credentialsDeleteInputSchema } from "./schemas.js";
+
+// Refuse to delete the user's last credential. Without this guard, a
+// user with passkey-only auth could lock themselves out by removing the
+// credential they're currently signed in with — recovery would require
+// admin intervention (re-issue invite). The user can still rotate by
+// enrolling the new device first (`/passkey/register/options` add-
+// device flow), then deleting the old one.
+export const del = base
+  .use(authenticated)
+  .input(credentialsDeleteInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const owned = await context.db.$count(
+      credentials,
+      eq(credentials.userId, context.user.id),
+    );
+    if (owned <= 1) {
+      throw errors.CONFLICT({ data: { reason: "last_credential" } });
+    }
+
+    const [row] = await context.db
+      .delete(credentials)
+      .where(
+        and(
+          eq(credentials.id, input.id),
+          eq(credentials.userId, context.user.id),
+        ),
+      )
+      .returning({ id: credentials.id });
+    if (!row) {
+      throw errors.NOT_FOUND({ data: { kind: "credential", id: input.id } });
+    }
+    return row;
+  });

--- a/packages/core/src/rpc/procedures/auth/credentials/index.ts
+++ b/packages/core/src/rpc/procedures/auth/credentials/index.ts
@@ -1,0 +1,9 @@
+import { del } from "./delete.js";
+import { list } from "./list.js";
+import { rename } from "./rename.js";
+
+export const credentialsRouter = {
+  list,
+  rename,
+  delete: del,
+} as const;

--- a/packages/core/src/rpc/procedures/auth/credentials/list.ts
+++ b/packages/core/src/rpc/procedures/auth/credentials/list.ts
@@ -1,0 +1,28 @@
+import { asc, eq } from "../../../../db/index.js";
+import { credentials } from "../../../../db/schema/credentials.js";
+import { authenticated } from "../../../authenticated.js";
+import { base } from "../../../base.js";
+import { credentialsListInputSchema } from "./schemas.js";
+
+// Returns the *current user's* registered passkeys. Self-scoped — no
+// capability check; users always see their own credentials. Drops the
+// raw `publicKey` blob (binary, useless to the admin UI, and a chunky
+// payload to ship over the wire on every list call).
+export const list = base
+  .use(authenticated)
+  .input(credentialsListInputSchema)
+  .handler(async ({ context }) => {
+    return context.db
+      .select({
+        id: credentials.id,
+        name: credentials.name,
+        deviceType: credentials.deviceType,
+        isBackedUp: credentials.isBackedUp,
+        transports: credentials.transports,
+        createdAt: credentials.createdAt,
+        lastUsedAt: credentials.lastUsedAt,
+      })
+      .from(credentials)
+      .where(eq(credentials.userId, context.user.id))
+      .orderBy(asc(credentials.createdAt));
+  });

--- a/packages/core/src/rpc/procedures/auth/credentials/list.ts
+++ b/packages/core/src/rpc/procedures/auth/credentials/list.ts
@@ -16,7 +16,6 @@ export const list = base
       .select({
         id: credentials.id,
         name: credentials.name,
-        deviceType: credentials.deviceType,
         isBackedUp: credentials.isBackedUp,
         transports: credentials.transports,
         createdAt: credentials.createdAt,

--- a/packages/core/src/rpc/procedures/auth/credentials/rename.ts
+++ b/packages/core/src/rpc/procedures/auth/credentials/rename.ts
@@ -1,0 +1,31 @@
+import { and, eq } from "../../../../db/index.js";
+import { credentials } from "../../../../db/schema/credentials.js";
+import { authenticated } from "../../../authenticated.js";
+import { base } from "../../../base.js";
+import { credentialsRenameInputSchema } from "./schemas.js";
+
+// Self-scoped: the WHERE clause pins both `id` and `userId`, so a user
+// can only rename their own credentials. Cross-user attempts return
+// NOT_FOUND with no oracle (same shape as a non-existent id).
+export const rename = base
+  .use(authenticated)
+  .input(credentialsRenameInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const [row] = await context.db
+      .update(credentials)
+      .set({ name: input.name })
+      .where(
+        and(
+          eq(credentials.id, input.id),
+          eq(credentials.userId, context.user.id),
+        ),
+      )
+      .returning({
+        id: credentials.id,
+        name: credentials.name,
+      });
+    if (!row) {
+      throw errors.NOT_FOUND({ data: { kind: "credential", id: input.id } });
+    }
+    return row;
+  });

--- a/packages/core/src/rpc/procedures/auth/credentials/schemas.ts
+++ b/packages/core/src/rpc/procedures/auth/credentials/schemas.ts
@@ -1,0 +1,34 @@
+import * as v from "valibot";
+
+// Defensive bound on credential id values from the URL/body. WebAuthn
+// credential IDs are typically tens to a few hundred bytes; 1024 chars
+// of base64url-equivalent text is generous. Match the cap the passkey
+// register/login routes already use.
+const credentialIdSchema = v.pipe(
+  v.string(),
+  v.minLength(1),
+  v.maxLength(1024),
+);
+
+// Human-readable label shown in the credential list. CR/LF blocked
+// defense-in-depth — same rationale as `siteName` and login-link
+// labels: a future audit-log consumer could splice into a line-
+// oriented format.
+const credentialNameSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1, "name must be non-empty"),
+  v.maxLength(64, "name must be ≤ 64 chars"),
+  v.regex(/^[^\r\n]+$/, "name must not contain newlines"),
+);
+
+export const credentialsListInputSchema = v.optional(v.object({}), {});
+
+export const credentialsRenameInputSchema = v.object({
+  id: credentialIdSchema,
+  name: credentialNameSchema,
+});
+
+export const credentialsDeleteInputSchema = v.object({
+  id: credentialIdSchema,
+});

--- a/packages/core/src/rpc/procedures/auth/index.ts
+++ b/packages/core/src/rpc/procedures/auth/index.ts
@@ -1,13 +1,17 @@
 import { allowedDomainsRouter } from "./allowed-domains/index.js";
+import { credentialsRouter } from "./credentials/index.js";
 import { loginLinks } from "./login-links.js";
 import { oauthProviders } from "./oauth-providers.js";
 import { session } from "./session.js";
+import { sessionsRouter } from "./sessions/index.js";
 
 export const authRouter = {
   session,
   oauthProviders,
   loginLinks,
   allowedDomains: allowedDomainsRouter,
+  credentials: credentialsRouter,
+  sessions: sessionsRouter,
 } as const;
 
 export type AuthRouter = typeof authRouter;

--- a/packages/core/src/rpc/procedures/auth/sessions/index.ts
+++ b/packages/core/src/rpc/procedures/auth/sessions/index.ts
@@ -1,0 +1,5 @@
+import { revokeOthers } from "./revoke-others.js";
+
+export const sessionsRouter = {
+  revokeOthers,
+} as const;

--- a/packages/core/src/rpc/procedures/auth/sessions/revoke-others.ts
+++ b/packages/core/src/rpc/procedures/auth/sessions/revoke-others.ts
@@ -1,0 +1,44 @@
+import { readSessionCookie } from "../../../../auth/cookies.js";
+import { hashToken } from "../../../../auth/tokens.js";
+import { and, eq, ne } from "../../../../db/index.js";
+import { sessions } from "../../../../db/schema/sessions.js";
+import { authenticated } from "../../../authenticated.js";
+import { base } from "../../../base.js";
+import { sessionsRevokeOthersInputSchema } from "./schemas.js";
+
+// Revoke every plumix session for the current user *except* the one
+// making the call. Used by the "Sign out other devices" button on the
+// profile page — the security-incident-response workflow.
+//
+// Two semantics worth flagging:
+//
+//   - Self-scoped. The WHERE clause pins `userId = ctx.user.id`; we
+//     never touch other users' sessions. The "sign out everyone in
+//     this org" workflow is `invalidateAllSessionsForUser` (admin-only,
+//     not surfaced via this proc).
+//
+//   - External authenticators (cfAccess, custom guards) don't mint
+//     plumix `sessions` rows — the IdP owns the session. The proc
+//     still runs (the user passed the `authenticated` middleware), but
+//     `readSessionCookie` returns null and there's nothing to delete.
+//     We return `{ revoked: 0 }` rather than erroring; the admin's UI
+//     can show "no plumix-managed sessions to revoke" and the operator
+//     uses the IdP's own session-management surface.
+export const revokeOthers = base
+  .use(authenticated)
+  .input(sessionsRevokeOthersInputSchema)
+  .handler(async ({ context }) => {
+    const currentToken = readSessionCookie(context.request);
+    if (!currentToken) {
+      return { revoked: 0 };
+    }
+    const currentId = await hashToken(currentToken);
+
+    const rows = await context.db
+      .delete(sessions)
+      .where(
+        and(eq(sessions.userId, context.user.id), ne(sessions.id, currentId)),
+      )
+      .returning({ id: sessions.id });
+    return { revoked: rows.length };
+  });

--- a/packages/core/src/rpc/procedures/auth/sessions/schemas.ts
+++ b/packages/core/src/rpc/procedures/auth/sessions/schemas.ts
@@ -1,0 +1,3 @@
+import * as v from "valibot";
+
+export const sessionsRevokeOthersInputSchema = v.optional(v.object({}), {});

--- a/packages/core/src/test/rpc.ts
+++ b/packages/core/src/test/rpc.ts
@@ -1,6 +1,7 @@
 import type { RouterClient } from "@orpc/server";
 import { createRouterClient } from "@orpc/server";
 
+import type { RequestAuthenticator } from "../auth/authenticator.js";
 import type { AppContext, Db } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
 import type { HookExecutor, HookRegistry } from "../hooks/registry.js";
@@ -43,6 +44,12 @@ export interface BaseRpcHarnessOptions {
    * default `[]` matches a passkey-only deploy.
    */
   readonly oauthProviders?: readonly OAuthProviderSummary[];
+  /**
+   * Override the default session-cookie authenticator. Tests for
+   * external-IdP-style flows (cfAccess, custom guards) pass an
+   * instance here; the RPC `authenticated` middleware delegates to it.
+   */
+  readonly authenticator?: RequestAuthenticator;
 }
 
 export interface AuthenticatedHarnessOptions extends BaseRpcHarnessOptions {
@@ -93,6 +100,7 @@ function buildContext(
   plugins: PluginRegistry,
   request: Request,
   oauthProviders: readonly OAuthProviderSummary[],
+  authenticator: RequestAuthenticator | undefined,
 ): AppContext {
   return createAppContext({
     db,
@@ -102,6 +110,7 @@ function buildContext(
     plugins,
     logger: silentLogger,
     oauthProviders,
+    authenticator,
   });
 }
 
@@ -128,6 +137,7 @@ function assemble<TUser extends User | null>(
   request: Request,
   user: TUser,
   oauthProviders: readonly OAuthProviderSummary[],
+  authenticator: RequestAuthenticator | undefined,
 ): RpcHarnessBase<TUser> {
   const context = buildContext(
     db,
@@ -136,6 +146,7 @@ function assemble<TUser extends User | null>(
     plugins,
     request,
     oauthProviders,
+    authenticator,
   );
   const client = createRouterClient(appRouter, { context });
 
@@ -156,7 +167,16 @@ function assemble<TUser extends User | null>(
           ? await userFactory.transient({ db }).create({ role: userOrRole })
           : userOrRole;
       const req = await authenticatedRequest(db, targetUser.id);
-      return assemble(db, env, hooks, plugins, req, targetUser, oauthProviders);
+      return assemble(
+        db,
+        env,
+        hooks,
+        plugins,
+        req,
+        targetUser,
+        oauthProviders,
+        authenticator,
+      );
     },
   };
   return harness;
@@ -182,7 +202,16 @@ export async function createRpcHarness(
       .transient({ db })
       .create({ role: options.authAs });
     const request = await authenticatedRequest(db, user.id);
-    return assemble(db, env, hooks, plugins, request, user, oauthProviders);
+    return assemble(
+      db,
+      env,
+      hooks,
+      plugins,
+      request,
+      user,
+      oauthProviders,
+      options.authenticator,
+    );
   }
 
   const request = options.request ?? unauthenticatedRequest();
@@ -194,5 +223,6 @@ export async function createRpcHarness(
     request,
     null,
     oauthProviders,
+    options.authenticator,
   );
 }


### PR DESCRIPTION
Adds the two security-critical pieces of admin auth UI flagged after the auth-extensibility audit (#115): users can now manage their own passkeys, and there's a one-click "sign out everywhere except here" for incident response. Both surfaces were missing — without them, a lost-device passkey is unrevocable and a leaked session can't be invalidated short of an admin clearing rows in the DB.

## What's new

**Backend — two RPC namespaces under `auth.*`**

- `auth.credentials.{list, rename, delete}` — self-scoped (`userId = ctx.user.id` predicate), `NOT_FOUND` for cross-user attempts (no oracle), `CONFLICT/last_credential` if deleting the user's only passkey would lock them out. The list query drops the `publicKey` blob from the wire payload.
- `auth.sessions.revokeOthers` — reads the current session token from the cookie, hashes it, deletes every other `sessions` row for the caller's user. Returns `{ revoked: count }`. Self-scoped via `userId` predicate; admin's "sign everyone out" workflow stays as the existing `invalidateAllSessionsForUser`. Returns `{ revoked: 0 }` cleanly when there's no plumix session cookie (e.g. cfAccess / external IdP owns the session).

**Admin — two cards on `/users/:id/edit` rendered when `isSelf`**

- `PasskeysCard` — lists passkeys with their transport label ("This device" / "Cross-device" / "Security key"), a "Synced" badge for backed-up credentials, inline rename, delete with confirmation. The Delete button is disabled with a tooltip when this is the user's only passkey, mirroring the server's `last_credential` guard. An "Add passkey" button kicks off the existing `add-device` register flow.
- `SessionsCard` — single "Sign out other devices" button with inline feedback. The current session is preserved server-side; user stays signed in.

Cross-user passkey/session management is intentionally not exposed even to admins — both surfaces are second-factor security primitives and forcing the action through the user's own profile keeps the threat model clean. Admins still have `disable user` (existing StatusCard) for "this account is compromised, lock it".

## Audit pass

All four sentry skills (find-bugs, security-review, code-review, code-simplifier) ran on the branch. Findings landed in two follow-up commits:

- **`fix(core)` — close TOCTOU in last-credential guard.** The original `delete` did `\$count` then `DELETE` as separate statements; two concurrent calls could both observe `count = 2` and both succeed, locking the user out. Folded the count check into the `DELETE`'s `WHERE` via a subquery — single SQLite statement, atomic by construction. Plus dropped unused `deviceType` from the list response (wire-shape lock-in pre-0.1.0). Also extends `createRpcHarness` with an `authenticator` override so the cfAccess revoke-others case can be tested.
- **`refactor(admin)` — orpc error helpers + UX polish.** Extracted `extractCode`/`extractReason` to `@/lib/orpc-errors.js` (was three identical inline copies across admin surfaces). Dropped the local `normaliseCred` helper — uses existing `@/lib/dates.js` `toDate` instead. Collapsed `formatTransport`'s nfc/ble/usb fallback to a single "Security key" label so end users never see raw WebAuthn transport tokens.

**Security-review verdict:** no high-confidence vulnerabilities. CSRF inherited from dispatcher. Self-scope predicate verified at every call site. The TOCTOU was caught by find-bugs and fixed.

## Tests

- 18 new backend tests: list (cross-user isolation, publicKey omission), rename (happy + cross-user → NOT_FOUND + invalid names), delete (happy + last-credential guard + cross-user + race-safety), revokeOthers (preserve current + scope isolation + zero-when-empty + cfAccess-no-cookie). 823 core tests pass overall.
- No new admin tests. The admin package doesn't have an established orpc-mock pattern; adding one for two cards in isolation would land oddly. The integration is type-checked, the RPC layer is comprehensively backend-tested, and the admin's existing 135 tests still pass. Worth picking up as part of broader admin UI test work.

## Out of scope (deferred)

- Per-session list with IP/UA + per-row revoke (`auth.sessions.list` + per-row `revoke({ id })`). The schema already has the columns; v0.2.0 UX. Blind revoke-all is the right primitive for v0.1.0.
- Audit log of credential / session events. No schema for it yet; significant feature.
- Toast feedback. Admin uses inline alerts everywhere; consistency wins.
- "Add passkey" preflight copy ("you'll be prompted for biometric"). Cheap fix; punted to follow-up.

## Commits

1. `chore(core): narrow drizzle-kit snapshot type at the boundary` — pre-existing lint blockage from the typescript-eslint update
2. `feat(core): auth.credentials + auth.sessions.revokeOthers RPC procs`
3. `feat(admin): passkey management + sign out other devices on profile`
4. `fix(core): close TOCTOU in last-credential guard; drop unused deviceType`
5. `refactor(admin): consolidate orpc error helpers; collapse passkey transports`