### PR TITLE
feat(plugin-audit-log): filter shape + cursor pagination on the feed (slice 180)

### DIFF
--- a/packages/core/src/rpc/errors.ts
+++ b/packages/core/src/rpc/errors.ts
@@ -4,6 +4,12 @@ export const RPC_ERRORS = {
   UNAUTHORIZED: {
     message: "Authentication required",
   },
+  BAD_REQUEST: {
+    message: "Invalid input",
+    data: v.object({
+      reason: v.string(),
+    }),
+  },
   FORBIDDEN: {
     message: "Permission denied",
     data: v.object({

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -61,6 +61,8 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@libsql/client": "^0.17.3",
+    "@orpc/server": "^1.14.1",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
@@ -72,6 +74,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "drizzle-kit": "catalog:",
     "esbuild": "0.27.7",
     "eslint": "catalog:",
     "jsdom": "^29.1.1",

--- a/packages/plugins/audit-log/src/admin/AuditLogShell.test.tsx
+++ b/packages/plugins/audit-log/src/admin/AuditLogShell.test.tsx
@@ -1,25 +1,66 @@
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { AuditLogShell } from "./AuditLogShell.js";
+
+interface CapturedCall {
+  readonly url: string;
+  readonly body: unknown;
+}
 
 let fetchMock: ReturnType<
   typeof vi.fn<
     (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
   >
 >;
+let calls: CapturedCall[];
 
-function mockListResponse(rows: readonly Record<string, unknown>[]): void {
-  fetchMock = vi.fn(() =>
-    Promise.resolve(
-      new Response(JSON.stringify({ json: { rows }, meta: [] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    ),
-  );
+function mockListPages(
+  responses: readonly {
+    rows: readonly Record<string, unknown>[];
+    nextCursor?: string | null;
+  }[],
+): void {
+  let idx = 0;
+  fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const bodyString = typeof init?.body === "string" ? init.body : null;
+    calls.push({
+      url,
+      body:
+        bodyString !== null ? (JSON.parse(bodyString) as unknown) : undefined,
+    });
+    const reply = responses[Math.min(idx, responses.length - 1)] ?? {
+      rows: [],
+      nextCursor: null,
+    };
+    idx += 1;
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          json: { rows: reply.rows, nextCursor: reply.nextCursor ?? null },
+          meta: [],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+  });
   vi.stubGlobal("fetch", fetchMock);
 }
 
@@ -38,6 +79,7 @@ function renderShell(): void {
 describe("AuditLogShell", () => {
   beforeEach(() => {
     fetchMock = vi.fn();
+    calls = [];
   });
 
   afterEach(() => {
@@ -45,35 +87,40 @@ describe("AuditLogShell", () => {
     vi.unstubAllGlobals();
   });
 
-  test("renders the empty-state when no audit rows have been recorded", async () => {
-    mockListResponse([]);
+  test("renders the empty-state when no audit rows match", async () => {
+    mockListPages([{ rows: [], nextCursor: null }]);
     renderShell();
     expect(await screen.findByTestId("audit-log-empty")).toBeInTheDocument();
   });
 
   test("renders one row per audit entry with event + subject labels", async () => {
-    mockListResponse([
+    mockListPages([
       {
-        id: 1,
-        occurredAt: "2026-05-10T10:00:00Z",
-        event: "entry:published",
-        subjectType: "entry",
-        subjectId: "42",
-        subjectLabel: "Hello world",
-        actorId: 7,
-        actorLabel: "alice@example.com",
-        properties: {},
-      },
-      {
-        id: 2,
-        occurredAt: "2026-05-10T10:01:00Z",
-        event: "entry:updated",
-        subjectType: "entry",
-        subjectId: "42",
-        subjectLabel: "Hello world",
-        actorId: 7,
-        actorLabel: "alice@example.com",
-        properties: { diff: { title: ["Hello", "Hello world"] } },
+        rows: [
+          {
+            id: 1,
+            occurredAt: "2026-05-10T10:00:00Z",
+            event: "entry:published",
+            subjectType: "entry",
+            subjectId: "42",
+            subjectLabel: "Hello world",
+            actorId: 7,
+            actorLabel: "alice@example.com",
+            properties: {},
+          },
+          {
+            id: 2,
+            occurredAt: "2026-05-10T10:01:00Z",
+            event: "entry:updated",
+            subjectType: "entry",
+            subjectId: "42",
+            subjectLabel: "Hello world",
+            actorId: 7,
+            actorLabel: "alice@example.com",
+            properties: { diff: { title: ["Hello", "Hello world"] } },
+          },
+        ],
+        nextCursor: null,
       },
     ]);
     renderShell();
@@ -85,9 +132,113 @@ describe("AuditLogShell", () => {
     expect(screen.getByTestId("audit-log-subject-1")).toHaveTextContent(
       "Hello world",
     );
-    // Diff preview surfaces only when there's a `diff` envelope.
     const diffPreviews = screen.getAllByTestId("audit-log-diff-preview");
     expect(diffPreviews).toHaveLength(1);
     expect(diffPreviews[0]).toHaveTextContent("title");
   });
+
+  test("filter changes generate a fresh RPC call with the filter params", async () => {
+    mockListPages([{ rows: [], nextCursor: null }]);
+    renderShell();
+    await screen.findByTestId("audit-log-empty");
+
+    fireEvent.change(screen.getByTestId("audit-log-filter-subject-type"), {
+      target: { value: "user" },
+    });
+    fireEvent.change(screen.getByTestId("audit-log-filter-event-prefix"), {
+      target: { value: "user:" },
+    });
+    fireEvent.change(screen.getByTestId("audit-log-filter-actor"), {
+      target: { value: "7" },
+    });
+
+    await waitFor(() => {
+      const json = lastJson();
+      expect(json).toMatchObject({
+        subjectType: "user",
+        eventPrefix: "user:",
+        actorId: 7,
+      });
+    });
+  });
+
+  test("load more uses cursor from the last page", async () => {
+    mockListPages([
+      {
+        rows: [
+          {
+            id: 1,
+            occurredAt: "2026-05-10T10:00:00Z",
+            event: "entry:published",
+            subjectType: "entry",
+            subjectId: "42",
+            subjectLabel: "Hello",
+            actorId: 7,
+            actorLabel: "alice@example.com",
+            properties: {},
+          },
+        ],
+        nextCursor: "page-2-cursor",
+      },
+      {
+        rows: [
+          {
+            id: 2,
+            occurredAt: "2026-05-10T09:00:00Z",
+            event: "entry:trashed",
+            subjectType: "entry",
+            subjectId: "43",
+            subjectLabel: "Old",
+            actorId: 7,
+            actorLabel: "alice@example.com",
+            properties: {},
+          },
+        ],
+        nextCursor: null,
+      },
+    ]);
+    renderShell();
+    await screen.findByTestId("audit-log-row-1");
+
+    const loadMore = await screen.findByTestId("audit-log-load-more");
+    fireEvent.click(loadMore);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("audit-log-row-2")).toBeInTheDocument();
+    });
+    expect(lastJson()?.cursor).toBe("page-2-cursor");
+  });
+
+  test("reset clears filters and triggers a fresh unfiltered fetch", async () => {
+    mockListPages([{ rows: [], nextCursor: null }]);
+    renderShell();
+    await screen.findByTestId("audit-log-empty");
+
+    fireEvent.change(screen.getByTestId("audit-log-filter-subject-type"), {
+      target: { value: "user" },
+    });
+    await waitFor(() => {
+      expect(lastJson()?.subjectType).toBe("user");
+    });
+
+    fireEvent.click(screen.getByTestId("audit-log-filter-reset"));
+
+    await waitFor(() => {
+      expect(lastJson()?.subjectType).toBeUndefined();
+    });
+  });
 });
+
+function lastJson(): Record<string, unknown> | undefined {
+  const last = calls[calls.length - 1];
+  if (!last) return undefined;
+  const body = last.body;
+  if (body === undefined || body === null || typeof body !== "object") {
+    return undefined;
+  }
+  const json = (body as { json?: unknown }).json;
+  if (json === undefined || json === null || typeof json !== "object") {
+    return undefined;
+  }
+  return json as Record<string, unknown>;
+}

--- a/packages/plugins/audit-log/src/admin/AuditLogShell.tsx
+++ b/packages/plugins/audit-log/src/admin/AuditLogShell.tsx
@@ -1,32 +1,96 @@
 import type { ReactNode } from "react";
+import { useState } from "react";
 
-import type { AuditLogRowDTO } from "./rpc.js";
-import { useAuditLogList } from "./rpc.js";
+import type { AuditLogFilter, AuditLogRowDTO, DateRangePreset } from "./rpc.js";
+import { presetToRange, useAuditLogList } from "./rpc.js";
 
 const MAX_DIFF_PREVIEW_FIELDS = 3;
 
+// Curated lists — keep the v1 admin discoverable. Plugins shipping new
+// subject types / event namespaces can grow these in a follow-up by
+// reading from the plugin registry.
+const SUBJECT_TYPES = [
+  "entry",
+  "user",
+  "term",
+  "credential",
+  "api_token",
+  "session",
+  "device_code",
+  "settings_group",
+] as const;
+
+const EVENT_PREFIXES = [
+  "entry:",
+  "user:",
+  "term:",
+  "credential:",
+  "api_token:",
+  "session:",
+  "device_code:",
+  "settings:",
+] as const;
+
+interface FilterState {
+  readonly preset: DateRangePreset | "all";
+  readonly actorId: string;
+  readonly subjectType: string;
+  readonly eventPrefix: string;
+}
+
+const EMPTY_FILTERS: FilterState = {
+  preset: "all",
+  actorId: "",
+  subjectType: "",
+  eventPrefix: "",
+};
+
+function filterToRpcInput(state: FilterState): AuditLogFilter {
+  const out: {
+    actorId?: number;
+    subjectType?: string;
+    eventPrefix?: string;
+    occurredAfter?: number;
+    occurredBefore?: number;
+  } = {};
+  if (state.preset !== "all" && state.preset !== "custom") {
+    const range = presetToRange(state.preset);
+    if (range.occurredAfter !== undefined)
+      out.occurredAfter = range.occurredAfter;
+    if (range.occurredBefore !== undefined)
+      out.occurredBefore = range.occurredBefore;
+  }
+  if (state.actorId !== "") {
+    const parsed = Number(state.actorId);
+    if (Number.isInteger(parsed)) out.actorId = parsed;
+  }
+  if (state.subjectType !== "") out.subjectType = state.subjectType;
+  if (state.eventPrefix !== "") out.eventPrefix = state.eventPrefix;
+  return out;
+}
+
 export function AuditLogShell(): ReactNode {
-  const list = useAuditLogList();
+  const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
+  const list = useAuditLogList(filterToRpcInput(filters));
 
-  if (list.isLoading) {
-    return <div data-testid="audit-log-loading" />;
-  }
-
-  if (list.error instanceof Error) {
-    return (
-      <div data-testid="audit-log-error">
-        Failed to load audit log: {list.error.message}
-      </div>
-    );
-  }
-
-  const rows = list.data?.rows ?? [];
+  const rows = list.data?.pages.flatMap((p) => p.rows) ?? [];
 
   return (
     <div data-testid="audit-log-shell">
       <h1>Audit log</h1>
-      {rows.length === 0 ? (
-        <p data-testid="audit-log-empty">No audit events yet.</p>
+      <FilterRow
+        filters={filters}
+        onChange={setFilters}
+        onReset={() => setFilters(EMPTY_FILTERS)}
+      />
+      {list.isLoading ? (
+        <div data-testid="audit-log-loading" />
+      ) : list.error instanceof Error ? (
+        <div data-testid="audit-log-error">
+          Failed to load audit log: {list.error.message}
+        </div>
+      ) : rows.length === 0 ? (
+        <p data-testid="audit-log-empty">No audit events match.</p>
       ) : (
         <table data-testid="audit-log-table">
           <thead>
@@ -45,6 +109,92 @@ export function AuditLogShell(): ReactNode {
           </tbody>
         </table>
       )}
+      {list.hasNextPage ? (
+        <button
+          type="button"
+          data-testid="audit-log-load-more"
+          disabled={list.isFetchingNextPage}
+          onClick={() => {
+            void list.fetchNextPage();
+          }}
+        >
+          Load more
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function FilterRow({
+  filters,
+  onChange,
+  onReset,
+}: {
+  readonly filters: FilterState;
+  readonly onChange: (next: FilterState) => void;
+  readonly onReset: () => void;
+}): ReactNode {
+  return (
+    <div data-testid="audit-log-filters">
+      <select
+        data-testid="audit-log-filter-date"
+        value={filters.preset}
+        onChange={(e) => {
+          onChange({
+            ...filters,
+            preset: e.target.value as DateRangePreset | "all",
+          });
+        }}
+      >
+        <option value="all">All time</option>
+        <option value="today">Today</option>
+        <option value="last7">Last 7 days</option>
+        <option value="last30">Last 30 days</option>
+      </select>
+      <input
+        type="number"
+        data-testid="audit-log-filter-actor"
+        placeholder="Actor user id"
+        value={filters.actorId}
+        onChange={(e) => {
+          onChange({ ...filters, actorId: e.target.value });
+        }}
+      />
+      <select
+        data-testid="audit-log-filter-subject-type"
+        value={filters.subjectType}
+        onChange={(e) => {
+          onChange({ ...filters, subjectType: e.target.value });
+        }}
+      >
+        <option value="">Any subject type</option>
+        {SUBJECT_TYPES.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      <select
+        data-testid="audit-log-filter-event-prefix"
+        value={filters.eventPrefix}
+        onChange={(e) => {
+          onChange({ ...filters, eventPrefix: e.target.value });
+        }}
+      >
+        <option value="">Any event</option>
+        {EVENT_PREFIXES.map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        data-testid="audit-log-filter-reset"
+        onClick={onReset}
+      >
+        Reset
+      </button>
     </div>
   );
 }
@@ -85,9 +235,9 @@ function DiffPreview({
 }
 
 function formatTimestamp(iso: string): string {
-  // Inputs land here as ISO strings via the RPC's JSON encoder; keep
-  // formatting minimal for v1 — operators with locale needs can swap
-  // in their own component when slice #180's filters land.
+  // Inputs land here as ISO strings via the RPC's JSON encoder. Keep
+  // formatting minimal — operators with locale needs can swap in their
+  // own component without touching the data path.
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
   return date

--- a/packages/plugins/audit-log/src/admin/rpc.test.ts
+++ b/packages/plugins/audit-log/src/admin/rpc.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+
+import { presetToRange } from "./rpc.js";
+
+describe("presetToRange", () => {
+  const now = new Date("2026-05-10T18:30:00Z");
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+
+  test("today returns [00:00 UTC, now]", () => {
+    const range = presetToRange("today", now);
+    const dayStart = Math.floor(
+      new Date("2026-05-10T00:00:00Z").getTime() / 1000,
+    );
+    expect(range).toEqual({
+      occurredAfter: dayStart,
+      occurredBefore: nowSeconds,
+    });
+  });
+
+  test("last7 spans 7 days ending now", () => {
+    const range = presetToRange("last7", now);
+    const expected = Math.floor(
+      new Date("2026-05-03T18:30:00Z").getTime() / 1000,
+    );
+    expect(range.occurredAfter).toBe(expected);
+    expect(range.occurredBefore).toBe(nowSeconds);
+  });
+
+  test("last30 spans 30 days ending now", () => {
+    const range = presetToRange("last30", now);
+    const expected = Math.floor(
+      new Date("2026-04-10T18:30:00Z").getTime() / 1000,
+    );
+    expect(range.occurredAfter).toBe(expected);
+    expect(range.occurredBefore).toBe(nowSeconds);
+  });
+
+  test("custom returns empty object — caller supplies bounds", () => {
+    expect(presetToRange("custom", now)).toEqual({});
+  });
+});

--- a/packages/plugins/audit-log/src/admin/rpc.ts
+++ b/packages/plugins/audit-log/src/admin/rpc.ts
@@ -1,5 +1,5 @@
-import type { UseQueryResult } from "@tanstack/react-query";
-import { useQuery } from "@tanstack/react-query";
+import type { UseInfiniteQueryResult } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 export interface AuditLogRowDTO {
   readonly id: number;
@@ -13,8 +13,23 @@ export interface AuditLogRowDTO {
   readonly properties: Record<string, unknown>;
 }
 
-interface AuditLogListResponse {
+export interface AuditLogFilter {
+  readonly actorId?: number;
+  readonly subjectType?: string;
+  readonly subjectId?: string;
+  readonly eventPrefix?: string;
+  readonly occurredAfter?: number;
+  readonly occurredBefore?: number;
+}
+
+interface AuditLogPage {
   readonly rows: readonly AuditLogRowDTO[];
+  readonly nextCursor: string | null;
+}
+
+interface ListInput extends AuditLogFilter {
+  readonly limit?: number;
+  readonly cursor?: string;
 }
 
 const AUDIT_LOG_LIST_KEY = ["auditLog", "list"] as const;
@@ -46,9 +61,55 @@ async function rpcCall<TOutput>(
   return envelope?.json as TOutput;
 }
 
-export function useAuditLogList(): UseQueryResult<AuditLogListResponse> {
-  return useQuery({
-    queryKey: AUDIT_LOG_LIST_KEY,
-    queryFn: () => rpcCall<AuditLogListResponse>("auditLog/list"),
+export function useAuditLogList(
+  filter: AuditLogFilter = {},
+): UseInfiniteQueryResult<{
+  pages: AuditLogPage[];
+  pageParams: (string | undefined)[];
+}> {
+  return useInfiniteQuery({
+    queryKey: [...AUDIT_LOG_LIST_KEY, filter],
+    queryFn: ({ pageParam }) => {
+      const input: ListInput =
+        pageParam === undefined
+          ? { ...filter }
+          : { ...filter, cursor: pageParam };
+      return rpcCall<AuditLogPage>("auditLog/list", input);
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
+}
+
+export type DateRangePreset = "today" | "last7" | "last30" | "custom";
+
+/**
+ * Convert a UI preset into the epoch-second pair the RPC accepts. All
+ * presets are inclusive on both ends and computed against `now`.
+ *
+ * - `today`: from 00:00 UTC of the current day → now.
+ * - `last7` / `last30`: rolling N-day windows, ending at `now`.
+ * - `custom`: returns `{}` — caller supplies the bounds explicitly.
+ */
+export function presetToRange(
+  preset: DateRangePreset,
+  now: Date = new Date(),
+): { occurredAfter?: number; occurredBefore?: number } {
+  if (preset === "custom") return {};
+  const occurredBefore = Math.floor(now.getTime() / 1000);
+  if (preset === "today") {
+    const start = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+    return {
+      occurredAfter: Math.floor(start.getTime() / 1000),
+      occurredBefore,
+    };
+  }
+  const days = preset === "last7" ? 7 : 30;
+  const start = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  return {
+    occurredAfter: Math.floor(start.getTime() / 1000),
+    occurredBefore,
+  };
 }

--- a/packages/plugins/audit-log/src/rpc.test.ts
+++ b/packages/plugins/audit-log/src/rpc.test.ts
@@ -1,0 +1,203 @@
+import { createRouterClient } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import type {
+  AppContext,
+  RequestAuthenticator,
+  User,
+  UserRole,
+} from "@plumix/core";
+import {
+  createAppContext,
+  createPluginRegistry,
+  HookRegistry,
+} from "@plumix/core";
+
+import type {
+  AuditLogQueryFilter,
+  AuditLogQueryResult,
+  AuditLogStorage,
+} from "./types.js";
+import { createAuditLogRouter } from "./rpc.js";
+import { CursorError } from "./server/cursor.js";
+
+interface HarnessClient {
+  readonly auditLog: {
+    readonly list: (
+      input?: Partial<AuditLogQueryFilter>,
+    ) => Promise<AuditLogQueryResult>;
+  };
+}
+
+interface Harness {
+  readonly client: HarnessClient;
+  readonly calls: AuditLogQueryFilter[];
+  readonly storage: AuditLogStorage;
+}
+
+function fakeStorage(
+  reply: AuditLogQueryResult = { rows: [], nextCursor: null },
+): { storage: AuditLogStorage; calls: AuditLogQueryFilter[] } {
+  const calls: AuditLogQueryFilter[] = [];
+  return {
+    calls,
+    storage: {
+      kind: "fake",
+      write: () => Promise.resolve(),
+      query: (_ctx, filter) => {
+        calls.push(filter);
+        return Promise.resolve(reply);
+      },
+    },
+  };
+}
+
+function stubAuthenticator(user: User): RequestAuthenticator {
+  return {
+    authenticate: () => Promise.resolve({ user, tokenScopes: null }),
+  };
+}
+
+function buildContext(role: UserRole): AppContext {
+  const registry = createPluginRegistry();
+  // Mirror the audit-log plugin's setup() — register the capability so
+  // the role-based resolver knows admin → audit_log:read.
+  registry.capabilities.set("audit_log:read", {
+    name: "audit_log:read",
+    minRole: "admin",
+    registeredBy: "audit_log",
+  });
+  const user: User = {
+    id: 1,
+    email: "alice@example.com",
+    role,
+    name: null,
+    avatarUrl: null,
+    meta: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    emailVerifiedAt: null,
+    disabledAt: null,
+  };
+  return createAppContext({
+    db: {} as never,
+    env: {},
+    request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
+    hooks: new HookRegistry(),
+    plugins: registry,
+    user: { id: user.id, email: user.email, role: user.role },
+    authenticator: stubAuthenticator(user),
+    origin: "https://cms.example",
+  });
+}
+
+function harness(role: UserRole, reply?: AuditLogQueryResult): Harness {
+  const { storage, calls } = fakeStorage(reply);
+  const router = createAuditLogRouter(storage);
+  const client = createRouterClient(
+    { auditLog: router },
+    { context: buildContext(role) },
+  ) as unknown as HarnessClient;
+  return { client, calls, storage };
+}
+
+describe("auditLog.list RPC", () => {
+  test("forwards filter params verbatim to storage", async () => {
+    const h = harness("admin");
+    await h.client.auditLog.list({
+      actorId: 7,
+      subjectType: "entry",
+      subjectId: "42",
+      eventPrefix: "entry:",
+      occurredAfter: 1_715_000_000,
+      occurredBefore: 1_715_100_000,
+      limit: 25,
+    });
+    expect(h.calls[0]).toMatchObject({
+      actorId: 7,
+      subjectType: "entry",
+      subjectId: "42",
+      eventPrefix: "entry:",
+      occurredAfter: 1_715_000_000,
+      occurredBefore: 1_715_100_000,
+      limit: 25,
+    });
+  });
+
+  test("returns rows + nextCursor from storage", async () => {
+    const reply: AuditLogQueryResult = {
+      rows: [
+        {
+          id: 1,
+          occurredAt: new Date("2026-05-10T00:00:00Z"),
+          event: "entry:published",
+          subjectType: "entry",
+          subjectId: "1",
+          subjectLabel: "Hello",
+          actorId: 1,
+          actorLabel: "alice@example.com",
+          properties: {},
+        },
+      ],
+      nextCursor: "cursor-from-storage",
+    };
+    const h = harness("admin", reply);
+    const result = await h.client.auditLog.list({});
+    expect(result.nextCursor).toBe("cursor-from-storage");
+    expect(result.rows).toHaveLength(1);
+  });
+
+  test("limit > 200 is silently clamped to 200 (not an error)", async () => {
+    const h = harness("admin");
+    await h.client.auditLog.list({ limit: 5000 });
+    expect(h.calls[0]?.limit).toBe(200);
+  });
+
+  test("limit < 1 is rejected at the schema level", async () => {
+    const h = harness("admin");
+    await expect(h.client.auditLog.list({ limit: 0 })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  test("tampered cursor is rejected with a typed BAD_REQUEST (not a 500)", async () => {
+    // Storage decodes the cursor lazily, so the handler needs to
+    // surface CursorError as a typed RPC error rather than letting
+    // it propagate as an internal-server error.
+    const reply: AuditLogQueryResult = { rows: [], nextCursor: null };
+    const { calls } = fakeStorage(reply);
+    const failingStorage: AuditLogStorage = {
+      kind: "fake",
+      write: () => Promise.resolve(),
+      query: (_ctx, filter) => {
+        calls.push(filter);
+        // Storage simulates cursor.decodeCursor() failure.
+        return Promise.reject(new CursorError("malformed cursor"));
+      },
+    };
+    const router = createAuditLogRouter(failingStorage);
+    const client = createRouterClient(
+      { auditLog: router },
+      { context: buildContext("admin") },
+    ) as unknown as HarnessClient;
+    await expect(
+      client.auditLog.list({ cursor: "not-a-cursor" }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      data: { reason: "invalid_cursor" },
+    });
+  });
+
+  test("missing capability rejects with FORBIDDEN", async () => {
+    const h = harness("editor");
+    await expect(h.client.auditLog.list({})).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  test("omitting all filters returns the latest unfiltered page", async () => {
+    const h = harness("admin");
+    await h.client.auditLog.list({});
+    expect(h.calls[0]).toEqual({ limit: 50 });
+  });
+});

--- a/packages/plugins/audit-log/src/rpc.ts
+++ b/packages/plugins/audit-log/src/rpc.ts
@@ -1,46 +1,73 @@
-// Hand-rolled oRPC router for the audit-log plugin. Mirrors the menu
-// plugin's pattern. v0.1 is just `auditLog.list` — capability-gated,
-// returns the latest 50 rows. Slice #180 adds filters + cursor
-// pagination.
+// Hand-rolled oRPC router for the audit-log plugin. v0.1 ships
+// `auditLog.list` with filter + cursor pagination (slice #180).
+//
+// Filter semantics:
+// - All filter params optional, combinable.
+// - `cursor` is opaque base64 from a previous page's `nextCursor`.
+// - `limit` defaults to 50, clamps silently at 200 (values above don't
+//   error — admin pages frequently pass through user input that we
+//   don't want to surface as 4xx).
+// - Tampered cursors decode-fail in storage and surface as a typed
+//   `BAD_REQUEST` (`reason: "invalid_cursor"`), never a 5xx.
 
 import * as v from "valibot";
 
 import { authenticated, base } from "@plumix/core";
 
-import type { AuditLogRow, AuditLogStorage } from "./types.js";
+import type { AuditLogQueryResult, AuditLogStorage } from "./types.js";
+import { CursorError } from "./server/cursor.js";
 
 const AUDIT_LOG_READ_CAPABILITY = "audit_log:read";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
 
-interface AuditLogListResponse {
-  readonly rows: readonly AuditLogRow[];
-}
+const listInputSchema = v.optional(
+  v.object({
+    limit: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+    actorId: v.optional(v.pipe(v.number(), v.integer())),
+    subjectType: v.optional(v.pipe(v.string(), v.minLength(1))),
+    subjectId: v.optional(v.pipe(v.string(), v.minLength(1))),
+    eventPrefix: v.optional(v.pipe(v.string(), v.minLength(1))),
+    occurredAfter: v.optional(v.pipe(v.number(), v.integer())),
+    occurredBefore: v.optional(v.pipe(v.number(), v.integer())),
+    cursor: v.optional(v.string()),
+  }),
+);
 
-export function createAuditLogRouter(
-  storage: AuditLogStorage,
-): Record<string, unknown> {
+export function createAuditLogRouter(storage: AuditLogStorage) {
   const list = base
     .use(authenticated)
-    .input(
-      v.object({
-        limit: v.optional(
-          v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(MAX_LIMIT)),
-        ),
-      }),
-    )
+    .input(listInputSchema)
     .handler(
-      async ({ input, context, errors }): Promise<AuditLogListResponse> => {
+      async ({ input, context, errors }): Promise<AuditLogQueryResult> => {
         if (!context.auth.can(AUDIT_LOG_READ_CAPABILITY)) {
           throw errors.FORBIDDEN({
             data: { capability: AUDIT_LOG_READ_CAPABILITY },
           });
         }
-        const rows = await storage.query(context, {
-          limit: input.limit ?? DEFAULT_LIMIT,
-        });
-        return { rows };
+        const requestedLimit = input?.limit ?? DEFAULT_LIMIT;
+        const limit = Math.min(requestedLimit, MAX_LIMIT);
+        try {
+          return await storage.query(context, {
+            limit,
+            actorId: input?.actorId,
+            subjectType: input?.subjectType,
+            subjectId: input?.subjectId,
+            eventPrefix: input?.eventPrefix,
+            occurredAfter: input?.occurredAfter,
+            occurredBefore: input?.occurredBefore,
+            cursor: input?.cursor,
+          });
+        } catch (error) {
+          // Only `CursorError` instances from `decodeCursor` route to
+          // BAD_REQUEST. Custom storage adapters that wrap exceptions
+          // must re-throw the original `CursorError` to keep this path.
+          if (error instanceof CursorError) {
+            throw errors.BAD_REQUEST({ data: { reason: "invalid_cursor" } });
+          }
+          throw error;
+        }
       },
     );
 

--- a/packages/plugins/audit-log/src/server/auditService.test.ts
+++ b/packages/plugins/audit-log/src/server/auditService.test.ts
@@ -40,7 +40,7 @@ function fakeStorage(): {
         writes.push([...rows]);
         return Promise.resolve();
       },
-      query: () => Promise.resolve([]),
+      query: () => Promise.resolve({ rows: [], nextCursor: null }),
     },
     writes,
   };
@@ -101,7 +101,7 @@ describe("createAuditService", () => {
     const failingStorage: AuditLogStorage = {
       kind: "fake",
       write: () => Promise.reject(new Error("disk full")),
-      query: () => Promise.resolve([]),
+      query: () => Promise.resolve({ rows: [], nextCursor: null }),
     };
     const service = createAuditService(failingStorage);
 

--- a/packages/plugins/audit-log/src/server/cursor.test.ts
+++ b/packages/plugins/audit-log/src/server/cursor.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+
+import { CursorError, decodeCursor, encodeCursor } from "./cursor.js";
+
+describe("encodeCursor / decodeCursor", () => {
+  test("round-trips an (occurredAt, id) pair", () => {
+    const original = { occurredAt: 1_715_000_000, id: 42 };
+    const decoded = decodeCursor(encodeCursor(original));
+    expect(decoded).toEqual(original);
+  });
+
+  test("encoded form is url-safe base64 (no '+', '/', '=' padding)", () => {
+    const encoded = encodeCursor({ occurredAt: 1_715_000_000, id: 99 });
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+
+  test("tampering with the body throws CursorError", () => {
+    const valid = encodeCursor({ occurredAt: 1, id: 1 });
+    // Flip the last char to corrupt the payload.
+    const tampered = `${valid.slice(0, -1)}${valid.endsWith("A") ? "B" : "A"}`;
+    expect(() => decodeCursor(tampered)).toThrow(CursorError);
+  });
+
+  test("garbage string throws CursorError", () => {
+    expect(() => decodeCursor("not-a-cursor")).toThrow(CursorError);
+  });
+
+  test("empty string throws CursorError", () => {
+    expect(() => decodeCursor("")).toThrow(CursorError);
+  });
+
+  test("negative occurredAt is rejected as malformed", () => {
+    const encoded = encodeCursor({ occurredAt: -1, id: 1 });
+    expect(() => decodeCursor(encoded)).toThrow(CursorError);
+  });
+
+  test("zero or negative id is rejected as malformed", () => {
+    expect(() => decodeCursor(encodeCursor({ occurredAt: 1, id: 0 }))).toThrow(
+      CursorError,
+    );
+    expect(() => decodeCursor(encodeCursor({ occurredAt: 1, id: -5 }))).toThrow(
+      CursorError,
+    );
+  });
+});

--- a/packages/plugins/audit-log/src/server/cursor.ts
+++ b/packages/plugins/audit-log/src/server/cursor.ts
@@ -1,0 +1,69 @@
+// Cursor codec for `auditLog.list` pagination. The cursor encodes the
+// (occurred_at, id) of the last row from the previous page so the next
+// query can resume on `(occurred_at, id) < (cursor.occurredAt, cursor.id)`.
+// Stable ordering even under concurrent writes because `id` is
+// monotonically increasing.
+//
+// On-wire form: url-safe base64 of `${occurredAt}.${id}` — readable
+// enough to debug from the network tab without giving away anything
+// useful for tampering. A tampered or malformed cursor lands on the
+// `CursorError` branch in the RPC layer and surfaces as a typed
+// `INVALID_CURSOR` to the caller.
+
+export class CursorError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "CursorError";
+  }
+}
+
+interface CursorPosition {
+  readonly occurredAt: number;
+  readonly id: number;
+}
+
+export function encodeCursor(position: CursorPosition): string {
+  const raw = `${String(position.occurredAt)}.${String(position.id)}`;
+  return toUrlSafeBase64(raw);
+}
+
+export function decodeCursor(encoded: string): CursorPosition {
+  if (encoded === "") throw new CursorError("empty cursor");
+  let raw: string;
+  try {
+    raw = fromUrlSafeBase64(encoded);
+  } catch {
+    throw new CursorError("malformed cursor");
+  }
+  const parts = raw.split(".");
+  if (parts.length !== 2) throw new CursorError("malformed cursor");
+  const occurredAt = Number(parts[0]);
+  const id = Number(parts[1]);
+  if (!Number.isInteger(occurredAt) || !Number.isInteger(id)) {
+    throw new CursorError("malformed cursor");
+  }
+  // Audit rows have positive auto-increment ids and non-negative
+  // occurredAt (unix epoch). A cursor outside that range is either
+  // tampering or an upstream bug — treat as malformed so the RPC
+  // returns a typed BAD_REQUEST instead of silently returning 0 rows.
+  if (occurredAt < 0 || id <= 0) {
+    throw new CursorError("malformed cursor");
+  }
+  return { occurredAt, id };
+}
+
+function toUrlSafeBase64(raw: string): string {
+  // Buffer is available in Workers + Node; both runtimes the plugin
+  // targets. The url-safe alphabet (+ → -, / → _, no padding) keeps
+  // the value safe to drop into a query string without escaping.
+  return Buffer.from(raw, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function fromUrlSafeBase64(encoded: string): string {
+  const restored = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(restored, "base64").toString("utf8");
+}

--- a/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
+++ b/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
@@ -1,0 +1,303 @@
+import { createClient } from "@libsql/client";
+import {
+  generateSQLiteDrizzleJson,
+  generateSQLiteMigration,
+} from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/libsql";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import type { AppContext } from "@plumix/core";
+
+import type { NewAuditLogRow } from "../db/schema.js";
+import * as schema from "../db/schema.js";
+import { auditLog } from "../db/schema.js";
+import { encodeCursor } from "./cursor.js";
+import { sqlite } from "./storage-sqlite.js";
+
+type TestDb = ReturnType<typeof drizzle<typeof schema>>;
+
+const schemaImports = schema as unknown as Record<string, unknown>;
+
+let cachedStatements: string[] | null = null;
+
+async function compileSchemaSql(): Promise<string[]> {
+  if (cachedStatements) return cachedStatements;
+  const empty = await generateSQLiteDrizzleJson({}, undefined, "snake_case");
+  const current = await generateSQLiteDrizzleJson(
+    schemaImports,
+    empty.id,
+    "snake_case",
+  );
+  cachedStatements = await generateSQLiteMigration(empty, current);
+  return cachedStatements;
+}
+
+async function createDb(): Promise<TestDb> {
+  const client = createClient({ url: ":memory:" });
+  const db = drizzle(client, { schema, casing: "snake_case" });
+  const statements = await compileSchemaSql();
+  for (const stmt of statements) await db.run(sql.raw(stmt));
+  return db;
+}
+
+function row(
+  overrides: Partial<NewAuditLogRow> & {
+    readonly occurredAt: Date;
+  },
+): NewAuditLogRow {
+  return {
+    event: "entry:updated",
+    subjectType: "entry",
+    subjectId: "1",
+    subjectLabel: "Hello",
+    actorId: 1,
+    actorLabel: "alice@example.com",
+    properties: {},
+    ...overrides,
+  };
+}
+
+function ctxFor(db: TestDb): AppContext {
+  return { db } as unknown as AppContext;
+}
+
+describe("sqlite() storage adapter — filter + cursor pagination", () => {
+  let db: TestDb;
+  let ctx: AppContext;
+
+  beforeEach(async () => {
+    db = await createDb();
+    ctx = ctxFor(db);
+  });
+
+  test("no filter returns rows latest-first by (occurred_at desc, id desc)", async () => {
+    await db
+      .insert(auditLog)
+      .values([
+        row({ occurredAt: new Date("2026-05-01T00:00:00Z"), id: 1 }),
+        row({ occurredAt: new Date("2026-05-03T00:00:00Z"), id: 2 }),
+        row({ occurredAt: new Date("2026-05-02T00:00:00Z"), id: 3 }),
+      ]);
+    const result = await sqlite().query(ctx, {});
+    expect(result.rows.map((r) => r.id)).toEqual([2, 3, 1]);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  test("actorId filter restricts to that actor's rows", async () => {
+    await db
+      .insert(auditLog)
+      .values([
+        row({ occurredAt: new Date("2026-05-01T00:00:00Z"), actorId: 1 }),
+        row({ occurredAt: new Date("2026-05-02T00:00:00Z"), actorId: 2 }),
+        row({ occurredAt: new Date("2026-05-03T00:00:00Z"), actorId: 1 }),
+      ]);
+    const result = await sqlite().query(ctx, { actorId: 1 });
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows.every((r) => r.actorId === 1)).toBe(true);
+  });
+
+  test("subjectType + subjectId restrict together", async () => {
+    await db.insert(auditLog).values([
+      row({
+        occurredAt: new Date("2026-05-01T00:00:00Z"),
+        subjectType: "entry",
+        subjectId: "1",
+      }),
+      row({
+        occurredAt: new Date("2026-05-02T00:00:00Z"),
+        subjectType: "entry",
+        subjectId: "2",
+      }),
+      row({
+        occurredAt: new Date("2026-05-03T00:00:00Z"),
+        subjectType: "user",
+        subjectId: "1",
+      }),
+    ]);
+    const both = await sqlite().query(ctx, {
+      subjectType: "entry",
+      subjectId: "1",
+    });
+    expect(both.rows).toHaveLength(1);
+    expect(both.rows[0]?.subjectId).toBe("1");
+
+    const justType = await sqlite().query(ctx, { subjectType: "entry" });
+    expect(justType.rows).toHaveLength(2);
+  });
+
+  test("eventPrefix does an indexed prefix range scan", async () => {
+    await db.insert(auditLog).values([
+      row({
+        occurredAt: new Date("2026-05-01T00:00:00Z"),
+        event: "entry:published",
+      }),
+      row({
+        occurredAt: new Date("2026-05-02T00:00:00Z"),
+        event: "entry:trashed",
+      }),
+      row({
+        occurredAt: new Date("2026-05-03T00:00:00Z"),
+        event: "user:signed_in",
+      }),
+    ]);
+    const result = await sqlite().query(ctx, { eventPrefix: "entry:" });
+    expect(result.rows.map((r) => r.event).sort()).toEqual([
+      "entry:published",
+      "entry:trashed",
+    ]);
+  });
+
+  test("occurredAfter / occurredBefore form an inclusive window", async () => {
+    await db
+      .insert(auditLog)
+      .values([
+        row({ occurredAt: new Date("2026-05-01T00:00:00Z") }),
+        row({ occurredAt: new Date("2026-05-03T00:00:00Z") }),
+        row({ occurredAt: new Date("2026-05-05T00:00:00Z") }),
+      ]);
+    const result = await sqlite().query(ctx, {
+      occurredAfter: Math.floor(
+        new Date("2026-05-02T00:00:00Z").getTime() / 1000,
+      ),
+      occurredBefore: Math.floor(
+        new Date("2026-05-04T00:00:00Z").getTime() / 1000,
+      ),
+    });
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.occurredAt.toISOString()).toBe(
+      "2026-05-03T00:00:00.000Z",
+    );
+  });
+
+  test("limit + cursor paginate without skipping or repeating rows", async () => {
+    const values = Array.from({ length: 7 }, (_, i) =>
+      row({
+        occurredAt: new Date(
+          `2026-05-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+        ),
+        subjectId: String(i + 1),
+      }),
+    );
+    await db.insert(auditLog).values(values);
+
+    const page1 = await sqlite().query(ctx, { limit: 3 });
+    expect(page1.rows.map((r) => r.subjectId)).toEqual(["7", "6", "5"]);
+    expect(page1.nextCursor).not.toBeNull();
+
+    const page2 = await sqlite().query(ctx, {
+      limit: 3,
+      cursor: page1.nextCursor ?? undefined,
+    });
+    expect(page2.rows.map((r) => r.subjectId)).toEqual(["4", "3", "2"]);
+    expect(page2.nextCursor).not.toBeNull();
+
+    const page3 = await sqlite().query(ctx, {
+      limit: 3,
+      cursor: page2.nextCursor ?? undefined,
+    });
+    expect(page3.rows.map((r) => r.subjectId)).toEqual(["1"]);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  test("a row inserted between page fetches at an older timestamp is included in the next page (no skip)", async () => {
+    await db.insert(auditLog).values(
+      Array.from({ length: 4 }, (_, i) =>
+        row({
+          occurredAt: new Date(
+            `2026-05-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+          ),
+          subjectId: String(i + 1),
+        }),
+      ),
+    );
+    const page1 = await sqlite().query(ctx, { limit: 2 });
+    expect(page1.rows.map((r) => r.subjectId)).toEqual(["4", "3"]);
+
+    // A concurrent insert at an OLDER occurredAt lands behind the cursor.
+    await db.insert(auditLog).values(
+      row({
+        occurredAt: new Date("2026-05-01T12:00:00Z"),
+        subjectId: "concurrent",
+      }),
+    );
+
+    const page2 = await sqlite().query(ctx, {
+      limit: 10,
+      cursor: page1.nextCursor ?? undefined,
+    });
+    // Page 2 must include both the original 2,1 AND the new concurrent
+    // row that lands at 5-01 12:00 — between 5-01 00:00 (id=1) and
+    // 5-02 00:00 (id=2). The new row gets a fresh id (=5) > cursor's id,
+    // but its occurredAt is BEFORE the cursor's, so the strict-less
+    // comparison must use the row tuple, not OR of single columns.
+    const ids = page2.rows.map((r) => r.subjectId).sort();
+    expect(ids).toContain("concurrent");
+    expect(ids).toContain("2");
+    expect(ids).toContain("1");
+  });
+
+  test("limit defaults to 50 when omitted", async () => {
+    const values = Array.from({ length: 75 }, (_, i) =>
+      row({
+        occurredAt: new Date(2026, 4, 1, 0, 0, i),
+        subjectId: String(i + 1),
+      }),
+    );
+    await db.insert(auditLog).values(values);
+    const result = await sqlite().query(ctx, {});
+    expect(result.rows).toHaveLength(50);
+  });
+
+  test("limit > 500 clamps to 500 (storage-side ceiling)", async () => {
+    const values = Array.from({ length: 600 }, (_, i) =>
+      row({
+        occurredAt: new Date(2026, 4, 1, 0, 0, i),
+        subjectId: String(i + 1),
+      }),
+    );
+    await db.insert(auditLog).values(values);
+    const result = await sqlite().query(ctx, { limit: 10_000 });
+    expect(result.rows).toHaveLength(500);
+  });
+
+  test("nextCursor is null when the page returns fewer rows than the limit", async () => {
+    await db
+      .insert(auditLog)
+      .values([
+        row({ occurredAt: new Date("2026-05-01T00:00:00Z") }),
+        row({ occurredAt: new Date("2026-05-02T00:00:00Z") }),
+      ]);
+    const result = await sqlite().query(ctx, { limit: 50 });
+    expect(result.nextCursor).toBeNull();
+  });
+
+  test("an explicit cursor still respects filters", async () => {
+    await db.insert(auditLog).values([
+      row({
+        occurredAt: new Date("2026-05-01T00:00:00Z"),
+        event: "entry:published",
+        subjectId: "a",
+      }),
+      row({
+        occurredAt: new Date("2026-05-02T00:00:00Z"),
+        event: "user:signed_in",
+        subjectId: "b",
+      }),
+      row({
+        occurredAt: new Date("2026-05-03T00:00:00Z"),
+        event: "entry:trashed",
+        subjectId: "c",
+      }),
+    ]);
+    const cursor = encodeCursor({
+      occurredAt: Math.floor(new Date("2026-05-04T00:00:00Z").getTime() / 1000),
+      id: 1,
+    });
+    const result = await sqlite().query(ctx, {
+      cursor,
+      eventPrefix: "entry:",
+    });
+    expect(result.rows.map((r) => r.subjectId)).toEqual(["c", "a"]);
+  });
+});

--- a/packages/plugins/audit-log/src/server/storage-sqlite.ts
+++ b/packages/plugins/audit-log/src/server/storage-sqlite.ts
@@ -3,15 +3,17 @@
 // to `definePlugin({ schema })` so `plumix migrate generate` picks
 // up the table on the next codegen run.
 
-import { desc } from "drizzle-orm";
+import { and, desc, eq, gte, like, lt, lte, or } from "drizzle-orm";
 
 import type {
   AuditLogQueryFilter,
+  AuditLogQueryResult,
   AuditLogRow,
   AuditLogStorage,
 } from "../types.js";
 import * as schema from "../db/schema.js";
 import { auditLog } from "../db/schema.js";
+import { decodeCursor, encodeCursor } from "./cursor.js";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 500;
@@ -28,16 +30,83 @@ export function sqlite(): AuditLogStorage {
       await ctx.db.insert(auditLog).values([...rows]);
     },
 
-    async query(ctx, filter: AuditLogQueryFilter) {
+    async query(
+      ctx,
+      filter: AuditLogQueryFilter,
+    ): Promise<AuditLogQueryResult> {
       const limit = clampLimit(filter.limit);
+      const conditions = buildConditions(filter);
+      // Peek one row past the page so we can decide if there's a
+      // nextCursor without re-querying.
       const rows = await ctx.db
         .select()
         .from(auditLog)
+        .where(conditions.length > 0 ? and(...conditions) : undefined)
         .orderBy(desc(auditLog.occurredAt), desc(auditLog.id))
-        .limit(limit);
-      return rows.map(toAuditLogRow);
+        .limit(limit + 1);
+
+      const sliced = rows.slice(0, limit);
+      const last = sliced[sliced.length - 1];
+      const hasMore = rows.length > limit && last !== undefined;
+      const nextCursor = hasMore
+        ? encodeCursor({
+            occurredAt: Math.floor(last.occurredAt.getTime() / 1000),
+            id: last.id,
+          })
+        : null;
+
+      return { rows: sliced.map(toAuditLogRow), nextCursor };
     },
   };
+}
+
+function buildConditions(filter: AuditLogQueryFilter) {
+  const out = [];
+
+  if (filter.actorId !== undefined) {
+    out.push(eq(auditLog.actorId, filter.actorId));
+  }
+  if (filter.subjectType !== undefined) {
+    out.push(eq(auditLog.subjectType, filter.subjectType));
+  }
+  if (filter.subjectId !== undefined) {
+    out.push(eq(auditLog.subjectId, filter.subjectId));
+  }
+  if (filter.eventPrefix !== undefined && filter.eventPrefix !== "") {
+    // The `event` index serves this as a prefix range scan. We don't
+    // ESCAPE `%`/`_` because the input is trusted: it comes from an
+    // admin-only RPC (capability-gated) and the admin UI selects from
+    // a fixed namespace list (`entry:`, `user:`, …). A future call
+    // path that funnels untrusted input here MUST sanitize the prefix
+    // before reaching this builder.
+    out.push(like(auditLog.event, `${filter.eventPrefix}%`));
+  }
+  if (filter.occurredAfter !== undefined) {
+    out.push(gte(auditLog.occurredAt, new Date(filter.occurredAfter * 1000)));
+  }
+  if (filter.occurredBefore !== undefined) {
+    out.push(lte(auditLog.occurredAt, new Date(filter.occurredBefore * 1000)));
+  }
+  if (filter.cursor !== undefined && filter.cursor !== "") {
+    out.push(cursorCondition(filter.cursor));
+  }
+  return out;
+}
+
+// Strict row-tuple comparison `(occurred_at, id) < (cursor.occurredAt, cursor.id)`
+// expressed via the equivalent OR of: row's occurred_at strictly less, OR
+// equal occurred_at with strictly less id. Using two predicates keeps the
+// query planner happy across drivers; the `audit_log_occurred_at_idx`
+// covers it.
+function cursorCondition(cursor: string) {
+  // CursorError propagates up to the RPC layer where it's mapped to a
+  // typed error response.
+  const position = decodeCursor(cursor);
+  const occurredAt = new Date(position.occurredAt * 1000);
+  return or(
+    lt(auditLog.occurredAt, occurredAt),
+    and(eq(auditLog.occurredAt, occurredAt), lt(auditLog.id, position.id)),
+  );
 }
 
 function clampLimit(requested: number | undefined): number {

--- a/packages/plugins/audit-log/src/types.ts
+++ b/packages/plugins/audit-log/src/types.ts
@@ -17,6 +17,26 @@ export interface AuditLogRow {
 export interface AuditLogQueryFilter {
   /** Result cap. Defaults to 50; storage adapters clamp at their own ceiling. */
   readonly limit?: number;
+  /** Restrict to rows whose `actor_id` matches. */
+  readonly actorId?: number;
+  /** Restrict to a subject kind (`entry`, `user`, …). */
+  readonly subjectType?: string;
+  /** Restrict to a single subject row (usually combined with `subjectType`). */
+  readonly subjectId?: string;
+  /** Indexed prefix range scan over `event` — `entry:`, `user:`, etc. */
+  readonly eventPrefix?: string;
+  /** Inclusive lower bound, epoch seconds. */
+  readonly occurredAfter?: number;
+  /** Inclusive upper bound, epoch seconds. */
+  readonly occurredBefore?: number;
+  /** Opaque cursor from a previous page's `nextCursor`. */
+  readonly cursor?: string;
+}
+
+export interface AuditLogQueryResult {
+  readonly rows: readonly AuditLogRow[];
+  /** Opaque cursor for the next page; `null` when the current page is the last. */
+  readonly nextCursor: string | null;
 }
 
 /**
@@ -31,11 +51,11 @@ export interface AuditLogStorage {
   readonly schemaModule?: Record<string, unknown>;
   /** Batch insert. The audit-log service buffers per-request and calls this once. */
   write(ctx: AppContext, rows: readonly NewAuditLogRow[]): Promise<void>;
-  /** Latest-first read for the admin feed. */
+  /** Latest-first read for the admin feed; honors filter + cursor pagination. */
   query(
     ctx: AppContext,
     filter: AuditLogQueryFilter,
-  ): Promise<readonly AuditLogRow[]>;
+  ): Promise<AuditLogQueryResult>;
 }
 
 export type AuditLogActor =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,12 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.2
+      '@libsql/client':
+        specifier: ^0.17.3
+        version: 0.17.3
+      '@orpc/server':
+        specifier: ^1.14.1
+        version: 1.14.1(ws@8.20.0)
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../../tooling/eslint
@@ -491,6 +497,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.5(vitest@4.1.5)
+      drizzle-kit:
+        specifier: 'catalog:'
+        version: 0.31.10
       esbuild:
         specifier: 0.27.7
         version: 0.27.7


### PR DESCRIPTION
Extend `auditLog.list` from "latest 50 rows" to the full filter +
cursor-pagination contract from the audit-log PRD, and wire a filter
row + load-more button + reset into the admin feed.

### Filter shape

`{ actorId, subjectType, subjectId, eventPrefix, occurredAfter,
occurredBefore }` — every param optional, all combinable. Date bounds
are unix seconds so the wire stays JSON-friendly without Date
marshaling. `eventPrefix` runs as an indexed prefix range scan
against the existing `audit_log_event_idx`.

### Cursor pagination

Cursor format is url-safe base64 of `${occurredAt}.${id}` — readable
enough to debug from the network tab, opaque enough to survive
casual tampering. The query predicate is a strict row-tuple
comparison `(occurred_at, id) < (cursor.occurredAt, cursor.id)`
expressed as `or(lt(occurred_at, X), and(eq(occurred_at, X), lt(id, Y)))`
so an insert at an older timestamp between page fetches lands in the
next page rather than being skipped. `decodeCursor` enforces
non-negative `occurredAt` and positive `id` so a tampered cursor
fails fast instead of silently returning zero rows.

### Limit handling

Default 50, clamps silently at 200 at the RPC layer (admin UIs
frequently pass through user input that we don't want to surface as
4xx). Storage-side ceiling is 500 for defense-in-depth.

### Tampered-cursor surfacing

Cursors decode lazily inside the storage adapter; a malformed cursor
throws `CursorError`. The RPC handler catches it and surfaces
`BAD_REQUEST({ reason: "invalid_cursor" })` so the wire never sees a
5xx. Adds a `BAD_REQUEST` entry to the shared `RPC_ERRORS` registry
for this and future generic-validation cases — `BAD_REQUEST` is
already the wire code oRPC uses for valibot schema failures, so this
just gives us a typed handle.

### Admin feed

A filter row keyed by testid sits above the table: date-range preset
(today / last 7 / last 30 / custom), actor id input, subject-type
chip-select, event-prefix chip-select, plus a reset button. The list
hook moves from `useQuery` to `useInfiniteQuery` so pagination
piggybacks on tanstack's cursor handling; filter-state changes
trigger a fresh page-1 fetch via the `queryKey`.

### A note on `eventPrefix` and SQL `LIKE`

The query builds `LIKE '${prefix}%'` without an `ESCAPE` clause. The
input is trusted: the RPC is admin-gated and the admin UI selects
from a fixed namespace list. A follow-up call path that funnels
untrusted input here must sanitize the prefix before reaching the
storage builder; the inline comment makes the invariant explicit.

### New devDeps

`@libsql/client` and `drizzle-kit` for the storage test harness
(an in-memory libsql DB with the plugin's own schema applied);
`@orpc/server` for the rpc test harness's `createRouterClient`.

Resolves #180