### PR TITLE
feat: mediaList multi field (#132)

### DIFF
--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -462,6 +462,23 @@ export interface MediaMetaBoxField extends MetaBoxFieldBase {
   readonly referenceTarget: ReferenceTarget;
 }
 
+/**
+ * Multi media reference. Storage is a JSON array of `MediaValue`
+ * objects — `[{ id, mime?, filename? }, ...]` — extending the cached-
+ * object pattern from `MediaMetaBoxField` to the array shape. The
+ * meta pipeline rewrites each entry's cached fields on every write,
+ * so admin renders thumbnails for every item without a per-item
+ * resolve. `referenceTarget.multiple` is `true`, `valueShape` is
+ * `"object"`; `max` caps the array length at write time.
+ */
+export interface MediaListMetaBoxField extends MetaBoxFieldBase {
+  readonly inputType: "mediaList";
+  readonly type: "json";
+  readonly referenceTarget: ReferenceTarget;
+  /** Max items allowed in the array. Omitted = unbounded. */
+  readonly max?: number;
+}
+
 /** Single-value dropdown picker; `options` is required. */
 export interface SelectMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "select";
@@ -534,6 +551,7 @@ export type MetaBoxField =
   | TermReferenceMetaBoxField
   | TermListMetaBoxField
   | MediaMetaBoxField
+  | MediaListMetaBoxField
   | SelectMetaBoxField
   | RadioMetaBoxField
   | CheckboxMetaBoxField
@@ -599,6 +617,7 @@ export type EntryMetaBoxField =
   | Omit<TermReferenceMetaBoxField, "span">
   | Omit<TermListMetaBoxField, "span">
   | Omit<MediaMetaBoxField, "span">
+  | Omit<MediaListMetaBoxField, "span">
   | Omit<SelectMetaBoxField, "span">
   | Omit<RadioMetaBoxField, "span">
   | Omit<CheckboxMetaBoxField, "span">

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -226,13 +226,16 @@ export async function validateMetaReferences(
         }
       }
       // Cached-object normalize step: replace user-supplied value
