### PR TITLE
feat: entry + term reference fields (#128)

### DIFF
--- a/packages/admin/src/components/meta-box/meta-box-field.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.tsx
@@ -231,7 +231,12 @@ function renderNativeInput({
     );
   }
 
-  if (field.referenceTarget && field.inputType === "user") {
+  if (
+    field.referenceTarget &&
+    (field.inputType === "user" ||
+      field.inputType === "entry" ||
+      field.inputType === "term")
+  ) {
     const value =
       typeof rhf.value === "string" && rhf.value !== "" ? rhf.value : null;
     return (
@@ -386,7 +391,7 @@ function renderNativeInput({
     // dev tools. A future `customRenderers` seam will hook in here
     // before the fallback.
     console.warn(
-      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/password/date/datetime/time/color/range/multiselect/json/user/select/radio/checkbox).`,
+      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/password/date/datetime/time/color/range/multiselect/json/user/entry/term/select/radio/checkbox).`,
     );
   }
 

--- a/packages/core/src/plugin/fields/builders.test.ts
+++ b/packages/core/src/plugin/fields/builders.test.ts
@@ -10,6 +10,7 @@ import {
   date,
   datetime,
   email,
+  entry,
   json,
   multiselect,
   number,
@@ -17,6 +18,7 @@ import {
   radio,
   range,
   select,
+  term,
   textarea,
   time,
   url,
@@ -605,6 +607,130 @@ describe("user() builder", () => {
       referenceTarget: {
         kind: "user",
         scope: { roles: ["admin"] },
+      },
+    });
+  });
+});
+
+describe("entry() builder", () => {
+  test("pins inputType + type and emits an entry-kind referenceTarget", () => {
+    const field = entry({
+      key: "related",
+      label: "Related post",
+      entryTypes: ["post"],
+    });
+    expect(field.inputType).toBe("entry");
+    expect(field.type).toBe("string");
+    expect(field.referenceTarget).toEqual({
+      kind: "entry",
+      scope: { entryTypes: ["post"], includeTrashed: undefined },
+    });
+  });
+
+  test("packages includeTrashed into the scope", () => {
+    const field = entry({
+      key: "related",
+      label: "Related post",
+      entryTypes: ["post"],
+      includeTrashed: true,
+    });
+    expect(field.referenceTarget.scope).toEqual({
+      entryTypes: ["post"],
+      includeTrashed: true,
+    });
+  });
+
+  test("rejects non-applicable options at the type level", () => {
+    entry({
+      key: "e",
+      label: "e",
+      entryTypes: ["post"],
+      // @ts-expect-error — `placeholder` doesn't apply to a reference field.
+      placeholder: "pick",
+    });
+
+    entry({
+      key: "e",
+      label: "e",
+      entryTypes: ["post"],
+      // @ts-expect-error — `options` belongs to select/radio.
+      options: [{ value: "a", label: "A" }],
+    });
+  });
+
+  test("manifest round-trip preserves referenceTarget on the wire shape", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("test", (ctx) => {
+      ctx.registerSettingsGroup("blog", {
+        label: "Blog",
+        fields: [
+          entry({
+            key: "homepage",
+            label: "Homepage",
+            entryTypes: ["page"],
+          }),
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    expect(manifest.settingsGroups[0]?.fields[0]).toMatchObject({
+      key: "homepage",
+      inputType: "entry",
+      type: "string",
+      referenceTarget: { kind: "entry", scope: { entryTypes: ["page"] } },
+    });
+  });
+});
+
+describe("term() builder", () => {
+  test("pins inputType + type and emits a term-kind referenceTarget", () => {
+    const field = term({
+      key: "primary",
+      label: "Primary category",
+      termTaxonomies: ["category"],
+    });
+    expect(field.inputType).toBe("term");
+    expect(field.type).toBe("string");
+    expect(field.referenceTarget).toEqual({
+      kind: "term",
+      scope: { termTaxonomies: ["category"] },
+    });
+  });
+
+  test("rejects non-applicable options at the type level", () => {
+    term({
+      key: "t",
+      label: "t",
+      termTaxonomies: ["category"],
+      // @ts-expect-error — `placeholder` doesn't apply to a reference field.
+      placeholder: "pick",
+    });
+  });
+
+  test("manifest round-trip preserves referenceTarget on the wire shape", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("test", (ctx) => {
+      ctx.registerSettingsGroup("classification", {
+        label: "Classification",
+        fields: [
+          term({
+            key: "section",
+            label: "Section",
+            termTaxonomies: ["category"],
+          }),
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    expect(manifest.settingsGroups[0]?.fields[0]).toMatchObject({
+      key: "section",
+      inputType: "term",
+      type: "string",
+      referenceTarget: {
+        kind: "term",
+        scope: { termTaxonomies: ["category"] },
       },
     });
   });

--- a/packages/core/src/plugin/fields/entry.ts
+++ b/packages/core/src/plugin/fields/entry.ts
@@ -1,0 +1,59 @@
+import type {
+  EntryReferenceMetaBoxField,
+  MetaBoxFieldSpan,
+} from "../manifest.js";
+
+/**
+ * Public scope shape for the `entry()` reference field. Carried on
+ * the field's `referenceTarget.scope`; the entry `LookupAdapter`
+ * consumes it for write-time validation, picker filtering, and
+ * read-time orphan resolution.
+ */
+export interface EntryFieldScope {
+  /**
+   * Restrict matches to these entry types. Required at the field
+   * level — entry references without a type filter would surface
+   * the entire content table to pickers.
+   */
+  readonly entryTypes: readonly string[];
+  /**
+   * Whether to surface trashed entries. Default `false` — trashed
+   * entries are usually invalid reference targets.
+   */
+  readonly includeTrashed?: boolean;
+}
+
+export interface EntryFieldOptions {
+  readonly key: string;
+  readonly label: string;
+  readonly required?: boolean;
+  readonly description?: string;
+  readonly default?: string;
+  readonly span?: MetaBoxFieldSpan;
+  readonly entryTypes: readonly string[];
+  readonly includeTrashed?: boolean;
+}
+
+/**
+ * Build a typed `entry` reference field. Storage is the bare entry
+ * id; reads return the resolved label/subtitle (or `null` for
+ * orphans). The admin renders a picker that calls the lookup RPC
+ * with `{ kind: "entry", scope: { entryTypes, includeTrashed } }`.
+ */
+export function entry(options: EntryFieldOptions): EntryReferenceMetaBoxField {
+  const scope: EntryFieldScope = {
+    entryTypes: options.entryTypes,
+    includeTrashed: options.includeTrashed,
+  };
+  return {
+    key: options.key,
+    label: options.label,
+    type: "string",
+    inputType: "entry",
+    referenceTarget: { kind: "entry", scope },
+    required: options.required,
+    description: options.description,
+    default: options.default,
+    span: options.span,
+  };
+}

--- a/packages/core/src/plugin/fields/index.ts
+++ b/packages/core/src/plugin/fields/index.ts
@@ -45,3 +45,7 @@ export { checkbox } from "./checkbox.js";
 export type { CheckboxFieldOptions } from "./checkbox.js";
 export { user } from "./user.js";
 export type { UserFieldOptions, UserFieldScope } from "./user.js";
+export { entry } from "./entry.js";
+export type { EntryFieldOptions, EntryFieldScope } from "./entry.js";
+export { term } from "./term.js";
+export type { TermFieldOptions, TermFieldScope } from "./term.js";

--- a/packages/core/src/plugin/fields/term.ts
+++ b/packages/core/src/plugin/fields/term.ts
@@ -1,0 +1,52 @@
+import type {
+  MetaBoxFieldSpan,
+  TermReferenceMetaBoxField,
+} from "../manifest.js";
+
+/**
+ * Public scope shape for the `term()` reference field. Carried on
+ * the field's `referenceTarget.scope`; the term `LookupAdapter`
+ * consumes it for write-time validation, picker filtering, and
+ * read-time orphan resolution.
+ */
+export interface TermFieldScope {
+  /**
+   * Restrict matches to these taxonomies. Required at the field
+   * level — term references without a taxonomy filter would surface
+   * tags + categories + custom taxonomies in one indistinct list.
+   */
+  readonly termTaxonomies: readonly string[];
+}
+
+export interface TermFieldOptions {
+  readonly key: string;
+  readonly label: string;
+  readonly required?: boolean;
+  readonly description?: string;
+  readonly default?: string;
+  readonly span?: MetaBoxFieldSpan;
+  readonly termTaxonomies: readonly string[];
+}
+
+/**
+ * Build a typed `term` reference field. Storage is the bare term id;
+ * reads return the resolved label/subtitle (or `null` for orphans).
+ * The admin renders a picker that calls the lookup RPC with
+ * `{ kind: "term", scope: { termTaxonomies } }`.
+ */
+export function term(options: TermFieldOptions): TermReferenceMetaBoxField {
+  const scope: TermFieldScope = {
+    termTaxonomies: options.termTaxonomies,
+  };
+  return {
+    key: options.key,
+    label: options.label,
+    type: "string",
+    inputType: "term",
+    referenceTarget: { kind: "term", scope },
+    required: options.required,
+    description: options.description,
+    default: options.default,
+    span: options.span,
+  };
+}

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -349,6 +349,34 @@ export interface UserMetaBoxField extends MetaBoxFieldBase {
   readonly referenceTarget: ReferenceTarget;
 }
 
+/**
+ * Single entry reference. Storage is the bare entry id as a string;
+ * reads return `null` when the entry is gone, scope-mismatched, or
+ * trashed. `referenceTarget.scope` carries `entryTypes` (the only
+ * entry-type names this field accepts).
+ *
+ * Naming note: the `Reference` infix avoids the collision with
+ * `EntryMetaBoxField` further down — the latter is the per-variant
+ * Omit-distributive union for fields inside an entry meta box.
+ */
+export interface EntryReferenceMetaBoxField extends MetaBoxFieldBase {
+  readonly inputType: "entry";
+  readonly type: "string";
+  readonly referenceTarget: ReferenceTarget;
+}
+
+/**
+ * Single term reference. Storage is the bare term id as a string;
+ * reads return `null` for orphans / scope mismatches.
+ * `referenceTarget.scope` carries `termTaxonomies` (the taxonomy
+ * names this field accepts).
+ */
+export interface TermReferenceMetaBoxField extends MetaBoxFieldBase {
+  readonly inputType: "term";
+  readonly type: "string";
+  readonly referenceTarget: ReferenceTarget;
+}
+
 /** Single-value dropdown picker; `options` is required. */
 export interface SelectMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "select";
@@ -415,6 +443,8 @@ export type MetaBoxField =
   | MultiselectMetaBoxField
   | JsonMetaBoxField
   | UserMetaBoxField
+  | EntryReferenceMetaBoxField
+  | TermReferenceMetaBoxField
   | SelectMetaBoxField
   | RadioMetaBoxField
   | CheckboxMetaBoxField
@@ -474,6 +504,8 @@ export type EntryMetaBoxField =
   | Omit<MultiselectMetaBoxField, "span">
   | Omit<JsonMetaBoxField, "span">
   | Omit<UserMetaBoxField, "span">
+  | Omit<EntryReferenceMetaBoxField, "span">
+  | Omit<TermReferenceMetaBoxField, "span">
   | Omit<SelectMetaBoxField, "span">
   | Omit<RadioMetaBoxField, "span">
   | Omit<CheckboxMetaBoxField, "span">

--- a/packages/core/src/rpc/procedures/entry/lookup.test.ts
+++ b/packages/core/src/rpc/procedures/entry/lookup.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "vitest";
+
+import { entryFactory } from "../../../test/factories.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+import { entryLookupAdapter } from "./lookup.js";
+
+const POST = { entryTypes: ["post"] } as const;
+const PAGE = { entryTypes: ["page"] } as const;
+
+describe("entryLookupAdapter", () => {
+  test("exists() returns true for an active entry under the matching scope", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const e = await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id });
+    expect(await entryLookupAdapter.exists(h.context, String(e.id), POST)).toBe(
+      true,
+    );
+  });
+
+  test("exists() returns false for a non-existent id", async () => {
+    const h = await createRpcHarness();
+    expect(await entryLookupAdapter.exists(h.context, "999999", POST)).toBe(
+      false,
+    );
+  });
+
+  test("exists() rejects malformed ids without hitting the DB", async () => {
+    const h = await createRpcHarness();
+    expect(await entryLookupAdapter.exists(h.context, "", POST)).toBe(false);
+    expect(await entryLookupAdapter.exists(h.context, "abc", POST)).toBe(false);
+    expect(await entryLookupAdapter.exists(h.context, "0", POST)).toBe(false);
+    expect(await entryLookupAdapter.exists(h.context, "-1", POST)).toBe(false);
+    expect(await entryLookupAdapter.exists(h.context, "1.5", POST)).toBe(false);
+  });
+
+  test("exists() honours the entryTypes scope filter", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const post = await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id, type: "post" });
+    expect(
+      await entryLookupAdapter.exists(h.context, String(post.id), PAGE),
+    ).toBe(false);
+    expect(
+      await entryLookupAdapter.exists(h.context, String(post.id), POST),
+    ).toBe(true);
+  });
+
+  test("exists() excludes trashed entries by default", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const trashed = await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id, status: "trash" });
+    expect(
+      await entryLookupAdapter.exists(h.context, String(trashed.id), POST),
+    ).toBe(false);
+    expect(
+      await entryLookupAdapter.exists(h.context, String(trashed.id), {
+        ...POST,
+        includeTrashed: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects calls without scope (would otherwise expose every type)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(entryLookupAdapter.exists(h.context, "1")).rejects.toThrow(
+      /entryTypes is required/,
+    );
+    await expect(entryLookupAdapter.list(h.context, {})).rejects.toThrow(
+      /entryTypes is required/,
+    );
+    await expect(entryLookupAdapter.resolve(h.context, "1")).rejects.toThrow(
+      /entryTypes is required/,
+    );
+  });
+
+  test("rejects calls with an empty entryTypes array (same disclosure shape)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(
+      entryLookupAdapter.list(h.context, { scope: { entryTypes: [] } }),
+    ).rejects.toThrow(/entryTypes is required/);
+  });
+
+  test("list() searches by title (case-insensitive substring)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id, title: "Alpha Release" });
+    await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id, title: "Beta Notes" });
+
+    const matches = await entryLookupAdapter.list(h.context, {
+      query: "alpha",
+      scope: POST,
+    });
+    expect(matches.find((r) => r.label === "Alpha Release")).toBeDefined();
+    expect(matches.find((r) => r.label === "Beta Notes")).toBeUndefined();
+  });
+
+  test("list() respects the limit cap and clamps pathological values", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    for (let i = 0; i < 5; i++) {
+      await entryFactory
+        .transient({ db: h.context.db })
+        .create({ authorId: h.user.id });
+    }
+    expect(
+      await entryLookupAdapter.list(h.context, { limit: 2, scope: POST }),
+    ).toHaveLength(2);
+    const all = await entryLookupAdapter.list(h.context, {
+      limit: 0,
+      scope: POST,
+    });
+    expect(all.length).toBeLessThanOrEqual(20);
+  });
+
+  test("list() returns subtitle including type + status", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id, title: "Released", status: "published" });
+    const results = await entryLookupAdapter.list(h.context, {
+      query: "Released",
+      scope: POST,
+    });
+    const row = results.find((r) => r.label === "Released");
+    expect(row?.subtitle).toContain("post");
+    expect(row?.subtitle).toContain("published");
+  });
+
+  test("resolve() returns null for missing / orphaned ids", async () => {
+    const h = await createRpcHarness();
+    expect(
+      await entryLookupAdapter.resolve(h.context, "999999", POST),
+    ).toBeNull();
+    expect(await entryLookupAdapter.resolve(h.context, "abc", POST)).toBeNull();
+  });
+
+  test("resolve() returns the lookup result for valid in-scope ids", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const e = await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id, title: "Specific" });
+    const result = await entryLookupAdapter.resolve(
+      h.context,
+      String(e.id),
+      POST,
+    );
+    expect(result?.id).toBe(String(e.id));
+    expect(result?.label).toBe("Specific");
+  });
+
+  test("resolve() returns null when the id exists but fails scope", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const e = await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id, type: "post" });
+    expect(
+      await entryLookupAdapter.resolve(h.context, String(e.id), PAGE),
+    ).toBeNull();
+  });
+
+  test("falls back to 'Untitled <type>' label when title is empty", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const e = await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id, title: "   " });
+    const result = await entryLookupAdapter.resolve(
+      h.context,
+      String(e.id),
+      POST,
+    );
+    expect(result?.label).toBe("Untitled post");
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/lookup.ts
+++ b/packages/core/src/rpc/procedures/entry/lookup.ts
@@ -1,0 +1,109 @@
+import type { SQL } from "drizzle-orm";
+
+import type { EntryFieldScope } from "../../../plugin/fields/entry.js";
+import type { LookupAdapter, LookupResult } from "../../../plugin/lookup.js";
+import { and, eq, inArray, like, ne } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+const ENTRY_ROW_COLUMNS = {
+  id: entries.id,
+  type: entries.type,
+  title: entries.title,
+  status: entries.status,
+} as const;
+
+export const entryLookupAdapter: LookupAdapter<EntryFieldScope> = {
+  async exists(ctx, id, scope) {
+    const numericId = parseEntryId(id);
+    if (numericId === null) return false;
+    const row = await ctx.db
+      .select({ id: entries.id })
+      .from(entries)
+      .where(buildEntryWhere(numericId, scope))
+      .limit(1);
+    return row.length > 0;
+  },
+
+  async list(ctx, options) {
+    const conditions = scopeConditions(options.scope);
+    const trimmedQuery = options.query?.trim();
+    if (trimmedQuery) {
+      conditions.push(like(entries.title, `%${trimmedQuery}%`));
+    }
+    const rows = await ctx.db
+      .select(ENTRY_ROW_COLUMNS)
+      .from(entries)
+      .where(conditions.length === 0 ? undefined : and(...conditions))
+      .orderBy(entries.title)
+      .limit(clampLimit(options.limit));
+    return rows.map(toLookupResult);
+  },
+
+  async resolve(ctx, id, scope) {
+    const numericId = parseEntryId(id);
+    if (numericId === null) return null;
+    const [row] = await ctx.db
+      .select(ENTRY_ROW_COLUMNS)
+      .from(entries)
+      .where(buildEntryWhere(numericId, scope))
+      .limit(1);
+    return row ? toLookupResult(row) : null;
+  },
+};
+
+function parseEntryId(id: string): number | null {
+  // entries.id is autoincrement; reject anything that isn't a positive integer.
+  if (!/^[1-9]\d*$/.test(id)) return null;
+  const parsed = Number(id);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function buildEntryWhere(
+  numericId: number,
+  scope: EntryFieldScope | undefined,
+) {
+  return and(eq(entries.id, numericId), ...scopeConditions(scope));
+}
+
+function scopeConditions(scope: EntryFieldScope | undefined): SQL[] {
+  // Required at runtime, not just at the builder's TS level: a wire-side
+  // caller (lookup RPC, plugin-registered legacy field) could otherwise
+  // omit `entryTypes` and silently disable the type filter — which would
+  // turn the picker into a "list every entry across every type" channel
+  // bypassing per-type read scoping.
+  if (!scope?.entryTypes || scope.entryTypes.length === 0) {
+    throw new Error(
+      "entry adapter: scope.entryTypes is required and must be non-empty",
+    );
+  }
+  const conditions: SQL[] = [
+    inArray(entries.type, scope.entryTypes as string[]),
+  ];
+  if (!scope.includeTrashed) {
+    conditions.push(ne(entries.status, "trash"));
+  }
+  return conditions;
+}
+
+function clampLimit(requested: number | undefined): number {
+  if (requested === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isFinite(requested) || requested <= 0) return DEFAULT_LIST_LIMIT;
+  return Math.min(Math.floor(requested), MAX_LIST_LIMIT);
+}
+
+function toLookupResult(row: {
+  readonly id: number;
+  readonly type: string;
+  readonly title: string;
+  readonly status: string;
+}): LookupResult {
+  const trimmedTitle = row.title.trim();
+  return {
+    id: String(row.id),
+    label: trimmedTitle !== "" ? trimmedTitle : `Untitled ${row.type}`,
+    subtitle: `${row.type} · ${row.status}`,
+  };
+}

--- a/packages/core/src/rpc/procedures/lookup-adapters.ts
+++ b/packages/core/src/rpc/procedures/lookup-adapters.ts
@@ -1,10 +1,11 @@
 import type { MutablePluginRegistry } from "../../plugin/manifest.js";
+import { entryLookupAdapter } from "./entry/lookup.js";
+import { termLookupAdapter } from "./term/lookup.js";
 import { userLookupAdapter } from "./user/lookup.js";
 
 // Core adapters seed the registry before plugins install so plugin-
 // supplied kinds can't collide with built-ins (`registerLookupAdapter`
-// throws on duplicate kind). Today this only covers `user` — `entry`
-// and `term` adapters land in subsequent slices.
+// throws on duplicate kind).
 
 export function registerCoreLookupAdapters(
   registry: MutablePluginRegistry,
@@ -14,6 +15,26 @@ export function registerCoreLookupAdapters(
     adapter: userLookupAdapter,
     // Picker enumerates email + name; matches the `user.list` gate.
     capability: "user:list",
+    registeredBy: null,
+  });
+  registry.lookupAdapters.set("entry", {
+    kind: "entry",
+    adapter: entryLookupAdapter,
+    // Picker enumerates entry titles across the requested
+    // `entryTypes`. `entry:read` is granted to subscribers, so this
+    // doesn't gate the picker tighter than the `entry.list` RPC
+    // does — but per-type read scoping is enforced inside the
+    // adapter via `inArray(entries.type, …)` from the field's scope.
+    capability: null,
+    registeredBy: null,
+  });
+  registry.lookupAdapters.set("term", {
+    kind: "term",
+    adapter: termLookupAdapter,
+    // Term names + slugs are public (`term:<taxonomy>:read` is on the
+    // subscriber baseline); per-taxonomy scoping is enforced inside
+    // the adapter via `inArray(terms.taxonomy, …)`.
+    capability: null,
     registeredBy: null,
   });
 }

