### PR TITLE
feat(create-plumix-app): scaffold smoke E2E — actually builds the result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,19 @@ jobs:
       # future PR renames a plumix API the template uses.
       - run: pnpm --filter create-plumix-app verify:template
 
+  scaffold-smoke:
+    name: Scaffold smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      # End-to-end smoke: scaffolds a project with the built CLI, wires
+      # it to workspace plumix packages, runs `pnpm install` and
+      # `plumix build`, asserts the worker bundle was emitted. Catches
+      # build-pipeline / vite / codegen drift that the typecheck-only
+      # template check misses.
+      - run: pnpm --filter create-plumix-app verify:scaffold
+
   knip:
     name: Knip
     runs-on: ubuntu-latest

--- a/packages/create-plumix-app/package.json
+++ b/packages/create-plumix-app/package.json
@@ -41,6 +41,7 @@
     "publint": "publint",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "verify:scaffold": "node scripts/verify-scaffold.mjs",
     "verify:template": "node scripts/typecheck-template.mjs"
   },
   "devDependencies": {

--- a/packages/create-plumix-app/scripts/build-assertions.mjs
+++ b/packages/create-plumix-app/scripts/build-assertions.mjs
@@ -1,0 +1,22 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Throw if any of the expected paths are missing under `targetDir`.
+ * Used by the scaffold smoke E2E to verify `plumix build` actually
+ * produced the bundle. "Exists" includes directories — callers can
+ * check for either a single output file or a top-level output dir.
+ *
+ * @param {string} targetDir — absolute scaffold path
+ * @param {readonly string[]} expectedRelativePaths
+ */
+export function assertBuildOutputs(targetDir, expectedRelativePaths) {
+  for (const rel of expectedRelativePaths) {
+    const abs = join(targetDir, rel);
+    if (!existsSync(abs)) {
+      throw new Error(
+        `Expected scaffold build to produce \`${rel}\` under ${targetDir}, but it does not exist.`,
+      );
+    }
+  }
+}

--- a/packages/create-plumix-app/scripts/build-assertions.test.mts
+++ b/packages/create-plumix-app/scripts/build-assertions.test.mts
@@ -1,0 +1,55 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { assertBuildOutputs } from "./build-assertions.mjs";
+
+describe("assertBuildOutputs", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "plumix-build-assert-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("returns silently when every expected path exists", () => {
+    mkdirSync(join(tmp, ".plumix"));
+    writeFileSync(join(tmp, ".plumix", "worker.ts"), "// ok");
+    mkdirSync(join(tmp, "dist"));
+    writeFileSync(join(tmp, "dist", "manifest.json"), "{}");
+
+    expect(() =>
+      assertBuildOutputs(tmp, [".plumix/worker.ts", "dist/manifest.json"]),
+    ).not.toThrow();
+  });
+
+  test("throws naming the first missing path", () => {
+    mkdirSync(join(tmp, ".plumix"));
+    writeFileSync(join(tmp, ".plumix", "worker.ts"), "// ok");
+
+    expect(() =>
+      assertBuildOutputs(tmp, [".plumix/worker.ts", "dist/manifest.json"]),
+    ).toThrow(/dist\/manifest\.json/);
+  });
+
+  test("error message includes the full target dir for grep-ability", () => {
+    // Substring-match against the raw path — building a regex from a
+    // filesystem path needs full metachar escaping (not just `/`);
+    // `toThrow(string)` does substring matching, which is what we want.
+    expect(() => assertBuildOutputs(tmp, ["dist/bundle.js"])).toThrow(tmp);
+  });
+
+  test("empty expected list never throws", () => {
+    expect(() => assertBuildOutputs(tmp, [])).not.toThrow();
+  });
+
+  test("treats a directory as 'exists' (not just files)", () => {
+    mkdirSync(join(tmp, "dist"));
+
+    expect(() => assertBuildOutputs(tmp, ["dist"])).not.toThrow();
+  });
+});

