### PR TITLE
feat(core): hierarchical forward-routing for entries and taxonomies

### DIFF
--- a/packages/core/src/route/compile.test.ts
+++ b/packages/core/src/route/compile.test.ts
@@ -46,6 +46,40 @@ describe("compileRouteMap", () => {
     expect(paginated?.priority).toBe(50);
   });
 
+  test("hierarchical taxonomy emits /<base>/:path+ and /<base>/:path+/page/:page", async () => {
+    const registry = await buildRegistry([
+      definePlugin("geo", (ctx) => {
+        ctx.registerTermTaxonomy("region", {
+          label: "Regions",
+          isHierarchical: true,
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    expect(patterns).toContain("/region/:path+");
+    expect(patterns).toContain("/region/:path+/page/:page");
+    expect(patterns).not.toContain("/region/:term");
+    expect(patterns).not.toContain("/region/:term/page/:page");
+  });
+
+  test("taxonomy with rewrite.isHierarchical:false keeps flat :term even when isHierarchical:true", async () => {
+    const registry = await buildRegistry([
+      definePlugin("geo", (ctx) => {
+        ctx.registerTermTaxonomy("region", {
+          label: "Regions",
+          isHierarchical: true,
+          rewrite: { isHierarchical: false },
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    expect(patterns).toContain("/region/:term");
+    expect(patterns).toContain("/region/:term/page/:page");
+    expect(patterns).not.toContain("/region/:path+");
+  });
+
   test("honors taxonomy rewrite.slug on the term-archive pattern", async () => {
     const registry = await buildRegistry([
       definePlugin("regions", (ctx) => {
@@ -106,6 +140,41 @@ describe("compileRouteMap", () => {
     expect(termIdx).toBeGreaterThanOrEqual(0);
     expect(singleIdx).toBeGreaterThanOrEqual(0);
     expect(termIdx).toBeLessThan(singleIdx);
+  });
+
+  test("hierarchical entry type emits /<base>/:path+ instead of /<base>/:slug", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    expect(patterns).toContain("/page/:path+");
+    expect(patterns).not.toContain("/page/:slug");
+    const single = map.find((r) => r.rawPattern === "/page/:path+");
+    expect(single?.intent).toEqual({ kind: "single", entryType: "page" });
+  });
+
+  test("entry type with rewrite.isHierarchical:false keeps flat :slug even when data is hierarchical", async () => {
+    const registry = await buildRegistry([
+      definePlugin("docs", (ctx) => {
+        ctx.registerEntryType("doc", {
+          label: "Docs",
+          isPublic: true,
+          isHierarchical: true,
+          rewrite: { isHierarchical: false },
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    expect(patterns).toContain("/doc/:slug");
+    expect(patterns).not.toContain("/doc/:path+");
   });
 
   test("auto-generates /{type}/:slug from a registered post type", async () => {

--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -84,7 +84,14 @@ function autoRulesForEntryType(entryType: RegisteredEntryType): CompiledRule[] {
     });
   }
 
-  const singlePattern = baseSlug === "" ? "/:slug" : `/${baseSlug}/:slug`;
+  // Hierarchical entry types match nested URLs like /about/team/leadership
+  // via URLPattern's `:path+` catch-all. Plugins can opt out per-type
+  // (rewrite.isHierarchical: false), which keeps the flat `:slug` pattern
+  // even when the data is hierarchical — same opt-out semantics
+  // `buildEntryPermalink` honors via `shouldNestUnderEntryParent`.
+  const capture = exposesHierarchicalUrls(entryType) ? ":path+" : ":slug";
+  const singlePattern =
+    baseSlug === "" ? `/${capture}` : `/${baseSlug}/${capture}`;
   rules.push({
     pattern: new URLPattern({ pathname: singlePattern }),
     rawPattern: singlePattern,
@@ -96,11 +103,31 @@ function autoRulesForEntryType(entryType: RegisteredEntryType): CompiledRule[] {
   return rules;
 }
 
+/**
+ * True when a registered entry type or taxonomy exposes nested URLs via
+ * `:path+`. `isHierarchical: true` is the data flag (the tree exists);
+ * `rewrite.isHierarchical: false` opts URLs back to the flat single-
+ * segment pattern even when the data is hierarchical — same opt-out the
+ * outbound permalink helpers honor.
+ */
+function exposesHierarchicalUrls(spec: {
+  readonly isHierarchical?: boolean;
+  readonly rewrite?: { readonly isHierarchical?: boolean };
+}): boolean {
+  if (spec.isHierarchical !== true) return false;
+  return spec.rewrite?.isHierarchical !== false;
+}
+
 function autoRulesForTermTaxonomy(
   taxonomy: RegisteredTermTaxonomy,
 ): CompiledRule[] {
   const baseSlug = taxonomy.rewrite?.slug ?? taxonomy.name;
-  const basePattern = `/${baseSlug}/:term`;
+  // Mirror the entry-type branch: hierarchical taxonomies expose nested
+  // term URLs via `:path+` (e.g. /region/europe/france); the
+  // rewrite.isHierarchical:false override keeps the flat `:term` shape
+  // even when the term tree itself is hierarchical.
+  const capture = exposesHierarchicalUrls(taxonomy) ? ":path+" : ":term";
+  const basePattern = `/${baseSlug}/${capture}`;
   const paginatedPattern = `${basePattern}/page/:page`;
   const intent: RouteIntent = { kind: "taxonomy", taxonomy: taxonomy.name };
   return [

--- a/packages/core/src/route/path-chain.ts
+++ b/packages/core/src/route/path-chain.ts
@@ -1,0 +1,89 @@
+/**
+ * Inbound counterpart to `permalink.ts` — given the segments captured
+ * by a `:path+` URLPattern match, find the leaf entity (entry or term)
+ * whose parent chain exactly matches the URL.
+ *
+ * The leaf is looked up by `(table, slug)` (single indexed lookup); for
+ * multi-segment URLs the leaf's ancestor chain is then loaded via the
+ * same recursive CTE `buildEntryPermalink` / `buildTermArchiveUrl` use
+ * to produce nested URLs in the outbound direction. The two sides
+ * round-trip on the same data.
+ *
+ * Returns `null` on any chain mismatch (extra segments, missing
+ * intermediate, wrong ancestor slug). The route matcher falls through
+ * to the next rule rather than 404'ing — WordPress's first-match-wins
+ * semantics.
+ */
+
+import type { AppContext } from "../context/app.js";
+import type { Entry } from "../db/schema/entries.js";
+import type { Term } from "../db/schema/terms.js";
+import { and, eq } from "../db/index.js";
+import { entries } from "../db/schema/entries.js";
+import { terms } from "../db/schema/terms.js";
+import { loadAncestorSlugs, loadTermAncestorSlugs } from "./permalink.js";
+
+export async function findEntryByPath(
+  ctx: AppContext,
+  entryType: string,
+  segments: readonly string[],
+): Promise<Entry | null> {
+  if (segments.length === 0) return null;
+  // Reject any empty segment — malformed URLs like /page/a//b split to
+  // ["a", "", "b"] which could match against a hypothetical empty-slug
+  // entry. Defense-in-depth: the slug columns are NOT NULL but don't
+  // forbid the empty string.
+  if (segments.some((segment) => segment === "")) return null;
+  const leafSlug = segments[segments.length - 1];
+  if (leafSlug === undefined) return null;
+
+  const leaf = await ctx.db.query.entries.findFirst({
+    where: and(
+      eq(entries.type, entryType),
+      eq(entries.slug, leafSlug),
+      eq(entries.status, "published"),
+    ),
+  });
+  if (!leaf) return null;
+
+  const expected = segments.slice(0, -1);
+  const actual =
+    leaf.parentId === null ? [] : await loadAncestorSlugs(ctx, leaf.parentId);
+
+  return chainsMatch(actual, expected) ? leaf : null;
+}
+
+export async function findTermByPath(
+  ctx: AppContext,
+  taxonomy: string,
+  segments: readonly string[],
+): Promise<Term | null> {
+  if (segments.length === 0) return null;
+  if (segments.some((segment) => segment === "")) return null;
+  const leafSlug = segments[segments.length - 1];
+  if (leafSlug === undefined) return null;
+
+  const leaf = await ctx.db.query.terms.findFirst({
+    where: and(eq(terms.taxonomy, taxonomy), eq(terms.slug, leafSlug)),
+  });
+  if (!leaf) return null;
+
+  const expected = segments.slice(0, -1);
+  const actual =
+    leaf.parentId === null
+      ? []
+      : await loadTermAncestorSlugs(ctx, leaf.parentId);
+
+  return chainsMatch(actual, expected) ? leaf : null;
+}
+
+function chainsMatch(
+  actual: readonly string[],
+  expected: readonly string[],
+): boolean {
+  if (actual.length !== expected.length) return false;
+  for (let i = 0; i < expected.length; i++) {
+    if (actual[i] !== expected[i]) return false;
+  }
+  return true;
+}

--- a/packages/core/src/route/permalink.ts
+++ b/packages/core/src/route/permalink.ts
@@ -18,13 +18,6 @@ import type {
  * `ancestorSlugs` to skip the CTE when the caller already has the chain
  * loaded (e.g. a breadcrumb renderer that just walked it).
  *
- * Known gap: `compileRouteMap` currently emits `/<baseSlug>/:slug` (single
- * segment) for every entry type, including hierarchical ones. The nested
- * URLs this helper produces for hierarchical types won't match against
- * the route map until that's updated to support a `:path+` capture for
- * hierarchical types. Tracked as follow-up; non-hierarchical paths are
- * symmetric today.
- *
  * Returns `null` when the entry type is `isPublic: false` (no public
  * surface exists) or when the type isn't registered.
  */
@@ -146,7 +139,12 @@ const MAX_ANCESTOR_DEPTH = 50;
  * `entries.parent_id` chain starting from `leafParentId`, returning slugs
  * ordered root-first.
  */
-async function loadAncestorSlugs(
+/**
+ * Exported for the path-chain matcher (`path-chain.ts`) so the inbound
+ * `URL → entity` resolver can reuse the same CTE the outbound permalink
+ * helper uses. Walks ancestors root-first; one round-trip; depth-capped.
+ */
+export async function loadAncestorSlugs(
   ctx: AppContext,
   leafParentId: number,
 ): Promise<string[]> {
@@ -165,7 +163,7 @@ async function loadAncestorSlugs(
   return rows.map((r) => r.slug);
 }
 
-async function loadTermAncestorSlugs(
+export async function loadTermAncestorSlugs(
   ctx: AppContext,
   leafParentId: number,
 ): Promise<string[]> {

--- a/packages/core/src/route/resolve.test.ts
+++ b/packages/core/src/route/resolve.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "vitest";
 
+import type { AppContext } from "../context/app.js";
 import { definePlugin } from "../plugin/define.js";
 import { createDispatcherHarness } from "../test/dispatcher.js";
+import { buildEntryPermalink, buildTermArchiveUrl } from "./permalink.js";
 
 const blogPlugin = definePlugin("blog", (ctx) => {
   ctx.registerEntryType("post", {
@@ -24,6 +26,178 @@ const TIPTAP_BODY = {
   type: "doc",
   content: [{ type: "paragraph", content: [{ type: "text", text: "Body." }] }],
 };
+
+const hierarchicalPagesPlugin = definePlugin("pages", (ctx) => {
+  ctx.registerEntryType("page", {
+    label: "Pages",
+    isPublic: true,
+    isHierarchical: true,
+  });
+});
+
+describe("resolvePublicRoute — hierarchical single", () => {
+  test("top-level /<base>/leaf resolves the entry with no parent", async () => {
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalPagesPlugin],
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "page",
+      slug: "about",
+      title: "About",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: null,
+    });
+    const response = await h.dispatch(
+      new Request("https://cms.example/page/about"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<h1>About</h1>");
+  });
+
+  test("nested /<base>/parent/leaf resolves the entry by walking the chain", async () => {
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalPagesPlugin],
+    });
+    const author = await h.seedUser("admin");
+    const about = await h.factory.entry.create({
+      type: "page",
+      slug: "about",
+      title: "About",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: null,
+    });
+    const team = await h.factory.entry.create({
+      type: "page",
+      slug: "team",
+      title: "Team",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: about.id,
+    });
+    await h.factory.entry.create({
+      type: "page",
+      slug: "leadership",
+      title: "Leadership",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: team.id,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/page/about/team/leadership"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<h1>Leadership</h1>");
+  });
+
+  test("URL with mismatched ancestor returns 404", async () => {
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalPagesPlugin],
+    });
+    const author = await h.seedUser("admin");
+    const about = await h.factory.entry.create({
+      type: "page",
+      slug: "about",
+      title: "About",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: null,
+    });
+    await h.factory.entry.create({
+      type: "page",
+      slug: "team",
+      title: "Team",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: about.id,
+    });
+    // "team" exists under "about", not under "wrong" — chain mismatch.
+    const response = await h.dispatch(
+      new Request("https://cms.example/page/wrong/team"),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("buildEntryPermalink round-trips through the route map (closes permalink.ts:21-26 gap)", async () => {
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalPagesPlugin],
+    });
+    const author = await h.seedUser("admin");
+    const about = await h.factory.entry.create({
+      type: "page",
+      slug: "about",
+      title: "About",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: null,
+    });
+    const team = await h.factory.entry.create({
+      type: "page",
+      slug: "team",
+      title: "Team",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: about.id,
+    });
+    const leadership = await h.factory.entry.create({
+      type: "page",
+      slug: "leadership",
+      title: "Leadership",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: team.id,
+    });
+
+    const ctx = { db: h.db, plugins: h.app.plugins } as unknown as AppContext;
+    const url = await buildEntryPermalink(ctx, {
+      type: "page",
+      slug: leadership.slug,
+      parentId: leadership.parentId,
+    });
+    expect(url).toBe("/page/about/team/leadership");
+
+    const response = await h.dispatch(new Request(`https://cms.example${url}`));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<h1>Leadership</h1>");
+  });
+
+  test("top-level URL with extra ancestor segments returns 404", async () => {
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalPagesPlugin],
+    });
+    const author = await h.seedUser("admin");
+    // "about" is top-level (no parent). /page/foo/about should 404 —
+    // it claims "about" has parent "foo", which is wrong.
+    await h.factory.entry.create({
+      type: "page",
+      slug: "about",
+      title: "About",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: null,
+    });
+    const response = await h.dispatch(
+      new Request("https://cms.example/page/foo/about"),
+    );
+    expect(response.status).toBe(404);
+  });
+});
 
 describe("resolvePublicRoute — single", () => {
   test("renders title + walked content for a published post", async () => {
@@ -481,6 +655,171 @@ describe("resolvePublicRoute — taxonomy", () => {
     expect(response.status).toBe(200);
     const body = await response.text();
     expect(body).toContain("No entries yet.");
+  });
+
+  test("hierarchical taxonomy /<base>/parent/leaf resolves the nested term", async () => {
+    const hierarchicalTaxPlugin = definePlugin("geo", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+      });
+      ctx.registerTermTaxonomy("region", {
+        label: "Regions",
+        isHierarchical: true,
+        entryTypes: ["post"],
+      });
+    });
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalTaxPlugin],
+    });
+    const author = await h.seedUser("admin");
+    const europe = await h.factory.term.create({
+      taxonomy: "region",
+      slug: "europe",
+      name: "Europe",
+    });
+    const france = await h.factory.term.create({
+      taxonomy: "region",
+      slug: "france",
+      name: "France",
+      parentId: europe.id,
+    });
+    const post = await h.factory.entry.create({
+      type: "post",
+      slug: "wine",
+      title: "Wine",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entryTerm.create({ entryId: post.id, termId: france.id });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/region/europe/france"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<h1>France</h1>");
+    expect(body).toContain("Wine");
+  });
+
+  test("buildTermArchiveUrl round-trips through the route map", async () => {
+    const hierarchicalTaxPlugin = definePlugin("geo", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerTermTaxonomy("region", {
+        label: "Regions",
+        isHierarchical: true,
+        entryTypes: ["post"],
+      });
+    });
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalTaxPlugin],
+    });
+    const europe = await h.factory.term.create({
+      taxonomy: "region",
+      slug: "europe",
+      name: "Europe",
+    });
+    const france = await h.factory.term.create({
+      taxonomy: "region",
+      slug: "france",
+      name: "France",
+      parentId: europe.id,
+    });
+
+    const ctx = { db: h.db, plugins: h.app.plugins } as unknown as AppContext;
+    const url = await buildTermArchiveUrl(ctx, {
+      taxonomy: "region",
+      slug: france.slug,
+      parentId: france.parentId,
+    });
+    expect(url).toBe("/region/europe/france");
+
+    const response = await h.dispatch(new Request(`https://cms.example${url}`));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("<h1>France</h1>");
+  });
+
+  test("paginated hierarchical taxonomy resolves /region/europe/france/page/2", async () => {
+    const hierarchicalTaxPlugin = definePlugin("geo", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerTermTaxonomy("region", {
+        label: "Regions",
+        isHierarchical: true,
+        entryTypes: ["post"],
+      });
+    });
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalTaxPlugin],
+    });
+    const author = await h.seedUser("admin");
+    const europe = await h.factory.term.create({
+      taxonomy: "region",
+      slug: "europe",
+      name: "Europe",
+    });
+    const france = await h.factory.term.create({
+      taxonomy: "region",
+      slug: "france",
+      name: "France",
+      parentId: europe.id,
+    });
+    for (let i = 1; i <= 25; i++) {
+      const post = await h.factory.entry.create({
+        type: "post",
+        slug: `p-${String(i).padStart(2, "0")}`,
+        title: `Wine ${String(i).padStart(2, "0")}`,
+        content: null,
+        status: "published",
+        authorId: author.id,
+        publishedAt: new Date(`2026-04-${String(i).padStart(2, "0")}`),
+      });
+      await h.factory.entryTerm.create({ entryId: post.id, termId: france.id });
+    }
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/region/europe/france/page/2"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    // perPage=20, page 2 shows the oldest 5.
+    expect(body).toContain("Wine 05");
+    expect(body).toContain("Wine 01");
+    expect(body).not.toContain("Wine 25");
+    expect(body).not.toContain("Wine 06");
+  });
+
+  test("hierarchical taxonomy with mismatched ancestor returns 404", async () => {
+    const hierarchicalTaxPlugin = definePlugin("geo", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerTermTaxonomy("region", {
+        label: "Regions",
+        isHierarchical: true,
+        entryTypes: ["post"],
+      });
+    });
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalTaxPlugin],
+    });
+    const europe = await h.factory.term.create({
+      taxonomy: "region",
+      slug: "europe",
+      name: "Europe",
+    });
+    await h.factory.term.create({
+      taxonomy: "region",
+      slug: "france",
+      name: "France",
+      parentId: europe.id,
+    });
+    // /region/asia/france — "france" exists under "europe", not "asia".
+    const response = await h.dispatch(
+      new Request("https://cms.example/region/asia/france"),
+    );
+    expect(response.status).toBe(404);
   });
 
   test("draft entries tagged with the term are excluded", async () => {

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -12,6 +12,7 @@ import { entryTerm } from "../db/schema/entry_term.js";
 import { terms } from "../db/schema/terms.js";
 import { notFound } from "../runtime/http.js";
 import { paginate } from "./paginate.js";
+import { findEntryByPath, findTermByPath } from "./path-chain.js";
 import {
   escapeAttr,
   escapeHtml,
@@ -54,14 +55,9 @@ async function resolveTaxonomy(
   intent: Extract<RouteIntent, { kind: "taxonomy" }>,
   params: Record<string, string>,
 ): Promise<Response> {
-  const slug = params.term;
-  if (typeof slug !== "string" || slug === "") {
-    return notFound("public-route-term-missing");
-  }
-
-  const term = await ctx.db.query.terms.findFirst({
-    where: and(eq(terms.taxonomy, intent.taxonomy), eq(terms.slug, slug)),
-  });
+  // Same dispatch as resolveSingle: `:path+` rules surface params.path
+  // (multi-segment), flat `:term` rules surface params.term.
+  const term = await findTermForTaxonomy(ctx, intent.taxonomy, params);
   if (!term) return notFound("public-term-not-found");
 
   ctx.resolvedEntity = { kind: "term", id: term.id };
@@ -121,18 +117,11 @@ async function resolveSingle(
   intent: Extract<RouteIntent, { kind: "single" }>,
   params: Record<string, string>,
 ): Promise<Response> {
-  const slug = params.slug;
-  if (typeof slug !== "string" || slug === "") {
-    return notFound("public-route-slug-missing");
-  }
-
-  const row = await ctx.db.query.entries.findFirst({
-    where: and(
-      eq(entries.type, intent.entryType),
-      eq(entries.slug, slug),
-      eq(entries.status, "published"),
-    ),
-  });
+  // `:path+` rules surface their capture as `params.path` (multi-segment);
+  // flat `:slug` rules surface a single segment as `params.slug`. The
+  // route compiler picks the capture name based on rewrite.isHierarchical
+  // — the resolver dispatches off whichever one was set.
+  const row = await findEntryForSingle(ctx, intent.entryType, params);
   if (!row) return notFound("public-post-not-found");
 
   // Stash the matched entity so render-side helpers (menu plugin's
@@ -181,6 +170,46 @@ async function resolveArchive(
 // archive matched (no /page/N).
 function parsePageParam(raw: string | undefined): number {
   return raw === undefined ? 1 : Number(raw);
+}
+
+async function findEntryForSingle(
+  ctx: AppContext,
+  entryType: string,
+  params: Record<string, string>,
+): Promise<Entry | null> {
+  const path = params.path;
+  if (typeof path === "string" && path !== "") {
+    return findEntryByPath(ctx, entryType, path.split("/"));
+  }
+  const slug = params.slug;
+  if (typeof slug !== "string" || slug === "") return null;
+  return (
+    (await ctx.db.query.entries.findFirst({
+      where: and(
+        eq(entries.type, entryType),
+        eq(entries.slug, slug),
+        eq(entries.status, "published"),
+      ),
+    })) ?? null
+  );
+}
+
+async function findTermForTaxonomy(
+  ctx: AppContext,
+  taxonomy: string,
+  params: Record<string, string>,
+): Promise<Term | null> {
+  const path = params.path;
+  if (typeof path === "string" && path !== "") {
+    return findTermByPath(ctx, taxonomy, path.split("/"));
+  }
+  const slug = params.term;
+  if (typeof slug !== "string" || slug === "") return null;
+  return (
+    (await ctx.db.query.terms.findFirst({
+      where: and(eq(terms.taxonomy, taxonomy), eq(terms.slug, slug)),
+    })) ?? null
+  );
 }
 
 /**


### PR DESCRIPTION
Implements slice 3 of #223 — closes the `permalink.ts:21-26` forward-routing gap. URLs like `/about/team/leadership` (hierarchical pages) and `/region/europe/france` (hierarchical taxonomies) now resolve correctly via the route map. `buildEntryPermalink` and `buildTermArchiveUrl` round-trip end-to-end.

## Design

- **Compiler** branches on `isHierarchical && rewrite.isHierarchical !== false` (same predicate the outbound permalink helpers honor via `shouldNestUnderEntryParent`). Emits `URLPattern :path+` catch-all for both entry types and taxonomies. Taxonomies also get the paginated `/<base>/:path+/page/:page` variant on top of the bare hierarchical rule — nested term archives can paginate the same way flat ones do (slice 2). The two predicates collapse into one structural `exposesHierarchicalUrls` helper.
- **Path-chain matcher** (`route/path-chain.ts`) is the inbound counterpart to `permalink.ts`. `findEntryByPath` / `findTermByPath` take the segment list URLPattern captured, look up the leaf entity via the indexed `(table, slug)` query, then validate the parent chain by reusing the same recursive CTE the outbound helpers already use. Mismatch returns `null` so the route matcher falls through to the next rule — WP first-match-wins.
- **Resolver dispatch** in `resolveSingle` / `resolveTaxonomy` is a small fork: `params.path` (from `:path+`) routes to the matcher; `params.slug` / `params.term` keep the existing single-lookup path. Pagination flows through unchanged since `params.page` lives in the same params bag.

## Coverage

1313 tests passing; lint + typecheck + knip + format all clean.

- 4 compiler tests: hierarchical entry `:path+` emission, entry opt-out via `rewrite.isHierarchical:false`, hierarchical taxonomy emits bare + paginated `:path+`, taxonomy opt-out.
- 7 resolver integration tests against in-memory D1: top-level hierarchical URL → leaf entry, nested 3-segment URL walks the chain, ancestor mismatch returns 404, top-level URL with extra ancestor segments returns 404, hierarchical taxonomy resolves nested term + its entries, hierarchical taxonomy ancestor mismatch returns 404, paginated hierarchical taxonomy URL composes all three (matcher + pagination + cross-entry-type).
- 2 round-trip tests: `buildEntryPermalink(entry)` and `buildTermArchiveUrl(term)` produce URLs that dispatch back to the same entity. This is the explicit closing of `permalink.ts:21-26`.

## Pre-PR QA

- `sentry-skills:find-bugs` — zero critical/high findings. One low-severity defense-in-depth note (malformed URLs with empty segments could theoretically match a hypothetical empty-slug entry) applied in-PR as an upfront segment guard.
- `sentry-skills:code-simplifier` — caught the duplicated hierarchical predicate; consolidated into `exposesHierarchicalUrls`. The findEntry/findTerm pair stays separate (entity-type symmetry is foundational in the codebase; generic extraction would obscure intent).
- `sentry-skills:code-review` — flagged two missing tests (taxonomy round-trip + paginated hierarchical taxonomy). Both added pre-PR.

## Spec note

Acceptance criteria #6 mentions emitting `/<base>/:path+/page/:page` generically. For entries the paginated variant doesn't apply — a hierarchical entry is a singular entity (one page in a tree), not an archive that paginates. The PR emits the paginated hierarchical rule only for **taxonomies** where the nested term IS an archive of tagged entries. Same scope decision a strict WP reading produces.

Fixes #226
Refs #223