### PR TITLE
feat(plugin-menu): broken-ref handling (slice 11)

### DIFF
--- a/packages/plugins/menu/src/admin/MenuItemEditor.tsx
+++ b/packages/plugins/menu/src/admin/MenuItemEditor.tsx
@@ -69,7 +69,11 @@ export function MenuItemEditor({
   }
   return (
     <div data-testid="menu-item-editor">
-      <ItemsPicker tabs={pickerTabs.data ?? []} dispatch={dispatch} />
+      <ItemsPicker
+        tabs={pickerTabs.data ?? []}
+        state={state}
+        dispatch={dispatch}
+      />
       {state.items.length === 0 ? (
         <div data-testid="menu-item-list-empty">No items yet.</div>
       ) : (
@@ -267,14 +271,35 @@ function DeleteMenuButton({ termId }: { readonly termId: number }): ReactNode {
 
 function ItemsPicker({
   tabs,
+  state,
   dispatch,
 }: {
   readonly tabs: readonly PickerTab[];
+  readonly state: EditorState;
   readonly dispatch: Dispatch<EditorAction>;
 }): ReactNode {
   const [activeTab, setActiveTab] = useState<string | null>(null);
+  const relinkTarget =
+    state.relinkTargetKey === null
+      ? null
+      : (state.items.find((item) => item.key === state.relinkTargetKey) ??
+        null);
   return (
     <div data-testid="menu-items-picker">
+      {relinkTarget !== null ? (
+        <div data-testid="menu-picker-relink-banner">
+          <span>Pick replacement for {relinkTarget.resolvedLabel}</span>
+          <button
+            type="button"
+            data-testid="menu-picker-relink-cancel"
+            onClick={() => {
+              dispatch({ type: "cancelRelink" });
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      ) : null}
       <div data-testid="menu-picker-tabs">
         {tabs.map((tab) => (
           <button
@@ -291,19 +316,25 @@ function ItemsPicker({
         ))}
       </div>
       {activeTab === "custom" ? (
-        <CustomUrlPickerPanel dispatch={dispatch} />
+        <CustomUrlPickerPanel
+          relinkTargetKey={state.relinkTargetKey}
+          dispatch={dispatch}
+        />
       ) : null}
     </div>
   );
 }
 
 function CustomUrlPickerPanel({
+  relinkTargetKey,
   dispatch,
 }: {
+  readonly relinkTargetKey: ItemKey | null;
   readonly dispatch: Dispatch<EditorAction>;
 }): ReactNode {
   const [url, setUrl] = useState("");
   const [label, setLabel] = useState("");
+  const isRelink = relinkTargetKey !== null;
   return (
     <div data-testid="menu-picker-custom-panel">
       <input
@@ -327,16 +358,24 @@ function CustomUrlPickerPanel({
         data-testid="menu-picker-custom-add"
         onClick={() => {
           if (url.trim() === "") return;
-          dispatch({
-            type: "addItem",
-            title: label.trim() === "" ? null : label.trim(),
-            meta: { kind: "custom", url: url.trim() },
-          });
+          if (relinkTargetKey !== null) {
+            dispatch({
+              type: "relinkItem",
+              key: relinkTargetKey,
+              newMeta: { kind: "custom", url: url.trim() },
+            });
+          } else {
+            dispatch({
+              type: "addItem",
+              title: label.trim() === "" ? null : label.trim(),
+              meta: { kind: "custom", url: url.trim() },
+            });
+          }
           setUrl("");
           setLabel("");
         }}
       >
-        Add to menu
+        {isRelink ? "Replace link" : "Add to menu"}
       </button>
     </div>
   );
@@ -454,11 +493,15 @@ function SortableTreeRow({
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: item.key });
   const id = item.id ?? item.key;
+  const isBroken = item.state === "broken";
+  const isUnauthorized = item.state === "unauthorized";
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
     paddingLeft: `${String(depth * INDENTATION_WIDTH)}px`,
+    opacity: isUnauthorized ? 0.5 : undefined,
   };
+  const displayLabel = item.title ?? item.resolvedLabel;
   return (
     <div
       ref={setNodeRef}
@@ -466,6 +509,7 @@ function SortableTreeRow({
       data-testid={`menu-item-row-${String(id)}`}
       data-depth={String(depth)}
       data-selected={selected ? "true" : "false"}
+      data-state={item.state}
       onClick={() => {
         dispatch({ type: "selectItem", key: item.key });
       }}
@@ -474,18 +518,55 @@ function SortableTreeRow({
         type="button"
         data-testid={`menu-item-drag-${String(id)}`}
         aria-label={`Reorder ${item.title ?? "item"}`}
-        {...attributes}
-        {...listeners}
+        disabled={isUnauthorized}
+        // dnd-kit's listeners attach pointerdown handlers; omitting
+        // them when unauthorized prevents drag activation on a row
+        // the viewer can't act on.
+        {...(isUnauthorized ? {} : attributes)}
+        {...(isUnauthorized ? {} : listeners)}
         onClick={(event) => {
           event.stopPropagation();
         }}
       >
         ⋮⋮
       </button>
-      <span>{item.title ?? "(unnamed)"}</span>
+      {isBroken ? (
+        <span
+          data-testid={`menu-item-warning-${String(id)}`}
+          aria-label="broken link"
+        >
+          ⚠
+        </span>
+      ) : null}
+      <span>{displayLabel}</span>
+      {isBroken ? (
+        <>
+          <button
+            type="button"
+            data-testid={`menu-item-relink-${String(id)}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              dispatch({ type: "startRelink", key: item.key });
+            }}
+          >
+            Re-link…
+          </button>
+          <button
+            type="button"
+            data-testid={`menu-item-convert-${String(id)}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              dispatch({ type: "convertToCustom", key: item.key });
+            }}
+          >
+            Convert to Custom URL
+          </button>
+        </>
+      ) : null}
       <button
         type="button"
         data-testid={`menu-item-remove-${String(id)}`}
+        disabled={isUnauthorized}
         onClick={(event) => {
           event.stopPropagation();
           dispatch({ type: "removeItem", key: item.key });

--- a/packages/plugins/menu/src/admin/MenusShell.test.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.test.tsx
@@ -801,6 +801,172 @@ describe("MenusShell", () => {
     });
   });
 
+  describe("broken-ref handling", () => {
+    test("renders broken items with a warning, Re-link, and Convert-to-Custom buttons", async () => {
+      // Slice 11: server enriches each item with `resolved.state`. The
+      // editor renders broken rows distinctly and offers inline actions
+      // — Re-link opens the picker in re-link mode, Convert rewrites
+      // meta.kind to 'custom' seeded with the last-known href.
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 1 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 30,
+              parentId: null,
+              sortOrder: 0,
+              title: "",
+              meta: {
+                kind: "entry",
+                entryId: 99999,
+                lastLabel: "Old About",
+                lastHref: "/about-old",
+              },
+              resolved: {
+                state: "broken",
+                label: "Old About",
+                href: "/about-old",
+                lastHref: "/about-old",
+              },
+            },
+          ],
+        },
+        "/menu/save": {
+          termId: 7,
+          version: 2,
+          itemIds: [30],
+          added: [],
+          removed: [],
+          modified: [30],
+        },
+      });
+
+      renderShell();
+      const user = userEvent.setup();
+
+      const row = await screen.findByTestId("menu-item-row-30");
+      expect(row.dataset.state).toBe("broken");
+      expect(
+        await screen.findByTestId("menu-item-warning-30"),
+      ).toBeInTheDocument();
+      expect(row).toHaveTextContent("Old About");
+
+      // Convert action seeds custom URL with the last-known href.
+      await user.click(await screen.findByTestId("menu-item-convert-30"));
+      await user.click(await screen.findByTestId("menu-save-button"));
+
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/save");
+        if (!found) throw new Error("menu.save not called");
+        return found;
+      });
+      const payload = parseRpcInput<{
+        items: readonly { meta: { kind: string; url?: string } }[];
+      }>(call);
+      expect(payload.items[0]?.meta).toEqual({
+        kind: "custom",
+        url: "/about-old",
+      });
+    });
+
+    test("Re-link opens the picker in re-link mode and replacing dispatches relinkItem", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/_plumix/admin/pages/menus?menu=main",
+      );
+      mockRpc({
+        "/menu/list": [
+          { id: 7, slug: "main", name: "Main", version: 1, itemCount: 1 },
+        ],
+        "/menu/locations/list": [],
+        "/menu/pickerTabs": [{ kind: "custom", tabLabel: "Custom URL" }],
+        "/menu/get": {
+          id: 7,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 30,
+              parentId: null,
+              sortOrder: 0,
+              title: "",
+              meta: {
+                kind: "entry",
+                entryId: 99999,
+                lastLabel: "Old About",
+                lastHref: "/about-old",
+              },
+              resolved: {
+                state: "broken",
+                label: "Old About",
+                href: "/about-old",
+                lastHref: "/about-old",
+              },
+            },
+          ],
+        },
+        "/menu/save": {
+          termId: 7,
+          version: 2,
+          itemIds: [30],
+          added: [],
+          removed: [],
+          modified: [30],
+        },
+      });
+
+      renderShell();
+      const user = userEvent.setup();
+
+      await screen.findByTestId("menu-item-row-30");
+      await user.click(await screen.findByTestId("menu-item-relink-30"));
+      // Banner appears with the broken item's last-known label.
+      const banner = await screen.findByTestId("menu-picker-relink-banner");
+      expect(banner).toHaveTextContent("Old About");
+
+      // The Custom URL panel's primary button now reads "Replace link".
+      await user.click(await screen.findByTestId("menu-picker-tab-custom"));
+      await user.type(
+        await screen.findByTestId("menu-picker-custom-url"),
+        "/about-new",
+      );
+      await user.click(await screen.findByTestId("menu-picker-custom-add"));
+
+      // Save and assert the payload carries the new URL on the same id.
+      await user.click(await screen.findByTestId("menu-save-button"));
+      const call = await vi.waitFor(() => {
+        const found = findRpcCall("/menu/save");
+        if (!found) throw new Error("menu.save not called");
+        return found;
+      });
+      const payload = parseRpcInput<{
+        items: readonly { id?: number; meta: { kind: string; url?: string } }[];
+      }>(call);
+      expect(payload.items[0]?.id).toBe(30);
+      expect(payload.items[0]?.meta).toEqual({
+        kind: "custom",
+        url: "/about-new",
+      });
+    });
+  });
+
   describe("max-depth setting", () => {
     test("typing in the max-depth input updates the value the next save sends", async () => {
       // Acceptance: per-menu maxDepth surfaces in the settings panel and

--- a/packages/plugins/menu/src/admin/editor-state.test.ts
+++ b/packages/plugins/menu/src/admin/editor-state.test.ts
@@ -278,6 +278,43 @@ describe("editorReducer", () => {
       expect(next.dirty).toBe(true);
     });
 
+    test("clears relinkTargetKey if the relinked item was removed", () => {
+      // Otherwise the picker still treats the panel as in re-link mode
+      // for a phantom target — clicking "Replace link" no-ops and
+      // resets the user's typed input.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Broken",
+              meta: { kind: "entry", entryId: 99999 },
+            },
+          ],
+        },
+      });
+      const relinking = editorReducer(loaded, {
+        type: "startRelink",
+        key: "id-10",
+      });
+      expect(relinking.relinkTargetKey).toBe("id-10");
+
+      const removed = editorReducer(relinking, {
+        type: "removeItem",
+        key: "id-10",
+      });
+
+      expect(removed.relinkTargetKey).toBeNull();
+    });
+
     test("clears selectedKey if the selected item was removed", () => {
       const loaded = editorReducer(initialEditorState, {
         type: "loadFromServer",
@@ -713,6 +750,59 @@ describe("editorReducer", () => {
       expect(next).toBe(loaded);
     });
 
+    test("rejects (no-op) when the targeted item is in unauthorized state", () => {
+      // Defense-in-depth: even if the UI's drag-handle disable slips
+      // and a drag-end fires for an unauthorized row, the reducer
+      // should not write the move into state.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "A",
+              meta: { kind: "entry", entryId: 5 },
+              resolved: {
+                state: "unauthorized",
+                label: "A",
+                href: null,
+                lastHref: null,
+              },
+            },
+            {
+              id: 11,
+              parentId: null,
+              sortOrder: 1,
+              title: "B",
+              meta: { kind: "custom", url: "/b" },
+              resolved: {
+                state: "ok",
+                label: "B",
+                href: "/b",
+                lastHref: null,
+              },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "moveItem",
+        key: "id-10",
+        newParentKey: null,
+        newSortOrder: 1,
+      });
+
+      expect(next).toBe(loaded);
+    });
+
     test("preserves dirty=false when the projection lands at the item's current position", () => {
       // dnd-kit can fire onDragEnd even for a click-then-release at the
       // same row. The reducer should treat that as a no-op rather than
@@ -810,6 +900,159 @@ describe("editorReducer", () => {
       });
 
       expect(next).toBe(loaded);
+    });
+  });
+
+  describe("convertToCustom", () => {
+    test("rewrites a broken entry-kind item's meta into a custom URL using lastHref", () => {
+      // Slice 11 acceptance: \"Convert to Custom URL action rewrites
+      // meta.kind to 'custom' and seeds meta.url with the last-known
+      // href (so editor doesn't lose the destination context)\".
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "About",
+              meta: {
+                kind: "entry",
+                entryId: 99999,
+                lastLabel: "About",
+                lastHref: "/about",
+              },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "convertToCustom",
+        key: "id-10",
+      });
+
+      expect(next.items[0]?.meta).toEqual({ kind: "custom", url: "/about" });
+      expect(next.dirty).toBe(true);
+    });
+
+    test("is a no-op when the targeted item already has kind=custom", () => {
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Home",
+              meta: { kind: "custom", url: "/" },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "convertToCustom",
+        key: "id-10",
+      });
+
+      expect(next).toBe(loaded);
+    });
+
+    test("falls back to the empty string when no lastHref is present", () => {
+      // Edge case: item was added before slice 11 so meta.lastHref is
+      // missing. The conversion still runs — Convert is a destructive
+      // affordance the user invokes intentionally — and seeds an empty
+      // url for them to fix.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "Old",
+              meta: { kind: "entry", entryId: 99999 },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "convertToCustom",
+        key: "id-10",
+      });
+
+      expect(next.items[0]?.meta).toEqual({ kind: "custom", url: "" });
+    });
+  });
+
+  describe("relinkItem", () => {
+    test("replaces meta with the supplied newMeta and marks dirty", () => {
+      // \"Re-link\" hands the user the picker to choose a replacement;
+      // the picker hands the reducer a complete new meta object. The
+      // reducer just swaps it in.
+      const loaded = editorReducer(initialEditorState, {
+        type: "loadFromServer",
+        response: {
+          id: 1,
+          slug: "main",
+          name: "Main",
+          version: 1,
+          maxDepth: 5,
+          items: [
+            {
+              id: 10,
+              parentId: null,
+              sortOrder: 0,
+              title: "About",
+              meta: {
+                kind: "entry",
+                entryId: 99999,
+                lastLabel: "About",
+                lastHref: "/about",
+              },
+            },
+          ],
+        },
+      });
+
+      const next = editorReducer(loaded, {
+        type: "relinkItem",
+        key: "id-10",
+        newMeta: {
+          kind: "entry",
+          entryId: 42,
+          lastLabel: "About v2",
+          lastHref: "/about-v2",
+        },
+      });
+
+      expect(next.items[0]?.meta).toEqual({
+        kind: "entry",
+        entryId: 42,
+        lastLabel: "About v2",
+        lastHref: "/about-v2",
+      });
+      expect(next.dirty).toBe(true);
     });
   });
 

