### PR TITLE
feat(core): extendAppContext plugin API for runtime context augmentation

### DIFF
--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -45,7 +45,19 @@ export interface AuthNamespace {
 
 export type AfterResponse = (promise: Promise<unknown>) => void;
 
-export interface AppContext<
+/**
+ * Declaration-merge target for plugin-contributed AppContext helpers.
+ * `extendAppContext(key, value)` registers an entry; the dispatcher
+ * merges entries onto each per-request `AppContext` so handlers (RPC,
+ * route, hook listeners) read them via `ctx.<key>`.
+ *
+ * Empty by default — plugins augment via TypeScript module merging,
+ * mirroring `PluginContextExtensions` / `ThemeContextExtensions`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface AppContextExtensions {}
+
+export interface AppContextBase<
   TSchema extends Record<string, unknown> = CoreSchema,
 > {
   readonly db: Db<TSchema>;
@@ -149,6 +161,9 @@ export interface AppContext<
   resolvedEntity: ResolvedEntity | null;
 }
 
+export type AppContext<TSchema extends Record<string, unknown> = CoreSchema> =
+  AppContextBase<TSchema> & AppContextExtensions;
+
 export type AuthenticatedAppContext<
   TSchema extends Record<string, unknown> = CoreSchema,
 > = Omit<AppContext<TSchema>, "user"> & {
@@ -174,6 +189,16 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly oauthProviders?: readonly OAuthProviderSummary[];
   readonly authenticator?: RequestAuthenticator;
   readonly bootstrapAllowed?: boolean;
+  /**
+   * Plugin-contributed `extendAppContext` entries — usually piped
+   * directly from `installPlugins(...).appContextExtensions`. Each
+   * entry's `value` lands at `ctx[key]` so handlers and hook
+   * listeners read them as `ctx.<key>`.
+   */
+  readonly appContextExtensions?: ReadonlyMap<
+    string,
+    { readonly value: unknown }
+  >;
 }
 
 const dropPromise: AfterResponse = () => undefined;
@@ -201,7 +226,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
   const resolver = createCapabilityResolver(args.plugins);
   const user = args.user ?? null;
   const tokenScopes = args.tokenScopes ?? null;
