### PR TITLE
refactor: enforce package layering via plumix umbrella + dependency-cruiser

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,0 +1,39 @@
+// Plumix package boundary enforcement.
+//
+// Consumer packages (plugins, runtimes, examples, playgrounds, the
+// scaffolder) must import from the public 'plumix' umbrella — never
+// reach into the internal @plumix/{core,admin,blocks} packages. This
+// file is the single source of truth.
+
+const INTERNAL_PACKAGES = "(core|admin|blocks)";
+
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  forbidden: [
+    {
+      name: "no-internal-from-consumer",
+      severity: "error",
+      comment:
+        "Use 'plumix' (or one of its subpaths) instead of reaching into internal @plumix/{core,admin,blocks} packages.",
+      from: {
+        path: "^(packages/(plugins|runtimes|create-plumix-app)|examples)/",
+        // Skip emitted .d.ts/.js — TypeScript's declaration emit may
+        // still reference @plumix/core (a publish-readiness concern
+        // tracked outside this PR).
+        pathNot: "/dist/",
+      },
+      to: {
+        path: `^(packages/${INTERNAL_PACKAGES}/|@plumix/${INTERNAL_PACKAGES}(/|$))`,
+      },
+    },
+  ],
+  options: {
+    doNotFollow: { path: "(node_modules|/dist/|/\\.cache/|/\\.turbo/)" },
+    tsPreCompilationDeps: true,
+    enhancedResolveOptions: {
+      exportsFields: ["exports"],
+      conditionNames: ["import", "require", "node", "default"],
+      mainFields: ["module", "main", "types"],
+    },
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      # `pnpm knip` builds plumix first (via turbo) so dist files
-      # referenced from plugin e2e configs and admin's vite.config.ts
-      # resolve during knip's config-file scan.
       - run: pnpm knip
+
+  boundaries:
+    name: Boundaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: pnpm boundaries
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      # @plumix/admin's vite.config.ts now imports from @plumix/core, so
-      # core's dist must exist before knip's config-file scan runs.
-      - run: pnpm --filter @plumix/core build
+      # `pnpm knip` builds plumix first (via turbo) so dist files
+      # referenced from plugin e2e configs and admin's vite.config.ts
+      # resolve during knip's config-file scan.
       - run: pnpm knip
 
   test:

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -85,7 +85,19 @@ const config: KnipConfig = {
         // knip's static analysis on fixtures doesn't resolve the .js→
         // .tsx extension swap; list explicitly.
         "e2e/fixtures/runtime-proof-plugin/src/MediaLibrary.tsx",
+        // With knip's playwright plugin disabled below, list the
+        // playwright config + spec/support files explicitly so they
+        // aren't flagged as unused.
+        "playwright.config.ts",
+        "e2e/*.spec.ts",
+        "e2e/support/*.ts",
       ],
+      // playwright.config.ts imports `@plumix/core/test/playwright` whose
+      // dist may not exist on a fresh clone. Knip's playwright plugin
+      // would import() the config (via jiti) and crash at resolve time.
+      // Disabling it lets `pnpm knip` run cold without a prior build.
+      // Pattern follows sanity-io/sdk's knip.config.ts.
+      playwright: false,
     },
     // The admin chunk is loaded by the plumix vite plugin at consumer
     // build time via `adminEntry` — knip can't follow that runtime path.
@@ -103,6 +115,8 @@ const config: KnipConfig = {
         "e2e/build-chunk.ts",
         "e2e/*.spec.ts",
       ],
+      // See packages/admin above for why the playwright plugin is off.
+      playwright: false,
     },
     // Same shape as plugin-media: admin chunk loaded via `adminEntry`
     // at consumer build time; playwright rig invokes build-chunk via
@@ -117,6 +131,7 @@ const config: KnipConfig = {
         "e2e/build-chunk.ts",
         "e2e/*.spec.ts",
       ],
+      playwright: false,
     },
     // Same shape as plugin-menu: admin chunk loaded via `adminEntry`
     // at consumer build time; `./server` subpath is consumer-facing

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "build": "turbo run build",
     "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo run clean",
+    "boundaries": "depcruise --config .dependency-cruiser.cjs packages examples",
     "commitlint": "commitlint",
     "dev": "turbo watch dev --continue",
     "format": "turbo run format --continue -- --cache --cache-location .cache/.prettiercache",
     "format:fix": "turbo run format --continue -- --write --cache --cache-location .cache/.prettiercache",
-    "knip": "turbo run build --filter=plumix && knip",
+    "knip": "knip",
     "lint": "turbo run lint --continue -- --cache --cache-location .cache/.eslintcache",
     "lint:fix": "turbo run lint --continue -- --fix --cache --cache-location .cache/.eslintcache",
     "postinstall": "pnpm dlx sherif@latest -r packages-without-package-json -r non-existant-packages",
@@ -30,6 +31,7 @@
     "@commitlint/config-conventional": "^20.5.3",
     "@commitlint/config-pnpm-scopes": "^20.5.2",
     "@commitlint/types": "^20.5.0",
+    "dependency-cruiser": "^17.4.0",
     "knip": "^6.6.0",
     "turbo": "^2.9.9"
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "turbo watch dev --continue",
     "format": "turbo run format --continue -- --cache --cache-location .cache/.prettiercache",
     "format:fix": "turbo run format --continue -- --write --cache --cache-location .cache/.prettiercache",
-    "knip": "knip",
+    "knip": "turbo run build --filter=plumix && knip",
     "lint": "turbo run lint --continue -- --cache --cache-location .cache/.eslintcache",
     "lint:fix": "turbo run lint --continue -- --fix --cache --cache-location .cache/.eslintcache",
     "postinstall": "pnpm dlx sherif@latest -r packages-without-package-json -r non-existant-packages",

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -51,12 +51,12 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@plumix/core": "workspace:*",
     "drizzle-orm": "catalog:",
     "valibot": "catalog:"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.99.2",
