### PR TITLE
feat(core): pagination on entry archives + taxonomy archives

### DIFF
--- a/packages/core/src/route/compile.test.ts
+++ b/packages/core/src/route/compile.test.ts
@@ -56,7 +56,10 @@ describe("compileRouteMap", () => {
       }),
     ]);
     const map = compileRouteMap(registry);
-    expect(map.map((r) => r.rawPattern)).toEqual(["/r/:term/page/:page", "/r/:term"]);
+    expect(map.map((r) => r.rawPattern)).toEqual([
+      "/r/:term/page/:page",
+      "/r/:term",
+    ]);
     const bare = map.find((r) => r.rawPattern === "/r/:term");
     expect(bare?.intent).toEqual({ kind: "taxonomy", taxonomy: "region" });
   });

--- a/packages/core/src/route/compile.test.ts
+++ b/packages/core/src/route/compile.test.ts
@@ -21,10 +21,29 @@ describe("compileRouteMap", () => {
       }),
     ]);
     const map = compileRouteMap(registry);
-    expect(map).toHaveLength(1);
-    expect(map[0]?.rawPattern).toBe("/category/:term");
-    expect(map[0]?.intent).toEqual({ kind: "taxonomy", taxonomy: "category" });
-    expect(map[0]?.priority).toBe(50);
+    const bare = map.find((r) => r.rawPattern === "/category/:term");
+    expect(bare?.intent).toEqual({ kind: "taxonomy", taxonomy: "category" });
+    expect(bare?.priority).toBe(50);
+  });
+
+  test("emits /<base>/:term/page/:page paginated rule alongside the bare term archive", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("category", { label: "Categories" });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    expect(patterns).toContain("/category/:term");
+    expect(patterns).toContain("/category/:term/page/:page");
+    const paginated = map.find(
+      (r) => r.rawPattern === "/category/:term/page/:page",
+    );
+    expect(paginated?.intent).toEqual({
+      kind: "taxonomy",
+      taxonomy: "category",
+    });
+    expect(paginated?.priority).toBe(50);
   });
 
   test("honors taxonomy rewrite.slug on the term-archive pattern", async () => {
@@ -37,8 +56,9 @@ describe("compileRouteMap", () => {
       }),
     ]);
     const map = compileRouteMap(registry);
-    expect(map.map((r) => r.rawPattern)).toEqual(["/r/:term"]);
-    expect(map[0]?.intent).toEqual({ kind: "taxonomy", taxonomy: "region" });
+    expect(map.map((r) => r.rawPattern)).toEqual(["/r/:term/page/:page", "/r/:term"]);
+    const bare = map.find((r) => r.rawPattern === "/r/:term");
+    expect(bare?.intent).toEqual({ kind: "taxonomy", taxonomy: "region" });
   });
 
   test("taxonomy isPublic defaults to true — omitting it still generates a route", async () => {
@@ -48,6 +68,7 @@ describe("compileRouteMap", () => {
       }),
     ]);
     expect(compileRouteMap(registry).map((r) => r.rawPattern)).toEqual([
+      "/topic/:term/page/:page",
       "/topic/:term",
     ]);
   });
@@ -97,6 +118,29 @@ describe("compileRouteMap", () => {
     expect(map[0]?.priority).toBe(50);
   });
 