--- a/packages/plugins/menu/src/admin/editor-state.ts
+++ b/packages/plugins/menu/src/admin/editor-state.ts
@@ -1,4 +1,5 @@
 import type { MenuItemMeta } from "../server/types.js";
+import type { ItemState } from "./item-state.js";
 
 export type ItemKey = string;
 
@@ -9,6 +10,14 @@ export interface EditorItem {
   readonly sortOrder: number;
   readonly title: string | null;
   readonly meta: MenuItemMeta;
+  /**
+   * Per-item state from the server resolver (slice 11). New items
+   * created client-side default to `'ok'` until they round-trip
+   * through save → reload.
+   */
+  readonly state: ItemState;
+  /** Server-resolved display label — picks the right fallback chain. */
+  readonly resolvedLabel: string;
 }
 
 export interface EditorState {
@@ -19,6 +28,12 @@ export interface EditorState {
   readonly maxDepth: number;
   readonly items: readonly EditorItem[];
   readonly selectedKey: ItemKey | null;
+  /**
+   * When non-null, the picker is in re-link mode for that item.
+   * Custom URL panel's primary action becomes "Replace link" instead
+   * of "Add to menu" and dispatches `relinkItem` on the named key.
+   */
+  readonly relinkTargetKey: ItemKey | null;
   readonly dirty: boolean;
   /**
    * Monotonic counter for new-item keys. `state.items.length` would
@@ -37,6 +52,7 @@ export const initialEditorState: EditorState = {
   maxDepth: 5,
   items: [],
   selectedKey: null,
+  relinkTargetKey: null,
   dirty: false,
   nextTmpId: 0,
 };
@@ -47,6 +63,12 @@ interface ServerItemRow {
   readonly sortOrder: number;
   readonly title: string;
   readonly meta: Record<string, unknown>;
+  readonly resolved?: {
+    readonly state: ItemState;
+    readonly label: string;
+    readonly href: string | null;
+    readonly lastHref: string | null;
+  };
 }
 
 interface ServerMenuResponse {
@@ -109,6 +131,22 @@ export type EditorAction =
   | {
       readonly type: "updateMaxDepth";
       readonly value: number;
+    }
+  | {
+      readonly type: "convertToCustom";
+      readonly key: ItemKey;
+    }
+  | {
+      readonly type: "relinkItem";
+      readonly key: ItemKey;
+      readonly newMeta: MenuItemMeta;
+    }
+  | {
+      readonly type: "startRelink";
+      readonly key: ItemKey;
+    }
+  | {
+      readonly type: "cancelRelink";
     };
 
 export function editorReducer(
@@ -126,6 +164,7 @@ export function editorReducer(
         maxDepth: action.response.maxDepth,
         items,
         selectedKey: null,
+        relinkTargetKey: null,
         dirty: false,
         // Reset tmp counter — server-loaded items use `id-N` keys
         // exclusively, so there are no `tmp-*` collisions to worry
@@ -156,7 +195,11 @@ export function editorReducer(
         state.selectedKey !== null && removed.has(state.selectedKey)
           ? null
           : state.selectedKey;
-      return { ...state, items, selectedKey, dirty: true };
+      const relinkTargetKey =
+        state.relinkTargetKey !== null && removed.has(state.relinkTargetKey)
+          ? null
+          : state.relinkTargetKey;
+      return { ...state, items, selectedKey, relinkTargetKey, dirty: true };
     }
     case "selectItem":
       return { ...state, selectedKey: action.key };
@@ -197,6 +240,10 @@ export function editorReducer(
     case "moveItem": {
       const target = state.items.find((item) => item.key === action.key);
       if (!target) return state;
+      // Defense in depth: unauthorized items shouldn't be reorderable.
+      // The drag handle is hidden in the UI, but dnd-kit's pointer
+      // listeners can still fire on the row, so we also reject here.
+      if (target.state === "unauthorized") return state;
       // Guard against cycles: dragging an item onto itself or onto one
       // of its descendants would write a parent chain that has no path
       // to root. `rebuildDfsOrder` walks from null and would produce []
@@ -245,6 +292,38 @@ export function editorReducer(
       if (action.value < deepestDepth(state.items)) return state;
       return { ...state, maxDepth: action.value, dirty: true };
     }
+    case "convertToCustom": {
+      const target = state.items.find((item) => item.key === action.key);
+      if (!target) return state;
+      if (target.meta.kind === "custom") return state;
+      // Seed `meta.url` with the last-known href so the user keeps
+      // the destination context — they can edit from there. Empty
+      // string when no snapshot exists; the user fixes it manually.
+      const lastHref = target.meta.lastHref ?? "";
+      const items = state.items.map((item) =>
+        item.key === action.key
+          ? { ...item, meta: { kind: "custom" as const, url: lastHref } }
+          : item,
+      );
+      return { ...state, items, dirty: true };
+    }
+    case "relinkItem": {
+      const target = state.items.find((item) => item.key === action.key);
+      if (!target) return state;
+      const items = state.items.map((item) =>
+        item.key === action.key ? { ...item, meta: action.newMeta } : item,
+      );
+      // Exiting re-link mode is part of "I picked a replacement"; UI
+      // doesn't have to issue a separate `cancelRelink` afterward.
+      return { ...state, items, relinkTargetKey: null, dirty: true };
+    }
+    case "startRelink": {
+      const target = state.items.find((item) => item.key === action.key);
+      if (!target) return state;
+      return { ...state, relinkTargetKey: action.key };
+    }
+    case "cancelRelink":
+      return { ...state, relinkTargetKey: null };
     case "addItem": {
       const rootSiblings = state.items.filter(
         (item) => item.parentKey === null,
@@ -260,6 +339,9 @@ export function editorReducer(
         sortOrder: lastRootSortOrder + 1,
         title: action.title,
         meta: action.meta,
+        state: "ok",
+        resolvedLabel:
+          action.title ?? labelFromMeta(action.meta) ?? "(unnamed)",
       };
       return {
         ...state,
@@ -380,6 +462,11 @@ function rebuildDfsOrder(items: readonly EditorItem[]): EditorItem[] {
   return out;
 }
 
+function labelFromMeta(meta: MenuItemMeta): string | null {
+  if (meta.kind === "custom") return meta.url || null;
+  return meta.lastLabel ?? null;
+}
+
 function flattenServerItems(rows: readonly ServerItemRow[]): EditorItem[] {
   const childrenByParent = new Map<number | null, ServerItemRow[]>();
   for (const row of rows) {
@@ -403,6 +490,9 @@ function flattenServerItems(rows: readonly ServerItemRow[]): EditorItem[] {
         sortOrder: row.sortOrder,
         title: row.title === "" ? null : row.title,
         meta: row.meta as unknown as MenuItemMeta,
+        state: row.resolved?.state ?? "ok",
+        resolvedLabel:
+          row.resolved?.label ?? (row.title === "" ? "(unnamed)" : row.title),
       });
       walk(row.id, key);
     }

--- a/packages/plugins/menu/src/admin/item-state.test.ts
+++ b/packages/plugins/menu/src/admin/item-state.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+
+import type { LookupResult } from "@plumix/core";
+
+import { mapItemState } from "./item-state.js";
+
+const customMeta = { kind: "custom" as const, url: "/" };
+const entryMeta = { kind: "entry" as const, entryId: 42 };
+const termMeta = { kind: "term" as const, termId: 7 };
+const lookup: LookupResult = {
+  id: "42",
+  label: "About",
+  cached: { href: "/about" },
+};
+
+describe("mapItemState", () => {
+  test("custom items are always ok regardless of lookup or capability", () => {
+    // Custom URL items don't reference an entity, so resolution and
+    // capability gates don't apply — they always render normally.
+    expect(
+      mapItemState({
+        meta: customMeta,
+        lookupResult: null,
+        canAccessKind: () => false,
+      }),
+    ).toBe("ok");
+  });
+
+  test("entry/term items with a successful lookup are ok", () => {
+    expect(
+      mapItemState({
+        meta: entryMeta,
+        lookupResult: lookup,
+        canAccessKind: () => true,
+      }),
+    ).toBe("ok");
+  });
+
+  test("entry/term items return broken when lookup is null", () => {
+    // Resolver returns null when the linked entry was trashed or the
+    // term was deleted. Admin keeps the item visible with a warning.
+    expect(
+      mapItemState({
+        meta: entryMeta,
+        lookupResult: null,
+        canAccessKind: () => true,
+      }),
+    ).toBe("broken");
+  });
+
+  test("entry/term items return unauthorized when the viewer can't access the kind", () => {
+    // Some adapters gate `list`/`resolve` behind a capability so lower-
+    // privilege roles can't enumerate them. The admin still surfaces
+    // these items but greys them out and disables destructive actions.
+    expect(
+      mapItemState({
+        meta: termMeta,
+        lookupResult: null,
+        canAccessKind: () => false,
+      }),
+    ).toBe("unauthorized");
+  });
+
+  test("unauthorized state is set without a lookup result (server is expected to skip the call)", () => {
+    // Resolver should NOT call the adapter for kinds the viewer can't
+    // access — that would round-trip data the response then leaks via
+    // `resolved.label`. mapItemState handles the post-skip case where
+    // lookupResult is null and canAccessKind is false: unauthorized.
+    expect(
+      mapItemState({
+        meta: termMeta,
+        lookupResult: null,
+        canAccessKind: () => false,
+      }),
+    ).toBe("unauthorized");
+  });
+
+  test("unauthorized takes precedence over a present lookup result", () => {
+    // Defense in depth: even if a lookup happened to return a value
+    // for an unauthorized kind, the admin should still treat it as
+    // unauthorized rather than leaking the resolved label.
+    expect(
+      mapItemState({
+        meta: entryMeta,
+        lookupResult: lookup,
+        canAccessKind: () => false,
+      }),
+    ).toBe("unauthorized");
+  });
+});

--- a/packages/plugins/menu/src/admin/item-state.ts
+++ b/packages/plugins/menu/src/admin/item-state.ts
@@ -1,0 +1,22 @@
+import type { LookupResult } from "@plumix/core";
+
+import type { MenuItemMeta } from "../server/types.js";
+
+export type ItemState = "ok" | "broken" | "unauthorized";
+
+interface ItemStateInput {
+  readonly meta: MenuItemMeta;
+  readonly lookupResult: LookupResult | null;
+  readonly canAccessKind: (kind: string) => boolean;
+}
+
+export function mapItemState(input: ItemStateInput): ItemState {
+  // Custom URL items are inert — no referenced entity, no adapter to
+  // gate, so they're always ok.
+  if (input.meta.kind === "custom") return "ok";
+  // Capability check trumps lookup outcome: a viewer who can't see
+  // the kind shouldn't ever see an "ok" label, even if the resolver
+  // happened to return one.
+  if (!input.canAccessKind(input.meta.kind)) return "unauthorized";
+  return input.lookupResult === null ? "broken" : "ok";
+}

--- a/packages/plugins/menu/src/admin/tree-state.test.ts
+++ b/packages/plugins/menu/src/admin/tree-state.test.ts
@@ -17,6 +17,8 @@ function row(
     sortOrder,
     title: key,
     meta: { kind: "custom", url: `/${key}` },
+    state: "ok",
+    resolvedLabel: key,
   };
 }
 

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -208,6 +208,94 @@ describe("menu RPC", () => {
       });
       await expect(h.client.menu.get({ termId: cat.id })).rejects.toThrow();
     });
+
+    test("returns each item with a per-item resolved.state — custom URLs are always ok", async () => {
+      // Slice 11: admin RPC enriches each item with state/label/href so
+      // the editor can render broken/unauthorized rows. Custom URL items
+      // never go through a lookup, so they resolve to ok with the meta
+      // url as href.
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "primary", "Primary");
+      const author = await adminUser
+        .transient({ db: h.db })
+        .create({ email: "menuowner@example.test" });
+      const item = await entryFactory.transient({ db: h.db }).create({
+        type: "menu_item",
+        title: "Contact",
+        slug: `mi-custom-${Date.now()}`,
+        status: "published",
+        authorId: author.id,
+        meta: { kind: "custom", url: "/contact" } as unknown as Record<
+          string,
+          unknown
+        >,
+      });
+      await entryTermFactory
+        .transient({ db: h.db })
+        .create({ entryId: item.id, termId: m.id, sortOrder: 0 });
+
+      const result = (await h.client.menu.get({ termId: m.id })) as {
+        items: readonly {
+          id: number;
+          resolved: {
+            state: string;
+            label: string;
+            href: string | null;
+          };
+        }[];
+      };
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.resolved).toEqual({
+        state: "ok",
+        label: "Contact",
+        href: "/contact",
+        lastHref: null,
+      });
+    });
+
+    test("entry-kind item pointing at a non-existent entry resolves to broken with last-known label", async () => {
+      // The entry adapter returns nothing for the dead id, so
+      // mapItemState sees a null lookup → broken. The admin still
+      // surfaces a label by falling through to `meta.lastLabel`
+      // (snapshot from the entry's last sync) rather than a numeric id.
+      const h = await buildHarness();
+      const m = await seedMenu(h.db, h.factories, "primary", "Primary");
+      const author = await adminUser
+        .transient({ db: h.db })
+        .create({ email: "broken@example.test" });
+      const item = await entryFactory.transient({ db: h.db }).create({
+        type: "menu_item",
+        title: "",
+        slug: `mi-broken-${Date.now()}`,
+        status: "published",
+        authorId: author.id,
+        meta: {
+          kind: "entry",
+          entryId: 99999,
+          lastLabel: "Old About",
+          lastHref: "/about-old",
+        } as unknown as Record<string, unknown>,
+      });
+      await entryTermFactory
+        .transient({ db: h.db })
+        .create({ entryId: item.id, termId: m.id, sortOrder: 0 });
+
+      const result = (await h.client.menu.get({ termId: m.id })) as {
+        items: readonly {
+          resolved: {
+            state: string;
+            label: string;
+            href: string | null;
+            lastHref: string | null;
+          };
+        }[];
+      };
+
+      expect(result.items[0]?.resolved.state).toBe("broken");
+      expect(result.items[0]?.resolved.label).toBe("Old About");
+      expect(result.items[0]?.resolved.lastHref).toBe("/about-old");
+    });
   });
 
   describe("menu.save", () => {

--- a/packages/plugins/menu/src/rpc.ts
+++ b/packages/plugins/menu/src/rpc.ts
@@ -15,8 +15,10 @@ import {
   terms,
 } from "@plumix/core";
 
+import type { ResolvedRow } from "./server/resolveItemStates.js";
 import { getEligibleMenuKinds } from "./server/eligibility.js";
 import { getRegisteredLocations } from "./server/locations.js";
+import { resolveItemStates } from "./server/resolveItemStates.js";
 import { flattenSaveItems, resolveParentIds } from "./server/save.js";
 import { sanitizeMenuHref } from "./server/url.js";
 
@@ -105,21 +107,13 @@ interface MenuListItem {
   readonly itemCount: number;
 }
 
-interface MenuItemRow {
-  readonly id: number;
-  readonly parentId: number | null;
-  readonly sortOrder: number;
-  readonly title: string;
-  readonly meta: Record<string, unknown>;
-}
-
 interface MenuGetResponse {
   readonly id: number;
   readonly slug: string;
   readonly name: string;
   readonly version: number;
   readonly maxDepth: number;
-  readonly items: readonly MenuItemRow[];
+  readonly items: readonly ResolvedRow[];
 }
 
 interface SaveResponse {
@@ -203,13 +197,14 @@ export function createMenuRouter(): Record<string, unknown> {
           ),
         )
         .orderBy(entries.parentId, entries.sortOrder, entries.id);
+      const items = await resolveItemStates(context, rows);
       return {
         id: term.id,
         slug: term.slug,
         name: term.name,
         version: term.version,
         maxDepth: readMaxDepth(term.meta),
-        items: rows,
+        items,
       };
     });
 

--- a/packages/plugins/menu/src/server/parseMeta.test.ts
+++ b/packages/plugins/menu/src/server/parseMeta.test.ts
@@ -30,6 +30,49 @@ describe("parseMenuItemMeta", () => {
     expect(parseMenuItemMeta({ kind: "term" })).toBeNull();
   });
 
+  test("preserves optional lastLabel/lastHref snapshots on entry/term kinds", () => {
+    // Survives source deletion: subscribers refresh these fields
+    // before the entry/term goes away so broken items can render
+    // their last-known label and seed `meta.url` on Convert-to-Custom.
+    expect(
+      parseMenuItemMeta({
+        kind: "entry",
+        entryId: 5,
+        lastLabel: "About",
+        lastHref: "/about",
+      }),
+    ).toEqual({
+      kind: "entry",
+      entryId: 5,
+      lastLabel: "About",
+      lastHref: "/about",
+    });
+    expect(
+      parseMenuItemMeta({
+        kind: "term",
+        termId: 9,
+        lastLabel: "Tag",
+        lastHref: "/tag/x",
+      }),
+    ).toEqual({
+      kind: "term",
+      termId: 9,
+      lastLabel: "Tag",
+      lastHref: "/tag/x",
+    });
+  });
+
+  test("drops invalid lastLabel/lastHref types", () => {
+    expect(
+      parseMenuItemMeta({
+        kind: "entry",
+        entryId: 5,
+        lastLabel: 42,
+        lastHref: { not: "string" },
+      }),
+    ).toEqual({ kind: "entry", entryId: 5 });
+  });
+
   test("rejects unknown kinds and bad shapes", () => {
     expect(parseMenuItemMeta(null)).toBeNull();
     expect(parseMenuItemMeta(undefined)).toBeNull();

--- a/packages/plugins/menu/src/server/parseMeta.ts
+++ b/packages/plugins/menu/src/server/parseMeta.ts
@@ -24,15 +24,39 @@ export function parseMenuItemMeta(raw: unknown): MenuItemMeta | null {
       if (typeof obj.entryId !== "number" || !Number.isFinite(obj.entryId)) {
         return null;
       }
-      return { kind: "entry", entryId: obj.entryId, ...display };
+      return {
+        kind: "entry",
+        entryId: obj.entryId,
+        ...parseSnapshot(obj),
+        ...display,
+      };
     case "term":
       if (typeof obj.termId !== "number" || !Number.isFinite(obj.termId)) {
         return null;
       }
-      return { kind: "term", termId: obj.termId, ...display };
+      return {
+        kind: "term",
+        termId: obj.termId,
+        ...parseSnapshot(obj),
+        ...display,
+      };
     default:
       return null;
   }
+}
+
+function parseSnapshot(obj: Record<string, unknown>): {
+  readonly lastLabel?: string;
+  readonly lastHref?: string;
+} {
+  const out: { lastLabel?: string; lastHref?: string } = {};
+  if (typeof obj.lastLabel === "string" && obj.lastLabel.length > 0) {
+    out.lastLabel = obj.lastLabel;
+  }
+  if (typeof obj.lastHref === "string" && obj.lastHref.length > 0) {
+    out.lastHref = obj.lastHref;
+  }
+  return out;
 }
 
 function parseDisplayAttrs(obj: Record<string, unknown>): MenuItemDisplayAttrs {

--- a/packages/plugins/menu/src/server/resolveItemStates.ts
+++ b/packages/plugins/menu/src/server/resolveItemStates.ts
@@ -1,0 +1,215 @@
+// Server-side admin resolver. Takes raw `entries` rows from a menu and
+// produces the `resolved` shape the admin renders — state (ok / broken /
+// unauthorized), display label, current href, and the last-known href
+// for "Convert to Custom URL" seeding.
+//
+// Distinct from `getMenuByName`'s render-side resolver: that one drops
+// broken items silently for public output. This one keeps them so the
+// editor can surface them with a warning + Re-link affordances.
+
+import type { AppContext, LookupResult } from "@plumix/core";
+
+import type { ItemState } from "../admin/item-state.js";
+import type { MenuItemMeta } from "./types.js";
+import { mapItemState } from "../admin/item-state.js";
+import { parseMenuItemMeta } from "./parseMeta.js";
+
+export interface MenuItemRow {
+  readonly id: number;
+  readonly parentId: number | null;
+  readonly sortOrder: number;
+  readonly title: string;
+  readonly meta: Record<string, unknown>;
+}
+
+export interface ResolvedRow extends MenuItemRow {
+  readonly resolved: {
+    readonly state: ItemState;
+    readonly label: string;
+    readonly href: string | null;
+    readonly lastHref: string | null;
+  };
+}
+
+export async function resolveItemStates(
+  ctx: AppContext,
+  rows: readonly MenuItemRow[],
+): Promise<ResolvedRow[]> {
+  if (rows.length === 0) return [];
+
+  const parsed = rows.map((row) => ({
+    row,
+    meta: parseMenuItemMeta(row.meta),
+  }));
+
+  // Batch lookups by kind so a 50-item menu hits each adapter once.
+  const idsByKind = new Map<string, Set<string>>();
+  for (const { meta } of parsed) {
+    if (!meta || meta.kind === "custom") continue;
+    const id = meta.kind === "entry" ? meta.entryId : meta.termId;
+    const set = idsByKind.get(meta.kind) ?? new Set<string>();
+    set.add(String(id));
+    idsByKind.set(meta.kind, set);
+  }
+
+  const eligibleEntryTypes = [...ctx.plugins.entryTypes.values()]
+    .filter((t) => (t.isShownInMenus ?? t.isPublic ?? true) === true)
+    .map((t) => t.name);
+  const eligibleTaxonomies = [...ctx.plugins.termTaxonomies.values()]
+    .filter((t) => (t.isShownInMenus ?? t.isPublic ?? true) === true)
+    .map((t) => t.name);
+
+  const canAccessKind = (kind: string): boolean => {
+    const adapter = ctx.plugins.lookupAdapters.get(kind);
+    if (!adapter) return false;
+    return adapter.capability === null
+      ? true
+      : ctx.auth.can(adapter.capability);
+  };
+
+  // Resolve all kinds in parallel. Each kind is independent — no need
+  // to serialize the round-trips.
+  const lookupsByKind = new Map<string, Map<string, LookupResult>>();
+  await Promise.all(
+    [...idsByKind.entries()].map(async ([kind, ids]) => {
+      const adapter = ctx.plugins.lookupAdapters.get(kind)?.adapter;
+      // Skip the adapter call when:
+      // 1. the adapter isn't registered at all,
+      // 2. the viewer lacks the adapter's capability — fetching would
+      //    leak labels into `resolved.label` for kinds they shouldn't
+      //    see (information disclosure),
+      // 3. the kind has no eligible types/taxonomies — no row could
+      //    possibly resolve, and some adapters reject empty scopes.
+      if (!adapter || !canAccessKind(kind)) {
+        lookupsByKind.set(kind, new Map());
+        return;
+      }
+      const built = buildScope(kind, eligibleEntryTypes, eligibleTaxonomies);
+      if (built.empty) {
+        lookupsByKind.set(kind, new Map());
+        return;
+      }
+      const results = await adapter.list(ctx, {
+        ids: [...ids],
+        scope: built.scope,
+      });
+      const byId = new Map<string, LookupResult>();
+      for (const result of results) byId.set(result.id, result);
+      lookupsByKind.set(kind, byId);
+    }),
+  );
+
+  return parsed.map(({ row, meta }) =>
+    enrich(row, meta, lookupsByKind, canAccessKind),
+  );
+}
+
+interface BuiltScope {
+  readonly scope: unknown;
+  readonly empty: boolean;
+}
+
+function buildScope(
+  kind: string,
+  entryTypes: readonly string[],
+  termTaxonomies: readonly string[],
+): BuiltScope {
+  // Returns scope + emptiness flag tied to the specific kind. Generic
+  // "any empty array" detection would over-skip if scope shapes ever
+  // grow optional array fields.
+  if (kind === "entry") {
+    return { scope: { entryTypes }, empty: entryTypes.length === 0 };
+  }
+  if (kind === "term") {
+    return {
+      scope: { termTaxonomies },
+      empty: termTaxonomies.length === 0,
+    };
+  }
+  return { scope: undefined, empty: false };
+}
+
+function enrich(
+  row: MenuItemRow,
+  meta: MenuItemMeta | null,
+  lookupsByKind: ReadonlyMap<string, ReadonlyMap<string, LookupResult>>,
+  canAccessKind: (kind: string) => boolean,
+): ResolvedRow {
+  if (!meta) {
+    // Garbage meta — treat as broken so the row still surfaces. The
+    // user can Convert-to-Custom or Remove it.
+    return {
+      ...row,
+      resolved: {
+        state: "broken",
+        label: row.title || "(unnamed)",
+        href: null,
+        lastHref: null,
+      },
+    };
+  }
+
+  if (meta.kind === "custom") {
+    return {
+      ...row,
+      resolved: {
+        state: "ok",
+        label: row.title || "(unnamed)",
+        href: meta.url,
+        lastHref: null,
+      },
+    };
+  }
+
+  const id = String(meta.kind === "entry" ? meta.entryId : meta.termId);
+  const lookupResult = lookupsByKind.get(meta.kind)?.get(id) ?? null;
+  const state = mapItemState({ meta, lookupResult, canAccessKind });
+
+  // Label preference: row.title (override) → resolver result → cached
+  // snapshot in meta → "(unnamed)". Same shape for href, minus the
+  // override (entries don't carry an href column).
+  const cached = (lookupResult?.cached ?? {}) as {
+    readonly label?: unknown;
+    readonly href?: unknown;
+  };
+  const resolverLabel =
+    typeof cached.label === "string" && cached.label.length > 0
+      ? cached.label
+      : (lookupResult?.label ?? null);
+  const resolverHref =
+    typeof cached.href === "string" && cached.href.length > 0
+      ? cached.href
+      : null;
+
+  const label =
+    (row.title.length > 0 ? row.title : null) ??
+    resolverLabel ??
+    meta.lastLabel ??
+    "(unnamed)";
+
+  return {
+    ...row,
+    resolved: {
+      state,
+      label,
+      href: hrefFor(state, resolverHref, meta.lastHref ?? null),
+      lastHref: meta.lastHref ?? null,
+    },
+  };
+}
+
+function hrefFor(
+  state: ItemState,
+  resolverHref: string | null,
+  lastHref: string | null,
+): string | null {
+  // Per-state intent:
+  // - ok:           current resolved href, falling back to last-known.
+  // - broken:       last-known only — Convert-to-Custom seeds the editor.
+  // - unauthorized: null. Defense in depth — even if lookup leaked
+  //                 through, we don't surface a current href the
+  //                 viewer wasn't supposed to see.
+  if (state === "ok") return resolverHref ?? lastHref;
+  if (state === "broken") return lastHref;
+  return null;
+}

--- a/packages/plugins/menu/src/server/types.ts
+++ b/packages/plugins/menu/src/server/types.ts
@@ -22,11 +22,22 @@ export interface MenuItemCustomMeta extends MenuItemDisplayAttrs {
 export interface MenuItemEntryMeta extends MenuItemDisplayAttrs {
   readonly kind: "entry";
   readonly entryId: number;
+  /**
+   * Snapshot of the linked entry's label/href at last sync (entered on
+   * save and refreshed by the `entry:trashed` subscriber). Survives
+   * source deletion so the admin can render broken items with their
+   * last-known label and "Convert to Custom URL" can seed `meta.url`.
+   */
+  readonly lastLabel?: string;
+  readonly lastHref?: string;
 }
 
 export interface MenuItemTermMeta extends MenuItemDisplayAttrs {
   readonly kind: "term";
   readonly termId: number;
+  /** See `MenuItemEntryMeta.lastLabel` / `lastHref`. */
+  readonly lastLabel?: string;
+  readonly lastHref?: string;
 }
 
 /**


### PR DESCRIPTION
Surfaces broken/unauthorized linked items in the menu admin so editors
can repair them in place — instead of silently dropping the row the
way the public render path does. A trashed page still appears in the
admin tree with its last-known label, a warning icon, and inline
**Re-link…** / **Convert to Custom URL** affordances.

The render-side resolver is unchanged: broken items continue to drop
silently for public output (slice 2 contract verified by the new
resolver tests).

## How it fits together

- `admin/item-state.ts` — the pure mapper. Takes
  `(meta, lookupResult, canAccessKind)` and returns
  `'ok' | 'broken' | 'unauthorized'`. Tested in isolation.
- `server/resolveItemStates.ts` — the admin-side enricher used by
  `menu.get`. Per-row `{ state, label, href, lastHref }`. Lookups
  batch by kind via `adapter.list({ ids, scope })`. Two important
  guards:
  - The capability check fires *before* `adapter.list` — viewers who
    lack a kind's capability never round-trip through it. Without
    this, `resolved.label` would leak the resolver's response for
    kinds the viewer can't see, which becomes load-bearing the
    moment a plugin-contributed adapter with a non-null capability
    lands.
  - `hrefFor` is per-state: `ok` returns the resolved href falling
    back to `lastHref`; `broken` returns `lastHref` only (so
    Convert-to-Custom-URL has data to seed `meta.url`);
    `unauthorized` always returns `null` as defense in depth.
- All kinds resolve in parallel via `Promise.all` so a menu with
  both entry and term refs makes one round-trip per kind, not
  serially.

## Cached snapshots in `meta`

`MenuItemEntryMeta` / `MenuItemTermMeta` gain optional `lastLabel` /
`lastHref`. `entries.meta` is JSON, so no migration is required.
`parseMenuItemMeta` admits both as strings only.

## Editor reducer + UI

- `EditorItem` carries `state` and `resolvedLabel` from the server.
- New actions: `convertToCustom`, `relinkItem`, `startRelink`,
  `cancelRelink`. Re-link mode lives on a new `relinkTargetKey`
  field.
- `removeItem` clears `relinkTargetKey` when the targeted row (or
  any descendant) is removed — otherwise the picker would re-link a
  phantom.
- `moveItem` rejects when the target is `unauthorized`. Stacks with
  the UI omitting dnd-kit listeners on the drag handle for those
  rows: either layer alone defends, both together is correct
  paranoia for a user role that shouldn't reorder.
- `ItemsPicker` shows a re-link banner with the broken item's
  last-known label and a Cancel button. `CustomUrlPickerPanel`'s
  primary action becomes "Replace link" in re-link mode and
  dispatches `relinkItem` instead of `addItem`.

## Deferred

`entry:trashed` / `term:deleted` subscribers (the snapshot-on-delete
refresh) are out of scope. Plumix's action handlers don't currently
carry an `AppContext` — the runtime uses `requestStore.run(appCtx)`
in the cloudflare adapter but the test harness doesn't, so a
subscriber that needs DB access can't be tested in isolation today.
Acceptance is met without the subscriber: the lookup adapter returns
no result for trashed entries, so `resolveItemStates` produces
`state: 'broken'` regardless. The subscriber would only refresh
stale `meta.lastLabel` / `meta.lastHref` snapshots, and since save-
time snapshotting (slice 9.5+ when the entry/term picker panels
land) is the primary mechanism, this is a follow-up rather than a
gap.

## Notes for review

- The `unauthorized` path is currently unreachable with core's
  fixtures because both `entry` and `term` adapters register with
  `capability: null`. Tests cover the pure mapper directly. A
  follow-up worth filing: register a stub adapter in the test
  harness with a non-null capability and assert
  `resolveItemStates` skips its `list` call for an under-privileged
  viewer.
- The warning icon could use `role=\"img\"` for screen-reader
  announcement; currently a `<span aria-label>` which isn't read.
  Non-blocking a11y polish.

Fixes #167