### PR TITLE
feat(core): warn in definePlugin when schema is set but schemaModule is missing

### DIFF
--- a/packages/core/src/plugin/define.test.ts
+++ b/packages/core/src/plugin/define.test.ts
@@ -1,0 +1,57 @@
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { definePlugin } from "./define.js";
+
+const noop = (): void => undefined;
+
+describe("definePlugin — schemaModule warning", () => {
+  let warnSpy: MockInstance<typeof console.warn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("warns when schema is set but schemaModule is missing", () => {
+    definePlugin("test_plugin_schema_only", noop, {
+      schema: { someTable: {} },
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0]);
+    expect(message).toContain("test_plugin_schema_only");
+    expect(message).toContain("schemaModule");
+  });
+
+  test("stays silent when both schema and schemaModule are set", () => {
+    definePlugin("test_plugin_with_both", noop, {
+      schema: { someTable: {} },
+      schemaModule: "@example/plugin/schema",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("stays silent when neither schema nor schemaModule is set", () => {
+    definePlugin("test_plugin_neither", noop);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("warns via the input-object form too", () => {
+    definePlugin("test_plugin_input_form", {
+      setup: noop,
+      schema: { someTable: {} },
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain(
+      "test_plugin_input_form",
+    );
+  });
+
+  test("warns only once when the same plugin id is defined repeatedly", () => {
+    definePlugin("test_plugin_repeat", noop, { schema: { someTable: {} } });
+    definePlugin("test_plugin_repeat", noop, { schema: { someTable: {} } });
+    definePlugin("test_plugin_repeat", noop, { schema: { someTable: {} } });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -83,6 +83,7 @@ export function definePlugin<TConfig = undefined>(
 ): PluginDescriptor<TConfig> {
   assertValidPluginId(id);
   if (typeof setupOrInput === "function") {
+    warnIfSchemaWithoutSchemaModule(id, legacyOptions);
     return {
       id,
       version: legacyOptions?.version,
@@ -102,6 +103,7 @@ export function definePlugin<TConfig = undefined>(
         `legacy third argument.`,
     );
   }
+  warnIfSchemaWithoutSchemaModule(id, setupOrInput);
   return {
     id,
     version: setupOrInput.version,
@@ -114,4 +116,26 @@ export function definePlugin<TConfig = undefined>(
     adminCss: setupOrInput.adminCss,
     adminPeerVersion: setupOrInput.adminPeerVersion,
   };
+}
+
+// Per-id dedup so a plugin defined twice (re-imports, HMR, repeat
+// build entries) only emits the warning once.
+const warnedIds = new Set<string>();
+
+function warnIfSchemaWithoutSchemaModule(
+  id: string,
+  opts: { readonly schema?: unknown; readonly schemaModule?: unknown } | undefined,
+): void {
+  if (!opts?.schema || opts.schemaModule) return;
+  if (warnedIds.has(id)) return;
+  warnedIds.add(id);
+  console.warn(
+    `[plumix] plugin "${id}" declares \`schema\` but not ` +
+      `\`schemaModule\`. Runtime queries will work, but ` +
+      `\`plumix migrate generate\` won't include this plugin's tables ` +
+      `in the generated migrations — you'll hit "no such table" the ` +
+      `first time a query runs. Add ` +
+      `\`schemaModule: "<package>/schema"\` and export the matching ` +
+      `subpath.`,
+  );
 }

--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -124,7 +124,9 @@ const warnedIds = new Set<string>();
 
 function warnIfSchemaWithoutSchemaModule(
   id: string,
-  opts: { readonly schema?: unknown; readonly schemaModule?: unknown } | undefined,
+  opts:
+    | { readonly schema?: unknown; readonly schemaModule?: unknown }
+    | undefined,
 ): void {
   if (!opts?.schema || opts.schemaModule) return;
   if (warnedIds.has(id)) return;


### PR DESCRIPTION
Closes #264. Surfaced during #262's audit-log e2e wiring — the plugin had `schema` (runtime drizzle object) declared but never declared `schemaModule` (the string specifier `plumix migrate generate` needs). Result: generated `.plumix/schema.ts` re-exported core only, codegen emitted core-only migrations, and the first runtime query hit `SqliteError: no such table: <plugin_table>` with no breadcrumb pointing at the misconfiguration.

This catches that footgun at module-load time with a `console.warn` instead of a runtime crash.

## Message

```
[plumix] plugin "<pluginId>" declares `schema` but not `schemaModule`.
Runtime queries will work, but `plumix migrate generate` won't include
this plugin's tables in the generated migrations — you'll hit "no such
table" the first time a query runs. Add `schemaModule: "<package>/schema"`
and export the matching subpath.
```

## Behavior

- Fires when `schema` is truthy and `schemaModule` is falsy.
- Both call shapes covered: legacy `definePlugin(id, setup, opts)` and modern `definePlugin(id, input)`.
- Dedupped per `pluginId` via a module-level `Set<string>` so HMR / re-imports / repeat-bundle entries don't spam.
- Plugins with no `schema` (menu, media, blog, pages) are unaffected.
- Plugins declaring both fields (`audit_log`) stay silent.

## Verification

- 5 unit tests in `packages/core/src/plugin/define.test.ts` covering: warn-fires-when-schema-only, silent-when-both, silent-when-neither, warns-via-input-form, dedups-per-id.
- `pnpm exec turbo run typecheck lint test publint attw` → 74/74 green.
- `pnpm knip` clean.