### PR TITLE
feat(plugin-audit-log): broader hook coverage for auth/user/term/settings (slice 179)

### DIFF
--- a/packages/plugins/audit-log/src/index.ts
+++ b/packages/plugins/audit-log/src/index.ts
@@ -4,7 +4,7 @@ import type { AuditLogStorage } from "./types.js";
 import * as schema from "./db/schema.js";
 import { createAuditLogRouter } from "./rpc.js";
 import { createAuditService } from "./server/auditService.js";
-import { registerEntryHooks } from "./server/hooks.js";
+import { registerHooks } from "./server/hooks.js";
 import { sqlite } from "./server/storage-sqlite.js";
 
 export type {
@@ -65,7 +65,7 @@ export function auditLog(options: AuditLogPluginOptions = {}) {
 
       ctx.registerRpcRouter(router);
 
-      registerEntryHooks(ctx, service);
+      registerHooks(ctx, service);
 
       ctx.registerAdminPage({
         path: "/audit-log",

--- a/packages/plugins/audit-log/src/server/hooks.test.ts
+++ b/packages/plugins/audit-log/src/server/hooks.test.ts
@@ -1,0 +1,389 @@
+// Hook subscription tests. Each test wires a `HookRegistry`, calls
+// `registerHooks(ctx, fakeService)`, fires the action via `doAction`
+// inside a `requestStore.run` frame, and asserts on the row that
+// landed in the fake service's record buffer. Avoids the real DB
+// path (slice 178's harness gap) and keeps each assertion pinned to
+// the row's shape.
+
+import { describe, expect, test } from "vitest";
+
+import type {
+  AppContext,
+  AuthenticatedUser,
+  HookOptions,
+  PluginSetupContext,
+  Term,
+  User,
+} from "@plumix/core";
+import { HookRegistry, requestStore } from "@plumix/core";
+
+import type { NewAuditLogRow } from "../db/schema.js";
+import type { AuditService } from "./auditService.js";
+import { registerHooks } from "./hooks.js";
+
+// Loose-typed dispatch — slice 178's defer.test.ts uses the same
+// pattern. The action names here aren't all in `ActionRegistry`'s
+// typed view (some are core lifecycle actions), so we cast once to
+// keep the tests readable.
+type ActionDispatcher = (name: string, ...args: unknown[]) => Promise<void>;
+
+function makeFakeAppCtx(user: AuthenticatedUser | null): AppContext {
+  return { user } as AppContext;
+}
+
+interface FakeServiceState {
+  readonly service: AuditService;
+  readonly rows: NewAuditLogRow[];
+  warnedNoContext: number;
+}
+
+function fakeService(): FakeServiceState {
+  const rows: NewAuditLogRow[] = [];
+  const state: FakeServiceState = {
+    rows,
+    warnedNoContext: 0,
+    service: {
+      record: (_ctx, row) => {
+        rows.push(row);
+      },
+      warnNoContextOnce: () => {
+        state.warnedNoContext += 1;
+      },
+    },
+  };
+  return state;
+}
+
+interface HarnessHandles {
+  readonly hooks: HookRegistry;
+  readonly state: FakeServiceState;
+  readonly fire: ActionDispatcher;
+  readonly fireOutsideRequest: ActionDispatcher;
+}
+
+function harness(user: AuthenticatedUser | null = adminUser): HarnessHandles {
+  const hooks = new HookRegistry();
+  const state = fakeService();
+
+  // Minimal PluginSetupContext stand-in: only `addAction` is needed
+  // by `registerHooks`. Casting through `unknown` lets us satisfy
+  // the strict type without conjuring every register* method.
+  const ctx = {
+    addAction: (
+      name: string,
+      fn: (...args: unknown[]) => unknown,
+      options?: HookOptions,
+    ) => {
+      hooks.addAction(name as never, fn as never, options);
+    },
+  } as unknown as PluginSetupContext;
+  registerHooks(ctx, state.service);
+
+  const fakeCtx = makeFakeAppCtx(user);
+  // Bound so the call sites don't drop `this` — `doAction` reads
+  // private state through `this.#actions`.
+  const dispatch: ActionDispatcher = (name, ...args) =>
+    (hooks.doAction as (n: string, ...a: unknown[]) => Promise<void>).call(
+      hooks,
+      name,
+      ...args,
+    );
+  return {
+    hooks,
+    state,
+    fire: (name, ...args) =>
+      requestStore.run(fakeCtx, () => dispatch(name, ...args)),
+    fireOutsideRequest: dispatch,
+  };
+}
+
+const adminUser: AuthenticatedUser = {
+  id: 7,
+  email: "alice@example.com",
+  role: "admin",
+};
+const subjectUser = {
+  id: 42,
+  email: "bob@example.com",
+  name: "Bob",
+  role: "editor",
+  status: "active",
+} as unknown as User;
+
+describe("registerHooks — entry surface (regression)", () => {
+  test("entry:published produces a row keyed on the entry", async () => {
+    const h = harness();
+    await h.fire("entry:published", {
+      id: 5,
+      title: "Hello",
+      slug: "hello",
+      type: "post",
+      status: "published",
+    });
+    expect(h.state.rows).toHaveLength(1);
+    expect(h.state.rows[0]).toMatchObject({
+      event: "entry:published",
+      subjectType: "entry",
+      subjectId: "5",
+      subjectLabel: "Hello",
+      actorId: 7,
+      actorLabel: "alice@example.com",
+    });
+  });
+
+  test("hook fired outside requestStore lands on warnNoContextOnce, not the service", async () => {
+    const h = harness();
+    await h.fireOutsideRequest("entry:published", {
+      id: 5,
+      title: "Hello",
+      slug: "hello",
+      type: "post",
+      status: "published",
+    });
+    expect(h.state.rows).toHaveLength(0);
+    expect(h.state.warnedNoContext).toBe(1);
+  });
+});
+
+describe("registerHooks — user surface", () => {
+  test("user:status_changed encodes the toggle as a [from, to] tuple", async () => {
+    const h = harness();
+    await h.fire("user:status_changed", subjectUser, { enabled: false });
+    expect(h.state.rows[0]).toMatchObject({
+      event: "user:status_changed",
+      subjectType: "user",
+      subjectId: "42",
+      subjectLabel: "Bob",
+      properties: { status: ["enabled", "disabled"] },
+    });
+  });
+
+  test("user:updated diffs the top-level user row, ignoring meta + timestamps", async () => {
+    const h = harness();
+    const previous = {
+      ...subjectUser,
+      name: "Bobby",
+      role: "author",
+      meta: { something: "old" },
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    } as unknown as User;
+    const next = {
+      ...subjectUser,
+      meta: { something: "new" },
+      updatedAt: new Date("2026-05-10T18:00:00Z"),
+    } as unknown as User;
+    await h.fire("user:updated", next, previous);
+
+    const row = h.state.rows[0];
+    if (!row) throw new Error("expected a captured row");
+    expect(row.event).toBe("user:updated");
+    const diff = row.properties?.diff as
+      | Record<string, [unknown, unknown]>
+      | undefined;
+    // `name` and `role` differed; `meta` + `updatedAt` are stripped.
+    expect(diff).toBeDefined();
+    expect(Object.keys(diff ?? {}).sort()).toEqual(["name", "role"]);
+    expect(diff?.name).toEqual(["Bobby", "Bob"]);
+  });
+
+  test("user:invited attributes to invitedBy with admin email as label, never logs the invite token", async () => {
+    const h = harness();
+    const expiresAt = new Date("2026-05-17T00:00:00Z");
+    await h.fire("user:invited", subjectUser, {
+      inviteToken: "secret-do-not-log",
+      invitedBy: 7,
+      expiresAt,
+    });
+    const row = h.state.rows[0];
+    expect(row?.event).toBe("user:invited");
+    expect(row?.actorId).toBe(7);
+    expect(row?.actorLabel).toBe("alice@example.com");
+    expect(row?.properties).toEqual({
+      expiresAt: expiresAt.toISOString(),
+    });
+    expect(JSON.stringify(row)).not.toContain("secret-do-not-log");
+  });
+
+  test("user:invited falls back to id-as-string label when ctx.user is unrelated (e.g. CLI)", async () => {
+    const h = harness(null);
+    const expiresAt = new Date("2026-05-17T00:00:00Z");
+    await h.fire("user:invited", subjectUser, {
+      invitedBy: 9,
+      expiresAt,
+    });
+    const row = h.state.rows[0];
+    expect(row?.actorId).toBe(9);
+    expect(row?.actorLabel).toBe("9");
+  });
+
+  test("user:registered self-attributes when ctx.user is null", async () => {
+    const h = harness(null);
+    await h.fire("user:registered", subjectUser);
+    const row = h.state.rows[0];
+    expect(row?.event).toBe("user:registered");
+    expect(row?.actorId).toBe(42);
+    expect(row?.actorLabel).toBe("bob@example.com");
+  });
+});
+
+describe("registerHooks — auth surface", () => {
+  test("user:signed_in self-attributes (ctx.user is null at sign-in time)", async () => {
+    const h = harness(null);
+    await h.fire("user:signed_in", subjectUser, {
+      method: "oauth",
+      provider: "github",
+      firstSignIn: false,
+    });
+    expect(h.state.rows[0]).toMatchObject({
+      event: "user:signed_in",
+      subjectType: "user",
+      subjectId: "42",
+      actorId: 42,
+      actorLabel: "bob@example.com",
+      properties: { method: "oauth", provider: "github", firstSignIn: false },
+    });
+  });
+
+  test("credential:created uses the credential subject + actor from context", async () => {
+    const h = harness();
+    await h.fire(
+      "credential:created",
+      {
+        id: "cred-1",
+        userId: 42,
+        name: "My laptop",
+        deviceType: "platform",
+        isBackedUp: true,
+      },
+      { actor: adminUser },
+    );
+    expect(h.state.rows[0]).toMatchObject({
+      event: "credential:created",
+      subjectType: "credential",
+      subjectId: "cred-1",
+      subjectLabel: "My laptop",
+      actorId: 7,
+      actorLabel: "alice@example.com",
+      properties: {
+        deviceType: "platform",
+        isBackedUp: true,
+        userId: 42,
+      },
+    });
+  });
+
+  test("api_token:revoked includes the mode (self vs admin) for downstream copy", async () => {
+    const h = harness();
+    await h.fire(
+      "api_token:revoked",
+      { id: "tok-9", userId: 42 },
+      { actor: adminUser, mode: "admin" },
+    );
+    expect(h.state.rows[0]?.properties).toMatchObject({
+      mode: "admin",
+      userId: 42,
+    });
+  });
+
+  test("device_code:approved labels the row with the userCode", async () => {
+    const h = harness();
+    await h.fire(
+      "device_code:approved",
+      {
+        id: "dev-9",
+        userCode: "ABCD-WXYZ",
+        tokenName: "CI deploy",
+        scopes: ["entry:read"],
+      },
+      { actor: adminUser },
+    );
+    expect(h.state.rows[0]).toMatchObject({
+      event: "device_code:approved",
+      subjectType: "device_code",
+      subjectId: "dev-9",
+      subjectLabel: "ABCD-WXYZ",
+      properties: { tokenName: "CI deploy", scopes: ["entry:read"] },
+    });
+  });
+});
+
+describe("registerHooks — term surface", () => {
+  test("term:updated diffs name/slug/parent (skipping meta + timestamps)", async () => {
+    const h = harness();
+    const previous = {
+      id: 3,
+      taxonomy: "category",
+      name: "Old",
+      slug: "old",
+      parentId: null,
+      meta: {},
+    } as unknown as Term;
+    const next = {
+      id: 3,
+      taxonomy: "category",
+      name: "New",
+      slug: "new",
+      parentId: 9,
+      meta: {},
+    } as unknown as Term;
+    await h.fire("term:updated", next, previous);
+
+    const row = h.state.rows[0];
+    if (!row) throw new Error("expected a captured row");
+    expect(row.event).toBe("term:updated");
+    const diff = row.properties?.diff as
+      | Record<string, [unknown, unknown]>
+      | undefined;
+    expect(diff).toBeDefined();
+    expect(Object.keys(diff ?? {}).sort()).toEqual([
+      "name",
+      "parentId",
+      "slug",
+    ]);
+  });
+
+  test("term:deleted produces a final row even though the source row is gone", async () => {
+    const h = harness();
+    await h.fire("term:deleted", {
+      id: 3,
+      taxonomy: "category",
+      name: "Old news",
+      slug: "old-news",
+    });
+    expect(h.state.rows[0]).toMatchObject({
+      event: "term:deleted",
+      subjectType: "term",
+      subjectId: "3",
+      subjectLabel: "Old news",
+    });
+  });
+});
+
+describe("registerHooks — settings surface", () => {
+  test("settings:group_changed records key names only, never raw values", async () => {
+    const h = harness();
+    await h.fire("settings:group_changed", {
+      group: "mailer",
+      set: {
+        fromAddress: "noreply@example.com",
+        smtpPassword: "super-secret-do-not-log",
+      },
+      removed: ["legacyKey"],
+    });
+    const row = h.state.rows[0];
+    if (!row) throw new Error("expected a captured row");
+    expect(row).toMatchObject({
+      event: "settings:group_changed",
+      subjectType: "settings_group",
+      subjectId: "mailer",
+      subjectLabel: "mailer",
+    });
+    expect(row.properties).toEqual({
+      keysSet: ["fromAddress", "smtpPassword"],
+      keysRemoved: ["legacyKey"],
+    });
+    // SECURITY: raw values must never land in the audit JSON column.
+    expect(JSON.stringify(row)).not.toContain("super-secret-do-not-log");
+    expect(JSON.stringify(row)).not.toContain("noreply@example.com");
+  });
+});

--- a/packages/plugins/audit-log/src/server/hooks.ts
+++ b/packages/plugins/audit-log/src/server/hooks.ts
@@ -1,91 +1,129 @@
-// Hook subscriptions that capture entry events into the audit log.
+// Hook subscriptions that capture lifecycle events into the audit log.
 // Each listener pulls the per-request `AppContext` out of
 // `requestStore.getStore()` (provided by the runtime via #176/#177)
 // so it can call `service.record(ctx, row)` against the buffered
 // per-request batch.
+//
+// Slice 178 wired the entry surface; #179 (this file's expansion)
+// adds user / auth / term / settings — the full curated list per the
+// audit-log PRD. Each thematic register* function is independent;
+// definePlugin's `setup` wires them all in one place.
 
-import type { Entry, EntryStatus, PluginSetupContext } from "@plumix/core";
+import type {
+  ApiToken,
+  AppContext,
+  AuthenticatedUser,
+  Credential,
+  Entry,
+  EntryStatus,
+  PluginSetupContext,
+  Term,
+  User,
+} from "@plumix/core";
 import { tryGetContext } from "@plumix/core";
 
+import type { NewAuditLogRow } from "../db/schema.js";
+import type { AuditLogActor } from "../types.js";
 import type { AuditService } from "./auditService.js";
 import type { EntryMetaChanges } from "./entry-meta-changes.js";
 import { buildAuditRow } from "./buildAuditRow.js";
 import { extractSubject } from "./subjectExtractors.js";
 
-interface EntryActorLookup {
-  readonly id: number | null;
-  readonly label: string | null;
+// Diff-stripping omit list per subject type. Auto-managed timestamps
+// would otherwise show as a "diff" on every update; nested JSON
+// (content / meta / settings.values) is covered by dedicated
+// `*:meta_changed` and `settings:group_changed` hooks so we don't
+// double-count.
+const ENTRY_DIFF_OMIT_KEYS = new Set([
+  "createdAt",
+  "updatedAt",
+  "content",
+  "meta",
+]);
+
+const USER_DIFF_OMIT_KEYS = new Set([
+  "createdAt",
+  "updatedAt",
+  "lastSignInAt",
+  "passwordHash",
+  "meta",
+]);
+
+const TERM_DIFF_OMIT_KEYS = new Set(["createdAt", "updatedAt", "meta"]);
+
+export function registerHooks(
+  ctx: PluginSetupContext,
+  service: AuditService,
+): void {
+  registerEntryHooks(ctx, service);
+  registerUserHooks(ctx, service);
+  registerAuthHooks(ctx, service);
+  registerTermHooks(ctx, service);
+  registerSettingsHooks(ctx, service);
 }
 
-export function registerEntryHooks(
+// Internal helper: resolve the request ctx + actor, build the row,
+// and route through the buffered service. Returning early on a missing
+// ctx surfaces a one-time DX warn (see auditService.warnNoContextOnce)
+// without spamming the log per event.
+function record(
+  service: AuditService,
+  buildFromCtx: (ctx: AppContext, actor: AuditLogActor) => NewAuditLogRow,
+): void {
+  const appCtx = tryGetContext();
+  if (!appCtx) {
+    service.warnNoContextOnce();
+    return;
+  }
+  service.record(appCtx, buildFromCtx(appCtx, actorOf(appCtx)));
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Entry surface (carried over from slice 178)
+// ──────────────────────────────────────────────────────────────────
+
+function registerEntryHooks(
   ctx: PluginSetupContext,
   service: AuditService,
 ): void {
   ctx.addAction("entry:updated", (entry: Entry, previous: Entry) => {
-    const appCtx = tryGetContext();
-    if (!appCtx) {
-      service.warnNoContextOnce();
-      return;
-    }
-    const subject = extractSubject("entry", entry);
-    service.record(
-      appCtx,
+    record(service, (_appCtx, actor) =>
       buildAuditRow({
         event: "entry:updated",
-        actor: actorOf(appCtx),
-        subject,
-        previous: stripDiffNoise(previous),
-        next: stripDiffNoise(entry),
+        actor,
+        subject: extractSubject("entry", entry),
+        previous: stripKeys(previous, ENTRY_DIFF_OMIT_KEYS),
+        next: stripKeys(entry, ENTRY_DIFF_OMIT_KEYS),
       }),
     );
   });
 
   ctx.addAction("entry:transition", (entry: Entry, oldStatus: EntryStatus) => {
-    const appCtx = tryGetContext();
-    if (!appCtx) {
-      service.warnNoContextOnce();
-      return;
-    }
-    service.record(
-      appCtx,
+    record(service, (_appCtx, actor) =>
       buildAuditRow({
         event: "entry:transition",
-        actor: actorOf(appCtx),
+        actor,
         subject: extractSubject("entry", entry),
-        extraProperties: {
-          status: { from: oldStatus, to: entry.status },
-        },
+        extraProperties: { status: { from: oldStatus, to: entry.status } },
       }),
     );
   });
 
   ctx.addAction("entry:published", (entry: Entry) => {
-    const appCtx = tryGetContext();
-    if (!appCtx) {
-      service.warnNoContextOnce();
-      return;
-    }
-    service.record(
-      appCtx,
+    record(service, (_appCtx, actor) =>
       buildAuditRow({
         event: "entry:published",
-        actor: actorOf(appCtx),
+        actor,
         subject: extractSubject("entry", entry),
       }),
     );
   });
 
   ctx.addAction("entry:trashed", (entry: Entry) => {
-    const appCtx = tryGetContext();
-    if (!appCtx) {
-      service.warnNoContextOnce();
-      return;
-    }
-    service.record(
-      appCtx,
+    record(service, (_appCtx, actor) =>
       buildAuditRow({
         event: "entry:trashed",
-        actor: actorOf(appCtx),
+        actor,
         subject: extractSubject("entry", entry),
       }),
     );
@@ -97,20 +135,13 @@ export function registerEntryHooks(
       entry: { readonly id: number; readonly type: string },
       changes: EntryMetaChanges,
     ) => {
-      const appCtx = tryGetContext();
-      if (!appCtx) return;
-      service.record(
-        appCtx,
+      record(service, (_appCtx, actor) =>
         buildAuditRow({
           event: "entry:meta_changed",
-          actor: actorOf(appCtx),
+          actor,
           subject: {
             type: "entry",
             id: String(entry.id),
-            // Meta-changed payload doesn't carry the title — fall back
-            // to the entry id as the label. The feed renders this as
-            // a numeric breadcrumb; consumers wanting a richer label
-            // can resolve at render time.
             label: `Entry #${String(entry.id)}`,
           },
           extraProperties: {
@@ -123,30 +154,525 @@ export function registerEntryHooks(
   );
 }
 
-function actorOf(ctx: {
-  readonly user: { readonly id: number; readonly email: string } | null;
-}): EntryActorLookup {
+// ──────────────────────────────────────────────────────────────────
+// User surface
+// ──────────────────────────────────────────────────────────────────
+
+function registerUserHooks(
+  ctx: PluginSetupContext,
+  service: AuditService,
+): void {
+  ctx.addAction("user:updated", (user: User, previous: User) => {
+    record(service, (_appCtx, actor) =>
+      buildAuditRow({
+        event: "user:updated",
+        actor,
+        subject: extractSubject("user", user),
+        previous: stripKeys(previous, USER_DIFF_OMIT_KEYS),
+        next: stripKeys(user, USER_DIFF_OMIT_KEYS),
+      }),
+    );
+  });
+
+  ctx.addAction(
+    "user:status_changed",
+    (user: User, context: { readonly enabled: boolean }) => {
+      record(service, (_appCtx, actor) =>
+        buildAuditRow({
+          event: "user:status_changed",
+          actor,
+          subject: extractSubject("user", user),
+          // Per the slice acceptance: render as `{ status: [old, new] }`
+          // even though the underlying signal is a boolean — the feed's
+          // diff renderer already understands the [old, new] tuple.
+          extraProperties: {
+            status: [
+              context.enabled ? "disabled" : "enabled",
+              context.enabled ? "enabled" : "disabled",
+            ],
+          },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "user:deleted",
+    (user: User, context: { readonly reassignedTo: number | null }) => {
+      record(service, (_appCtx, actor) =>
+        buildAuditRow({
+          event: "user:deleted",
+          actor,
+          subject: extractSubject("user", user),
+          extraProperties: { reassignedTo: context.reassignedTo },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "user:meta_changed",
+    (user: { readonly id: number }, changes: EntryMetaChanges) => {
+      record(service, (_appCtx, actor) =>
+        buildAuditRow({
+          event: "user:meta_changed",
+          actor,
+          subject: {
+            type: "user",
+            id: String(user.id),
+            label: `User #${String(user.id)}`,
+          },
+          extraProperties: {
+            metaSet: Object.keys(changes.set),
+            metaRemoved: changes.removed,
+          },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "user:invited",
+    (
+      user: User,
+      context: {
+        readonly invitedBy: number;
+        readonly expiresAt: Date;
+      },
+    ) => {
+      record(service, (appCtx) => {
+        // The hook explicitly carries `invitedBy` — the admin who
+        // initiated the invite. When the admin is also the request's
+        // ctx.user, prefer their email as the label so the feed reads
+        // consistently with their other actions; otherwise (e.g. a
+        // CLI-initiated invite) fall back to the id-as-string.
+        // SECURITY: `inviteToken` is never recorded.
+        const label =
+          appCtx.user?.id === context.invitedBy
+            ? appCtx.user.email
+            : String(context.invitedBy);
+        return buildAuditRow({
+          event: "user:invited",
+          actor: { id: context.invitedBy, label },
+          subject: extractSubject("user", user),
+          extraProperties: {
+            expiresAt: context.expiresAt.toISOString(),
+          },
+        });
+      });
+    },
+  );
+
+  ctx.addAction("user:registered", (user: User) => {
+    record(service, () =>
+      buildAuditRow({
+        event: "user:registered",
+        // Self-registration: the user who just registered IS the actor.
+        // `ctx.user` is null at this point because the session is being
+        // established in the same request, so fall back to the payload.
+        actor: actorFromUser(user),
+        subject: extractSubject("user", user),
+      }),
+    );
+  });
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Auth surface — sign-ins, credentials, sessions, API tokens, device flow
+// ──────────────────────────────────────────────────────────────────
+
+function registerAuthHooks(
+  ctx: PluginSetupContext,
+  service: AuditService,
+): void {
+  ctx.addAction(
+    "user:signed_in",
+    (
+      user: User,
+      context: {
+        readonly method: string;
+        readonly provider?: string;
+        readonly firstSignIn: boolean;
+      },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "user:signed_in",
+          // Self sign-in: `ctx.user` is null on the request that just
+          // authenticated (middleware ran before auth completed), so
+          // attribute the row to the user being signed in directly.
+          actor: actorFromUser(user),
+          subject: extractSubject("user", user),
+          extraProperties: {
+            method: context.method,
+            provider: context.provider ?? null,
+            firstSignIn: context.firstSignIn,
+          },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction("user:signed_out", (user: User) => {
+    record(service, () =>
+      buildAuditRow({
+        event: "user:signed_out",
+        // Self sign-out: same self-attribution as signed_in for symmetry.
+        actor: actorFromUser(user),
+        subject: extractSubject("user", user),
+      }),
+    );
+  });
+
+  ctx.addAction(
+    "user:email_change_requested",
+    (
+      user: User,
+      context: {
+        readonly actor: AuthenticatedUser;
+        readonly newEmail: string;
+        readonly expiresAt: Date;
+      },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "user:email_change_requested",
+          // The hook explicitly carries `context.actor` (which may
+          // differ from `user` when an admin requests the change for
+          // someone else). Prefer the explicit actor over ctx.user
+          // so the row reflects the responsible party.
+          actor: actorFromUser(context.actor),
+          subject: extractSubject("user", user),
+          extraProperties: {
+            newEmail: context.newEmail,
+            expiresAt: context.expiresAt.toISOString(),
+          },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "user:email_changed",
+    (user: User, context: { readonly previousEmail: string }) => {
+      record(service, (_appCtx, actor) =>
+        buildAuditRow({
+          event: "user:email_changed",
+          actor,
+          subject: extractSubject("user", user),
+          extraProperties: {
+            email: [context.previousEmail, user.email],
+          },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "credential:created",
+    (
+      credential: Pick<
+        Credential,
+        "id" | "userId" | "name" | "deviceType" | "isBackedUp"
+      >,
+      context: { readonly actor: AuthenticatedUser },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "credential:created",
+          actor: actorFromUser(context.actor),
+          subject: extractSubject("credential", credential),
+          extraProperties: {
+            deviceType: credential.deviceType,
+            isBackedUp: credential.isBackedUp,
+            userId: credential.userId,
+          },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "credential:revoked",
+    (
+      credential: { readonly id: string; readonly userId: number },
+      context: { readonly actor: AuthenticatedUser },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "credential:revoked",
+          actor: actorFromUser(context.actor),
+          subject: extractSubject("credential", credential),
+          extraProperties: { userId: credential.userId },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "credential:renamed",
+    (
+      credential: { readonly id: string; readonly userId: number },
+      context: { readonly actor: AuthenticatedUser; readonly name: string },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "credential:renamed",
+          actor: actorFromUser(context.actor),
+          subject: {
+            type: "credential",
+            id: String(credential.id),
+            label: context.name,
+          },
+          extraProperties: { userId: credential.userId },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "session:revoked",
+    (
+      session: { readonly id: string; readonly userId: number },
+      context: {
+        readonly actor: AuthenticatedUser;
+        readonly mode: "single" | "all_others";
+      },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "session:revoked",
+          actor: actorFromUser(context.actor),
+          subject: extractSubject("session", session),
+          extraProperties: { mode: context.mode, userId: session.userId },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "api_token:created",
+    (
+      token: Pick<
+        ApiToken,
+        "id" | "userId" | "name" | "prefix" | "scopes" | "expiresAt"
+      >,
+      context: { readonly actor: AuthenticatedUser },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "api_token:created",
+          actor: actorFromUser(context.actor),
+          subject: extractSubject("api_token", token),
+          extraProperties: {
+            prefix: token.prefix,
+            scopes: token.scopes,
+            userId: token.userId,
+            expiresAt: token.expiresAt ? token.expiresAt.toISOString() : null,
+          },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "api_token:revoked",
+    (
+      token: { readonly id: string; readonly userId: number },
+      context: {
+        readonly actor: AuthenticatedUser;
+        readonly mode: "self" | "admin";
+      },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "api_token:revoked",
+          actor: actorFromUser(context.actor),
+          subject: extractSubject("api_token", token),
+          extraProperties: { mode: context.mode, userId: token.userId },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "device_code:approved",
+    (
+      deviceCode: {
+        readonly id: string;
+        readonly userCode: string;
+        readonly tokenName: string;
+        readonly scopes: readonly string[] | null;
+      },
+      context: { readonly actor: AuthenticatedUser },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "device_code:approved",
+          actor: actorFromUser(context.actor),
+          // The user-facing handle for a device-code session is the
+          // `userCode` (e.g. `ABCD-WXYZ`). Map it through the
+          // extractor by feeding it as `title` — that's what the
+          // device_code extractor reads.
+          subject: extractSubject("device_code", {
+            id: deviceCode.id,
+            title: deviceCode.userCode,
+          }),
+          extraProperties: {
+            tokenName: deviceCode.tokenName,
+            scopes: deviceCode.scopes,
+          },
+        }),
+      );
+    },
+  );
+
+  ctx.addAction(
+    "device_code:denied",
+    (
+      deviceCode: { readonly id: string; readonly userCode: string },
+      context: { readonly actor: AuthenticatedUser },
+    ) => {
+      record(service, () =>
+        buildAuditRow({
+          event: "device_code:denied",
+          actor: actorFromUser(context.actor),
+          subject: extractSubject("device_code", {
+            id: deviceCode.id,
+            title: deviceCode.userCode,
+          }),
+        }),
+      );
+    },
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Term surface
+// ──────────────────────────────────────────────────────────────────
+
+function registerTermHooks(
+  ctx: PluginSetupContext,
+  service: AuditService,
+): void {
+  ctx.addAction("term:created", (term: Term) => {
+    record(service, (_appCtx, actor) =>
+      buildAuditRow({
+        event: "term:created",
+        actor,
+        subject: extractSubject("term", term),
+      }),
+    );
+  });
+
+  ctx.addAction("term:updated", (term: Term, previous: Term) => {
+    record(service, (_appCtx, actor) =>
+      buildAuditRow({
+        event: "term:updated",
+        actor,
+        subject: extractSubject("term", term),
+        previous: stripKeys(previous, TERM_DIFF_OMIT_KEYS),
+        next: stripKeys(term, TERM_DIFF_OMIT_KEYS),
+      }),
+    );
+  });
+
+  ctx.addAction("term:deleted", (term: Term) => {
+    record(service, (_appCtx, actor) =>
+      buildAuditRow({
+        event: "term:deleted",
+        actor,
+        subject: extractSubject("term", term),
+      }),
+    );
+  });
+
+  ctx.addAction(
+    "term:meta_changed",
+    (
+      term: { readonly id: number; readonly taxonomy: string },
+      changes: EntryMetaChanges,
+    ) => {
+      record(service, (_appCtx, actor) =>
+        buildAuditRow({
+          event: "term:meta_changed",
+          actor,
+          subject: {
+            type: "term",
+            id: String(term.id),
+            label: `Term #${String(term.id)}`,
+          },
+          extraProperties: {
+            taxonomy: term.taxonomy,
+            metaSet: Object.keys(changes.set),
+            metaRemoved: changes.removed,
+          },
+        }),
+      );
+    },
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Settings surface
+// ──────────────────────────────────────────────────────────────────
+
+function registerSettingsHooks(
+  ctx: PluginSetupContext,
+  service: AuditService,
+): void {
+  ctx.addAction(
+    "settings:group_changed",
+    (changes: {
+      readonly group: string;
+      readonly set: Readonly<Record<string, unknown>>;
+      readonly removed: readonly string[];
+    }) => {
+      record(service, (_appCtx, actor) =>
+        // SECURITY: settings values can carry secrets (SMTP password,
+        // OAuth client secret, API keys). Record only the changed key
+        // names — never the values — so the audit table doesn't become
+        // a credential mirror. Consumers that need values should read
+        // them through the settings API with proper redaction in v0.2.
+        buildAuditRow({
+          event: "settings:group_changed",
+          actor,
+          subject: {
+            type: "settings_group",
+            id: changes.group,
+            label: changes.group,
+          },
+          extraProperties: {
+            keysSet: Object.keys(changes.set),
+            keysRemoved: changes.removed,
+          },
+        }),
+      );
+    },
+  );
+}
+
+function actorOf(ctx: AppContext): AuditLogActor {
   if (ctx.user === null) {
     return { id: null, label: null };
   }
-  return { id: ctx.user.id, label: ctx.user.email };
+  return actorFromUser(ctx.user);
 }
 
-const DIFF_OMIT_KEYS = new Set([
-  // Auto-managed timestamps would always show as a "diff" on every
-  // update. Skip them so the diff envelope only carries fields the
-  // user actually changed.
-  "createdAt",
-  "updatedAt",
-  // Nested JSON; covered by the dedicated `entry:meta_changed` hook.
-  "content",
-  "meta",
-]);
+function actorFromUser(user: {
+  readonly id: number;
+  readonly email: string;
+}): AuditLogActor {
+  return { id: user.id, label: user.email };
+}
 
-function stripDiffNoise(entry: Entry): Record<string, unknown> {
+function stripKeys<T extends Record<string, unknown>>(
+  source: T,
+  omit: ReadonlySet<string>,
+): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(entry)) {
-    if (DIFF_OMIT_KEYS.has(key)) continue;
+  for (const [key, value] of Object.entries(source)) {
+    if (omit.has(key)) continue;
     out[key] = value;
   }
   return out;

--- a/packages/plugins/audit-log/src/server/subjectExtractors.test.ts
+++ b/packages/plugins/audit-log/src/server/subjectExtractors.test.ts
@@ -55,6 +55,61 @@ describe("extractSubject", () => {
   test("subjectExtractors map exposes per-type extractors directly", () => {
     expect(typeof subjectExtractors.entry).toBe("function");
     expect(typeof subjectExtractors.user).toBe("function");
-    expect(subjectExtractors.term).toBeUndefined();
+    // Slice 179: full curated set landed.
+    expect(typeof subjectExtractors.term).toBe("function");
+    expect(typeof subjectExtractors.credential).toBe("function");
+    expect(typeof subjectExtractors.api_token).toBe("function");
+    expect(typeof subjectExtractors.session).toBe("function");
+    expect(typeof subjectExtractors.device_code).toBe("function");
+    expect(typeof subjectExtractors.settings_group).toBe("function");
+    expect(subjectExtractors.unknown_kind_xyz).toBeUndefined();
+  });
+
+  test("term extractor prefers name, falls back to slug, then (unnamed)", () => {
+    expect(
+      extractSubject("term", { id: 1, name: "News", slug: "news" }),
+    ).toEqual({ type: "term", id: "1", label: "News" });
+
+    expect(extractSubject("term", { id: 2, name: null, slug: "tech" })).toEqual(
+      { type: "term", id: "2", label: "tech" },
+    );
+
+    expect(extractSubject("term", { id: 3, name: "  ", slug: "  " })).toEqual({
+      type: "term",
+      id: "3",
+      label: "(unnamed)",
+    });
+  });
+
+  test("credential / api_token extractors prefer the user-set name", () => {
+    expect(
+      extractSubject("credential", { id: "abc", name: "My laptop" }),
+    ).toEqual({ type: "credential", id: "abc", label: "My laptop" });
+
+    expect(
+      extractSubject("api_token", { id: "tok-1", name: "CI deploy" }),
+    ).toEqual({ type: "api_token", id: "tok-1", label: "CI deploy" });
+  });
+
+  test("session extractor uses the fallback label (no human handle)", () => {
+    expect(extractSubject("session", { id: "sess-uuid", name: null })).toEqual({
+      type: "session",
+      id: "sess-uuid",
+      label: "(unnamed)",
+    });
+  });
+
+  test("device_code extractor uses the userCode passed via title", () => {
+    expect(
+      extractSubject("device_code", { id: "dev-1", title: "ABCD-WXYZ" }),
+    ).toEqual({ type: "device_code", id: "dev-1", label: "ABCD-WXYZ" });
+  });
+
+  test("settings_group extractor uses the group name as both id and label", () => {
+    expect(extractSubject("settings_group", { id: "mailer" })).toEqual({
+      type: "settings_group",
+      id: "mailer",
+      label: "mailer",
+    });
   });
 });

--- a/packages/plugins/audit-log/src/server/subjectExtractors.ts
+++ b/packages/plugins/audit-log/src/server/subjectExtractors.ts
@@ -8,6 +8,8 @@ interface SubjectInput {
   readonly slug?: string | null;
   readonly email?: string | null;
   readonly name?: string | null;
+  /** Term taxonomy label, used for `term` subject debugging. */
+  readonly taxonomy?: string | null;
 }
 
 interface ResolvedSubject {
@@ -38,9 +40,70 @@ const userExtractor: SubjectExtractor = (entity) => ({
   label: nonEmpty(entity.name) ?? nonEmpty(entity.email) ?? FALLBACK_LABEL,
 });
 
+// Slice 179 surface — per-subject extractors covering everything the
+// audit log subscribes to. Subjects that lack a human label (sessions,
+// device codes) deliberately resolve to `subject_id` via the
+// FALLBACK; the feed renders that as a numeric breadcrumb.
+const termExtractor: SubjectExtractor = (entity) => ({
+  type: "term",
+  id: String(entity.id),
+  // Term tables denormalise `name` and `slug`; admins typically search
+  // by name, so prefer it. Slug is the next-best stable identifier.
+  label: nonEmpty(entity.name) ?? nonEmpty(entity.slug) ?? FALLBACK_LABEL,
+});
+
+const credentialExtractor: SubjectExtractor = (entity) => ({
+  type: "credential",
+  id: String(entity.id),
+  // Passkeys carry a user-set `name` ("My laptop"). Falling back to
+  // the credential's id is acceptable — it's the only stable handle.
+  label: nonEmpty(entity.name) ?? FALLBACK_LABEL,
+});
+
+const apiTokenExtractor: SubjectExtractor = (entity) => ({
+  type: "api_token",
+  id: String(entity.id),
+  // Personal access tokens require a name on mint, so this is
+  // always set in practice.
+  label: nonEmpty(entity.name) ?? FALLBACK_LABEL,
+});
+
+const sessionExtractor: SubjectExtractor = (entity) => ({
+  type: "session",
+  id: String(entity.id),
+  // No human label exists for a session row — fall through to id-as-
+  // label so the feed shows something stable. The id is the session
+  // PK (UUID-shaped), readable enough for cross-referencing.
+  label: FALLBACK_LABEL,
+});
+
+const deviceCodeExtractor: SubjectExtractor = (entity) => ({
+  type: "device_code",
+  id: String(entity.id),
+  // The device code's user-facing label is the user_code (8-letter
+  // grouping like `ABCD-WXYZ`). When provided via the input.title
+  // field by the listener (we map `userCode` → `title` at the call
+  // site), use it; else fall through.
+  label: nonEmpty(entity.title) ?? FALLBACK_LABEL,
+});
+
+const settingsGroupExtractor: SubjectExtractor = (entity) => ({
+  type: "settings_group",
+  id: String(entity.id),
+  // The `id` IS the group name (e.g. `mailer`, `oauth`). Re-using it
+  // as the label keeps the row self-explanatory.
+  label: String(entity.id),
+});
+
 export const subjectExtractors: Readonly<Record<string, SubjectExtractor>> = {
   entry: entryExtractor,
   user: userExtractor,
+  term: termExtractor,
+  credential: credentialExtractor,
+  api_token: apiTokenExtractor,
+  session: sessionExtractor,
+  device_code: deviceCodeExtractor,
+  settings_group: settingsGroupExtractor,
 };
 
 export function extractSubject(


### PR DESCRIPTION
Expand `@plumix/plugin-audit-log` from the entry-only surface that landed
in slice 178 to the full curated hook coverage from the audit-log PRD:
user lifecycle, auth/sign-in, credentials, sessions, API tokens, the
device flow, terms, and settings.

`hooks.ts` is reorganized as five thematic `register*` functions
dispatched from a single `registerHooks()` entrypoint. Listeners share
a `record()` helper that resolves the per-request `AppContext`, hands
back a one-time DX warn when fired outside a request, and routes the
audit row through the buffered service from #178. A small
`actorFromUser({id, email})` helper collapses twelve inline actor
literals across the auth surface.

### Self-actions self-attribute

`user:signed_in`, `user:signed_out`, and `user:registered` fire on the
request that just authenticated — `ctx.user` is still null at that
point because middleware ran before the session was created. Falling
back to the user payload as the actor avoids audit rows with null
`actorId` on every sign-in and self-registration.

### Invite attribution prefers the request user when it matches

`user:invited` records `context.invitedBy` as the actor id. When that
id matches `ctx.user.id` (the normal admin-initiated invite flow), the
admin's email becomes the actor label so the audit feed reads
consistently with the same admin's other actions; CLI-initiated
invites fall back to id-as-string. `inviteToken` is never recorded.

### Settings group changes record key names only

`settings:group_changed` records only `keysSet` and `keysRemoved`.
Settings values can carry secrets (SMTP password, OAuth client secret,
API keys) — the audit table should not become a credential mirror.
Consumers needing values will read them through the settings API in a
later slice once a redaction story exists.

### Per-subject diff filters

Each entity surface defines its own omit list so the row-level diff
keeps only meaningful columns: timestamps, `content`, `meta`,
`passwordHash`, and `lastSignInAt` are stripped, while `name`, `slug`,
`role`, `parentId`, and similar columns still flow through.

### Tests

`hooks.test.ts` is new — 12 tests using `HookRegistry` + a fake
service + `requestStore.run` to exercise each thematic surface,
including a regression test for the slice-178 entry surface and an
explicit assertion that `inviteToken` and raw settings values never
land in the serialized row. `subjectExtractors.test.ts` gains five
tests covering the new extractors. 40 tests on the package, all five
gates green.

Resolves #179