### PR TITLE
feat(plugin-menu): admin shell + create + locations tab (slice 7)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -104,6 +104,20 @@ const config: KnipConfig = {
         "e2e/*.spec.ts",
       ],
     },
+    // Same shape as plugin-media: admin chunk loaded via `adminEntry`
+    // at consumer build time; playwright rig invokes build-chunk via
+    // tsx and the spec via the playwright CLI — none are static
+    // imports knip can follow. The `./server` subpath is consumer-
+    // facing (themes import server-only helpers from there); listed
+    // so knip auto-discovery doesn't miss the subdir-index layout.
+    "packages/plugins/menu": {
+      entry: [
+        "src/admin/index.tsx",
+        "src/server/index.ts",
+        "e2e/build-chunk.ts",
+        "e2e/*.spec.ts",
+      ],
+    },
   },
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export {
 export { memoryStorage } from "./runtime/memory-storage.js";
 export type { MemoryStorageConfig } from "./runtime/memory-storage.js";
 export type * from "./runtime/slots.js";
+export { slugify } from "./slugify.js";
 export { defineTheme } from "./theme.js";
 export type {
   ThemeDescriptor,

--- a/packages/plugins/menu/e2e/build-chunk.ts
+++ b/packages/plugins/menu/e2e/build-chunk.ts
@@ -1,0 +1,16 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { buildAdminPluginChunkForE2E } from "@plumix/core/test/playwright";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = resolve(HERE, "..");
+const REPO_ROOT = resolve(PLUGIN_ROOT, "../../..");
+
+await buildAdminPluginChunkForE2E({
+  entryPoint: resolve(PLUGIN_ROOT, "src/admin/index.tsx"),
+  adminDist: resolve(REPO_ROOT, "packages/admin/dist"),
+  plumixAdminSrc: resolve(REPO_ROOT, "packages/plumix/src/admin"),
+  scriptMarker: "data-plumix-menu-e2e",
+  logTag: "[menu-e2e] menu plugin chunk",
+});

--- a/packages/plugins/menu/e2e/menu.spec.ts
+++ b/packages/plugins/menu/e2e/menu.spec.ts
@@ -1,0 +1,161 @@
+// Plugin E2E. Mocks the manifest + session + RPC layer using
+// `@plumix/core/test/playwright` so the real built admin chunk runs
+// against a deterministic backend — no D1 needed for CI.
+//
+// Slice 7 acceptance:
+//   1. Create a new menu.
+//   2. Switch tabs.
+//   3. Assign a menu to a location.
+//   4. Reload — the assignment persists.
+
+import type { Page, Route } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+import { slugify } from "@plumix/core";
+import { emptyManifest } from "@plumix/core/manifest";
+import {
+  AUTHED_ADMIN,
+  mockManifest,
+  rpcOkBody,
+  withCapabilities,
+} from "@plumix/core/test/playwright";
+
+const MENU_NAV_LABEL = "Menus";
+
+const MANIFEST: PlumixManifest = {
+  ...emptyManifest(),
+  adminNav: [
+    {
+      id: "appearance",
+      label: "Appearance",
+      priority: 175,
+      items: [
+        {
+          to: "/pages/menus",
+          label: MENU_NAV_LABEL,
+          order: 10,
+          capability: "term:menu:manage",
+          coreIcon: "layout",
+          component: "MenusShell",
+        },
+      ],
+    },
+  ],
+};
+
+const SESSION = withCapabilities(AUTHED_ADMIN, "term:menu:manage");
+
+interface MenuRow {
+  readonly id: number;
+  readonly slug: string;
+  readonly name: string;
+  readonly version: number;
+  readonly itemCount: number;
+}
+
+interface LocationRow {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly boundTermId: number | null;
+}
+
+interface MockState {
+  menus: MenuRow[];
+  locations: LocationRow[];
+}
+
+function readJsonInput(route: Route): Record<string, unknown> {
+  const body = route.request().postData();
+  if (!body) return {};
+  const parsed = JSON.parse(body) as { json?: Record<string, unknown> };
+  return parsed.json ?? {};
+}
+
+async function mockMenuRpc(page: Page, state: MockState): Promise<void> {
+  await page.route("**/_plumix/rpc/**", async (route) => {
+    const url = route.request().url();
+    const respond = (body: unknown): Promise<void> =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(body),
+      });
+
+    if (url.endsWith("/auth/session")) return respond(SESSION);
+    if (url.endsWith("/menu/list")) return respond(state.menus);
+    if (url.endsWith("/menu/locations/list")) return respond(state.locations);
+    if (url.endsWith("/menu/create")) {
+      const input = readJsonInput(route) as { name: string };
+      const name = input.name.trim();
+      const slug = slugify(name);
+      const newId = state.menus.reduce((max, m) => Math.max(max, m.id), 0) + 1;
+      const created: MenuRow = {
+        id: newId,
+        slug,
+        name,
+        version: 0,
+        itemCount: 0,
+      };
+      state.menus = [...state.menus, created];
+      return respond({ termId: newId, slug, version: 0 });
+    }
+    if (url.endsWith("/menu/assignLocation")) {
+      const input = readJsonInput(route) as {
+        location: string;
+        termSlug: string | null;
+      };
+      const matched = state.menus.find((m) => m.slug === input.termSlug);
+      state.locations = state.locations.map((loc) =>
+        loc.id === input.location
+          ? { ...loc, boundTermId: matched ? matched.id : null }
+          : loc,
+      );
+      return respond({ location: input.location, termSlug: input.termSlug });
+    }
+    return route.fulfill({ status: 404, body: "not-mocked" });
+  });
+}
+
+test.describe("@plumix/plugin-menu — admin shell (slice 7)", () => {
+  test("create menu, switch tab, assign location, reload — assignment persists", async ({
+    page,
+  }) => {
+    const state: MockState = {
+      menus: [],
+      locations: [{ id: "primary", label: "Primary Nav", boundTermId: null }],
+    };
+
+    page.on("dialog", (dialog) => {
+      void dialog.accept("Header Nav");
+    });
+    await mockManifest(page, MANIFEST);
+    await mockMenuRpc(page, state);
+
+    await page.goto("pages/menus");
+    await expect(page.getByTestId("menus-shell")).toBeVisible();
+
+    // 1. Create a new menu via the sentinel.
+    await page.getByTestId("menus-selector-create-new").click();
+    await expect(
+      page.getByTestId("menus-selector-option-header-nav"),
+    ).toBeVisible();
+
+    // 2. Switch to the Locations tab.
+    await page.getByTestId("menus-tab-locations").click();
+    await expect(page.getByTestId("menus-tab-locations-panel")).toBeVisible();
+
+    // 3. Assign the new menu to the Primary Nav location.
+    await page
+      .getByTestId("menus-location-select-primary")
+      .selectOption("header-nav");
+
+    // 4. Reload and confirm the binding persists from the mocked backend.
+    await page.reload();
+    await page.getByTestId("menus-tab-locations").click();
+    await expect(page.getByTestId("menus-location-select-primary")).toHaveValue(
+      "header-nav",
+    );
+  });
+});

