### PR TITLE
feat: LookupAdapter interface + user single reference (#126)

### DIFF
--- a/packages/admin/src/components/meta-box/meta-box-field.test.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.test.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { Form } from "@/components/ui/form.js";
+import { createQueryClient } from "@/providers/query-client.js";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useForm, useWatch } from "react-hook-form";
@@ -43,11 +45,21 @@ function Harness({
   const form = useForm<Record<string, unknown>>({
     defaultValues: { [fieldDef.key]: initial },
   });
+  // Reference fields call `useQuery`; provide a fresh QueryClient
+  // per-test so the surrounding tests stay independent. No fetcher
+  // is wired here — the smoke tests only assert dispatch + initial
+  // state, not query results (those are covered by the lookup RPC
+  // tests in core).
+  const queryClient = createQueryClient();
   return (
-    <Form {...form}>
-      <MetaBoxField field={fieldDef} name={fieldDef.key} />
-      {onChangeSpy ? <Spy name={fieldDef.key} onChange={onChangeSpy} /> : null}
-    </Form>
+    <QueryClientProvider client={queryClient}>
+      <Form {...form}>
+        <MetaBoxField field={fieldDef} name={fieldDef.key} />
+        {onChangeSpy ? (
+          <Spy name={fieldDef.key} onChange={onChangeSpy} />
+        ) : null}
+      </Form>
+    </QueryClientProvider>
   );
 }
 
@@ -210,6 +222,42 @@ describe("MetaBoxField dispatcher", () => {
 
     await userEvent.clear(input);
     expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  test("user reference: empty state shows 'None selected' + 'Select' button", () => {
+    render(
+      <Harness
+        fieldDef={field({
+          inputType: "user",
+          referenceTarget: { kind: "user", scope: { roles: ["admin"] } },
+        })}
+        initial={null}
+      />,
+    );
+    expect(screen.getByTestId("meta-box-field-k-input")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("meta-box-field-k-input-empty"),
+    ).toHaveTextContent("None selected");
+    expect(screen.getByTestId("meta-box-field-k-input-open")).toHaveTextContent(
+      "Select",
+    );
+  });
+
+  test("user reference: required fields hide the Clear button when populated", () => {
+    render(
+      <Harness
+        fieldDef={field({
+          inputType: "user",
+          required: true,
+          referenceTarget: { kind: "user" },
+        })}
+        initial="42"
+      />,
+    );
+    // No clear button while required + populated.
+    expect(
+      screen.queryByTestId("meta-box-field-k-input-clear"),
+    ).not.toBeInTheDocument();
   });
 
   test("multiselect: clicking a toggle item emits the updated array", async () => {

--- a/packages/admin/src/components/meta-box/meta-box-field.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.tsx
@@ -17,6 +17,8 @@ import { cn } from "@/lib/utils";
 
 import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 
+import { ReferencePicker } from "./reference-picker.js";
+
 // Schema-driven field renderer wired to react-hook-form. Each meta-box
 // field becomes a shadcn `FormField` under the supplied `name` path so
 // label/description/error rendering + ARIA wiring match every other
@@ -229,6 +231,27 @@ function renderNativeInput({
     );
   }
 
+  if (field.referenceTarget && field.inputType === "user") {
+    const value =
+      typeof rhf.value === "string" && rhf.value !== "" ? rhf.value : null;
+    return (
+      <ReferencePicker
+        value={value}
+        onChange={(next) => {
+          rhf.onChange(next);
+        }}
+        kind={field.referenceTarget.kind}
+        scope={
+          field.referenceTarget.scope as Record<string, unknown> | undefined
+        }
+        disabled={disabled}
+        required={field.required}
+        label={field.label}
+        testId={testId}
+      />
+    );
+  }
+
   if (field.inputType === "multiselect") {
     const selected = Array.isArray(rhf.value)
       ? rhf.value.filter((v): v is string => typeof v === "string")
@@ -363,7 +386,7 @@ function renderNativeInput({
     // dev tools. A future `customRenderers` seam will hook in here
     // before the fallback.
     console.warn(
-      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/password/date/datetime/time/color/range/multiselect/json/select/radio/checkbox).`,
+      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/password/date/datetime/time/color/range/multiselect/json/user/select/radio/checkbox).`,
     );
   }
 

--- a/packages/admin/src/components/meta-box/reference-picker.tsx
+++ b/packages/admin/src/components/meta-box/reference-picker.tsx
@@ -1,0 +1,212 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button.js";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command.js";
+import { orpc } from "@/lib/orpc.js";
+import { useQuery } from "@tanstack/react-query";
+
+// Generic picker for reference fields (`user`, future `entry` /
+// `term` / `media`). The field's `referenceTarget.kind` selects the
+// adapter; `referenceTarget.scope` rides through to the lookup RPC
+// untouched. Same component, same UX, regardless of target.
+//
+// Storage is the bare ID string; the picker's job is to swap the
+// admin-side display from "42" to a human-readable label without
+// changing what the form submits.
+
+interface ReferencePickerProps {
+  readonly value: string | null;
+  readonly onChange: (next: string | null) => void;
+  readonly kind: string;
+  readonly scope?: Record<string, unknown>;
+  readonly disabled?: boolean;
+  readonly required?: boolean;
+  readonly label: string;
+  readonly testId: string;
+}
+
+export function ReferencePicker({
+  value,
+  onChange,
+  kind,
+  scope,
+  disabled = false,
+  required = false,
+  label,
+  testId,
+}: ReferencePickerProps): ReactNode {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  // Resolve the currently-selected id to its label/subtitle. Skips
+  // when value is null. Stale-data tolerant — if the target was
+  // deleted server-side, `result` comes back null and we render a
+  // "Missing" badge so the author knows to re-pick.
+  const resolveQuery = useQuery({
+    ...orpc.lookup.resolve.queryOptions({
+      input: { kind, id: value ?? "", scope },
+    }),
+    enabled: value !== null,
+  });
+
+  const listQuery = useQuery({
+    ...orpc.lookup.list.queryOptions({
+      input: { kind, query: query.trim() || undefined, scope, limit: 20 },
+    }),
+    enabled: open,
+  });
+
+  const selected = value !== null ? (resolveQuery.data?.result ?? null) : null;
+  const items = listQuery.data?.items ?? [];
+
+  return (
+    <div className="flex items-center gap-2" data-testid={testId}>
+      <div className="min-w-0 flex-1">
+        {renderDisplay({
+          testId,
+          value,
+          selected,
+          isResolving: resolveQuery.isLoading,
+        })}
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={disabled}
+        onClick={() => {
+          setQuery("");
+          setOpen(true);
+        }}
+        data-testid={`${testId}-open`}
+      >
+        {value === null ? "Select" : "Change"}
+      </Button>
+      {value !== null && !required ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={disabled}
+          onClick={() => {
+            onChange(null);
+          }}
+          data-testid={`${testId}-clear`}
+        >
+          Clear
+        </Button>
+      ) : null}
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        title={label}
+        description={`Search and pick a ${kind}`}
+      >
+        <CommandInput
+          placeholder={`Search ${kind}…`}
+          value={query}
+          onValueChange={setQuery}
+          data-testid={`${testId}-search`}
+        />
+        <CommandList>
+          {renderListBody({
+            isLoading: listQuery.isLoading,
+            items,
+            testId,
+            onSelect: (id) => {
+              onChange(id);
+              setOpen(false);
+            },
+          })}
+        </CommandList>
+      </CommandDialog>
+    </div>
+  );
+}
+
+interface LookupItem {
+  readonly id: string;
+  readonly label: string;
+  readonly subtitle?: string;
+}
+
+function renderDisplay({
+  testId,
+  value,
+  selected,
+  isResolving,
+}: {
+  testId: string;
+  value: string | null;
+  selected: LookupItem | null;
+  isResolving: boolean;
+}): ReactNode {
+  if (value === null) {
+    return (
+      <p
+        className="text-muted-foreground text-sm"
+        data-testid={`${testId}-empty`}
+      >
+        None selected
+      </p>
+    );
+  }
+  if (selected) {
+    return (
+      <div className="text-sm" data-testid={`${testId}-selected`}>
+        <p className="truncate font-medium">{selected.label}</p>
+        {selected.subtitle ? (
+          <p className="text-muted-foreground truncate text-xs">
+            {selected.subtitle}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+  if (isResolving) {
+    return <p className="text-muted-foreground text-sm">Resolving…</p>;
+  }
+  return (
+    <p className="text-destructive text-sm" data-testid={`${testId}-orphan`}>
+      Reference missing — re-pick or clear
+    </p>
+  );
+}
+
+function renderListBody({
+  isLoading,
+  items,
+  testId,
+  onSelect,
+}: {
+  isLoading: boolean;
+  items: readonly LookupItem[];
+  testId: string;
+  onSelect: (id: string) => void;
+}): ReactNode {
+  if (isLoading) return <CommandEmpty>Loading…</CommandEmpty>;
+  if (items.length === 0) return <CommandEmpty>No matches</CommandEmpty>;
+  return items.map((item) => (
+    <CommandItem
+      key={item.id}
+      value={`${item.label} ${item.subtitle ?? ""}`}
+      onSelect={() => {
+        onSelect(item.id);
+      }}
+      data-testid={`${testId}-option-${item.id}`}
+    >
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium">{item.label}</span>
+        {item.subtitle ? (
+          <span className="text-muted-foreground text-xs">{item.subtitle}</span>
+        ) : null}
+      </div>
+    </CommandItem>
+  ));
+}

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -13,6 +13,7 @@ import type {
   HookOptions,
 } from "../hooks/types.js";
 import type { RouteIntent } from "../route/intent.js";
+import type { LookupAdapterOptions } from "./lookup.js";
 import type {
   AdminPageOptions,
   BlockOptions,
@@ -181,6 +182,15 @@ export interface PluginSetupContextBase {
   registerAdminPage(options: AdminPageOptions): void;
   registerBlock(options: BlockOptions): void;
   registerFieldType(options: FieldTypeOptions): void;
+  /**
+   * Register a `LookupAdapter` for a reference target kind. The
+   * `kind` matches the `referenceTarget.kind` carried on a reference
+   * field's manifest entry; core ships adapters for `entry` /
+   * `term` / `user`, and plugins can add more (`media` from
+   * `@plumix/plugin-media`, future `comment` from a comments plugin,
+   * etc.). Duplicate kinds throw.
+   */
+  registerLookupAdapter(options: LookupAdapterOptions): void;
 
   /**
    * Surface a button on the standard login screen pointing at this
@@ -517,6 +527,19 @@ export function createPluginSetupContext({
       });
     },
 
+    registerLookupAdapter: (options) => {
+      assertValidLookupAdapterKind(pluginId, options.kind);
+      if (registry.lookupAdapters.has(options.kind)) {
+        throw new DuplicateRegistrationError("lookup adapter", options.kind);
+      }
+      registry.lookupAdapters.set(options.kind, {
+        kind: options.kind,
+        adapter: options.adapter,
+        capability: options.capability ?? null,
+        registeredBy: pluginId,
+      });
+    },
+
     registerLoginLink: (options) => {
       assertValidLoginLink(pluginId, options);
       for (const existing of registry.loginLinks) {
@@ -606,6 +629,16 @@ function assertValidFieldTypeName(pluginId: string, type: string): void {
     throw new Error(
       `Plugin "${pluginId}" registered meta-box field type with invalid ` +
         `name "${type}" — must match ${BLOCK_NAME_RE} and be at most 64 ` +
+        `characters.`,
+    );
+  }
+}
+
+function assertValidLookupAdapterKind(pluginId: string, kind: string): void {
+  if (!BLOCK_NAME_RE.test(kind) || kind.length > 64) {
+    throw new Error(
+      `Plugin "${pluginId}" registered lookup adapter with invalid ` +
+        `kind "${kind}" — must match ${BLOCK_NAME_RE} and be at most 64 ` +
         `characters.`,
     );
   }

--- a/packages/core/src/plugin/fields/builders.test.ts
+++ b/packages/core/src/plugin/fields/builders.test.ts
@@ -20,6 +20,7 @@ import {
   textarea,
   time,
   url,
+  user,
 } from "./index.js";
 
 // One combined suite for the seven straightforward variants whose
@@ -539,5 +540,72 @@ describe("manifest round-trip across all built-in builders", () => {
     expect(fields[1]).toMatchObject({ min: 0, max: 120 });
     expect(fields[4]?.options).toEqual([{ value: "m", label: "M" }]);
     expect(fields[6]).toMatchObject({ default: false });
+  });
+});
+
+describe("user() builder", () => {
+  test("pins inputType + type and emits a user-kind referenceTarget", () => {
+    const field = user({
+      key: "owner",
+      label: "Owner",
+      roles: ["editor", "admin"],
+    });
+    expect(field.inputType).toBe("user");
+    expect(field.type).toBe("string");
+    expect(field.referenceTarget).toEqual({
+      kind: "user",
+      scope: { roles: ["editor", "admin"], includeDisabled: undefined },
+    });
+  });
+
+  test("packages includeDisabled into the scope", () => {
+    const field = user({
+      key: "owner",
+      label: "Owner",
+      includeDisabled: true,
+    });
+    expect(field.referenceTarget.scope).toEqual({
+      roles: undefined,
+      includeDisabled: true,
+    });
+  });
+
+  test("rejects non-applicable options at the type level", () => {
+    user({
+      key: "u",
+      label: "u",
+      // @ts-expect-error — `placeholder` doesn't apply to a reference field.
+      placeholder: "pick",
+    });
+
+    user({
+      key: "u",
+      label: "u",
+      // @ts-expect-error — `options` belongs to select/radio.
+      options: [{ value: "a", label: "A" }],
+    });
+  });
+
+  test("manifest round-trip preserves referenceTarget on the wire shape", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("test", (ctx) => {
+      ctx.registerSettingsGroup("identity", {
+        label: "Site identity",
+        fields: [user({ key: "owner", label: "Owner", roles: ["admin"] })],
+      });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    const projected = manifest.settingsGroups[0]?.fields[0];
+    expect(projected).toMatchObject({
+      key: "owner",
+      inputType: "user",
+      type: "string",
+      referenceTarget: {
+        kind: "user",
+        scope: { roles: ["admin"] },
+      },
+    });
   });
 });

--- a/packages/core/src/plugin/fields/index.ts
+++ b/packages/core/src/plugin/fields/index.ts
@@ -43,3 +43,5 @@ export { radio } from "./radio.js";
 export type { RadioFieldOptions } from "./radio.js";
 export { checkbox } from "./checkbox.js";
 export type { CheckboxFieldOptions } from "./checkbox.js";
+export { user } from "./user.js";
+export type { UserFieldOptions, UserFieldScope } from "./user.js";

--- a/packages/core/src/plugin/fields/user.ts
+++ b/packages/core/src/plugin/fields/user.ts
@@ -1,0 +1,59 @@
+import type { UserRole } from "../../db/schema/users.js";
+import type { MetaBoxFieldSpan, UserMetaBoxField } from "../manifest.js";
+
+/**
+ * Public scope shape for the `user()` reference field. Carried on
+ * the field's `referenceTarget.scope`; the user `LookupAdapter`
+ * consumes it for write-time validation, picker filtering, and
+ * read-time orphan resolution.
+ */
+export interface UserFieldScope {
+  /** Restrict matches to these roles. Empty/absent → any role. */
+  readonly roles?: readonly UserRole[];
+  /**
+   * Whether to surface disabled accounts. Default `false` —
+   * disabled users are usually invalid reference targets even
+   * though the row still exists.
+   */
+  readonly includeDisabled?: boolean;
+}
+
+export interface UserFieldOptions {
+  readonly key: string;
+  readonly label: string;
+  readonly required?: boolean;
+  readonly description?: string;
+  readonly default?: string;
+  readonly span?: MetaBoxFieldSpan;
+  readonly roles?: readonly UserRole[];
+  readonly includeDisabled?: boolean;
+}
+
+/**
+ * Build a typed `user` reference field. Storage is the bare user id
+ * as a string (`"42"` → `users.id = 42`); reads return the resolved
+ * user (or `null` when the target is gone or no longer matches
+ * scope). The admin renders a picker that calls the lookup RPC with
+ * `{ kind: "user", scope: { roles, includeDisabled } }`.
+ *
+ * Scope rolls the two filters (`roles`, `includeDisabled`) into the
+ * builder's flat option shape — internally they're packaged into a
+ * `referenceTarget.scope` object the user adapter consumes.
+ */
+export function user(options: UserFieldOptions): UserMetaBoxField {
+  const scope: UserFieldScope = {
+    roles: options.roles,
+    includeDisabled: options.includeDisabled,
+  };
+  return {
+    key: options.key,
+    label: options.label,
+    type: "string",
+    inputType: "user",
+    referenceTarget: { kind: "user", scope },
+    required: options.required,
+    description: options.description,
+    default: options.default,
+    span: options.span,
+  };
+}

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -1,4 +1,5 @@
 export * from "./context.js";
 export * from "./define.js";
+export * from "./lookup.js";
 export * from "./manifest.js";
 export * from "./register.js";

--- a/packages/core/src/plugin/lookup.ts
+++ b/packages/core/src/plugin/lookup.ts
@@ -1,0 +1,67 @@
+import type { AppContext } from "../context/app.js";
+
+// Reference fields (entry / term / user / media) share three
+// operations per target kind: write-time existence check, read-time
+// orphan handling, admin picker search/list. `LookupAdapter` is the
+// seam where each kind plugs them in once; core ships adapters for
+// `entry` / `term` / `user`, plugins register their own via
+// `PluginContext.registerLookupAdapter`.
+
+export interface LookupResult {
+  readonly id: string;
+  readonly label: string;
+  readonly subtitle?: string;
+}
+
+export interface LookupListOptions<TScope = unknown> {
+  readonly query?: string;
+  readonly scope?: TScope;
+  readonly limit?: number;
+}
+
+/**
+ * `TScope` is the shape carried on the field's `referenceTarget.scope`
+ * — e.g. `{ roles: UserRole[] }` for `user`. Adapters interpret it
+ * however makes sense for their target. All methods are async so
+ * future implementations can hit the database without a contract
+ * break.
+ */
+export interface LookupAdapter<TScope = unknown> {
+  /** Returning `false` surfaces as `invalid_value` in the meta write pipeline. */
+  exists(ctx: AppContext, id: string, scope?: TScope): Promise<boolean>;
+
+  list(
+    ctx: AppContext,
+    options: LookupListOptions<TScope>,
+  ): Promise<readonly LookupResult[]>;
+
+  /** Returns `null` when the target is gone or no longer matches scope (orphan). */
+  resolve(
+    ctx: AppContext,
+    id: string,
+    scope?: TScope,
+  ): Promise<LookupResult | null>;
+}
+
+export interface RegisteredLookupAdapter<TScope = unknown> {
+  readonly kind: string;
+  readonly adapter: LookupAdapter<TScope>;
+  /**
+   * Capability the lookup RPC requires for `list` / `resolve` calls
+   * targeting this kind. Without it, any authenticated user could
+   * enumerate the adapter's universe — a real concern for `user` /
+   * `entry` whose rows leak email/name/title to lower-privilege
+   * roles. Server-side write validation (the meta pipeline calling
+   * `exists`) already runs after the entity-level write capability
+   * check, so this gate covers only the picker-facing surface.
+   */
+  readonly capability: string | null;
+  readonly registeredBy: string | null;
+}
+
+export interface LookupAdapterOptions<TScope = unknown> {
+  readonly kind: string;
+  readonly adapter: LookupAdapter<TScope>;
+  /** See `RegisteredLookupAdapter.capability`. `null` opts out (public lookup). */
+  readonly capability?: string | null;
+}

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -5,7 +5,6 @@ import type {
 import type { AppContext } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { RouteIntent } from "../route/intent.js";
-
 import type { RegisteredLookupAdapter } from "./lookup.js";
 
 export interface EntryTypeOptions {
@@ -323,6 +322,33 @@ export interface JsonMetaBoxField extends MetaBoxFieldBase {
   readonly type: "json";
 }
 
+/**
+ * Reference target descriptor carried on every reference field
+ * variant (`user`, `entry`, `term`, `media`, plugin-registered
+ * custom kinds). The `kind` matches a registered `LookupAdapter`;
+ * the adapter interprets `scope` according to its own contract.
+ *
+ * Reading the manifest, the admin dispatches to a generic picker
+ * that calls the lookup RPC with `{ kind, scope }` — picker UI is
+ * one component, target-specific knowledge lives in the adapter.
+ */
+export interface ReferenceTarget<TScope = unknown> {
+  readonly kind: string;
+  readonly scope?: TScope;
+}
+
+/**
+ * Single user reference. Storage is the bare user id as a string
+ * (`"42"` → `users.id = 42`); reads return `null` when the user is
+ * gone or no longer matches scope. The `referenceTarget.scope`
+ * accepts the user adapter's scope shape (roles + disabled-state).
+ */
+export interface UserMetaBoxField extends MetaBoxFieldBase {
+  readonly inputType: "user";
+  readonly type: "string";
+  readonly referenceTarget: ReferenceTarget;
+}
+
 /** Single-value dropdown picker; `options` is required. */
 export interface SelectMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "select";
@@ -388,6 +414,7 @@ export type MetaBoxField =
   | RangeMetaBoxField
   | MultiselectMetaBoxField
   | JsonMetaBoxField
+  | UserMetaBoxField
   | SelectMetaBoxField
   | RadioMetaBoxField
   | CheckboxMetaBoxField
@@ -446,6 +473,7 @@ export type EntryMetaBoxField =
   | Omit<RangeMetaBoxField, "span">
   | Omit<MultiselectMetaBoxField, "span">
   | Omit<JsonMetaBoxField, "span">
+  | Omit<UserMetaBoxField, "span">
   | Omit<SelectMetaBoxField, "span">
   | Omit<RadioMetaBoxField, "span">
   | Omit<CheckboxMetaBoxField, "span">
@@ -958,6 +986,13 @@ export interface MetaBoxFieldManifestEntry {
   readonly options?: readonly MetaBoxFieldOption[];
   readonly default?: unknown;
   readonly span?: MetaBoxFieldSpan;
+  /**
+   * Carried for reference field variants (`user`, `entry`, `term`,
+   * `media`, plugin-registered kinds). The admin's generic picker
+   * dispatches on `referenceTarget.kind` to call the matching
+   * lookup RPC; `scope` rides along untouched.
+   */
+  readonly referenceTarget?: ReferenceTarget;
 }
 
 /**
@@ -1851,6 +1886,7 @@ interface MetaBoxFieldOptionView {
   readonly max?: number | string;
   readonly step?: number;
   readonly options?: readonly MetaBoxFieldOption[];
+  readonly referenceTarget?: ReferenceTarget;
 }
 
 function toEntryMetaBoxFieldEntry(
@@ -1871,6 +1907,7 @@ function toEntryMetaBoxFieldEntry(
     step: view.step,
     options: view.options,
     default: field.default,
+    referenceTarget: view.referenceTarget,
   };
 }
 

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -798,6 +798,7 @@ export const CORE_RPC_NAMESPACES: ReadonlySet<string> = new Set([
   "entry",
   "term",
   "user",
+  "lookup",
   "settings",
 ]);
 

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -6,6 +6,8 @@ import type { AppContext } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { RouteIntent } from "../route/intent.js";
 
+import type { RegisteredLookupAdapter } from "./lookup.js";
+
 export interface EntryTypeOptions {
   readonly label: string;
   /**
@@ -787,6 +789,7 @@ export interface PluginRegistry {
   readonly adminPages: ReadonlyMap<string, RegisteredAdminPage>;
   readonly blocks: ReadonlyMap<string, RegisteredBlock>;
   readonly fieldTypes: ReadonlyMap<string, RegisteredFieldType>;
+  readonly lookupAdapters: ReadonlyMap<string, RegisteredLookupAdapter>;
 }
 
 export interface MutablePluginRegistry extends PluginRegistry {
@@ -805,6 +808,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly adminPages: Map<string, RegisteredAdminPage>;
   readonly blocks: Map<string, RegisteredBlock>;
   readonly fieldTypes: Map<string, RegisteredFieldType>;
+  readonly lookupAdapters: Map<string, RegisteredLookupAdapter>;
 }
 
 export function createPluginRegistry(): MutablePluginRegistry {
@@ -824,6 +828,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     adminPages: new Map(),
     blocks: new Map(),
     fieldTypes: new Map(),
+    lookupAdapters: new Map(),
   };
 }
 

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -3,7 +3,11 @@ import type { SQLiteColumn } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 
 import type { AppContext } from "../../context/app.js";
-import type { MetaBoxField, MetaScalarType } from "../../plugin/manifest.js";
+import type {
+  MetaBoxField,
+  MetaScalarType,
+  ReferenceTarget,
+} from "../../plugin/manifest.js";
 import { eq } from "../../db/index.js";
 
 // Shared meta plumbing for every entity that stores a `meta` JSON
@@ -155,6 +159,105 @@ export function sanitizeMetaForRpc(
     }
     throw error;
   }
+}
+
+/**
+ * Walk a sanitized patch and call each reference field's
+ * `LookupAdapter.exists` to confirm the upserted ID is real and in
+ * scope. Sync `sanitize` callbacks can't run DB queries, so this is
+ * a separate async step the RPC procedures invoke between
+ * sanitisation and `applyMetaPatch`. Missing adapters are treated
+ * the same as missing targets — both surface `invalid_value`.
+ */
+export async function validateMetaReferences(
+  ctx: AppContext,
+  findField: (key: string) => MetaBoxField | undefined,
+  patch: MetaPatch,
+): Promise<void> {
+  for (const [key, value] of patch.upserts) {
+    const target = referenceTargetOf(findField(key));
+    if (!target) continue;
+    if (typeof value !== "string") {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+    const registered = ctx.plugins.lookupAdapters.get(target.kind);
+    if (!registered) {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+    const exists = await registered.adapter.exists(ctx, value, target.scope);
+    if (!exists) {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+  }
+}
+
+/**
+ * RPC-shaped wrapper around `validateMetaReferences` — same envelope
+ * translation as `sanitizeMetaForRpc`. Procedures call this right
+ * after `sanitizeMetaForRpc` so reference validation rides on the
+ * same `meta_invalid_value` error surface authors already match on.
+ */
+export async function validateMetaReferencesForRpc(
+  ctx: AppContext,
+  findField: (key: string) => MetaBoxField | undefined,
+  patch: MetaPatch,
+  errors: RpcErrorsForMeta,
+): Promise<void> {
+  try {
+    await validateMetaReferences(ctx, findField, patch);
+  } catch (error) {
+    if (error instanceof MetaSanitizationError) {
+      throw errors.CONFLICT({
+        data: { reason: `meta_${error.reason}`, key: error.key },
+      });
+    }
+    throw error;
+  }
+}
+
+/**
+ * Resolve reference fields in a decoded meta bag, replacing any
+ * stored ID whose target is gone (or no longer matches scope) with
+ * `null`. Caller passes a freshly-decoded bag (e.g. from
+ * `decodeMetaBag`); the returned bag is a shallow copy with orphan
+ * keys nulled. Non-reference keys pass through untouched.
+ *
+ * Optional — call this from RPC handlers that surface meta to the
+ * admin/UI; internal callers that don't need orphan filtering can
+ * skip the extra round-trips.
+ *
+ * Perf: each reference key issues one `adapter.resolve` round-trip,
+ * so this scales O(refs) per entity load. Fine for single-entity
+ * `*.get` reads; list endpoints rendering many entities should
+ * either skip the filter (orphan IDs render as raw strings, the
+ * caller absorbs the staleness) or batch-resolve via a future
+ * `LookupAdapter.resolveMany(ids)` helper. Today's reference set
+ * is small enough that the per-entity cost is acceptable.
+ */
+export async function filterMetaOrphans(
+  ctx: AppContext,
+  findField: (key: string) => MetaBoxField | undefined,
+  decoded: MetaMap,
+): Promise<MetaMap> {
+  const out: MetaMap = { ...decoded };
+  for (const [key, value] of Object.entries(decoded)) {
+    if (typeof value !== "string") continue;
+    const target = referenceTargetOf(findField(key));
+    if (!target) continue;
+    const registered = ctx.plugins.lookupAdapters.get(target.kind);
+    if (!registered) continue;
+    const resolved = await registered.adapter.resolve(ctx, value, target.scope);
+    if (resolved === null) out[key] = null;
+  }
+  return out;
+}
+
+function referenceTargetOf(
+  field: MetaBoxField | undefined,
+): ReferenceTarget | undefined {
+  if (!field) return undefined;
+  return (field as { readonly referenceTarget?: ReferenceTarget })
+    .referenceTarget;
 }
 
 /**

--- a/packages/core/src/rpc/meta/references.test.ts
+++ b/packages/core/src/rpc/meta/references.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "vitest";
+
+import type {
+  MetaBoxField,
+  MutablePluginRegistry,
+} from "../../plugin/manifest.js";
+import { createPluginRegistry } from "../../plugin/manifest.js";
+import { adminUser, userFactory } from "../../test/factories.js";
+import { createRpcHarness } from "../../test/rpc.js";
+import { registerCoreLookupAdapters } from "../procedures/lookup-adapters.js";
+import {
+  filterMetaOrphans,
+  MetaSanitizationError,
+  sanitizeMetaInput,
+  validateMetaReferences,
+} from "./core.js";
+
+// Build a registry with the core lookup adapters registered + a
+// single user-meta box carrying a `user` reference field. The
+// reference field shape is the same one `user()` produces; we
+// build it inline rather than importing the builder so this test
+// stays focused on the pipeline.
+function registryWithUserRef(field: Partial<MetaBoxField> = {}) {
+  const registry: MutablePluginRegistry = createPluginRegistry();
+  registerCoreLookupAdapters(registry);
+  const fullField: MetaBoxField = {
+    key: "owner",
+    label: "Owner",
+    type: "string",
+    inputType: "user",
+    referenceTarget: { kind: "user" },
+    ...field,
+  } as MetaBoxField;
+  registry.userMetaBoxes.set("ownership", {
+    id: "ownership",
+    label: "Ownership",
+    fields: [fullField],
+    registeredBy: null,
+  });
+  return {
+    registry,
+    findField: (key: string) => (key === fullField.key ? fullField : undefined),
+  };
+}
+
+describe("validateMetaReferences", () => {
+  test("accepts an upsert whose reference id resolves under scope", async () => {
+    const { findField } = registryWithUserRef();
+    const h = await createRpcHarness({
+      authAs: "admin",
+      plugins: registryWithUserRef().registry,
+    });
+    const target = await userFactory.transient({ db: h.context.db }).create();
+
+    const patch = sanitizeMetaInput(findField, { owner: String(target.id) });
+    if (!patch) throw new Error("patch should not be null");
+
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects upserts with non-existent reference targets", async () => {
+    const { findField, registry } = registryWithUserRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, { owner: "999999" });
+    if (!patch) throw new Error("patch should not be null");
+
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("rejects upserts whose target falls outside the declared scope", async () => {
+    const { findField, registry } = registryWithUserRef({
+      referenceTarget: { kind: "user", scope: { roles: ["admin"] } },
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const author = await userFactory
+      .transient({ db: h.context.db })
+      .create({ role: "author" });
+    const patch = sanitizeMetaInput(findField, { owner: String(author.id) });
+    if (!patch) throw new Error("patch should not be null");
+
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("rejects when no adapter is registered for the field's kind", async () => {
+    const { findField, registry } = registryWithUserRef({
+      referenceTarget: { kind: "nonexistent-kind" },
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, { owner: "1" });
+    if (!patch) throw new Error("patch should not be null");
+
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("ignores upserts on non-reference fields", async () => {
+    // A patch carrying a non-reference key shouldn't trigger any
+    // adapter call; pass an empty findField to confirm nothing is
+    // looked up beyond what the upsert keys reference.
+    const registry = createPluginRegistry();
+    registerCoreLookupAdapters(registry);
+    const findField = (): MetaBoxField | undefined => undefined;
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    await expect(
+      validateMetaReferences(h.context, findField, {
+        upserts: new Map([["title", "Hello"]]),
+        deletes: [],
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("filterMetaOrphans", () => {
+  test("keeps in-scope reference values intact", async () => {
+    const { findField, registry } = registryWithUserRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const target = await adminUser.transient({ db: h.context.db }).create();
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      owner: String(target.id),
+    });
+    expect(filtered.owner).toBe(String(target.id));
+  });
+
+  test("nulls out orphan reference values whose target is gone", async () => {
+    const { findField, registry } = registryWithUserRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      owner: "999999",
+    });
+    expect(filtered.owner).toBeNull();
+  });
+
+  test("nulls out values that exist but fail scope", async () => {
+    const { findField, registry } = registryWithUserRef({
+      referenceTarget: { kind: "user", scope: { roles: ["admin"] } },
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const author = await userFactory
+      .transient({ db: h.context.db })
+      .create({ role: "author" });
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      owner: String(author.id),
+    });
+    expect(filtered.owner).toBeNull();
+  });
+
+  test("passes through non-reference keys untouched", async () => {
+    const registry = createPluginRegistry();
+    registerCoreLookupAdapters(registry);
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const filtered = await filterMetaOrphans(h.context, () => undefined, {
+      title: "Hello",
+      count: 7,
+    });
+    expect(filtered).toEqual({ title: "Hello", count: 7 });
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -4,6 +4,7 @@ import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
+import { registerCoreLookupAdapters } from "../lookup-adapters.js";
 
 describe("entry.create", () => {
   test("contributor can create a draft", async () => {
@@ -281,6 +282,43 @@ describe("entry.create", () => {
     ).rejects.toMatchObject({
       code: "CONFLICT",
       data: { reason: "meta_not_registered", key: "mystery" },
+    });
+  });
+
+  test("meta: reference field rejects an upsert pointing at a missing user", async () => {
+    // Smoke test for the validateEntryMetaReferences wiring in
+    // create.ts — confirms the LookupAdapter pipeline runs before the
+    // entity insert and surfaces missing references through the same
+    // `meta_invalid_value` envelope as a sanitize rejection. The
+    // term + user wrappers share the same machinery; covering entry
+    // is enough for regression detection.
+    const plugins = createPluginRegistry();
+    registerCoreLookupAdapters(plugins);
+    plugins.entryMetaBoxes.set("ownership", {
+      id: "ownership",
+      label: "Ownership",
+      entryTypes: ["post"],
+      fields: [
+        {
+          key: "owner",
+          label: "Owner",
+          type: "string",
+          inputType: "user",
+          referenceTarget: { kind: "user" },
+        },
+      ],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    await expect(
+      h.client.entry.create({
+        title: "missing-ref",
+        slug: "missing-ref",
+        meta: { owner: "999999" },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "meta_invalid_value", key: "owner" },
     });
   });
 

--- a/packages/core/src/rpc/procedures/entry/create.ts
+++ b/packages/core/src/rpc/procedures/entry/create.ts
@@ -14,6 +14,7 @@ import {
   decodeMetaBag,
   loadEntryMeta,
   sanitizeMetaForRpc,
+  validateEntryMetaReferences,
   writeEntryMeta,
 } from "./meta.js";
 import { entryCreateInputSchema } from "./schemas.js";
@@ -69,6 +70,14 @@ export const create = base
       filtered.meta,
       errors,
     );
+    if (metaPatch) {
+      await validateEntryMetaReferences(
+        context,
+        filtered.type,
+        metaPatch,
+        errors,
+      );
+    }
 
     // Same up-front validation: a bad term reference shouldn't leave a
     // half-created entry behind.

--- a/packages/core/src/rpc/procedures/entry/meta.ts
+++ b/packages/core/src/rpc/procedures/entry/meta.ts
@@ -6,9 +6,11 @@ import { findEntryMetaField } from "../../../plugin/manifest.js";
 import {
   applyMetaPatch,
   decodeMetaBag as decodeMetaBagCore,
+  filterMetaOrphans as filterMetaOrphansCore,
   isEmptyMetaPatch,
   loadMeta,
   sanitizeMetaForRpc as sanitizeMetaForRpcCore,
+  validateMetaReferencesForRpc,
 } from "../../meta/core.js";
 
 export type { MetaChanges as EntryMetaChanges } from "../../meta/core.js";
@@ -23,6 +25,26 @@ export function sanitizeMetaForRpc(
   return sanitizeMetaForRpcCore(
     (key) => findEntryMetaField(registry, entryType, key),
     input,
+    errors,
+  );
+}
+
+/**
+ * Async second pass on a sanitised entry-meta patch: validates each
+ * reference field's upserted ID against its registered
+ * `LookupAdapter`. RPC procedures call this between
+ * `sanitizeMetaForRpc` and `writeEntryMeta`.
+ */
+export async function validateEntryMetaReferences(
+  ctx: AppContext,
+  entryType: string,
+  patch: MetaPatch,
+  errors: Parameters<typeof sanitizeMetaForRpcCore>[2],
+): Promise<void> {
+  await validateMetaReferencesForRpc(
+    ctx,
+    (key) => findEntryMetaField(ctx.plugins, entryType, key),
+    patch,
     errors,
   );
 }
@@ -42,8 +64,13 @@ export async function loadEntryMeta(
   ctx: AppContext,
   entry: { readonly id: number; readonly type: string },
 ): Promise<Record<string, unknown>> {
-  return loadMeta(ctx, entries, entries.id, entry.id, (key) =>
+  const decoded = await loadMeta(ctx, entries, entries.id, entry.id, (key) =>
     findEntryMetaField(ctx.plugins, entry.type, key),
+  );
+  return filterMetaOrphansCore(
+    ctx,
+    (key) => findEntryMetaField(ctx.plugins, entry.type, key),
+    decoded,
   );
 }
 

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -20,6 +20,7 @@ import {
   decodeMetaBag,
   loadEntryMeta,
   sanitizeMetaForRpc,
+  validateEntryMetaReferences,
   writeEntryMeta,
 } from "./meta.js";
 import { entryUpdateInputSchema } from "./schemas.js";
@@ -189,6 +190,14 @@ export const update = base
       metaInput,
       errors,
     );
+    if (metaPatch) {
+      await validateEntryMetaReferences(
+        context,
+        existing.type,
+        metaPatch,
+        errors,
+      );
+    }
     if (termsPatch !== undefined) {
       await assertTermsPatchValid(
         context,

--- a/packages/core/src/rpc/procedures/lookup-adapters.ts
+++ b/packages/core/src/rpc/procedures/lookup-adapters.ts
@@ -1,0 +1,19 @@
+import type { MutablePluginRegistry } from "../../plugin/manifest.js";
+import { userLookupAdapter } from "./user/lookup.js";
+
+// Core adapters seed the registry before plugins install so plugin-
+// supplied kinds can't collide with built-ins (`registerLookupAdapter`
+// throws on duplicate kind). Today this only covers `user` — `entry`
+// and `term` adapters land in subsequent slices.
+
+export function registerCoreLookupAdapters(
+  registry: MutablePluginRegistry,
+): void {
+  registry.lookupAdapters.set("user", {
+    kind: "user",
+    adapter: userLookupAdapter,
+    // Picker enumerates email + name; matches the `user.list` gate.
+    capability: "user:list",
+    registeredBy: null,
+  });
+}

--- a/packages/core/src/rpc/procedures/lookup/index.ts
+++ b/packages/core/src/rpc/procedures/lookup/index.ts
@@ -1,0 +1,7 @@
+import { list } from "./list.js";
+import { resolve } from "./resolve.js";
+
+export const lookupRouter = {
+  list,
+  resolve,
+} as const;

--- a/packages/core/src/rpc/procedures/lookup/list.ts
+++ b/packages/core/src/rpc/procedures/lookup/list.ts
@@ -1,0 +1,23 @@
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { lookupListInputSchema, requireAdapter } from "./schemas.js";
+
+// Generic pickers in the admin (`UserPicker`, `EntryPicker`, etc.)
+// dispatch to this procedure with `{ kind, query, scope }`. Server
+// looks up the registered `LookupAdapter` for the kind and forwards
+// the call. Unknown kinds 404 — the admin should never reach here
+// with a kind absent from the manifest, so a missing kind means
+// either a stale wire payload or a malicious caller.
+
+export const list = base
+  .use(authenticated)
+  .input(lookupListInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const { adapter } = requireAdapter(context, input.kind, errors);
+    const items = await adapter.list(context, {
+      query: input.query,
+      scope: input.scope,
+      limit: input.limit,
+    });
+    return { items };
+  });

--- a/packages/core/src/rpc/procedures/lookup/lookup.test.ts
+++ b/packages/core/src/rpc/procedures/lookup/lookup.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { adminUser, userFactory } from "../../../test/factories.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+import { registerCoreLookupAdapters } from "../lookup-adapters.js";
+
+function registryWithCoreAdapters() {
+  const registry = createPluginRegistry();
+  registerCoreLookupAdapters(registry);
+  return registry;
+}
+
+describe("lookup.list", () => {
+  test("returns adapter list results for a known kind", async () => {
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    await userFactory
+      .transient({ db: h.context.db })
+      .create({ email: "alpha@example.test", name: "Alpha" });
+    await userFactory
+      .transient({ db: h.context.db })
+      .create({ email: "beta@example.test", name: "Beta" });
+
+    const result = await h.client.lookup.list({
+      kind: "user",
+      query: "alpha",
+    });
+    expect(result.items.find((i) => i.label === "Alpha")).toBeDefined();
+    expect(result.items.find((i) => i.label === "Beta")).toBeUndefined();
+  });
+
+  test("404s when the kind has no registered adapter", async () => {
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    await expect(
+      h.client.lookup.list({ kind: "nonexistent" }),
+    ).rejects.toThrow();
+  });
+
+  test("forwards scope to the adapter", async () => {
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    await adminUser.transient({ db: h.context.db }).create({ name: "Admin1" });
+    await userFactory
+      .transient({ db: h.context.db })
+      .create({ role: "author", name: "Author1" });
+
+    const adminsOnly = await h.client.lookup.list({
+      kind: "user",
+      scope: { roles: ["admin"] },
+    });
+    expect(adminsOnly.items.find((i) => i.label === "Admin1")).toBeDefined();
+    expect(adminsOnly.items.find((i) => i.label === "Author1")).toBeUndefined();
+  });
+});
+
+describe("lookup.resolve", () => {
+  test("returns the lookup result for a valid id", async () => {
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const u = await userFactory
+      .transient({ db: h.context.db })
+      .create({ name: "Cara" });
+    const result = await h.client.lookup.resolve({
+      kind: "user",
+      id: String(u.id),
+    });
+    expect(result.result?.label).toBe("Cara");
+  });
+
+  test("returns null for orphan ids", async () => {
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    const result = await h.client.lookup.resolve({
+      kind: "user",
+      id: "999999",
+    });
+    expect(result.result).toBeNull();
+  });
+
+  test("404s when the kind has no registered adapter", async () => {
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ authAs: "admin", plugins });
+    await expect(
+      h.client.lookup.resolve({ kind: "nope", id: "1" }),
+    ).rejects.toThrow();
+  });
+
+  test("requires authentication", async () => {
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ plugins });
+    await expect(
+      h.client.lookup.resolve({ kind: "user", id: "1" }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("lookup capability gating", () => {
+  test("subscribers (no `user:list` capability) get FORBIDDEN on user lookup", async () => {
+    // Subscribers can authenticate but can't list users — picker access
+    // would otherwise enumerate every email + name across the system.
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ authAs: "subscriber", plugins });
+    await userFactory
+      .transient({ db: h.context.db })
+      .create({ email: "leak@example.test", name: "Leak Target" });
+
+    await expect(h.client.lookup.list({ kind: "user" })).rejects.toThrow();
+    await expect(
+      h.client.lookup.resolve({ kind: "user", id: "1" }),
+    ).rejects.toThrow();
+  });
+
+  test("editors (with `user:list`) can call user lookup", async () => {
+    const plugins = registryWithCoreAdapters();
+    const h = await createRpcHarness({ authAs: "editor", plugins });
+    const result = await h.client.lookup.list({ kind: "user", limit: 1 });
+    expect(result.items).toBeDefined();
+  });
+});

--- a/packages/core/src/rpc/procedures/lookup/resolve.ts
+++ b/packages/core/src/rpc/procedures/lookup/resolve.ts
@@ -1,0 +1,19 @@
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { lookupResolveInputSchema, requireAdapter } from "./schemas.js";
+
+// Picker uses this to render the label of an already-selected ID
+// (e.g. when an entry's saved meta points at user id "42", the form
+// loads showing the user's name + role rather than the bare "42").
+// Returns `{ result: null }` when the target is gone or no longer
+// matches scope — same orphan semantics as `filterMetaOrphans`
+// applies here.
+
+export const resolve = base
+  .use(authenticated)
+  .input(lookupResolveInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const { adapter } = requireAdapter(context, input.kind, errors);
+    const result = await adapter.resolve(context, input.id, input.scope);
+    return { result };
+  });

--- a/packages/core/src/rpc/procedures/lookup/schemas.ts
+++ b/packages/core/src/rpc/procedures/lookup/schemas.ts
@@ -1,0 +1,61 @@
+import * as v from "valibot";
+
+import type { AppContext } from "../../../context/app.js";
+import type { RegisteredLookupAdapter } from "../../../plugin/lookup.js";
+
+// `kind` matches the discriminator a reference field carries on its
+// `referenceTarget.kind`. Valid kinds are checked against the
+// adapter registry at handler time, so the schema only enforces a
+// shape (lowercase alphanum + dash/underscore, ≤ 64 chars) the
+// registry contract can store.
+const kindSchema = v.pipe(v.string(), v.regex(/^[a-z][a-z0-9_-]{0,63}$/i));
+
+const querySchema = v.pipe(v.string(), v.trim(), v.maxLength(200));
+
+// Scope rides through to the adapter as an opaque JSON object.
+// Per-kind validation lives in the adapter (e.g. `user` validates
+// `roles` against `USER_ROLES`); the RPC schema only confirms the
+// shape isn't an array or scalar.
+const scopeSchema = v.optional(v.record(v.string(), v.unknown()));
+
+export const lookupListInputSchema = v.object({
+  kind: kindSchema,
+  query: v.optional(querySchema),
+  scope: scopeSchema,
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
+  ),
+});
+
+export const lookupResolveInputSchema = v.object({
+  kind: kindSchema,
+  id: v.pipe(v.string(), v.maxLength(256)),
+  scope: scopeSchema,
+});
+
+interface LookupErrors {
+  NOT_FOUND: (args: { data: { kind: string; id: string } }) => Error;
+  FORBIDDEN: (args: { data: { capability: string } }) => Error;
+}
+
+export function requireAdapter(
+  context: AppContext,
+  kind: string,
+  errors: LookupErrors,
+): RegisteredLookupAdapter {
+  const registered = context.plugins.lookupAdapters.get(kind);
+  if (!registered) {
+    throw errors.NOT_FOUND({ data: { kind: "lookup_adapter", id: kind } });
+  }
+  // Picker-facing surface: the adapter's owner declared which
+  // capability gates list/resolve. Without it, any authenticated
+  // user could enumerate the adapter's universe (emails for `user`,
+  // titles for future `entry`, etc.) at a lower privilege than the
+  // matching list RPC enforces. Adapters that opt out (`null`) are
+  // public — make that an explicit decision per kind.
+  const { capability } = registered;
+  if (capability !== null && !context.auth.can(capability)) {
+    throw errors.FORBIDDEN({ data: { capability } });
+  }
+  return registered;
+}

--- a/packages/core/src/rpc/procedures/term/create.ts
+++ b/packages/core/src/rpc/procedures/term/create.ts
@@ -7,6 +7,7 @@ import {
   decodeMetaBag,
   loadTermMeta,
   sanitizeMetaForRpc,
+  validateTermMetaReferences,
   writeTermMeta,
 } from "./meta.js";
 import { termCreateInputSchema } from "./schemas.js";
@@ -51,6 +52,14 @@ export const create = base
       filtered.meta,
       errors,
     );
+    if (metaPatch) {
+      await validateTermMetaReferences(
+        context,
+        filtered.taxonomy,
+        metaPatch,
+        errors,
+      );
+    }
 
     let created;
     try {

--- a/packages/core/src/rpc/procedures/term/meta.ts
+++ b/packages/core/src/rpc/procedures/term/meta.ts
@@ -6,9 +6,11 @@ import { findTermMetaField } from "../../../plugin/manifest.js";
 import {
   applyMetaPatch,
   decodeMetaBag as decodeMetaBagCore,
+  filterMetaOrphans as filterMetaOrphansCore,
   isEmptyMetaPatch,
   loadMeta,
   sanitizeMetaForRpc as sanitizeMetaForRpcCore,
+  validateMetaReferencesForRpc,
 } from "../../meta/core.js";
 
 export type { MetaChanges as TermMetaChanges } from "../../meta/core.js";
@@ -23,6 +25,20 @@ export function sanitizeMetaForRpc(
   return sanitizeMetaForRpcCore(
     (key) => findTermMetaField(registry, taxonomy, key),
     input,
+    errors,
+  );
+}
+
+export async function validateTermMetaReferences(
+  ctx: AppContext,
+  taxonomy: string,
+  patch: MetaPatch,
+  errors: Parameters<typeof sanitizeMetaForRpcCore>[2],
+): Promise<void> {
+  await validateMetaReferencesForRpc(
+    ctx,
+    (key) => findTermMetaField(ctx.plugins, taxonomy, key),
+    patch,
     errors,
   );
 }
@@ -42,8 +58,13 @@ export async function loadTermMeta(
   ctx: AppContext,
   term: { readonly id: number; readonly taxonomy: string },
 ): Promise<Record<string, unknown>> {
-  return loadMeta(ctx, terms, terms.id, term.id, (key) =>
+  const decoded = await loadMeta(ctx, terms, terms.id, term.id, (key) =>
     findTermMetaField(ctx.plugins, term.taxonomy, key),
+  );
+  return filterMetaOrphansCore(
+    ctx,
+    (key) => findTermMetaField(ctx.plugins, term.taxonomy, key),
+    decoded,
   );
 }
 

--- a/packages/core/src/rpc/procedures/term/update.ts
+++ b/packages/core/src/rpc/procedures/term/update.ts
@@ -10,6 +10,7 @@ import {
   decodeMetaBag,
   loadTermMeta,
   sanitizeMetaForRpc,
+  validateTermMetaReferences,
   writeTermMeta,
 } from "./meta.js";
 import { termUpdateInputSchema } from "./schemas.js";
@@ -66,6 +67,14 @@ export const update = base
       metaInput,
       errors,
     );
+    if (metaPatch) {
+      await validateTermMetaReferences(
+        context,
+        existing.taxonomy,
+        metaPatch,
+        errors,
+      );
+    }
 
     const patch: Partial<NewTerm> = stripUndefined(changes);
 

--- a/packages/core/src/rpc/procedures/user/lookup.test.ts
+++ b/packages/core/src/rpc/procedures/user/lookup.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+
+import { adminUser, userFactory } from "../../../test/factories.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+import { userLookupAdapter } from "./lookup.js";
+
+describe("userLookupAdapter", () => {
+  test("exists() returns true for an active user", async () => {
+    const h = await createRpcHarness();
+    const u = await userFactory.transient({ db: h.context.db }).create();
+    expect(await userLookupAdapter.exists(h.context, String(u.id))).toBe(true);
+  });
+
+  test("exists() returns false for a non-existent id", async () => {
+    const h = await createRpcHarness();
+    expect(await userLookupAdapter.exists(h.context, "999999")).toBe(false);
+  });
+
+  test("exists() rejects malformed ids without hitting the DB", async () => {
+    const h = await createRpcHarness();
+    expect(await userLookupAdapter.exists(h.context, "")).toBe(false);
+    expect(await userLookupAdapter.exists(h.context, "abc")).toBe(false);
+    expect(await userLookupAdapter.exists(h.context, "0")).toBe(false);
+    expect(await userLookupAdapter.exists(h.context, "-1")).toBe(false);
+    expect(await userLookupAdapter.exists(h.context, "1.5")).toBe(false);
+  });
+
+  test("exists() honours the roles scope filter", async () => {
+    const h = await createRpcHarness();
+    const author = await userFactory
+      .transient({ db: h.context.db })
+      .create({ role: "author" });
+    expect(
+      await userLookupAdapter.exists(h.context, String(author.id), {
+        roles: ["editor", "admin"],
+      }),
+    ).toBe(false);
+    expect(
+      await userLookupAdapter.exists(h.context, String(author.id), {
+        roles: ["author"],
+      }),
+    ).toBe(true);
+  });
+
+  test("exists() excludes disabled users by default", async () => {
+    const h = await createRpcHarness();
+    const u = await userFactory
+      .transient({ db: h.context.db })
+      .create({ disabledAt: new Date() });
+    expect(await userLookupAdapter.exists(h.context, String(u.id))).toBe(false);
+    expect(
+      await userLookupAdapter.exists(h.context, String(u.id), {
+        includeDisabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("list() searches by email and name (case-insensitive substring)", async () => {
+    const h = await createRpcHarness();
+    await userFactory
+      .transient({ db: h.context.db })
+      .create({ email: "alice@example.test", name: "Alice" });
+    await userFactory
+      .transient({ db: h.context.db })
+      .create({ email: "bob@example.test", name: "Bob" });
+
+    const aliceMatches = await userLookupAdapter.list(h.context, {
+      query: "alice",
+    });
+    expect(aliceMatches.map((r) => r.label).sort()).toContain("Alice");
+    expect(aliceMatches.find((r) => r.label === "Bob")).toBeUndefined();
+  });
+
+  test("list() respects the limit cap and rejects pathological values", async () => {
+    const h = await createRpcHarness();
+    for (let i = 0; i < 5; i++) {
+      await userFactory.transient({ db: h.context.db }).create();
+    }
+    expect(await userLookupAdapter.list(h.context, { limit: 2 })).toHaveLength(
+      2,
+    );
+    // Negative / zero / NaN fall back to the default (20), capped by row
+    // count.
+    const all = await userLookupAdapter.list(h.context, { limit: 0 });
+    expect(all.length).toBeLessThanOrEqual(20);
+  });
+
+  test("list() returns subtitle that includes role for users with names", async () => {
+    const h = await createRpcHarness();
+    await adminUser.transient({ db: h.context.db }).create({ name: "Ada" });
+    const results = await userLookupAdapter.list(h.context, { query: "Ada" });
+    const row = results.find((r) => r.label === "Ada");
+    expect(row?.subtitle).toContain("admin");
+  });
+
+  test("resolve() returns null for missing / orphaned ids", async () => {
+    const h = await createRpcHarness();
+    expect(await userLookupAdapter.resolve(h.context, "999999")).toBeNull();
+    expect(await userLookupAdapter.resolve(h.context, "abc")).toBeNull();
+  });
+
+  test("resolve() returns the lookup result for valid in-scope ids", async () => {
+    const h = await createRpcHarness();
+    const u = await adminUser
+      .transient({ db: h.context.db })
+      .create({ name: "Eva" });
+    const result = await userLookupAdapter.resolve(h.context, String(u.id), {
+      roles: ["admin"],
+    });
+    expect(result?.id).toBe(String(u.id));
+    expect(result?.label).toBe("Eva");
+  });
+
+  test("resolve() returns null when the id exists but fails scope", async () => {
+    const h = await createRpcHarness();
+    const u = await userFactory
+      .transient({ db: h.context.db })
+      .create({ role: "author" });
+    expect(
+      await userLookupAdapter.resolve(h.context, String(u.id), {
+        roles: ["admin"],
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/rpc/procedures/user/lookup.ts
+++ b/packages/core/src/rpc/procedures/user/lookup.ts
@@ -1,24 +1,10 @@
 import type { SQL } from "drizzle-orm";
 
 import type { UserRole } from "../../../db/schema/users.js";
+import type { UserFieldScope } from "../../../plugin/fields/user.js";
 import type { LookupAdapter, LookupResult } from "../../../plugin/lookup.js";
 import { and, eq, inArray, isNull, like, or, sql } from "../../../db/index.js";
 import { users } from "../../../db/schema/users.js";
-
-// Pluggable scope config for the `user` reference field. Carried on
-// the field's `referenceTarget.scope` and passed verbatim into each
-// adapter call. Keeping this as a public type lets future variants
-// (`userList`) reuse the same shape unchanged.
-export interface UserLookupScope {
-  /** Restrict matches to these roles. Empty/absent → any role. */
-  readonly roles?: readonly UserRole[];
-  /**
-   * Whether to surface disabled accounts. Default `false` — disabled
-   * users are usually invalid reference targets even though the row
-   * still exists.
-   */
-  readonly includeDisabled?: boolean;
-}
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
@@ -30,7 +16,7 @@ const USER_ROW_COLUMNS = {
   role: users.role,
 } as const;
 
-export const userLookupAdapter: LookupAdapter<UserLookupScope> = {
+export const userLookupAdapter: LookupAdapter<UserFieldScope> = {
   async exists(ctx, id, scope) {
     const numericId = parseUserId(id);
     if (numericId === null) return false;
@@ -81,11 +67,11 @@ function parseUserId(id: string): number | null {
   return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
-function buildUserWhere(numericId: number, scope: UserLookupScope | undefined) {
+function buildUserWhere(numericId: number, scope: UserFieldScope | undefined) {
   return and(eq(users.id, numericId), ...scopeConditions(scope));
 }
 
-function scopeConditions(scope: UserLookupScope | undefined): SQL[] {
+function scopeConditions(scope: UserFieldScope | undefined): SQL[] {
   const conditions: SQL[] = [];
   if (scope?.roles && scope.roles.length > 0) {
     conditions.push(inArray(users.role, scope.roles as UserRole[]));

--- a/packages/core/src/rpc/procedures/user/lookup.ts
+++ b/packages/core/src/rpc/procedures/user/lookup.ts
@@ -1,0 +1,118 @@
+import type { SQL } from "drizzle-orm";
+
+import type { UserRole } from "../../../db/schema/users.js";
+import type { LookupAdapter, LookupResult } from "../../../plugin/lookup.js";
+import { and, eq, inArray, isNull, like, or, sql } from "../../../db/index.js";
+import { users } from "../../../db/schema/users.js";
+
+// Pluggable scope config for the `user` reference field. Carried on
+// the field's `referenceTarget.scope` and passed verbatim into each
+// adapter call. Keeping this as a public type lets future variants
+// (`userList`) reuse the same shape unchanged.
+export interface UserLookupScope {
+  /** Restrict matches to these roles. Empty/absent → any role. */
+  readonly roles?: readonly UserRole[];
+  /**
+   * Whether to surface disabled accounts. Default `false` — disabled
+   * users are usually invalid reference targets even though the row
+   * still exists.
+   */
+  readonly includeDisabled?: boolean;
+}
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+const USER_ROW_COLUMNS = {
+  id: users.id,
+  email: users.email,
+  name: users.name,
+  role: users.role,
+} as const;
+
+export const userLookupAdapter: LookupAdapter<UserLookupScope> = {
+  async exists(ctx, id, scope) {
+    const numericId = parseUserId(id);
+    if (numericId === null) return false;
+    const row = await ctx.db
+      .select({ id: users.id })
+      .from(users)
+      .where(buildUserWhere(numericId, scope))
+      .limit(1);
+    return row.length > 0;
+  },
+
+  async list(ctx, options) {
+    const conditions = scopeConditions(options.scope);
+    const trimmedQuery = options.query?.trim();
+    if (trimmedQuery) {
+      const pattern = `%${trimmedQuery}%`;
+      const queryMatch = or(
+        like(users.email, pattern),
+        like(users.name, pattern),
+      );
+      if (queryMatch) conditions.push(queryMatch);
+    }
+    const rows = await ctx.db
+      .select(USER_ROW_COLUMNS)
+      .from(users)
+      .where(conditions.length === 0 ? undefined : and(...conditions))
+      .orderBy(sql`coalesce(${users.name}, ${users.email})`)
+      .limit(clampLimit(options.limit));
+    return rows.map(toLookupResult);
+  },
+
+  async resolve(ctx, id, scope) {
+    const numericId = parseUserId(id);
+    if (numericId === null) return null;
+    const [row] = await ctx.db
+      .select(USER_ROW_COLUMNS)
+      .from(users)
+      .where(buildUserWhere(numericId, scope))
+      .limit(1);
+    return row ? toLookupResult(row) : null;
+  },
+};
+
+function parseUserId(id: string): number | null {
+  // users.id is autoincrement; reject anything that isn't a positive integer.
+  if (!/^[1-9]\d*$/.test(id)) return null;
+  const parsed = Number(id);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function buildUserWhere(numericId: number, scope: UserLookupScope | undefined) {
+  return and(eq(users.id, numericId), ...scopeConditions(scope));
+}
+
+function scopeConditions(scope: UserLookupScope | undefined): SQL[] {
+  const conditions: SQL[] = [];
+  if (scope?.roles && scope.roles.length > 0) {
+    conditions.push(inArray(users.role, scope.roles as UserRole[]));
+  }
+  if (!scope?.includeDisabled) {
+    conditions.push(isNull(users.disabledAt));
+  }
+  return conditions;
+}
+
+function clampLimit(requested: number | undefined): number {
+  if (requested === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isFinite(requested) || requested <= 0) return DEFAULT_LIST_LIMIT;
+  return Math.min(Math.floor(requested), MAX_LIST_LIMIT);
+}
+
+function toLookupResult(row: {
+  readonly id: number;
+  readonly email: string;
+  readonly name: string | null;
+  readonly role: UserRole;
+}): LookupResult {
+  const trimmedName = row.name?.trim();
+  return {
+    id: String(row.id),
+    label:
+      trimmedName !== undefined && trimmedName !== "" ? trimmedName : row.email,
+    subtitle: row.name ? `${row.email} · ${row.role}` : row.role,
+  };
+}

--- a/packages/core/src/rpc/procedures/user/meta.ts
+++ b/packages/core/src/rpc/procedures/user/meta.ts
@@ -6,9 +6,11 @@ import { findUserMetaField } from "../../../plugin/manifest.js";
 import {
   applyMetaPatch,
   decodeMetaBag as decodeMetaBagCore,
+  filterMetaOrphans as filterMetaOrphansCore,
   isEmptyMetaPatch,
   loadMeta,
   sanitizeMetaForRpc as sanitizeMetaForRpcCore,
+  validateMetaReferencesForRpc,
 } from "../../meta/core.js";
 
 export type { MetaChanges as UserMetaChanges } from "../../meta/core.js";
@@ -27,6 +29,19 @@ export function sanitizeMetaForRpc(
   );
 }
 
+export async function validateUserMetaReferences(
+  ctx: AppContext,
+  patch: MetaPatch,
+  errors: Parameters<typeof sanitizeMetaForRpcCore>[2],
+): Promise<void> {
+  await validateMetaReferencesForRpc(
+    ctx,
+    (key) => findUserMetaField(ctx.plugins, key),
+    patch,
+    errors,
+  );
+}
+
 export function decodeMetaBag(
   registry: PluginRegistry,
   raw: Readonly<Record<string, unknown>> | null | undefined,
@@ -38,8 +53,13 @@ export async function loadUserMeta(
   ctx: AppContext,
   user: { readonly id: number },
 ): Promise<Record<string, unknown>> {
-  return loadMeta(ctx, users, users.id, user.id, (key) =>
+  const decoded = await loadMeta(ctx, users, users.id, user.id, (key) =>
     findUserMetaField(ctx.plugins, key),
+  );
+  return filterMetaOrphansCore(
+    ctx,
+    (key) => findUserMetaField(ctx.plugins, key),
+    decoded,
   );
 }
 

--- a/packages/core/src/rpc/procedures/user/update.ts
+++ b/packages/core/src/rpc/procedures/user/update.ts
@@ -12,6 +12,7 @@ import {
   decodeMetaBag,
   loadUserMeta,
   sanitizeMetaForRpc,
+  validateUserMetaReferences,
   writeUserMeta,
 } from "./meta.js";
 import { userUpdateInputSchema } from "./schemas.js";
@@ -120,6 +121,9 @@ export const update = base
     // front so a bad key fails before any write.
     const { id: _id, meta: metaInput, ...changes } = filtered;
     const metaPatch = sanitizeMetaForRpc(context.plugins, metaInput, errors);
+    if (metaPatch) {
+      await validateUserMetaReferences(context, metaPatch, errors);
+    }
     const patch: Partial<NewUser> = stripUndefined(changes);
 
     // Nothing to write anywhere? Return the existing row with its

--- a/packages/core/src/rpc/router.ts
+++ b/packages/core/src/rpc/router.ts
@@ -2,6 +2,7 @@ import type { RouterClient } from "@orpc/server";
 
 import { authRouter } from "./procedures/auth/index.js";
 import { entryRouter } from "./procedures/entry/index.js";
+import { lookupRouter } from "./procedures/lookup/index.js";
 import { settingsRouter } from "./procedures/settings/index.js";
 import { termRouter } from "./procedures/term/index.js";
 import { userRouter } from "./procedures/user/index.js";
@@ -11,6 +12,7 @@ export const appRouter = {
   entry: entryRouter,
   term: termRouter,
   user: userRouter,
+  lookup: lookupRouter,
   settings: settingsRouter,
 } as const;
 

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -14,9 +14,13 @@ import { createCapabilityResolver } from "../auth/rbac.js";
 import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
 import * as coreSchema from "../db/schema/index.js";
 import { HookRegistry } from "../hooks/registry.js";
-import { CORE_RPC_NAMESPACES } from "../plugin/manifest.js";
+import {
+  CORE_RPC_NAMESPACES,
+  createPluginRegistry,
+} from "../plugin/manifest.js";
 import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
+import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { appRouter } from "../rpc/router.js";
 
 export interface OAuthProviderSummary {
@@ -74,7 +78,13 @@ export interface PlumixApp {
 
 export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   const hooks = new HookRegistry();
-  const { registry } = await installPlugins({ hooks, plugins: config.plugins });
+  const seededRegistry = createPluginRegistry();
+  registerCoreLookupAdapters(seededRegistry);
+  const { registry } = await installPlugins({
+    hooks,
+    plugins: config.plugins,
+    registry: seededRegistry,
+  });
 
   const schema: Record<string, unknown> = { ...coreSchema };
   const origin = new Map<string, string>();


### PR DESCRIPTION
## Summary

Lands the `LookupAdapter` extensibility seam for reference fields and ships the first concrete adapter + field type: a single `user` reference. The seam is the high-leverage piece — every future reference target (`entry`, `term`, `media`, plugin-registered kinds) plugs in by implementing the same three-method interface, so this PR locks the contract that the rest of #119's reference family will follow.

## Resolves

- Resolves #126 — `LookupAdapter` interface + `user` single reference

## What landed

**Core seam (`packages/core/src/plugin/lookup.ts`)**
- `LookupAdapter<TScope>` interface with `exists` (write-time validation), `list` (picker search), `resolve` (read-time orphan handling). Async by design.
- `PluginRegistry.lookupAdapters` joins the registry alongside `fieldTypes` / `blocks`; `PluginContext.registerLookupAdapter` is the plugin-facing entry point with the same dupe-check + validation shape as `registerFieldType`.
- Core adapters register via `registerCoreLookupAdapters` before plugin install, so plugin-supplied kinds can't collide with built-ins.

**`user` reference (`packages/core/src/rpc/procedures/user/lookup.ts` + `packages/core/src/plugin/fields/user.ts`)**
- `userLookupAdapter` queries the `users` table with role + disabled-state filtering, parses bare numeric IDs, and returns `LookupResult` rows with label + subtitle.
- `user({ roles?, includeDisabled? })` builder produces a `UserMetaBoxField` variant with `referenceTarget: { kind: "user", scope }`.
- Manifest projection forwards `referenceTarget` through both the entry-meta and full meta serializers.

**Pipeline wiring (`packages/core/src/rpc/meta/core.ts`)**
- `validateMetaReferences(ctx, findField, patch)` walks each upsert for a reference field and calls the adapter's `exists`. Missing IDs / missing adapters surface `meta_invalid_value` via the same RPC envelope as a sanitize rejection.
- `validateMetaReferencesForRpc` is the CONFLICT-translating wrapper; each entity's meta module exports a thin `validate*MetaReferences` helper that the matching create/update RPC procedure calls between sanitisation and `applyMetaPatch`.
- `filterMetaOrphans(ctx, findField, decoded)` replaces stored reference IDs whose target is gone (or no longer matches scope) with `null` on read. Wired transparently into `loadEntryMeta` / `loadTermMeta` / `loadUserMeta` so admin reads see clean data.

**Generic lookup RPC (`packages/core/src/rpc/procedures/lookup/`)**
- `lookup.list` — adapter `list` for picker search/scroll.
- `lookup.resolve` — adapter `resolve` for rendering an already-selected ID's label.
- Unknown kinds 404; `lookup` joins `CORE_RPC_NAMESPACES` so plugins can't shadow it.

**Admin picker (`packages/admin/src/components/meta-box/reference-picker.tsx`)**
- Generic `ReferencePicker` — same component, same UX, regardless of target kind.
- Empty / selected / orphan / loading states each have a dedicated test ID. Required fields hide the "Clear" button.
- Search opens a shadcn `CommandDialog` over `lookup.list`; clicking an item closes the dialog and propagates the bare ID.
- Storage stays the bare ID string; the picker just swaps the admin-side display from "42" to a human-readable label.
- Dispatcher routes `inputType: "user"` to the picker via the `referenceTarget` discriminator. Future reference variants (entry/term/media) plug into the same code path.

## Test plan

- [x] `pnpm --filter @plumix/core test` — 1055 passing (+31 for adapter, validation, orphan filter, RPC, builder)
- [x] `pnpm --filter @plumix/admin test` — 147 passing (+2 for picker dispatch)
- [x] `pnpm --filter @plumix/core typecheck` clean
- [x] `pnpm --filter @plumix/admin typecheck` clean
- [x] `pnpm --filter plumix typecheck` clean
- [x] Both packages' `lint` clean (only pre-existing warnings)
- [x] Both packages' `format` clean
- [x] `pnpm knip` clean

## Notes for review

- `LookupAdapter` is the contract slice #128 (`entry` + `term`) and #129 (`userList` multi-reference) build on. Worth a careful read of the interface shape — locking it in here.
- The cascade default is null-on-read, ID retained on disk (per the PRD). No write-time cascade in 0.1.
- The picker is a thin shadcn wrapper on `cmdk`; future references reuse it via the `kind` + `scope` props.
- `lookup` is a new RPC namespace under `withplumix/plumix#119`'s umbrella; reserved against plugin shadowing in `CORE_RPC_NAMESPACES`.