### PR TITLE
feat(core): flat taxonomy routing + WP template hierarchy walker

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,14 @@ export * from "./plugin/index.js";
 export { isCurrentSource } from "./route/current.js";
 export type { CurrentSource, ResolvedEntity } from "./route/current.js";
 export type { RouteIntent, RouteRule } from "./route/intent.js";
+export { isEntryArchive, isTaxonomy } from "./route/render/archive-props.js";
+export type {
+  ArchiveEntry,
+  ArchiveProps,
+  EntryArchiveProps,
+  TaxonomyArchiveProps,
+} from "./route/render/archive-props.js";
+export type { ResolvedNode } from "./route/render/template-hierarchy.js";
 export * from "./rpc/index.js";
 export type * from "./runtime/adapter.js";
 export { buildApp } from "./runtime/app.js";

--- a/packages/core/src/route/compile.test.ts
+++ b/packages/core/src/route/compile.test.ts
@@ -14,6 +14,76 @@ async function buildRegistry(plugins: ReturnType<typeof definePlugin>[]) {
 }
 
 describe("compileRouteMap", () => {
+  test("auto-generates /{taxonomy}/:term from a registered term taxonomy", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("category", { label: "Categories" });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    expect(map).toHaveLength(1);
+    expect(map[0]?.rawPattern).toBe("/category/:term");
+    expect(map[0]?.intent).toEqual({ kind: "taxonomy", taxonomy: "category" });
+    expect(map[0]?.priority).toBe(50);
+  });
+
+  test("honors taxonomy rewrite.slug on the term-archive pattern", async () => {
+    const registry = await buildRegistry([
+      definePlugin("regions", (ctx) => {
+        ctx.registerTermTaxonomy("region", {
+          label: "Regions",
+          rewrite: { slug: "r" },
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    expect(map.map((r) => r.rawPattern)).toEqual(["/r/:term"]);
+    expect(map[0]?.intent).toEqual({ kind: "taxonomy", taxonomy: "region" });
+  });
+
+  test("taxonomy isPublic defaults to true — omitting it still generates a route", async () => {
+    const registry = await buildRegistry([
+      definePlugin("default", (ctx) => {
+        ctx.registerTermTaxonomy("topic", { label: "Topics" });
+      }),
+    ]);
+    expect(compileRouteMap(registry).map((r) => r.rawPattern)).toEqual([
+      "/topic/:term",
+    ]);
+  });
+
+  test("skips taxonomies with isPublic:false", async () => {
+    const registry = await buildRegistry([
+      definePlugin("internal", (ctx) => {
+        ctx.registerTermTaxonomy("workflow_state", {
+          label: "Workflow",
+          isPublic: false,
+        });
+      }),
+    ]);
+    expect(compileRouteMap(registry)).toHaveLength(0);
+  });
+
+  test("taxonomy rule beats colliding entry-type single on slug match (WP-faithful)", async () => {
+    const registry = await buildRegistry([
+      definePlugin("shop", (ctx) => {
+        ctx.registerEntryType("category-page", {
+          label: "Category Pages",
+          isPublic: true,
+          rewrite: { slug: "category" },
+        });
+        ctx.registerTermTaxonomy("category", { label: "Categories" });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    const termIdx = patterns.indexOf("/category/:term");
+    const singleIdx = patterns.indexOf("/category/:slug");
+    expect(termIdx).toBeGreaterThanOrEqual(0);
+    expect(singleIdx).toBeGreaterThanOrEqual(0);
+    expect(termIdx).toBeLessThan(singleIdx);
+  });
+
   test("auto-generates /{type}/:slug from a registered post type", async () => {
     const registry = await buildRegistry([
       definePlugin("blog", (ctx) => {

--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -1,6 +1,7 @@
 import type {
   PluginRegistry,
   RegisteredEntryType,
+  RegisteredTermTaxonomy,
 } from "../plugin/manifest.js";
 import type { RouteRule } from "./intent.js";
 
@@ -21,6 +22,16 @@ export function compileRouteMap(
   registry: PluginRegistry,
 ): readonly RouteRule[] {
   const rules: CompiledRule[] = [];
+
+  // Taxonomies emit before entry types so that a slug collision (e.g. a
+  // post type with `rewrite.slug: 'category'` shadowing a `category`
+  // taxonomy) resolves taxonomy-first under the stable-sort tie-break.
+  // WP-faithful: `\$wp_rewrite->rules` orders taxonomy archives ahead of
+  // post-type singles.
+  for (const taxonomy of registry.termTaxonomies.values()) {
+    if (taxonomy.isPublic === false) continue;
+    for (const rule of autoRulesForTermTaxonomy(taxonomy)) rules.push(rule);
+  }
 
   for (const entryType of registry.entryTypes.values()) {
     if (entryType.isPublic === false) continue;
@@ -68,6 +79,22 @@ function autoRulesForEntryType(entryType: RegisteredEntryType): CompiledRule[] {
   });
 
   return rules;
+}
+
+function autoRulesForTermTaxonomy(
+  taxonomy: RegisteredTermTaxonomy,
+): CompiledRule[] {
+  const baseSlug = taxonomy.rewrite?.slug ?? taxonomy.name;
+  const pattern = `/${baseSlug}/:term`;
+  return [
+    {
+      pattern: new URLPattern({ pathname: pattern }),
+      rawPattern: pattern,
+      intent: { kind: "taxonomy", taxonomy: taxonomy.name },
+      priority: AUTO_ROUTE_PRIORITY,
+      registeredBy: taxonomy.registeredBy,
+    },
+  ];
 }
 
 // Archive slugs need to be a single path segment — slashes would let a

--- a/packages/core/src/route/intent.ts
+++ b/packages/core/src/route/intent.ts
@@ -1,12 +1,16 @@
 /**
  * Discriminated union describing what a matched URL represents. Resolved
- * into a Response by the public-route resolver. Kept narrow for now — the
- * arch doc specs `taxonomy` / `search` / `front-page` / `handler` /
- * `redirect`; those land when a plugin actually needs them.
+ * into a Response by the public-route resolver. URL params (slug, term,
+ * page) live on `RouteMatch.params`, not on the intent itself — the
+ * intent describes the *route shape*, the match carries the request.
+ *
+ * `search` / `front-page` / `handler` / `redirect` land when a plugin
+ * actually needs them.
  */
 export type RouteIntent =
   | { readonly kind: "single"; readonly entryType: string }
-  | { readonly kind: "archive"; readonly entryType: string };
+  | { readonly kind: "archive"; readonly entryType: string }
+  | { readonly kind: "taxonomy"; readonly taxonomy: string };
 
 /**
  * Compiled rule. `priority` preserves arch-doc ordering semantics — lower

--- a/packages/core/src/route/render/archive-props.test.ts
+++ b/packages/core/src/route/render/archive-props.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import type { ArchiveProps } from "./archive-props.js";
+import { isEntryArchive, isTaxonomy } from "./archive-props.js";
+
+const entryArchive: ArchiveProps = {
+  kind: "entry-archive",
+  entryType: "post",
+  entries: [],
+};
+
+const taxonomyArchive: ArchiveProps = {
+  kind: "taxonomy",
+  taxonomy: "category",
+  term: { name: "News", slug: "news" },
+  entries: [],
+};
+
+describe("isTaxonomy", () => {
+  test("narrows a taxonomy archive", () => {
+    expect(isTaxonomy(taxonomyArchive)).toBe(true);
+    expect(isTaxonomy(entryArchive)).toBe(false);
+  });
+
+  test("optional name argument scopes the predicate", () => {
+    expect(isTaxonomy(taxonomyArchive, "category")).toBe(true);
+    expect(isTaxonomy(taxonomyArchive, "tag")).toBe(false);
+    expect(isTaxonomy(entryArchive, "category")).toBe(false);
+  });
+});
+
+describe("isEntryArchive", () => {
+  test("narrows an entry archive", () => {
+    expect(isEntryArchive(entryArchive)).toBe(true);
+    expect(isEntryArchive(taxonomyArchive)).toBe(false);
+  });
+
+  test("optional entryType argument scopes the predicate", () => {
+    expect(isEntryArchive(entryArchive, "post")).toBe(true);
+    expect(isEntryArchive(entryArchive, "doc")).toBe(false);
+    expect(isEntryArchive(taxonomyArchive, "post")).toBe(false);
+  });
+});

--- a/packages/core/src/route/render/archive-props.ts
+++ b/packages/core/src/route/render/archive-props.ts
@@ -1,0 +1,55 @@
+/**
+ * `ArchiveProps` is the discriminated union the shared `archive` /
+ * `index` fallback templates receive. Specific templates
+ * (`taxonomy-category.tsx`, `single-post.tsx`, …) stay strictly typed
+ * via `TemplateProps<K>` — themes that fall through to `archive` accept
+ * the wider shape and narrow with `isTaxonomy` / `isEntryArchive`.
+ *
+ * Mirrors WordPress's `is_tax()` / `is_post_type_archive()` conditional
+ * tags, but typed: each predicate also acts as a TypeScript type guard
+ * so a single `if (isTaxonomy(props))` branch unlocks `props.term` and
+ * `props.taxonomy` without casts.
+ *
+ * The shape is intentionally minimal at this slice — it carries the
+ * fields a fallback template needs to discriminate and render. Slices
+ * that add pagination, terms-as-children, and meta widen this without
+ * breaking the discriminator.
+ */
+
+export type ArchiveProps = EntryArchiveProps | TaxonomyArchiveProps;
+
+export interface EntryArchiveProps {
+  readonly kind: "entry-archive";
+  readonly entryType: string;
+  readonly entries: readonly ArchiveEntry[];
+}
+
+export interface TaxonomyArchiveProps {
+  readonly kind: "taxonomy";
+  readonly taxonomy: string;
+  readonly term: { readonly name: string; readonly slug: string };
+  readonly entries: readonly ArchiveEntry[];
+}
+
+export interface ArchiveEntry {
+  readonly title: string;
+  readonly slug: string;
+}
+
+export function isTaxonomy(
+  props: ArchiveProps,
+  taxonomy?: string,
+): props is TaxonomyArchiveProps {
+  if (props.kind !== "taxonomy") return false;
+  if (taxonomy === undefined) return true;
+  return props.taxonomy === taxonomy;
+}
+
+export function isEntryArchive(
+  props: ArchiveProps,
+  entryType?: string,
+): props is EntryArchiveProps {
+  if (props.kind !== "entry-archive") return false;
+  if (entryType === undefined) return true;
+  return props.entryType === entryType;
+}

--- a/packages/core/src/route/render/template-hierarchy.test.ts
+++ b/packages/core/src/route/render/template-hierarchy.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry } from "../../hooks/registry.js";
+import {
+  getPossibleTemplates,
+  resolveTemplateCandidates,
+} from "./template-hierarchy.js";
+
+describe("getPossibleTemplates — term nodes", () => {
+  test("built-in `category` taxonomy emits the WP category chain", () => {
+    expect(
+      getPossibleTemplates({
+        kind: "term",
+        taxonomy: "category",
+        slug: "news",
+        databaseId: 42,
+      }),
+    ).toEqual(["category-news", "category-42", "category", "archive", "index"]);
+  });
+
+  test("built-in `tag` taxonomy emits the WP tag chain", () => {
+    expect(
+      getPossibleTemplates({
+        kind: "term",
+        taxonomy: "tag",
+        slug: "javascript",
+        databaseId: 7,
+      }),
+    ).toEqual(["tag-javascript", "tag-7", "tag", "archive", "index"]);
+  });
+
+  test("`post` entry type emits single-{type}-{slug} → single-{type} → single → singular → index", () => {
+    expect(
+      getPossibleTemplates({
+        kind: "content",
+        entryType: "post",
+        slug: "hello-world",
+        databaseId: 1,
+      }),
+    ).toEqual([
+      "single-post-hello-world",
+      "single-post",
+      "single",
+      "singular",
+      "index",
+    ]);
+  });
+
+  test("custom entry type (`doc`) falls through `single` like `post`", () => {
+    expect(
+      getPossibleTemplates({
+        kind: "content",
+        entryType: "doc",
+        slug: "installation",
+        databaseId: 12,
+      }),
+    ).toEqual([
+      "single-doc-installation",
+      "single-doc",
+      "single",
+      "singular",
+      "index",
+    ]);
+  });
+
+  test("`page` entry type emits page-{slug} → page-{id} → page → singular → index (no `single`)", () => {
+    expect(
+      getPossibleTemplates({
+        kind: "content",
+        entryType: "page",
+        slug: "about",
+        databaseId: 5,
+      }),
+    ).toEqual(["page-about", "page-5", "page", "singular", "index"]);
+  });
+
+  test("content-type archive emits archive-{type} → archive → index", () => {
+    expect(
+      getPossibleTemplates({
+        kind: "content-type-archive",
+        entryType: "product",
+      }),
+    ).toEqual(["archive-product", "archive", "index"]);
+  });
+
+  test("front-page emits front-page → home → index", () => {
+    expect(getPossibleTemplates({ kind: "front-page" })).toEqual([
+      "front-page",
+      "home",
+      "index",
+    ]);
+  });
+
+  test("posts-page (blog home assigned to a page) emits home → index", () => {
+    expect(getPossibleTemplates({ kind: "posts-page" })).toEqual([
+      "home",
+      "index",
+    ]);
+  });
+});
+
+describe("resolveTemplateCandidates — `template:hierarchy` filter", () => {
+  test("filter can prepend new candidates ahead of the WP chain", async () => {
+    const hooks = new HookRegistry();
+    hooks.addFilter("template:hierarchy", (candidates, ctx) => {
+      if (ctx.node.kind !== "content") return candidates;
+      return [`single-${ctx.node.entryType}-by-author`, ...candidates];
+    });
+
+    const result = await resolveTemplateCandidates(
+      {
+        kind: "content",
+        entryType: "post",
+        slug: "hello",
+        databaseId: 1,
+      },
+      hooks,
+    );
+
+    expect(result[0]).toBe("single-post-by-author");
+    expect(result).toContain("index");
+  });
+
+  test("filter can drop candidates from the list", async () => {
+    const hooks = new HookRegistry();
+    hooks.addFilter("template:hierarchy", (candidates) =>
+      candidates.filter((c) => c !== "archive"),
+    );
+
+    const result = await resolveTemplateCandidates(
+      { kind: "term", taxonomy: "category", slug: "news", databaseId: 1 },
+      hooks,
+    );
+
+    expect(result).not.toContain("archive");
+    expect(result).toContain("category");
+  });
+
+  test("with no registered filter the result equals the pure walker output", async () => {
+    const hooks = new HookRegistry();
+    const node = {
+      kind: "term" as const,
+      taxonomy: "tag",
+      slug: "x",
+      databaseId: 1,
+    };
+    expect(await resolveTemplateCandidates(node, hooks)).toEqual(
+      getPossibleTemplates(node),
+    );
+  });
+
+  test("custom taxonomy emits the generic taxonomy-{tax} chain", () => {
+    expect(
+      getPossibleTemplates({
+        kind: "term",
+        taxonomy: "region",
+        slug: "europe",
+        databaseId: 3,
+      }),
+    ).toEqual([
+      "taxonomy-region-europe",
+      "taxonomy-region-3",
+      "taxonomy-region",
+      "taxonomy",
+      "archive",
+      "index",
+    ]);
+  });
+});

--- a/packages/core/src/route/render/template-hierarchy.ts
+++ b/packages/core/src/route/render/template-hierarchy.ts
@@ -1,0 +1,142 @@
+/**
+ * The WordPress template hierarchy, ported to a typed React world.
+ *
+ * `getPossibleTemplates(node)` is a pure function returning the ordered
+ * candidate template names a theme can register for a given resolved
+ * request. The render pipeline walks this list greedy-first-match
+ * against the registered template map.
+ *
+ * Mirrors WordPress's hierarchy verbatim — including the `category-…` /
+ * `tag-…` aliases for the built-in taxonomies (a hard-coded WP rule that
+ * predates the generic `taxonomy-{tax}-…` chain) and the fall-through to
+ * `archive` / `index`. Faust.js exposes the same shape from
+ * `getTemplate.ts`; the two implementations should produce identical
+ * candidate lists for the same input.
+ *
+ * `resolveTemplateCandidates(node, hooks)` is the async orchestrator the
+ * renderer calls: it runs the pure walker, then applies the
+ * `template:hierarchy` filter chain so plugins can mutate the list.
+ */
+
+import type { HookExecutor } from "../../hooks/registry.js";
+
+declare module "../../hooks/types.js" {
+  interface FilterRegistry {
+    "template:hierarchy": (
+      candidates: readonly string[],
+      ctx: { readonly node: ResolvedNode },
+    ) => readonly string[] | Promise<readonly string[]>;
+  }
+}
+
+export type ResolvedNode =
+  | ResolvedTermNode
+  | ResolvedContentNode
+  | ResolvedContentTypeArchive
+  | ResolvedFrontPage
+  | ResolvedPostsPage;
+
+interface ResolvedTermNode {
+  readonly kind: "term";
+  readonly taxonomy: string;
+  readonly slug: string;
+  readonly databaseId: number;
+}
+
+interface ResolvedContentNode {
+  readonly kind: "content";
+  readonly entryType: string;
+  readonly slug: string;
+  readonly databaseId: number;
+}
+
+interface ResolvedContentTypeArchive {
+  readonly kind: "content-type-archive";
+  readonly entryType: string;
+}
+
+interface ResolvedFrontPage {
+  readonly kind: "front-page";
+}
+
+/**
+ * The "posts page" — when a site assigns a page as the blog home in
+ * Settings → Reading. Falls through to `home` then `index`. Distinct from
+ * `front-page` because the front page may or may not be the posts page.
+ */
+interface ResolvedPostsPage {
+  readonly kind: "posts-page";
+}
+
+export function getPossibleTemplates(node: ResolvedNode): readonly string[] {
+  const candidates: string[] = [];
+  switch (node.kind) {
+    case "term":
+      appendTermNodeCandidates(node, candidates);
+      break;
+    case "content":
+      appendContentNodeCandidates(node, candidates);
+      break;
+    case "content-type-archive":
+      candidates.push(`archive-${node.entryType}`, "archive");
+      break;
+    case "front-page":
+      candidates.push("front-page", "home");
+      break;
+    case "posts-page":
+      candidates.push("home");
+      break;
+  }
+  candidates.push("index");
+  return candidates;
+}
+
+/**
+ * The async orchestrator the renderer calls: runs the pure walker, then
+ * applies the `template:hierarchy` filter chain. Kept separate from the
+ * pure walker so unit tests don't need a HookRegistry to exercise the
+ * branching logic.
+ */
+export async function resolveTemplateCandidates(
+  node: ResolvedNode,
+  hooks: HookExecutor,
+): Promise<readonly string[]> {
+  const initial = getPossibleTemplates(node);
+  return hooks.applyFilter("template:hierarchy", initial, { node });
+}
+
+function appendTermNodeCandidates(node: ResolvedTermNode, out: string[]): void {
+  // Built-in taxonomies retain their WP-historical aliases. New taxonomies
+  // (registered via `registerTermTaxonomy('region', …)`) flow through the
+  // generic `taxonomy-{tax}-…` chain below.
+  if (node.taxonomy === "category" || node.taxonomy === "tag") {
+    out.push(`${node.taxonomy}-${node.slug}`);
+    out.push(`${node.taxonomy}-${node.databaseId}`);
+    out.push(node.taxonomy);
+  } else {
+    out.push(`taxonomy-${node.taxonomy}-${node.slug}`);
+    out.push(`taxonomy-${node.taxonomy}-${node.databaseId}`);
+    out.push(`taxonomy-${node.taxonomy}`);
+    out.push("taxonomy");
+  }
+  out.push("archive");
+}
+
+function appendContentNodeCandidates(
+  node: ResolvedContentNode,
+  out: string[],
+): void {
+  // `page` short-circuits the `single` chain — page-{slug}, page-{id}, page,
+  // then singular. Every other entry type (post + custom CPTs) walks the
+  // full single-* chain.
+  if (node.entryType === "page") {
+    out.push(`page-${node.slug}`);
+    out.push(`page-${node.databaseId}`);
+    out.push("page");
+  } else {
+    out.push(`single-${node.entryType}-${node.slug}`);
+    out.push(`single-${node.entryType}`);
+    out.push("single");
+  }
+  out.push("singular");
+}

--- a/packages/core/src/route/resolve.test.ts
+++ b/packages/core/src/route/resolve.test.ts
@@ -161,3 +161,195 @@ describe("resolvePublicRoute — archive", () => {
     expect(body).toContain("<title>Docs</title>");
   });
 });
+
+const taxonomyPlugin = definePlugin("blog", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+  ctx.registerTermTaxonomy("category", {
+    label: "Categories",
+    entryTypes: ["post"],
+  });
+});
+
+describe("resolvePublicRoute — taxonomy", () => {
+  test("returns 404 when the term slug doesn't exist", async () => {
+    const h = await createDispatcherHarness({ plugins: [taxonomyPlugin] });
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/missing"),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("renders a 200 empty archive when the term exists but has no entries", async () => {
+    const h = await createDispatcherHarness({ plugins: [taxonomyPlugin] });
+    await h.factory.category.create({ slug: "news", name: "News" });
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/news"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<h1>News</h1>");
+    expect(body).toContain("No entries yet.");
+  });
+
+  test("lists published entries tagged with the term, newest first", async () => {
+    const h = await createDispatcherHarness({ plugins: [taxonomyPlugin] });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.category.create({
+      slug: "news",
+      name: "News",
+    });
+    const older = await h.factory.entry.create({
+      type: "post",
+      slug: "older",
+      title: "Older",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-04-01"),
+    });
+    const newer = await h.factory.entry.create({
+      type: "post",
+      slug: "newer",
+      title: "Newer",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-04-20"),
+    });
+    await h.factory.entryTerm.create({ entryId: older.id, termId: term.id });
+    await h.factory.entryTerm.create({ entryId: newer.id, termId: term.id });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/news"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Newer");
+    expect(body).toContain("Older");
+    expect(body.indexOf("Newer")).toBeLessThan(body.indexOf("Older"));
+  });
+
+  test("cross-entry-type taxonomy includes entries from every attached type", async () => {
+    const multiTypePlugin = definePlugin("multi", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerEntryType("doc", { label: "Docs", isPublic: true });
+      ctx.registerTermTaxonomy("topic", {
+        label: "Topics",
+        entryTypes: ["post", "doc"],
+      });
+    });
+    const h = await createDispatcherHarness({ plugins: [multiTypePlugin] });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.term.create({
+      taxonomy: "topic",
+      slug: "edge",
+      name: "Edge",
+    });
+    const post = await h.factory.entry.create({
+      type: "post",
+      slug: "p",
+      title: "Post P",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-04-10"),
+    });
+    const doc = await h.factory.entry.create({
+      type: "doc",
+      slug: "d",
+      title: "Doc D",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-04-20"),
+    });
+    await h.factory.entryTerm.create({ entryId: post.id, termId: term.id });
+    await h.factory.entryTerm.create({ entryId: doc.id, termId: term.id });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/topic/edge"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('<a href="/post/p">Post P</a>');
+    expect(body).toContain('<a href="/doc/d">Doc D</a>');
+  });
+
+  test("resolve:taxonomy:data filter can drop entries before rendering", async () => {
+    const filterPlugin = definePlugin("hide", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerTermTaxonomy("category", {
+        label: "Categories",
+        entryTypes: ["post"],
+      });
+      ctx.addFilter("resolve:taxonomy:data", (data) => {
+        return {
+          ...data,
+          entries: data.entries.filter((e) => e.slug !== "hidden"),
+        };
+      });
+    });
+    const h = await createDispatcherHarness({ plugins: [filterPlugin] });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.category.create({
+      slug: "news",
+      name: "News",
+    });
+    const shown = await h.factory.entry.create({
+      type: "post",
+      slug: "shown",
+      title: "Shown",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-04-10"),
+    });
+    const hidden = await h.factory.entry.create({
+      type: "post",
+      slug: "hidden",
+      title: "Hidden",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-04-20"),
+    });
+    await h.factory.entryTerm.create({ entryId: shown.id, termId: term.id });
+    await h.factory.entryTerm.create({ entryId: hidden.id, termId: term.id });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/news"),
+    );
+    const body = await response.text();
+    expect(body).toContain("Shown");
+    expect(body).not.toContain("Hidden");
+  });
+
+  test("draft entries tagged with the term are excluded", async () => {
+    const h = await createDispatcherHarness({ plugins: [taxonomyPlugin] });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.category.create({
+      slug: "news",
+      name: "News",
+    });
+    const draft = await h.factory.entry.create({
+      type: "post",
+      slug: "draft",
+      title: "Draft",
+      content: null,
+      status: "draft",
+      authorId: author.id,
+    });
+    await h.factory.entryTerm.create({ entryId: draft.id, termId: term.id });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/news"),
+    );
+    const body = await response.text();
+    expect(body).toContain("No entries yet.");
+    expect(body).not.toContain("Draft");
+  });
+});

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -1,9 +1,12 @@
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
+import type { Term } from "../db/schema/terms.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
-import { and, desc, eq } from "../db/index.js";
+import { and, desc, eq, inArray } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
+import { entryTerm } from "../db/schema/entry_term.js";
+import { terms } from "../db/schema/terms.js";
 import { notFound } from "../runtime/http.js";
 import {
   escapeAttr,
@@ -11,6 +14,20 @@ import {
   renderDefaultDocument,
 } from "./render/document.js";
 import { renderTiptapContent } from "./render/tiptap.js";
+
+interface ResolvedTaxonomyData {
+  readonly taxonomy: string;
+  readonly term: Term;
+  readonly entries: readonly Entry[];
+}
+
+declare module "../hooks/types.js" {
+  interface FilterRegistry {
+    "resolve:taxonomy:data": (
+      data: ResolvedTaxonomyData,
+    ) => ResolvedTaxonomyData | Promise<ResolvedTaxonomyData>;
+  }
+}
 
 const ARCHIVE_LIMIT = 20;
 
@@ -23,7 +40,78 @@ export async function resolvePublicRoute(
       return resolveSingle(ctx, match.intent, match.params);
     case "archive":
       return resolveArchive(ctx, match.intent);
+    case "taxonomy":
+      return resolveTaxonomy(ctx, match.intent, match.params);
   }
+}
+
+async function resolveTaxonomy(
+  ctx: AppContext,
+  intent: Extract<RouteIntent, { kind: "taxonomy" }>,
+  params: Record<string, string>,
+): Promise<Response> {
+  const slug = params.term;
+  if (typeof slug !== "string" || slug === "") {
+    return notFound("public-route-term-missing");
+  }
+
+  const term = await ctx.db.query.terms.findFirst({
+    where: and(eq(terms.taxonomy, intent.taxonomy), eq(terms.slug, slug)),
+  });
+  if (!term) return notFound("public-term-not-found");
+
+  ctx.resolvedEntity = { kind: "term", id: term.id };
+
+  const taxonomy = ctx.plugins.termTaxonomies.get(intent.taxonomy);
+  const allowedTypes = taxonomy?.entryTypes ?? [];
+
+  // Empty `allowedTypes` short-circuits — a taxonomy registered without
+  // any attached entry types yields an empty archive.
+  const rows =
+    allowedTypes.length === 0
+      ? []
+      : await ctx.db
+          .select()
+          .from(entries)
+          .where(
+            and(
+              eq(entries.status, "published"),
+              inArray(entries.type, allowedTypes),
+              inArray(
+                entries.id,
+                ctx.db
+                  .select({ id: entryTerm.entryId })
+                  .from(entryTerm)
+                  .where(eq(entryTerm.termId, term.id)),
+              ),
+            ),
+          )
+          .orderBy(desc(entries.publishedAt), desc(entries.id))
+          .limit(ARCHIVE_LIMIT);
+
+  // Run plugin filters before render so plugins can mutate the resolved
+  // shape (drop entries, append plugin-contributed fields, etc.) without
+  // forking the resolver. Mirrors WP's `pre_get_posts` ergonomics.
+  const data = await ctx.hooks.applyFilter("resolve:taxonomy:data", {
+    taxonomy: intent.taxonomy,
+    term,
+    entries: rows,
+  });
+
+  const title = taxonomy?.labels?.singular ?? taxonomy?.label ?? data.term.name;
+  const heading = escapeHtml(data.term.name);
+  const body =
+    data.entries.length === 0
+      ? `<h1>${heading}</h1><p>No entries yet.</p>`
+      : `<h1>${heading}</h1><ul>${data.entries.map(renderTaxonomyItem).join("")}</ul>`;
+  return htmlResponse(title, body);
+}
+
+function renderTaxonomyItem(row: Entry): string {
+  // Reuse the entry-type's permalink base — taxonomy archives can mix
+  // multiple entry types, so each item needs its own type-specific URL.
+  const href = `/${row.type}/${row.slug}`;
+  return `<li><a href="${escapeAttr(href)}">${escapeHtml(row.title)}</a></li>`;
 }
 
 async function resolveSingle(

--- a/packages/plumix/src/theme/index.ts
+++ b/packages/plumix/src/theme/index.ts
@@ -1,1 +1,10 @@
-export {};
+export {
+  defineTheme,
+  isEntryArchive,
+  isTaxonomy,
+  type ArchiveEntry,
+  type ArchiveProps,
+  type EntryArchiveProps,
+  type TaxonomyArchiveProps,
+  type ThemeDescriptor,
+} from "@plumix/core";


### PR DESCRIPTION
Implements slice 1 of #223 — WordPress-exact flat taxonomy routing plus the template hierarchy walker that drives template resolution across the full WP chain (term archives, content nodes, content-type archives, front page, posts page, fall-through to `archive` / `index`).

Today a visitor to `/category/javascript` on the blog example gets a 404 — the route compiler doesn't iterate `registry.termTaxonomies` at all (the deferred-gap comment at `packages/core/src/route/intent.ts:5-9` flagged it). After this PR, every registered term taxonomy emits a public `/<base>/:term` rule, resolves through a cross-entry-type query, and feeds a template-hierarchy walker that themes will consume once #225 / #226 land and the renderer is fully wired.

## Design

- **Faust.js-shaped walker.** `getPossibleTemplates(node)` is a pure function returning the ordered candidate template names — mirrors `wpengine/faustjs`'s `getTemplate.ts` so the WP hierarchy port is auditable side-by-side. `resolveTemplateCandidates(node, hooks)` is the async orchestrator the renderer calls; it runs the pure walker then applies the new `template:hierarchy` filter.
- **Typed-template world, narrowed.** Specific templates keep narrow `TemplateProps<K>` generic typing; the shared `archive` / `index` fallbacks receive a discriminated `ArchiveProps` union with `isTaxonomy(props, name?)` and `isEntryArchive(props, type?)` runtime guards — typed equivalents of WP's `is_tax()` / `is_post_type_archive()`. See #223 for the longer design write-up on why Faust's unified flag-bag node would fight the rest of the codebase.
- **Slug-collision behavior is WP-faithful.** When a post type with `rewrite.slug: 'category'` shadows a `category` taxonomy, the taxonomy term archive wins. The compiler iterates taxonomies before entry types so stable sort preserves taxonomy-first at equal priority — the same ordering WP relies on in `$wp_rewrite->rules`.
- **Two plugin extension hooks** land alongside: `resolve:taxonomy:data` (pre-render data mutation, mirrors WP's `pre_get_posts` ergonomics) and `template:hierarchy` (candidate-list mutation).

## Scope and what's deferred

Pagination (`/page/N` on both archive kinds) and hierarchical URLs (`:path+` capture for both entry types and taxonomies, closing the `permalink.ts:21-26` gap) are explicitly out of scope. They land in #225 and #226 respectively.

The `examples/blog/e2e/taxonomy.spec.ts` Playwright spec from #224's acceptance criteria is split out to #227. The blog example has no e2e harness today; building that scaffold is orthogonal scope and is reusable for #225 and #226. The dispatcher harness already exercises the full match → resolve → response pipeline against real D1, so the functional surface is verified end-to-end through unit + integration coverage in this PR.

## Coverage

1282 tests passing; lint + typecheck clean across `@plumix/core` and `plumix`.

- 5 compiler tests: rule emission, taxonomy-before-entry ordering on slug collision, `isPublic: false` skip, `rewrite.slug` honored, `isPublic` default.
- 7 template-hierarchy walker tests across every WP branch (built-in taxonomies, custom taxonomies, post, custom CPT, page, content-type archive, front-page, posts-page) + 3 filter-integration tests.
- 4 `ArchiveProps` discriminator helper tests.
- 6 resolver integration tests against in-memory D1: term-not-found 404, empty term 200, listed entries newest-first, drafts excluded, cross-entry-type, `resolve:taxonomy:data` filter layering.

## Pre-PR QA

- `sentry-skills:find-bugs` — no critical or high findings. Two low-severity defense-in-depth notes (unvalidated `rewrite.slug`, filter-output trust) both with pre-existing symmetric gaps on the entry-type side; both worth filing as follow-ups rather than expanding this PR.
- `sentry-skills:code-simplifier` — one import-region split caught and fixed in `5cf30e3`.
- `sentry-skills:code-review` — flagged two missing symmetric tests (`rewrite.slug` honored, `isPublic` default for taxonomies); added in `734361f`.

Fixes #224
Refs #223