### PR TITLE
feat: userList + dnd-kit + multi-reference pattern (#129)

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -14,6 +14,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@hookform/resolvers": "^5.2.2",

--- a/packages/admin/src/components/meta-box/meta-box-field.test.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.test.tsx
@@ -260,6 +260,49 @@ describe("MetaBoxField dispatcher", () => {
     ).not.toBeInTheDocument();
   });
 
+  test("multi reference (userList): empty state + Add button + max counter", () => {
+    render(
+      <Harness
+        fieldDef={field({
+          inputType: "userList",
+          type: "json",
+          referenceTarget: { kind: "user", multiple: true },
+          max: 3,
+        })}
+        initial={[]}
+      />,
+    );
+    expect(
+      screen.getByTestId("meta-box-field-k-input-empty"),
+    ).toHaveTextContent("None selected");
+    expect(screen.getByTestId("meta-box-field-k-input-add")).toHaveTextContent(
+      "Select",
+    );
+    expect(
+      screen.getByTestId("meta-box-field-k-input-count"),
+    ).toHaveTextContent("0 / 3");
+  });
+
+  test("multi reference: Add button switches label + disables at max", () => {
+    render(
+      <Harness
+        fieldDef={field({
+          inputType: "userList",
+          type: "json",
+          referenceTarget: { kind: "user", multiple: true },
+          max: 2,
+        })}
+        initial={["1", "2"]}
+      />,
+    );
+    const addBtn = screen.getByTestId("meta-box-field-k-input-add");
+    expect(addBtn).toHaveTextContent("Add");
+    expect(addBtn).toBeDisabled();
+    expect(
+      screen.getByTestId("meta-box-field-k-input-count"),
+    ).toHaveTextContent("2 / 2");
+  });
+
   test("multiselect: clicking a toggle item emits the updated array", async () => {
     const onChange = vi.fn();
     render(

--- a/packages/admin/src/components/meta-box/meta-box-field.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 
 import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 
+import { MultiReferencePicker } from "./multi-reference-picker.js";
 import { ReferencePicker } from "./reference-picker.js";
 
 // Schema-driven field renderer wired to react-hook-form. Each meta-box
@@ -231,6 +232,29 @@ function renderNativeInput({
     );
   }
 
+  if (field.referenceTarget?.multiple === true) {
+    const value = Array.isArray(rhf.value)
+      ? rhf.value.filter((v): v is string => typeof v === "string")
+      : [];
+    return (
+      <MultiReferencePicker
+        value={value}
+        onChange={(next) => {
+          rhf.onChange(next);
+        }}
+        kind={field.referenceTarget.kind}
+        scope={
+          field.referenceTarget.scope as Record<string, unknown> | undefined
+        }
+        max={typeof field.max === "number" ? field.max : undefined}
+        disabled={disabled}
+        required={field.required}
+        label={field.label}
+        testId={testId}
+      />
+    );
+  }
+
   if (
     field.referenceTarget &&
     (field.inputType === "user" ||
@@ -391,7 +415,7 @@ function renderNativeInput({
     // dev tools. A future `customRenderers` seam will hook in here
     // before the fallback.
     console.warn(
-      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/password/date/datetime/time/color/range/multiselect/json/user/entry/term/select/radio/checkbox).`,
+      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/password/date/datetime/time/color/range/multiselect/json/user/userList/entry/term/select/radio/checkbox).`,
     );
   }
 

--- a/packages/admin/src/components/meta-box/multi-reference-picker.tsx
+++ b/packages/admin/src/components/meta-box/multi-reference-picker.tsx
@@ -1,0 +1,198 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button.js";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command.js";
+import { SortableList } from "@/components/ui/sortable.js";
+import { orpc } from "@/lib/orpc.js";
+import { useQueries, useQuery } from "@tanstack/react-query";
+
+// Multi-value counterpart to `ReferencePicker`. Shares the same
+// `kind` / `scope` dispatch shape — same lookup RPC, same adapter
+// — but the UX is different: selected rows render as a sortable
+// list with drag-reorder + per-row remove, the picker dialog stays
+// open across selections (so authors can pick several without
+// re-clicking "Add"), and `max` caps the array length both in the
+// "Add" button (disables when full) and inside the dialog (no-op
+// on item click).
+
+interface MultiReferencePickerProps {
+  readonly value: readonly string[];
+  readonly onChange: (next: readonly string[]) => void;
+  readonly kind: string;
+  readonly scope?: Record<string, unknown>;
+  readonly max?: number;
+  readonly disabled?: boolean;
+  readonly required?: boolean;
+  readonly label: string;
+  readonly testId: string;
+}
+
+export function MultiReferencePicker({
+  value,
+  onChange,
+  kind,
+  scope,
+  max,
+  disabled = false,
+  required = false,
+  label,
+  testId,
+}: MultiReferencePickerProps): ReactNode {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  // Resolve every selected ID in parallel. `useQueries` keeps each
+  // resolution independent so a single missing target shows up as
+  // an orphan row without poisoning its neighbours.
+  const resolved = useQueries({
+    queries: value.map((id) =>
+      orpc.lookup.resolve.queryOptions({ input: { kind, id, scope } }),
+    ),
+  });
+
+  const listQuery = useQuery({
+    ...orpc.lookup.list.queryOptions({
+      input: { kind, query: query.trim() || undefined, scope, limit: 20 },
+    }),
+    enabled: open,
+  });
+
+  const items = listQuery.data?.items ?? [];
+  const selectedSet = new Set(value);
+  const atMax = max !== undefined && value.length >= max;
+
+  const handlePick = (id: string): void => {
+    if (selectedSet.has(id)) return;
+    if (atMax) return;
+    onChange([...value, id]);
+  };
+
+  const handleRemove = (id: string): void => {
+    onChange(value.filter((v) => v !== id));
+  };
+
+  const handleReorder = (next: readonly { readonly id: string }[]): void => {
+    onChange(next.map((row) => row.id));
+  };
+
+  const sortableItems = value.map((id, index) => {
+    const result = resolved[index]?.data?.result ?? null;
+    return { id, result };
+  });
+
+  return (
+    <div className="flex flex-col gap-2" data-testid={testId}>
+      {value.length === 0 ? (
+        <p
+          className="text-muted-foreground text-sm"
+          data-testid={`${testId}-empty`}
+        >
+          None selected
+        </p>
+      ) : (
+        <SortableList
+          items={sortableItems}
+          onReorder={handleReorder}
+          onRemove={required && value.length === 1 ? undefined : handleRemove}
+          renderItem={(item) =>
+            item.result ? (
+              <div className="text-sm">
+                <p className="truncate font-medium">{item.result.label}</p>
+                {item.result.subtitle ? (
+                  <p className="text-muted-foreground truncate text-xs">
+                    {item.result.subtitle}
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <p
+                className="text-destructive text-sm"
+                data-testid={`${testId}-orphan-${item.id}`}
+              >
+                Reference missing — remove or re-pick
+              </p>
+            )
+          }
+          disabled={disabled}
+          testId={`${testId}-list`}
+        />
+      )}
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || atMax}
+          onClick={() => {
+            setQuery("");
+            setOpen(true);
+          }}
+          data-testid={`${testId}-add`}
+        >
+          {value.length === 0 ? "Select" : "Add"}
+        </Button>
+        {max !== undefined ? (
+          <span
+            className="text-muted-foreground text-xs"
+            data-testid={`${testId}-count`}
+          >
+            {value.length} / {max}
+          </span>
+        ) : null}
+      </div>
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        title={label}
+        description={`Search and pick ${kind} entries`}
+      >
+        <CommandInput
+          placeholder={`Search ${kind}…`}
+          value={query}
+          onValueChange={setQuery}
+          data-testid={`${testId}-search`}
+        />
+        <CommandList>
+          {listQuery.isLoading ? (
+            <CommandEmpty>Loading…</CommandEmpty>
+          ) : items.length === 0 ? (
+            <CommandEmpty>No matches</CommandEmpty>
+          ) : (
+            items.map((item) => {
+              const alreadySelected = selectedSet.has(item.id);
+              return (
+                <CommandItem
+                  key={item.id}
+                  value={`${item.label} ${item.subtitle ?? ""}`}
+                  disabled={alreadySelected || atMax}
+                  onSelect={() => {
+                    handlePick(item.id);
+                  }}
+                  data-testid={`${testId}-option-${item.id}`}
+                >
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-sm font-medium">
+                      {item.label}
+                      {alreadySelected ? " ✓" : ""}
+                    </span>
+                    {item.subtitle ? (
+                      <span className="text-muted-foreground text-xs">
+                        {item.subtitle}
+                      </span>
+                    ) : null}
+                  </div>
+                </CommandItem>
+              );
+            })
+          )}
+        </CommandList>
+      </CommandDialog>
+    </div>
+  );
+}

--- a/packages/admin/src/components/meta-box/multi-reference-picker.tsx
+++ b/packages/admin/src/components/meta-box/multi-reference-picker.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button.js";
 import {
   CommandDialog,
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/command.js";
 import { SortableList } from "@/components/ui/sortable.js";
 import { orpc } from "@/lib/orpc.js";
-import { useQueries, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
 // Multi-value counterpart to `ReferencePicker`. Shares the same
 // `kind` / `scope` dispatch shape — same lookup RPC, same adapter
@@ -47,14 +47,27 @@ export function MultiReferencePicker({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
 
-  // Resolve every selected ID in parallel. `useQueries` keeps each
-  // resolution independent so a single missing target shows up as
-  // an orphan row without poisoning its neighbours.
-  const resolved = useQueries({
-    queries: value.map((id) =>
-      orpc.lookup.resolve.queryOptions({ input: { kind, id, scope } }),
-    ),
+  // Single batch round-trip to resolve every selected ID. The
+  // adapter's `list` honours the `ids` filter and returns one row
+  // per live target — orphans simply don't come back. We map by id
+  // below so the sortable list still iterates `value` in order.
+  // `limit` is omitted: the adapter sizes the result to the parsed-id
+  // count for the `ids` path. Spread to drop `readonly` — the wire
+  // schema produces a mutable `string[]` and TS won't narrow.
+  const resolveQuery = useQuery({
+    ...orpc.lookup.list.queryOptions({
+      input: { kind, scope, ids: [...value] },
+    }),
+    enabled: value.length > 0,
   });
+  const resolvedById = useMemo(() => {
+    const map = new Map<
+      string,
+      { id: string; label: string; subtitle?: string }
+    >();
+    for (const row of resolveQuery.data?.items ?? []) map.set(row.id, row);
+    return map;
+  }, [resolveQuery.data]);
 
   const listQuery = useQuery({
     ...orpc.lookup.list.queryOptions({
@@ -81,13 +94,24 @@ export function MultiReferencePicker({
     onChange(next.map((row) => row.id));
   };
 
-  const sortableItems = value.map((id, index) => {
-    const result = resolved[index]?.data?.result ?? null;
-    return { id, result };
-  });
+  const sortableItems = value.map((id) => ({
+    id,
+    result: resolvedById.get(id) ?? null,
+  }));
 
   return (
     <div className="flex flex-col gap-2" data-testid={testId}>
+      {resolveQuery.isError ? (
+        // Don't conflate "fetch failed" with "every selected id is an
+        // orphan" — without this banner, a transient network error
+        // would render every row as `Reference missing`.
+        <p
+          className="text-destructive text-sm"
+          data-testid={`${testId}-resolve-error`}
+        >
+          Couldn&rsquo;t load selected items — refresh to retry.
+        </p>
+      ) : null}
       {value.length === 0 ? (
         <p
           className="text-muted-foreground text-sm"

--- a/packages/admin/src/components/ui/sortable.tsx
+++ b/packages/admin/src/components/ui/sortable.tsx
@@ -1,0 +1,153 @@
+import type { DragEndEvent } from "@dnd-kit/core";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button.js";
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVerticalIcon, XIcon } from "lucide-react";
+
+// Generic vertical-list sortable primitive built around dnd-kit. Used
+// by `mediaList` / `userList` / `entryList` / repeater rows — any
+// place an admin author needs to drag-reorder a small list. Single-
+// thumb (no nested drop targets); keyboard reorder works out of the
+// box via dnd-kit's `KeyboardSensor` + `sortableKeyboardCoordinates`.
+
+interface SortableListProps<T extends { readonly id: string }> {
+  readonly items: readonly T[];
+  readonly onReorder: (next: readonly T[]) => void;
+  readonly onRemove?: (id: string) => void;
+  readonly renderItem: (item: T) => ReactNode;
+  readonly disabled?: boolean;
+  readonly testId?: string;
+}
+
+export function SortableList<T extends { readonly id: string }>({
+  items,
+  onReorder,
+  onRemove,
+  renderItem,
+  disabled = false,
+  testId,
+}: SortableListProps<T>): ReactNode {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = items.findIndex((i) => i.id === active.id);
+    const newIndex = items.findIndex((i) => i.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+    onReorder(arrayMove([...items], oldIndex, newIndex));
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      modifiers={[restrictToVerticalAxis]}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={items.map((i) => i.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <ul className="flex flex-col gap-1" data-testid={testId}>
+          {items.map((item) => (
+            <SortableRow
+              key={item.id}
+              id={item.id}
+              disabled={disabled}
+              onRemove={onRemove}
+              testId={testId ? `${testId}-row-${item.id}` : undefined}
+            >
+              {renderItem(item)}
+            </SortableRow>
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+interface SortableRowProps {
+  readonly id: string;
+  readonly children: ReactNode;
+  readonly disabled: boolean;
+  readonly onRemove?: (id: string) => void;
+  readonly testId?: string;
+}
+
+function SortableRow({
+  id,
+  children,
+  disabled,
+  onRemove,
+  testId,
+}: SortableRowProps): ReactNode {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.6 : 1,
+      }}
+      className="border-input bg-background flex items-center gap-2 rounded-md border px-2 py-1.5"
+      data-testid={testId}
+    >
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground cursor-grab touch-none disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled}
+        aria-label="Reorder"
+        data-testid={testId ? `${testId}-handle` : undefined}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVerticalIcon className="size-4" />
+      </button>
+      <div className="min-w-0 flex-1">{children}</div>
+      {onRemove ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={disabled}
+          onClick={() => {
+            onRemove(id);
+          }}
+          aria-label="Remove"
+          data-testid={testId ? `${testId}-remove` : undefined}
+        >
+          <XIcon className="size-4" />
+        </Button>
+      ) : null}
+    </li>
+  );
+}

--- a/packages/core/src/plugin/fields/builders.test.ts
+++ b/packages/core/src/plugin/fields/builders.test.ts
@@ -23,6 +23,7 @@ import {
   time,
   url,
   user,
+  userList,
 } from "./index.js";
 
 // One combined suite for the seven straightforward variants whose
@@ -731,6 +732,84 @@ describe("term() builder", () => {
       referenceTarget: {
         kind: "term",
         scope: { termTaxonomies: ["category"] },
+      },
+    });
+  });
+});
+
+describe("userList() builder", () => {
+  test("pins inputType + json type and emits a multi user-kind referenceTarget", () => {
+    const field = userList({
+      key: "owners",
+      label: "Owners",
+      roles: ["editor", "admin"],
+      max: 5,
+    });
+    expect(field.inputType).toBe("userList");
+    expect(field.type).toBe("json");
+    expect(field.max).toBe(5);
+    expect(field.referenceTarget).toEqual({
+      kind: "user",
+      scope: { roles: ["editor", "admin"], includeDisabled: undefined },
+      multiple: true,
+    });
+  });
+
+  test("packages includeDisabled into the scope and supports unbounded max", () => {
+    const field = userList({
+      key: "owners",
+      label: "Owners",
+      includeDisabled: true,
+    });
+    expect(field.max).toBeUndefined();
+    expect(field.referenceTarget.scope).toEqual({
+      roles: undefined,
+      includeDisabled: true,
+    });
+  });
+
+  test("rejects non-applicable options at the type level", () => {
+    userList({
+      key: "u",
+      label: "u",
+      // @ts-expect-error — `placeholder` doesn't apply to a reference field.
+      placeholder: "pick",
+    });
+
+    userList({
+      key: "u",
+      label: "u",
+      // @ts-expect-error — `options` belongs to select/radio.
+      options: [{ value: "a", label: "A" }],
+    });
+  });
+
+  test("manifest round-trip preserves multi referenceTarget + max on the wire shape", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("test", (ctx) => {
+      ctx.registerSettingsGroup("identity", {
+        label: "Site identity",
+        fields: [
+          userList({
+            key: "owners",
+            label: "Owners",
+            roles: ["admin"],
+            max: 3,
+          }),
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    expect(manifest.settingsGroups[0]?.fields[0]).toMatchObject({
+      key: "owners",
+      inputType: "userList",
+      type: "json",
+      max: 3,
+      referenceTarget: {
+        kind: "user",
+        scope: { roles: ["admin"] },
+        multiple: true,
       },
     });
   });

--- a/packages/core/src/plugin/fields/index.ts
+++ b/packages/core/src/plugin/fields/index.ts
@@ -45,6 +45,8 @@ export { checkbox } from "./checkbox.js";
 export type { CheckboxFieldOptions } from "./checkbox.js";
 export { user } from "./user.js";
 export type { UserFieldOptions, UserFieldScope } from "./user.js";
+export { userList } from "./user-list.js";
+export type { UserListFieldOptions } from "./user-list.js";
 export { entry } from "./entry.js";
 export type { EntryFieldOptions, EntryFieldScope } from "./entry.js";
 export { term } from "./term.js";

--- a/packages/core/src/plugin/fields/user-list.ts
+++ b/packages/core/src/plugin/fields/user-list.ts
@@ -1,0 +1,46 @@
+import type { UserRole } from "../../db/schema/users.js";
+import type { MetaBoxFieldSpan, UserListMetaBoxField } from "../manifest.js";
+import type { UserFieldScope } from "./user.js";
+
+export interface UserListFieldOptions {
+  readonly key: string;
+  readonly label: string;
+  readonly required?: boolean;
+  readonly description?: string;
+  readonly default?: readonly string[];
+  readonly span?: MetaBoxFieldSpan;
+  readonly roles?: readonly UserRole[];
+  readonly includeDisabled?: boolean;
+  /** Max items allowed in the array. Omitted = unbounded. */
+  readonly max?: number;
+}
+
+/**
+ * Build a typed `userList` reference field — the multi-value
+ * counterpart to `user()`. Storage is a JSON array of bare user
+ * ids (`["42", "43"]`); reads filter out orphans (the array stays
+ * dense — missing IDs are dropped, not nulled). The admin renders
+ * a `MultiReferencePicker` with drag-to-reorder; the picker stays
+ * open until the author closes it or hits `max`.
+ *
+ * Reuses `UserFieldScope` so the same `roles` / `includeDisabled`
+ * filters carry through to the user adapter.
+ */
+export function userList(options: UserListFieldOptions): UserListMetaBoxField {
+  const scope: UserFieldScope = {
+    roles: options.roles,
+    includeDisabled: options.includeDisabled,
+  };
+  return {
+    key: options.key,
+    label: options.label,
+    type: "json",
+    inputType: "userList",
+    referenceTarget: { kind: "user", scope, multiple: true },
+    max: options.max,
+    required: options.required,
+    description: options.description,
+    default: options.default,
+    span: options.span,
+  };
+}

--- a/packages/core/src/plugin/lookup.ts
+++ b/packages/core/src/plugin/lookup.ts
@@ -17,19 +17,36 @@ export interface LookupListOptions<TScope = unknown> {
   readonly query?: string;
   readonly scope?: TScope;
   readonly limit?: number;
+  /**
+   * Resolve-by-id batch: when set, the adapter ignores `query` and
+   * returns rows whose id matches any in this list (still subject to
+   * `scope`). Result order is up to the adapter — callers expecting
+   * positional access should map to a `{ id -> result }` Map. Used
+   * by the multi-reference orphan filter and the admin's
+   * `MultiReferencePicker` so a 50-item field renders as one query
+   * (single `WHERE id IN (...)`) rather than 50.
+   */
+  readonly ids?: readonly string[];
 }
 
 /**
  * `TScope` is the shape carried on the field's `referenceTarget.scope`
  * — e.g. `{ roles: UserRole[] }` for `user`. Adapters interpret it
- * however makes sense for their target. All methods are async so
- * future implementations can hit the database without a contract
- * break.
+ * however makes sense for their target.
+ *
+ * Two methods, one round-trip per call regardless of selection size:
+ *  - `list` covers search/browse (no `ids`, optional `query`) and
+ *    resolve-by-id batch (`ids` set, `query` ignored). The meta
+ *    pipeline (`validateMetaReferences` + `filterMetaOrphans`)
+ *    groups all reference fields by `(kind, scope)` and issues one
+ *    `list({ ids })` per group, eliminating per-field N+1 on both
+ *    reads and writes. The `MultiReferencePicker` batches the same
+ *    way for label rendering.
+ *  - `resolve` powers the single-reference admin picker (`lookup.
+ *    resolve` RPC). One id per call but each picker on the page is
+ *    its own component, so this stays simple.
  */
 export interface LookupAdapter<TScope = unknown> {
-  /** Returning `false` surfaces as `invalid_value` in the meta write pipeline. */
-  exists(ctx: AppContext, id: string, scope?: TScope): Promise<boolean>;
-
   list(
     ctx: AppContext,
     options: LookupListOptions<TScope>,

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -335,6 +335,14 @@ export interface JsonMetaBoxField extends MetaBoxFieldBase {
 export interface ReferenceTarget<TScope = unknown> {
   readonly kind: string;
   readonly scope?: TScope;
+  /**
+   * Storage cardinality. `false`/absent → single ID stored as a
+   * string (e.g. `user`, `entry`, `term`). `true` → array of IDs
+   * stored as JSON (e.g. `userList`, `entryList`, `mediaList`).
+   * The server-side write validator and read-side orphan filter
+   * dispatch on this flag to handle both shapes uniformly.
+   */
+  readonly multiple?: boolean;
 }
 
 /**
@@ -347,6 +355,21 @@ export interface UserMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "user";
   readonly type: "string";
   readonly referenceTarget: ReferenceTarget;
+}
+
+/**
+ * Multi user reference. Storage is a JSON array of bare user ids
+ * (`["42", "43"]`); reads filter out orphans (the bag's array stays
+ * dense — missing IDs are dropped, not nulled, so consumers iterate
+ * without branching). `referenceTarget.multiple` is `true`; `max`
+ * caps the array length at write time.
+ */
+export interface UserListMetaBoxField extends MetaBoxFieldBase {
+  readonly inputType: "userList";
+  readonly type: "json";
+  readonly referenceTarget: ReferenceTarget;
+  /** Max items allowed in the array. Omitted = unbounded. */
+  readonly max?: number;
 }
 
 /**
@@ -443,6 +466,7 @@ export type MetaBoxField =
   | MultiselectMetaBoxField
   | JsonMetaBoxField
   | UserMetaBoxField
+  | UserListMetaBoxField
   | EntryReferenceMetaBoxField
   | TermReferenceMetaBoxField
   | SelectMetaBoxField
@@ -504,6 +528,7 @@ export type EntryMetaBoxField =
   | Omit<MultiselectMetaBoxField, "span">
   | Omit<JsonMetaBoxField, "span">
   | Omit<UserMetaBoxField, "span">
+  | Omit<UserListMetaBoxField, "span">
   | Omit<EntryReferenceMetaBoxField, "span">
   | Omit<TermReferenceMetaBoxField, "span">
   | Omit<SelectMetaBoxField, "span">

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -175,20 +175,68 @@ export async function validateMetaReferences(
   patch: MetaPatch,
 ): Promise<void> {
   for (const [key, value] of patch.upserts) {
-    const target = referenceTargetOf(findField(key));
+    const field = findField(key);
+    const target = referenceTargetOf(field);
     if (!target) continue;
-    if (typeof value !== "string") {
-      throw new MetaSanitizationError(key, "invalid_value");
-    }
     const registered = ctx.plugins.lookupAdapters.get(target.kind);
     if (!registered) {
       throw new MetaSanitizationError(key, "invalid_value");
     }
-    const exists = await registered.adapter.exists(ctx, value, target.scope);
-    if (!exists) {
-      throw new MetaSanitizationError(key, "invalid_value");
+    const ids = referenceIdsForValidation(key, value, target, fieldMax(field));
+    for (const id of ids) {
+      const exists = await registered.adapter.exists(ctx, id, target.scope);
+      if (!exists) {
+        throw new MetaSanitizationError(key, "invalid_value");
+      }
     }
   }
+}
+
+// Defensive upper bound on multi-reference array length, applied
+// before any per-id adapter call. `LookupAdapter.exists` is a per-id
+// round-trip today (no `existsMany` batch path), so without this guard
+// a caller could ship `meta: { owners: [<10k strings>] }` and force
+// the validator into 10k sequential queries. 100 covers any realistic
+// multi-reference field (authors, tags, related entries) — fields can
+// declare a lower `max` and the validator picks the smaller of the two.
+const HARD_MULTI_REFERENCE_LIMIT = 100;
+
+// Multi-reference (`userList` / `entryList` / etc.): value must be a
+// string array of non-empty strings, capped by both the hard limit
+// above and the field's optional `max`. Single-reference: value
+// must be a string. Returns the IDs to validate individually — the
+// per-ID adapter call happens in the caller.
+function referenceIdsForValidation(
+  key: string,
+  value: unknown,
+  target: ReferenceTarget,
+  max: number | undefined,
+): readonly string[] {
+  if (target.multiple) {
+    if (!Array.isArray(value)) {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+    if (value.length > HARD_MULTI_REFERENCE_LIMIT) {
+      throw new MetaSanitizationError(key, "value_too_large");
+    }
+    if (max !== undefined && value.length > max) {
+      throw new MetaSanitizationError(key, "invalid_value");
+    }
+    for (const item of value) {
+      if (typeof item !== "string" || item === "") {
+        throw new MetaSanitizationError(key, "invalid_value");
+      }
+    }
+    return value as readonly string[];
+  }
+  if (typeof value !== "string") {
+    throw new MetaSanitizationError(key, "invalid_value");
+  }
+  return [value];
+}
+
+function fieldMax(field: MetaBoxField | undefined): number | undefined {
+  return (field as { readonly max?: number } | undefined)?.max;
 }
 
 /**
@@ -241,11 +289,31 @@ export async function filterMetaOrphans(
 ): Promise<MetaMap> {
   const out: MetaMap = { ...decoded };
   for (const [key, value] of Object.entries(decoded)) {
-    if (typeof value !== "string") continue;
     const target = referenceTargetOf(findField(key));
     if (!target) continue;
     const registered = ctx.plugins.lookupAdapters.get(target.kind);
     if (!registered) continue;
+    if (target.multiple) {
+      // Multi: drop orphan IDs from the array, keeping order. The
+      // bag stays dense — consumers iterate without branching.
+      // Non-array storage shape is tolerated as unknown garbage and
+      // left untouched (the write validator should have rejected it
+      // upstream, but reads are forgiving).
+      if (!Array.isArray(value)) continue;
+      const kept: string[] = [];
+      for (const id of value) {
+        if (typeof id !== "string") continue;
+        const resolved = await registered.adapter.resolve(
+          ctx,
+          id,
+          target.scope,
+        );
+        if (resolved !== null) kept.push(id);
+      }
+      out[key] = kept;
+      continue;
+    }
+    if (typeof value !== "string") continue;
     const resolved = await registered.adapter.resolve(ctx, value, target.scope);
     if (resolved === null) out[key] = null;
   }

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -3,6 +3,7 @@ import type { SQLiteColumn } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 
 import type { AppContext } from "../../context/app.js";
+import type { LookupAdapter } from "../../plugin/lookup.js";
 import type {
   MetaBoxField,
   MetaScalarType,
@@ -162,18 +163,29 @@ export function sanitizeMetaForRpc(
 }
 
 /**
- * Walk a sanitized patch and call each reference field's
- * `LookupAdapter.exists` to confirm the upserted ID is real and in
- * scope. Sync `sanitize` callbacks can't run DB queries, so this is
- * a separate async step the RPC procedures invoke between
- * sanitisation and `applyMetaPatch`. Missing adapters are treated
- * the same as missing targets — both surface `invalid_value`.
+ * Walk a sanitized patch, group every reference upsert by
+ * `(kind, scope)`, and issue one `LookupAdapter.list({ ids })`
+ * query per group to confirm all upserted IDs are real and in
+ * scope **at validation time**. Throws `invalid_value` for any id
+ * missing from its group's live-id set — same surface whether the
+ * adapter is unregistered, the target is gone, or scope rejected
+ * it. Sync `sanitize` callbacks can't run DB queries, so this is a
+ * separate async step the RPC procedures invoke between
+ * sanitisation and `applyMetaPatch`.
+ *
+ * TOCTOU note: validate runs in a separate query from the eventual
+ * `applyMetaPatch`, and callers don't share a transaction. A
+ * concurrent delete between validate and apply leaves an orphan id
+ * in the meta bag; `filterMetaOrphans` masks it on read. Wrap the
+ * validate/apply pair in `ctx.db.transaction()` if a caller needs
+ * serializable consistency.
  */
 export async function validateMetaReferences(
   ctx: AppContext,
   findField: (key: string) => MetaBoxField | undefined,
   patch: MetaPatch,
 ): Promise<void> {
+  const groups = new Map<string, ReferenceGroup>();
   for (const [key, value] of patch.upserts) {
     const field = findField(key);
     const target = referenceTargetOf(field);
@@ -183,29 +195,117 @@ export async function validateMetaReferences(
       throw new MetaSanitizationError(key, "invalid_value");
     }
     const ids = referenceIdsForValidation(key, value, target, fieldMax(field));
-    for (const id of ids) {
-      const exists = await registered.adapter.exists(ctx, id, target.scope);
-      if (!exists) {
-        throw new MetaSanitizationError(key, "invalid_value");
+    const groupKey = referenceGroupKey(target);
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = { registered, scope: target.scope, ids: new Set(), keys: [] };
+      groups.set(groupKey, group);
+    }
+    for (const id of ids) group.ids.add(id);
+    group.keys.push({ key, ids });
+  }
+  for (const group of groups.values()) {
+    if (group.ids.size === 0) continue;
+    const liveIds = await fetchLiveIds(
+      ctx,
+      group.registered,
+      group.scope,
+      group.ids,
+      "validateMetaReferences",
+    );
+    for (const upsert of group.keys) {
+      for (const id of upsert.ids) {
+        if (!liveIds.has(id)) {
+          throw new MetaSanitizationError(upsert.key, "invalid_value");
+        }
       }
     }
   }
 }
 
+interface ReferenceGroup {
+  readonly registered: { readonly adapter: LookupAdapter };
+  readonly scope: unknown;
+  // De-duped ids across every field in this group — one query
+  // resolves them all regardless of how many fields reference them.
+  readonly ids: Set<string>;
+  // Upsert-side: which keys contributed which ids, so a missing
+  // live-id can be attributed back to the field that supplied it.
+  readonly keys: { readonly key: string; readonly ids: readonly string[] }[];
+}
+
+// Defense-in-depth ceiling on the internal-aggregated id-batch size.
+// Above this, the live-id fetch throws rather than silently truncating.
+// The wire cap (100) and per-field cap (`HARD_MULTI_REFERENCE_LIMIT`,
+// 100) keep external + per-field batches small; this ceiling only
+// kicks in if many fields share `(kind, scope)` and aggregate.
+const MAX_REFERENCE_GROUP_BATCH = 1000;
+
+// Same kind + same scope = same SQL filter, so they batch into one
+// `list({ ids })` call. JSON.stringify is good enough for the scope
+// shapes we ship (`UserFieldScope`, `EntryFieldScope`,
+// `TermFieldScope` are all simple objects with stable key order at
+// build time). Plugin authors who construct scopes with non-stable
+// key order get separate groups — extra query, no correctness issue.
+//
+// `::` separator is collision-safe by construction: `kind` is
+// constrained to `[a-z][a-z0-9_-]{0,63}` (no colons) by the lookup
+// RPC schema, and core registers `user`/`entry`/`term` directly.
+//
+// `LookupAdapter` requires JSON-serializable scope; rethrow with a
+// clear message if `JSON.stringify` rejects (BigInt, cycle, function)
+// rather than letting the downstream read crash with a generic.
+function referenceGroupKey(target: ReferenceTarget): string {
+  try {
+    return `${target.kind}::${JSON.stringify(target.scope ?? null)}`;
+  } catch (cause) {
+    throw new Error(
+      `lookup adapter scope for kind "${target.kind}" must be JSON-serializable`,
+      { cause },
+    );
+  }
+}
+
+// Run one `list({ ids })` per group, throwing if the aggregated batch
+// blew past `MAX_REFERENCE_GROUP_BATCH`. The wire schema caps `ids` at
+// 100 per-request and `HARD_MULTI_REFERENCE_LIMIT` caps each field at
+// 100, so we only hit the ceiling when many fields share `(kind, scope)`
+// and aggregate — at which point throwing beats silent truncation
+// (truncation would either reject valid writes or hide live targets).
+async function fetchLiveIds(
+  ctx: AppContext,
+  registered: { readonly adapter: LookupAdapter },
+  scope: unknown,
+  ids: ReadonlySet<string>,
+  callsite: string,
+): Promise<ReadonlySet<string>> {
+  if (ids.size > MAX_REFERENCE_GROUP_BATCH) {
+    throw new Error(
+      `${callsite}: aggregated batch size ${ids.size} exceeds MAX_REFERENCE_GROUP_BATCH (${MAX_REFERENCE_GROUP_BATCH})`,
+    );
+  }
+  const idList = [...ids];
+  const rows = await registered.adapter.list(ctx, {
+    ids: idList,
+    scope,
+    limit: idList.length,
+  });
+  return new Set(rows.map((row) => row.id));
+}
+
 // Defensive upper bound on multi-reference array length, applied
-// before any per-id adapter call. `LookupAdapter.exists` is a per-id
-// round-trip today (no `existsMany` batch path), so without this guard
-// a caller could ship `meta: { owners: [<10k strings>] }` and force
-// the validator into 10k sequential queries. 100 covers any realistic
-// multi-reference field (authors, tags, related entries) — fields can
-// declare a lower `max` and the validator picks the smaller of the two.
+// per-field before grouping. Even with the batched `list({ ids })`
+// path, an unbounded array still pulls 10k rows in one query — the
+// cap protects the wire / response size. 100 covers any realistic
+// multi-reference field (authors, tags, related entries); fields
+// can declare a lower `max` and the validator picks the smaller.
 const HARD_MULTI_REFERENCE_LIMIT = 100;
 
 // Multi-reference (`userList` / `entryList` / etc.): value must be a
 // string array of non-empty strings, capped by both the hard limit
 // above and the field's optional `max`. Single-reference: value
-// must be a string. Returns the IDs to validate individually — the
-// per-ID adapter call happens in the caller.
+// must be a string. Returns the IDs that feed the group's batched
+// `list({ ids })` call in `validateMetaReferences`.
 function referenceIdsForValidation(
   key: string,
   value: unknown,
@@ -264,60 +364,107 @@ export async function validateMetaReferencesForRpc(
 }
 
 /**
- * Resolve reference fields in a decoded meta bag, replacing any
- * stored ID whose target is gone (or no longer matches scope) with
- * `null`. Caller passes a freshly-decoded bag (e.g. from
- * `decodeMetaBag`); the returned bag is a shallow copy with orphan
- * keys nulled. Non-reference keys pass through untouched.
+ * Resolve reference fields in a decoded meta bag, dropping any
+ * stored ID whose target is gone (or no longer matches scope).
+ * Single-reference orphans become `null`; multi-reference orphans
+ * are removed from the array (which stays dense, in order). Caller
+ * passes a freshly-decoded bag (e.g. from `decodeMetaBag`); the
+ * returned bag is a shallow copy with orphans handled. Non-reference
+ * keys pass through untouched.
  *
- * Optional — call this from RPC handlers that surface meta to the
- * admin/UI; internal callers that don't need orphan filtering can
- * skip the extra round-trips.
- *
- * Perf: each reference key issues one `adapter.resolve` round-trip,
- * so this scales O(refs) per entity load. Fine for single-entity
- * `*.get` reads; list endpoints rendering many entities should
- * either skip the filter (orphan IDs render as raw strings, the
- * caller absorbs the staleness) or batch-resolve via a future
- * `LookupAdapter.resolveMany(ids)` helper. Today's reference set
- * is small enough that the per-entity cost is acceptable.
+ * Two-pass: first walk groups every reference key by `(kind, scope)`
+ * and issues one `LookupAdapter.list({ ids })` per group; second
+ * walk applies the live-id sets. So a meta bag with five user-refs,
+ * three entry-refs, and two term-refs costs three queries total —
+ * not ten. Adapter `list` honours `scope` (`entryTypes`,
+ * `termTaxonomies`, `roles`, …) so out-of-scope ids fall out of the
+ * result naturally and read as orphans.
  */
 export async function filterMetaOrphans(
   ctx: AppContext,
   findField: (key: string) => MetaBoxField | undefined,
   decoded: MetaMap,
 ): Promise<MetaMap> {
-  const out: MetaMap = { ...decoded };
+  // Pass 1: classify each reference key, cache the per-key triple, and
+  // accumulate ids per `(kind, scope)` group. Pass 3 walks the cache
+  // directly so it doesn't redo the findField / registry lookups.
+  interface Candidate {
+    readonly key: string;
+    readonly multiple: boolean;
+    readonly groupKey: string;
+    readonly ids: readonly string[];
+  }
+  const candidates: Candidate[] = [];
+  const groups = new Map<
+    string,
+    {
+      readonly registered: { readonly adapter: LookupAdapter };
+      readonly scope: unknown;
+      readonly ids: Set<string>;
+    }
+  >();
   for (const [key, value] of Object.entries(decoded)) {
     const target = referenceTargetOf(findField(key));
     if (!target) continue;
     const registered = ctx.plugins.lookupAdapters.get(target.kind);
     if (!registered) continue;
-    if (target.multiple) {
-      // Multi: drop orphan IDs from the array, keeping order. The
-      // bag stays dense — consumers iterate without branching.
-      // Non-array storage shape is tolerated as unknown garbage and
-      // left untouched (the write validator should have rejected it
-      // upstream, but reads are forgiving).
-      if (!Array.isArray(value)) continue;
-      const kept: string[] = [];
-      for (const id of value) {
-        if (typeof id !== "string") continue;
-        const resolved = await registered.adapter.resolve(
-          ctx,
-          id,
-          target.scope,
-        );
-        if (resolved !== null) kept.push(id);
-      }
-      out[key] = kept;
+    const ids = orphanCandidateIds(target, value);
+    if (ids === null) continue; // non-array multi / non-string single — leave untouched
+    const groupKey = referenceGroupKey(target);
+    candidates.push({ key, multiple: target.multiple === true, groupKey, ids });
+    if (ids.length === 0) continue; // empty array — apply step still runs, no group work
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = { registered, scope: target.scope, ids: new Set() };
+      groups.set(groupKey, group);
+    }
+    for (const id of ids) group.ids.add(id);
+  }
+
+  // Pass 2: one `list({ ids })` per group, keyed for O(1) apply lookup.
+  const liveIdsByGroup = new Map<string, ReadonlySet<string>>();
+  for (const [groupKey, group] of groups) {
+    liveIdsByGroup.set(
+      groupKey,
+      await fetchLiveIds(
+        ctx,
+        group.registered,
+        group.scope,
+        group.ids,
+        "filterMetaOrphans",
+      ),
+    );
+  }
+
+  // Pass 3: apply the filter. Orphan handling differs single vs multi.
+  const out: MetaMap = { ...decoded };
+  const empty: ReadonlySet<string> = new Set();
+  for (const { key, multiple, groupKey, ids } of candidates) {
+    const liveIds = liveIdsByGroup.get(groupKey) ?? empty;
+    if (multiple) {
+      out[key] = ids.filter((id) => liveIds.has(id));
       continue;
     }
-    if (typeof value !== "string") continue;
-    const resolved = await registered.adapter.resolve(ctx, value, target.scope);
-    if (resolved === null) out[key] = null;
+    const [singleId] = ids;
+    if (singleId === undefined) continue; // single non-string already filtered upstream
+    if (!liveIds.has(singleId)) out[key] = null;
   }
   return out;
+}
+
+// Returns `null` to mean "no candidates from this key" (skip), or
+// the ids to feed into the group's batch query. Mirrors the storage-
+// shape guards in the apply step so we don't enqueue work that's
+// going to be skipped.
+function orphanCandidateIds(
+  target: ReferenceTarget,
+  value: unknown,
+): readonly string[] | null {
+  if (target.multiple) {
+    if (!Array.isArray(value)) return null;
+    return value.filter((id): id is string => typeof id === "string");
+  }
+  return typeof value === "string" ? [value] : null;
 }
 
 function referenceTargetOf(

--- a/packages/core/src/rpc/meta/references.test.ts
+++ b/packages/core/src/rpc/meta/references.test.ts
@@ -162,3 +162,154 @@ describe("filterMetaOrphans", () => {
     expect(filtered).toEqual({ title: "Hello", count: 7 });
   });
 });
+
+// Multi-value reference shape (`userList` and friends). The pipeline
+// dispatches on `referenceTarget.multiple` — array values get
+// per-item existence checks + a `max` length guard, while orphan
+// filtering drops missing IDs and keeps the array dense.
+function registryWithUserListRef(
+  field: Partial<MetaBoxField & { readonly max?: number }> = {},
+) {
+  const registry: MutablePluginRegistry = createPluginRegistry();
+  registerCoreLookupAdapters(registry);
+  const fullField = {
+    key: "owners",
+    label: "Owners",
+    type: "json",
+    inputType: "userList",
+    referenceTarget: { kind: "user", multiple: true },
+    ...field,
+  } as MetaBoxField;
+  registry.userMetaBoxes.set("ownership", {
+    id: "ownership",
+    label: "Ownership",
+    fields: [fullField],
+    registeredBy: null,
+  });
+  return {
+    registry,
+    findField: (key: string) => (key === fullField.key ? fullField : undefined),
+  };
+}
+
+describe("validateMetaReferences (multi)", () => {
+  test("accepts an array of in-scope ids", async () => {
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const a = await userFactory.transient({ db: h.context.db }).create();
+    const b = await userFactory.transient({ db: h.context.db }).create();
+    const patch = sanitizeMetaInput(findField, {
+      owners: [String(a.id), String(b.id)],
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects when any single id in the array is missing", async () => {
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const a = await userFactory.transient({ db: h.context.db }).create();
+    const patch = sanitizeMetaInput(findField, {
+      owners: [String(a.id), "999999"],
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("rejects a non-array value for a multi field", async () => {
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, { owners: "1" });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("rejects an array containing non-string entries", async () => {
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, {
+      owners: ["1", 2 as unknown as string],
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("enforces the field's max length cap", async () => {
+    const { registry, findField } = registryWithUserListRef({ max: 1 });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const a = await userFactory.transient({ db: h.context.db }).create();
+    const b = await userFactory.transient({ db: h.context.db }).create();
+    const patch = sanitizeMetaInput(findField, {
+      owners: [String(a.id), String(b.id)],
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("accepts an empty array", async () => {
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, { owners: [] });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects oversized arrays as value_too_large, even without a field-level max", async () => {
+    // Defensive cap: a multi field that doesn't declare `max` still
+    // can't be coerced into N+ sequential `adapter.exists` round-trips
+    // in one request. Surfaces as `value_too_large` rather than
+    // `invalid_value` so the caller can distinguish "your shape is
+    // wrong" from "this is too big".
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const oversized = Array.from({ length: 101 }, (_, i) => String(i + 1));
+    const patch = sanitizeMetaInput(findField, { owners: oversized });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toMatchObject({ reason: "value_too_large", key: "owners" });
+  });
+});
+
+describe("filterMetaOrphans (multi)", () => {
+  test("drops missing IDs from the array, keeping the rest in order", async () => {
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const a = await adminUser.transient({ db: h.context.db }).create();
+    const b = await adminUser.transient({ db: h.context.db }).create();
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      owners: [String(a.id), "999999", String(b.id)],
+    });
+    expect(filtered.owners).toEqual([String(a.id), String(b.id)]);
+  });
+
+  test("returns an empty array when every entry is orphaned", async () => {
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      owners: ["999999", "888888"],
+    });
+    expect(filtered.owners).toEqual([]);
+  });
+
+  test("leaves non-array storage untouched (read forgiveness)", async () => {
+    const { registry, findField } = registryWithUserListRef();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      owners: "not-an-array",
+    });
+    expect(filtered.owners).toBe("not-an-array");
+  });
+});

--- a/packages/core/src/rpc/meta/references.test.ts
+++ b/packages/core/src/rpc/meta/references.test.ts
@@ -266,6 +266,67 @@ describe("validateMetaReferences (multi)", () => {
     ).resolves.toBeUndefined();
   });
 
+  test("two same-(kind,scope) reference fields batch into one adapter.list call", async () => {
+    // Headline guarantee of kind-grouped batching: a meta patch with
+    // multiple reference upserts targeting the same `(kind, scope)`
+    // costs exactly one adapter call, not one per key. Wrap the core
+    // user adapter with a counting proxy and confirm.
+    const registry = createPluginRegistry();
+    registerCoreLookupAdapters(registry);
+    const userEntry = registry.lookupAdapters.get("user");
+    if (!userEntry) throw new Error("user adapter should be registered");
+    let listCalls = 0;
+    registry.lookupAdapters.set("user", {
+      ...userEntry,
+      adapter: {
+        list: (ctx, options) => {
+          listCalls += 1;
+          return userEntry.adapter.list(ctx, options);
+        },
+        resolve: (ctx, id, scope) => userEntry.adapter.resolve(ctx, id, scope),
+      },
+    });
+    const ownerField: MetaBoxField = {
+      key: "owner",
+      label: "Owner",
+      type: "string",
+      inputType: "user",
+      referenceTarget: { kind: "user" },
+    };
+    const reviewerField: MetaBoxField = {
+      key: "reviewer",
+      label: "Reviewer",
+      type: "string",
+      inputType: "user",
+      referenceTarget: { kind: "user" },
+    };
+    registry.userMetaBoxes.set("ownership", {
+      id: "ownership",
+      label: "Ownership",
+      fields: [ownerField, reviewerField],
+      registeredBy: null,
+    });
+    const findField = (key: string): MetaBoxField | undefined =>
+      key === ownerField.key
+        ? ownerField
+        : key === reviewerField.key
+          ? reviewerField
+          : undefined;
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const owner = await userFactory.transient({ db: h.context.db }).create();
+    const reviewer = await userFactory.transient({ db: h.context.db }).create();
+    const patch = sanitizeMetaInput(findField, {
+      owner: String(owner.id),
+      reviewer: String(reviewer.id),
+    });
+    if (!patch) throw new Error("patch should not be null");
+
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).resolves.toBeUndefined();
+    expect(listCalls).toBe(1);
+  });
+
   test("rejects oversized arrays as value_too_large, even without a field-level max", async () => {
     // Defensive cap: a multi field that doesn't declare `max` still
     // can't be coerced into N+ sequential `adapter.exists` round-trips

--- a/packages/core/src/rpc/procedures/entry/lookup.test.ts
+++ b/packages/core/src/rpc/procedures/entry/lookup.test.ts
@@ -7,70 +7,94 @@ import { entryLookupAdapter } from "./lookup.js";
 const POST = { entryTypes: ["post"] } as const;
 const PAGE = { entryTypes: ["page"] } as const;
 
+// Existence checks now ride the `list({ ids })` batch path — same
+// scope rules, single query.
+async function existsViaList(
+  h: Awaited<ReturnType<typeof createRpcHarness>>,
+  id: string,
+  scope: { entryTypes: readonly string[]; includeTrashed?: boolean },
+): Promise<boolean> {
+  const rows = await entryLookupAdapter.list(h.context, {
+    ids: [id],
+    scope,
+    limit: 1,
+  });
+  return rows.some((row) => row.id === id);
+}
+
 describe("entryLookupAdapter", () => {
-  test("exists() returns true for an active entry under the matching scope", async () => {
+  test("list({ ids }) returns a row for an active entry under matching scope", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
     const e = await entryFactory
       .transient({ db: h.context.db })
       .create({ authorId: h.user.id });
-    expect(await entryLookupAdapter.exists(h.context, String(e.id), POST)).toBe(
-      true,
-    );
+    expect(await existsViaList(h, String(e.id), POST)).toBe(true);
   });
 
-  test("exists() returns false for a non-existent id", async () => {
+  test("list({ ids }) returns nothing for a non-existent id", async () => {
     const h = await createRpcHarness();
-    expect(await entryLookupAdapter.exists(h.context, "999999", POST)).toBe(
-      false,
-    );
+    expect(await existsViaList(h, "999999", POST)).toBe(false);
   });
 
-  test("exists() rejects malformed ids without hitting the DB", async () => {
+  test("list({ ids }) drops malformed ids before querying", async () => {
     const h = await createRpcHarness();
-    expect(await entryLookupAdapter.exists(h.context, "", POST)).toBe(false);
-    expect(await entryLookupAdapter.exists(h.context, "abc", POST)).toBe(false);
-    expect(await entryLookupAdapter.exists(h.context, "0", POST)).toBe(false);
-    expect(await entryLookupAdapter.exists(h.context, "-1", POST)).toBe(false);
-    expect(await entryLookupAdapter.exists(h.context, "1.5", POST)).toBe(false);
+    expect(await existsViaList(h, "", POST)).toBe(false);
+    expect(await existsViaList(h, "abc", POST)).toBe(false);
+    expect(await existsViaList(h, "0", POST)).toBe(false);
+    expect(await existsViaList(h, "-1", POST)).toBe(false);
+    expect(await existsViaList(h, "1.5", POST)).toBe(false);
   });
 
-  test("exists() honours the entryTypes scope filter", async () => {
+  test("list({ ids }) honours the entryTypes scope filter", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
     const post = await entryFactory
       .transient({ db: h.context.db })
       .create({ authorId: h.user.id, type: "post" });
-    expect(
-      await entryLookupAdapter.exists(h.context, String(post.id), PAGE),
-    ).toBe(false);
-    expect(
-      await entryLookupAdapter.exists(h.context, String(post.id), POST),
-    ).toBe(true);
+    expect(await existsViaList(h, String(post.id), PAGE)).toBe(false);
+    expect(await existsViaList(h, String(post.id), POST)).toBe(true);
   });
 
-  test("exists() excludes trashed entries by default", async () => {
+  test("list({ ids }) excludes trashed entries by default", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
     const trashed = await entryFactory
       .transient({ db: h.context.db })
       .create({ authorId: h.user.id, status: "trash" });
+    expect(await existsViaList(h, String(trashed.id), POST)).toBe(false);
     expect(
-      await entryLookupAdapter.exists(h.context, String(trashed.id), POST),
-    ).toBe(false);
-    expect(
-      await entryLookupAdapter.exists(h.context, String(trashed.id), {
+      await existsViaList(h, String(trashed.id), {
         ...POST,
         includeTrashed: true,
       }),
     ).toBe(true);
   });
 
+  test("list({ ids }) batches multiple ids in one query", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const a = await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id });
+    const b = await entryFactory
+      .transient({ db: h.context.db })
+      .create({ authorId: h.user.id });
+    const rows = await entryLookupAdapter.list(h.context, {
+      ids: [String(a.id), String(b.id), "999999"],
+      scope: POST,
+      limit: 3,
+    });
+    const idSet = new Set(rows.map((r) => r.id));
+    expect(idSet.has(String(a.id))).toBe(true);
+    expect(idSet.has(String(b.id))).toBe(true);
+    expect(idSet.has("999999")).toBe(false);
+  });
+
   test("rejects calls without scope (would otherwise expose every type)", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
-    await expect(entryLookupAdapter.exists(h.context, "1")).rejects.toThrow(
-      /entryTypes is required/,
-    );
     await expect(entryLookupAdapter.list(h.context, {})).rejects.toThrow(
       /entryTypes is required/,
     );
+    await expect(
+      entryLookupAdapter.list(h.context, { ids: ["1"] }),
+    ).rejects.toThrow(/entryTypes is required/);
     await expect(entryLookupAdapter.resolve(h.context, "1")).rejects.toThrow(
       /entryTypes is required/,
     );

--- a/packages/core/src/rpc/procedures/entry/lookup.ts
+++ b/packages/core/src/rpc/procedures/entry/lookup.ts
@@ -16,29 +16,35 @@ const ENTRY_ROW_COLUMNS = {
 } as const;
 
 export const entryLookupAdapter: LookupAdapter<EntryFieldScope> = {
-  async exists(ctx, id, scope) {
-    const numericId = parseEntryId(id);
-    if (numericId === null) return false;
-    const row = await ctx.db
-      .select({ id: entries.id })
-      .from(entries)
-      .where(buildEntryWhere(numericId, scope))
-      .limit(1);
-    return row.length > 0;
-  },
-
   async list(ctx, options) {
     const conditions = scopeConditions(options.scope);
-    const trimmedQuery = options.query?.trim();
-    if (trimmedQuery) {
-      conditions.push(like(entries.title, `%${trimmedQuery}%`));
+    let limit: number;
+    if (options.ids !== undefined) {
+      // Resolve-by-id batch path: ignore `query`, return only the
+      // requested ids (still subject to scope). Invalid ids are
+      // silently dropped — they read as orphans on the caller's side.
+      // Limit tracks `numericIds.length` (not `MAX_LIST_LIMIT`) since
+      // the meta pipeline aggregates ids across same-`(kind,scope)`
+      // fields and may legitimately request >100 in one call.
+      const numericIds = options.ids
+        .map((id) => parseEntryId(id))
+        .filter((id): id is number => id !== null);
+      if (numericIds.length === 0) return [];
+      conditions.push(inArray(entries.id, numericIds));
+      limit = numericIds.length;
+    } else {
+      const trimmedQuery = options.query?.trim();
+      if (trimmedQuery) {
+        conditions.push(like(entries.title, `%${trimmedQuery}%`));
+      }
+      limit = clampLimit(options.limit);
     }
     const rows = await ctx.db
       .select(ENTRY_ROW_COLUMNS)
       .from(entries)
       .where(conditions.length === 0 ? undefined : and(...conditions))
       .orderBy(entries.title)
-      .limit(clampLimit(options.limit));
+      .limit(limit);
     return rows.map(toLookupResult);
   },
 

--- a/packages/core/src/rpc/procedures/lookup/list.ts
+++ b/packages/core/src/rpc/procedures/lookup/list.ts
@@ -18,6 +18,7 @@ export const list = base
       query: input.query,
       scope: input.scope,
       limit: input.limit,
+      ids: input.ids,
     });
     return { items };
   });

--- a/packages/core/src/rpc/procedures/lookup/schemas.ts
+++ b/packages/core/src/rpc/procedures/lookup/schemas.ts
@@ -18,6 +18,23 @@ const querySchema = v.pipe(v.string(), v.trim(), v.maxLength(200));
 // shape isn't an array or scalar.
 const scopeSchema = v.optional(v.record(v.string(), v.unknown()));
 
+// Realistic upper bound on a single id string. UUIDs are 36 chars;
+// `Number.MAX_SAFE_INTEGER` is 16 digits. 64 covers both with room
+// for plugin-supplied id formats (slug-like, prefixed) while
+// preventing CPU amplification on the regex parsers each adapter
+// runs against incoming ids.
+const ID_MAX_LENGTH = 64;
+
+// `ids` is the resolve-by-id batch path: when set, the adapter
+// returns rows matching any of these ids (still scope-filtered) in
+// a single query. Capped at 100 to match the meta pipeline's
+// `HARD_MULTI_REFERENCE_LIMIT` — the picker can't ship a wider
+// selection through to the validator anyway.
+const lookupListIdsSchema = v.pipe(
+  v.array(v.pipe(v.string(), v.maxLength(ID_MAX_LENGTH))),
+  v.maxLength(100),
+);
+
 export const lookupListInputSchema = v.object({
   kind: kindSchema,
   query: v.optional(querySchema),
@@ -25,11 +42,12 @@ export const lookupListInputSchema = v.object({
   limit: v.optional(
     v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
   ),
+  ids: v.optional(lookupListIdsSchema),
 });
 
 export const lookupResolveInputSchema = v.object({
   kind: kindSchema,
-  id: v.pipe(v.string(), v.maxLength(256)),
+  id: v.pipe(v.string(), v.maxLength(ID_MAX_LENGTH)),
   scope: scopeSchema,
 });
 

--- a/packages/core/src/rpc/procedures/term/lookup.test.ts
+++ b/packages/core/src/rpc/procedures/term/lookup.test.ts
@@ -7,55 +7,69 @@ import { termLookupAdapter } from "./lookup.js";
 const CATEGORY = { termTaxonomies: ["category"] } as const;
 const TAG = { termTaxonomies: ["tag"] } as const;
 
+async function existsViaList(
+  h: Awaited<ReturnType<typeof createRpcHarness>>,
+  id: string,
+  scope: { termTaxonomies: readonly string[] },
+): Promise<boolean> {
+  const rows = await termLookupAdapter.list(h.context, {
+    ids: [id],
+    scope,
+    limit: 1,
+  });
+  return rows.some((row) => row.id === id);
+}
+
 describe("termLookupAdapter", () => {
-  test("exists() returns true for a real term in the matching scope", async () => {
+  test("list({ ids }) returns a row for a real term in the matching scope", async () => {
     const h = await createRpcHarness();
     const t = await termFactory.transient({ db: h.context.db }).create();
-    expect(
-      await termLookupAdapter.exists(h.context, String(t.id), CATEGORY),
-    ).toBe(true);
+    expect(await existsViaList(h, String(t.id), CATEGORY)).toBe(true);
   });
 
-  test("exists() returns false for a non-existent id", async () => {
+  test("list({ ids }) returns nothing for a non-existent id", async () => {
     const h = await createRpcHarness();
-    expect(await termLookupAdapter.exists(h.context, "999999", CATEGORY)).toBe(
-      false,
-    );
+    expect(await existsViaList(h, "999999", CATEGORY)).toBe(false);
   });
 
-  test("exists() rejects malformed ids without hitting the DB", async () => {
+  test("list({ ids }) drops malformed ids before querying", async () => {
     const h = await createRpcHarness();
-    expect(await termLookupAdapter.exists(h.context, "", CATEGORY)).toBe(false);
-    expect(await termLookupAdapter.exists(h.context, "abc", CATEGORY)).toBe(
-      false,
-    );
-    expect(await termLookupAdapter.exists(h.context, "0", CATEGORY)).toBe(
-      false,
-    );
-    expect(await termLookupAdapter.exists(h.context, "-1", CATEGORY)).toBe(
-      false,
-    );
+    expect(await existsViaList(h, "", CATEGORY)).toBe(false);
+    expect(await existsViaList(h, "abc", CATEGORY)).toBe(false);
+    expect(await existsViaList(h, "0", CATEGORY)).toBe(false);
+    expect(await existsViaList(h, "-1", CATEGORY)).toBe(false);
   });
 
-  test("exists() honours the termTaxonomies scope filter", async () => {
+  test("list({ ids }) honours the termTaxonomies scope filter", async () => {
     const h = await createRpcHarness();
     const cat = await categoryTerm.transient({ db: h.context.db }).create();
-    expect(await termLookupAdapter.exists(h.context, String(cat.id), TAG)).toBe(
-      false,
-    );
-    expect(
-      await termLookupAdapter.exists(h.context, String(cat.id), CATEGORY),
-    ).toBe(true);
+    expect(await existsViaList(h, String(cat.id), TAG)).toBe(false);
+    expect(await existsViaList(h, String(cat.id), CATEGORY)).toBe(true);
+  });
+
+  test("list({ ids }) batches multiple ids in one query", async () => {
+    const h = await createRpcHarness();
+    const a = await categoryTerm.transient({ db: h.context.db }).create();
+    const b = await categoryTerm.transient({ db: h.context.db }).create();
+    const rows = await termLookupAdapter.list(h.context, {
+      ids: [String(a.id), String(b.id), "999999"],
+      scope: CATEGORY,
+      limit: 3,
+    });
+    const idSet = new Set(rows.map((r) => r.id));
+    expect(idSet.has(String(a.id))).toBe(true);
+    expect(idSet.has(String(b.id))).toBe(true);
+    expect(idSet.has("999999")).toBe(false);
   });
 
   test("rejects calls without scope (would otherwise expose every taxonomy)", async () => {
     const h = await createRpcHarness();
-    await expect(termLookupAdapter.exists(h.context, "1")).rejects.toThrow(
-      /termTaxonomies is required/,
-    );
     await expect(termLookupAdapter.list(h.context, {})).rejects.toThrow(
       /termTaxonomies is required/,
     );
+    await expect(
+      termLookupAdapter.list(h.context, { ids: ["1"] }),
+    ).rejects.toThrow(/termTaxonomies is required/);
     await expect(termLookupAdapter.resolve(h.context, "1")).rejects.toThrow(
       /termTaxonomies is required/,
     );

--- a/packages/core/src/rpc/procedures/term/lookup.ts
+++ b/packages/core/src/rpc/procedures/term/lookup.ts
@@ -16,34 +16,40 @@ const TERM_ROW_COLUMNS = {
 } as const;
 
 export const termLookupAdapter: LookupAdapter<TermFieldScope> = {
-  async exists(ctx, id, scope) {
-    const numericId = parseTermId(id);
-    if (numericId === null) return false;
-    const row = await ctx.db
-      .select({ id: terms.id })
-      .from(terms)
-      .where(buildTermWhere(numericId, scope))
-      .limit(1);
-    return row.length > 0;
-  },
-
   async list(ctx, options) {
     const conditions = scopeConditions(options.scope);
-    const trimmedQuery = options.query?.trim();
-    if (trimmedQuery) {
-      const pattern = `%${trimmedQuery}%`;
-      const queryMatch = or(
-        like(terms.name, pattern),
-        like(terms.slug, pattern),
-      );
-      if (queryMatch) conditions.push(queryMatch);
+    let limit: number;
+    if (options.ids !== undefined) {
+      // Resolve-by-id batch path: ignore `query`, return only the
+      // requested ids (still subject to scope). Invalid ids are
+      // silently dropped — they read as orphans on the caller's side.
+      // Limit tracks `numericIds.length` (not `MAX_LIST_LIMIT`) since
+      // the meta pipeline aggregates ids across same-`(kind,scope)`
+      // fields and may legitimately request >100 in one call.
+      const numericIds = options.ids
+        .map((id) => parseTermId(id))
+        .filter((id): id is number => id !== null);
+      if (numericIds.length === 0) return [];
+      conditions.push(inArray(terms.id, numericIds));
+      limit = numericIds.length;
+    } else {
+      const trimmedQuery = options.query?.trim();
+      if (trimmedQuery) {
+        const pattern = `%${trimmedQuery}%`;
+        const queryMatch = or(
+          like(terms.name, pattern),
+          like(terms.slug, pattern),
+        );
+        if (queryMatch) conditions.push(queryMatch);
+      }
+      limit = clampLimit(options.limit);
     }
     const rows = await ctx.db
       .select(TERM_ROW_COLUMNS)
       .from(terms)
       .where(conditions.length === 0 ? undefined : and(...conditions))
       .orderBy(terms.name)
-      .limit(clampLimit(options.limit));
+      .limit(limit);
     return rows.map(toLookupResult);
   },
 

--- a/packages/core/src/rpc/procedures/user/lookup.test.ts
+++ b/packages/core/src/rpc/procedures/user/lookup.test.ts
@@ -4,55 +4,90 @@ import { adminUser, userFactory } from "../../../test/factories.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 import { userLookupAdapter } from "./lookup.js";
 
+// Existence checks now ride the `list({ ids })` batch path — same
+// scope rules, single query. These tests mirror the semantics that
+// used to live on `adapter.exists`: id present in result ⇔ exists.
+async function existsViaList(
+  h: Awaited<ReturnType<typeof createRpcHarness>>,
+  id: string,
+  scope?: {
+    roles?: readonly ("admin" | "editor" | "author")[];
+    includeDisabled?: boolean;
+  },
+): Promise<boolean> {
+  const rows = await userLookupAdapter.list(h.context, {
+    ids: [id],
+    scope,
+    limit: 1,
+  });
+  return rows.some((row) => row.id === id);
+}
+
 describe("userLookupAdapter", () => {
-  test("exists() returns true for an active user", async () => {
+  test("list({ ids }) returns a row for an active user", async () => {
     const h = await createRpcHarness();
     const u = await userFactory.transient({ db: h.context.db }).create();
-    expect(await userLookupAdapter.exists(h.context, String(u.id))).toBe(true);
+    expect(await existsViaList(h, String(u.id))).toBe(true);
   });
 
-  test("exists() returns false for a non-existent id", async () => {
+  test("list({ ids }) returns nothing for a non-existent id", async () => {
     const h = await createRpcHarness();
-    expect(await userLookupAdapter.exists(h.context, "999999")).toBe(false);
+    expect(await existsViaList(h, "999999")).toBe(false);
   });
 
-  test("exists() rejects malformed ids without hitting the DB", async () => {
+  test("list({ ids }) drops malformed ids before querying", async () => {
     const h = await createRpcHarness();
-    expect(await userLookupAdapter.exists(h.context, "")).toBe(false);
-    expect(await userLookupAdapter.exists(h.context, "abc")).toBe(false);
-    expect(await userLookupAdapter.exists(h.context, "0")).toBe(false);
-    expect(await userLookupAdapter.exists(h.context, "-1")).toBe(false);
-    expect(await userLookupAdapter.exists(h.context, "1.5")).toBe(false);
+    expect(await existsViaList(h, "")).toBe(false);
+    expect(await existsViaList(h, "abc")).toBe(false);
+    expect(await existsViaList(h, "0")).toBe(false);
+    expect(await existsViaList(h, "-1")).toBe(false);
+    expect(await existsViaList(h, "1.5")).toBe(false);
   });
 
-  test("exists() honours the roles scope filter", async () => {
+  test("list({ ids }) honours the roles scope filter", async () => {
     const h = await createRpcHarness();
     const author = await userFactory
       .transient({ db: h.context.db })
       .create({ role: "author" });
     expect(
-      await userLookupAdapter.exists(h.context, String(author.id), {
+      await existsViaList(h, String(author.id), {
         roles: ["editor", "admin"],
       }),
     ).toBe(false);
     expect(
-      await userLookupAdapter.exists(h.context, String(author.id), {
-        roles: ["author"],
-      }),
+      await existsViaList(h, String(author.id), { roles: ["author"] }),
     ).toBe(true);
   });
 
-  test("exists() excludes disabled users by default", async () => {
+  test("list({ ids }) excludes disabled users by default", async () => {
     const h = await createRpcHarness();
     const u = await userFactory
       .transient({ db: h.context.db })
       .create({ disabledAt: new Date() });
-    expect(await userLookupAdapter.exists(h.context, String(u.id))).toBe(false);
+    expect(await existsViaList(h, String(u.id))).toBe(false);
     expect(
-      await userLookupAdapter.exists(h.context, String(u.id), {
-        includeDisabled: true,
-      }),
+      await existsViaList(h, String(u.id), { includeDisabled: true }),
     ).toBe(true);
+  });
+
+  test("list({ ids }) returns multiple rows in one query (batch path)", async () => {
+    const h = await createRpcHarness();
+    const a = await userFactory.transient({ db: h.context.db }).create();
+    const b = await userFactory.transient({ db: h.context.db }).create();
+    const rows = await userLookupAdapter.list(h.context, {
+      ids: [String(a.id), String(b.id), "999999"],
+      limit: 3,
+    });
+    const idSet = new Set(rows.map((r) => r.id));
+    expect(idSet.has(String(a.id))).toBe(true);
+    expect(idSet.has(String(b.id))).toBe(true);
+    expect(idSet.has("999999")).toBe(false);
+  });
+
+  test("list({ ids: [] }) short-circuits without querying", async () => {
+    const h = await createRpcHarness();
+    const rows = await userLookupAdapter.list(h.context, { ids: [], limit: 1 });
+    expect(rows).toEqual([]);
   });
 
   test("list() searches by email and name (case-insensitive substring)", async () => {

--- a/packages/core/src/rpc/procedures/user/lookup.ts
+++ b/packages/core/src/rpc/procedures/user/lookup.ts
@@ -17,34 +17,40 @@ const USER_ROW_COLUMNS = {
 } as const;
 
 export const userLookupAdapter: LookupAdapter<UserFieldScope> = {
-  async exists(ctx, id, scope) {
-    const numericId = parseUserId(id);
-    if (numericId === null) return false;
-    const row = await ctx.db
-      .select({ id: users.id })
-      .from(users)
-      .where(buildUserWhere(numericId, scope))
-      .limit(1);
-    return row.length > 0;
-  },
-
   async list(ctx, options) {
     const conditions = scopeConditions(options.scope);
-    const trimmedQuery = options.query?.trim();
-    if (trimmedQuery) {
-      const pattern = `%${trimmedQuery}%`;
-      const queryMatch = or(
-        like(users.email, pattern),
-        like(users.name, pattern),
-      );
-      if (queryMatch) conditions.push(queryMatch);
+    let limit: number;
+    if (options.ids !== undefined) {
+      // Resolve-by-id batch path: ignore `query` and bound the result
+      // to the parsed ids. Invalid (non-numeric) ids are silently
+      // dropped — they read as orphans on the caller's side. Limit
+      // tracks `numericIds.length` (not `MAX_LIST_LIMIT`) because the
+      // meta pipeline aggregates ids across same-`(kind,scope)` fields
+      // and can legitimately request >100 in one call.
+      const numericIds = options.ids
+        .map((id) => parseUserId(id))
+        .filter((id): id is number => id !== null);
+      if (numericIds.length === 0) return [];
+      conditions.push(inArray(users.id, numericIds));
+      limit = numericIds.length;
+    } else {
+      const trimmedQuery = options.query?.trim();
+      if (trimmedQuery) {
+        const pattern = `%${trimmedQuery}%`;
+        const queryMatch = or(
+          like(users.email, pattern),
+          like(users.name, pattern),
+        );
+        if (queryMatch) conditions.push(queryMatch);
+      }
+      limit = clampLimit(options.limit);
     }
     const rows = await ctx.db
       .select(USER_ROW_COLUMNS)
       .from(users)
       .where(conditions.length === 0 ? undefined : and(...conditions))
       .orderBy(sql`coalesce(${users.name}, ${users.email})`)
-      .limit(clampLimit(options.limit));
+      .limit(limit);
     return rows.map(toLookupResult);
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,18 @@ importers:
 
   packages/admin:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.5)
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
@@ -1203,6 +1215,34 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -6721,6 +6761,38 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
 


### PR DESCRIPTION
## Summary

Establishes the multi-reference field pattern via the first concrete instance: `userList`. The seam — `ReferenceTarget.multiple` flag + `validateMetaReferences` / `filterMetaOrphans` array dispatch + `MultiReferencePicker` admin component + `SortableList` primitive — is the foundation for `entryList` / `termList` (#131) and `mediaList` (#132). After this lands, those become thin slices that just plug their kind into the established machinery.

## Resolves

- Resolves #129 — `userList` (introduces `@dnd-kit` + multi-reference pattern)

## What landed

**Multi-reference manifest shape (`packages/core/src/plugin/manifest.ts`)**
- `ReferenceTarget.multiple?: boolean` — cardinality discriminator. Single → string storage, multi → JSON array storage.
- `UserListMetaBoxField` variant with `inputType: "userList"`, `type: "json"`, `max?: number` length cap.

**`userList()` builder (`packages/core/src/plugin/fields/user-list.ts`)**
- Reuses `UserFieldScope` (same `roles` / `includeDisabled` filters).
- Storage as JSON array of bare user IDs. Reads filter out orphans inline.

**Pipeline dispatch (`packages/core/src/rpc/meta/core.ts`)**
- `validateMetaReferences` now branches on `referenceTarget.multiple`. Multi: array required, every entry non-empty string, length ≤ `max`, per-id `adapter.exists` check. Empty array is valid.
- `filterMetaOrphans` for multi: drops missing IDs from the array preserving order. Non-array storage at a multi key falls through untouched (read forgiveness).

**Admin primitives (`packages/admin/src/components/ui/sortable.tsx`)**
- `SortableList<T>` — generic vertical sortable backed by `@dnd-kit/core` + `/sortable` + `/utilities` + `/modifiers`. Pointer-with-distance threshold (4px), keyboard reorder out of the box, vertical-axis lock, optional remove. Reused for `entryList` / `termList` / `mediaList` / repeater rows in subsequent slices.

**`MultiReferencePicker` (`packages/admin/src/components/meta-box/multi-reference-picker.tsx`)**
- Selected rows: sortable list with drag-reorder, per-row remove, orphan badge per missing target.
- Resolves selected IDs in parallel via `useQueries` so a single missing target doesn't poison the rest.
- Dialog stays open across selections (✓ marker on already-picked items, disabled when full or already selected).
- `max` enforced at the Add button (disabled, label switches between "Select"/"Add", `count / max` indicator).
- Required + single-selected hides the remove button.

**Dispatch (`packages/admin/src/components/meta-box/meta-box-field.tsx`)**
- Any `referenceTarget.multiple === true` field routes through `MultiReferencePicker`. Same shape will handle `entryList` / `termList` / `mediaList` once they land.

## Test plan

- [x] `pnpm --filter @plumix/core test` — 1105 passing (+13 covering builder, multi validation, multi orphan filter)
- [x] `pnpm --filter @plumix/admin test` — 149 passing (+2 covering multi dispatch + max cap)
- [x] `pnpm --filter @plumix/core typecheck`, `lint`, `format` clean
- [x] `pnpm --filter @plumix/admin typecheck`, `lint`, `format` clean (only pre-existing warnings)
- [x] `pnpm --filter plumix typecheck` clean
- [x] `pnpm knip` clean

## Notes for review

- The `multiple` discriminator on `ReferenceTarget` is the critical seam — once #131 / #132 / repeater rows land, they all plug into this same single switch.
- `MultiReferencePicker` shares the orpc dispatch + scope shape with `ReferencePicker`, so it inherits the same capability gating from #135 (subscribers can't enumerate users via `userList` either).
- Default-public `entry` / `term` adapters (registered with `capability: null` in #136) flow through unchanged — `entryList` / `termList` will inherit the same posture.
- `@dnd-kit` is the same toolkit reserved for `mediaList` and the repeater field; this is the first usage that pulls it in.