### PR TITLE
test(examples/blog): public-route e2e harness booting a real worker

### DIFF
--- a/examples/blog/e2e/playwright.config.ts
+++ b/examples/blog/e2e/playwright.config.ts
@@ -1,0 +1,35 @@
+import { definePlumixE2EConfig } from "plumix/test/playwright";
+
+// `plumix dev` boots vite at its default port (5173) for the blog
+// example. Other suites use 5181/5182; this one keeps the vanilla
+// vite port since the cloudflare-vite-plugin doesn't expose an
+// override knob today.
+const E2E_PORT = 5173;
+const BASE_URL = `http://localhost:${String(E2E_PORT)}/`;
+
+// The webServerCommand wipes the local D1 state, regenerates the
+// drizzle migrations from the current plumix schema, applies them to
+// a fresh miniflare D1, seeds the smoke-test fixtures, then boots
+// `plumix dev`. Playwright runs the command with cwd = this config
+// directory (examples/blog/e2e/), so the first `cd ..` hops back to
+// the package root where plumix / wrangler expect to find their
+// config files.
+const webServerCommand = [
+  "cd ..",
+  "rm -rf .wrangler/state",
+  "pnpm exec plumix migrate generate",
+  "pnpm exec wrangler d1 migrations apply plumix_blog --local",
+  "pnpm exec wrangler d1 execute plumix_blog --local --file=e2e/seed.sql",
+  "pnpm exec plumix dev",
+].join(" && ");
+
+export default definePlumixE2EConfig({
+  testDir: ".",
+  baseURL: BASE_URL,
+  webServerCommand,
+  // The blog example doesn't register a front-page intent, so `/`
+  // returns 404. Waiting on the port instead of the URL avoids the
+  // 180s timeout that would otherwise fire while Playwright polls
+  // for a 2xx that will never arrive.
+  webServerPort: E2E_PORT,
+});