--- a/packages/create-plumix-app/scripts/template-deps.mjs
+++ b/packages/create-plumix-app/scripts/template-deps.mjs
@@ -1,0 +1,26 @@
+/**
+ * Single source of truth for the dep overrides both drift-detection
+ * scripts apply to the template's `package.json` before running
+ * `pnpm install`. The template pins plumix-shipped packages at
+ * `^0.1.0` (target release; not on npm yet), so for local verification
+ * we swap them to `workspace:*` and shared externals to `catalog:`.
+ *
+ * If the template gains a new dep, add it here — both
+ * `typecheck-template.mjs` and `verify-scaffold.mjs` consume this.
+ */
+export const TEMPLATE_DEP_OVERRIDES = {
+  plumix: "workspace:*",
+  "@plumix/runtime-cloudflare": "workspace:*",
+  "@plumix/plugin-blog": "workspace:*",
+  "@plumix/plugin-pages": "workspace:*",
+  "drizzle-orm": "catalog:",
+  react: "catalog:",
+  "react-dom": "catalog:",
+  "@cloudflare/workers-types": "catalog:",
+  "@types/node": "catalog:",
+  "@types/react": "catalog:",
+  "@types/react-dom": "catalog:",
+  "drizzle-kit": "catalog:",
+  typescript: "catalog:",
+  wrangler: "catalog:",
+};

