### PR TITLE
feat: starter template for new Plumix apps

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -8,6 +8,10 @@ const config: KnipConfig = {
   // by splitting vendor UI into its own package, or tag-based filtering
   // via `@internal` JSDoc once that convention is in place.
   exclude: ["exports"],
+  // `templates/` ships ready-to-copy seed files for `create-plumix-app`,
+  // not a workspace package — the files have no workspace-side
+  // consumers (by design), so knip's reachability scan can't see them.
+  ignore: ["templates/**"],
   workspaces: {
     "tooling/typescript": {
       entry: ["*.json"],
@@ -137,11 +141,7 @@ const config: KnipConfig = {
     // at consumer build time; `./server` subpath is consumer-facing
     // for themes that need server-only helpers.
     "packages/plugins/audit-log": {
-      entry: [
-        "src/index.ts",
-        "src/admin/index.tsx",
-        "src/server/index.ts",
-      ],
+      entry: ["src/index.ts", "src/admin/index.tsx", "src/server/index.ts"],
     },
   },
 };

--- a/templates/starter/README.md
+++ b/templates/starter/README.md
@@ -1,0 +1,72 @@
+# plumix-starter
+
+Plumix app with the blog and pages plugins on Cloudflare Workers + D1.
+
+## Develop
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Opens a local Workers dev server (via `@cloudflare/vite-plugin`) on
+`http://localhost:8787`. The admin signs in via passkey — register
+the first admin from `/admin/login` on first boot.
+
+## Build
+
+```bash
+pnpm build
+```
+
+Emits the worker bundle to `dist/plumix_starter/`. Equivalent to
+`pnpm exec plumix build`.
+
+## Deploy
+
+Edit `wrangler.jsonc` and `plumix.config.ts` for your account first:
+
+- `wrangler.jsonc` → `name` and `d1_databases[0].database_name` /
+  `database_id` (run `wrangler d1 create plumix_starter` and paste the id).
+- `plumix.config.ts` → `cloudflareDeployOrigin({ workerName, accountSubdomain })`
+  with your worker name + Cloudflare account subdomain.
+
+Then:
+
+```bash
+pnpm exec plumix migrate generate
+pnpm exec plumix migrate apply --remote
+pnpm exec plumix deploy
+```
+
+`plumix migrate generate` wraps `drizzle-kit generate` and walks the
+schema contributed by every installed plugin. `plumix migrate apply`
+auto-discovers the D1 database name from `wrangler.jsonc`.
+
+## What's included
+
+- **`@plumix/plugin-blog`** — posts, archives, single views, draft
+  workflow.
+- **`@plumix/plugin-pages`** — hierarchical pages with permalink
+  routing.
+- **`consoleMailer()`** — outgoing mail (email-change confirmation,
+  plus magic-link if you wire it up later) logs to the worker output.
+  Swap in any `Mailer` (one method) for production — Postmark, SES,
+  Resend, etc.
+
+## What's not included
+
+- Media uploads (`@plumix/plugin-media`) — add an R2 binding to
+  `wrangler.jsonc`, install the plugin, and pass `storage: r2(...)`
+  to `plumix({...})`. See `examples/blog` in the plumix repo.
+- Navigation menus (`@plumix/plugin-menu`) — install the plugin and
+  call `registerMenuLocation(...)` from your theme to surface slots.
+- Activity-feed audit log (`@plumix/plugin-audit-log`) — install and
+  pass to `plugins: [auditLog()]` to capture admin actions.
+
+## Customising further
+
+Every `plumix` subcommand (`doctor`, `types`, `migrate generate`,
+`deploy`, …) is reachable via `pnpm exec plumix <cmd>` — only the
+conventional `dev` / `build` are wrapped as scripts. Run `pnpm exec
+plumix --help` to see the full list.

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "plumix-starter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Plumix starter — Cloudflare Workers + D1 + blog and pages plugins",
+  "license": "MIT",
+  "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": ">=24",
+    "pnpm": ">=10"
+  },
+  "scripts": {
+    "build": "plumix build",
+    "clean": "git clean -xdf .plumix .wrangler dist node_modules",
+    "dev": "plumix dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@plumix/plugin-blog": "^0.1.0",
+    "@plumix/plugin-pages": "^0.1.0",
+    "@plumix/runtime-cloudflare": "^0.1.0",
+    "drizzle-orm": "^0.45.2",
+    "plumix": "^0.1.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260421.1",
+    "@types/node": "^24.12.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "drizzle-kit": "^0.31.10",
+    "typescript": "^6.0.3",
+    "wrangler": "^4.86.0"
+  }
+}

