### PR TITLE
feat(plugin-menu): eligibility flags + picker resolver (slice 6)

### DIFF
--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -532,9 +532,11 @@ export function createPluginSetupContext({
       if (registry.lookupAdapters.has(options.kind)) {
         throw new DuplicateRegistrationError("lookup adapter", options.kind);
       }
+      // Spread to preserve plugin-contributed option fields (e.g. the
+      // `menuPicker` field that @plumix/plugin-menu adds via declaration
+      // merging).
       registry.lookupAdapters.set(options.kind, {
-        kind: options.kind,
-        adapter: options.adapter,
+        ...options,
         capability: options.capability ?? null,
         registeredBy: pluginId,
       });

--- a/packages/core/src/plugin/lookup.ts
+++ b/packages/core/src/plugin/lookup.ts
@@ -71,7 +71,13 @@ export interface LookupAdapter<TScope = unknown> {
   ): Promise<LookupResult | null>;
 }
 
-export interface RegisteredLookupAdapter<TScope = unknown> {
+// `RegisteredLookupAdapter` extends `LookupAdapterOptions` so plugin-
+// contributed fields (declaration-merged via TypeScript module
+// augmentation) survive into the manifest. The `registerLookupAdapter`
+// implementation spreads `options` to preserve them.
+export interface RegisteredLookupAdapter<
+  TScope = unknown,
+> extends LookupAdapterOptions<TScope> {
   readonly kind: string;
   readonly adapter: LookupAdapter<TScope>;
   /**

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -17,13 +17,38 @@ export type {
 } from "./server/types.js";
 
 // `@plumix/plugin-menu` augments the theme setup context with
-// `registerMenuLocation`. TypeScript surfaces the method only when this
-// plugin is in the project's `node_modules`; the implementation is wired
-// at install time via `extendThemeContext` from the plugin's `provides`
-// callback below.
+// `registerMenuLocation`, plus three core option shapes with
+// menu-eligibility flags. TypeScript surfaces all of these only when
+// this plugin is in the project's `node_modules`. The runtime
+// implementation of `registerMenuLocation` is wired via
+// `extendThemeContext` below; the eligibility flags are read at admin
+// time by the eligibility resolver (`getEligibleMenuKinds`).
 declare module "@plumix/core" {
   interface ThemeContextExtensions {
     registerMenuLocation: (id: string, options: MenuLocationOptions) => void;
+  }
+  interface EntryTypeOptions {
+    /**
+     * Whether this entry type appears in the menu plugin's item picker.
+     * Defaults to `isPublic`. Mirrors WordPress's `show_in_nav_menus`.
+     */
+    readonly isShownInMenus?: boolean;
+    /** Override the picker tab label. Defaults to `labels.plural`. */
+    readonly menuPickerLabel?: string;
+  }
+  interface TermTaxonomyOptions {
+    readonly isShownInMenus?: boolean;
+    readonly menuPickerLabel?: string;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface LookupAdapterOptions<TScope = unknown> {
+    /**
+     * Opt-in for non-default kinds (`media`, `user`, future custom
+     * kinds) to appear in the menu picker. Default kinds (`entry`,
+     * `term`) follow `isShownInMenus`; other adapters are off unless
+     * this is set.
+     */
+    readonly menuPicker?: { readonly tabLabel: string };
   }
 }
 

--- a/packages/plugins/menu/src/server/eligibility.test.ts
+++ b/packages/plugins/menu/src/server/eligibility.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "vitest";
+
+import type { PluginRegistry } from "@plumix/core";
+import {
+  createPluginRegistry,
+  definePlugin,
+  HookRegistry,
+  installPlugins,
+  registerCoreLookupAdapters,
+} from "@plumix/core";
+
+import { getEligibleMenuKinds } from "./eligibility.js";
+
+async function buildRegistry(
+  plugins: ReturnType<typeof definePlugin>[],
+): Promise<PluginRegistry> {
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  registerCoreLookupAdapters(registry);
+  await installPlugins({ hooks, plugins, registry });
+  return registry;
+}
+
+describe("getEligibleMenuKinds", () => {
+  test("an empty registry surfaces only the Custom URL tab", async () => {
+    const registry = await buildRegistry([]);
+    const tabs = getEligibleMenuKinds(registry);
+    expect(tabs).toEqual([{ kind: "custom", tabLabel: "Custom URL" }]);
+  });
+
+  test.each([
+    {
+      name: "isPublic: true, no override",
+      register: { isPublic: true },
+      eligible: true,
+    },
+    {
+      name: "isPublic: true, isShownInMenus: false",
+      register: { isPublic: true, isShownInMenus: false },
+      eligible: false,
+    },
+    {
+      name: "isPublic: false, no override",
+      register: { isPublic: false },
+      eligible: false,
+    },
+    {
+      name: "isPublic: false, isShownInMenus: true (override)",
+      register: { isPublic: false, isShownInMenus: true },
+      eligible: true,
+    },
+    {
+      name: "isPublic unset, no override (default true)",
+      register: {},
+      eligible: true,
+    },
+  ])("entry type cascade — $name", async ({ register, eligible }) => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", { label: "Posts", ...register });
+      }),
+    ]);
+    const tabs = getEligibleMenuKinds(registry);
+    const hasEntryTab = tabs.some(
+      (t) => t.kind === "entry" && t.target === "post",
+    );
+    expect(hasEntryTab).toBe(eligible);
+  });
+
+  test.each([
+    {
+      name: "isPublic: true, no override",
+      register: { isPublic: true },
+      eligible: true,
+    },
+    {
+      name: "isPublic: true, isShownInMenus: false",
+      register: { isPublic: true, isShownInMenus: false },
+      eligible: false,
+    },
+    {
+      name: "isPublic: false, isShownInMenus: true",
+      register: { isPublic: false, isShownInMenus: true },
+      eligible: true,
+    },
+    {
+      name: "isPublic: false default",
+      register: { isPublic: false },
+      eligible: false,
+    },
+  ])("term taxonomy cascade — $name", async ({ register, eligible }) => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("category", {
+          label: "Categories",
+          ...register,
+        });
+      }),
+    ]);
+    const tabs = getEligibleMenuKinds(registry);
+    const hasTermTab = tabs.some(
+      (t) => t.kind === "term" && t.target === "category",
+    );
+    expect(hasTermTab).toBe(eligible);
+  });
+
+  test("menuPickerLabel overrides the default tab label for entry types", async () => {
+    const registry = await buildRegistry([
+      definePlugin("shop", (ctx) => {
+        ctx.registerEntryType("product", {
+          label: "Products",
+          labels: { plural: "Products" },
+          isPublic: true,
+          menuPickerLabel: "Catalog",
+        });
+      }),
+    ]);
+    const tabs = getEligibleMenuKinds(registry);
+    expect(tabs.find((t) => t.kind === "entry")?.tabLabel).toBe("Catalog");
+  });
+
+  test("falls back to labels.plural, then label, when menuPickerLabel is unset", async () => {
+    const registry = await buildRegistry([
+      definePlugin("a", (ctx) => {
+        ctx.registerEntryType("a-type", {
+          label: "A label",
+          labels: { plural: "A plurals" },
+          isPublic: true,
+        });
+        ctx.registerEntryType("b-type", {
+          label: "B label",
+          isPublic: true,
+        });
+      }),
+    ]);
+    const tabs = getEligibleMenuKinds(registry);
+    const a = tabs.find((t) => t.target === "a-type");
+    const b = tabs.find((t) => t.target === "b-type");
+    expect(a?.tabLabel).toBe("A plurals");
+    expect(b?.tabLabel).toBe("B label");
+  });
+
+  test("built-in entry / term lookup adapters do not surface as their own tabs", async () => {
+    const registry = await buildRegistry([]);
+    const tabs = getEligibleMenuKinds(registry);
+    // `entry` and `term` lookup adapters are seeded by
+    // `registerCoreLookupAdapters` but should NOT appear as picker
+    // kinds — they're per-target via entry types / taxonomies.
+    expect(tabs.find((t) => t.kind === "entry")).toBeUndefined();
+    expect(tabs.find((t) => t.kind === "term")).toBeUndefined();
+  });
+
+  test("non-default lookup adapters need menuPicker to opt in", async () => {
+    const stubAdapter = {
+      list: () => Promise.resolve([]),
+      resolve: () => Promise.resolve(null),
+    };
+    const offRegistry = await buildRegistry([
+      definePlugin("media-off", (ctx) => {
+        ctx.registerLookupAdapter({
+          kind: "media-off",
+          adapter: stubAdapter,
+          capability: null,
+        });
+      }),
+    ]);
+    expect(
+      getEligibleMenuKinds(offRegistry).find((t) => t.kind === "media-off"),
+    ).toBeUndefined();
+
+    const onRegistry = await buildRegistry([
+      definePlugin("media-on", (ctx) => {
+        ctx.registerLookupAdapter({
+          kind: "media-on",
+          adapter: stubAdapter,
+          capability: null,
+          menuPicker: { tabLabel: "Media files" },
+        });
+      }),
+    ]);
+    const onTabs = getEligibleMenuKinds(onRegistry);
+    expect(onTabs.find((t) => t.kind === "media-on")?.tabLabel).toBe(
+      "Media files",
+    );
+  });
+
+  test("Custom URL is always the last tab", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+        ctx.registerTermTaxonomy("tag", { label: "Tags", isPublic: true });
+      }),
+    ]);
+    const tabs = getEligibleMenuKinds(registry);
+    expect(tabs[tabs.length - 1]?.kind).toBe("custom");
+  });
+});

