### PR TITLE
feat(core): named-error factories for runtime + route + theme

### DIFF
--- a/packages/core/eslint.config.ts
+++ b/packages/core/eslint.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(
+  baseConfig,
+  // Migrated areas per umbrella #232. Subsequent slices extend this list.
+  noBareThrowErrorFor([
+    "src/runtime/**/*.ts",
+    "src/route/**/*.ts",
+    "src/theme.ts",
+    "src/theme-errors.ts",
+  ]),
+);

--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -4,6 +4,7 @@ import type {
   RegisteredTermTaxonomy,
 } from "../plugin/manifest.js";
 import type { RouteIntent, RouteRule } from "./intent.js";
+import { RouteCompileError } from "./errors.js";
 
 const AUTO_ROUTE_PRIORITY = 50;
 export const DEFAULT_REWRITE_RULE_PRIORITY = 10;
@@ -161,10 +162,10 @@ function archiveSlugFor(
   if (!hasArchive) return null;
   if (typeof hasArchive === "string") {
     if (!ARCHIVE_SLUG_RE.test(hasArchive)) {
-      throw new Error(
-        `Entry type "${entryType.name}" has invalid hasArchive "${hasArchive}" — ` +
-          `expected a single lowercase kebab-case path segment.`,
-      );
+      throw RouteCompileError.invalidArchiveSlug({
+        entryType: entryType.name,
+        hasArchive,
+      });
     }
     return hasArchive;
   }
@@ -177,15 +178,12 @@ function assertUniquePatterns(rules: readonly CompiledRule[]): void {
   for (const rule of rules) {
     const existing = first.get(rule.rawPattern);
     if (existing !== undefined) {
-      throw new Error(
-        `Rewrite rule "${rule.rawPattern}" is registered twice ` +
-          `(by ${formatOwner(existing)} and ${formatOwner(rule.registeredBy)}).`,
-      );
+      throw RouteCompileError.duplicateRewriteRule({
+        rawPattern: rule.rawPattern,
+        firstOwner: existing,
+        secondOwner: rule.registeredBy,
+      });
     }
     first.set(rule.rawPattern, rule.registeredBy);
   }
-}
-
-function formatOwner(plugin: string | null): string {
-  return plugin === null ? "core" : `plugin "${plugin}"`;
 }

--- a/packages/core/src/route/errors.test.ts
+++ b/packages/core/src/route/errors.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+
+import { RouteCompileError } from "./errors.js";
+
+describe("RouteCompileError.invalidArchiveSlug", () => {
+  test("class identity, code, and exposed entryType + hasArchive", () => {
+    const err = RouteCompileError.invalidArchiveSlug({
+      entryType: "post",
+      hasArchive: "Bad Slug",
+    });
+    expect(err).toBeInstanceOf(RouteCompileError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("RouteCompileError");
+    expect(err.code).toBe("invalid_archive_slug");
+    expect(err.entryType).toBe("post");
+    expect(err.hasArchive).toBe("Bad Slug");
+  });
+
+  test("message names the entry type, the bad slug, and the expected shape", () => {
+    const err = RouteCompileError.invalidArchiveSlug({
+      entryType: "post",
+      hasArchive: "Bad Slug",
+    });
+    expect(err.message).toContain('Entry type "post"');
+    expect(err.message).toContain('invalid hasArchive "Bad Slug"');
+    expect(err.message).toContain("single lowercase kebab-case path segment");
+  });
+});
+
+describe("RouteCompileError.duplicateRewriteRule", () => {
+  test("class identity, code, and exposed pattern + owners", () => {
+    const err = RouteCompileError.duplicateRewriteRule({
+      rawPattern: "/cart",
+      firstOwner: "a",
+      secondOwner: "b",
+    });
+    expect(err).toBeInstanceOf(RouteCompileError);
+    expect(err.name).toBe("RouteCompileError");
+    expect(err.code).toBe("duplicate_rewrite_rule");
+    expect(err.rawPattern).toBe("/cart");
+    expect(err.firstOwner).toBe("a");
+    expect(err.secondOwner).toBe("b");
+  });
+
+  test('message names the pattern and both plugin owners as `plugin "X"`', () => {
+    const err = RouteCompileError.duplicateRewriteRule({
+      rawPattern: "/cart",
+      firstOwner: "a",
+      secondOwner: "a",
+    });
+    expect(err.message).toContain('Rewrite rule "/cart" is registered twice');
+    expect(err.message).toContain('plugin "a"');
+  });
+
+  test("null owners are formatted as `core`", () => {
+    const err = RouteCompileError.duplicateRewriteRule({
+      rawPattern: "/p/:slug",
+      firstOwner: null,
+      secondOwner: "plugin-a",
+    });
+    expect(err.message).toContain("by core");
+    expect(err.message).toContain('plugin "plugin-a"');
+  });
+});

--- a/packages/core/src/route/errors.ts
+++ b/packages/core/src/route/errors.ts
@@ -38,7 +38,7 @@ export class RouteCompileError extends Error {
       "invalid_archive_slug",
       `Entry type "${ctx.entryType}" has invalid hasArchive "${ctx.hasArchive}" — ` +
         `expected a single lowercase kebab-case path segment.`,
-      { entryType: ctx.entryType, hasArchive: ctx.hasArchive },
+      ctx,
     );
   }
 
@@ -51,11 +51,7 @@ export class RouteCompileError extends Error {
       "duplicate_rewrite_rule",
       `Rewrite rule "${ctx.rawPattern}" is registered twice ` +
         `(by ${formatOwner(ctx.firstOwner)} and ${formatOwner(ctx.secondOwner)}).`,
-      {
-        rawPattern: ctx.rawPattern,
-        firstOwner: ctx.firstOwner,
-        secondOwner: ctx.secondOwner,
-      },
+      ctx,
     );
   }
 }

