### PR TITLE
build: silence sherif's spurious workspace-glob warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "knip": "knip",
     "lint": "turbo run lint --continue -- --cache --cache-location .cache/.eslintcache",
     "lint:fix": "turbo run lint --continue -- --fix --cache --cache-location .cache/.eslintcache",
-    "postinstall": "pnpm dlx sherif@latest -r packages-without-package-json",
+    "postinstall": "pnpm dlx sherif@latest -r packages-without-package-json -r non-existant-packages",
     "publint": "turbo run publint",
     "test": "turbo run test",
     "test:e2e": "turbo run test:e2e",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,5 @@
 packages:
   - "packages/*"
-  - "!packages/plugins"
-  - "!packages/runtimes"
   - "packages/runtimes/*"
   - "packages/plugins/*"
   - "packages/plugins/*/playground"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 packages:
   - "packages/*"
+  - "!packages/plugins"
+  - "!packages/runtimes"
   - "packages/runtimes/*"
   - "packages/plugins/*"
   - "packages/plugins/*/playground"


### PR DESCRIPTION
Silence sherif's `non-existant-packages` warning by adding it to the postinstall `-r` list, alongside the already-silenced `packages-without-package-json`.

Sherif walks `pnpm-workspace.yaml`'s `packages/*` glob and flags `packages/plugins` and `packages/runtimes` because they're container directories that hold sub-packages, not workspace packages themselves. The follow-on `non-existant-packages` warning fires for the same reason. The underlying workspace shape is correct — pnpm resolves everything fine — these two rules are just sherif's blind spot.

I initially tried fixing this at the source with `!packages/plugins` / `!packages/runtimes` negations in `pnpm-workspace.yaml`. pnpm honored them, but **turbo discovers workspaces by parsing `pnpm-workspace.yaml` directly and doesn't understand pnpm's `!negation` syntax** — it dropped `@plumix/runtime-cloudflare` and all plugin packages from its task graph, breaking typecheck / test / publint / attw on CI. Reverted to a one-line `-r` change instead.

The substantive dep-hygiene rules (`multiple-dependency-versions`, `types-in-dependencies`, `no-repeated-dependencies`, etc.) still run on every install — only the two glob-shape rules sherif gets wrong are muted.