--- a/packages/plugins/menu/src/server/eligibility.ts
+++ b/packages/plugins/menu/src/server/eligibility.ts
@@ -1,0 +1,103 @@
+import type { PluginRegistry } from "@plumix/core";
+
+/**
+ * One picker tab in the admin's "Add menu items" rail. The tab label
+ * defaults to `labels.plural` for entry types, the taxonomy `label` for
+ * term taxonomies, and `menuPicker.tabLabel` for plugin-contributed
+ * lookup-adapter kinds. Custom URL is always present as the last tab.
+ *
+ * `kind` is one of:
+ * - `entry`    — links to a `menu_item.meta.kind = 'entry'` ref
+ * - `term`     — links to a `menu_item.meta.kind = 'term'` ref
+ * - `custom`   — literal URL; always available
+ * - other      — plugin-contributed lookup adapter kinds (`media`,
+ *                `user`, etc.) that opted in via `menuPicker`
+ */
+export interface PickerTab {
+  readonly kind: string;
+  readonly tabLabel: string;
+  /** For entry/term tabs, the underlying type/taxonomy name. */
+  readonly target?: string;
+}
+
+/**
+ * Pure function over the registered manifest. Returns the ordered list
+ * of picker tabs the admin's "Add menu items" rail should render.
+ *
+ * Eligibility rules:
+ * - Entry types: eligible iff `isShownInMenus ?? isPublic ?? true`.
+ * - Term taxonomies: same rule against `isShownInMenus ?? isPublic`.
+ * - Built-in lookup adapters (`entry`, `term`): NOT enumerated as their
+ *   own picker tabs — entry types and term taxonomies above already
+ *   surface them per-target. Skipping avoids a redundant "Entries" tab
+ *   that lists every entry across every type.
+ * - Other lookup adapters (`media`, `user`, plugin-contributed): eligible
+ *   iff `menuPicker` is set on the registration.
+ * - Custom URL: always last.
+ */
+export function getEligibleMenuKinds(registry: PluginRegistry): PickerTab[] {
+  const tabs: PickerTab[] = [];
+
+  for (const entryType of registry.entryTypes.values()) {
+    if (!isMenuEligibleType(entryType)) continue;
+    tabs.push({
+      kind: "entry",
+      tabLabel: pickerLabelForEntryType(entryType),
+      target: entryType.name,
+    });
+  }
+
+  for (const taxonomy of registry.termTaxonomies.values()) {
+    if (!isMenuEligibleTaxonomy(taxonomy)) continue;
+    tabs.push({
+      kind: "term",
+      tabLabel: pickerLabelForTaxonomy(taxonomy),
+      target: taxonomy.name,
+    });
+  }
+
+  for (const adapter of registry.lookupAdapters.values()) {
+    if (adapter.kind === "entry" || adapter.kind === "term") continue;
+    const opt = adapter.menuPicker;
+    if (!opt) continue;
+    tabs.push({ kind: adapter.kind, tabLabel: opt.tabLabel });
+  }
+
+  tabs.push({ kind: "custom", tabLabel: "Custom URL" });
+  return tabs;
+}
+
+interface MenuEligibleEntryType {
+  readonly name: string;
+  readonly label: string;
+  readonly labels?: { readonly plural?: string };
+  readonly isPublic?: boolean;
+  readonly isShownInMenus?: boolean;
+  readonly menuPickerLabel?: string;
+}
+
+function isMenuEligibleType(entryType: MenuEligibleEntryType): boolean {
+  return entryType.isShownInMenus ?? entryType.isPublic ?? true;
+}
+
+function pickerLabelForEntryType(entryType: MenuEligibleEntryType): string {
+  return (
+    entryType.menuPickerLabel ?? entryType.labels?.plural ?? entryType.label
+  );
+}
+
+interface MenuEligibleTaxonomy {
+  readonly name: string;
+  readonly label: string;
+  readonly isPublic?: boolean;
+  readonly isShownInMenus?: boolean;
+  readonly menuPickerLabel?: string;
+}
+
+function isMenuEligibleTaxonomy(taxonomy: MenuEligibleTaxonomy): boolean {
+  return taxonomy.isShownInMenus ?? taxonomy.isPublic ?? true;
+}
+
+function pickerLabelForTaxonomy(taxonomy: MenuEligibleTaxonomy): string {
+  return taxonomy.menuPickerLabel ?? taxonomy.label;
+}

