### PR TITLE
feat(create-plumix-app): drift detection between starter template and plumix API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,18 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm typecheck
 
+  template-typecheck:
+    name: Template typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      # Drift detection: temp-wires `templates/starter` into the workspace
+      # with `workspace:*` deps, runs `tsc --noEmit` against the live
+      # plumix sources, restores the workspace. Catches the case where a
+      # future PR renames a plumix API the template uses.
+      - run: pnpm --filter create-plumix-app verify:template
+
   knip:
     name: Knip
     runs-on: ubuntu-latest

--- a/packages/create-plumix-app/package.json
+++ b/packages/create-plumix-app/package.json
@@ -40,7 +40,8 @@
     "lint": "eslint",
     "publint": "publint",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "verify:template": "node scripts/typecheck-template.mjs"
   },
   "devDependencies": {
     "@plumix/eslint-config": "workspace:*",

--- a/packages/create-plumix-app/scripts/template-rewrite.mjs
+++ b/packages/create-plumix-app/scripts/template-rewrite.mjs
@@ -1,0 +1,66 @@
+/**
+ * Pure helpers for the template-drift-detection script. Kept side-effect
+ * free so they're unit-testable; the orchestrator in
+ * `typecheck-template.mjs` is the only piece that touches the
+ * filesystem.
+ *
+ * @module template-rewrite
+ */
+
+/**
+ * Rewrite the listed deps in a package.json string. Both
+ * `dependencies` and `devDependencies` are scanned; override keys that
+ * don't appear in either are silently skipped (the caller passes a
+ * broad map covering every package the template might reference).
+ *
+ * Output formatting: 2-space indent + POSIX trailing newline. Any
+ * comments or non-standard ordering in the input are lost — the
+ * template's package.json is plain JSON we control, so this is fine.
+ *
+ * @param {string} raw — package.json file contents
+ * @param {Record<string, string>} overrides — `{ "plumix": "workspace:*", ... }`
+ * @returns {string}
+ */
+export function rewriteTemplatePackageJson(raw, overrides) {
+  const pkg = JSON.parse(raw);
+  for (const field of ["dependencies", "devDependencies"]) {
+    const deps = pkg[field];
+    if (deps === undefined || deps === null) continue;
+    for (const [key, value] of Object.entries(overrides)) {
+      if (key in deps) deps[key] = value;
+    }
+  }
+  return `${JSON.stringify(pkg, null, 2)}\n`;
+}
+
+/**
+ * Add a path to the `packages:` list in a pnpm-workspace.yaml.
+ * Idempotent — re-adding an already-present path is a no-op.
+ * Everything outside the `packages:` block is preserved verbatim.
+ *
+ * @param {string} yamlRaw — pnpm-workspace.yaml contents
+ * @param {string} path — glob to add, e.g. "packages/create-plumix-app/templates/*"
+ * @returns {string}
+ */
+export function addWorkspacePath(yamlRaw, path) {
+  const newLine = `  - "${path}"`;
+  if (yamlRaw.includes(newLine)) return yamlRaw;
+
+  const lines = yamlRaw.split("\n");
+  const packagesIdx = lines.findIndex((line) => line.startsWith("packages:"));
+  if (packagesIdx === -1) {
+    throw new Error(
+      "Cannot add workspace path — `packages:` key not found in workspace yaml.",
+    );
+  }
+
+  // Walk forward from `packages:` while we see indented list items
+  // (`  - "..."`), inserting after the last one.
+  let insertAt = packagesIdx + 1;
+  while (insertAt < lines.length && /^\s+-\s/.test(lines[insertAt] ?? "")) {
+    insertAt += 1;
+  }
+
+  lines.splice(insertAt, 0, newLine);
+  return lines.join("\n");
+}

--- a/packages/create-plumix-app/scripts/template-rewrite.test.mts
+++ b/packages/create-plumix-app/scripts/template-rewrite.test.mts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  addWorkspacePath,
+  rewriteTemplatePackageJson,
+} from "./template-rewrite.mjs";
+
+describe("rewriteTemplatePackageJson", () => {
+  const baseInput = `{
+  "name": "plumix-starter",
+  "dependencies": {
+    "plumix": "^0.1.0",
+    "@plumix/runtime-cloudflare": "^0.1.0",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "@plumix/vitest-config": "workspace:*"
+  }
+}
+`;
+
+  test("rewrites listed deps and leaves the rest untouched", () => {
+    const out = rewriteTemplatePackageJson(baseInput, {
+      plumix: "workspace:*",
+      "@plumix/runtime-cloudflare": "workspace:*",
+      "drizzle-orm": "catalog:",
+    });
+
+    const parsed = JSON.parse(out) as {
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(parsed.dependencies.plumix).toBe("workspace:*");
+    expect(parsed.dependencies["@plumix/runtime-cloudflare"]).toBe(
+      "workspace:*",
+    );
+    expect(parsed.dependencies["drizzle-orm"]).toBe("catalog:");
+    expect(parsed.devDependencies.typescript).toBe("^6.0.3");
+    expect(parsed.devDependencies["@plumix/vitest-config"]).toBe("workspace:*");
+  });
+
+  test("rewrites in devDependencies too when a key sits there", () => {
+    const input = `{
+  "name": "x",
+  "devDependencies": {
+    "drizzle-kit": "^0.31.10"
+  }
+}
+`;
+    const out = rewriteTemplatePackageJson(input, {
+      "drizzle-kit": "catalog:",
+    });
+    const parsed = JSON.parse(out) as {
+      devDependencies: Record<string, string>;
+    };
+    expect(parsed.devDependencies["drizzle-kit"]).toBe("catalog:");
+  });
+
+  test("ignores override keys that don't appear in deps", () => {
+    const input = `{
+  "name": "x",
+  "dependencies": { "plumix": "^0.1.0" }
+}
+`;
+    const out = rewriteTemplatePackageJson(input, {
+      plumix: "workspace:*",
+      "ghost-package": "workspace:*",
+    });
+    const parsed = JSON.parse(out) as {
+      dependencies: Record<string, string>;
+    };
+    expect(parsed.dependencies.plumix).toBe("workspace:*");
+    expect(parsed.dependencies["ghost-package"]).toBeUndefined();
+  });
+
+  test("handles a package.json with no dependencies field", () => {
+    const input = `{ "name": "x" }
+`;
+    expect(() =>
+      rewriteTemplatePackageJson(input, { plumix: "workspace:*" }),
+    ).not.toThrow();
+  });
+
+  test("output ends with a trailing newline (POSIX)", () => {
+    const out = rewriteTemplatePackageJson(baseInput, {
+      plumix: "workspace:*",
+    });
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  test("output uses 2-space indentation", () => {
+    const out = rewriteTemplatePackageJson(baseInput, {
+      plumix: "workspace:*",
+    });
+    // First nested line under the root object — 2 spaces of indent.
+    const firstKeyLine = out
+      .split("\n")
+      .find((line) => line.includes('"name"'));
+    expect(firstKeyLine?.startsWith("  ")).toBe(true);
+    expect(firstKeyLine?.startsWith("   ")).toBe(false);
+  });
+});
+
+describe("addWorkspacePath", () => {
+  const baseYaml = `packages:
+  - "packages/*"
+  - "packages/runtimes/*"
+  - "examples/*"
+
+catalog:
+  drizzle-orm: ^0.45.2
+`;
+
+  test("inserts the new path as the last entry under packages:", () => {
+    const out = addWorkspacePath(
+      baseYaml,
+      "packages/create-plumix-app/templates/*",
+    );
+    expect(out).toContain('- "packages/create-plumix-app/templates/*"');
+    // Catalog section untouched.
+    expect(out).toContain("catalog:");
+    expect(out).toContain("drizzle-orm: ^0.45.2");
+  });
+
+  test("is idempotent — adding the same path twice yields the same yaml", () => {
+    const once = addWorkspacePath(baseYaml, "templates/*");
+    const twice = addWorkspacePath(once, "templates/*");
+    expect(twice).toBe(once);
+  });
+
+  test("preserves the original packages: list ordering and content", () => {
+    const out = addWorkspacePath(baseYaml, "templates/*");
+    expect(out).toContain('- "packages/*"');
+    expect(out).toContain('- "packages/runtimes/*"');
+    expect(out).toContain('- "examples/*"');
+  });
+
+  test("adds the new path after the last existing entry, not in the middle", () => {
+    const out = addWorkspacePath(baseYaml, "templates/*");
+    const lines = out.split("\n");
+    const examples = lines.findIndex((l) => l.includes('"examples/*"'));
+    const templates = lines.findIndex((l) => l.includes('"templates/*"'));
+    expect(templates).toBeGreaterThan(examples);
+  });
+
+  test("preserves yaml outside the packages: section verbatim", () => {
+    const out = addWorkspacePath(baseYaml, "templates/*");
+    // Everything from `catalog:` onwards should be byte-identical.
+    const tailFrom = (s: string) => s.slice(s.indexOf("catalog:"));
+    expect(tailFrom(out)).toBe(tailFrom(baseYaml));
+  });
+});

--- a/packages/create-plumix-app/scripts/typecheck-template.mjs
+++ b/packages/create-plumix-app/scripts/typecheck-template.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Drift detection — typechecks the bundled starter template against
+ * the live workspace `plumix` packages. Catches the failure mode
+ * where a future PR renames a plumix API the template uses; without
+ * this guard nothing fires until a user runs `pnpm create plumix-app`
+ * and hits the TypeScript error.
+ *
+ * The script temporarily mutates three repo-root files:
+ *   - `pnpm-workspace.yaml` — adds the template path to the workspace
+ *   - `pnpm-lock.yaml` — backed up and restored byte-for-byte
+ *   - `<template>/package.json` — swaps pinned `^0.1.0` deps to
+ *     `workspace:*` / `catalog:` so pnpm resolves them locally
+ *
+ * All three are backed up and restored via `try/finally` and signal
+ * handlers, so Ctrl-C during the typecheck still leaves the repo
+ * byte-clean. The transient `node_modules/` pnpm creates inside the
+ * template is also removed on restore.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  addWorkspacePath,
+  rewriteTemplatePackageJson,
+} from "./template-rewrite.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.resolve(HERE, "..");
+const REPO_ROOT = path.resolve(PACKAGE_ROOT, "..", "..");
+
+const WORKSPACE_YAML = path.join(REPO_ROOT, "pnpm-workspace.yaml");
+const LOCKFILE = path.join(REPO_ROOT, "pnpm-lock.yaml");
+const TEMPLATE_DIR = path.join(PACKAGE_ROOT, "templates", "starter");
+const TEMPLATE_PKG = path.join(TEMPLATE_DIR, "package.json");
+const TEMPLATE_NODE_MODULES = path.join(TEMPLATE_DIR, "node_modules");
+const WORKSPACE_BACKUP = `${WORKSPACE_YAML}.template-typecheck-backup`;
+const LOCKFILE_BACKUP = `${LOCKFILE}.template-typecheck-backup`;
+const TEMPLATE_PKG_BACKUP = `${TEMPLATE_PKG}.template-typecheck-backup`;
+
+const WORKSPACE_PATH = "packages/create-plumix-app/templates/*";
+const DEP_OVERRIDES = {
+  plumix: "workspace:*",
+  "@plumix/runtime-cloudflare": "workspace:*",
+  "@plumix/plugin-blog": "workspace:*",
+  "@plumix/plugin-pages": "workspace:*",
+  "drizzle-orm": "catalog:",
+  react: "catalog:",
+  "react-dom": "catalog:",
+  "@cloudflare/workers-types": "catalog:",
+  "@types/node": "catalog:",
+  "@types/react": "catalog:",
+  "@types/react-dom": "catalog:",
+  "drizzle-kit": "catalog:",
+  typescript: "catalog:",
+  wrangler: "catalog:",
+};
+
+let restored = false;
+
+function restore() {
+  if (restored) return;
+  restored = true;
+  if (existsSync(WORKSPACE_BACKUP)) {
+    copyFileSync(WORKSPACE_BACKUP, WORKSPACE_YAML);
+    rmSync(WORKSPACE_BACKUP);
+  }
+  if (existsSync(LOCKFILE_BACKUP)) {
+    copyFileSync(LOCKFILE_BACKUP, LOCKFILE);
+    rmSync(LOCKFILE_BACKUP);
+  }
+  if (existsSync(TEMPLATE_PKG_BACKUP)) {
+    copyFileSync(TEMPLATE_PKG_BACKUP, TEMPLATE_PKG);
+    rmSync(TEMPLATE_PKG_BACKUP);
+  }
+  // The transient `pnpm install` created a node_modules inside the
+  // template; remove it so the template directory is byte-clean again.
+  // Otherwise it'd leak into scaffolded projects (the scaffolder's
+  // copy filter excludes it, but leaving cruft around is sloppy).
+  if (existsSync(TEMPLATE_NODE_MODULES)) {
+    rmSync(TEMPLATE_NODE_MODULES, { recursive: true, force: true });
+  }
+}
+
+// Signal handlers — Ctrl-C during the typecheck must still restore.
+process.on("SIGINT", () => {
+  restore();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  restore();
+  process.exit(143);
+});
+
+function run(label, command, args) {
+  console.log(`[typecheck-template] ${label}…`);
+  const result = spawnSync(command, args, { cwd: REPO_ROOT, stdio: "inherit" });
+  return result.status ?? 1;
+}
+
+// Refuse to run if a previous invocation crashed without cleanup —
+// the backup files still hold the ORIGINAL state. Overwriting them
+// here would mean a subsequent "restore" puts the previously-modified
+// state back, not the original.
+const STALE_BACKUPS = [
+  WORKSPACE_BACKUP,
+  LOCKFILE_BACKUP,
+  TEMPLATE_PKG_BACKUP,
+].filter((p) => existsSync(p));
+if (STALE_BACKUPS.length > 0) {
+  console.error(
+    "[typecheck-template] Refusing to run: backup files from a prior crashed run still exist:",
+  );
+  for (const p of STALE_BACKUPS) console.error(`  - ${p}`);
+  console.error(
+    "Restore each by moving the backup back over its target (e.g. `mv <file>.template-typecheck-backup <file>`), then retry. If you've already restored manually, delete the leftover backup files.",
+  );
+  process.exit(1);
+}
+
+let exitCode = 0;
+try {
+  copyFileSync(WORKSPACE_YAML, WORKSPACE_BACKUP);
+  copyFileSync(LOCKFILE, LOCKFILE_BACKUP);
+  copyFileSync(TEMPLATE_PKG, TEMPLATE_PKG_BACKUP);
+
+  writeFileSync(
+    WORKSPACE_YAML,
+    addWorkspacePath(readFileSync(WORKSPACE_YAML, "utf-8"), WORKSPACE_PATH),
+  );
+  writeFileSync(
+    TEMPLATE_PKG,
+    rewriteTemplatePackageJson(
+      readFileSync(TEMPLATE_PKG, "utf-8"),
+      DEP_OVERRIDES,
+    ),
+  );
+
+  // Not `--silent`: if the install fails on CI we want the full error
+  // in the log, not just a non-zero exit. CI runs are rare; verbose
+  // output > a silent failure.
+  const installStatus = run("install with template wired in", "pnpm", [
+    "install",
+    "--no-frozen-lockfile",
+  ]);
+  if (installStatus !== 0) {
+    exitCode = installStatus;
+  } else {
+    // Invoke via turbo so `typecheck`'s `dependsOn: ["^topo", "^build"]`
+    // builds the upstream plumix packages first. Bypassing turbo (e.g.
+    // `pnpm --filter plumix-starter typecheck`) leaves their `dist/`
+    // directories empty on a cold CI checkout, and tsc can't resolve
+    // the `plumix` / `@plumix/...` modules without the built `.d.ts`s.
+    exitCode = run("build deps + typecheck template", "pnpm", [
+      "exec",
+      "turbo",
+      "run",
+      "typecheck",
+      "--filter",
+      "plumix-starter",
+    ]);
+  }
+} catch (error) {
+  console.error("[typecheck-template] unexpected error:", error);
+  exitCode = 1;
+} finally {
+  restore();
+}
+
+if (exitCode === 0) {
+  console.log("[typecheck-template] OK — template matches current plumix API.");
+} else {
+  console.error(
+    "[typecheck-template] FAIL — template no longer typechecks against the current plumix API. See output above.",
+  );
+}
+process.exit(exitCode);

--- a/packages/create-plumix-app/vitest.config.ts
+++ b/packages/create-plumix-app/vitest.config.ts
@@ -1,5 +1,19 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 import { baseConfig } from "@plumix/vitest-config/base";
 
-export default defineConfig(baseConfig);
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      // Default base config only scans `src/**` and `test/**`. The
+      // template-drift-detection script's pure helpers live under
+      // `scripts/` so vitest needs to pick them up here too.
+      include: [
+        "src/**/*.test.{ts,tsx}",
+        "test/**/*.test.{ts,tsx}",
+        "scripts/**/*.test.{ts,mts}",
+      ],
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- Flagged as a follow-up in #204 and #206 — there was no automated check that `templates/starter/plumix.config.ts` typechecks against the live workspace plumix packages.
- New CI job "Template typecheck" runs on every PR. Catches the case where a future PR renames a plumix API the template uses.
- Pure helpers (`rewriteTemplatePackageJson`, `addWorkspacePath`) TDD-tested with 11 cases. Orchestrator (`typecheck-template.mjs`) is verified by acceptance criteria — see below.

Closes #207.

## How it works

The orchestrator temporarily wires `templates/starter` into the workspace (`pnpm-workspace.yaml`), swaps the template's pinned `^0.1.0` deps to `workspace:*` / `catalog:` so pnpm resolves them locally, runs `pnpm install --no-frozen-lockfile` + `pnpm --filter plumix-starter typecheck`, then restores three repo-root files (workspace yaml, lockfile, template package.json) + removes the transient `node_modules/`. Restore runs on every exit path: `try/finally`, `SIGINT` (exit 130), `SIGTERM` (exit 143).

## Verified

- Script succeeds against the current template (will be the green path on CI).
- Mutating the template with a non-existent import (`cloudflareDeployOrigin, totallyMadeUpExport,`) causes the script to exit non-zero with the underlying tsc error intact.
- After every run (success or failure), `git status` shows no changes to `pnpm-workspace.yaml`, `pnpm-lock.yaml`, or the template files; no leaked `node_modules/`.
- Phantom backup file (simulating a crashed prior run) causes the script to refuse with a clear "restore from backups, then retry" message and exit 1, without modifying anything.

## Pre-existing gap surfaced (not fixed here)

The template's `tsconfig.json` extends `@plumix/typescript-config/base.json` — that package is `private: true` and not listed in the template's devDeps. Inside the workspace it resolves via the workspace symlink graph, so drift detection works. But an external user running `pnpm create plumix-app` then `tsc` would hit a missing-module error. Separate fix: either publish that package or inline the relevant compilerOptions. Out of scope here.

## Test plan

- [x] `pnpm --filter create-plumix-app test` — 32 passing (11 new helper tests)
- [x] `pnpm --filter create-plumix-app verify:template` — succeeds against current template
- [x] Mutated template exits non-zero
- [x] Phantom backup file → refuses + exits 1 cleanly
- [x] `pnpm typecheck` / `lint` / `format` / `knip` / `boundaries` — all clean