--- a/packages/create-plumix-app/scripts/typecheck-template.mjs
+++ b/packages/create-plumix-app/scripts/typecheck-template.mjs
@@ -29,6 +29,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { TEMPLATE_DEP_OVERRIDES } from "./template-deps.mjs";
 import {
   addWorkspacePath,
   rewriteTemplatePackageJson,
@@ -48,22 +49,6 @@ const LOCKFILE_BACKUP = `${LOCKFILE}.template-typecheck-backup`;
 const TEMPLATE_PKG_BACKUP = `${TEMPLATE_PKG}.template-typecheck-backup`;
 
 const WORKSPACE_PATH = "packages/create-plumix-app/templates/*";
-const DEP_OVERRIDES = {
-  plumix: "workspace:*",
-  "@plumix/runtime-cloudflare": "workspace:*",
-  "@plumix/plugin-blog": "workspace:*",
-  "@plumix/plugin-pages": "workspace:*",
-  "drizzle-orm": "catalog:",
-  react: "catalog:",
-  "react-dom": "catalog:",
-  "@cloudflare/workers-types": "catalog:",
-  "@types/node": "catalog:",
-  "@types/react": "catalog:",
-  "@types/react-dom": "catalog:",
-  "drizzle-kit": "catalog:",
-  typescript: "catalog:",
-  wrangler: "catalog:",
-};
 
 let restored = false;
 
@@ -141,7 +126,7 @@ try {
     TEMPLATE_PKG,
     rewriteTemplatePackageJson(
       readFileSync(TEMPLATE_PKG, "utf-8"),
-      DEP_OVERRIDES,
+      TEMPLATE_DEP_OVERRIDES,
     ),
   );
 

--- a/packages/create-plumix-app/scripts/verify-scaffold.mjs
+++ b/packages/create-plumix-app/scripts/verify-scaffold.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Scaffold smoke E2E — proves a freshly-scaffolded project actually
+ * builds end-to-end against the current workspace plumix packages.
+ * Complements the typecheck-only drift detection in
+ * `typecheck-template.mjs`: this one runs the CLI binary, installs,
+ * and invokes `plumix build`, so it catches breakage at the build /
+ * vite / codegen layer that pure typecheck would miss.
+ *
+ * Mutations:
+ *   - `pnpm-workspace.yaml` — adds the scaffold dir glob
+ *   - `pnpm-lock.yaml` — backed up + restored byte-for-byte
+ *   - `.cache/scaffold-smoke/` — the temp scaffold root, wiped on
+ *     every exit path (try/finally, SIGINT, SIGTERM)
+ */
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { assertBuildOutputs } from "./build-assertions.mjs";
+import { TEMPLATE_DEP_OVERRIDES } from "./template-deps.mjs";
+import {
+  addWorkspacePath,
+  rewriteTemplatePackageJson,
+} from "./template-rewrite.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.resolve(HERE, "..");
+const REPO_ROOT = path.resolve(PACKAGE_ROOT, "..", "..");
+
+const WORKSPACE_YAML = path.join(REPO_ROOT, "pnpm-workspace.yaml");
+const LOCKFILE = path.join(REPO_ROOT, "pnpm-lock.yaml");
+const SMOKE_ROOT = path.join(REPO_ROOT, ".cache", "scaffold-smoke");
+const SMOKE_WORKSPACE_GLOB = ".cache/scaffold-smoke/*";
+const SCAFFOLD_NAME = "smoke-app";
+const SCAFFOLD_DIR = path.join(SMOKE_ROOT, SCAFFOLD_NAME);
+
+const WORKSPACE_BACKUP = `${WORKSPACE_YAML}.scaffold-smoke-backup`;
+const LOCKFILE_BACKUP = `${LOCKFILE}.scaffold-smoke-backup`;
+
+// Check the actual worker bundle vite emits. `.plumix/worker.ts` is
+// also produced, but it's not declared in turbo's `outputs:` for
+// `build`, so cache-hit replays don't restore it — picking a real
+// build artifact instead so any output-existence check is meaningful.
+const EXPECTED_OUTPUTS = ["dist/plumix_starter/index.js"];
+
+let restored = false;
+
+function restore() {
+  if (restored) return;
+  restored = true;
+  if (existsSync(WORKSPACE_BACKUP)) {
+    copyFileSync(WORKSPACE_BACKUP, WORKSPACE_YAML);
+    rmSync(WORKSPACE_BACKUP);
+  }
+  if (existsSync(LOCKFILE_BACKUP)) {
+    copyFileSync(LOCKFILE_BACKUP, LOCKFILE);
+    rmSync(LOCKFILE_BACKUP);
+  }
+  if (existsSync(SMOKE_ROOT)) {
+    rmSync(SMOKE_ROOT, { recursive: true, force: true });
+  }
+}
+
+process.on("SIGINT", () => {
+  restore();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  restore();
+  process.exit(143);
+});
+
+function run(label, command, args, cwd = REPO_ROOT) {
+  console.log(`[verify-scaffold] ${label}…`);
+  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  return result.status ?? 1;
+}
+
+// Refuse to run if a previous invocation crashed mid-flight — backup
+// files / smoke dir from the prior run hold pre-modification state.
+// Overwriting them here would corrupt the restore path.
+const STALE = [WORKSPACE_BACKUP, LOCKFILE_BACKUP].filter((p) => existsSync(p));
+if (STALE.length > 0 || existsSync(SMOKE_ROOT)) {
+  console.error(
+    "[verify-scaffold] Refusing to run: leftovers from a prior crashed run exist:",
+  );
+  for (const p of STALE) console.error(`  - ${p}`);
+  if (existsSync(SMOKE_ROOT)) console.error(`  - ${SMOKE_ROOT}`);
+  console.error(
+    "Restore the backup files (move each `.scaffold-smoke-backup` back over its target) and remove the smoke dir, then retry.",
+  );
+  process.exit(1);
+}
+
+let exitCode = 0;
+try {
+  copyFileSync(WORKSPACE_YAML, WORKSPACE_BACKUP);
+  copyFileSync(LOCKFILE, LOCKFILE_BACKUP);
+
+  // Build the CLI itself before invoking it — the smoke proves the
+  // BUILT artifact works, not just the source.
+  const cliBuildStatus = run("build create-plumix-app", "pnpm", [
+    "exec",
+    "turbo",
+    "run",
+    "build",
+    "--filter",
+    "create-plumix-app",
+  ]);
+  if (cliBuildStatus !== 0) {
+    exitCode = cliBuildStatus;
+    throw new Error("CLI build failed; see output above.");
+  }
+
+  mkdirSync(SMOKE_ROOT, { recursive: true });
+
+  const scaffoldStatus = run("scaffold to tempdir", "node", [
+    path.join(PACKAGE_ROOT, "dist", "index.js"),
+    SCAFFOLD_DIR,
+  ]);
+  if (scaffoldStatus !== 0) {
+    exitCode = scaffoldStatus;
+    throw new Error("CLI scaffold failed; see output above.");
+  }
+
+  // Wire scaffold into the workspace so pnpm resolves workspace:*
+  // versions of the plumix packages — none of them are on npm yet.
+  writeFileSync(
+    WORKSPACE_YAML,
+    addWorkspacePath(
+      readFileSync(WORKSPACE_YAML, "utf-8"),
+      SMOKE_WORKSPACE_GLOB,
+    ),
+  );
+
+  const scaffoldPkg = path.join(SCAFFOLD_DIR, "package.json");
+  writeFileSync(
+    scaffoldPkg,
+    rewriteTemplatePackageJson(
+      readFileSync(scaffoldPkg, "utf-8"),
+      TEMPLATE_DEP_OVERRIDES,
+    ),
+  );
+
+  const installStatus = run("install workspace deps", "pnpm", [
+    "install",
+    "--no-frozen-lockfile",
+  ]);
+  if (installStatus !== 0) {
+    exitCode = installStatus;
+    throw new Error("workspace install failed; see output above.");
+  }
+
+  // Build the workspace plumix packages the scaffold imports.
+  // Turbo's cache is honoured here — upstream re-builds only when
+  // their own sources change.
+  const upstreamBuildStatus = run("build workspace plumix packages", "pnpm", [
+    "exec",
+    "turbo",
+    "run",
+    "build",
+    "--filter",
+    "plumix",
+    "--filter",
+    "@plumix/runtime-cloudflare",
+    "--filter",
+    "@plumix/plugin-blog",
+    "--filter",
+    "@plumix/plugin-pages",
+  ]);
+  if (upstreamBuildStatus !== 0) {
+    exitCode = upstreamBuildStatus;
+    throw new Error("workspace plumix build failed; see output above.");
+  }
+
+  // Build the scaffold directly with `plumix build`, NOT via turbo.
+  // The scaffold dir is `.gitignore`d, which means turbo doesn't see
+  // its source files for hash computation — every run cache-hits with
+  // the first run's output, masking template breakage. Going around
+  // turbo for this step keeps cache semantics correct (upstream stays
+  // cached) while ensuring the smoke build always executes fresh.
+  const buildStatus = run(
+    "build scaffolded project",
+    "pnpm",
+    ["exec", "plumix", "build"],
+    SCAFFOLD_DIR,
+  );
+  if (buildStatus !== 0) {
+    exitCode = buildStatus;
+    throw new Error("scaffold build failed; see output above.");
+  }
+
+  assertBuildOutputs(SCAFFOLD_DIR, EXPECTED_OUTPUTS);
+} catch (error) {
+  if (exitCode === 0) {
+    console.error("[verify-scaffold] unexpected error:", error);
+    exitCode = 1;
+  }
+} finally {
+  restore();
+}
+
+if (exitCode === 0) {
+  console.log(
+    "[verify-scaffold] OK — scaffold + install + build round-trip succeeded.",
+  );
+} else {
+  console.error("[verify-scaffold] FAIL — see output above.");
+}
+process.exit(exitCode);


### PR DESCRIPTION
## Summary

- End-to-end smoke that complements #208's typecheck-only drift detection. This one builds the CLI, scaffolds to a tempdir, installs, runs `plumix build`, asserts the worker bundle was emitted.
- Catches build-pipeline / vite / codegen breakage that pure typecheck misses.
- Extracted `TEMPLATE_DEP_OVERRIDES` into `scripts/template-deps.mjs` (single source of truth, shared with #208's typecheck-template script).

Closes #209.

## Key design call: bypassing turbo for the scaffold build

The scaffold dir lives under `.cache/scaffold-smoke/` which is `.gitignore`d. Turbo's input-hash for the smoke-app build doesn't include those files — every run cache-hits with the first run's outputs, so a broken template would silently "pass" on the second run.

Caught this with a mutation test during dev. Fix: run `pnpm exec plumix build` directly in the scaffold dir (skipping turbo for that one step) while still letting turbo cache the upstream plumix package builds.

## Verified

- Green path: ~30s locally, vite emits `dist/plumix_starter/index.js` (~650 KB worker bundle).
- Mutation: injecting `notAReal_Export` into the template's imports causes exit non-zero with the underlying rolldown "Missing export" error.
- Clean restore: `git status` byte-clean after every run; `.cache/scaffold-smoke/` doesn't persist.
- Crash-recovery guard: a phantom `*.scaffold-smoke-backup` file causes the script to refuse + exit 1.

## Test plan

- [x] `pnpm --filter create-plumix-app test` — 37 passing (5 new in build-assertions.test.mts)
- [x] `pnpm --filter create-plumix-app verify:scaffold` — green
- [x] `pnpm --filter create-plumix-app verify:template` — still green after the DEP_OVERRIDES extraction
- [x] `pnpm typecheck` / `lint` / `format` / `knip` / `boundaries` — clean
- [x] Mutation test: broken template → script exit 1
- [x] Crash-recovery guard test → script exit 1 + helpful message