--- a/packages/plugins/menu/src/server/index.ts
+++ b/packages/plugins/menu/src/server/index.ts
@@ -1,3 +1,5 @@
+export { getEligibleMenuKinds } from "./eligibility.js";
+export type { PickerTab } from "./eligibility.js";
 export { getMenuByName } from "./getMenuByName.js";
 export { getMenuForLocation } from "./getMenuForLocation.js";
 export {


### PR DESCRIPTION
## Summary

Slice 6 of the menu plugin breakdown — closes [#160](https://github.com/withplumix/plumix/issues/160). Parent PRD: [#155](https://github.com/withplumix/plumix/issues/155).

Two commits:

1. **`feat(core)`** — `RegisteredLookupAdapter` now extends `LookupAdapterOptions`, and `registerLookupAdapter` spreads `options` instead of destructuring. Plugin-contributed adapter option fields (declaration-merged from plugin modules) now round-trip into the manifest the way entry-type / taxonomy options already do.
2. **`feat(plugin-menu)`** — declaration-merges `isShownInMenus` + `menuPickerLabel` onto `EntryTypeOptions` / `TermTaxonomyOptions`, and `menuPicker.tabLabel` onto `LookupAdapterOptions`. Adds `getEligibleMenuKinds(registry)` — a pure function returning the ordered list of picker tabs the admin's "Add menu items" rail will render in slice 7.

## Eligibility rules

- **Entry types**: eligible iff `isShownInMenus ?? isPublic ?? true`. Mirrors WordPress's `show_in_nav_menus` semantics with plumix-native naming.
- **Term taxonomies**: same cascade.
- **Built-in `entry` / `term` lookup adapters**: explicitly NOT enumerated as their own picker tabs — entry types and taxonomies above surface them per-target. Skipping avoids a flat "Entries" tab that lists every entry across every type.
- **Other adapter kinds** (`media`, `user`, future plugin-contributed): eligible iff `menuPicker` is set on registration.
- **Custom URL**: always last tab.

Tab label resolution: `menuPickerLabel` → `labels.plural` (entry types) → `label`, in priority order.

## Test plan

- [x] `pnpm typecheck` — 22/22 turbo tasks
- [x] `pnpm test` — 21/21 (1196 core + 118 plugin-menu, +15 new)
- [x] `pnpm lint`, `pnpm format` — clean
- [x] `pnpm publint`, `pnpm attw`, `pnpm knip` — clean
- [x] Commitlint — 2 commits, conventional + pnpm-scopes
- [x] Per-package `build/typecheck/test/lint` for `@plumix/core` and `@plumix/plugin-menu`

## Tests

`eligibility.test.ts` — 9 new cases covering:
- Empty registry → only Custom URL
- Entry-type cascade matrix (5 cells: isPublic-true/false × isShownInMenus override)
- Term-taxonomy cascade matrix (4 cells)
- `menuPickerLabel` overrides default
- Label fallback chain (`menuPickerLabel` → `labels.plural` → `label`)
- Built-in `entry`/`term` adapters never surface as their own tabs
- Non-default adapters need `menuPicker` opt-in
- Custom URL is always last