### PR TITLE
feat(core): ctx.defer portable runtime adapter shim

### DIFF
--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -43,7 +43,26 @@ export interface AuthNamespace {
   can(capability: KnownCapability | (string & {})): boolean;
 }
 
-export type AfterResponse = (promise: Promise<unknown>) => void;
+/**
+ * Schedule fire-and-forget work whose result the caller doesn't await.
+ * Runtime adapters bind this to their platform primitive:
+ *
+ * - Cloudflare Workers: `executionCtx.waitUntil(promise)` — extends
+ *   the worker's lifetime past the response so background work
+ *   completes before the isolate is recycled.
+ * - Long-lived runtimes (Node, Bun): the default `void p.catch(...)`
+ *   shim in `createAppContext` — the event loop holds the promise;
+ *   rejections are caught and logged so an unhandled rejection
+ *   doesn't crash the process.
+ * - Test runtimes: a queue + `drainDeferred()` helper for harness
+ *   assertions on background work.
+ *
+ * `defer` itself never throws — pass any promise, log-and-forget is
+ * the contract. Rejection logging always routes through `ctx.logger`
+ * so an operator-wired logger sees deferred rejections regardless of
+ * which runtime is underneath.
+ */
+export type DeferFn = (promise: Promise<unknown>) => void;
 
 /**
  * Declaration-merge target for plugin-contributed AppContext helpers.
@@ -98,12 +117,13 @@ export interface AppContextBase<
    */
   readonly oauthProviders: readonly OAuthProviderSummary[];
   /**
-   * Extend work past the returned Response. Runtime adapters bind this
-   * to their platform primitive (CF Workers: `ExecutionContext.waitUntil`).
-   * Default: fire-and-forget — handlers must tolerate the promise being
-   * dropped on runtimes that opt out.
+   * Extend work past the returned Response — see `DeferFn` for the
+   * full per-runtime contract. Default fallback (long-lived runtimes,
+   * tests with no adapter wired) catches rejections and logs them
+   * via `ctx.logger.error` so a fire-and-forget plugin task can't
+   * crash the process on an unhandled rejection.
    */
