### PR TITLE
feat(plugin-audit-log): worker-driven e2e + two latent admin/migration bug fixes

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -35,6 +35,9 @@ const config: KnipConfig = {
     "packages/plugins/menu/playground": {
       entry: ["plumix.config.ts"],
     },
+    "packages/plugins/audit-log/playground": {
+      entry: ["plumix.config.ts"],
+    },
     // @plumix/core is a dependency but has no real imports yet (empty skeleton).
     // Remove these once packages have actual code importing from core.
     "packages/blocks": {
@@ -146,7 +149,15 @@ const config: KnipConfig = {
     // at consumer build time; `./server` subpath is consumer-facing
     // for themes that need server-only helpers.
     "packages/plugins/audit-log": {
-      entry: ["src/index.ts", "src/admin/index.tsx", "src/server/index.ts"],
+      entry: [
+        "src/index.ts",
+        "src/admin/index.tsx",
+        "src/server/index.ts",
+        "e2e/globalSetup.ts",
+        "e2e/*.spec.ts",
+      ],
+      // See packages/admin above for why the playwright plugin is off.
+      playwright: false,
     },
   },
 };

--- a/packages/plugins/audit-log/e2e/audit-log.spec.ts
+++ b/packages/plugins/audit-log/e2e/audit-log.spec.ts
@@ -1,0 +1,97 @@
+// Worker-driven plugin e2e (#253 / #250). Runs against the real
+// audit-log playground at `../playground` via `plumix dev`, seeded by
+// globalSetup with an admin user + storageState carrying the session
+// cookie. No RPC mocking — the spec exercises the audit-log plugin
+// end-to-end through the actual oRPC + D1 round-trip.
+
+import { resolve } from "node:path";
+import { expect, test } from "@playwright/test";
+import { openPlaygroundDb } from "plumix/test/playwright";
+
+// Seed audit_log rows directly via D1. Audit-log hooks only fire when
+// the worker handles an action through the request pipeline; for e2e
+// rendering coverage we go around them with raw SQL so the table has
+// something to render + filter against without depending on
+// additional admin UI flows that aren't this plugin's responsibility.
+// The hook→record path is exercised by `hooks.test.ts` against an
+// in-memory db.
+async function seedAuditRows(): Promise<void> {
+  const db = await openPlaygroundDb({
+    cwd: resolve(process.cwd(), "playground"),
+  });
+  const stmt = `INSERT INTO audit_log (event, subject_type, subject_id, subject_label, actor_id, actor_label, properties) VALUES (?, ?, ?, ?, ?, ?, ?)`;
+  const seeds: readonly (readonly [string, string, string, string])[] = [
+    ["user:created", "user", "2", "alpha@example.test"],
+    ["user:updated", "user", "2", "alpha@example.test"],
+    ["entry:published", "entry", "10", "Hello world"],
+  ];
+  for (const [event, subjectType, subjectId, subjectLabel] of seeds) {
+    await db.$client.execute({
+      sql: stmt,
+      args: [
+        event,
+        subjectType,
+        subjectId,
+        subjectLabel,
+        1,
+        "user-1@example.test",
+        "{}",
+      ],
+    });
+  }
+}
+
+test.describe.serial("@plumix/plugin-audit-log — worker-driven happy path", () => {
+  test.beforeAll(seedAuditRows);
+
+  test("audit log table renders the seeded rows", async ({ page }) => {
+    await page.goto("pages/audit-log");
+    await expect(page.getByTestId("audit-log-shell")).toBeVisible();
+
+    const rows = page
+      .getByTestId("audit-log-table")
+      .locator("[data-testid^='audit-log-row-']");
+    await expect(rows).toHaveCount(3);
+    await expect(rows.nth(0)).toContainText("entry:published");
+    await expect(rows.nth(1)).toContainText("user:updated");
+    await expect(rows.nth(2)).toContainText("user:created");
+  });
+
+  test("event-prefix filter narrows the table to matching events", async ({
+    page,
+  }) => {
+    await page.goto("pages/audit-log");
+    await expect(page.getByTestId("audit-log-table")).toBeVisible();
+
+    await page
+      .getByTestId("audit-log-filter-event-prefix")
+      .selectOption("user:");
+
+    const rows = page
+      .getByTestId("audit-log-table")
+      .locator("[data-testid^='audit-log-row-']");
+    await expect(rows).toHaveCount(2);
+    await expect(rows.nth(0)).toContainText("user:updated");
+    await expect(rows.nth(1)).toContainText("user:created");
+  });
+
+  test("reset clears the filter and restores the full list", async ({
+    page,
+  }) => {
+    await page.goto("pages/audit-log");
+    await page
+      .getByTestId("audit-log-filter-event-prefix")
+      .selectOption("user:");
+    const filtered = page
+      .getByTestId("audit-log-table")
+      .locator("[data-testid^='audit-log-row-']");
+    await expect(filtered).toHaveCount(2);
+
+    await page.getByTestId("audit-log-filter-reset").click();
+
+    const rows = page
+      .getByTestId("audit-log-table")
+      .locator("[data-testid^='audit-log-row-']");
+    await expect(rows).toHaveCount(3);
+  });
+});

--- a/packages/plugins/audit-log/e2e/audit-log.spec.ts
+++ b/packages/plugins/audit-log/e2e/audit-log.spec.ts
@@ -6,39 +6,55 @@
 
 import { resolve } from "node:path";
 import { expect, test } from "@playwright/test";
+import { drizzle } from "drizzle-orm/libsql";
 import { openPlaygroundDb } from "plumix/test/playwright";
+
+import { auditLog } from "@plumix/plugin-audit-log/schema";
 
 // Seed audit_log rows directly via D1. Audit-log hooks only fire when
 // the worker handles an action through the request pipeline; for e2e
-// rendering coverage we go around them with raw SQL so the table has
-// something to render + filter against without depending on
-// additional admin UI flows that aren't this plugin's responsibility.
-// The hook→record path is exercised by `hooks.test.ts` against an
-// in-memory db.
+// rendering coverage we go around them so the table has something to
+// render + filter against without depending on additional admin UI
+// flows that aren't this plugin's responsibility. The hook→record
+// path is exercised by `hooks.test.ts` against an in-memory db.
+//
+// Insert through drizzle's typed builder against the audit-log
+// plugin's own schema so column renames / new NOT NULL fields surface
+// as a TypeScript error here, not a runtime SqliteError mid-test.
 async function seedAuditRows(): Promise<void> {
-  const db = await openPlaygroundDb({
+  const playgroundDb = await openPlaygroundDb({
     cwd: resolve(process.cwd(), "playground"),
   });
-  const stmt = `INSERT INTO audit_log (event, subject_type, subject_id, subject_label, actor_id, actor_label, properties) VALUES (?, ?, ?, ?, ?, ?, ?)`;
-  const seeds: readonly (readonly [string, string, string, string])[] = [
-    ["user:created", "user", "2", "alpha@example.test"],
-    ["user:updated", "user", "2", "alpha@example.test"],
-    ["entry:published", "entry", "10", "Hello world"],
-  ];
-  for (const [event, subjectType, subjectId, subjectLabel] of seeds) {
-    await db.$client.execute({
-      sql: stmt,
-      args: [
-        event,
-        subjectType,
-        subjectId,
-        subjectLabel,
-        1,
-        "user-1@example.test",
-        "{}",
-      ],
-    });
-  }
+  const db = drizzle(playgroundDb.$client, {
+    schema: { auditLog },
+    casing: "snake_case",
+  });
+  await db.insert(auditLog).values([
+    {
+      event: "user:created",
+      subjectType: "user",
+      subjectId: "2",
+      subjectLabel: "alpha@example.test",
+      actorId: 1,
+      actorLabel: "user-1@example.test",
+    },
+    {
+      event: "user:updated",
+      subjectType: "user",
+      subjectId: "2",
+      subjectLabel: "alpha@example.test",
+      actorId: 1,
+      actorLabel: "user-1@example.test",
+    },
+    {
+      event: "entry:published",
+      subjectType: "entry",
+      subjectId: "10",
+      subjectLabel: "Hello world",
+      actorId: 1,
+      actorLabel: "user-1@example.test",
+    },
+  ]);
 }
 
 test.describe

--- a/packages/plugins/audit-log/e2e/audit-log.spec.ts
+++ b/packages/plugins/audit-log/e2e/audit-log.spec.ts
@@ -9,7 +9,13 @@ import { expect, test } from "@playwright/test";
 import { drizzle } from "drizzle-orm/libsql";
 import { openPlaygroundDb } from "plumix/test/playwright";
 
-import { auditLog } from "@plumix/plugin-audit-log/schema";
+// Import the schema via the relative source path, not the
+// `@plumix/plugin-audit-log/schema` package-export. The export points
+// at `./dist/db/schema` which doesn't exist when CI runs lint (turbo
+// `^build` builds upstream deps but never builds the package being
+// linted), so the import would resolve to nothing and trip
+// `no-unsafe-assignment`. The source path always exists.
+import { auditLog } from "../src/db/schema.js";
 
 // Seed audit_log rows directly via D1. Audit-log hooks only fire when
 // the worker handles an action through the request pipeline; for e2e

--- a/packages/plugins/audit-log/e2e/audit-log.spec.ts
+++ b/packages/plugins/audit-log/e2e/audit-log.spec.ts
@@ -41,7 +41,8 @@ async function seedAuditRows(): Promise<void> {
   }
 }
 
-test.describe.serial("@plumix/plugin-audit-log — worker-driven happy path", () => {
+test.describe
+  .serial("@plumix/plugin-audit-log — worker-driven happy path", () => {
   test.beforeAll(seedAuditRows);
 
   test("audit log table renders the seeded rows", async ({ page }) => {

--- a/packages/plugins/audit-log/e2e/globalSetup.ts
+++ b/packages/plugins/audit-log/e2e/globalSetup.ts
@@ -1,6 +1,5 @@
 import { writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
-
 import { actingAs, openPlaygroundDb } from "plumix/test/playwright";
 
 // Runs once after the baked webServer is ready, before the spec

--- a/packages/plugins/audit-log/e2e/globalSetup.ts
+++ b/packages/plugins/audit-log/e2e/globalSetup.ts
@@ -1,0 +1,20 @@
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { actingAs, openPlaygroundDb } from "plumix/test/playwright";
+
+// Runs once after the baked webServer is ready, before the spec
+// suite. Seeds an admin user into the migrated D1, mints a session,
+// and writes the storageState.json that playwright's
+// `use.storageState` reads per-context. See menu/e2e/globalSetup.ts
+// for the cwd-anchor rationale.
+export default async function globalSetup(): Promise<void> {
+  const playgroundCwd = resolve(process.cwd(), "playground");
+  const db = await openPlaygroundDb({ cwd: playgroundCwd });
+  const { storageState } = await actingAs(db, "admin");
+  await writeFile(
+    resolve(process.cwd(), "storageState.json"),
+    JSON.stringify(storageState, null, 2),
+    "utf8",
+  );
+}

--- a/packages/plugins/audit-log/e2e/playwright.config.ts
+++ b/packages/plugins/audit-log/e2e/playwright.config.ts
@@ -1,0 +1,5 @@
+import { definePlumixE2EConfig } from "plumix/test/playwright";
+
+export default definePlumixE2EConfig({
+  playground: "../playground",
+});

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -29,6 +29,10 @@
     "./server": {
       "types": "./dist/server/index.d.ts",
       "default": "./dist/server/index.js"
+    },
+    "./schema": {
+      "types": "./dist/db/schema.d.ts",
+      "default": "./dist/db/schema.js"
     }
   },
   "files": [
@@ -48,6 +52,7 @@
     "lint": "eslint",
     "publint": "publint",
     "test": "vitest run",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
@@ -63,6 +68,7 @@
     "@arethetypeswrong/cli": "catalog:",
     "@libsql/client": "^0.17.3",
     "@orpc/server": "^1.14.3",
+    "@playwright/test": "^1.59.1",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",

--- a/packages/plugins/audit-log/playground/package.json
+++ b/packages/plugins/audit-log/playground/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@plumix/plugin-audit-log-playground",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Plumix consumer that wires only @plumix/plugin-audit-log — for worker-driven e2e + manual dogfooding",
+  "license": "MIT",
+  "scripts": {
+    "build": "plumix build",
+    "clean": "git clean -xdf .plumix .wrangler dist node_modules",
+    "dev": "plumix dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@plumix/plugin-audit-log": "workspace:*",
+    "@plumix/runtime-cloudflare": "workspace:*",
+    "plumix": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
+    "@plumix/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "wrangler": "catalog:"
+  }
+}

--- a/packages/plugins/audit-log/playground/plumix.config.ts
+++ b/packages/plugins/audit-log/playground/plumix.config.ts
@@ -1,0 +1,38 @@
+import { auth, plumix } from "plumix";
+
+import { auditLog } from "@plumix/plugin-audit-log";
+import {
+  cloudflare,
+  cloudflareDeployOrigin,
+  d1,
+} from "@plumix/runtime-cloudflare";
+
+// Plumix consumer wiring only the audit-log plugin — the smallest
+// config you can run to dogfood `@plumix/plugin-audit-log` without
+// bringing the rest of the plumix surface (blog, pages, etc.) along.
+// The worker-driven plugin e2e suite in `../e2e` boots this playground
+// via `plumix dev` and walks the audit-log happy path against the real
+// worker.
+
+const { rpId, origin } = cloudflareDeployOrigin({
+  workerName: "plumix-audit-log-playground",
+  accountSubdomain: "local",
+  // `plumix dev` binds the worker to vite's port (5173); the CSRF
+  // origin-allowlist must match what the browser actually sends.
+  // Default would be 8787 (wrangler dev), which mismatches and 403s
+  // every POST.
+  localOrigin: "http://localhost:5173",
+});
+
+export default plumix({
+  runtime: cloudflare(),
+  database: d1({ binding: "DB", session: "auto" }),
+  auth: auth({
+    passkey: {
+      rpName: "Plumix — Audit log playground",
+      rpId,
+      origin,
+    },
+  }),
+  plugins: [auditLog()],
+});

--- a/packages/plugins/audit-log/playground/tsconfig.json
+++ b/packages/plugins/audit-log/playground/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@plumix/typescript-config/base.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/workers-types"],
+    // Resolve workspace packages from `src/` (not `dist/`) — see the
+    // comment in `packages/plugins/media/playground/tsconfig.json` for
+    // the full rationale.
+    "paths": {
+      "plumix": ["../../../plumix/src/index.ts"],
+      "@plumix/plugin-audit-log": ["../src/index.ts"],
+      "@plumix/runtime-cloudflare": [
+        "../../../runtimes/cloudflare/src/index.ts"
+      ]
+    }
+  },
+  "include": ["plumix.config.ts", ".plumix"]
+}

--- a/packages/plugins/audit-log/playground/wrangler.jsonc
+++ b/packages/plugins/audit-log/playground/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://unpkg.com/wrangler/config-schema.json",
+  "name": "plumix-audit-log-playground",
+  "main": ".plumix/worker.ts",
+  "compatibility_date": "2026-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "plumix_audit_log_playground",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "drizzle",
+    },
+  ],
+  "assets": {
+    "directory": ".plumix/public",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+  },
+}

--- a/packages/plugins/audit-log/src/admin/rpc.ts
+++ b/packages/plugins/audit-log/src/admin/rpc.ts
@@ -74,7 +74,7 @@ export function useAuditLogList(
         pageParam === undefined
           ? { ...filter }
           : { ...filter, cursor: pageParam };
-      return rpcCall<AuditLogPage>("auditLog/list", input);
+      return rpcCall<AuditLogPage>("audit_log/list", input);
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,

--- a/packages/plugins/audit-log/src/index.ts
+++ b/packages/plugins/audit-log/src/index.ts
@@ -124,6 +124,11 @@ export function auditLog(options: AuditLogPluginOptions = {}) {
   return definePlugin("audit_log", {
     adminEntry: ADMIN_ENTRY_PATH,
     schema: storage.schemaModule ?? schema,
+    // Module specifier `plumix migrate generate` uses to include this
+    // plugin's table in the host's drizzle-kit codegen. Without it the
+    // generated `.plumix/schema.ts` only re-exports `plumix/schema`
+    // (core only) and `audit_log` is missing from emitted migrations.
+    schemaModule: "@plumix/plugin-audit-log/schema",
     provides: (ctx) => {
       ctx.extendAppContext("audit", extension);
     },

--- a/packages/plugins/audit-log/tsconfig.json
+++ b/packages/plugins/audit-log/tsconfig.json
@@ -6,5 +6,5 @@
     "rootDir": ".",
     "types": ["node", "@testing-library/jest-dom"]
   },
-  "include": ["src", "test"]
+  "include": ["src", "e2e", "test"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,6 +479,9 @@ importers:
       '@orpc/server':
         specifier: ^1.14.3
         version: 1.14.3(ws@8.20.0)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../../tooling/eslint
@@ -542,6 +545,34 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/plugins/audit-log/playground:
+    dependencies:
+      '@plumix/plugin-audit-log':
+        specifier: workspace:*
+        version: link:..
+      '@plumix/runtime-cloudflare':
+        specifier: workspace:*
+        version: link:../../../runtimes/cloudflare
+      plumix:
+        specifier: workspace:*
+        version: link:../../../plumix
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260421.1
+      '@plumix/typescript-config':
+        specifier: workspace:*
+        version: link:../../../../tooling/typescript
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.86.0(@cloudflare/workers-types@4.20260421.1)
 
   packages/plugins/blog:
     devDependencies:


### PR DESCRIPTION
Implements #253 — adds a fresh playground and a worker-driven Playwright
e2e for `@plumix/plugin-audit-log`. The plugin had no Playwright e2e
before; this is its first end-to-end admin-shell ↔ worker test.

Wiring the e2e surfaced two latent bugs in the plugin itself, both of
which were invisible because the admin-shell-against-real-worker path
wasn't exercised anywhere (vitest covered hooks → record against an
in-memory db, but never the round-trip).

## Bugs fixed (commit 1)

- **Missing `schemaModule` declaration.** The plugin owns the
  `audit_log` table but the descriptor never declared `schemaModule`,
  so `plumix migrate generate` only re-exported `plumix/schema` and
  drizzle-kit emitted core-only migrations. First query against the
  table hit `SqliteError: no such table: audit_log`. Fix: declare
  `schemaModule: "@plumix/plugin-audit-log/schema"` and expose the
  matching subpath in `package.json`'s exports.
- **Wire-path mismatch between admin client and server router.** The
  admin RPC client hardcoded `auditLog/list` (camelCase). The worker
  mounts plugin routers at the plugin id verbatim — `audit_log`
  (snake_case). The path mismatched and every list fetch 404'd with
  "Failed to load audit log: rpc_404". Fix: switch the client path
  to `audit_log/list` to match the mount point.

Both were single-line plugin-source changes the e2e immediately
caught at boot.

## E2E suite (commit 2)

Mirrors the menu / media shape from #251:
- `packages/plugins/audit-log/playground/` — minimal plumix consumer
  wiring only audit-log. Same `localOrigin: "http://localhost:5173"`
  override as menu/media so the CSRF allowlist matches `plumix dev`'s
  actual port.
- `e2e/globalSetup.ts` — byte-identical to menu/media's globalSetup;
  seeds an admin user + storageState via the helpers from #251.
- `e2e/playwright.config.ts` — collapses to
  `definePlumixE2EConfig({ playground: "../playground" })`.
- `e2e/audit-log.spec.ts` — three serial tests covering the user-
  facing surface: render seeded rows, narrow via event-prefix filter,
  reset to restore the full list. Seeding goes through D1 directly
  (raw SQL in `test.beforeAll`) — the audit-log hook → record path
  is already vitest-tested and isn't the e2e's responsibility.

Filter-persistence-across-reload is intentionally not asserted —
`AuditLogShell` keeps filters in local `useState` (not URL state), so
reload genuinely resets them. The issue body's "survives a reload"
note doesn't match current implementation.

## Validation

- `pnpm --filter @plumix/plugin-audit-log test:e2e` — 3 tests, 8.1s
- `pnpm exec turbo run typecheck test lint` — 55/55 (audit-log
  needed `e2e` added to `tsconfig.json`'s `include` list so eslint's
  type-aware lint sees the new files)
- `knip.config.ts` updated to declare the new playground workspace
  and recognise the new `e2e/` entries

## Forward-compat note

The same `localOrigin` override now lives in three playgrounds
(menu, media, audit-log). #254 + #255 (blog plugin, pages plugin)
will need the same. Worth filing a follow-up to either flip
`cloudflareDeployOrigin`'s default or ship a `plumixDevOrigin`
sibling so playground configs stop carrying boilerplate.

Closes #253
Refs #250, #254, #255