### PR TITLE
feat(plugin-audit-log): retention purge — storage seam + policy math

### DIFF
--- a/packages/plugins/audit-log/src/index.ts
+++ b/packages/plugins/audit-log/src/index.ts
@@ -1,12 +1,14 @@
 import { definePlugin } from "plumix/plugin";
 
 import type { AuditExtension } from "./server/auditExtension.js";
+import type { AuditLogRetentionConfig } from "./server/retention.js";
 import type { AuditLogStorage } from "./types.js";
 import * as schema from "./db/schema.js";
 import { createAuditLogRouter } from "./rpc.js";
 import { createAuditExtension } from "./server/auditExtension.js";
 import { createAuditService } from "./server/auditService.js";
 import { registerHooks } from "./server/hooks.js";
+import { assertValidRetention, DEFAULT_RETENTION } from "./server/retention.js";
 import { sqlite } from "./server/storage-sqlite.js";
 
 export type {
@@ -15,6 +17,17 @@ export type {
   AuditLogQueryFilter,
 } from "./types.js";
 export type { AuditExtension, AuditLogInput } from "./server/auditExtension.js";
+export type {
+  AuditLogRetentionConfig,
+  AuditLogRetentionPolicy,
+  RunRetentionPurgeArgs,
+  RunRetentionPurgeResult,
+} from "./server/retention.js";
+export {
+  assertValidRetention,
+  DEFAULT_RETENTION,
+  runRetentionPurge,
+} from "./server/retention.js";
 export { sqlite } from "./server/storage-sqlite.js";
 
 // Declaration-merge contribution. Declared optional so consumers that
@@ -34,6 +47,13 @@ export interface AuditLogPluginOptions {
    * BigQuery, ...) without touching the plugin's write pipeline.
    */
   readonly storage?: AuditLogStorage;
+  /**
+   * How long rows are kept. Defaults to `{ maxAgeDays: 90 }`. Pass
+   * `retention: false` to keep rows forever. Triggering the purge is
+   * a separate concern — call `runRetentionPurge(ctx, ...)` from your
+   * ops script or a scheduled handler.
+   */
+  readonly retention?: AuditLogRetentionConfig;
 }
 
 const ADMIN_ENTRY_PATH =