--- a/packages/core/src/route/errors.ts
+++ b/packages/core/src/route/errors.ts
@@ -1,0 +1,65 @@
+export class RouteCompileError extends Error {
+  static {
+    RouteCompileError.prototype.name = "RouteCompileError";
+  }
+
+  readonly code: "invalid_archive_slug" | "duplicate_rewrite_rule";
+  readonly entryType: string | undefined;
+  readonly hasArchive: string | undefined;
+  readonly rawPattern: string | undefined;
+  readonly firstOwner: string | null | undefined;
+  readonly secondOwner: string | null | undefined;
+
+  private constructor(
+    code: "invalid_archive_slug" | "duplicate_rewrite_rule",
+    message: string,
+    fields: {
+      entryType?: string;
+      hasArchive?: string;
+      rawPattern?: string;
+      firstOwner?: string | null;
+      secondOwner?: string | null;
+    },
+  ) {
+    super(message);
+    this.code = code;
+    this.entryType = fields.entryType;
+    this.hasArchive = fields.hasArchive;
+    this.rawPattern = fields.rawPattern;
+    this.firstOwner = fields.firstOwner;
+    this.secondOwner = fields.secondOwner;
+  }
+
+  static invalidArchiveSlug(ctx: {
+    entryType: string;
+    hasArchive: string;
+  }): RouteCompileError {
+    return new RouteCompileError(
+      "invalid_archive_slug",
+      `Entry type "${ctx.entryType}" has invalid hasArchive "${ctx.hasArchive}" — ` +
+        `expected a single lowercase kebab-case path segment.`,
+      { entryType: ctx.entryType, hasArchive: ctx.hasArchive },
+    );
+  }
+
+  static duplicateRewriteRule(ctx: {
+    rawPattern: string;
+    firstOwner: string | null;
+    secondOwner: string | null;
+  }): RouteCompileError {
+    return new RouteCompileError(
+      "duplicate_rewrite_rule",
+      `Rewrite rule "${ctx.rawPattern}" is registered twice ` +
+        `(by ${formatOwner(ctx.firstOwner)} and ${formatOwner(ctx.secondOwner)}).`,
+      {
+        rawPattern: ctx.rawPattern,
+        firstOwner: ctx.firstOwner,
+        secondOwner: ctx.secondOwner,
+      },
+    );
+  }
+}
+
+function formatOwner(plugin: string | null): string {
+  return plugin === null ? "core" : `plugin "${plugin}"`;
+}

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -28,6 +28,7 @@ import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { appRouter } from "../rpc/router.js";
+import { AppBootError } from "./errors.js";
 
 export interface OAuthProviderSummary {
   /** Map key in `auth.oauth.providers`; the URL path segment. */
@@ -112,9 +113,7 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   const themeIds = new Set<string>();
   for (const theme of config.themes) {
     if (themeIds.has(theme.id)) {
-      throw new Error(
-        `Theme id "${theme.id}" appears more than once in config.themes`,
-      );
+      throw AppBootError.duplicateThemeId({ themeId: theme.id });
     }
     themeIds.add(theme.id);
     if (theme.setup) {
@@ -131,9 +130,11 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     for (const [key, value] of Object.entries(plugin.schema)) {
       const previous = origin.get(key);
       if (previous !== undefined) {
-        throw new Error(
-          `Plugin "${plugin.id}" redefines schema export "${key}" (already defined by "${previous}")`,
-        );
+        throw AppBootError.schemaExportConflict({
+          pluginId: plugin.id,
+          schemaKey: key,
+          previousOwner: previous,
+        });
       }
       origin.set(key, plugin.id);
       schema[key] = value;
@@ -145,16 +146,10 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   const mergedRouter = { ...appRouter } as Record<string, unknown>;
   for (const [pluginId, pluginRouter] of registry.rpcRouters) {
     if (CORE_RPC_NAMESPACES.has(pluginId)) {
-      throw new Error(
-        `Plugin id "${pluginId}" collides with a core RPC namespace ` +
-          `at buildApp; rename the plugin.`,
-      );
+      throw AppBootError.pluginIdCollidesWithCoreRpcNamespace({ pluginId });
     }
     if (pluginId in appRouter) {
-      throw new Error(
-        `Plugin id "${pluginId}" collides with the core RPC router key ` +
-          `at buildApp; rename the plugin.`,
-      );
+      throw AppBootError.pluginIdCollidesWithCoreRpcRouter({ pluginId });
     }
     mergedRouter[pluginId] = pluginRouter;
   }

--- a/packages/core/src/runtime/errors.test.ts
+++ b/packages/core/src/runtime/errors.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+
+import { AppBootError } from "./errors.js";
+
+describe("AppBootError.duplicateThemeId", () => {
+  test("class identity, code, and exposed themeId", () => {
+    const err = AppBootError.duplicateThemeId({ themeId: "blog" });
+    expect(err).toBeInstanceOf(AppBootError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("AppBootError");
+    expect(err.code).toBe("duplicate_theme_id");
+    expect(err.themeId).toBe("blog");
+  });
+
+  test("message names the duplicated theme id", () => {
+    const err = AppBootError.duplicateThemeId({ themeId: "blog" });
+    expect(err.message).toContain('Theme id "blog" appears more than once');
+  });
+});
+
+describe("AppBootError.schemaExportConflict", () => {
+  test("class identity, code, and exposed plugin + schema + previous owner", () => {
+    const err = AppBootError.schemaExportConflict({
+      pluginId: "blog",
+      schemaKey: "posts",
+      previousOwner: "core",
+    });
+    expect(err).toBeInstanceOf(AppBootError);
+    expect(err.name).toBe("AppBootError");
+    expect(err.code).toBe("schema_export_conflict");
+    expect(err.pluginId).toBe("blog");
+    expect(err.schemaKey).toBe("posts");
+    expect(err.previousOwner).toBe("core");
+  });
+
+  test("message names plugin, schema key, and previous owner", () => {
+    const err = AppBootError.schemaExportConflict({
+      pluginId: "blog",
+      schemaKey: "posts",
+      previousOwner: "core",
+    });
+    expect(err.message).toContain(
+      'Plugin "blog" redefines schema export "posts"',
+    );
+    expect(err.message).toContain('already defined by "core"');
+  });
+});
+
+describe("AppBootError.pluginIdCollidesWithCoreRpcNamespace", () => {
+  test("class identity, code, and exposed pluginId", () => {
+    const err = AppBootError.pluginIdCollidesWithCoreRpcNamespace({
+      pluginId: "auth",
+    });
+    expect(err).toBeInstanceOf(AppBootError);
+    expect(err.name).toBe("AppBootError");
+    expect(err.code).toBe("plugin_id_collides_with_core_rpc_namespace");
+    expect(err.pluginId).toBe("auth");
+  });
+
+  test("message names the plugin id and asks for a rename", () => {
+    const err = AppBootError.pluginIdCollidesWithCoreRpcNamespace({
+      pluginId: "auth",
+    });
+    expect(err.message).toContain(
+      'Plugin id "auth" collides with a core RPC namespace',
+    );
+    expect(err.message).toContain("rename the plugin");
+  });
+});
+
+describe("AppBootError.pluginIdCollidesWithCoreRpcRouter", () => {
+  test("class identity, code, and exposed pluginId", () => {
+    const err = AppBootError.pluginIdCollidesWithCoreRpcRouter({
+      pluginId: "posts",
+    });
+    expect(err).toBeInstanceOf(AppBootError);
+    expect(err.name).toBe("AppBootError");
+    expect(err.code).toBe("plugin_id_collides_with_core_rpc_router");
+    expect(err.pluginId).toBe("posts");
+  });
+
+  test("message names the plugin id and the core RPC router key", () => {
+    const err = AppBootError.pluginIdCollidesWithCoreRpcRouter({
+      pluginId: "posts",
+    });
+    expect(err.message).toContain(
+      'Plugin id "posts" collides with the core RPC router key',
+    );
+    expect(err.message).toContain("rename the plugin");
+  });
+});

--- a/packages/core/src/runtime/errors.ts
+++ b/packages/core/src/runtime/errors.ts
@@ -37,7 +37,7 @@ export class AppBootError extends Error {
     return new AppBootError(
       "duplicate_theme_id",
       `Theme id "${ctx.themeId}" appears more than once in config.themes`,
-      { themeId: ctx.themeId },
+      ctx,
     );
   }
 
@@ -49,11 +49,7 @@ export class AppBootError extends Error {
     return new AppBootError(
       "schema_export_conflict",
       `Plugin "${ctx.pluginId}" redefines schema export "${ctx.schemaKey}" (already defined by "${ctx.previousOwner}")`,
-      {
-        pluginId: ctx.pluginId,
-        schemaKey: ctx.schemaKey,
-        previousOwner: ctx.previousOwner,
-      },
+      ctx,
     );
   }
 
@@ -64,7 +60,7 @@ export class AppBootError extends Error {
       "plugin_id_collides_with_core_rpc_namespace",
       `Plugin id "${ctx.pluginId}" collides with a core RPC namespace ` +
         `at buildApp; rename the plugin.`,
-      { pluginId: ctx.pluginId },
+      ctx,
     );
   }
 
@@ -75,7 +71,7 @@ export class AppBootError extends Error {
       "plugin_id_collides_with_core_rpc_router",
       `Plugin id "${ctx.pluginId}" collides with the core RPC router key ` +
         `at buildApp; rename the plugin.`,
-      { pluginId: ctx.pluginId },
+      ctx,
     );
   }
 }

--- a/packages/core/src/runtime/errors.ts
+++ b/packages/core/src/runtime/errors.ts
@@ -1,0 +1,81 @@
+type AppBootErrorCode =
+  | "duplicate_theme_id"
+  | "schema_export_conflict"
+  | "plugin_id_collides_with_core_rpc_namespace"
+  | "plugin_id_collides_with_core_rpc_router";
+
+export class AppBootError extends Error {
+  static {
+    AppBootError.prototype.name = "AppBootError";
+  }
+
+  readonly code: AppBootErrorCode;
+  readonly themeId: string | undefined;
+  readonly pluginId: string | undefined;
+  readonly schemaKey: string | undefined;
+  readonly previousOwner: string | undefined;
+
+  private constructor(
+    code: AppBootErrorCode,
+    message: string,
+    fields: {
+      themeId?: string;
+      pluginId?: string;
+      schemaKey?: string;
+      previousOwner?: string;
+    },
+  ) {
+    super(message);
+    this.code = code;
+    this.themeId = fields.themeId;
+    this.pluginId = fields.pluginId;
+    this.schemaKey = fields.schemaKey;
+    this.previousOwner = fields.previousOwner;
+  }
+
+  static duplicateThemeId(ctx: { themeId: string }): AppBootError {
+    return new AppBootError(
+      "duplicate_theme_id",
+      `Theme id "${ctx.themeId}" appears more than once in config.themes`,
+      { themeId: ctx.themeId },
+    );
+  }
+
+  static schemaExportConflict(ctx: {
+    pluginId: string;
+    schemaKey: string;
+    previousOwner: string;
+  }): AppBootError {
+    return new AppBootError(
+      "schema_export_conflict",
+      `Plugin "${ctx.pluginId}" redefines schema export "${ctx.schemaKey}" (already defined by "${ctx.previousOwner}")`,
+      {
+        pluginId: ctx.pluginId,
+        schemaKey: ctx.schemaKey,
+        previousOwner: ctx.previousOwner,
+      },
+    );
+  }
+
+  static pluginIdCollidesWithCoreRpcNamespace(ctx: {
+    pluginId: string;
+  }): AppBootError {
+    return new AppBootError(
+      "plugin_id_collides_with_core_rpc_namespace",
+      `Plugin id "${ctx.pluginId}" collides with a core RPC namespace ` +
+        `at buildApp; rename the plugin.`,
+      { pluginId: ctx.pluginId },
+    );
+  }
+
+  static pluginIdCollidesWithCoreRpcRouter(ctx: {
+    pluginId: string;
+  }): AppBootError {
+    return new AppBootError(
+      "plugin_id_collides_with_core_rpc_router",
+      `Plugin id "${ctx.pluginId}" collides with the core RPC router key ` +
+        `at buildApp; rename the plugin.`,
+      { pluginId: ctx.pluginId },
+    );
+  }
+}

--- a/packages/core/src/theme-errors.test.ts
+++ b/packages/core/src/theme-errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+
+import { ThemeError } from "./theme-errors.js";
+
+describe("ThemeError.invalidThemeId", () => {
+  test("class identity, code, and exposed themeId", () => {
+    const err = ThemeError.invalidThemeId({
+      themeId: "Bad Id!",
+      pattern: "^[a-z][a-z0-9-]*$",
+      maxLength: 64,
+    });
+    expect(err).toBeInstanceOf(ThemeError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ThemeError");
+    expect(err.code).toBe("invalid_theme_id");
+    expect(err.themeId).toBe("Bad Id!");
+  });
+
+  test("message interpolates the bad id, the regex, and the length cap from context", () => {
+    const err = ThemeError.invalidThemeId({
+      themeId: "Bad Id!",
+      pattern: "^[a-z][a-z0-9-]*$",
+      maxLength: 64,
+    });
+    expect(err.message).toContain('defineTheme: id "Bad Id!" is invalid');
+    expect(err.message).toContain("^[a-z][a-z0-9-]*$");
+    expect(err.message).toContain("64");
+  });
+});
+
+describe("ThemeError.setupNotAFunction", () => {
+  test("class identity, code, and exposed themeId", () => {
+    const err = ThemeError.setupNotAFunction({ themeId: "blog" });
+    expect(err).toBeInstanceOf(ThemeError);
+    expect(err.name).toBe("ThemeError");
+    expect(err.code).toBe("setup_not_a_function");
+    expect(err.themeId).toBe("blog");
+  });
+
+  test("message names defineTheme and the offending theme id", () => {
+    const err = ThemeError.setupNotAFunction({ themeId: "blog" });
+    expect(err.message).toContain('defineTheme("blog")');
+    expect(err.message).toContain("`setup` must be a function");
+  });
+});

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -1,0 +1,39 @@
+export class ThemeError extends Error {
+  static {
+    ThemeError.prototype.name = "ThemeError";
+  }
+
+  readonly code: "invalid_theme_id" | "setup_not_a_function";
+  readonly themeId: string;
+
+  private constructor(
+    code: "invalid_theme_id" | "setup_not_a_function",
+    message: string,
+    themeId: string,
+  ) {
+    super(message);
+    this.code = code;
+    this.themeId = themeId;
+  }
+
+  static invalidThemeId(ctx: {
+    themeId: string;
+    pattern: string;
+    maxLength: number;
+  }): ThemeError {
+    return new ThemeError(
+      "invalid_theme_id",
+      `defineTheme: id "${ctx.themeId}" is invalid. Theme ids must ` +
+        `match /${ctx.pattern}/ and be 1–${String(ctx.maxLength)} chars.`,
+      ctx.themeId,
+    );
+  }
+
+  static setupNotAFunction(ctx: { themeId: string }): ThemeError {
+    return new ThemeError(
+      "setup_not_a_function",
+      `defineTheme("${ctx.themeId}"): \`setup\` must be a function when provided.`,
+      ctx.themeId,
+    );
+  }
+}

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,4 +1,5 @@
 import type { ThemeContextExtensions } from "./plugin/context.js";
+import { ThemeError } from "./theme-errors.js";
 
 export interface ThemeSetupContextBase {
   readonly id: string;
@@ -33,18 +34,17 @@ export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
     descriptor.id.length > MAX_THEME_ID_LENGTH ||
     !THEME_ID_RE.test(descriptor.id)
   ) {
-    throw new Error(
-      `defineTheme: id "${descriptor.id}" is invalid. Theme ids must ` +
-        `match /${THEME_ID_RE.source}/ and be 1–${MAX_THEME_ID_LENGTH} chars.`,
-    );
+    throw ThemeError.invalidThemeId({
+      themeId: String(descriptor.id),
+      pattern: THEME_ID_RE.source,
+      maxLength: MAX_THEME_ID_LENGTH,
+    });
   }
   if (
     descriptor.setup !== undefined &&
     typeof descriptor.setup !== "function"
   ) {
-    throw new Error(
-      `defineTheme("${descriptor.id}"): \`setup\` must be a function when provided.`,
-    );
+    throw ThemeError.setupNotAFunction({ themeId: descriptor.id });
   }
   return descriptor;
 }

--- a/tooling/eslint/base.ts
+++ b/tooling/eslint/base.ts
@@ -55,27 +55,32 @@ export const baseConfig = defineConfig(
 );
 
 // Named-errors convention (umbrella #232). Production code in opted-in
-// packages may not `throw new Error(...)` — use a factory from the area's
+// areas may not `throw new Error(...)` — use a factory from the area's
 // errors.ts (e.g. R2Error.bindingMissing({ binding })). Packages opt in
-// by spreading this config alongside baseConfig in their eslint.config.ts.
-// Pilot is packages/runtimes/cloudflare (PR 1 / issue #236); subsequent
-// PRs add the import to more packages.
-export const noBareThrowError = defineConfig({
-  files: ["src/**/*.ts", "src/**/*.tsx"],
-  ignores: [
-    "src/**/*.test.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.ts",
-    "src/**/test/**",
-  ],
-  rules: {
-    "no-restricted-syntax": [
-      "error",
-      {
-        selector: "ThrowStatement > NewExpression[callee.name='Error']",
-        message:
-          "Use a named factory instead of `throw new Error(...)` — see the area's errors.ts for the pattern (umbrella #232).",
-      },
-    ],
-  },
-});
+// by spreading one of these configs alongside baseConfig in their
+// eslint.config.ts. Subsequent PRs broaden the scope by adding the import
+// (or expanding the file globs) on a per-area basis.
+export function noBareThrowErrorFor(filesGlobs: readonly string[]) {
+  return defineConfig({
+    files: [...filesGlobs],
+    ignores: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/test/**"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ThrowStatement > NewExpression[callee.name='Error']",
+          message:
+            "Use a named factory instead of `throw new Error(...)` — see the area's errors.ts for the pattern (umbrella #232).",
+        },
+      ],
+    },
+  });
+}
+
+// Whole-`src/` opt-in. Suitable for packages where every production-code
+// throw site has already been migrated to a factory. Cloudflare runtime
+// uses this shape (issue #236).
+export const noBareThrowError = noBareThrowErrorFor([
+  "src/**/*.ts",
+  "src/**/*.tsx",
+]);


### PR DESCRIPTION
Slice #238 of the named-errors convention. Adds three factory-pattern error classes (`AppBootError`, `RouteCompileError`, `ThemeError`) covering 8 bare `throw new Error(...)` sites across `runtime/app.ts`, `route/compile.ts`, and `theme.ts`. Follows the HITL precedent locked in #275. Existing call-site regex assertions still pass verbatim (1331 → 1344 tests, +13 for the factory contracts).

**Parameterized ESLint rule helper**

`@plumix/eslint-config/base` gains a `noBareThrowErrorFor(filesGlobs)` helper alongside the existing whole-`src/` `noBareThrowError`. Cloudflare's broad opt-in is unchanged; core opts in narrowly to just the migrated areas:

```ts
// packages/core/eslint.config.ts
noBareThrowErrorFor([
  "src/runtime/**/*.ts",
  "src/route/**/*.ts",
  "src/theme.ts",
  "src/theme-errors.ts",
])
```

Subsequent slices extend this array as each area lands. Verified via `pnpm eslint --print-config` that the rule fires inside scope and stays inactive in `src/plugin/**` (which still has ~50 bare throws pending #237).

**`ThemeError` is a sibling file, not a directory**

`theme.ts` is one 50-LOC module. Rather than promote it to `theme/index.ts` to honor the umbrella PRD's literal `theme/errors.ts` path, this slice puts `ThemeError` at `packages/core/src/theme-errors.ts` next to `theme.ts`. Avoids churn on every consumer of `./theme.js`. The ESLint files-glob lists both files explicitly.

**`RouteCompileError.duplicateRewriteRule` absorbs the `formatOwner` helper**

The previous code computed `core` vs `plugin "X"` formatting at the throw site via a `formatOwner` helper. The factory now owns the formatting; callers pass raw `string | null` owners. The helper is deleted from `compile.ts`.

**Theme-id rule constants flow through the factory as context**

`ThemeError.invalidThemeId` takes `{ themeId, pattern, maxLength }` rather than hardcoding the regex source / length cap in the factory message. If `theme.ts` ever tightens the rule, the user-visible message updates without a separate edit to the factory.

Refs #232
Refs #233
Refs #238