### PR TITLE
feat(plugin-menu): drag-drop tree (slice 9)

### DIFF
--- a/packages/plugins/menu/package.json
+++ b/packages/plugins/menu/package.json
@@ -52,6 +52,9 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@plumix/core": "workspace:*",
     "drizzle-orm": "catalog:",
     "valibot": "catalog:"

--- a/packages/plugins/menu/src/admin/MenuItemEditor.tsx
+++ b/packages/plugins/menu/src/admin/MenuItemEditor.tsx
@@ -1,5 +1,21 @@
-import type { Dispatch, ReactNode } from "react";
+import type { DragEndEvent, DragMoveEvent } from "@dnd-kit/core";
+import type { CSSProperties, Dispatch, ReactNode } from "react";
 import { useEffect, useReducer, useState } from "react";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useQueryClient } from "@tanstack/react-query";
 
 import type {
@@ -22,6 +38,9 @@ import {
   usePickerTabs,
   useSaveMenu,
 } from "./rpc.js";
+import { dragEndToAction, getProjection } from "./tree-state.js";
+
+const INDENTATION_WIDTH = 24;
 
 export function MenuItemEditor({
   termId,
@@ -53,7 +72,7 @@ export function MenuItemEditor({
       {state.items.length === 0 ? (
         <div data-testid="menu-item-list-empty">No items yet.</div>
       ) : (
-        <MenuItemList state={state} dispatch={dispatch} />
+        <MenuTree state={state} dispatch={dispatch} />
       )}
       <ItemDetailPanel state={state} dispatch={dispatch} />
       <MenuSettingsPanel state={state} dispatch={dispatch} />
@@ -119,6 +138,7 @@ function MenuSettingsPanel({
   return (
     <div data-testid="menu-settings-panel">
       <LocationsBindings termId={state.termId} slug={state.slug} />
+      <MaxDepthField state={state} dispatch={dispatch} />
       {conflict ? (
         <div data-testid="menu-conflict-banner" role="alert">
           Another editor saved changes since you loaded this menu.
@@ -150,6 +170,7 @@ function MenuSettingsPanel({
             {
               termId: state.termId,
               version: state.version,
+              maxDepth: state.maxDepth,
               items: buildSavePayload(state),
             },
             {
@@ -171,6 +192,42 @@ function MenuSettingsPanel({
       </button>
       <DeleteMenuButton termId={state.termId} />
     </div>
+  );
+}
+
+function MaxDepthField({
+  state,
+  dispatch,
+}: {
+  readonly state: EditorState;
+  readonly dispatch: Dispatch<EditorAction>;
+}): ReactNode {
+  // A local draft buys the user a transient empty string while editing —
+  // without it, controlled-input + reject-on-NaN traps the field on the
+  // last valid value. The reducer is still the source of truth: when
+  // state.maxDepth changes (load, undo, etc.) the draft snaps back.
+  const [draft, setDraft] = useState(String(state.maxDepth));
+  useEffect(() => {
+    setDraft(String(state.maxDepth));
+  }, [state.maxDepth]);
+  return (
+    <label data-testid="menu-settings-max-depth-row">
+      Max depth
+      <input
+        type="number"
+        data-testid="menu-settings-max-depth"
+        min={0}
+        value={draft}
+        onChange={(event) => {
+          const next = event.target.value;
+          setDraft(next);
+          const parsed = Number.parseInt(next, 10);
+          if (Number.isFinite(parsed)) {
+            dispatch({ type: "updateMaxDepth", value: parsed });
+          }
+        }}
+      />
+    </label>
   );
 }
 
@@ -273,30 +330,105 @@ function CustomUrlPickerPanel({
   );
 }
 
-function MenuItemList({
+function MenuTree({
   state,
   dispatch,
 }: {
   readonly state: EditorState;
   readonly dispatch: Dispatch<EditorAction>;
 }): ReactNode {
+  const sensors = useSensors(
+    // A small distance unblocks plain clicks (selectItem) without
+    // accidentally entering a drag the moment the user puts their
+    // finger down on a row.
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+  const [activeKey, setActiveKey] = useState<ItemKey | null>(null);
+  const [overKey, setOverKey] = useState<ItemKey | null>(null);
+  const [dragOffsetX, setDragOffsetX] = useState(0);
+
+  const projection =
+    activeKey !== null && overKey !== null
+      ? getProjection(
+          state.items,
+          activeKey,
+          overKey,
+          dragOffsetX,
+          INDENTATION_WIDTH,
+          state.maxDepth,
+        )
+      : null;
+
   const depths = computeDepths(state);
+  const itemKeys = state.items.map((item) => item.key);
+
+  function reset(): void {
+    setActiveKey(null);
+    setOverKey(null);
+    setDragOffsetX(0);
+  }
+
+  function handleDragMove(event: DragMoveEvent): void {
+    setDragOffsetX(event.delta.x);
+    if (event.over) setOverKey(String(event.over.id));
+  }
+
+  function handleDragEnd(event: DragEndEvent): void {
+    const targetActive = String(event.active.id);
+    const targetOver = event.over ? String(event.over.id) : null;
+    if (targetOver !== null) {
+      // Pull the offset from the event rather than React state — handlers
+      // share a render closure and the latest setDragOffsetX may not be
+      // committed by the time onDragEnd fires.
+      const action = dragEndToAction(
+        state.items,
+        targetActive,
+        targetOver,
+        event.delta.x,
+        INDENTATION_WIDTH,
+        state.maxDepth,
+      );
+      if (action) dispatch(action);
+    }
+    reset();
+  }
+
   return (
-    <ol data-testid="menu-item-list">
-      {state.items.map((item) => (
-        <MenuItemRow
-          key={item.key}
-          item={item}
-          depth={depths.get(item.key) ?? 0}
-          selected={state.selectedKey === item.key}
-          dispatch={dispatch}
-        />
-      ))}
-    </ol>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={(event) => {
+        setActiveKey(String(event.active.id));
+      }}
+      onDragMove={handleDragMove}
+      onDragEnd={handleDragEnd}
+      onDragCancel={reset}
+    >
+      <SortableContext items={itemKeys} strategy={verticalListSortingStrategy}>
+        <div data-testid="menu-tree">
+          {state.items.map((item) => (
+            <SortableTreeRow
+              key={item.key}
+              item={item}
+              depth={
+                projection !== null && item.key === activeKey
+                  ? projection.depth
+                  : (depths.get(item.key) ?? 0)
+              }
+              selected={state.selectedKey === item.key}
+              dispatch={dispatch}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
   );
 }
 
-function MenuItemRow({
+function SortableTreeRow({
   item,
   depth,
   selected,
@@ -307,58 +439,38 @@ function MenuItemRow({
   readonly selected: boolean;
   readonly dispatch: Dispatch<EditorAction>;
 }): ReactNode {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: item.key });
   const id = item.id ?? item.key;
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    paddingLeft: `${String(depth * INDENTATION_WIDTH)}px`,
+  };
   return (
-    <li
+    <div
+      ref={setNodeRef}
+      style={style}
       data-testid={`menu-item-row-${String(id)}`}
       data-depth={String(depth)}
       data-selected={selected ? "true" : "false"}
-      style={{ paddingLeft: `${String(depth * 16)}px` }}
       onClick={() => {
         dispatch({ type: "selectItem", key: item.key });
       }}
     >
+      <button
+        type="button"
+        data-testid={`menu-item-drag-${String(id)}`}
+        aria-label={`Reorder ${item.title ?? "item"}`}
+        {...attributes}
+        {...listeners}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        ⋮⋮
+      </button>
       <span>{item.title ?? "(unnamed)"}</span>
-      <button
-        type="button"
-        data-testid={`menu-item-up-${String(id)}`}
-        onClick={(event) => {
-          event.stopPropagation();
-          dispatch({ type: "moveUp", key: item.key });
-        }}
-      >
-        Up
-      </button>
-      <button
-        type="button"
-        data-testid={`menu-item-down-${String(id)}`}
-        onClick={(event) => {
-          event.stopPropagation();
-          dispatch({ type: "moveDown", key: item.key });
-        }}
-      >
-        Down
-      </button>
-      <button
-        type="button"
-        data-testid={`menu-item-promote-${String(id)}`}
-        onClick={(event) => {
-          event.stopPropagation();
-          dispatch({ type: "promote", key: item.key });
-        }}
-      >
-        Promote
-      </button>
-      <button
-        type="button"
-        data-testid={`menu-item-demote-${String(id)}`}
-        onClick={(event) => {
-          event.stopPropagation();
-          dispatch({ type: "demote", key: item.key });
-        }}
-      >
-        Demote
-      </button>
       <button
         type="button"
         data-testid={`menu-item-remove-${String(id)}`}
@@ -369,7 +481,7 @@ function MenuItemRow({
       >
         Remove
       </button>
-    </li>
+    </div>
   );
 }
 

--- a/packages/plugins/menu/src/admin/MenuItemEditor.tsx
+++ b/packages/plugins/menu/src/admin/MenuItemEditor.tsx
@@ -27,6 +27,7 @@ import type {
 import type { PickerTab } from "./rpc.js";
 import {
   buildSavePayload,
+  computeDepths,
   editorReducer,
   initialEditorState,
 } from "./editor-state.js";
@@ -210,6 +211,12 @@ function MaxDepthField({
   useEffect(() => {
     setDraft(String(state.maxDepth));
   }, [state.maxDepth]);
+  // The reducer no-ops `updateMaxDepth` below the deepest-existing
+  // depth. Surface that explicitly so the user can tell their value
+  // didn't take — without this the input keeps showing a number that
+  // never made it into state and the next save sends the old value.
+  const parsed = Number.parseInt(draft, 10);
+  const rejected = Number.isFinite(parsed) && parsed !== state.maxDepth;
   return (
     <label data-testid="menu-settings-max-depth-row">
       Max depth
@@ -221,12 +228,17 @@ function MaxDepthField({
         onChange={(event) => {
           const next = event.target.value;
           setDraft(next);
-          const parsed = Number.parseInt(next, 10);
-          if (Number.isFinite(parsed)) {
-            dispatch({ type: "updateMaxDepth", value: parsed });
+          const nextParsed = Number.parseInt(next, 10);
+          if (Number.isFinite(nextParsed)) {
+            dispatch({ type: "updateMaxDepth", value: nextParsed });
           }
         }}
       />
+      {rejected ? (
+        <span data-testid="menu-settings-max-depth-error">
+          Cannot set below the current deepest item.
+        </span>
+      ) : null}
     </label>
   );
 }
@@ -362,7 +374,7 @@ function MenuTree({
         )
       : null;
 
-  const depths = computeDepths(state);
+  const depths = computeDepths(state.items);
   const itemKeys = state.items.map((item) => item.key);
 
   function reset(): void {
@@ -373,7 +385,7 @@ function MenuTree({
 
   function handleDragMove(event: DragMoveEvent): void {
     setDragOffsetX(event.delta.x);
-    if (event.over) setOverKey(String(event.over.id));
+    setOverKey(event.over ? String(event.over.id) : null);
   }
 
   function handleDragEnd(event: DragEndEvent): void {
@@ -514,17 +526,4 @@ function ItemDetailPanel({
       />
     </div>
   );
-}
-
-function computeDepths(state: EditorState): Map<ItemKey, number> {
-  const depthByKey = new Map<ItemKey, number>();
-  for (const item of state.items) {
-    if (item.parentKey === null) {
-      depthByKey.set(item.key, 0);
-    } else {
-      const parentDepth = depthByKey.get(item.parentKey) ?? 0;
-      depthByKey.set(item.key, parentDepth + 1);
-    }
-  }
-  return depthByKey;
 }

--- a/packages/plugins/menu/src/admin/MenusShell.test.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.test.tsx
@@ -869,6 +869,77 @@ describe("MenusShell", () => {
       const payload = parseRpcInput<{ maxDepth?: number }>(call);
       expect(payload.maxDepth).toBe(3);
     });
+
+    test("typing a value below the deepest item shows an inline error and saves the accepted value", async () => {
+      // Regression: the reducer no-ops `updateMaxDepth` below the
+      // deepest-existing depth. Without an inline error the component
+      // silently kept showing the rejected draft and let the user think
+      // the change took — the save then sent the still-accepted value.
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 2 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Parent",
+              meta: { kind: "custom", url: "/p" },
+            },
+            {
+              id: 20,
+              parentId: 10,
+              sortOrder: 0,
+              title: "Child",
+              meta: { kind: "custom", url: "/p/c" },
+            },
+          ],
+        },
+        "/menu/save": {
+          termId: 7,
+          version: 2,
+          itemIds: [10, 20],
+          added: [],
+          removed: [],
+          modified: [],
+        },
+      });
+
+      renderShell();
+      const user = userEvent.setup();
+      const input = await screen.findByTestId<HTMLInputElement>(
+        "menu-settings-max-depth",
+      );
+      await user.clear(input);
+      await user.type(input, "0");
+      // Items have a depth-1 child, so 0 is rejected by the reducer.
+      const error = await screen.findByTestId("menu-settings-max-depth-error");
+      expect(error).toBeInTheDocument();
+
+      await user.click(await screen.findByTestId("menu-save-button"));
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/save");
+        if (!found) throw new Error("menu.save not called");
+        return found;
+      });
+      const payload = parseRpcInput<{ maxDepth?: number }>(call);
+      expect(payload.maxDepth).toBe(5);
+    });
   });
 
   describe("menu selector", () => {

--- a/packages/plugins/menu/src/admin/MenusShell.test.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.test.tsx
@@ -600,68 +600,6 @@ describe("MenusShell", () => {
       expect(input).toEqual({ location: "footer", termSlug: "main" });
     });
 
-    test("up button on second item swaps it with the first; save sends the new order", async () => {
-      window.history.replaceState(
-        {},
-        "",
-        "/_plumix/admin/pages/menus?menu=main",
-      );
-      mockRpc({
-        "/menu/list": [
-          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 2 },
-        ],
-        "/menu/locations/list": [],
-        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
-        "/menu/get": {
-          id: 7,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "First",
-              meta: { kind: "custom", url: "/1" },
-            },
-            {
-              id: 11,
-              parentId: null,
-              sortOrder: 1,
-              title: "Second",
-              meta: { kind: "custom", url: "/2" },
-            },
-          ],
-        },
-        "/menu/save": {
-          termId: 7,
-          version: 2,
-          itemIds: [11, 10],
-          added: [],
-          removed: [],
-          modified: [10, 11],
-        },
-      });
-
-      renderShell();
-      const user = userEvent.setup();
-      await screen.findByTestId("menu-item-row-11");
-      await user.click(await screen.findByTestId("menu-item-up-11"));
-      await user.click(await screen.findByTestId("menu-save-button"));
-
-      const call = await vi.waitFor(() => {
-        const found = findRpcCall("/menu/save");
-        if (!found) throw new Error("menu.save not called");
-        return found;
-      });
-      const input = parseRpcInput<{
-        items: readonly { id?: number }[];
-      }>(call);
-      expect(input.items.map((i) => i.id)).toEqual([11, 10]);
-    });
-
     test("clicking a row opens a detail panel; clearing the label override saves as title null", async () => {
       window.history.replaceState(
         {},
@@ -765,8 +703,8 @@ describe("MenusShell", () => {
       // The new item appears in the list with the typed label and no
       // RPC has been called yet (acceptance: "ready to save (no
       // immediate persistence)").
-      const list = await screen.findByTestId("menu-item-list");
-      expect(list).toHaveTextContent("Contact");
+      const tree = await screen.findByTestId("menu-tree");
+      expect(tree).toHaveTextContent("Contact");
       expect(findRpcCall("/menu/save")).toBeUndefined();
     });
 
@@ -860,6 +798,76 @@ describe("MenusShell", () => {
       expect(
         await screen.findByTestId("menu-item-list-empty"),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("max-depth setting", () => {
+    test("typing in the max-depth input updates the value the next save sends", async () => {
+      // Acceptance: per-menu maxDepth surfaces in the settings panel and
+      // round-trips through save. The reducer guards against lowering
+      // below the deepest current item — fixture sits at depth 1 so a
+      // bump to 3 is accepted.
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 2 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Parent",
+              meta: { kind: "custom", url: "/p" },
+            },
+            {
+              id: 20,
+              parentId: 10,
+              sortOrder: 0,
+              title: "Child",
+              meta: { kind: "custom", url: "/p/c" },
+            },
+          ],
+        },
+        "/menu/save": {
+          termId: 7,
+          version: 2,
+          itemIds: [10, 20],
+          added: [],
+          removed: [],
+          modified: [],
+        },
+      });
+
+      renderShell();
+      const user = userEvent.setup();
+      const input = await screen.findByTestId<HTMLInputElement>(
+        "menu-settings-max-depth",
+      );
+      expect(input.value).toBe("5");
+      await user.clear(input);
+      await user.type(input, "3");
+      await user.click(await screen.findByTestId("menu-save-button"));
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/save");
+        if (!found) throw new Error("menu.save not called");
+        return found;
+      });
+      const payload = parseRpcInput<{ maxDepth?: number }>(call);
+      expect(payload.maxDepth).toBe(3);
     });
   });
 

--- a/packages/plugins/menu/src/admin/editor-state.test.ts
+++ b/packages/plugins/menu/src/admin/editor-state.test.ts
@@ -111,204 +111,6 @@ describe("editorReducer", () => {
     });
   });
 
-  describe("moveUp", () => {
-    test("swaps an item with its previous sibling and updates sortOrder accordingly", () => {
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "First",
-              meta: { kind: "custom", url: "/1" },
-            },
-            {
-              id: 11,
-              parentId: null,
-              sortOrder: 1,
-              title: "Second",
-              meta: { kind: "custom", url: "/2" },
-            },
-          ],
-        },
-      });
-      const next = editorReducer(loaded, {
-        type: "moveUp",
-        key: "id-11",
-      });
-
-      expect(next.items.map((item) => item.id)).toEqual([11, 10]);
-      // sortOrder reflects the new position so the next save round-trip
-      // sends the order the user sees, not the order the server saw.
-      expect(next.items[0]?.sortOrder).toBe(0);
-      expect(next.items[1]?.sortOrder).toBe(1);
-      expect(next.dirty).toBe(true);
-    });
-
-    test("moves a sibling's subtree along with it so DFS order survives", () => {
-      // Regression: `[A, A.child, B]` → moveUp(B) used to leave
-      // A.child stranded between B and A in the array, which then
-      // produced a `forward_parent_reference` on save (A.child's
-      // resolved parentIndex pointed past its own index).
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "A",
-              meta: { kind: "custom", url: "/a" },
-            },
-            {
-              id: 20,
-              parentId: 10,
-              sortOrder: 0,
-              title: "A.child",
-              meta: { kind: "custom", url: "/a/c" },
-            },
-            {
-              id: 11,
-              parentId: null,
-              sortOrder: 1,
-              title: "B",
-              meta: { kind: "custom", url: "/b" },
-            },
-          ],
-        },
-      });
-
-      const next = editorReducer(loaded, { type: "moveUp", key: "id-11" });
-
-      // Order must be: B (root), A (root), A.child (under A).
-      expect(next.items.map((item) => item.id)).toEqual([11, 10, 20]);
-      // Every payload entry's parentIndex must reference an earlier
-      // entry — that's the contract `flattenSaveItems` enforces.
-      const payload = buildSavePayload(next);
-      payload.forEach((entry, index) => {
-        if (entry.parentIndex !== null) {
-          expect(entry.parentIndex).toBeLessThan(index);
-        }
-      });
-    });
-
-    test("is a no-op when the item is already first among its siblings", () => {
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "First",
-              meta: { kind: "custom", url: "/1" },
-            },
-            {
-              id: 11,
-              parentId: null,
-              sortOrder: 1,
-              title: "Second",
-              meta: { kind: "custom", url: "/2" },
-            },
-          ],
-        },
-      });
-      const next = editorReducer(loaded, {
-        type: "moveUp",
-        key: "id-10",
-      });
-
-      expect(next.items.map((item) => item.id)).toEqual([10, 11]);
-      expect(next.dirty).toBe(false);
-    });
-  });
-
-  describe("moveDown", () => {
-    test("swaps an item with its next sibling", () => {
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "First",
-              meta: { kind: "custom", url: "/1" },
-            },
-            {
-              id: 11,
-              parentId: null,
-              sortOrder: 1,
-              title: "Second",
-              meta: { kind: "custom", url: "/2" },
-            },
-          ],
-        },
-      });
-      const next = editorReducer(loaded, {
-        type: "moveDown",
-        key: "id-10",
-      });
-
-      expect(next.items.map((item) => item.id)).toEqual([11, 10]);
-      expect(next.dirty).toBe(true);
-    });
-
-    test("is a no-op when the item is already last among its siblings", () => {
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "Only",
-              meta: { kind: "custom", url: "/" },
-            },
-          ],
-        },
-      });
-      const next = editorReducer(loaded, {
-        type: "moveDown",
-        key: "id-10",
-      });
-
-      expect(next.items.map((item) => item.id)).toEqual([10]);
-      expect(next.dirty).toBe(false);
-    });
-  });
-
   describe("applySaveResult", () => {
     test("assigns returned ids to new items in payload order and bumps the version", () => {
       // After save, the editor must rekey new items from `tmp-*` to
@@ -402,9 +204,12 @@ describe("editorReducer", () => {
         meta: { kind: "custom", url: "/p/c" },
       });
       const childKey = child.items[1]?.key ?? "";
+      const parentKey = child.items[0]?.key ?? null;
       const reparented = editorReducer(child, {
-        type: "demote",
+        type: "moveItem",
         key: childKey,
+        newParentKey: parentKey,
+        newSortOrder: 0,
       });
 
       const next = editorReducer(reparented, {
@@ -415,148 +220,6 @@ describe("editorReducer", () => {
       expect(next.items[0]?.key).toBe("id-50");
       expect(next.items[1]?.key).toBe("id-51");
       expect(next.items[1]?.parentKey).toBe("id-50");
-    });
-  });
-
-  describe("demote", () => {
-    test("nests an item under its immediately-prior sibling", () => {
-      // Acceptance: "promote/demote affordance moves an item between
-      // parent groups". Demote = pop down a level — the item becomes
-      // the last child of the sibling immediately above it.
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "A",
-              meta: { kind: "custom", url: "/a" },
-            },
-            {
-              id: 11,
-              parentId: null,
-              sortOrder: 1,
-              title: "B",
-              meta: { kind: "custom", url: "/b" },
-            },
-          ],
-        },
-      });
-
-      const next = editorReducer(loaded, {
-        type: "demote",
-        key: "id-11",
-      });
-
-      expect(next.items[1]?.parentKey).toBe("id-10");
-      expect(next.items[1]?.sortOrder).toBe(0);
-      expect(next.dirty).toBe(true);
-    });
-
-    test("is a no-op when the item is the first among its siblings (no parent to nest under)", () => {
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "A",
-              meta: { kind: "custom", url: "/a" },
-            },
-          ],
-        },
-      });
-      const next = editorReducer(loaded, {
-        type: "demote",
-        key: "id-10",
-      });
-
-      expect(next).toEqual(loaded);
-    });
-  });
-
-  describe("promote", () => {
-    test("pops a child up one level so its parent becomes a sibling", () => {
-      // Inverse of demote — promote moves the item out of its current
-      // parent's child list and into the grandparent's, positioned
-      // immediately after the old parent.
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "A",
-              meta: { kind: "custom", url: "/a" },
-            },
-            {
-              id: 20,
-              parentId: 10,
-              sortOrder: 0,
-              title: "A.child",
-              meta: { kind: "custom", url: "/a/child" },
-            },
-          ],
-        },
-      });
-
-      const next = editorReducer(loaded, {
-        type: "promote",
-        key: "id-20",
-      });
-
-      expect(next.items[1]?.parentKey).toBeNull();
-      expect(next.dirty).toBe(true);
-    });
-
-    test("is a no-op when the item is already at root", () => {
-      const loaded = editorReducer(initialEditorState, {
-        type: "loadFromServer",
-        response: {
-          id: 1,
-          slug: "main",
-          name: "Main",
-          version: 1,
-          maxDepth: 5,
-          items: [
-            {
-              id: 10,
-              parentId: null,
-              sortOrder: 0,
-              title: "A",
-              meta: { kind: "custom", url: "/a" },
-            },
-          ],
-        },
-      });
-
-      const next = editorReducer(loaded, {
-        type: "promote",
-        key: "id-10",
-      });
-
-      expect(next).toEqual(loaded);
     });
   });
 
