### PR TITLE
chore: scaffold agent-facing docs and reconcile triage labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -33,12 +33,26 @@
   description: Dependency updates
 
 # Status
-- name: needs-repro
-  color: "fbca04"
-  description: Needs a minimal reproduction
 - name: "good first issue"
   color: "7057ff"
   description: Good for newcomers
+
+# Triage (mapped to the five canonical roles in docs/agents/triage-labels.md)
+- name: needs-triage
+  color: "fbca04"
+  description: Maintainer needs to evaluate
+- name: needs-info
+  color: "fbca04"
+  description: Waiting on reporter for more information
+- name: ready-for-agent
+  color: "0e8a16"
+  description: Fully specified, ready for an AFK agent
+- name: ready-for-human
+  color: "0e8a16"
+  description: Requires human implementation
+- name: wontfix
+  color: "ffffff"
+  description: Will not be actioned
 
 # CI gate
 - name: run-e2e

--- a/.github/workflows/issue-needs-info.yml
+++ b/.github/workflows/issue-needs-info.yml
@@ -1,4 +1,4 @@
-name: Needs Reproduction
+name: Needs Info
 
 on:
   issues:
@@ -10,9 +10,9 @@ permissions:
   issues: write
 
 jobs:
-  needs-repro:
-    if: github.event_name == 'schedule' || github.event.label.name == 'needs-repro'
-    name: Request reproduction
+  needs-info:
+    if: github.event_name == 'schedule' || github.event.label.name == 'needs-info'
+    name: Request additional info
     runs-on: ubuntu-latest
     steps:
       - name: Comment on labeled issues
@@ -24,10 +24,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `Thanks for the report! We need a minimal reproduction to investigate this issue.\n\nPlease provide a link to a minimal repo, CodeSandbox, or StackBlitz that reproduces the problem. Without a reproduction, we can't debug effectively.\n\nIf we don't hear back within 3 days, this issue will be closed automatically.`
+              body: `Thanks for the report! A maintainer has marked this as needing more information to investigate. Please reply with the details requested above. If no specifics were given, a minimal reproduction (link to a repo, CodeSandbox, or StackBlitz) is the most useful starting point.\n\nIf we don't hear back within 3 days, this issue will be closed automatically.`
             });
 
-      - name: Close stale needs-repro issues
+      - name: Close stale needs-info issues
         if: github.event_name == 'schedule'
         uses: actions/github-script@v9
         with:
@@ -35,7 +35,7 @@ jobs:
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'needs-repro',
+              labels: 'needs-info',
               state: 'open',
               per_page: 50,
             });
@@ -51,7 +51,7 @@ jobs:
               });
 
               const labeledEvent = events.data