@@ -89,6 +109,8 @@ const AUDIT_LOG_READ_CAPABILITY = "audit_log:read";
  */
 export function auditLog(options: AuditLogPluginOptions = {}) {
   const storage = options.storage ?? sqlite();
+  // Fail fast on misconfigured retention — see assertValidRetention.
+  assertValidRetention(options.retention ?? DEFAULT_RETENTION);
   const service = createAuditService(storage);
   const router = createAuditLogRouter(storage);
   const extension = createAuditExtension(service);

--- a/packages/plugins/audit-log/src/server/retention.test.ts
+++ b/packages/plugins/audit-log/src/server/retention.test.ts
@@ -1,0 +1,208 @@
+import type { AppContext } from "plumix/plugin";
+import { describe, expect, test, vi } from "vitest";
+
+import type { AuditLogStorage } from "../types.js";
+import { auditLog } from "../index.js";
+import {
+  assertValidRetention,
+  computeRetentionCutoff,
+  DEFAULT_RETENTION,
+  runRetentionPurge,
+} from "./retention.js";
+
+interface FakeCtx {
+  readonly logger: {
+    debug: () => void;
+    info: () => void;
+    warn: ReturnType<typeof vi.fn>;
+    error: () => void;
+  };
+}
+
+function fakeCtx(): FakeCtx {
+  return {
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: vi.fn(),
+      error: () => undefined,
+    },
+  };
+}
+
+function fakeStorage(opts: { withPurge: boolean }): {
+  storage: AuditLogStorage;
+  purgeCalls: { cutoff: Date }[];
+  purgeReturn: { deleted: number };
+} {
+  const purgeCalls: { cutoff: Date }[] = [];
+  const purgeReturn = { deleted: 0 };
+  const storage: AuditLogStorage = {
+    kind: opts.withPurge ? "fake-with-purge" : "fake-no-purge",
+    write: () => Promise.resolve(),
+    query: () => Promise.resolve({ rows: [], nextCursor: null }),
+    ...(opts.withPurge
+      ? {
+          purge: (_ctx, args) => {
+            purgeCalls.push(args);
+            return Promise.resolve(purgeReturn);
+          },
+        }
+      : {}),
+  };
+  return { storage, purgeCalls, purgeReturn };
+}
+
+describe("computeRetentionCutoff", () => {
+  test.each([
+    {
+      name: "90-day default — typical case",
+      now: new Date("2026-05-11T00:00:00Z"),
+      policy: { maxAgeDays: 90 },
+      expected: new Date("2026-02-10T00:00:00Z"),
+    },
+    {
+      name: "zero days — cutoff equals now",
+      now: new Date("2026-05-11T12:34:56Z"),
+      policy: { maxAgeDays: 0 },
+      expected: new Date("2026-05-11T12:34:56Z"),
+    },
+    {
+      name: "one day",
+      now: new Date("2026-05-11T00:00:00Z"),
+      policy: { maxAgeDays: 1 },
+      expected: new Date("2026-05-10T00:00:00Z"),
+    },
+    {
+      name: "long retention — 730 days back lands two years prior (no leap-day in the May→May window)",
+      now: new Date("2026-05-11T00:00:00Z"),
+      policy: { maxAgeDays: 730 },
+      expected: new Date("2024-05-11T00:00:00Z"),
+    },
+    {
+      name: "preserves sub-day precision",
+      now: new Date("2026-05-11T18:45:30.500Z"),
+      policy: { maxAgeDays: 7 },
+      expected: new Date("2026-05-04T18:45:30.500Z"),
+    },
+  ])("$name", ({ now, policy, expected }) => {
+    expect(computeRetentionCutoff(now, policy).toISOString()).toBe(
+      expected.toISOString(),
+    );
+  });
+
+  test("DEFAULT_RETENTION is 90 days", () => {
+    expect(DEFAULT_RETENTION.maxAgeDays).toBe(90);
+  });
+
+  test("rejects negative maxAgeDays (would otherwise place cutoff in the future and wipe the log)", () => {
+    expect(() =>
+      computeRetentionCutoff(new Date("2026-05-11T00:00:00Z"), {
+        maxAgeDays: -1,
+      }),
+    ).toThrow(/maxAgeDays must be a non-negative finite number/);
+  });
+});
+
+describe("assertValidRetention", () => {
+  test("retention: false is always valid", () => {
+    expect(() => assertValidRetention(false)).not.toThrow();
+  });
+
+  test.each([
+    { name: "zero", value: 0 },
+    { name: "positive integer", value: 90 },
+    { name: "large value", value: 36500 },
+  ])("accepts maxAgeDays = $name ($value)", ({ value }) => {
+    expect(() => assertValidRetention({ maxAgeDays: value })).not.toThrow();
+  });
+
+  test.each([
+    { name: "negative", value: -1 },
+    { name: "NaN", value: Number.NaN },
+    { name: "Infinity", value: Number.POSITIVE_INFINITY },
+    { name: "-Infinity", value: Number.NEGATIVE_INFINITY },
+  ])("rejects maxAgeDays = $name ($value)", ({ value }) => {
+    expect(() => assertValidRetention({ maxAgeDays: value })).toThrow(
+      /maxAgeDays must be a non-negative finite number/,
+    );
+  });
+});
+
+describe("auditLog() factory wires retention validation", () => {
+  test("constructs without throwing when retention is omitted", () => {
+    expect(() => auditLog()).not.toThrow();
+  });
+
+  test("constructs without throwing when retention is false", () => {
+    expect(() => auditLog({ retention: false })).not.toThrow();
+  });
+
+  test("throws at factory time on negative maxAgeDays — fails fast at app startup", () => {
+    expect(() => auditLog({ retention: { maxAgeDays: -1 } })).toThrow(
+      /maxAgeDays must be a non-negative finite number/,
+    );
+  });
+});
+
+describe("runRetentionPurge", () => {
+  test("calls storage.purge with the cutoff computed from policy + clock", async () => {
+    const ctx = fakeCtx();
+    const { storage, purgeCalls } = fakeStorage({ withPurge: true });
+    const now = new Date("2026-05-11T00:00:00Z");
+
+    await runRetentionPurge(ctx as unknown as AppContext, {
+      storage,
+      retention: { maxAgeDays: 30 },
+      now,
+    });
+
+    expect(purgeCalls).toHaveLength(1);
+    expect(purgeCalls[0]?.cutoff.toISOString()).toBe(
+      new Date("2026-04-11T00:00:00Z").toISOString(),
+    );
+  });
+
+  test("returns the storage's deleted count", async () => {
+    const ctx = fakeCtx();
+    const { storage, purgeReturn } = fakeStorage({ withPurge: true });
+    purgeReturn.deleted = 42;
+
+    const result = await runRetentionPurge(ctx as unknown as AppContext, {
+      storage,
+      retention: { maxAgeDays: 7 },
+    });
+
+    expect(result.deleted).toBe(42);
+  });
+
+  test("retention: false is a no-op (no purge call, no warn)", async () => {
+    const ctx = fakeCtx();
+    const { storage, purgeCalls } = fakeStorage({ withPurge: true });
+
+    const result = await runRetentionPurge(ctx as unknown as AppContext, {
+      storage,
+      retention: false,
+    });
+
+    expect(result).toEqual({ deleted: 0 });
+    expect(purgeCalls).toHaveLength(0);
+    expect(ctx.logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("storage without purge() warns once and returns deleted: 0", async () => {
+    const ctx = fakeCtx();
+    const { storage } = fakeStorage({ withPurge: false });
+
+    const result = await runRetentionPurge(ctx as unknown as AppContext, {
+      storage,
+      retention: { maxAgeDays: 30 },
+    });
+
+    expect(result).toEqual({ deleted: 0 });
+    expect(ctx.logger.warn).toHaveBeenCalledTimes(1);
+    const message = String(ctx.logger.warn.mock.calls[0]?.[0]);
+    expect(message).toContain("fake-no-purge");
+    expect(message).toContain("retention skipped");
+  });
+});

--- a/packages/plugins/audit-log/src/server/retention.ts
+++ b/packages/plugins/audit-log/src/server/retention.ts
@@ -1,0 +1,62 @@
+import type { AppContext } from "plumix/plugin";
+
+import type { AuditLogStorage } from "../types.js";
+
+export interface AuditLogRetentionPolicy {
+  readonly maxAgeDays: number;
+}
+
+export type AuditLogRetentionConfig = AuditLogRetentionPolicy | false;
+
+export const DEFAULT_RETENTION: AuditLogRetentionPolicy = { maxAgeDays: 90 };
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Throws on configs that would corrupt the audit log. Negative
+ * `maxAgeDays` puts the cutoff in the future and deletes every row;
+ * `NaN` / `Infinity` produce an Invalid Date that silently no-ops in
+ * SQL. Either way, fail loud at the config site.
+ */
+export function assertValidRetention(retention: AuditLogRetentionConfig): void {
+  if (retention === false) return;
+  if (!Number.isFinite(retention.maxAgeDays) || retention.maxAgeDays < 0) {
+    throw new Error(
+      `[plumix/plugin-audit-log] retention.maxAgeDays must be a non-negative finite number (got ${retention.maxAgeDays})`,
+    );
+  }
+}
+
+export function computeRetentionCutoff(
+  now: Date,
+  policy: AuditLogRetentionPolicy,
+): Date {
+  assertValidRetention(policy);
+  return new Date(now.getTime() - policy.maxAgeDays * MS_PER_DAY);
+}
+
+export interface RunRetentionPurgeArgs {
+  readonly storage: AuditLogStorage;
+  readonly retention: AuditLogRetentionConfig;
+  /** Override the clock; defaults to `new Date()`. Tests pass an explicit value. */
+  readonly now?: Date;
+}
+
+export interface RunRetentionPurgeResult {
+  readonly deleted: number;
+}
+
+export async function runRetentionPurge(
+  ctx: AppContext,
+  args: RunRetentionPurgeArgs,
+): Promise<RunRetentionPurgeResult> {
+  if (args.retention === false) return { deleted: 0 };
+  if (!args.storage.purge) {
+    ctx.logger.warn(
+      `[plumix/plugin-audit-log] storage "${args.storage.kind}" does not implement purge() — retention skipped`,
+    );
+    return { deleted: 0 };
+  }
+  const cutoff = computeRetentionCutoff(args.now ?? new Date(), args.retention);
+  return args.storage.purge(ctx, { cutoff });
+}

--- a/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
+++ b/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
@@ -20,6 +20,9 @@ const schemaImports = schema as unknown as Record<string, unknown>;
 
 let cachedStatements: string[] | null = null;
 
+// drizzle-kit's `api` surface is loosely typed (`SQLiteSchema` is opaque);
+// we treat it as a black-box snapshot blob and only read its `id` field.
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
 async function compileSchemaSql(): Promise<string[]> {
   if (cachedStatements) return cachedStatements;
   const empty = await generateSQLiteDrizzleJson({}, undefined, "snake_case");
@@ -31,6 +34,7 @@ async function compileSchemaSql(): Promise<string[]> {
   cachedStatements = await generateSQLiteMigration(empty, current);
   return cachedStatements;
 }
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
 
 async function createDb(): Promise<TestDb> {
   const client = createClient({ url: ":memory:" });
@@ -298,5 +302,69 @@ describe("sqlite() storage adapter — filter + cursor pagination", () => {
       eventPrefix: "entry:",
     });
     expect(result.rows.map((r) => r.subjectId)).toEqual(["c", "a"]);
+  });
+});
+
+describe("sqlite() storage adapter — purge", () => {
+  let db: TestDb;
+  let ctx: AppContext;
+  let adapter: ReturnType<typeof sqlite>;
+
+  beforeEach(async () => {
+    db = await createDb();
+    ctx = ctxFor(db);
+    adapter = sqlite();
+  });
+
+  async function runPurge(cutoff: Date) {
+    if (!adapter.purge) {
+      throw new Error("sqlite() adapter must implement purge");
+    }
+    return adapter.purge(ctx, { cutoff });
+  }
+
+  test("deletes rows strictly older than the cutoff and reports the count", async () => {
+    await db.insert(auditLog).values([
+      row({ occurredAt: new Date("2026-01-01T00:00:00Z"), subjectId: "old-1" }),
+      row({ occurredAt: new Date("2026-02-01T00:00:00Z"), subjectId: "old-2" }),
+      row({
+        occurredAt: new Date("2026-04-11T00:00:00Z"),
+        subjectId: "boundary",
+      }),
+      row({
+        occurredAt: new Date("2026-04-15T00:00:00Z"),
+        subjectId: "kept-1",
+      }),
+      row({
+        occurredAt: new Date("2026-05-11T00:00:00Z"),
+        subjectId: "kept-2",
+      }),
+    ]);
+
+    const result = await runPurge(new Date("2026-04-11T00:00:00Z"));
+
+    expect(result.deleted).toBe(2);
+
+    const remaining = await adapter.query(ctx, {});
+    expect(remaining.rows.map((r) => r.subjectId).sort()).toEqual([
+      "boundary",
+      "kept-1",
+      "kept-2",
+    ]);
+  });
+
+  test("returns deleted: 0 when no rows match the cutoff", async () => {
+    await db
+      .insert(auditLog)
+      .values([row({ occurredAt: new Date("2026-05-11T00:00:00Z") })]);
+
+    const result = await runPurge(new Date("2026-01-01T00:00:00Z"));
+
+    expect(result.deleted).toBe(0);
+  });
+
+  test("empty table — deleted: 0", async () => {
+    const result = await runPurge(new Date("2026-05-11T00:00:00Z"));
+    expect(result.deleted).toBe(0);
   });
 });

--- a/packages/plugins/audit-log/src/server/storage-sqlite.ts
+++ b/packages/plugins/audit-log/src/server/storage-sqlite.ts
@@ -57,6 +57,14 @@ export function sqlite(): AuditLogStorage {
 
       return { rows: sliced.map(toAuditLogRow), nextCursor };
     },
+
+    async purge(ctx, { cutoff }) {
+      const deleted = await ctx.db
+        .delete(auditLog)
+        .where(lt(auditLog.occurredAt, cutoff))
+        .returning({ id: auditLog.id });
+      return { deleted: deleted.length };
+    },
   };
 }
 