@@ -865,6 +528,225 @@ describe("editorReducer", () => {
       expect(next.items).toHaveLength(2);
       expect(next.items[1]?.sortOrder).toBe(1);
       expect(next.items[1]?.parentKey).toBeNull();
+    });
+  });
+
+  describe("moveItem", () => {
+    test("reorders an item among same-parent siblings using newSortOrder", () => {
+      // Drop the third sibling into position 0 — siblings re-number
+      // 0..n in DFS order. dnd-kit's onDragEnd hands us the projected
+      // (parentKey, sortOrder); the reducer is responsible for
+      // re-flowing the rest of the parent's children.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "First",
+              meta: { kind: "custom", url: "/1" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "Second",
+              meta: { kind: "custom", url: "/2" },
+            },
+            {
+              id: 12,
+              parentId: null,
+              sortOrder: 2,
+              title: "Third",
+              meta: { kind: "custom", url: "/3" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "moveItem",
+        key: "id-12",
+        newParentKey: null,
+        newSortOrder: 0,
+      });
+
+      expect(next.items.map((item) => item.id)).toEqual([12, 10, 11]);
+      expect(next.items.map((item) => item.sortOrder)).toEqual([0, 1, 2]);
+      expect(next.dirty).toBe(true);
+    });
+
+    test("reparents and the target's descendants follow into DFS order under the new parent", () => {
+      // Move A under B; A still owns A.child, so DFS pre-order becomes
+      // [B, A, A.child] without any explicit handling of descendants.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+            {
+              id: 20,
+              parentId: 10,
+              sortOrder: 0,
+              title: "A.child",
+              meta: { kind: "custom", url: "/a/child" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "B",
+              meta: { kind: "custom", url: "/b" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "moveItem",
+        key: "id-10",
+        newParentKey: "id-11",
+        newSortOrder: 0,
+      });
+
+      expect(next.items.map((item) => item.id)).toEqual([11, 10, 20]);
+      expect(next.items.map((item) => item.parentKey)).toEqual([
+        null,
+        "id-11",
+        "id-10",
+      ]);
+    });
+
+    test("is a no-op when the move would push the target's subtree past maxDepth", () => {
+      // maxDepth=2 means depth values 0..2 are allowed. Moving B under A
+      // pushes B.grandchild from depth 2 to depth 3, exceeding the cap.
+      // The reducer should return the input state unchanged so dnd-kit's
+      // drop preview can render disabled feedback without the editor
+      // committing the move.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 2,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "B",
+              meta: { kind: "custom", url: "/b" },
+            },
+            {
+              id: 20,
+              parentId: 11,
+              sortOrder: 0,
+              title: "B.child",
+              meta: { kind: "custom", url: "/b/child" },
+            },
+            {
+              id: 30,
+              parentId: 20,
+              sortOrder: 0,
+              title: "B.grandchild",
+              meta: { kind: "custom", url: "/b/child/grand" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "moveItem",
+        key: "id-11",
+        newParentKey: "id-10",
+        newSortOrder: 0,
+      });
+
+      expect(next).toBe(loaded);
+    });
+  });
+
+  describe("updateMaxDepth", () => {
+    test("updates state.maxDepth and flips dirty", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 3,
+          items: [],
+        },
+      });
+
+      const next = editorReducer(loaded, { type: "updateMaxDepth", value: 7 });
+
+      expect(next.maxDepth).toBe(7);
+      expect(next.dirty).toBe(true);
+    });
+
+    test("is a no-op when the new value is below the deepest existing item", () => {
+      // Items already nest 2 deep (B.child at depth 1). Lowering maxDepth
+      // to 0 would invalidate existing state, so the action is rejected
+      // — the user has to remove/move items before tightening the cap.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+            {
+              id: 20,
+              parentId: 10,
+              sortOrder: 0,
+              title: "A.child",
+              meta: { kind: "custom", url: "/a/child" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, { type: "updateMaxDepth", value: 0 });
+
+      expect(next).toBe(loaded);
     });
   });
 });