-  return {
+  const base: AppContextBase<TSchema> = {
     db: args.db,
     env: args.env,
     request: args.request,
@@ -229,6 +254,29 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     origin: args.origin ?? new URL(args.request.url).origin,
     siteName: args.siteName,
   };
+  // Spread plugin-contributed entries onto the base. The cast is the
+  // unavoidable seam between an open `Record`-of-unknown registry and
+  // the `AppContextExtensions` declaration-merge type — plugin authors
+  // augment the latter, the dispatcher feeds the former.
+  if (args.appContextExtensions !== undefined) {
+    const target = base as unknown as Record<string, unknown>;
+    for (const [key, entry] of args.appContextExtensions) {
+      // Defense in depth — `extendAppContext` already rejects these at
+      // registration time. Throwing here means a malformed map (built
+      // by a test or dev tool that bypasses the registration guard)
+      // fails fast on the first request rather than silently
+      // corrupting `db` / `auth` / etc. for the rest of the process.
+      if (key in target) {
+        throw new Error(
+          `appContextExtensions entry "${key}" shadows a built-in ` +
+            `AppContext field. Reserve plugin-scoped names; built-in ` +
+            `members like \`db\` and \`auth\` aren't extendable.`,
+        );
+      }
+      target[key] = entry.value;
+    }
+  }
+  return base as AppContext<TSchema>;
 }
 
 export function withUser<TSchema extends Record<string, unknown>>(

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -1,5 +1,5 @@
 import type { DerivedCapability } from "../auth/rbac.js";
-import type { AppContext } from "../context/app.js";
+import type { AppContext, AppContextExtensions } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { HookRegistry } from "../hooks/registry.js";
 import type {
@@ -60,6 +60,16 @@ export interface PluginProvidesContext {
   extendThemeContext<TKey extends keyof ThemeContextExtensions>(
     key: TKey,
     value: ThemeContextExtensions[TKey],
+  ): void;
+  /**
+   * Register a runtime helper on every per-request `AppContext`. Reads
+   * are typed via the `AppContextExtensions` declaration-merge target —
+   * a plugin augments it once and `ctx.<key>` is autocompleted in
+   * every RPC/route/hook handler. Duplicate keys throw.
+   */
+  extendAppContext<TKey extends keyof AppContextExtensions>(
+    key: TKey,
+    value: AppContextExtensions[TKey],
   ): void;
 }
 
@@ -218,16 +228,55 @@ interface CreateProvidesContextArgs {
   readonly pluginId: string;
   readonly pluginExtensions: Map<string, ContextExtensionEntry>;
   readonly themeExtensions: Map<string, ContextExtensionEntry>;
+  readonly appExtensions: Map<string, ContextExtensionEntry>;
 }
+
+// Names that would corrupt the per-request `AppContext` if a plugin
+// tried to register them. `__proto__` triggers the Object.prototype
+// setter and reparents the ctx; `constructor` / `prototype` shadow
+// inherited members and confuse downstream introspection.
+const RESERVED_EXTENSION_KEYS: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+// Built-in `AppContextBase` members. extendAppContext rejects these so
+// a plugin can't silently replace `db`, `auth`, etc. at request time.
+// Mirrors the `key in target` shadow check `extendPluginContext`
+// runs against the constructed PluginSetupContext at install.
+const APP_CONTEXT_BASE_KEYS: ReadonlySet<string> = new Set([
+  "db",
+  "env",
+  "request",
+  "user",
+  "tokenScopes",
+  "hooks",
+  "plugins",
+  "logger",
+  "auth",
+  "authenticator",
+  "bootstrapAllowed",
+  "oauthProviders",
+  "after",
+  "assets",
+  "storage",
+  "imageDelivery",
+  "mailer",
+  "origin",
+  "siteName",
+  "resolvedEntity",
+]);
 
 export function createPluginProvidesContext({
   pluginId,
   pluginExtensions,
   themeExtensions,
+  appExtensions,
 }: CreateProvidesContextArgs): PluginProvidesContext {
   const stash = (
     target: Map<string, ContextExtensionEntry>,
-    kind: "Plugin" | "Theme",
+    kind: "Plugin" | "Theme" | "App",
     key: string,
     value: unknown,
   ): void => {
@@ -235,6 +284,22 @@ export function createPluginProvidesContext({
       throw new Error(
         `Plugin "${pluginId}" called extend${kind}Context with an ` +
           `invalid key — must be a non-empty string.`,
+      );
+    }
+    if (RESERVED_EXTENSION_KEYS.has(key)) {
+      throw new Error(
+        `Plugin "${pluginId}" called extend${kind}Context with the ` +
+          `reserved name "${key}". JS-builtins (\`__proto__\`, ` +
+          `\`constructor\`, \`prototype\`) can't be used as extension ` +
+          `keys — they would corrupt the per-request context object.`,
+      );
+    }
+    if (kind === "App" && APP_CONTEXT_BASE_KEYS.has(key)) {
+      throw new Error(
+        `Plugin "${pluginId}" called extendAppContext with "${key}", ` +
+          `which collides with a built-in AppContext member. The ` +
+          `dispatcher would overwrite the runtime field on every ` +
+          `request — rename the extension to a plugin-scoped key.`,
       );
     }
     const existing = target.get(key);
@@ -255,6 +320,9 @@ export function createPluginProvidesContext({
     },
     extendThemeContext: (key, value) => {
       stash(themeExtensions, "Theme", key, value);
+    },
+    extendAppContext: (key, value) => {
+      stash(appExtensions, "App", key, value);
     },
   };
 }

--- a/packages/core/src/plugin/provides.test.ts
+++ b/packages/core/src/plugin/provides.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
 
+import type { AppContext } from "../context/app.js";
+import { createAppContext } from "../context/app.js";
+import { getContext, requestStore } from "../context/stores.js";
 import { HookRegistry } from "../hooks/registry.js";
 import { definePlugin } from "./define.js";
 import { installPlugins } from "./register.js";
@@ -13,6 +16,13 @@ declare module "./context.js" {
   }
   interface ThemeContextExtensions {
     registerMenuLocation(id: string, opts: { readonly label: string }): void;
+  }
+}
+
+declare module "../context/app.js" {
+  interface AppContextExtensions {
+    audit: { readonly log: (message: string) => void };
+    metrics: { readonly inc: (name: string) => void };
   }
 }
 
@@ -169,6 +179,234 @@ describe("provides phase", () => {
     ).rejects.toThrow(
       /Plugin "b" extended.*"registerMenuLocation".*"a" already registered/s,
     );
+  });
+
+  test("app-context extensions are collected and surfaced on the install result", async () => {
+    // Slice 11 deferred subscribers because action handlers couldn't
+    // reach AppContext from the test harness; this opens the door —
+    // a plugin registers a helper, the install result hands it to the
+    // dispatcher, the dispatcher merges it into each per-request ctx.
+    const audit = definePlugin("audit", {
+      provides: (ctx) => {
+        ctx.extendAppContext("audit", {
+          log: (message: string) => `logged:${message}`,
+        });
+      },
+      setup: () => undefined,
+    });
+
+    const result = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [audit],
+    });
+
+    const entry = result.appContextExtensions.get("audit");
+    expect(entry?.pluginId).toBe("audit");
+    expect(typeof entry?.value).toBe("object");
+  });
+
+  test("createAppContext merges install-result app extensions onto ctx", async () => {
+    // Surface contract: a plugin's extendAppContext entry shows up at
+    // `ctx.<key>` after installPlugins → createAppContext. This is what
+    // RPC handlers, route handlers, and (cycle 4) hook listeners read.
+    const audit = definePlugin("audit", {
+      provides: (ctx) => {
+        ctx.extendAppContext("audit", {
+          log: (m: string) => `audit:${m}`,
+        });
+      },
+      setup: () => undefined,
+    });
+
+    const result = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [audit],
+    });
+
+    // Stub Db typed as the default CoreSchema so AppContext doesn't
+    // resolve to a non-default generic that breaks requestStore.run().
+    const stubDb = {} as Parameters<typeof createAppContext>[0]["db"];
+    const ctx = createAppContext({
+      db: stubDb,
+      env: {},
+      request: new Request("https://x.example/"),
+      hooks: result.hooks,
+      plugins: result.registry,
+      appContextExtensions: result.appContextExtensions,
+    });
+
+    expect(ctx.audit.log("hello")).toBe("audit:hello");
+  });
+
+  test("createAppContext refuses to overwrite a base field via a malformed extensions map", () => {
+    // Belt-and-braces: even when the registration-time guard is bypassed
+    // (a test or dev tool builds an extensions map by hand), the
+    // dispatcher won't let an entry shadow `db` etc. on the per-request
+    // ctx — fail fast rather than silently corrupt every request.
+    const stubDb = {} as Parameters<typeof createAppContext>[0]["db"];
+    const malformed = new Map<string, { readonly value: unknown }>([
+      ["db", { value: { broken: true } }],
+    ]);
+
+    expect(() =>
+      createAppContext({
+        db: stubDb,
+        env: {},
+        request: new Request("https://x.example/"),
+        hooks: new HookRegistry(),
+        plugins: { entryTypes: new Map() } as never,
+        appContextExtensions: malformed,
+      }),
+    ).toThrow(/"db".*built-in AppContext field/);
+  });
+
+  test("two plugins extending different app-context keys both land on ctx", async () => {
+    const audit = definePlugin("audit", {
+      provides: (ctx) => {
+        ctx.extendAppContext("audit", { log: () => "audit-ok" });
+      },
+      setup: () => undefined,
+    });
+    const metrics = definePlugin("metrics", {
+      provides: (ctx) => {
+        ctx.extendAppContext("metrics", { inc: () => undefined });
+      },
+      setup: () => undefined,
+    });
+
+    const result = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [audit, metrics],
+    });
+
+    // Stub Db typed as the default CoreSchema so AppContext doesn't
+    // resolve to a non-default generic that breaks requestStore.run().
+    const stubDb = {} as Parameters<typeof createAppContext>[0]["db"];
+    const ctx = createAppContext({
+      db: stubDb,
+      env: {},
+      request: new Request("https://x.example/"),
+      hooks: result.hooks,
+      plugins: result.registry,
+      appContextExtensions: result.appContextExtensions,
+    });
+
+    expect(ctx.audit.log("x")).toBe("audit-ok");
+    expect(typeof ctx.metrics.inc).toBe("function");
+  });
+
+  test("hook listener reads extensions via requestStore.getStore() at fire-time", async () => {
+    // The motivating use case from slice 11 deferred subscribers: a
+    // plugin's `addAction` listener can't take an AppContext arg
+    // because the action signature is fixed, so it pulls ctx out of
+    // the requestStore. Once that ctx carries plugin-contributed
+    // extensions, the listener gets cross-plugin helpers for free.
+    const captured: string[] = [];
+
+    const auditProvider = definePlugin("audit", {
+      provides: (ctx) => {
+        ctx.extendAppContext("audit", {
+          log: (m: string) => {
+            captured.push(m);
+          },
+        });
+      },
+      setup: () => undefined,
+    });
+
+    const consumer = definePlugin("consumer", {
+      setup: (ctx) => {
+        ctx.registerAction("ping", () => {
+          getContext().audit.log("from-listener");
+        });
+      },
+    });
+
+    const result = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [auditProvider, consumer],
+    });
+
+    // Stub Db typed as the default CoreSchema so AppContext doesn't
+    // resolve to a non-default generic that breaks requestStore.run().
+    const stubDb = {} as Parameters<typeof createAppContext>[0]["db"];
+    const ctx = createAppContext({
+      db: stubDb,
+      env: {},
+      request: new Request("https://x.example/"),
+      hooks: result.hooks,
+      plugins: result.registry,
+      appContextExtensions: result.appContextExtensions,
+    });
+
+    // The hook is registered as a plugin-prefixed dynamic action — its
+    // name isn't in the ActionRegistry, so loosen the call type.
+    const doAction = (name: string): Promise<void> =>
+      (result.hooks.doAction as (name: string) => Promise<void>)(name);
+    await requestStore.run(ctx as AppContext, async () => {
+      await doAction("consumer:ping");
+    });
+
+    expect(captured).toEqual(["from-listener"]);
+  });
+
+  test("extending with a key that shadows a built-in AppContext field throws", async () => {
+    // Without this guard, a plugin calling extendAppContext("db", ...)
+    // would silently overwrite the real database connection on every
+    // request — same hazard the extendPluginContext shadow check
+    // already protects against for setup-time members.
+    const evil = definePlugin("evil", {
+      provides: (ctx) => {
+        (
+          ctx.extendAppContext as unknown as (
+            key: string,
+            value: unknown,
+          ) => void
+        )("db", { broken: true });
+      },
+      setup: () => undefined,
+    });
+
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [evil] }),
+    ).rejects.toThrow(/"db".*collides with a built-in AppContext member/s);
+  });
+
+  test("extending with a reserved name like __proto__ throws (no prototype pollution)", async () => {
+    const evil = definePlugin("evil", {
+      provides: (ctx) => {
+        (
+          ctx.extendAppContext as unknown as (
+            key: string,
+            value: unknown,
+          ) => void
+        )("__proto__", { polluted: true });
+      },
+      setup: () => undefined,
+    });
+
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [evil] }),
+    ).rejects.toThrow(/reserved name "__proto__"/);
+  });
+
+  test("two plugins extending the same app-context key throw with both ids", async () => {
+    const a = definePlugin("a", {
+      provides: (ctx) => {
+        ctx.extendAppContext("audit", { log: () => undefined });
+      },
+      setup: () => undefined,
+    });
+    const b = definePlugin("b", {
+      provides: (ctx) => {
+        ctx.extendAppContext("audit", { log: () => undefined });
+      },
+      setup: () => undefined,
+    });
+
+    await expect(
+      installPlugins({ hooks: new HookRegistry(), plugins: [a, b] }),
+    ).rejects.toThrow(/Plugin "b" extended.*"audit".*"a" already registered/s);
   });
 
   test("plugin without provides still installs (back-compat)", async () => {

--- a/packages/core/src/plugin/register.ts
+++ b/packages/core/src/plugin/register.ts
@@ -13,6 +13,14 @@ export interface PluginInstallResult {
   readonly hooks: HookRegistry;
   readonly registry: PluginRegistry;
   readonly themeExtensions: ReadonlyMap<string, ContextExtensionEntry>;
+  /**
+   * Plugin-contributed AppContext helpers from
+   * `provides(ctx).extendAppContext(...)`. Runtime adapters merge these
+   * onto each per-request `AppContext` so any handler — RPC, route,
+   * scheduled, or hook listener via `requestStore.getStore()` — reads
+   * them as `ctx.<key>`.
+   */
+  readonly appContextExtensions: ReadonlyMap<string, ContextExtensionEntry>;
 }
 
 interface InstallPluginsArgs {
@@ -41,12 +49,14 @@ export async function installPlugins({
 
   const pluginExtensions = new Map<string, ContextExtensionEntry>();
   const themeExtensions = new Map<string, ContextExtensionEntry>();
+  const appContextExtensions = new Map<string, ContextExtensionEntry>();
   for (const descriptor of plugins) {
     if (!descriptor.provides) continue;
     const providesCtx = createPluginProvidesContext({
       pluginId: descriptor.id,
       pluginExtensions,
       themeExtensions,
+      appExtensions: appContextExtensions,
     });
     await descriptor.provides(providesCtx);
   }
@@ -66,5 +76,5 @@ export async function installPlugins({
     await descriptor.setup(ctx, undefined);
   }
 
-  return { hooks, registry, themeExtensions };
+  return { hooks, registry, themeExtensions, appContextExtensions };
 }

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -76,17 +76,24 @@ export interface PlumixApp {
   readonly routeMap: readonly RouteRule[];
   readonly rawRoutes: readonly RegisteredRawRoute[];
   readonly capabilityResolver: CapabilityResolver;
+  /**
+   * Plugin-contributed AppContext entries from `extendAppContext`.
+   * Runtime adapters spread these onto every per-request `AppContext`
+   * via `createAppContext({ appContextExtensions })`.
+   */
+  readonly appContextExtensions: ReadonlyMap<string, ContextExtensionEntry>;
 }
 
 export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   const hooks = new HookRegistry();
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
-  const { registry, themeExtensions } = await installPlugins({
-    hooks,
-    plugins: config.plugins,
-    registry: seededRegistry,
-  });
+  const { registry, themeExtensions, appContextExtensions } =
+    await installPlugins({
+      hooks,
+      plugins: config.plugins,
+      registry: seededRegistry,
+    });
 
   // Themes run after plugins so plugins' `provides` callbacks have already
   // populated `themeExtensions`. Each theme's setup runs in declared
@@ -166,6 +173,7 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     routeMap: compileRouteMap(registry),
     rawRoutes: registry.rawRoutes,
     capabilityResolver: createCapabilityResolver(registry),
+    appContextExtensions,
   };
 }
 

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -218,6 +218,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
         bootstrapAllowed: app.bootstrapAllowed,
         origin: app.origin,
         siteName: app.config.auth.magicLink?.siteName,
+        appContextExtensions: app.appContextExtensions,
       });
       const response = await requestStore.run(appCtx, () => dispatcher(appCtx));
       return finalize(response);


### PR DESCRIPTION
Adds the third member of the plugin context-extension family. Setup-time
already has `extendPluginContext`; frontend render has `extendThemeContext`;
this PR closes the gap with `extendAppContext(key, value)` so plugins can
register helpers on every per-request `AppContext`. Reads are typed via a
new `AppContextExtensions` declaration-merge target so handlers get
autocomplete on `ctx.<key>` from any RPC procedure, route handler, or
hook listener.

## Why now

Slice 11 shipped with a deferred subscriber: an `addAction("entry:trashed", …)`
listener can't take an `AppContext` argument because the action signature
is fixed, so it has to pull ctx out of `requestStore`. With this primitive
in place that ctx now carries cross-plugin helpers too — a plugin's
listener can call `getContext().audit.log(...)` without cross-plugin
imports. This is the prerequisite for the audit-log, analytics, and
error-reporting plugins called out in #175.

## How the wiring fits together

- `PluginProvidesContext.extendAppContext(key, value)` registers in a
  new map alongside `pluginExtensions` / `themeExtensions` during the
  provides phase.
- `installPlugins(...)` returns `appContextExtensions` on its result.
- `buildApp` surfaces it on `PlumixApp.appContextExtensions`.
- The cloudflare adapter passes that map to `createAppContext` per
  request; the spread loop assigns each entry onto the returned ctx.
- `AppContext` is now `AppContextBase & AppContextExtensions` so the
  typed plugin keys flow through to every consumer without per-call
  generics.

## Defensive guards

A plugin sidestepping TS via cast could otherwise register dangerous
keys, so two layers reject them:

- **Reserved JS names** (`__proto__`, `constructor`, `prototype`).
  `__proto__` is the load-bearing one — its `Object.prototype` setter
  reparents the per-request ctx. Caught in the shared `stash` helper
  for all three `extend*Context` kinds.
- **`AppContextBase` field names** (`db`, `auth`, `request`, `hooks`,
  …). Without this guard `extendAppContext(\"db\", evilDb)` would
  silently overwrite the real database connection on every request.
  Fails at boot rather than first request.

A `key in target` check in `createAppContext` is belt-and-braces — a
malformed map built by a test or dev tool that bypasses the
registration guard fails loudly on the first request instead of
silently corrupting ctx.

## Notes for review

- `APP_CONTEXT_BASE_KEYS` is a hand-maintained Set in
  `packages/core/src/plugin/context.ts`. A future field added to
  `AppContextBase` needs a matching entry there. A unit test that
  builds a sample ctx and asserts every own-key appears in the Set
  would catch drift; worth a follow-up.
- Asymmetric defense: registration rejects \"reserved JS names\" +
  \"base-context fields\"; `createAppContext`'s `key in target`
  additionally rejects inherited `Object.prototype` methods like
  `toString`. So `extendAppContext(\"toString\", ...)` would succeed
  at boot and crash the first request — fail-loud, but the boot path
  could be tightened to match. Cosmetic.

Fixes #176