### PR TITLE
feat(plugin-audit-log): wire retention purge to scheduled-task contract

### DIFF
--- a/packages/plugins/audit-log/src/index.ts
+++ b/packages/plugins/audit-log/src/index.ts
@@ -8,7 +8,12 @@ import { createAuditLogRouter } from "./rpc.js";
 import { createAuditExtension } from "./server/auditExtension.js";
 import { createAuditService } from "./server/auditService.js";
 import { registerHooks } from "./server/hooks.js";
-import { assertValidRetention, DEFAULT_RETENTION } from "./server/retention.js";
+import {
+  assertValidRetention,
+  DEFAULT_PURGE_CRON,
+  DEFAULT_RETENTION,
+  runRetentionPurge,
+} from "./server/retention.js";
 import { sqlite } from "./server/storage-sqlite.js";
 
 export type {
@@ -109,8 +114,9 @@ const AUDIT_LOG_READ_CAPABILITY = "audit_log:read";
  */
 export function auditLog(options: AuditLogPluginOptions = {}) {
   const storage = options.storage ?? sqlite();
+  const retention = options.retention ?? DEFAULT_RETENTION;
   // Fail fast on misconfigured retention — see assertValidRetention.
-  assertValidRetention(options.retention ?? DEFAULT_RETENTION);
+  assertValidRetention(retention);
   const service = createAuditService(storage);
   const router = createAuditLogRouter(storage);
   const extension = createAuditExtension(service);
@@ -139,6 +145,24 @@ export function auditLog(options: AuditLogPluginOptions = {}) {
         },
         component: "AuditLogShell",
       });
+
+      if (retention !== false) {
+        ctx.registerScheduledTask({
+          id: "retention-purge",
+          cron: retention.purgeAt ?? DEFAULT_PURGE_CRON,
+          handler: async (appCtx) => {
+            const result = await runRetentionPurge(appCtx, {
+              storage,
+              retention,
+            });
+            appCtx.logger.info(
+              `[plumix/plugin-audit-log] retention purge deleted ${result.deleted} row${
+                result.deleted === 1 ? "" : "s"
+              }`,
+            );
+          },
+        });
+      }
     },
   });
 }

--- a/packages/plugins/audit-log/src/server/retention.test.ts
+++ b/packages/plugins/audit-log/src/server/retention.test.ts
@@ -1,4 +1,5 @@
 import type { AppContext } from "plumix/plugin";
+import { HookRegistry, installPlugins } from "plumix/plugin";
 import { describe, expect, test, vi } from "vitest";
 
 import type { AuditLogStorage } from "../types.js";
@@ -6,6 +7,7 @@ import { auditLog } from "../index.js";
 import {
   assertValidRetention,
   computeRetentionCutoff,
+  DEFAULT_PURGE_CRON,
   DEFAULT_RETENTION,
   runRetentionPurge,
 } from "./retention.js";
