### PR TITLE
feat(plugin-audit-log): public ctx.audit.log() API for third-party plugins (slice 181)

### DIFF
--- a/packages/plugins/audit-log/src/index.ts
+++ b/packages/plugins/audit-log/src/index.ts
@@ -1,8 +1,10 @@
 import { definePlugin } from "@plumix/core";
 
+import type { AuditExtension } from "./server/auditExtension.js";
 import type { AuditLogStorage } from "./types.js";
 import * as schema from "./db/schema.js";
 import { createAuditLogRouter } from "./rpc.js";
+import { createAuditExtension } from "./server/auditExtension.js";
 import { createAuditService } from "./server/auditService.js";
 import { registerHooks } from "./server/hooks.js";
 import { sqlite } from "./server/storage-sqlite.js";
@@ -12,7 +14,18 @@ export type {
   AuditLogRow,
   AuditLogQueryFilter,
 } from "./types.js";
+export type { AuditExtension, AuditLogInput } from "./server/auditExtension.js";
 export { sqlite } from "./server/storage-sqlite.js";
+
+// Declaration-merge contribution. Declared optional so consumers that
+// don't install the plugin can still write `ctx.audit?.log(...)` and
+// have it compile + no-op at runtime. The augmentation is picked up
+// automatically when any module imports from `@plumix/plugin-audit-log`.
+declare module "@plumix/core" {
+  interface AppContextExtensions {
+    readonly audit?: AuditExtension;
+  }
+}
 
 export interface AuditLogPluginOptions {
   /**
@@ -51,15 +64,41 @@ const AUDIT_LOG_READ_CAPABILITY = "audit_log:read";
  * - **RPC** `auditLog.list` is gated on the `audit_log:read`
  *   capability (admin-only by default); slice #180 adds filter +
  *   cursor pagination.
+ * - **Public API** `ctx.audit.log({ event, subject, properties })`
+ *   from #181 — third-party plugins emit their own events through
+ *   the same buffered flush. Drops the call when `ctx.user` is null
+ *   so frontend / anonymous events can't leak into the admin feed.
+ *
+ * Example — a comments plugin records moderation actions:
+ *
+ *     definePlugin("comments", {
+ *       setup: (ctx) => {
+ *         ctx.addAction("comment:approved", (comment) => {
+ *           // `tryGetContext()` returns the current AppContext, which
+ *           // carries `ctx.audit` when the audit-log plugin is also
+ *           // installed; the optional chain makes this a no-op when
+ *           // it isn't.
+ *           tryGetContext()?.audit?.log({
+ *             event: "comment:approved",
+ *             subject: { type: "comment", id: comment.id, label: comment.body.slice(0, 40) },
+ *             properties: { postId: comment.postId },
+ *           });
+ *         });
+ *       },
+ *     });
  */
 export function auditLog(options: AuditLogPluginOptions = {}) {
   const storage = options.storage ?? sqlite();
   const service = createAuditService(storage);
   const router = createAuditLogRouter(storage);
+  const extension = createAuditExtension(service);
 
   return definePlugin("audit_log", {
     adminEntry: ADMIN_ENTRY_PATH,
     schema: storage.schemaModule ?? schema,
+    provides: (ctx) => {
+      ctx.extendAppContext("audit", extension);
+    },
     setup: (ctx) => {
       ctx.registerCapability(AUDIT_LOG_READ_CAPABILITY, "admin");
 

--- a/packages/plugins/audit-log/src/server/auditExtension.test.ts
+++ b/packages/plugins/audit-log/src/server/auditExtension.test.ts
@@ -1,0 +1,321 @@
+// Public `ctx.audit.log()` API tests. Uses the same fake-service +
+// requestStore.run pattern as hooks.test.ts so we test the full
+// chokepoint (ctx resolve → actor gate → service.record) without
+// touching a real DB.
+
+import { describe, expect, test, vi } from "vitest";
+
+import type {
+  AppContext,
+  AuthenticatedUser,
+  Entry,
+  HookOptions,
+  PluginSetupContext,
+} from "@plumix/core";
+import { HookRegistry, requestStore } from "@plumix/core";
+
+import type { NewAuditLogRow } from "../db/schema.js";
+import type { AuditLogStorage } from "../types.js";
+import type { AuditService } from "./auditService.js";
+import { createAuditExtension } from "./auditExtension.js";
+import { createAuditService } from "./auditService.js";
+import { registerHooks } from "./hooks.js";
+
+interface FakeServiceState {
+  readonly service: AuditService;
+  readonly rows: NewAuditLogRow[];
+  warnedNoContext: number;
+}
+
+function fakeService(): FakeServiceState {
+  const rows: NewAuditLogRow[] = [];
+  const state: FakeServiceState = {
+    rows,
+    warnedNoContext: 0,
+    service: {
+      record: (_ctx, row) => {
+        rows.push(row);
+      },
+      warnNoContextOnce: () => {
+        state.warnedNoContext += 1;
+      },
+    },
+  };
+  return state;
+}
+
+interface FakeLogger {
+  debug: ReturnType<typeof vi.fn>;
+  info: () => void;
+  warn: () => void;
+  error: () => void;
+}
+
+function makeCtx(user: AuthenticatedUser | null): AppContext {
+  const logger: FakeLogger = {
+    debug: vi.fn(),
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  };
+  return { user, logger } as unknown as AppContext;
+}
+
+const adminUser: AuthenticatedUser = {
+  id: 7,
+  email: "alice@example.com",
+  role: "admin",
+};
+
+describe("createAuditExtension", () => {
+  test("logs a row when ctx.user is set", () => {
+    const state = fakeService();
+    const audit = createAuditExtension(state.service);
+    requestStore.run(makeCtx(adminUser), () => {
+      audit.log({
+        event: "comment:approved",
+        subject: { type: "comment", id: 42, label: "First post!" },
+        properties: { approvedBy: "moderator" },
+      });
+    });
+    expect(state.rows).toHaveLength(1);
+    expect(state.rows[0]).toMatchObject({
+      event: "comment:approved",
+      subjectType: "comment",
+      subjectId: "42",
+      subjectLabel: "First post!",
+      actorId: 7,
+      actorLabel: "alice@example.com",
+      properties: { approvedBy: "moderator" },
+    });
+  });
+
+  test("returns void synchronously — caller cannot await the storage write", () => {
+    const state = fakeService();
+    const audit = createAuditExtension(state.service);
+    let result: unknown;
+    requestStore.run(makeCtx(adminUser), () => {
+      result = audit.log({
+        event: "x:y",
+        subject: { type: "x", id: 1, label: "x" },
+      });
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test("drops the call when ctx.user is null + debug-logs", () => {
+    const state = fakeService();
+    const audit = createAuditExtension(state.service);
+    const ctx = makeCtx(null);
+    requestStore.run(ctx, () => {
+      audit.log({
+        event: "comment:approved",
+        subject: { type: "comment", id: 42, label: "x" },
+      });
+    });
+    expect(state.rows).toHaveLength(0);
+    const debug = (ctx.logger as unknown as FakeLogger).debug;
+    expect(debug).toHaveBeenCalledTimes(1);
+    const call = debug.mock.calls[0]?.[0] as string;
+    expect(call).toMatch(/no user|no actor|dropped/i);
+  });
+
+  test("drops the call when fired outside requestStore — no buffer key to write to", () => {
+    const state = fakeService();
+    const audit = createAuditExtension(state.service);
+    audit.log({
+      event: "x:y",
+      subject: { type: "x", id: 1, label: "x" },
+    });
+    expect(state.rows).toHaveLength(0);
+    expect(state.warnedNoContext).toBe(0);
+  });
+
+  test("multiple log() calls in one request all land on the same service buffer", () => {
+    const state = fakeService();
+    const audit = createAuditExtension(state.service);
+    requestStore.run(makeCtx(adminUser), () => {
+      audit.log({ event: "a:1", subject: { type: "a", id: 1, label: "1" } });
+      audit.log({ event: "a:2", subject: { type: "a", id: 2, label: "2" } });
+      audit.log({ event: "a:3", subject: { type: "a", id: 3, label: "3" } });
+    });
+    expect(state.rows.map((r) => r.event)).toEqual(["a:1", "a:2", "a:3"]);
+  });
+
+  test("missing subject.label falls back to '(unnamed)'", () => {
+    const state = fakeService();
+    const audit = createAuditExtension(state.service);
+    requestStore.run(makeCtx(adminUser), () => {
+      audit.log({
+        event: "x:y",
+        subject: { type: "x", id: 1 },
+      });
+    });
+    expect(state.rows[0]?.subjectLabel).toBe("(unnamed)");
+  });
+
+  test("subject.id is stringified — accepts numbers AND strings", () => {
+    const state = fakeService();
+    const audit = createAuditExtension(state.service);
+    requestStore.run(makeCtx(adminUser), () => {
+      audit.log({
+        event: "x:y",
+        subject: { type: "x", id: 99, label: "n" },
+      });
+      audit.log({
+        event: "x:y",
+        subject: { type: "x", id: "uuid-1", label: "s" },
+      });
+    });
+    expect(state.rows.map((r) => r.subjectId)).toEqual(["99", "uuid-1"]);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Integration: public log() + internal hooks share the single per-
+// request flush from the real AuditService. Use a fake storage so we
+// can count `storage.write` invocations end-to-end.
+// ──────────────────────────────────────────────────────────────────
+
+interface CapturedFlush {
+  readonly writes: NewAuditLogRow[][];
+}
+
+function captureStorage(): {
+  storage: AuditLogStorage;
+  capture: CapturedFlush;
+} {
+  const writes: NewAuditLogRow[][] = [];
+  return {
+    capture: { writes },
+    storage: {
+      kind: "capture",
+      write: (_ctx, rows) => {
+        writes.push([...rows]);
+        return Promise.resolve();
+      },
+      query: () => Promise.resolve({ rows: [], nextCursor: null }),
+    },
+  };
+}
+
+function realServiceCtx(user: AuthenticatedUser | null): {
+  ctx: AppContext;
+  flush: () => Promise<void>;
+} {
+  const deferred: Promise<unknown>[] = [];
+  const ctx = {
+    user,
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    defer: (p: Promise<unknown>) => {
+      deferred.push(p);
+    },
+  } as unknown as AppContext;
+  return {
+    ctx,
+    flush: async () => {
+      await Promise.all(deferred);
+    },
+  };
+}
+
+describe("createAuditExtension — integration with the real AuditService", () => {
+  test("multiple log() calls in one request batch into a single storage.write", async () => {
+    const { storage, capture } = captureStorage();
+    const service = createAuditService(storage);
+    const audit = createAuditExtension(service);
+    const { ctx, flush } = realServiceCtx(adminUser);
+
+    requestStore.run(ctx, () => {
+      audit.log({ event: "a:1", subject: { type: "a", id: 1, label: "1" } });
+      audit.log({ event: "a:2", subject: { type: "a", id: 2, label: "2" } });
+      audit.log({ event: "a:3", subject: { type: "a", id: 3, label: "3" } });
+    });
+    await flush();
+
+    expect(capture.writes).toHaveLength(1);
+    expect(capture.writes[0]).toHaveLength(3);
+  });
+
+  test("public log() + internal entry hook route to the same service — both rows land", async () => {
+    // Pins the "share the same buffer / no double-write" criterion: a
+    // third-party plugin's ctx.audit.log() and a core entry-hook
+    // capture in the same request route through the same AuditService
+    // instance and both rows reach storage. (The synchronous batching
+    // window is a microtask — see auditService.ts:48-54 — so an
+    // intervening `await` may produce multiple flushes, but neither
+    // call sets up a separate buffer.)
+    const { storage, capture } = captureStorage();
+    const service = createAuditService(storage);
+    const audit = createAuditExtension(service);
+    const hooks = new HookRegistry();
+    const setupCtx = {
+      addAction: (
+        name: string,
+        fn: (...args: unknown[]) => unknown,
+        options?: HookOptions,
+      ) => {
+        hooks.addAction(name as never, fn as never, options);
+      },
+    } as unknown as PluginSetupContext;
+    registerHooks(setupCtx, service);
+
+    const { ctx, flush } = realServiceCtx(adminUser);
+
+    await requestStore.run(ctx, async () => {
+      audit.log({
+        event: "comment:approved",
+        subject: { type: "comment", id: 5, label: "first" },
+      });
+      await hooks.doAction("entry:published", {
+        id: 99,
+        title: "Hello",
+        slug: "hello",
+        type: "post",
+        status: "published",
+      } as unknown as Entry);
+    });
+    await flush();
+
+    const allRows = capture.writes.flat();
+    expect(allRows.map((r) => r.event).sort()).toEqual([
+      "comment:approved",
+      "entry:published",
+    ]);
+  });
+
+  test("public log() + internal hook fired in the same sync tick batch into one flush", async () => {
+    // Synchronous siblings within the microtask window collapse into a
+    // single storage.write — matches the existing service-test
+    // guarantee for multiple internal calls and proves the public API
+    // joins that same window when fired without an intervening await.
+    const { storage, capture } = captureStorage();
+    const service = createAuditService(storage);
+    const audit = createAuditExtension(service);
+
+    const { ctx, flush } = realServiceCtx(adminUser);
+    requestStore.run(ctx, () => {
+      audit.log({ event: "x:1", subject: { type: "x", id: 1, label: "1" } });
+      // Direct service.record mirrors what an internal hook listener
+      // does — no await between, so the buffer is still alive.
+      service.record(ctx, {
+        event: "entry:published",
+        subjectType: "entry",
+        subjectId: "99",
+        subjectLabel: "Hello",
+        actorId: 7,
+        actorLabel: "alice@example.com",
+        properties: {},
+      });
+    });
+    await flush();
+
+    expect(capture.writes).toHaveLength(1);
+    expect(capture.writes[0]).toHaveLength(2);
+  });
+});

--- a/packages/plugins/audit-log/src/server/auditExtension.ts
+++ b/packages/plugins/audit-log/src/server/auditExtension.ts
@@ -1,0 +1,77 @@
+// Public `ctx.audit.log()` API. Exposed via the plugin's `provides()`
+// callback as a declaration-merge contribution to `AppContextExtensions`
+// — third-party plugins call `ctx.audit?.log({...})` from RPC handlers,
+// route handlers, or hook listeners and the row joins the same buffered
+// flush that the internal entry/user/term/settings listeners use.
+//
+// Chokepoint: the helper checks `ctx.user` before recording. A frontend
+// request (no signed-in user) drops with a debug log instead of writing
+// to the audit feed. This enforces "no anonymous events in the admin
+// activity log" by code, not by convention.
+//
+// Contract:
+//   - Returns void (not Promise<void>) so callers can't accidentally
+//     await the deferred storage write.
+//   - Calls outside `requestStore.run` drop silently — there's no
+//     per-request buffer to attach to.
+//   - Multiple calls in one request batch into the same flush as the
+//     internal hook listeners (same WeakMap key, same `ctx.defer`).
+
+import { tryGetContext } from "@plumix/core";
+
+import type { AuditService } from "./auditService.js";
+import { buildAuditRow } from "./buildAuditRow.js";
+
+export interface AuditLogInput {
+  readonly event: string;
+  readonly subject: {
+    readonly type: string;
+    readonly id: string | number;
+    readonly label?: string;
+  };
+  /** Free-form key/value map merged into the row's `properties` JSON. */
+  readonly properties?: Readonly<Record<string, unknown>>;
+}
+
+export interface AuditExtension {
+  log(input: AuditLogInput): void;
+}
+
+const FALLBACK_LABEL = "(unnamed)";
+
+export function createAuditExtension(service: AuditService): AuditExtension {
+  return {
+    log(input) {
+      const ctx = tryGetContext();
+      if (!ctx) {
+        // Outside requestStore — no per-request buffer exists. Silent
+        // drop is intentional: a stray call during plugin setup or a
+        // background task shouldn't crash.
+        return;
+      }
+      if (!ctx.user) {
+        ctx.logger.debug(
+          `ctx.audit.log("${input.event}") dropped — no user on AppContext`,
+        );
+        return;
+      }
+      const row = buildAuditRow({
+        event: input.event,
+        actor: { id: ctx.user.id, label: ctx.user.email },
+        subject: {
+          type: input.subject.type,
+          id: String(input.subject.id),
+          label: nonEmpty(input.subject.label) ?? FALLBACK_LABEL,
+        },
+        extraProperties: input.properties,
+      });
+      service.record(ctx, row);
+    },
+  };
+}
+
+function nonEmpty(value: string | undefined): string | null {
+  if (value === undefined) return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}


### PR DESCRIPTION
Expose the buffered audit service as `ctx.audit?.log({ event, subject,
properties })` via the `extendAppContext` API from #176, so any
third-party plugin can record its own events into the activity feed
through the same batched flush the internal listeners already use.

### Chokepoint, not contract

The helper itself enforces the safety rule. `log()` reads the
per-request `AppContext` via `tryGetContext()` and drops the call
(with a debug breadcrumb) when `ctx.user` is null. Anonymous or
frontend requests never reach the admin feed, by code rather than by
docs — there's no input field that lets a caller override the actor.

### Fire-and-forget return type

Returns `void`, not `Promise<void>`. Callers can't accidentally
`await` the deferred storage write and defeat the batched flush. A
call outside `requestStore.run` (plugin setup, background task)
drops silently — by contract, a stray call should be a no-op rather
than crash.

### Shared buffer with the internal hooks

The plugin already constructs one `AuditService` per `auditLog()`
call; the same instance backs both `registerHooks(ctx, service)` and
`createAuditExtension(service)`. A public `log()` and an internal
hook capture fired in the same synchronous tick batch into one
`storage.write`. An intervening `await` may produce multiple flushes
(by the microtask-defer design from #178), but neither path sets up
its own separate buffer.

### Optional declaration merge

```ts
declare module \"@plumix/core\" {
  interface AppContextExtensions {
    readonly audit?: AuditExtension;
  }
}
```

Declared optional so consumer code written as `ctx.audit?.log(...)`
compiles when the plugin isn't installed and is a runtime no-op (the
key is simply missing from the merged context).

### Example

The plugin's index.ts docstring includes a comments-plugin pattern —
a third-party plugin's action listener calls
`tryGetContext()?.audit?.log({...})` to record a moderation event.
The optional chain on both sides keeps it safe whether or not the
audit-log plugin is installed in the deploy.

Resolves #181