--- a/packages/plugins/menu/src/admin/editor-state.test.ts
+++ b/packages/plugins/menu/src/admin/editor-state.test.ts
@@ -635,6 +635,126 @@ describe("editorReducer", () => {
       ]);
     });
 
+    test("is a no-op when the new parent is the target itself (no self-cycle)", () => {
+      // Regression: dnd-kit's projection helper can land on a parent
+      // chain that resolves to the active item itself. Without this
+      // guard the reducer happily writes target.parentKey = target.key,
+      // and the next rebuildDfsOrder finds no roots — every entry's
+      // parent chain dead-ends in a cycle, so the walk returns [] and
+      // the entire menu disappears.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "moveItem",
+        key: "id-10",
+        newParentKey: "id-10",
+        newSortOrder: 0,
+      });
+
+      expect(next).toBe(loaded);
+    });
+
+    test("is a no-op when the new parent is a descendant of the target (would cycle)", () => {
+      // Same family of bug as the self-parent check above — dragging A
+      // onto its own child A.child can resolve to parentKey=A.child.
+      // The cycle wipes items if accepted.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+            {
+              id: 20,
+              parentId: 10,
+              sortOrder: 0,
+              title: "A.child",
+              meta: { kind: "custom", url: "/a/c" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "moveItem",
+        key: "id-10",
+        newParentKey: "id-20",
+        newSortOrder: 0,
+      });
+
+      expect(next).toBe(loaded);
+    });
+
+    test("preserves dirty=false when the projection lands at the item's current position", () => {
+      // dnd-kit can fire onDragEnd even for a click-then-release at the
+      // same row. The reducer should treat that as a no-op rather than
+      // re-flowing the same shape and flipping dirty — otherwise just
+      // tapping a row makes the editor think it has unsaved changes.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "custom", url: "/a" },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "B",
+              meta: { kind: "custom", url: "/b" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "moveItem",
+        key: "id-10",
+        newParentKey: null,
+        newSortOrder: 0,
+      });
+
+      expect(next).toBe(loaded);
+    });
+
     test("is a no-op when the move would push the target's subtree past maxDepth", () => {
       // maxDepth=2 means depth values 0..2 are allowed. Moving B under A
       // pushes B.grandchild from depth 2 to depth 3, exceeding the cap.
@@ -711,6 +831,27 @@ describe("editorReducer", () => {
 
       expect(next.maxDepth).toBe(7);
       expect(next.dirty).toBe(true);
+    });
+
+    test("preserves dirty=false when the new value equals the current maxDepth", () => {
+      // Symmetric with the no-op short-circuit on `moveItem`. Re-typing
+      // the same number into the field shouldn't flip `dirty` and arm
+      // the save button — there's no observable change.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [],
+        },
+      });
+
+      const next = editorReducer(loaded, { type: "updateMaxDepth", value: 5 });
+
+      expect(next).toBe(loaded);
     });
 
     test("is a no-op when the new value is below the deepest existing item", () => {

--- a/packages/plugins/menu/src/admin/editor-state.ts
+++ b/packages/plugins/menu/src/admin/editor-state.ts
@@ -197,20 +197,25 @@ export function editorReducer(
     case "moveItem": {
       const target = state.items.find((item) => item.key === action.key);
       if (!target) return state;
+      // Guard against cycles: dragging an item onto itself or onto one
+      // of its descendants would write a parent chain that has no path
+      // to root. `rebuildDfsOrder` walks from null and would produce []
+      // — the entire menu silently disappears.
+      if (action.newParentKey !== null) {
+        const subtree = collectSubtreeKeys(state.items, action.key);
+        if (subtree.has(action.newParentKey)) return state;
+      }
+      const targetUpdated: EditorItem = {
+        ...target,
+        parentKey: action.newParentKey,
+        sortOrder: action.newSortOrder,
+      };
       const updated = state.items.map((item) =>
-        item.key === action.key
-          ? {
-              ...item,
-              parentKey: action.newParentKey,
-              sortOrder: action.newSortOrder,
-            }
-          : item,
+        item.key === action.key ? targetUpdated : item,
       );
       // Re-flow newParentKey's children: drop target out, splice it in at
       // the desired index, renumber 0..n. Anyone else whose order changed
       // gets a fresh sortOrder; the rest stay put.
-      const targetUpdated = updated.find((item) => item.key === action.key);
-      if (!targetUpdated) return state;
       const siblings = updated
         .filter(
           (item) =>
@@ -218,23 +223,25 @@ export function editorReducer(
         )
         .sort((a, b) => a.sortOrder - b.sortOrder);
       siblings.splice(action.newSortOrder, 0, targetUpdated);
-      const newOrderByKey = new Map<ItemKey, number>();
-      siblings.forEach((child, index) => {
-        newOrderByKey.set(child.key, index);
-      });
-      const items = updated.map((item) =>
-        newOrderByKey.has(item.key)
-          ? {
-              ...item,
-              sortOrder: newOrderByKey.get(item.key) ?? item.sortOrder,
-            }
-          : item,
+      const newOrderByKey = new Map(
+        siblings.map((child, index) => [child.key, index]),
       );
+      const items = updated.map((item) => {
+        const nextOrder = newOrderByKey.get(item.key);
+        return nextOrder === undefined
+          ? item
+          : { ...item, sortOrder: nextOrder };
+      });
       const rebuilt = rebuildDfsOrder(items);
       if (deepestDepth(rebuilt) > state.maxDepth) return state;
+      // No-op short-circuit: a drag that ends where it started would
+      // otherwise renumber siblings into identical values and flip
+      // `dirty`, fooling the editor into thinking the menu changed.
+      if (itemsAreEquivalent(state.items, rebuilt)) return state;
       return { ...state, items: rebuilt, dirty: true };
     }
     case "updateMaxDepth": {
+      if (action.value === state.maxDepth) return state;
       if (action.value < deepestDepth(state.items)) return state;
       return { ...state, maxDepth: action.value, dirty: true };
     }
@@ -292,7 +299,7 @@ export function buildSavePayload(
   });
 }
 
-function collectSubtreeKeys(
+export function collectSubtreeKeys(
   items: readonly EditorItem[],
   rootKey: ItemKey,
 ): Set<ItemKey> {
@@ -309,15 +316,42 @@ function collectSubtreeKeys(
   return out;
 }
 
-function deepestDepth(items: readonly EditorItem[]): number {
+function itemsAreEquivalent(
+  a: readonly EditorItem[],
+  b: readonly EditorItem[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x?.key !== y?.key ||
+      x?.parentKey !== y?.parentKey ||
+      x?.sortOrder !== y?.sortOrder
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function computeDepths(
+  items: readonly EditorItem[],
+): Map<ItemKey, number> {
   // Items are in DFS pre-order, so each parent's depth is already set
   // by the time we reach its children — no second pass needed.
-  const depthByKey = new Map<ItemKey, number>();
-  let max = 0;
+  const out = new Map<ItemKey, number>();
   for (const item of items) {
     const depth =
-      item.parentKey === null ? 0 : (depthByKey.get(item.parentKey) ?? 0) + 1;
-    depthByKey.set(item.key, depth);
+      item.parentKey === null ? 0 : (out.get(item.parentKey) ?? 0) + 1;
+    out.set(item.key, depth);
+  }
+  return out;
+}
+
+function deepestDepth(items: readonly EditorItem[]): number {
+  let max = 0;
+  for (const depth of computeDepths(items).values()) {
     if (depth > max) max = depth;
   }
   return max;

--- a/packages/plugins/menu/src/admin/editor-state.ts
+++ b/packages/plugins/menu/src/admin/editor-state.ts
@@ -69,14 +69,6 @@ export type EditorAction =
       readonly meta: MenuItemMeta;
     }
   | {
-      readonly type: "moveUp";
-      readonly key: ItemKey;
-    }
-  | {
-      readonly type: "moveDown";
-      readonly key: ItemKey;
-    }
-  | {
       readonly type: "updateField";
       readonly key: ItemKey;
       readonly patch: {
@@ -109,12 +101,14 @@ export type EditorAction =
       };
     }
   | {
-      readonly type: "demote";
+      readonly type: "moveItem";
       readonly key: ItemKey;
+      readonly newParentKey: ItemKey | null;
+      readonly newSortOrder: number;
     }
   | {
-      readonly type: "promote";
-      readonly key: ItemKey;
+      readonly type: "updateMaxDepth";
+      readonly value: number;
     };
 
 export function editorReducer(
@@ -139,10 +133,6 @@ export function editorReducer(
         nextTmpId: 0,
       };
     }
-    case "moveUp":
-      return swapWithSibling(state, action.key, "previous");
-    case "moveDown":
-      return swapWithSibling(state, action.key, "next");
     case "updateField": {
       const items = state.items.map((item) =>
         item.key === action.key
@@ -170,60 +160,6 @@ export function editorReducer(
     }
     case "selectItem":
       return { ...state, selectedKey: action.key };
-    case "promote": {
-      const target = state.items.find((item) => item.key === action.key);
-      if (target?.parentKey == null) return state;
-      const oldParent = state.items.find(
-        (item) => item.key === target.parentKey,
-      );
-      if (!oldParent) return state;
-      const newParentKey = oldParent.parentKey;
-      // Slot the promoted item right after the old parent in its
-      // grandparent's child list. Bumping later sortOrder values keeps
-      // the relative order stable without reflowing the whole array.
-      const insertAfterSortOrder = oldParent.sortOrder;
-      const items = state.items.map((item) => {
-        if (item.key === target.key) {
-          return {
-            ...item,
-            parentKey: newParentKey,
-            sortOrder: insertAfterSortOrder + 1,
-          };
-        }
-        if (
-          item.parentKey === newParentKey &&
-          item.key !== target.key &&
-          item.sortOrder > insertAfterSortOrder
-        ) {
-          return { ...item, sortOrder: item.sortOrder + 1 };
-        }
-        return item;
-      });
-      return { ...state, items, dirty: true };
-    }
-    case "demote": {
-      const target = state.items.find((item) => item.key === action.key);
-      if (!target) return state;
-      const siblings = state.items
-        .filter((item) => item.parentKey === target.parentKey)
-        .sort((a, b) => a.sortOrder - b.sortOrder);
-      const idx = siblings.findIndex((s) => s.key === target.key);
-      const newParent = siblings[idx - 1];
-      if (!newParent) return state;
-      const lastChildSortOrder = state.items
-        .filter((item) => item.parentKey === newParent.key)
-        .reduce((max, item) => Math.max(max, item.sortOrder), -1);
-      const items = state.items.map((item) =>
-        item.key === action.key
-          ? {
-              ...item,
-              parentKey: newParent.key,
-              sortOrder: lastChildSortOrder + 1,
-            }
-          : item,
-      );
-      return { ...state, items, dirty: true };
-    }
     case "applySaveResult": {
       const { version, itemIds } = action.result;
       const snapshotKeys =
@@ -257,6 +193,50 @@ export function editorReducer(
         selectedKey,
         dirty: false,
       };
+    }
+    case "moveItem": {
+      const target = state.items.find((item) => item.key === action.key);
+      if (!target) return state;
+      const updated = state.items.map((item) =>
+        item.key === action.key
+          ? {
+              ...item,
+              parentKey: action.newParentKey,
+              sortOrder: action.newSortOrder,
+            }
+          : item,
+      );
+      // Re-flow newParentKey's children: drop target out, splice it in at
+      // the desired index, renumber 0..n. Anyone else whose order changed
+      // gets a fresh sortOrder; the rest stay put.
+      const targetUpdated = updated.find((item) => item.key === action.key);
+      if (!targetUpdated) return state;
+      const siblings = updated
+        .filter(
+          (item) =>
+            item.parentKey === action.newParentKey && item.key !== action.key,
+        )
+        .sort((a, b) => a.sortOrder - b.sortOrder);
+      siblings.splice(action.newSortOrder, 0, targetUpdated);
+      const newOrderByKey = new Map<ItemKey, number>();
+      siblings.forEach((child, index) => {
+        newOrderByKey.set(child.key, index);
+      });
+      const items = updated.map((item) =>
+        newOrderByKey.has(item.key)
+          ? {
+              ...item,
+              sortOrder: newOrderByKey.get(item.key) ?? item.sortOrder,
+            }
+          : item,
+      );
+      const rebuilt = rebuildDfsOrder(items);
+      if (deepestDepth(rebuilt) > state.maxDepth) return state;
+      return { ...state, items: rebuilt, dirty: true };
+    }
+    case "updateMaxDepth": {
+      if (action.value < deepestDepth(state.items)) return state;
+      return { ...state, maxDepth: action.value, dirty: true };
     }
     case "addItem": {
       const rootSiblings = state.items.filter(
@@ -329,33 +309,18 @@ function collectSubtreeKeys(
   return out;
 }
 
-function swapWithSibling(
-  state: EditorState,
-  key: ItemKey,
-  direction: "previous" | "next",
-): EditorState {
-  const target = state.items.find((item) => item.key === key);
-  if (!target) return state;
-  // Pick the sibling adjacent in `(parentKey, sortOrder)` order rather
-  // than adjacent in the array — there may be a different subtree
-  // sitting between the two siblings (e.g. `[A, A.child, B]`), and
-  // that's not who we want to swap with.
-  const siblings = state.items
-    .filter((item) => item.parentKey === target.parentKey)
-    .sort((a, b) => a.sortOrder - b.sortOrder);
-  const idx = siblings.findIndex((s) => s.key === key);
-  const adj = direction === "previous" ? siblings[idx - 1] : siblings[idx + 1];
-  if (!adj) return state;
-  const swapped = state.items.map((item) => {
-    if (item.key === target.key) return { ...item, sortOrder: adj.sortOrder };
-    if (item.key === adj.key) return { ...item, sortOrder: target.sortOrder };
-    return item;
-  });
-  // Rebuild the array in DFS pre-order so descendants follow their
-  // parent. `flattenSaveItems` enforces `parentIndex < itemIndex`;
-  // an array-level swap leaves children stranded before the moved
-  // parent and trips that check.
-  return { ...state, items: rebuildDfsOrder(swapped), dirty: true };
+function deepestDepth(items: readonly EditorItem[]): number {
+  // Items are in DFS pre-order, so each parent's depth is already set
+  // by the time we reach its children — no second pass needed.
+  const depthByKey = new Map<ItemKey, number>();
+  let max = 0;
+  for (const item of items) {
+    const depth =
+      item.parentKey === null ? 0 : (depthByKey.get(item.parentKey) ?? 0) + 1;
+    depthByKey.set(item.key, depth);
+    if (depth > max) max = depth;
+  }
+  return max;
 }
 
 function rebuildDfsOrder(items: readonly EditorItem[]): EditorItem[] {

--- a/packages/plugins/menu/src/admin/tree-state.test.ts
+++ b/packages/plugins/menu/src/admin/tree-state.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+
+import type { EditorItem } from "./editor-state.js";
+import { dragEndToAction, getProjection } from "./tree-state.js";
+
+function row(
+  key: string,
+  parentKey: string | null,
+  sortOrder: number,
+): EditorItem {
+  // dnd-kit's projection only consults key, parentKey, and sortOrder
+  // — the rest is irrelevant for these tests, hence the stub values.
+  return {
+    key,
+    id: null,
+    parentKey,
+    sortOrder,
+    title: key,
+    meta: { kind: "custom", url: `/${key}` },
+  };
+}
+
+describe("getProjection", () => {
+  test("returns the over item's slot at the same depth when there is no horizontal drag", () => {
+    // Drag A onto B with zero offset. The dnd-kit Sortable Tree pattern
+    // simulates the post-drop array `[B, A]`, takes A's previous item B
+    // as the depth anchor, and produces (parentKey=null, depth=0,
+    // sortOrder=1) — A becomes B's sibling after B.
+    const items = [row("a", null, 0), row("b", null, 1)];
+
+    const projection = getProjection(items, "a", "b", 0, 24, 5);
+
+    expect(projection).toEqual({
+      parentKey: null,
+      depth: 0,
+      sortOrder: 1,
+    });
+  });
+
+  test("drag-right past one indentation step nests the active item under the previous one", () => {
+    // After dropping A behind B, dragging right by one indent unit asks
+    // dnd-kit "nest under the previous item." `previous` here is B in
+    // the post-reorder list, so A becomes B's first child.
+    const items = [row("a", null, 0), row("b", null, 1)];
+
+    const projection = getProjection(items, "a", "b", 24, 24, 5);
+
+    expect(projection).toEqual({
+      parentKey: "b",
+      depth: 1,
+      sortOrder: 0,
+    });
+  });
+
+  test("drag-left past one indentation step unparents the active item", () => {
+    // [A (root), A.child (under A)]. Dragging A.child left without
+    // changing its over — projection drops a level: parentKey null,
+    // depth 0, slotted after A among root-level items.
+    const items = [row("a", null, 0), row("achild", "a", 0)];
+
+    const projection = getProjection(items, "achild", "achild", -24, 24, 5);
+
+    expect(projection).toEqual({
+      parentKey: null,
+      depth: 0,
+      sortOrder: 1,
+    });
+  });
+
+  test("caps depth so the active item's subtree stays within maxDepth", () => {
+    // Active A has a child at depth 1. Dragging A right behind B would
+    // try to nest A under B (depth 1), pushing A.child to depth 2.
+    // With maxDepth=1 the projection clamps depth to 0 so the visible
+    // indicator stops at root level — the visible "rejection" feedback.
+    const items = [row("a", null, 0), row("achild", "a", 0), row("b", null, 1)];
+
+    const projection = getProjection(items, "a", "b", 99, 24, 1);
+
+    expect(projection).toEqual({ parentKey: null, depth: 0, sortOrder: 1 });
+  });
+});
+
+describe("dragEndToAction", () => {
+  test("returns a moveItem action carrying the projected drop target", () => {
+    // The component wires dnd-kit's onDragEnd to this helper so the
+    // projection-to-action translation lives outside React. Cycle-9 wiring
+    // can then stay a thin call-site that only knows about React state.
+    const items = [row("a", null, 0), row("b", null, 1)];
+
+    const action = dragEndToAction(items, "a", "b", 24, 24, 5);
+
+    expect(action).toEqual({
+      type: "moveItem",
+      key: "a",
+      newParentKey: "b",
+      newSortOrder: 0,
+    });
+  });
+
+  test("returns null when the projection cannot be resolved (active key missing)", () => {
+    const items = [row("a", null, 0), row("b", null, 1)];
+
+    const action = dragEndToAction(items, "ghost", "b", 0, 24, 5);
+
+    expect(action).toBeNull();
+  });
+});

--- a/packages/plugins/menu/src/admin/tree-state.test.ts
+++ b/packages/plugins/menu/src/admin/tree-state.test.ts
@@ -67,6 +67,18 @@ describe("getProjection", () => {
     });
   });
 
+  test("returns null when the resolved parent is the active item or one of its descendants", () => {
+    // Dragging A onto its own child A.child with rightward offset would
+    // resolve to parentKey === A.child (or even A itself). Releasing
+    // there forms a cycle — the reducer also guards, but failing fast
+    // here means the live drop indicator never lies.
+    const items = [row("a", null, 0), row("achild", "a", 0)];
+
+    const projection = getProjection(items, "a", "achild", 99, 24, 5);
+
+    expect(projection).toBeNull();
+  });
+
   test("caps depth so the active item's subtree stays within maxDepth", () => {
     // Active A has a child at depth 1. Dragging A right behind B would
     // try to nest A under B (depth 1), pushing A.child to depth 2.

--- a/packages/plugins/menu/src/admin/tree-state.ts
+++ b/packages/plugins/menu/src/admin/tree-state.ts
@@ -5,6 +5,7 @@
 // `moveItem(parentKey, sortOrder)`.
 
 import type { EditorAction, EditorItem, ItemKey } from "./editor-state.js";
+import { collectSubtreeKeys, computeDepths } from "./editor-state.js";
 
 interface Projection {
   readonly parentKey: ItemKey | null;
@@ -81,6 +82,13 @@ export function getProjection(
   );
 
   const parentKey = resolveParentAtDepth(items, previousItem, depth, depths);
+  // Reject projections that would form a cycle (parent is active itself
+  // or any descendant). The reducer also guards, but null here keeps
+  // the live drop indicator honest.
+  if (parentKey !== null) {
+    const subtree = collectSubtreeKeys(items, activeKey);
+    if (subtree.has(parentKey)) return null;
+  }
   const sortOrder = indexAmongSiblingsAfterMove(
     reordered,
     activeKey,
@@ -112,18 +120,6 @@ function clamp(value: number, min: number, max: number): number {
   if (value < min) return min;
   if (value > max) return max;
   return value;
-}
-
-function computeDepths(items: readonly EditorItem[]): Map<ItemKey, number> {
-  // Items are stored in DFS pre-order, so parents always come before
-  // children — one forward pass is enough.
-  const out = new Map<ItemKey, number>();
-  for (const item of items) {
-    const depth =
-      item.parentKey === null ? 0 : (out.get(item.parentKey) ?? 0) + 1;
-    out.set(item.key, depth);
-  }
-  return out;
 }
 
 function resolveParentAtDepth(

--- a/packages/plugins/menu/src/admin/tree-state.ts
+++ b/packages/plugins/menu/src/admin/tree-state.ts
@@ -1,0 +1,157 @@
+// Pure projection helpers for the dnd-kit Sortable Tree integration.
+// `getProjection` answers "if the user releases the drag now, where
+// would the item land?" — the editor consumes the result both to
+// preview the drop indicator and, on `onDragEnd`, to dispatch
+// `moveItem(parentKey, sortOrder)`.
+
+import type { EditorAction, EditorItem, ItemKey } from "./editor-state.js";
+
+interface Projection {
+  readonly parentKey: ItemKey | null;
+  readonly depth: number;
+  readonly sortOrder: number;
+}
+
+export function dragEndToAction(
+  items: readonly EditorItem[],
+  activeKey: ItemKey,
+  overKey: ItemKey,
+  dragOffsetX: number,
+  indentationWidth: number,
+  maxDepth: number,
+): EditorAction | null {
+  const projection = getProjection(
+    items,
+    activeKey,
+    overKey,
+    dragOffsetX,
+    indentationWidth,
+    maxDepth,
+  );
+  if (!projection) return null;
+  return {
+    type: "moveItem",
+    key: activeKey,
+    newParentKey: projection.parentKey,
+    newSortOrder: projection.sortOrder,
+  };
+}
+
+export function getProjection(
+  items: readonly EditorItem[],
+  activeKey: ItemKey,
+  overKey: ItemKey,
+  dragOffsetX: number,
+  indentationWidth: number,
+  maxDepth: number,
+): Projection | null {
+  const activeIndex = items.findIndex((item) => item.key === activeKey);
+  const overIndex = items.findIndex((item) => item.key === overKey);
+  if (activeIndex < 0 || overIndex < 0) return null;
+
+  const reordered = [...items];
+  const [active] = reordered.splice(activeIndex, 1);
+  if (!active) return null;
+  reordered.splice(overIndex, 0, active);
+
+  const depths = computeDepths(items);
+  const activeDepth = depths.get(activeKey) ?? 0;
+
+  const previousItem = reordered[overIndex - 1];
+  const nextItem = reordered[overIndex + 1];
+  const previousDepth =
+    previousItem === undefined ? -1 : (depths.get(previousItem.key) ?? 0);
+  const nextDepth =
+    nextItem === undefined ? 0 : (depths.get(nextItem.key) ?? 0);
+
+  const projectedDepth =
+    activeDepth + Math.round(dragOffsetX / indentationWidth);
+  const maxAllowedDepth = previousItem === undefined ? 0 : previousDepth + 1;
+  const minAllowedDepth = nextDepth;
+  // The active item carries its subtree along on the move, so its depth
+  // ceiling is `maxDepth - subtreeExtra` — anything higher would push a
+  // descendant past `maxDepth`. Clamping here makes the drop indicator
+  // visibly stop short instead of letting the user release into a
+  // position the reducer would reject.
+  const subtreeExtra = subtreeDepthExtra(items, activeIndex, depths);
+  const depthCap = Math.max(0, maxDepth - subtreeExtra);
+  const depth = Math.min(
+    clamp(projectedDepth, minAllowedDepth, maxAllowedDepth),
+    depthCap,
+  );
+
+  const parentKey = resolveParentAtDepth(items, previousItem, depth, depths);
+  const sortOrder = indexAmongSiblingsAfterMove(
+    reordered,
+    activeKey,
+    parentKey,
+  );
+  return { parentKey, depth, sortOrder };
+}
+
+function subtreeDepthExtra(
+  items: readonly EditorItem[],
+  activeIndex: number,
+  depths: ReadonlyMap<ItemKey, number>,
+): number {
+  const active = items[activeIndex];
+  if (!active) return 0;
+  const activeDepth = depths.get(active.key) ?? 0;
+  let max = 0;
+  for (let i = activeIndex + 1; i < items.length; i += 1) {
+    const item = items[i];
+    if (!item) continue;
+    const d = depths.get(item.key) ?? 0;
+    if (d <= activeDepth) break;
+    if (d - activeDepth > max) max = d - activeDepth;
+  }
+  return max;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function computeDepths(items: readonly EditorItem[]): Map<ItemKey, number> {
+  // Items are stored in DFS pre-order, so parents always come before
+  // children — one forward pass is enough.
+  const out = new Map<ItemKey, number>();
+  for (const item of items) {
+    const depth =
+      item.parentKey === null ? 0 : (out.get(item.parentKey) ?? 0) + 1;
+    out.set(item.key, depth);
+  }
+  return out;
+}
+
+function resolveParentAtDepth(
+  items: readonly EditorItem[],
+  previousItem: EditorItem | undefined,
+  targetDepth: number,
+  depths: ReadonlyMap<ItemKey, number>,
+): ItemKey | null {
+  if (targetDepth === 0 || previousItem === undefined) return null;
+  let current: EditorItem | undefined = previousItem;
+  while (
+    current !== undefined &&
+    (depths.get(current.key) ?? 0) > targetDepth - 1
+  ) {
+    current = items.find((item) => item.key === current?.parentKey);
+  }
+  return current?.key ?? null;
+}
+
+function indexAmongSiblingsAfterMove(
+  reordered: readonly EditorItem[],
+  activeKey: ItemKey,
+  parentKey: ItemKey | null,
+): number {
+  let count = 0;
+  for (const item of reordered) {
+    if (item.key === activeKey) return count;
+    if (item.parentKey === parentKey) count += 1;
+  }
+  return count;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,15 @@ importers:
 
   packages/plugins/menu:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.5)
       '@plumix/core':
         specifier: workspace:*
         version: link:../../core


### PR DESCRIPTION
Replaces slice-8's flat list with a dnd-kit Sortable Tree (`MenuTree`).
Items reorder and reparent via drag-and-drop, with a keyboard fallback
through dnd-kit's `KeyboardSensor` + `sortableKeyboardCoordinates`.

The four single-step reducer actions (`moveUp` / `moveDown` /
`promote` / `demote`) and their inline buttons are gone — they're all
special cases of the new `moveItem`, which the issue explicitly asked
to supersede.

## Highlights

- **`moveItem` reducer**: takes `(key, newParentKey, newSortOrder)`,
  renumbers the destination parent's children, then DFS-rebuilds the
  whole array so descendants always trail their parent. The maxDepth
  guard rejects (no-op) when the active subtree's deepest descendant
  would exceed `state.maxDepth`.
- **`getProjection` helper** (pure, in `tree-state.ts`): the dnd-kit
  Sortable Tree projection. Emits `(parentKey, depth, sortOrder)`
  for a hypothetical drop. Clamps depth by previous-item ceiling
  AND by `maxDepth − subtreeExtra`, so the live drop indicator
  visibly stops short rather than letting the user release into a
  position the reducer would discard.
- **`dragEndToAction`**: projection → `moveItem` action. Keeps the
  React component a thin wiring layer.
- **Settings panel maxDepth input**: local draft string so transient
  empty values during edits don't trap the field on the last valid
  number; round-trips through `useSaveMenu`'s `maxDepth` field.
- **Active subtree depth preview**: the dragged row renders at
  `projection.depth` while in flight, so the user sees where it
  would land.

dnd-kit's three packages land as direct deps of `plugin-menu` (per
the single-consumer rule — no catalog entry).

## Notable design call

`handleDragEnd` reads `event.delta.x` directly rather than from
React state. dnd-kit's `onDragMove` and `onDragEnd` share a render
closure; relying on `setDragOffsetX` would risk a stale value if
the last move's render hadn't committed.

## Tests

206 vitest passing. Coverage:

- `editor-state.test.ts` — `moveItem` (sibling reorder, reparent,
  maxDepth rejection), `updateMaxDepth` (raise, reject below deepest).
- `tree-state.test.ts` — `getProjection` (no offset, drag-right,
  drag-left, maxDepth cap) and `dragEndToAction` (round-trip + null on
  unknown active key).
- `MenusShell.test.tsx` — flat-list test renamed to `menu-tree`
  container; new max-depth-input → save-payload test; obsolete
  up-button click test removed.

## Deferred

The three Playwright e2e cases listed on the issue (drag-nest,
max-depth rejection, keyboard reorder) are filed as #185 per the
slice-9 plan agreed up front.

Fixes #166
Refs #185