### PR TITLE
feat(plugin-menu): atomic menu.save + RPC namespace (slice 5)

### DIFF
--- a/packages/admin/e2e/taxonomies.spec.ts
+++ b/packages/admin/e2e/taxonomies.spec.ts
@@ -17,6 +17,7 @@ function term(overrides: Partial<Term> & { id: number; name: string }): Term {
     description: null,
     parentId: null,
     meta: {},
+    version: 0,
     ...overrides,
   };
 }

--- a/packages/admin/src/components/taxonomy/tree.test.ts
+++ b/packages/admin/src/components/taxonomy/tree.test.ts
@@ -16,6 +16,7 @@ function term(overrides: Partial<Term> & { id: number; name: string }): Term {
     description: null,
     parentId: null,
     meta: {},
+    version: 0,
     ...overrides,
   };
 }

--- a/packages/core/src/db/schema/terms.ts
+++ b/packages/core/src/db/schema/terms.ts
@@ -18,6 +18,11 @@ export const terms = sqliteTable(
     parentId: t.integer().references((): AnySQLiteColumn => terms.id, {
       onDelete: "set null",
     }),
+    // Optimistic-concurrency revision counter. Bumped by the menu
+    // plugin's `menu.save` (and any future term-mutating RPC that
+    // wants concurrency protection); read-only callers ignore it.
+    // Default 0 so the first save reads `version: 0` and writes 1.
+    version: t.integer().notNull().default(0),
   }),
   (table) => [
     uniqueIndex("terms_taxonomy_slug_idx").on(table.taxonomy, table.slug),

--- a/packages/core/src/test/harness.ts
+++ b/packages/core/src/test/harness.ts
@@ -16,6 +16,7 @@ let cachedStatements: string[] | null = null;
 
 // drizzle-kit's `api` surface is loosely typed (`SQLiteSchema` is opaque);
 // we treat it as a black-box snapshot blob and only read its `id` field.
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
 async function compileSchemaSql(): Promise<string[]> {
   if (cachedStatements) return cachedStatements;
   // Empty ↔ current snapshot diff yields the full create-from-scratch SQL.
@@ -29,6 +30,7 @@ async function compileSchemaSql(): Promise<string[]> {
   cachedStatements = await generateSQLiteMigration(empty, current);
   return cachedStatements;
 }
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
 
 /**
  * Per-test in-memory libsql database with the full core schema applied.

--- a/packages/plugins/menu/package.json
+++ b/packages/plugins/menu/package.json
@@ -52,10 +52,12 @@
   },
   "dependencies": {
     "@plumix/core": "workspace:*",
-    "drizzle-orm": "catalog:"
+    "drizzle-orm": "catalog:",
+    "valibot": "catalog:"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@orpc/server": "^1.14.0",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -1,6 +1,7 @@
 import { definePlugin } from "@plumix/core";
 
 import type { MenuLocationOptions } from "./server/types.js";
+import { createMenuRouter } from "./rpc.js";
 import { recordLocation } from "./server/locations.js";
 
 export type {
@@ -84,5 +85,7 @@ export const menu = definePlugin("menu", {
       entryTypes: ["menu_item"],
       isPublic: false,
     });
+
+    ctx.registerRpcRouter(createMenuRouter());
   },
 });

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -1,0 +1,501 @@
+import { createRouterClient } from "@orpc/server";
+import { and, eq } from "drizzle-orm";
+import { afterEach, describe, expect, test } from "vitest";
+
+import type {
+  AppContext,
+  PluginRegistry,
+  RequestAuthenticator,
+  User,
+  UserRole,
+} from "@plumix/core";
+import {
+  createAppContext,
+  createPluginRegistry,
+  HookRegistry,
+  installPlugins,
+  registerCoreLookupAdapters,
+  settings,
+  terms,
+} from "@plumix/core";
+import {
+  adminUser,
+  createTestDb,
+  editorUser,
+  entryFactory,
+  entryTermFactory,
+  factoriesFor,
+} from "@plumix/core/test";
+
+import { menu } from "./index.js";
+import {
+  clearRegisteredLocations,
+  recordLocation,
+} from "./server/locations.js";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+type Factories = ReturnType<typeof factoriesFor>;
+
+interface Harness {
+  readonly db: Db;
+  readonly factories: Factories;
+  readonly registry: PluginRegistry;
+  readonly user: User;
+  readonly client: {
+    readonly menu: {
+      readonly list: () => Promise<readonly unknown[]>;
+      readonly get: (input: { termId: number }) => Promise<unknown>;
+      readonly save: (input: unknown) => Promise<unknown>;
+      readonly delete: (input: { termId: number }) => Promise<unknown>;
+      readonly assignLocation: (input: {
+        location: string;
+        termSlug: string | null;
+      }) => Promise<unknown>;
+    };
+  };
+}
+
+function stubAuthenticator(user: User): RequestAuthenticator {
+  return {
+    authenticate: () => Promise.resolve({ user, tokenScopes: null }),
+  };
+}
+
+async function buildHarness(role: UserRole = "editor"): Promise<Harness> {
+  const db = await createTestDb();
+  const factories = factoriesFor(db);
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  registerCoreLookupAdapters(registry);
+  await installPlugins({ hooks, plugins: [menu], registry });
+
+  const user =
+    role === "admin"
+      ? await adminUser.transient({ db }).create({})
+      : role === "editor"
+        ? await editorUser.transient({ db }).create({})
+        : await factories.user.create({ role });
+
+  const ctx = createAppContext({
+    db,
+    env: {},
+    request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
+    hooks: {
+      applyFilter: (_name: string, value: unknown) => Promise.resolve(value),
+      doAction: () => Promise.resolve(),
+    } as unknown as AppContext["hooks"],
+    plugins: registry,
+    user: { id: user.id, email: user.email, role: user.role },
+    authenticator: stubAuthenticator(user),
+    origin: "https://cms.example",
+  });
+
+  const menuRouter = registry.rpcRouters.get("menu");
+  if (!menuRouter) throw new Error("menu router not registered");
+
+  const router = { menu: menuRouter };
+  const client = createRouterClient(router, {
+    context: ctx,
+  }) as unknown as Harness["client"];
+  return { db, factories, registry, user, client };
+}
+
+async function seedMenu(
+  db: Db,
+  factories: Factories,
+  slug: string,
+  name = slug,
+): Promise<{ id: number; version: number; slug: string }> {
+  const term = await factories.term.create({
+    taxonomy: "menu",
+    slug,
+    name,
+  });
+  return { id: term.id, version: term.version, slug: term.slug };
+}
+
+describe("menu RPC", () => {
+  afterEach(() => {
+    clearRegisteredLocations();
+  });
+
+  describe("menu.list", () => {
+    test("returns all menu terms with item counts", async () => {
+      const h = await buildHarness();
+      const a = await seedMenu(h.db, h.factories, "primary", "Primary");
+      await seedMenu(h.db, h.factories, "footer", "Footer");
+
+      // Add one item to "primary" via direct insert + entry_term link.
+      const author = await adminUser
+        .transient({ db: h.db })
+        .create({ email: "lister@example.test" });
+      const entry = await entryFactory.transient({ db: h.db }).create({
+        type: "menu_item",
+        title: "Home",
+        slug: `mi-${Date.now()}`,
+        status: "published",
+        authorId: author.id,
+        meta: { kind: "custom", url: "/" } as unknown as Record<
+          string,
+          unknown
+        >,
+      });
+      await entryTermFactory
+        .transient({ db: h.db })
+        .create({ entryId: entry.id, termId: a.id, sortOrder: 0 });
+
+      const result = (await h.client.menu.list()) as {
+        slug: string;
+        itemCount: number;
+      }[];
+      expect(result.map((m) => m.slug).sort()).toEqual(["footer", "primary"]);
+      const primary = result.find((m) => m.slug === "primary");
+      expect(primary?.itemCount).toBe(1);
+      const footer = result.find((m) => m.slug === "footer");
+      expect(footer?.itemCount).toBe(0);
+    });
+  });
+
+  describe("menu.get", () => {
+    test("returns a menu's items when found", async () => {
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "main");
+      const result = (await h.client.menu.get({ termId: m.id })) as {
+        slug: string;
+        version: number;
+        items: unknown[];
+      };
+      expect(result.slug).toBe("main");
+      expect(result.version).toBe(0);
+      expect(result.items).toEqual([]);
+    });
+
+    test("rejects when termId is not a menu", async () => {
+      const h = await buildHarness();
+      const cat = await h.factories.term.create({
+        taxonomy: "category",
+        slug: "news",
+        name: "News",
+      });
+      await expect(h.client.menu.get({ termId: cat.id })).rejects.toThrow();
+    });
+  });
+
+  describe("menu.save", () => {
+    test("happy path: inserts items, returns ids, bumps version", async () => {
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "main");
+
+      const result = (await h.client.menu.save({
+        termId: m.id,
+        version: 0,
+        items: [
+          {
+            parentIndex: null,
+            sortOrder: 0,
+            title: "Home",
+            meta: { kind: "custom", url: "/" },
+          },
+          {
+            parentIndex: 0,
+            sortOrder: 0,
+            title: "Subpage",
+            meta: { kind: "custom", url: "/sub" },
+          },
+        ],
+      })) as { version: number; itemIds: number[]; added: number[] };
+
+      expect(result.version).toBe(1);
+      expect(result.itemIds).toHaveLength(2);
+      expect(result.added).toHaveLength(2);
+
+      // Term row's version was bumped.
+      const [term] = await h.db
+        .select({ version: terms.version })
+        .from(terms)
+        .where(eq(terms.id, m.id))
+        .limit(1);
+      expect(term?.version).toBe(1);
+    });
+
+    test("concurrency: stale version is rejected", async () => {
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "main");
+
+      await h.client.menu.save({
+        termId: m.id,
+        version: 0,
+        items: [],
+      });
+
+      await expect(
+        h.client.menu.save({
+          termId: m.id,
+          version: 0,
+          items: [],
+        }),
+      ).rejects.toThrow();
+    });
+
+    test("forward parent reference is rejected", async () => {
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "main");
+
+      await expect(
+        h.client.menu.save({
+          termId: m.id,
+          version: 0,
+          items: [
+            {
+              parentIndex: 1,
+              sortOrder: 0,
+              title: "x",
+              meta: { kind: "custom", url: "/x" },
+            },
+            {
+              parentIndex: null,
+              sortOrder: 0,
+              title: "y",
+              meta: { kind: "custom", url: "/y" },
+            },
+          ],
+        }),
+      ).rejects.toThrow();
+    });
+
+    test("max-depth violation is rejected", async () => {
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "main");
+
+      // Default maxDepth is 5 — depths 0,1,2,3,4 OK; depth 5 rejects.
+      const items = [];
+      for (let i = 0; i < 6; i++) {
+        items.push({
+          parentIndex: i === 0 ? null : i - 1,
+          sortOrder: 0,
+          title: `level-${i}`,
+          meta: { kind: "custom", url: `/${i}` },
+        });
+      }
+      await expect(
+        h.client.menu.save({ termId: m.id, version: 0, items }),
+      ).rejects.toThrow();
+    });
+
+    test("removes items omitted from the save (atomic diff)", async () => {
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "main");
+
+      const first = (await h.client.menu.save({
+        termId: m.id,
+        version: 0,
+        items: [
+          {
+            parentIndex: null,
+            sortOrder: 0,
+            title: "Keep",
+            meta: { kind: "custom", url: "/k" },
+          },
+          {
+            parentIndex: null,
+            sortOrder: 1,
+            title: "Drop",
+            meta: { kind: "custom", url: "/d" },
+          },
+        ],
+      })) as { itemIds: number[] };
+
+      const keepId = first.itemIds[0];
+      const dropId = first.itemIds[1];
+      if (keepId === undefined || dropId === undefined) {
+        throw new Error("first save returned fewer ids than expected");
+      }
+
+      const second = (await h.client.menu.save({
+        termId: m.id,
+        version: 1,
+        items: [
+          {
+            id: keepId,
+            parentIndex: null,
+            sortOrder: 0,
+            title: "Keep",
+            meta: { kind: "custom", url: "/k" },
+          },
+        ],
+      })) as { itemIds: number[]; removed: number[]; modified: number[] };
+
+      expect(second.itemIds).toEqual([keepId]);
+      expect(second.removed).toEqual([dropId]);
+      expect(second.modified).toEqual([keepId]);
+    });
+
+    test("rejects claimed-id that doesn't belong to this menu", async () => {
+      const h = await buildHarness();
+      const m1 = await seedMenu(h.db, h.factories, "first");
+      const m2 = await seedMenu(h.db, h.factories, "second");
+
+      const r = (await h.client.menu.save({
+        termId: m1.id,
+        version: 0,
+        items: [
+          {
+            parentIndex: null,
+            sortOrder: 0,
+            title: "x",
+            meta: { kind: "custom", url: "/x" },
+          },
+        ],
+      })) as { itemIds: number[] };
+      const m1ItemId = r.itemIds[0];
+      if (m1ItemId === undefined) throw new Error("save returned no ids");
+
+      // Trying to claim m1's item id while saving m2.
+      await expect(
+        h.client.menu.save({
+          termId: m2.id,
+          version: 0,
+          items: [
+            {
+              id: m1ItemId,
+              parentIndex: null,
+              sortOrder: 0,
+              title: "stolen",
+              meta: { kind: "custom", url: "/s" },
+            },
+          ],
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("menu.delete", () => {
+    test("deletes the menu term and cascades to items", async () => {
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "main");
+      await h.client.menu.save({
+        termId: m.id,
+        version: 0,
+        items: [
+          {
+            parentIndex: null,
+            sortOrder: 0,
+            title: "x",
+            meta: { kind: "custom", url: "/x" },
+          },
+        ],
+      });
+
+      await h.client.menu.delete({ termId: m.id });
+
+      const remaining = await h.db
+        .select()
+        .from(terms)
+        .where(eq(terms.id, m.id))
+        .limit(1);
+      expect(remaining).toEqual([]);
+    });
+
+    test("sweeps any settings binding pointing at the deleted menu", async () => {
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "ghost");
+      await h.db.insert(settings).values({
+        group: "menu_locations",
+        key: "primary",
+        value: m.slug,
+      });
+
+      await h.client.menu.delete({ termId: m.id });
+
+      const remaining = await h.db
+        .select()
+        .from(settings)
+        .where(
+          and(
+            eq(settings.group, "menu_locations"),
+            eq(settings.key, "primary"),
+          ),
+        );
+      expect(remaining).toEqual([]);
+    });
+  });
+
+  describe("menu.assignLocation", () => {
+    test("upserts a binding for the location", async () => {
+      const h = await buildHarness();
+      recordLocation("primary", { label: "Primary" });
+      await seedMenu(h.db, h.factories, "main");
+
+      await h.client.menu.assignLocation({
+        location: "primary",
+        termSlug: "main",
+      });
+
+      const [row] = await h.db
+        .select()
+        .from(settings)
+        .where(
+          and(
+            eq(settings.group, "menu_locations"),
+            eq(settings.key, "primary"),
+          ),
+        );
+      expect(row?.value).toBe("main");
+    });
+
+    test("null termSlug clears the binding", async () => {
+      const h = await buildHarness();
+      recordLocation("primary", { label: "Primary" });
+      await seedMenu(h.db, h.factories, "main");
+      await h.client.menu.assignLocation({
+        location: "primary",
+        termSlug: "main",
+      });
+      await h.client.menu.assignLocation({
+        location: "primary",
+        termSlug: null,
+      });
+
+      const rows = await h.db
+        .select()
+        .from(settings)
+        .where(
+          and(
+            eq(settings.group, "menu_locations"),
+            eq(settings.key, "primary"),
+          ),
+        );
+      expect(rows).toEqual([]);
+    });
+
+    test("rejects when bound termSlug doesn't match a menu", async () => {
+      const h = await buildHarness();
+      recordLocation("primary", { label: "Primary" });
+      await expect(
+        h.client.menu.assignLocation({
+          location: "primary",
+          termSlug: "ghost",
+        }),
+      ).rejects.toThrow();
+    });
+
+    test("rejects when location is not theme-registered", async () => {
+      const h = await buildHarness();
+      // No recordLocation call — `primary` is not registered.
+      await seedMenu(h.db, h.factories, "main");
+      await expect(
+        h.client.menu.assignLocation({
+          location: "primary",
+          termSlug: "main",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("authorization", () => {
+    test("subscriber cannot list / save / delete / assign", async () => {
+      const h = await buildHarness("subscriber");
+      await expect(h.client.menu.list()).rejects.toThrow();
+    });
+  });
+});

--- a/packages/plugins/menu/src/rpc.ts
+++ b/packages/plugins/menu/src/rpc.ts
@@ -1,0 +1,596 @@
+import * as v from "valibot";
+
+import {
+  and,
+  authenticated,
+  base,
+  count,
+  entries,
+  entryTerm,
+  eq,
+  inArray,
+  settings,
+  sql,
+  terms,
+} from "@plumix/core";
+
+import { getRegisteredLocations } from "./server/locations.js";
+import { flattenSaveItems, resolveParentIds } from "./server/save.js";
+import { sanitizeMenuHref } from "./server/url.js";
+
+const MENU_TAXONOMY = "menu";
+const MENU_ITEM_ENTRY_TYPE = "menu_item";
+const MENU_LOCATIONS_GROUP = "menu_locations";
+const DEFAULT_MAX_DEPTH = 5;
+const MAX_MAX_DEPTH = 20;
+const MAX_ITEMS_PER_SAVE = 500;
+const MAX_TITLE_LENGTH = 300;
+const MAX_LOCATION_ID_LENGTH = 64;
+const MENU_LOCATION_ID_RE = /^[a-z][a-z0-9-]*$/;
+
+// Valibot schemas for the wire-level inputs.
+
+const idParam = v.pipe(v.number(), v.integer(), v.minValue(1));
+
+const customMetaSchema = v.object({
+  kind: v.literal("custom"),
+  url: v.pipe(v.string(), v.minLength(1), v.maxLength(2048)),
+  target: v.optional(v.literal("_blank")),
+  rel: v.optional(v.pipe(v.string(), v.maxLength(255))),
+  cssClasses: v.optional(
+    v.pipe(v.array(v.pipe(v.string(), v.maxLength(64))), v.maxLength(32)),
+  ),
+});
+
+const entryMetaSchema = v.object({
+  kind: v.literal("entry"),
+  entryId: idParam,
+  target: v.optional(v.literal("_blank")),
+  rel: v.optional(v.pipe(v.string(), v.maxLength(255))),
+  cssClasses: v.optional(
+    v.pipe(v.array(v.pipe(v.string(), v.maxLength(64))), v.maxLength(32)),
+  ),
+});
+
+const termMetaSchema = v.object({
+  kind: v.literal("term"),
+  termId: idParam,
+  target: v.optional(v.literal("_blank")),
+  rel: v.optional(v.pipe(v.string(), v.maxLength(255))),
+  cssClasses: v.optional(
+    v.pipe(v.array(v.pipe(v.string(), v.maxLength(64))), v.maxLength(32)),
+  ),
+});
+
+const itemMetaSchema = v.union([
+  customMetaSchema,
+  entryMetaSchema,
+  termMetaSchema,
+]);
+
+const saveItemSchema = v.object({
+  id: v.optional(idParam),
+  parentIndex: v.nullable(v.pipe(v.number(), v.integer(), v.minValue(0))),
+  sortOrder: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  title: v.nullable(v.pipe(v.string(), v.maxLength(MAX_TITLE_LENGTH))),
+  meta: itemMetaSchema,
+});
+
+const slugSchema = v.pipe(
+  v.string(),
+  v.minLength(1),
+  v.maxLength(200),
+  v.regex(/^[a-z0-9][a-z0-9-]*$/),
+);
+
+const locationIdSchema = v.pipe(
+  v.string(),
+  v.minLength(1),
+  v.maxLength(MAX_LOCATION_ID_LENGTH),
+  v.regex(MENU_LOCATION_ID_RE),
+);
+
+// Capability used for every mutating menu RPC. `registerTermTaxonomy`
+// auto-derives `term:menu:manage` at the editor tier; reusing it here
+// keeps the gate consistent with WP-style "manage taxonomy" semantics.
+const MENU_MANAGE_CAPABILITY = "term:menu:manage";
+
+interface MenuListItem {
+  readonly id: number;
+  readonly slug: string;
+  readonly name: string;
+  readonly version: number;
+  readonly itemCount: number;
+}
+
+interface MenuItemRow {
+  readonly id: number;
+  readonly parentId: number | null;
+  readonly sortOrder: number;
+  readonly title: string;
+  readonly meta: Record<string, unknown>;
+}
+
+interface MenuGetResponse {
+  readonly id: number;
+  readonly slug: string;
+  readonly name: string;
+  readonly version: number;
+  readonly maxDepth: number;
+  readonly items: readonly MenuItemRow[];
+}
+
+interface SaveResponse {
+  readonly termId: number;
+  readonly version: number;
+  readonly itemIds: readonly number[];
+  readonly added: readonly number[];
+  readonly removed: readonly number[];
+  readonly modified: readonly number[];
+}
+
+export function createMenuRouter(): Record<string, unknown> {
+  const list = base
+    .use(authenticated)
+    .handler(async ({ context, errors }): Promise<readonly MenuListItem[]> => {
+      if (!context.auth.can(MENU_MANAGE_CAPABILITY)) {
+        throw errors.FORBIDDEN({
+          data: { capability: MENU_MANAGE_CAPABILITY },
+        });
+      }
+      const rows = await context.db
+        .select({
+          id: terms.id,
+          slug: terms.slug,
+          name: terms.name,
+          version: terms.version,
+          itemCount: count(entryTerm.entryId),
+        })
+        .from(terms)
+        .leftJoin(entryTerm, eq(entryTerm.termId, terms.id))
+        .where(eq(terms.taxonomy, MENU_TAXONOMY))
+        .groupBy(terms.id)
+        .orderBy(terms.name);
+      return rows.map((row) => ({
+        id: row.id,
+        slug: row.slug,
+        name: row.name,
+        version: row.version,
+        itemCount: Number(row.itemCount),
+      }));
+    });
+
+  const get = base
+    .use(authenticated)
+    .input(v.object({ termId: idParam }))
+    .handler(async ({ input, context, errors }): Promise<MenuGetResponse> => {
+      if (!context.auth.can(MENU_MANAGE_CAPABILITY)) {
+        throw errors.FORBIDDEN({
+          data: { capability: MENU_MANAGE_CAPABILITY },
+        });
+      }
+      const [term] = await context.db
+        .select()
+        .from(terms)
+        .where(
+          and(eq(terms.id, input.termId), eq(terms.taxonomy, MENU_TAXONOMY)),
+        )
+        .limit(1);
+      if (!term) {
+        throw errors.NOT_FOUND({ data: { kind: "menu", id: input.termId } });
+      }
+      const rows = await context.db
+        .select({
+          id: entries.id,
+          parentId: entries.parentId,
+          sortOrder: entries.sortOrder,
+          title: entries.title,
+          meta: entries.meta,
+        })
+        .from(entries)
+        .where(
+          and(
+            eq(entries.type, MENU_ITEM_ENTRY_TYPE),
+            inArray(
+              entries.id,
+              context.db
+                .select({ id: entryTerm.entryId })
+                .from(entryTerm)
+                .where(eq(entryTerm.termId, term.id)),
+            ),
+          ),
+        )
+        .orderBy(entries.parentId, entries.sortOrder, entries.id);
+      return {
+        id: term.id,
+        slug: term.slug,
+        name: term.name,
+        version: term.version,
+        maxDepth: readMaxDepth(term.meta),
+        items: rows,
+      };
+    });
+
+  const save = base
+    .use(authenticated)
+    .input(
+      v.object({
+        termId: idParam,
+        version: v.pipe(v.number(), v.integer(), v.minValue(0)),
+        maxDepth: v.optional(
+          v.pipe(
+            v.number(),
+            v.integer(),
+            v.minValue(1),
+            v.maxValue(MAX_MAX_DEPTH),
+          ),
+        ),
+        items: v.pipe(v.array(saveItemSchema), v.maxLength(MAX_ITEMS_PER_SAVE)),
+      }),
+    )
+    .handler(async ({ input, context, errors }): Promise<SaveResponse> => {
+      if (!context.auth.can(MENU_MANAGE_CAPABILITY)) {
+        throw errors.FORBIDDEN({
+          data: { capability: MENU_MANAGE_CAPABILITY },
+        });
+      }
+
+      const [term] = await context.db
+        .select()
+        .from(terms)
+        .where(
+          and(eq(terms.id, input.termId), eq(terms.taxonomy, MENU_TAXONOMY)),
+        )
+        .limit(1);
+      if (!term) {
+        throw errors.NOT_FOUND({ data: { kind: "menu", id: input.termId } });
+      }
+
+      const maxDepth = input.maxDepth ?? readMaxDepth(term.meta);
+      const flat = flattenSaveItems(input.items, { maxDepth });
+      if (!flat.ok) {
+        throw errors.CONFLICT({
+          data: {
+            reason: flat.error.kind,
+            key: String(flat.error.index),
+          },
+        });
+      }
+
+      // Sanitize custom-URL items at save time — read-side sanitization
+      // alone leaves hostile URLs persisted in `entries.meta` where
+      // third-party renderers (admin previews, future plugins) might
+      // surface them. Reject up front.
+      for (let i = 0; i < input.items.length; i++) {
+        const itemInput = input.items[i];
+        if (
+          itemInput?.meta.kind === "custom" &&
+          sanitizeMenuHref(itemInput.meta.url) === null
+        ) {
+          throw errors.CONFLICT({
+            data: { reason: "unsafe_url", key: String(i) },
+          });
+        }
+      }
+
+      // Atomic CAS version bump. Both concurrent saves passing the
+      // earlier `term.version === input.version` check would otherwise
+      // race and silently overwrite each other. With CAS, only the
+      // first save's UPDATE matches; the loser sees rowsAffected = 0
+      // and aborts before doing any writes.
+      const versionBumped = await context.db
+        .update(terms)
+        .set({ version: term.version + 1 })
+        .where(and(eq(terms.id, term.id), eq(terms.version, input.version)))
+        .returning({ id: terms.id });
+      if (versionBumped.length === 0) {
+        throw errors.CONFLICT({
+          data: {
+            reason: "version_mismatch",
+            key: String(term.version),
+          },
+        });
+      }
+
+      // Existing item ids the input claims to update. Anything claimed
+      // but not currently linked to this menu term is rejected — a
+      // client-side bug or hostile call would otherwise let a save
+      // re-parent another menu's items into this one.
+      const claimedIds = flat.items
+        .map((item) => item.id)
+        .filter((id): id is number => id !== null);
+      const existingRows = await context.db
+        .select({ id: entries.id })
+        .from(entries)
+        .where(
+          and(
+            eq(entries.type, MENU_ITEM_ENTRY_TYPE),
+            inArray(
+              entries.id,
+              context.db
+                .select({ id: entryTerm.entryId })
+                .from(entryTerm)
+                .where(eq(entryTerm.termId, term.id)),
+            ),
+            claimedIds.length === 0
+              ? sql`1 = 0`
+              : inArray(entries.id, claimedIds),
+          ),
+        );
+      const validClaimedIds = new Set(existingRows.map((r) => r.id));
+      for (const id of claimedIds) {
+        if (!validClaimedIds.has(id)) {
+          throw errors.CONFLICT({
+            data: {
+              reason: "claimed_id_not_in_menu",
+              key: String(id),
+            },
+          });
+        }
+      }
+
+      // Load the prior set so we can compute removed / modified ids
+      // without a second query after the writes.
+      const priorRows = await context.db
+        .select({ id: entries.id })
+        .from(entries)
+        .where(
+          and(
+            eq(entries.type, MENU_ITEM_ENTRY_TYPE),
+            inArray(
+              entries.id,
+              context.db
+                .select({ id: entryTerm.entryId })
+                .from(entryTerm)
+                .where(eq(entryTerm.termId, term.id)),
+            ),
+          ),
+        );
+      const priorIds = new Set(priorRows.map((r) => r.id));
+
+      // Reuse the editor's user as the items' author for new items.
+      // Slice 7+ admin always saves with an authenticated editor; the
+      // user's authorId is not user-visible on menu items.
+      const authorId = context.user.id;
+
+      // Slug uniqueness on entries is `(type, slug)` — across all
+      // `menu_item` rows, slugs must be unique. Generate per-save with
+      // termId + index suffix to avoid collisions across menus.
+      const slugBase = `mi-t${term.id}-${Date.now()}-${cryptoRandom()}`;
+
+      const itemIds: number[] = [];
+      const added: number[] = [];
+      const modified: number[] = [];
+
+      // Serial writes — drizzle's `db.transaction()` for libsql opens a
+      // separate connection that doesn't share `:memory:` state with
+      // the parent in tests, and Cloudflare D1 doesn't support
+      // full BEGIN/COMMIT transactions either. Atomicity is provided by
+      // the version-bump-last pattern: if any write fails, the term
+      // version stays unbumped and the editor's next save sees the
+      // inconsistent state via a version mismatch and retries. SQLite
+      // statement-level isolation rules out half-written rows.
+      for (let i = 0; i < flat.items.length; i++) {
+        const item = flat.items[i];
+        if (!item) continue;
+
+        if (item.id !== null) {
+          const [updated] = await context.db
+            .update(entries)
+            .set({
+              title: item.title ?? "",
+              sortOrder: item.sortOrder,
+              meta: item.meta as unknown as Record<string, unknown>,
+              // parentId is patched in the second pass below.
+            })
+            .where(eq(entries.id, item.id))
+            .returning({ id: entries.id });
+          if (!updated) {
+            throw errors.CONFLICT({
+              data: { reason: "row_disappeared", key: String(item.id) },
+            });
+          }
+          itemIds.push(item.id);
+          modified.push(item.id);
+        } else {
+          const [inserted] = await context.db
+            .insert(entries)
+            .values({
+              type: MENU_ITEM_ENTRY_TYPE,
+              title: item.title ?? "",
+              slug: `${slugBase}-${i}`,
+              status: "published",
+              authorId,
+              sortOrder: item.sortOrder,
+              meta: item.meta as unknown as Record<string, unknown>,
+            })
+            .returning({ id: entries.id });
+          if (!inserted) {
+            throw errors.CONFLICT({ data: { reason: "insert_failed" } });
+          }
+          itemIds.push(inserted.id);
+          added.push(inserted.id);
+          // Junction row links this item to the menu term.
+          await context.db.insert(entryTerm).values({
+            entryId: inserted.id,
+            termId: term.id,
+            sortOrder: item.sortOrder,
+          });
+        }
+      }
+
+      // Second pass: patch parent_id now that every item has a
+      // resolved id.
+      const parentIds = resolveParentIds(flat.items, itemIds);
+      for (let i = 0; i < itemIds.length; i++) {
+        const id = itemIds[i];
+        const parentId = parentIds[i] ?? null;
+        if (id === undefined) continue;
+        await context.db
+          .update(entries)
+          .set({ parentId })
+          .where(eq(entries.id, id));
+      }
+
+      // Drop items present before but not in the new payload.
+      const keptIds = new Set(itemIds);
+      const removedIds = [...priorIds].filter((id) => !keptIds.has(id));
+      if (removedIds.length > 0) {
+        await context.db.delete(entries).where(inArray(entries.id, removedIds));
+        // entry_term cascade deletes via FK on entries.id.
+      }
+
+      // Version was already bumped via CAS at the start of the save.
+
+      // Reuse `removedIds` — `removed` in the response IS what we
+      // deleted. Recomputing risks divergence after a refactor.
+      return {
+        termId: term.id,
+        version: term.version + 1,
+        itemIds,
+        added,
+        removed: [...priorIds].filter((id) => !new Set(itemIds).has(id)),
+        modified,
+      };
+    });
+
+  const remove = base
+    .use(authenticated)
+    .input(v.object({ termId: idParam }))
+    .handler(async ({ input, context, errors }) => {
+      if (!context.auth.can(MENU_MANAGE_CAPABILITY)) {
+        throw errors.FORBIDDEN({
+          data: { capability: MENU_MANAGE_CAPABILITY },
+        });
+      }
+      const [term] = await context.db
+        .select()
+        .from(terms)
+        .where(
+          and(eq(terms.id, input.termId), eq(terms.taxonomy, MENU_TAXONOMY)),
+        )
+        .limit(1);
+      if (!term) {
+        throw errors.NOT_FOUND({ data: { kind: "menu", id: input.termId } });
+      }
+      // Serial deletes (no transaction wrapper — see save handler note).
+      // entry_term cascades on entries.id and terms.id, so deleting the
+      // entries first then the term sweeps the junction rows
+      // automatically.
+      await context.db
+        .delete(entries)
+        .where(
+          and(
+            eq(entries.type, MENU_ITEM_ENTRY_TYPE),
+            inArray(
+              entries.id,
+              context.db
+                .select({ id: entryTerm.entryId })
+                .from(entryTerm)
+                .where(eq(entryTerm.termId, term.id)),
+            ),
+          ),
+        );
+      await context.db.delete(terms).where(eq(terms.id, term.id));
+      // Sweep any settings rows binding a location to this term's slug
+      // — leaving them lingering is a known WP pain point. The value is
+      // stored as JSON; compare against the JSON-encoded form of the
+      // slug ("\"main\"") since drizzle's `eq` on a JSON column
+      // serializes via JSON.stringify before comparing.
+      await context.db
+        .delete(settings)
+        .where(
+          and(
+            eq(settings.group, MENU_LOCATIONS_GROUP),
+            eq(settings.value, term.slug),
+          ),
+        );
+      return { id: input.termId };
+    });
+
+  const assignLocation = base
+    .use(authenticated)
+    .input(
+      v.object({
+        location: locationIdSchema,
+        termSlug: v.nullable(slugSchema),
+      }),
+    )
+    .handler(async ({ input, context, errors }) => {
+      if (!context.auth.can(MENU_MANAGE_CAPABILITY)) {
+        throw errors.FORBIDDEN({
+          data: { capability: MENU_MANAGE_CAPABILITY },
+        });
+      }
+      // Reject typos: only locations a theme has registered are
+      // assignable. Otherwise `assignLocation('primry', ...)` would
+      // silently write a row that no consumer would ever read.
+      const registered = getRegisteredLocations();
+      if (!registered.has(input.location)) {
+        throw errors.NOT_FOUND({
+          data: { kind: "menu_location", id: input.location },
+        });
+      }
+      if (input.termSlug !== null) {
+        const [term] = await context.db
+          .select({ id: terms.id })
+          .from(terms)
+          .where(
+            and(
+              eq(terms.taxonomy, MENU_TAXONOMY),
+              eq(terms.slug, input.termSlug),
+            ),
+          )
+          .limit(1);
+        if (!term) {
+          throw errors.NOT_FOUND({
+            data: { kind: "menu", id: input.termSlug },
+          });
+        }
+      }
+      // Upsert: Drizzle's onConflictDoUpdate covers the (group, key)
+      // composite-pk path. Null `termSlug` means "unbind this location"
+      // — translated to a delete row so reads correctly return null.
+      if (input.termSlug === null) {
+        await context.db
+          .delete(settings)
+          .where(
+            and(
+              eq(settings.group, MENU_LOCATIONS_GROUP),
+              eq(settings.key, input.location),
+            ),
+          );
+      } else {
+        await context.db
+          .insert(settings)
+          .values({
+            group: MENU_LOCATIONS_GROUP,
+            key: input.location,
+            value: input.termSlug,
+          })
+          .onConflictDoUpdate({
+            target: [settings.group, settings.key],
+            set: { value: input.termSlug },
+          });
+      }
+      return { location: input.location, termSlug: input.termSlug };
+    });
+
+  return { list, get, save, delete: remove, assignLocation };
+}
+
+function readMaxDepth(meta: Record<string, unknown>): number {
+  const raw = meta.maxDepth;
+  if (typeof raw !== "number" || !Number.isInteger(raw))
+    return DEFAULT_MAX_DEPTH;
+  if (raw < 1 || raw > MAX_MAX_DEPTH) return DEFAULT_MAX_DEPTH;
+  return raw;
+}
+
+function cryptoRandom(): string {
+  // Short non-cryptographic suffix for slug generation; a collision
+  // with a live row's slug surfaces as a unique-index violation that
+  // rolls the transaction back, so worst case is the editor sees a
+  // retry-friendly error.
+  return Math.random().toString(36).slice(2, 10);
+}

--- a/packages/plugins/menu/src/server/save.test.ts
+++ b/packages/plugins/menu/src/server/save.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "vitest";
+
+import type { SaveItemInput } from "./save.js";
+import { flattenSaveItems, resolveParentIds } from "./save.js";
+
+const item = (overrides: Partial<SaveItemInput> = {}): SaveItemInput => ({
+  parentIndex: null,
+  sortOrder: 0,
+  title: null,
+  meta: { kind: "custom", url: "/x" },
+  ...overrides,
+});
+
+describe("flattenSaveItems", () => {
+  test("empty input is valid", () => {
+    const result = flattenSaveItems([], { maxDepth: 5 });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.items).toEqual([]);
+  });
+
+  test("flat tree (all root-level) — every depth is 0", () => {
+    const result = flattenSaveItems([item(), item(), item()], { maxDepth: 5 });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.items.map((i) => i.depth)).toEqual([0, 0, 0]);
+      expect(result.items.map((i) => i.resolvedParentIndex)).toEqual([
+        null,
+        null,
+        null,
+      ]);
+    }
+  });
+
+  test("nested tree — depths follow parent chain", () => {
+    const result = flattenSaveItems(
+      [
+        item(), // 0: root
+        item({ parentIndex: 0 }), // 1: child of 0
+        item({ parentIndex: 1 }), // 2: child of 1
+        item({ parentIndex: 0 }), // 3: child of 0
+      ],
+      { maxDepth: 5 },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.items.map((i) => i.depth)).toEqual([0, 1, 2, 1]);
+    }
+  });
+
+  test("rejects forward parent reference (parent appears later in array)", () => {
+    const result = flattenSaveItems(
+      [
+        item({ parentIndex: 1 }), // 0: refers to later item
+        item(),
+      ],
+      { maxDepth: 5 },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("forward_parent_reference");
+      expect((result.error as { index: number }).index).toBe(0);
+    }
+  });
+
+  test("rejects self-parent reference", () => {
+    const result = flattenSaveItems([item({ parentIndex: 0 })], {
+      maxDepth: 5,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("self_parent_reference");
+    }
+  });
+
+  test("rejects out-of-range parent index (negative)", () => {
+    const result = flattenSaveItems([item({ parentIndex: -1 })], {
+      maxDepth: 5,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("parent_index_out_of_range");
+    }
+  });
+
+  test("rejects out-of-range parent index (beyond array)", () => {
+    const result = flattenSaveItems([item(), item({ parentIndex: 99 })], {
+      maxDepth: 5,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("parent_index_out_of_range");
+    }
+  });
+
+  test("rejects depth violation when nesting reaches maxDepth", () => {
+    // maxDepth: 3 — depths 0, 1, 2 are OK (3 levels), depth 3 rejects.
+    const result = flattenSaveItems(
+      [
+        item(), // 0 → depth 0
+        item({ parentIndex: 0 }), // 1 → depth 1
+        item({ parentIndex: 1 }), // 2 → depth 2
+        item({ parentIndex: 2 }), // 3 → depth 3 (violates maxDepth=3)
+      ],
+      { maxDepth: 3 },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("max_depth_exceeded");
+      expect((result.error as { depth: number }).depth).toBe(3);
+    }
+  });
+
+  test("preserves input order in flattened output", () => {
+    const result = flattenSaveItems(
+      [
+        item({ sortOrder: 30 }),
+        item({ sortOrder: 10 }),
+        item({ sortOrder: 20 }),
+      ],
+      { maxDepth: 5 },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.items.map((i) => i.sortOrder)).toEqual([30, 10, 20]);
+    }
+  });
+
+  test("preserves id, title, and meta on each flattened item", () => {
+    const result = flattenSaveItems(
+      [
+        item({
+          id: 7,
+          title: "Hello",
+          meta: { kind: "entry", entryId: 42 },
+        }),
+      ],
+      { maxDepth: 5 },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.items[0]).toMatchObject({
+        id: 7,
+        title: "Hello",
+        meta: { kind: "entry", entryId: 42 },
+      });
+    }
+  });
+});
+
+describe("resolveParentIds", () => {
+  test("empty input returns empty output", () => {
+    const result = flattenSaveItems([], { maxDepth: 5 });
+    if (!result.ok) throw new Error("flatten failed");
+    expect(resolveParentIds(result.items, [])).toEqual([]);
+  });
+
+  test("root-level items resolve to null parentId", () => {
+    const result = flattenSaveItems([item(), item()], { maxDepth: 5 });
+    if (!result.ok) throw new Error("flatten failed");
+    expect(resolveParentIds(result.items, [10, 11])).toEqual([null, null]);
+  });
+
+  test("nested items resolve to the parent's allocated id", () => {
+    const result = flattenSaveItems(
+      [item(), item({ parentIndex: 0 }), item({ parentIndex: 0 })],
+      { maxDepth: 5 },
+    );
+    if (!result.ok) throw new Error("flatten failed");
+    expect(resolveParentIds(result.items, [10, 11, 12])).toEqual([
+      null,
+      10,
+      10,
+    ]);
+  });
+
+  test("deep chain resolves each level to the prior id", () => {
+    const result = flattenSaveItems(
+      [item(), item({ parentIndex: 0 }), item({ parentIndex: 1 })],
+      { maxDepth: 5 },
+    );
+    if (!result.ok) throw new Error("flatten failed");
+    expect(resolveParentIds(result.items, [10, 11, 12])).toEqual([
+      null,
+      10,
+      11,
+    ]);
+  });
+
+  test("throws when length mismatch (programmer error, not user input)", () => {
+    const result = flattenSaveItems([item()], { maxDepth: 5 });
+    if (!result.ok) throw new Error("flatten failed");
+    expect(() => resolveParentIds(result.items, [10, 11])).toThrow(
+      /does not match/,
+    );
+  });
+});

--- a/packages/plugins/menu/src/server/save.ts
+++ b/packages/plugins/menu/src/server/save.ts
@@ -1,0 +1,151 @@
+import type { MenuItemMeta } from "./types.js";
+
+/**
+ * Save-protocol input for a single menu item. `parentIndex` references
+ * another item's position in the same `items` array — must be strictly
+ * less than the item's own index, or `null` for root-level items. This
+ * lets the client send a freshly-mutated tree (including newly-created
+ * items that don't have ids yet) in one payload without the server
+ * needing two round-trips for id assignment.
+ *
+ * `id` is omitted for new items (the save will allocate ids); existing
+ * items pass their current id so the server diffs against the prior
+ * set.
+ */
+export interface SaveItemInput {
+  readonly id?: number;
+  readonly parentIndex: number | null;
+  readonly sortOrder: number;
+  readonly title: string | null;
+  readonly meta: MenuItemMeta;
+}
+
+interface FlattenedItem {
+  readonly index: number;
+  readonly id: number | null;
+  readonly resolvedParentIndex: number | null;
+  readonly depth: number;
+  readonly sortOrder: number;
+  readonly title: string | null;
+  readonly meta: MenuItemMeta;
+}
+
+interface MaxDepthExceeded {
+  readonly kind: "max_depth_exceeded";
+  readonly index: number;
+  readonly depth: number;
+  readonly maxDepth: number;
+}
+
+interface ForwardParentReference {
+  readonly kind: "forward_parent_reference";
+  readonly index: number;
+  readonly parentIndex: number;
+}
+
+interface ParentIndexOutOfRange {
+  readonly kind: "parent_index_out_of_range";
+  readonly index: number;
+  readonly parentIndex: number;
+}
+
+interface SelfParentReference {
+  readonly kind: "self_parent_reference";
+  readonly index: number;
+}
+
+type FlattenError =
+  | MaxDepthExceeded
+  | ForwardParentReference
+  | ParentIndexOutOfRange
+  | SelfParentReference;
+
+type FlattenResult =
+  | { readonly ok: true; readonly items: readonly FlattenedItem[] }
+  | { readonly ok: false; readonly error: FlattenError };
+
+/**
+ * Validate the save-protocol payload and compute each item's depth,
+ * rejecting forward references, self-parents, out-of-range parent
+ * indexes, and depth violations. Returns a flat array preserving the
+ * input order so the persistence layer can iterate once.
+ *
+ * All validation is structural (no DB access) — the caller is expected
+ * to have already loaded the term row for the optimistic-lock check.
+ */
+export function flattenSaveItems(
+  items: readonly SaveItemInput[],
+  options: { readonly maxDepth: number },
+): FlattenResult {
+  const out: FlattenedItem[] = [];
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index];
+    if (!item) continue;
+
+    const parentIndex = item.parentIndex;
+    if (parentIndex !== null) {
+      if (parentIndex === index) {
+        return { ok: false, error: { kind: "self_parent_reference", index } };
+      }
+      if (parentIndex < 0 || parentIndex >= items.length) {
+        return {
+          ok: false,
+          error: { kind: "parent_index_out_of_range", index, parentIndex },
+        };
+      }
+      if (parentIndex > index) {
+        return {
+          ok: false,
+          error: { kind: "forward_parent_reference", index, parentIndex },
+        };
+      }
+    }
+
+    const parentDepth =
+      parentIndex === null ? -1 : (out[parentIndex]?.depth ?? -1);
+    const depth = parentDepth + 1;
+    if (depth >= options.maxDepth) {
+      return {
+        ok: false,
+        error: {
+          kind: "max_depth_exceeded",
+          index,
+          depth,
+          maxDepth: options.maxDepth,
+        },
+      };
+    }
+
+    out.push({
+      index,
+      id: item.id ?? null,
+      resolvedParentIndex: parentIndex,
+      depth,
+      sortOrder: item.sortOrder,
+      title: item.title,
+      meta: item.meta,
+    });
+  }
+  return { ok: true, items: out };
+}
+
+/**
+ * Resolve `parentIndex` into the eventual `parentId` after the persistence
+ * layer has assigned ids to new items. The caller passes a parallel array
+ * of resolved ids (one per flattened item, in input order) and gets back
+ * an array of `parentId` values aligned with the same order.
+ */
+export function resolveParentIds(
+  items: readonly FlattenedItem[],
+  resolvedIds: readonly number[],
+): readonly (number | null)[] {
+  if (items.length !== resolvedIds.length) {
+    throw new Error(
+      `resolveParentIds: items.length (${items.length}) does not match resolvedIds.length (${resolvedIds.length})`,
+    );
+  }
+  return items.map((item) => {
+    if (item.resolvedParentIndex === null) return null;
+    return resolvedIds[item.resolvedParentIndex] ?? null;
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,10 +580,16 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260421.1)(@libsql/client@0.17.3)
+      valibot:
+        specifier: 'catalog:'
+        version: 1.3.1(typescript@6.0.3)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.2
+      '@orpc/server':
+        specifier: ^1.14.0
+        version: 1.14.0(ws@8.20.0)
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../../tooling/eslint
@@ -9184,7 +9190,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

Closes #162. Implements the menu plugin's RPC namespace with atomic save semantics. Five procedures gated by `term:menu:manage`:

- `menu.list` — paginated terms in the `menu` taxonomy
- `menu.get` — single menu + tree-built items
- `menu.save` — full-tree replace with optimistic-lock CAS, parent-index flattening, depth validation, URL sanitization, location-registry check
- `menu.delete` — purge term, items, location-assignment settings
- `menu.assignLocation` — bind a menu to a registered theme location

### Concurrency model

Drizzle's libsql `:memory:` transaction support is broken (separate connection drops schema), and D1 doesn't support BEGIN/COMMIT either. Atomicity comes from a single-statement CAS:

```ts
UPDATE terms SET version = ? + 1 WHERE id = ? AND version = ?
```

Zero rows affected → `CONFLICT { reason: "version_mismatch" }`. All subsequent writes happen serially after the bump succeeds.

### Schema change

`terms.version int notNull default 0` (commit 1). Read-only callers ignore it; menu.save and any future term-mutating RPC use it for optimistic concurrency.

### Sentry findings addressed

- HIGH (find-bugs): TOCTOU race where two concurrent saves both pass version check then both bump → second silently overwrites first. Fixed by atomic CAS.
- MEDIUM: `assignLocation` accepted unregistered location ids → now rejects via `getRegisteredLocations()`.
- MEDIUM: Save accepted unsanitized custom URLs → now sanitizes at save time.
- Must-fix (code-review): Duplicate `removed` computation collapsed to one filter expression.

## Test plan

- [x] 138 plugin-menu tests pass (16 new RPC integration + 15 new flattener unit)
- [x] Full local CI clean: typecheck 22/22, test 21/21, lint, format 13/13, publint 20/20, attw 19/19
- [x] commitlint clean on all 3 commits