### PR TITLE
feat: repeater meta-box field (#133)

### DIFF
--- a/packages/admin/src/components/meta-box/meta-box-field.test.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.test.tsx
@@ -632,3 +632,98 @@ describe("MetaBoxField dispatcher", () => {
     consoleError.mockRestore();
   });
 });
+
+describe("MetaBoxField — repeater dispatch", () => {
+  function repeaterField(
+    overrides?: Partial<MetaBoxFieldManifestEntry>,
+  ): MetaBoxFieldManifestEntry {
+    return field({
+      key: "links",
+      label: "Links",
+      type: "json",
+      inputType: "repeater",
+      subFields: [
+        { key: "label", label: "Label", type: "string", inputType: "text" },
+        { key: "href", label: "URL", type: "string", inputType: "url" },
+      ],
+      ...overrides,
+    });
+  }
+
+  test("renders empty placeholder + Add row button when value is missing", () => {
+    render(<Harness fieldDef={repeaterField()} initial={undefined} />);
+    expect(
+      screen.getByTestId("meta-box-field-links-input-empty"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("meta-box-field-links-input-add"),
+    ).toBeInTheDocument();
+  });
+
+  test("Add row appends a row whose subfields render via the same dispatcher", async () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        fieldDef={repeaterField()}
+        initial={[]}
+        onChangeSpy={onChange}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("meta-box-field-links-input-add"));
+    // Row 0's subfields render with dot-pathed names through the
+    // recursive dispatcher.
+    expect(
+      screen.getByTestId("meta-box-field-label-input"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("meta-box-field-href-input")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith([{ label: null, href: null }]);
+  });
+
+  test("typing into a subfield writes to the form's nested path", async () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        fieldDef={repeaterField()}
+        initial={[{ label: "", href: "" }]}
+        onChangeSpy={onChange}
+      />,
+    );
+    await userEvent.type(
+      screen.getByTestId("meta-box-field-label-input"),
+      "Home",
+    );
+    expect(onChange).toHaveBeenLastCalledWith([{ label: "Home", href: "" }]);
+  });
+
+  test("max bound disables Add row at capacity", () => {
+    render(
+      <Harness
+        fieldDef={repeaterField({ max: 1 })}
+        initial={[{ label: "", href: "" }]}
+      />,
+    );
+    expect(screen.getByTestId("meta-box-field-links-input-add")).toBeDisabled();
+  });
+
+  test("count display shows current / min / max", () => {
+    render(
+      <Harness
+        fieldDef={repeaterField({ min: 1, max: 3 })}
+        initial={[
+          { label: "", href: "" },
+          { label: "", href: "" },
+        ]}
+      />,
+    );
+    expect(
+      screen.getByTestId("meta-box-field-links-input-count"),
+    ).toHaveTextContent("2 / min 1 / max 3");
+  });
+
+  test("non-array initial value renders empty (defensive normalize)", () => {
+    render(<Harness fieldDef={repeaterField()} initial="not an array" />);
+    expect(
+      screen.getByTestId("meta-box-field-links-input-empty"),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/meta-box/meta-box-field.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.tsx
@@ -22,6 +22,7 @@ import { TiptapEditor } from "../editor/tiptap-editor.js";
 import { MultiReferencePicker } from "./multi-reference-picker.js";
 import { PluginFieldErrorBoundary } from "./plugin-field-error-boundary.js";
 import { ReferencePicker } from "./reference-picker.js";
+import { RepeaterField } from "./repeater-field.js";
 
 // Schema-driven field renderer wired to react-hook-form. Each meta-box
 // field becomes a shadcn `FormField` under the supplied `name` path so
@@ -266,6 +267,20 @@ function renderNativeInput({
     );
   }
 
+  if (field.inputType === "repeater") {
+    // Repeater check ahead of reference-target branches: a hand-rolled
+    // manifest literal that smuggled both `inputType: "repeater"` and
+    // `referenceTarget` would otherwise route to MultiReferencePicker.
+    return (
+      <RepeaterField
+        field={field}
+        rhf={rhf}
+        disabled={disabled}
+        testId={testId}
+      />
+    );
+  }
+
   if (field.referenceTarget?.multiple === true) {
     const value = Array.isArray(rhf.value)
       ? rhf.value.filter((v): v is string => typeof v === "string")
@@ -470,7 +485,7 @@ function renderNativeInput({
     // dev tools. A future `customRenderers` seam will hook in here
     // before the fallback.
     console.warn(
-      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/password/date/datetime/time/color/range/multiselect/json/richtext/user/userList/entry/entryList/term/termList/select/radio/checkbox).`,
+      `[plumix] unknown meta-box field inputType "${field.inputType}" — falling back to text input. Register a custom renderer or use a built-in type (text/textarea/number/email/url/password/date/datetime/time/color/range/multiselect/json/richtext/repeater/user/userList/entry/entryList/term/termList/select/radio/checkbox).`,
     );
   }
 

--- a/packages/admin/src/components/meta-box/repeater-field.tsx
+++ b/packages/admin/src/components/meta-box/repeater-field.tsx
@@ -1,0 +1,165 @@
+import type { ReactNode } from "react";
+import type { ControllerRenderProps, FieldValues } from "react-hook-form";
+import { useId } from "react";
+import { Button } from "@/components/ui/button.js";
+import { SortableList } from "@/components/ui/sortable.js";
+import { PlusIcon } from "lucide-react";
+
+import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
+
+import { MetaBoxField } from "./meta-box-field.js";
+
+// Row ids are index-derived. dnd-kit only needs stability within a single
+// drag; controlled subfields live at `${rowName}.${subKey}` in RHF state, so
+// React identity at row level matters only for uncontrolled state (focus,
+// selection). Accepting an occasional focus shift on reorder beats the
+// impurity of mint-on-render.
+
+interface RepeaterRow {
+  readonly id: string;
+  readonly index: number;
+}
+
+// Render-side tolerance for malformed rows from migration / hand-edited
+// DB rows. Bad rows drop from display but the validator still rejects
+// them on save, surfacing the error to the author at write time.
+function asRows(raw: unknown): readonly Record<string, unknown>[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (r): r is Record<string, unknown> =>
+      typeof r === "object" && r !== null && !Array.isArray(r),
+  );
+}
+
+export function RepeaterField({
+  field,
+  rhf,
+  disabled,
+  testId,
+}: {
+  readonly field: MetaBoxFieldManifestEntry;
+  readonly rhf: ControllerRenderProps<FieldValues, string>;
+  readonly disabled: boolean;
+  readonly testId: string;
+}): ReactNode {
+  const subFields = field.subFields ?? [];
+  const max = typeof field.max === "number" ? field.max : undefined;
+  const min = typeof field.min === "number" ? field.min : undefined;
+  const rows = asRows(rhf.value);
+  const idPrefix = useId();
+
+  const atMax = max !== undefined && rows.length >= max;
+  const items: readonly RepeaterRow[] = rows.map((_, i) => ({
+    id: `${idPrefix}-r${i}`,
+    index: i,
+  }));
+
+  // onChange-only — match MultiReferencePicker / ReferencePicker. Calling
+  // onBlur on every Add/Remove/Reorder would mark the field touched in
+  // `mode: "onTouched"` forms, surfacing required-field errors on a
+  // freshly-Added blank row before the user types anything.
+  const commit = (nextRows: readonly Record<string, unknown>[]): void => {
+    rhf.onChange(nextRows);
+  };
+
+  const handleReorder = (next: readonly RepeaterRow[]): void => {
+    commit(next.map((n) => rows[n.index] ?? {}));
+  };
+
+  const handleRemove = (id: string): void => {
+    const idx = items.findIndex((it) => it.id === id);
+    if (idx === -1) return;
+    const nextRows = [...rows];
+    nextRows.splice(idx, 1);
+    commit(nextRows);
+  };
+
+  const handleAdd = (): void => {
+    if (atMax) return;
+    const blank: Record<string, unknown> = {};
+    for (const sf of subFields) {
+      blank[sf.key] = sf.default ?? null;
+    }
+    commit([...rows, blank]);
+  };
+
+  return (
+    <div
+      data-testid={testId}
+      className="border-input flex flex-col gap-2 rounded-md border p-2"
+    >
+      {rows.length === 0 ? (
+        <p
+          className="text-muted-foreground text-sm"
+          data-testid={`${testId}-empty`}
+        >
+          No rows
+        </p>
+      ) : (
+        <SortableList
+          items={items}
+          onReorder={handleReorder}
+          onRemove={disabled ? undefined : handleRemove}
+          disabled={disabled}
+          testId={`${testId}-list`}
+          renderItem={(item) => (
+            <RepeaterRowFields
+              subFields={subFields}
+              rowName={`${rhf.name}.${item.index}`}
+              disabled={disabled}
+              testId={`${testId}-row-${item.index}`}
+            />
+          )}
+        />
+      )}
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || atMax}
+          onClick={handleAdd}
+          data-testid={`${testId}-add`}
+        >
+          <PlusIcon className="size-4" />
+          {rows.length === 0 ? "Add row" : "Add another"}
+        </Button>
+        {max !== undefined || min !== undefined ? (
+          <span
+            className="text-muted-foreground text-xs"
+            data-testid={`${testId}-count`}
+          >
+            {rows.length}
+            {min !== undefined ? ` / min ${min}` : ""}
+            {max !== undefined ? ` / max ${max}` : ""}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function RepeaterRowFields({
+  subFields,
+  rowName,
+  disabled,
+  testId,
+}: {
+  readonly subFields: readonly MetaBoxFieldManifestEntry[];
+  readonly rowName: string;
+  readonly disabled: boolean;
+  readonly testId: string;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-2" data-testid={testId}>
+      {subFields.map((sf) => (
+        <MetaBoxField
+          key={sf.key}
+          field={sf}
+          name={`${rowName}.${sf.key}`}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/admin/src/lib/plugin-registry.ts
+++ b/packages/admin/src/lib/plugin-registry.ts
@@ -104,6 +104,7 @@ const RESERVED_INPUT_TYPES: ReadonlySet<string> = new Set([
   "multiselect",
   "json",
   "richtext",
+  "repeater",
   "select",
   "radio",
   "checkbox",

--- a/packages/core/src/plugin/fields/builders.test.ts
+++ b/packages/core/src/plugin/fields/builders.test.ts
@@ -18,10 +18,12 @@ import {
   password,
   radio,
   range,
+  repeater,
   richtext,
   select,
   term,
   termList,
+  text,
   textarea,
   time,
   url,
@@ -1043,5 +1045,128 @@ describe("richtext() builder", () => {
       nodes: ["heading"],
       blocks: ["my-block"],
     });
+  });
+});
+
+describe("repeater() builder", () => {
+  test("pins inputType + json type and carries subFields, min, max", () => {
+    const field = repeater({
+      key: "links",
+      label: "Links",
+      min: 1,
+      max: 5,
+      subFields: [
+        text({ key: "label", label: "Label" }),
+        text({ key: "href", label: "URL" }),
+      ],
+    });
+    expect(field.inputType).toBe("repeater");
+    expect(field.type).toBe("json");
+    expect(field.min).toBe(1);
+    expect(field.max).toBe(5);
+    expect(field.subFields).toHaveLength(2);
+    expect(field.subFields[0]).toMatchObject({
+      key: "label",
+      inputType: "text",
+    });
+    expect(field.subFields[1]).toMatchObject({
+      key: "href",
+      inputType: "text",
+    });
+  });
+
+  test("rejects subField keys that risk prototype pollution", () => {
+    expect(() =>
+      repeater({
+        key: "rows",
+        label: "Rows",
+        subFields: [text({ key: "__proto__", label: "Bad" })],
+      }),
+    ).toThrow(/forbidden/);
+    expect(() =>
+      repeater({
+        key: "rows",
+        label: "Rows",
+        subFields: [text({ key: "constructor", label: "Bad" })],
+      }),
+    ).toThrow(/forbidden/);
+  });
+
+  test("rejects a subField key that doesn't match the meta-key shape", () => {
+    expect(() =>
+      repeater({
+        key: "rows",
+        label: "Rows",
+        subFields: [text({ key: "with space", label: "Bad" })],
+      }),
+    ).toThrow(/must match/);
+  });
+
+  test("rejects duplicate subField keys at registration time", () => {
+    expect(() =>
+      repeater({
+        key: "rows",
+        label: "Rows",
+        subFields: [
+          text({ key: "label", label: "Label" }),
+          text({ key: "label", label: "Other" }),
+        ],
+      }),
+    ).toThrow(/declares subField "label" more than once/);
+  });
+
+  test("rejects a nested repeater at registration time", () => {
+    expect(() =>
+      repeater({
+        key: "outer",
+        label: "Outer",
+        subFields: [
+          repeater({
+            key: "inner",
+            label: "Inner",
+            subFields: [text({ key: "v", label: "Value" })],
+          }),
+        ],
+      }),
+    ).toThrow(/nested repeater/i);
+  });
+
+  test("manifest round-trip recurses subFields with sanitize stripped + span dropped", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("test", (ctx) => {
+      ctx.registerSettingsGroup("blog", {
+        label: "Blog",
+        fields: [
+          repeater({
+            key: "links",
+            label: "Links",
+            subFields: [
+              text({ key: "label", label: "Label", maxLength: 80 }),
+              text({ key: "href", label: "URL" }),
+            ],
+          }),
+        ],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    const entry = manifest.settingsGroups[0]?.fields[0];
+    expect(entry).toMatchObject({
+      key: "links",
+      inputType: "repeater",
+      type: "json",
+    });
+    expect(entry?.subFields).toHaveLength(2);
+    expect(entry?.subFields?.[0]).toMatchObject({
+      key: "label",
+      inputType: "text",
+      maxLength: 80,
+    });
+    // Sanitize callbacks (and any function values) are not on the wire.
+    for (const sf of entry?.subFields ?? []) {
+      for (const v of Object.values(sf)) {
+        expect(typeof v).not.toBe("function");
+      }
+    }
   });
 });

--- a/packages/core/src/plugin/fields/index.ts
+++ b/packages/core/src/plugin/fields/index.ts
@@ -39,6 +39,8 @@ export { json } from "./json.js";
 export type { JsonFieldOptions } from "./json.js";
 export { richtext } from "./richtext.js";
 export type { RichtextFieldOptions } from "./richtext.js";
+export { repeater } from "./repeater.js";
+export type { RepeaterFieldOptions } from "./repeater.js";
 export { select } from "./select.js";
 export type { SelectFieldOptions } from "./select.js";
 export { radio } from "./radio.js";

--- a/packages/core/src/plugin/fields/repeater-validate.test.ts
+++ b/packages/core/src/plugin/fields/repeater-validate.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "vitest";
+
+import type { MetaBoxField } from "../manifest.js";
+import {
+  RepeaterValidationError,
+  walkRepeaterRows,
+} from "./repeater-validate.js";
+
+// Minimal subfield builder — full builder helpers live in `text.ts`
+// etc., but tests only need the shape (`key`, `inputType`, `type`,
+// optional `sanitize`). Building inline keeps tests self-contained
+// and lets each suite assert exactly the sanitize behavior it wants.
+function stubField(opts: {
+  key: string;
+  inputType?: string;
+  sanitize?: (v: unknown) => unknown;
+}): MetaBoxField {
+  return {
+    key: opts.key,
+    label: opts.key,
+    type: "string",
+    inputType: opts.inputType ?? "text",
+    sanitize: opts.sanitize,
+  };
+}
+
+describe("walkRepeaterRows — passthrough", () => {
+  test("null and undefined pass through unchanged", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })]);
+    expect(validate(null)).toBeNull();
+    expect(validate(undefined)).toBeUndefined();
+  });
+
+  test("returns a fresh array — doesn't mutate input", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })]);
+    const input = [{ x: "a" }];
+    const out = validate(input) as unknown[];
+    expect(out).not.toBe(input);
+    expect(out).toEqual([{ x: "a" }]);
+  });
+});
+
+describe("walkRepeaterRows — empty-row stripping", () => {
+  test("drops rows where every declared subfield is null/undefined/empty", () => {
+    const validate = walkRepeaterRows([
+      stubField({ key: "label" }),
+      stubField({ key: "href" }),
+    ]);
+    const out = validate([
+      { label: "First", href: "/" },
+      { label: "", href: null },
+      { label: "Second", href: "/two" },
+      {},
+    ]);
+    expect(out).toEqual([
+      { label: "First", href: "/" },
+      { label: "Second", href: "/two" },
+    ]);
+  });
+
+  test("a row with at least one non-empty subfield survives", () => {
+    const validate = walkRepeaterRows([
+      stubField({ key: "label" }),
+      stubField({ key: "href" }),
+    ]);
+    const out = validate([{ label: "Just a label", href: "" }]);
+    expect(out).toEqual([{ label: "Just a label", href: "" }]);
+  });
+
+  test("strips extraneous keys not declared in subFields", () => {
+    const validate = walkRepeaterRows([stubField({ key: "label" })]);
+    const out = validate([{ label: "x", smuggled: "should not survive" }]);
+    expect(out).toEqual([{ label: "x" }]);
+  });
+});
+
+describe("walkRepeaterRows — min / max enforcement", () => {
+  test("below min throws below_min after stripping", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })], { min: 2 });
+    expect(() => validate([{ x: "a" }, { x: "" }])).toThrow(
+      RepeaterValidationError,
+    );
+    try {
+      validate([{ x: "a" }, { x: "" }]);
+    } catch (err) {
+      expect((err as RepeaterValidationError).reason).toBe("below_min");
+    }
+  });
+
+  test("above max throws above_max", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })], { max: 1 });
+    expect(() => validate([{ x: "a" }, { x: "b" }])).toThrow(
+      RepeaterValidationError,
+    );
+    try {
+      validate([{ x: "a" }, { x: "b" }]);
+    } catch (err) {
+      expect((err as RepeaterValidationError).reason).toBe("above_max");
+    }
+  });
+
+  test("min counts only non-empty rows (stripped rows don't count)", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })], { min: 1 });
+    expect(() => validate([{ x: "" }, {}])).toThrow(RepeaterValidationError);
+    expect(() => validate([{ x: "real" }, {}])).not.toThrow();
+  });
+
+  test("zero rows allowed when no min set", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })]);
+    expect(validate([])).toEqual([]);
+  });
+});
+
+describe("walkRepeaterRows — subfield sanitize dispatch", () => {
+  test("runs each subfield's sanitize callback per row", () => {
+    const calls: string[] = [];
+    const validate = walkRepeaterRows([
+      stubField({
+        key: "label",
+        sanitize: (v) => {
+          calls.push(`label:${String(v)}`);
+          return typeof v === "string" ? v.trim() : v;
+        },
+      }),
+    ]);
+    const out = validate([{ label: "  spaced  " }, { label: "tight" }]);
+    expect(out).toEqual([{ label: "spaced" }, { label: "tight" }]);
+    expect(calls).toEqual(["label:  spaced  ", "label:tight"]);
+  });
+
+  test("subfield sanitize throw → subfield_invalid with row+key path", () => {
+    const validate = walkRepeaterRows([
+      stubField({
+        key: "href",
+        sanitize: (v) => {
+          if (typeof v === "string" && v.startsWith("javascript:")) {
+            throw new Error("unsafe scheme");
+          }
+          return v;
+        },
+      }),
+    ]);
+    try {
+      validate([{ href: "https://ok" }, { href: "javascript:alert(1)" }]);
+    } catch (err) {
+      const e = err as RepeaterValidationError;
+      expect(e.reason).toBe("subfield_invalid");
+      expect(e.path).toBe("[1].href");
+      expect(e.message).toContain("unsafe scheme");
+      return;
+    }
+    throw new Error("expected throw");
+  });
+
+  test("missing subfield key in input passes undefined into the row (and is treated empty)", () => {
+    const validate = walkRepeaterRows([
+      stubField({ key: "label" }),
+      stubField({ key: "href" }),
+    ]);
+    const out = validate([{ label: "x" }]);
+    expect(out).toEqual([{ label: "x", href: undefined }]);
+  });
+});
+
+describe("walkRepeaterRows — shape errors", () => {
+  test("non-array root throws invalid_shape", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })]);
+    expect(() => validate("nope")).toThrow(RepeaterValidationError);
+    expect(() => validate({ rows: [] })).toThrow(RepeaterValidationError);
+    expect(() => validate(42)).toThrow(RepeaterValidationError);
+  });
+
+  test("non-object row throws invalid_shape with [i] pointer", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })]);
+    try {
+      validate([{ x: "a" }, "not a row", { x: "b" }]);
+    } catch (err) {
+      const e = err as RepeaterValidationError;
+      expect(e.reason).toBe("invalid_shape");
+      expect(e.path).toBe("[1]");
+      return;
+    }
+    throw new Error("expected throw");
+  });
+
+  test("array-shaped row rejected as invalid_shape", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })]);
+    expect(() => validate([["nope"]])).toThrow(RepeaterValidationError);
+  });
+
+  test("input exceeding the hard row cap rejects with invalid_shape", () => {
+    const validate = walkRepeaterRows([stubField({ key: "x" })]);
+    const tooMany = Array.from({ length: 1001 }, () => ({ x: "a" }));
+    expect(() => validate(tooMany)).toThrow(RepeaterValidationError);
+    try {
+      validate(tooMany);
+    } catch (err) {
+      const e = err as RepeaterValidationError;
+      expect(e.reason).toBe("invalid_shape");
+      expect(e.message).toMatch(/exceeds/);
+    }
+  });
+});

--- a/packages/core/src/plugin/fields/repeater-validate.test.ts
+++ b/packages/core/src/plugin/fields/repeater-validate.test.ts
@@ -131,22 +131,22 @@ describe("walkRepeaterRows — subfield sanitize dispatch", () => {
   test("subfield sanitize throw → subfield_invalid with row+key path", () => {
     const validate = walkRepeaterRows([
       stubField({
-        key: "href",
+        key: "rating",
         sanitize: (v) => {
-          if (typeof v === "string" && v.startsWith("javascript:")) {
-            throw new Error("unsafe scheme");
+          if (typeof v === "number" && (v < 0 || v > 5)) {
+            throw new Error("out of range");
           }
           return v;
         },
       }),
     ]);
     try {
-      validate([{ href: "https://ok" }, { href: "javascript:alert(1)" }]);
+      validate([{ rating: 3 }, { rating: 99 }]);
     } catch (err) {
       const e = err as RepeaterValidationError;
       expect(e.reason).toBe("subfield_invalid");
-      expect(e.path).toBe("[1].href");
-      expect(e.message).toContain("unsafe scheme");
+      expect(e.path).toBe("[1].rating");
+      expect(e.message).toContain("out of range");
       return;
     }
     throw new Error("expected throw");

--- a/packages/core/src/plugin/fields/repeater-validate.ts
+++ b/packages/core/src/plugin/fields/repeater-validate.ts
@@ -1,0 +1,121 @@
+// Empty rows are stripped before min/max bounds apply: blank rows are an
+// authoring affordance, not data the caller meant to persist. Reference
+// subfields inside rows skip the live-id check that top-level refs get
+// from validateMetaReferences — recursion into rows is a post-0.1 follow-up.
+
+import type { MetaBoxField } from "../manifest.js";
+
+interface RepeaterValidationOptions {
+  readonly min?: number;
+  readonly max?: number;
+}
+
+// Hard ceiling on row count regardless of field-level `max`. The 256 KiB
+// meta byte cap doesn't bound work pre-walk: a payload of N empty rows
+// allocates O(N) before the byte cap measures the post-strip output.
+// 1000 covers any realistic authoring (FAQ lists, link strips, gallery
+// captions); above that, the user has modeled the wrong abstraction.
+const MAX_REPEATER_ROWS = 1000;
+
+export function walkRepeaterRows(
+  subFields: readonly MetaBoxField[],
+  options: RepeaterValidationOptions = {},
+): (value: unknown) => unknown {
+  return (value) => {
+    if (value === null || value === undefined) return value;
+    if (!Array.isArray(value)) {
+      throw new RepeaterValidationError(
+        "invalid_shape",
+        "<root>",
+        "repeater value must be an array of rows",
+      );
+    }
+    if (value.length > MAX_REPEATER_ROWS) {
+      throw new RepeaterValidationError(
+        "invalid_shape",
+        "<root>",
+        `repeater input exceeds ${MAX_REPEATER_ROWS} rows`,
+      );
+    }
+    const rows: Record<string, unknown>[] = [];
+    value.forEach((rawRow, i) => {
+      if (
+        rawRow === null ||
+        typeof rawRow !== "object" ||
+        Array.isArray(rawRow)
+      ) {
+        throw new RepeaterValidationError(
+          "invalid_shape",
+          `[${i}]`,
+          "repeater row must be a plain object",
+        );
+      }
+      const inputRow = rawRow as Record<string, unknown>;
+      const next: Record<string, unknown> = {};
+      let hasValue = false;
+      for (const sf of subFields) {
+        const raw = inputRow[sf.key];
+        const sanitized = sf.sanitize
+          ? runSubSanitize(sf, raw, `[${i}].${sf.key}`)
+          : raw;
+        if (sanitized !== null && sanitized !== undefined && sanitized !== "") {
+          hasValue = true;
+        }
+        next[sf.key] = sanitized;
+      }
+      if (hasValue) rows.push(next);
+    });
+    if (options.min !== undefined && rows.length < options.min) {
+      throw new RepeaterValidationError(
+        "below_min",
+        "<root>",
+        `repeater requires at least ${options.min} non-empty row(s); got ${rows.length}`,
+      );
+    }
+    if (options.max !== undefined && rows.length > options.max) {
+      throw new RepeaterValidationError(
+        "above_max",
+        "<root>",
+        `repeater allows at most ${options.max} row(s); got ${rows.length}`,
+      );
+    }
+    return rows;
+  };
+}
+
+export class RepeaterValidationError extends Error {
+  readonly path: string;
+  readonly reason:
+    | "invalid_shape"
+    | "below_min"
+    | "above_max"
+    | "subfield_invalid";
+  constructor(
+    reason: RepeaterValidationError["reason"],
+    path: string,
+    message: string,
+  ) {
+    super(message);
+    this.path = path;
+    this.reason = reason;
+  }
+}
+
+function runSubSanitize(
+  field: MetaBoxField,
+  value: unknown,
+  path: string,
+): unknown {
+  // Caller gates on `field.sanitize` — cast is a type-narrowing shortcut.
+  const sanitize = field.sanitize as (v: unknown) => unknown;
+  try {
+    return sanitize(value);
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    throw new RepeaterValidationError(
+      "subfield_invalid",
+      path,
+      `repeater subfield "${field.key}" rejected value: ${detail}`,
+    );
+  }
+}

--- a/packages/core/src/plugin/fields/repeater.ts
+++ b/packages/core/src/plugin/fields/repeater.ts
@@ -1,0 +1,83 @@
+import type {
+  MetaBoxField,
+  MetaBoxFieldSpan,
+  RepeaterMetaBoxField,
+} from "../manifest.js";
+import { walkRepeaterRows } from "./repeater-validate.js";
+
+export interface RepeaterFieldOptions {
+  readonly key: string;
+  readonly label: string;
+  readonly required?: boolean;
+  readonly description?: string;
+  readonly default?: unknown;
+  readonly span?: MetaBoxFieldSpan;
+  readonly subFields: readonly MetaBoxField[];
+  readonly min?: number;
+  readonly max?: number;
+}
+
+// Mirrors `META_FIELD_KEY_RE` in plugin/context.ts. The top-level
+// registrar validates field keys against this regex but doesn't
+// recurse into subFields, so the repeater builder enforces it locally
+// — guards row-object shape and protects against duplicate-key clobber.
+const REPEATER_SUBFIELD_KEY_RE = /^[a-zA-Z0-9_:-]+$/;
+
+// `__proto__`/`constructor`/`prototype` match the key regex but writing
+// them into a fresh object literal mutates the prototype chain. Reject
+// at registration regardless of regex pass.
+const FORBIDDEN_SUBFIELD_KEYS: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+// Nested repeaters rejected at registration to keep v0.1 UX flat.
+// Subfield keys are also validated here for shape + uniqueness — the
+// top-level `assertMetaBoxFields` only walks the outer fields array.
+export function repeater(options: RepeaterFieldOptions): RepeaterMetaBoxField {
+  const seen = new Set<string>();
+  for (const sf of options.subFields) {
+    if (sf.inputType === "repeater") {
+      throw new Error(
+        `repeater("${options.key}") subFields contains a nested repeater ` +
+          `("${sf.key}"); nested repeaters are not supported in v0.1.`,
+      );
+    }
+    if (FORBIDDEN_SUBFIELD_KEYS.has(sf.key)) {
+      throw new Error(
+        `repeater("${options.key}") subField key "${sf.key}" is forbidden ` +
+          `(prototype-pollution risk).`,
+      );
+    }
+    if (!REPEATER_SUBFIELD_KEY_RE.test(sf.key)) {
+      throw new Error(
+        `repeater("${options.key}") subField key "${sf.key}" must match ` +
+          `${REPEATER_SUBFIELD_KEY_RE}.`,
+      );
+    }
+    if (seen.has(sf.key)) {
+      throw new Error(
+        `repeater("${options.key}") declares subField "${sf.key}" more than once.`,
+      );
+    }
+    seen.add(sf.key);
+  }
+  return {
+    key: options.key,
+    label: options.label,
+    type: "json",
+    inputType: "repeater",
+    subFields: options.subFields,
+    min: options.min,
+    max: options.max,
+    required: options.required,
+    description: options.description,
+    default: options.default,
+    span: options.span,
+    sanitize: walkRepeaterRows(options.subFields, {
+      min: options.min,
+      max: options.max,
+    }),
+  };
+}

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -510,6 +510,29 @@ export interface RichtextMetaBoxField extends MetaBoxFieldBase {
   readonly blocks?: readonly string[];
 }
 
+/**
+ * Flat list of structured rows. Each row carries the same fixed schema
+ * declared via `subFields`; mixed-row "flexible content" is explicitly
+ * out of scope (`registerBlock` covers that authoring need). Subfields
+ * may be any registered field type *except* another repeater — nesting
+ * is rejected at registration time so v0.1 doesn't ship recursive UX
+ * (lift later non-breakingly if a real use case appears).
+ *
+ * Storage rides on the `json` primitive so any JSON-serialisable row
+ * shape survives the wire. The auto-injected sanitizer drops rows
+ * where every subfield value is empty (`null` / `undefined` / `""`),
+ * then enforces optional `min` / `max` row counts. "Empty" is strictly
+ * those three: a row whose only populated subfield is `0` (number) or
+ * `false` (checkbox) survives — those are real values.
+ */
+export interface RepeaterMetaBoxField extends MetaBoxFieldBase {
+  readonly inputType: "repeater";
+  readonly type: "json";
+  readonly subFields: readonly MetaBoxField[];
+  readonly min?: number;
+  readonly max?: number;
+}
+
 /** Single-value dropdown picker; `options` is required. */
 export interface SelectMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "select";
@@ -584,6 +607,7 @@ export type MetaBoxField =
   | MediaMetaBoxField
   | MediaListMetaBoxField
   | RichtextMetaBoxField
+  | RepeaterMetaBoxField
   | SelectMetaBoxField
   | RadioMetaBoxField
   | CheckboxMetaBoxField
@@ -651,6 +675,7 @@ export type EntryMetaBoxField =
   | Omit<MediaMetaBoxField, "span">
   | Omit<MediaListMetaBoxField, "span">
   | Omit<RichtextMetaBoxField, "span">
+  | Omit<RepeaterMetaBoxField, "span">
   | Omit<SelectMetaBoxField, "span">
   | Omit<RadioMetaBoxField, "span">
   | Omit<CheckboxMetaBoxField, "span">
@@ -1182,6 +1207,13 @@ export interface MetaBoxFieldManifestEntry {
   readonly marks?: readonly string[];
   readonly nodes?: readonly string[];
   readonly blocks?: readonly string[];
+  /**
+   * Repeater subfield manifest, keyed positionally — same shape as a
+   * top-level field minus `span` (rows are full-width). Sanitize
+   * callbacks are stripped from the wire shape; the admin recurses
+   * through this list when rendering each row.
+   */
+  readonly subFields?: readonly EntryMetaBoxFieldManifestEntry[];
 }
 
 /**
@@ -2079,6 +2111,7 @@ interface MetaBoxFieldOptionView {
   readonly marks?: readonly string[];
   readonly nodes?: readonly string[];
   readonly blocks?: readonly string[];
+  readonly subFields?: readonly MetaBoxField[];
 }
 
 function toEntryMetaBoxFieldEntry(
@@ -2103,6 +2136,10 @@ function toEntryMetaBoxFieldEntry(
     marks: view.marks,
     nodes: view.nodes,
     blocks: view.blocks,
+    // Repeater subfields recurse through the same projection — the
+    // wire shape is uniform end to end, span dropped (rows are
+    // full-width), sanitize callbacks stripped (server-only).
+    subFields: view.subFields?.map((sf) => toEntryMetaBoxFieldEntry(sf)),
   };
 }
 


### PR DESCRIPTION
## Summary

Slice #133 — repeater meta-box field. Final v0.1 catalog item.

- `repeater()` builder: flat array of structured rows; `subFields` declares the per-row schema. Nested repeaters rejected at registration; subField keys validated for shape, uniqueness, and prototype-pollution-safe names.
- `walkRepeaterRows` server-side sanitizer (auto-injected): drops empty rows, enforces optional `min` / `max`, runs each subfield's own sanitize per row, hard `MAX_REPEATER_ROWS=1000` cap, JSON-path-pointer error reporting.
- Admin `RepeaterField` renderer: `SortableList` dnd-kit drag + keyboard reorder, Add / Remove, recursive `MetaBoxField` dispatch for subfields. Dispatch branch sits ahead of reference-target branches.

References inside repeater rows skip the live-id check + cached-object normalize (top-level only in v0.1) — separate follow-up issue to extend `validateMetaReferences` for nested refs in v0.2.

Closes #133.

## Test plan

- [x] Core builder tests (subFields carry-through, nested-repeater rejection, key validation, prototype-pollution rejection, manifest round-trip)
- [x] Validator tests (passthrough, empty-row stripping, extraneous-key drop, min/max enforcement, sanitize dispatch, row cap, shape errors)
- [x] Admin tests (empty placeholder, Add row, typed input writes nested path, max-bound, count display, defensive normalize)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing warnings unrelated)
- [x] `pnpm format` clean
- [x] `pnpm knip` clean
- [x] `pnpm test` clean (1180 tests)
- [x] `pnpm commitlint` clean
- [x] sentry-skills:code-review applied (drop `onBlur` from `commit`, refine asRows comment, document empty-row semantics, add subFields key uniqueness)
- [x] sentry-skills:find-bugs applied (subField key validation + prototype-pollution forbidden list, MAX_REPEATER_ROWS cap, dispatch ordering ahead of reference branches)
- [x] sentry-skills:code-simplifier applied (comment trimming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)