### PR TITLE
feat(plugin-audit-log): first tracer for entry events

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -118,6 +118,16 @@ const config: KnipConfig = {
         "e2e/*.spec.ts",
       ],
     },
+    // Same shape as plugin-menu: admin chunk loaded via `adminEntry`
+    // at consumer build time; `./server` subpath is consumer-facing
+    // for themes that need server-only helpers.
+    "packages/plugins/audit-log": {
+      entry: [
+        "src/index.ts",
+        "src/admin/index.tsx",
+        "src/server/index.ts",
+      ],
+    },
   },
 };
 

--- a/packages/plugins/audit-log/eslint.config.ts
+++ b/packages/plugins/audit-log/eslint.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "eslint/config";
+
+import { baseConfig } from "@plumix/eslint-config/base";
+
+export default defineConfig(baseConfig);

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@plumix/plugin-audit-log",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Activity-feed audit log plugin for Plumix — captures entry, user, term, and settings events to a queryable feed.",
+  "license": "MIT",
+  "author": "Plumix Contributors",
+  "homepage": "https://github.com/withplumix/plumix#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/withplumix/plumix.git",
+    "directory": "packages/plugins/audit-log"
+  },
+  "bugs": {
+    "url": "https://github.com/withplumix/plumix/issues"
+  },
+  "keywords": [
+    "plumix",
+    "plugin",
+    "audit-log",
+    "activity-feed"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "default": "./dist/server/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "attw": "attw --pack . --profile esm-only",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "format": "prettier --check . --ignore-path ../../../.gitignore",
+    "lint": "eslint",
+    "publint": "publint",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@plumix/core": "workspace:*",
+    "drizzle-orm": "catalog:",
+    "valibot": "catalog:"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.99.2",
+    "react": "catalog:"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "catalog:",
+    "@plumix/eslint-config": "workspace:*",
+    "@plumix/prettier-config": "workspace:*",
+    "@plumix/typescript-config": "workspace:*",
+    "@plumix/vitest-config": "workspace:*",
+    "@tanstack/react-query": "^5.99.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "esbuild": "0.27.7",
+    "eslint": "catalog:",
+    "jsdom": "^29.1.1",
+    "prettier": "catalog:",
+    "publint": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "prettier": "@plumix/prettier-config"
+}

