### PR TITLE
feat(plugin-menu): isCurrent / isAncestor + resolvedEntity on AppContext (slice 10)

### DIFF
--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -7,6 +7,7 @@ import type * as coreSchema from "../db/schema/index.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { HookExecutor } from "../hooks/registry.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
+import type { ResolvedEntity } from "../route/current.js";
 import type { OAuthProviderSummary } from "../runtime/app.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
 import type {
@@ -137,6 +138,15 @@ export interface AppContext<
    * a config-missing reason in that case.
    */
   readonly siteName?: string;
+  /**
+   * Set by the public-route resolver after URL → entity matching;
+   * `null` for non-public routes (admin, RPC, etc.) and on cold-start.
+   * Consumers (breadcrumbs, canonical tags, menu plugin's `isCurrent`)
+   * read this to answer "is this the entity we're currently rendering."
+   * Mutable by design — the resolver writes once between cookie auth
+   * and response rendering, and read paths see the populated value.
+   */
+  resolvedEntity: ResolvedEntity | null;
 }
 
 export type AuthenticatedAppContext<
@@ -211,6 +221,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     oauthProviders: args.oauthProviders ?? [],
     authenticator: args.authenticator ?? defaultAuthenticator(),
     bootstrapAllowed: args.bootstrapAllowed ?? false,
+    resolvedEntity: null,
     // Best-effort fallback for tests / runtimes that don't pass an
     // explicit origin: derive from the inbound request URL. Production
     // always passes the canonical operator-set origin so URLs in

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,8 @@ export * from "./db/index.js";
 export * from "./db/schema/index.js";
 export * from "./hooks/index.js";
 export * from "./plugin/index.js";
+export { isCurrentSource } from "./route/current.js";
+export type { CurrentSource, ResolvedEntity } from "./route/current.js";
 export type { RouteIntent, RouteRule } from "./route/intent.js";
 export * from "./rpc/index.js";
 export type * from "./runtime/adapter.js";