@@ -204,5 +206,91 @@ describe("runRetentionPurge", () => {
     const message = String(ctx.logger.warn.mock.calls[0]?.[0]);
     expect(message).toContain("fake-no-purge");
     expect(message).toContain("retention skipped");
+  });
+});
+
+describe("auditLog() factory registers the retention scheduled task", () => {
+  test("default retention registers one task with the default cron", async () => {
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [auditLog()],
+    });
+    expect(registry.scheduledTasks).toHaveLength(1);
+    const task = registry.scheduledTasks[0];
+    expect(task?.id).toBe("retention-purge");
+    expect(task?.cron).toBe(DEFAULT_PURGE_CRON);
+    expect(task?.registeredBy).toBe("audit_log");
+  });
+
+  test("custom purgeAt plumbs through to the registered task's cron", async () => {
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [
+        auditLog({ retention: { maxAgeDays: 30, purgeAt: "0 0 * * 0" } }),
+      ],
+    });
+    expect(registry.scheduledTasks[0]?.cron).toBe("0 0 * * 0");
+  });
+
+  test("retention: false skips registration entirely", async () => {
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [auditLog({ retention: false })],
+    });
+    expect(registry.scheduledTasks).toHaveLength(0);
+  });
+
+  test("handler invokes storage.purge with the cutoff and logs the deleted count", async () => {
+    const storageStub = fakeStorage({ withPurge: true });
+    storageStub.purgeReturn.deleted = 7;
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [
+        auditLog({
+          storage: storageStub.storage,
+          retention: { maxAgeDays: 14 },
+        }),
+      ],
+    });
+    const task = registry.scheduledTasks[0];
+    if (!task) throw new Error("expected one scheduled task");
+
+    const logger = {
+      debug: () => undefined,
+      info: vi.fn(),
+      warn: () => undefined,
+      error: () => undefined,
+    };
+    await task.handler({ logger } as unknown as AppContext);
+
+    expect(storageStub.purgeCalls).toHaveLength(1);
+    // Cutoff sits in the past by `maxAgeDays`; just check it's a Date
+    // (clock is `new Date()` inside runRetentionPurge — exact value
+    // doesn't matter for this test, the math is covered above).
+    expect(storageStub.purgeCalls[0]?.cutoff).toBeInstanceOf(Date);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(String(logger.info.mock.calls[0]?.[0])).toContain("deleted 7 rows");
+  });
+
+  test("handler renders the singular row count correctly", async () => {
+    const storageStub = fakeStorage({ withPurge: true });
+    storageStub.purgeReturn.deleted = 1;
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [auditLog({ storage: storageStub.storage })],
+    });
+    const task = registry.scheduledTasks[0];
+    if (!task) throw new Error("expected one scheduled task");
+
+    const logger = {
+      debug: () => undefined,
+      info: vi.fn(),
+      warn: () => undefined,
+      error: () => undefined,
+    };
+    await task.handler({ logger } as unknown as AppContext);
+
+    expect(String(logger.info.mock.calls[0]?.[0])).toContain("deleted 1 row");
+    expect(String(logger.info.mock.calls[0]?.[0])).not.toContain("1 rows");
   });
 });

--- a/packages/plugins/audit-log/src/server/retention.ts
+++ b/packages/plugins/audit-log/src/server/retention.ts
@@ -4,11 +4,25 @@ import type { AuditLogStorage } from "../types.js";
 
 export interface AuditLogRetentionPolicy {
   readonly maxAgeDays: number;
+  /**
+   * Cron expression metadata for the registered scheduled task.
+   * Informational in v1 — runtime dispatch fires every registered
+   * task on each scheduled invocation regardless of this value (see
+   * `registerScheduledTask` docs). Operators set the actual cadence
+   * via `wrangler.toml [triggers] crons`. Defaults to `"0 3 * * *"`
+   * (daily at 03:00 UTC).
+   */
+  readonly purgeAt?: string;
 }
 
 export type AuditLogRetentionConfig = AuditLogRetentionPolicy | false;
 
-export const DEFAULT_RETENTION: AuditLogRetentionPolicy = { maxAgeDays: 90 };
+export const DEFAULT_PURGE_CRON = "0 3 * * *";
+
+export const DEFAULT_RETENTION: AuditLogRetentionPolicy = {
+  maxAgeDays: 90,
+  purgeAt: DEFAULT_PURGE_CRON,
+};
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

- Adds `AuditLogRetentionPolicy.purgeAt?: string` (cron metadata, default `"0 3 * * *"` per PRD).
- `auditLog({ retention })` factory now registers one scheduled task with `id: "retention-purge"` at setup time. The handler awaits `runRetentionPurge(ctx, { storage, retention })` and emits a single `ctx.logger.info` line reporting the deleted count.
- `retention: false` skips the registration entirely.

Closes #201.

## Design notes

`purgeAt` is informational in v1 — runtime dispatch from #199 fires every registered task on each scheduled invocation regardless of this value. Operators set the actual cadence via `wrangler.toml [triggers] crons`. Per-cron filtering is a follow-up.

## Test plan

- [x] `pnpm --filter @plumix/plugin-audit-log test` — 112 passing (5 new in retention.test.ts)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm boundaries` — clean