### PR TITLE
feat: MediaPickerField + skeleton retrofits (admin half of #130) [WIP]

### DIFF
--- a/packages/admin/src/components/meta-box/meta-box-field.test.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.test.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { Form } from "@/components/ui/form.js";
+import {
+  _resetPluginRegistry,
+  registerPluginFieldType,
+} from "@/lib/plugin-registry.js";
 import { createQueryClient } from "@/providers/query-client.js";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
@@ -15,6 +19,7 @@ import { MetaBoxField } from "./meta-box-field.js";
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  _resetPluginRegistry();
 });
 
 function field(
@@ -528,5 +533,102 @@ describe("MetaBoxField dispatcher", () => {
       />,
     );
     expect(screen.getByTestId("meta-box-field-k-input")).toBeRequired();
+  });
+
+  test("plugin renderer: registered inputType dispatches to the plugin component", () => {
+    registerPluginFieldType("custom-stub", ({ field, testId }) => (
+      <span data-testid={`${testId}-plugin`}>plugin:{field.inputType}</span>
+    ));
+    render(
+      <Harness
+        fieldDef={field({ inputType: "custom-stub" })}
+        initial="value"
+      />,
+    );
+    expect(
+      screen.getByTestId("meta-box-field-k-input-plugin"),
+    ).toHaveTextContent("plugin:custom-stub");
+  });
+
+  test("plugin renderer: a thrown render is caught by the error boundary, not the form", () => {
+    // Suppress the React error logs the boundary's catch path produces;
+    // the test asserts the visible fallback, not the console output.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    registerPluginFieldType("crashy", () => {
+      throw new Error("boom");
+    });
+    render(
+      <Harness fieldDef={field({ inputType: "crashy" })} initial="value" />,
+    );
+    expect(
+      screen.getByTestId("meta-box-field-k-input-plugin-error"),
+    ).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  test("plugin renderer: unknown inputType falls through to the legacy text fallback", () => {
+    // No plugin registered — exercising the existing dev-mode warning
+    // path. The fallback renders an `<input type="text">`.
+    const consoleWarn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    render(<Harness fieldDef={field({ inputType: "unknown" })} initial="" />);
+    expect(screen.getByTestId("meta-box-field-k-input")).toBeInTheDocument();
+    consoleWarn.mockRestore();
+  });
+
+  test("plugin renderer: error boundary resets when the field value changes", async () => {
+    // Boundary recovery path: an initial render with `value === "bad"`
+    // throws, then a sibling button flips the form value to "good" via
+    // `form.setValue`. The same MetaBoxField instance stays mounted —
+    // only the field value changes. Without `resetKey` wired to
+    // rhf.value the boundary would stay stuck on the error placeholder.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    registerPluginFieldType("conditional-crashy", ({ rhf, testId }) => {
+      if (rhf.value === "bad") throw new Error("boom");
+      return <span data-testid={`${testId}-ok`}>ok:{String(rhf.value)}</span>;
+    });
+
+    function ResetHarness(): ReactNode {
+      const fieldDef = field({ inputType: "conditional-crashy" });
+      const form = useForm<Record<string, unknown>>({
+        defaultValues: { [fieldDef.key]: "bad" },
+      });
+      const queryClient = createQueryClient();
+      return (
+        <QueryClientProvider client={queryClient}>
+          <Form {...form}>
+            <MetaBoxField field={fieldDef} name={fieldDef.key} />
+            <button
+              type="button"
+              data-testid="flip"
+              onClick={() => form.setValue(fieldDef.key, "good")}
+            >
+              flip
+            </button>
+          </Form>
+        </QueryClientProvider>
+      );
+    }
+
+    render(<ResetHarness />);
+    // Initial render with "bad" → boundary catches the throw.
+    expect(
+      screen.getByTestId("meta-box-field-k-input-plugin-error"),
+    ).toBeInTheDocument();
+    // Flip the value — same boundary instance, new props.
+    await userEvent.click(screen.getByTestId("flip"));
+    // Boundary resets on resetKey change, plugin renders successfully.
+    expect(screen.getByTestId("meta-box-field-k-input-ok")).toHaveTextContent(
+      "ok:good",
+    );
+    expect(
+      screen.queryByTestId("meta-box-field-k-input-plugin-error"),
+    ).not.toBeInTheDocument();
+    consoleError.mockRestore();
   });
 });