-      // with `{ id, ...adapterRow.cached }`. Adapter is authoritative
-      // for cached fields (mime/filename); user-supplied non-id keys
-      // are dropped to prevent spoofed metadata. v0.1 covers single
-      // refs only; multi + object (`mediaList`) lands in slice #132
-      // alongside the array-of-objects shape support in
-      // `referenceIdsForValidation`.
-      if (upsert.target.valueShape !== "object" || upsert.target.multiple) {
+      // with `{ id, ...adapterRow.cached }` (single) or an array
+      // thereof (multi). Adapter is authoritative for cached fields
+      // (mime/filename); user-supplied non-id keys are dropped to
+      // prevent spoofed metadata.
+      if (upsert.target.valueShape !== "object") continue;
+      if (upsert.target.multiple) {
+        patch.upserts.set(
+          upsert.key,
+          upsert.ids.map((id) => buildCachedReference(id, rowsById)),
+        );
         continue;
       }
       const [id] = upsert.ids;
@@ -345,16 +348,18 @@ async function fetchLiveRows(
 const HARD_MULTI_REFERENCE_LIMIT = 100;
 
 // Validates the wire shape of a reference value and returns the ids
-// to feed into the group's batched `list({ ids })` call. Three shapes
+// to feed into the group's batched `list({ ids })` call. Four shapes
 // are accepted, dispatching on `target.multiple` + `target.valueShape`:
 //
 //  - multi=true,  valueShape="id"  (default): string[] of non-empty ids
+//  - multi=true,  valueShape="object":        `{ id }[]` — each item a
+//                                             cached-object reference
+//                                             (or bare strings for
+//                                             leniency on first write)
 //  - multi=false, valueShape="id"  (default): bare string id
 //  - multi=false, valueShape="object":        `{ id: string, ... }`
 //                                             (or a bare string for
 //                                             leniency on first write)
-//
-// Multi + object (mediaList) is reserved for slice #132.
 function referenceIdsForValidation(
   key: string,
   value: unknown,
@@ -370,6 +375,25 @@ function referenceIdsForValidation(
     }
     if (max !== undefined && value.length > max) {
       throw new MetaSanitizationError(key, "invalid_value");
+    }
+    if (target.valueShape === "object") {
+      // Lenient on input: each item can be `"42"` (first-write
+      // convenience) or `{ id: "42", ... }`. Always rewritten to the
+      // canonical `{ id, ...cached }` shape after the live-id check.
+      const ids: string[] = [];
+      for (const item of value) {
+        if (typeof item === "string" && item !== "") {
+          ids.push(item);
+          continue;
+        }
+        const id = extractStringId(item);
+        if (id !== null && id !== "") {
+          ids.push(id);
+          continue;
+        }
+        throw new MetaSanitizationError(key, "invalid_value");
+      }
+      return ids;
     }
     for (const item of value) {
       if (typeof item !== "string" || item === "") {

--- a/packages/core/src/rpc/meta/references.test.ts
+++ b/packages/core/src/rpc/meta/references.test.ts
@@ -780,3 +780,150 @@ describe("validateMetaReferences (cached-object shape)", () => {
     expect(filtered.hero).toEqual(stored);
   });
 });
+
+// Multi + cached-object shape (`mediaList`). Same architecture as
+// single + cached-object — adapter-supplied cached fields are merged
+// into each entry on write; read keeps the stored snapshot dense by
+// dropping orphans.
+describe("validateMetaReferences (multi cached-object shape)", () => {
+  function registryWithCachedListRef(
+    cached: Readonly<Record<string, unknown>>,
+    options: { liveIds?: ReadonlySet<string>; max?: number } = {},
+  ) {
+    const registry: MutablePluginRegistry = createPluginRegistry();
+    const fullField = {
+      key: "gallery",
+      label: "Gallery",
+      type: "json",
+      inputType: "mediaList",
+      referenceTarget: {
+        kind: "stub",
+        valueShape: "object",
+        multiple: true,
+      },
+      max: options.max,
+    } as MetaBoxField;
+    registry.userMetaBoxes.set("gallery", {
+      id: "gallery",
+      label: "Gallery",
+      fields: [fullField],
+      registeredBy: null,
+    });
+    const isLive = (id: string) =>
+      options.liveIds === undefined || options.liveIds.has(id);
+    registry.lookupAdapters.set("stub", {
+      kind: "stub",
+      capability: null,
+      registeredBy: null,
+      adapter: {
+        list: (_ctx, opts) =>
+          Promise.resolve(
+            (opts.ids ?? [])
+              .filter(isLive)
+              .map((id) => ({ id, label: `stub-${id}`, cached })),
+          ),
+        resolve: (_ctx, id) =>
+          Promise.resolve(
+            isLive(id) ? { id, label: `stub-${id}`, cached } : null,
+          ),
+      },
+    });
+    return {
+      registry,
+      findField: (key: string) =>
+        key === fullField.key ? fullField : undefined,
+    };
+  }
+
+  test("rewrites an array of bare-id strings to canonical { id, ...cached }[] shape", async () => {
+    const { registry, findField } = registryWithCachedListRef({
+      mime: "image/png",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, { gallery: ["42", "43"] });
+    if (!patch) throw new Error("patch should not be null");
+    await validateMetaReferences(h.context, findField, patch);
+    expect(patch.upserts.get("gallery")).toEqual([
+      { id: "42", mime: "image/png" },
+      { id: "43", mime: "image/png" },
+    ]);
+  });
+
+  test("rewrites an array of { id } objects, dropping spoofed extras", async () => {
+    const { registry, findField } = registryWithCachedListRef({
+      mime: "image/png",
+      filename: "shared.png",
+    });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, {
+      gallery: [
+        { id: "42", spoofed: "ignored" },
+        { id: "43", mime: "image/jpeg" },
+      ],
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await validateMetaReferences(h.context, findField, patch);
+    expect(patch.upserts.get("gallery")).toEqual([
+      { id: "42", mime: "image/png", filename: "shared.png" },
+      { id: "43", mime: "image/png", filename: "shared.png" },
+    ]);
+  });
+
+  test("rejects when any item id is missing from live results", async () => {
+    const { registry, findField } = registryWithCachedListRef(
+      {},
+      { liveIds: new Set(["42"]) },
+    );
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, {
+      gallery: ["42", "999"],
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("enforces the field's max length cap on the multi-object shape", async () => {
+    const { registry, findField } = registryWithCachedListRef({}, { max: 2 });
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const patch = sanitizeMetaInput(findField, {
+      gallery: ["1", "2", "3"],
+    });
+    if (!patch) throw new Error("patch should not be null");
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toBeInstanceOf(MetaSanitizationError);
+  });
+
+  test("filterMetaOrphans drops missing entries from the array, keeping order", async () => {
+    const { registry, findField } = registryWithCachedListRef(
+      {},
+      { liveIds: new Set(["42", "44"]) },
+    );
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      gallery: [
+        { id: "42", mime: "image/png", filename: "a.png" },
+        { id: "43", mime: "image/png", filename: "b.png" }, // orphan
+        { id: "44", mime: "image/png", filename: "c.png" },
+      ],
+    });
+    expect(filtered.gallery).toEqual([
+      { id: "42", mime: "image/png", filename: "a.png" },
+      { id: "44", mime: "image/png", filename: "c.png" },
+    ]);
+  });
+
+  test("filterMetaOrphans returns an empty array when every entry is gone", async () => {
+    const { registry, findField } = registryWithCachedListRef(
+      {},
+      { liveIds: new Set() },
+    );
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      gallery: [{ id: "42" }, { id: "43" }],
+    });
+    expect(filtered.gallery).toEqual([]);
+  });
+});

--- a/packages/plugins/media/src/admin/MediaListPickerField.tsx
+++ b/packages/plugins/media/src/admin/MediaListPickerField.tsx
@@ -1,0 +1,325 @@
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+
+import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
+
+import { MediaLibrary } from "./MediaLibrary.js";
+
+// `mediaList` field admin renderer. Reads the value as
+// `MediaValue[]` — `[{ id, mime?, filename? }, ...]`. Renders each
+// entry as a row in a vertical strip with Up / Down / Remove
+// buttons; "Add more" opens MediaLibrary in modal/picker mode.
+//
+// Picker stays open across selections (the modal doesn't close on
+// pick — only on Cancel or when the array hits `max`). Cached
+// storage means each row's preview renders directly from the
+// stored snapshot — zero resolve roundtrips per render.
+//
+// Drag-reorder is deferred to a follow-up — exposing dnd-kit as a
+// shared runtime module to plugin chunks needs separate work, and
+// up/down buttons satisfy the keyboard-reorder acceptance criterion
+// for v0.1.
+
+interface MediaValue {
+  readonly id: string;
+  readonly mime?: string;
+  readonly filename?: string;
+}
+
+function normalizeArray(raw: unknown): readonly MediaValue[] {
+  if (!Array.isArray(raw)) return [];
+  const out: MediaValue[] = [];
+  for (const item of raw) {
+    if (typeof item === "string" && item !== "") {
+      // Interim bare-string state right after a pick, before the
+      // meta pipeline normalizes on save. Treat as `{ id }` so the
+      // row still renders (with a "Selected (id N)" placeholder).
+      out.push({ id: item });
+      continue;
+    }
+    if (
+      typeof item === "object" &&
+      item !== null &&
+      typeof (item as { readonly id?: unknown }).id === "string"
+    ) {
+      const obj = item as Record<string, unknown>;
+      const id = obj.id as string;
+      if (id === "") continue;
+      out.push({
+        id,
+        mime: typeof obj.mime === "string" ? obj.mime : undefined,
+        filename: typeof obj.filename === "string" ? obj.filename : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+function readAccept(
+  field: MetaBoxFieldManifestEntry,
+): string | readonly string[] | undefined {
+  const scope = field.referenceTarget?.scope as
+    | { readonly accept?: unknown }
+    | undefined;
+  const accept = scope?.accept;
+  if (typeof accept === "string") return accept;
+  if (Array.isArray(accept)) {
+    return accept.filter((s): s is string => typeof s === "string");
+  }
+  return undefined;
+}
+
+function readMax(field: MetaBoxFieldManifestEntry): number | undefined {
+  const max = (field as { readonly max?: unknown }).max;
+  return typeof max === "number" ? max : undefined;
+}
+
+export function MediaListPickerField({
+  field,
+  rhf,
+  disabled,
+  testId,
+}: {
+  readonly field: MetaBoxFieldManifestEntry;
+  readonly rhf: {
+    readonly value: unknown;
+    readonly onChange: (next: unknown) => void;
+    readonly onBlur: () => void;
+    readonly name: string;
+  };
+  readonly disabled: boolean;
+  readonly testId: string;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+  const value = normalizeArray(rhf.value);
+  const accept = readAccept(field);
+  const max = readMax(field);
+  const atMax = max !== undefined && value.length >= max;
+
+  // Auto-close when the array hits `max` — picker shouldn't stay
+  // open if there's nowhere to put the next pick. `handlePick` is
+  // sync today; if it ever becomes async (e.g. server-side accept
+  // re-validation before commit), this effect will close the modal
+  // before the pick lands. Defer that fix until the async path
+  // actually exists.
+  useEffect(() => {
+    if (open && atMax) setOpen(false);
+  }, [open, atMax]);
+
+  const updateAt = (next: readonly MediaValue[]): void => {
+    rhf.onChange(next);
+    rhf.onBlur();
+  };
+
+  const handlePick = (id: string): void => {
+    if (atMax) return;
+    // Admin-side dedup: the picker rejects re-adding an id that's
+    // already in the array. The server-side meta pipeline does NOT
+    // dedup — an API caller submitting `[id1, id1]` over the wire
+    // gets `[{id:id1, ...}, {id:id1, ...}]` stored. The contract:
+    // the picker enforces the common case, the API stays minimal.
+    // Re-saving an API-supplied duplicate through the admin will
+    // collapse it.
+    if (value.some((v) => v.id === id)) return;
+    updateAt([...value, { id }]);
+  };
+
+  const handleRemove = (idx: number): void => {
+    const next = [...value];
+    next.splice(idx, 1);
+    updateAt(next);
+  };
+
+  const handleMove = (idx: number, direction: -1 | 1): void => {
+    const target = idx + direction;
+    if (target < 0 || target >= value.length) return;
+    const next = [...value];
+    const [item] = next.splice(idx, 1);
+    if (item !== undefined) next.splice(target, 0, item);
+    updateAt(next);
+  };
+
+  return (
+    <div
+      data-testid={testId}
+      className="border-input flex flex-col gap-2 rounded-md border p-2"
+    >
+      {value.length === 0 ? (
+        <p
+          className="text-muted-foreground text-sm"
+          data-testid={`${testId}-empty`}
+        >
+          No media selected
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1" data-testid={`${testId}-list`}>
+          {value.map((item, idx) => (
+            // `key` is the bare id, NOT id+idx. `handlePick` rejects
+            // duplicate ids (admin-side dedup) so id is unique per
+            // array. Reordering then preserves React identity for
+            // each row — Tab focus stays on the button the user just
+            // clicked instead of resetting on every move.
+            <MediaListItem
+              key={item.id}
+              item={item}
+              index={idx}
+              count={value.length}
+              testId={testId}
+              disabled={disabled}
+              onMove={handleMove}
+              onRemove={handleRemove}
+            />
+          ))}
+        </ul>
+      )}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="hover:bg-muted rounded border px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled || atMax}
+          onClick={() => setOpen(true)}
+          data-testid={`${testId}-add`}
+        >
+          {value.length === 0 ? "Select" : "Add more"}
+        </button>
+        {max !== undefined ? (
+          <span
+            className="text-muted-foreground text-xs"
+            data-testid={`${testId}-count`}
+          >
+            {value.length} / {max}
+          </span>
+        ) : null}
+      </div>
+      {open ? (
+        <MediaListPickerModal
+          accept={accept}
+          onSelect={handlePick}
+          onCancel={() => setOpen(false)}
+          testId={`${testId}-modal`}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function MediaListItem({
+  item,
+  index,
+  count,
+  testId,
+  disabled,
+  onMove,
+  onRemove,
+}: {
+  readonly item: MediaValue;
+  readonly index: number;
+  readonly count: number;
+  readonly testId: string;
+  readonly disabled: boolean;
+  readonly onMove: (idx: number, direction: -1 | 1) => void;
+  readonly onRemove: (idx: number) => void;
+}): ReactNode {
+  const rowTestId = `${testId}-row-${item.id}`;
+  const displayName = item.filename ?? item.id;
+  return (
+    <li
+      className="border-input bg-background flex items-center gap-2 rounded-md border px-2 py-1.5"
+      data-testid={rowTestId}
+    >
+      <div className="min-w-0 flex-1 text-sm">
+        {item.filename ? (
+          <>
+            <p className="truncate font-medium" title={item.filename}>
+              {item.filename}
+            </p>
+            {item.mime ? (
+              <p className="text-muted-foreground text-xs">{item.mime}</p>
+            ) : null}
+          </>
+        ) : (
+          <p data-testid={`${rowTestId}-pending`}>Selected (id {item.id})</p>
+        )}
+      </div>
+      <button
+        type="button"
+        className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled || index === 0}
+        onClick={() => onMove(index, -1)}
+        aria-label={`Move ${displayName} up`}
+        data-testid={`${rowTestId}-up`}
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled || index === count - 1}
+        onClick={() => onMove(index, 1)}
+        aria-label={`Move ${displayName} down`}
+        data-testid={`${rowTestId}-down`}
+      >
+        ↓
+      </button>
+      <button
+        type="button"
+        className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled}
+        onClick={() => onRemove(index)}
+        aria-label={`Remove ${displayName}`}
+        data-testid={`${rowTestId}-remove`}
+      >
+        ✕
+      </button>
+    </li>
+  );
+}
+
+// Modal that hosts MediaLibrary in picker mode. Doesn't close on
+// `onSelect` — multi-select stays open until the user clicks Cancel
+// or the parent's effect closes it on `atMax`. Window-level Escape
+// listener mirrors the single-pick modal in MediaPickerField.
+function MediaListPickerModal({
+  accept,
+  onSelect,
+  onCancel,
+  testId,
+}: {
+  readonly accept: string | readonly string[] | undefined;
+  readonly onSelect: (id: string) => void;
+  readonly onCancel: () => void;
+  readonly testId: string;
+}): ReactNode {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      data-testid={testId}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add media"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        className="bg-background relative flex max-h-[90vh] w-full max-w-5xl flex-col overflow-y-auto rounded-lg p-4 shadow-lg"
+        data-testid={`${testId}-panel`}
+      >
+        <MediaLibrary
+          mode="picker"
+          accept={accept}
+          onSelect={onSelect}
+          onCancel={onCancel}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/plugins/media/src/admin/index.tsx
+++ b/packages/plugins/media/src/admin/index.tsx
@@ -13,6 +13,7 @@
 
 import type { ComponentType } from "react";
 
+import { MediaListPickerField } from "./MediaListPickerField.js";
 import { MediaPickerField } from "./MediaPickerField.js";
 
 // Minimal structural shape of the host admin's `window.plumix` —
@@ -37,19 +38,24 @@ if (typeof window !== "undefined") {
       "media",
       MediaPickerField as ComponentType<never>,
     );
+    window.plumix.registerPluginFieldType(
+      "mediaList",
+      MediaListPickerField as ComponentType<never>,
+    );
   } else {
-    // Silent no-op would leave the `media` field renderer unregistered
-    // for the whole session — every media field would fall through to
-    // the legacy text-input fallback with no error visible. Surface the
-    // misconfiguration so a deployment with a broken load-order is
-    // diagnosable instead of silently degraded.
+    // Silent no-op would leave the `media`/`mediaList` field renderers
+    // unregistered for the whole session — every media field would fall
+    // through to the legacy text-input fallback with no error visible.
+    // Surface the misconfiguration so a deployment with a broken
+    // load-order is diagnosable instead of silently degraded.
     console.warn(
-      "[plumix-plugin-media] window.plumix not initialized — `media` " +
-        "field renderer not registered. Verify the host admin has booted " +
+      "[plumix-plugin-media] window.plumix not initialized — media " +
+        "field renderers not registered. Verify the host admin has booted " +
         "plumix-globals before the plugin chunk loads.",
     );
   }
 }
 
 export { MediaLibrary } from "./MediaLibrary.js";
+export { MediaListPickerField } from "./MediaListPickerField.js";
 export { MediaPickerField } from "./MediaPickerField.js";

--- a/packages/plugins/media/src/builder.test.ts
+++ b/packages/plugins/media/src/builder.test.ts
@@ -7,9 +7,13 @@ import {
   installPlugins,
 } from "@plumix/core";
 
-import type { MediaFieldOptions, MediaValue } from "./fields.js";
+import type {
+  MediaFieldOptions,
+  MediaListFieldOptions,
+  MediaValue,
+} from "./fields.js";
 import type { MediaFieldScope } from "./index.js";
-import { media } from "./fields.js";
+import { media, mediaList } from "./fields.js";
 import { media as mediaPlugin } from "./index.js";
 
 // Public type exports get a type-level smoke test so the package
@@ -18,6 +22,7 @@ import { media as mediaPlugin } from "./index.js";
 // shape at compile time, which is what we care about here.
 const _typeSurface: {
   readonly opts: MediaFieldOptions;
+  readonly listOpts: MediaListFieldOptions;
   readonly value: MediaValue;
   readonly scope: MediaFieldScope;
 } = {
@@ -25,6 +30,12 @@ const _typeSurface: {
     key: "hero",
     label: "Hero",
     accept: ["image/png"],
+  },
+  listOpts: {
+    key: "gallery",
+    label: "Gallery",
+    accept: "image/",
+    max: 12,
   },
   value: { id: "42", mime: "image/png", filename: "cat.png" },
   scope: { accept: "image/" },
@@ -114,6 +125,90 @@ describe("media() builder", () => {
         kind: "media",
         scope: { accept: "image/" },
         valueShape: "object",
+      },
+    });
+  });
+});
+
+describe("mediaList() builder", () => {
+  test("pins inputType + json type and emits a multi media referenceTarget", () => {
+    const field = mediaList({
+      key: "gallery",
+      label: "Gallery",
+      accept: "image/",
+      max: 6,
+    });
+    expect(field.inputType).toBe("mediaList");
+    expect(field.type).toBe("json");
+    expect(field.max).toBe(6);
+    expect(field.referenceTarget).toEqual({
+      kind: "media",
+      scope: { accept: "image/" },
+      valueShape: "object",
+      multiple: true,
+    });
+  });
+
+  test("supports unbounded max (no cap declared)", () => {
+    const field = mediaList({
+      key: "gallery",
+      label: "Gallery",
+    });
+    expect(field.max).toBeUndefined();
+    expect(field.referenceTarget).toEqual({
+      kind: "media",
+      scope: { accept: undefined },
+      valueShape: "object",
+      multiple: true,
+    });
+  });
+
+  test("rejects non-applicable options at the type level", () => {
+    mediaList({
+      key: "g",
+      label: "g",
+      // @ts-expect-error — placeholder doesn't apply to a reference field.
+      placeholder: "pick",
+    });
+
+    mediaList({
+      key: "g",
+      label: "g",
+      // @ts-expect-error — options belongs to select/radio.
+      options: [{ value: "a", label: "A" }],
+    });
+  });
+
+  test("manifest round-trip preserves multi referenceTarget + max on the wire shape", async () => {
+    const hooks = new HookRegistry();
+    const userPlugin = definePlugin("test", (ctx) => {
+      ctx.registerSettingsGroup("branding", {
+        label: "Branding",
+        fields: [
+          mediaList({
+            key: "carousel",
+            label: "Hero carousel",
+            accept: "image/",
+            max: 8,
+          }),
+        ],
+      });
+    });
+    const { registry } = await installPlugins({
+      hooks,
+      plugins: [mediaPlugin(), userPlugin],
+    });
+    const manifest = buildManifest(registry);
+    expect(manifest.settingsGroups[0]?.fields[0]).toMatchObject({
+      key: "carousel",
+      inputType: "mediaList",
+      type: "json",
+      max: 8,
+      referenceTarget: {
+        kind: "media",
+        scope: { accept: "image/" },
+        valueShape: "object",
+        multiple: true,
       },
     });
   });

--- a/packages/plugins/media/src/builder.ts
+++ b/packages/plugins/media/src/builder.ts
@@ -1,4 +1,8 @@
-import type { MediaMetaBoxField, MetaBoxFieldSpan } from "@plumix/core";
+import type {
+  MediaListMetaBoxField,
+  MediaMetaBoxField,
+  MetaBoxFieldSpan,
+} from "@plumix/core";
 
 import type { MediaFieldScope } from "./lookup.js";
 
@@ -59,6 +63,59 @@ export function media(options: MediaFieldOptions): MediaMetaBoxField {
     type: "json",
     inputType: "media",
     referenceTarget: { kind: "media", scope, valueShape: "object" },
+    required: options.required,
+    description: options.description,
+    default: options.default,
+    span: options.span,
+  };
+}
+
+/**
+ * Per-field options for the `mediaList()` builder. Multi-value
+ * counterpart to `media()` — same `accept` semantics, plus a `max`
+ * length cap. Storage is `MediaValue[]`.
+ */
+export interface MediaListFieldOptions {
+  readonly key: string;
+  readonly label: string;
+  readonly required?: boolean;
+  readonly description?: string;
+  readonly default?: readonly MediaValue[];
+  readonly span?: MetaBoxFieldSpan;
+  readonly accept?: string | readonly string[];
+  /** Max items allowed in the array. Omitted = unbounded. */
+  readonly max?: number;
+}
+
+/**
+ * Build a typed `mediaList` reference field — the multi-value
+ * counterpart to `media()`. Storage is `MediaValue[]` —
+ * `[{ id, mime?, filename? }, ...]`. The meta pipeline rewrites
+ * each entry's cached fields on every write so reads can render
+ * thumbnails without a per-item resolve round-trip.
+ *
+ * Picker stays open across selections (so authors can pick several
+ * without re-opening) and auto-stops when `max` is reached.
+ * Selected items render as a vertical list with up/down reorder
+ * and per-item removal; drag-reorder is deferred to a follow-up
+ * (see `MediaListPickerField`).
+ */
+export function mediaList(
+  options: MediaListFieldOptions,
+): MediaListMetaBoxField {
+  const scope: MediaFieldScope = { accept: options.accept };
+  return {
+    key: options.key,
+    label: options.label,
+    type: "json",
+    inputType: "mediaList",
+    referenceTarget: {
+      kind: "media",
+      scope,
+      valueShape: "object",
+      multiple: true,
+    },
+    max: options.max,
     required: options.required,
     description: options.description,
     default: options.default,

--- a/packages/plugins/media/src/fields.ts
+++ b/packages/plugins/media/src/fields.ts
@@ -4,5 +4,9 @@
 // package root. Mirrors the `plumix/fields` subpath convention from
 // core.
 
-export { media } from "./builder.js";
-export type { MediaFieldOptions, MediaValue } from "./builder.js";
+export { media, mediaList } from "./builder.js";
+export type {
+  MediaFieldOptions,
+  MediaListFieldOptions,
+  MediaValue,
+} from "./builder.js";


### PR DESCRIPTION
## Summary

Multi-value counterpart to `media` — `mediaList({ accept?, max? })`. Storage is `MediaValue[]` riding the cached-object pipeline shipped in #139.

- **Core**: `MediaListMetaBoxField` variant + restored multi+object validator path (input shape support in `referenceIdsForValidation` + array-aware normalize step in `validateMetaReferences`). The branch was deliberately dropped in #139's review fixes — comes back here alongside its input-shape sibling.
- **Plugin**: `mediaList()` builder via `@plumix/plugin-media/fields`. `MediaListPickerField` admin renderer with up/down/remove buttons + "Add more" modal hosting MediaLibrary in picker mode. Picker stays open across selections, auto-closes at `max`.
- **Cached-storage rendering**: strip preview reads `{ id, mime, filename }` directly — zero resolve roundtrips per row.
- **Drag-reorder deferred**: exposing dnd-kit as a shared runtime module to plugin chunks is its own slice; up/down buttons satisfy "keyboard reorder" for v0.1.

## Test plan

- [x] core 1139 tests (+6 multi-object pipeline) / admin 155 / plugin-media 90 (+4 builder)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm knip`, `pnpm commitlint` clean
- [ ] Sentry skills review (running)
- [ ] e2e for picker flow (follow-up alongside the dnd-kit runtime work)

Closes #132