+    "plumix": "workspace:*",
     "react": "catalog:"
   },
   "devDependencies": {
@@ -75,9 +75,9 @@
     "@types/react-dom": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "drizzle-kit": "catalog:",
-    "esbuild": "0.27.7",
     "eslint": "catalog:",
     "jsdom": "^29.1.1",
+    "plumix": "workspace:*",
     "prettier": "catalog:",
     "publint": "catalog:",
     "react": "catalog:",

--- a/packages/plugins/audit-log/src/index.ts
+++ b/packages/plugins/audit-log/src/index.ts
@@ -1,4 +1,4 @@
-import { definePlugin } from "@plumix/core";
+import { definePlugin } from "plumix/plugin";
 
 import type { AuditExtension } from "./server/auditExtension.js";
 import type { AuditLogStorage } from "./types.js";
@@ -21,7 +21,7 @@ export { sqlite } from "./server/storage-sqlite.js";
 // don't install the plugin can still write `ctx.audit?.log(...)` and
 // have it compile + no-op at runtime. The augmentation is picked up
 // automatically when any module imports from `@plumix/plugin-audit-log`.
-declare module "@plumix/core" {
+declare module "plumix/plugin" {
   interface AppContextExtensions {
     readonly audit?: AuditExtension;
   }

--- a/packages/plugins/audit-log/src/rpc.test.ts
+++ b/packages/plugins/audit-log/src/rpc.test.ts
@@ -1,17 +1,16 @@
-import { createRouterClient } from "@orpc/server";
-import { describe, expect, test } from "vitest";
-
 import type {
   AppContext,
   RequestAuthenticator,
   User,
   UserRole,
-} from "@plumix/core";
+} from "plumix/plugin";
+import { createRouterClient } from "@orpc/server";
 import {
   createAppContext,
   createPluginRegistry,
   HookRegistry,
-} from "@plumix/core";
+} from "plumix/plugin";
+import { describe, expect, test } from "vitest";
 
 import type {
   AuditLogQueryFilter,

--- a/packages/plugins/audit-log/src/rpc.ts
+++ b/packages/plugins/audit-log/src/rpc.ts
@@ -10,9 +10,8 @@
 // - Tampered cursors decode-fail in storage and surface as a typed
 //   `BAD_REQUEST` (`reason: "invalid_cursor"`), never a 5xx.
 
+import { authenticated, base } from "plumix/plugin";
 import * as v from "valibot";
-
-import { authenticated, base } from "@plumix/core";
 
 import type { AuditLogQueryResult, AuditLogStorage } from "./types.js";
 import { CursorError } from "./server/cursor.js";

--- a/packages/plugins/audit-log/src/server/auditExtension.test.ts
+++ b/packages/plugins/audit-log/src/server/auditExtension.test.ts
@@ -3,16 +3,15 @@
 // chokepoint (ctx resolve → actor gate → service.record) without
 // touching a real DB.
 
-import { describe, expect, test, vi } from "vitest";
-
 import type {
   AppContext,
   AuthenticatedUser,
   Entry,
   HookOptions,
   PluginSetupContext,
-} from "@plumix/core";
-import { HookRegistry, requestStore } from "@plumix/core";
+} from "plumix/plugin";
+import { HookRegistry, requestStore } from "plumix/plugin";
+import { describe, expect, test, vi } from "vitest";
 
 import type { NewAuditLogRow } from "../db/schema.js";
 import type { AuditLogStorage } from "../types.js";

--- a/packages/plugins/audit-log/src/server/auditExtension.ts
+++ b/packages/plugins/audit-log/src/server/auditExtension.ts
@@ -17,7 +17,7 @@
 //   - Multiple calls in one request batch into the same flush as the
 //     internal hook listeners (same WeakMap key, same `ctx.defer`).
 
-import { tryGetContext } from "@plumix/core";
+import { tryGetContext } from "plumix/plugin";
 
 import type { AuditService } from "./auditService.js";
 import { buildAuditRow } from "./buildAuditRow.js";

--- a/packages/plugins/audit-log/src/server/auditService.test.ts
+++ b/packages/plugins/audit-log/src/server/auditService.test.ts
@@ -1,6 +1,5 @@
+import type { AppContext } from "plumix/plugin";
 import { describe, expect, test, vi } from "vitest";
-
-import type { AppContext } from "@plumix/core";
 
 import type { NewAuditLogRow } from "../db/schema.js";
 import type { AuditLogStorage } from "../types.js";

--- a/packages/plugins/audit-log/src/server/auditService.ts
+++ b/packages/plugins/audit-log/src/server/auditService.ts
@@ -4,7 +4,7 @@
 // to the same WeakMap-keyed buffer. One INSERT runs after the response
 // — six entry events from a single update RPC become one audit write.
 
-import type { AppContext, Logger } from "@plumix/core";
+import type { AppContext, Logger } from "plumix/plugin";
 
 import type { NewAuditLogRow } from "../db/schema.js";
 import type { AuditLogStorage } from "../types.js";

--- a/packages/plugins/audit-log/src/server/entry-meta-changes.ts
+++ b/packages/plugins/audit-log/src/server/entry-meta-changes.ts
@@ -1,6 +1,6 @@
-// Re-typing the shape we observe on `entry:meta_changed` so the
-// hooks file can stay free of deep `@plumix/core` internals. Matches
-// `MetaChanges` in core's meta/core.ts.
+// Re-typing the shape we observe on `entry:meta_changed` so the hooks
+// file can stay free of plumix internals. Matches `MetaChanges` in
+// core's meta/core.ts.
 
 export interface EntryMetaChanges {
   readonly set: Readonly<Record<string, unknown>>;

--- a/packages/plugins/audit-log/src/server/hooks.test.ts
+++ b/packages/plugins/audit-log/src/server/hooks.test.ts
@@ -5,8 +5,6 @@
 // path (slice 178's harness gap) and keeps each assertion pinned to
 // the row's shape.
 
-import { describe, expect, test } from "vitest";
-
 import type {
   AppContext,
   AuthenticatedUser,
@@ -14,8 +12,9 @@ import type {
   PluginSetupContext,
   Term,
   User,
-} from "@plumix/core";
-import { HookRegistry, requestStore } from "@plumix/core";
+} from "plumix/plugin";
+import { HookRegistry, requestStore } from "plumix/plugin";
+import { describe, expect, test } from "vitest";
 
 import type { NewAuditLogRow } from "../db/schema.js";
 import type { AuditService } from "./auditService.js";

--- a/packages/plugins/audit-log/src/server/hooks.ts
+++ b/packages/plugins/audit-log/src/server/hooks.ts
@@ -19,8 +19,8 @@ import type {
   PluginSetupContext,
   Term,
   User,
-} from "@plumix/core";
-import { tryGetContext } from "@plumix/core";
+} from "plumix/plugin";
+import { tryGetContext } from "plumix/plugin";
 
 import type { NewAuditLogRow } from "../db/schema.js";
 import type { AuditLogActor } from "../types.js";

--- a/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
+++ b/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
@@ -1,3 +1,4 @@
+import type { AppContext } from "plumix/plugin";
 import { createClient } from "@libsql/client";
 import {
   generateSQLiteDrizzleJson,
@@ -6,8 +7,6 @@ import {
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/libsql";
 import { beforeEach, describe, expect, test } from "vitest";
-
-import type { AppContext } from "@plumix/core";
 
 import type { NewAuditLogRow } from "../db/schema.js";
 import * as schema from "../db/schema.js";

--- a/packages/plugins/audit-log/src/types.ts
+++ b/packages/plugins/audit-log/src/types.ts
@@ -1,4 +1,4 @@
-import type { AppContext } from "@plumix/core";
+import type { AppContext } from "plumix/plugin";
 
 import type { NewAuditLogRow } from "./db/schema.js";
 

--- a/packages/plugins/blog/package.json
+++ b/packages/plugins/blog/package.json
@@ -46,8 +46,8 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
-  "dependencies": {
-    "@plumix/core": "workspace:*"
+  "peerDependencies": {
+    "plumix": "workspace:*"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
@@ -57,6 +57,7 @@
     "@plumix/vitest-config": "workspace:*",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
+    "plumix": "workspace:*",
     "prettier": "catalog:",
     "publint": "catalog:",
     "typescript": "catalog:",

--- a/packages/plugins/blog/src/index.test.ts
+++ b/packages/plugins/blog/src/index.test.ts
@@ -1,6 +1,5 @@
+import { HookRegistry, installPlugins } from "plumix/plugin";
 import { describe, expect, test } from "vitest";
-
-import { HookRegistry, installPlugins } from "@plumix/core";
 
 import { blog } from "./index.js";
 

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -1,4 +1,4 @@
-import { definePlugin } from "@plumix/core";
+import { definePlugin } from "plumix/plugin";
 
 export const blog = definePlugin("blog", (ctx) => {
   ctx.registerEntryType("post", {

--- a/packages/plugins/media/e2e/build-chunk.ts
+++ b/packages/plugins/media/e2e/build-chunk.ts
@@ -6,8 +6,7 @@
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-
-import { buildAdminPluginChunkForE2E } from "@plumix/core/test/playwright";
+import { buildAdminPluginChunkForE2E } from "plumix/test/playwright";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = resolve(HERE, "..");

--- a/packages/plugins/media/e2e/media.spec.ts
+++ b/packages/plugins/media/e2e/media.spec.ts
@@ -1,5 +1,5 @@
 // Plugin E2E. Mocks the manifest + session + RPC layer using
-// `@plumix/core/test/playwright` so we exercise the real built admin
+// `plumix/test/playwright` so we exercise the real built admin
 // chunk against a deterministic backend — no D1/R2 needed for CI.
 // (Manual end-to-end against a real worker lives in `playground/`,
 // run via `pnpm --filter @plumix/plugin-media-playground dev`.)
@@ -12,16 +12,15 @@
 //   4. Delete removes the card after confirmation.
 
 import type { Page, Route } from "@playwright/test";
+import type { PlumixManifest } from "plumix/plugin";
 import { expect, test } from "@playwright/test";
-
-import type { PlumixManifest } from "@plumix/core/manifest";
-import { emptyManifest } from "@plumix/core/manifest";
+import { emptyManifest } from "plumix/plugin";
 import {
   AUTHED_ADMIN,
   mockManifest,
   rpcOkBody,
   withCapabilities,
-} from "@plumix/core/test/playwright";
+} from "plumix/test/playwright";
 
 const MEDIA_NAV_LABEL = "Media Library";
 

--- a/packages/plugins/media/e2e/playwright.config.ts
+++ b/packages/plugins/media/e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-import { definePlumixE2EConfig } from "@plumix/core/test/playwright";
+import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 const E2E_PORT = 5181;
 const ADMIN_BASE = "/_plumix/admin";

--- a/packages/plugins/media/package.json
+++ b/packages/plugins/media/package.json
@@ -52,11 +52,11 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@plumix/core": "workspace:*",
     "valibot": "catalog:"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.99.2",
+    "plumix": "workspace:*",
     "react": "catalog:"
   },
   "devDependencies": {
@@ -70,8 +70,8 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@vitest/coverage-v8": "catalog:",
-    "esbuild": "0.27.7",
     "eslint": "catalog:",
+    "plumix": "workspace:*",
     "prettier": "catalog:",
     "publint": "catalog:",
     "react": "catalog:",

--- a/packages/plugins/media/src/admin/MediaListPickerField.tsx
+++ b/packages/plugins/media/src/admin/MediaListPickerField.tsx
@@ -1,7 +1,6 @@
+import type { MetaBoxFieldManifestEntry } from "plumix/plugin";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-
-import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 
 import { MediaLibrary } from "./MediaLibrary.js";
 

--- a/packages/plugins/media/src/admin/MediaPickerField.tsx
+++ b/packages/plugins/media/src/admin/MediaPickerField.tsx
@@ -1,7 +1,6 @@
+import type { MetaBoxFieldManifestEntry } from "plumix/plugin";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-
-import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 
 import { MediaLibrary } from "./MediaLibrary.js";
 

--- a/packages/plugins/media/src/builder.test.ts
+++ b/packages/plugins/media/src/builder.test.ts
@@ -1,11 +1,10 @@
-import { describe, expect, test } from "vitest";
-
 import {
   buildManifest,
   definePlugin,
   HookRegistry,
   installPlugins,
-} from "@plumix/core";
+} from "plumix/plugin";
+import { describe, expect, test } from "vitest";
 
 import type {
   MediaFieldOptions,

--- a/packages/plugins/media/src/builder.ts
+++ b/packages/plugins/media/src/builder.ts
@@ -2,7 +2,7 @@ import type {
   MediaListMetaBoxField,
   MediaMetaBoxField,
   MetaBoxFieldSpan,
-} from "@plumix/core";
+} from "plumix/plugin";
 
 import type { MediaFieldScope } from "./lookup.js";
 

--- a/packages/plugins/media/src/index.test.ts
+++ b/packages/plugins/media/src/index.test.ts
@@ -1,7 +1,6 @@
+import { HookRegistry, installPlugins, memoryStorage } from "plumix/plugin";
+import { createDispatcherHarness, plumixRequest } from "plumix/test";
 import { describe, expect, test } from "vitest";
-
-import { HookRegistry, installPlugins, memoryStorage } from "@plumix/core";
-import { createDispatcherHarness, plumixRequest } from "@plumix/core/test";
 
 import { DEFAULT_ACCEPTED_TYPES, media } from "./index.js";
 

--- a/packages/plugins/media/src/index.ts
+++ b/packages/plugins/media/src/index.ts
@@ -1,5 +1,5 @@
-import type { PluginDescriptor } from "@plumix/core";
-import { definePlugin } from "@plumix/core";
+import type { PluginDescriptor } from "plumix/plugin";
+import { definePlugin } from "plumix/plugin";
 
 import { mediaLookupAdapter } from "./lookup.js";
 import { DEFAULT_ACCEPTED_TYPES } from "./mime.js";

--- a/packages/plugins/media/src/lookup.test.ts
+++ b/packages/plugins/media/src/lookup.test.ts
@@ -1,7 +1,6 @@
+import { entries, HookRegistry, installPlugins } from "plumix/plugin";
+import { createRpcHarness } from "plumix/test";
 import { describe, expect, test } from "vitest";
-
-import { entries, HookRegistry, installPlugins } from "@plumix/core";
-import { createRpcHarness } from "@plumix/core/test";
 
 import { media } from "./index.js";
 import { mediaLookupAdapter } from "./lookup.js";

--- a/packages/plugins/media/src/lookup.ts
+++ b/packages/plugins/media/src/lookup.ts
@@ -1,5 +1,5 @@
-import type { LookupAdapter, LookupResult, SQL } from "@plumix/core";
-import { and, desc, entries, eq, inArray, like, sql } from "@plumix/core";
+import type { LookupAdapter, LookupResult, SQL } from "plumix/plugin";
+import { and, desc, entries, eq, inArray, like, sql } from "plumix/plugin";
 
 import { parseMediaMeta } from "./meta.js";
 

--- a/packages/plugins/media/src/rpc.ts
+++ b/packages/plugins/media/src/rpc.ts
@@ -1,6 +1,4 @@
-import * as v from "valibot";
-
-import type { AppContext, AuthenticatedAppContext, SQL } from "@plumix/core";
+import type { AppContext, AuthenticatedAppContext, SQL } from "plumix/plugin";
 import {
   and,
   authenticated,
@@ -11,7 +9,8 @@ import {
   inArray,
   like,
   sql,
-} from "@plumix/core";
+} from "plumix/plugin";
+import * as v from "valibot";
 
 import { looksLikeMime, MAGIC_BYTE_SAMPLE_SIZE } from "./magic-bytes.js";
 import { parseMediaMeta } from "./meta.js";

--- a/packages/plugins/media/src/serve-route.ts
+++ b/packages/plugins/media/src/serve-route.ts
@@ -1,5 +1,5 @@
-import type { AppContext } from "@plumix/core";
-import { and, entries, eq } from "@plumix/core";
+import type { AppContext } from "plumix/plugin";
+import { and, entries, eq } from "plumix/plugin";
 
 import { parseMediaMeta } from "./meta.js";
 

--- a/packages/plugins/media/src/upload-route.ts
+++ b/packages/plugins/media/src/upload-route.ts
@@ -1,5 +1,5 @@
-import type { AppContext } from "@plumix/core";
-import { and, entries, eq } from "@plumix/core";
+import type { AppContext } from "plumix/plugin";
+import { and, entries, eq } from "plumix/plugin";
 
 import { parseMediaMeta } from "./meta.js";
 

--- a/packages/plugins/menu/e2e/build-chunk.ts
+++ b/packages/plugins/menu/e2e/build-chunk.ts
@@ -1,7 +1,6 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-
-import { buildAdminPluginChunkForE2E } from "@plumix/core/test/playwright";
+import { buildAdminPluginChunkForE2E } from "plumix/test/playwright";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = resolve(HERE, "..");

--- a/packages/plugins/menu/e2e/menu.spec.ts
+++ b/packages/plugins/menu/e2e/menu.spec.ts
@@ -1,5 +1,5 @@
 // Plugin E2E. Mocks the manifest + session + RPC layer using
-// `@plumix/core/test/playwright` so the real built admin chunk runs
+// `plumix/test/playwright` so the real built admin chunk runs
 // against a deterministic backend — no D1 needed for CI.
 //
 // Slice 7 acceptance:
@@ -7,21 +7,29 @@
 //   2. Switch tabs.
 //   3. Assign a menu to a location.
 //   4. Reload — the assignment persists.
+//
+// Slice 9.5 (#185) — drag-drop tree:
+//   - Drag-nest round-trips through save + reload.
+//   - Max-depth ceiling rejects a drop that would push a descendant
+//     past the configured ceiling.
+//   - KeyboardSensor reorder round-trips the same path as pointer
+//     drag.
 
 import type { Page, Route } from "@playwright/test";
+import type { PlumixManifest } from "plumix/plugin";
 import { expect, test } from "@playwright/test";
-
-import type { PlumixManifest } from "@plumix/core/manifest";
-import { slugify } from "@plumix/core";
-import { emptyManifest } from "@plumix/core/manifest";
+import { emptyManifest, slugify } from "plumix/plugin";
 import {
   AUTHED_ADMIN,
   mockManifest,
   rpcOkBody,
   withCapabilities,
-} from "@plumix/core/test/playwright";
+} from "plumix/test/playwright";
 
 const MENU_NAV_LABEL = "Menus";
+// MenuItemEditor.tsx — must match the constant in the component
+// because drag projection compares `delta.x` against this width.
+const INDENTATION_WIDTH = 24;
 
 const MANIFEST: PlumixManifest = {
   ...emptyManifest(),
@@ -61,9 +69,33 @@ interface LocationRow {
   readonly boundTermId: number | null;
 }
 
+interface ServerMenuItem {
+  readonly id: number;
+  readonly parentId: number | null;
+  readonly sortOrder: number;
+  readonly title: string;
+  readonly meta: Record<string, unknown>;
+}
+
+interface MenuDetail {
+  readonly termId: number;
+  version: number;
+  maxDepth: number;
+  items: ServerMenuItem[];
+}
+
 interface MockState {
   menus: MenuRow[];
   locations: LocationRow[];
+  details: Map<number, MenuDetail>;
+}
+
+interface SavePayloadItem {
+  readonly id?: number;
+  readonly parentIndex: number | null;
+  readonly sortOrder: number;
+  readonly title: string | null;
+  readonly meta: Record<string, unknown>;
 }
 
 function readJsonInput(route: Route): Record<string, unknown> {
@@ -86,6 +118,7 @@ async function mockMenuRpc(page: Page, state: MockState): Promise<void> {
     if (url.endsWith("/auth/session")) return respond(SESSION);
     if (url.endsWith("/menu/list")) return respond(state.menus);
     if (url.endsWith("/menu/locations/list")) return respond(state.locations);
+    if (url.endsWith("/menu/pickerTabs")) return respond([]);
     if (url.endsWith("/menu/create")) {
       const input = readJsonInput(route) as { name: string };
       const name = input.name.trim();
@@ -99,6 +132,12 @@ async function mockMenuRpc(page: Page, state: MockState): Promise<void> {
         itemCount: 0,
       };
       state.menus = [...state.menus, created];
+      state.details.set(newId, {
+        termId: newId,
+        version: 0,
+        maxDepth: 5,
+        items: [],
+      });
       return respond({ termId: newId, slug, version: 0 });
     }
     if (url.endsWith("/menu/assignLocation")) {
@@ -114,8 +153,211 @@ async function mockMenuRpc(page: Page, state: MockState): Promise<void> {
       );
       return respond({ location: input.location, termSlug: input.termSlug });
     }
+    if (url.endsWith("/menu/get")) {
+      const input = readJsonInput(route) as { termId: number };
+      const detail = state.details.get(input.termId);
+      const menu = state.menus.find((m) => m.id === input.termId);
+      if (!detail || !menu) {
+        return route.fulfill({ status: 404, body: "menu-not-found" });
+      }
+      return respond({
+        id: detail.termId,
+        slug: menu.slug,
+        name: menu.name,
+        version: detail.version,
+        maxDepth: detail.maxDepth,
+        items: detail.items,
+      });
+    }
+    if (url.endsWith("/menu/save")) {
+      const input = readJsonInput(route) as {
+        readonly termId: number;
+        readonly version: number;
+        readonly maxDepth?: number;
+        readonly items: readonly SavePayloadItem[];
+      };
+      const detail = state.details.get(input.termId);
+      if (!detail) {
+        return route.fulfill({ status: 404, body: "menu-not-found" });
+      }
+      // Mirror the server: items in `input.items` reference their
+      // parent by index in the SAME list. We translate parentIndex →
+      // parentId by assigning fresh ids in flat order, then walking
+      // the resulting array to back-fill parent ids.
+      const idForIndex: number[] = [];
+      let nextId = detail.items.reduce((max, it) => Math.max(max, it.id), 0);
+      input.items.forEach((row, index) => {
+        const id = row.id ?? ++nextId;
+        idForIndex[index] = id;
+      });
+      const items: ServerMenuItem[] = input.items.map((row, index) => ({
+        id: idForIndex[index] ?? 0,
+        parentId:
+          row.parentIndex === null
+            ? null
+            : (idForIndex[row.parentIndex] ?? null),
+        sortOrder: row.sortOrder,
+        title: row.title ?? "",
+        meta: row.meta,
+      }));
+      detail.items = items;
+      detail.version += 1;
+      if (input.maxDepth !== undefined) detail.maxDepth = input.maxDepth;
+      state.menus = state.menus.map((m) =>
+        m.id === input.termId
+          ? { ...m, version: detail.version, itemCount: items.length }
+          : m,
+      );
+      return respond({
+        termId: input.termId,
+        version: detail.version,
+        itemIds: items.map((it) => it.id),
+        added: [],
+        removed: [],
+        modified: items.map((it) => it.id),
+      });
+    }
     return route.fulfill({ status: 404, body: "not-mocked" });
   });
+}
+
+function seededMenuState({
+  items,
+  maxDepth = 5,
+}: {
+  readonly items: readonly ServerMenuItem[];
+  readonly maxDepth?: number;
+}): MockState {
+  const menu: MenuRow = {
+    id: 1,
+    slug: "primary",
+    name: "Primary",
+    version: 0,
+    itemCount: items.length,
+  };
+  const detail: MenuDetail = {
+    termId: 1,
+    version: 0,
+    maxDepth,
+    items: items.map((it) => ({ ...it })),
+  };
+  return {
+    menus: [menu],
+    locations: [{ id: "primary", label: "Primary Nav", boundTermId: null }],
+    details: new Map([[1, detail]]),
+  };
+}
+
+function customItem(
+  id: number,
+  title: string,
+  url: string,
+  parentId: number | null,
+  sortOrder = 0,
+): ServerMenuItem {
+  return {
+    id,
+    parentId,
+    sortOrder,
+    title,
+    meta: { kind: "custom", url },
+  };
+}
+
+async function openItemsEditor(page: Page): Promise<void> {
+  await page.goto("pages/menus");
+  await expect(page.getByTestId("menus-shell")).toBeVisible();
+  await page.getByTestId("menus-selector-option-primary").click();
+  await expect(page.getByTestId("menu-item-editor")).toBeVisible();
+}
+
+async function dragRowOverTarget(
+  page: Page,
+  sourceId: number,
+  targetId: number,
+  options: { readonly nestPx?: number } = {},
+): Promise<void> {
+  // dnd-kit's PointerSensor listens for native `pointerdown` /
+  // `pointermove` / `pointerup` events with a `distance: 5`
+  // activation gate. Playwright's `page.mouse` API and `dragTo`
+  // helper synthesize Mouse events but the corresponding Pointer
+  // events don't always fire in a sequence the sensor accepts, so
+  // we dispatch the pointer events ourselves inside a single
+  // `page.evaluate` call (one CDP roundtrip instead of 14) so the
+  // sequence runs in a single microtask burst without test timeout
+  // pressure.
+  const handle = page.getByTestId(`menu-item-drag-${String(sourceId)}`);
+  const target = page.getByTestId(`menu-item-row-${String(targetId)}`);
+  const handleBox = await handle.boundingBox();
+  const targetBox = await target.boundingBox();
+  if (!handleBox || !targetBox) {
+    throw new Error(
+      `missing bounding box for source ${String(sourceId)} or target ${String(targetId)}`,
+    );
+  }
+  const sourceSelector = `[data-testid="menu-item-drag-${String(sourceId)}"]`;
+  const startX = handleBox.x + handleBox.width / 2;
+  const startY = handleBox.y + handleBox.height / 2;
+  const dropX = targetBox.x + targetBox.width / 2 + (options.nestPx ?? 0);
+  const dropY = targetBox.y + targetBox.height / 2;
+
+  await page.evaluate(
+    async ({ selector, startX, startY, dropX, dropY }) => {
+      const el = document.querySelector(selector);
+      if (!el) throw new Error(`drag handle not found: ${selector}`);
+      const base = {
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        bubbles: true,
+        cancelable: true,
+      } as const;
+      const yieldToReact = (): Promise<void> =>
+        new Promise((resolve) => requestAnimationFrame(() => resolve()));
+
+      // pointerdown is dispatched on the activator (drag handle) so
+      // dnd-kit's PointerSensor binds the drag to this pointerId.
+      el.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          ...base,
+          button: 0,
+          buttons: 1,
+          clientX: startX,
+          clientY: startY,
+        }),
+      );
+      await yieldToReact();
+
+      // After activation, dnd-kit attaches `pointermove` / `pointerup`
+      // listeners on `ownerDocument`, NOT on the activator element. So
+      // the rest of the sequence must dispatch on `document` to reach
+      // the sensor.
+      const steps = 12;
+      for (let i = 1; i <= steps; i += 1) {
+        const t = i / steps;
+        document.dispatchEvent(
+          new PointerEvent("pointermove", {
+            ...base,
+            button: 0,
+            buttons: 1,
+            clientX: startX + (dropX - startX) * t,
+            clientY: startY + (dropY - startY) * t,
+          }),
+        );
+        await yieldToReact();
+      }
+      document.dispatchEvent(
+        new PointerEvent("pointerup", {
+          ...base,
+          button: 0,
+          buttons: 0,
+          clientX: dropX,
+          clientY: dropY,
+        }),
+      );
+    },
+    { selector: sourceSelector, startX, startY, dropX, dropY },
+  );
 }
 
 test.describe("@plumix/plugin-menu — admin shell (slice 7)", () => {
@@ -125,6 +367,7 @@ test.describe("@plumix/plugin-menu — admin shell (slice 7)", () => {
     const state: MockState = {
       menus: [],
       locations: [{ id: "primary", label: "Primary Nav", boundTermId: null }],
+      details: new Map(),
     };
 
     page.on("dialog", (dialog) => {
@@ -157,5 +400,140 @@ test.describe("@plumix/plugin-menu — admin shell (slice 7)", () => {
     await expect(page.getByTestId("menus-location-select-primary")).toHaveValue(
       "header-nav",
     );
+  });
+});
+
+test.describe("@plumix/plugin-menu — drag-drop tree (slice 9.5)", () => {
+  // The pointer-driven tests dispatch a sequence of pointer events
+  // with rAF yields between moves so React commits dnd-kit's `active`
+  // state between hits. That dispatch loop adds ~250ms on top of the
+  // usual editor boot, so allow the test more headroom than the
+  // 30s default.
+  test.setTimeout(60_000);
+
+  test("drag-nest: dropping B under A persists across reload", async ({
+    page,
+  }) => {
+    const state = seededMenuState({
+      items: [
+        customItem(1, "Home", "/", null, 0),
+        customItem(2, "Docs", "/docs", null, 1),
+      ],
+    });
+    await mockManifest(page, MANIFEST);
+    await mockMenuRpc(page, state);
+    await openItemsEditor(page);
+
+    // Drop Docs (id=2) onto its own row with a one-indent horizontal
+    // offset. The projection then sees previous=Home (depth 0) and
+    // bumps Docs to depth 1 (child of Home).
+    await dragRowOverTarget(page, 2, 2, { nestPx: INDENTATION_WIDTH });
+
+    // After drag, the in-memory state's depth bumped.
+    const rowBefore = page.getByTestId("menu-item-row-2");
+    await expect(rowBefore).toHaveAttribute("data-depth", "1");
+
+    // Give React time to commit the post-drag state to the save
+    // button's click handler closure. Without this gap the click
+    // routes to a stale onClick that captures `state.dirty=false`,
+    // short-circuits the mutation, and never fires the fetch.
+    await page.waitForTimeout(100);
+
+    const saved = page.waitForResponse(
+      (r) => r.url().endsWith("/menu/save") && r.status() === 200,
+    );
+    await page.getByTestId("menu-save-button").click();
+    await saved;
+
+    await page.reload();
+    await openItemsEditor(page);
+    await expect(page.getByTestId("menu-item-row-2")).toHaveAttribute(
+      "data-depth",
+      "1",
+    );
+  });
+
+  test("max-depth ceiling: drag attempt past the configured depth makes no change", async ({
+    page,
+  }) => {
+    // maxDepth=1 means everything must live at depth 0 or 1. With
+    // items [Home (0), Docs (0)], dragging Docs under Home is the
+    // permitted depth-1 case; attempting any deeper push (no parent
+    // chain to nest under, so a single drop can't exceed 1) leaves
+    // Docs at depth 1 maximum. With a single-flat list and maxDepth=0
+    // we instead verify that the projection's depthCap clamps the
+    // drop to depth 0 — i.e. no nesting happens even when the
+    // pointer offset asks for it.
+    const state = seededMenuState({
+      items: [
+        customItem(1, "Home", "/", null, 0),
+        customItem(2, "Docs", "/docs", null, 1),
+      ],
+      maxDepth: 0,
+    });
+    await mockManifest(page, MANIFEST);
+    await mockMenuRpc(page, state);
+    await openItemsEditor(page);
+
+    await expect(page.getByTestId("menu-item-row-2")).toHaveAttribute(
+      "data-depth",
+      "0",
+    );
+    // The horizontal offset asks for depth 1 (one indent width to the
+    // right of the row's own slot), but the projection clamps to
+    // depthCap=maxDepth=0.
+    await dragRowOverTarget(page, 2, 2, { nestPx: INDENTATION_WIDTH });
+    await expect(page.getByTestId("menu-item-row-2")).toHaveAttribute(
+      "data-depth",
+      "0",
+    );
+  });
+
+  test("keyboard reorder: Space + ArrowDown + Space swaps two adjacent items", async ({
+    page,
+  }) => {
+    const state = seededMenuState({
+      items: [
+        customItem(1, "Home", "/", null, 0),
+        customItem(2, "Docs", "/docs", null, 1),
+      ],
+    });
+    await mockManifest(page, MANIFEST);
+    await mockMenuRpc(page, state);
+    await openItemsEditor(page);
+
+    // Reorder via the KeyboardSensor wired in MenuItemEditor. Pickup
+    // with Space, move down past the next row, drop with Space. The
+    // drag handle is a `<button>`, so Space would normally trigger
+    // a native click — dnd-kit's KeyboardSensor calls preventDefault
+    // when it sees Space on the focused activator, so the click is
+    // suppressed and the sensor activates instead.
+    const handle = page.getByTestId("menu-item-drag-1");
+    await handle.focus();
+    await page.keyboard.press("Space");
+    await page.waitForTimeout(50);
+    await page.keyboard.press("ArrowDown");
+    await page.waitForTimeout(50);
+    await page.keyboard.press("Space");
+
+    // After reorder, the persisted save→reload trip should show Docs
+    // before Home in the DOM order. We assert via the rows' order in
+    // the menu-tree container.
+    const saved = page.waitForResponse(
+      (r) => r.url().endsWith("/menu/save") && r.status() === 200,
+    );
+    await page.getByTestId("menu-save-button").click();
+    await saved;
+    await page.reload();
+    await openItemsEditor(page);
+
+    const rows = page
+      .getByTestId("menu-tree")
+      .locator("[data-testid^='menu-item-row-']");
+    await expect(rows.first()).toHaveAttribute(
+      "data-testid",
+      "menu-item-row-2",
+    );
+    await expect(rows.last()).toHaveAttribute("data-testid", "menu-item-row-1");
   });
 });

--- a/packages/plugins/menu/e2e/playwright.config.ts
+++ b/packages/plugins/menu/e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-import { definePlumixE2EConfig } from "@plumix/core/test/playwright";
+import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 const E2E_PORT = 5182;
 const ADMIN_BASE = "/_plumix/admin";

--- a/packages/plugins/menu/package.json
+++ b/packages/plugins/menu/package.json
@@ -55,12 +55,12 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@plumix/core": "workspace:*",
     "drizzle-orm": "catalog:",
     "valibot": "catalog:"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.99.2",
+    "plumix": "workspace:*",
     "react": "catalog:"
   },
   "devDependencies": {
@@ -79,9 +79,9 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitest/coverage-v8": "catalog:",
-    "esbuild": "0.27.7",
     "eslint": "catalog:",
     "jsdom": "^29.1.1",
+    "plumix": "workspace:*",
     "prettier": "catalog:",
     "publint": "catalog:",
     "react": "catalog:",

--- a/packages/plugins/menu/src/admin/item-state.test.ts
+++ b/packages/plugins/menu/src/admin/item-state.test.ts
@@ -1,6 +1,5 @@
+import type { LookupResult } from "plumix/plugin";
 import { describe, expect, test } from "vitest";
-
-import type { LookupResult } from "@plumix/core";
 
 import { mapItemState } from "./item-state.js";
 

--- a/packages/plugins/menu/src/admin/item-state.ts
+++ b/packages/plugins/menu/src/admin/item-state.ts
@@ -1,4 +1,4 @@
-import type { LookupResult } from "@plumix/core";
+import type { LookupResult } from "plumix/plugin";
 
 import type { MenuItemMeta } from "../server/types.js";
 

--- a/packages/plugins/menu/src/hooks.test.ts
+++ b/packages/plugins/menu/src/hooks.test.ts
@@ -1,12 +1,10 @@
-import { createRouterClient } from "@orpc/server";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
-
 import type {
   AppContext,
   PluginRegistry,
   RequestAuthenticator,
   User,
-} from "@plumix/core";
+} from "plumix/plugin";
+import { createRouterClient } from "@orpc/server";
 import {
   createAppContext,
   createPluginRegistry,
@@ -14,14 +12,15 @@ import {
   installPlugins,
   registerCoreLookupAdapters,
   settings,
-} from "@plumix/core";
+} from "plumix/plugin";
 import {
   adminUser,
   createTestDb,
   entryFactory,
   entryTermFactory,
   factoriesFor,
-} from "@plumix/core/test";
+} from "plumix/test";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import type { ResolvedMenuItem } from "./server/types.js";
 import { menu } from "./index.js";

--- a/packages/plugins/menu/src/index.test.ts
+++ b/packages/plugins/menu/src/index.test.ts
@@ -1,6 +1,5 @@
+import { HookRegistry, installPlugins } from "plumix/plugin";
 import { describe, expect, test } from "vitest";
-
-import { HookRegistry, installPlugins } from "@plumix/core";
 
 import { menu } from "./index.js";
 

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -1,4 +1,4 @@
-import { definePlugin } from "@plumix/core";
+import { definePlugin } from "plumix/plugin";
 
 import type { MenuLocationOptions, ResolvedMenuItem } from "./server/types.js";
 import { createMenuRouter } from "./rpc.js";
@@ -13,7 +13,7 @@ import { recordLocation } from "./server/locations.js";
 // the eligibility flags are read at admin time by the eligibility
 // resolver (`getEligibleMenuKinds`); the hooks are fired by
 // `getMenuByName` and `menu.save`.
-declare module "@plumix/core" {
+declare module "plumix/plugin" {
   interface ThemeContextExtensions {
     registerMenuLocation: (id: string, options: MenuLocationOptions) => void;
   }

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -1,13 +1,11 @@
-import { createRouterClient } from "@orpc/server";
-import { and, eq } from "drizzle-orm";
-import { afterEach, describe, expect, test } from "vitest";
-
 import type {
   PluginRegistry,
   RequestAuthenticator,
   User,
   UserRole,
-} from "@plumix/core";
+} from "plumix/plugin";
+import { createRouterClient } from "@orpc/server";
+import { and, eq } from "drizzle-orm";
 import {
   createAppContext,
   createPluginRegistry,
@@ -16,7 +14,7 @@ import {
   registerCoreLookupAdapters,
   settings,
   terms,
-} from "@plumix/core";
+} from "plumix/plugin";
 import {
   adminUser,
   createTestDb,
@@ -24,7 +22,8 @@ import {
   entryFactory,
   entryTermFactory,
   factoriesFor,
-} from "@plumix/core/test";
+} from "plumix/test";
+import { afterEach, describe, expect, test } from "vitest";
 
 import { menu } from "./index.js";
 import {

--- a/packages/plugins/menu/src/rpc.ts
+++ b/packages/plugins/menu/src/rpc.ts
@@ -1,5 +1,3 @@
-import * as v from "valibot";
-
 import {
   and,
   authenticated,
@@ -13,7 +11,8 @@ import {
   slugify,
   sql,
   terms,
-} from "@plumix/core";
+} from "plumix/plugin";
+import * as v from "valibot";
 
 import type { ResolvedRow } from "./server/resolveItemStates.js";
 import { getEligibleMenuKinds } from "./server/eligibility.js";

--- a/packages/plugins/menu/src/server/eligibility.test.ts
+++ b/packages/plugins/menu/src/server/eligibility.test.ts
@@ -1,13 +1,12 @@
-import { describe, expect, test } from "vitest";
-
-import type { PluginRegistry } from "@plumix/core";
+import type { PluginRegistry } from "plumix/plugin";
 import {
   createPluginRegistry,
   definePlugin,
   HookRegistry,
   installPlugins,
   registerCoreLookupAdapters,
-} from "@plumix/core";
+} from "plumix/plugin";
+import { describe, expect, test } from "vitest";
 
 import { getEligibleMenuKinds } from "./eligibility.js";
 

--- a/packages/plugins/menu/src/server/eligibility.ts
+++ b/packages/plugins/menu/src/server/eligibility.ts
@@ -1,4 +1,4 @@
-import type { PluginRegistry } from "@plumix/core";
+import type { PluginRegistry } from "plumix/plugin";
 
 /**
  * One picker tab in the admin's "Add menu items" rail. The tab label

--- a/packages/plugins/menu/src/server/getMenuByName.test.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.test.ts
@@ -1,7 +1,5 @@
+import type { AppContext, PluginRegistry } from "plumix/plugin";
 import { eq } from "drizzle-orm";
-import { beforeEach, describe, expect, test } from "vitest";
-
-import type { AppContext, PluginRegistry } from "@plumix/core";
 import {
   createPluginRegistry,
   definePlugin,
@@ -9,14 +7,15 @@ import {
   HookRegistry,
   installPlugins,
   registerCoreLookupAdapters,
-} from "@plumix/core";
+} from "plumix/plugin";
 import {
   adminUser,
   createTestDb,
   entryFactory,
   entryTermFactory,
   factoriesFor,
-} from "@plumix/core/test";
+} from "plumix/test";
+import { beforeEach, describe, expect, test } from "vitest";
 
 import type { MenuItemMeta } from "./types.js";
 import { getMenuByName } from "./getMenuByName.js";

--- a/packages/plugins/menu/src/server/getMenuByName.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.ts
@@ -1,7 +1,6 @@
+import type { AppContext, LookupResult } from "plumix/plugin";
 import { and, eq, inArray } from "drizzle-orm";
-
-import type { AppContext, LookupResult } from "@plumix/core";
-import { entries, entryTerm, isCurrentSource, terms } from "@plumix/core";
+import { entries, entryTerm, isCurrentSource, terms } from "plumix/plugin";
 
 import type { TreeNode } from "./buildTree.js";
 import type { MenuItemMeta, ResolvedMenu, ResolvedMenuItem } from "./types.js";

--- a/packages/plugins/menu/src/server/getMenuForLocation.test.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
-
-import type { AppContext, PluginRegistry, ThemeDescriptor } from "@plumix/core";
+import type {
+  AppContext,
+  PluginRegistry,
+  ThemeDescriptor,
+} from "plumix/plugin";
 import {
   auth,
   buildApp,
@@ -10,14 +12,15 @@ import {
   installPlugins,
   registerCoreLookupAdapters,
   settings,
-} from "@plumix/core";
+} from "plumix/plugin";
 import {
   adminUser,
   createTestDb,
   entryFactory,
   entryTermFactory,
   factoriesFor,
-} from "@plumix/core/test";
+} from "plumix/test";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { menu } from "../index.js";
 import { getMenuForLocation } from "./getMenuForLocation.js";

--- a/packages/plugins/menu/src/server/getMenuForLocation.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.ts
@@ -1,7 +1,6 @@
+import type { AppContext } from "plumix/plugin";
 import { and, eq } from "drizzle-orm";
-
-import type { AppContext } from "@plumix/core";
-import { settings } from "@plumix/core";
+import { settings } from "plumix/plugin";
 
 import type { ResolvedMenu } from "./types.js";
 import { getMenuByName } from "./getMenuByName.js";

--- a/packages/plugins/menu/src/server/resolveItemStates.ts
+++ b/packages/plugins/menu/src/server/resolveItemStates.ts
@@ -7,7 +7,7 @@
 // broken items silently for public output. This one keeps them so the
 // editor can surface them with a warning + Re-link affordances.
 
-import type { AppContext, LookupResult } from "@plumix/core";
+import type { AppContext, LookupResult } from "plumix/plugin";
 
 import type { ItemState } from "../admin/item-state.js";
 import type { MenuItemMeta } from "./types.js";

--- a/packages/plugins/pages/package.json
+++ b/packages/plugins/pages/package.json
@@ -46,8 +46,8 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
-  "dependencies": {
-    "@plumix/core": "workspace:*"
+  "peerDependencies": {
+    "plumix": "workspace:*"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
@@ -57,6 +57,7 @@
     "@plumix/vitest-config": "workspace:*",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
+    "plumix": "workspace:*",
     "prettier": "catalog:",
     "publint": "catalog:",
     "typescript": "catalog:",

--- a/packages/plugins/pages/src/index.test.ts
+++ b/packages/plugins/pages/src/index.test.ts
@@ -1,6 +1,5 @@
+import { HookRegistry, installPlugins } from "plumix/plugin";
 import { describe, expect, test } from "vitest";
-
-import { HookRegistry, installPlugins } from "@plumix/core";
 
 import { pages } from "./index.js";
 

--- a/packages/plugins/pages/src/index.ts
+++ b/packages/plugins/pages/src/index.ts
@@ -1,4 +1,4 @@
-import { definePlugin } from "@plumix/core";
+import { definePlugin } from "plumix/plugin";
 
 export const pages = definePlugin("pages", (ctx) => {
   ctx.registerEntryType("page", {

--- a/packages/runtimes/cloudflare/package.json
+++ b/packages/runtimes/cloudflare/package.json
@@ -53,15 +53,14 @@
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.33.0",
-    "@plumix/core": "workspace:*",
     "jose": "^6.2.3",
     "jsonc-parser": "^3.3.1",
-    "plumix": "workspace:*",
     "smol-toml": "^1.6.1",
     "vite": "catalog:"
   },
   "peerDependencies": {
     "drizzle-orm": "catalog:",
+    "plumix": "workspace:*",
     "wrangler": "^4"
   },
   "peerDependenciesMeta": {
@@ -79,6 +78,7 @@
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
+    "plumix": "workspace:*",
     "prettier": "catalog:",
     "publint": "catalog:",
     "typescript": "catalog:",

--- a/packages/runtimes/cloudflare/src/adapter.test.ts
+++ b/packages/runtimes/cloudflare/src/adapter.test.ts
@@ -1,18 +1,17 @@
-import { describe, expect, test } from "vitest";
-
 import type {
   DatabaseAdapter,
   RequestScopedDb,
   RequestScopedDbArgs,
-} from "@plumix/core";
+} from "plumix";
 import {
+  auth as authConfig,
   buildApp,
   definePlugin,
   plumix,
   requestStore,
   SESSION_COOKIE_NAME,
-} from "@plumix/core";
-import { auth as authConfig } from "@plumix/core/auth";
+} from "plumix";
+import { describe, expect, test } from "vitest";
 
 import { cloudflare } from "./adapter.js";
 import { d1 } from "./d1.js";

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -1,5 +1,4 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-
 import type {
   AssetsBinding,
   Db,
@@ -7,14 +6,14 @@ import type {
   PlumixApp,
   PlumixEnv,
   RuntimeAdapter,
-} from "@plumix/core";
+} from "plumix";
 import {
   createAppContext,
   createPlumixDispatcher,
   jsonResponse,
   readSessionCookie,
   requestStore,
-} from "@plumix/core";
+} from "plumix";
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 

--- a/packages/runtimes/cloudflare/src/cf-access.test.ts
+++ b/packages/runtimes/cloudflare/src/cf-access.test.ts
@@ -1,7 +1,6 @@
+import type { Db } from "plumix";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-
-import type { Db } from "@plumix/core";
 
 import { cfAccess, cfAccessLogoutUrl } from "./cf-access.js";
 
@@ -186,7 +185,7 @@ describe("cfAccess.authenticate — full crypto path", () => {
     "provisions and returns the user when the JWT is valid",
     { timeout: 30_000 },
     async () => {
-      const { createTestDb } = await import("@plumix/core/test");
+      const { createTestDb } = await import("plumix/test");
       const db = await createTestDb();
 
       const guard = cfAccess({
@@ -213,7 +212,7 @@ describe("cfAccess.authenticate — full crypto path", () => {
   );
 
   test("returns null when bootstrap is disabled and zero users exist", async () => {
-    const { createTestDb } = await import("@plumix/core/test");
+    const { createTestDb } = await import("plumix/test");
     const db = await createTestDb();
 
     const guard = cfAccess({
@@ -237,7 +236,7 @@ describe("cfAccess.authenticate — full crypto path", () => {
   });
 
   test("JWKS is fetched once across many authenticate calls (cache contract)", async () => {
-    const { createTestDb } = await import("@plumix/core/test");
+    const { createTestDb } = await import("plumix/test");
     const db = await createTestDb();
 
     const guard = cfAccess({
@@ -273,7 +272,7 @@ describe("cfAccess.authenticate — full crypto path", () => {
   });
 
   test("returns null when the email claim is missing", async () => {
-    const { createTestDb } = await import("@plumix/core/test");
+    const { createTestDb } = await import("plumix/test");
     const db = await createTestDb();
 
     const guard = cfAccess({

--- a/packages/runtimes/cloudflare/src/cf-access.ts
+++ b/packages/runtimes/cloudflare/src/cf-access.ts
@@ -1,7 +1,6 @@
+import type { Db, RequestAuthenticator, UserRole } from "plumix";
 import { createRemoteJWKSet, jwtVerify } from "jose";
-
-import type { Db, RequestAuthenticator, UserRole } from "@plumix/core";
-import { ExternalIdentityError, resolveExternalIdentity } from "@plumix/core";
+import { ExternalIdentityError, resolveExternalIdentity } from "plumix";
 
 // Header CF Access sets on every request that passed the application's
 // policy. Documented in `https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/application-token/`.

--- a/packages/runtimes/cloudflare/src/commands/build.ts
+++ b/packages/runtimes/cloudflare/src/commands/build.ts
@@ -1,4 +1,4 @@
-import type { CommandDefinition } from "@plumix/core";
+import type { CommandDefinition } from "plumix";
 
 import { createCloudflareVite } from "./vite.js";
 

--- a/packages/runtimes/cloudflare/src/commands/deploy.ts
+++ b/packages/runtimes/cloudflare/src/commands/deploy.ts
@@ -1,5 +1,5 @@
-import type { CommandDefinition } from "@plumix/core";
-import { spawnInherit } from "@plumix/core";
+import type { CommandDefinition } from "plumix";
+import { spawnInherit } from "plumix";
 
 export const deployCommand: CommandDefinition = {
   describe: "Deploy to Cloudflare (via wrangler)",

--- a/packages/runtimes/cloudflare/src/commands/dev.ts
+++ b/packages/runtimes/cloudflare/src/commands/dev.ts
@@ -1,4 +1,4 @@
-import type { CommandDefinition } from "@plumix/core";
+import type { CommandDefinition } from "plumix";
 
 import { createCloudflareVite } from "./vite.js";
 

--- a/packages/runtimes/cloudflare/src/commands/index.ts
+++ b/packages/runtimes/cloudflare/src/commands/index.ts
@@ -1,4 +1,4 @@
-import type { CommandRegistry } from "@plumix/core";
+import type { CommandRegistry } from "plumix";
 
 import { buildCommand } from "./build.js";
 import { deployCommand } from "./deploy.js";

--- a/packages/runtimes/cloudflare/src/commands/migrate-apply.test.ts
+++ b/packages/runtimes/cloudflare/src/commands/migrate-apply.test.ts
@@ -1,6 +1,5 @@
+import type { CommandContext, PlumixApp } from "plumix";
 import { afterEach, describe, expect, test, vi } from "vitest";
-
-import type { CommandContext, PlumixApp } from "@plumix/core";
 
 import { migrateApplyCommand, migrateApplyDeps } from "./migrate-apply.js";
 

--- a/packages/runtimes/cloudflare/src/commands/migrate-apply.ts
+++ b/packages/runtimes/cloudflare/src/commands/migrate-apply.ts
@@ -1,5 +1,5 @@
-import type { CommandDefinition } from "@plumix/core";
-import { CliError, spawnInherit } from "@plumix/core";
+import type { CommandDefinition } from "plumix";
+import { CliError, spawnInherit } from "plumix";
 
 import { loadWranglerConfig } from "../wrangler-config.js";
 

--- a/packages/runtimes/cloudflare/src/commands/types.ts
+++ b/packages/runtimes/cloudflare/src/commands/types.ts
@@ -1,5 +1,5 @@
-import type { CommandDefinition } from "@plumix/core";
-import { spawnInherit } from "@plumix/core";
+import type { CommandDefinition } from "plumix";
+import { spawnInherit } from "plumix";
 
 export const typesCommand: CommandDefinition = {
   describe: "Generate Worker binding types (via wrangler)",

--- a/packages/runtimes/cloudflare/src/commands/vite.ts
+++ b/packages/runtimes/cloudflare/src/commands/vite.ts
@@ -1,6 +1,5 @@
+import type { CommandContext } from "plumix";
 import type { Plugin } from "vite";
-
-import type { CommandContext } from "@plumix/core";
 
 export async function createCloudflareVite(
   ctx: CommandContext,

--- a/packages/runtimes/cloudflare/src/d1.test.ts
+++ b/packages/runtimes/cloudflare/src/d1.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, test } from "vitest";
-
 import type {
   DatabaseAdapter,
   RequestScopedDb,
   RequestScopedDbArgs,
-} from "@plumix/core";
+} from "plumix";
+import { describe, expect, test } from "vitest";
 
 import { d1 } from "./d1.js";
 

--- a/packages/runtimes/cloudflare/src/d1.ts
+++ b/packages/runtimes/cloudflare/src/d1.ts
@@ -1,11 +1,10 @@
-import { drizzle } from "drizzle-orm/d1";
-
 import type {
   DatabaseAdapter,
   RequestScopedDb,
   RequestScopedDbArgs,
-} from "@plumix/core";
-import { isSecureRequest, readSessionCookie } from "@plumix/core";
+} from "plumix";
+import { drizzle } from "drizzle-orm/d1";
+import { isSecureRequest, readSessionCookie } from "plumix";
 
 import {
   buildBookmarkCookie,

--- a/packages/runtimes/cloudflare/src/env.ts
+++ b/packages/runtimes/cloudflare/src/env.ts
@@ -1,6 +1,6 @@
 /// <reference types="@cloudflare/workers-types" />
 
-declare module "@plumix/core" {
+declare module "plumix" {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface PlumixEnv extends Cloudflare.Env {}
 }

--- a/packages/runtimes/cloudflare/src/images.ts
+++ b/packages/runtimes/cloudflare/src/images.ts
@@ -1,4 +1,4 @@
-import type { ImageDelivery, TransformOpts } from "@plumix/core";
+import type { ImageDelivery, TransformOpts } from "plumix";
 
 export interface ImagesConfig {
   /**

--- a/packages/runtimes/cloudflare/src/kv.ts
+++ b/packages/runtimes/cloudflare/src/kv.ts
@@ -1,4 +1,4 @@
-import type { KV } from "@plumix/core";
+import type { KV } from "plumix";
 
 export interface KVConfig {
   readonly binding: string;

--- a/packages/runtimes/cloudflare/src/r2.ts
+++ b/packages/runtimes/cloudflare/src/r2.ts
@@ -9,7 +9,7 @@ import type {
   PresignPutOptions,
   PutOptions,
   UrlOptions,
-} from "@plumix/core";
+} from "plumix";
 
 import { presignPutUrl } from "./sigv4.js";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,9 +445,6 @@ importers:
 
   packages/plugins/audit-log:
     dependencies:
-      '@plumix/core':
-        specifier: workspace:*
-        version: link:../../core
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260421.1)(@libsql/client@0.17.3)
@@ -500,15 +497,15 @@ importers:
       drizzle-kit:
         specifier: 'catalog:'
         version: 0.31.10
-      esbuild:
-        specifier: 0.27.7
-        version: 0.27.7
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      plumix:
+        specifier: workspace:*
+        version: link:../../plumix
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -529,10 +526,6 @@ importers:
         version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugins/blog:
-    dependencies:
-      '@plumix/core':
-        specifier: workspace:*
-        version: link:../../core
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -555,6 +548,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
+      plumix:
+        specifier: workspace:*
+        version: link:../../plumix
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -570,9 +566,6 @@ importers:
 
   packages/plugins/media:
     dependencies:
-      '@plumix/core':
-        specifier: workspace:*
-        version: link:../../core
       valibot:
         specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.3)
@@ -607,12 +600,12 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.5(vitest@4.1.5)
-      esbuild:
-        specifier: 0.27.7
-        version: 0.27.7
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
+      plumix:
+        specifier: workspace:*
+        version: link:../../plumix
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -668,9 +661,6 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.5)
-      '@plumix/core':
-        specifier: workspace:*
-        version: link:../../core
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260421.1)(@libsql/client@0.17.3)
@@ -723,15 +713,15 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.5(vitest@4.1.5)
-      esbuild:
-        specifier: 0.27.7
-        version: 0.27.7
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      plumix:
+        specifier: workspace:*
+        version: link:../../plumix
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -752,10 +742,6 @@ importers:
         version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugins/pages:
-    dependencies:
-      '@plumix/core':
-        specifier: workspace:*
-        version: link:../../core
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -778,6 +764,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
+      plumix:
+        specifier: workspace:*
+        version: link:../../plumix
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -896,9 +885,6 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.33.0
         version: 1.33.0(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260426.1)(wrangler@4.86.0(@cloudflare/workers-types@4.20260421.1))
-      '@plumix/core':
-        specifier: workspace:*
-        version: link:../../core
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260421.1)(@libsql/client@0.17.3)
@@ -908,9 +894,6 @@ importers:
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1
-      plumix:
-        specifier: workspace:*
-        version: link:../../plumix
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
@@ -945,6 +928,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
+      plumix:
+        specifier: workspace:*
+        version: link:../../plumix
       prettier:
         specifier: 'catalog:'
         version: 3.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@commitlint/types':
         specifier: ^20.5.0
         version: 20.5.0
+      dependency-cruiser:
+        specifier: ^17.4.0
+        version: 17.4.0
       knip:
         specifier: ^6.6.0
         version: 6.6.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
@@ -4147,10 +4150,21 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  acorn-jsx-walk@2.0.0:
+    resolution: {integrity: sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -4384,6 +4398,10 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   comment-parser@1.4.6:
     resolution: {integrity: sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==}
     engines: {node: '>= 12.0.0'}
@@ -4486,6 +4504,11 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  dependency-cruiser@17.4.0:
+    resolution: {integrity: sha512-+WdFoOb+fT1XNC0iPqOyLpfhLd8xVh7eLXJxPAtiXCS+YmXzGrjqVTte7+L8SZIsnJj0aFhb8LxECIBJY5TTIA==}
+    engines: {node: ^20.12||^22||>=24}
+    hasBin: true
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -4644,6 +4667,10 @@ packages:
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
 
   entities@8.0.0:
@@ -4951,6 +4978,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
+
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
     engines: {node: '>=20'}
@@ -5037,6 +5068,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -5044,6 +5079,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  interpret@3.1.1:
+    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
+    engines: {node: '>=10.13.0'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -5104,6 +5143,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-installed-globally@1.0.0:
+    resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
+    engines: {node: '>=18'}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -5123,6 +5166,10 @@ packages:
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
 
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
@@ -5267,6 +5314,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -5698,6 +5749,10 @@ packages:
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -5831,6 +5886,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  rechoir@0.8.0:
+    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
+    engines: {node: '>= 10.13.0'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -5838,6 +5897,10 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -5861,6 +5924,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   resolve@2.0.0-next.6:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
@@ -5897,6 +5965,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safe-regex@2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -5981,6 +6052,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
@@ -6045,6 +6119,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
@@ -6091,6 +6169,10 @@ packages:
 
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   thenify-all@1.6.0:
@@ -6143,6 +6225,14 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tsconfig-paths-webpack-plugin@4.2.0:
+    resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
+    engines: {node: '>=10.13.0'}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -6383,6 +6473,11 @@ packages:
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
+
+  watskeburt@5.0.3:
+    resolution: {integrity: sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==}
+    engines: {node: ^20.12||^22.13||>=24.0}
+    hasBin: true
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -9316,7 +9411,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -9367,7 +9462,17 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  acorn-jsx-walk@2.0.0: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
@@ -9642,6 +9747,8 @@ snapshots:
 
   commander@10.0.1: {}
 
+  commander@14.0.3: {}
+
   comment-parser@1.4.6: {}
 
   compare-func@2.0.0:
@@ -9746,6 +9853,27 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dependency-cruiser@17.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn-jsx-walk: 2.0.0
+      acorn-loose: 8.5.2
+      acorn-walk: 8.3.5
+      commander: 14.0.3
+      enhanced-resolve: 5.21.0
+      ignore: 7.0.5
+      interpret: 3.1.1
+      is-installed-globally: 1.0.0
+      json5: 2.2.3
+      picomatch: 4.0.4
+      prompts: 2.4.2
+      rechoir: 0.8.0
+      safe-regex: 2.1.1
+      semver: 7.7.4
+      tsconfig-paths-webpack-plugin: 4.2.0
+      watskeburt: 5.0.3
+
   dequal@2.0.3: {}
 
   detect-europe-js@0.1.2: {}
@@ -9805,6 +9933,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  enhanced-resolve@5.21.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   entities@8.0.0: {}
 
@@ -10287,6 +10420,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
+
   global-directory@5.0.0:
     dependencies:
       ini: 6.0.0
@@ -10357,6 +10494,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  ini@4.1.1: {}
+
   ini@6.0.0: {}
 
   internal-slot@1.1.0:
@@ -10364,6 +10503,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  interpret@3.1.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -10431,6 +10572,11 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-installed-globally@1.0.0:
+    dependencies:
+      global-directory: 4.0.1
+      is-path-inside: 4.0.0
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -10443,6 +10589,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
+
+  is-path-inside@4.0.0: {}
 
   is-plain-obj@2.1.0: {}
 
@@ -10587,6 +10735,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -11008,6 +11158,11 @@ snapshots:
 
   promise-limit@2.7.0: {}
 
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -11215,6 +11370,10 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  rechoir@0.8.0:
+    dependencies:
+      resolve: 1.22.12
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -11230,6 +11389,8 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regexp-tree@0.1.27: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -11249,6 +11410,13 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@2.0.0-next.6:
     dependencies:
@@ -11310,6 +11478,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safe-regex@2.1.1:
+    dependencies:
+      regexp-tree: 0.1.27
 
   saxes@6.0.0:
     dependencies:
@@ -11424,6 +11596,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sisteransi@1.0.5: {}
+
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
@@ -11508,6 +11682,8 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-bom@3.0.0: {}
+
   strip-bom@4.0.0: {}
 
   strip-comments-strings@1.2.0: {}
@@ -11540,6 +11716,8 @@ snapshots:
   tailwindcss@4.2.4: {}
 
   tapable@2.3.2: {}
+
+  tapable@2.3.3: {}
 
   thenify-all@1.6.0:
     dependencies:
@@ -11583,6 +11761,19 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  tsconfig-paths-webpack-plugin@4.2.0:
+    dependencies:
+      chalk: 4.1.2
+      enhanced-resolve: 5.21.0
+      tapable: 2.3.2
+      tsconfig-paths: 4.2.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@2.8.1: {}
 
@@ -11851,6 +12042,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   walk-up-path@4.0.0: {}
+
+  watskeburt@5.0.3: {}
 
   webidl-conversions@8.0.1: {}
 


### PR DESCRIPTION
Plugins, the Cloudflare runtime, and `create-plumix-app` now consume the public `plumix` package (and its subpaths) instead of importing `@plumix/core` directly. Boundary enforcement is declarative — a single `.dependency-cruiser.cjs` at the repo root.

## The layering

| Tier | Packages | Allowed to import |
|------|----------|-------------------|
| Public umbrella | `plumix`, `create-plumix-app` | anything |
| Internal implementation | `@plumix/core`, `@plumix/admin`, `@plumix/blocks` | each other |
| Published downstream | `@plumix/plugin-*`, `@plumix/runtime-*` | `plumix` only |
| Consumers | `examples/*`, `packages/plugins/*/playground` | `plumix`, plugins, runtimes |

The contract in one sentence: anything outside the umbrella + internal pair must consume the public `plumix` package and never reach into the internal packages directly.

## The motivation

As we approach a 0.1.0 publish, the public contract should be the same surface internal plugins/runtimes use, not a private path that external authors can't follow. Dogfooding `plumix/plugin` and friends keeps the umbrella's export map honest. The enforcement layer makes the contract impossible to quietly regress.

## How it's enforced

- **Install-time** — consumer `package.json` files don't list `@plumix/core` as a dep; `plumix` is declared as a peer + dev. External installs of a plugin can't resolve internal packages because they aren't pulled in.
- **CI-time** — `.dependency-cruiser.cjs` declares the forbidden import paths. `pnpm depcheck` (a new root script) and the corresponding `DepCheck` CI job fail on any violation. Path-based, language-aware, walks pnpm workspace symlinks.
- **Single source of truth** — the depcruiser config IS the tier declaration. No per-package eslint config wiring, no opt-in/opt-out flags scattered across the repo. Adding a new package requires zero eslint changes — the rule applies automatically based on path.

## Considered and chosen against

Earlier iterations tried ESLint-side enforcement (a `consumerBoundariesConfig` extended per-package; later, an `internalBoundariesConfig` + `consumerBoundariesConfig` split + a tier-check script). Both ran into the same wall: flat-config `files`/`ignores` patterns are matched against the lint cwd, and there's no clean way to express "internal packages opt out" without polluting the rule namespace. Dependency-cruiser sidesteps the framework friction entirely — boundary enforcement is exactly what it was built for.

## Known follow-ups (out of scope here)

- Plugins' published `.d.ts` files still reference `@plumix/core` because TypeScript emits canonical module paths, not the re-export route. Either `@plumix/core` needs to become a publishable package (drop `private: true`) or the build pipeline needs to rewrite/bundle declarations before 0.1.0 ships. The depcruiser rule scopes its `from` to non-`/dist/` paths so this pre-existing concern doesn't block the source-level check.
- `plumix/plugin` is currently `export * from \"@plumix/core\"` — the wildcard publishes the entire core surface. Tighten to a named export list in a follow-up so the plugin-author API is intentional.

## Commits

1. `refactor: route plugins and runtimes through the public plumix umbrella` — drops `@plumix/core` from consumer deps, swaps imports to `plumix/plugin`, `plumix/test`, `plumix/test/playwright`, moves module augmentations to `plumix/plugin`. Also updates the CI knip step to build plumix first via turbo so plugin e2e configs resolve.
2. `feat: enforce package boundaries via dependency-cruiser` — adds the depcruiser config, root `depcheck` script, and CI job.