--- a/packages/plugins/menu/e2e/playwright.config.ts
+++ b/packages/plugins/menu/e2e/playwright.config.ts
@@ -1,0 +1,19 @@
+import { definePlumixE2EConfig } from "@plumix/core/test/playwright";
+
+const E2E_PORT = 5182;
+const ADMIN_BASE = "/_plumix/admin";
+const BASE_URL = `http://localhost:${String(E2E_PORT)}${ADMIN_BASE}/`;
+
+export default definePlumixE2EConfig({
+  testDir: ".",
+  baseURL: BASE_URL,
+  // Build the menu admin chunk into admin's dist, then preview the
+  // patched dist. Admin must be built first (`pnpm --filter
+  // @plumix/admin build`); the e2e rig reuses its static output as
+  // the host shell.
+  webServerCommand: [
+    "pnpm exec tsx ./build-chunk.ts",
+    "cd ../../../admin",
+    `pnpm exec vite preview --port ${String(E2E_PORT)} --strictPort`,
+  ].join(" && "),
+});

--- a/packages/plugins/menu/package.json
+++ b/packages/plugins/menu/package.json
@@ -43,11 +43,12 @@
   "scripts": {
     "attw": "attw --pack . --profile esm-only",
     "build": "tsc -p tsconfig.build.json",
-    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "clean": "git clean -xdf .cache .turbo dist node_modules e2e/playwright-report e2e/test-results",
     "format": "prettier --check . --ignore-path ../../../.gitignore",
     "lint": "eslint",
     "publint": "publint",
     "test": "vitest run",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
@@ -55,17 +56,33 @@
     "drizzle-orm": "catalog:",
     "valibot": "catalog:"
   },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.99.2",
+    "react": "catalog:"
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
     "@orpc/server": "^1.14.1",
+    "@playwright/test": "^1.59.1",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
     "@plumix/vitest-config": "workspace:*",
+    "@tanstack/react-query": "^5.99.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "esbuild": "0.27.7",
     "eslint": "catalog:",
+    "jsdom": "^29.1.1",
     "prettier": "catalog:",
     "publint": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/plugins/menu/src/admin/MenusShell.test.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.test.tsx