--- a/packages/plugins/audit-log/src/types.ts
+++ b/packages/plugins/audit-log/src/types.ts
@@ -56,6 +56,15 @@ export interface AuditLogStorage {
     ctx: AppContext,
     filter: AuditLogQueryFilter,
   ): Promise<AuditLogQueryResult>;
+  /**
+   * Delete rows older than `cutoff`. Optional — adapters that can't
+   * express this (e.g. append-only analytics sinks) omit it and the
+   * retention runner short-circuits with a warning.
+   */
+  purge?(
+    ctx: AppContext,
+    args: { readonly cutoff: Date },
+  ): Promise<{ readonly deleted: number }>;
 }
 
 export type AuditLogActor =


### PR DESCRIPTION
## Summary

- Adds `AuditLogStorage.purge?(ctx, { cutoff })` (optional) and implements it on the default `sqlite()` adapter as a single bounded `DELETE`.
- Adds a pure `computeRetentionCutoff(now, policy)` plus a top-level `runRetentionPurge(ctx, args)` helper that short-circuits when retention is disabled or the adapter lacks `purge`.
- Adds `retention?: AuditLogRetentionConfig | false` to `auditLog({ ... })` with the PRD-spec default of `{ maxAgeDays: 90 }`.
- Drive-by: adds the same `eslint-disable` pair around `compileSchemaSql` in `storage-sqlite.test.ts` that `core/src/test/harness.ts` already carries — see the commit body for why this surfaced now.

Closes #197.

## Design call: `purge({ cutoff })` not `purge(policy)`

The PRD spec listed `purge?(policy)` on the storage interface, but keeping the math in the pure module and passing storage only a pre-computed `Date` is cleaner: storage adapters stay ignorant of `maxAgeDays` semantics, future policy fields (`maxRows`, etc.) won't reshape the storage interface, and the pure cutoff function is the single unit-under-test for retention math.

## Why this slice stops short of the cron

`ScheduledHandler` exists on the runtime adapter type, but no runtime wires `buildScheduledHandler` and there's no plugin API for registering a scheduled task. That's a separate, broader concern. Until it ships, `runRetentionPurge` is callable from ops scripts or tests — enough to exercise the seam end-to-end.

## Test plan

- [x] `pnpm --filter @plumix/plugin-audit-log test` — 95 passing (13 new across `retention.test.ts` and the `purge` describe block in `storage-sqlite.test.ts`)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean (new types re-exported from `index.ts`)
- [x] `pnpm boundaries` — clean
- [x] `pnpm format` — clean