-                .filter(e => e.event === 'labeled' && e.label?.name === 'needs-repro')
+                .filter(e => e.event === 'labeled' && e.label?.name === 'needs-info')
                 .pop();
 
               if (labeledEvent && new Date(labeledEvent.created_at) < threeDaysAgo) {
@@ -59,7 +59,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
-                  body: 'Closing due to lack of reproduction. Feel free to reopen with a minimal repro link.'
+                  body: 'Closing due to lack of response. Feel free to reopen with the requested information.'
                 });
                 await github.rest.issues.update({
                   owner: context.repo.owner,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# AGENTS.md
+
+Agent-facing conventions for the Plumix repo.
+
+## What this is
+
+CMS inspired by WordPress, with pluggable runtime adapters. Cloudflare (`@plumix/runtime-cloudflare`, using D1/KV/R2) is the only runtime shipped today; more are planned. Pre-1.0: every `0.x` minor may break.
+
+Current target is Cloudflare Workers, so runtime code must stay Worker-compatible — no Node built-ins, no `fs`, no dynamic require.
+
+## Commands
+
+Turborepo drives everything from the root:
+
+- `pnpm build` — every package in topological order
+- `pnpm typecheck` / `pnpm lint` / `pnpm format` — turbo tasks; `lint` and `typecheck` `dependsOn: ^build` so they need built upstream deps
+- `pnpm test` — vitest across every package that defines tests
+- `pnpm test:e2e` — Playwright e2e (only the packages that opt in)
+- `pnpm knip` — unused-export and dependency check
+- `pnpm boundaries` — dependency-cruiser; enforces the umbrella-vs-internals rule (see Architecture)
+- `pnpm commitlint` — conventional-commit lint
+
+**Single-package commands.** Use turbo, not pnpm, for any task with `dependsOn` set (`build`, `lint`, `typecheck`, `test`, `test:e2e`, `publint`, `attw`):
+
+```bash
+pnpm exec turbo run test --filter @plumix/core
+```
+
+Bare `pnpm --filter @plumix/core test` works locally with a warm tree but fails cold in CI because upstream `build` won't have run.
+
+**Single test file.** Inside a package: `pnpm exec vitest run path/to/file.test.ts`. With coverage: `pnpm exec vitest run --coverage`.
+
+## Architecture
+
+### Workspaces
+
+```
+packages/
+├── core/                @plumix/core              — engine: schema, auth, hooks, RPC, route, plugin manifest
+├── admin/               @plumix/admin             — React SPA (Vite + Tanstack Router/Query); shadcn-based UI
+├── blocks/              @plumix/blocks            — block primitives (currently `export {}`; design intent)
+├── plumix/              plumix                    — public umbrella; subpath exports re-export internals
+├── create-plumix-app/                             — scaffolder
+├── plugins/
+│   ├── audit-log/ blog/ media/ menu/ pages/       — first-party plugins
+└── runtimes/
+    └── cloudflare/      @plumix/runtime-cloudflare — Cloudflare D1/R2/KV bindings
+examples/{blog,minimal}                            — playgrounds + e2e fixtures
+tooling/{eslint,prettier,typescript,vitest}        — shared configs as workspace packages
+```
+
+### The umbrella rule
+
+The `plumix` package re-exports the public API surface from internal `@plumix/{core,admin,blocks}` under subpaths (`plumix`, `plumix/vite`, `plumix/admin`, `plumix/admin/react`, `plumix/theme`, `plumix/plugin`, …).
+
+**Consumer packages — plugins, runtimes, examples, `create-plumix-app` — must import from `plumix` (or its subpaths). They must not import from `@plumix/core`, `@plumix/admin`, or `@plumix/blocks` directly.**
+
+This is the boundary that lets internal packages refactor freely while the published surface stays stable. Violations are caught by `pnpm boundaries` (config in `.dependency-cruiser.cjs`).
+
+### Plugin model
+
+A plugin is a function returning a `PluginManifest` (defined in `@plumix/core`, exposed publicly as `plumix/plugin` and `plumix/manifest`). The manifest declares the plugin's schema (drizzle tables), routes, RPC procedures, admin routes/components, hooks, and capabilities. First-party plugins under `packages/plugins/*` are the canonical examples.
+
+### Dependency catalog
+
+`pnpm-workspace.yaml` defines a `catalog:` for deps used by multiple packages (drizzle, react, vite, vitest, etc.). A dep used by exactly one package goes direct in that package's `package.json`, **not** in the catalog — the catalog is for de-duplication, not centralization.
+
+## Tests
+
+One vitest suite per package. Two layouts, in order of preference:
+
+1. **Colocate** — `src/foo.test.ts` next to `src/foo.ts`. Default for everything, including tests that use in-memory DBs or the harnesses from `@plumix/core/test` (they run inside the vitest worker).
+2. **Package-level `test/`** — only when colocation can't work: tests that spawn a real binary, run against built `dist/`, or exercise the package as an external consumer.
+
+E2E (Playwright) is separate, lives under each package's `e2e/`, runs via `pnpm test:e2e`.
+
+### Selectors
+
+Tests use `getByTestId` only — never `getByRole`, `getByText`, or `getByLabel`.
+
+### Coverage
+
+Wired in every test-having package (`pnpm exec vitest run --coverage`). Tracked, not enforced; no thresholds.
+
+### shadcn
+
+`packages/admin/src/components/ui/*` is vendored from shadcn. Wrap or extend — never edit in place.
+
+## Commits, branches, PRs
+
+- Conventional Commits enforced by commitlint (`@commitlint/config-conventional` + `config-pnpm-scopes`).
+- **Scopes** are validated against workspace package names — run `pnpm ls -r --depth -1` to list them. For `.github/` meta changes, use `ci:` with no scope.
+- Use `refactor`, not `ref` — `ref` isn't in the allowed type-enum.
+- **Subject must start lowercase.** Rephrase to start with a lowercase verb if you'd otherwise lead with `CI`, `API`, `OAuth`, etc.
+- **Wrap commit body lines at ≤100 chars** — footer-max-line-length inherits from config-conventional even though body-max-line-length is disabled.
+- Never put "claude" in a branch name or commit message.
+- All PRs are squash-merged.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `withplumix/plumix`, operated via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`); will be created on first use. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Multi-context: `CONTEXT-MAP.md` at the root points at per-package `CONTEXT.md` files under `packages/<pkg>/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,49 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root — it points at one `CONTEXT.md` per package. Read each one relevant to the topic.
+- **`docs/adr/`** — repo-wide architectural decisions.
+- **`packages/<pkg>/CONTEXT.md`** and **`packages/<pkg>/docs/adr/`** — package-scoped glossary and decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure (Plumix monorepo)
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                              ← repo-wide decisions
+└── packages/
+    ├── core/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                      ← package-scoped decisions
+    ├── admin/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/
+    ├── plugins/
+    │   ├── blog/
+    │   │   ├── CONTEXT.md
+    │   │   └── docs/adr/
+    │   └── pages/
+    │       ├── CONTEXT.md
+    │       └── docs/adr/
+    └── runtimes/
+        └── cloudflare/
+            ├── CONTEXT.md
+            └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in the relevant `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Set up the canonical agent-facing repo docs and align the GitHub label catalog with them.

**AGENTS.md and docs/agents/**

`AGENTS.md` at the repo root now indexes the things engineering skills need: workspace commands (turbo task map and the `pnpm exec turbo --filter` gotcha), architecture (umbrella-vs-internals boundary enforced by `pnpm boundaries`), test conventions, and commit/branch rules. The `docs/agents/` directory holds the three companion files that Matt Pocock's engineering skills read (`triage`, `to-issues`, `to-prd`, `grill-with-docs`, `improve-codebase-architecture`, `diagnose`, `tdd`):

- `issue-tracker.md` — GitHub Issues via the `gh` CLI
- `triage-labels.md` — maps the five canonical roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) to repo labels
- `domain.md` — multi-context layout per package

**Label catalog alignment**

`.github/labels.yml` previously had only `pkg:*`, `bug`, `dependencies`, `needs-repro`, `good first issue`, and `run-e2e`. The five canonical triage labels are now added. The narrower `needs-repro` is dropped in favor of the canonical `needs-info`.

The auto-comment workflow `.github/workflows/issue-needs-repro.yml` is renamed to `issue-needs-info.yml` and generalized — the auto-comment no longer asks specifically for a reproduction, since `needs-info` covers more than repro requests.

`labels.yml` remains manually managed; no sync workflow is added.