### PR TITLE
feat(runtime-cloudflare): named-error factories + no-bare-throw rule

### DIFF
--- a/packages/runtimes/cloudflare/eslint.config.ts
+++ b/packages/runtimes/cloudflare/eslint.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(baseConfig, noBareThrowError);

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -150,6 +150,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
   // stubbed symbol (some edge-runtime shims do) the cryptic error bubbles up
   // from the first AsyncLocalStorage.run() call. Fail fast with a useful hint.
   if (typeof AsyncLocalStorage !== "function") {
+    // eslint-disable-next-line no-restricted-syntax -- migrated alongside PlumixRuntimeConfigError in PR 2 (#234)
     throw new Error(
       '@plumix/runtime-cloudflare requires AsyncLocalStorage. Add `compatibility_flags = ["nodejs_compat"]` to wrangler.toml.',
     );
@@ -238,6 +239,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
 
 function buildScheduled(app: PlumixApp): ScheduledHandler {
   if (typeof AsyncLocalStorage !== "function") {
+    // eslint-disable-next-line no-restricted-syntax -- migrated alongside PlumixRuntimeConfigError in PR 2 (#234)
     throw new Error(
       '@plumix/runtime-cloudflare requires AsyncLocalStorage. Add `compatibility_flags = ["nodejs_compat"]` to wrangler.toml.',
     );

--- a/packages/runtimes/cloudflare/src/cf-access.ts
+++ b/packages/runtimes/cloudflare/src/cf-access.ts
@@ -2,6 +2,8 @@ import type { Db, RequestAuthenticator, UserRole } from "plumix";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import { ExternalIdentityError, resolveExternalIdentity } from "plumix";
 
+import { CfAccessError } from "./errors.js";
+
 // Header CF Access sets on every request that passed the application's
 // policy. Documented in `https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/application-token/`.
 const CF_ACCESS_HEADER = "cf-access-jwt-assertion";
@@ -175,11 +177,7 @@ export function cfAccess(config: CfAccessConfig): RequestAuthenticator {
 
 function validateConfig(config: CfAccessConfig): void {
   if (!CF_TEAM_DOMAIN_RE.test(config.teamDomain)) {
-    throw new Error(
-      `cfAccess: teamDomain must match "<team>.cloudflareaccess.com" — ` +
-        `got "${config.teamDomain}". Strip any "https://" prefix or path; ` +
-        `the helper composes the full URL.`,
-    );
+    throw CfAccessError.invalidTeamDomain({ teamDomain: config.teamDomain });
   }
   // Empty audience silently disables jose's audience equality check
   // (truthy guard at jwt_claims_set.js): every JWT for the team domain
@@ -187,11 +185,7 @@ function validateConfig(config: CfAccessConfig): void {
   // applications. Fail-fast on missing config (e.g.
   // `audience: env.CF_ACCESS_AUD ?? ""` after a missing binding).
   if (config.audience.length === 0) {
-    throw new Error(
-      `cfAccess: audience must be non-empty (the AUD tag from the ` +
-        `application's CF Access dashboard). An empty value would ` +
-        `disable per-application audience binding.`,
-    );
+    throw CfAccessError.audienceEmpty();
   }
 }
 

--- a/packages/runtimes/cloudflare/src/commands/dev.ts
+++ b/packages/runtimes/cloudflare/src/commands/dev.ts
@@ -12,6 +12,7 @@ export function parseDevArgs(argv: readonly string[]): DevArgs {
     if (token === "--port") {
       const raw = argv[i + 1];
       if (raw === undefined) {
+        // eslint-disable-next-line no-restricted-syntax -- DevCommandError factory to land in a follow-up CLI-errors slice
         throw new Error(
           "plumix dev: --port requires a value (e.g. --port 3030)",
         );
@@ -28,6 +29,7 @@ export function parseDevArgs(argv: readonly string[]): DevArgs {
 function parsePort(raw: string): number {
   const port = Number(raw);
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    // eslint-disable-next-line no-restricted-syntax -- DevCommandError factory to land in a follow-up CLI-errors slice
     throw new Error(
       `plumix dev: --port value "${raw}" must be a number between 1 and 65535`,
     );

--- a/packages/runtimes/cloudflare/src/d1.ts
+++ b/packages/runtimes/cloudflare/src/d1.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_BOOKMARK_COOKIE,
   isValidBookmark,
 } from "./d1-session.js";
+import { D1Error } from "./errors.js";
 
 type D1SessionMode = "disabled" | "auto" | "primary-first";
 
@@ -119,9 +120,7 @@ function getBinding(env: unknown, name: string): D1Database {
   const bindings = env as Record<string, D1Database | undefined>;
   const binding = bindings[name];
   if (!binding) {
-    throw new Error(
-      `@plumix/runtime-cloudflare: D1 binding "${name}" missing from env`,
-    );
+    throw D1Error.bindingMissing({ binding: name });
   }
   return binding;
 }

--- a/packages/runtimes/cloudflare/src/errors.test.ts
+++ b/packages/runtimes/cloudflare/src/errors.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  CfAccessError,
+  D1Error,
+  R2Error,
+  SigV4Error,
+  WranglerConfigError,
+} from "./errors.js";
+
+describe("D1Error.bindingMissing", () => {
+  test("class identity, code, and exposed binding", () => {
+    const err = D1Error.bindingMissing({ binding: "MY_DB" });
+    expect(err).toBeInstanceOf(D1Error);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("D1Error");
+    expect(err.code).toBe("binding_missing");
+    expect(err.binding).toBe("MY_DB");
+  });
+
+  test("message interpolates the binding name", () => {
+    const err = D1Error.bindingMissing({ binding: "DB" });
+    expect(err.message).toContain("D1 binding \"DB\" missing from env");
+  });
+});
+
+describe("R2Error.envNotObject", () => {
+  test("class identity and code, no binding context", () => {
+    const err = R2Error.envNotObject();
+    expect(err).toBeInstanceOf(R2Error);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("R2Error");
+    expect(err.code).toBe("env_not_object");
+    expect(err.binding).toBeUndefined();
+  });
+
+  test("message identifies the failure as a runtime adapter misconfiguration", () => {
+    expect(R2Error.envNotObject().message).toContain("env is not an object");
+  });
+});
+
+describe("R2Error.bindingMissing", () => {
+  test("class identity, code, and exposed binding", () => {
+    const err = R2Error.bindingMissing({ binding: "MEDIA" });
+    expect(err).toBeInstanceOf(R2Error);
+    expect(err.name).toBe("R2Error");
+    expect(err.code).toBe("binding_missing");
+    expect(err.binding).toBe("MEDIA");
+  });
+
+  test("message interpolates binding and mentions R2 bucket shape", () => {
+    const err = R2Error.bindingMissing({ binding: "MEDIA" });
+    expect(err.message).toContain("binding \"MEDIA\" is missing");
+    expect(err.message).toContain("not an R2 bucket");
+  });
+});
+
+describe("CfAccessError.invalidTeamDomain", () => {
+  test("class identity, code, and exposed teamDomain", () => {
+    const err = CfAccessError.invalidTeamDomain({ teamDomain: "bogus" });
+    expect(err).toBeInstanceOf(CfAccessError);
+    expect(err.name).toBe("CfAccessError");
+    expect(err.code).toBe("invalid_team_domain");
+    expect(err.teamDomain).toBe("bogus");
+  });
+
+  test("message mentions teamDomain and the bad value", () => {
+    const err = CfAccessError.invalidTeamDomain({ teamDomain: "bogus" });
+    expect(err.message).toContain("teamDomain");
+    expect(err.message).toContain("\"bogus\"");
+  });
+});
+
+describe("CfAccessError.audienceEmpty", () => {
+  test("class identity and code", () => {
+    const err = CfAccessError.audienceEmpty();
+    expect(err).toBeInstanceOf(CfAccessError);
+    expect(err.name).toBe("CfAccessError");
+    expect(err.code).toBe("audience_empty");
+    expect(err.teamDomain).toBeUndefined();
+  });
+
+  test("message explains the non-empty requirement", () => {
+    expect(CfAccessError.audienceEmpty().message).toContain(
+      "audience must be non-empty",
+    );
+  });
+});
+
+describe("SigV4Error.expiresInOutOfRange", () => {
+  test("class identity, code, and exposed expiresIn", () => {
+    const err = SigV4Error.expiresInOutOfRange({ expiresIn: 0 });
+    expect(err).toBeInstanceOf(SigV4Error);
+    expect(err.name).toBe("SigV4Error");
+    expect(err.code).toBe("expires_in_out_of_range");
+    expect(err.expiresIn).toBe(0);
+  });
+
+  test("message bakes in the [1..604800] range and includes the bad value", () => {
+    const err = SigV4Error.expiresInOutOfRange({ expiresIn: 604_801 });
+    expect(err.message).toContain("expiresIn must be in [1..604800]");
+    expect(err.message).toContain("604801");
+  });
+
+  test("NaN is stringified into the message", () => {
+    expect(
+      SigV4Error.expiresInOutOfRange({ expiresIn: Number.NaN }).message,
+    ).toContain("NaN");
+  });
+});
+
+describe("WranglerConfigError.parseFailed", () => {
+  test("class identity, code, and exposed filename + errorCount", () => {
+    const err = WranglerConfigError.parseFailed({
+      filename: "wrangler.jsonc",
+      errorCount: 2,
+    });
+    expect(err).toBeInstanceOf(WranglerConfigError);
+    expect(err.name).toBe("WranglerConfigError");
+    expect(err.code).toBe("parse_failed");
+    expect(err.filename).toBe("wrangler.jsonc");
+    expect(err.errorCount).toBe(2);
+  });
+
+  test("message interpolates filename and error count", () => {
+    const err = WranglerConfigError.parseFailed({
+      filename: "wrangler.toml",
+      errorCount: 3,
+    });
+    expect(err.message).toContain("Failed to parse wrangler.toml");
+    expect(err.message).toContain("3 syntax error(s)");
+  });
+});

--- a/packages/runtimes/cloudflare/src/errors.test.ts
+++ b/packages/runtimes/cloudflare/src/errors.test.ts
@@ -20,7 +20,7 @@ describe("D1Error.bindingMissing", () => {
 
   test("message interpolates the binding name", () => {
     const err = D1Error.bindingMissing({ binding: "DB" });
-    expect(err.message).toContain("D1 binding \"DB\" missing from env");
+    expect(err.message).toContain('D1 binding "DB" missing from env');
   });
 });
 
@@ -50,7 +50,7 @@ describe("R2Error.bindingMissing", () => {
 
   test("message interpolates binding and mentions R2 bucket shape", () => {
     const err = R2Error.bindingMissing({ binding: "MEDIA" });
-    expect(err.message).toContain("binding \"MEDIA\" is missing");
+    expect(err.message).toContain('binding "MEDIA" is missing');
     expect(err.message).toContain("not an R2 bucket");
   });
 });
@@ -67,7 +67,7 @@ describe("CfAccessError.invalidTeamDomain", () => {
   test("message mentions teamDomain and the bad value", () => {
     const err = CfAccessError.invalidTeamDomain({ teamDomain: "bogus" });
     expect(err.message).toContain("teamDomain");
-    expect(err.message).toContain("\"bogus\"");
+    expect(err.message).toContain('"bogus"');
   });
 });
 

--- a/packages/runtimes/cloudflare/src/errors.ts
+++ b/packages/runtimes/cloudflare/src/errors.ts
@@ -1,0 +1,162 @@
+export class D1Error extends Error {
+  static {
+    D1Error.prototype.name = "D1Error";
+  }
+
+  readonly code: "binding_missing";
+  readonly binding: string;
+
+  private constructor(
+    code: "binding_missing",
+    message: string,
+    binding: string,
+  ) {
+    super(message);
+    this.code = code;
+    this.binding = binding;
+  }
+
+  static bindingMissing(ctx: { binding: string }): D1Error {
+    return new D1Error(
+      "binding_missing",
+      `@plumix/runtime-cloudflare: D1 binding "${ctx.binding}" missing from env`,
+      ctx.binding,
+    );
+  }
+}
+
+export class R2Error extends Error {
+  static {
+    R2Error.prototype.name = "R2Error";
+  }
+
+  readonly code: "env_not_object" | "binding_missing";
+  readonly binding: string | undefined;
+
+  private constructor(
+    code: "env_not_object" | "binding_missing",
+    message: string,
+    binding: string | undefined,
+  ) {
+    super(message);
+    this.code = code;
+    this.binding = binding;
+  }
+
+  static envNotObject(): R2Error {
+    return new R2Error(
+      "env_not_object",
+      "r2(): env is not an object — runtime adapter misconfiguration.",
+      undefined,
+    );
+  }
+
+  static bindingMissing(ctx: { binding: string }): R2Error {
+    return new R2Error(
+      "binding_missing",
+      `r2(): env binding "${ctx.binding}" is missing or not an R2 bucket. ` +
+        `Declare it in wrangler.toml and ensure the name matches.`,
+      ctx.binding,
+    );
+  }
+}
+
+export class CfAccessError extends Error {
+  static {
+    CfAccessError.prototype.name = "CfAccessError";
+  }
+
+  readonly code: "invalid_team_domain" | "audience_empty";
+  readonly teamDomain: string | undefined;
+
+  private constructor(
+    code: "invalid_team_domain" | "audience_empty",
+    message: string,
+    teamDomain: string | undefined,
+  ) {
+    super(message);
+    this.code = code;
+    this.teamDomain = teamDomain;
+  }
+
+  static invalidTeamDomain(ctx: { teamDomain: string }): CfAccessError {
+    return new CfAccessError(
+      "invalid_team_domain",
+      `cfAccess: teamDomain must match "<team>.cloudflareaccess.com" — ` +
+        `got "${ctx.teamDomain}". Strip any "https://" prefix or path; ` +
+        `the helper composes the full URL.`,
+      ctx.teamDomain,
+    );
+  }
+
+  static audienceEmpty(): CfAccessError {
+    return new CfAccessError(
+      "audience_empty",
+      `cfAccess: audience must be non-empty (the AUD tag from the ` +
+        `application's CF Access dashboard). An empty value would ` +
+        `disable per-application audience binding.`,
+      undefined,
+    );
+  }
+}
+
+export class SigV4Error extends Error {
+  static {
+    SigV4Error.prototype.name = "SigV4Error";
+  }
+
+  readonly code: "expires_in_out_of_range";
+  readonly expiresIn: number;
+
+  private constructor(
+    code: "expires_in_out_of_range",
+    message: string,
+    expiresIn: number,
+  ) {
+    super(message);
+    this.code = code;
+    this.expiresIn = expiresIn;
+  }
+
+  static expiresInOutOfRange(ctx: { expiresIn: number }): SigV4Error {
+    return new SigV4Error(
+      "expires_in_out_of_range",
+      `presignPutUrl: expiresIn must be in [1..604800] seconds, got ${String(ctx.expiresIn)}`,
+      ctx.expiresIn,
+    );
+  }
+}
+
+export class WranglerConfigError extends Error {
+  static {
+    WranglerConfigError.prototype.name = "WranglerConfigError";
+  }
+
+  readonly code: "parse_failed";
+  readonly filename: string;
+  readonly errorCount: number;
+
+  private constructor(
+    code: "parse_failed",
+    message: string,
+    filename: string,
+    errorCount: number,
+  ) {
+    super(message);
+    this.code = code;
+    this.filename = filename;
+    this.errorCount = errorCount;
+  }
+
+  static parseFailed(ctx: {
+    filename: string;
+    errorCount: number;
+  }): WranglerConfigError {
+    return new WranglerConfigError(
+      "parse_failed",
+      `Failed to parse ${ctx.filename}: ${String(ctx.errorCount)} syntax error(s)`,
+      ctx.filename,
+      ctx.errorCount,
+    );
+  }
+}

--- a/packages/runtimes/cloudflare/src/r2.ts
+++ b/packages/runtimes/cloudflare/src/r2.ts
@@ -11,6 +11,7 @@ import type {
   UrlOptions,
 } from "plumix";
 
+import { R2Error } from "./errors.js";
 import { presignPutUrl } from "./sigv4.js";
 
 /**
@@ -104,9 +105,7 @@ interface R2ListOutput {
 
 function readR2Binding(env: unknown, bindingName: string): R2Bucket {
   if (env === null || typeof env !== "object") {
-    throw new Error(
-      `r2(): env is not an object — runtime adapter misconfiguration.`,
-    );
+    throw R2Error.envNotObject();
   }
   const bucket = (env as Record<string, unknown>)[bindingName];
   if (
@@ -114,10 +113,7 @@ function readR2Binding(env: unknown, bindingName: string): R2Bucket {
     typeof bucket !== "object" ||
     typeof (bucket as { put?: unknown }).put !== "function"
   ) {
-    throw new Error(
-      `r2(): env binding "${bindingName}" is missing or not an R2 bucket. ` +
-        `Declare it in wrangler.toml and ensure the name matches.`,
-    );
+    throw R2Error.bindingMissing({ binding: bindingName });
   }
   return bucket as unknown as R2Bucket;
 }

--- a/packages/runtimes/cloudflare/src/sigv4.ts
+++ b/packages/runtimes/cloudflare/src/sigv4.ts
@@ -5,6 +5,8 @@
 // Reference:
 // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
 
+import { SigV4Error } from "./errors.js";
+
 interface SigV4Credentials {
   readonly accessKeyId: string;
   readonly secretAccessKey: string;
@@ -50,9 +52,7 @@ export async function presignPutUrl(
     input.expiresIn < MIN_EXPIRES_IN ||
     input.expiresIn > MAX_EXPIRES_IN
   ) {
-    throw new Error(
-      `presignPutUrl: expiresIn must be in [${String(MIN_EXPIRES_IN)}..${String(MAX_EXPIRES_IN)}] seconds, got ${String(input.expiresIn)}`,
-    );
+    throw SigV4Error.expiresInOutOfRange({ expiresIn: input.expiresIn });
   }
 
   const region = input.credentials.region ?? "auto";

--- a/packages/runtimes/cloudflare/src/wrangler-config.ts
+++ b/packages/runtimes/cloudflare/src/wrangler-config.ts
@@ -4,6 +4,8 @@ import type { ParseError } from "jsonc-parser";
 import { parse as parseJsonc } from "jsonc-parser";
 import { parse as parseToml } from "smol-toml";
 
+import { WranglerConfigError } from "./errors.js";
+
 interface D1BindingEntry {
   readonly binding?: string;
   readonly database_name?: string;
@@ -61,9 +63,10 @@ function parseJsoncStrict(text: string, filename: string): unknown {
   const errors: ParseError[] = [];
   const value: unknown = parseJsonc(text, errors, { allowTrailingComma: true });
   if (errors.length > 0) {
-    throw new Error(
-      `Failed to parse ${filename}: ${errors.length} syntax error(s)`,
-    );
+    throw WranglerConfigError.parseFailed({
+      filename,
+      errorCount: errors.length,
+    });
   }
   return value;
 }

--- a/tooling/eslint/base.ts
+++ b/tooling/eslint/base.ts
@@ -53,3 +53,29 @@ export const baseConfig = defineConfig(
     },
   },
 );
+
+// Named-errors convention (umbrella #232). Production code in opted-in
+// packages may not `throw new Error(...)` — use a factory from the area's
+// errors.ts (e.g. R2Error.bindingMissing({ binding })). Packages opt in
+// by spreading this config alongside baseConfig in their eslint.config.ts.
+// Pilot is packages/runtimes/cloudflare (PR 1 / issue #236); subsequent
+// PRs add the import to more packages.
+export const noBareThrowError = defineConfig({
+  files: ["src/**/*.ts", "src/**/*.tsx"],
+  ignores: [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/test/**",
+  ],
+  rules: {
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector: "ThrowStatement > NewExpression[callee.name='Error']",
+        message:
+          "Use a named factory instead of `throw new Error(...)` — see the area's errors.ts for the pattern (umbrella #232).",
+      },
+    ],
+  },
+});


### PR DESCRIPTION
Pilot of the named-errors convention from umbrella #232 for `@plumix/runtime-cloudflare`. Adds 5 factory-pattern error classes, migrates 7 bare `throw new Error(...)` sites, and ships an opt-in ESLint rule that prevents regressions. Sets the **HITL precedent** for the rollout in subsequent PRs; existing message text is preserved verbatim so call-site regex assertions still pass (146/146 tests).

**Optional-field pattern: `T | undefined` on the instance**

Multi-code classes carry per-code fields flat on the instance, typed as `T | undefined`:

```ts
readonly code: "env_not_object" | "binding_missing";
readonly binding: string | undefined;
```

Pro: matches the PRD's "fields set inline" wording; flat access (`err.binding`). Con: no TS-level link between `code === "binding_missing"` and the field, so consumers narrowing on code must add an explicit `&& err.binding`. Cost is invisible at 1–2 codes; revisit when a class accumulates 3+ codes with distinct field shapes (e.g. PR 2's `PasskeyError` with 15 sub-causes).

**ESLint rule shipped as opt-in, not `files` overrides in base**

The PRD said *"rule in shared base config; `overrides` scopes to `packages/runtimes/cloudflare/src/**`"*. In practice, flat-config `files` globs don't bind cleanly when `eslint` runs from a package subdirectory (verified empirically with relative globs, `**/`-prefixed globs, and `import.meta.dirname` absolute paths).

Instead, `@plumix/eslint-config/base` exports a separate `noBareThrowError` config. Packages opt in explicitly:

```ts
// packages/runtimes/cloudflare/eslint.config.ts
export default defineConfig(baseConfig, noBareThrowError);
```

PR 2/3 broaden the scope by adding the import to one package at a time — smaller diffs, clearer audit trail, no shared glob to maintain. Worth updating the umbrella PRD wording in a follow-up doc PR.

**Errors intentionally not re-exported through `src/index.ts`**

Matches the existing convention for `PlumixRuntimeConfigError` in `adapter.ts`: cloudflare-runtime errors are operator-facing (surfaced via the HTTP response body in `handleAdapterFailure`), not consumer-facing. Plugin authors don't catch these by class.

---

4 throws are left as `throw new Error(...)` with inline lint disables and follow-up refs: 2 `AsyncLocalStorage` boot checks in `adapter.ts` migrate alongside `PlumixRuntimeConfigError` in PR 2 (#234); 2 CLI-flag throws in `commands/dev.ts` go in a future CLI-errors slice. Cause-preservation precedent isn't in this slice (all 7 migrated throws are pure validation) — PR 2's `OAuthError` / `MagicLinkError` migrations will set that precedent.

Refs #232
Refs #233
Refs #236