### PR TITLE
feat(runtime-cloudflare): plumix dev --port knob + per-suite e2e ports

### DIFF
--- a/packages/core/src/test/playwright/playwright-config.test.ts
+++ b/packages/core/src/test/playwright/playwright-config.test.ts
@@ -42,7 +42,7 @@ describe("definePlumixE2EConfig", () => {
     expect(cmd).toContain("rm -rf .wrangler/state");
     expect(cmd).toContain("plumix migrate generate");
     expect(cmd).toContain("wrangler d1 migrations apply DB --local");
-    expect(cmd).toContain("plumix dev");
+    expect(cmd).toContain("plumix dev --port 3040");
   });
 
   test("extraSetup injects an additional step between migrations apply and plumix dev", () => {
@@ -57,7 +57,7 @@ describe("definePlumixE2EConfig", () => {
         ? config.webServer.command
         : "";
     expect(cmd).toMatch(
-      /wrangler d1 migrations apply DB --local && pnpm exec wrangler d1 execute plumix_blog --local --file=e2e\/seed\.sql && pnpm exec plumix dev/,
+      /wrangler d1 migrations apply DB --local && pnpm exec wrangler d1 execute plumix_blog --local --file=e2e\/seed\.sql && pnpm exec plumix dev --port \d+/,
     );
   });
 

--- a/packages/core/src/test/playwright/playwright-config.ts
+++ b/packages/core/src/test/playwright/playwright-config.ts
@@ -4,13 +4,11 @@ import { defineConfig, devices } from "@playwright/test";
 export interface PlumixE2EConfigOptions {
   /**
    * Port the worker / preview listens on. Used to derive `baseURL`
-   * when not explicitly set.
-   *
-   * Defaults to `5173` — the cloudflare-vite-plugin's vite port. Once
-   * `plumix dev` exposes a `--port` knob, this value will be honored
-   * end-to-end and plugin authors can override per-suite. Until then,
-   * any value other than `5173` will leave playwright polling a port
-   * the worker isn't bound to.
+   * when not explicitly set, and passed through to the baked
+   * `plumix dev --port <port>` so the worker binds where playwright
+   * polls. Suites should pick distinct ports so they can run in
+   * parallel under turbo without colliding. Defaults to `5173`
+   * (vite's default) for back-compat.
    */
   readonly port?: number;
   /**
@@ -66,6 +64,7 @@ const DEFAULT_PORT = 5173;
 
 function bakePlaygroundCommand(
   playground: string,
+  port: number,
   extraSetup: string | undefined,
 ): string {
   const steps = [
@@ -75,7 +74,7 @@ function bakePlaygroundCommand(
     `pnpm exec wrangler d1 migrations apply ${DEFAULT_BINDING} --local`,
   ];
   if (extraSetup) steps.push(extraSetup);
-  steps.push("pnpm exec plumix dev");
+  steps.push(`pnpm exec plumix dev --port ${String(port)}`);
   return steps.join(" && ");
 }
 
@@ -123,7 +122,7 @@ export function definePlumixE2EConfig(
   const webServerCommand =
     options.webServerCommand ??
     (options.playground !== undefined
-      ? bakePlaygroundCommand(options.playground, options.extraSetup)
+      ? bakePlaygroundCommand(options.playground, port, options.extraSetup)
       : "");
 
   return defineConfig({

--- a/packages/plugins/audit-log/e2e/playwright.config.ts
+++ b/packages/plugins/audit-log/e2e/playwright.config.ts
@@ -1,5 +1,8 @@
 import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 export default definePlumixE2EConfig({
+  // Distinct per-plugin port so the suite can run in parallel with
+  // menu (3040) and media (3030) under turbo.
+  port: 3010,
   playground: "../playground",
 });

--- a/packages/plugins/audit-log/playground/plumix.config.ts
+++ b/packages/plugins/audit-log/playground/plumix.config.ts
@@ -17,11 +17,11 @@ import {
 const { rpId, origin } = cloudflareDeployOrigin({
   workerName: "plumix-audit-log-playground",
   accountSubdomain: "local",
-  // `plumix dev` binds the worker to vite's port (5173); the CSRF
-  // origin-allowlist must match what the browser actually sends.
-  // Default would be 8787 (wrangler dev), which mismatches and 403s
-  // every POST.
-  localOrigin: "http://localhost:5173",
+  // CSRF origin-allowlist must match what the browser sends. The
+  // e2e harness boots `plumix dev --port 3010` (see
+  // `e2e/playwright.config.ts`); override here if you boot the
+  // playground manually with a different `--port`.
+  localOrigin: "http://localhost:3010",
 });
 
 export default plumix({

--- a/packages/plugins/media/e2e/playwright.config.ts
+++ b/packages/plugins/media/e2e/playwright.config.ts
@@ -1,5 +1,8 @@
 import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 export default definePlumixE2EConfig({
+  // Distinct per-plugin port so the suite can run in parallel with
+  // menu (3040) and audit-log (3010) under turbo.
+  port: 3030,
   playground: "../playground",
 });

--- a/packages/plugins/media/playground/plumix.config.ts
+++ b/packages/plugins/media/playground/plumix.config.ts
@@ -27,11 +27,11 @@ import {
 const { rpId, origin } = cloudflareDeployOrigin({
   workerName: "plumix-media-playground",
   accountSubdomain: "local",
-  // `plumix dev` binds the worker to vite's port (5173); the CSRF
-  // origin-allowlist must match what the browser actually sends.
-  // Default would be 8787 (wrangler dev), which mismatches and 403s
-  // every POST.
-  localOrigin: "http://localhost:5173",
+  // CSRF origin-allowlist must match what the browser sends. The
+  // e2e harness boots `plumix dev --port 3030` (see
+  // `e2e/playwright.config.ts`); override here if you boot the
+  // playground manually with a different `--port`.
+  localOrigin: "http://localhost:3030",
 });
 
 const s3 = resolveS3Credentials();

--- a/packages/plugins/menu/e2e/playwright.config.ts
+++ b/packages/plugins/menu/e2e/playwright.config.ts
@@ -1,5 +1,8 @@
 import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 export default definePlumixE2EConfig({
+  // Distinct per-plugin port so the suite can run in parallel with
+  // media (3030) and audit-log (3010) under turbo.
+  port: 3040,
   playground: "../playground",
 });

--- a/packages/plugins/menu/playground/plumix.config.ts
+++ b/packages/plugins/menu/playground/plumix.config.ts
@@ -29,11 +29,12 @@ const playgroundTheme = defineTheme({
 const { rpId, origin } = cloudflareDeployOrigin({
   workerName: "plumix-menu-playground",
   accountSubdomain: "local",
-  // `plumix dev` binds the worker to vite's port (5173); the CSRF
-  // origin-allowlist must match what the browser actually sends.
-  // Default would be 8787 (wrangler dev), which mismatches and 403s
-  // every POST.
-  localOrigin: "http://localhost:5173",
+  // CSRF origin-allowlist must match what the browser actually sends.
+  // The e2e harness boots `plumix dev --port 3040` (see
+  // `e2e/playwright.config.ts`), so this matches that port. If you
+  // boot the playground manually with a different `--port`, override
+  // this constant accordingly.
+  localOrigin: "http://localhost:3040",
 });
 
 export default plumix({

--- a/packages/runtimes/cloudflare/src/commands/dev.test.ts
+++ b/packages/runtimes/cloudflare/src/commands/dev.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+
+import { parseDevArgs } from "./dev.js";
+
+describe("parseDevArgs", () => {
+  test("extracts --port followed by a numeric value", () => {
+    expect(parseDevArgs(["--port", "3030"])).toEqual({ port: 3030 });
+  });
+
+  test("accepts the --port=N equals form", () => {
+    expect(parseDevArgs(["--port=3030"])).toEqual({ port: 3030 });
+  });
+
+  test("returns an empty object when --port is absent (vite default)", () => {
+    expect(parseDevArgs([])).toEqual({});
+    expect(parseDevArgs(["--verbose"])).toEqual({});
+  });
+
+  test("throws on a non-numeric --port value", () => {
+    expect(() => parseDevArgs(["--port", "abc"])).toThrow(
+      /--port.*must be a number/i,
+    );
+    expect(() => parseDevArgs(["--port="])).toThrow(
+      /--port.*must be a number/i,
+    );
+  });
+
+  test("throws when --port has no value following it", () => {
+    expect(() => parseDevArgs(["--port"])).toThrow(/--port.*requires a value/i);
+  });
+});

--- a/packages/runtimes/cloudflare/src/commands/dev.ts
+++ b/packages/runtimes/cloudflare/src/commands/dev.ts
@@ -2,7 +2,7 @@ import type { CommandDefinition } from "plumix";
 
 import { createCloudflareVite } from "./vite.js";
 
-export interface DevArgs {
+interface DevArgs {
   readonly port?: number;
 }
 

--- a/packages/runtimes/cloudflare/src/commands/dev.ts
+++ b/packages/runtimes/cloudflare/src/commands/dev.ts
@@ -2,16 +2,54 @@ import type { CommandDefinition } from "plumix";
 
 import { createCloudflareVite } from "./vite.js";
 
+export interface DevArgs {
+  readonly port?: number;
+}
+
+export function parseDevArgs(argv: readonly string[]): DevArgs {
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--port") {
+      const raw = argv[i + 1];
+      if (raw === undefined) {
+        throw new Error(
+          "plumix dev: --port requires a value (e.g. --port 3030)",
+        );
+      }
+      return { port: parsePort(raw) };
+    }
+    if (token?.startsWith("--port=")) {
+      return { port: parsePort(token.slice("--port=".length)) };
+    }
+  }
+  return {};
+}
+
+function parsePort(raw: string): number {
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(
+      `plumix dev: --port value "${raw}" must be a number between 1 and 65535`,
+    );
+  }
+  return port;
+}
+
 export const devCommand: CommandDefinition = {
   describe: "Start the Workers dev server (vite + @cloudflare/vite-plugin)",
   async run(ctx) {
+    const { port } = parseDevArgs(ctx.argv);
     const vite = await import("vite");
     const { plugins, root } = await createCloudflareVite(ctx);
 
+    // `strictPort: true` when --port is explicit: e2e harnesses point
+    // playwright at the requested port and need a fail-fast if it's
+    // taken, not vite's silent fallback to the next free one.
     const server = await vite.createServer({
       configFile: false,
       root,
       plugins,
+      ...(port !== undefined ? { server: { port, strictPort: true } } : {}),
     });
     await server.listen();
     server.printUrls();


### PR DESCRIPTION
Adds a \`--port\` flag to \`plumix dev\` and uses it to give each
worker-driven plugin e2e suite its own port (audit-log 3010, media
3030, menu 3040). Closes the parallel-execution gap that #252 left
open and unblocks parallel e2e for the rest of the migrations
(#254 plugin-blog, #255 plugin-pages).

## Why

Before this PR, \`plumix dev\` always bound to vite's default port
(5173) because the cloudflare runtime's \`devCommand\` ignored
\`ctx.argv\` entirely. Every plugin's worker-driven e2e wanted its own
listening port (so they could run in parallel under turbo) but they
all fought over 5173, so CI had to serialise them via separate
\`pnpm --filter\` invocations. This was a known forward-compat item
from #251, called out explicitly in #252's PRD body and as a recurring
"localOrigin override per playground" pattern across menu, media, and
audit-log.

## What

Three thematic commits:

1. **\`feat(runtime-cloudflare): add --port knob to plumix dev\`** —
   the core feature. Adds a tiny pure \`parseDevArgs(argv)\` parser
   that extracts \`--port N\` / \`--port=N\` (handles missing/invalid
   values with clear errors), and threads the value into
   \`vite.createServer\` as \`server: { port, strictPort: true }\`.
   \`strictPort\` matters here — without it vite silently picks the
   next free port if the requested one is taken, which is the exact
   footgun e2e users hit.

2. **\`feat(plumix): pass --port through definePlumixE2EConfig bake\`**
   — the helper now bakes \`plumix dev --port <port>\` so the
   webServerCommand honors the suite-author's chosen port. Drops the
   "\`plumix dev\` doesn't honor --port today" caveat from the
   \`port?\` JSDoc.

3. **\`feat(plumix): give each plugin e2e a distinct worker port\`** —
   audit-log → 3010, media → 3030, menu → 3040. Each playground's
   \`localOrigin\` follows so CSRF still passes.

## Validation

- 6 unit tests on \`parseDevArgs\` (colocated in \`dev.test.ts\`)
- All three plugin e2e suites pass on their new ports:
  - audit-log: 3 tests, 7.7s
  - media: 1 test, 7.5s
  - menu: 4 tests, 9.9s
- \`turbo run typecheck test lint --filter=...\` — 24/24

## Follow-up not in this PR

The actual parallel-CI step (a turbo \`test:e2e\` task with the right
filter graph) is the natural next move now that the port collision
is gone. Defer to a separate PR so this one stays focused on the
knob itself.

Closes #252
Refs #250, #251, #253, #254