### PR TITLE
feat(plugin-menu): admin item editor (slice 8)

### DIFF
--- a/packages/plugins/menu/src/admin/MenuItemEditor.tsx
+++ b/packages/plugins/menu/src/admin/MenuItemEditor.tsx
@@ -1,0 +1,418 @@
+import type { Dispatch, ReactNode } from "react";
+import { useEffect, useReducer, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import type {
+  EditorAction,
+  EditorItem,
+  EditorState,
+  ItemKey,
+} from "./editor-state.js";
+import type { PickerTab } from "./rpc.js";
+import {
+  buildSavePayload,
+  editorReducer,
+  initialEditorState,
+} from "./editor-state.js";
+import {
+  useAssignLocation,
+  useDeleteMenu,
+  useLocationsList,
+  useMenuGet,
+  usePickerTabs,
+  useSaveMenu,
+} from "./rpc.js";
+
+export function MenuItemEditor({
+  termId,
+}: {
+  readonly termId: number;
+}): ReactNode {
+  const menu = useMenuGet(termId);
+  const pickerTabs = usePickerTabs();
+  const [state, dispatch] = useReducer(editorReducer, initialEditorState);
+
+  useEffect(() => {
+    if (!menu.data) return;
+    // Reload either when the user switches menus (term id changes) or
+    // when the server's version moves past the editor's — the latter
+    // is how the conflict-reload action makes its way into local state.
+    // applySaveResult bumps state.version to the new server value, so
+    // the matching case stays a no-op after a clean save.
+    if (menu.data.id !== state.termId || menu.data.version !== state.version) {
+      dispatch({ type: "loadFromServer", response: menu.data });
+    }
+  }, [menu.data, state.termId, state.version]);
+
+  if (menu.isLoading || state.termId !== menu.data?.id) {
+    return <div data-testid="menu-item-editor-loading" />;
+  }
+  return (
+    <div data-testid="menu-item-editor">
+      <ItemsPicker tabs={pickerTabs.data ?? []} dispatch={dispatch} />
+      {state.items.length === 0 ? (
+        <div data-testid="menu-item-list-empty">No items yet.</div>
+      ) : (
+        <MenuItemList state={state} dispatch={dispatch} />
+      )}
+      <ItemDetailPanel state={state} dispatch={dispatch} />
+      <MenuSettingsPanel state={state} dispatch={dispatch} />
+    </div>
+  );
+}
+
+function LocationsBindings({
+  termId,
+  slug,
+}: {
+  readonly termId: number;
+  readonly slug: string;
+}): ReactNode {
+  const locations = useLocationsList();
+  const assign = useAssignLocation();
+  return (
+    <div data-testid="menu-settings-locations">
+      {(locations.data ?? []).map((row) => {
+        const isBound = row.boundTermId === termId;
+        return (
+          <label
+            key={row.id}
+            data-testid={`menu-settings-location-row-${row.id}`}
+          >
+            <input
+              type="checkbox"
+              data-testid={`menu-settings-location-${row.id}`}
+              checked={isBound}
+              onChange={() => {
+                assign.mutate({
+                  location: row.id,
+                  termSlug: isBound ? null : slug,
+                });
+              }}
+            />
+            {row.label}
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+function MenuSettingsPanel({
+  state,
+  dispatch,
+}: {
+  readonly state: EditorState;
+  readonly dispatch: Dispatch<EditorAction>;
+}): ReactNode {
+  const save = useSaveMenu();
+  const queryClient = useQueryClient();
+  // The conflict banner persists past the mutation's transient error
+  // state (mutation goes idle on dismiss/refetch). A separate flag lets
+  // the user explicitly dismiss via the reload action.
+  const [conflict, setConflict] = useState(false);
+  const isVersionMismatch =
+    save.error instanceof Error && save.error.message === "version_mismatch";
+  useEffect(() => {
+    if (isVersionMismatch) setConflict(true);
+  }, [isVersionMismatch]);
+  return (
+    <div data-testid="menu-settings-panel">
+      <LocationsBindings termId={state.termId} slug={state.slug} />
+      {conflict ? (
+        <div data-testid="menu-conflict-banner" role="alert">
+          Another editor saved changes since you loaded this menu.
+          <button
+            type="button"
+            data-testid="menu-conflict-reload"
+            onClick={() => {
+              setConflict(false);
+              save.reset();
+              void queryClient.invalidateQueries({
+                queryKey: ["menu", "get", state.termId] as const,
+              });
+            }}
+          >
+            Reload to see latest
+          </button>
+        </div>
+      ) : null}
+      <button
+        type="button"
+        data-testid="menu-save-button"
+        disabled={save.isPending}
+        onClick={() => {
+          // Snapshot the keys at click time so onSuccess can reattach
+          // ids to the right items even if the user mutated state
+          // while the save was in flight.
+          const snapshotKeys = state.items.map((item) => item.key);
+          save.mutate(
+            {
+              termId: state.termId,
+              version: state.version,
+              items: buildSavePayload(state),
+            },
+            {
+              onSuccess: (result) => {
+                dispatch({
+                  type: "applySaveResult",
+                  result: {
+                    version: result.version,
+                    itemIds: result.itemIds,
+                    snapshotKeys,
+                  },
+                });
+              },
+            },
+          );
+        }}
+      >
+        Save menu
+      </button>
+      <DeleteMenuButton termId={state.termId} />
+    </div>
+  );
+}
+
+function DeleteMenuButton({ termId }: { readonly termId: number }): ReactNode {
+  const remove = useDeleteMenu();
+  return (
+    <button
+      type="button"
+      data-testid="menu-delete-button"
+      disabled={remove.isPending}
+      onClick={() => {
+        if (
+          typeof window !== "undefined" &&
+          !window.confirm("Delete this menu?")
+        ) {
+          return;
+        }
+        remove.mutate({ termId });
+      }}
+    >
+      Delete menu
+    </button>
+  );
+}
+
+function ItemsPicker({
+  tabs,
+  dispatch,
+}: {
+  readonly tabs: readonly PickerTab[];
+  readonly dispatch: Dispatch<EditorAction>;
+}): ReactNode {
+  const [activeTab, setActiveTab] = useState<string | null>(null);
+  return (
+    <div data-testid="menu-items-picker">
+      <div data-testid="menu-picker-tabs">
+        {tabs.map((tab) => (
+          <button
+            key={tab.kind + (tab.target ?? "")}
+            type="button"
+            data-testid={`menu-picker-tab-${tab.kind}`}
+            aria-selected={activeTab === tab.kind}
+            onClick={() => {
+              setActiveTab(tab.kind);
+            }}
+          >
+            {tab.tabLabel}
+          </button>
+        ))}
+      </div>
+      {activeTab === "custom" ? (
+        <CustomUrlPickerPanel dispatch={dispatch} />
+      ) : null}
+    </div>
+  );
+}
+
+function CustomUrlPickerPanel({
+  dispatch,
+}: {
+  readonly dispatch: Dispatch<EditorAction>;
+}): ReactNode {
+  const [url, setUrl] = useState("");
+  const [label, setLabel] = useState("");
+  return (
+    <div data-testid="menu-picker-custom-panel">
+      <input
+        type="text"
+        data-testid="menu-picker-custom-url"
+        value={url}
+        onChange={(event) => {
+          setUrl(event.target.value);
+        }}
+      />
+      <input
+        type="text"
+        data-testid="menu-picker-custom-label"
+        value={label}
+        onChange={(event) => {
+          setLabel(event.target.value);
+        }}
+      />
+      <button
+        type="button"
+        data-testid="menu-picker-custom-add"
+        onClick={() => {
+          if (url.trim() === "") return;
+          dispatch({
+            type: "addItem",
+            title: label.trim() === "" ? null : label.trim(),
+            meta: { kind: "custom", url: url.trim() },
+          });
+          setUrl("");
+          setLabel("");
+        }}
+      >
+        Add to menu
+      </button>
+    </div>
+  );
+}
+
+function MenuItemList({
+  state,
+  dispatch,
+}: {
+  readonly state: EditorState;
+  readonly dispatch: Dispatch<EditorAction>;
+}): ReactNode {
+  const depths = computeDepths(state);
+  return (
+    <ol data-testid="menu-item-list">
+      {state.items.map((item) => (
+        <MenuItemRow
+          key={item.key}
+          item={item}
+          depth={depths.get(item.key) ?? 0}
+          selected={state.selectedKey === item.key}
+          dispatch={dispatch}
+        />
+      ))}
+    </ol>
+  );
+}
+
+function MenuItemRow({
+  item,
+  depth,
+  selected,
+  dispatch,
+}: {
+  readonly item: EditorItem;
+  readonly depth: number;
+  readonly selected: boolean;
+  readonly dispatch: Dispatch<EditorAction>;
+}): ReactNode {
+  const id = item.id ?? item.key;
+  return (
+    <li
+      data-testid={`menu-item-row-${String(id)}`}
+      data-depth={String(depth)}
+      data-selected={selected ? "true" : "false"}
+      style={{ paddingLeft: `${String(depth * 16)}px` }}
+      onClick={() => {
+        dispatch({ type: "selectItem", key: item.key });
+      }}
+    >
+      <span>{item.title ?? "(unnamed)"}</span>
+      <button
+        type="button"
+        data-testid={`menu-item-up-${String(id)}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          dispatch({ type: "moveUp", key: item.key });
+        }}
+      >
+        Up
+      </button>
+      <button
+        type="button"
+        data-testid={`menu-item-down-${String(id)}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          dispatch({ type: "moveDown", key: item.key });
+        }}
+      >
+        Down
+      </button>
+      <button
+        type="button"
+        data-testid={`menu-item-promote-${String(id)}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          dispatch({ type: "promote", key: item.key });
+        }}
+      >
+        Promote
+      </button>
+      <button
+        type="button"
+        data-testid={`menu-item-demote-${String(id)}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          dispatch({ type: "demote", key: item.key });
+        }}
+      >
+        Demote
+      </button>
+      <button
+        type="button"
+        data-testid={`menu-item-remove-${String(id)}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          dispatch({ type: "removeItem", key: item.key });
+        }}
+      >
+        Remove
+      </button>
+    </li>
+  );
+}
+
+function ItemDetailPanel({
+  state,
+  dispatch,
+}: {
+  readonly state: EditorState;
+  readonly dispatch: Dispatch<EditorAction>;
+}): ReactNode {
+  const selected =
+    state.selectedKey === null
+      ? null
+      : (state.items.find((item) => item.key === state.selectedKey) ?? null);
+  if (!selected) return <div data-testid="menu-item-detail-empty" />;
+  return (
+    <div data-testid="menu-item-detail-panel">
+      <input
+        type="text"
+        data-testid="menu-item-detail-title"
+        value={selected.title ?? ""}
+        onChange={(event) => {
+          const next = event.target.value;
+          dispatch({
+            type: "updateField",
+            key: selected.key,
+            patch: { title: next === "" ? null : next },
+          });
+        }}
+      />
+    </div>
+  );
+}
+
+function computeDepths(state: EditorState): Map<ItemKey, number> {
+  const depthByKey = new Map<ItemKey, number>();
+  for (const item of state.items) {
+    if (item.parentKey === null) {
+      depthByKey.set(item.key, 0);
+    } else {
+      const parentDepth = depthByKey.get(item.parentKey) ?? 0;
+      depthByKey.set(item.key, parentDepth + 1);
+    }
+  }
+  return depthByKey;
+}

--- a/packages/plugins/menu/src/admin/MenusShell.test.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.test.tsx
@@ -20,11 +20,35 @@ function urlOf(input: RequestInfo | URL): string {
   return input.url;
 }
 
+interface ErrorResponse {
+  readonly status: number;
+  readonly error: {
+    readonly message?: string;
+    readonly data?: { reason?: string };
+  };
+}
+function isErrorResponse(value: unknown): value is ErrorResponse {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    "error" in value
+  );
+}
+
 function mockRpc(routes: Record<string, unknown>): void {
   fetchMock = vi.fn((input: RequestInfo | URL): Promise<Response> => {
     const url = urlOf(input);
     for (const [suffix, body] of Object.entries(routes)) {
       if (url.endsWith(suffix)) {
+        if (isErrorResponse(body)) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ json: body.error, meta: [] }), {
+              status: body.status,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+        }
         return Promise.resolve(
           new Response(JSON.stringify({ json: body, meta: [] }), {
             status: 200,
@@ -291,6 +315,551 @@ describe("MenusShell", () => {
         termSlug: string | null;
       }>(call);
       expect(input).toEqual({ location: "primary", termSlug: null });
+    });
+  });
+
+  describe("edit tab — item editor", () => {
+    test("on version_mismatch CONFLICT renders a reload banner that refetches menu.get", async () => {
+      // The server returns 409 with `data.reason: 'version_mismatch'`
+      // when another tab saved between this editor's load and this
+      // save. Acceptance: surface the conflict as a visible banner with
+      // a reload action; no silent data loss.
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      let getCallCount = 0;
+      const fetchImpl = vi.fn((input: RequestInfo | URL): Promise<Response> => {
+        const url = typeof input === "string" ? input : (input as URL).href;
+        if (url.endsWith("/menu/list")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                json: [
+                  {
+                    id: 7,
+                    slug: "main",
+                    name: "Main",
+                    version: 1,
+                    itemCount: 0,
+                  },
+                ],
+                meta: [],
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        if (url.endsWith("/menu/locations/list")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ json: [], meta: [] }), {
+              status: 200,
+            }),
+          );
+        }
+        if (url.endsWith("/menu/pickerTabs")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                json: [{ kind: "custom", tabLabel: "Custom URL" }],
+                meta: [],
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        if (url.endsWith("/menu/get")) {
+          getCallCount += 1;
+          // First fetch returns v1 (editor's starting point); after the
+          // user clicks Reload, refetch returns v2 with a fresh item —
+          // so the test can assert state actually mirrored the new
+          // server data.
+          const body =
+            getCallCount === 1
+              ? {
+                  id: 7,
+                  slug: "main",
+                  name: "Main",
+                  version: 1,
+                  maxDepth: 5,
+                  items: [],
+                }
+              : {
+                  id: 7,
+                  slug: "main",
+                  name: "Main",
+                  version: 2,
+                  maxDepth: 5,
+                  items: [
+                    {
+                      id: 42,
+                      parentId: null,
+                      sortOrder: 0,
+                      title: "Reloaded",
+                      meta: { kind: "custom", url: "/r" },
+                    },
+                  ],
+                };
+          return Promise.resolve(
+            new Response(JSON.stringify({ json: body, meta: [] }), {
+              status: 200,
+            }),
+          );
+        }
+        if (url.endsWith("/menu/save")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                json: {
+                  message: "concurrent edit",
+                  data: { reason: "version_mismatch", key: "1" },
+                },
+                meta: [],
+              }),
+              { status: 409 },
+            ),
+          );
+        }
+        return Promise.resolve(new Response("not-mocked", { status: 404 }));
+      });
+      vi.stubGlobal("fetch", fetchImpl);
+
+      renderShell();
+      const user = userEvent.setup();
+      await screen.findByTestId("menu-item-list-empty");
+      const initialGetCount = getCallCount;
+      await user.click(await screen.findByTestId("menu-save-button"));
+
+      const banner = await screen.findByTestId("menu-conflict-banner");
+      expect(banner).toBeInTheDocument();
+      const reload = await screen.findByTestId("menu-conflict-reload");
+      await user.click(reload);
+
+      await vi.waitFor(() => {
+        expect(getCallCount).toBeGreaterThan(initialGetCount);
+      });
+      // The acceptance is "no silent data loss" — the user clicked
+      // Reload and must actually see the new server state, not the
+      // stale local one. The fresh fixture has a new row with id 42.
+      expect(await screen.findByTestId("menu-item-row-42")).toBeInTheDocument();
+    });
+
+    test("Save button posts current items + version to menu.save", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 4, itemCount: 0 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 4,
+          maxDepth: 5,
+          items: [],
+        },
+        "/menu/save": {
+          termId: 7,
+          version: 5,
+          itemIds: [101],
+          added: [101],
+          removed: [],
+          modified: [],
+        },
+      });
+
+      renderShell();
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId("menu-picker-tab-custom"));
+      await user.type(
+        await screen.findByTestId("menu-picker-custom-url"),
+        "/x",
+      );
+      await user.type(
+        await screen.findByTestId("menu-picker-custom-label"),
+        "X",
+      );
+      await user.click(await screen.findByTestId("menu-picker-custom-add"));
+
+      await user.click(await screen.findByTestId("menu-save-button"));
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/save");
+        if (!found) throw new Error("menu.save not called");
+        return found;
+      });
+      const input = parseRpcInput<{
+        termId: number;
+        version: number;
+        items: readonly { title: string | null; meta: { kind: string } }[];
+      }>(call);
+      expect(input).toMatchObject({
+        termId: 7,
+        version: 4,
+      });
+      expect(input.items).toHaveLength(1);
+      expect(input.items[0]?.title).toBe("X");
+      expect(input.items[0]?.meta).toEqual({ kind: "custom", url: "/x" });
+    });
+
+    test("delete-menu button confirms then calls menu.delete with the termId", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [],
+        },
+        "/menu/delete": { id: 7 },
+      });
+      vi.stubGlobal("confirm", vi.fn().mockReturnValue(true));
+
+      renderShell();
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId("menu-delete-button"));
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/delete");
+        if (!found) throw new Error("menu.delete not called");
+        return found;
+      });
+      const input = parseRpcInput<{ termId: number }>(call);
+      expect(input.termId).toBe(7);
+    });
+
+    test("settings panel location checkboxes reflect bindings and toggle via menu.assignLocation", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [
+          { id: "primary", label: "Primary Nav", boundTermId: 7 },
+          { id: "footer", label: "Footer Slot", boundTermId: null },
+        ],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [],
+        },
+        "/menu/assignLocation": { location: "footer", termSlug: "main" },
+      });
+
+      renderShell();
+
+      const primary = await screen.findByTestId<HTMLInputElement>(
+        "menu-settings-location-primary",
+      );
+      expect(primary.checked).toBe(true);
+
+      const footer = await screen.findByTestId<HTMLInputElement>(
+        "menu-settings-location-footer",
+      );
+      expect(footer.checked).toBe(false);
+
+      const user = userEvent.setup();
+      await user.click(footer);
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/assignLocation");
+        if (!found) throw new Error("assignLocation not called");
+        return found;
+      });
+      const input = parseRpcInput<{
+        location: string;
+        termSlug: string | null;
+      }>(call);
+      expect(input).toEqual({ location: "footer", termSlug: "main" });
+    });
+
+    test("up button on second item swaps it with the first; save sends the new order", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 2 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "First",
+              meta: { kind: "custom", url: "/1" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "Second",
+              meta: { kind: "custom", url: "/2" },
+            },
+          ],
+        },
+        "/menu/save": {
+          termId: 7,
+          version: 2,
+          itemIds: [11, 10],
+          added: [],
+          removed: [],
+          modified: [10, 11],
+        },
+      });
+
+      renderShell();
+      const user = userEvent.setup();
+      await screen.findByTestId("menu-item-row-11");
+      await user.click(await screen.findByTestId("menu-item-up-11"));
+      await user.click(await screen.findByTestId("menu-save-button"));
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/save");
+        if (!found) throw new Error("menu.save not called");
+        return found;
+      });
+      const input = parseRpcInput<{
+        items: readonly { id?: number }[];
+      }>(call);
+      expect(input.items.map((i) => i.id)).toEqual([11, 10]);
+    });
+
+    test("clicking a row opens a detail panel; clearing the label override saves as title null", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 1 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 99,
+              parentId: null,
+              sortOrder: 0,
+              title: "Original",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+        "/menu/save": {
+          termId: 7,
+          version: 2,
+          itemIds: [99],
+          added: [],
+          removed: [],
+          modified: [99],
+        },
+      });
+
+      renderShell();
+
+      const user = userEvent.setup();
+      const row = await screen.findByTestId("menu-item-row-99");
+      await user.click(row);
+
+      const titleInput = await screen.findByTestId<HTMLInputElement>(
+        "menu-item-detail-title",
+      );
+      expect(titleInput.value).toBe("Original");
+      await user.clear(titleInput);
+
+      await user.click(await screen.findByTestId("menu-save-button"));
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/save");
+        if (!found) throw new Error("menu.save not called");
+        return found;
+      });
+      const input = parseRpcInput<{
+        items: readonly { id?: number; title: string | null }[];
+      }>(call);
+      expect(input.items[0]?.id).toBe(99);
+      expect(input.items[0]?.title).toBeNull();
+    });
+
+    test("custom URL picker tab adds a new item to the in-memory list", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 0 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [],
+        },
+      });
+
+      renderShell();
+
+      const customTab = await screen.findByTestId("menu-picker-tab-custom");
+      const user = userEvent.setup();
+      await user.click(customTab);
+
+      const urlInput = await screen.findByTestId("menu-picker-custom-url");
+      const labelInput = await screen.findByTestId("menu-picker-custom-label");
+      const addButton = await screen.findByTestId("menu-picker-custom-add");
+
+      await user.type(urlInput, "/contact");
+      await user.type(labelInput, "Contact");
+      await user.click(addButton);
+
+      // The new item appears in the list with the typed label and no
+      // RPC has been called yet (acceptance: "ready to save (no
+      // immediate persistence)").
+      const list = await screen.findByTestId("menu-item-list");
+      expect(list).toHaveTextContent("Contact");
+      expect(findRpcCall("/menu/save")).toBeUndefined();
+    });
+
+    test("renders existing items as a flat list in DFS order with parent-depth indent", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 3, itemCount: 3 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 3,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Home",
+              meta: { kind: "custom", url: "/" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "About",
+              meta: { kind: "custom", url: "/about" },
+            },
+            {
+              id: 20,
+              parentId: 11,
+              sortOrder: 0,
+              title: "Team",
+              meta: { kind: "custom", url: "/about/team" },
+            },
+          ],
+        },
+      });
+
+      renderShell();
+
+      // Each row has data-testid `menu-item-row-${id}` with a depth attr
+      // so the flat-list interim still communicates hierarchy via indent.
+      const home = await screen.findByTestId("menu-item-row-10");
+      expect(home.dataset.depth).toBe("0");
+      const about = await screen.findByTestId("menu-item-row-11");
+      expect(about.dataset.depth).toBe("0");
+      const team = await screen.findByTestId("menu-item-row-20");
+      expect(team.dataset.depth).toBe("1");
+    });
+
+    test("when ?menu=<slug> resolves to a known menu, calls menu.get for its termId", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 3, itemCount: 0 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 3,
+          maxDepth: 5,
+          items: [],
+        },
+      });
+
+      renderShell();
+
+      const getCall = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/get");
+        if (!found) throw new Error("menu.get not called");
+        return found;
+      });
+      const input = parseRpcInput<{ termId: number }>(getCall);
+      expect(input.termId).toBe(7);
+      expect(
+        await screen.findByTestId("menu-item-list-empty"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/packages/plugins/menu/src/admin/MenusShell.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import type { MenuListItem, MenuLocationRow } from "./rpc.js";
 import type { TabId } from "./url-state.js";
+import { MenuItemEditor } from "./MenuItemEditor.js";
 import {
   useAssignLocation,
   useCreateMenu,
@@ -10,6 +11,7 @@ import {
   useMenuList,
 } from "./rpc.js";
 import {
+  getSelectedMenuSlug,
   getSelectedTab,
   setSelectedMenu,
   setSelectedTab,
@@ -24,13 +26,19 @@ export function MenusShell(): ReactNode {
   const menus = useMenuList();
   const createMenu = useCreateMenu();
   const [tab, setTab] = useState<TabId>(getSelectedTab());
+  const [slug, setSlug] = useState<string | null>(getSelectedMenuSlug());
 
   function handleCreate(): void {
     const name = window.prompt("Menu name")?.trim();
     if (!name) return;
     createMenu.mutate(
       { name },
-      { onSuccess: (result) => setSelectedMenu(result.slug) },
+      {
+        onSuccess: (result) => {
+          setSelectedMenu(result.slug);
+          setSlug(result.slug);
+        },
+      },
     );
   }
 
@@ -39,15 +47,30 @@ export function MenusShell(): ReactNode {
     setTab(next);
   }
 
+  function handleSelectMenu(next: string): void {
+    setSelectedMenu(next);
+    setSlug(next);
+  }
+
   if (menus.isLoading) {
     return <div data-testid="menus-shell-loading" />;
   }
   const menuList = menus.data ?? [];
+  const selectedMenu =
+    slug === null ? null : (menuList.find((m) => m.slug === slug) ?? null);
   return (
     <div data-testid="menus-shell">
-      <MenuSelector menus={menuList} onCreate={handleCreate} />
+      <MenuSelector
+        menus={menuList}
+        onCreate={handleCreate}
+        onSelect={handleSelectMenu}
+      />
       <Tabs activeTab={tab} onChange={handleTabChange} />
-      {tab === "edit" ? <EditPanel /> : <LocationsPanel menus={menuList} />}
+      {tab === "edit" ? (
+        <EditPanel selectedMenu={selectedMenu} />
+      ) : (
+        <LocationsPanel menus={menuList} />
+      )}
       {menuList.length === 0 ? (
         <div data-testid="menus-empty-cta">
           No menus yet. Create your first menu to get started.
@@ -60,9 +83,11 @@ export function MenusShell(): ReactNode {
 function MenuSelector({
   menus,
   onCreate,
+  onSelect,
 }: {
   readonly menus: readonly MenuListItem[];
   readonly onCreate: () => void;
+  readonly onSelect: (slug: string) => void;
 }): ReactNode {
   return (
     <div data-testid="menus-selector">
@@ -71,6 +96,9 @@ function MenuSelector({
           key={menu.id}
           type="button"
           data-testid={`menus-selector-option-${menu.slug}`}
+          onClick={() => {
+            onSelect(menu.slug);
+          }}
         >
           {menu.name}
         </button>
@@ -112,9 +140,22 @@ function Tabs({
   );
 }
 
-function EditPanel(): ReactNode {
-  // Item editor lands in slice 8.
-  return <div data-testid="menus-tab-edit-panel" />;
+function EditPanel({
+  selectedMenu,
+}: {
+  readonly selectedMenu: MenuListItem | null;
+}): ReactNode {
+  return (
+    <div data-testid="menus-tab-edit-panel">
+      {selectedMenu === null ? (
+        <p data-testid="menus-edit-no-selection">
+          Select a menu to start editing.
+        </p>
+      ) : (
+        <MenuItemEditor termId={selectedMenu.id} />
+      )}
+    </div>
+  );
 }
 
 function LocationsPanel({

--- a/packages/plugins/menu/src/admin/editor-state.test.ts
+++ b/packages/plugins/menu/src/admin/editor-state.test.ts
@@ -1,0 +1,973 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildSavePayload,
+  editorReducer,
+  initialEditorState,
+} from "./editor-state.js";
+
+describe("editorReducer", () => {
+  describe("loadFromServer", () => {
+    test("populates termId / slug / name / version / maxDepth from the response", () => {
+      const next = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 3,
+          maxDepth: 4,
+          items: [],
+        },
+      });
+
+      expect(next.termId).toBe(7);
+      expect(next.slug).toBe("main");
+      expect(next.name).toBe("Main");
+      expect(next.version).toBe(3);
+      expect(next.maxDepth).toBe(4);
+      expect(next.items).toEqual([]);
+      expect(next.selectedKey).toBeNull();
+      expect(next.dirty).toBe(false);
+    });
+
+    test("converts server items into editor items in (parentId, sortOrder) DFS order with stable keys", () => {
+      // Server sends items already ordered by (parentId, sortOrder, id).
+      // The editor stores them in DFS pre-order so parents always come
+      // before children — this matches what `buildSavePayload` will emit
+      // and what `flattenSaveItems` requires server-side.
+      const next = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Home",
+              meta: { kind: "custom", url: "/" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "About",
+              meta: { kind: "custom", url: "/about" },
+            },
+            {
+              id: 20,
+              parentId: 11,
+              sortOrder: 0,
+              title: "Team",
+              meta: { kind: "custom", url: "/about/team" },
+            },
+          ],
+        },
+      });
+
+      expect(next.items.map((item) => item.id)).toEqual([10, 11, 20]);
+      expect(next.items.map((item) => item.parentKey)).toEqual([
+        null,
+        null,
+        next.items[1]?.key,
+      ]);
+      // Existing items get a key derived from their server id so save
+      // round-trips can map back without ambiguity.
+      expect(next.items[0]?.key).toBe("id-10");
+      expect(next.items[2]?.key).toBe("id-20");
+    });
+
+    test("treats empty title as null so live-resolve fallback applies", () => {
+      // Server stores `''` (the entries.title default) when a user has
+      // never set a label override. The editor needs to distinguish
+      // "no override" from "explicit empty string" — both round-trip
+      // as null on save.
+      const next = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+
+      expect(next.items[0]?.title).toBeNull();
+    });
+  });
+
+  describe("moveUp", () => {
+    test("swaps an item with its previous sibling and updates sortOrder accordingly", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "First",
+              meta: { kind: "custom", url: "/1" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "Second",
+              meta: { kind: "custom", url: "/2" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "moveUp",
+        key: "id-11",
+      });
+
+      expect(next.items.map((item) => item.id)).toEqual([11, 10]);
+      // sortOrder reflects the new position so the next save round-trip
+      // sends the order the user sees, not the order the server saw.
+      expect(next.items[0]?.sortOrder).toBe(0);
+      expect(next.items[1]?.sortOrder).toBe(1);
+      expect(next.dirty).toBe(true);
+    });
+
+    test("moves a sibling's subtree along with it so DFS order survives", () => {
+      // Regression: `[A, A.child, B]` → moveUp(B) used to leave
+      // A.child stranded between B and A in the array, which then
+      // produced a `forward_parent_reference` on save (A.child's
+      // resolved parentIndex pointed past its own index).
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+            {
+              id: 20,
+              parentId: 10,
+              sortOrder: 0,
+              title: "A.child",
+              meta: { kind: "custom", url: "/a/c" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "B",
+              meta: { kind: "custom", url: "/b" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, { type: "moveUp", key: "id-11" });
+
+      // Order must be: B (root), A (root), A.child (under A).
+      expect(next.items.map((item) => item.id)).toEqual([11, 10, 20]);
+      // Every payload entry's parentIndex must reference an earlier
+      // entry — that's the contract `flattenSaveItems` enforces.
+      const payload = buildSavePayload(next);
+      payload.forEach((entry, index) => {
+        if (entry.parentIndex !== null) {
+          expect(entry.parentIndex).toBeLessThan(index);
+        }
+      });
+    });
+
+    test("is a no-op when the item is already first among its siblings", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "First",
+              meta: { kind: "custom", url: "/1" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "Second",
+              meta: { kind: "custom", url: "/2" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "moveUp",
+        key: "id-10",
+      });
+
+      expect(next.items.map((item) => item.id)).toEqual([10, 11]);
+      expect(next.dirty).toBe(false);
+    });
+  });
+
+  describe("moveDown", () => {
+    test("swaps an item with its next sibling", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "First",
+              meta: { kind: "custom", url: "/1" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "Second",
+              meta: { kind: "custom", url: "/2" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "moveDown",
+        key: "id-10",
+      });
+
+      expect(next.items.map((item) => item.id)).toEqual([11, 10]);
+      expect(next.dirty).toBe(true);
+    });
+
+    test("is a no-op when the item is already last among its siblings", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Only",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "moveDown",
+        key: "id-10",
+      });
+
+      expect(next.items.map((item) => item.id)).toEqual([10]);
+      expect(next.dirty).toBe(false);
+    });
+  });
+
+  describe("applySaveResult", () => {
+    test("assigns returned ids to new items in payload order and bumps the version", () => {
+      // After save, the editor must rekey new items from `tmp-*` to
+      // their final `id-*` form so subsequent edits send the existing
+      // id (not another insert). The server returns `itemIds[i]` aligned
+      // with the input `items[i]` — same order buildSavePayload emits.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 4,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Existing",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+      const added = editorReducer(loaded, {
+        type: "addItem",
+        title: "New",
+        meta: { kind: "custom", url: "/new" },
+      });
+      const next = editorReducer(added, {
+        type: "applySaveResult",
+        result: { version: 5, itemIds: [10, 99] },
+      });
+
+      expect(next.version).toBe(5);
+      expect(next.items.map((item) => item.id)).toEqual([10, 99]);
+      expect(next.items[1]?.key).toBe("id-99");
+      expect(next.dirty).toBe(false);
+    });
+
+    test("matches ids to items by snapshot key, ignoring slots whose key was removed mid-flight", () => {
+      // Regression: a positional zip between `state.items` and the
+      // returned `itemIds` misaligns ids if the user removed an item
+      // between firing the save and its onSuccess. Carrying the
+      // snapshot keys keeps the mapping stable.
+      const a = editorReducer(initialEditorState, {
+        type: "addItem",
+        title: "A",
+        meta: { kind: "custom", url: "/a" },
+      });
+      const ab = editorReducer(a, {
+        type: "addItem",
+        title: "B",
+        meta: { kind: "custom", url: "/b" },
+      });
+      const aKey = ab.items[0]?.key ?? "";
+      const bKey = ab.items[1]?.key ?? "";
+      // User removed A while the save was in flight.
+      const removed = editorReducer(ab, { type: "removeItem", key: aKey });
+
+      const next = editorReducer(removed, {
+        type: "applySaveResult",
+        result: {
+          version: 1,
+          itemIds: [10, 11],
+          snapshotKeys: [aKey, bKey],
+        },
+      });
+
+      // The surviving item must be tagged with its own server id, not
+      // the id of the slot that vanished from state.
+      expect(next.items).toHaveLength(1);
+      expect(next.items[0]?.id).toBe(11);
+      expect(next.items[0]?.key).toBe("id-11");
+    });
+
+    test("rewrites parentKey on descendants when the parent's tmp key becomes id", () => {
+      // A newly-added parent's children carry `parentKey: tmp-N`.
+      // After save, the parent's key becomes `id-X`; descendants must
+      // be updated so subsequent saves serialise with the right
+      // parentIndex.
+      const parent = editorReducer(initialEditorState, {
+        type: "addItem",
+        title: "Parent",
+        meta: { kind: "custom", url: "/p" },
+      });
+      const child = editorReducer(parent, {
+        type: "addItem",
+        title: "Child",
+        meta: { kind: "custom", url: "/p/c" },
+      });
+      const childKey = child.items[1]?.key ?? "";
+      const reparented = editorReducer(child, {
+        type: "demote",
+        key: childKey,
+      });
+
+      const next = editorReducer(reparented, {
+        type: "applySaveResult",
+        result: { version: 1, itemIds: [50, 51] },
+      });
+
+      expect(next.items[0]?.key).toBe("id-50");
+      expect(next.items[1]?.key).toBe("id-51");
+      expect(next.items[1]?.parentKey).toBe("id-50");
+    });
+  });
+
+  describe("demote", () => {
+    test("nests an item under its immediately-prior sibling", () => {
+      // Acceptance: "promote/demote affordance moves an item between
+      // parent groups". Demote = pop down a level — the item becomes
+      // the last child of the sibling immediately above it.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "B",
+              meta: { kind: "custom", url: "/b" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "demote",
+        key: "id-11",
+      });
+
+      expect(next.items[1]?.parentKey).toBe("id-10");
+      expect(next.items[1]?.sortOrder).toBe(0);
+      expect(next.dirty).toBe(true);
+    });
+
+    test("is a no-op when the item is the first among its siblings (no parent to nest under)", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "demote",
+        key: "id-10",
+      });
+
+      expect(next).toEqual(loaded);
+    });
+  });
+
+  describe("promote", () => {
+    test("pops a child up one level so its parent becomes a sibling", () => {
+      // Inverse of demote — promote moves the item out of its current
+      // parent's child list and into the grandparent's, positioned
+      // immediately after the old parent.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+            {
+              id: 20,
+              parentId: 10,
+              sortOrder: 0,
+              title: "A.child",
+              meta: { kind: "custom", url: "/a/child" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "promote",
+        key: "id-20",
+      });
+
+      expect(next.items[1]?.parentKey).toBeNull();
+      expect(next.dirty).toBe(true);
+    });
+
+    test("is a no-op when the item is already at root", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "promote",
+        key: "id-10",
+      });
+
+      expect(next).toEqual(loaded);
+    });
+  });
+
+  describe("removeItem", () => {
+    test("drops the targeted item and any descendants in one shot", () => {
+      // Removing a parent without the children would leave orphan rows
+      // referencing a non-existent parentKey — cheaper to cascade in
+      // the reducer than to discover the broken link at save time.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Parent",
+              meta: { kind: "custom", url: "/parent" },
+            },
+            {
+              id: 20,
+              parentId: 10,
+              sortOrder: 0,
+              title: "Child",
+              meta: { kind: "custom", url: "/parent/child" },
+            },
+            {
+              id: 30,
+              parentId: 20,
+              sortOrder: 0,
+              title: "Grandchild",
+              meta: { kind: "custom", url: "/parent/child/g" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "Sibling",
+              meta: { kind: "custom", url: "/sibling" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "removeItem",
+        key: "id-10",
+      });
+
+      expect(next.items.map((item) => item.id)).toEqual([11]);
+      expect(next.dirty).toBe(true);
+    });
+
+    test("clears selectedKey if the selected item was removed", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Only",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+      const selected = editorReducer(loaded, {
+        type: "selectItem",
+        key: "id-10",
+      });
+      expect(selected.selectedKey).toBe("id-10");
+
+      const next = editorReducer(selected, {
+        type: "removeItem",
+        key: "id-10",
+      });
+
+      expect(next.selectedKey).toBeNull();
+    });
+  });
+
+  describe("selectItem", () => {
+    test("sets selectedKey without flipping the dirty flag", () => {
+      // Selection is purely UI state — selecting an item should not
+      // count as an unsaved change.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Only",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "selectItem",
+        key: "id-10",
+      });
+
+      expect(next.selectedKey).toBe("id-10");
+      expect(next.dirty).toBe(false);
+    });
+  });
+
+  describe("updateField", () => {
+    test("patches the targeted item's title and marks the state dirty", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Original",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "updateField",
+        key: "id-10",
+        patch: { title: "Override" },
+      });
+
+      expect(next.items[0]?.title).toBe("Override");
+      expect(next.dirty).toBe(true);
+    });
+
+    test("storing null for title round-trips as null in the save payload (live-resolve fallback)", () => {
+      // Acceptance: "Label override field stores `null` (not empty string)
+      // when cleared, so live-resolve fallback applies." The reducer
+      // accepts null directly; the call site is responsible for
+      // translating `''` from the input element to `null`.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Original",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "updateField",
+        key: "id-10",
+        patch: { title: null },
+      });
+
+      expect(next.items[0]?.title).toBeNull();
+      expect(buildSavePayload(next)[0]?.title).toBeNull();
+    });
+
+    test("patches meta (e.g. custom URL) without affecting other fields", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Site",
+              meta: { kind: "custom", url: "/old" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "updateField",
+        key: "id-10",
+        patch: {
+          meta: { kind: "custom", url: "/new", target: "_blank" },
+        },
+      });
+
+      expect(next.items[0]?.meta).toEqual({
+        kind: "custom",
+        url: "/new",
+        target: "_blank",
+      });
+      expect(next.items[0]?.title).toBe("Site");
+    });
+  });
+
+  describe("addItem", () => {
+    test("appends a new root-level item with id null and an unused tmp key", () => {
+      const next = editorReducer(initialEditorState, {
+        type: "addItem",
+        title: "Home",
+        meta: { kind: "custom", url: "/" },
+      });
+
+      expect(next.items).toHaveLength(1);
+      const added = next.items[0];
+      expect(added?.id).toBeNull();
+      expect(added?.parentKey).toBeNull();
+      expect(added?.sortOrder).toBe(0);
+      expect(added?.title).toBe("Home");
+      expect(added?.meta).toEqual({ kind: "custom", url: "/" });
+      expect(added?.key.startsWith("tmp-")).toBe(true);
+      expect(next.dirty).toBe(true);
+    });
+
+    test("never reuses a tmp key after a removeItem clears one", () => {
+      // Regression: the tmp counter must be monotonic across the
+      // editor's lifetime. A naive `tmp-${items.length}` collides with
+      // the surviving item after an add/add/remove sequence.
+      const a = editorReducer(initialEditorState, {
+        type: "addItem",
+        title: "A",
+        meta: { kind: "custom", url: "/a" },
+      });
+      const ab = editorReducer(a, {
+        type: "addItem",
+        title: "B",
+        meta: { kind: "custom", url: "/b" },
+      });
+      const aKey = ab.items[0]?.key ?? "";
+      const bKey = ab.items[1]?.key ?? "";
+      const removed = editorReducer(ab, { type: "removeItem", key: aKey });
+      const c = editorReducer(removed, {
+        type: "addItem",
+        title: "C",
+        meta: { kind: "custom", url: "/c" },
+      });
+
+      const newKey = c.items[1]?.key ?? "";
+      expect(newKey).not.toBe(aKey);
+      expect(newKey).not.toBe(bKey);
+    });
+
+    test("appends after the last existing root-level item with sortOrder = prior+1", () => {
+      // The flat-list interim treats "add" as "append at the end of the
+      // root group". Slice 9's drag-drop changes how items move into
+      // child groups; for now everything new lands at the root.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "First",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+      const next = editorReducer(loaded, {
+        type: "addItem",
+        title: "Second",
+        meta: { kind: "custom", url: "/two" },
+      });
+
+      expect(next.items).toHaveLength(2);
+      expect(next.items[1]?.sortOrder).toBe(1);
+      expect(next.items[1]?.parentKey).toBeNull();
+    });
+  });
+});
+
+describe("buildSavePayload", () => {
+  test("emits an empty array when no items have been loaded or added", () => {
+    // The save endpoint accepts `items: []` (e.g. after the user
+    // removes everything). Building from a freshly-created menu with no
+    // items must round-trip through `menu.save` cleanly.
+    expect(buildSavePayload(initialEditorState)).toEqual([]);
+  });
+
+  test("emits one new custom-URL item with parentIndex null and no id", () => {
+    // The server's save accepts items with optional `id` (omitted for
+    // new) and `parentIndex` referencing earlier indexes. A single new
+    // root item should serialise with no id and parentIndex null.
+    const state = editorReducer(initialEditorState, {
+      type: "addItem",
+      title: "Home",
+      meta: { kind: "custom", url: "/" },
+    });
+
+    const payload = buildSavePayload(state);
+
+    expect(payload).toEqual([
+      {
+        parentIndex: null,
+        sortOrder: 0,
+        title: "Home",
+        meta: { kind: "custom", url: "/" },
+      },
+    ]);
+  });
+
+  test("preserves an existing item's id so the server treats it as an update", () => {
+    const state = editorReducer(initialEditorState, {
+      type: "loadFromServer",
+      response: {
+        id: 1,
+        slug: "main",
+        name: "Main",
+        version: 4,
+        maxDepth: 5,
+        items: [
+          {
+            id: 42,
+            parentId: null,
+            sortOrder: 0,
+            title: "About",
+            meta: { kind: "entry", entryId: 99 },
+          },
+        ],
+      },
+    });
+
+    const payload = buildSavePayload(state);
+
+    expect(payload).toEqual([
+      {
+        id: 42,
+        parentIndex: null,
+        sortOrder: 0,
+        title: "About",
+        meta: { kind: "entry", entryId: 99 },
+      },
+    ]);
+  });
+
+  test("translates parentKey into parentIndex referring to an earlier output index", () => {
+    // `flattenSaveItems` requires `parentIndex < itemIndex`. Editor
+    // items are stored in DFS order so parents always precede children;
+    // buildSavePayload preserves that order and looks up each parent's
+    // index in the output array.
+    const state = editorReducer(initialEditorState, {
+      type: "loadFromServer",
+      response: {
+        id: 1,
+        slug: "main",
+        name: "Main",
+        version: 1,
+        maxDepth: 5,
+        items: [
+          {
+            id: 10,
+            parentId: null,
+            sortOrder: 0,
+            title: "Parent",
+            meta: { kind: "custom", url: "/parent" },
+          },
+          {
+            id: 20,
+            parentId: 10,
+            sortOrder: 0,
+            title: "Child",
+            meta: { kind: "custom", url: "/parent/child" },
+          },
+        ],
+      },
+    });
+
+    const payload = buildSavePayload(state);
+
+    expect(payload[0]?.parentIndex).toBeNull();
+    expect(payload[1]?.parentIndex).toBe(0);
+  });
+});

--- a/packages/plugins/menu/src/admin/editor-state.ts
+++ b/packages/plugins/menu/src/admin/editor-state.ts
@@ -1,0 +1,413 @@
+import type { MenuItemMeta } from "../server/types.js";
+
+export type ItemKey = string;
+
+export interface EditorItem {
+  readonly key: ItemKey;
+  readonly id: number | null;
+  readonly parentKey: ItemKey | null;
+  readonly sortOrder: number;
+  readonly title: string | null;
+  readonly meta: MenuItemMeta;
+}
+
+export interface EditorState {
+  readonly termId: number;
+  readonly slug: string;
+  readonly name: string;
+  readonly version: number;
+  readonly maxDepth: number;
+  readonly items: readonly EditorItem[];
+  readonly selectedKey: ItemKey | null;
+  readonly dirty: boolean;
+  /**
+   * Monotonic counter for new-item keys. `state.items.length` would
+   * collide after add/add/remove/add — the third add would reuse the
+   * surviving item's tmp key. Carrying a counter on state side-steps
+   * that without needing a global.
+   */
+  readonly nextTmpId: number;
+}
+
+export const initialEditorState: EditorState = {
+  termId: 0,
+  slug: "",
+  name: "",
+  version: 0,
+  maxDepth: 5,
+  items: [],
+  selectedKey: null,
+  dirty: false,
+  nextTmpId: 0,
+};
+
+interface ServerItemRow {
+  readonly id: number;
+  readonly parentId: number | null;
+  readonly sortOrder: number;
+  readonly title: string;
+  readonly meta: Record<string, unknown>;
+}
+
+interface ServerMenuResponse {
+  readonly id: number;
+  readonly slug: string;
+  readonly name: string;
+  readonly version: number;
+  readonly maxDepth: number;
+  readonly items: readonly ServerItemRow[];
+}
+
+export type EditorAction =
+  | {
+      readonly type: "loadFromServer";
+      readonly response: ServerMenuResponse;
+    }
+  | {
+      readonly type: "addItem";
+      readonly title: string | null;
+      readonly meta: MenuItemMeta;
+    }
+  | {
+      readonly type: "moveUp";
+      readonly key: ItemKey;
+    }
+  | {
+      readonly type: "moveDown";
+      readonly key: ItemKey;
+    }
+  | {
+      readonly type: "updateField";
+      readonly key: ItemKey;
+      readonly patch: {
+        readonly title?: string | null;
+        readonly meta?: MenuItemMeta;
+      };
+    }
+  | {
+      readonly type: "removeItem";
+      readonly key: ItemKey;
+    }
+  | {
+      readonly type: "selectItem";
+      readonly key: ItemKey | null;
+    }
+  | {
+      readonly type: "applySaveResult";
+      readonly result: {
+        readonly version: number;
+        readonly itemIds: readonly number[];
+        /**
+         * Editor item keys captured at save-mutation time. Without
+         * this, ids would be zipped positionally against the current
+         * items list — which drifts if the user removed/added items
+         * while the save was in flight. The matched `snapshotKeys[i]`
+         * receives `itemIds[i]`; keys no longer in state are skipped.
+         * Optional for callers that build payloads in a single render.
+         */
+        readonly snapshotKeys?: readonly ItemKey[];
+      };
+    }
+  | {
+      readonly type: "demote";
+      readonly key: ItemKey;
+    }
+  | {
+      readonly type: "promote";
+      readonly key: ItemKey;
+    };
+
+export function editorReducer(
+  state: EditorState,
+  action: EditorAction,
+): EditorState {
+  switch (action.type) {
+    case "loadFromServer": {
+      const items = flattenServerItems(action.response.items);
+      return {
+        termId: action.response.id,
+        slug: action.response.slug,
+        name: action.response.name,
+        version: action.response.version,
+        maxDepth: action.response.maxDepth,
+        items,
+        selectedKey: null,
+        dirty: false,
+        // Reset tmp counter — server-loaded items use `id-N` keys
+        // exclusively, so there are no `tmp-*` collisions to worry
+        // about. Subsequent addItems start fresh from 0.
+        nextTmpId: 0,
+      };
+    }
+    case "moveUp":
+      return swapWithSibling(state, action.key, "previous");
+    case "moveDown":
+      return swapWithSibling(state, action.key, "next");
+    case "updateField": {
+      const items = state.items.map((item) =>
+        item.key === action.key
+          ? {
+              ...item,
+              title:
+                action.patch.title === undefined
+                  ? item.title
+                  : action.patch.title,
+              meta: action.patch.meta ?? item.meta,
+            }
+          : item,
+      );
+      return { ...state, items, dirty: true };
+    }
+    case "removeItem": {
+      const removed = collectSubtreeKeys(state.items, action.key);
+      if (removed.size === 0) return state;
+      const items = state.items.filter((item) => !removed.has(item.key));
+      const selectedKey =
+        state.selectedKey !== null && removed.has(state.selectedKey)
+          ? null
+          : state.selectedKey;
+      return { ...state, items, selectedKey, dirty: true };
+    }
+    case "selectItem":
+      return { ...state, selectedKey: action.key };
+    case "promote": {
+      const target = state.items.find((item) => item.key === action.key);
+      if (target?.parentKey == null) return state;
+      const oldParent = state.items.find(
+        (item) => item.key === target.parentKey,
+      );
+      if (!oldParent) return state;
+      const newParentKey = oldParent.parentKey;
+      // Slot the promoted item right after the old parent in its
+      // grandparent's child list. Bumping later sortOrder values keeps
+      // the relative order stable without reflowing the whole array.
+      const insertAfterSortOrder = oldParent.sortOrder;
+      const items = state.items.map((item) => {
+        if (item.key === target.key) {
+          return {
+            ...item,
+            parentKey: newParentKey,
+            sortOrder: insertAfterSortOrder + 1,
+          };
+        }
+        if (
+          item.parentKey === newParentKey &&
+          item.key !== target.key &&
+          item.sortOrder > insertAfterSortOrder
+        ) {
+          return { ...item, sortOrder: item.sortOrder + 1 };
+        }
+        return item;
+      });
+      return { ...state, items, dirty: true };
+    }
+    case "demote": {
+      const target = state.items.find((item) => item.key === action.key);
+      if (!target) return state;
+      const siblings = state.items
+        .filter((item) => item.parentKey === target.parentKey)
+        .sort((a, b) => a.sortOrder - b.sortOrder);
+      const idx = siblings.findIndex((s) => s.key === target.key);
+      const newParent = siblings[idx - 1];
+      if (!newParent) return state;
+      const lastChildSortOrder = state.items
+        .filter((item) => item.parentKey === newParent.key)
+        .reduce((max, item) => Math.max(max, item.sortOrder), -1);
+      const items = state.items.map((item) =>
+        item.key === action.key
+          ? {
+              ...item,
+              parentKey: newParent.key,
+              sortOrder: lastChildSortOrder + 1,
+            }
+          : item,
+      );
+      return { ...state, items, dirty: true };
+    }
+    case "applySaveResult": {
+      const { version, itemIds } = action.result;
+      const snapshotKeys =
+        action.result.snapshotKeys ?? state.items.map((item) => item.key);
+      const idBySnapshotKey = new Map<ItemKey, number>();
+      snapshotKeys.forEach((key, index) => {
+        const id = itemIds[index];
+        if (id !== undefined) idBySnapshotKey.set(key, id);
+      });
+      const keyRemap = new Map<ItemKey, ItemKey>();
+      const items = state.items.map((item) => {
+        const id = idBySnapshotKey.get(item.key) ?? item.id;
+        if (id === null) return item;
+        const newKey = `id-${String(id)}`;
+        if (newKey !== item.key) keyRemap.set(item.key, newKey);
+        return { ...item, id, key: newKey };
+      });
+      const remappedItems = items.map((item) =>
+        item.parentKey !== null && keyRemap.has(item.parentKey)
+          ? { ...item, parentKey: keyRemap.get(item.parentKey) ?? null }
+          : item,
+      );
+      const selectedKey =
+        state.selectedKey !== null
+          ? (keyRemap.get(state.selectedKey) ?? state.selectedKey)
+          : null;
+      return {
+        ...state,
+        version,
+        items: remappedItems,
+        selectedKey,
+        dirty: false,
+      };
+    }
+    case "addItem": {
+      const rootSiblings = state.items.filter(
+        (item) => item.parentKey === null,
+      );
+      const lastRootSortOrder = rootSiblings.reduce(
+        (max, item) => Math.max(max, item.sortOrder),
+        -1,
+      );
+      const newItem: EditorItem = {
+        key: `tmp-${String(state.nextTmpId)}`,
+        id: null,
+        parentKey: null,
+        sortOrder: lastRootSortOrder + 1,
+        title: action.title,
+        meta: action.meta,
+      };
+      return {
+        ...state,
+        items: [...state.items, newItem],
+        nextTmpId: state.nextTmpId + 1,
+        dirty: true,
+      };
+    }
+  }
+}
+
+export interface SaveItemPayload {
+  readonly id?: number;
+  readonly parentIndex: number | null;
+  readonly sortOrder: number;
+  readonly title: string | null;
+  readonly meta: MenuItemMeta;
+}
+
+export function buildSavePayload(
+  state: EditorState,
+): readonly SaveItemPayload[] {
+  const indexByKey = new Map<ItemKey, number>();
+  state.items.forEach((item, index) => {
+    indexByKey.set(item.key, index);
+  });
+  return state.items.map((item) => {
+    const parentIndex =
+      item.parentKey === null ? null : (indexByKey.get(item.parentKey) ?? null);
+    const base: SaveItemPayload = {
+      parentIndex,
+      sortOrder: item.sortOrder,
+      title: item.title,
+      meta: item.meta,
+    };
+    return item.id === null ? base : { id: item.id, ...base };
+  });
+}
+
+function collectSubtreeKeys(
+  items: readonly EditorItem[],
+  rootKey: ItemKey,
+): Set<ItemKey> {
+  const out = new Set<ItemKey>();
+  if (!items.some((item) => item.key === rootKey)) return out;
+  out.add(rootKey);
+  // DFS pre-order means every descendant appears after its parent;
+  // a single forward pass collects the full subtree.
+  for (const item of items) {
+    if (item.parentKey !== null && out.has(item.parentKey)) {
+      out.add(item.key);
+    }
+  }
+  return out;
+}
+
+function swapWithSibling(
+  state: EditorState,
+  key: ItemKey,
+  direction: "previous" | "next",
+): EditorState {
+  const target = state.items.find((item) => item.key === key);
+  if (!target) return state;
+  // Pick the sibling adjacent in `(parentKey, sortOrder)` order rather
+  // than adjacent in the array — there may be a different subtree
+  // sitting between the two siblings (e.g. `[A, A.child, B]`), and
+  // that's not who we want to swap with.
+  const siblings = state.items
+    .filter((item) => item.parentKey === target.parentKey)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+  const idx = siblings.findIndex((s) => s.key === key);
+  const adj = direction === "previous" ? siblings[idx - 1] : siblings[idx + 1];
+  if (!adj) return state;
+  const swapped = state.items.map((item) => {
+    if (item.key === target.key) return { ...item, sortOrder: adj.sortOrder };
+    if (item.key === adj.key) return { ...item, sortOrder: target.sortOrder };
+    return item;
+  });
+  // Rebuild the array in DFS pre-order so descendants follow their
+  // parent. `flattenSaveItems` enforces `parentIndex < itemIndex`;
+  // an array-level swap leaves children stranded before the moved
+  // parent and trips that check.
+  return { ...state, items: rebuildDfsOrder(swapped), dirty: true };
+}
+
+function rebuildDfsOrder(items: readonly EditorItem[]): EditorItem[] {
+  const childrenByParent = new Map<ItemKey | null, EditorItem[]>();
+  for (const item of items) {
+    const list = childrenByParent.get(item.parentKey) ?? [];
+    list.push(item);
+    childrenByParent.set(item.parentKey, list);
+  }
+  for (const list of childrenByParent.values()) {
+    list.sort(
+      (a, b) => a.sortOrder - b.sortOrder || a.key.localeCompare(b.key),
+    );
+  }
+  const out: EditorItem[] = [];
+  function walk(parentKey: ItemKey | null): void {
+    for (const child of childrenByParent.get(parentKey) ?? []) {
+      out.push(child);
+      walk(child.key);
+    }
+  }
+  walk(null);
+  return out;
+}
+
+function flattenServerItems(rows: readonly ServerItemRow[]): EditorItem[] {
+  const childrenByParent = new Map<number | null, ServerItemRow[]>();
+  for (const row of rows) {
+    const list = childrenByParent.get(row.parentId) ?? [];
+    list.push(row);
+    childrenByParent.set(row.parentId, list);
+  }
+  for (const list of childrenByParent.values()) {
+    list.sort((a, b) => a.sortOrder - b.sortOrder || a.id - b.id);
+  }
+
+  const out: EditorItem[] = [];
+  function walk(parentId: number | null, parentKey: ItemKey | null): void {
+    const children = childrenByParent.get(parentId) ?? [];
+    for (const row of children) {
+      const key = `id-${String(row.id)}`;
+      out.push({
+        key,
+        id: row.id,
+        parentKey,
+        sortOrder: row.sortOrder,
+        title: row.title === "" ? null : row.title,
+        meta: row.meta as unknown as MenuItemMeta,
+      });
+      walk(row.id, key);
+    }
+  }
+  walk(null, null);
+  return out;
+}

--- a/packages/plugins/menu/src/admin/rpc.ts
+++ b/packages/plugins/menu/src/admin/rpc.ts
@@ -34,7 +34,7 @@ interface AssignLocationInput {
   readonly termSlug: string | null;
 }
 
-export interface MenuItemRow {
+interface MenuItemRow {
   readonly id: number;
   readonly parentId: number | null;
   readonly sortOrder: number;
@@ -42,7 +42,7 @@ export interface MenuItemRow {
   readonly meta: Record<string, unknown>;
 }
 
-export interface MenuGetResponse {
+interface MenuGetResponse {
   readonly id: number;
   readonly slug: string;
   readonly name: string;
@@ -81,14 +81,14 @@ export async function rpcCall<TOutput>(
   return envelope?.json as TOutput;
 }
 
-export interface SaveMenuInput {
+interface SaveMenuInput {
   readonly termId: number;
   readonly version: number;
   readonly maxDepth?: number;
   readonly items: readonly SaveItemPayload[];
 }
 
-export interface SaveMenuResult {
+interface SaveMenuResult {
   readonly termId: number;
   readonly version: number;
   readonly itemIds: readonly number[];

--- a/packages/plugins/menu/src/admin/rpc.ts
+++ b/packages/plugins/menu/src/admin/rpc.ts
@@ -6,6 +6,8 @@
 import type { UseMutationResult, UseQueryResult } from "@tanstack/react-query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import type { SaveItemPayload } from "./editor-state.js";
+
 export interface MenuListItem {
   readonly id: number;
   readonly slug: string;
@@ -30,6 +32,23 @@ export interface MenuLocationRow {
 interface AssignLocationInput {
   readonly location: string;
   readonly termSlug: string | null;
+}
+
+export interface MenuItemRow {
+  readonly id: number;
+  readonly parentId: number | null;
+  readonly sortOrder: number;
+  readonly title: string;
+  readonly meta: Record<string, unknown>;
+}
+
+export interface MenuGetResponse {
+  readonly id: number;
+  readonly slug: string;
+  readonly name: string;
+  readonly version: number;
+  readonly maxDepth: number;
+  readonly items: readonly MenuItemRow[];
 }
 
 const MENU_LIST_KEY = ["menu", "list"] as const;
@@ -60,6 +79,77 @@ export async function rpcCall<TOutput>(
     throw new Error(reason);
   }
   return envelope?.json as TOutput;
+}
+
+export interface SaveMenuInput {
+  readonly termId: number;
+  readonly version: number;
+  readonly maxDepth?: number;
+  readonly items: readonly SaveItemPayload[];
+}
+
+export interface SaveMenuResult {
+  readonly termId: number;
+  readonly version: number;
+  readonly itemIds: readonly number[];
+  readonly added: readonly number[];
+  readonly removed: readonly number[];
+  readonly modified: readonly number[];
+}
+
+export function useDeleteMenu(): UseMutationResult<
+  { readonly id: number },
+  Error,
+  { readonly termId: number }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input) =>
+      rpcCall<{ readonly id: number }>("menu/delete", input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: MENU_LIST_KEY });
+    },
+  });
+}
+
+export function useSaveMenu(): UseMutationResult<
+  SaveMenuResult,
+  Error,
+  SaveMenuInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input) => rpcCall<SaveMenuResult>("menu/save", input),
+    onSuccess: (_, input) => {
+      void queryClient.invalidateQueries({ queryKey: MENU_LIST_KEY });
+      void queryClient.invalidateQueries({
+        queryKey: ["menu", "get", input.termId] as const,
+      });
+    },
+  });
+}
+
+export interface PickerTab {
+  readonly kind: string;
+  readonly tabLabel: string;
+  readonly target?: string;
+}
+
+export function usePickerTabs(): UseQueryResult<readonly PickerTab[]> {
+  return useQuery({
+    queryKey: ["menu", "pickerTabs"] as const,
+    queryFn: () => rpcCall<readonly PickerTab[]>("menu/pickerTabs"),
+  });
+}
+
+export function useMenuGet(
+  termId: number | null,
+): UseQueryResult<MenuGetResponse> {
+  return useQuery({
+    queryKey: ["menu", "get", termId] as const,
+    queryFn: () => rpcCall<MenuGetResponse>("menu/get", { termId }),
+    enabled: termId !== null,
+  });
 }
 
 export function useMenuList(): UseQueryResult<readonly MenuListItem[]> {

--- a/packages/plugins/menu/src/admin/url-state.ts
+++ b/packages/plugins/menu/src/admin/url-state.ts
@@ -23,3 +23,7 @@ export function getSelectedTab(): TabId {
   const value = new URL(window.location.href).searchParams.get("tab");
   return value === "locations" ? "locations" : "edit";
 }
+
+export function getSelectedMenuSlug(): string | null {
+  return new URL(window.location.href).searchParams.get("menu");
+}

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -168,6 +168,23 @@ describe("menu RPC", () => {
     });
   });
 
+  describe("menu.pickerTabs", () => {
+    test("returns an ordered tab list from the eligibility resolver", async () => {
+      // The admin's left rail builds picker tabs from this list. With
+      // only the menu plugin installed, no entry type or taxonomy is
+      // menu-eligible (`menu_item` and `menu` are both `isPublic: false`)
+      // and the only registered non-built-in lookup adapter is none —
+      // so the response is just the always-present Custom URL tab.
+      const h = await buildHarness();
+      const tabs = (await (
+        h.client.menu as unknown as {
+          pickerTabs: () => Promise<readonly { kind: string }[]>;
+        }
+      ).pickerTabs()) as readonly { kind: string; tabLabel: string }[];
+      expect(tabs.at(-1)).toEqual({ kind: "custom", tabLabel: "Custom URL" });
+    });
+  });
+
   describe("menu.get", () => {
     test("returns a menu's items when found", async () => {
       const h = await buildHarness();

--- a/packages/plugins/menu/src/rpc.ts
+++ b/packages/plugins/menu/src/rpc.ts
@@ -15,6 +15,7 @@ import {
   terms,
 } from "@plumix/core";
 
+import { getEligibleMenuKinds } from "./server/eligibility.js";
 import { getRegisteredLocations } from "./server/locations.js";
 import { flattenSaveItems, resolveParentIds } from "./server/save.js";
 import { sanitizeMenuHref } from "./server/url.js";
@@ -658,6 +659,26 @@ export function createMenuRouter(): Record<string, unknown> {
       return { location: input.location, termSlug: input.termSlug };
     });
 
+  const pickerTabs = base.use(authenticated).handler(
+    async ({
+      context,
+      errors,
+    }): Promise<
+      readonly {
+        readonly kind: string;
+        readonly tabLabel: string;
+        readonly target?: string;
+      }[]
+    > => {
+      if (!context.auth.can(MENU_MANAGE_CAPABILITY)) {
+        throw errors.FORBIDDEN({
+          data: { capability: MENU_MANAGE_CAPABILITY },
+        });
+      }
+      return Promise.resolve(getEligibleMenuKinds(context.plugins));
+    },
+  );
+
   const locationsList = base
     .use(authenticated)
     .handler(async ({ context, errors }): Promise<readonly LocationRow[]> => {
@@ -726,6 +747,7 @@ export function createMenuRouter(): Record<string, unknown> {
     create,
     delete: remove,
     assignLocation,
+    pickerTabs,
     locations: { list: locationsList },
   };
 }


### PR DESCRIPTION
Adds the menu item editor in the admin: a flat-list interim view (no
drag-drop yet) with up/down/promote/demote/remove controls, custom-URL
picker tab, detail panel for editing titles, locations bindings, and a
delete action.

Save uses optimistic concurrency. A 409 with `data.reason: 'version_mismatch'`
surfaces a banner with a Reload action that pulls the latest server state
into local state — no silent data loss.

Notable design points worth a careful look:

- The reducer (`editor-state.ts`) is pure and tested in isolation. After
  any sibling swap the items array is rebuilt in DFS pre-order, so the
  `flattenSaveItems` invariant `parentIndex < itemIndex` always holds —
  an array-level swap of `[A, A.child, B]` would otherwise strand
  `A.child` ahead of its parent.
- `applySaveResult` keys server-returned ids to a snapshot of editor
  keys captured at save-click time. Without this the server's
  positional `itemIds` would zip against state that may have changed
  during the in-flight save and misattribute new ids.
- A monotonic `nextTmpId` field replaces the obvious-but-wrong
  `tmp-${items.length}` pattern; the latter collides after
  add/add/remove/add.
- New server procedure `menu/pickerTabs` is gated on
  `term:menu:manage` and sources tabs from the existing eligibility
  resolver — the registry is read at boot, so the response is stable
  for the server's lifetime.

Slice 8 deliberately defers drag-and-drop, an entry/term picker UI
beyond the static tab list, and a save-success toast. The flat list is
keyboard- and a11y-friendlier as an interim shape, and matches the
acceptance criteria on the issue.

Out-of-scope follow-ups identified during review (filed separately):

- Promote `version_mismatch` from a string compare to a typed error code
- Share the `PickerTab` shape between server and admin to lock against
  drift
- Assert in `buildSavePayload` rather than silently demoting orphans

Fixes #165