-  readonly after: AfterResponse;
+  readonly defer: DeferFn;
   /**
    * Platform asset serving, when the runtime exposes one. Populated by
    * the CF adapter from `env.ASSETS`; undefined on runtimes without an
@@ -181,7 +201,7 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly origin?: string;
   readonly siteName?: string;
   readonly logger?: Logger;
-  readonly after?: AfterResponse;
+  readonly defer?: DeferFn;
   readonly assets?: AssetsBinding;
   readonly storage?: ConnectedObjectStorage;
   readonly imageDelivery?: ImageDelivery;
@@ -201,7 +221,46 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   >;
 }
 
-const dropPromise: AfterResponse = () => undefined;
+function logRejection(logger: Logger, error: unknown): void {
+  // Both the error message and the raw value land in the log — the
+  // message is the grep-friendly bit; the raw value (with stack) goes
+  // through the logger's `meta` channel for structured backends.
+  // Wrapped in try/catch because a custom logger backend can throw
+  // (broken transport, fs full, etc.); a fire-and-forget task must
+  // not surface a downstream rejection just because logging failed.
+  const message = errorMessage(error);
+  try {
+    logger.error(`[plumix] deferred promise rejected: ${message}`, {
+      error,
+    });
+  } catch {
+    // Best-effort logging — swallow.
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return String(error);
+}
+
+function wrapDefer(logger: Logger, target: DeferFn | undefined): DeferFn {
+  // Wrap the caller's `defer` so the inner promise's rejection is
+  // logged through the configured logger before the runtime sees it.
+  // Runtimes (cloudflare, tests) only handle the success path —
+  // logging is centralised here so an operator's structured logger
+  // always wins.
+  return (promise) => {
+    const handled = promise.catch((error: unknown) => {
+      logRejection(logger, error);
+    });
+    if (target === undefined) {
+      void handled;
+      return;
+    }
+    target(handled);
+  };
+}
 
 function makeAuthCan(
   resolver: ReturnType<typeof createCapabilityResolver>,
@@ -238,7 +297,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     auth: {
       can: makeAuthCan(resolver, user, tokenScopes),
     },
-    after: args.after ?? dropPromise,
+    defer: wrapDefer(args.logger ?? consoleLogger, args.defer),
     assets: args.assets,
     storage: args.storage,
     imageDelivery: args.imageDelivery,

--- a/packages/core/src/context/defer.example.test.ts
+++ b/packages/core/src/context/defer.example.test.ts
@@ -1,0 +1,58 @@
+// Runnable example: a plugin handler kicks off fire-and-forget work
+// via `ctx.defer`. The test runtime's `createDeferQueue()` lets the
+// test wait for the background task to settle before asserting.
+//
+// In production (CF Workers) the same `ctx.defer` call would route
+// through `executionCtx.waitUntil` and the work continues after the
+// response is sent. In Node-style runtimes the default fallback
+// catches rejections so a misbehaving task can't crash the process.
+
+import { describe, expect, test } from "vitest";
+
+import type { AppContext, Db } from "./app.js";
+import { HookRegistry } from "../hooks/registry.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { createDeferQueue } from "../test/defer.js";
+import { createAppContext } from "./app.js";
+
+const stubDb = {} as Db;
+
+describe("ctx.defer — runnable example", () => {
+  test("plugin handler dispatches background work that lands after the response", async () => {
+    const writes: string[] = [];
+
+    function pretendHandler(ctx: AppContext): string {
+      // Synchronous return — simulating an RPC handler that returns
+      // its response while sending an audit event in the background.
+      ctx.defer(
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            writes.push("audit:event-recorded");
+            resolve();
+          }, 5),
+        ),
+      );
+      return "response-sent";
+    }
+
+    const queue = createDeferQueue();
+    const ctx = createAppContext({
+      db: stubDb,
+      env: {},
+      request: new Request("https://x.example/"),
+      hooks: new HookRegistry(),
+      plugins: createPluginRegistry(),
+      defer: queue.defer,
+    });
+
+    // The handler returns immediately; the audit write hasn't run yet.
+    expect(pretendHandler(ctx)).toBe("response-sent");
+    expect(writes).toEqual([]);
+
+    // Drain the queue — equivalent to letting `waitUntil` finish its
+    // tail in production. After this resolves, observable side effects
+    // are committed.
+    await queue.drainDeferred();
+    expect(writes).toEqual(["audit:event-recorded"]);
+  });
+});

--- a/packages/core/src/context/defer.test.ts
+++ b/packages/core/src/context/defer.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Db, Logger } from "./app.js";
+import { HookRegistry } from "../hooks/registry.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { createAppContext } from "./app.js";
+
+// Stub Db typed as the default CoreSchema so AppContext doesn't
+// resolve to a non-default generic.
+const stubDb = {} as Db;
+
+describe("AppContext.defer", () => {
+  test("ctx.defer forwards the promise to the runtime adapter implementation", () => {
+    const calls: Promise<unknown>[] = [];
+    const ctx = createAppContext({
+      db: stubDb,
+      env: {},
+      request: new Request("https://x.example/"),
+      hooks: new HookRegistry(),
+      plugins: createPluginRegistry(),
+      defer: (promise) => {
+        calls.push(promise);
+      },
+    });
+
+    const work = Promise.resolve("done");
+    ctx.defer(work);
+
+    expect(calls).toEqual([work]);
+  });
+
+  test("rejections from a caller-supplied defer route through the configured logger", async () => {
+    // Bug 1 fix: the cloudflare adapter (and any other runtime that
+    // wires `defer`) shouldn't have to know about logging. Whatever
+    // promise the caller's `defer` receives must already carry a
+    // .catch that lands in `ctx.logger.error` so an operator-wired
+    // logger sees deferred rejections in production.
+    const seen: { msg: string; meta?: Record<string, unknown> }[] = [];
+    const captureLogger: Logger = {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: (msg, meta) => {
+        seen.push({ msg, meta });
+      },
+    };
+    const passedThrough: Promise<unknown>[] = [];
+
+    const ctx = createAppContext({
+      db: {} as Db,
+      env: {},
+      request: new Request("https://x.example/"),
+      hooks: new HookRegistry(),
+      plugins: createPluginRegistry(),
+      logger: captureLogger,
+      // Mimic the cloudflare-adapter shape: a thin handler that just
+      // forwards the (already-wrapped) promise. The wrap should have
+      // happened inside createAppContext.
+      defer: (p) => {
+        passedThrough.push(p);
+      },
+    });
+
+    ctx.defer(Promise.reject(new Error("boom-cf")));
+
+    expect(passedThrough).toHaveLength(1);
+    // Drain the wrapped promise's rejection handler.
+    await Promise.allSettled(passedThrough);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.msg).toContain("boom-cf");
+  });
+
+  test("a logger that throws inside its error handler doesn't crash the process", async () => {
+    // Bug 2 fix: defer is fire-and-forget. A misbehaving logger that
+    // throws on .error() must not surface as an unhandled rejection.
+    const buggyLogger: Logger = {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => {
+        throw new Error("logger backend exploded");
+      },
+    };
+    const ctx = createAppContext({
+      db: {} as Db,
+      env: {},
+      request: new Request("https://x.example/"),
+      hooks: new HookRegistry(),
+      plugins: createPluginRegistry(),
+      logger: buggyLogger,
+    });
+
+    let unhandled: unknown = null;
+    const trap = (event: PromiseRejectionEvent | { reason: unknown }): void => {
+      unhandled = "reason" in event ? event.reason : event;
+    };
+    process.on("unhandledRejection", trap);
+    try {
+      ctx.defer(Promise.reject(new Error("rejected-task")));
+      // Give the rejection chain time to settle.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(unhandled).toBeNull();
+    } finally {
+      process.off("unhandledRejection", trap);
+    }
+  });
+
+  test("default fallback swallows rejections so plugin code never throws on `defer`", async () => {
+    // Long-lived runtimes default to fire-and-forget. The promise
+    // hasn't been intercepted by waitUntil; we still don't want the
+    // process to crash on unhandled rejection.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // swallow — assertion checks the captured calls.
+    });
+    try {
+      const ctx = createAppContext({
+        db: stubDb,
+        env: {},
+        request: new Request("https://x.example/"),
+        hooks: new HookRegistry(),
+        plugins: createPluginRegistry(),
+      });
+
+      ctx.defer(Promise.reject(new Error("boom")));
+
+      // Wait one microtask tick so the rejection handler runs.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(errorSpy).toHaveBeenCalled();
+      const matched = errorSpy.mock.calls.some((args) =>
+        args.some((a) => String(a).includes("boom")),
+      );
+      expect(matched).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/test/defer.test.ts
+++ b/packages/core/src/test/defer.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+
+import { createDeferQueue } from "./defer.js";
+
+describe("createDeferQueue", () => {
+  test("drainDeferred awaits every queued promise before resolving", async () => {
+    const events: string[] = [];
+    const { defer, drainDeferred } = createDeferQueue();
+
+    defer(
+      new Promise<void>((resolve) =>
+        setTimeout(() => {
+          events.push("first");
+          resolve();
+        }, 10),
+      ),
+    );
+    defer(
+      new Promise<void>((resolve) =>
+        setTimeout(() => {
+          events.push("second");
+          resolve();
+        }, 5),
+      ),
+    );
+
+    await drainDeferred();
+
+    // Both timers fired before drain resolved (order depends on the
+    // scheduler — only the count matters).
+    expect(events).toHaveLength(2);
+  });
+
+  test("rejections in queued promises don't bubble out of drainDeferred", async () => {
+    // The harness mirrors the production fire-and-forget contract —
+    // a misbehaving deferred task can't fail an unrelated test by
+    // surfacing as an unhandled rejection inside `drainDeferred`.
+    const { defer, drainDeferred } = createDeferQueue();
+    defer(Promise.reject(new Error("boom")));
+    defer(Promise.resolve("ok"));
+
+    await expect(drainDeferred()).resolves.toBeUndefined();
+  });
+
+  test("drainDeferred is a no-op when nothing was deferred", async () => {
+    const { drainDeferred } = createDeferQueue();
+    await expect(drainDeferred()).resolves.toBeUndefined();
+  });
+
+  test("drainDeferred picks up tasks deferred during a previous drain", async () => {
+    // Re-entrant `defer` calls (a deferred task itself enqueues more
+    // work) should be visible to the next `drainDeferred()` so a
+    // chain of background work can be tested deterministically.
+    const events: string[] = [];
+    const { defer, drainDeferred } = createDeferQueue();
+
+    defer(
+      Promise.resolve().then(() => {
+        events.push("first");
+        // Nested deferred work uses setTimeout so it doesn't drain in
+        // the same microtask as the parent — that's the real-world
+        // shape of "background task A queues background task B".
+        defer(
+          new Promise<void>((resolve) =>
+            setTimeout(() => {
+              events.push("nested");
+              resolve();
+            }, 5),
+          ),
+        );
+      }),
+    );
+
+    await drainDeferred();
+    expect(events).toEqual(["first"]);
+
+    await drainDeferred();
+    expect(events).toEqual(["first", "nested"]);
+  });
+});

--- a/packages/core/src/test/defer.ts
+++ b/packages/core/src/test/defer.ts
@@ -1,0 +1,41 @@
+// Test harness for `AppContext.defer`. Production runtimes route
+// fire-and-forget work through their platform primitive (CF Workers'
+// `waitUntil`, Node's event loop). Tests need a deterministic queue
+// they can flush + await before asserting on side effects, so this
+// helper builds a `defer` implementation backed by an array plus a
+// `drainDeferred()` that waits for everything queued so far.
+
+import type { DeferFn } from "../context/app.js";
+
+export interface DeferQueue {
+  /** Pass to `createAppContext({ defer })` so handlers route here. */
+  readonly defer: DeferFn;
+  /**
+   * Wait for every promise queued so far to settle (rejections are
+   * swallowed — the test asserts on observable side effects, not on
+   * the promise return values). Subsequent `defer` calls are queued
+   * onto the same array, so a follow-up `drainDeferred()` picks them
+   * up.
+   *
+   * `this: void` annotation lets callers destructure freely
+   * (`const { drainDeferred } = createDeferQueue()`) without the
+   * unbound-method lint rule complaining.
+   */
+  drainDeferred(this: void): Promise<void>;
+}
+
+export function createDeferQueue(): DeferQueue {
+  const queued: Promise<unknown>[] = [];
+  return {
+    defer: (promise) => {
+      queued.push(promise);
+    },
+    drainDeferred: async () => {
+      // Splice rather than re-assign so a re-entrant `defer` during
+      // the await captures into the SAME array — chained drains see
+      // the new entries.
+      const batch = queued.splice(0, queued.length);
+      await Promise.allSettled(batch);
+    },
+  };
+}

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -34,6 +34,9 @@ export type {
   CreateDispatcherHarnessOptions,
 } from "./dispatcher.js";
 