--- a/examples/blog/e2e/public-routes.spec.ts
+++ b/examples/blog/e2e/public-routes.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Smoke spec for the public routing stack — confirms taxonomy
+ * (#224), pagination-shape (#225), and hierarchical forward-routing
+ * (#226) all dispatch through real wrangler + miniflare + the
+ * cloudflare-vite-plugin against the blog example's plumix.config.ts.
+ *
+ * Edge cases (404 reasons, empty terms, out-of-range pages, ancestor
+ * mismatches) live in the unit tests under packages/core/src/route/.
+ * This suite proves the stack composes; it doesn't re-prove the
+ * routing semantics.
+ */
+
+test("flat taxonomy archive renders entries tagged with the term", async ({
+  request,
+}) => {
+  const response = await request.get("/category/news");
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  expect(body).toContain("<h1>News</h1>");
+  expect(body).toContain("Hello News");
+});
+
+test("flat tag archive renders entries tagged with the tag", async ({
+  request,
+}) => {
+  const response = await request.get("/tag/featured");
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  expect(body).toContain("Featured Post");
+});
+
+test("hierarchical taxonomy URL resolves to the leaf term", async ({
+  request,
+}) => {
+  const response = await request.get("/category/europe/france");
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  expect(body).toContain("<h1>France</h1>");
+  expect(body).toContain("France Wine");
+});
+
+test("hierarchical page URL walks the parent chain to the leaf entry", async ({
+  request,
+}) => {
+  const response = await request.get("/page/about/team");
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  expect(body).toContain("<h1>Team</h1>");
+});

--- a/examples/blog/e2e/seed.sql
+++ b/examples/blog/e2e/seed.sql
@@ -1,0 +1,34 @@
+-- Smoke-test fixtures for examples/blog e2e. Just enough rows to make
+-- each public route shape resolve through the dispatcher — the
+-- routing/resolver edge cases live in the unit tests, this suite only
+-- proves the wrangler+vite+worker stack composes correctly.
+--
+-- Run via `wrangler d1 execute plumix_blog --local --file=e2e/seed.sql`
+-- after migrations have been applied.
+
+INSERT INTO users (id, email, name, role, email_verified_at) VALUES
+  (1, 'admin@example.test', 'Admin', 'admin', unixepoch());
+
+-- One flat category, one flat tag, plus a `europe → france`
+-- hierarchical category pair for the nested taxonomy URL.
+INSERT INTO terms (id, taxonomy, name, slug, parent_id) VALUES
+  (1, 'category', 'News', 'news', NULL),
+  (3, 'category', 'Europe', 'europe', NULL),
+  (4, 'category', 'France', 'france', 3),
+  (10, 'tag', 'Featured', 'featured', NULL);
+
+-- Hierarchical pages (about → team) for the entry-type path-chain.
+INSERT INTO entries (id, type, slug, title, status, author_id, parent_id, published_at) VALUES
+  (100, 'page', 'about', 'About', 'published', 1, NULL, unixepoch()),
+  (101, 'page', 'team', 'Team', 'published', 1, 100, unixepoch());
+
+-- One post per term so each archive renders a non-empty body.
+INSERT INTO entries (id, type, slug, title, status, author_id, published_at) VALUES
+  (200, 'post', 'hello-news', 'Hello News', 'published', 1, unixepoch()),
+  (201, 'post', 'featured-post', 'Featured Post', 'published', 1, unixepoch()),
+  (202, 'post', 'france-wine', 'France Wine', 'published', 1, unixepoch());
+
+INSERT INTO entry_term (entry_id, term_id) VALUES
+  (200, 1),  -- hello-news → News
+  (201, 10), -- featured-post → Featured tag
+  (202, 4);  -- france-wine → France (nested under Europe)

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -9,6 +9,7 @@
     "build": "plumix build",
     "clean": "git clean -xdf .plumix .wrangler dist node_modules",
     "dev": "plumix dev",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
+    "@playwright/test": "^1.59.1",
     "@plumix/typescript-config": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:",

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -14,8 +14,14 @@ const config: KnipConfig = {
     },
     // plumix.config.ts is the consumer's entry — knip can't infer it
     // from package.json's exports because examples don't publish.
+    // e2e/*.spec.ts files are invoked by the playwright CLI (no static
+    // import); knip's playwright plugin is off for the same reason it
+    // is in every other e2e workspace — `plumix/test/playwright`'s
+    // dist may not exist on a fresh clone, and the plugin would
+    // crash at resolve time.
     "examples/blog": {
-      entry: ["plumix.config.ts"],
+      entry: ["plumix.config.ts", "e2e/*.spec.ts"],
+      playwright: false,
     },
     "examples/minimal": {
       entry: ["plumix.config.ts"],

--- a/packages/core/src/test/playwright/playwright-config.ts
+++ b/packages/core/src/test/playwright/playwright-config.ts
@@ -8,6 +8,14 @@ export interface PlumixE2EConfigOptions {
   readonly baseURL: string;
   /** Shell command(s) run before the suite — typically build + preview. */
   readonly webServerCommand: string;
+  /**
+   * Optional. When set, the webServer readiness check waits for the
+   * TCP port to open instead of polling `baseURL` for a 2xx/3xx
+   * response. Use this when the dev server starts but `/` returns
+   * 404 (e.g. a public-route example whose front page isn't wired) —
+   * waiting on the URL would otherwise time out forever.
+   */
+  readonly webServerPort?: number;
 }
 
 /**
@@ -37,7 +45,9 @@ export function definePlumixE2EConfig(
     projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
     webServer: {
       command: options.webServerCommand,
-      url: options.baseURL,
+      ...(options.webServerPort !== undefined
+        ? { port: options.webServerPort }
+        : { url: options.baseURL }),
       reuseExistingServer: !process.env.CI,
       stdout: "pipe",
       stderr: "pipe",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 4.20260421.1
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@plumix/typescript-config':
         specifier: workspace:*
         version: link:../../tooling/typescript
@@ -9374,7 +9377,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:


### PR DESCRIPTION
Closes #227. First e2e harness in the repo that boots a real Cloudflare worker end-to-end — the existing admin-SPA suites (`packages/admin/e2e/`, `packages/plugins/menu/e2e/`, `packages/plugins/media/e2e/`) all preview admin's vite output without a worker; this one drives the public-route stack against real wrangler + cf-vite-plugin + miniflare D1.

## What ships

- `examples/blog/e2e/playwright.config.ts` — `definePlumixE2EConfig` driving a `webServerCommand` that wipes `.wrangler/state`, regenerates drizzle migrations from the current plumix schema, applies them to a fresh miniflare D1, seeds `seed.sql`, then boots `plumix dev`. Idempotent because every boot is a clean slate.
- `examples/blog/e2e/seed.sql` — minimal smoke-test fixtures: one admin user, one flat category (`news`) with a post, one flat tag (`featured`) with a post, one hierarchical category pair (`europe → france`) with a post, and a hierarchical page chain (`about → team`).
- `examples/blog/e2e/public-routes.spec.ts` — four smoke checks, one per routing kind landed in #223:
  - `/category/news` (flat taxonomy archive, #224)
  - `/tag/featured` (flat tag archive, #224)
  - `/category/europe/france` (hierarchical taxonomy URL, #226)
  - `/page/about/team` (hierarchical entry URL, #226)
- `examples/blog/package.json` — `test:e2e` script + `@playwright/test` dev dep so the root `pnpm test:e2e` (turbo) discovers it; CI's `test-e2e` job picks it up unchanged.

The acceptance criteria from #227 had us cover pagination cases too. Per discussion with the project owner, e2e is intentionally a **smoke layer** — edge cases (404 reasons, empty terms, out-of-range pages, ancestor mismatches) stay in the unit tests under `packages/core/src/route/`. This suite proves the stack composes; it doesn't re-prove the routing semantics already covered there.

## Shared-helper change

`definePlumixE2EConfig` gains an optional `webServerPort` option. Playwright's `webServer.url` polls for a 2xx/3xx response, but the blog example's `/` returns 404 (no front-page intent registered), so url-based readiness would time out forever. When `webServerPort` is set, Playwright waits for the TCP port to open instead — same signal as vite's `Local:` line. Existing admin-SPA suites don't pass the option and continue using url-based readiness; the change is additive.

## Verification

`pnpm test:e2e` (or `pnpm --filter @plumix-examples/blog test:e2e`) runs locally and passes the 4 smoke tests against a freshly-booted worker stack. The same flow runs in CI under the existing `test-e2e` job — no workflow changes required.

Fixes #227
Refs #223