--- a/packages/admin/src/components/meta-box/meta-box-field.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.tsx
@@ -13,11 +13,13 @@ import {
 import { Input } from "@/components/ui/input.js";
 import { Slider } from "@/components/ui/slider.js";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.js";
+import { getPluginFieldType } from "@/lib/plugin-registry.js";
 import { cn } from "@/lib/utils";
 
 import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 
 import { MultiReferencePicker } from "./multi-reference-picker.js";
+import { PluginFieldErrorBoundary } from "./plugin-field-error-boundary.js";
 import { ReferencePicker } from "./reference-picker.js";
 
 // Schema-driven field renderer wired to react-hook-form. Each meta-box
@@ -129,6 +131,37 @@ function renderNativeInput({
   disabled: boolean;
   testId: string;
 }): ReactNode {
+  // Plugin-supplied field renderers slot in here, BEFORE the built-in
+  // switch. A plugin's admin chunk calls `window.plumix.
+  // registerPluginFieldType(inputType, Component)` at module load —
+  // this dispatch consults the registry on every render. Wrapped in
+  // `PluginFieldErrorBoundary` so a thrown render doesn't take down
+  // the whole entry editor; the boundary surfaces a static "couldn't
+  // render" placeholder and logs to the dev console.
+  const PluginRenderer = getPluginFieldType(field.inputType);
+  if (PluginRenderer) {
+    return (
+      <PluginFieldErrorBoundary
+        fieldKey={field.key}
+        inputType={field.inputType}
+        testId={testId}
+        // Resetting on value change lets the boundary recover after a
+        // bad render — a user who picks a different (valid) value
+        // re-attempts instead of staying stuck on the placeholder.
+        // String coercion handles both bare-id (string) and cached-
+        // object (object) shapes via JSON.stringify.
+        resetKey={stringifyForResetKey(rhf.value)}
+      >
+        <PluginRenderer
+          field={field}
+          rhf={rhf}
+          disabled={disabled}
+          testId={testId}
+        />
+      </PluginFieldErrorBoundary>
+    );
+  }
+
   const common = {
     name: rhf.name,
     ref: rhf.ref,
@@ -563,5 +596,19 @@ function formatInitial(value: unknown): string {
     return JSON.stringify(value, null, 2);
   } catch {
     return "";
+  }
+}
+
+// Stable string for the error boundary's `resetKey`. Bare-id (string)
+// values pass through; object/array values JSON-stringify; primitives
+// coerce. Cycles or BigInts (very rare for meta values) fall back to
+// a constant — the boundary just won't reset on those, which is fine.
+function stringifyForResetKey(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "__unserializable__";
   }
 }

--- a/packages/admin/src/components/meta-box/multi-reference-picker.tsx
+++ b/packages/admin/src/components/meta-box/multi-reference-picker.tsx
@@ -8,6 +8,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
 import { SortableList } from "@/components/ui/sortable.js";
 import { orpc } from "@/lib/orpc.js";
 import { useQuery } from "@tanstack/react-query";
@@ -94,10 +95,23 @@ export function MultiReferencePicker({
     onChange(next.map((row) => row.id));
   };
 
-  const sortableItems = value.map((id) => ({
-    id,
-    result: resolvedById.get(id) ?? null,
-  }));
+  // Three states per row: `found` (result in cache), `orphan` (resolve
+  // settled, no result — really gone), `pending` (resolve still in
+  // flight). The pending case renders as a skeleton so the brief gap
+  // between mount and the first resolve doesn't flash "Reference
+  // missing" for every row.
+  const isResolvePending =
+    value.length > 0 &&
+    resolveQuery.data === undefined &&
+    !resolveQuery.isError;
+  const sortableItems = value.map((id) => {
+    const result = resolvedById.get(id) ?? null;
+    return {
+      id,
+      result,
+      pending: result === null && isResolvePending,
+    };
+  });
 
   return (
     <div className="flex flex-col gap-2" data-testid={testId}>
@@ -124,25 +138,40 @@ export function MultiReferencePicker({
           items={sortableItems}
           onReorder={handleReorder}
           onRemove={required && value.length === 1 ? undefined : handleRemove}
-          renderItem={(item) =>
-            item.result ? (
-              <div className="text-sm">
-                <p className="truncate font-medium">{item.result.label}</p>
-                {item.result.subtitle ? (
-                  <p className="text-muted-foreground truncate text-xs">
-                    {item.result.subtitle}
-                  </p>
-                ) : null}
-              </div>
-            ) : (
+          renderItem={(item) => {
+            if (item.result) {
+              return (
+                <div className="text-sm">
+                  <p className="truncate font-medium">{item.result.label}</p>
+                  {item.result.subtitle ? (
+                    <p className="text-muted-foreground truncate text-xs">
+                      {item.result.subtitle}
+                    </p>
+                  ) : null}
+                </div>
+              );
+            }
+            if (item.pending) {
+              return (
+                <div
+                  className="flex flex-col gap-1.5"
+                  data-testid={`${testId}-resolving-${item.id}`}
+                  aria-busy="true"
+                >
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-20" />
+                </div>
+              );
+            }
+            return (
               <p
                 className="text-destructive text-sm"
                 data-testid={`${testId}-orphan-${item.id}`}
               >
                 Reference missing — remove or re-pick
               </p>
-            )
-          }
+            );
+          }}
           disabled={disabled}
           testId={`${testId}-list`}
         />

--- a/packages/admin/src/components/meta-box/plugin-field-error-boundary.tsx
+++ b/packages/admin/src/components/meta-box/plugin-field-error-boundary.tsx
@@ -1,0 +1,77 @@
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+
+// Render-time crash containment for plugin-supplied field components.
+// One bad plugin field shouldn't take down the whole entry editor —
+// when the registered renderer throws we catch it, log to the console
+// for the developer, and fall back to a static "this field couldn't
+// render" placeholder so the rest of the form stays usable.
+//
+// Adapted from emdash's PluginFieldErrorBoundary pattern. Class
+// component because React error boundaries still require it (no hook
+// equivalent exists for `componentDidCatch` as of React 19).
+
+interface Props {
+  readonly fieldKey: string;
+  readonly inputType: string;
+  readonly testId: string;
+  /**
+   * Reset signal — bumped by the parent when the field's value changes.
+   * When `resetKey` differs from the last one we caught against, we
+   * clear the error state and re-attempt the render. Without this the
+   * boundary stays in error state forever after one bad render, so a
+   * user who picks a different (valid) value can never recover.
+   */
+  readonly resetKey: string;
+  readonly children: ReactNode;
+}
+
+interface State {
+  readonly error: Error | null;
+  readonly resetKey: string;
+}
+
+export class PluginFieldErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null, resetKey: props.resetKey };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  static getDerivedStateFromProps(
+    nextProps: Props,
+    state: State,
+  ): Partial<State> | null {
+    if (nextProps.resetKey !== state.resetKey) {
+      return { error: null, resetKey: nextProps.resetKey };
+    }
+    return null;
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(
+      `[plumix] plugin field renderer for "${this.props.inputType}" ` +
+        `(field "${this.props.fieldKey}") crashed:`,
+      error,
+      info,
+    );
+  }
+
+  override render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <p
+          className="text-destructive text-sm"
+          data-testid={`${this.props.testId}-plugin-error`}
+        >
+          This field couldn&rsquo;t render. Check the browser console for
+          details.
+        </p>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/admin/src/components/meta-box/reference-picker.tsx
+++ b/packages/admin/src/components/meta-box/reference-picker.tsx
@@ -8,6 +8,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
 import { orpc } from "@/lib/orpc.js";
 import { useQuery } from "@tanstack/react-query";
 
@@ -170,7 +171,19 @@ function renderDisplay({
     );
   }
   if (isResolving) {
-    return <p className="text-muted-foreground text-sm">Resolving…</p>;
+    // Loading state distinct from orphan — without this skeleton the
+    // brief gap between "value set" and "resolve returns" would
+    // render as "Reference missing", which reads as an actual error.
+    return (
+      <div
+        className="flex flex-col gap-1.5"
+        data-testid={`${testId}-resolving`}
+        aria-busy="true"
+      >
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-3 w-20" />
+      </div>
+    );
   }
   return (
     <p className="text-destructive text-sm" data-testid={`${testId}-orphan`}>

--- a/packages/admin/src/lib/plugin-registry.test.ts
+++ b/packages/admin/src/lib/plugin-registry.test.ts
@@ -55,8 +55,29 @@ describe("plugin field-type registry", () => {
   });
 
   test("rejects duplicates", () => {
-    registerPluginFieldType("color", Stub);
-    expect(() => registerPluginFieldType("color", Stub)).toThrow(
+    registerPluginFieldType("custom_field", Stub);
+    expect(() => registerPluginFieldType("custom_field", Stub)).toThrow(
+      /already registered/,
+    );
+  });
+
+  test("rejects built-in inputType names (reservation guards both accidental + malicious overrides)", () => {
+    expect(() => registerPluginFieldType("text", Stub)).toThrow(/reserved/);
+    expect(() => registerPluginFieldType("number", Stub)).toThrow(/reserved/);
+    expect(() => registerPluginFieldType("checkbox", Stub)).toThrow(/reserved/);
+    expect(() => registerPluginFieldType("user", Stub)).toThrow(/reserved/);
+    expect(() => registerPluginFieldType("entry", Stub)).toThrow(/reserved/);
+    expect(() => registerPluginFieldType("term", Stub)).toThrow(/reserved/);
+    expect(() => registerPluginFieldType("userList", Stub)).toThrow(/reserved/);
+  });
+
+  test("plugin-shipped reference types (media) are not reserved — duplicate detection is enough", () => {
+    // `media` is plugin-shipped (`@plumix/plugin-media`); reserving it
+    // would block the very plugin that owns it. Two media plugins
+    // would still conflict via `already registered`.
+    registerPluginFieldType("media", Stub);
+    expect(getPluginFieldType("media")).toBe(Stub);
+    expect(() => registerPluginFieldType("media", Stub)).toThrow(
       /already registered/,
     );
   });

--- a/packages/admin/src/lib/plugin-registry.ts
+++ b/packages/admin/src/lib/plugin-registry.ts
@@ -10,15 +10,20 @@ import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
  * manifest entry plus a react-hook-form controller binding. The
  * renderer must return a single element — shadcn's `<FormControl>`
  * uses Radix `Slot` to forward id/aria-* onto it.
+ *
+ * Internal — plugin authors register components against
+ * `window.plumix.registerPluginFieldType` at runtime; the host
+ * exposes that bridge from `plumix-globals.ts`. Plugins type their
+ * own props inline.
  */
-export interface PluginFieldRendererProps {
+interface PluginFieldRendererProps {
   readonly field: MetaBoxFieldManifestEntry;
   readonly rhf: ControllerRenderProps<FieldValues, string>;
   readonly disabled: boolean;
   readonly testId: string;
 }
 
-export type PluginFieldComponent = ComponentType<PluginFieldRendererProps>;
+type PluginFieldComponent = ComponentType<PluginFieldRendererProps>;
 
 interface PluginRegistryEntry<TComponent> {
   readonly map: Map<string, TComponent>;

--- a/packages/admin/src/lib/plugin-registry.ts
+++ b/packages/admin/src/lib/plugin-registry.ts
@@ -1,22 +1,46 @@
 import type { ComponentType } from "react";
+import type { ControllerRenderProps, FieldValues } from "react-hook-form";
 
-interface PluginRegistryEntry {
-  readonly map: Map<string, ComponentType>;
+import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
+
+/**
+ * Contract for plugin-supplied field renderers. The admin's
+ * `MetaBoxField` dispatcher resolves the renderer via
+ * `getPluginFieldType(field.inputType)` and hands it the field
+ * manifest entry plus a react-hook-form controller binding. The
+ * renderer must return a single element — shadcn's `<FormControl>`
+ * uses Radix `Slot` to forward id/aria-* onto it.
+ */
+export interface PluginFieldRendererProps {
+  readonly field: MetaBoxFieldManifestEntry;
+  readonly rhf: ControllerRenderProps<FieldValues, string>;
+  readonly disabled: boolean;
+  readonly testId: string;
+}
+
+export type PluginFieldComponent = ComponentType<PluginFieldRendererProps>;
+
+interface PluginRegistryEntry<TComponent> {
+  readonly map: Map<string, TComponent>;
   readonly registerName: string;
 }
 
-function makeRegistry(registerName: string): PluginRegistryEntry {
+function makeRegistry<TComponent>(
+  registerName: string,
+): PluginRegistryEntry<TComponent> {
   return { map: new Map(), registerName };
 }
 
-const pages = makeRegistry("registerPluginPage");
-const blocks = makeRegistry("registerPluginBlock");
-const fieldTypes = makeRegistry("registerPluginFieldType");
+const pages = makeRegistry<ComponentType>("registerPluginPage");
+const blocks = makeRegistry<ComponentType>("registerPluginBlock");
+const fieldTypes = makeRegistry<PluginFieldComponent>(
+  "registerPluginFieldType",
+);
 
-function register(
-  registry: PluginRegistryEntry,
+function register<TComponent>(
+  registry: PluginRegistryEntry<TComponent>,
   key: string,
-  component: ComponentType,
+  component: TComponent,
 ): void {
   if (registry.map.has(key)) {
     throw new Error(
@@ -49,14 +73,59 @@ export function getPluginBlock(name: string): ComponentType | undefined {
   return blocks.map.get(name);
 }
 
+// Built-in `inputType` names handled by the host's meta-box-field
+// dispatcher. Reserving them prevents two failure modes:
+//  - accidental: a plugin author picks "text" for their custom field
+//    and silently replaces the host's text input across the whole admin
+//  - malicious: a plugin overrides every built-in to harvest form data
+// Kept in sync with the dispatcher in
+// `packages/admin/src/components/meta-box/meta-box-field.tsx` plus the
+// reference renderers (user/userList/entry/entryList/term/termList).
+// Plugin-shipped reference types (notably `media`) are NOT in this set
+// — the duplicate-detection in `register` already prevents two plugins
+// from both claiming the same name.
+const RESERVED_INPUT_TYPES: ReadonlySet<string> = new Set([
+  "text",
+  "textarea",
+  "number",
+  "email",
+  "url",
+  "password",
+  "date",
+  "datetime",
+  "time",
+  "color",
+  "range",
+  "multiselect",
+  "json",
+  "select",
+  "radio",
+  "checkbox",
+  "user",
+  "userList",
+  "entry",
+  "entryList",
+  "term",
+  "termList",
+]);
+
 export function registerPluginFieldType(
   type: string,
-  component: ComponentType,
+  component: PluginFieldComponent,
 ): void {
+  if (RESERVED_INPUT_TYPES.has(type)) {
+    throw new Error(
+      `registerPluginFieldType: "${type}" is reserved for built-in renderers. ` +
+        `Pick a different inputType for your custom field — see the host's ` +
+        `RESERVED_INPUT_TYPES list.`,
+    );
+  }
   register(fieldTypes, type, component);
 }
 
-export function getPluginFieldType(type: string): ComponentType | undefined {
+export function getPluginFieldType(
+  type: string,
+): PluginFieldComponent | undefined {
   return fieldTypes.map.get(type);
 }
 

--- a/packages/plugins/media/src/admin/MediaLibrary.tsx
+++ b/packages/plugins/media/src/admin/MediaLibrary.tsx
@@ -7,8 +7,16 @@ import {
 } from "@tanstack/react-query";
 
 const PAGE_SIZE = 24;
-const MEDIA_LIST_KEY = ["media", "list"] as const;
 const UPLOAD_CONCURRENCY = 4;
+
+// `MEDIA_LIST_KEY` is parametric over `accept` so the picker grid
+// stays in its own cache slot — the page-mode library and a picker
+// scoped to `accept: "image/"` never poison each other's data.
+function mediaListKey(
+  accept: string | readonly string[] | undefined,
+): readonly unknown[] {
+  return ["media", "list", accept ?? null] as const;
+}
 
 // Resolve a media URL to absolute form for copy/display. The plugin
 // emits relative `/_plumix/media/serve/<id>` URLs in binding-only
@@ -242,18 +250,55 @@ function useInfiniteScrollSentinel(
   }, [sentinelRef, hasNextPage, isFetchingNextPage, fetchNextPage, dataLength]);
 }
 
-export function MediaLibrary(): ReactNode {
+/**
+ * `MediaLibrary` is dual-mode: a full-page browser + uploader at
+ * `/media`, or an in-modal picker that emits a selection back to a
+ * meta-box field renderer. Page mode (default) preserves every
+ * existing behavior — the picker mode swaps the detail drawer for
+ * a footer "Use selection" CTA, accepts a hybrid card click (single
+ * = select, double = confirm + close), and applies a server-side
+ * `accept` MIME filter to the grid.
+ */
+export interface MediaLibraryProps {
+  readonly mode?: "page" | "picker";
+  /**
+   * Server-side MIME filter forwarded to `media.list`. String form is
+   * a prefix match (`"image/"` → every `image/*` MIME); array form is
+   * an exact whitelist. Picker-mode only — page mode ignores it.
+   */
+  readonly accept?: string | readonly string[];
+  /**
+   * Picker-mode only: called with the bare media id (`"42"`) when the
+   * user confirms a selection. Single-pick semantics — caller is
+   * responsible for closing the modal.
+   */
+  readonly onSelect?: (id: string) => void;
+  /** Picker-mode only: called when the user clicks Cancel. */
+  readonly onCancel?: () => void;
+}
+
+export function MediaLibrary({
+  mode = "page",
+  accept,
+  onSelect,
+  onCancel,
+}: MediaLibraryProps = {}): ReactNode {
   const queryClient = useQueryClient();
   const [dragging, setDragging] = useState(false);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const isPicker = mode === "picker";
 
+  const queryKey = mediaListKey(accept);
   const list = useInfiniteQuery({
-    queryKey: MEDIA_LIST_KEY,
+    queryKey,
     initialPageParam: 0,
     queryFn: ({ pageParam }: { pageParam: number }) =>
       rpcCall<MediaListResponse>("media/list", {
         limit: PAGE_SIZE,
         offset: pageParam,
+        // `accept` only flows through in picker mode. Page mode shows
+        // the full library regardless.
+        ...(isPicker && accept !== undefined ? { accept } : {}),
       }),
     getNextPageParam: (last, allPages) =>
       last.hasMore ? allPages.length * PAGE_SIZE : undefined,
@@ -265,8 +310,8 @@ export function MediaLibrary(): ReactNode {
   );
 
   const invalidateList = useCallback((): void => {
-    void queryClient.invalidateQueries({ queryKey: MEDIA_LIST_KEY });
-  }, [queryClient]);
+    void queryClient.invalidateQueries({ queryKey });
+  }, [queryClient, queryKey]);
 
   // `list.fetchNextPage` is a stable React Query callback. Passing it
   // directly (rather than wrapping it in a fresh arrow each render)
@@ -338,6 +383,29 @@ export function MediaLibrary(): ReactNode {
     }
   }, [items, list.status, list.isFetching, selectedItem]);
 
+  // Picker-mode selection (single-pick). Hybrid click model:
+  //   - single click → set this id as the picked one (footer enables)
+  //   - double click → confirm + close (auto-close)
+  // Footer "Use selection" is the keyboard-friendly confirmation.
+  const [pickerSelectedId, setPickerSelectedId] = useState<number | null>(null);
+  const handleCardActivate = useCallback(
+    (item: MediaItem): void => {
+      if (isPicker) {
+        setPickerSelectedId(item.id);
+        return;
+      }
+      setSelectedItem(item);
+    },
+    [isPicker],
+  );
+  const handleCardConfirm = useCallback(
+    (item: MediaItem): void => {
+      if (!isPicker) return;
+      onSelect?.(String(item.id));
+    },
+    [isPicker, onSelect],
+  );
+
   // ESC closes the detail drawer. Depend on the boolean `open` flag
   // (primitive) so the listener doesn't tear down/rebind on every
   // refresh of `selectedItem`.
@@ -354,6 +422,7 @@ export function MediaLibrary(): ReactNode {
   return (
     <div
       data-testid="media-library"
+      data-mode={mode}
       className="relative flex min-h-full gap-6"
       {...dropProps}
     >
@@ -361,9 +430,9 @@ export function MediaLibrary(): ReactNode {
         <header className="flex items-center justify-between">
           <h1
             data-testid="media-library-title"
-            className="text-3xl font-semibold tracking-tight"
+            className={`${isPicker ? "text-xl" : "text-3xl"} font-semibold tracking-tight`}
           >
-            Media Library
+            {isPicker ? "Select media" : "Media Library"}
           </h1>
           <UploadButton onSelect={(files) => void startUpload(files)} />
         </header>
@@ -393,14 +462,31 @@ export function MediaLibrary(): ReactNode {
             data-testid="media-library-grid"
             className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4"
           >
-            {items.map((item) => (
-              <MediaCard
-                key={item.id}
-                item={item}
-                selected={selectedItem?.id === item.id}
-                onOpen={() => setSelectedItem(item)}
-              />
-            ))}
+            {items.map((item) => {
+              const selected = isPicker
+                ? pickerSelectedId === item.id
+                : selectedItem?.id === item.id;
+              return (
+                <MediaCard
+                  key={item.id}
+                  item={item}
+                  selected={selected}
+                  onActivate={() => handleCardActivate(item)}
+                  // Page mode: double-click is idempotent with single-
+                  // click (open detail). Picker mode: confirm + close.
+                  onConfirm={
+                    isPicker
+                      ? () => handleCardConfirm(item)
+                      : () => handleCardActivate(item)
+                  }
+                  ariaActionLabel={
+                    isPicker
+                      ? `Pick ${item.title}`
+                      : `Open details for ${item.title}`
+                  }
+                />
+              );
+            })}
           </div>
         )}
 
@@ -425,9 +511,38 @@ export function MediaLibrary(): ReactNode {
             className="border-primary pointer-events-none absolute inset-4 rounded-lg border-2 border-dashed bg-white/5"
           />
         )}
+
+        {isPicker && (
+          <footer
+            data-testid="media-library-picker-footer"
+            className="bg-background sticky bottom-0 -mx-2 flex items-center justify-end gap-2 border-t px-2 py-3"
+          >
+            <button
+              type="button"
+              className="hover:bg-muted rounded px-3 py-1.5 text-sm"
+              onClick={() => onCancel?.()}
+              data-testid="media-library-picker-cancel"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={pickerSelectedId === null}
+              onClick={() => {
+                if (pickerSelectedId !== null) {
+                  onSelect?.(String(pickerSelectedId));
+                }
+              }}
+              data-testid="media-library-picker-confirm"
+            >
+              Use selection
+            </button>
+          </footer>
+        )}
       </div>
 
-      {selectedItem && (
+      {!isPicker && selectedItem && (
         <MediaDetailDrawer
           item={selectedItem}
           onClose={() => setSelectedItem(null)}
@@ -646,11 +761,19 @@ function UploadProgressBar({
 function MediaCard({
   item,
   selected,
-  onOpen,
+  onActivate,
+  onConfirm,
+  ariaActionLabel,
 }: {
   item: MediaItem;
   selected: boolean;
-  onOpen: () => void;
+  // Single-click action — opens the drawer (page mode) OR sets the
+  // picker selection (picker mode).
+  onActivate: () => void;
+  // Double-click action — only meaningful in picker mode (confirm +
+  // close). Page mode passes an empty fn.
+  onConfirm?: () => void;
+  ariaActionLabel: string;
   // onDelete + onAltChange removed from card — both belong to the
   // detail drawer now (matches the WP/screenshot pattern: card is
   // the index, drawer is the detail editor).
@@ -664,16 +787,17 @@ function MediaCard({
       className={`border-border bg-card relative flex cursor-pointer flex-col gap-2 rounded-lg border p-3 ${
         selected ? "outline-primary outline-2 outline-offset-1" : ""
       }`}
-      onClick={onOpen}
+      onClick={onActivate}
+      onDoubleClick={onConfirm}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          onOpen();
+          onActivate();
         }
       }}
       role="button"
       tabIndex={0}
-      aria-label={`Open details for ${item.title}`}
+      aria-label={ariaActionLabel}
     >
       <div className="bg-muted relative flex aspect-square w-full items-center justify-center overflow-hidden rounded-sm">
         {isImage ? (

--- a/packages/plugins/media/src/admin/MediaPickerField.tsx
+++ b/packages/plugins/media/src/admin/MediaPickerField.tsx
@@ -1,0 +1,222 @@
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+
+import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
+
+import { MediaLibrary } from "./MediaLibrary.js";
+
+// `media` field admin renderer. Registered into the host admin's
+// plugin-field-type registry on module load (see admin/index.tsx),
+// dispatched from the meta-box-field renderer's plugin path.
+//
+// Reads value as a `MediaValue`-shaped object: `{ id, mime?, filename? }`.
+// Renders the cached snapshot directly — zero resolve round-trips per
+// render. The "Select" / "Change" button opens a fixed-position modal
+// containing `<MediaLibrary mode="picker" accept={accept} />`; on
+// confirm the modal closes and writes back the bare id (the meta
+// pipeline normalizes to the cached-object shape on save).
+
+interface MediaValue {
+  readonly id: string;
+  readonly mime?: string;
+  readonly filename?: string;
+}
+
+function normalizeValue(raw: unknown): MediaValue | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "string" || obj.id === "") return null;
+  return {
+    id: obj.id,
+    mime: typeof obj.mime === "string" ? obj.mime : undefined,
+    filename: typeof obj.filename === "string" ? obj.filename : undefined,
+  };
+}
+
+function readAccept(
+  field: MetaBoxFieldManifestEntry,
+): string | readonly string[] | undefined {
+  const scope = field.referenceTarget?.scope as
+    | { readonly accept?: unknown }
+    | undefined;
+  const accept = scope?.accept;
+  if (typeof accept === "string") return accept;
+  if (Array.isArray(accept)) {
+    return accept.filter((s): s is string => typeof s === "string");
+  }
+  return undefined;
+}
+
+export function MediaPickerField({
+  field,
+  rhf,
+  disabled,
+  testId,
+}: {
+  readonly field: MetaBoxFieldManifestEntry;
+  readonly rhf: {
+    readonly value: unknown;
+    readonly onChange: (next: unknown) => void;
+    readonly onBlur: () => void;
+    readonly name: string;
+  };
+  readonly disabled: boolean;
+  readonly testId: string;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+  const value = normalizeValue(rhf.value);
+  const accept = readAccept(field);
+  const required = field.required === true;
+
+  const handleSelect = (id: string): void => {
+    // Write back the bare id; the meta pipeline normalizes to the
+    // cached-object shape on save (`{ id, mime, filename }`). Until
+    // the next save lands, the form holds a bare-string interim
+    // value — `normalizeValue` accepts both shapes.
+    rhf.onChange(id);
+    setOpen(false);
+    rhf.onBlur();
+  };
+
+  const handleClear = (): void => {
+    rhf.onChange(null);
+    rhf.onBlur();
+  };
+
+  return (
+    <div
+      data-testid={testId}
+      className="border-input flex items-center gap-2 rounded-md border px-2 py-1.5"
+    >
+      <div className="min-w-0 flex-1">
+        {value ? (
+          <MediaPreview value={value} testId={testId} />
+        ) : (
+          <p
+            className="text-muted-foreground text-sm"
+            data-testid={`${testId}-empty`}
+          >
+            No media selected
+          </p>
+        )}
+      </div>
+      <button
+        type="button"
+        className="hover:bg-muted rounded border px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled}
+        onClick={() => setOpen(true)}
+        data-testid={`${testId}-open`}
+      >
+        {value ? "Change" : "Select"}
+      </button>
+      {value && !required ? (
+        <button
+          type="button"
+          className="hover:bg-muted rounded px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled}
+          onClick={handleClear}
+          data-testid={`${testId}-clear`}
+        >
+          Clear
+        </button>
+      ) : null}
+      {open ? (
+        <MediaPickerModal
+          accept={accept}
+          onSelect={handleSelect}
+          onCancel={() => setOpen(false)}
+          testId={`${testId}-modal`}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function MediaPreview({
+  value,
+  testId,
+}: {
+  readonly value: MediaValue;
+  readonly testId: string;
+}): ReactNode {
+  // The cached storage gives us `mime` + `filename` directly — no
+  // resolve round-trip per render. If they're missing (interim
+  // bare-string state right after pick), fall back to "Selected: <id>"
+  // until the next save normalizes the shape.
+  if (!value.filename) {
+    return (
+      <p className="text-sm" data-testid={`${testId}-pending`}>
+        Selected (id {value.id})
+      </p>
+    );
+  }
+  return (
+    <div className="min-w-0 text-sm">
+      <p
+        className="truncate font-medium"
+        data-testid={`${testId}-filename`}
+        title={value.filename}
+      >
+        {value.filename}
+      </p>
+      {value.mime ? (
+        <p className="text-muted-foreground text-xs">{value.mime}</p>
+      ) : null}
+    </div>
+  );
+}
+
+// Fixed-position modal hosting the MediaLibrary in picker mode.
+// Mirrors the `ConfirmDialog` pattern in MediaLibrary.tsx (no shadcn
+// `Dialog` shim is exposed to plugin chunks, so the plugin can't
+// import it). Backdrop click + Escape dismiss. Body scroll is locked
+// while open by the surrounding admin route layout.
+function MediaPickerModal({
+  accept,
+  onSelect,
+  onCancel,
+  testId,
+}: {
+  readonly accept: string | readonly string[] | undefined;
+  readonly onSelect: (id: string) => void;
+  readonly onCancel: () => void;
+  readonly testId: string;
+}): ReactNode {
+  // Window-level Escape listener — React's `onKeyDown` only fires when
+  // focus is inside the modal. If the user clicked the backdrop (focus
+  // goes to body) or focus drifted outside, the React handler misses
+  // the event. Mounted only while the modal is open so it doesn't
+  // intercept keystrokes on the rest of the admin.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      data-testid={testId}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Select media"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        className="bg-background relative flex max-h-[90vh] w-full max-w-5xl flex-col overflow-y-auto rounded-lg p-4 shadow-lg"
+        data-testid={`${testId}-panel`}
+      >
+        <MediaLibrary
+          mode="picker"
+          accept={accept}
+          onSelect={onSelect}
+          onCancel={onCancel}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/plugins/media/src/admin/index.tsx
+++ b/packages/plugins/media/src/admin/index.tsx
@@ -4,5 +4,52 @@
 // call into the synthesised admin chunk based on the `component:
 // "MediaLibrary"` ref we passed to `ctx.registerAdminPage`. So the
 // plugin's only job here is to expose the export by name.
+//
+// Field-type registration is a side-effect of module load — the
+// host's plumix-globals bootstrap runs first, then the plugin chunk
+// loads and the side-effect call below pushes the renderer into
+// `registerPluginFieldType`'s registry. The host's meta-box-field
+// dispatcher consults that registry on every render.
+
+import type { ComponentType } from "react";
+
+import { MediaPickerField } from "./MediaPickerField.js";
+
+// Minimal structural shape of the host admin's `window.plumix` —
+// we only need the field-type registration entry. The host's full
+// declaration lives in `packages/admin/src/lib/plumix-globals.ts`.
+interface PlumixWindowGlobal {
+  readonly registerPluginFieldType: (
+    type: string,
+    component: ComponentType<never>,
+  ) => void;
+}
+
+declare const window:
+  | {
+      readonly plumix?: PlumixWindowGlobal;
+    }
+  | undefined;
+
+if (typeof window !== "undefined") {
+  if (window.plumix) {
+    window.plumix.registerPluginFieldType(
+      "media",
+      MediaPickerField as ComponentType<never>,
+    );
+  } else {
+    // Silent no-op would leave the `media` field renderer unregistered
+    // for the whole session — every media field would fall through to
+    // the legacy text-input fallback with no error visible. Surface the
+    // misconfiguration so a deployment with a broken load-order is
+    // diagnosable instead of silently degraded.
+    console.warn(
+      "[plumix-plugin-media] window.plumix not initialized — `media` " +
+        "field renderer not registered. Verify the host admin has booted " +
+        "plumix-globals before the plugin chunk loads.",
+    );
+  }
+}
 
 export { MediaLibrary } from "./MediaLibrary.js";
+export { MediaPickerField } from "./MediaPickerField.js";

--- a/packages/plugins/media/src/rpc.ts
+++ b/packages/plugins/media/src/rpc.ts
@@ -1,7 +1,17 @@
 import * as v from "valibot";
 
-import type { AppContext, AuthenticatedAppContext } from "@plumix/core";
-import { and, authenticated, base, desc, entries, eq } from "@plumix/core";
+import type { AppContext, AuthenticatedAppContext, SQL } from "@plumix/core";
+import {
+  and,
+  authenticated,
+  base,
+  desc,
+  entries,
+  eq,
+  inArray,
+  like,
+  sql,
+} from "@plumix/core";
 
 import { looksLikeMime, MAGIC_BYTE_SAMPLE_SIZE } from "./magic-bytes.js";
 import { parseMediaMeta } from "./meta.js";
@@ -344,23 +354,39 @@ export function createMediaRouter(
           DEFAULT_PAGE_SIZE,
         ),
         offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+        // MIME filter for picker mode. String form (`"image/"`) does
+        // a `LIKE 'image/%'` prefix match; array form does an exact
+        // match against the supplied MIMEs. Pushed into SQL so the
+        // `limit` clause counts only matching rows — JS post-filter
+        // would silently under-fill the picker grid for a field whose
+        // accept rejects a chunk of recent uploads.
+        accept: v.optional(
+          v.union([
+            v.pipe(v.string(), v.maxLength(64)),
+            v.pipe(
+              v.array(v.pipe(v.string(), v.maxLength(64))),
+              v.maxLength(32),
+            ),
+          ]),
+        ),
       }),
     )
     .handler(async ({ input, context, errors }): Promise<MediaListResponse> => {
       if (!context.auth.can("entry:media:read")) {
         throw errors.FORBIDDEN({ data: { capability: "entry:media:read" } });
       }
+      const conditions: SQL[] = [
+        eq(entries.type, MEDIA_ENTRY_TYPE),
+        eq(entries.status, "published"),
+      ];
+      const acceptCondition = buildAcceptCondition(input.accept);
+      if (acceptCondition) conditions.push(acceptCondition);
       // Fetch one extra row so we can report `hasMore` without a
       // separate COUNT(*) query.
       const rows = await context.db
         .select()
         .from(entries)
-        .where(
-          and(
-            eq(entries.type, MEDIA_ENTRY_TYPE),
-            eq(entries.status, "published"),
-          ),
-        )
+        .where(and(...conditions))
         .orderBy(desc(entries.updatedAt), desc(entries.id))
         .limit(input.limit + 1)
         .offset(input.offset);
@@ -534,4 +560,23 @@ function sanitizeExtension(filename: string): string | undefined {
   if (ext.length > MAX_EXT_LEN) return undefined;
   if (!SAFE_EXT_RE.test(ext)) return undefined;
   return ext;
+}
+
+// Translate the `accept` input into a SQL predicate against the
+// extracted JSON `mime` field. Mirrors the `mediaLookupAdapter`'s
+// approach (see lookup.ts) so the picker grid and the lookup adapter
+// apply identical filtering. Real MIME strings don't contain `%`/`_`
+// and the accept input is plugin-supplied (or omitted), so no LIKE
+// escaping is needed.
+function buildAcceptCondition(
+  accept: string | readonly string[] | undefined,
+): SQL | undefined {
+  if (accept === undefined) return undefined;
+  const mimeExpr = sql<string>`json_extract(${entries.meta}, '$.mime')`;
+  if (typeof accept === "string") {
+    if (accept === "") return undefined;
+    return like(mimeExpr, `${accept}%`);
+  }
+  if (accept.length === 0) return undefined;
+  return inArray(mimeExpr, accept as string[]);
 }


### PR DESCRIPTION
**Status: draft, 3 of 5 commits.** Server half + cached storage shipped via #139. This PR ships the admin half — plugin field-type dispatch, MediaLibrary dual-mode, and the MediaPickerField renderer. Skeletons + e2e remaining.

## Done

- **Plugin field-type dispatch + error boundary** in `MetaBoxField`: `getPluginFieldType(field.inputType)` consulted before the built-in switch. Wrapped in `PluginFieldErrorBoundary` so a thrown render falls back to a static placeholder rather than blowing up the form.
- **MediaLibrary dual-mode**: `mode: "page" | "picker"` prop. Page mode unchanged. Picker mode swaps the title, runs hybrid card click (single = select, double = confirm + close), shows a sticky footer with Cancel + "Use selection", suppresses the detail drawer. `media.list` gains an `accept` filter pushed into SQL via `json_extract` so the LIMIT respects it.
- **MediaPickerField**: per-field admin renderer. Renders cached `{ id, mime, filename }` directly (no resolve roundtrip per render). "Select"/"Change" opens a fixed-position modal hosting MediaLibrary in picker mode. Auto-registers into `registerPluginFieldType("media", ...)` on module load.

## Remaining

- Skeleton retrofit for `ReferencePicker` + `MultiReferencePicker` (loading state currently rendered as orphan badge — fixing for consistent UX)
- E2E coverage for picker flow, modal interactions, accept filtering

## Test plan

- [x] core 1133 / admin 152 / plugin-media 86 unit tests pass
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm knip` all clean
- [ ] e2e (commit 5)

Refs #130