+  test("emits /<archive>/page/:page paginated rule alongside the bare archive", async () => {
+    const registry = await buildRegistry([
+      definePlugin("shop", (ctx) => {
+        ctx.registerEntryType("product", {
+          label: "Products",
+          isPublic: true,
+          hasArchive: true,
+          rewrite: { slug: "shop" },
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    expect(patterns).toContain("/shop");
+    expect(patterns).toContain("/shop/page/:page");
+    const paginated = map.find((r) => r.rawPattern === "/shop/page/:page");
+    expect(paginated?.intent).toEqual({
+      kind: "archive",
+      entryType: "product",
+    });
+    expect(paginated?.priority).toBe(50);
+  });
+
   test("honors rewrite.slug for both single and archive patterns", async () => {
     const registry = await buildRegistry([
       definePlugin("shop", (ctx) => {
@@ -110,9 +154,10 @@ describe("compileRouteMap", () => {
     ]);
     const map = compileRouteMap(registry);
     const patterns = map.map((r) => r.rawPattern);
-    expect(patterns).toEqual(["/shop", "/shop/:slug"]);
+    expect(patterns).toEqual(["/shop/page/:page", "/shop", "/shop/:slug"]);
     expect(map[0]?.intent).toEqual({ kind: "archive", entryType: "product" });
-    expect(map[1]?.intent).toEqual({ kind: "single", entryType: "product" });
+    expect(map[1]?.intent).toEqual({ kind: "archive", entryType: "product" });
+    expect(map[2]?.intent).toEqual({ kind: "single", entryType: "product" });
   });
 
   test("hasArchive: string overrides the auto archive slug", async () => {
@@ -127,7 +172,11 @@ describe("compileRouteMap", () => {
       }),
     ]);
     const map = compileRouteMap(registry);
-    expect(map.map((r) => r.rawPattern)).toEqual(["/store", "/p/:slug"]);
+    expect(map.map((r) => r.rawPattern)).toEqual([
+      "/store/page/:page",
+      "/store",
+      "/p/:slug",
+    ]);
   });
 
   test("skips private post types entirely", async () => {

--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -3,7 +3,7 @@ import type {
   RegisteredEntryType,
   RegisteredTermTaxonomy,
 } from "../plugin/manifest.js";
-import type { RouteRule } from "./intent.js";
+import type { RouteIntent, RouteRule } from "./intent.js";
 
 const AUTO_ROUTE_PRIORITY = 50;
 export const DEFAULT_REWRITE_RULE_PRIORITY = 10;
@@ -59,11 +59,26 @@ function autoRulesForEntryType(entryType: RegisteredEntryType): CompiledRule[] {
   const rules: CompiledRule[] = [];
 
   if (archiveSlug !== null) {
-    const pattern = `/${archiveSlug}`;
+    const basePattern = `/${archiveSlug}`;
+    const paginatedPattern = `${basePattern}/page/:page`;
+    const intent: RouteIntent = {
+      kind: "archive",
+      entryType: entryType.name,
+    };
+    // Paginated variant goes first so /shop/page/2 doesn't accidentally
+    // match the bare archive's URLPattern (it wouldn't today, but keep
+    // the more-specific rule earlier as a defensive ordering invariant).
     rules.push({
-      pattern: new URLPattern({ pathname: pattern }),
-      rawPattern: pattern,
-      intent: { kind: "archive", entryType: entryType.name },
+      pattern: new URLPattern({ pathname: paginatedPattern }),
+      rawPattern: paginatedPattern,
+      intent,
+      priority: AUTO_ROUTE_PRIORITY,
+      registeredBy: entryType.registeredBy,
+    });
+    rules.push({
+      pattern: new URLPattern({ pathname: basePattern }),
+      rawPattern: basePattern,
+      intent,
       priority: AUTO_ROUTE_PRIORITY,
       registeredBy: entryType.registeredBy,
     });
@@ -85,12 +100,21 @@ function autoRulesForTermTaxonomy(
   taxonomy: RegisteredTermTaxonomy,
 ): CompiledRule[] {
   const baseSlug = taxonomy.rewrite?.slug ?? taxonomy.name;
-  const pattern = `/${baseSlug}/:term`;
+  const basePattern = `/${baseSlug}/:term`;
+  const paginatedPattern = `${basePattern}/page/:page`;
+  const intent: RouteIntent = { kind: "taxonomy", taxonomy: taxonomy.name };
   return [
     {
-      pattern: new URLPattern({ pathname: pattern }),
-      rawPattern: pattern,
-      intent: { kind: "taxonomy", taxonomy: taxonomy.name },
+      pattern: new URLPattern({ pathname: paginatedPattern }),
+      rawPattern: paginatedPattern,
+      intent,
+      priority: AUTO_ROUTE_PRIORITY,
+      registeredBy: taxonomy.registeredBy,
+    },
+    {
+      pattern: new URLPattern({ pathname: basePattern }),
+      rawPattern: basePattern,
+      intent,
       priority: AUTO_ROUTE_PRIORITY,
       registeredBy: taxonomy.registeredBy,
     },

--- a/packages/core/src/route/paginate.test.ts
+++ b/packages/core/src/route/paginate.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+
+import { paginate } from "./paginate.js";
+
+describe("paginate", () => {
+  test("page 1 of a non-empty result set returns offset 0", () => {
+    expect(paginate({ page: 1, perPage: 10, total: 25 })).toEqual({
+      offset: 0,
+      limit: 10,
+      totalPages: 3,
+      outOfRange: false,
+    });
+  });
+
+  test("page 2 with perPage 10 returns offset 10", () => {
+    expect(paginate({ page: 2, perPage: 10, total: 25 })).toEqual({
+      offset: 10,
+      limit: 10,
+      totalPages: 3,
+      outOfRange: false,
+    });
+  });
+
+  test("page > totalPages on a non-empty result is out of range", () => {
+    expect(paginate({ page: 4, perPage: 10, total: 25 })).toMatchObject({
+      totalPages: 3,
+      outOfRange: true,
+    });
+  });
+
+  test("page === totalPages is still in range", () => {
+    expect(paginate({ page: 3, perPage: 10, total: 25 })).toMatchObject({
+      totalPages: 3,
+      outOfRange: false,
+    });
+  });
+
+  test("page 1 of an empty result set is in range (renders the empty archive)", () => {
+    expect(paginate({ page: 1, perPage: 10, total: 0 })).toEqual({
+      offset: 0,
+      limit: 10,
+      totalPages: 1,
+      outOfRange: false,
+    });
+  });
+
+  test("page > 1 on an empty result set is out of range", () => {
+    expect(paginate({ page: 2, perPage: 10, total: 0 })).toMatchObject({
+      outOfRange: true,
+    });
+  });
+
+  test("page < 1 is out of range — caller passed an invalid URL param", () => {
+    expect(paginate({ page: 0, perPage: 10, total: 25 })).toMatchObject({
+      outOfRange: true,
+    });
+    expect(paginate({ page: -1, perPage: 10, total: 25 })).toMatchObject({
+      outOfRange: true,
+    });
+  });
+
+  test("non-integer page is out of range", () => {
+    expect(paginate({ page: 1.5, perPage: 10, total: 25 })).toMatchObject({
+      outOfRange: true,
+    });
+    expect(paginate({ page: Number.NaN, perPage: 10, total: 25 })).toMatchObject(
+      {
+        outOfRange: true,
+      },
+    );
+  });
+});

--- a/packages/core/src/route/paginate.test.ts
+++ b/packages/core/src/route/paginate.test.ts
@@ -63,10 +63,10 @@ describe("paginate", () => {
     expect(paginate({ page: 1.5, perPage: 10, total: 25 })).toMatchObject({
       outOfRange: true,
     });
-    expect(paginate({ page: Number.NaN, perPage: 10, total: 25 })).toMatchObject(
-      {
-        outOfRange: true,
-      },
-    );
+    expect(
+      paginate({ page: Number.NaN, perPage: 10, total: 25 }),
+    ).toMatchObject({
+      outOfRange: true,
+    });
   });
 });

--- a/packages/core/src/route/paginate.ts
+++ b/packages/core/src/route/paginate.ts
@@ -1,0 +1,37 @@
+/**
+ * Pagination math shared by the archive and taxonomy resolvers. Pure
+ * function so the two resolvers can't drift on boundary conditions —
+ * any rule about "what counts as out of range" lives here, in one place,
+ * with a single set of tests.
+ *
+ * `total === 0` is intentionally **not** out of range when `page === 1`
+ * — an empty archive renders the 200 empty-state page, mirroring how
+ * #224's taxonomy resolver treats a term that exists but has no entries
+ * tagged with it.
+ */
+
+export interface PaginateInput {
+  readonly page: number;
+  readonly perPage: number;
+  readonly total: number;
+}
+
+export interface PaginateResult {
+  readonly offset: number;
+  readonly limit: number;
+  readonly totalPages: number;
+  readonly outOfRange: boolean;
+}
+
+export function paginate(input: PaginateInput): PaginateResult {
+  const { page, perPage, total } = input;
+  const totalPages = Math.max(1, Math.ceil(total / perPage));
+  const validPage = Number.isInteger(page) && page >= 1;
+  const inRange = validPage && (total === 0 ? page === 1 : page <= totalPages);
+  return {
+    offset: Math.max(0, (page - 1) * perPage),
+    limit: perPage,
+    totalPages,
+    outOfRange: !inRange,
+  };
+}

--- a/packages/core/src/route/paginate.ts
+++ b/packages/core/src/route/paginate.ts
@@ -10,13 +10,13 @@
  * tagged with it.
  */
 
-export interface PaginateInput {
+interface PaginateInput {
   readonly page: number;
   readonly perPage: number;
   readonly total: number;
 }
 
-export interface PaginateResult {
+interface PaginateResult {
   readonly offset: number;
   readonly limit: number;
   readonly totalPages: number;

--- a/packages/core/src/route/resolve.test.ts
+++ b/packages/core/src/route/resolve.test.ts
@@ -147,6 +147,94 @@ describe("resolvePublicRoute — archive", () => {
     expect(body).not.toContain("Draft One");
   });
 
+  test("page=2 returns the offset slice of entries", async () => {
+    const h = await createDispatcherHarness({ plugins: [shopPlugin] });
+    const author = await h.seedUser("admin");
+    // Seed 25 entries — perPage=20 means page 2 has 5 entries.
+    for (let i = 1; i <= 25; i++) {
+      await h.factory.entry.create({
+        type: "product",
+        slug: `p-${String(i).padStart(2, "0")}`,
+        title: `Product ${String(i).padStart(2, "0")}`,
+        content: null,
+        status: "published",
+        authorId: author.id,
+        publishedAt: new Date(`2026-04-${String(i).padStart(2, "0")}`),
+      });
+    }
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/shop/page/2"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    // perPage=20, page 2 shows entries 1..5 (oldest, since newest are on page 1)
+    expect(body).toContain("Product 05");
+    expect(body).toContain("Product 01");
+    expect(body).not.toContain("Product 25");
+    expect(body).not.toContain("Product 06");
+  });
+
+  test("page > totalPages returns 404", async () => {
+    const h = await createDispatcherHarness({ plugins: [shopPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "product",
+      slug: "only-one",
+      title: "Only One",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/shop/page/99"),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("non-numeric :page param returns 404", async () => {
+    const h = await createDispatcherHarness({ plugins: [shopPlugin] });
+    const response = await h.dispatch(
+      new Request("https://cms.example/shop/page/abc"),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("explicit /page/1 resolves the same content as the bare archive", async () => {
+    const h = await createDispatcherHarness({ plugins: [shopPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "product",
+      slug: "thing",
+      title: "Thing",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const bare = await h.dispatch(new Request("https://cms.example/shop"));
+    const paginated = await h.dispatch(
+      new Request("https://cms.example/shop/page/1"),
+    );
+    expect(bare.status).toBe(200);
+    expect(paginated.status).toBe(200);
+    const bareBody = await bare.text();
+    const paginatedBody = await paginated.text();
+    expect(paginatedBody).toBe(bareBody);
+  });
+
+  test("empty archive on page=1 still returns 200 (regression from #224)", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/page/1"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("No entries yet.");
+  });
+
   test("archive title falls back label → entryType when labels.plural is absent", async () => {
     const plugin = definePlugin("docs", (ctx) => {
       ctx.registerEntryType("doc", {
@@ -326,6 +414,73 @@ describe("resolvePublicRoute — taxonomy", () => {
     const body = await response.text();
     expect(body).toContain("Shown");
     expect(body).not.toContain("Hidden");
+  });
+
+  test("taxonomy page=2 returns the offset slice of tagged entries", async () => {
+    const h = await createDispatcherHarness({ plugins: [taxonomyPlugin] });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.category.create({
+      slug: "news",
+      name: "News",
+    });
+    for (let i = 1; i <= 25; i++) {
+      const post = await h.factory.entry.create({
+        type: "post",
+        slug: `p-${String(i).padStart(2, "0")}`,
+        title: `Tagged ${String(i).padStart(2, "0")}`,
+        content: null,
+        status: "published",
+        authorId: author.id,
+        publishedAt: new Date(`2026-04-${String(i).padStart(2, "0")}`),
+      });
+      await h.factory.entryTerm.create({ entryId: post.id, termId: term.id });
+    }
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/news/page/2"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    // perPage=20, page 2 shows the oldest 5 entries (newest 20 on page 1).
+    expect(body).toContain("Tagged 05");
+    expect(body).toContain("Tagged 01");
+    expect(body).not.toContain("Tagged 25");
+    expect(body).not.toContain("Tagged 06");
+  });
+
+  test("taxonomy page > totalPages returns 404", async () => {
+    const h = await createDispatcherHarness({ plugins: [taxonomyPlugin] });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.category.create({
+      slug: "news",
+      name: "News",
+    });
+    const post = await h.factory.entry.create({
+      type: "post",
+      slug: "only",
+      title: "Only",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entryTerm.create({ entryId: post.id, termId: term.id });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/news/page/99"),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("empty term on page=1 still returns 200 (regression from #224)", async () => {
+    const h = await createDispatcherHarness({ plugins: [taxonomyPlugin] });
+    await h.factory.category.create({ slug: "empty", name: "Empty" });
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/empty/page/1"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("No entries yet.");
   });
 
   test("draft entries tagged with the term are excluded", async () => {

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -1,3 +1,6 @@
+import type { SQL } from "drizzle-orm";
+import { count } from "drizzle-orm";
+
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
@@ -8,6 +11,7 @@ import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
 import { terms } from "../db/schema/terms.js";
 import { notFound } from "../runtime/http.js";
+import { paginate } from "./paginate.js";
 import {
   escapeAttr,
   escapeHtml,
@@ -39,7 +43,7 @@ export async function resolvePublicRoute(
     case "single":
       return resolveSingle(ctx, match.intent, match.params);
     case "archive":
-      return resolveArchive(ctx, match.intent);
+      return resolveArchive(ctx, match.intent, match.params);
     case "taxonomy":
       return resolveTaxonomy(ctx, match.intent, match.params);
   }
@@ -64,30 +68,28 @@ async function resolveTaxonomy(
 
   const taxonomy = ctx.plugins.termTaxonomies.get(intent.taxonomy);
   const allowedTypes = taxonomy?.entryTypes ?? [];
+  const page = parsePageParam(params.page);
 
   // Empty `allowedTypes` short-circuits — a taxonomy registered without
   // any attached entry types yields an empty archive.
-  const rows =
+  const where =
     allowedTypes.length === 0
-      ? []
-      : await ctx.db
-          .select()
-          .from(entries)
-          .where(
-            and(
-              eq(entries.status, "published"),
-              inArray(entries.type, allowedTypes),
-              inArray(
-                entries.id,
-                ctx.db
-                  .select({ id: entryTerm.entryId })
-                  .from(entryTerm)
-                  .where(eq(entryTerm.termId, term.id)),
-              ),
-            ),
-          )
-          .orderBy(desc(entries.publishedAt), desc(entries.id))
-          .limit(ARCHIVE_LIMIT);
+      ? null
+      : and(
+          eq(entries.status, "published"),
+          inArray(entries.type, allowedTypes),
+          inArray(
+            entries.id,
+            ctx.db
+              .select({ id: entryTerm.entryId })
+              .from(entryTerm)
+              .where(eq(entryTerm.termId, term.id)),
+          ),
+        );
+
+  const result = await paginatedEntries(ctx, where, page);
+  if (result.outOfRange) return notFound("public-term-page-out-of-range");
+  const rows = result.rows;
 
   // Run plugin filters before render so plugins can mutate the resolved
   // shape (drop entries, append plugin-contributed fields, etc.) without
@@ -145,15 +147,17 @@ async function resolveSingle(
 async function resolveArchive(
   ctx: AppContext,
   intent: Extract<RouteIntent, { kind: "archive" }>,
+  params: Record<string, string>,
 ): Promise<Response> {
-  const rows = await ctx.db
-    .select()
-    .from(entries)
-    .where(
-      and(eq(entries.type, intent.entryType), eq(entries.status, "published")),
-    )
-    .orderBy(desc(entries.publishedAt), desc(entries.id))
-    .limit(ARCHIVE_LIMIT);
+  const page = parsePageParam(params.page);
+  const where = and(
+    eq(entries.type, intent.entryType),
+    eq(entries.status, "published"),
+  );
+
+  const result = await paginatedEntries(ctx, where, page);
+  if (result.outOfRange) return notFound("public-archive-page-out-of-range");
+  const rows = result.rows;
 
   // Set after the query so a thrown query doesn't leave a stale entity
   // on ctx for any downstream middleware (logging, error pages) that
@@ -169,6 +173,50 @@ async function resolveArchive(
       ? `<h1>${escapeHtml(title)}</h1><p>No entries yet.</p>`
       : `<h1>${escapeHtml(title)}</h1><ul>${rows.map((row) => renderArchiveItem(row, baseSlug)).join("")}</ul>`;
   return htmlResponse(title, body);
+}
+
+// URL :page captures are always strings; invalid input (non-numeric,
+// negative, zero) coerces to NaN/<1 and flows into paginate() which
+// marks it out-of-range and triggers a 404. Default 1 when the bare
+// archive matched (no /page/N).
+function parsePageParam(raw: string | undefined): number {
+  return raw === undefined ? 1 : Number(raw);
+}
+
+/**
+ * Shared paginated-entries query used by archive and taxonomy
+ * resolvers. Returns `{ outOfRange: true }` so the caller can pick the
+ * 404 reason. `where === null` short-circuits to an empty result with
+ * no DB round-trip — used by the taxonomy resolver when a taxonomy is
+ * registered without any attached entry types.
+ */
+async function paginatedEntries(
+  ctx: AppContext,
+  where: SQL | null | undefined,
+  page: number,
+): Promise<{ readonly rows: readonly Entry[]; readonly outOfRange: boolean }> {
+  if (where == null) {
+    const slice = paginate({ page, perPage: ARCHIVE_LIMIT, total: 0 });
+    return { rows: [], outOfRange: slice.outOfRange };
+  }
+
+  const totalRow = await ctx.db
+    .select({ total: count() })
+    .from(entries)
+    .where(where);
+  const total = totalRow[0]?.total ?? 0;
+
+  const slice = paginate({ page, perPage: ARCHIVE_LIMIT, total });
+  if (slice.outOfRange) return { rows: [], outOfRange: true };
+
+  const rows = await ctx.db
+    .select()
+    .from(entries)
+    .where(where)
+    .orderBy(desc(entries.publishedAt), desc(entries.id))
+    .limit(slice.limit)
+    .offset(slice.offset);
+  return { rows, outOfRange: false };
 }
 
 function renderArchiveItem(row: Entry, baseSlug: string): string {


### PR DESCRIPTION
Implements slice 2 of #223 — `/page/N` pagination on both archive kinds shipped in #224. `/post/page/2` and `/category/javascript/page/2/` now resolve; `/page/99` returns 404; the empty-archive 200 from #224 is preserved on the implicit page 1.

## Design

- **`paginate()` is the boundary owner.** A pure helper takes `{ page, perPage, total }` and returns `{ offset, limit, totalPages, outOfRange }`. Every "is this page valid?" decision lives in one function with one set of tests — the two resolvers can't drift on edge cases. Notably, `total === 0` paginates to `outOfRange: page > 1`, so empty term archives still render the 200 empty-state page on page 1 while `/category/empty/page/2` returns 404.
- **`paginatedEntries(ctx, where, page)` is the shared query helper.** Archive and taxonomy resolvers were running the same five-step dance — build `where`, count, paginate, short-circuit on out-of-range, select with limit/offset. Lifted into one helper; callers pick their own 404 reason. A `null` where short-circuits the taxonomy case where no entry types are attached to the taxonomy.
- **Compiler emits paginated rule before the bare archive.** `/<archive>/page/:page` lands first in the registered rule list so its more-specific URLPattern is checked ahead of the bare archive. URLPattern's single-segment `:slug` / `:term` groups already prevent `/shop/page/2` from accidentally matching `/shop`; the ordering is a defensive invariant.

## Intentional spec deviations

Two notes for the reviewer — both deliberate, both with rationale:

1. **`posts_per_page` option is deferred.** The issue acceptance criteria say "per-page cap, default 10, configurable via `posts_per_page` option". This PR keeps the hardcoded `ARCHIVE_LIMIT = 20` from #224. Building out the options/settings machinery is orthogonal scope (touches the settings registry, admin UI, and option-resolution path) and isn't blocking pagination semantics. Suggested as a follow-up once the settings surface lands.
2. **`RouteIntent` does not carry `page`.** The issue acceptance criteria say "RouteIntent.archive gains `page: number`; taxonomy gains `page: number`". This PR keeps URL params on `RouteMatch.params` — consistent with #224's decision (and the comment now baked into `intent.ts`) that "the intent describes the route shape, the match carries the request". `page` is a URL parameter, not a route-shape descriptor. Resolvers read `params.page` and coerce via `parsePageParam`.

## Out of scope

- Hierarchical `/page/N` URLs like `/region/europe/france/page/2/` land in #226 (hierarchical forward-routing).
- The `examples/blog/e2e/` Playwright spec gated on #227 will extend to cover pagination once that harness lands.

## Coverage

1300 tests passing, lint + typecheck + knip + format all clean.

- 8 `paginate` unit tests covering page 1/2/N, totalPages boundary, empty results page 1 vs page > 1, negative / zero / NaN / non-integer input.
- 2 compiler tests for the new `/page/:page` rule emission on archive and taxonomy, plus 4 fixture updates for existing tests that asserted exact rule-list shape.
- 8 resolver integration tests against in-memory D1: archive page=2 slice, archive page > totalPages 404, taxonomy page=2 slice, taxonomy page > totalPages 404, empty archive page=1 200 (regression), empty term page=1 200 (regression), non-numeric `:page` 404, explicit `/page/1` matches the bare archive byte-for-byte.

## Pre-PR QA

- `sentry-skills:find-bugs` — zero correctness or security findings. Boundary inputs (Infinity, scientific notation, hex, MAX_SAFE_INTEGER, BigInt-from-D1) all flow into the `paginate()` gate or fall through to existing 404 paths.
- `sentry-skills:code-simplifier` — caught duplicated query dance between the two resolvers; applied the `paginatedEntries` extraction in the same PR. Also collapsed a redundant `Number.isFinite` branch in `parsePageParam`.
- `sentry-skills:code-review` — flagged the two intentional spec deviations above (now noted in this description) and two missing integration tests (non-numeric `:page` + explicit `/page/1`); both added.

Fixes #225
Refs #223