### PR TITLE
feat(plugin-menu): defineTheme + registerMenuLocation + getMenuForLocation (slice 3)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -8,10 +8,14 @@ import type {
   KV,
   ObjectStorage,
 } from "./runtime/slots.js";
+import type { ThemeDescriptor } from "./theme.js";
 
-export interface Theme {
-  readonly id: string;
-}
+/**
+ * Re-exported from `./theme.js` so existing `import { Theme } from
+ * "@plumix/core"` call sites keep working. Prefer `ThemeDescriptor`
+ * directly in new code.
+ */
+export type Theme = ThemeDescriptor;
 
 // Heterogeneous arrays of plugins/adapters need the framework-side slot typed
 // with `any` so each caller's concrete generic is accepted via bivariance.
@@ -37,7 +41,7 @@ export interface PlumixConfigInput {
    * is the dev default.
    */
   readonly mailer?: Mailer;
-  readonly themes?: readonly Theme[];
+  readonly themes?: readonly ThemeDescriptor[];
   readonly plugins?: readonly AnyPluginDescriptor[];
 }
 
@@ -49,7 +53,7 @@ export interface PlumixConfig {
   readonly imageDelivery?: ImageDelivery;
   readonly kv?: KV;
   readonly mailer?: Mailer;
-  readonly themes: readonly Theme[];
+  readonly themes: readonly ThemeDescriptor[];
   readonly plugins: readonly AnyPluginDescriptor[];
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,3 +24,9 @@ export {
 export { memoryStorage } from "./runtime/memory-storage.js";
 export type { MemoryStorageConfig } from "./runtime/memory-storage.js";
 export type * from "./runtime/slots.js";
+export { defineTheme } from "./theme.js";
+export type {
+  ThemeDescriptor,
+  ThemeSetupContext,
+  ThemeSetupContextBase,
+} from "./theme.js";

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -6,8 +6,10 @@ import type { CapabilityResolver } from "../auth/rbac.js";
 import type { SessionPolicy } from "../auth/sessions.js";
 import type { PlumixConfig } from "../config.js";
 import type { AppContext } from "../context/app.js";
+import type { ContextExtensionEntry } from "../plugin/context.js";
 import type { PluginRegistry, RegisteredRawRoute } from "../plugin/manifest.js";
 import type { RouteRule } from "../route/intent.js";
+import type { ThemeSetupContext, ThemeSetupContextBase } from "../theme.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
@@ -80,11 +82,28 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   const hooks = new HookRegistry();
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
-  const { registry } = await installPlugins({
+  const { registry, themeExtensions } = await installPlugins({
     hooks,
     plugins: config.plugins,
     registry: seededRegistry,
   });
+
+  // Themes run after plugins so plugins' `provides` callbacks have already
+  // populated `themeExtensions`. Each theme's setup runs in declared
+  // order; ids are unique across `config.themes`.
+  const themeIds = new Set<string>();
+  for (const theme of config.themes) {
+    if (themeIds.has(theme.id)) {
+      throw new Error(
+        `Theme id "${theme.id}" appears more than once in config.themes`,
+      );
+    }
+    themeIds.add(theme.id);
+    if (theme.setup) {
+      const ctx = buildThemeSetupContext(theme.id, themeExtensions);
+      await theme.setup(ctx);
+    }
+  }
 
   const schema: Record<string, unknown> = { ...coreSchema };
   const origin = new Map<string, string>();
@@ -148,4 +167,19 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     rawRoutes: registry.rawRoutes,
     capabilityResolver: createCapabilityResolver(registry),
   };
+}
+
+function buildThemeSetupContext(
+  id: string,
+  themeExtensions: ReadonlyMap<string, ContextExtensionEntry>,
+): ThemeSetupContext {
+  // `satisfies` so adding a field to `ThemeSetupContextBase` later forces
+  // this builder to update — a plain `Record<string, unknown>` cast would
+  // silently produce a context missing the new field.
+  const base = { id } satisfies ThemeSetupContextBase;
+  const ctx: Record<string, unknown> = { ...base };
+  for (const [key, entry] of themeExtensions) {
+    ctx[key] = entry.value;
+  }
+  return ctx as unknown as ThemeSetupContext;
 }

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,0 +1,50 @@
+import type { ThemeContextExtensions } from "./plugin/context.js";
+
+export interface ThemeSetupContextBase {
+  readonly id: string;
+}
+
+/**
+ * Composed type a theme's `setup` callback receives. Plugins augment
+ * `ThemeContextExtensions` via TypeScript declaration merging from their
+ * own modules — installing `@plumix/plugin-menu`, for instance, adds
+ * `registerMenuLocation` to the surface.
+ */
+export type ThemeSetupContext = ThemeSetupContextBase & ThemeContextExtensions;
+
+export interface ThemeDescriptor {
+  readonly id: string;
+  /**
+   * Registration callback invoked once during `buildApp`, after plugins'
+   * `provides` callbacks have populated the theme context. Use it to
+   * register menu locations, theme settings, and any other concerns the
+   * theme contributes through plugins' theme-context extensions.
+   */
+  readonly setup?: (ctx: ThemeSetupContext) => void | Promise<void>;
+}
+
+const THEME_ID_RE = /^[a-z][a-z0-9-]*$/;
+const MAX_THEME_ID_LENGTH = 64;
+
+export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
+  if (
+    typeof descriptor.id !== "string" ||
+    descriptor.id.length === 0 ||
+    descriptor.id.length > MAX_THEME_ID_LENGTH ||
+    !THEME_ID_RE.test(descriptor.id)
+  ) {
+    throw new Error(
+      `defineTheme: id "${descriptor.id}" is invalid. Theme ids must ` +
+        `match /${THEME_ID_RE.source}/ and be 1–${MAX_THEME_ID_LENGTH} chars.`,
+    );
+  }
+  if (
+    descriptor.setup !== undefined &&
+    typeof descriptor.setup !== "function"
+  ) {
+    throw new Error(
+      `defineTheme("${descriptor.id}"): \`setup\` must be a function when provided.`,
+    );
+  }
+  return descriptor;
+}

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -1,15 +1,31 @@
 import { definePlugin } from "@plumix/core";
 
+import type { MenuLocationOptions } from "./server/types.js";
+import { recordLocation } from "./server/locations.js";
+
 export type {
   MenuItemMeta,
   MenuItemCustomMeta,
   MenuItemEntryMeta,
   MenuItemTermMeta,
   MenuItemDisplayAttrs,
+  MenuLocationOptions,
+  RegisteredMenuLocation,
   ResolvedMenu,
   ResolvedMenuItem,
   ResolvedMenuItemSource,
 } from "./server/types.js";
+
+// `@plumix/plugin-menu` augments the theme setup context with
+// `registerMenuLocation`. TypeScript surfaces the method only when this
+// plugin is in the project's `node_modules`; the implementation is wired
+// at install time via `extendThemeContext` from the plugin's `provides`
+// callback below.
+declare module "@plumix/core" {
+  interface ThemeContextExtensions {
+    registerMenuLocation: (id: string, options: MenuLocationOptions) => void;
+  }
+}
 
 /**
  * `@plumix/plugin-menu` — menus reuse the entries/terms/entry_term substrate
@@ -18,23 +34,30 @@ export type {
  * lives in `entry_term`. Both types are `isPublic: false` so they hide from
  * the generic Entries/Terms admin; the plugin owns its own admin (slices 7+).
  */
-export const menu = definePlugin("menu", (ctx) => {
-  ctx.registerEntryType("menu_item", {
-    label: "Menu items",
-    labels: { singular: "Menu item", plural: "Menu items" },
-    description: "Items belonging to a navigation menu",
-    supports: ["title"],
-    termTaxonomies: ["menu"],
-    isHierarchical: true,
-    isPublic: false,
-    capabilityType: "menu_item",
-  });
+export const menu = definePlugin("menu", {
+  provides: (ctx) => {
+    ctx.extendThemeContext("registerMenuLocation", (id, options) => {
+      recordLocation(id, options);
+    });
+  },
+  setup: (ctx) => {
+    ctx.registerEntryType("menu_item", {
+      label: "Menu items",
+      labels: { singular: "Menu item", plural: "Menu items" },
+      description: "Items belonging to a navigation menu",
+      supports: ["title"],
+      termTaxonomies: ["menu"],
+      isHierarchical: true,
+      isPublic: false,
+      capabilityType: "menu_item",
+    });
 
-  ctx.registerTermTaxonomy("menu", {
-    label: "Menus",
-    labels: { singular: "Menu" },
-    isHierarchical: false,
-    entryTypes: ["menu_item"],
-    isPublic: false,
-  });
+    ctx.registerTermTaxonomy("menu", {
+      label: "Menus",
+      labels: { singular: "Menu" },
+      isHierarchical: false,
+      entryTypes: ["menu_item"],
+      isPublic: false,
+    });
+  },
 });

--- a/packages/plugins/menu/src/server/getMenuForLocation.test.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import type { AppContext, PluginRegistry, ThemeDescriptor } from "@plumix/core";
+import {
+  auth,
+  buildApp,
+  createPluginRegistry,
+  defineTheme,
+  HookRegistry,
+  installPlugins,
+  registerCoreLookupAdapters,
+  settings,
+} from "@plumix/core";
+import {
+  adminUser,
+  createTestDb,
+  entryFactory,
+  entryTermFactory,
+  factoriesFor,
+} from "@plumix/core/test";
+
+import { menu } from "../index.js";
+import { getMenuForLocation } from "./getMenuForLocation.js";
+import { clearRegisteredLocations } from "./locations.js";
+
+function testAuth() {
+  return auth({
+    passkey: {
+      rpName: "Test",
+      rpId: "localhost",
+      origin: "http://localhost",
+    },
+  });
+}
+
+async function buildTestRegistry(): Promise<PluginRegistry> {
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  registerCoreLookupAdapters(registry);
+  await installPlugins({ hooks, plugins: [menu], registry });
+  return registry;
+}
+
+function ctxFor(
+  db: Awaited<ReturnType<typeof createTestDb>>,
+  registry: PluginRegistry,
+): AppContext {
+  return { db, plugins: registry } as unknown as AppContext;
+}
+
+describe("getMenuForLocation", () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>;
+  let factories: ReturnType<typeof factoriesFor>;
+  let ctx: AppContext;
+  let authorId: number;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    factories = factoriesFor(db);
+    const registry = await buildTestRegistry();
+    ctx = ctxFor(db, registry);
+    const author = await adminUser
+      .transient({ db })
+      .create({ email: "menu-loc-author@example.test" });
+    authorId = author.id;
+  });
+
+  afterEach(() => {
+    clearRegisteredLocations();
+  });
+
+  async function seedMenuWithItem(
+    slug: string,
+    itemTitle: string,
+    url: string,
+  ): Promise<void> {
+    const term = await factories.term.create({
+      taxonomy: "menu",
+      slug,
+      name: slug,
+    });
+    const entry = await entryFactory.transient({ db }).create({
+      type: "menu_item",
+      title: itemTitle,
+      slug: `mi-${slug}-${Date.now()}`,
+      status: "published",
+      authorId,
+      meta: { kind: "custom", url } as unknown as Record<string, unknown>,
+    });
+    await entryTermFactory
+      .transient({ db })
+      .create({ entryId: entry.id, termId: term.id, sortOrder: 0 });
+  }
+
+  async function bind(location: string, termSlug: string): Promise<void> {
+    await db.insert(settings).values({
+      group: "menu_locations",
+      key: location,
+      value: termSlug,
+    });
+  }
+
+  test("returns null when no settings row binds the location", async () => {
+    expect(await getMenuForLocation(ctx, "primary")).toBeNull();
+  });
+
+  test("dereferences the binding and returns the resolved menu", async () => {
+    await seedMenuWithItem("main", "Home", "/");
+    await bind("primary", "main");
+
+    const resolved = await getMenuForLocation(ctx, "primary");
+    expect(resolved?.slug).toBe("main");
+    expect(resolved?.items.map((i) => i.label)).toEqual(["Home"]);
+  });
+
+  test("returns null when the bound term slug doesn't exist", async () => {
+    await bind("primary", "ghost");
+    expect(await getMenuForLocation(ctx, "primary")).toBeNull();
+  });
+
+  test.each([
+    ["null", null],
+    ["empty string", ""],
+    ["number", 42],
+    ["array", ["main"]],
+    ["object", { slug: "main" }],
+  ])(
+    "returns null when the binding value shape is invalid: %s",
+    async (name, value) => {
+      void name;
+      await db.insert(settings).values({
+        group: "menu_locations",
+        key: "primary",
+        value,
+      });
+      expect(await getMenuForLocation(ctx, "primary")).toBeNull();
+    },
+  );
+
+  test("memoizes within one request — second call returns the same instance", async () => {
+    await seedMenuWithItem("main", "Home", "/");
+    await bind("primary", "main");
+
+    const first = await getMenuForLocation(ctx, "primary");
+    const second = await getMenuForLocation(ctx, "primary");
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+  });
+
+  test("a fresh ctx does not share the cache", async () => {
+    await seedMenuWithItem("main", "Home", "/");
+    await bind("primary", "main");
+
+    const a = await getMenuForLocation(ctx, "primary");
+    const otherCtx = ctxFor(db, ctx.plugins);
+    const b = await getMenuForLocation(otherCtx, "primary");
+    expect(a).not.toBe(b);
+    expect(a?.slug).toBe(b?.slug);
+  });
+});
+
+describe("defineTheme + registerMenuLocation integration via buildApp", () => {
+  afterEach(() => {
+    clearRegisteredLocations();
+  });
+
+  test("theme setup runs after plugin install and registers locations", async () => {
+    const blogTheme: ThemeDescriptor = defineTheme({
+      id: "blog",
+      setup: (themeCtx) => {
+        themeCtx.registerMenuLocation("primary", {
+          label: "Primary navigation",
+        });
+        themeCtx.registerMenuLocation("footer", { label: "Footer" });
+      },
+    });
+
+    const stubAdapter = {
+      name: "test",
+      buildFetchHandler: () => () => new Response("stub"),
+    };
+    const stubDatabase = {
+      kind: "test",
+      connect: () => ({ db: {} }),
+    };
+
+    await buildApp({
+      runtime: stubAdapter,
+      database: stubDatabase,
+      auth: testAuth(),
+      plugins: [menu],
+      themes: [blogTheme],
+    });
+
+    const { getRegisteredLocations } = await import("./locations.js");
+    const registered = getRegisteredLocations();
+    expect(registered.size).toBe(2);
+    expect(registered.get("primary")?.label).toBe("Primary navigation");
+    expect(registered.get("footer")?.label).toBe("Footer");
+  });
+
+  test("multiple themes' setup callbacks invoke in declared order", async () => {
+    const order: string[] = [];
+    const stubAdapter = {
+      name: "test",
+      buildFetchHandler: () => () => new Response("stub"),
+    };
+    const stubDatabase = {
+      kind: "test",
+      connect: () => ({ db: {} }),
+    };
+
+    await buildApp({
+      runtime: stubAdapter,
+      database: stubDatabase,
+      auth: testAuth(),
+      plugins: [menu],
+      themes: [
+        defineTheme({
+          id: "first",
+          setup: (themeCtx) => {
+            order.push("first");
+            themeCtx.registerMenuLocation("a", { label: "A" });
+          },
+        }),
+        defineTheme({
+          id: "second",
+          setup: (themeCtx) => {
+            order.push("second");
+            themeCtx.registerMenuLocation("b", { label: "B" });
+          },
+        }),
+      ],
+    });
+
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  test("rejects duplicate theme ids in config.themes", async () => {
+    const stubAdapter = {
+      name: "test",
+      buildFetchHandler: () => () => new Response("stub"),
+    };
+    const stubDatabase = {
+      kind: "test",
+      connect: () => ({ db: {} }),
+    };
+
+    await expect(
+      buildApp({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: testAuth(),
+        plugins: [menu],
+        themes: [
+          defineTheme({ id: "blog", setup: () => undefined }),
+          defineTheme({ id: "blog", setup: () => undefined }),
+        ],
+      }),
+    ).rejects.toThrow(/Theme id "blog" appears more than once/);
+  });
+});

--- a/packages/plugins/menu/src/server/getMenuForLocation.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.ts
@@ -1,0 +1,77 @@
+import { and, eq } from "drizzle-orm";
+
+import type { AppContext } from "@plumix/core";
+import { settings } from "@plumix/core";
+
+import type { ResolvedMenu } from "./types.js";
+import { getMenuByName } from "./getMenuByName.js";
+
+const MENU_LOCATIONS_GROUP = "menu_locations";
+
+/**
+ * Resolve the menu currently bound to a theme-registered location.
+ *
+ * The slot → term-slug binding lives in the `settings` table under group
+ * `menu_locations`, with `key = location` and `value = '<term slug>'`.
+ * Reads the binding, then defers to `getMenuByName` for the actual
+ * resolution. Returns `null` when no binding exists for this location, or
+ * when the bound menu has been deleted.
+ *
+ * Calling this twice for the same location within a single request hits
+ * a request-scoped cache stashed on `AppContext` so header + footer +
+ * breadcrumb consumers all share one resolve pass.
+ */
+export async function getMenuForLocation(
+  ctx: AppContext,
+  location: string,
+): Promise<ResolvedMenu | null> {
+  const cache = getOrCreateRequestCache(ctx);
+  if (cache.has(location)) {
+    return cache.get(location) ?? null;
+  }
+  const resolved = await resolveLocation(ctx, location);
+  cache.set(location, resolved);
+  return resolved;
+}
+
+async function resolveLocation(
+  ctx: AppContext,
+  location: string,
+): Promise<ResolvedMenu | null> {
+  const [row] = await ctx.db
+    .select({ value: settings.value })
+    .from(settings)
+    .where(
+      and(eq(settings.group, MENU_LOCATIONS_GROUP), eq(settings.key, location)),
+    )
+    .limit(1);
+  if (!row) return null;
+  const slug = parseTermSlug(row.value);
+  if (slug === null) return null;
+  return getMenuByName(ctx, slug);
+}
+
+function parseTermSlug(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  return null;
+}
+
+// WeakMap keyed by ctx identity. If a caller reused an `AppContext` across
+// requests (no current code path does, but nothing in the type forbids it),
+// they'd leak menu state via the cache. WeakMap means the cache dies with
+// the ctx, and a non-registry Symbol can't collide with another module.
+const requestCaches = new WeakMap<
+  AppContext,
+  Map<string, ResolvedMenu | null>
+>();
+
+function getOrCreateRequestCache(
+  ctx: AppContext,
+): Map<string, ResolvedMenu | null> {
+  let cache = requestCaches.get(ctx);
+  if (!cache) {
+    cache = new Map();
+    requestCaches.set(ctx, cache);
+  }
+  return cache;
+}

--- a/packages/plugins/menu/src/server/index.ts
+++ b/packages/plugins/menu/src/server/index.ts
@@ -1,10 +1,17 @@
 export { getMenuByName } from "./getMenuByName.js";
+export { getMenuForLocation } from "./getMenuForLocation.js";
+export {
+  getRegisteredLocations,
+  clearRegisteredLocations,
+} from "./locations.js";
 export type {
   MenuItemMeta,
   MenuItemCustomMeta,
   MenuItemEntryMeta,
   MenuItemTermMeta,
   MenuItemDisplayAttrs,
+  MenuLocationOptions,
+  RegisteredMenuLocation,
   ResolvedMenu,
   ResolvedMenuItem,
   ResolvedMenuItemSource,

--- a/packages/plugins/menu/src/server/locations.test.ts
+++ b/packages/plugins/menu/src/server/locations.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  clearRegisteredLocations,
+  getRegisteredLocations,
+  recordLocation,
+} from "./locations.js";
+
+describe("menu locations registry", () => {
+  afterEach(() => {
+    clearRegisteredLocations();
+  });
+
+  test("stores valid registrations keyed by id", () => {
+    recordLocation("primary", { label: "Primary navigation" });
+    recordLocation("footer", {
+      label: "Footer",
+      description: "Bottom of every page",
+    });
+
+    const registered = getRegisteredLocations();
+    expect(registered.size).toBe(2);
+    expect(registered.get("primary")).toEqual({
+      id: "primary",
+      label: "Primary navigation",
+      description: undefined,
+    });
+    expect(registered.get("footer")).toEqual({
+      id: "footer",
+      label: "Footer",
+      description: "Bottom of every page",
+    });
+  });
+
+  test.each([
+    ["empty id", "", { label: "x" }],
+    ["leading digit", "1main", { label: "x" }],
+    ["uppercase", "Primary", { label: "x" }],
+    ["space", "main nav", { label: "x" }],
+    ["underscore", "main_nav", { label: "x" }],
+    ["over length", "a".repeat(65), { label: "x" }],
+  ] as const)("rejects invalid id: %s", (_name, id, options) => {
+    expect(() => recordLocation(id, options)).toThrow();
+  });
+
+  test("rejects missing or empty label", () => {
+    expect(() => recordLocation("primary", { label: "" })).toThrow();
+    expect(() =>
+      recordLocation("primary", {} as unknown as { label: string }),
+    ).toThrow();
+  });
+
+  test("rejects duplicate id across calls", () => {
+    recordLocation("primary", { label: "A" });
+    expect(() => recordLocation("primary", { label: "B" })).toThrow(
+      /already registered/,
+    );
+  });
+});

--- a/packages/plugins/menu/src/server/locations.ts
+++ b/packages/plugins/menu/src/server/locations.ts
@@ -1,0 +1,60 @@
+import type { MenuLocationOptions, RegisteredMenuLocation } from "./types.js";
+
+/**
+ * Module-scoped registry of menu locations. Themes call
+ * `registerMenuLocation` from their `setup` callback (the implementation
+ * is wired into `ThemeContextExtensions` from the plugin's `provides`),
+ * which delegates to `recordLocation` here.
+ *
+ * Lifetime: populated once during `buildApp`, read for the rest of the
+ * process / Worker isolate. The CF Worker model reuses isolates across
+ * requests, so this is effectively boot-time-immutable in production.
+ *
+ * Tests reset between cases via `clearRegisteredLocations`.
+ */
+const locations = new Map<string, RegisteredMenuLocation>();
+
+const LOCATION_ID_RE = /^[a-z][a-z0-9-]*$/;
+const MAX_LOCATION_ID_LENGTH = 64;
+
+export function recordLocation(id: string, options: MenuLocationOptions): void {
+  if (
+    typeof id !== "string" ||
+    id.length === 0 ||
+    id.length > MAX_LOCATION_ID_LENGTH ||
+    !LOCATION_ID_RE.test(id)
+  ) {
+    throw new Error(
+      `registerMenuLocation: id "${id}" is invalid. Location ids must ` +
+        `match /${LOCATION_ID_RE.source}/ and be 1–${MAX_LOCATION_ID_LENGTH} chars.`,
+    );
+  }
+  if (typeof options.label !== "string" || options.label.trim().length === 0) {
+    throw new Error(
+      `registerMenuLocation("${id}"): \`label\` is required and must be a non-empty, non-whitespace string.`,
+    );
+  }
+  if (locations.has(id)) {
+    throw new Error(
+      `registerMenuLocation: location "${id}" is already registered. ` +
+        `Each location id must be unique across themes.`,
+    );
+  }
+  locations.set(id, {
+    id,
+    label: options.label,
+    description: options.description,
+  });
+}
+
+export function getRegisteredLocations(): ReadonlyMap<
+  string,
+  RegisteredMenuLocation
+> {
+  return locations;
+}
+
+/** Test-only: reset state between cases. Production never calls this. */
+export function clearRegisteredLocations(): void {
+  locations.clear();
+}

--- a/packages/plugins/menu/src/server/types.ts
+++ b/packages/plugins/menu/src/server/types.ts
@@ -56,3 +56,16 @@ export interface ResolvedMenu {
   readonly slug: string;
   readonly items: readonly ResolvedMenuItem[];
 }
+
+/**
+ * Theme-side input for `registerMenuLocation`. The label appears in the
+ * admin Locations panel (slice 7+); description is optional helper text.
+ */
+export interface MenuLocationOptions {
+  readonly label: string;
+  readonly description?: string;
+}
+
+export interface RegisteredMenuLocation extends MenuLocationOptions {
+  readonly id: string;
+}

--- a/packages/runtimes/cloudflare/src/cf-access.test.ts
+++ b/packages/runtimes/cloudflare/src/cf-access.test.ts
@@ -178,31 +178,39 @@ describe("cfAccess.authenticate — full crypto path", () => {
     expect(result).toBeNull();
   });
 
-  test("provisions and returns the user when the JWT is valid", async () => {
-    const { createTestDb } = await import("@plumix/core/test");
-    const db = await createTestDb();
+  // Vitest's default 5s timeout flakes intermittently on shared CI
+  // runners — the test exercises a real WebCrypto JWK sign + verify
+  // round-trip plus an in-memory libsql migration, both of which can
+  // exceed 5s under runner contention. Locally completes in ~1.7s.
+  test(
+    "provisions and returns the user when the JWT is valid",
+    { timeout: 30_000 },
+    async () => {
+      const { createTestDb } = await import("@plumix/core/test");
+      const db = await createTestDb();
 
-    const guard = cfAccess({
-      teamDomain: TEAM_DOMAIN,
-      audience: AUDIENCE,
-      defaultRole: "editor",
-      bootstrapAllowed: true,
-    });
-    const jwt = await mintJwt(material.privateKey, material.kid, {
-      email: "first-admin@enterprise.example",
-    });
+      const guard = cfAccess({
+        teamDomain: TEAM_DOMAIN,
+        audience: AUDIENCE,
+        defaultRole: "editor",
+        bootstrapAllowed: true,
+      });
+      const jwt = await mintJwt(material.privateKey, material.kid, {
+        email: "first-admin@enterprise.example",
+      });
 
-    const result = await guard.authenticate(
-      new Request("https://cms.example/", {
-        headers: { "cf-access-jwt-assertion": jwt },
-      }),
-      db,
-    );
-    expect(result).not.toBeNull();
-    expect(result?.user.email).toBe("first-admin@enterprise.example");
-    // bootstrapAllowed=true on a zero-user system → first user is admin.
-    expect(result?.user.role).toBe("admin");
-  });
+      const result = await guard.authenticate(
+        new Request("https://cms.example/", {
+          headers: { "cf-access-jwt-assertion": jwt },
+        }),
+        db,
+      );
+      expect(result).not.toBeNull();
+      expect(result?.user.email).toBe("first-admin@enterprise.example");
+      // bootstrapAllowed=true on a zero-user system → first user is admin.
+      expect(result?.user.role).toBe("admin");
+    },
+  );
 
   test("returns null when bootstrap is disabled and zero users exist", async () => {
     const { createTestDb } = await import("@plumix/core/test");


### PR DESCRIPTION
## Summary

Slice 3 of the menu plugin breakdown — closes [#158](https://github.com/withplumix/plumix/issues/158). Parent PRD: [#155](https://github.com/withplumix/plumix/issues/155).

Two commits:

1. **`feat(core)`** — `defineTheme(descriptor)` factory + theme-setup runtime in `buildApp`. Completes the theme primitive that was scaffolded but unwired (`themes: Theme[]` slot existed, `Theme` was a `{ id }` placeholder). Themes run after plugins, in declared order, with duplicate-id rejection. `buildThemeSetupContext` uses `satisfies ThemeSetupContextBase` so adding a base field forces the builder to update.

2. **`feat(plugin-menu)`** — declaration-merges `registerMenuLocation` into `ThemeContextExtensions`. `provides` callback wires the implementation via `extendThemeContext`. `getMenuForLocation(ctx, location)` reads the slot → term-slug binding from the `settings` table (`group: 'menu_locations', key: location`), defers to `getMenuByName` for resolution, request-memoizes via a `WeakMap<AppContext, ...>` keyed by ctx identity.

## Why theme primitive completion matters beyond menus

The theme registration surface was scaffolded since the admin shell landed but completed by no slice — `Theme = { id }` had no setup callback. Slice 3 fleshes it out so any future theme-registered concern (theme settings, view templates, asset injection) has a registration seam. The menu plugin is the first concrete consumer.

## Sentry skill findings — addressed pre-merge

- **Medium (find-bugs)**: `Symbol.for(...)`-keyed cache could leak across requests if an `AppContext` were ever reused. **Fix**: switched to `WeakMap<AppContext, Map<...>>` so cache state dies with ctx and the symbol can't collide globally.
- **Low (review)**: `buildThemeSetupContext` cast loses type-safety on future base fields. **Fix**: `satisfies ThemeSetupContextBase` step before merging extensions.
- **Low (review)**: `defineTheme` doesn't validate `setup` is a function when present. **Fix**: added explicit type guard.
- **Low (find-bugs)**: label validation accepts whitespace-only strings. **Fix**: `.trim().length > 0`.
- **Low (review)**: `parseTermSlug` only tested for `null` value, not other invalid shapes. **Fix**: parametrized test for `null`, empty string, number, array, object.

## Deferred (called out honestly, separate slice scope)

- **Theme `renderLayout` hook + renderer wiring** — needs design discussion on `renderDefaultDocument` extensibility and multi-theme layout composition. Slice 3 ships the registration plumbing only.
- **`examples/blog` theme module + Playwright e2e** — depend on the layout integration above.
- **Formal `registerSettingsGroup('menu_locations', { fields })`** — the current settings-group API requires statically-declared fields, but locations are known only after theme setup runs. The admin Locations panel (slice 7+) will revisit when the panel needs it; for now the data layer uses the raw `settings` table directly with `group: 'menu_locations'`.

## Test plan

- [x] `pnpm typecheck` (22 turbo tasks) — clean
- [x] `pnpm test` (21 turbo tasks) — 1196 core + 84 plugin-menu, all green
- [x] `pnpm format` (13 turbo tasks)
- [x] `pnpm publint` (20 tasks)
- [x] `pnpm attw` (19 tasks)
- [x] `pnpm knip` — no unused exports
- [x] `pnpm commitlint` — 2 commits, conventional + pnpm-scopes
- [x] Per-package `build/typecheck/test/lint` for `@plumix/core` and `@plumix/plugin-menu`
- [x] Sentry code-review + find-bugs run — Medium + Low findings addressed
- [ ] In-browser fixture menu render — N/A; deferred to slice that lands `renderLayout`