--- a/packages/core/src/route/current.test.ts
+++ b/packages/core/src/route/current.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import { isCurrentSource } from "./current.js";
+
+function ctxWith(
+  resolvedEntity: AppContext["resolvedEntity"],
+  url = "https://cms.example/about",
+): AppContext {
+  return {
+    request: new Request(url),
+    resolvedEntity,
+  } as unknown as AppContext;
+}
+
+describe("isCurrentSource", () => {
+  describe("entry kind", () => {
+    test("matches when ctx.resolvedEntity is the same entry id", () => {
+      const ctx = ctxWith({ kind: "entry", id: 42 });
+      expect(isCurrentSource(ctx, { kind: "entry", id: 42 })).toBe(true);
+    });
+
+    test("does not match a different entry id", () => {
+      const ctx = ctxWith({ kind: "entry", id: 42 });
+      expect(isCurrentSource(ctx, { kind: "entry", id: 99 })).toBe(false);
+    });
+
+    test("does not match across kinds (term id matching entry id is a different entity)", () => {
+      const ctx = ctxWith({ kind: "term", id: 42 });
+      expect(isCurrentSource(ctx, { kind: "entry", id: 42 })).toBe(false);
+    });
+
+    test("does not match an archive resolvedEntity", () => {
+      const ctx = ctxWith({ kind: "archive", entryType: "post" });
+      expect(isCurrentSource(ctx, { kind: "entry", id: 1 })).toBe(false);
+    });
+
+    test("returns false when ctx.resolvedEntity is null", () => {
+      const ctx = ctxWith(null);
+      expect(isCurrentSource(ctx, { kind: "entry", id: 1 })).toBe(false);
+    });
+  });
+
+  describe("term kind", () => {
+    test("matches when ctx.resolvedEntity is the same term id", () => {
+      const ctx = ctxWith({ kind: "term", id: 7 });
+      expect(isCurrentSource(ctx, { kind: "term", id: 7 })).toBe(true);
+    });
+
+    test("does not cross-match entry id", () => {
+      const ctx = ctxWith({ kind: "entry", id: 7 });
+      expect(isCurrentSource(ctx, { kind: "term", id: 7 })).toBe(false);
+    });
+  });
+
+  describe("custom kind", () => {
+    test("matches identical pathname", () => {
+      const ctx = ctxWith(null, "https://cms.example/about");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/about" })).toBe(
+        true,
+      );
+    });
+
+    test("trailing-slash insensitive — request has trailing, source doesn't", () => {
+      const ctx = ctxWith(null, "https://cms.example/about/");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/about" })).toBe(
+        true,
+      );
+    });
+
+    test("trailing-slash insensitive — source has trailing, request doesn't", () => {
+      const ctx = ctxWith(null, "https://cms.example/about");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/about/" })).toBe(
+        true,
+      );
+    });
+
+    test("ignores query string (path-equality semantics)", () => {
+      const ctx = ctxWith(null, "https://cms.example/about?utm=foo");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/about" })).toBe(
+        true,
+      );
+    });
+
+    test("ignores fragment", () => {
+      const ctx = ctxWith(null, "https://cms.example/about");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/about#top" })).toBe(
+        true,
+      );
+    });
+
+    test("does not match a different pathname", () => {
+      const ctx = ctxWith(null, "https://cms.example/about");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/contact" })).toBe(
+        false,
+      );
+    });
+
+    test("absolute source URL with same pathname matches", () => {
+      const ctx = ctxWith(null, "https://cms.example/about");
+      expect(
+        isCurrentSource(ctx, {
+          kind: "custom",
+          url: "https://cms.example/about",
+        }),
+      ).toBe(true);
+    });
+
+    test("cross-origin source URL never matches (external link is not current)", () => {
+      const ctx = ctxWith(null, "https://cms.example/about");
+      expect(
+        isCurrentSource(ctx, {
+          kind: "custom",
+          url: "https://other.example/about",
+        }),
+      ).toBe(false);
+    });
+
+    test("malformed source url returns false (graceful degradation)", () => {
+      const ctx = ctxWith(null, "https://cms.example/about");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "::not a url" })).toBe(
+        false,
+      );
+    });
+
+    test("ignores resolvedEntity for custom-URL items (URL-only check)", () => {
+      const ctx = ctxWith(
+        { kind: "entry", id: 99 },
+        "https://cms.example/contact",
+      );
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/contact" })).toBe(
+        true,
+      );
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/about" })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("root path edge cases", () => {
+    test("matches `/` exactly", () => {
+      const ctx = ctxWith(null, "https://cms.example/");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/" })).toBe(true);
+    });
+
+    test("`/` does not normalize away to empty", () => {
+      const ctx = ctxWith(null, "https://cms.example/");
+      expect(isCurrentSource(ctx, { kind: "custom", url: "/about" })).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/packages/core/src/route/current.ts
+++ b/packages/core/src/route/current.ts
@@ -1,0 +1,85 @@
+import type { AppContext } from "../context/app.js";
+
+/**
+ * The "current request entity" — populated by the public-route resolver
+ * after URL → entity matching. Consumers (breadcrumbs, canonical tags,
+ * the menu plugin's `isCurrent` detection) read it via `AppContext` to
+ * answer "is this the page we're currently rendering."
+ *
+ * Archive routes set the `archive` variant carrying the entry type
+ * being listed. Single routes set the `entry` variant with the resolved
+ * row id. Term-archive routes will set `term` once the route module
+ * supports them — the variant is declared now so consumers can branch
+ * on it without a future migration.
+ */
+export type ResolvedEntity =
+  | { readonly kind: "entry"; readonly id: number }
+  | { readonly kind: "term"; readonly id: number }
+  | { readonly kind: "archive"; readonly entryType: string };
+
+/**
+ * Discriminated source the menu plugin (and similar consumers) pass when
+ * asking "is this thing the current page". Mirrors the menu item's
+ * `source` shape but adds a `url` carrier for custom-URL items, which
+ * have no upstream id.
+ */
+export type CurrentSource =
+  | { readonly kind: "entry"; readonly id: number }
+  | { readonly kind: "term"; readonly id: number }
+  | { readonly kind: "custom"; readonly url: string };
+
+/**
+ * Returns `true` when `source` identifies the current request entity.
+ *
+ * - `entry` / `term`: id-based match against `ctx.resolvedEntity`.
+ *   Survives URL changes (query strings, trailing slashes) because
+ *   the comparison is by id, not by path string. Returns `false` when
+ *   `resolvedEntity` is null (non-public route, 404, login page).
+ *   Match keys on `(kind, id)` only — relies on `entries.id` /
+ *   `terms.id` global uniqueness within their table.
+ * - `custom`: pathname-based match against `ctx.request.url`, with
+ *   trailing-slash normalization on both sides. Cross-origin sources
+ *   never match (an external link is by definition not the current
+ *   page). Custom URLs have no id to match against; `resolvedEntity`
+ *   is ignored on this path.
+ */
+export function isCurrentSource(
+  ctx: AppContext,
+  source: CurrentSource,
+): boolean {
+  if (source.kind === "custom") {
+    return matchesPathname(ctx.request.url, source.url);
+  }
+  const resolved = ctx.resolvedEntity;
+  if (!resolved) return false;
+  return resolved.kind === source.kind && resolved.id === source.id;
+}
+
+function matchesPathname(requestUrl: string, sourceUrl: string): boolean {
+  let here: string;
+  let target: URL;
+  try {
+    here = new URL(requestUrl).pathname;
+    target = new URL(sourceUrl, requestUrl);
+  } catch {
+    return false;
+  }
+
+  // Cross-origin sources are never the "current page" — an external link
+  // is by definition somewhere else, even if its pathname coincides with
+  // ours. Compared against the request's host (resolved against the
+  // request URL so a relative `/about` sees the same host as `here`).
+  const requestHost = new URL(requestUrl).host;
+  if (target.host !== requestHost) return false;
+
+  return (
+    normalizeTrailingSlash(here) === normalizeTrailingSlash(target.pathname)
+  );
+}
+
+function normalizeTrailingSlash(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -45,6 +45,11 @@ async function resolveSingle(
   });
   if (!row) return notFound("public-post-not-found");
 
+  // Stash the matched entity so render-side helpers (menu plugin's
+  // `isCurrent`, breadcrumbs, canonical tags) can identify the
+  // current page without re-running URL matching.
+  ctx.resolvedEntity = { kind: "entry", id: row.id };
+
   const body = `<article><h1>${escapeHtml(row.title)}</h1>${renderTiptapContent(row.content)}</article>`;
   return htmlResponse(row.title, body);
 }
@@ -61,6 +66,11 @@ async function resolveArchive(
     )
     .orderBy(desc(entries.publishedAt), desc(entries.id))
     .limit(ARCHIVE_LIMIT);
+
+  // Set after the query so a thrown query doesn't leave a stale entity
+  // on ctx for any downstream middleware (logging, error pages) that
+  // reads it. Mirrors `resolveSingle`.
+  ctx.resolvedEntity = { kind: "archive", entryType: intent.entryType };
 
   const registered = ctx.plugins.entryTypes.get(intent.entryType);
   const title =

--- a/packages/plugins/menu/src/server/getMenuByName.test.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.test.ts
@@ -37,7 +37,12 @@ function ctxFor(
   db: Awaited<ReturnType<typeof createTestDb>>,
   registry: PluginRegistry,
 ): AppContext {
-  return { db, plugins: registry } as unknown as AppContext;
+  return {
+    db,
+    plugins: registry,
+    request: new Request("https://test.example/"),
+    resolvedEntity: null,
+  } as unknown as AppContext;
 }
 
 interface SeedItemInput {
@@ -382,6 +387,92 @@ describe("getMenuByName", () => {
 
     const menu = await getMenuByName(ctx, "unpublished");
     expect(menu?.items).toHaveLength(0);
+  });
+
+  describe("isCurrent / isAncestor", () => {
+    function ctxAtUrl(url: string, resolved: unknown): AppContext {
+      return {
+        db,
+        plugins: ctx.plugins,
+        request: new Request(url),
+        resolvedEntity: resolved,
+      } as unknown as AppContext;
+    }
+
+    test("entry-kind item is current when resolvedEntity matches its id", async () => {
+      const post = await factories.entry.create({
+        type: "post",
+        slug: "active",
+        title: "Active",
+        status: "published",
+        authorId,
+      });
+      const termId = await seedMenu("active");
+      await seedItems(termId, [
+        { title: "Other", meta: { kind: "custom", url: "/other" } },
+        { title: "Linked", meta: { kind: "entry", entryId: post.id } },
+      ]);
+
+      const localCtx = ctxAtUrl("https://test.example/post/active", {
+        kind: "entry",
+        id: post.id,
+      });
+      const menu = await getMenuByName(localCtx, "active");
+      const items = menu?.items ?? [];
+      // Entry-kind items render the linked entry's title — "Linked" is
+      // the menu item's stored title; "Active" is the post's live title.
+      expect(items.find((i) => i.label === "Active")?.isCurrent).toBe(true);
+      expect(items.find((i) => i.label === "Other")?.isCurrent).toBe(false);
+    });
+
+    test("custom-URL item is current when its href matches the request pathname", async () => {
+      const termId = await seedMenu("paths");
+      await seedItems(termId, [
+        { title: "Home", meta: { kind: "custom", url: "/" } },
+        { title: "About", meta: { kind: "custom", url: "/about" } },
+      ]);
+
+      const localCtx = ctxAtUrl("https://test.example/about", null);
+      const items = (await getMenuByName(localCtx, "paths"))?.items ?? [];
+      expect(items.find((i) => i.label === "About")?.isCurrent).toBe(true);
+      expect(items.find((i) => i.label === "Home")?.isCurrent).toBe(false);
+    });
+
+    test("isAncestor is true on a parent whose descendant is current", async () => {
+      const termId = await seedMenu("nested-current");
+      const [rootId] = await seedItems(termId, [
+        { title: "Docs", meta: { kind: "custom", url: "/docs" } },
+      ]);
+      await seedItems(termId, [
+        {
+          title: "API",
+          meta: { kind: "custom", url: "/docs/api" },
+          parentId: rootId,
+        },
+      ]);
+
+      const localCtx = ctxAtUrl("https://test.example/docs/api", null);
+      const items = (await getMenuByName(localCtx, "nested-current"))?.items;
+      const docs = items?.[0];
+      expect(docs?.label).toBe("Docs");
+      expect(docs?.isCurrent).toBe(false);
+      expect(docs?.isAncestor).toBe(true);
+      expect(docs?.children[0]?.label).toBe("API");
+      expect(docs?.children[0]?.isCurrent).toBe(true);
+      expect(docs?.children[0]?.isAncestor).toBe(false);
+    });
+
+    test("isCurrent and isAncestor are both false when nothing in the menu matches", async () => {
+      const termId = await seedMenu("none-current");
+      await seedItems(termId, [
+        { title: "Home", meta: { kind: "custom", url: "/" } },
+      ]);
+
+      const localCtx = ctxAtUrl("https://test.example/elsewhere", null);
+      const items = (await getMenuByName(localCtx, "none-current"))?.items;
+      expect(items?.[0]?.isCurrent).toBe(false);
+      expect(items?.[0]?.isAncestor).toBe(false);
+    });
   });
 
   test("drops entry items linked to isPublic: false types", async () => {

--- a/packages/plugins/menu/src/server/getMenuByName.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray } from "drizzle-orm";
 
 import type { AppContext, LookupResult } from "@plumix/core";
-import { entries, entryTerm, terms } from "@plumix/core";
+import { entries, entryTerm, isCurrentSource, terms } from "@plumix/core";
 
 import type { TreeNode } from "./buildTree.js";
 import type { MenuItemMeta, ResolvedMenu, ResolvedMenuItem } from "./types.js";
@@ -74,7 +74,7 @@ export async function getMenuByName(
   const refs = await resolveRefs(ctx, rows);
   const { tree } = buildTree(rows);
   const items = tree
-    .map((node) => toResolvedItem(node, refs))
+    .map((node) => toResolvedItem(ctx, node, refs))
     .filter((item): item is ResolvedMenuItem => item !== null);
 
   return { termId: term.id, name: term.name, slug: term.slug, items };
@@ -175,30 +175,42 @@ function refMapFromResults(
 }
 
 function toResolvedItem(
+  ctx: AppContext,
   node: TreeNode<MenuItemRow>,
   refs: ResolvedRefs,
 ): ResolvedMenuItem | null {
   const meta = parseMenuItemMeta(node.meta);
   if (!meta) return null;
-  const resolved = resolveByKind(node, meta, refs);
+  const resolved = resolveByKind(ctx, node, meta, refs);
   if (!resolved) return null;
 
   const children = node.children
-    .map((child) => toResolvedItem(child, refs))
+    .map((child) => toResolvedItem(ctx, child, refs))
     .filter((child): child is ResolvedMenuItem => child !== null);
 
-  return { ...resolved, children };
+  // Menu-tree ancestor: any descendant is current. Pure JS walk over
+  // the children we just built. Entity-tree ancestry (linked entry is
+  // ancestor of current entry) is deliberately not built-in — it
+  // requires walking the entries.parent_id chain at render time and
+  // is a `menu:item` filter consumer's job when needed.
+  const isAncestor = children.some(
+    (child) => child.isCurrent || child.isAncestor,
+  );
+
+  return { ...resolved, isAncestor, children };
 }
 
-type ResolvedNoChildren = Omit<ResolvedMenuItem, "children">;
+type ResolvedNoChildren = Omit<ResolvedMenuItem, "children" | "isAncestor">;
 
 function resolveByKind(
+  ctx: AppContext,
   node: TreeNode<MenuItemRow>,
   meta: MenuItemMeta,
   refs: ResolvedRefs,
 ): ResolvedNoChildren | null {
   const resolved = resolveLabelHrefSource(node, meta, refs);
   if (!resolved) return null;
+  const isCurrent = isCurrentSource(ctx, currentSourceFor(resolved));
   return {
     id: node.id,
     parentId: node.parentId,
@@ -208,7 +220,20 @@ function resolveByKind(
     rel: meta.rel,
     cssClasses: meta.cssClasses ?? [],
     source: resolved.source,
+    isCurrent,
   };
+}
+
+function currentSourceFor(
+  resolved: LabelHrefSource,
+):
+  | { readonly kind: "entry"; readonly id: number }
+  | { readonly kind: "term"; readonly id: number }
+  | { readonly kind: "custom"; readonly url: string } {
+  if (resolved.source.kind === "custom") {
+    return { kind: "custom", url: resolved.href };
+  }
+  return { kind: resolved.source.kind, id: resolved.source.id };
 }
 
 interface LabelHrefSource {

--- a/packages/plugins/menu/src/server/getMenuForLocation.test.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.test.ts
@@ -45,7 +45,12 @@ function ctxFor(
   db: Awaited<ReturnType<typeof createTestDb>>,
   registry: PluginRegistry,
 ): AppContext {
-  return { db, plugins: registry } as unknown as AppContext;
+  return {
+    db,
+    plugins: registry,
+    request: new Request("https://test.example/"),
+    resolvedEntity: null,
+  } as unknown as AppContext;
 }
 
 describe("getMenuForLocation", () => {

--- a/packages/plugins/menu/src/server/types.ts
+++ b/packages/plugins/menu/src/server/types.ts
@@ -47,6 +47,19 @@ export interface ResolvedMenuItem {
   readonly rel?: string;
   readonly cssClasses: readonly string[];
   readonly source: ResolvedMenuItemSource;
+  /**
+   * True iff this item identifies the request's current entity (or
+   * matches its pathname for `kind: 'custom'`). Computed via core's
+   * `isCurrentSource(ctx, source)` helper at render time.
+   */
+  readonly isCurrent: boolean;
+  /**
+   * True iff any descendant in this menu's tree has `isCurrent: true`.
+   * Menu-tree ancestry only — entity-tree ancestry (item links to a
+   * page that's an ancestor of the current page in the entries tree)
+   * is a `menu:item` filter consumer's job, not built-in.
+   */
+  readonly isAncestor: boolean;
   readonly children: readonly ResolvedMenuItem[];
 }
 


### PR DESCRIPTION
## Summary

Slice 10 of the menu plugin breakdown — closes [#161](https://github.com/withplumix/plumix/issues/161). Parent PRD: [#155](https://github.com/withplumix/plumix/issues/155).

Two commits:

1. **`feat(core)`** — `AppContext.resolvedEntity` (mutable, set by the public-route resolver) + `isCurrentSource(ctx, source)` helper in `@plumix/core/route/current`. `ResolvedEntity` declares `entry` / `term` / `archive` variants so future term-archive routes don't need a migration. Match semantics: id-based for entry/term, pathname-equality with trailing-slash normalization for custom URLs. Cross-origin custom URLs never match.
2. **`feat(plugin-menu)`** — `ResolvedMenuItem` gains `isCurrent` and `isAncestor` booleans. The resolver computes them via the core helper + a JS tree walk. Menu-tree ancestry only; entity-tree ancestry stays a `menu:item` filter consumer's job.

## Sentry skill findings — addressed pre-merge

- **Must-fix** (find-bugs): `matchesPathname` re-parsed `requestUrl` outside the try/catch — malformed request URL would throw. **Fix**: both URLs parsed inside the same try/catch, return `false` on either failure.
- **Must-fix** (find-bugs): cross-origin custom URLs (e.g. `https://other.example/about`) matched on pathname alone — wrong semantics, an external link is never the current page. **Fix**: explicit host comparison; cross-origin sources return `false`. Test updated to assert this.
- **Should-fix** (find-bugs): `resolveArchive` set `ctx.resolvedEntity` before its DB query — a thrown query would leave a stale entity on ctx. **Fix**: moved the assignment to after the query, mirroring `resolveSingle`.
- **Should-fix** (review): id-collision concern between `entries.id` and `terms.id` is acceptable today (different tables, both autoincrement). Documented in JSDoc that the helper relies on per-table id uniqueness.

Skipped (with rationale in the review): `CurrentSource` vs `ResolvedMenuItemSource` duplication (small, deferable), `makeTestCtx` helper extraction (only 3 call sites today), readonly mutability brand on `resolvedEntity` (ctx is per-request).

## Test plan

- [x] `pnpm typecheck` 22/22, `pnpm test` 21/21 (1216 core + 107 plugin-menu, +23 new across both)
- [x] `pnpm format`, `pnpm publint`, `pnpm attw`, `pnpm knip` clean
- [x] `pnpm commitlint` — 2 commits, conventional + pnpm-scopes
- [x] Per-package `build/typecheck/test/lint` for `@plumix/core` and `@plumix/plugin-menu`

## What this unblocks

- Slice 7+ admin Locations panel — has the eligibility resolver from slice 6 and now also `isCurrent` / `isAncestor` on resolved menu items for preview rendering
- Public-site nav active-state styling — themes calling `getMenuForLocation('primary')` now get items they can mark as current/active without re-running URL matching
- Sitemap, RSS, canonical-tag plugins (when they land) can read `ctx.resolvedEntity` instead of re-resolving the URL