+export { createDeferQueue } from "./defer.js";
+export type { DeferQueue } from "./defer.js";
+
 export { createRpcHarness } from "./rpc.js";
 export type {
   RpcHarness,

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -175,8 +175,14 @@ function buildFetch(app: PlumixApp): FetchHandler {
       const workerCtx = isExecutionContext(executionCtx)
         ? executionCtx
         : undefined;
-      const after = workerCtx
-        ? (promise: Promise<unknown>) => workerCtx.waitUntil(promise)
+      // Route fire-and-forget work through `waitUntil` so the isolate
+      // stays alive past the response. `createAppContext` wraps this
+      // with a `.catch` that logs through the configured logger, so
+      // a rejected deferred promise can't surface as an
+      // `unhandledRejection` (which the platform would otherwise mark
+      // as a failed request in the dashboard).
+      const defer = workerCtx
+        ? (promise: Promise<unknown>): void => workerCtx.waitUntil(promise)
         : undefined;
 
       const { database } = app.config;
@@ -208,7 +214,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
         request,
         hooks: app.hooks,
         plugins: app.plugins,
-        after,
+        defer,
         assets: readAssetsBinding(env),
         storage,
         imageDelivery: app.config.imageDelivery,


### PR DESCRIPTION
Renames the existing \`AppContext.after\` shim to \`AppContext.defer\` and
fills out the contract with rejection-logging, a test-runtime helper,
and a runnable example — the second of two core prerequisites that
#175's audit log builds on (the first was #176's \`extendAppContext\`).

## Shape

\`ctx.defer(promise)\` schedules work whose result the caller doesn't
await. Each runtime adapter contributes its own implementation:

- **Cloudflare Workers**: \`executionCtx.waitUntil(promise)\` — keeps
  the isolate alive past the response so background work runs to
  completion.
- **Long-lived runtimes (Node, Bun)**: the default \`.catch\` shim —
  the event loop holds the promise; rejections route through
  \`ctx.logger.error\` so unhandled rejections can't crash the
  process.
- **Test runtime**: \`createDeferQueue()\` returns
  \`{ defer, drainDeferred }\` for harness-driven assertions on
  background work.

## Centralised rejection-logging

\`createAppContext\` wraps any caller-supplied \`defer\` so the inner
promise's rejection always lands at \`ctx.logger.error\` before the
runtime sees it. Runtimes (cloudflare, tests) only handle the
success path — logging happens in one place. An operator wiring a
structured logger (Workers Logs, external sink) sees deferred
rejections in production regardless of which runtime is underneath.

The wrap is \`try\`/\`catch\`'d on \`logger.error\` so a misbehaving
custom logger backend (broken transport, fs full, etc.) can't
itself surface as an \`unhandledRejection\` and crash the process —
fire-and-forget means fire-and-forget.

## Cloudflare adapter simplification

Drops the inline \`console.error\` wrap in favor of the centralised
path. The CF defer is now a thin \`waitUntil\` call:

\`\`\`ts
const defer = workerCtx
  ? (promise: Promise<unknown>): void => workerCtx.waitUntil(promise)
  : undefined;
\`\`\`

## Notes for review

- \`createDeferQueue()\` is exported from \`@plumix/core/test\` —
  plugin authors writing background-work tests can drain
  deterministically without faking timers or resorting to
  setTimeout-dance.
- One follow-up nit: \`createAppContext\` reads
  \`args.logger ?? consoleLogger\` twice (once for the \`logger\`
  field, once for \`wrapDefer\`'s arg). Hoisting to a single
  \`const logger = args.logger ?? consoleLogger\` would tighten
  things up. Skipped for this PR to keep the diff focused; trivial
  one-line change for a follow-up sweep.

Fixes #177