### PR TITLE
feat: MediaLibrary dual-mode + media() field (#130) [WIP]

### DIFF
--- a/packages/core/src/plugin/lookup.ts
+++ b/packages/core/src/plugin/lookup.ts
@@ -11,6 +11,17 @@ export interface LookupResult {
   readonly id: string;
   readonly label: string;
   readonly subtitle?: string;
+  /**
+   * Adapter-provided cached fields. When the field's
+   * `referenceTarget.valueShape === "object"`, the meta pipeline
+   * merges these into the stored value on every write so reads can
+   * render without a resolve round-trip. Examples: `mime`,
+   * `filename` for media; could be `width`/`height` later.
+   *
+   * Picker UIs may also read `cached` to render preview thumbnails
+   * (e.g. `cached.mime` to decide image vs file icon).
+   */
+  readonly cached?: Readonly<Record<string, unknown>>;
 }
 
 export interface LookupListOptions<TScope = unknown> {

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -336,13 +336,26 @@ export interface ReferenceTarget<TScope = unknown> {
   readonly kind: string;
   readonly scope?: TScope;
   /**
-   * Storage cardinality. `false`/absent → single ID stored as a
-   * string (e.g. `user`, `entry`, `term`). `true` → array of IDs
-   * stored as JSON (e.g. `userList`, `entryList`, `mediaList`).
+   * Storage cardinality. `false`/absent → single value (string or
+   * cached object). `true` → array (of strings or cached objects).
    * The server-side write validator and read-side orphan filter
    * dispatch on this flag to handle both shapes uniformly.
    */
   readonly multiple?: boolean;
+  /**
+   * Storage shape per item. `"id"` (default) → bare id string —
+   * every read needs a join/resolve to get a label. `"object"` →
+   * `{ id, ...cachedFields, ...userFields }` — the meta pipeline
+   * normalizes cached fields from the adapter on every write so
+   * reads can render without a join. Used by `media` (where the
+   * thumbnail/mime/filename are needed on every render and a
+   * resolve per render is wasteful on the edge).
+   *
+   * The cached fields come from `LookupResult.cached` returned by
+   * the adapter; user-supplied keys (e.g. per-usage `alt`) survive
+   * the merge so editors can override per-usage metadata.
+   */
+  readonly valueShape?: "id" | "object";
 }
 
 /**
@@ -430,6 +443,25 @@ export interface TermListMetaBoxField extends MetaBoxFieldBase {
   readonly max?: number;
 }
 
+/**
+ * Single media reference with cached metadata. Storage is the
+ * `MediaValue` object — `{ id, mime?, filename?, alt? }` — not a
+ * bare id, so admin renders show a thumbnail + filename without an
+ * extra resolve round-trip per render. `referenceTarget.valueShape`
+ * is `"object"`; the meta pipeline overwrites the cached fields
+ * (mime/filename) from the lookup adapter on every write but lets
+ * user-supplied keys (e.g. per-usage `alt`) survive the merge.
+ *
+ * Lives in core so the typed builder narrows correctly at call
+ * sites — same convention as `entry` / `term`. The actual builder
+ * + adapter are in `@plumix/plugin-media`.
+ */
+export interface MediaMetaBoxField extends MetaBoxFieldBase {
+  readonly inputType: "media";
+  readonly type: "json";
+  readonly referenceTarget: ReferenceTarget;
+}
+
 /** Single-value dropdown picker; `options` is required. */
 export interface SelectMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "select";
@@ -501,6 +533,7 @@ export type MetaBoxField =
   | EntryListMetaBoxField
   | TermReferenceMetaBoxField
   | TermListMetaBoxField
+  | MediaMetaBoxField
   | SelectMetaBoxField
   | RadioMetaBoxField
   | CheckboxMetaBoxField
@@ -565,6 +598,7 @@ export type EntryMetaBoxField =
   | Omit<EntryListMetaBoxField, "span">
   | Omit<TermReferenceMetaBoxField, "span">
   | Omit<TermListMetaBoxField, "span">
+  | Omit<MediaMetaBoxField, "span">
   | Omit<SelectMetaBoxField, "span">
   | Omit<RadioMetaBoxField, "span">
   | Omit<CheckboxMetaBoxField, "span">

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -3,7 +3,7 @@ import type { SQLiteColumn } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 
 import type { AppContext } from "../../context/app.js";
-import type { LookupAdapter } from "../../plugin/lookup.js";
+import type { LookupAdapter, LookupResult } from "../../plugin/lookup.js";
 import type {
   MetaBoxField,
   MetaScalarType,
@@ -31,9 +31,14 @@ type MetaMap = Record<string, unknown>;
  * see this shape, so keeping decoded values here means a plugin
  * doesn't have to double-parse. `applyMetaPatch` JSON-encodes at the
  * last moment, before the UPDATE.
+ *
+ * `upserts` is mutable: `validateMetaReferences` rewrites values for
+ * cached-object reference fields (`referenceTarget.valueShape ===
+ * "object"`) to merge adapter-supplied cached fields into the
+ * stored shape. Other callers should treat it as read-only.
  */
 export interface MetaPatch {
-  readonly upserts: ReadonlyMap<string, unknown>;
+  readonly upserts: Map<string, unknown>;
   readonly deletes: readonly string[];
 }
 
@@ -202,25 +207,54 @@ export async function validateMetaReferences(
       groups.set(groupKey, group);
     }
     for (const id of ids) group.ids.add(id);
-    group.keys.push({ key, ids });
+    group.keys.push({ key, ids, target });
   }
   for (const group of groups.values()) {
     if (group.ids.size === 0) continue;
-    const liveIds = await fetchLiveIds(
+    const liveRows = await fetchLiveRows(
       ctx,
       group.registered,
       group.scope,
       group.ids,
       "validateMetaReferences",
     );
+    const rowsById = new Map(liveRows.map((r) => [r.id, r]));
     for (const upsert of group.keys) {
       for (const id of upsert.ids) {
-        if (!liveIds.has(id)) {
+        if (!rowsById.has(id)) {
           throw new MetaSanitizationError(upsert.key, "invalid_value");
         }
       }
+      // Cached-object normalize step: replace user-supplied value
+      // with `{ id, ...adapterRow.cached }`. Adapter is authoritative
+      // for cached fields (mime/filename); user-supplied non-id keys
+      // are dropped to prevent spoofed metadata. v0.1 covers single
+      // refs only; multi + object (`mediaList`) lands in slice #132
+      // alongside the array-of-objects shape support in
+      // `referenceIdsForValidation`.
+      if (upsert.target.valueShape !== "object" || upsert.target.multiple) {
+        continue;
+      }
+      const [id] = upsert.ids;
+      if (id !== undefined) {
+        patch.upserts.set(upsert.key, buildCachedReference(id, rowsById));
+      }
     }
   }
+}
+
+// Adapter cached fields override anything; user-supplied non-id keys
+// don't survive. Per-usage user fields (e.g. alt overrides) are a
+// post-v0.1 feature — when added, this is where they'd merge in.
+function buildCachedReference(
+  id: string,
+  rowsById: ReadonlyMap<
+    string,
+    { readonly cached?: Readonly<Record<string, unknown>> }
+  >,
+): Readonly<Record<string, unknown>> {
+  const row = rowsById.get(id);
+  return { id, ...(row?.cached ?? {}) };
 }
 
 interface ReferenceGroup {
@@ -229,9 +263,15 @@ interface ReferenceGroup {
   // De-duped ids across every field in this group — one query
   // resolves them all regardless of how many fields reference them.
   readonly ids: Set<string>;
-  // Upsert-side: which keys contributed which ids, so a missing
-  // live-id can be attributed back to the field that supplied it.
-  readonly keys: { readonly key: string; readonly ids: readonly string[] }[];
+  // Upsert-side: which keys contributed which ids + the field's
+  // target so the validator can dispatch on `valueShape` for the
+  // normalize step. Per-key error attribution still works on
+  // `key`.
+  readonly keys: {
+    readonly key: string;
+    readonly ids: readonly string[];
+    readonly target: ReferenceTarget;
+  }[];
 }
 
 // Defense-in-depth ceiling on the internal-aggregated id-batch size.
@@ -272,25 +312,28 @@ function referenceGroupKey(target: ReferenceTarget): string {
 // 100, so we only hit the ceiling when many fields share `(kind, scope)`
 // and aggregate — at which point throwing beats silent truncation
 // (truncation would either reject valid writes or hide live targets).
-async function fetchLiveIds(
+//
+// Returns `LookupResult[]` rather than just live ids so the validator
+// can read `cached` for the cached-object normalize step. Callers that
+// only care about presence build a `Set` from the row ids.
+async function fetchLiveRows(
   ctx: AppContext,
   registered: { readonly adapter: LookupAdapter },
   scope: unknown,
   ids: ReadonlySet<string>,
   callsite: string,
-): Promise<ReadonlySet<string>> {
+): Promise<readonly LookupResult[]> {
   if (ids.size > MAX_REFERENCE_GROUP_BATCH) {
     throw new Error(
       `${callsite}: aggregated batch size ${ids.size} exceeds MAX_REFERENCE_GROUP_BATCH (${MAX_REFERENCE_GROUP_BATCH})`,
     );
   }
   const idList = [...ids];
-  const rows = await registered.adapter.list(ctx, {
+  return registered.adapter.list(ctx, {
     ids: idList,
     scope,
     limit: idList.length,
   });
-  return new Set(rows.map((row) => row.id));
 }
 
 // Defensive upper bound on multi-reference array length, applied
@@ -301,11 +344,17 @@ async function fetchLiveIds(
 // can declare a lower `max` and the validator picks the smaller.
 const HARD_MULTI_REFERENCE_LIMIT = 100;
 
-// Multi-reference (`userList` / `entryList` / etc.): value must be a
-// string array of non-empty strings, capped by both the hard limit
-// above and the field's optional `max`. Single-reference: value
-// must be a string. Returns the IDs that feed the group's batched
-// `list({ ids })` call in `validateMetaReferences`.
+// Validates the wire shape of a reference value and returns the ids
+// to feed into the group's batched `list({ ids })` call. Three shapes
+// are accepted, dispatching on `target.multiple` + `target.valueShape`:
+//
+//  - multi=true,  valueShape="id"  (default): string[] of non-empty ids
+//  - multi=false, valueShape="id"  (default): bare string id
+//  - multi=false, valueShape="object":        `{ id: string, ... }`
+//                                             (or a bare string for
+//                                             leniency on first write)
+//
+// Multi + object (mediaList) is reserved for slice #132.
 function referenceIdsForValidation(
   key: string,
   value: unknown,
@@ -329,10 +378,29 @@ function referenceIdsForValidation(
     }
     return value as readonly string[];
   }
+  if (target.valueShape === "object") {
+    // Lenient on input: accept either `"42"` (first-write convenience)
+    // or `{ id: "42", ... }`. Always rewritten to the canonical
+    // `{ id, ...cached }` shape after the live-id check.
+    if (typeof value === "string" && value !== "") return [value];
+    const id = extractStringId(value);
+    if (id !== null && id !== "") return [id];
+    throw new MetaSanitizationError(key, "invalid_value");
+  }
   if (typeof value !== "string") {
     throw new MetaSanitizationError(key, "invalid_value");
   }
   return [value];
+}
+
+// Returns the `id` string of a `{ id: string, ... }` object, or null
+// for any other shape (string, array, null, primitive, missing key).
+function extractStringId(value: unknown): string | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const id = (value as { readonly id?: unknown }).id;
+  return typeof id === "string" ? id : null;
 }
 
 function fieldMax(field: MetaBoxField | undefined): number | undefined {
@@ -391,6 +459,7 @@ export async function filterMetaOrphans(
   interface Candidate {
     readonly key: string;
     readonly multiple: boolean;
+    readonly valueShape: "id" | "object";
     readonly groupKey: string;
     readonly ids: readonly string[];
   }
@@ -411,7 +480,13 @@ export async function filterMetaOrphans(
     const ids = orphanCandidateIds(target, value);
     if (ids === null) continue; // non-array multi / non-string single — leave untouched
     const groupKey = referenceGroupKey(target);
-    candidates.push({ key, multiple: target.multiple === true, groupKey, ids });
+    candidates.push({
+      key,
+      multiple: target.multiple === true,
+      valueShape: target.valueShape ?? "id",
+      groupKey,
+      ids,
+    });
     if (ids.length === 0) continue; // empty array — apply step still runs, no group work
     let group = groups.get(groupKey);
     if (!group) {
@@ -424,24 +499,35 @@ export async function filterMetaOrphans(
   // Pass 2: one `list({ ids })` per group, keyed for O(1) apply lookup.
   const liveIdsByGroup = new Map<string, ReadonlySet<string>>();
   for (const [groupKey, group] of groups) {
-    liveIdsByGroup.set(
-      groupKey,
-      await fetchLiveIds(
-        ctx,
-        group.registered,
-        group.scope,
-        group.ids,
-        "filterMetaOrphans",
-      ),
+    const rows = await fetchLiveRows(
+      ctx,
+      group.registered,
+      group.scope,
+      group.ids,
+      "filterMetaOrphans",
     );
+    liveIdsByGroup.set(groupKey, new Set(rows.map((row) => row.id)));
   }
 
-  // Pass 3: apply the filter. Orphan handling differs single vs multi.
+  // Pass 3: apply the filter. Orphan handling differs by shape:
+  //  - multi + id: filter the string[] in place, dropping missing
+  //  - multi + object: filter the object[] preserving order
+  //  - single + id: null on missing
+  //  - single + object: null on missing; otherwise keep the stored
+  //    cached value as-is (no read-time refresh — write rewrites)
   const out: MetaMap = { ...decoded };
   const empty: ReadonlySet<string> = new Set();
-  for (const { key, multiple, groupKey, ids } of candidates) {
+  for (const { key, multiple, valueShape, groupKey, ids } of candidates) {
     const liveIds = liveIdsByGroup.get(groupKey) ?? empty;
     if (multiple) {
+      if (valueShape === "object") {
+        const stored = decoded[key] as readonly unknown[];
+        out[key] = stored.filter((item) => {
+          const id = extractStringId(item);
+          return id !== null && liveIds.has(id);
+        });
+        continue;
+      }
       out[key] = ids.filter((id) => liveIds.has(id));
       continue;
     }
@@ -455,14 +541,29 @@ export async function filterMetaOrphans(
 // Returns `null` to mean "no candidates from this key" (skip), or
 // the ids to feed into the group's batch query. Mirrors the storage-
 // shape guards in the apply step so we don't enqueue work that's
-// going to be skipped.
+// going to be skipped. Cached-object values (`valueShape === "object"`)
+// extract `id` from the object — the rest of the cached fields are
+// trusted on read (refresh happens on next write via the validator's
+// normalize step, not on every render).
 function orphanCandidateIds(
   target: ReferenceTarget,
   value: unknown,
 ): readonly string[] | null {
   if (target.multiple) {
     if (!Array.isArray(value)) return null;
+    if (target.valueShape === "object") {
+      const ids: string[] = [];
+      for (const item of value) {
+        const id = extractStringId(item);
+        if (id !== null) ids.push(id);
+      }
+      return ids;
+    }
     return value.filter((id): id is string => typeof id === "string");
+  }
+  if (target.valueShape === "object") {
+    const id = extractStringId(value);
+    return id !== null ? [id] : null;
   }
   return typeof value === "string" ? [value] : null;
 }

--- a/packages/core/src/rpc/meta/references.test.ts
+++ b/packages/core/src/rpc/meta/references.test.ts
@@ -648,3 +648,135 @@ describe("entryList / termList multi-reference pipeline", () => {
     expect(entryListCalls).toBe(1);
   });
 });
+
+// Cached-object reference fields (`referenceTarget.valueShape ===
+// "object"`): the validator merges adapter-supplied cached fields
+// into the stored value on write. The user-submitted shape can be
+// either a bare id string or an `{ id, ... }` object — both rewrite
+// to the canonical `{ id, ...cached }` shape.
+describe("validateMetaReferences (cached-object shape)", () => {
+  function registryWithCachedRef(
+    cached: Readonly<Record<string, unknown>>,
+    options: { liveIds?: ReadonlySet<string> } = {},
+  ) {
+    const registry: MutablePluginRegistry = createPluginRegistry();
+    const fullField = {
+      key: "hero",
+      label: "Hero",
+      type: "json",
+      inputType: "media",
+      referenceTarget: { kind: "stub", valueShape: "object" },
+    } as MetaBoxField;
+    registry.userMetaBoxes.set("hero", {
+      id: "hero",
+      label: "Hero",
+      fields: [fullField],
+      registeredBy: null,
+    });
+    const isLive = (id: string) =>
+      options.liveIds === undefined || options.liveIds.has(id);
+    registry.lookupAdapters.set("stub", {
+      kind: "stub",
+      capability: null,
+      registeredBy: null,
+      adapter: {
+        list: (_ctx, opts) =>
+          Promise.resolve(
+            (opts.ids ?? [])
+              .filter(isLive)
+              .map((id) => ({ id, label: `stub-${id}`, cached })),
+          ),
+        resolve: (_ctx, id) =>
+          Promise.resolve(
+            isLive(id) ? { id, label: `stub-${id}`, cached } : null,
+          ),
+      },
+    });
+    return {
+      registry,
+      findField: (key: string) =>
+        key === fullField.key ? fullField : undefined,
+    };
+  }
+
+  test("rewrites a bare-id input to the canonical { id, ...cached } shape", async () => {
+    const { registry, findField } = registryWithCachedRef({
+      mime: "image/png",
+      filename: "cat.png",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, { hero: "42" });
+    if (!patch) throw new Error("patch should not be null");
+    await validateMetaReferences(h.context, findField, patch);
+    expect(patch.upserts.get("hero")).toEqual({
+      id: "42",
+      mime: "image/png",
+      filename: "cat.png",
+    });
+  });
+
+  test("rewrites an { id } object input to include cached fields, dropping spoofed extras", async () => {
+    const { registry, findField } = registryWithCachedRef({
+      mime: "image/png",
+      filename: "cat.png",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, {
+      // `mime` here is a lie — the adapter is authoritative and overwrites.
+      hero: { id: "42", mime: "image/jpeg", spoofed: "ignored" },
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await validateMetaReferences(h.context, findField, patch);
+    expect(patch.upserts.get("hero")).toEqual({
+      id: "42",
+      mime: "image/png",
+      filename: "cat.png",
+    });
+  });
+
+  test("rejects a missing id under the cached-object shape", async () => {
+    // Empty live-id set — every input looks like an orphan.
+    const { registry, findField } = registryWithCachedRef(
+      {},
+      { liveIds: new Set() },
+    );
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, {
+      hero: { id: "999999" },
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("filterMetaOrphans nulls out a cached-object whose id is gone", async () => {
+    const { registry, findField } = registryWithCachedRef(
+      {},
+      { liveIds: new Set() },
+    );
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      hero: { id: "999999", mime: "image/png", filename: "cat.png" },
+    });
+    expect(filtered.hero).toBeNull();
+  });
+
+  test("filterMetaOrphans keeps a cached-object whose id is live without refreshing cache", async () => {
+    // v0.1 contract: read-time orphan filter checks existence only;
+    // the stored cached fields are NOT refreshed. Re-saving the entry
+    // refreshes via the validator's normalize step.
+    const { registry, findField } = registryWithCachedRef({
+      // Adapter would tell us the canonical mime is image/jpeg, but
+      // the stored value already has image/png. Reads keep the stored
+      // snapshot intact.
+      mime: "image/jpeg",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const stored = { id: "42", mime: "image/png", filename: "cat.png" };
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      hero: stored,
+    });
+    expect(filtered.hero).toEqual(stored);
+  });
+});

--- a/packages/plugins/media/package.json
+++ b/packages/plugins/media/package.json
@@ -25,6 +25,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./fields": {
+      "types": "./dist/fields.d.ts",
+      "default": "./dist/fields.js"
     }
   },
   "files": [

--- a/packages/plugins/media/src/builder.test.ts
+++ b/packages/plugins/media/src/builder.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildManifest,
+  definePlugin,
+  HookRegistry,
+  installPlugins,
+} from "@plumix/core";
+
+import type { MediaFieldOptions, MediaValue } from "./fields.js";
+import type { MediaFieldScope } from "./index.js";
+import { media } from "./fields.js";
+import { media as mediaPlugin } from "./index.js";
+
+// Public type exports get a type-level smoke test so the package
+// surface stays consumable by external plugin authors. The body
+// values are intentionally small — TypeScript checks the assignment
+// shape at compile time, which is what we care about here.
+const _typeSurface: {
+  readonly opts: MediaFieldOptions;
+  readonly value: MediaValue;
+  readonly scope: MediaFieldScope;
+} = {
+  opts: {
+    key: "hero",
+    label: "Hero",
+    accept: ["image/png"],
+  },
+  value: { id: "42", mime: "image/png", filename: "cat.png" },
+  scope: { accept: "image/" },
+};
+void _typeSurface;
+
+describe("media() builder", () => {
+  test("pins inputType + json type and emits a media-kind referenceTarget with valueShape='object'", () => {
+    const field = media({
+      key: "hero",
+      label: "Hero",
+      accept: "image/",
+    });
+    expect(field.inputType).toBe("media");
+    expect(field.type).toBe("json");
+    expect(field.referenceTarget).toEqual({
+      kind: "media",
+      scope: { accept: "image/" },
+      valueShape: "object",
+    });
+  });
+
+  test("supports an exact MIME whitelist via array accept", () => {
+    const field = media({
+      key: "doc",
+      label: "Doc",
+      accept: ["image/png", "application/pdf"],
+    });
+    expect(field.referenceTarget.scope).toEqual({
+      accept: ["image/png", "application/pdf"],
+    });
+  });
+
+  test("omits accept entirely when no filter is configured", () => {
+    const field = media({ key: "hero", label: "Hero" });
+    // Scope object exists but with `accept: undefined` — JSON.stringify
+    // drops the key, so this is identical on the wire to no scope at
+    // all. The adapter's `buildAcceptMatcher` returns null on
+    // undefined.
+    expect(field.referenceTarget).toEqual({
+      kind: "media",
+      scope: { accept: undefined },
+      valueShape: "object",
+    });
+  });
+
+  test("rejects non-applicable options at the type level", () => {
+    media({
+      key: "h",
+      label: "h",
+      // @ts-expect-error — placeholder doesn't apply to a reference field.
+      placeholder: "pick",
+    });
+
+    media({
+      key: "h",
+      label: "h",
+      // @ts-expect-error — options belongs to select/radio.
+      options: [{ value: "a", label: "A" }],
+    });
+  });
+
+  test("manifest round-trip preserves cached-object referenceTarget on the wire shape", async () => {
+    const hooks = new HookRegistry();
+    const userPlugin = definePlugin("test", (ctx) => {
+      ctx.registerSettingsGroup("branding", {
+        label: "Branding",
+        fields: [
+          media({
+            key: "hero",
+            label: "Hero image",
+            accept: "image/",
+          }),
+        ],
+      });
+    });
+    const { registry } = await installPlugins({
+      hooks,
+      plugins: [mediaPlugin(), userPlugin],
+    });
+    const manifest = buildManifest(registry);
+    expect(manifest.settingsGroups[0]?.fields[0]).toMatchObject({
+      key: "hero",
+      inputType: "media",
+      type: "json",
+      referenceTarget: {
+        kind: "media",
+        scope: { accept: "image/" },
+        valueShape: "object",
+      },
+    });
+  });
+});

--- a/packages/plugins/media/src/builder.ts
+++ b/packages/plugins/media/src/builder.ts
@@ -1,0 +1,67 @@
+import type { MediaMetaBoxField, MetaBoxFieldSpan } from "@plumix/core";
+
+import type { MediaFieldScope } from "./lookup.js";
+
+/**
+ * Per-field options for the `media()` builder.
+ *
+ * `accept` filters the picker grid client-side (UX hint) AND the
+ * `mediaLookupAdapter`'s `list({ ids })` path on the server (security
+ * boundary — re-validated at write time). Format: a single MIME prefix
+ * string (`"image/"` matches every `image/*` mime) OR a readonly array
+ * of exact MIME matches (`["image/png", "application/pdf"]`).
+ *
+ * `default` is a `MediaValue` shape (`{ id, ... }`) — the meta pipeline
+ * normalizes the cached fields on every write, so a new entry with a
+ * `default: { id: "42" }` ships with the canonical `{ id, mime,
+ * filename }` after the first save.
+ */
+export interface MediaFieldOptions {
+  readonly key: string;
+  readonly label: string;
+  readonly required?: boolean;
+  readonly description?: string;
+  readonly default?: MediaValue;
+  readonly span?: MetaBoxFieldSpan;
+  readonly accept?: string | readonly string[];
+}
+
+/**
+ * Storage shape for a single `media` field. The meta pipeline writes
+ * `{ id, ...adapterCached }` on every save (mime + filename today;
+ * width/height/etc once the upload pipeline captures them). Renders
+ * read straight from this object — no `lookup.resolve` per field.
+ */
+export interface MediaValue {
+  readonly id: string;
+  readonly mime?: string;
+  readonly filename?: string;
+}
+
+/**
+ * Build a typed `media` reference field. Stored as a `MediaValue`
+ * object — admin thumbnails render without a resolve round-trip, the
+ * meta pipeline rewrites the cached fields on every write so the
+ * snapshot stays close to the asset.
+ *
+ * The picker opens the existing Media Library in modal/picker mode,
+ * filters the grid to MIME `accept` if set, and emits the bare id +
+ * cached fields back to the form on selection.
+ *
+ * Single-value only — `mediaList()` covers the multi case (slice
+ * #132).
+ */
+export function media(options: MediaFieldOptions): MediaMetaBoxField {
+  const scope: MediaFieldScope = { accept: options.accept };
+  return {
+    key: options.key,
+    label: options.label,
+    type: "json",
+    inputType: "media",
+    referenceTarget: { kind: "media", scope, valueShape: "object" },
+    required: options.required,
+    description: options.description,
+    default: options.default,
+    span: options.span,
+  };
+}

--- a/packages/plugins/media/src/fields.ts
+++ b/packages/plugins/media/src/fields.ts
@@ -1,0 +1,8 @@
+// Public field-builder surface. Imported via `@plumix/plugin-media/fields`
+// so consumers can pull the typed `media()` builder without colliding
+// with `media()` (the plugin descriptor factory) exported from the
+// package root. Mirrors the `plumix/fields` subpath convention from
+// core.
+
+export { media } from "./builder.js";
+export type { MediaFieldOptions, MediaValue } from "./builder.js";

--- a/packages/plugins/media/src/index.ts
+++ b/packages/plugins/media/src/index.ts
@@ -1,10 +1,13 @@
 import type { PluginDescriptor } from "@plumix/core";
 import { definePlugin } from "@plumix/core";
 
+import { mediaLookupAdapter } from "./lookup.js";
 import { DEFAULT_ACCEPTED_TYPES } from "./mime.js";
 import { createMediaRouter } from "./rpc.js";
 import { handleMediaServe } from "./serve-route.js";
 import { handleWorkerUpload } from "./upload-route.js";
+
+export type { MediaFieldScope } from "./lookup.js";
 
 export { DEFAULT_ACCEPTED_TYPES };
 
@@ -103,6 +106,17 @@ export function media(
       ctx.registerRpcRouter(
         createMediaRouter({ acceptedTypes, maxUploadSize }),
       );
+
+      // Reference-field surface: any `media({ ... })` field calls
+      // through `lookup.list({ kind: "media", ids })` for write
+      // validation + read-time orphan filter, and through the same
+      // RPC for picker label resolution. Capability matches the
+      // existing media library page gate.
+      ctx.registerLookupAdapter({
+        kind: "media",
+        adapter: mediaLookupAdapter,
+        capability: "entry:media:read",
+      });
 
       // Worker-routed upload fallback. `media.createUploadUrl` returns
       // this URL when `storage.presignPut` isn't configured (e.g. the

--- a/packages/plugins/media/src/lookup.test.ts
+++ b/packages/plugins/media/src/lookup.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from "vitest";
+
+import { entries, HookRegistry, installPlugins } from "@plumix/core";
+import { createRpcHarness } from "@plumix/core/test";
+
+import { media } from "./index.js";
+import { mediaLookupAdapter } from "./lookup.js";
+
+// Seed a published `media` entry directly through the entries table —
+// keeps the test independent of `media.createUploadUrl` / `confirm` so
+// the adapter's contract is exercised in isolation.
+interface SeedOptions {
+  readonly title: string;
+  readonly mime: string;
+  readonly status?: "draft" | "published" | "trash";
+  readonly authorId: number;
+}
+
+async function seedMedia(
+  h: Awaited<ReturnType<typeof createRpcHarness>>,
+  opts: SeedOptions,
+): Promise<{ id: number }> {
+  const status = opts.status ?? "published";
+  const [row] = await h.context.db
+    .insert(entries)
+    .values({
+      type: "media",
+      slug: `media-${opts.title.replace(/\s+/g, "-")}-${Math.random()}`,
+      title: opts.title,
+      status,
+      authorId: opts.authorId,
+      meta: {
+        mime: opts.mime,
+        size: 1024,
+        storageKey: `media/${opts.title}`,
+        originalName: opts.title,
+        alt: null,
+      },
+      publishedAt: status === "published" ? new Date() : null,
+    })
+    .returning();
+  if (!row) throw new Error("seedMedia: insert returned no row");
+  return { id: row.id };
+}
+
+async function harnessWithMediaPlugin() {
+  const { registry } = await installPlugins({
+    hooks: new HookRegistry(),
+    plugins: [media()],
+  });
+  return createRpcHarness({ authAs: "admin", plugins: registry });
+}
+
+describe("mediaLookupAdapter", () => {
+  test("list({ ids }) returns published rows with cached fields", async () => {
+    const h = await harnessWithMediaPlugin();
+    const a = await seedMedia(h, {
+      title: "cat.png",
+      mime: "image/png",
+      authorId: h.user.id,
+    });
+    const b = await seedMedia(h, {
+      title: "dog.jpg",
+      mime: "image/jpeg",
+      authorId: h.user.id,
+    });
+    const rows = await mediaLookupAdapter.list(h.context, {
+      ids: [String(a.id), String(b.id)],
+    });
+    expect(rows).toHaveLength(2);
+    const cat = rows.find((r) => r.id === String(a.id));
+    expect(cat).toEqual({
+      id: String(a.id),
+      label: "cat.png",
+      subtitle: "image/png",
+      cached: { mime: "image/png", filename: "cat.png" },
+    });
+  });
+
+  test("list({ ids }) excludes draft media (asset bytes unverified)", async () => {
+    const h = await harnessWithMediaPlugin();
+    const draft = await seedMedia(h, {
+      title: "wip.png",
+      mime: "image/png",
+      status: "draft",
+      authorId: h.user.id,
+    });
+    const rows = await mediaLookupAdapter.list(h.context, {
+      ids: [String(draft.id)],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  test("list({ ids }) excludes trashed media", async () => {
+    const h = await harnessWithMediaPlugin();
+    const trashed = await seedMedia(h, {
+      title: "old.png",
+      mime: "image/png",
+      status: "trash",
+      authorId: h.user.id,
+    });
+    const rows = await mediaLookupAdapter.list(h.context, {
+      ids: [String(trashed.id)],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  test("list({ ids }) silently drops malformed ids before querying", async () => {
+    const h = await harnessWithMediaPlugin();
+    const rows = await mediaLookupAdapter.list(h.context, {
+      ids: ["", "abc", "0", "-1", "1.5"],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  test("list({ query }) searches by title and orders by publishedAt desc", async () => {
+    const h = await harnessWithMediaPlugin();
+    await seedMedia(h, {
+      title: "alpha.png",
+      mime: "image/png",
+      authorId: h.user.id,
+    });
+    await seedMedia(h, {
+      title: "beta.png",
+      mime: "image/png",
+      authorId: h.user.id,
+    });
+    const matches = await mediaLookupAdapter.list(h.context, {
+      query: "alpha",
+    });
+    expect(matches.find((r) => r.label === "alpha.png")).toBeDefined();
+    expect(matches.find((r) => r.label === "beta.png")).toBeUndefined();
+  });
+
+  test("accept (prefix string) filters by MIME prefix", async () => {
+    const h = await harnessWithMediaPlugin();
+    const png = await seedMedia(h, {
+      title: "img.png",
+      mime: "image/png",
+      authorId: h.user.id,
+    });
+    const pdf = await seedMedia(h, {
+      title: "doc.pdf",
+      mime: "application/pdf",
+      authorId: h.user.id,
+    });
+    const rows = await mediaLookupAdapter.list(h.context, {
+      ids: [String(png.id), String(pdf.id)],
+      scope: { accept: "image/" },
+    });
+    const ids = rows.map((r) => r.id);
+    expect(ids).toContain(String(png.id));
+    expect(ids).not.toContain(String(pdf.id));
+  });
+
+  test("accept (exact array) filters by exact MIME match", async () => {
+    const h = await harnessWithMediaPlugin();
+    const png = await seedMedia(h, {
+      title: "a.png",
+      mime: "image/png",
+      authorId: h.user.id,
+    });
+    const jpg = await seedMedia(h, {
+      title: "b.jpg",
+      mime: "image/jpeg",
+      authorId: h.user.id,
+    });
+    const rows = await mediaLookupAdapter.list(h.context, {
+      ids: [String(png.id), String(jpg.id)],
+      scope: { accept: ["image/png"] },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(String(png.id));
+  });
+
+  test("resolve() returns the row with cached fields when in scope", async () => {
+    const h = await harnessWithMediaPlugin();
+    const a = await seedMedia(h, {
+      title: "logo.svg",
+      mime: "image/svg+xml",
+      authorId: h.user.id,
+    });
+    const result = await mediaLookupAdapter.resolve(h.context, String(a.id));
+    expect(result).toEqual({
+      id: String(a.id),
+      label: "logo.svg",
+      subtitle: "image/svg+xml",
+      cached: { mime: "image/svg+xml", filename: "logo.svg" },
+    });
+  });
+
+  test("resolve() returns null when MIME fails the accept scope", async () => {
+    const h = await harnessWithMediaPlugin();
+    const pdf = await seedMedia(h, {
+      title: "doc.pdf",
+      mime: "application/pdf",
+      authorId: h.user.id,
+    });
+    const result = await mediaLookupAdapter.resolve(h.context, String(pdf.id), {
+      accept: "image/",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("resolve() returns null for a draft id (asset unverified)", async () => {
+    const h = await harnessWithMediaPlugin();
+    const draft = await seedMedia(h, {
+      title: "wip.png",
+      mime: "image/png",
+      status: "draft",
+      authorId: h.user.id,
+    });
+    const result = await mediaLookupAdapter.resolve(
+      h.context,
+      String(draft.id),
+    );
+    expect(result).toBeNull();
+  });
+
+  test("browse path with `accept` set: LIMIT counts only matching rows (no silent under-fill)", async () => {
+    // Mixed library: more PDFs than the LIMIT, plus a single image.
+    // With JS post-filter the picker would fetch 3 rows, drop the
+    // PDFs, and return 1 item — looking like "no more results" even
+    // though more images exist further back. With SQL post-filter
+    // the LIMIT counts only matching rows, so the picker sees the
+    // image and the limit is respected.
+    const h = await harnessWithMediaPlugin();
+    for (let i = 0; i < 5; i++) {
+      await seedMedia(h, {
+        title: `pdf-${i}.pdf`,
+        mime: "application/pdf",
+        authorId: h.user.id,
+      });
+    }
+    const image = await seedMedia(h, {
+      title: "single.png",
+      mime: "image/png",
+      authorId: h.user.id,
+    });
+    const rows = await mediaLookupAdapter.list(h.context, {
+      limit: 3,
+      scope: { accept: "image/" },
+    });
+    expect(rows.map((r) => r.id)).toEqual([String(image.id)]);
+  });
+});

--- a/packages/plugins/media/src/lookup.ts
+++ b/packages/plugins/media/src/lookup.ts
@@ -1,0 +1,163 @@
+import type { LookupAdapter, LookupResult, SQL } from "@plumix/core";
+import { and, desc, entries, eq, inArray, like, sql } from "@plumix/core";
+
+import { parseMediaMeta } from "./meta.js";
+
+const MEDIA_ENTRY_TYPE = "media";
+
+const DEFAULT_LIST_LIMIT = 24;
+const MAX_LIST_LIMIT = 100;
+
+const MEDIA_ROW_COLUMNS = {
+  id: entries.id,
+  title: entries.title,
+  meta: entries.meta,
+} as const;
+
+/**
+ * Public scope shape for the `media` reference field. Carried on the
+ * field's `referenceTarget.scope`; the media `LookupAdapter` consumes
+ * it for write-time validation, picker filtering, and read-time
+ * orphan resolution.
+ *
+ * `accept` is either a single MIME prefix string (`"image/"` matches
+ * `image/png`, `image/jpeg`, …) or a readonly array of exact MIME
+ * matches. Drop HTML's `image/*` wildcard syntax — the trailing slash
+ * already conveys "category" and avoids the `image/*` vs `image/`
+ * ambiguity.
+ */
+export interface MediaFieldScope {
+  readonly accept?: string | readonly string[];
+}
+
+/**
+ * Server-side adapter for the `media` reference field. Storage is the
+ * cached-object shape (`{ id, mime, filename }`) — the meta pipeline
+ * pulls `cached` from `LookupResult` and merges it into the stored
+ * value on every write so reads render thumbnails without an extra
+ * resolve round-trip.
+ *
+ * Queries:
+ *  - `list({ ids })`: PK lookup via `inArray(entries.id, …)` + the
+ *    `entries_type_status_published_idx` partition. SQLite picks the
+ *    PK as the most selective; the type+status filter is post-applied
+ *    to a small rowset.
+ *  - `list({ query })`: leverages `entries_type_status_published_idx`
+ *    for the `(type, status)` prefix; ordered by `desc(publishedAt)`
+ *    matches the index's third column (no extra sort).
+ *  - MIME `accept` filter: post-filter in JS against the meta JSON.
+ *    The narrowed rowset (type+status or PK) keeps this tractable
+ *    without a generated column.
+ *
+ * Drafts and trashed media are invisible to the picker — only
+ * `status = "published"` rows surface. A draft media entry exists
+ * between `media.createUploadUrl` (writes a draft row) and
+ * `media.confirm` (flips to published) — referencing one would point
+ * at an asset whose bytes haven't been verified.
+ */
+export const mediaLookupAdapter: LookupAdapter<MediaFieldScope> = {
+  async list(ctx, options) {
+    const conditions: SQL[] = [
+      eq(entries.type, MEDIA_ENTRY_TYPE),
+      eq(entries.status, "published"),
+    ];
+    const acceptCondition = buildAcceptCondition(options.scope?.accept);
+    if (acceptCondition) conditions.push(acceptCondition);
+
+    let limit: number;
+    if (options.ids !== undefined) {
+      const numericIds = options.ids
+        .map((id) => parseMediaId(id))
+        .filter((id): id is number => id !== null);
+      if (numericIds.length === 0) return [];
+      conditions.push(inArray(entries.id, numericIds));
+      limit = numericIds.length;
+    } else {
+      const trimmedQuery = options.query?.trim();
+      if (trimmedQuery) {
+        conditions.push(like(entries.title, `%${trimmedQuery}%`));
+      }
+      limit = clampLimit(options.limit);
+    }
+    const rows = await ctx.db
+      .select(MEDIA_ROW_COLUMNS)
+      .from(entries)
+      .where(and(...conditions))
+      .orderBy(desc(entries.publishedAt), desc(entries.id))
+      .limit(limit);
+
+    const results: LookupResult[] = [];
+    for (const row of rows) {
+      const meta = parseMediaMeta(row.meta);
+      if (!meta) continue;
+      results.push(toLookupResult(row.id, row.title, meta.mime));
+    }
+    return results;
+  },
+
+  async resolve(ctx, id, scope) {
+    const numericId = parseMediaId(id);
+    if (numericId === null) return null;
+    const conditions: SQL[] = [
+      eq(entries.id, numericId),
+      eq(entries.type, MEDIA_ENTRY_TYPE),
+      eq(entries.status, "published"),
+    ];
+    const acceptCondition = buildAcceptCondition(scope?.accept);
+    if (acceptCondition) conditions.push(acceptCondition);
+    const [row] = await ctx.db
+      .select(MEDIA_ROW_COLUMNS)
+      .from(entries)
+      .where(and(...conditions))
+      .limit(1);
+    if (!row) return null;
+    const meta = parseMediaMeta(row.meta);
+    if (!meta) return null;
+    return toLookupResult(row.id, row.title, meta.mime);
+  },
+};
+
+function parseMediaId(id: string): number | null {
+  if (!/^[1-9]\d{0,15}$/.test(id)) return null;
+  const parsed = Number(id);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function clampLimit(requested: number | undefined): number {
+  if (requested === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isFinite(requested) || requested <= 0) return DEFAULT_LIST_LIMIT;
+  return Math.min(Math.floor(requested), MAX_LIST_LIMIT);
+}
+
+// Translate the `accept` scope into a SQL predicate against the
+// extracted JSON `mime` field. Pushing the filter into SQL means the
+// browse path's LIMIT clause counts only rows that pass the accept
+// filter — post-filtering in JS would silently under-fill the picker
+// grid for fields whose accept rejects a chunk of the recent uploads.
+//
+// `meta.mime` isn't indexed (no generated column), but the type+status
+// filter has already narrowed the rowset before this predicate is
+// applied, so the cost is bounded. Real MIME strings don't contain
+// `%`/`_`, and plugin-supplied prefixes are trusted (set at field-
+// build time, not user input), so no LIKE escaping needed.
+function buildAcceptCondition(
+  accept: string | readonly string[] | undefined,
+): SQL | undefined {
+  if (accept === undefined) return undefined;
+  const mimeExpr = sql<string>`json_extract(${entries.meta}, '$.mime')`;
+  if (typeof accept === "string") {
+    if (accept === "") return undefined;
+    return like(mimeExpr, `${accept}%`);
+  }
+  if (accept.length === 0) return undefined;
+  return inArray(mimeExpr, accept as string[]);
+}
+
+function toLookupResult(id: number, title: string, mime: string): LookupResult {
+  return {
+    id: String(id),
+    label: title,
+    subtitle: mime,
+    cached: { mime, filename: title },
+  };
+}


### PR DESCRIPTION
**Status: draft, 3 of 6 commits done.** Halting before the admin work (commits 4–6) for sentry-skills review of the architecture choices in commits 1–3.

## Summary so far

- **Cached-object reference shape** — new `ReferenceTarget.valueShape: "id" | "object"` discriminator. Default `"id"` keeps existing user/entry/term/userList/etc. on bare-ID storage; `"object"` fields store `{ id, ...cachedFields }`. Validator merges adapter-supplied cached fields into the stored value on every write so the admin renders thumbnails without a per-render resolve round-trip. `filterMetaOrphans` handles object-shape orphans.
- **`mediaLookupAdapter`** — index-friendly queries (PK on ids path, `entries_type_status_published_idx` on browse). Drafts/trashed excluded. `accept` filter is `string | readonly string[]` (prefix OR exact). Returns `cached: { mime, filename }`. Capability `entry:media:read`.
- **`media()` builder** — `@plumix/plugin-media/fields` subpath export (avoids collision with the `media()` plugin descriptor at root). `MediaValue` is the public storage shape.

## Pending (commits 4–6)
- Admin: plugin-field-type dispatch + `PluginFieldErrorBoundary` (uses existing `registerPluginFieldType` seam)
- `MediaLibrary` dual-mode (`mode: "page" | "picker"`), `MediaPickerField` admin renderer, skeleton retrofits for `ReferencePicker` + `MultiReferencePicker`
- E2E coverage

## Test plan

- [x] `pnpm --filter @plumix/core test` (1133 pass, +5 cached-object pipeline)
- [x] `pnpm --filter @plumix/plugin-media test` (85 pass, +15 lookup adapter + builder)
- [x] `pnpm typecheck` clean
- [ ] e2e (post-commit-6)

Refs #130