--- a/packages/plugins/audit-log/src/admin/AuditLogShell.test.tsx
+++ b/packages/plugins/audit-log/src/admin/AuditLogShell.test.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { AuditLogShell } from "./AuditLogShell.js";
+
+let fetchMock: ReturnType<
+  typeof vi.fn<
+    (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+  >
+>;
+
+function mockListResponse(rows: readonly Record<string, unknown>[]): void {
+  fetchMock = vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ json: { rows }, meta: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+function renderShell(): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { readonly children: ReactNode }): ReactNode {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  }
+  render(<AuditLogShell />, { wrapper: Wrapper });
+}
+
+describe("AuditLogShell", () => {
+  beforeEach(() => {
+    fetchMock = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  test("renders the empty-state when no audit rows have been recorded", async () => {
+    mockListResponse([]);
+    renderShell();
+    expect(await screen.findByTestId("audit-log-empty")).toBeInTheDocument();
+  });
+
+  test("renders one row per audit entry with event + subject labels", async () => {
+    mockListResponse([
+      {
+        id: 1,
+        occurredAt: "2026-05-10T10:00:00Z",
+        event: "entry:published",
+        subjectType: "entry",
+        subjectId: "42",
+        subjectLabel: "Hello world",
+        actorId: 7,
+        actorLabel: "alice@example.com",
+        properties: {},
+      },
+      {
+        id: 2,
+        occurredAt: "2026-05-10T10:01:00Z",
+        event: "entry:updated",
+        subjectType: "entry",
+        subjectId: "42",
+        subjectLabel: "Hello world",
+        actorId: 7,
+        actorLabel: "alice@example.com",
+        properties: { diff: { title: ["Hello", "Hello world"] } },
+      },
+    ]);
+    renderShell();
+
+    expect(await screen.findByTestId("audit-log-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("audit-log-event-1")).toHaveTextContent(
+      "entry:published",
+    );
+    expect(screen.getByTestId("audit-log-subject-1")).toHaveTextContent(
+      "Hello world",
+    );
+    // Diff preview surfaces only when there's a `diff` envelope.
+    const diffPreviews = screen.getAllByTestId("audit-log-diff-preview");
+    expect(diffPreviews).toHaveLength(1);
+    expect(diffPreviews[0]).toHaveTextContent("title");
+  });
+});

--- a/packages/plugins/audit-log/src/admin/AuditLogShell.tsx
+++ b/packages/plugins/audit-log/src/admin/AuditLogShell.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+
+import type { AuditLogRowDTO } from "./rpc.js";
+import { useAuditLogList } from "./rpc.js";
+
+const MAX_DIFF_PREVIEW_FIELDS = 3;
+
+export function AuditLogShell(): ReactNode {
+  const list = useAuditLogList();
+
+  if (list.isLoading) {
+    return <div data-testid="audit-log-loading" />;
+  }
+
+  if (list.error instanceof Error) {
+    return (
+      <div data-testid="audit-log-error">
+        Failed to load audit log: {list.error.message}
+      </div>
+    );
+  }
+
+  const rows = list.data?.rows ?? [];
+
+  return (
+    <div data-testid="audit-log-shell">
+      <h1>Audit log</h1>
+      {rows.length === 0 ? (
+        <p data-testid="audit-log-empty">No audit events yet.</p>
+      ) : (
+        <table data-testid="audit-log-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Actor</th>
+              <th>Event</th>
+              <th>Subject</th>
+              <th>Changes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <AuditLogRow key={row.id} row={row} />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function AuditLogRow({ row }: { readonly row: AuditLogRowDTO }): ReactNode {
+  return (
+    <tr data-testid={`audit-log-row-${String(row.id)}`}>
+      <td>{formatTimestamp(row.occurredAt)}</td>
+      <td>{row.actorLabel ?? "(system)"}</td>
+      <td data-testid={`audit-log-event-${String(row.id)}`}>{row.event}</td>
+      <td data-testid={`audit-log-subject-${String(row.id)}`}>
+        {row.subjectLabel}
+      </td>
+      <td>
+        <DiffPreview properties={row.properties} />
+      </td>
+    </tr>
+  );
+}
+
+function DiffPreview({
+  properties,
+}: {
+  readonly properties: Record<string, unknown>;
+}): ReactNode {
+  const diff = properties.diff;
+  if (!diff || typeof diff !== "object" || Array.isArray(diff)) return null;
+  const fields = Object.keys(diff);
+  if (fields.length === 0) return null;
+  const preview = fields.slice(0, MAX_DIFF_PREVIEW_FIELDS).join(", ");
+  const overflow = fields.length - MAX_DIFF_PREVIEW_FIELDS;
+  return (
+    <span data-testid="audit-log-diff-preview">
+      {preview}
+      {overflow > 0 ? ` +${String(overflow)} more` : null}
+    </span>
+  );
+}
+
+function formatTimestamp(iso: string): string {
+  // Inputs land here as ISO strings via the RPC's JSON encoder; keep
+  // formatting minimal for v1 — operators with locale needs can swap
+  // in their own component when slice #180's filters land.
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d+Z$/, "Z");
+}

--- a/packages/plugins/audit-log/src/admin/index.tsx
+++ b/packages/plugins/audit-log/src/admin/index.tsx
@@ -1,0 +1,19 @@
+import type { ComponentType } from "react";
+
+import { AuditLogShell } from "./AuditLogShell.js";
+
+interface PlumixWindowGlobal {
+  readonly registerPluginPage: (path: string, component: ComponentType) => void;
+}
+
+declare const window:
+  | {
+      readonly plumix?: PlumixWindowGlobal;
+    }
+  | undefined;
+
+if (typeof window !== "undefined") {
+  window.plumix?.registerPluginPage("/audit-log", AuditLogShell);
+}
+
+export { AuditLogShell };

--- a/packages/plugins/audit-log/src/admin/rpc.ts
+++ b/packages/plugins/audit-log/src/admin/rpc.ts
@@ -1,0 +1,54 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
+
+export interface AuditLogRowDTO {
+  readonly id: number;
+  readonly occurredAt: string;
+  readonly event: string;
+  readonly subjectType: string;
+  readonly subjectId: string;
+  readonly subjectLabel: string;
+  readonly actorId: number | null;
+  readonly actorLabel: string | null;
+  readonly properties: Record<string, unknown>;
+}
+
+interface AuditLogListResponse {
+  readonly rows: readonly AuditLogRowDTO[];
+}
+
+const AUDIT_LOG_LIST_KEY = ["auditLog", "list"] as const;
+
+async function rpcCall<TOutput>(
+  procedure: string,
+  input: unknown = {},
+): Promise<TOutput> {
+  const res = await fetch(`/_plumix/rpc/${procedure}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-plumix-request": "1",
+    },
+    body: JSON.stringify({ json: input, meta: [] }),
+  });
+  const envelope = (await res.json().catch(() => null)) as {
+    json?: unknown;
+    meta?: unknown;
+  } | null;
+  if (!res.ok) {
+    const error = envelope?.json as
+      | { message?: string; data?: { reason?: string } }
+      | undefined;
+    const reason =
+      error?.data?.reason ?? error?.message ?? `rpc_${String(res.status)}`;
+    throw new Error(reason);
+  }
+  return envelope?.json as TOutput;
+}
+
+export function useAuditLogList(): UseQueryResult<AuditLogListResponse> {
+  return useQuery({
+    queryKey: AUDIT_LOG_LIST_KEY,
+    queryFn: () => rpcCall<AuditLogListResponse>("auditLog/list"),
+  });
+}

--- a/packages/plugins/audit-log/src/db/schema.ts
+++ b/packages/plugins/audit-log/src/db/schema.ts
@@ -1,0 +1,56 @@
+import { sql } from "drizzle-orm";
+import { index, sqliteTable } from "drizzle-orm/sqlite-core";
+
+/**
+ * Activity-log row. Denormalized by design — every label that the
+ * admin feed needs to render lives in the row itself, so the source
+ * entity can be hard-deleted without losing the history. The audit
+ * log is a time machine; resolving a stale id at read time would
+ * defeat the purpose.
+ *
+ * Columns:
+ * - `event`         dotted action name (`entry:published`, `user:invited`, …)
+ * - `subject_*`     the thing acted on; `subject_label` is the
+ *                   human-friendly snapshot (entry title, user email).
+ * - `actor_*`       who did it; `actor_id` is `null` for system / cron /
+ *                   anonymous actions.
+ * - `properties`    free-form JSON — currently `{ diff: { field: [old, new] } }`
+ *                   for entry mutations; future events may add their own keys.
+ */
+export const auditLog = sqliteTable(
+  "audit_log",
+  (t) => ({
+    id: t.integer().primaryKey({ autoIncrement: true }),
+    occurredAt: t
+      .integer({ mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    event: t.text().notNull(),
+    subjectType: t.text().notNull(),
+    subjectId: t.text().notNull(),
+    subjectLabel: t.text().notNull(),
+    actorId: t.integer(),
+    actorLabel: t.text(),
+    properties: t
+      .text({ mode: "json" })
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+  }),
+  (table) => [
+    // Default chronological feed.
+    index("audit_log_occurred_at_idx").on(table.occurredAt),
+    // "Show me everything that happened to entry 42" / term 7 / user 3.
+    index("audit_log_subject_idx").on(
+      table.subjectType,
+      table.subjectId,
+      table.occurredAt,
+    ),
+    // "Who did what" filter — actor profile pages, audit reports.
+    index("audit_log_actor_idx").on(table.actorId, table.occurredAt),
+    // Event-specific drilldown ("show me every `entry:trashed`").
+    index("audit_log_event_idx").on(table.event, table.occurredAt),
+  ],
+);
+
+export type NewAuditLogRow = typeof auditLog.$inferInsert;

--- a/packages/plugins/audit-log/src/index.ts
+++ b/packages/plugins/audit-log/src/index.ts
@@ -1,0 +1,83 @@
+import { definePlugin } from "@plumix/core";
+
+import type { AuditLogStorage } from "./types.js";
+import * as schema from "./db/schema.js";
+import { createAuditLogRouter } from "./rpc.js";
+import { createAuditService } from "./server/auditService.js";
+import { registerEntryHooks } from "./server/hooks.js";
+import { sqlite } from "./server/storage-sqlite.js";
+
+export type {
+  AuditLogStorage,
+  AuditLogRow,
+  AuditLogQueryFilter,
+} from "./types.js";
+export { sqlite } from "./server/storage-sqlite.js";
+
+export interface AuditLogPluginOptions {
+  /**
+   * Storage seam. Defaults to `sqlite()` writing to `ctx.db`. A
+   * deploy can swap in a separate database / external sink (Tinybird,
+   * BigQuery, ...) without touching the plugin's write pipeline.
+   */
+  readonly storage?: AuditLogStorage;
+}
+
+const ADMIN_ENTRY_PATH =
+  "node_modules/@plumix/plugin-audit-log/dist/admin/index.js";
+
+const AUDIT_LOG_READ_CAPABILITY = "audit_log:read";
+
+/**
+ * `@plumix/plugin-audit-log` — captures lifecycle events to a queryable
+ * activity feed. v0.1 covers entry events; #179+ add user, term, and
+ * settings hooks plus the public `ctx.audit.log()` API for third-party
+ * plugins.
+ *
+ * Architectural seams:
+ *
+ * - **Storage** is pluggable via the `storage` option. The default
+ *   `sqlite()` writes to `ctx.db` against the plugin's own Drizzle
+ *   table; the schema is forwarded into `definePlugin({ schema })` so
+ *   `plumix migrate generate` picks up the table on the next codegen
+ *   run.
+ * - **Service** buffers per-request via a WeakMap keyed by AppContext
+ *   and flushes once via `ctx.defer` (the runtime shim from #177).
+ *   Multiple events from one RPC become one INSERT.
+ * - **Hooks** subscribe to entry lifecycle events; each listener
+ *   pulls AppContext out of `requestStore.getStore()` so action
+ *   handlers (which don't take a ctx arg) can still find the per-
+ *   request batch.
+ * - **RPC** `auditLog.list` is gated on the `audit_log:read`
+ *   capability (admin-only by default); slice #180 adds filter +
+ *   cursor pagination.
+ */
+export function auditLog(options: AuditLogPluginOptions = {}) {
+  const storage = options.storage ?? sqlite();
+  const service = createAuditService(storage);
+  const router = createAuditLogRouter(storage);
+
+  return definePlugin("audit_log", {
+    adminEntry: ADMIN_ENTRY_PATH,
+    schema: storage.schemaModule ?? schema,
+    setup: (ctx) => {
+      ctx.registerCapability(AUDIT_LOG_READ_CAPABILITY, "admin");
+
+      ctx.registerRpcRouter(router);
+
+      registerEntryHooks(ctx, service);
+
+      ctx.registerAdminPage({
+        path: "/audit-log",
+        title: "Audit log",
+        capability: AUDIT_LOG_READ_CAPABILITY,
+        nav: {
+          group: { id: "tools", label: "Tools", priority: 600 },
+          label: "Audit log",
+          order: 10,
+        },
+        component: "AuditLogShell",
+      });
+    },
+  });
+}

--- a/packages/plugins/audit-log/src/rpc.ts
+++ b/packages/plugins/audit-log/src/rpc.ts
@@ -1,0 +1,48 @@
+// Hand-rolled oRPC router for the audit-log plugin. Mirrors the menu
+// plugin's pattern. v0.1 is just `auditLog.list` — capability-gated,
+// returns the latest 50 rows. Slice #180 adds filters + cursor
+// pagination.
+
+import * as v from "valibot";
+
+import { authenticated, base } from "@plumix/core";
+
+import type { AuditLogRow, AuditLogStorage } from "./types.js";
+
+const AUDIT_LOG_READ_CAPABILITY = "audit_log:read";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+interface AuditLogListResponse {
+  readonly rows: readonly AuditLogRow[];
+}
+
+export function createAuditLogRouter(
+  storage: AuditLogStorage,
+): Record<string, unknown> {
+  const list = base
+    .use(authenticated)
+    .input(
+      v.object({
+        limit: v.optional(
+          v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(MAX_LIMIT)),
+        ),
+      }),
+    )
+    .handler(
+      async ({ input, context, errors }): Promise<AuditLogListResponse> => {
+        if (!context.auth.can(AUDIT_LOG_READ_CAPABILITY)) {
+          throw errors.FORBIDDEN({
+            data: { capability: AUDIT_LOG_READ_CAPABILITY },
+          });
+        }
+        const rows = await storage.query(context, {
+          limit: input.limit ?? DEFAULT_LIMIT,
+        });
+        return { rows };
+      },
+    );
+
+  return { list };
+}

--- a/packages/plugins/audit-log/src/server/auditService.test.ts
+++ b/packages/plugins/audit-log/src/server/auditService.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { AppContext } from "@plumix/core";
+
+import type { NewAuditLogRow } from "../db/schema.js";
+import type { AuditLogStorage } from "../types.js";
+import { createAuditService } from "./auditService.js";
+
+interface FakeCtx {
+  readonly logger: {
+    debug: () => void;
+    info: () => void;
+    warn: ReturnType<typeof vi.fn>;
+    error: () => void;
+  };
+  defer: ReturnType<typeof vi.fn>;
+}
+
+function fakeCtx(): FakeCtx {
+  return {
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: vi.fn(),
+      error: () => undefined,
+    },
+    defer: vi.fn(),
+  };
+}
+
+function fakeStorage(): {
+  storage: AuditLogStorage;
+  writes: NewAuditLogRow[][];
+} {
+  const writes: NewAuditLogRow[][] = [];
+  return {
+    storage: {
+      kind: "fake",
+      write: (_ctx, rows) => {
+        writes.push([...rows]);
+        return Promise.resolve();
+      },
+      query: () => Promise.resolve([]),
+    },
+    writes,
+  };
+}
+
+const sampleRow: NewAuditLogRow = {
+  event: "entry:updated",
+  subjectType: "entry",
+  subjectId: "1",
+  subjectLabel: "Hello",
+  actorId: 1,
+  actorLabel: "alice@example.com",
+  properties: {},
+};
+
+describe("createAuditService", () => {
+  test("first record schedules defer once; subsequent records append to the same buffer", async () => {
+    const ctx = fakeCtx();
+    const { storage, writes } = fakeStorage();
+    const service = createAuditService(storage);
+
+    service.record(ctx as unknown as AppContext, sampleRow);
+    service.record(ctx as unknown as AppContext, sampleRow);
+    service.record(ctx as unknown as AppContext, sampleRow);
+
+    expect(ctx.defer).toHaveBeenCalledTimes(1);
+
+    // Drain the deferred flush.
+    await ctx.defer.mock.calls[0]?.[0];
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toHaveLength(3);
+  });
+
+  test("each AppContext gets its own buffer (no cross-request leak)", async () => {
+    const ctxA = fakeCtx();
+    const ctxB = fakeCtx();
+    const { storage, writes } = fakeStorage();
+    const service = createAuditService(storage);
+
+    service.record(ctxA as unknown as AppContext, sampleRow);
+    service.record(ctxB as unknown as AppContext, sampleRow);
+    service.record(ctxA as unknown as AppContext, sampleRow);
+
+    await Promise.all([
+      ctxA.defer.mock.calls[0]?.[0],
+      ctxB.defer.mock.calls[0]?.[0],
+    ]);
+
+    // 2 writes — one per ctx. ctxA has 2 rows, ctxB has 1.
+    expect(writes).toHaveLength(2);
+    const counts = writes.map((w) => w.length).sort();
+    expect(counts).toEqual([1, 2]);
+  });
+
+  test("storage.write failure logs a warning and does not throw to the caller", async () => {
+    const ctx = fakeCtx();
+    const failingStorage: AuditLogStorage = {
+      kind: "fake",
+      write: () => Promise.reject(new Error("disk full")),
+      query: () => Promise.resolve([]),
+    };
+    const service = createAuditService(failingStorage);
+
+    service.record(ctx as unknown as AppContext, sampleRow);
+
+    // The deferred flush captures the rejection internally.
+    await ctx.defer.mock.calls[0]?.[0];
+
+    expect(ctx.logger.warn).toHaveBeenCalled();
+    const calls = ctx.logger.warn.mock.calls.flat().map(String);
+    expect(calls.some((c) => c.includes("storage.write failed"))).toBe(true);
+  });
+
+  test("a record() after the previous flush has run schedules a fresh defer (no orphan rows)", async () => {
+    // Race regression: previously `flush` spliced the buffer empty,
+    // but the buffer object stayed in the WeakMap. A subsequent
+    // record() found the (empty) array, pushed onto it, and returned
+    // without scheduling — the row was orphaned until ctx GC'd it.
+    const ctx = fakeCtx();
+    const { storage, writes } = fakeStorage();
+    const service = createAuditService(storage);
+
+    service.record(ctx as unknown as AppContext, sampleRow);
+    await ctx.defer.mock.calls[0]?.[0];
+    expect(writes).toHaveLength(1);
+
+    // Second record after the first flush completed must schedule a
+    // brand-new defer; otherwise the row never lands in storage.
+    service.record(ctx as unknown as AppContext, sampleRow);
+    expect(ctx.defer).toHaveBeenCalledTimes(2);
+    await ctx.defer.mock.calls[1]?.[0];
+    expect(writes).toHaveLength(2);
+  });
+
+  test("warnNoContextOnce only logs the first time, no matter how many hook drops fire", () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // swallow — assertion checks call count below
+    });
+    try {
+      const { storage } = fakeStorage();
+      const service = createAuditService(storage);
+      service.warnNoContextOnce();
+      service.warnNoContextOnce();
+      service.warnNoContextOnce();
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      const [first] = consoleWarnSpy.mock.calls;
+      expect(first?.[0]).toContain("requestStore");
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  test("a row whose properties exceed 256 KiB is dropped with a warning, not written", () => {
+    const ctx = fakeCtx();
+    const { storage, writes } = fakeStorage();
+    const service = createAuditService(storage);
+
+    // Build an oversized properties envelope deliberately.
+    const huge = "x".repeat(300_000);
+    const oversized: NewAuditLogRow = {
+      ...sampleRow,
+      properties: { diff: { content: ["", huge] } },
+    };
+
+    service.record(ctx as unknown as AppContext, oversized);
+
+    // Defer was never scheduled — record() short-circuited.
+    expect(ctx.defer).not.toHaveBeenCalled();
+    expect(writes).toHaveLength(0);
+    expect(ctx.logger.warn).toHaveBeenCalled();
+    const calls = ctx.logger.warn.mock.calls.flat().map(String);
+    expect(calls.some((c) => c.toLowerCase().includes("exceed"))).toBe(true);
+  });
+
+  test("a row whose properties contain a non-serializable value (BigInt) is dropped with a warning", () => {
+    const ctx = fakeCtx();
+    const { storage, writes } = fakeStorage();
+    const service = createAuditService(storage);
+
+    const unserializable: NewAuditLogRow = {
+      ...sampleRow,
+      properties: { weight: 42n as unknown as number },
+    };
+
+    service.record(ctx as unknown as AppContext, unserializable);
+
+    expect(ctx.defer).not.toHaveBeenCalled();
+    expect(writes).toHaveLength(0);
+    expect(ctx.logger.warn).toHaveBeenCalled();
+    const calls = ctx.logger.warn.mock.calls.flat().map(String);
+    expect(calls.some((c) => c.toLowerCase().includes("serializable"))).toBe(
+      true,
+    );
+  });
+
+  test("a defer that throws synchronously is caught and warn-logged", () => {
+    const ctx = fakeCtx();
+    ctx.defer.mockImplementation(() => {
+      throw new Error("runtime missing defer shim");
+    });
+    const { storage } = fakeStorage();
+    const service = createAuditService(storage);
+
+    expect(() =>
+      service.record(ctx as unknown as AppContext, sampleRow),
+    ).not.toThrow();
+
+    expect(ctx.logger.warn).toHaveBeenCalled();
+    const calls = ctx.logger.warn.mock.calls.flat().map(String);
+    expect(calls.some((c) => c.includes("failed to schedule"))).toBe(true);
+  });
+});

--- a/packages/plugins/audit-log/src/server/auditService.ts
+++ b/packages/plugins/audit-log/src/server/auditService.ts
@@ -1,0 +1,138 @@
+// Per-request batched-write service for the audit log. Hook listeners
+// call `service.record(ctx, row)`; the first call schedules a single
+// `ctx.defer(flush)` and subsequent calls in the same request append
+// to the same WeakMap-keyed buffer. One INSERT runs after the response
+// — six entry events from a single update RPC become one audit write.
+
+import type { AppContext, Logger } from "@plumix/core";
+
+import type { NewAuditLogRow } from "../db/schema.js";
+import type { AuditLogStorage } from "../types.js";
+
+export interface AuditService {
+  record(ctx: AppContext, row: NewAuditLogRow): void;
+  /**
+   * Test seam: emit a one-time warn when a hook listener fires
+   * without a `requestStore` frame. Hook subscribers call this
+   * directly (instead of `record`) when `tryGetContext()` returns
+   * null, so a developer running an out-of-context test sees a
+   * clear diagnostic the first time.
+   */
+  warnNoContextOnce(): void;
+}
+
+// Single-row JSON cap before the audit row is dropped. Mirrors the
+// 256 KiB cap in core's meta pipeline. A misbehaving subscriber can
+// build an arbitrarily-large `properties` envelope; this prevents
+// one row from blowing the SQLite column limit while still letting
+// large-but-reasonable diffs through.
+const MAX_PROPERTIES_BYTES = 256 * 1024;
+
+export function createAuditService(storage: AuditLogStorage): AuditService {
+  // Per-request buffer keyed by AppContext so an isolated request can
+  // never flush another request's rows. WeakMap means the entries
+  // garbage-collect alongside ctx — no per-request init/teardown
+  // needed.
+  const buffers = new WeakMap<AppContext, NewAuditLogRow[]>();
+  let warnedNoContext = false;
+
+  function record(ctx: AppContext, row: NewAuditLogRow): void {
+    if (!fitsSizeCap(ctx.logger, row)) return;
+    const existing = buffers.get(ctx);
+    if (existing) {
+      existing.push(row);
+      return;
+    }
+    const buffer: NewAuditLogRow[] = [row];
+    buffers.set(ctx, buffer);
+    // First record for this request — schedule the flush. Wrapping
+    // in `Promise.resolve().then(...)` defers the buffer drain into
+    // a microtask so synchronous record() siblings (one RPC handler
+    // producing 2-3 events in a row) land in the same buffer before
+    // flush runs. Without the wrap, an `async` flush would execute
+    // synchronously up to its first await and steal the buffer.
+    //
+    // The outer try/catch covers the rare runtime that hasn't wired
+    // `defer` (it'd throw at the call); audit writes are
+    // observability and must never affect user-perceived response.
+    try {
+      ctx.defer(Promise.resolve().then(() => flush(buffers, storage, ctx)));
+    } catch (error) {
+      ctx.logger.warn(
+        `[plumix/plugin-audit-log] failed to schedule flush: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { error },
+      );
+    }
+  }
+
+  function warnNoContextOnce(): void {
+    if (warnedNoContext) return;
+    warnedNoContext = true;
+    // No ctx in this branch — best we can do is log to console. A
+    // hook firing outside `requestStore.run` is a misconfigured test
+    // harness; production runtimes always wrap.
+    console.warn(
+      "[plumix/plugin-audit-log] hook fired outside requestStore — " +
+        "audit row dropped. If this is a test, wrap your harness " +
+        "in `requestStore.run(ctx, ...)` so action listeners can " +
+        "find the per-request buffer.",
+    );
+  }
+
+  return { record, warnNoContextOnce };
+}
+
+async function flush(
+  buffers: WeakMap<AppContext, NewAuditLogRow[]>,
+  storage: AuditLogStorage,
+  ctx: AppContext,
+): Promise<void> {
+  // Detach the buffer from the map first. A re-entrant `record`
+  // during the upcoming `await` lands in a fresh buffer with its own
+  // scheduled flush — it can't append to the rows we're about to
+  // write, and we can't lose its row.
+  const rows = buffers.get(ctx);
+  if (!rows || rows.length === 0) return;
+  buffers.delete(ctx);
+  // Audit-write failures never bubble to the caller. ctx.defer's own
+  // catch logs through ctx.logger.error already; we add a warn-level
+  // breadcrumb so operators see the audit-write specifically (vs a
+  // generic "deferred promise rejected").
+  try {
+    await storage.write(ctx, rows);
+  } catch (error) {
+    ctx.logger.warn(
+      `[plumix/plugin-audit-log] storage.write failed (${String(rows.length)} rows dropped): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { error },
+    );
+  }
+}
+
+function fitsSizeCap(logger: Logger, row: NewAuditLogRow): boolean {
+  // JSON.stringify on the `properties` column. Drop the row + warn
+  // when over-cap so the SQLite column doesn't accept a payload that
+  // a misbehaving subscriber assembled. Empty / small `properties`
+  // is the common case and short-circuits cheaply.
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(row.properties ?? {});
+  } catch (error) {
+    logger.warn(
+      `[plumix/plugin-audit-log] properties not JSON-serializable: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { event: row.event, error },
+    );
+    return false;
+  }
+  if (serialized.length <= MAX_PROPERTIES_BYTES) return true;
+  logger.warn(
+    `[plumix/plugin-audit-log] properties exceeds ${String(MAX_PROPERTIES_BYTES)} bytes (${String(serialized.length)}); row dropped`,
+    { event: row.event, subjectId: row.subjectId },
+  );
+  return false;
+}

--- a/packages/plugins/audit-log/src/server/buildAuditRow.test.ts
+++ b/packages/plugins/audit-log/src/server/buildAuditRow.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+
+import { buildAuditRow } from "./buildAuditRow.js";
+
+describe("buildAuditRow", () => {
+  test("denormalizes actor and subject fields onto the row", () => {
+    const row = buildAuditRow({
+      event: "entry:published",
+      actor: { id: 7, label: "alice@example.com" },
+      subject: { type: "entry", id: "42", label: "Hello world" },
+    });
+
+    expect(row).toMatchObject({
+      event: "entry:published",
+      subjectType: "entry",
+      subjectId: "42",
+      subjectLabel: "Hello world",
+      actorId: 7,
+      actorLabel: "alice@example.com",
+    });
+  });
+
+  test("emits a diff envelope only for fields that changed", () => {
+    const row = buildAuditRow({
+      event: "entry:updated",
+      actor: { id: 1, label: "a" },
+      subject: { type: "entry", id: "1", label: "Post" },
+      previous: { title: "Old", slug: "p", status: "draft" },
+      next: { title: "New", slug: "p", status: "draft" },
+    });
+
+    expect(row.properties).toEqual({
+      diff: { title: ["Old", "New"] },
+    });
+  });
+
+  test("treats missing keys on either side as null", () => {
+    // Adding a brand-new column on next: appears as [null, value].
+    const row = buildAuditRow({
+      event: "entry:updated",
+      actor: { id: 1, label: "a" },
+      subject: { type: "entry", id: "1", label: "Post" },
+      previous: { title: "T" },
+      next: { title: "T", excerpt: "summary" },
+    });
+
+    expect(row.properties).toEqual({
+      diff: { excerpt: [null, "summary"] },
+    });
+  });
+
+  test("treats Date instances as equal when their .getTime() matches", () => {
+    // Drizzle reads timestamp columns as Date — same epoch, distinct
+    // instances. Without the Date special-case, JSON.stringify would
+    // emit identical strings (both ISO), so the equality holds — but
+    // the explicit branch keeps the contract obvious.
+    const row = buildAuditRow({
+      event: "entry:updated",
+      actor: { id: 1, label: "a" },
+      subject: { type: "entry", id: "1", label: "Post" },
+      previous: { publishedAt: new Date("2026-01-01T00:00:00Z") },
+      next: { publishedAt: new Date("2026-01-01T00:00:00Z") },
+    });
+
+    expect(row.properties).not.toHaveProperty("diff");
+  });
+
+  test("omits the diff envelope when previous or next is missing", () => {
+    // Lifecycle events that don't carry a before/after pair (publish,
+    // trash) shouldn't have a `diff` key at all.
+    const row = buildAuditRow({
+      event: "entry:published",
+      actor: { id: 1, label: "a" },
+      subject: { type: "entry", id: "1", label: "Post" },
+    });
+
+    expect(row.properties).toEqual({});
+  });
+
+  test("merges extraProperties without clobbering the diff", () => {
+    const row = buildAuditRow({
+      event: "entry:transition",
+      actor: { id: 1, label: "a" },
+      subject: { type: "entry", id: "1", label: "Post" },
+      extraProperties: { status: { from: "draft", to: "published" } },
+    });
+
+    expect(row.properties).toEqual({
+      status: { from: "draft", to: "published" },
+    });
+  });
+
+  test("anonymous actor lands as null id + null label", () => {
+    const row = buildAuditRow({
+      event: "entry:trashed",
+      actor: { id: null, label: null },
+      subject: { type: "entry", id: "1", label: "Post" },
+    });
+
+    expect(row.actorId).toBeNull();
+    expect(row.actorLabel).toBeNull();
+  });
+});

--- a/packages/plugins/audit-log/src/server/buildAuditRow.ts
+++ b/packages/plugins/audit-log/src/server/buildAuditRow.ts
@@ -1,0 +1,79 @@
+import type { NewAuditLogRow } from "../db/schema.js";
+import type { AuditLogActor } from "../types.js";
+
+/**
+ * Pure helper that turns an event payload into a denormalized audit
+ * row. The `properties` envelope is intentionally narrow for v1 —
+ * `{ diff: { field: [old, new] } }` for entity mutations; future
+ * events can add their own keys without breaking older readers
+ * because the column is JSON.
+ *
+ * Diff shape rules:
+ * - Only top-level entity columns are diffed. Nested JSON (meta,
+ *   content) is intentionally skipped — those have their own
+ *   dedicated events (`entry:meta_changed`).
+ * - A field appears in the diff iff `previous[k] !== next[k]`. Missing
+ *   keys on either side are treated as `null`.
+ * - Date instances compare via `.getTime()`; everything else uses
+ *   structural equality through `JSON.stringify` so `[1,2]` and
+ *   `[1,2]` count as equal.
+ */
+interface BuildAuditRowInput {
+  readonly event: string;
+  readonly actor: AuditLogActor;
+  readonly subject: {
+    readonly type: string;
+    readonly id: string;
+    readonly label: string;
+  };
+  readonly previous?: Readonly<Record<string, unknown>>;
+  readonly next?: Readonly<Record<string, unknown>>;
+  /** Extra fields merged into `properties` after the diff. */
+  readonly extraProperties?: Readonly<Record<string, unknown>>;
+}
+
+export function buildAuditRow(input: BuildAuditRowInput): NewAuditLogRow {
+  const properties: Record<string, unknown> = { ...input.extraProperties };
+  const diff = computeDiff(input.previous, input.next);
+  if (diff !== null) properties.diff = diff;
+  return {
+    event: input.event,
+    subjectType: input.subject.type,
+    subjectId: input.subject.id,
+    subjectLabel: input.subject.label,
+    actorId: input.actor.id,
+    actorLabel: input.actor.label,
+    properties,
+  };
+}
+
+function computeDiff(
+  previous: Readonly<Record<string, unknown>> | undefined,
+  next: Readonly<Record<string, unknown>> | undefined,
+): Record<string, [unknown, unknown]> | null {
+  if (previous === undefined || next === undefined) return null;
+  const out: Record<string, [unknown, unknown]> = {};
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  for (const key of keys) {
+    const oldValue = previous[key] ?? null;
+    const newValue = next[key] ?? null;
+    if (!shallowEqual(oldValue, newValue)) {
+      out[key] = [oldValue, newValue];
+    }
+  }
+  return Object.keys(out).length === 0 ? null : out;
+}
+
+function shallowEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a instanceof Date && b instanceof Date)
+    return a.getTime() === b.getTime();
+  // Structural fallback for arrays / plain objects. Cheap enough for
+  // top-level columns; expensive for nested content (which we don't
+  // diff anyway).
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}

--- a/packages/plugins/audit-log/src/server/entry-meta-changes.ts
+++ b/packages/plugins/audit-log/src/server/entry-meta-changes.ts
@@ -1,0 +1,8 @@
+// Re-typing the shape we observe on `entry:meta_changed` so the
+// hooks file can stay free of deep `@plumix/core` internals. Matches
+// `MetaChanges` in core's meta/core.ts.
+
+export interface EntryMetaChanges {
+  readonly set: Readonly<Record<string, unknown>>;
+  readonly removed: readonly string[];
+}

--- a/packages/plugins/audit-log/src/server/hooks.ts
+++ b/packages/plugins/audit-log/src/server/hooks.ts
@@ -1,0 +1,153 @@
+// Hook subscriptions that capture entry events into the audit log.
+// Each listener pulls the per-request `AppContext` out of
+// `requestStore.getStore()` (provided by the runtime via #176/#177)
+// so it can call `service.record(ctx, row)` against the buffered
+// per-request batch.
+
+import type { Entry, EntryStatus, PluginSetupContext } from "@plumix/core";
+import { tryGetContext } from "@plumix/core";
+
+import type { AuditService } from "./auditService.js";
+import type { EntryMetaChanges } from "./entry-meta-changes.js";
+import { buildAuditRow } from "./buildAuditRow.js";
+import { extractSubject } from "./subjectExtractors.js";
+
+interface EntryActorLookup {
+  readonly id: number | null;
+  readonly label: string | null;
+}
+
+export function registerEntryHooks(
+  ctx: PluginSetupContext,
+  service: AuditService,
+): void {
+  ctx.addAction("entry:updated", (entry: Entry, previous: Entry) => {
+    const appCtx = tryGetContext();
+    if (!appCtx) {
+      service.warnNoContextOnce();
+      return;
+    }
+    const subject = extractSubject("entry", entry);
+    service.record(
+      appCtx,
+      buildAuditRow({
+        event: "entry:updated",
+        actor: actorOf(appCtx),
+        subject,
+        previous: stripDiffNoise(previous),
+        next: stripDiffNoise(entry),
+      }),
+    );
+  });
+
+  ctx.addAction("entry:transition", (entry: Entry, oldStatus: EntryStatus) => {
+    const appCtx = tryGetContext();
+    if (!appCtx) {
+      service.warnNoContextOnce();
+      return;
+    }
+    service.record(
+      appCtx,
+      buildAuditRow({
+        event: "entry:transition",
+        actor: actorOf(appCtx),
+        subject: extractSubject("entry", entry),
+        extraProperties: {
+          status: { from: oldStatus, to: entry.status },
+        },
+      }),
+    );
+  });
+
+  ctx.addAction("entry:published", (entry: Entry) => {
+    const appCtx = tryGetContext();
+    if (!appCtx) {
+      service.warnNoContextOnce();
+      return;
+    }
+    service.record(
+      appCtx,
+      buildAuditRow({
+        event: "entry:published",
+        actor: actorOf(appCtx),
+        subject: extractSubject("entry", entry),
+      }),
+    );
+  });
+
+  ctx.addAction("entry:trashed", (entry: Entry) => {
+    const appCtx = tryGetContext();
+    if (!appCtx) {
+      service.warnNoContextOnce();
+      return;
+    }
+    service.record(
+      appCtx,
+      buildAuditRow({
+        event: "entry:trashed",
+        actor: actorOf(appCtx),
+        subject: extractSubject("entry", entry),
+      }),
+    );
+  });
+
+  ctx.addAction(
+    "entry:meta_changed",
+    (
+      entry: { readonly id: number; readonly type: string },
+      changes: EntryMetaChanges,
+    ) => {
+      const appCtx = tryGetContext();
+      if (!appCtx) return;
+      service.record(
+        appCtx,
+        buildAuditRow({
+          event: "entry:meta_changed",
+          actor: actorOf(appCtx),
+          subject: {
+            type: "entry",
+            id: String(entry.id),
+            // Meta-changed payload doesn't carry the title — fall back
+            // to the entry id as the label. The feed renders this as
+            // a numeric breadcrumb; consumers wanting a richer label
+            // can resolve at render time.
+            label: `Entry #${String(entry.id)}`,
+          },
+          extraProperties: {
+            metaSet: Object.keys(changes.set),
+            metaRemoved: changes.removed,
+          },
+        }),
+      );
+    },
+  );
+}
+
+function actorOf(ctx: {
+  readonly user: { readonly id: number; readonly email: string } | null;
+}): EntryActorLookup {
+  if (ctx.user === null) {
+    return { id: null, label: null };
+  }
+  return { id: ctx.user.id, label: ctx.user.email };
+}
+
+const DIFF_OMIT_KEYS = new Set([
+  // Auto-managed timestamps would always show as a "diff" on every
+  // update. Skip them so the diff envelope only carries fields the
+  // user actually changed.
+  "createdAt",
+  "updatedAt",
+  // Nested JSON; covered by the dedicated `entry:meta_changed` hook.
+  "content",
+  "meta",
+]);
+
+function stripDiffNoise(entry: Entry): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(entry)) {
+    if (DIFF_OMIT_KEYS.has(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}

--- a/packages/plugins/audit-log/src/server/index.ts
+++ b/packages/plugins/audit-log/src/server/index.ts
@@ -1,0 +1,9 @@
+// Server-only public surface. Themes / consumer integrations import
+// from `@plumix/plugin-audit-log/server` so the admin React bundle
+// (plus its peer deps) doesn't leak into the worker chunk.
+
+export { sqlite } from "./storage-sqlite.js";
+export type { AuditService } from "./auditService.js";
+export { createAuditService } from "./auditService.js";
+export { buildAuditRow } from "./buildAuditRow.js";
+export { extractSubject, subjectExtractors } from "./subjectExtractors.js";

--- a/packages/plugins/audit-log/src/server/storage-sqlite.ts
+++ b/packages/plugins/audit-log/src/server/storage-sqlite.ts
@@ -1,0 +1,61 @@
+// Default storage: write + query against `ctx.db` using the plugin's
+// own Drizzle table definition. The `schemaModule` field is forwarded
+// to `definePlugin({ schema })` so `plumix migrate generate` picks
+// up the table on the next codegen run.
+
+import { desc } from "drizzle-orm";
+
+import type {
+  AuditLogQueryFilter,
+  AuditLogRow,
+  AuditLogStorage,
+} from "../types.js";
+import * as schema from "../db/schema.js";
+import { auditLog } from "../db/schema.js";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+export function sqlite(): AuditLogStorage {
+  return {
+    kind: "sqlite",
+    schemaModule: schema,
+
+    async write(ctx, rows) {
+      if (rows.length === 0) return;
+      // SQLite INSERT … VALUES (?, …), (?, …) — drizzle batches
+      // multi-row inserts into a single statement.
+      await ctx.db.insert(auditLog).values([...rows]);
+    },
+
+    async query(ctx, filter: AuditLogQueryFilter) {
+      const limit = clampLimit(filter.limit);
+      const rows = await ctx.db
+        .select()
+        .from(auditLog)
+        .orderBy(desc(auditLog.occurredAt), desc(auditLog.id))
+        .limit(limit);
+      return rows.map(toAuditLogRow);
+    },
+  };
+}
+
+function clampLimit(requested: number | undefined): number {
+  if (requested === undefined) return DEFAULT_LIMIT;
+  if (!Number.isFinite(requested) || requested <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(requested), MAX_LIMIT);
+}
+
+function toAuditLogRow(row: typeof auditLog.$inferSelect): AuditLogRow {
+  return {
+    id: row.id,
+    occurredAt: row.occurredAt,
+    event: row.event,
+    subjectType: row.subjectType,
+    subjectId: row.subjectId,
+    subjectLabel: row.subjectLabel,
+    actorId: row.actorId,
+    actorLabel: row.actorLabel,
+    properties: row.properties,
+  };
+}

--- a/packages/plugins/audit-log/src/server/subjectExtractors.test.ts
+++ b/packages/plugins/audit-log/src/server/subjectExtractors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+
+import { extractSubject, subjectExtractors } from "./subjectExtractors.js";
+
+describe("extractSubject", () => {
+  test("entry extractor prefers title, falls back to slug, then (unnamed)", () => {
+    expect(
+      extractSubject("entry", { id: 1, title: "Hello", slug: "hello" }),
+    ).toEqual({ type: "entry", id: "1", label: "Hello" });
+
+    expect(
+      extractSubject("entry", { id: 2, title: null, slug: "no-title" }),
+    ).toEqual({ type: "entry", id: "2", label: "no-title" });
+
+    expect(extractSubject("entry", { id: 3, title: "  ", slug: "  " })).toEqual(
+      { type: "entry", id: "3", label: "(unnamed)" },
+    );
+  });
+
+  test("user extractor prefers name, falls back to email", () => {
+    expect(
+      extractSubject("user", {
+        id: 5,
+        name: "Alice",
+        email: "alice@example.com",
+      }),
+    ).toEqual({ type: "user", id: "5", label: "Alice" });
+
+    expect(
+      extractSubject("user", {
+        id: 6,
+        name: null,
+        email: "bob@example.com",
+      }),
+    ).toEqual({ type: "user", id: "6", label: "bob@example.com" });
+  });
+
+  test("unknown subject types fall through with their best-effort label", () => {
+    // Plugins shipping their own subject types (term, comment, ...)
+    // should ideally register an extractor, but the unknown path
+    // surfaces a row regardless so the feed never loses an event.
+    expect(extractSubject("term", { id: 9, name: "Tag" })).toEqual({
+      type: "term",
+      id: "9",
+      label: "Tag",
+    });
+
+    expect(extractSubject("ufo", { id: 10 })).toEqual({
+      type: "ufo",
+      id: "10",
+      label: "(unnamed)",
+    });
+  });
+
+  test("subjectExtractors map exposes per-type extractors directly", () => {
+    expect(typeof subjectExtractors.entry).toBe("function");
+    expect(typeof subjectExtractors.user).toBe("function");
+    expect(subjectExtractors.term).toBeUndefined();
+  });
+});

--- a/packages/plugins/audit-log/src/server/subjectExtractors.ts
+++ b/packages/plugins/audit-log/src/server/subjectExtractors.ts
@@ -1,0 +1,71 @@
+// Per-subject-type extractor for the audit row's denormalized labels.
+// Plugins shipping their own subject types (term, comment, …) will
+// register their extractor here in follow-up slices (#179+).
+
+interface SubjectInput {
+  readonly id: number | string;
+  readonly title?: string | null;
+  readonly slug?: string | null;
+  readonly email?: string | null;
+  readonly name?: string | null;
+}
+
+interface ResolvedSubject {
+  readonly type: string;
+  readonly id: string;
+  readonly label: string;
+}
+
+type SubjectExtractor = (entity: SubjectInput) => ResolvedSubject;
+
+const FALLBACK_LABEL = "(unnamed)";
+
+const entryExtractor: SubjectExtractor = (entity) => ({
+  type: "entry",
+  id: String(entity.id),
+  // Entry labels prefer title → slug → fallback. Slug is the human-
+  // friendly URL fragment, so it's the next-best identifier when the
+  // editor never set a title.
+  label: nonEmpty(entity.title) ?? nonEmpty(entity.slug) ?? FALLBACK_LABEL,
+});
+
+const userExtractor: SubjectExtractor = (entity) => ({
+  type: "user",
+  id: String(entity.id),
+  // User labels prefer name → email → fallback. Email is always set
+  // (it's the auth handle) so the fallback is only reachable through
+  // a programming error.
+  label: nonEmpty(entity.name) ?? nonEmpty(entity.email) ?? FALLBACK_LABEL,
+});
+
+export const subjectExtractors: Readonly<Record<string, SubjectExtractor>> = {
+  entry: entryExtractor,
+  user: userExtractor,
+};
+
+export function extractSubject(
+  type: string,
+  entity: SubjectInput,
+): ResolvedSubject {
+  const extractor = subjectExtractors[type];
+  if (extractor) return extractor(entity);
+  // Unknown subject type — record what we can, label falls through.
+  // Slice #179 adds term + settings extractors; until then, anything
+  // unrecognized lands here so the row still surfaces in the feed.
+  return {
+    type,
+    id: String(entity.id),
+    label:
+      nonEmpty(entity.title) ??
+      nonEmpty(entity.name) ??
+      nonEmpty(entity.email) ??
+      nonEmpty(entity.slug) ??
+      FALLBACK_LABEL,
+  };
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}

--- a/packages/plugins/audit-log/src/types.ts
+++ b/packages/plugins/audit-log/src/types.ts
@@ -1,0 +1,43 @@
+import type { AppContext } from "@plumix/core";
+
+import type { NewAuditLogRow } from "./db/schema.js";
+
+export interface AuditLogRow {
+  readonly id: number;
+  readonly occurredAt: Date;
+  readonly event: string;
+  readonly subjectType: string;
+  readonly subjectId: string;
+  readonly subjectLabel: string;
+  readonly actorId: number | null;
+  readonly actorLabel: string | null;
+  readonly properties: Record<string, unknown>;
+}
+
+export interface AuditLogQueryFilter {
+  /** Result cap. Defaults to 50; storage adapters clamp at their own ceiling. */
+  readonly limit?: number;
+}
+
+/**
+ * Pluggable storage seam. Defaults to SQLite (`sqlite()`) but the
+ * shape lets a deploy hot-swap to a separate database / external
+ * sink (Tinybird, BigQuery, etc.) without touching the plugin's
+ * write pipeline.
+ */
+export interface AuditLogStorage {
+  readonly kind: string;
+  /** Drizzle module to forward into `definePlugin({ schema })`. */
+  readonly schemaModule?: Record<string, unknown>;
+  /** Batch insert. The audit-log service buffers per-request and calls this once. */
+  write(ctx: AppContext, rows: readonly NewAuditLogRow[]): Promise<void>;
+  /** Latest-first read for the admin feed. */
+  query(
+    ctx: AppContext,
+    filter: AuditLogQueryFilter,
+  ): Promise<readonly AuditLogRow[]>;
+}
+
+export type AuditLogActor =
+  | { readonly id: number; readonly label: string | null }
+  | { readonly id: null; readonly label: string | null };

--- a/packages/plugins/audit-log/test/setup.ts
+++ b/packages/plugins/audit-log/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/plugins/audit-log/tsconfig.build.json
+++ b/packages/plugins/audit-log/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "stripInternal": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/plugins/audit-log/tsconfig.json
+++ b/packages/plugins/audit-log/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@plumix/typescript-config/library.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "rootDir": ".",
+    "types": ["node", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/plugins/audit-log/vitest.config.ts
+++ b/packages/plugins/audit-log/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import { baseConfig } from "@plumix/vitest-config/base";
+
+// jsdom is needed for the admin component suites (`src/admin/*.test.tsx`).
+// The server-side suites are environment-agnostic and work fine under
+// jsdom too, so we set one environment for the whole package rather than
+// branching per file pattern.
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      setupFiles: ["./test/setup.ts"],
+    },
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,82 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  packages/plugins/audit-log:
+    dependencies:
+      '@plumix/core':
+        specifier: workspace:*
+        version: link:../../core
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.2(@cloudflare/workers-types@4.20260421.1)(@libsql/client@0.17.3)
+      valibot:
+        specifier: 'catalog:'
+        version: 1.3.1(typescript@6.0.3)
+    devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: 'catalog:'
+        version: 0.18.2
+      '@plumix/eslint-config':
+        specifier: workspace:*
+        version: link:../../../tooling/eslint
+      '@plumix/prettier-config':
+        specifier: workspace:*
+        version: link:../../../tooling/prettier
+      '@plumix/typescript-config':
+        specifier: workspace:*
+        version: link:../../../tooling/typescript
+      '@plumix/vitest-config':
+        specifier: workspace:*
+        version: link:../../../tooling/vitest
+      '@tanstack/react-query':
+        specifier: ^5.99.2
+        version: 5.99.2(react@19.2.5)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      esbuild:
+        specifier: 0.27.7
+        version: 0.27.7
+      eslint:
+        specifier: 'catalog:'
+        version: 10.3.0(jiti@2.6.1)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      prettier:
+        specifier: 'catalog:'
+        version: 3.8.3
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.18
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/plugins/blog:
     dependencies:
       '@plumix/core':


### PR DESCRIPTION
First end-to-end tracer for the audit-log plugin (#175). Captures
entry lifecycle events into a queryable activity feed surfaced on
\`/admin/audit-log\`. v0.1 covers the entry event surface; #179+
adds user/term/settings hooks plus the public \`ctx.audit.log()\`
API for third-party plugins.

## Architecture

- **Storage seam** via \`AuditLogStorage\` with a default \`sqlite()\`
  adapter. The schema (one \`audit_log\` table + four indexes)
  forwards into \`definePlugin({ schema })\` so
  \`plumix migrate generate\` picks it up. Operators with their own
  observability stack can swap in a custom storage (Tinybird,
  BigQuery, separate DB) without touching the write pipeline.
- **\`createAuditService\`** buffers per-request via a WeakMap keyed
  by \`AppContext\` and flushes once via \`ctx.defer\` (the runtime
  shim from #177). One INSERT per request regardless of how many
  events fire — so a publish that triggers \`entry:updated +
  entry:transition + entry:published\` is one row's worth of
  storage cost, three rows of audit data.
- **Hook listeners** on \`entry:updated\` / \`entry:transition\` /
  \`entry:published\` / \`entry:trashed\` / \`entry:meta_changed\`.
  Pull \`AppContext\` out of \`requestStore.getStore()\` since the
  action signature can't carry it (requires #176/#177's runtime
  primitives).
- **\`auditLog.list\` RPC** gated on the new \`audit_log:read\`
  capability (registered with \`minRole: \"admin\"\`).
- **Admin page** — chronological table with timestamp, actor,
  event, subject, top-3 changed fields with \`+N more\`. Plain-text
  labels for v1; #180+ adds filters and link resolution.

## Load-bearing details worth a careful look

Three scheduling subtleties in \`createAuditService\` that are easy
to get wrong:

1. **Microtask-deferred splice.** The flush is wrapped in
   \`Promise.resolve().then(...)\` so its drain runs in a microtask.
   Without that wrap, an \`async\` flush would execute synchronously
   up to its first await — including the buffer drain — and steal
   the buffer before sibling synchronous \`record\` calls could
   append.
2. **Detach-before-await on flush.** The flush deletes the WeakMap
   entry _before_ awaiting \`storage.write\`. Re-entrant \`record\`
   during that await sees no active buffer for this ctx and
   schedules a fresh flush. Without the early delete, the new row
   would orphan into a now-empty array reference and disappear
   when ctx is GC'd.
3. **256 KiB \`properties\` cap.** Mirrors core's meta-pipeline cap.
   A misbehaving subscriber that builds a huge diff envelope gets
   the row dropped + a warn log instead of stuffing 100MB into the
   JSON column. Non-serializable values (BigInt, cycles) drop the
   same way.

## Notes for review

- **\`entry:created\` doesn't exist as a core hook** — only \`updated\`,
  \`transition\`, \`published\`, \`trashed\`, \`meta_changed\` are
  emitted. The listener set is what core ships. A \`created\`
  signal can be derived later from the first \`entry:transition\`
  with \`oldStatus === undefined\`.
- **\`AuditService.warnNoContextOnce\` is on the public interface** —
  useful for the hook-listener call site, but technically a leaked
  diagnostic seam. A future cleanup could split into
  \`AuditService\` (just \`record\`) + an implementation-specific
  return type from \`createAuditService\`. Not blocking; the
  docstring already calls it out.
- **Schema fallback when a consumer passes a custom storage** —
  if their \`storage.schemaModule\` is unset, \`definePlugin\` falls
  through to the default sqlite \`audit_log\` schema, which would
  end up in their migration codegen even though their storage
  doesn't use it. Worth a docstring note for plugin authors.
- **End-to-end integration test deferred** — applying plugin
  schemas to the test DB needs harness work (\`createTestDb\` only
  applies core schema today). The pure helpers + service-level
  race + RPC capability gating are all unit-tested. Worth filing
  a follow-up to add the harness path.

Fixes #178