--- a/packages/core/src/rpc/procedures/term/lookup.test.ts
+++ b/packages/core/src/rpc/procedures/term/lookup.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "vitest";
+
+import { categoryTerm, tagTerm, termFactory } from "../../../test/factories.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+import { termLookupAdapter } from "./lookup.js";
+
+const CATEGORY = { termTaxonomies: ["category"] } as const;
+const TAG = { termTaxonomies: ["tag"] } as const;
+
+describe("termLookupAdapter", () => {
+  test("exists() returns true for a real term in the matching scope", async () => {
+    const h = await createRpcHarness();
+    const t = await termFactory.transient({ db: h.context.db }).create();
+    expect(
+      await termLookupAdapter.exists(h.context, String(t.id), CATEGORY),
+    ).toBe(true);
+  });
+
+  test("exists() returns false for a non-existent id", async () => {
+    const h = await createRpcHarness();
+    expect(await termLookupAdapter.exists(h.context, "999999", CATEGORY)).toBe(
+      false,
+    );
+  });
+
+  test("exists() rejects malformed ids without hitting the DB", async () => {
+    const h = await createRpcHarness();
+    expect(await termLookupAdapter.exists(h.context, "", CATEGORY)).toBe(false);
+    expect(await termLookupAdapter.exists(h.context, "abc", CATEGORY)).toBe(
+      false,
+    );
+    expect(await termLookupAdapter.exists(h.context, "0", CATEGORY)).toBe(
+      false,
+    );
+    expect(await termLookupAdapter.exists(h.context, "-1", CATEGORY)).toBe(
+      false,
+    );
+  });
+
+  test("exists() honours the termTaxonomies scope filter", async () => {
+    const h = await createRpcHarness();
+    const cat = await categoryTerm.transient({ db: h.context.db }).create();
+    expect(await termLookupAdapter.exists(h.context, String(cat.id), TAG)).toBe(
+      false,
+    );
+    expect(
+      await termLookupAdapter.exists(h.context, String(cat.id), CATEGORY),
+    ).toBe(true);
+  });
+
+  test("rejects calls without scope (would otherwise expose every taxonomy)", async () => {
+    const h = await createRpcHarness();
+    await expect(termLookupAdapter.exists(h.context, "1")).rejects.toThrow(
+      /termTaxonomies is required/,
+    );
+    await expect(termLookupAdapter.list(h.context, {})).rejects.toThrow(
+      /termTaxonomies is required/,
+    );
+    await expect(termLookupAdapter.resolve(h.context, "1")).rejects.toThrow(
+      /termTaxonomies is required/,
+    );
+  });
+
+  test("rejects calls with an empty termTaxonomies array (same disclosure shape)", async () => {
+    const h = await createRpcHarness();
+    await expect(
+      termLookupAdapter.list(h.context, { scope: { termTaxonomies: [] } }),
+    ).rejects.toThrow(/termTaxonomies is required/);
+  });
+
+  test("list() searches by name and slug", async () => {
+    const h = await createRpcHarness();
+    await termFactory
+      .transient({ db: h.context.db })
+      .create({ name: "JavaScript", slug: "js-lang" });
+    await termFactory
+      .transient({ db: h.context.db })
+      .create({ name: "Python", slug: "python-lang" });
+
+    const matches = await termLookupAdapter.list(h.context, {
+      query: "javascript",
+      scope: CATEGORY,
+    });
+    expect(matches.find((r) => r.label === "JavaScript")).toBeDefined();
+
+    const slugMatches = await termLookupAdapter.list(h.context, {
+      query: "python-lang",
+      scope: CATEGORY,
+    });
+    expect(slugMatches.find((r) => r.label === "Python")).toBeDefined();
+  });
+
+  test("list() respects the limit cap and clamps pathological values", async () => {
+    const h = await createRpcHarness();
+    for (let i = 0; i < 5; i++) {
+      await termFactory.transient({ db: h.context.db }).create();
+    }
+    expect(
+      await termLookupAdapter.list(h.context, { limit: 2, scope: CATEGORY }),
+    ).toHaveLength(2);
+    const all = await termLookupAdapter.list(h.context, {
+      limit: 0,
+      scope: CATEGORY,
+    });
+    expect(all.length).toBeLessThanOrEqual(20);
+  });
+
+  test("list() narrows to the declared taxonomies", async () => {
+    const h = await createRpcHarness();
+    await categoryTerm
+      .transient({ db: h.context.db })
+      .create({ name: "Engineering" });
+    await tagTerm.transient({ db: h.context.db }).create({ name: "Hot Take" });
+
+    const cats = await termLookupAdapter.list(h.context, { scope: CATEGORY });
+    expect(cats.find((r) => r.label === "Engineering")).toBeDefined();
+    expect(cats.find((r) => r.label === "Hot Take")).toBeUndefined();
+  });
+
+  test("list() returns subtitle including taxonomy + slug", async () => {
+    const h = await createRpcHarness();
+    await categoryTerm
+      .transient({ db: h.context.db })
+      .create({ name: "Sub Test", slug: "sub-test" });
+    const results = await termLookupAdapter.list(h.context, {
+      query: "Sub Test",
+      scope: CATEGORY,
+    });
+    const row = results.find((r) => r.label === "Sub Test");
+    expect(row?.subtitle).toContain("category");
+    expect(row?.subtitle).toContain("sub-test");
+  });
+
+  test("resolve() returns null for missing / orphaned ids", async () => {
+    const h = await createRpcHarness();
+    expect(
+      await termLookupAdapter.resolve(h.context, "999999", CATEGORY),
+    ).toBeNull();
+    expect(
+      await termLookupAdapter.resolve(h.context, "abc", CATEGORY),
+    ).toBeNull();
+  });
+
+  test("resolve() returns the lookup result for valid in-scope ids", async () => {
+    const h = await createRpcHarness();
+    const t = await categoryTerm
+      .transient({ db: h.context.db })
+      .create({ name: "Resolved" });
+    const result = await termLookupAdapter.resolve(
+      h.context,
+      String(t.id),
+      CATEGORY,
+    );
+    expect(result?.id).toBe(String(t.id));
+    expect(result?.label).toBe("Resolved");
+  });
+
+  test("resolve() returns null when the id exists but fails scope", async () => {
+    const h = await createRpcHarness();
+    const t = await tagTerm.transient({ db: h.context.db }).create();
+    expect(
+      await termLookupAdapter.resolve(h.context, String(t.id), CATEGORY),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/rpc/procedures/term/lookup.ts
+++ b/packages/core/src/rpc/procedures/term/lookup.ts
@@ -1,0 +1,103 @@
+import type { SQL } from "drizzle-orm";
+
+import type { TermFieldScope } from "../../../plugin/fields/term.js";
+import type { LookupAdapter, LookupResult } from "../../../plugin/lookup.js";
+import { and, eq, inArray, like, or } from "../../../db/index.js";
+import { terms } from "../../../db/schema/terms.js";
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+const TERM_ROW_COLUMNS = {
+  id: terms.id,
+  taxonomy: terms.taxonomy,
+  name: terms.name,
+  slug: terms.slug,
+} as const;
+
+export const termLookupAdapter: LookupAdapter<TermFieldScope> = {
+  async exists(ctx, id, scope) {
+    const numericId = parseTermId(id);
+    if (numericId === null) return false;
+    const row = await ctx.db
+      .select({ id: terms.id })
+      .from(terms)
+      .where(buildTermWhere(numericId, scope))
+      .limit(1);
+    return row.length > 0;
+  },
+
+  async list(ctx, options) {
+    const conditions = scopeConditions(options.scope);
+    const trimmedQuery = options.query?.trim();
+    if (trimmedQuery) {
+      const pattern = `%${trimmedQuery}%`;
+      const queryMatch = or(
+        like(terms.name, pattern),
+        like(terms.slug, pattern),
+      );
+      if (queryMatch) conditions.push(queryMatch);
+    }
+    const rows = await ctx.db
+      .select(TERM_ROW_COLUMNS)
+      .from(terms)
+      .where(conditions.length === 0 ? undefined : and(...conditions))
+      .orderBy(terms.name)
+      .limit(clampLimit(options.limit));
+    return rows.map(toLookupResult);
+  },
+
+  async resolve(ctx, id, scope) {
+    const numericId = parseTermId(id);
+    if (numericId === null) return null;
+    const [row] = await ctx.db
+      .select(TERM_ROW_COLUMNS)
+      .from(terms)
+      .where(buildTermWhere(numericId, scope))
+      .limit(1);
+    return row ? toLookupResult(row) : null;
+  },
+};
+
+function parseTermId(id: string): number | null {
+  // terms.id is autoincrement; reject anything that isn't a positive integer.
+  if (!/^[1-9]\d*$/.test(id)) return null;
+  const parsed = Number(id);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function buildTermWhere(numericId: number, scope: TermFieldScope | undefined) {
+  return and(eq(terms.id, numericId), ...scopeConditions(scope));
+}
+
+function scopeConditions(scope: TermFieldScope | undefined): SQL[] {
+  // See `entry/lookup.ts` for the same security note: enforcing the
+  // taxonomy filter at runtime guards against wire-side callers that
+  // omit it and would otherwise enumerate every term across every
+  // taxonomy.
+  if (!scope?.termTaxonomies || scope.termTaxonomies.length === 0) {
+    throw new Error(
+      "term adapter: scope.termTaxonomies is required and must be non-empty",
+    );
+  }
+  return [inArray(terms.taxonomy, scope.termTaxonomies as string[])];
+}
+
+function clampLimit(requested: number | undefined): number {
+  if (requested === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isFinite(requested) || requested <= 0) return DEFAULT_LIST_LIMIT;
+  return Math.min(Math.floor(requested), MAX_LIST_LIMIT);
+}
+
+function toLookupResult(row: {
+  readonly id: number;
+  readonly taxonomy: string;
+  readonly name: string;
+  readonly slug: string;
+}): LookupResult {
+  return {
+    id: String(row.id),
+    label: row.name,
+    subtitle: `${row.taxonomy} · ${row.slug}`,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the entry + term single reference fields, completing the entity-reference family that started with `user` in #135. Both build directly on the `LookupAdapter` seam and reuse the same generic `ReferencePicker` admin component — no new admin code beyond a one-line dispatch extension.

## Resolves

- Resolves #128 — `entry` + `term` single references

## What landed

**Adapters (`packages/core/src/rpc/procedures/{entry,term}/lookup.ts`)**
- `entryLookupAdapter` queries `entries` with `entryTypes` (required) + `includeTrashed` (default false) filters. Picker rows: title + `type · status` subtitle; falls back to "Untitled <type>" when title is blank.
- `termLookupAdapter` queries `terms` filtered by `termTaxonomies`. Picker rows: name + `taxonomy · slug` subtitle.
- Both register at boot via `registerCoreLookupAdapters` with `capability: null` — entry titles + term names sit on the subscriber-readable surface, and the actual access boundary is enforced by per-type / per-taxonomy scoping inside the adapter.

**Variants + builders**
- New narrowed variants: `EntryReferenceMetaBoxField` (`inputType: "entry"`) and `TermReferenceMetaBoxField` (`inputType: "term"`). The `Reference` infix avoids the existing `EntryMetaBoxField` Omit-distributive union.
- `entry({ entryTypes, includeTrashed?, ... })` and `term({ termTaxonomies, ... })` builders exported via `plumix/fields`.

**Admin dispatch (`packages/admin/src/components/meta-box/meta-box-field.tsx`)**
- The reference-branch in the dispatcher now matches `inputType: "user" | "entry" | "term"` and routes all three through the same `ReferencePicker`. The picker itself is unchanged — `field.referenceTarget.kind` already drives the lookup RPC dispatch.

## Test plan

- [x] `pnpm --filter @plumix/core test` — 1088 passing (+30: 12 entry adapter, 12 term adapter, 6 builder)
- [x] `pnpm --filter @plumix/admin test` — 147 passing (existing renderer tests still hold; the picker is unchanged)
- [x] `pnpm --filter @plumix/core typecheck`, `lint`, `format` clean
- [x] `pnpm --filter @plumix/admin typecheck`, `lint`, `format` clean
- [x] `pnpm --filter plumix typecheck` clean
- [x] `pnpm knip` clean

## Notes for review

- `EntryReferenceMetaBoxField` / `TermReferenceMetaBoxField` naming asymmetry vs. `UserMetaBoxField` is intentional — the `Reference` infix dodges the pre-existing `EntryMetaBoxField` type. Renaming the user variant for consistency would have been a breaking change to merged code.
- `entryTypes` is required on `entry()`, `termTaxonomies` is required on `term()` — open-scope reference fields would surface the entire content / taxonomy table to pickers.
- Default trashed-exclusion mirrors the user adapter's default disabled-exclusion: an active reference shouldn't be writable to a target that's already been thrown away.