### PR TITLE
feat(core): Validate references inside repeater rows

### DIFF
--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -139,7 +139,7 @@ function runSanitize(
     // but loses the underlying stack. Log it before translating so
     // server logs preserve the diagnostic trail.
     console.error(
-      `[plumix] sanitize callback for meta key "${key}" threw:`,
+      `[plumix] sanitize callback for meta key ${JSON.stringify(key)} threw:`,
       error,
     );
     throw new MetaSanitizationError(key, "invalid_value");
@@ -194,20 +194,48 @@ export async function validateMetaReferences(
   for (const [key, value] of patch.upserts) {
     const field = findField(key);
     const target = referenceTargetOf(field);
-    if (!target) continue;
-    const registered = ctx.plugins.lookupAdapters.get(target.kind);
-    if (!registered) {
-      throw new MetaSanitizationError(key, "invalid_value");
+    if (target) {
+      const registered = ctx.plugins.lookupAdapters.get(target.kind);
+      if (!registered) {
+        throw new MetaSanitizationError(key, "invalid_value");
+      }
+      const ids = referenceIdsForValidation(
+        key,
+        value,
+        target,
+        fieldMax(field),
+      );
+      const group = upsertGroup(groups, target, registered);
+      for (const id of ids) group.ids.add(id);
+      group.contributions.push({
+        errorKey: key,
+        ids,
+        applyNormalize: (rowsById) => {
+          if (target.valueShape !== "object") return;
+          if (target.multiple) {
+            patch.upserts.set(
+              key,
+              ids.map((id) => buildCachedReference(id, rowsById)),
+            );
+            return;
+          }
+          const [singleId] = ids;
+          if (singleId !== undefined) {
+            patch.upserts.set(key, buildCachedReference(singleId, rowsById));
+          }
+        },
+      });
+      continue;
     }
-    const ids = referenceIdsForValidation(key, value, target, fieldMax(field));
-    const groupKey = referenceGroupKey(target);
-    let group = groups.get(groupKey);
-    if (!group) {
-      group = { registered, scope: target.scope, ids: new Set(), keys: [] };
-      groups.set(groupKey, group);
-    }
-    for (const id of ids) group.ids.add(id);
-    group.keys.push({ key, ids, target });
+    // Repeater fields don't carry a `referenceTarget` themselves but
+    // their rows can. Walk into rows so nested `entry` / `term` /
+    // `user` / `media` refs flow through the same `(kind, scope)`
+    // batch as top-level fields. Errors attribute to the top-level
+    // repeater key — the row index + subKey live in the developer
+    // log, not the wire response (per slice acceptance).
+    if (!isRepeaterField(field)) continue;
+    if (!Array.isArray(value)) continue;
+    collectRepeaterReferences(ctx, key, field, value, groups);
   }
   for (const group of groups.values()) {
     if (group.ids.size === 0) continue;
@@ -219,31 +247,122 @@ export async function validateMetaReferences(
       "validateMetaReferences",
     );
     const rowsById = new Map(liveRows.map((r) => [r.id, r]));
-    for (const upsert of group.keys) {
-      for (const id of upsert.ids) {
+    for (const contribution of group.contributions) {
+      for (const id of contribution.ids) {
         if (!rowsById.has(id)) {
-          throw new MetaSanitizationError(upsert.key, "invalid_value");
+          if (contribution.diagnostic !== undefined) {
+            // Wire error keys on the top-level field; this log line
+            // is the only place the row index + subKey surface, so
+            // an engineer debugging a `meta_invalid_value` on a
+            // repeater can locate the offending subField without
+            // bisecting the saved bag. `JSON.stringify(id)` escapes
+            // control characters so a user-supplied id with newlines
+            // can't poison the log stream.
+            console.error(
+              `[plumix] meta repeater ${JSON.stringify(contribution.errorKey)} ` +
+                `row ${String(contribution.diagnostic.rowIdx)} ` +
+                `subField ${JSON.stringify(contribution.diagnostic.subKey)} ` +
+                `references missing id ${JSON.stringify(id)}`,
+            );
+          }
+          throw new MetaSanitizationError(
+            contribution.errorKey,
+            "invalid_value",
+          );
         }
       }
-      // Cached-object normalize step: replace user-supplied value
-      // with `{ id, ...adapterRow.cached }` (single) or an array
-      // thereof (multi). Adapter is authoritative for cached fields
-      // (mime/filename); user-supplied non-id keys are dropped to
-      // prevent spoofed metadata.
-      if (upsert.target.valueShape !== "object") continue;
-      if (upsert.target.multiple) {
-        patch.upserts.set(
-          upsert.key,
-          upsert.ids.map((id) => buildCachedReference(id, rowsById)),
-        );
-        continue;
-      }
-      const [id] = upsert.ids;
-      if (id !== undefined) {
-        patch.upserts.set(upsert.key, buildCachedReference(id, rowsById));
-      }
+      contribution.applyNormalize(rowsById);
     }
   }
+}
+
+interface RepeaterFieldShape {
+  readonly inputType: "repeater";
+  readonly subFields: readonly MetaBoxField[];
+}
+
+function isRepeaterField(
+  field: MetaBoxField | undefined,
+): field is MetaBoxField & RepeaterFieldShape {
+  if (!field) return false;
+  return (field as { readonly inputType?: unknown }).inputType === "repeater";
+}
+
+function collectRepeaterReferences(
+  ctx: AppContext,
+  topKey: string,
+  field: MetaBoxField & RepeaterFieldShape,
+  rows: readonly unknown[],
+  groups: Map<string, ReferenceGroup>,
+): void {
+  // Nested repeaters are rejected at registration by `repeater()`, so
+  // any subField that's itself a repeater wouldn't get here in
+  // practice. We don't recurse into subField repeaters either way —
+  // single-source-of-truth on the registration guard.
+  for (const [rowIdx, row] of rows.entries()) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) continue;
+    const rowObj = row as Record<string, unknown>;
+    for (const subField of field.subFields) {
+      const target = referenceTargetOf(subField);
+      if (!target) continue;
+      const subValue = rowObj[subField.key];
+      if (subValue === undefined || subValue === null) continue;
+      const registered = ctx.plugins.lookupAdapters.get(target.kind);
+      if (!registered) {
+        throw new MetaSanitizationError(topKey, "invalid_value");
+      }
+      const ids = referenceIdsForValidation(
+        topKey,
+        subValue,
+        target,
+        fieldMax(subField),
+      );
+      const group = upsertGroup(groups, target, registered);
+      for (const id of ids) group.ids.add(id);
+      const subKey = subField.key;
+      group.contributions.push({
+        errorKey: topKey,
+        ids,
+        diagnostic: { rowIdx, subKey },
+        applyNormalize: (rowsById) => {
+          if (target.valueShape !== "object") return;
+          // Rewrite the row's cached-object value in place — the
+          // top-level upsert array is the live storage shape, so
+          // mutating an object inside it is what the caller will
+          // serialize.
+          if (target.multiple) {
+            rowObj[subKey] = ids.map((id) =>
+              buildCachedReference(id, rowsById),
+            );
+            return;
+          }
+          const [singleId] = ids;
+          if (singleId !== undefined) {
+            rowObj[subKey] = buildCachedReference(singleId, rowsById);
+          }
+        },
+      });
+    }
+  }
+}
+
+function upsertGroup(
+  groups: Map<string, ReferenceGroup>,
+  target: ReferenceTarget,
+  registered: { readonly adapter: LookupAdapter },
+): ReferenceGroup {
+  const groupKey = referenceGroupKey(target);
+  let group = groups.get(groupKey);
+  if (!group) {
+    group = {
+      registered,
+      scope: target.scope,
+      ids: new Set(),
+      contributions: [],
+    };
+    groups.set(groupKey, group);
+  }
+  return group;
 }
 
 // Adapter cached fields override anything; user-supplied non-id keys
@@ -266,15 +385,31 @@ interface ReferenceGroup {
   // De-duped ids across every field in this group — one query
   // resolves them all regardless of how many fields reference them.
   readonly ids: Set<string>;
-  // Upsert-side: which keys contributed which ids + the field's
-  // target so the validator can dispatch on `valueShape` for the
-  // normalize step. Per-key error attribution still works on
-  // `key`.
-  readonly keys: {
-    readonly key: string;
-    readonly ids: readonly string[];
-    readonly target: ReferenceTarget;
-  }[];
+  // Per-contribution error attribution + normalize callback. Top-level
+  // and nested-in-repeater contributions share this shape; the
+  // callback closes over the storage location so the validator
+  // doesn't need to rebranch on shape during apply.
+  readonly contributions: ReferenceContribution[];
+}
+
+interface ReferenceContribution {
+  /** The top-level key surfaced in `MetaSanitizationError`. */
+  readonly errorKey: string;
+  readonly ids: readonly string[];
+  /** Rewrite the storage location for cached-object refs. No-op for id-shape. */
+  readonly applyNormalize: (
+    rowsById: ReadonlyMap<string, LookupResult>,
+  ) => void;
+  /**
+   * Diagnostic only — set for nested-in-repeater contributions so
+   * server logs identify the offending row/subField. The wire error
+   * always keys on the top-level field per slice acceptance, but
+   * engineers debugging a save need to know which row.
+   */
+  readonly diagnostic?: {
+    readonly rowIdx: number;
+    readonly subKey: string;
+  };
 }
 
 // Defense-in-depth ceiling on the internal-aggregated id-batch size.
@@ -481,11 +616,17 @@ export async function filterMetaOrphans(
   // accumulate ids per `(kind, scope)` group. Pass 3 walks the cache
   // directly so it doesn't redo the findField / registry lookups.
   interface Candidate {
+    /** Top-level meta key — the storage location for top-level refs. */
     readonly key: string;
     readonly multiple: boolean;
     readonly valueShape: "id" | "object";
     readonly groupKey: string;
     readonly ids: readonly string[];
+    /** When set, the candidate is a reference subField inside a repeater row. */
+    readonly nested?: {
+      readonly rowIdx: number;
+      readonly subKey: string;
+    };
   }
   const candidates: Candidate[] = [];
   const groups = new Map<
@@ -497,27 +638,65 @@ export async function filterMetaOrphans(
     }
   >();
   for (const [key, value] of Object.entries(decoded)) {
-    const target = referenceTargetOf(findField(key));
-    if (!target) continue;
-    const registered = ctx.plugins.lookupAdapters.get(target.kind);
-    if (!registered) continue;
-    const ids = orphanCandidateIds(target, value);
-    if (ids === null) continue; // non-array multi / non-string single — leave untouched
-    const groupKey = referenceGroupKey(target);
-    candidates.push({
-      key,
-      multiple: target.multiple === true,
-      valueShape: target.valueShape ?? "id",
-      groupKey,
-      ids,
-    });
-    if (ids.length === 0) continue; // empty array — apply step still runs, no group work
-    let group = groups.get(groupKey);
-    if (!group) {
-      group = { registered, scope: target.scope, ids: new Set() };
-      groups.set(groupKey, group);
+    const field = findField(key);
+    const target = referenceTargetOf(field);
+    if (target) {
+      const registered = ctx.plugins.lookupAdapters.get(target.kind);
+      if (!registered) continue;
+      const ids = orphanCandidateIds(target, value);
+      if (ids === null) continue; // non-array multi / non-string single — leave untouched
+      const groupKey = referenceGroupKey(target);
+      candidates.push({
+        key,
+        multiple: target.multiple === true,
+        valueShape: target.valueShape ?? "id",
+        groupKey,
+        ids,
+      });
+      if (ids.length === 0) continue;
+      let group = groups.get(groupKey);
+      if (!group) {
+        group = { registered, scope: target.scope, ids: new Set() };
+        groups.set(groupKey, group);
+      }
+      for (const id of ids) group.ids.add(id);
+      continue;
     }
-    for (const id of ids) group.ids.add(id);
+    if (!isRepeaterField(field)) continue;
+    if (!Array.isArray(value)) continue;
+    // Repeater rows: each row's reference subField gets the same
+    // orphan-strip treatment top-level refs receive — caller passes
+    // `decoded` as a freshly-decoded bag, so we mutate the row
+    // objects in place inside the eventual shallow-copy below.
+    for (const [rowIdx, row] of value.entries()) {
+      if (!row || typeof row !== "object" || Array.isArray(row)) continue;
+      const rowObj = row as Record<string, unknown>;
+      for (const subField of field.subFields) {
+        const subTarget = referenceTargetOf(subField);
+        if (!subTarget) continue;
+        const registered = ctx.plugins.lookupAdapters.get(subTarget.kind);
+        if (!registered) continue;
+        const subValue = rowObj[subField.key];
+        const ids = orphanCandidateIds(subTarget, subValue);
+        if (ids === null) continue;
+        const groupKey = referenceGroupKey(subTarget);
+        candidates.push({
+          key,
+          multiple: subTarget.multiple === true,
+          valueShape: subTarget.valueShape ?? "id",
+          groupKey,
+          ids,
+          nested: { rowIdx, subKey: subField.key },
+        });
+        if (ids.length === 0) continue;
+        let group = groups.get(groupKey);
+        if (!group) {
+          group = { registered, scope: subTarget.scope, ids: new Set() };
+          groups.set(groupKey, group);
+        }
+        for (const id of ids) group.ids.add(id);
+      }
+    }
   }
 
   // Pass 2: one `list({ ids })` per group, keyed for O(1) apply lookup.
@@ -539,10 +718,26 @@ export async function filterMetaOrphans(
   //  - single + id: null on missing
   //  - single + object: null on missing; otherwise keep the stored
   //    cached value as-is (no read-time refresh — write rewrites)
+  // Nested-in-repeater candidates rewrite the row's subField slot in
+  // a per-key cloned array so the input bag stays untouched.
   const out: MetaMap = { ...decoded };
   const empty: ReadonlySet<string> = new Set();
-  for (const { key, multiple, valueShape, groupKey, ids } of candidates) {
+  for (const candidate of candidates) {
+    const { key, multiple, valueShape, groupKey, ids, nested } = candidate;
     const liveIds = liveIdsByGroup.get(groupKey) ?? empty;
+    if (nested !== undefined) {
+      const rowObj = takeWritableRow(out, decoded, key, nested.rowIdx);
+      if (!rowObj) continue;
+      applyOrphanToSlot(
+        rowObj,
+        nested.subKey,
+        multiple,
+        valueShape,
+        ids,
+        liveIds,
+      );
+      continue;
+    }
     if (multiple) {
       if (valueShape === "object") {
         const stored = decoded[key] as readonly unknown[];
@@ -560,6 +755,57 @@ export async function filterMetaOrphans(
     if (!liveIds.has(singleId)) out[key] = null;
   }
   return out;
+}
+
+function takeWritableRow(
+  out: MetaMap,
+  decoded: MetaMap,
+  key: string,
+  rowIdx: number,
+): Record<string, unknown> | null {
+  // Lazily clone the rows array (and the targeted row inside it) on
+  // first nested write so the caller's `decoded` bag stays untouched.
+  // Subsequent nested writes hit the same cloned array.
+  let arr: unknown = out[key];
+  if (arr === decoded[key]) {
+    if (!Array.isArray(arr)) return null;
+    const cloned: unknown[] = arr.map((row: unknown) =>
+      row && typeof row === "object" && !Array.isArray(row)
+        ? { ...(row as Record<string, unknown>) }
+        : row,
+    );
+    out[key] = cloned;
+    arr = cloned;
+  }
+  if (!Array.isArray(arr)) return null;
+  const row: unknown = arr[rowIdx];
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  return row as Record<string, unknown>;
+}
+
+function applyOrphanToSlot(
+  rowObj: Record<string, unknown>,
+  subKey: string,
+  multiple: boolean,
+  valueShape: "id" | "object",
+  ids: readonly string[],
+  liveIds: ReadonlySet<string>,
+): void {
+  if (multiple) {
+    if (valueShape === "object") {
+      const stored = rowObj[subKey] as readonly unknown[];
+      rowObj[subKey] = stored.filter((item) => {
+        const id = extractStringId(item);
+        return id !== null && liveIds.has(id);
+      });
+      return;
+    }
+    rowObj[subKey] = ids.filter((id) => liveIds.has(id));
+    return;
+  }
+  const [singleId] = ids;
+  if (singleId === undefined) return;
+  if (!liveIds.has(singleId)) rowObj[subKey] = null;
 }
 
 // Returns `null` to mean "no candidates from this key" (skip), or

--- a/packages/core/src/rpc/meta/references.test.ts
+++ b/packages/core/src/rpc/meta/references.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import type {
   MetaBoxField,
@@ -925,5 +925,294 @@ describe("validateMetaReferences (multi cached-object shape)", () => {
       gallery: [{ id: "42" }, { id: "43" }],
     });
     expect(filtered.gallery).toEqual([]);
+  });
+});
+
+describe("validateMetaReferences (repeater subFields)", () => {
+  // Repeater rows can contain reference subFields (entry/term/user/media).
+  // v0.1 wrote them through without the live-id check or the cached-
+  // object normalize pass — orphan ids landed in the bag silently.
+  // These tests pin the v0.2 contract: walk into rows, group nested
+  // refs into the same `(kind, scope)` batch as top-level fields, and
+  // surface failures keyed on the top-level repeater key.
+
+  function repeaterWithUserSubField(): {
+    readonly registry: MutablePluginRegistry;
+    readonly findField: (key: string) => MetaBoxField | undefined;
+  } {
+    const registry: MutablePluginRegistry = createPluginRegistry();
+    registerCoreLookupAdapters(registry);
+    const userSubField: MetaBoxField = {
+      key: "owner",
+      label: "Owner",
+      type: "string",
+      inputType: "user",
+      referenceTarget: { kind: "user" },
+    };
+    const repeaterField: MetaBoxField = {
+      key: "rows",
+      label: "Rows",
+      type: "json",
+      inputType: "repeater",
+      subFields: [userSubField],
+    };
+    registry.userMetaBoxes.set("ownership", {
+      id: "ownership",
+      label: "Ownership",
+      fields: [repeaterField],
+      registeredBy: null,
+    });
+    return {
+      registry,
+      findField: (key) =>
+        key === repeaterField.key ? repeaterField : undefined,
+    };
+  }
+
+  test("rejects with meta_invalid_value when a nested ref id is dead", async () => {
+    const { findField, registry } = repeaterWithUserSubField();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+
+    const patch = {
+      upserts: new Map<string, unknown>([["rows", [{ owner: "999999" }]]]),
+      deletes: [] as readonly string[],
+    };
+
+    await expect(
+      validateMetaReferences(h.context, findField, patch),
+    ).rejects.toMatchObject({ reason: "invalid_value", key: "rows" });
+  });
+
+  test("logs row index and subKey on nested rejection so debug logs aren't blind", async () => {
+    // The wire error keys on the top-level repeater field per the
+    // slice's acceptance, so engineers reading server logs would
+    // otherwise have no idea which row or which subField rejected.
+    const { findField, registry } = repeaterWithUserSubField();
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+
+    const patch = {
+      upserts: new Map<string, unknown>([
+        [
+          "rows",
+          [
+            { owner: "1" },
+            { owner: "999999" }, // ← the dead one
+          ],
+        ],
+      ]),
+      deletes: [] as readonly string[],
+    };
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // swallow — the test asserts on the captured calls instead.
+    });
+    try {
+      await expect(
+        validateMetaReferences(h.context, findField, patch),
+      ).rejects.toBeInstanceOf(MetaSanitizationError);
+      const lines = errorSpy.mock.calls.map((args) =>
+        args.map(String).join(" "),
+      );
+      const matched = lines.find(
+        (line) =>
+          line.includes("rows") &&
+          line.includes("999999") &&
+          line.includes("owner") &&
+          /row\s*1/.test(line),
+      );
+      expect(matched).toBeDefined();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("rewrites a nested cached-object subField with the adapter's cached snapshot", async () => {
+    // Media-shaped (`valueShape: "object"`) refs inside repeater rows
+    // weren't normalized before — they round-tripped as the user's raw
+    // input, with no `mime` / `filename` snapshot. The new walk applies
+    // the same merge top-level fields receive: spoofed extras drop,
+    // adapter-supplied cached fields land.
+    const registry: MutablePluginRegistry = createPluginRegistry();
+    registry.lookupAdapters.set("stub", {
+      kind: "stub",
+      capability: null,
+      registeredBy: null,
+      adapter: {
+        list: (_ctx, opts) =>
+          Promise.resolve(
+            (opts.ids ?? []).map((id) => ({
+              id,
+              label: `stub-${id}`,
+              cached: { mime: "image/png", filename: "cat.png" },
+            })),
+          ),
+        resolve: () => Promise.resolve(null),
+      },
+    });
+    const heroSubField: MetaBoxField = {
+      key: "hero",
+      label: "Hero",
+      type: "json",
+      inputType: "media",
+      referenceTarget: { kind: "stub", valueShape: "object" },
+    };
+    const repeaterField: MetaBoxField = {
+      key: "rows",
+      label: "Rows",
+      type: "json",
+      inputType: "repeater",
+      subFields: [heroSubField],
+    };
+    registry.userMetaBoxes.set("hero", {
+      id: "hero",
+      label: "Hero",
+      fields: [repeaterField],
+      registeredBy: null,
+    });
+    const findField = (key: string) =>
+      key === "rows" ? repeaterField : undefined;
+
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const rows: { hero: unknown }[] = [
+      // Lenient input: bare id string.
+      { hero: "1" },
+      // Spoofed extras must drop after normalize.
+      { hero: { id: "2", mime: "image/jpeg", spoofed: "ignored" } },
+    ];
+    const patch = {
+      upserts: new Map<string, unknown>([["rows", rows]]),
+      deletes: [] as readonly string[],
+    };
+
+    await validateMetaReferences(h.context, findField, patch);
+
+    expect(rows[0]?.hero).toEqual({
+      id: "1",
+      mime: "image/png",
+      filename: "cat.png",
+    });
+    expect(rows[1]?.hero).toEqual({
+      id: "2",
+      mime: "image/png",
+      filename: "cat.png",
+    });
+  });
+
+  test("groups top-level and nested refs of the same (kind, scope) into one adapter.list call", async () => {
+    // Headline guarantee that mirrors the existing top-level batching
+    // test — the nested walk feeds into the same `(kind, scope)` group,
+    // so a patch with one top-level user field + N user-ref subFields
+    // across M repeater rows still costs exactly one adapter call.
+    const registry = createPluginRegistry();
+    registerCoreLookupAdapters(registry);
+    const userEntry = registry.lookupAdapters.get("user");
+    if (!userEntry) throw new Error("user adapter should be registered");
+    let listCalls = 0;
+    registry.lookupAdapters.set("user", {
+      ...userEntry,
+      adapter: {
+        list: (ctx, options) => {
+          listCalls += 1;
+          return userEntry.adapter.list(ctx, options);
+        },
+        resolve: (ctx, id, scope) => userEntry.adapter.resolve(ctx, id, scope),
+      },
+    });
+    const ownerField: MetaBoxField = {
+      key: "owner",
+      label: "Owner",
+      type: "string",
+      inputType: "user",
+      referenceTarget: { kind: "user" },
+    };
+    const reviewerSubField: MetaBoxField = {
+      key: "reviewer",
+      label: "Reviewer",
+      type: "string",
+      inputType: "user",
+      referenceTarget: { kind: "user" },
+    };
+    const reviewersRepeater: MetaBoxField = {
+      key: "reviewers",
+      label: "Reviewers",
+      type: "json",
+      inputType: "repeater",
+      subFields: [reviewerSubField],
+    };
+    registry.userMetaBoxes.set("ownership", {
+      id: "ownership",
+      label: "Ownership",
+      fields: [ownerField, reviewersRepeater],
+      registeredBy: null,
+    });
+    const findField = (key: string): MetaBoxField | undefined =>
+      key === "owner"
+        ? ownerField
+        : key === "reviewers"
+          ? reviewersRepeater
+          : undefined;
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const owner = await userFactory.transient({ db: h.context.db }).create();
+    const r1 = await userFactory.transient({ db: h.context.db }).create();
+    const r2 = await userFactory.transient({ db: h.context.db }).create();
+
+    const patch = {
+      upserts: new Map<string, unknown>([
+        ["owner", String(owner.id)],
+        [
+          "reviewers",
+          [{ reviewer: String(r1.id) }, { reviewer: String(r2.id) }],
+        ],
+      ]),
+      deletes: [] as readonly string[],
+    };
+
+    await validateMetaReferences(h.context, findField, patch);
+    expect(listCalls).toBe(1);
+  });
+});
+
+describe("filterMetaOrphans (repeater subFields)", () => {
+  test("nulls out a nested orphan single ref on read", async () => {
+    // A concurrent delete between save and read can leave a dead id in
+    // the meta bag. Top-level refs already null-out on read; nested
+    // refs need the same treatment so a stale row doesn't leak through
+    // the resolved view.
+    const registry: MutablePluginRegistry = createPluginRegistry();
+    registerCoreLookupAdapters(registry);
+    const ownerSubField: MetaBoxField = {
+      key: "owner",
+      label: "Owner",
+      type: "string",
+      inputType: "user",
+      referenceTarget: { kind: "user" },
+    };
+    const repeaterField: MetaBoxField = {
+      key: "rows",
+      label: "Rows",
+      type: "json",
+      inputType: "repeater",
+      subFields: [ownerSubField],
+    };
+    registry.userMetaBoxes.set("ownership", {
+      id: "ownership",
+      label: "Ownership",
+      fields: [repeaterField],
+      registeredBy: null,
+    });
+    const findField = (key: string) =>
+      key === "rows" ? repeaterField : undefined;
+
+    const h = await createRpcHarness({ authAs: "admin", plugins: registry });
+    const live = await userFactory.transient({ db: h.context.db }).create();
+
+    const filtered = await filterMetaOrphans(h.context, findField, {
+      rows: [{ owner: String(live.id) }, { owner: "999999" }],
+    });
+
+    const rows = filtered.rows as readonly { readonly owner: unknown }[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.owner).toBe(String(live.id));
+    expect(rows[1]?.owner).toBeNull();
   });
 });


### PR DESCRIPTION
Slice 0.1 of the meta-box pipeline (#133) shipped repeaters with a flat
row sanitize step but no live-id check or cached-object normalize for
reference subFields. An entry / term / user / media ref nested inside a
repeater row would round-trip a user-supplied id to the DB without
confirming the target existed, and a media subField never received the
\`{ id, mime, filename, ... }\` snapshot top-level media fields get on
every write.

This change extends \`validateMetaReferences\` and \`filterMetaOrphans\`
to walk into repeater rows, grouping nested refs into the same
\`(kind, scope)\` batch as top-level fields. The headline guarantee
holds: a patch with one top-level user ref + N user-ref subFields
across M repeater rows still costs exactly one \`adapter.list\` call.

## Refactor

\`ReferenceGroup.keys[]\` becomes \`ReferenceGroup.contributions[]\`,
where each contribution carries an \`applyNormalize\` callback closing
over its storage location — top-level callbacks rewrite
\`patch.upserts.set(key, ...)\`, nested ones rewrite the row's subField
slot directly. The validate-side per-contribution loop stays small and
the per-shape branching lives in one place.

## Read path

\`filterMetaOrphans\` walks rows the same way. The new
\`takeWritableRow\` helper lazily clones the rows array (and each
plain-object row inside it) on first nested write so the caller's
freshly-decoded \`decoded\` bag stays untouched — subsequent nested
writes to the same key hit the already-cloned array.
\`applyOrphanToSlot\` mirrors the existing per-shape orphan-strip logic
for the four (multiple × valueShape) combinations.

## Diagnostics

Per the slice acceptance, wire errors stay keyed on the top-level
repeater field — the row index + subKey live in a server log line only.
\`console.error\` fires with \`[plumix]\`-prefixed text including the
field name, row index, subKey, and offending id. User-supplied id
values are wrapped via \`JSON.stringify\` so newlines or control chars
can't poison the log stream; the same fix lands on the existing
\`runSanitize\` log line that had the same shape.

## Notes for review

- Nested repeaters are rejected at registration by \`repeater()\`. The
  runtime walk doesn't re-check — single-source-of-truth on the
  registration guard. There's a code comment in
  \`collectRepeaterReferences\` calling this out.
- The DRY opportunities between top-level and nested apply paths
  (cached-object normalize and orphan-strip) were left as duplicated
  code per simplifier guidance to avoid introducing a setter-based
  abstraction. If a third storage shape ever shows up, that's the
  natural moment to extract a helper.
- TOCTOU between validate and apply is the same as it was before this
  change; \`filterMetaOrphans\` masks any concurrent delete on read,
  including for nested refs now too.

Fixes #144