@@ -1,0 +1,321 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { MenusShell } from "./MenusShell.js";
+
+type FetchCall = readonly [input: RequestInfo | URL, init?: RequestInit];
+
+let fetchMock: ReturnType<
+  typeof vi.fn<
+    (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+  >
+>;
+
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function mockRpc(routes: Record<string, unknown>): void {
+  fetchMock = vi.fn((input: RequestInfo | URL): Promise<Response> => {
+    const url = urlOf(input);
+    for (const [suffix, body] of Object.entries(routes)) {
+      if (url.endsWith(suffix)) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ json: body, meta: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+    }
+    return Promise.resolve(new Response("not-mocked", { status: 404 }));
+  });
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+function findRpcCall(suffix: string): FetchCall | undefined {
+  return fetchMock.mock.calls.find((call) => {
+    const url = call[0];
+    return typeof url === "string" && url.endsWith(suffix);
+  });
+}
+
+function parseRpcInput<T>(call: FetchCall): T {
+  const init = call[1];
+  const body = init?.body;
+  if (typeof body !== "string") {
+    throw new Error("expected request body to be a JSON string");
+  }
+  return (JSON.parse(body) as { json: T }).json;
+}
+
+function renderShell(): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { readonly children: ReactNode }): ReactNode {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  }
+  render(<MenusShell />, { wrapper: Wrapper });
+}
+
+describe("MenusShell", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/_plumix/admin/pages/menus");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  describe("empty state", () => {
+    test("renders the create-first-menu CTA when no menus exist", async () => {
+      mockRpc({
+        "/menu/list": [],
+        "/menu/locations/list": [],
+      });
+      renderShell();
+
+      const cta = await screen.findByTestId("menus-empty-cta");
+      expect(cta).toBeInTheDocument();
+    });
+  });
+
+  describe("create flow", () => {
+    test("clicking + Create new menu prompts and calls menu.save with empty items", async () => {
+      mockRpc({
+        "/menu/list": [],
+        "/menu/locations/list": [],
+        "/menu/create": {
+          termId: 99,
+          slug: "header-nav",
+          version: 1,
+        },
+      });
+      vi.stubGlobal("prompt", vi.fn().mockReturnValue("Header Nav"));
+
+      renderShell();
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId("menus-selector-create-new"));
+
+      const createCall = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/create");
+        if (!found) throw new Error("menu.create not called yet");
+        return found;
+      });
+      const input = parseRpcInput<{ name: string }>(createCall);
+      expect(input.name).toBe("Header Nav");
+      await vi.waitFor(() =>
+        expect(window.location.search).toMatch(/[?&]menu=header-nav\b/),
+      );
+    });
+
+    test("dismissing the prompt is a no-op", async () => {
+      mockRpc({
+        "/menu/list": [],
+        "/menu/locations/list": [],
+      });
+      vi.stubGlobal("prompt", vi.fn().mockReturnValue(null));
+
+      renderShell();
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId("menus-selector-create-new"));
+
+      expect(findRpcCall("/menu/create")).toBeUndefined();
+    });
+  });
+
+  describe("tabs", () => {
+    test("defaults to the edit tab when ?tab= is absent", async () => {
+      mockRpc({
+        "/menu/list": [
+          { id: 1, slug: "main", name: "Main", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [],
+      });
+
+      renderShell();
+
+      expect(
+        await screen.findByTestId("menus-tab-edit-panel"),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("menus-tab-locations-panel")).toBeNull();
+    });
+
+    test("renders the locations panel when ?tab=locations is set", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?tab=locations",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 1, slug: "main", name: "Main", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [],
+      });
+
+      renderShell();
+
+      expect(
+        await screen.findByTestId("menus-tab-locations-panel"),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("menus-tab-edit-panel")).toBeNull();
+    });
+
+    test("clicking a tab updates the query param and swaps panels", async () => {
+      mockRpc({
+        "/menu/list": [
+          { id: 1, slug: "main", name: "Main", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [],
+      });
+
+      renderShell();
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId("menus-tab-locations"));
+
+      expect(window.location.search).toMatch(/[?&]tab=locations\b/);
+      expect(
+        await screen.findByTestId("menus-tab-locations-panel"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("locations table", () => {
+    test("renders one row per registered location with current binding selected", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?tab=locations",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 1, slug: "main", name: "Main", version: 1, itemCount: 0 },
+          { id: 2, slug: "footer", name: "Footer", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [
+          { id: "footer", label: "Footer Slot", boundTermId: null },
+          { id: "primary", label: "Primary Nav", boundTermId: 1 },
+        ],
+      });
+
+      renderShell();
+
+      const primarySelect = await screen.findByTestId<HTMLSelectElement>(
+        "menus-location-select-primary",
+      );
+      expect(primarySelect).toBeInTheDocument();
+      expect(primarySelect.value).toBe("main");
+
+      const footerSelect = await screen.findByTestId<HTMLSelectElement>(
+        "menus-location-select-footer",
+      );
+      expect(footerSelect.value).toBe("");
+    });
+
+    test("changing a select calls menu.assignLocation with the new termSlug", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?tab=locations",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 1, slug: "main", name: "Main", version: 1, itemCount: 0 },
+          { id: 2, slug: "footer", name: "Footer", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [
+          { id: "primary", label: "Primary Nav", boundTermId: null },
+        ],
+        "/menu/assignLocation": { location: "primary", termSlug: "main" },
+      });
+
+      renderShell();
+      const select = await screen.findByTestId<HTMLSelectElement>(
+        "menus-location-select-primary",
+      );
+      const user = userEvent.setup();
+      await user.selectOptions(select, "main");
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/assignLocation");
+        if (!found) throw new Error("assignLocation not called");
+        return found;
+      });
+      const input = parseRpcInput<{
+        location: string;
+        termSlug: string | null;
+      }>(call);
+      expect(input).toEqual({ location: "primary", termSlug: "main" });
+    });
+
+    test("selecting the empty option clears the binding (null termSlug)", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?tab=locations",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 1, slug: "main", name: "Main", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [
+          { id: "primary", label: "Primary Nav", boundTermId: 1 },
+        ],
+        "/menu/assignLocation": { location: "primary", termSlug: null },
+      });
+
+      renderShell();
+      const select = await screen.findByTestId<HTMLSelectElement>(
+        "menus-location-select-primary",
+      );
+      const user = userEvent.setup();
+      await user.selectOptions(select, "");
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/assignLocation");
+        if (!found) throw new Error("assignLocation not called");
+        return found;
+      });
+      const input = parseRpcInput<{
+        location: string;
+        termSlug: string | null;
+      }>(call);
+      expect(input).toEqual({ location: "primary", termSlug: null });
+    });
+  });
+
+  describe("menu selector", () => {
+    test("renders one option per menu plus the Create-new sentinel", async () => {
+      mockRpc({
+        "/menu/list": [
+          { id: 1, slug: "main", name: "Main", version: 1, itemCount: 3 },
+          { id: 2, slug: "footer", name: "Footer", version: 1, itemCount: 2 },
+        ],
+        "/menu/locations/list": [],
+      });
+      renderShell();
+
+      const selector = await screen.findByTestId("menus-selector");
+      expect(selector).toBeInTheDocument();
+      expect(
+        screen.getByTestId("menus-selector-option-main"),
+      ).toHaveTextContent("Main");
+      expect(
+        screen.getByTestId("menus-selector-option-footer"),
+      ).toHaveTextContent("Footer");
+      expect(
+        screen.getByTestId("menus-selector-create-new"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/plugins/menu/src/admin/MenusShell.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.tsx
@@ -1,0 +1,181 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import type { MenuListItem, MenuLocationRow } from "./rpc.js";
+import type { TabId } from "./url-state.js";
+import {
+  useAssignLocation,
+  useCreateMenu,
+  useLocationsList,
+  useMenuList,
+} from "./rpc.js";
+import {
+  getSelectedTab,
+  setSelectedMenu,
+  setSelectedTab,
+} from "./url-state.js";
+
+const TABS: readonly { readonly id: TabId; readonly label: string }[] = [
+  { id: "edit", label: "Edit Menus" },
+  { id: "locations", label: "Manage Locations" },
+];
+
+export function MenusShell(): ReactNode {
+  const menus = useMenuList();
+  const createMenu = useCreateMenu();
+  const [tab, setTab] = useState<TabId>(getSelectedTab());
+
+  function handleCreate(): void {
+    const name = window.prompt("Menu name")?.trim();
+    if (!name) return;
+    createMenu.mutate(
+      { name },
+      { onSuccess: (result) => setSelectedMenu(result.slug) },
+    );
+  }
+
+  function handleTabChange(next: TabId): void {
+    setSelectedTab(next);
+    setTab(next);
+  }
+
+  if (menus.isLoading) {
+    return <div data-testid="menus-shell-loading" />;
+  }
+  const menuList = menus.data ?? [];
+  return (
+    <div data-testid="menus-shell">
+      <MenuSelector menus={menuList} onCreate={handleCreate} />
+      <Tabs activeTab={tab} onChange={handleTabChange} />
+      {tab === "edit" ? <EditPanel /> : <LocationsPanel menus={menuList} />}
+      {menuList.length === 0 ? (
+        <div data-testid="menus-empty-cta">
+          No menus yet. Create your first menu to get started.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MenuSelector({
+  menus,
+  onCreate,
+}: {
+  readonly menus: readonly MenuListItem[];
+  readonly onCreate: () => void;
+}): ReactNode {
+  return (
+    <div data-testid="menus-selector">
+      {menus.map((menu) => (
+        <button
+          key={menu.id}
+          type="button"
+          data-testid={`menus-selector-option-${menu.slug}`}
+        >
+          {menu.name}
+        </button>
+      ))}
+      <button
+        type="button"
+        data-testid="menus-selector-create-new"
+        onClick={onCreate}
+      >
+        + Create new menu
+      </button>
+    </div>
+  );
+}
+
+function Tabs({
+  activeTab,
+  onChange,
+}: {
+  readonly activeTab: TabId;
+  readonly onChange: (next: TabId) => void;
+}): ReactNode {
+  return (
+    <div data-testid="menus-tabs">
+      {TABS.map((entry) => (
+        <button
+          key={entry.id}
+          type="button"
+          data-testid={`menus-tab-${entry.id}`}
+          aria-selected={activeTab === entry.id}
+          onClick={() => {
+            onChange(entry.id);
+          }}
+        >
+          {entry.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function EditPanel(): ReactNode {
+  // Item editor lands in slice 8.
+  return <div data-testid="menus-tab-edit-panel" />;
+}
+
+function LocationsPanel({
+  menus,
+}: {
+  readonly menus: readonly MenuListItem[];
+}): ReactNode {
+  const locations = useLocationsList();
+  const assign = useAssignLocation();
+  const slugFromTermId = new Map(menus.map((m) => [m.id, m.slug]));
+
+  return (
+    <div data-testid="menus-tab-locations-panel">
+      {(locations.data ?? []).map((row) => (
+        <LocationRow
+          key={row.id}
+          row={row}
+          menus={menus}
+          currentSlug={
+            row.boundTermId === null
+              ? ""
+              : (slugFromTermId.get(row.boundTermId) ?? "")
+          }
+          onChange={(termSlug) => {
+            assign.mutate({ location: row.id, termSlug });
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function LocationRow({
+  row,
+  menus,
+  currentSlug,
+  onChange,
+}: {
+  readonly row: MenuLocationRow;
+  readonly menus: readonly MenuListItem[];
+  readonly currentSlug: string;
+  readonly onChange: (termSlug: string | null) => void;
+}): ReactNode {
+  return (
+    <div data-testid={`menus-location-row-${row.id}`}>
+      <span data-testid={`menus-location-label-${row.id}`}>{row.label}</span>
+      <select
+        data-testid={`menus-location-select-${row.id}`}
+        value={currentSlug}
+        onChange={(event) => {
+          const value = event.target.value;
+          onChange(value === "" ? null : value);
+        }}
+      >
+        <option value="">— Unassigned —</option>
+        {menus.map((menu) => (
+          <option key={menu.id} value={menu.slug}>
+            {menu.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/packages/plugins/menu/src/admin/index.tsx
+++ b/packages/plugins/menu/src/admin/index.tsx
@@ -1,0 +1,25 @@
+// Plugin admin entry. The plumix vite plugin namespace-imports this
+// module and emits a `window.plumix.registerPluginPage("/menus",
+// MenusShell)` call into the synthesised admin chunk based on the
+// `component: "MenusShell"` ref we passed to `ctx.registerAdminPage`.
+// All this entry has to do is expose the export by name.
+
+import type { ComponentType } from "react";
+
+import { MenusShell } from "./MenusShell.js";
+
+interface PlumixWindowGlobal {
+  readonly registerPluginPage: (path: string, component: ComponentType) => void;
+}
+
+declare const window:
+  | {
+      readonly plumix?: PlumixWindowGlobal;
+    }
+  | undefined;
+
+if (typeof window !== "undefined") {
+  window.plumix?.registerPluginPage("/menus", MenusShell);
+}
+
+export { MenusShell };

--- a/packages/plugins/menu/src/admin/rpc.ts
+++ b/packages/plugins/menu/src/admin/rpc.ts
@@ -1,0 +1,106 @@
+// Hand-rolled oRPC POST client for the menu plugin admin. Plumix's
+// typed admin client (`AppRouterClient`) covers core only; plugin
+// procedures speak the StandardRPC envelope (`{ json, meta: [] }`)
+// directly. Mirrors the helper in `@plumix/plugin-media`.
+
+import type { UseMutationResult, UseQueryResult } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export interface MenuListItem {
+  readonly id: number;
+  readonly slug: string;
+  readonly name: string;
+  readonly version: number;
+  readonly itemCount: number;
+}
+
+interface CreateMenuResult {
+  readonly termId: number;
+  readonly slug: string;
+  readonly version: number;
+}
+
+export interface MenuLocationRow {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly boundTermId: number | null;
+}
+
+interface AssignLocationInput {
+  readonly location: string;
+  readonly termSlug: string | null;
+}
+
+const MENU_LIST_KEY = ["menu", "list"] as const;
+const MENU_LOCATIONS_KEY = ["menu", "locations", "list"] as const;
+
+export async function rpcCall<TOutput>(
+  procedure: string,
+  input: unknown = {},
+): Promise<TOutput> {
+  const res = await fetch(`/_plumix/rpc/${procedure}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-plumix-request": "1",
+    },
+    body: JSON.stringify({ json: input, meta: [] }),
+  });
+  const envelope = (await res.json().catch(() => null)) as {
+    json?: unknown;
+    meta?: unknown;
+  } | null;
+  if (!res.ok) {
+    const error = envelope?.json as
+      | { message?: string; data?: { reason?: string } }
+      | undefined;
+    const reason =
+      error?.data?.reason ?? error?.message ?? `rpc_${String(res.status)}`;
+    throw new Error(reason);
+  }
+  return envelope?.json as TOutput;
+}
+
+export function useMenuList(): UseQueryResult<readonly MenuListItem[]> {
+  return useQuery({
+    queryKey: MENU_LIST_KEY,
+    queryFn: () => rpcCall<readonly MenuListItem[]>("menu/list"),
+  });
+}
+
+export function useCreateMenu(): UseMutationResult<
+  CreateMenuResult,
+  Error,
+  { readonly name: string }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input) => rpcCall<CreateMenuResult>("menu/create", input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: MENU_LIST_KEY });
+    },
+  });
+}
+
+export function useLocationsList(): UseQueryResult<readonly MenuLocationRow[]> {
+  return useQuery({
+    queryKey: MENU_LOCATIONS_KEY,
+    queryFn: () => rpcCall<readonly MenuLocationRow[]>("menu/locations/list"),
+  });
+}
+
+export function useAssignLocation(): UseMutationResult<
+  AssignLocationInput,
+  Error,
+  AssignLocationInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input) =>
+      rpcCall<AssignLocationInput>("menu/assignLocation", input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: MENU_LOCATIONS_KEY });
+    },
+  });
+}

--- a/packages/plugins/menu/src/admin/url-state.ts
+++ b/packages/plugins/menu/src/admin/url-state.ts
@@ -1,0 +1,25 @@
+// Menu admin internal state lives in `?menu=<slug>` and `?tab=<id>`
+// query params (matches WordPress's `wp-admin/nav-menus.php` model
+// and dodges `:param` paths in `registerAdminPage`). Manipulated via
+// `history.replaceState` so React Router upstream of the plugin
+// doesn't get involved.
+
+export type TabId = "edit" | "locations";
+
+export function setSelectedMenu(slug: string): void {
+  const url = new URL(window.location.href);
+  url.searchParams.set("menu", slug);
+  window.history.replaceState({}, "", url);
+}
+
+export function setSelectedTab(tab: TabId): void {
+  const url = new URL(window.location.href);
+  if (tab === "edit") url.searchParams.delete("tab");
+  else url.searchParams.set("tab", tab);
+  window.history.replaceState({}, "", url);
+}
+
+export function getSelectedTab(): TabId {
+  const value = new URL(window.location.href).searchParams.get("tab");
+  return value === "locations" ? "locations" : "edit";
+}

--- a/packages/plugins/menu/src/index.test.ts
+++ b/packages/plugins/menu/src/index.test.ts
@@ -4,6 +4,8 @@ import { HookRegistry, installPlugins } from "@plumix/core";
 
 import { menu } from "./index.js";
 
+const ADMIN_ENTRY_PATH = "node_modules/@plumix/plugin-menu/dist/admin/index.js";
+
 async function install() {
   return installPlugins({ hooks: new HookRegistry(), plugins: [menu] });
 }
@@ -33,5 +35,25 @@ describe("@plumix/plugin-menu", () => {
     const { registry } = await install();
     expect(registry.capabilities.get("entry:menu_item:create")).toBeDefined();
     expect(registry.capabilities.get("entry:menu_item:edit_any")).toBeDefined();
+  });
+
+  test("registers the Menus admin page in the Appearance nav group", async () => {
+    const { registry } = await install();
+    const page = registry.adminPages.get("/menus");
+    expect(page).toBeDefined();
+    expect(page?.title).toBe("Menus");
+    expect(page?.capability).toBe("term:menu:manage");
+    expect(page?.nav?.group).toEqual({
+      id: "appearance",
+      label: "Appearance",
+      priority: 175,
+    });
+    expect(page?.nav?.label).toBe("Menus");
+    expect(page?.nav?.order).toBe(10);
+    expect(page?.component).toBe("MenusShell");
+  });
+
+  test("declares the adminEntry chunk path the plumix vite plugin loads", () => {
+    expect(menu.adminEntry).toBe(ADMIN_ENTRY_PATH);
   });
 });

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -4,19 +4,6 @@ import type { MenuLocationOptions, ResolvedMenuItem } from "./server/types.js";
 import { createMenuRouter } from "./rpc.js";
 import { recordLocation } from "./server/locations.js";
 
-export type {
-  MenuItemMeta,
-  MenuItemCustomMeta,
-  MenuItemEntryMeta,
-  MenuItemTermMeta,
-  MenuItemDisplayAttrs,
-  MenuLocationOptions,
-  RegisteredMenuLocation,
-  ResolvedMenu,
-  ResolvedMenuItem,
-  ResolvedMenuItemSource,
-} from "./server/types.js";
-
 // `@plumix/plugin-menu` augments the theme setup context with
 // `registerMenuLocation`, plus three core option shapes with
 // menu-eligibility flags, plus the hook registries with three menu
@@ -88,6 +75,8 @@ declare module "@plumix/core" {
   }
 }
 
+const ADMIN_ENTRY_PATH = "node_modules/@plumix/plugin-menu/dist/admin/index.js";
+
 /**
  * `@plumix/plugin-menu` — menus reuse the entries/terms/entry_term substrate
  * rather than adding tables: a menu is a `terms` row (`taxonomy = 'menu'`),
@@ -96,6 +85,7 @@ declare module "@plumix/core" {
  * the generic Entries/Terms admin; the plugin owns its own admin (slices 7+).
  */
 export const menu = definePlugin("menu", {
+  adminEntry: ADMIN_ENTRY_PATH,
   provides: (ctx) => {
     ctx.extendThemeContext("registerMenuLocation", (id, options) => {
       recordLocation(id, options);
@@ -122,5 +112,17 @@ export const menu = definePlugin("menu", {
     });
 
     ctx.registerRpcRouter(createMenuRouter());
+
+    ctx.registerAdminPage({
+      path: "/menus",
+      title: "Menus",
+      capability: "term:menu:manage",
+      nav: {
+        group: { id: "appearance", label: "Appearance", priority: 175 },
+        label: "Menus",
+        order: 10,
+      },
+      component: "MenusShell",
+    });
   },
 });

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -47,12 +47,27 @@ interface Harness {
       readonly get: (input: { termId: number }) => Promise<unknown>;
       readonly save: (input: unknown) => Promise<unknown>;
       readonly delete: (input: { termId: number }) => Promise<unknown>;
+      readonly create: (input: { name: string }) => Promise<{
+        readonly termId: number;
+        readonly slug: string;
+        readonly version: number;
+      }>;
       readonly assignLocation: (input: {
         location: string;
         termSlug: string | null;
       }) => Promise<unknown>;
+      readonly locations: {
+        readonly list: () => Promise<readonly LocationRow[]>;
+      };
     };
   };
+}
+
+interface LocationRow {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly boundTermId: number | null;
 }
 
 function stubAuthenticator(user: User): RequestAuthenticator {
@@ -489,10 +504,101 @@ describe("menu RPC", () => {
     });
   });
 
+  describe("menu.create", () => {
+    test("mints a new menu term with a slug derived from the name", async () => {
+      const h = await buildHarness();
+
+      const result = await h.client.menu.create({ name: "Header Nav" });
+
+      expect(result.slug).toBe("header-nav");
+      expect(result.version).toBe(0);
+      const [row] = await h.db
+        .select()
+        .from(terms)
+        .where(and(eq(terms.id, result.termId), eq(terms.taxonomy, "menu")));
+      expect(row?.name).toBe("Header Nav");
+      expect(row?.slug).toBe("header-nav");
+    });
+
+    test("appends a numeric suffix when the derived slug is taken", async () => {
+      const h = await buildHarness();
+      await seedMenu(h.db, h.factories, "header-nav", "Header Nav");
+
+      const result = await h.client.menu.create({ name: "Header Nav" });
+
+      expect(result.slug).toMatch(/^header-nav-\d+$/);
+    });
+
+    test("rejects empty / whitespace-only names", async () => {
+      const h = await buildHarness();
+      await expect(h.client.menu.create({ name: "   " })).rejects.toThrow();
+      await expect(h.client.menu.create({ name: "" })).rejects.toThrow();
+    });
+
+    test("subscriber cannot create", async () => {
+      const h = await buildHarness("subscriber");
+      await expect(h.client.menu.create({ name: "Nope" })).rejects.toThrow();
+    });
+  });
+
+  describe("menu.locations.list", () => {
+    test("returns each registered location with its current binding", async () => {
+      const h = await buildHarness();
+      recordLocation("primary", { label: "Primary", description: "Header" });
+      recordLocation("footer", { label: "Footer" });
+      const main = await seedMenu(h.db, h.factories, "main");
+      await h.client.menu.assignLocation({
+        location: "primary",
+        termSlug: "main",
+      });
+
+      const rows = await h.client.menu.locations.list();
+      expect(rows).toEqual([
+        {
+          id: "footer",
+          label: "Footer",
+          boundTermId: null,
+        },
+        {
+          id: "primary",
+          label: "Primary",
+          description: "Header",
+          boundTermId: main.id,
+        },
+      ]);
+    });
+
+    test("returns an empty array when no locations are registered", async () => {
+      const h = await buildHarness();
+      const rows = await h.client.menu.locations.list();
+      expect(rows).toEqual([]);
+    });
+
+    test("ignores stale settings rows for unregistered locations", async () => {
+      const h = await buildHarness();
+      recordLocation("primary", { label: "Primary" });
+      await seedMenu(h.db, h.factories, "main");
+      await h.db.insert(settings).values({
+        group: "menu_locations",
+        key: "ghost",
+        value: "main",
+      });
+
+      const rows = await h.client.menu.locations.list();
+      expect(rows.map((r) => r.id)).toEqual(["primary"]);
+    });
+  });
+
   describe("authorization", () => {
     test("subscriber cannot list / save / delete / assign", async () => {
       const h = await buildHarness("subscriber");
       await expect(h.client.menu.list()).rejects.toThrow();
+    });
+
+    test("subscriber cannot list locations", async () => {
+      const h = await buildHarness("subscriber");
+      recordLocation("primary", { label: "Primary" });
+      await expect(h.client.menu.locations.list()).rejects.toThrow();
     });
   });
 });

--- a/packages/plugins/menu/src/rpc.ts
+++ b/packages/plugins/menu/src/rpc.ts
@@ -10,6 +10,7 @@ import {
   eq,
   inArray,
   settings,
+  slugify,
   sql,
   terms,
 } from "@plumix/core";
@@ -523,6 +524,72 @@ export function createMenuRouter(): Record<string, unknown> {
       return { id: input.termId };
     });
 
+  const create = base
+    .use(authenticated)
+    .input(
+      v.object({
+        name: v.pipe(
+          v.string(),
+          v.transform((s) => s.trim()),
+          v.minLength(1),
+          v.maxLength(MAX_TITLE_LENGTH),
+        ),
+      }),
+    )
+    .handler(
+      async ({
+        input,
+        context,
+        errors,
+      }): Promise<{
+        readonly termId: number;
+        readonly slug: string;
+        readonly version: number;
+      }> => {
+        if (!context.auth.can(MENU_MANAGE_CAPABILITY)) {
+          throw errors.FORBIDDEN({
+            data: { capability: MENU_MANAGE_CAPABILITY },
+          });
+        }
+        const baseSlug = slugify(input.name) || `menu-${cryptoRandom()}`;
+        let slug = baseSlug;
+        let attempt = 0;
+        // Probe-then-insert keeps the typical case to one query and
+        // resolves contention with a deterministic numeric suffix.
+        while (true) {
+          const [conflict] = await context.db
+            .select({ id: terms.id })
+            .from(terms)
+            .where(and(eq(terms.taxonomy, MENU_TAXONOMY), eq(terms.slug, slug)))
+            .limit(1);
+          if (!conflict) break;
+          attempt += 1;
+          if (attempt > 50) {
+            throw errors.CONFLICT({
+              data: { reason: "slug_exhausted", key: baseSlug },
+            });
+          }
+          slug = `${baseSlug}-${String(attempt + 1)}`;
+        }
+        const [row] = await context.db
+          .insert(terms)
+          .values({
+            taxonomy: MENU_TAXONOMY,
+            slug,
+            name: input.name,
+          })
+          .returning({ id: terms.id, version: terms.version });
+        if (!row) {
+          // Defensive: `.returning()` on an INSERT that just succeeded
+          // returning the affected row is contractually non-empty for
+          // SQLite/D1. Surface as a plain error (mapped to 500 by the
+          // RPC layer) rather than papering over a driver regression.
+          throw new Error("menu.create: insert returned no row");
+        }
+        return { termId: row.id, slug, version: row.version };
+      },
+    );
+
   const assignLocation = base
     .use(authenticated)
     .input(
@@ -591,7 +658,83 @@ export function createMenuRouter(): Record<string, unknown> {
       return { location: input.location, termSlug: input.termSlug };
     });
 
-  return { list, get, save, delete: remove, assignLocation };
+  const locationsList = base
+    .use(authenticated)
+    .handler(async ({ context, errors }): Promise<readonly LocationRow[]> => {
+      if (!context.auth.can(MENU_MANAGE_CAPABILITY)) {
+        throw errors.FORBIDDEN({
+          data: { capability: MENU_MANAGE_CAPABILITY },
+        });
+      }
+      const registered = getRegisteredLocations();
+      if (registered.size === 0) return [];
+
+      // settings.value is a JSON-encoded text column, so a SQL-level
+      // join against terms.slug would compare `"main"` (quoted) with
+      // `main` (unquoted). Two small queries are clearer than reaching
+      // for json_extract, and the rowcount is bounded by the number of
+      // theme-registered locations.
+      const settingRows = await context.db
+        .select({ key: settings.key, value: settings.value })
+        .from(settings)
+        .where(
+          and(
+            eq(settings.group, MENU_LOCATIONS_GROUP),
+            inArray(settings.key, [...registered.keys()]),
+          ),
+        );
+      const slugToLocation = new Map<string, string>();
+      for (const row of settingRows) {
+        if (typeof row.value === "string")
+          slugToLocation.set(row.value, row.key);
+      }
+      const bindings = new Map<string, number>();
+      if (slugToLocation.size > 0) {
+        const termRows = await context.db
+          .select({ id: terms.id, slug: terms.slug })
+          .from(terms)
+          .where(
+            and(
+              eq(terms.taxonomy, MENU_TAXONOMY),
+              inArray(terms.slug, [...slugToLocation.keys()]),
+            ),
+          );
+        for (const row of termRows) {
+          const locationId = slugToLocation.get(row.slug);
+          if (locationId) bindings.set(locationId, row.id);
+        }
+      }
+
+      return [...registered.values()]
+        .sort((a, b) => a.id.localeCompare(b.id))
+        .map((location) => {
+          const result: LocationRow = {
+            id: location.id,
+            label: location.label,
+            boundTermId: bindings.get(location.id) ?? null,
+          };
+          return location.description === undefined
+            ? result
+            : { ...result, description: location.description };
+        });
+    });
+
+  return {
+    list,
+    get,
+    save,
+    create,
+    delete: remove,
+    assignLocation,
+    locations: { list: locationsList },
+  };
+}
+
+interface LocationRow {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly boundTermId: number | null;
 }
 
 function readMaxDepth(meta: Record<string, unknown>): number {

--- a/packages/plugins/menu/src/server/eligibility.ts
+++ b/packages/plugins/menu/src/server/eligibility.ts
@@ -13,7 +13,7 @@ import type { PluginRegistry } from "@plumix/core";
  * - other      — plugin-contributed lookup adapter kinds (`media`,
  *                `user`, etc.) that opted in via `menuPicker`
  */
-export interface PickerTab {
+interface PickerTab {
   readonly kind: string;
   readonly tabLabel: string;
   /** For entry/term tabs, the underlying type/taxonomy name. */

--- a/packages/plugins/menu/src/server/index.ts
+++ b/packages/plugins/menu/src/server/index.ts
@@ -1,5 +1,4 @@
 export { getEligibleMenuKinds } from "./eligibility.js";
-export type { PickerTab } from "./eligibility.js";
 export { getMenuByName } from "./getMenuByName.js";
 export { getMenuForLocation } from "./getMenuForLocation.js";
 export {

--- a/packages/plugins/menu/test/setup.ts
+++ b/packages/plugins/menu/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/plugins/menu/tsconfig.build.json
+++ b/packages/plugins/menu/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "stripInternal": true
   },
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/plugins/menu/tsconfig.json
+++ b/packages/plugins/menu/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "@plumix/typescript-config/library.json",
-  "include": ["src"]
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "rootDir": ".",
+    "types": ["node", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "e2e", "test"]
 }

--- a/packages/plugins/menu/vitest.config.ts
+++ b/packages/plugins/menu/vitest.config.ts
@@ -1,5 +1,17 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 import { baseConfig } from "@plumix/vitest-config/base";
 
-export default defineConfig(baseConfig);
+// jsdom is needed for the admin component suites (`src/admin/*.test.tsx`).
+// The server-side suites are environment-agnostic and work fine under
+// jsdom too, so we set one environment for the whole package rather than
+// branching per file pattern.
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      setupFiles: ["./test/setup.ts"],
+    },
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
       '@orpc/server':
         specifier: ^1.14.1
         version: 1.14.1(ws@8.20.0)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../../tooling/eslint
@@ -602,24 +605,57 @@ importers:
       '@plumix/vitest-config':
         specifier: workspace:*
         version: link:../../../tooling/vitest
+      '@tanstack/react-query':
+        specifier: ^5.99.2
+        version: 5.99.2(react@19.2.5)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.5(vitest@4.1.5)
+      esbuild:
+        specifier: 0.27.7
+        version: 0.27.7
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
       publint:
         specifier: 'catalog:'
         version: 0.3.18
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugins/pages:
     dependencies:


### PR DESCRIPTION
## Summary

Slice 7 of the [@plumix/plugin-menu](https://github.com/withplumix/plumix/issues/155) rollout — the admin shell.

- **Admin page**: `ctx.registerAdminPage({ path: "/menus", ... })` lights up under **Appearance > Menus**, capability-gated on `term:menu:manage`.
- **Menus shell** (`MenusShell.tsx`): selector with one button per menu plus a **+ Create new menu** sentinel, tab switcher (Edit placeholder, Manage Locations), and a locations table whose `<select>` is bound to `menu.assignLocation`.
- **`menu.create` RPC**: slugify the name, probe-then-insert with numeric suffix on collision, capability-gated, valibot-validated (1..MAX trimmed).
- **`menu.locations.list` RPC**: joins `getRegisteredLocations()` against the `menu_locations` settings group via two batched `inArray` queries (settings.value is JSON-encoded text, so a SQL-level join would miscompare quoted vs. unquoted slugs).
- **`slugify` exported** from `@plumix/core` so the e2e mock mirrors real server behavior.
- **`./admin` added** to plugin-menu's package exports + new `adminEntry` chunk path so the plumix vite plugin can pick up the bundle.
- **URL state** lives in `?menu=<slug>` and `?tab=<id>` query params (matches WP `nav-menus.php`, dodges `:param` paths in `registerAdminPage`).

Item editor, drag-drop tree, and broken-ref UI stay deferred to slices [#165](https://github.com/withplumix/plumix/issues/165), [#166](https://github.com/withplumix/plumix/issues/166), and [#167](https://github.com/withplumix/plumix/issues/167) per plan. Edit tab body is a placeholder `<div data-testid="menus-tab-edit-panel" />`.

Closes [#163](https://github.com/withplumix/plumix/issues/163).

## Test plan

- [x] `pnpm --filter @plumix/plugin-menu test` — 166 passed (12 files), incl. `menu.create` (slug derivation, collision suffix, empty-name rejection, capability check), `menu.locations.list` (binding, empty, ignores stale settings, capability check), and `MenusShell` (empty state, selector, tab switching, locations table render + change + clear, create flow + dismissed prompt)
- [x] `pnpm --filter @plumix/plugin-menu typecheck` — clean
- [x] `pnpm --filter @plumix/plugin-menu lint` — clean
- [ ] `pnpm --filter @plumix/plugin-menu test:e2e` — single Playwright spec covers create → switch tab → assign location → reload → assignment persists. Requires `pnpm --filter @plumix/admin build` first.

## Notes

- Capability is `term:menu:manage` everywhere (issue text drift mentioned `term:menu:edit`; existing rpc.ts wins).
- `menu.create` probe-then-insert is non-atomic — two concurrent admin creates of the same name would race into a unique-constraint error. Acceptable for slice 7 (admin-only, very low traffic); a `INSERT ... ON CONFLICT DO NOTHING` retry could be a follow-up.
- No optimistic update on `assignLocation`; React Query refetches on success. UX delay is small.