### PR TITLE
feat(plugin-menu): permalink helpers + entry/term-kind menu items (slice 2)

### DIFF
--- a/packages/core/src/route/permalink.test.ts
+++ b/packages/core/src/route/permalink.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, test } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import type { PluginRegistry } from "../plugin/manifest.js";
+import { HookRegistry } from "../hooks/registry.js";
+import { definePlugin } from "../plugin/define.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { installPlugins } from "../plugin/register.js";
+import { adminUser, createTestDb, factoriesFor } from "../test/index.js";
+import { buildEntryPermalink, buildTermArchiveUrl } from "./permalink.js";
+
+async function buildRegistry(
+  plugins: ReturnType<typeof definePlugin>[],
+): Promise<PluginRegistry> {
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  await installPlugins({ hooks, plugins, registry });
+  return registry;
+}
+
+function ctxFor(
+  db: Awaited<ReturnType<typeof createTestDb>>,
+  registry: PluginRegistry,
+): AppContext {
+  return { db, plugins: registry } as unknown as AppContext;
+}
+
+describe("buildEntryPermalink", () => {
+  test("non-hierarchical type: pure substitution, no DB hit", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    const url = await buildEntryPermalink(ctx, {
+      type: "post",
+      slug: "hello-world",
+    });
+    expect(url).toBe("/post/hello-world");
+  });
+
+  test("honors rewrite.slug as the base segment", async () => {
+    const registry = await buildRegistry([
+      definePlugin("shop", (ctx) => {
+        ctx.registerEntryType("product", {
+          label: "Products",
+          isPublic: true,
+          rewrite: { slug: "store" },
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildEntryPermalink(ctx, { type: "product", slug: "widget" }),
+    ).toBe("/store/widget");
+  });
+
+  test("returns null for isPublic: false types", async () => {
+    const registry = await buildRegistry([
+      definePlugin("internal", (ctx) => {
+        ctx.registerEntryType("hidden", { label: "Hidden", isPublic: false });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildEntryPermalink(ctx, { type: "hidden", slug: "x" }),
+    ).toBeNull();
+  });
+
+  test("returns null for unregistered types", async () => {
+    const registry = await buildRegistry([]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildEntryPermalink(ctx, { type: "ghost", slug: "x" }),
+    ).toBeNull();
+  });
+
+  test("non-hierarchical type ignores parentId for URL shape", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildEntryPermalink(ctx, {
+        type: "post",
+        slug: "child",
+        parentId: 7,
+      }),
+    ).toBe("/post/child");
+  });
+
+  test("hierarchical type with no parentId: just baseSlug + slug", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildEntryPermalink(ctx, {
+        type: "page",
+        slug: "about",
+        parentId: null,
+      }),
+    ).toBe("/page/about");
+  });
+
+  test("hierarchical type with parents: walks ancestor chain via CTE", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const factories = factoriesFor(db);
+    const author = await adminUser
+      .transient({ db })
+      .create({ email: "perm@example.test" });
+
+    const root = await factories.entry.create({
+      type: "page",
+      slug: "about",
+      title: "About",
+      authorId: author.id,
+      parentId: null,
+      status: "published",
+    });
+    const mid = await factories.entry.create({
+      type: "page",
+      slug: "team",
+      title: "Team",
+      authorId: author.id,
+      parentId: root.id,
+      status: "published",
+    });
+    const leaf = await factories.entry.create({
+      type: "page",
+      slug: "leadership",
+      title: "Leadership",
+      authorId: author.id,
+      parentId: mid.id,
+      status: "published",
+    });
+
+    const ctx = ctxFor(db, registry);
+    expect(
+      await buildEntryPermalink(ctx, {
+        type: leaf.type,
+        slug: leaf.slug,
+        parentId: leaf.parentId,
+      }),
+    ).toBe("/page/about/team/leadership");
+  });
+
+  test("ancestorSlugs option skips DB lookup", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    // parentId 9999 doesn't exist in DB — would fail if CTE was hit.
+    expect(
+      await buildEntryPermalink(
+        ctx,
+        { type: "page", slug: "leaf", parentId: 9999 },
+        { ancestorSlugs: ["root", "mid"] },
+      ),
+    ).toBe("/page/root/mid/leaf");
+  });
+
+  test("rewrite.isHierarchical: false flattens the URL even for hierarchical types", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+          rewrite: { slug: "page", isHierarchical: false },
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildEntryPermalink(
+        ctx,
+        { type: "page", slug: "leaf", parentId: 7 },
+        { ancestorSlugs: ["root"] },
+      ),
+    ).toBe("/page/leaf");
+  });
+
+  test("strips leading and trailing slashes from supplied segments", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", {
+          label: "Posts",
+          isPublic: true,
+          rewrite: { slug: "/blog/" },
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildEntryPermalink(ctx, { type: "post", slug: "/hello/" }),
+    ).toBe("/blog/hello");
+  });
+
+  test("splits internal slashes in segments rather than embedding them", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    // A slug stored with an embedded `/` (or traversal markers) gets
+    // normalized into separate segments, not embedded literally.
+    expect(await buildEntryPermalink(ctx, { type: "post", slug: "a/b" })).toBe(
+      "/post/a/b",
+    );
+    expect(await buildEntryPermalink(ctx, { type: "post", slug: "./.." })).toBe(
+      "/post",
+    );
+  });
+});
+
+describe("buildTermArchiveUrl", () => {
+  test("flat taxonomy: pure substitution", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("tag", {
+          label: "Tags",
+          isPublic: true,
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildTermArchiveUrl(ctx, { taxonomy: "tag", slug: "javascript" }),
+    ).toBe("/tag/javascript");
+  });
+
+  test("returns null for isPublic: false taxonomies", async () => {
+    const registry = await buildRegistry([
+      definePlugin("menu", (ctx) => {
+        ctx.registerTermTaxonomy("menu", { label: "Menus", isPublic: false });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildTermArchiveUrl(ctx, { taxonomy: "menu", slug: "primary" }),
+    ).toBeNull();
+  });
+
+  test("returns null for unregistered taxonomies", async () => {
+    const registry = await buildRegistry([]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildTermArchiveUrl(ctx, { taxonomy: "ghost", slug: "x" }),
+    ).toBeNull();
+  });
+
+  test("hierarchical taxonomy with parents: walks term chain", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("category", {
+          label: "Categories",
+          isPublic: true,
+          isHierarchical: true,
+          rewrite: { slug: "category", isHierarchical: true },
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const factories = factoriesFor(db);
+
+    const root = await factories.term.create({
+      taxonomy: "category",
+      slug: "news",
+      name: "News",
+    });
+    const leaf = await factories.term.create({
+      taxonomy: "category",
+      slug: "local",
+      name: "Local",
+      parentId: root.id,
+    });
+
+    const ctx = ctxFor(db, registry);
+    expect(
+      await buildTermArchiveUrl(ctx, {
+        taxonomy: leaf.taxonomy,
+        slug: leaf.slug,
+        parentId: leaf.parentId,
+      }),
+    ).toBe("/category/news/local");
+  });
+
+  test("honors taxonomy rewrite.slug override", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("category", {
+          label: "Categories",
+          isPublic: true,
+          rewrite: { slug: "topic" },
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      await buildTermArchiveUrl(ctx, { taxonomy: "category", slug: "news" }),
+    ).toBe("/topic/news");
+  });
+});

--- a/packages/core/src/route/permalink.ts
+++ b/packages/core/src/route/permalink.ts
@@ -1,0 +1,185 @@
+import { sql } from "drizzle-orm";
+
+import type { AppContext } from "../context/app.js";
+import type {
+  RegisteredEntryType,
+  RegisteredTermTaxonomy,
+} from "../plugin/manifest.js";
+
+/**
+ * Reverse of `compileRouteMap` — given an entry, produce its public URL.
+ * Symmetric to `match.ts` (URL → entity); used by sitemap, RSS, canonical
+ * tags, the menu plugin's resolver, and any reference-field "go to source"
+ * link.
+ *
+ * Non-hierarchical types: pure substitution into the registered rewrite
+ * pattern, no DB hit. Hierarchical types: one recursive CTE walks the
+ * `parent_id` chain and prepends each ancestor's slug. Pass
+ * `ancestorSlugs` to skip the CTE when the caller already has the chain
+ * loaded (e.g. a breadcrumb renderer that just walked it).
+ *
+ * Known gap: `compileRouteMap` currently emits `/<baseSlug>/:slug` (single
+ * segment) for every entry type, including hierarchical ones. The nested
+ * URLs this helper produces for hierarchical types won't match against
+ * the route map until that's updated to support a `:path+` capture for
+ * hierarchical types. Tracked as follow-up; non-hierarchical paths are
+ * symmetric today.
+ *
+ * Returns `null` when the entry type is `isPublic: false` (no public
+ * surface exists) or when the type isn't registered.
+ */
+export async function buildEntryPermalink(
+  ctx: AppContext,
+  entry: {
+    readonly type: string;
+    readonly slug: string;
+    readonly parentId?: number | null;
+  },
+  options?: { readonly ancestorSlugs?: readonly string[] },
+): Promise<string | null> {
+  const entryType = ctx.plugins.entryTypes.get(entry.type);
+  if (!entryType || entryType.isPublic === false) return null;
+
+  const baseSlug = entryTypeBaseSlug(entryType);
+  const parentId = entry.parentId ?? null;
+
+  if (!shouldNestUnderEntryParent(entryType, parentId)) {
+    return joinSegments([baseSlug, entry.slug]);
+  }
+
+  // shouldNestUnderEntryParent guarantees parentId is non-null here.
+  const ancestors =
+    options?.ancestorSlugs ?? (await loadAncestorSlugs(ctx, parentId));
+  return joinSegments([baseSlug, ...ancestors, entry.slug]);
+}
+
+/**
+ * Reverse routing for taxonomy archives. Same shape as
+ * `buildEntryPermalink` — pure substitution for flat taxonomies, single
+ * recursive CTE for hierarchical ones.
+ */
+export async function buildTermArchiveUrl(
+  ctx: AppContext,
+  term: {
+    readonly taxonomy: string;
+    readonly slug: string;
+    readonly parentId?: number | null;
+  },
+  options?: { readonly ancestorSlugs?: readonly string[] },
+): Promise<string | null> {
+  const taxonomy = ctx.plugins.termTaxonomies.get(term.taxonomy);
+  if (!taxonomy || taxonomy.isPublic === false) return null;
+
+  const baseSlug = termTaxonomyBaseSlug(taxonomy);
+  const parentId = term.parentId ?? null;
+
+  if (!shouldNestUnderTermParent(taxonomy, parentId)) {
+    return joinSegments([baseSlug, term.slug]);
+  }
+
+  const ancestors =
+    options?.ancestorSlugs ?? (await loadTermAncestorSlugs(ctx, parentId));
+  return joinSegments([baseSlug, ...ancestors, term.slug]);
+}
+
+function entryTypeBaseSlug(entryType: RegisteredEntryType): string {
+  return entryType.rewrite?.slug ?? entryType.name;
+}
+
+function termTaxonomyBaseSlug(taxonomy: RegisteredTermTaxonomy): string {
+  return taxonomy.rewrite?.slug ?? taxonomy.name;
+}
+
+function shouldNestUnderEntryParent(
+  entryType: RegisteredEntryType,
+  parentId: number | null,
+): parentId is number {
+  if (parentId === null) return false;
+  if (entryType.isHierarchical !== true) return false;
+  // `rewrite.isHierarchical: false` opts out of nested URLs even when the
+  // type itself is hierarchical (matches WP's `rewrite => ['hierarchical' => false]`).
+  return entryType.rewrite?.isHierarchical !== false;
+}
+
+function shouldNestUnderTermParent(
+  taxonomy: RegisteredTermTaxonomy,
+  parentId: number | null,
+): parentId is number {
+  if (parentId === null) return false;
+  if (taxonomy.isHierarchical !== true) return false;
+  return taxonomy.rewrite?.isHierarchical !== false;
+}
+
+/**
+ * Build a URL pathname from segment-shaped inputs. Splits on internal `/`
+ * (so a slug stored as `"a/b"` produces two segments rather than embedding
+ * the slash literally and shadowing a sibling route), drops empty parts
+ * and `.` / `..` traversal markers.
+ */
+function joinSegments(
+  segments: readonly (string | null | undefined)[],
+): string {
+  const parts: string[] = [];
+  for (const segment of segments) {
+    if (typeof segment !== "string" || segment.length === 0) continue;
+    for (const part of segment.split("/")) {
+      const trimmed = part.trim();
+      if (trimmed.length === 0 || trimmed === "." || trimmed === "..") continue;
+      parts.push(trimmed);
+    }
+  }
+  return "/" + parts.join("/");
+}
+
+interface SlugRow {
+  readonly slug: string;
+}
+
+// `parent_id` is a self-FK with no DB-level cycle prevention. Cap recursion
+// depth so a malformed chain (a→b, b→a) returns truncated rather than
+// hitting SQLite's default 1000-deep limit and bubbling as a 500. Real
+// content trees stay well under 50 levels.
+const MAX_ANCESTOR_DEPTH = 50;
+
+/**
+ * One round-trip ancestor lookup via SQLite recursive CTE. Walks the
+ * `entries.parent_id` chain starting from `leafParentId`, returning slugs
+ * ordered root-first.
+ */
+async function loadAncestorSlugs(
+  ctx: AppContext,
+  leafParentId: number,
+): Promise<string[]> {
+  const rows = await ctx.db.all<SlugRow>(sql`
+    WITH RECURSIVE chain(id, parent_id, slug, depth) AS (
+      SELECT id, parent_id, slug, 0
+      FROM entries
+      WHERE id = ${leafParentId}
+      UNION ALL
+      SELECT e.id, e.parent_id, e.slug, c.depth + 1
+      FROM entries e JOIN chain c ON e.id = c.parent_id
+      WHERE c.depth < ${MAX_ANCESTOR_DEPTH}
+    )
+    SELECT slug FROM chain ORDER BY depth DESC
+  `);
+  return rows.map((r) => r.slug);
+}
+
+async function loadTermAncestorSlugs(
+  ctx: AppContext,
+  leafParentId: number,
+): Promise<string[]> {
+  const rows = await ctx.db.all<SlugRow>(sql`
+    WITH RECURSIVE chain(id, parent_id, slug, depth) AS (
+      SELECT id, parent_id, slug, 0
+      FROM terms
+      WHERE id = ${leafParentId}
+      UNION ALL
+      SELECT t.id, t.parent_id, t.slug, c.depth + 1
+      FROM terms t JOIN chain c ON t.id = c.parent_id
+      WHERE c.depth < ${MAX_ANCESTOR_DEPTH}
+    )
+    SELECT slug FROM chain ORDER BY depth DESC
+  `);
+  return rows.map((r) => r.slug);
+}

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -1,6 +1,7 @@
 import "./hooks.js";
 
 export { authenticated } from "./authenticated.js";
+export { registerCoreLookupAdapters } from "./procedures/lookup-adapters.js";
 export { base } from "./base.js";
 export type { Base } from "./base.js";
 export { RPC_ERRORS } from "./errors.js";

--- a/packages/core/src/rpc/procedures/entry/lookup.ts
+++ b/packages/core/src/rpc/procedures/entry/lookup.ts
@@ -1,9 +1,11 @@
 import type { SQL } from "drizzle-orm";
 
+import type { AppContext } from "../../../context/app.js";
 import type { EntryFieldScope } from "../../../plugin/fields/entry.js";
 import type { LookupAdapter, LookupResult } from "../../../plugin/lookup.js";
 import { and, eq, inArray, like, ne } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
+import { buildEntryPermalink } from "../../../route/permalink.js";
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
@@ -13,7 +15,18 @@ const ENTRY_ROW_COLUMNS = {
   type: entries.type,
   title: entries.title,
   status: entries.status,
+  slug: entries.slug,
+  parentId: entries.parentId,
 } as const;
+
+interface EntryLookupRow {
+  readonly id: number;
+  readonly type: string;
+  readonly title: string;
+  readonly status: string;
+  readonly slug: string;
+  readonly parentId: number | null;
+}
 
 export const entryLookupAdapter: LookupAdapter<EntryFieldScope> = {
   async list(ctx, options) {
@@ -45,7 +58,7 @@ export const entryLookupAdapter: LookupAdapter<EntryFieldScope> = {
       .where(conditions.length === 0 ? undefined : and(...conditions))
       .orderBy(entries.title)
       .limit(limit);
-    return rows.map(toLookupResult);
+    return Promise.all(rows.map((row) => toLookupResult(ctx, row)));
   },
 
   async resolve(ctx, id, scope) {
@@ -56,7 +69,7 @@ export const entryLookupAdapter: LookupAdapter<EntryFieldScope> = {
       .from(entries)
       .where(buildEntryWhere(numericId, scope))
       .limit(1);
-    return row ? toLookupResult(row) : null;
+    return row ? toLookupResult(ctx, row) : null;
   },
 };
 
@@ -100,16 +113,28 @@ function clampLimit(requested: number | undefined): number {
   return Math.min(Math.floor(requested), MAX_LIST_LIMIT);
 }
 
-function toLookupResult(row: {
-  readonly id: number;
-  readonly type: string;
-  readonly title: string;
-  readonly status: string;
-}): LookupResult {
+async function toLookupResult(
+  ctx: AppContext,
+  row: EntryLookupRow,
+): Promise<LookupResult> {
   const trimmedTitle = row.title.trim();
+  const label = trimmedTitle !== "" ? trimmedTitle : `Untitled ${row.type}`;
+  // Resolve the public URL when the type has one; falls back to omitted
+  // `cached.href` for `isPublic: false` types (e.g. `menu_item`). The meta
+  // pipeline merges `cached.{label,href}` into stored meta on every write
+  // so consumers (menu plugin, reference fields) have last-known fallbacks
+  // when the linked entity is later deleted.
+  const href = await buildEntryPermalink(ctx, {
+    type: row.type,
+    slug: row.slug,
+    parentId: row.parentId,
+  });
+  const cached: Record<string, unknown> = { label };
+  if (href !== null) cached.href = href;
   return {
     id: String(row.id),
-    label: trimmedTitle !== "" ? trimmedTitle : `Untitled ${row.type}`,
+    label,
     subtitle: `${row.type} · ${row.status}`,
+    cached,
   };
 }

--- a/packages/core/src/rpc/procedures/term/lookup.ts
+++ b/packages/core/src/rpc/procedures/term/lookup.ts
@@ -1,9 +1,11 @@
 import type { SQL } from "drizzle-orm";
 
+import type { AppContext } from "../../../context/app.js";
 import type { TermFieldScope } from "../../../plugin/fields/term.js";
 import type { LookupAdapter, LookupResult } from "../../../plugin/lookup.js";
 import { and, eq, inArray, like, or } from "../../../db/index.js";
 import { terms } from "../../../db/schema/terms.js";
+import { buildTermArchiveUrl } from "../../../route/permalink.js";
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
@@ -13,7 +15,16 @@ const TERM_ROW_COLUMNS = {
   taxonomy: terms.taxonomy,
   name: terms.name,
   slug: terms.slug,
+  parentId: terms.parentId,
 } as const;
+
+interface TermLookupRow {
+  readonly id: number;
+  readonly taxonomy: string;
+  readonly name: string;
+  readonly slug: string;
+  readonly parentId: number | null;
+}
 
 export const termLookupAdapter: LookupAdapter<TermFieldScope> = {
   async list(ctx, options) {
@@ -50,7 +61,7 @@ export const termLookupAdapter: LookupAdapter<TermFieldScope> = {
       .where(conditions.length === 0 ? undefined : and(...conditions))
       .orderBy(terms.name)
       .limit(limit);
-    return rows.map(toLookupResult);
+    return Promise.all(rows.map((row) => toLookupResult(ctx, row)));
   },
 
   async resolve(ctx, id, scope) {
@@ -61,7 +72,7 @@ export const termLookupAdapter: LookupAdapter<TermFieldScope> = {
       .from(terms)
       .where(buildTermWhere(numericId, scope))
       .limit(1);
-    return row ? toLookupResult(row) : null;
+    return row ? toLookupResult(ctx, row) : null;
   },
 };
 
@@ -95,15 +106,25 @@ function clampLimit(requested: number | undefined): number {
   return Math.min(Math.floor(requested), MAX_LIST_LIMIT);
 }
 
-function toLookupResult(row: {
-  readonly id: number;
-  readonly taxonomy: string;
-  readonly name: string;
-  readonly slug: string;
-}): LookupResult {
+async function toLookupResult(
+  ctx: AppContext,
+  row: TermLookupRow,
+): Promise<LookupResult> {
+  // Same `cached.{label,href}` contract as the entry adapter — the meta
+  // pipeline merges these into stored meta on every write, giving menu
+  // items + reference fields a last-known fallback when the linked term
+  // is later deleted.
+  const href = await buildTermArchiveUrl(ctx, {
+    taxonomy: row.taxonomy,
+    slug: row.slug,
+    parentId: row.parentId,
+  });
+  const cached: Record<string, unknown> = { label: row.name };
+  if (href !== null) cached.href = href;
   return {
     id: String(row.id),
     label: row.name,
     subtitle: `${row.taxonomy} · ${row.slug}`,
+    cached,
   };
 }

--- a/packages/plugins/menu/src/server/getMenuByName.test.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.test.ts
@@ -1,6 +1,15 @@
+import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, test } from "vitest";
 
-import type { AppContext } from "@plumix/core";
+import type { AppContext, PluginRegistry } from "@plumix/core";
+import {
+  createPluginRegistry,
+  definePlugin,
+  entries as entriesTable,
+  HookRegistry,
+  installPlugins,
+  registerCoreLookupAdapters,
+} from "@plumix/core";
 import {
   adminUser,
   createTestDb,
@@ -12,10 +21,23 @@ import {
 import type { MenuItemMeta } from "./types.js";
 import { getMenuByName } from "./getMenuByName.js";
 
-// The resolver only reads `ctx.db`. Cast a partial test ctx since wiring
-// up a full AppContext is overkill for a pure-data integration test.
-function ctxFor(db: Awaited<ReturnType<typeof createTestDb>>): AppContext {
-  return { db } as unknown as AppContext;
+async function buildRegistry(
+  plugins: ReturnType<typeof definePlugin>[],
+): Promise<PluginRegistry> {
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  // Mirror runtime/app.ts: core adapters seed the registry before plugins
+  // install so the menu resolver can dispatch to `entry`/`term` adapters.
+  registerCoreLookupAdapters(registry);
+  await installPlugins({ hooks, plugins, registry });
+  return registry;
+}
+
+function ctxFor(
+  db: Awaited<ReturnType<typeof createTestDb>>,
+  registry: PluginRegistry,
+): AppContext {
+  return { db, plugins: registry } as unknown as AppContext;
 }
 
 interface SeedItemInput {
@@ -24,6 +46,32 @@ interface SeedItemInput {
   readonly sortOrder?: number;
   readonly parentId?: number | null;
   readonly status?: "draft" | "published" | "scheduled" | "trash";
+}
+
+// A registry that registers `menu` taxonomy plus a public `post` entry type
+// and `category` term taxonomy — the latter two so the entry/term lookup
+// adapters report results within scope. Built once per test for isolation.
+async function defaultRegistry(): Promise<PluginRegistry> {
+  return buildRegistry([
+    definePlugin("menu-test-host", (ctx) => {
+      ctx.registerEntryType("menu_item", {
+        label: "Menu items",
+        isHierarchical: true,
+        isPublic: false,
+        termTaxonomies: ["menu"],
+      });
+      ctx.registerTermTaxonomy("menu", {
+        label: "Menus",
+        isPublic: false,
+        entryTypes: ["menu_item"],
+      });
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerTermTaxonomy("category", {
+        label: "Categories",
+        isPublic: true,
+      });
+    }),
+  ]);
 }
 
 describe("getMenuByName", () => {
@@ -35,7 +83,8 @@ describe("getMenuByName", () => {
   beforeEach(async () => {
     db = await createTestDb();
     factories = factoriesFor(db);
-    ctx = ctxFor(db);
+    const registry = await defaultRegistry();
+    ctx = ctxFor(db, registry);
     const author = await adminUser
       .transient({ db })
       .create({ email: "menu-author@example.test" });
@@ -215,16 +264,191 @@ describe("getMenuByName", () => {
     expect(menu?.items.map((i) => i.label)).toEqual(["Healthy"]);
   });
 
-  test("drops kind='entry' and kind='term' items in slice 1 (deferred)", async () => {
+  test("resolves kind='entry' items via the entry lookup adapter", async () => {
+    const post = await factories.entry.create({
+      type: "post",
+      slug: "hello-world",
+      title: "Hello, world",
+      status: "published",
+      authorId,
+    });
+    const termId = await seedMenu("entry-kind");
+    await seedItems(termId, [
+      { title: "Stored title", meta: { kind: "entry", entryId: post.id } },
+    ]);
+
+    const menu = await getMenuByName(ctx, "entry-kind");
+    expect(menu?.items[0]).toMatchObject({
+      label: "Hello, world",
+      href: "/post/hello-world",
+      source: { kind: "entry", id: post.id },
+    });
+  });
+
+  test("renaming the linked entry propagates to the menu output without re-saving", async () => {
+    const post = await factories.entry.create({
+      type: "post",
+      slug: "first",
+      title: "First name",
+      status: "published",
+      authorId,
+    });
+    const termId = await seedMenu("rename");
+    await seedItems(termId, [
+      { title: "snapshot", meta: { kind: "entry", entryId: post.id } },
+    ]);
+
+    const before = await getMenuByName(ctx, "rename");
+    expect(before?.items[0]?.label).toBe("First name");
+
+    // Rename the source entry — no menu save in between.
+    await db
+      .update(entriesTable)
+      .set({ title: "New name", slug: "second" })
+      .where(eq(entriesTable.id, post.id));
+
+    const after = await getMenuByName(ctx, "rename");
+    expect(after?.items[0]?.label).toBe("New name");
+    expect(after?.items[0]?.href).toBe("/post/second");
+  });
+
+  test("resolves kind='term' items via the term lookup adapter", async () => {
+    const category = await factories.term.create({
+      taxonomy: "category",
+      slug: "news",
+      name: "News",
+    });
+    const termId = await seedMenu("term-kind");
+    await seedItems(termId, [
+      { title: "ignored", meta: { kind: "term", termId: category.id } },
+    ]);
+
+    const menu = await getMenuByName(ctx, "term-kind");
+    expect(menu?.items[0]).toMatchObject({
+      label: "News",
+      href: "/category/news",
+      source: { kind: "term", id: category.id },
+    });
+  });
+
+  test("drops entry items whose linked entry is deleted (broken ref)", async () => {
+    const termId = await seedMenu("broken-entry");
+    await seedItems(termId, [
+      { title: "Healthy", meta: { kind: "custom", url: "/h" } },
+      { title: "Dangling", meta: { kind: "entry", entryId: 999_999 } },
+    ]);
+
+    const menu = await getMenuByName(ctx, "broken-entry");
+    expect(menu?.items.map((i) => i.label)).toEqual(["Healthy"]);
+  });
+
+  test("drops entry items in trash status (excluded by adapter scope)", async () => {
+    const post = await factories.entry.create({
+      type: "post",
+      slug: "trashed-post",
+      title: "Trashed",
+      status: "trash",
+      authorId,
+    });
+    const termId = await seedMenu("trashed");
+    await seedItems(termId, [
+      { title: "ignored", meta: { kind: "entry", entryId: post.id } },
+    ]);
+
+    const menu = await getMenuByName(ctx, "trashed");
+    expect(menu?.items).toHaveLength(0);
+  });
+
+  test("drops entry items in draft / scheduled status (public-nav published-only filter)", async () => {
+    const draft = await factories.entry.create({
+      type: "post",
+      slug: "draft-post",
+      title: "Draft",
+      status: "draft",
+      authorId,
+    });
+    const scheduled = await factories.entry.create({
+      type: "post",
+      slug: "scheduled-post",
+      title: "Scheduled",
+      status: "scheduled",
+      authorId,
+    });
+    const termId = await seedMenu("unpublished");
+    await seedItems(termId, [
+      { title: "Draft", meta: { kind: "entry", entryId: draft.id } },
+      { title: "Scheduled", meta: { kind: "entry", entryId: scheduled.id } },
+    ]);
+
+    const menu = await getMenuByName(ctx, "unpublished");
+    expect(menu?.items).toHaveLength(0);
+  });
+
+  test("drops entry items linked to isPublic: false types", async () => {
+    // Register a private type via a one-off registry; menu_item itself is
+    // private so we link to one of those by id.
+    const privateRegistry = await buildRegistry([
+      definePlugin("private-host", (ctx) => {
+        ctx.registerEntryType("menu_item", {
+          label: "Menu items",
+          isHierarchical: true,
+          isPublic: false,
+          termTaxonomies: ["menu"],
+        });
+        ctx.registerTermTaxonomy("menu", {
+          label: "Menus",
+          isPublic: false,
+          entryTypes: ["menu_item"],
+        });
+      }),
+    ]);
+    const localCtx = ctxFor(db, privateRegistry);
+
+    // Seed a menu_item entry (private type) directly and then link to it.
+    const privateEntry = await factories.entry.create({
+      type: "menu_item",
+      slug: "x",
+      title: "private-target",
+      status: "published",
+      authorId,
+      meta: { kind: "custom", url: "/x" } as unknown as Record<string, unknown>,
+    });
+    const termId = await seedMenu("private-link");
+    await seedItems(termId, [
+      { title: "ignored", meta: { kind: "entry", entryId: privateEntry.id } },
+    ]);
+
+    const menu = await getMenuByName(localCtx, "private-link");
+    expect(menu?.items).toHaveLength(0);
+  });
+
+  test("mixed-kind menu: custom + entry + term resolve together in one render", async () => {
+    const post = await factories.entry.create({
+      type: "post",
+      slug: "p",
+      title: "Post",
+      status: "published",
+      authorId,
+    });
+    const tag = await factories.term.create({
+      taxonomy: "category",
+      slug: "t",
+      name: "Tag",
+    });
     const termId = await seedMenu("mixed");
     await seedItems(termId, [
-      { title: "Custom item", meta: { kind: "custom", url: "/c" } },
-      { title: "Entry item", meta: { kind: "entry", entryId: 999 } },
-      { title: "Term item", meta: { kind: "term", termId: 999 } },
+      { title: "Custom", meta: { kind: "custom", url: "/c" } },
+      { title: "ignored", meta: { kind: "entry", entryId: post.id } },
+      { title: "ignored", meta: { kind: "term", termId: tag.id } },
     ]);
 
     const menu = await getMenuByName(ctx, "mixed");
-    expect(menu?.items.map((i) => i.label)).toEqual(["Custom item"]);
+    expect(menu?.items.map((i) => i.label)).toEqual(["Custom", "Post", "Tag"]);
+    expect(menu?.items.map((i) => i.href)).toEqual([
+      "/c",
+      "/post/p",
+      "/category/t",
+    ]);
   });
 
   test("ignores entries of other types linked to the same term", async () => {

--- a/packages/plugins/menu/src/server/getMenuByName.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray } from "drizzle-orm";
 
-import type { AppContext } from "@plumix/core";
+import type { AppContext, LookupResult } from "@plumix/core";
 import { entries, entryTerm, terms } from "@plumix/core";
 
 import type { TreeNode } from "./buildTree.js";
@@ -17,14 +17,21 @@ interface MenuItemRow {
   readonly meta: Record<string, unknown>;
 }
 
+interface ResolvedRef {
+  readonly label: string;
+  readonly href: string;
+}
+
 /**
  * `name` is matched against `terms.slug` (NOT `terms.name`) — the parameter
  * name mirrors WordPress's `wp_get_nav_menu_object()`.
  *
- * Slice 1: only `kind: 'custom'` items resolve; `entry` and `term` items
- * (and their descendants) are dropped until slice 2 lands the permalink
- * helpers they depend on. Items with unparseable meta or unsafe URLs are
- * dropped the same way.
+ * Resolution at render time is live: entry/term refs go through the
+ * registered `LookupAdapter` per kind, batched by id, so a renamed page or
+ * retitled category propagates without re-saving the menu. Items whose
+ * ref fails to resolve (deleted, unpublished, scope-excluded) drop
+ * silently along with their descendants — mirrors how broken refs will
+ * be surfaced in admin from slice 11.
  */
 export async function getMenuByName(
   ctx: AppContext,
@@ -64,22 +71,120 @@ export async function getMenuByName(
     )
     .orderBy(entries.parentId, entries.sortOrder, entries.id);
 
+  const refs = await resolveRefs(ctx, rows);
   const { tree } = buildTree(rows);
   const items = tree
-    .map(toResolvedItem)
+    .map((node) => toResolvedItem(node, refs))
     .filter((item): item is ResolvedMenuItem => item !== null);
 
   return { termId: term.id, name: term.name, slug: term.slug, items };
 }
 
-function toResolvedItem(node: TreeNode<MenuItemRow>): ResolvedMenuItem | null {
+interface ResolvedRefs {
+  readonly entries: ReadonlyMap<number, ResolvedRef>;
+  readonly terms: ReadonlyMap<number, ResolvedRef>;
+}
+
+async function resolveRefs(
+  ctx: AppContext,
+  rows: readonly MenuItemRow[],
+): Promise<ResolvedRefs> {
+  const entryIds = new Set<number>();
+  const termIds = new Set<number>();
+  for (const row of rows) {
+    const meta = parseMenuItemMeta(row.meta);
+    if (meta?.kind === "entry") entryIds.add(meta.entryId);
+    else if (meta?.kind === "term") termIds.add(meta.termId);
+  }
+
+  const [entryRefs, termRefs] = await Promise.all([
+    entryIds.size === 0 ? new Map() : resolveEntryRefs(ctx, entryIds),
+    termIds.size === 0 ? new Map() : resolveTermRefs(ctx, termIds),
+  ]);
+  return { entries: entryRefs, terms: termRefs };
+}
+
+async function resolveEntryRefs(
+  ctx: AppContext,
+  ids: ReadonlySet<number>,
+): Promise<Map<number, ResolvedRef>> {
+  const adapter = ctx.plugins.lookupAdapters.get("entry")?.adapter;
+  if (!adapter) return new Map();
+
+  const eligibleTypes = [...ctx.plugins.entryTypes.values()]
+    .filter((t) => t.isPublic === true)
+    .map((t) => t.name);
+  if (eligibleTypes.length === 0) return new Map();
+
+  // The entry adapter excludes trash by default but admits drafts and
+  // scheduled — fine for the picker (editors want to link to drafts), wrong
+  // for public nav. Pre-filter to published ids so a draft that was added
+  // to a menu doesn't render until it ships.
+  const publishedIds = await ctx.db
+    .select({ id: entries.id })
+    .from(entries)
+    .where(and(inArray(entries.id, [...ids]), eq(entries.status, "published")));
+  if (publishedIds.length === 0) return new Map();
+
+  const results = await adapter.list(ctx, {
+    scope: { entryTypes: eligibleTypes },
+    ids: publishedIds.map((r) => String(r.id)),
+  });
+  return refMapFromResults(results);
+}
+
+async function resolveTermRefs(
+  ctx: AppContext,
+  ids: ReadonlySet<number>,
+): Promise<Map<number, ResolvedRef>> {
+  const adapter = ctx.plugins.lookupAdapters.get("term")?.adapter;
+  if (!adapter) return new Map();
+
+  const eligibleTaxonomies = [...ctx.plugins.termTaxonomies.values()]
+    .filter((t) => t.isPublic === true)
+    .map((t) => t.name);
+  if (eligibleTaxonomies.length === 0) return new Map();
+
+  const results = await adapter.list(ctx, {
+    scope: { termTaxonomies: eligibleTaxonomies },
+    ids: [...ids].map(String),
+  });
+  return refMapFromResults(results);
+}
+
+function refMapFromResults(
+  results: readonly LookupResult[],
+): Map<number, ResolvedRef> {
+  const map = new Map<number, ResolvedRef>();
+  for (const result of results) {
+    const numericId = Number(result.id);
+    if (!Number.isFinite(numericId)) continue;
+    const cached = (result.cached ?? {}) as {
+      readonly label?: unknown;
+      readonly href?: unknown;
+    };
+    const href = typeof cached.href === "string" ? cached.href : null;
+    if (!href) continue; // No public URL → can't render in nav
+    const label =
+      typeof cached.label === "string" && cached.label.length > 0
+        ? cached.label
+        : result.label;
+    map.set(numericId, { label, href });
+  }
+  return map;
+}
+
+function toResolvedItem(
+  node: TreeNode<MenuItemRow>,
+  refs: ResolvedRefs,
+): ResolvedMenuItem | null {
   const meta = parseMenuItemMeta(node.meta);
   if (!meta) return null;
-  const resolved = resolveByKind(node, meta);
+  const resolved = resolveByKind(node, meta, refs);
   if (!resolved) return null;
 
   const children = node.children
-    .map(toResolvedItem)
+    .map((child) => toResolvedItem(child, refs))
     .filter((child): child is ResolvedMenuItem => child !== null);
 
   return { ...resolved, children };
@@ -90,22 +195,44 @@ type ResolvedNoChildren = Omit<ResolvedMenuItem, "children">;
 function resolveByKind(
   node: TreeNode<MenuItemRow>,
   meta: MenuItemMeta,
+  refs: ResolvedRefs,
 ): ResolvedNoChildren | null {
-  // Entry / term resolution lands in slice 2 (needs permalink helpers).
-  // Drop silently so mixed menus stay partially functional in the meantime.
-  if (meta.kind !== "custom") return null;
-
-  const href = sanitizeMenuHref(meta.url);
-  if (!href) return null;
-
+  const resolved = resolveLabelHrefSource(node, meta, refs);
+  if (!resolved) return null;
   return {
     id: node.id,
     parentId: node.parentId,
-    label: node.title,
-    href,
+    label: resolved.label,
+    href: resolved.href,
     target: meta.target,
     rel: meta.rel,
     cssClasses: meta.cssClasses ?? [],
-    source: { kind: "custom" },
+    source: resolved.source,
   };
+}
+
+interface LabelHrefSource {
+  readonly label: string;
+  readonly href: string;
+  readonly source: ResolvedMenuItem["source"];
+}
+
+function resolveLabelHrefSource(
+  node: TreeNode<MenuItemRow>,
+  meta: MenuItemMeta,
+  refs: ResolvedRefs,
+): LabelHrefSource | null {
+  if (meta.kind === "custom") {
+    const href = sanitizeMenuHref(meta.url);
+    if (!href) return null;
+    return { label: node.title, href, source: { kind: "custom" } };
+  }
+  if (meta.kind === "entry") {
+    const ref = refs.entries.get(meta.entryId);
+    if (!ref) return null;
+    return { ...ref, source: { kind: "entry", id: meta.entryId } };
+  }
+  const ref = refs.terms.get(meta.termId);
+  if (!ref) return null;
+  return { ...ref, source: { kind: "term", id: meta.termId } };
 }


### PR DESCRIPTION
## Summary

Slice 2 of the menu plugin breakdown — closes [#157](https://github.com/withplumix/plumix/issues/157). Parent PRD: [#155](https://github.com/withplumix/plumix/issues/155).

Two commits:

1. **`feat(core)`** — `buildEntryPermalink` + `buildTermArchiveUrl` in `@plumix/core/route/permalink`, plus `cached.{label,href}` populated on built-in entry/term lookup adapter results. Also exports `registerCoreLookupAdapters` from `@plumix/core` so plugin tests can mirror the runtime/app.ts seeding order.
2. **`feat(plugin-menu)`** — resolver now handles `kind: 'entry'` and `kind: 'term'` items via batched `LookupAdapter.list({ scope, ids })` per kind. Reads `cached.href` + `cached.label`; drops broken refs silently.

## Design notes

**Reverse routing:**
- Non-hierarchical types: pure substitution into `entryType.rewrite?.slug`. No DB hit.
- Hierarchical types (when `isHierarchical: true` and `rewrite.isHierarchical !== false`): single recursive CTE walks `parent_id` chain, prepends ancestor slugs root-first.
- `ancestorSlugs` escape-hatch lets callers (breadcrumb renderers, etc.) skip the CTE when they already have the chain.

**Hardening (sentry findings, addressed):**
- `MAX_ANCESTOR_DEPTH = 50` cap on the CTE recursive arm — a malformed cycle (a→b, b→a) returns truncated instead of bubbling SQLite's 1000-deep abort as a 500.
- `joinSegments` splits each input on `/`, drops empty parts and `.`/`..` traversal markers — a slug with an embedded slash produces multiple segments rather than shadowing a sibling route.
- Resolver pre-filters entry-ref ids to `status = 'published'` before calling the adapter — adapter admits drafts (correct for picker UI), public nav can't ship them.

## Known gap (called out in JSDoc)

`compileRouteMap` still emits `/<baseSlug>/:slug` (single segment) for every entry type. The nested URLs `buildEntryPermalink` produces for hierarchical types won't match the forward router until that's updated to a `:path+` capture. Non-hierarchical paths are symmetric today. Tracked as a follow-up; out of scope for slice 2.

## Sentry skill findings — addressed pre-merge

| Severity | Finding | Resolution |
|---|---|---|
| HIGH | Recursive CTE has no depth bound (cycle = SQLite 1000-deep abort) | Added `WHERE c.depth < ${MAX_ANCESTOR_DEPTH}` to the recursive arm in both helpers. |
| MEDIUM | `joinSegments` doesn't split internal slashes (slug `"a/b"` could shadow routes) | Splits each input on `/`, drops empty/`.`/`..`, with regression test. |
| MEDIUM | Draft/scheduled posts surface in public nav (adapter admits them) | Resolver pre-filters to `status='published'` before calling the adapter; new test covers draft + scheduled drops. |
| SHOULD-FIX | Misleading test name "non-public types" actually tested trash | Renamed to "drops entry items in trash status"; added separate test for `isPublic: false` type drops. |
| nit | Dynamic `import()` inside test body | Hoisted to top-level imports. |

Code-simplifier extracted a `resolveLabelHrefSource` helper to dedupe the three near-identical envelope blocks in `resolveByKind`.

## Test plan

- [x] `pnpm typecheck` (22 turbo tasks pass)
- [x] `pnpm test` (21 turbo tasks pass — 1196 core + 66 plugin-menu)
- [x] `pnpm format` (13 turbo tasks pass)
- [x] `pnpm publint` (20 pass)
- [x] `pnpm attw` (19 pass — both `.` and `./server` exports green for ESM + bundler tiers)
- [x] `pnpm knip` (no unused exports)
- [x] `pnpm commitlint` (2 commits, conventional + pnpm-scopes)
- [x] Sentry skills: code-simplifier, code-review, find-bugs — all findings addressed or deferred with rationale
- [x] Renaming the linked entity (slug or title) propagates without re-saving the menu — covered by test
- [ ] In-browser fixture menu render — N/A; defers to slice 3 alongside the theme primitive