### PR TITLE
test(plugin-menu): Playwright e2e for drag-drop tree (slice 9.5)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -117,6 +117,11 @@ const config: KnipConfig = {
       ],
       // See packages/admin above for why the playwright plugin is off.
       playwright: false,
+      // `tsx` is invoked as `pnpm exec tsx ./build-chunk.ts` inside
+      // the playwright webServer string — knip's static analysis
+      // can't see that. Declared as a direct devDep so the bin
+      // resolves on a fresh CI install.
+      ignoreDependencies: ["tsx"],
     },
     // Same shape as plugin-media: admin chunk loaded via `adminEntry`
     // at consumer build time; playwright rig invokes build-chunk via
@@ -132,6 +137,8 @@ const config: KnipConfig = {
         "e2e/*.spec.ts",
       ],
       playwright: false,
+      // See packages/plugins/media for the rationale.
+      ignoreDependencies: ["tsx"],
     },
     // Same shape as plugin-menu: admin chunk loaded via `adminEntry`
     // at consumer build time; `./server` subpath is consumer-facing

--- a/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
+++ b/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
@@ -20,6 +20,9 @@ const schemaImports = schema as unknown as Record<string, unknown>;
 
 let cachedStatements: string[] | null = null;
 
+// drizzle-kit's `api` surface is loosely typed (`SQLiteSchema` is opaque);
+// treat it as a black-box snapshot blob and only read its `id` field.
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
 async function compileSchemaSql(): Promise<string[]> {
   if (cachedStatements) return cachedStatements;
   const empty = await generateSQLiteDrizzleJson({}, undefined, "snake_case");
@@ -31,6 +34,7 @@ async function compileSchemaSql(): Promise<string[]> {
   cachedStatements = await generateSQLiteMigration(empty, current);
   return cachedStatements;
 }
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
 
 async function createDb(): Promise<TestDb> {
   const client = createClient({ url: ":memory:" });

--- a/packages/plugins/media/package.json
+++ b/packages/plugins/media/package.json
@@ -75,6 +75,7 @@
     "prettier": "catalog:",
     "publint": "catalog:",
     "react": "catalog:",
+    "tsx": "4.21.0",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/plugins/menu/package.json
+++ b/packages/plugins/menu/package.json
@@ -86,6 +86,7 @@
     "publint": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "tsx": "4.21.0",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,6 +618,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.5
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -737,6 +740,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,10 @@
     "test": {
       "dependsOn": ["build"]
     },
+    "test:e2e": {
+      "dependsOn": ["build"],
+      "outputs": ["playwright-report/**", "test-results/**"]
+    },
     "clean": {
       "cache": false
     },


### PR DESCRIPTION
Adds the three Playwright e2e tests deferred from #166 plus the turbo
plumbing so plugin e2e suites actually run in CI.

### What the tests cover

- **drag-nest**: drops `Docs` onto its own row with `INDENTATION_WIDTH`
  horizontal offset; `getProjection` bumps depth to 1 (child of
  `Home`); the save round-trips through the mocked `menu/save` back to
  a fresh `menu/get`; the row's `data-depth` is verified after reload.
- **max-depth ceiling**: with `maxDepth=0` the same horizontal-offset
  drop is clamped to depth 0 by `getProjection`'s `depthCap` — proves
  the drop indicator's ceiling is honored by the reducer.
- **keyboard reorder**: focuses the drag handle, runs Space +
  ArrowDown + Space through dnd-kit's `KeyboardSensor`; the save →
  reload trip swaps the row order in the DOM.

All four tests in `menu.spec.ts` (the existing slice 7 admin-shell
case plus the three new ones) pass locally in ~6s.

### Why the dispatch helper is the way it is

dnd-kit's `PointerSensor` listens for native `pointerdown` /
`pointermove` / `pointerup` events with a `distance: 5` activation
gate. Playwright's `page.mouse` API and `locator.dragTo` helper
synthesize Mouse events but the corresponding Pointer events don't
always fire in a sequence the sensor accepts — the result was an
"event fires, but `active` never sets" failure mode that was easy to
mistake for a logic bug in the tree state.

`dragRowOverTarget` dispatches the native `PointerEvent` sequence
inside a single `page.evaluate` call. The sensor attaches the
`pointermove` / `pointerup` listeners on `ownerDocument` (not the
activator element), so those events are dispatched on `document`;
`pointerdown` stays on the handle so the sensor binds the drag to
that `pointerId`. A `requestAnimationFrame` yield between moves lets
React commit dnd-kit's `active` state before the next move's
`dragMove` handler runs, otherwise the sensor sees stale state. A
final 100ms `waitForTimeout` after the drag-end is what bridges the
React commit gap before the save button's onClick — without it the
click captures a stale `dirty: false` and the mutation never fires.

### turbo wiring

`turbo.json` now declares a `test:e2e` task with `dependsOn: ["build"]`.
Without it the root `pnpm test:e2e` only auto-discovers `@plumix/admin`'s
suite (a quirk of turbo's task discovery), and menu's + media's e2e
suites silently sit out of CI. With the task wired, all three suites
run.

### Mock layer changes

The mock RPC layer now tracks per-menu items + version + maxDepth so
`menu/save` / `menu/get` round-trip the way the real server would.
The `parentIndex → parentId` allocator pre-seeds `nextId` from the
union of existing AND explicit-input ids so a new (no-id) row can't
be assigned an id that collides with another row's explicit id later
in the same payload.

Resolves #185