### PR TITLE
feat(plugin-menu): hook surface (menu:tree, menu:item, menu:saved) (slice 12)

### DIFF
--- a/packages/plugins/menu/src/hooks.test.ts
+++ b/packages/plugins/menu/src/hooks.test.ts
@@ -1,0 +1,318 @@
+import { createRouterClient } from "@orpc/server";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import type {
+  AppContext,
+  PluginRegistry,
+  RequestAuthenticator,
+  User,
+} from "@plumix/core";
+import {
+  createAppContext,
+  createPluginRegistry,
+  HookRegistry,
+  installPlugins,
+  registerCoreLookupAdapters,
+  settings,
+} from "@plumix/core";
+import {
+  adminUser,
+  createTestDb,
+  entryFactory,
+  entryTermFactory,
+  factoriesFor,
+} from "@plumix/core/test";
+
+import type { ResolvedMenuItem } from "./server/types.js";
+import { menu } from "./index.js";
+import { getMenuByName } from "./server/getMenuByName.js";
+import { getMenuForLocation } from "./server/getMenuForLocation.js";
+import {
+  clearRegisteredLocations,
+  recordLocation,
+} from "./server/locations.js";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+type Factories = ReturnType<typeof factoriesFor>;
+
+interface Bundle {
+  readonly db: Db;
+  readonly factories: Factories;
+  readonly registry: PluginRegistry;
+  readonly hooks: HookRegistry;
+  readonly ctx: AppContext;
+  readonly user: User;
+}
+
+function stubAuthenticator(user: User): RequestAuthenticator {
+  return {
+    authenticate: () => Promise.resolve({ user, tokenScopes: null }),
+  };
+}
+
+async function setup(): Promise<Bundle> {
+  const db = await createTestDb();
+  const factories = factoriesFor(db);
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  registerCoreLookupAdapters(registry);
+  await installPlugins({ hooks, plugins: [menu], registry });
+  const user = await adminUser
+    .transient({ db })
+    .create({ email: "hooks@example.test" });
+  const ctx = createAppContext({
+    db,
+    env: {},
+    request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
+    hooks,
+    plugins: registry,
+    user: { id: user.id, email: user.email, role: user.role },
+    authenticator: stubAuthenticator(user),
+    origin: "https://cms.example",
+  });
+  return { db, factories, registry, hooks, ctx, user };
+}
+
+async function seedMenuTerm(b: Bundle, slug: string): Promise<number> {
+  const term = await b.factories.term.create({
+    taxonomy: "menu",
+    slug,
+    name: slug,
+  });
+  return term.id;
+}
+
+interface SaveClient {
+  readonly save: (input: unknown) => Promise<{
+    readonly itemIds: readonly number[];
+    readonly version: number;
+  }>;
+}
+
+function saveClientFor(b: Bundle): SaveClient {
+  const menuRouter = b.registry.rpcRouters.get("menu");
+  if (!menuRouter) throw new Error("menu router not registered");
+  const client = createRouterClient(
+    { menu: menuRouter },
+    { context: b.ctx },
+  ) as unknown as { readonly menu: SaveClient };
+  return client.menu;
+}
+
+async function seedItem(
+  b: Bundle,
+  termId: number,
+  title: string,
+  url: string,
+): Promise<number> {
+  const entry = await entryFactory.transient({ db: b.db }).create({
+    type: "menu_item",
+    title,
+    slug: `mi-${termId}-${title}-${Date.now()}-${Math.random()}`,
+    status: "published",
+    authorId: b.user.id,
+    sortOrder: 0,
+    meta: { kind: "custom", url } as unknown as Record<string, unknown>,
+  });
+  await entryTermFactory
+    .transient({ db: b.db })
+    .create({ entryId: entry.id, termId, sortOrder: 0 });
+  return entry.id;
+}
+
+describe("menu hook surface", () => {
+  let b: Bundle;
+
+  beforeEach(async () => {
+    b = await setup();
+  });
+
+  afterEach(() => {
+    clearRegisteredLocations();
+  });
+
+  describe("menu:item filter", () => {
+    test("fires per resolved item with the resolved shape", async () => {
+      const termId = await seedMenuTerm(b, "primary");
+      await seedItem(b, termId, "Home", "/");
+      await seedItem(b, termId, "About", "/about");
+
+      const seen: ResolvedMenuItem[] = [];
+      b.hooks.addFilter("menu:item", (item) => {
+        seen.push(item);
+        return item;
+      });
+
+      await getMenuByName(b.ctx, "primary");
+      expect(seen.map((item) => item.label).sort()).toEqual(["About", "Home"]);
+    });
+
+    test("transforms each item — mutations land in render output", async () => {
+      const termId = await seedMenuTerm(b, "primary");
+      await seedItem(b, termId, "Home", "/");
+
+      b.hooks.addFilter("menu:item", (item) => ({
+        ...item,
+        cssClasses: [...item.cssClasses, "decorated"],
+      }));
+
+      const result = await getMenuByName(b.ctx, "primary");
+      expect(result?.items[0]?.cssClasses).toContain("decorated");
+    });
+
+    test("subscribers see already-resolved children", async () => {
+      const termId = await seedMenuTerm(b, "primary");
+      const parent = await entryFactory.transient({ db: b.db }).create({
+        type: "menu_item",
+        title: "Parent",
+        slug: `mi-p-${Date.now()}`,
+        status: "published",
+        authorId: b.user.id,
+        sortOrder: 0,
+        meta: { kind: "custom", url: "/p" } as unknown as Record<
+          string,
+          unknown
+        >,
+      });
+      await entryTermFactory
+        .transient({ db: b.db })
+        .create({ entryId: parent.id, termId, sortOrder: 0 });
+      const child = await entryFactory.transient({ db: b.db }).create({
+        type: "menu_item",
+        title: "Child",
+        slug: `mi-c-${Date.now()}`,
+        status: "published",
+        authorId: b.user.id,
+        parentId: parent.id,
+        sortOrder: 0,
+        meta: { kind: "custom", url: "/p/c" } as unknown as Record<
+          string,
+          unknown
+        >,
+      });
+      await entryTermFactory
+        .transient({ db: b.db })
+        .create({ entryId: child.id, termId, sortOrder: 0 });
+
+      b.hooks.addFilter("menu:item", (item) => ({
+        ...item,
+        cssClasses: [...item.cssClasses, `seen-${item.children.length}`],
+      }));
+
+      const result = await getMenuByName(b.ctx, "primary");
+      // Parent is filtered AFTER children — sees one child.
+      expect(result?.items[0]?.cssClasses).toContain("seen-1");
+      // Child is filtered first — sees zero children.
+      expect(result?.items[0]?.children[0]?.cssClasses).toContain("seen-0");
+    });
+  });
+
+  describe("menu:tree filter", () => {
+    test("fires once after assembly with location and termId", async () => {
+      const termId = await seedMenuTerm(b, "primary");
+      await seedItem(b, termId, "Home", "/");
+
+      const calls: { termId: number; location: string | null; len: number }[] =
+        [];
+      b.hooks.addFilter("menu:tree", (items, ctx) => {
+        calls.push({
+          termId: ctx.termId,
+          location: ctx.location,
+          len: items.length,
+        });
+        return items;
+      });
+
+      await getMenuByName(b.ctx, "primary");
+      expect(calls).toEqual([{ termId, location: null, len: 1 }]);
+    });
+
+    test("transforms full tree — pruning lands in render output", async () => {
+      const termId = await seedMenuTerm(b, "primary");
+      await seedItem(b, termId, "Public", "/");
+      await seedItem(b, termId, "Hidden", "/secret");
+
+      b.hooks.addFilter("menu:tree", (items) =>
+        items.filter((item) => item.label !== "Hidden"),
+      );
+
+      const result = await getMenuByName(b.ctx, "primary");
+      expect(result?.items.map((item) => item.label)).toEqual(["Public"]);
+    });
+
+    test("location is populated when called via getMenuForLocation", async () => {
+      recordLocation("primary", { label: "Primary" });
+      const termId = await seedMenuTerm(b, "primary");
+      await seedItem(b, termId, "Home", "/");
+      await b.db.insert(settings).values({
+        group: "menu_locations",
+        key: "primary",
+        value: "primary",
+      });
+
+      const seen: { location: string | null; termId: number }[] = [];
+      b.hooks.addFilter("menu:tree", (items, ctx) => {
+        seen.push({ location: ctx.location, termId: ctx.termId });
+        return items;
+      });
+
+      await getMenuForLocation(b.ctx, "primary");
+      expect(seen).toEqual([{ location: "primary", termId }]);
+    });
+  });
+
+  describe("menu:saved action", () => {
+    test("fires after save with addedIds / removedIds / modifiedIds", async () => {
+      const termId = await seedMenuTerm(b, "primary");
+
+      const calls: {
+        termId: number;
+        addedIds: readonly number[];
+        removedIds: readonly number[];
+        modifiedIds: readonly number[];
+      }[] = [];
+      b.hooks.addAction("menu:saved", (payload) => {
+        calls.push({
+          termId: payload.termId,
+          addedIds: payload.addedIds,
+          removedIds: payload.removedIds,
+          modifiedIds: payload.modifiedIds,
+        });
+      });
+
+      const result = await saveClientFor(b).save({
+        termId,
+        version: 0,
+        items: [
+          {
+            parentIndex: null,
+            sortOrder: 0,
+            title: "Home",
+            meta: { kind: "custom", url: "/" },
+          },
+        ],
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.termId).toBe(termId);
+      expect(calls[0]?.addedIds).toEqual(result.itemIds);
+      expect(calls[0]?.removedIds).toEqual([]);
+      expect(calls[0]?.modifiedIds).toEqual([]);
+    });
+
+    test("subscriber failure does not abort the commit", async () => {
+      const termId = await seedMenuTerm(b, "primary");
+
+      b.hooks.addAction("menu:saved", () => {
+        throw new Error("subscriber blew up");
+      });
+
+      const result = await saveClientFor(b).save({
+        termId,
+        version: 0,
+        items: [],
+      });
+      expect(result.version).toBe(1);
+    });
+  });
+});

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -1,6 +1,6 @@
 import { definePlugin } from "@plumix/core";
 
-import type { MenuLocationOptions } from "./server/types.js";
+import type { MenuLocationOptions, ResolvedMenuItem } from "./server/types.js";
 import { createMenuRouter } from "./rpc.js";
 import { recordLocation } from "./server/locations.js";
 
@@ -19,11 +19,13 @@ export type {
 
 // `@plumix/plugin-menu` augments the theme setup context with
 // `registerMenuLocation`, plus three core option shapes with
-// menu-eligibility flags. TypeScript surfaces all of these only when
-// this plugin is in the project's `node_modules`. The runtime
-// implementation of `registerMenuLocation` is wired via
-// `extendThemeContext` below; the eligibility flags are read at admin
-// time by the eligibility resolver (`getEligibleMenuKinds`).
+// menu-eligibility flags, plus the hook registries with three menu
+// hooks. TypeScript surfaces all of these only when this plugin is
+// in the project's `node_modules`. The runtime implementation of
+// `registerMenuLocation` is wired via `extendThemeContext` below;
+// the eligibility flags are read at admin time by the eligibility
+// resolver (`getEligibleMenuKinds`); the hooks are fired by
+// `getMenuByName` and `menu.save`.
 declare module "@plumix/core" {
   interface ThemeContextExtensions {
     registerMenuLocation: (id: string, options: MenuLocationOptions) => void;
@@ -50,6 +52,39 @@ declare module "@plumix/core" {
      * this is set.
      */
     readonly menuPicker?: { readonly tabLabel: string };
+  }
+
+  /**
+   * Hook surface. `menu:item` runs per resolved item during tree
+   * assembly (children resolve first, so subscribers see the
+   * already-transformed subtree). `menu:tree` runs once after
+   * assembly with `{ location, termId }` so a single subscriber can
+   * branch by slot. `menu:saved` fires after every successful
+   * `menu.save` commit — including no-op saves — so cache
+   * invalidators don't need to sniff the payload to decide whether
+   * to run.
+   */
+  interface FilterRegistry {
+    "menu:tree": (
+      items: readonly ResolvedMenuItem[],
+      context: {
+        readonly location: string | null;
+        readonly termId: number;
+      },
+    ) => readonly ResolvedMenuItem[] | Promise<readonly ResolvedMenuItem[]>;
+
+    "menu:item": (
+      item: ResolvedMenuItem,
+    ) => ResolvedMenuItem | Promise<ResolvedMenuItem>;
+  }
+
+  interface ActionRegistry {
+    "menu:saved": (payload: {
+      readonly termId: number;
+      readonly addedIds: readonly number[];
+      readonly removedIds: readonly number[];
+      readonly modifiedIds: readonly number[];
+    }) => void | Promise<void>;
   }
 }
 

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -3,7 +3,6 @@ import { and, eq } from "drizzle-orm";
 import { afterEach, describe, expect, test } from "vitest";
 
 import type {
-  AppContext,
   PluginRegistry,
   RequestAuthenticator,
   User,
@@ -40,6 +39,7 @@ interface Harness {
   readonly db: Db;
   readonly factories: Factories;
   readonly registry: PluginRegistry;
+  readonly hooks: HookRegistry;
   readonly user: User;
   readonly client: {
     readonly menu: {
@@ -80,10 +80,7 @@ async function buildHarness(role: UserRole = "editor"): Promise<Harness> {
     db,
     env: {},
     request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
-    hooks: {
-      applyFilter: (_name: string, value: unknown) => Promise.resolve(value),
-      doAction: () => Promise.resolve(),
-    } as unknown as AppContext["hooks"],
+    hooks,
     plugins: registry,
     user: { id: user.id, email: user.email, role: user.role },
     authenticator: stubAuthenticator(user),
@@ -97,7 +94,7 @@ async function buildHarness(role: UserRole = "editor"): Promise<Harness> {
   const client = createRouterClient(router, {
     context: ctx,
   }) as unknown as Harness["client"];
-  return { db, factories, registry, user, client };
+  return { db, factories, registry, hooks, user, client };
 }
 
 async function seedMenu(

--- a/packages/plugins/menu/src/rpc.ts
+++ b/packages/plugins/menu/src/rpc.ts
@@ -444,12 +444,27 @@ export function createMenuRouter(): Record<string, unknown> {
 
       // Reuse `removedIds` — `removed` in the response IS what we
       // deleted. Recomputing risks divergence after a refactor.
+      const itemIdSet = new Set(itemIds);
+      const removed = [...priorIds].filter((id) => !itemIdSet.has(id));
+
+      // `menu:saved` fires after every successful save (including
+      // no-op saves where added/removed/modified are all empty), so
+      // cache invalidators can run unconditionally without sniffing
+      // the payload. Failures in subscribers don't roll back the
+      // commit (Promise.allSettled inside doAction).
+      await context.hooks.doAction("menu:saved", {
+        termId: term.id,
+        addedIds: added,
+        removedIds: removed,
+        modifiedIds: modified,
+      });
+
       return {
         termId: term.id,
         version: term.version + 1,
         itemIds,
         added,
-        removed: [...priorIds].filter((id) => !new Set(itemIds).has(id)),
+        removed,
         modified,
       };
     });

--- a/packages/plugins/menu/src/server/getMenuByName.test.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.test.ts
@@ -21,25 +21,31 @@ import {
 import type { MenuItemMeta } from "./types.js";
 import { getMenuByName } from "./getMenuByName.js";
 
+interface TestBundle {
+  readonly registry: PluginRegistry;
+  readonly hooks: HookRegistry;
+}
+
 async function buildRegistry(
   plugins: ReturnType<typeof definePlugin>[],
-): Promise<PluginRegistry> {
+): Promise<TestBundle> {
   const hooks = new HookRegistry();
   const registry = createPluginRegistry();
   // Mirror runtime/app.ts: core adapters seed the registry before plugins
   // install so the menu resolver can dispatch to `entry`/`term` adapters.
   registerCoreLookupAdapters(registry);
   await installPlugins({ hooks, plugins, registry });
-  return registry;
+  return { registry, hooks };
 }
 
 function ctxFor(
   db: Awaited<ReturnType<typeof createTestDb>>,
-  registry: PluginRegistry,
+  bundle: TestBundle,
 ): AppContext {
   return {
     db,
-    plugins: registry,
+    plugins: bundle.registry,
+    hooks: bundle.hooks,
     request: new Request("https://test.example/"),
     resolvedEntity: null,
   } as unknown as AppContext;
@@ -56,7 +62,7 @@ interface SeedItemInput {
 // A registry that registers `menu` taxonomy plus a public `post` entry type
 // and `category` term taxonomy — the latter two so the entry/term lookup
 // adapters report results within scope. Built once per test for isolation.
-async function defaultRegistry(): Promise<PluginRegistry> {
+async function defaultRegistry(): Promise<TestBundle> {
   return buildRegistry([
     definePlugin("menu-test-host", (ctx) => {
       ctx.registerEntryType("menu_item", {
@@ -394,6 +400,7 @@ describe("getMenuByName", () => {
       return {
         db,
         plugins: ctx.plugins,
+        hooks: ctx.hooks,
         request: new Request(url),
         resolvedEntity: resolved,
       } as unknown as AppContext;

--- a/packages/plugins/menu/src/server/getMenuByName.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.ts
@@ -32,10 +32,17 @@ interface ResolvedRef {
  * ref fails to resolve (deleted, unpublished, scope-excluded) drop
  * silently along with their descendants — mirrors how broken refs will
  * be surfaced in admin from slice 11.
+ *
+ * Hook ordering: `menu:item` filter runs once per resolved item during
+ * tree assembly (per-item transforms see already-transformed children),
+ * then `menu:tree` runs once on the final array. `location` is
+ * forwarded from `getMenuForLocation` when the resolution started from
+ * a registered slot, otherwise `null`.
  */
 export async function getMenuByName(
   ctx: AppContext,
   name: string,
+  options?: { readonly location?: string | null },
 ): Promise<ResolvedMenu | null> {
   const [term] = await ctx.db
     .select({ id: terms.id, name: terms.name, slug: terms.slug })
@@ -73,11 +80,24 @@ export async function getMenuByName(
 
   const refs = await resolveRefs(ctx, rows);
   const { tree } = buildTree(rows);
-  const items = tree
-    .map((node) => toResolvedItem(ctx, node, refs))
-    .filter((item): item is ResolvedMenuItem => item !== null);
+  const resolved = await Promise.all(
+    tree.map((node) => toResolvedItem(ctx, node, refs)),
+  );
+  const items = resolved.filter(
+    (item): item is ResolvedMenuItem => item !== null,
+  );
 
-  return { termId: term.id, name: term.name, slug: term.slug, items };
+  const filtered = await ctx.hooks.applyFilter("menu:tree", items, {
+    location: options?.location ?? null,
+    termId: term.id,
+  });
+
+  return {
+    termId: term.id,
+    name: term.name,
+    slug: term.slug,
+    items: filtered,
+  };
 }
 
 interface ResolvedRefs {
@@ -174,19 +194,22 @@ function refMapFromResults(
   return map;
 }
 
-function toResolvedItem(
+async function toResolvedItem(
   ctx: AppContext,
   node: TreeNode<MenuItemRow>,
   refs: ResolvedRefs,
-): ResolvedMenuItem | null {
+): Promise<ResolvedMenuItem | null> {
   const meta = parseMenuItemMeta(node.meta);
   if (!meta) return null;
   const resolved = resolveByKind(ctx, node, meta, refs);
   if (!resolved) return null;
 
-  const children = node.children
-    .map((child) => toResolvedItem(ctx, child, refs))
-    .filter((child): child is ResolvedMenuItem => child !== null);
+  const childResults = await Promise.all(
+    node.children.map((child) => toResolvedItem(ctx, child, refs)),
+  );
+  const children = childResults.filter(
+    (child): child is ResolvedMenuItem => child !== null,
+  );
 
   // Menu-tree ancestor: any descendant is current. Pure JS walk over
   // the children we just built. Entity-tree ancestry (linked entry is
@@ -197,7 +220,14 @@ function toResolvedItem(
     (child) => child.isCurrent || child.isAncestor,
   );
 
-  return { ...resolved, isAncestor, children };
+  // Per-item filter runs after children resolve so subscribers see the
+  // already-transformed subtree. Tree-level filter still runs once on
+  // the full assembled array in `getMenuByName`.
+  return ctx.hooks.applyFilter("menu:item", {
+    ...resolved,
+    isAncestor,
+    children,
+  });
 }
 
 type ResolvedNoChildren = Omit<ResolvedMenuItem, "children" | "isAncestor">;

--- a/packages/plugins/menu/src/server/getMenuForLocation.test.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.test.ts
@@ -33,21 +33,27 @@ function testAuth() {
   });
 }
 
-async function buildTestRegistry(): Promise<PluginRegistry> {
+interface TestRegistryBundle {
+  readonly registry: PluginRegistry;
+  readonly hooks: HookRegistry;
+}
+
+async function buildTestRegistry(): Promise<TestRegistryBundle> {
   const hooks = new HookRegistry();
   const registry = createPluginRegistry();
   registerCoreLookupAdapters(registry);
   await installPlugins({ hooks, plugins: [menu], registry });
-  return registry;
+  return { registry, hooks };
 }
 
 function ctxFor(
   db: Awaited<ReturnType<typeof createTestDb>>,
-  registry: PluginRegistry,
+  bundle: TestRegistryBundle,
 ): AppContext {
   return {
     db,
-    plugins: registry,
+    plugins: bundle.registry,
+    hooks: bundle.hooks,
     request: new Request("https://test.example/"),
     resolvedEntity: null,
   } as unknown as AppContext;
@@ -57,13 +63,14 @@ describe("getMenuForLocation", () => {
   let db: Awaited<ReturnType<typeof createTestDb>>;
   let factories: ReturnType<typeof factoriesFor>;
   let ctx: AppContext;
+  let bundle: TestRegistryBundle;
   let authorId: number;
 
   beforeEach(async () => {
     db = await createTestDb();
     factories = factoriesFor(db);
-    const registry = await buildTestRegistry();
-    ctx = ctxFor(db, registry);
+    bundle = await buildTestRegistry();
+    ctx = ctxFor(db, bundle);
     const author = await adminUser
       .transient({ db })
       .create({ email: "menu-loc-author@example.test" });
@@ -157,7 +164,7 @@ describe("getMenuForLocation", () => {
     await bind("primary", "main");
 
     const a = await getMenuForLocation(ctx, "primary");
-    const otherCtx = ctxFor(db, ctx.plugins);
+    const otherCtx = ctxFor(db, bundle);
     const b = await getMenuForLocation(otherCtx, "primary");
     expect(a).not.toBe(b);
     expect(a?.slug).toBe(b?.slug);

--- a/packages/plugins/menu/src/server/getMenuForLocation.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.ts
@@ -48,7 +48,7 @@ async function resolveLocation(
   if (!row) return null;
   const slug = parseTermSlug(row.value);
   if (slug === null) return null;
-  return getMenuByName(ctx, slug);
+  return getMenuByName(ctx, slug, { location });
 }
 
 function parseTermSlug(value: unknown): string | null {


### PR DESCRIPTION
## Summary

Closes #164. Adds the menu plugin's extension surface via three hooks declared through TypeScript declaration merging on `@plumix/core`'s `FilterRegistry` / `ActionRegistry`:

- `menu:item` (filter) — fires per resolved item during tree assembly; children resolve first so subscribers see the already-transformed subtree
- `menu:tree` (filter) — fires once on the assembled array, receives `{ location, termId }` for slot-aware branching
- `menu:saved` (action) — fires after every successful `menu.save` with `{ termId, addedIds, removedIds, modifiedIds }`

### Hook ordering

Per-item runs first, tree-level last (per-item transforms then full-tree transforms). Asserted by the `"subscribers see already-resolved children"` test — parent's filter sees `children: [filtered_child]`.

### Failure semantics

Filter errors propagate (critical path); action errors are swallowed by `Promise.allSettled` in `HookRegistry.doAction`. Both behaviors tested.

### Sentry findings addressed

- **find-bugs**: clean — no critical or high. Filter latency / error propagation noted as by-design (matches WP semantics).
- **code-review**: approve. Strengths: type-first design, test ergonomics. Nits: per-hook docstrings (deferred).
- **code-simplifier**:
  - Fixed pre-existing O(N²) `Set` rebuild in `removed` computation (`new Set(itemIds)` was inside the filter closure).
  - Extracted `saveClientFor(b)` helper in hooks.test.ts to dedupe router-client construction.

### Test coverage

8 new integration tests in `hooks.test.ts`:
- menu:item fires per item with resolved shape
- menu:item transforms land in render
- menu:item sees already-resolved children
- menu:tree fires once with correct location/termId
- menu:tree pruning lands in render
- menu:tree gets location forwarded from getMenuForLocation
- menu:saved payload matches save's return triple
- menu:saved subscriber failure does not abort the commit

## Test plan

- [x] 146 plugin-menu tests pass (138 prior + 8 new)
- [x] Full local CI clean: typecheck/test/lint/format/publint/attw — 72/72
- [x] commitlint clean