--- a/templates/starter/plumix.config.ts
+++ b/templates/starter/plumix.config.ts
@@ -1,0 +1,41 @@
+import { blog } from "@plumix/plugin-blog";
+import { pages } from "@plumix/plugin-pages";
+import {
+  cloudflare,
+  cloudflareDeployOrigin,
+  d1,
+} from "@plumix/runtime-cloudflare";
+import { auth, consoleMailer, plumix } from "plumix";
+
+// Derives `rpId` + `origin` from the Workers Builds env (`WORKERS_CI`,
+// `WORKERS_CI_BRANCH`): production deploys → `<worker>.<account>.workers.dev`,
+// preview deploys → `<branch>-<worker>.<account>.workers.dev`,
+// local `pnpm dev` → `http://localhost:8787`. Swap to a hardcoded
+// `{ rpId, origin }` once you wire a custom domain.
+const { rpId, origin } = cloudflareDeployOrigin({
+  workerName: "plumix-starter",
+  // Replace with your Cloudflare account's workers.dev subdomain
+  // (the bit before `.workers.dev` on your account's default route).
+  accountSubdomain: "<replace-with-your-cloudflare-account-subdomain>",
+});
+
+export default plumix({
+  runtime: cloudflare(),
+  // `session: "auto"` routes writes to primary, anon reads to the nearest
+  // replica, and resumes authenticated reads from a bookmark cookie for
+  // read-your-writes consistency. Drop the option to stay primary-only.
+  database: d1({ binding: "DB", session: "auto" }),
+  auth: auth({
+    passkey: {
+      rpName: "Plumix Starter",
+      rpId,
+      origin,
+    },
+  }),
+  // `consoleMailer()` logs outgoing mail bodies to the worker logs —
+  // fine for development, swap in an SES/Postmark/etc. transport
+  // before production. Pre-wired here so email-change flows (and
+  // magic-link if you enable it later) work out of the box.
+  mailer: consoleMailer(),
+  plugins: [blog, pages],
+});

--- a/templates/starter/tsconfig.json
+++ b/templates/starter/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@plumix/typescript-config/base.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/workers-types"]
+  },
+  "include": ["plumix.config.ts", ".plumix"]
+}

--- a/templates/starter/wrangler.jsonc
+++ b/templates/starter/wrangler.jsonc
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://unpkg.com/wrangler/config-schema.json",
+  "name": "plumix-starter",
+  "main": ".plumix/worker.ts",
+  "compatibility_date": "2026-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "plumix_starter",
+      // Replace with the id returned by `wrangler d1 create plumix_starter`.
+      "database_id": "<replace-with-output-of-wrangler-d1-create>",
+      "migrations_dir": "drizzle",
+    },
+  ],
+  "assets": {
+    "directory": ".plumix/public",
+    "binding": "ASSETS",
+    "not_found_handling": "none",
+  },
+}


### PR DESCRIPTION
## Summary

- New `templates/starter/` — seed directory `create-plumix-app` will copy into new projects once the scaffolder ships (currently a stub at `packages/create-plumix-app/`).
- 5 files: `package.json` (deps pinned at `^0.1.0` for plumix packages + catalog versions for react/drizzle/etc.), `plumix.config.ts` (Cloudflare + D1 + passkey auth + blog/pages plugins + consoleMailer), `wrangler.jsonc`, `tsconfig.json`, `README.md`.
- `knip.config.ts` — adds `ignore: ["templates/**"]` since the template is intentionally outside the pnpm workspace.

Closes #203.

## Design notes

- Pinned at `^0.1.0` for plumix-shipped packages (the target release). Template won't `pnpm install` cleanly until 0.1.0 publishes — that's expected; the scaffold-test CI job from PLAN.md runs *after* the release.
- No `vite.config.ts`. PLAN.md mentions one, but `plumix dev` / `plumix build` invoke vite via the runtime's command module — the existing `examples/minimal` and `examples/blog` don't ship one either.
- Template lives outside the pnpm workspace (`templates/` not in `pnpm-workspace.yaml`) so the unreleased `^0.1.0` versions don't break `pnpm install` on the monorepo.

## Known gap (separate follow-up slice)

No automated drift detection. If a future PR renames a plumix API the template uses, nothing fails until someone runs `create-plumix-app`. A `scripts/typecheck-template.mjs` that automates the temp-workspace-wire dance in CI would close this — out of scope here; verified manually for this PR.

## Verification

Manually verified `plumix.config.ts` typechecks against the workspace by temporarily wiring `templates/*` into `pnpm-workspace.yaml`, swapping deps to `workspace:*`, running `tsc --noEmit`, reverting before commit.

## Test plan

- [x] `pnpm typecheck` — clean (template not in workspace, so no per-package check)
- [x] `pnpm lint` — clean
- [x] `pnpm format` — clean (incl. template files via prettier from tooling/)
- [x] `pnpm knip` — clean (after `templates/**` ignore)
- [x] `pnpm boundaries` — clean (depcruise)
- [x] `pnpm test` — clean