### PR TITLE
feat(core): named-error factories for plugin-authoring surface

### DIFF
--- a/packages/core/eslint.config.ts
+++ b/packages/core/eslint.config.ts
@@ -10,5 +10,6 @@ export default defineConfig(
     "src/route/**/*.ts",
     "src/theme.ts",
     "src/theme-errors.ts",
+    "src/plugin/**/*.ts",
   ]),
 );

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -38,6 +38,7 @@ import {
 } from "../auth/rbac.js";
 import { DEFAULT_REWRITE_RULE_PRIORITY } from "../route/compile.js";
 import { MAX_PLUGIN_ID_LENGTH, PLUGIN_ID_RE } from "./define.js";
+import { PluginContextError } from "./errors.js";
 import { CORE_RPC_NAMESPACES, DuplicateRegistrationError } from "./manifest.js";
 
 export interface ContextExtensionEntry {
@@ -293,35 +294,29 @@ export function createPluginProvidesContext({
     value: unknown,
   ): void => {
     if (typeof key !== "string" || key.length === 0) {
-      throw new Error(
-        `Plugin "${pluginId}" called extend${kind}Context with an ` +
-          `invalid key — must be a non-empty string.`,
-      );
+      throw PluginContextError.extendContextInvalidKey({ pluginId, kind });
     }
     if (RESERVED_EXTENSION_KEYS.has(key)) {
-      throw new Error(
-        `Plugin "${pluginId}" called extend${kind}Context with the ` +
-          `reserved name "${key}". JS-builtins (\`__proto__\`, ` +
-          `\`constructor\`, \`prototype\`) can't be used as extension ` +
-          `keys — they would corrupt the per-request context object.`,
-      );
+      throw PluginContextError.extendContextReservedKey({
+        pluginId,
+        kind,
+        key,
+      });
     }
     if (kind === "App" && APP_CONTEXT_BASE_KEYS.has(key)) {
-      throw new Error(
-        `Plugin "${pluginId}" called extendAppContext with "${key}", ` +
-          `which collides with a built-in AppContext member. The ` +
-          `dispatcher would overwrite the runtime field on every ` +
-          `request — rename the extension to a plugin-scoped key.`,
-      );
+      throw PluginContextError.extendAppContextBuiltinCollision({
+        pluginId,
+        key,
+      });
     }
     const existing = target.get(key);
     if (existing) {
-      throw new Error(
-        `Plugin "${pluginId}" extended the ${kind.toLowerCase()} context ` +
-          `with "${key}", but "${existing.pluginId}" already registered it. ` +
-          `Each extension key has exactly one provider — rename one or ` +
-          `consolidate the providing plugin.`,
-      );
+      throw PluginContextError.extendContextDuplicate({
+        pluginId,
+        kind,
+        key,
+        existingOwner: existing.pluginId,
+      });
     }
     target.set(key, { value, pluginId });
   };
@@ -353,14 +348,13 @@ export function createPluginSetupContext({
       const existing = registry.capabilities.get(cap.name);
       if (existing) {
         if (existing.minRole !== cap.minRole) {
-          throw new Error(
-            `Plugin "${pluginId}" derived capability "${cap.name}" with ` +
-              `minRole "${cap.minRole}", but it was already registered ` +
-              `with minRole "${existing.minRole}" by ` +
-              `"${existing.registeredBy ?? "<unknown>"}". Two entry types ` +
-              `/ termTaxonomies sharing a capabilityType must agree on any ` +
-              `\`capabilities\` override — the pool has one cap per name.`,
-          );
+          throw PluginContextError.derivedCapabilityMinRoleMismatch({
+            pluginId,
+            capName: cap.name,
+            minRole: cap.minRole,
+            existingMinRole: existing.minRole,
+            existingOwner: existing.registeredBy ?? "<unknown>",
+          });
         }
         continue;
       }
@@ -481,10 +475,7 @@ export function createPluginSetupContext({
         assertValidIdentifier("settings group reference", groupName);
       }
       if (new Set(options.groups).size !== options.groups.length) {
-        throw new Error(
-          `Settings page "${name}" lists a group more than once; ` +
-            `each group may appear at most once per page.`,
-        );
+        throw PluginContextError.settingsPageDuplicateGroup({ name });
       }
       registry.settingsPages.set(name, {
         ...options,
@@ -504,11 +495,10 @@ export function createPluginSetupContext({
 
     registerRpcRouter: (router) => {
       if (CORE_RPC_NAMESPACES.has(pluginId)) {
-        throw new Error(
-          `Plugin id "${pluginId}" collides with core RPC namespace. ` +
-            `Rename the plugin — reserved names are: ` +
-            `${[...CORE_RPC_NAMESPACES].sort().join(", ")}.`,
-        );
+        throw PluginContextError.pluginIdCollidesWithCoreRpcNamespace({
+          pluginId,
+          coreNamespaces: [...CORE_RPC_NAMESPACES],
+        });
       }
       if (registry.rpcRouters.has(pluginId)) {
         throw new DuplicateRegistrationError("plugin RPC router", pluginId);
@@ -524,10 +514,7 @@ export function createPluginSetupContext({
           existing.method === method &&
           existing.path === path
         ) {
-          throw new Error(
-            `Plugin "${pluginId}" already registered a route for ` +
-              `${method} ${path}.`,
-          );
+          throw PluginContextError.duplicateRoute({ pluginId, method, path });
         }
       }
       registry.rawRoutes.push({
@@ -633,11 +620,7 @@ export function createPluginSetupContext({
     const target = ctx as unknown as Record<string, unknown>;
     for (const [key, value] of extensions) {
       if (key in target) {
-        throw new Error(
-          `Plugin context extension key "${key}" collides with a built-in ` +
-            `PluginSetupContext member. Rename the extension to avoid ` +
-            `shadowing core registration APIs.`,
-        );
+        throw PluginContextError.extensionShadowsBuiltin({ key });
       }
       target[key] = value;
     }
@@ -674,11 +657,7 @@ function assertComponentRef(
   ref: unknown,
 ): void {
   if (typeof ref !== "string" || ref.length === 0) {
-    throw new Error(
-      `Plugin "${pluginId}" registered ${descriptor} with an invalid ` +
-        `component ref — must be a non-empty string naming the export on ` +
-        `the plugin's adminEntry module (e.g. "MediaLibrary").`,
-    );
+    throw PluginContextError.invalidComponentRef({ pluginId, descriptor });
   }
 }
 
@@ -686,21 +665,23 @@ const IDENTIFIER_NAME_RE = /^[a-z][a-z0-9_-]*$/;
 
 function assertValidFieldTypeName(pluginId: string, type: string): void {
   if (!IDENTIFIER_NAME_RE.test(type) || type.length > 64) {
-    throw new Error(
-      `Plugin "${pluginId}" registered meta-box field type with invalid ` +
-        `name "${type}" — must match ${IDENTIFIER_NAME_RE} and be at most 64 ` +
-        `characters.`,
-    );
+    throw PluginContextError.invalidFieldTypeName({
+      pluginId,
+      type,
+      pattern: IDENTIFIER_NAME_RE.source,
+      maxLength: 64,
+    });
   }
 }
 
 function assertValidLookupAdapterKind(pluginId: string, kind: string): void {
   if (!IDENTIFIER_NAME_RE.test(kind) || kind.length > 64) {
-    throw new Error(
-      `Plugin "${pluginId}" registered lookup adapter with invalid ` +
-        `kind "${kind}" — must match ${IDENTIFIER_NAME_RE} and be at most 64 ` +
-        `characters.`,
-    );
+    throw PluginContextError.invalidLookupAdapterKind({
+      pluginId,
+      kind,
+      pattern: IDENTIFIER_NAME_RE.source,
+      maxLength: 64,
+    });
   }
 }
 
@@ -715,16 +696,13 @@ const SCHEDULED_TASK_ID_RE = /^[a-z0-9][a-z0-9_/-]{0,63}$/i;
 
 function assertValidScheduledTask(pluginId: string, task: ScheduledTask): void {
   if (!SCHEDULED_TASK_ID_RE.test(task.id)) {
-    throw new Error(
-      `Plugin "${pluginId}" registered a scheduled task with invalid id ` +
-        `"${task.id}" — must be alphanum + dash/underscore/slash, 1..64 chars.`,
-    );
+    throw PluginContextError.invalidScheduledTaskId({ pluginId, id: task.id });
   }
   if (typeof task.handler !== "function") {
-    throw new Error(
-      `Plugin "${pluginId}" registered scheduled task "${task.id}" without ` +
-        `a handler function.`,
-    );
+    throw PluginContextError.scheduledTaskHandlerMissing({
+      pluginId,
+      id: task.id,
+    });
   }
 }
 
@@ -733,26 +711,25 @@ function assertValidLoginLink(
   options: LoginLinkOptions,
 ): void {
   if (!LOGIN_LINK_KEY_RE.test(options.key)) {
-    throw new Error(
-      `Plugin "${pluginId}" registered a login link with invalid key ` +
-        `"${options.key}" — must be lowercase alphanum + dash/underscore, ` +
-        `1..32 chars.`,
-    );
+    throw PluginContextError.invalidLoginLinkKey({
+      pluginId,
+      key: options.key,
+    });
   }
   if (options.label.length === 0) {
-    throw new Error(
-      `Plugin "${pluginId}" registered login link "${options.key}" with ` +
-        `an empty label.`,
-    );
+    throw PluginContextError.loginLinkEmptyLabel({
+      pluginId,
+      key: options.key,
+    });
   }
   // CR/LF defense: label is rendered into HTML by the admin, but a
   // future logger / audit-trail consumer might splice it into a
   // line-oriented format. Block at the boundary.
   if (/[\r\n]/.test(options.label)) {
-    throw new Error(
-      `Plugin "${pluginId}" registered login link "${options.key}" with ` +
-        `a label containing CR/LF.`,
-    );
+    throw PluginContextError.loginLinkLabelHasCrLf({
+      pluginId,
+      key: options.key,
+    });
   }
   // href must be a same-origin path or an https:// URL — block
   // `javascript:`, `data:`, protocol-relative `//`, and other schemes
@@ -761,26 +738,28 @@ function assertValidLoginLink(
     options.href.startsWith("/") && !options.href.startsWith("//");
   const isHttps = options.href.startsWith("https://");
   if (!isSameOriginPath && !isHttps) {
-    throw new Error(
-      `Plugin "${pluginId}" registered login link "${options.key}" with ` +
-        `href "${options.href}" — must start with "/" (same-origin path) ` +
-        `or "https://".`,
-    );
+    throw PluginContextError.invalidLoginLinkHref({
+      pluginId,
+      key: options.key,
+      href: options.href,
+    });
   }
 }
 
 function assertValidNavGroupId(pluginId: string, id: string): void {
   if (id.length === 0 || id.length > MAX_PLUGIN_ID_LENGTH) {
-    throw new Error(
-      `Plugin "${pluginId}" registered admin nav group with invalid id ` +
-        `"${id}" — length must be 1..${MAX_PLUGIN_ID_LENGTH}.`,
-    );
+    throw PluginContextError.invalidNavGroupIdLength({
+      pluginId,
+      id,
+      maxLength: MAX_PLUGIN_ID_LENGTH,
+    });
   }
   if (!PLUGIN_ID_RE.test(id)) {
-    throw new Error(
-      `Plugin "${pluginId}" registered admin nav group with invalid id ` +
-        `"${id}" — must match ${PLUGIN_ID_RE}.`,
-    );
+    throw PluginContextError.invalidNavGroupIdShape({
+      pluginId,
+      id,
+      pattern: PLUGIN_ID_RE.source,
+    });
   }
 }
 
@@ -794,31 +773,24 @@ function assertValidPathPrefix(
   kind: string,
 ): void {
   if (!path.startsWith("/")) {
-    throw new Error(
-      `Plugin "${pluginId}" ${kind} path "${path}" must start with "/".`,
-    );
+    throw PluginContextError.pathMustStartWithSlash({ pluginId, kind, path });
   }
   if (path.includes("//") || path.includes("..")) {
-    throw new Error(
-      `Plugin "${pluginId}" ${kind} path "${path}" contains "//" or "..".`,
-    );
+    throw PluginContextError.pathContainsTraversal({ pluginId, kind, path });
   }
   if (path.includes("?") || path.includes("#")) {
-    throw new Error(
-      `Plugin "${pluginId}" ${kind} path "${path}" must not include a query ` +
-        `string or fragment — match on the pathname only.`,
-    );
+    throw PluginContextError.pathContainsQueryOrFragment({
+      pluginId,
+      kind,
+      path,
+    });
   }
 }
 
 function assertValidAdminPagePath(pluginId: string, path: string): void {
   assertValidPathPrefix(pluginId, path, "admin page");
   if (path.includes("*")) {
-    throw new Error(
-      `Plugin "${pluginId}" admin page path "${path}" must not contain "*" ` +
-        `— register nested routes via TanStack Router children inside the ` +
-        `page component rather than a wildcard suffix.`,
-    );
+    throw PluginContextError.adminPagePathContainsWildcard({ pluginId, path });
   }
 }
 
@@ -827,19 +799,13 @@ function assertValidPluginRoutePath(pluginId: string, path: string): void {
   // Allow exactly `/*` at the very end. Any other `*` is ambiguous.
   const starIndex = path.indexOf("*");
   if (starIndex !== -1 && starIndex !== path.length - 1) {
-    throw new Error(
-      `Plugin "${pluginId}" route path "${path}" may only contain "*" ` +
-        `as a trailing wildcard (e.g. "/storage/*").`,
-    );
+    throw PluginContextError.routePathWildcardNotAtEnd({ pluginId, path });
   }
   if (
     path.endsWith("*") &&
     (path.length < 2 || path[path.length - 2] !== "/")
   ) {
-    throw new Error(
-      `Plugin "${pluginId}" route path "${path}" must place the trailing ` +
-        `wildcard after a "/" ("/prefix/*", not "/prefix*").`,
-    );
+    throw PluginContextError.routePathWildcardNotAfterSlash({ pluginId, path });
   }
 }
 
@@ -855,17 +821,18 @@ const MAX_SETTINGS_IDENTIFIER_LENGTH = 64;
 
 function assertValidIdentifier(kind: string, name: string): void {
   if (name.length > MAX_SETTINGS_IDENTIFIER_LENGTH) {
-    throw new Error(
-      `Invalid ${kind} name "${name}" — names are capped at ` +
-        `${MAX_SETTINGS_IDENTIFIER_LENGTH} characters to match the RPC ` +
-        `input schema.`,
-    );
+    throw PluginContextError.identifierTooLong({
+      kind,
+      name,
+      maxLength: MAX_SETTINGS_IDENTIFIER_LENGTH,
+    });
   }
   if (!SETTINGS_NAME_RE.test(name)) {
-    throw new Error(
-      `Invalid ${kind} name "${name}" — expected lowercase ASCII ` +
-        `[a-z][a-z0-9_]* so storage keys, testids, and URLs stay portable.`,
-    );
+    throw PluginContextError.identifierShapeInvalid({
+      kind,
+      name,
+      pattern: SETTINGS_NAME_RE.source,
+    });
   }
 }
 
@@ -886,23 +853,29 @@ function assertMetaBoxFields(
   fields: readonly MetaBoxField[],
 ): void {
   if (fields.length > MAX_FIELDS_PER_META_BOX) {
-    throw new Error(
-      `${kind} "${id}" declares ${fields.length} fields; the admin caps ` +
-        `a single box at ${MAX_FIELDS_PER_META_BOX}. Split into multiple boxes.`,
-    );
+    throw PluginContextError.metaBoxTooManyFields({
+      kind,
+      id,
+      count: fields.length,
+      maxFields: MAX_FIELDS_PER_META_BOX,
+    });
   }
   const seen = new Set<string>();
   for (const field of fields) {
     if (!META_FIELD_KEY_RE.test(field.key)) {
-      throw new Error(
-        `${kind} "${id}" declares field with invalid key "${field.key}" — ` +
-          `meta keys must match ${META_FIELD_KEY_RE}.`,
-      );
+      throw PluginContextError.metaBoxFieldInvalidKey({
+        kind,
+        id,
+        fieldKey: field.key,
+        pattern: META_FIELD_KEY_RE.source,
+      });
     }
     if (seen.has(field.key)) {
-      throw new Error(
-        `${kind} "${id}" declares field "${field.key}" more than once.`,
-      );
+      throw PluginContextError.metaBoxFieldDuplicateKey({
+        kind,
+        id,
+        fieldKey: field.key,
+      });
     }
     seen.add(field.key);
   }

--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -1,4 +1,5 @@
 import type { PluginProvidesContext, PluginSetupContext } from "./context.js";
+import { PluginDefinitionError } from "./errors.js";
 
 export type PluginSetup<TConfig> = (
   ctx: PluginSetupContext,
@@ -54,16 +55,16 @@ export const MAX_PLUGIN_ID_LENGTH = 64;
 
 export function assertValidPluginId(id: string): void {
   if (id.length === 0 || id.length > MAX_PLUGIN_ID_LENGTH) {
-    throw new Error(
-      `Plugin id "${id}" must be between 1 and ${MAX_PLUGIN_ID_LENGTH} ` +
-        `characters.`,
-    );
+    throw PluginDefinitionError.invalidPluginIdLength({
+      pluginId: id,
+      pluginIdMaxLength: MAX_PLUGIN_ID_LENGTH,
+    });
   }
   if (!PLUGIN_ID_RE.test(id)) {
-    throw new Error(
-      `Plugin id "${id}" must match ${PLUGIN_ID_RE} (lowercase ASCII ` +
-        `starting with a letter; alphanumerics, hyphens, and underscores).`,
-    );
+    throw PluginDefinitionError.invalidPluginIdShape({
+      pluginId: id,
+      pattern: PLUGIN_ID_RE.source,
+    });
   }
 }
 
@@ -97,11 +98,7 @@ export function definePlugin<TConfig = undefined>(
     };
   }
   if (legacyOptions !== undefined) {
-    throw new Error(
-      `definePlugin("${id}", input) — pass options inside the input ` +
-        `object (\`setup\`, \`provides\`, \`schema\`, ...) instead of the ` +
-        `legacy third argument.`,
-    );
+    throw PluginDefinitionError.definePluginLegacyThirdArg({ pluginId: id });
   }
   warnIfSchemaWithoutSchemaModule(id, setupOrInput);
   return {

--- a/packages/core/src/plugin/errors.test.ts
+++ b/packages/core/src/plugin/errors.test.ts
@@ -1,0 +1,512 @@
+import { describe, expect, test } from "vitest";
+
+import { PluginContextError, PluginDefinitionError } from "./errors.js";
+
+describe("PluginContextError.duplicateRoute", () => {
+  test("class identity, code, and exposed fields", () => {
+    const err = PluginContextError.duplicateRoute({
+      pluginId: "blog",
+      method: "GET",
+      path: "/api/posts",
+    });
+    expect(err).toBeInstanceOf(PluginContextError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("PluginContextError");
+    expect(err.code).toBe("duplicate_route");
+    expect(err.pluginId).toBe("blog");
+    expect(err.kind).toBe("GET");
+    expect(err.path).toBe("/api/posts");
+  });
+
+  test("message names plugin, method, and path", () => {
+    const err = PluginContextError.duplicateRoute({
+      pluginId: "blog",
+      method: "POST",
+      path: "/api/posts",
+    });
+    expect(err.message).toContain(
+      'Plugin "blog" already registered a route for POST /api/posts',
+    );
+  });
+});
+
+describe("PluginContextError — extend-context factories", () => {
+  test("extendContextInvalidKey", () => {
+    const err = PluginContextError.extendContextInvalidKey({
+      pluginId: "blog",
+      kind: "Plugin",
+    });
+    expect(err.code).toBe("extend_context_invalid_key");
+    expect(err.pluginId).toBe("blog");
+    expect(err.kind).toBe("Plugin");
+    expect(err.message).toContain("extendPluginContext with an invalid key");
+  });
+
+  test("extendContextReservedKey", () => {
+    const err = PluginContextError.extendContextReservedKey({
+      pluginId: "blog",
+      kind: "Theme",
+      key: "__proto__",
+    });
+    expect(err.code).toBe("extend_context_reserved_key");
+    expect(err.key).toBe("__proto__");
+    expect(err.message).toContain("extendThemeContext with the reserved name");
+    expect(err.message).toContain('"__proto__"');
+  });
+
+  test("extendAppContextBuiltinCollision", () => {
+    const err = PluginContextError.extendAppContextBuiltinCollision({
+      pluginId: "blog",
+      key: "db",
+    });
+    expect(err.code).toBe("extend_app_context_builtin_collision");
+    expect(err.key).toBe("db");
+    expect(err.message).toContain('extendAppContext with "db"');
+    expect(err.message).toContain("built-in AppContext member");
+  });
+
+  test("extendContextDuplicate", () => {
+    const err = PluginContextError.extendContextDuplicate({
+      pluginId: "blog",
+      kind: "Plugin",
+      key: "logger",
+      existingOwner: "core-logger",
+    });
+    expect(err.code).toBe("extend_context_duplicate");
+    expect(err.existingOwner).toBe("core-logger");
+    expect(err.message).toContain('extended the plugin context with "logger"');
+    expect(err.message).toContain('"core-logger" already registered it');
+  });
+});
+
+describe("PluginContextError — capability + settings + RPC factories", () => {
+  test("derivedCapabilityMinRoleMismatch", () => {
+    const err = PluginContextError.derivedCapabilityMinRoleMismatch({
+      pluginId: "blog",
+      capName: "edit_posts",
+      minRole: "editor",
+      existingMinRole: "author",
+      existingOwner: "core",
+    });
+    expect(err.code).toBe("derived_capability_min_role_mismatch");
+    expect(err.capName).toBe("edit_posts");
+    expect(err.minRole).toBe("editor");
+    expect(err.existingMinRole).toBe("author");
+    expect(err.message).toContain('capability "edit_posts"');
+    expect(err.message).toContain('minRole "editor"');
+    expect(err.message).toContain('minRole "author"');
+  });
+
+  test("settingsPageDuplicateGroup", () => {
+    const err = PluginContextError.settingsPageDuplicateGroup({
+      name: "general",
+    });
+    expect(err.code).toBe("settings_page_duplicate_group");
+    expect(err.identifierName).toBe("general");
+    expect(err.message).toContain('Settings page "general"');
+    expect(err.message).toContain("lists a group more than once");
+  });
+
+  test("pluginIdCollidesWithCoreRpcNamespace", () => {
+    const err = PluginContextError.pluginIdCollidesWithCoreRpcNamespace({
+      pluginId: "auth",
+      coreNamespaces: ["auth", "posts"],
+    });
+    expect(err.code).toBe("plugin_id_collides_with_core_rpc_namespace");
+    expect(err.coreNamespaces).toEqual(["auth", "posts"]);
+    expect(err.message).toContain(
+      'Plugin id "auth" collides with core RPC namespace',
+    );
+    expect(err.message).toContain("auth, posts");
+  });
+
+  test("extensionShadowsBuiltin", () => {
+    const err = PluginContextError.extensionShadowsBuiltin({
+      key: "registerEntryType",
+    });
+    expect(err.code).toBe("extension_shadows_builtin");
+    expect(err.key).toBe("registerEntryType");
+    expect(err.message).toContain(
+      'Plugin context extension key "registerEntryType"',
+    );
+  });
+});
+
+describe("PluginContextError — registration-validation factories", () => {
+  test("invalidComponentRef", () => {
+    const err = PluginContextError.invalidComponentRef({
+      pluginId: "media",
+      descriptor: 'admin page "/media"',
+    });
+    expect(err.code).toBe("invalid_component_ref");
+    expect(err.descriptor).toBe('admin page "/media"');
+    expect(err.message).toContain(
+      'Plugin "media" registered admin page "/media"',
+    );
+    expect(err.message).toContain("invalid component ref");
+  });
+
+  test("invalidFieldTypeName", () => {
+    const err = PluginContextError.invalidFieldTypeName({
+      pluginId: "blog",
+      type: "Bad Type!",
+      pattern: "^[a-z][a-z0-9_-]*$",
+      maxLength: 64,
+    });
+    expect(err.code).toBe("invalid_field_type_name");
+    expect(err.type).toBe("Bad Type!");
+    expect(err.message).toContain('field type with invalid name "Bad Type!"');
+    expect(err.message).toContain("^[a-z][a-z0-9_-]*$");
+    expect(err.message).toContain("64");
+  });
+
+  test("invalidLookupAdapterKind", () => {
+    const err = PluginContextError.invalidLookupAdapterKind({
+      pluginId: "media",
+      kind: "Bad",
+      pattern: "^[a-z][a-z0-9_-]*$",
+      maxLength: 64,
+    });
+    expect(err.code).toBe("invalid_lookup_adapter_kind");
+    expect(err.kind).toBe("Bad");
+    expect(err.message).toContain('lookup adapter with invalid kind "Bad"');
+  });
+
+  test("invalidScheduledTaskId", () => {
+    const err = PluginContextError.invalidScheduledTaskId({
+      pluginId: "blog",
+      id: "Bad Id!",
+    });
+    expect(err.code).toBe("invalid_scheduled_task_id");
+    expect(err.id).toBe("Bad Id!");
+    expect(err.message).toContain('scheduled task with invalid id "Bad Id!"');
+  });
+
+  test("scheduledTaskHandlerMissing", () => {
+    const err = PluginContextError.scheduledTaskHandlerMissing({
+      pluginId: "blog",
+      id: "daily-purge",
+    });
+    expect(err.code).toBe("scheduled_task_handler_missing");
+    expect(err.id).toBe("daily-purge");
+    expect(err.message).toContain('scheduled task "daily-purge" without');
+    expect(err.message).toContain("handler function");
+  });
+});
+
+describe("PluginContextError — login link factories", () => {
+  test("invalidLoginLinkKey", () => {
+    const err = PluginContextError.invalidLoginLinkKey({
+      pluginId: "saml",
+      key: "Bad Key!",
+    });
+    expect(err.code).toBe("invalid_login_link_key");
+    expect(err.key).toBe("Bad Key!");
+    expect(err.message).toContain('login link with invalid key "Bad Key!"');
+  });
+
+  test("loginLinkEmptyLabel", () => {
+    const err = PluginContextError.loginLinkEmptyLabel({
+      pluginId: "saml",
+      key: "sso",
+    });
+    expect(err.code).toBe("login_link_empty_label");
+    expect(err.key).toBe("sso");
+    expect(err.message).toContain('login link "sso" with an empty label');
+  });
+
+  test("loginLinkLabelHasCrLf", () => {
+    const err = PluginContextError.loginLinkLabelHasCrLf({
+      pluginId: "saml",
+      key: "sso",
+    });
+    expect(err.code).toBe("login_link_label_has_crlf");
+    expect(err.message).toContain("label containing CR/LF");
+  });
+
+  test("invalidLoginLinkHref", () => {
+    const err = PluginContextError.invalidLoginLinkHref({
+      pluginId: "saml",
+      key: "sso",
+      href: "javascript:alert(1)",
+    });
+    expect(err.code).toBe("invalid_login_link_href");
+    expect(err.href).toBe("javascript:alert(1)");
+    expect(err.message).toContain('href "javascript:alert(1)"');
+    expect(err.message).toContain('must start with "/"');
+    expect(err.message).toContain('"https://"');
+  });
+});
+
+describe("PluginContextError — nav group factories", () => {
+  test("invalidNavGroupIdLength", () => {
+    const err = PluginContextError.invalidNavGroupIdLength({
+      pluginId: "blog",
+      id: "",
+      maxLength: 64,
+    });
+    expect(err.code).toBe("invalid_nav_group_id_length");
+    expect(err.maxLength).toBe(64);
+    expect(err.message).toContain("admin nav group with invalid id");
+    expect(err.message).toContain("length must be 1..64");
+  });
+
+  test("invalidNavGroupIdShape", () => {
+    const err = PluginContextError.invalidNavGroupIdShape({
+      pluginId: "blog",
+      id: "Bad Id!",
+      pattern: "^[a-z][a-z0-9-]*$",
+    });
+    expect(err.code).toBe("invalid_nav_group_id_shape");
+    expect(err.pattern).toBe("^[a-z][a-z0-9-]*$");
+    expect(err.message).toContain('admin nav group with invalid id "Bad Id!"');
+    expect(err.message).toContain("^[a-z][a-z0-9-]*$");
+  });
+});
+
+describe("PluginContextError — path validation factories", () => {
+  test("pathMustStartWithSlash", () => {
+    const err = PluginContextError.pathMustStartWithSlash({
+      pluginId: "blog",
+      kind: "admin page",
+      path: "no-slash",
+    });
+    expect(err.code).toBe("path_must_start_with_slash");
+    expect(err.kind).toBe("admin page");
+    expect(err.message).toContain(
+      'admin page path "no-slash" must start with "/"',
+    );
+  });
+
+  test("pathContainsTraversal", () => {
+    const err = PluginContextError.pathContainsTraversal({
+      pluginId: "blog",
+      kind: "route",
+      path: "/foo//bar",
+    });
+    expect(err.code).toBe("path_contains_traversal");
+    expect(err.message).toContain(
+      'route path "/foo//bar" contains "//" or ".."',
+    );
+  });
+
+  test("pathContainsQueryOrFragment", () => {
+    const err = PluginContextError.pathContainsQueryOrFragment({
+      pluginId: "blog",
+      kind: "admin page",
+      path: "/foo?bar",
+    });
+    expect(err.code).toBe("path_contains_query_or_fragment");
+    expect(err.message).toContain('admin page path "/foo?bar"');
+    expect(err.message).toContain(
+      "must not include a query string or fragment",
+    );
+  });
+
+  test("adminPagePathContainsWildcard", () => {
+    const err = PluginContextError.adminPagePathContainsWildcard({
+      pluginId: "blog",
+      path: "/foo/*",
+    });
+    expect(err.code).toBe("admin_page_path_contains_wildcard");
+    expect(err.message).toContain(
+      'admin page path "/foo/*" must not contain "*"',
+    );
+  });
+
+  test("routePathWildcardNotAtEnd", () => {
+    const err = PluginContextError.routePathWildcardNotAtEnd({
+      pluginId: "blog",
+      path: "/foo/*/bar",
+    });
+    expect(err.code).toBe("route_path_wildcard_not_at_end");
+    expect(err.message).toContain(
+      'route path "/foo/*/bar" may only contain "*" as a trailing wildcard',
+    );
+  });
+
+  test("routePathWildcardNotAfterSlash", () => {
+    const err = PluginContextError.routePathWildcardNotAfterSlash({
+      pluginId: "blog",
+      path: "/foo*",
+    });
+    expect(err.code).toBe("route_path_wildcard_not_after_slash");
+    expect(err.message).toContain(
+      'route path "/foo*" must place the trailing wildcard after a "/"',
+    );
+  });
+});
+
+describe("PluginContextError — identifier + meta-box factories", () => {
+  test("identifierTooLong", () => {
+    const err = PluginContextError.identifierTooLong({
+      kind: "settings group",
+      name: "x".repeat(65),
+      maxLength: 64,
+    });
+    expect(err.code).toBe("identifier_too_long");
+    expect(err.kind).toBe("settings group");
+    expect(err.maxLength).toBe(64);
+    expect(err.message).toContain("Invalid settings group name");
+    expect(err.message).toContain("capped at 64 characters");
+  });
+
+  test("identifierShapeInvalid", () => {
+    const err = PluginContextError.identifierShapeInvalid({
+      kind: "settings group",
+      name: "Bad Name!",
+      pattern: "^[a-z][a-z0-9_]*$",
+    });
+    expect(err.code).toBe("identifier_shape_invalid");
+    expect(err.message).toContain('Invalid settings group name "Bad Name!"');
+    expect(err.message).toContain("^[a-z][a-z0-9_]*$");
+  });
+
+  test("metaBoxTooManyFields", () => {
+    const err = PluginContextError.metaBoxTooManyFields({
+      kind: "entry meta box",
+      id: "seo",
+      count: 250,
+      maxFields: 200,
+    });
+    expect(err.code).toBe("meta_box_too_many_fields");
+    expect(err.count).toBe(250);
+    expect(err.maxFields).toBe(200);
+    expect(err.message).toContain('entry meta box "seo" declares 250 fields');
+    expect(err.message).toContain("caps a single box at 200");
+  });
+
+  test("metaBoxFieldInvalidKey", () => {
+    const err = PluginContextError.metaBoxFieldInvalidKey({
+      kind: "entry meta box",
+      id: "seo",
+      fieldKey: "bad key!",
+      pattern: "^[a-zA-Z0-9_:-]+$",
+    });
+    expect(err.code).toBe("meta_box_field_invalid_key");
+    expect(err.fieldKey).toBe("bad key!");
+    expect(err.message).toContain(
+      'entry meta box "seo" declares field with invalid key "bad key!"',
+    );
+  });
+
+  test("metaBoxFieldDuplicateKey", () => {
+    const err = PluginContextError.metaBoxFieldDuplicateKey({
+      kind: "entry meta box",
+      id: "seo",
+      fieldKey: "title",
+    });
+    expect(err.code).toBe("meta_box_field_duplicate_key");
+    expect(err.fieldKey).toBe("title");
+    expect(err.message).toContain(
+      'entry meta box "seo" declares field "title" more than once',
+    );
+  });
+});
+
+describe("PluginDefinitionError", () => {
+  test("invalidPluginIdLength", () => {
+    const err = PluginDefinitionError.invalidPluginIdLength({
+      pluginId: "",
+      pluginIdMaxLength: 64,
+    });
+    expect(err).toBeInstanceOf(PluginDefinitionError);
+    expect(err.name).toBe("PluginDefinitionError");
+    expect(err.code).toBe("invalid_plugin_id_length");
+    expect(err.pluginIdMaxLength).toBe(64);
+    expect(err.message).toContain('Plugin id "" must be between 1 and 64');
+  });
+
+  test("invalidPluginIdShape", () => {
+    const err = PluginDefinitionError.invalidPluginIdShape({
+      pluginId: "Bad",
+      pattern: "^[a-z][a-z0-9_-]*$",
+    });
+    expect(err.code).toBe("invalid_plugin_id_shape");
+    expect(err.message).toContain('Plugin id "Bad" must match');
+    expect(err.message).toContain("^[a-z][a-z0-9_-]*$");
+  });
+
+  test("definePluginLegacyThirdArg", () => {
+    const err = PluginDefinitionError.definePluginLegacyThirdArg({
+      pluginId: "blog",
+    });
+    expect(err.code).toBe("define_plugin_legacy_third_arg");
+    expect(err.pluginId).toBe("blog");
+    expect(err.message).toContain('definePlugin("blog", input)');
+    expect(err.message).toContain("legacy third argument");
+  });
+
+  test("duplicatePluginIdInConfig", () => {
+    const err = PluginDefinitionError.duplicatePluginIdInConfig({
+      pluginId: "blog",
+    });
+    expect(err.code).toBe("duplicate_plugin_id_in_config");
+    expect(err.message).toContain(
+      'Plugin id "blog" appears more than once in config.plugins',
+    );
+  });
+
+  test("metaFieldClashAcrossBoxes", () => {
+    const err = PluginDefinitionError.metaFieldClashAcrossBoxes({
+      kind: "entry",
+      fieldKey: "title",
+      firstBoxId: "seo",
+      secondBoxId: "social",
+      scope: "post",
+    });
+    expect(err.code).toBe("meta_field_clash_across_boxes");
+    expect(err.firstBoxId).toBe("seo");
+    expect(err.secondBoxId).toBe("social");
+    expect(err.message).toContain('Meta field "title"');
+    expect(err.message).toContain('"seo" and "social"');
+    expect(err.message).toContain('"post"');
+  });
+
+  test("metaBoxReferencesUnknownScope", () => {
+    const err = PluginDefinitionError.metaBoxReferencesUnknownScope({
+      boxKind: "entry meta box",
+      boxId: "seo",
+      scopeKind: "entry type",
+      scope: "page",
+    });
+    expect(err.code).toBe("meta_box_references_unknown_scope");
+    expect(err.message).toContain(
+      'entry meta box "seo" references entry type "page"',
+    );
+    expect(err.message).toContain("hasn't been registered");
+  });
+
+  test("settingsPageReferencesUnknownGroup", () => {
+    const err = PluginDefinitionError.settingsPageReferencesUnknownGroup({
+      pageName: "general",
+      groupName: "missing",
+    });
+    expect(err.code).toBe("settings_page_references_unknown_group");
+    expect(err.message).toContain(
+      'Settings page "general" references group "missing"',
+    );
+    expect(err.message).toContain("ctx.registerSettingsGroup");
+  });
+
+  test("adminSlugDerivationFailed", () => {
+    const err = PluginDefinitionError.adminSlugDerivationFailed({
+      entryTypeName: "post",
+      from: "its name",
+    });
+    expect(err.code).toBe("admin_slug_derivation_failed");
+    expect(err.entryTypeName).toBe("post");
+    expect(err.from).toBe("its name");
+    expect(err.message).toContain(
+      'Cannot derive an admin slug for post type "post" from its name',
+    );
+  });
+
+  test("adminManifestPlaceholderMissing", () => {
+    const err = PluginDefinitionError.adminManifestPlaceholderMissing({
+      scriptId: "plumix-manifest",
+    });
+    expect(err.code).toBe("admin_manifest_placeholder_missing");
+    expect(err.message).toContain('<script id="plumix-manifest">');
+  });
+});

--- a/packages/core/src/plugin/errors.test.ts
+++ b/packages/core/src/plugin/errors.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, test } from "vitest";
 import { PluginContextError, PluginDefinitionError } from "./errors.js";
 
 describe("PluginContextError.duplicateRoute", () => {
-  test("class identity, code, and exposed fields", () => {
+  test("class identity, code, exposed fields, and message", () => {
     const err = PluginContextError.duplicateRoute({
       pluginId: "blog",
-      method: "GET",
+      method: "POST",
       path: "/api/posts",
     });
     expect(err).toBeInstanceOf(PluginContextError);
@@ -14,16 +14,8 @@ describe("PluginContextError.duplicateRoute", () => {
     expect(err.name).toBe("PluginContextError");
     expect(err.code).toBe("duplicate_route");
     expect(err.pluginId).toBe("blog");
-    expect(err.kind).toBe("GET");
+    expect(err.kind).toBe("POST");
     expect(err.path).toBe("/api/posts");
-  });
-
-  test("message names plugin, method, and path", () => {
-    const err = PluginContextError.duplicateRoute({
-      pluginId: "blog",
-      method: "POST",
-      path: "/api/posts",
-    });
     expect(err.message).toContain(
       'Plugin "blog" already registered a route for POST /api/posts',
     );

--- a/packages/core/src/plugin/errors.ts
+++ b/packages/core/src/plugin/errors.ts
@@ -1,0 +1,714 @@
+type PluginContextErrorCode =
+  | "duplicate_route"
+  | "extend_context_invalid_key"
+  | "extend_context_reserved_key"
+  | "extend_app_context_builtin_collision"
+  | "extend_context_duplicate"
+  | "derived_capability_min_role_mismatch"
+  | "settings_page_duplicate_group"
+  | "plugin_id_collides_with_core_rpc_namespace"
+  | "extension_shadows_builtin"
+  | "invalid_component_ref"
+  | "invalid_field_type_name"
+  | "invalid_lookup_adapter_kind"
+  | "invalid_scheduled_task_id"
+  | "scheduled_task_handler_missing"
+  | "invalid_login_link_key"
+  | "login_link_empty_label"
+  | "login_link_label_has_crlf"
+  | "invalid_login_link_href"
+  | "invalid_nav_group_id_length"
+  | "invalid_nav_group_id_shape"
+  | "path_must_start_with_slash"
+  | "path_contains_traversal"
+  | "path_contains_query_or_fragment"
+  | "admin_page_path_contains_wildcard"
+  | "route_path_wildcard_not_at_end"
+  | "route_path_wildcard_not_after_slash"
+  | "identifier_too_long"
+  | "identifier_shape_invalid"
+  | "meta_box_too_many_fields"
+  | "meta_box_field_invalid_key"
+  | "meta_box_field_duplicate_key";
+
+interface PluginContextErrorFields {
+  pluginId?: string;
+  kind?: string;
+  key?: string;
+  path?: string;
+  identifierName?: string;
+  id?: string;
+  type?: string;
+  href?: string;
+  descriptor?: string;
+  existingOwner?: string;
+  capName?: string;
+  minRole?: string;
+  existingMinRole?: string;
+  fieldKey?: string;
+  pattern?: string;
+  count?: number;
+  maxLength?: number;
+  maxFields?: number;
+  coreNamespaces?: readonly string[];
+}
+
+export class PluginContextError extends Error {
+  static {
+    PluginContextError.prototype.name = "PluginContextError";
+  }
+
+  readonly code: PluginContextErrorCode;
+  readonly pluginId: string | undefined;
+  readonly kind: string | undefined;
+  readonly key: string | undefined;
+  readonly path: string | undefined;
+  readonly identifierName: string | undefined;
+  readonly id: string | undefined;
+  readonly type: string | undefined;
+  readonly href: string | undefined;
+  readonly descriptor: string | undefined;
+  readonly existingOwner: string | undefined;
+  readonly capName: string | undefined;
+  readonly minRole: string | undefined;
+  readonly existingMinRole: string | undefined;
+  readonly fieldKey: string | undefined;
+  readonly pattern: string | undefined;
+  readonly count: number | undefined;
+  readonly maxLength: number | undefined;
+  readonly maxFields: number | undefined;
+  readonly coreNamespaces: readonly string[] | undefined;
+
+  private constructor(
+    code: PluginContextErrorCode,
+    message: string,
+    fields: PluginContextErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.pluginId = fields.pluginId;
+    this.kind = fields.kind;
+    this.key = fields.key;
+    this.path = fields.path;
+    this.identifierName = fields.identifierName;
+    this.id = fields.id;
+    this.type = fields.type;
+    this.href = fields.href;
+    this.descriptor = fields.descriptor;
+    this.existingOwner = fields.existingOwner;
+    this.capName = fields.capName;
+    this.minRole = fields.minRole;
+    this.existingMinRole = fields.existingMinRole;
+    this.fieldKey = fields.fieldKey;
+    this.pattern = fields.pattern;
+    this.count = fields.count;
+    this.maxLength = fields.maxLength;
+    this.maxFields = fields.maxFields;
+    this.coreNamespaces = fields.coreNamespaces;
+  }
+
+  static duplicateRoute(ctx: {
+    pluginId: string;
+    method: string;
+    path: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "duplicate_route",
+      `Plugin "${ctx.pluginId}" already registered a route for ${ctx.method} ${ctx.path}.`,
+      { pluginId: ctx.pluginId, kind: ctx.method, path: ctx.path },
+    );
+  }
+
+  static extendContextInvalidKey(ctx: {
+    pluginId: string;
+    kind: "Plugin" | "Theme" | "App";
+  }): PluginContextError {
+    return new PluginContextError(
+      "extend_context_invalid_key",
+      `Plugin "${ctx.pluginId}" called extend${ctx.kind}Context with an ` +
+        `invalid key — must be a non-empty string.`,
+      ctx,
+    );
+  }
+
+  static extendContextReservedKey(ctx: {
+    pluginId: string;
+    kind: "Plugin" | "Theme" | "App";
+    key: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "extend_context_reserved_key",
+      `Plugin "${ctx.pluginId}" called extend${ctx.kind}Context with the ` +
+        `reserved name "${ctx.key}". JS-builtins (\`__proto__\`, ` +
+        `\`constructor\`, \`prototype\`) can't be used as extension ` +
+        `keys — they would corrupt the per-request context object.`,
+      ctx,
+    );
+  }
+
+  static extendAppContextBuiltinCollision(ctx: {
+    pluginId: string;
+    key: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "extend_app_context_builtin_collision",
+      `Plugin "${ctx.pluginId}" called extendAppContext with "${ctx.key}", ` +
+        `which collides with a built-in AppContext member. The ` +
+        `dispatcher would overwrite the runtime field on every ` +
+        `request — rename the extension to a plugin-scoped key.`,
+      ctx,
+    );
+  }
+
+  static extendContextDuplicate(ctx: {
+    pluginId: string;
+    kind: "Plugin" | "Theme" | "App";
+    key: string;
+    existingOwner: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "extend_context_duplicate",
+      `Plugin "${ctx.pluginId}" extended the ${ctx.kind.toLowerCase()} context ` +
+        `with "${ctx.key}", but "${ctx.existingOwner}" already registered it. ` +
+        `Each extension key has exactly one provider — rename one or ` +
+        `consolidate the providing plugin.`,
+      ctx,
+    );
+  }
+
+  static derivedCapabilityMinRoleMismatch(ctx: {
+    pluginId: string;
+    capName: string;
+    minRole: string;
+    existingMinRole: string;
+    existingOwner: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "derived_capability_min_role_mismatch",
+      `Plugin "${ctx.pluginId}" derived capability "${ctx.capName}" with ` +
+        `minRole "${ctx.minRole}", but it was already registered ` +
+        `with minRole "${ctx.existingMinRole}" by ` +
+        `"${ctx.existingOwner}". Two entry types ` +
+        `/ termTaxonomies sharing a capabilityType must agree on any ` +
+        `\`capabilities\` override — the pool has one cap per name.`,
+      ctx,
+    );
+  }
+
+  static settingsPageDuplicateGroup(ctx: { name: string }): PluginContextError {
+    return new PluginContextError(
+      "settings_page_duplicate_group",
+      `Settings page "${ctx.name}" lists a group more than once; ` +
+        `each group may appear at most once per page.`,
+      { identifierName: ctx.name },
+    );
+  }
+
+  static pluginIdCollidesWithCoreRpcNamespace(ctx: {
+    pluginId: string;
+    coreNamespaces: readonly string[];
+  }): PluginContextError {
+    return new PluginContextError(
+      "plugin_id_collides_with_core_rpc_namespace",
+      `Plugin id "${ctx.pluginId}" collides with core RPC namespace. ` +
+        `Rename the plugin — reserved names are: ` +
+        `${[...ctx.coreNamespaces].sort().join(", ")}.`,
+      ctx,
+    );
+  }
+
+  static extensionShadowsBuiltin(ctx: { key: string }): PluginContextError {
+    return new PluginContextError(
+      "extension_shadows_builtin",
+      `Plugin context extension key "${ctx.key}" collides with a built-in ` +
+        `PluginSetupContext member. Rename the extension to avoid ` +
+        `shadowing core registration APIs.`,
+      ctx,
+    );
+  }
+
+  static invalidComponentRef(ctx: {
+    pluginId: string;
+    descriptor: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "invalid_component_ref",
+      `Plugin "${ctx.pluginId}" registered ${ctx.descriptor} with an invalid ` +
+        `component ref — must be a non-empty string naming the export on ` +
+        `the plugin's adminEntry module (e.g. "MediaLibrary").`,
+      ctx,
+    );
+  }
+
+  static invalidFieldTypeName(ctx: {
+    pluginId: string;
+    type: string;
+    pattern: string;
+    maxLength: number;
+  }): PluginContextError {
+    return new PluginContextError(
+      "invalid_field_type_name",
+      `Plugin "${ctx.pluginId}" registered meta-box field type with invalid ` +
+        `name "${ctx.type}" — must match /${ctx.pattern}/ and be at most ${String(ctx.maxLength)} ` +
+        `characters.`,
+      ctx,
+    );
+  }
+
+  static invalidLookupAdapterKind(ctx: {
+    pluginId: string;
+    kind: string;
+    pattern: string;
+    maxLength: number;
+  }): PluginContextError {
+    return new PluginContextError(
+      "invalid_lookup_adapter_kind",
+      `Plugin "${ctx.pluginId}" registered lookup adapter with invalid ` +
+        `kind "${ctx.kind}" — must match /${ctx.pattern}/ and be at most ${String(ctx.maxLength)} ` +
+        `characters.`,
+      ctx,
+    );
+  }
+
+  static invalidScheduledTaskId(ctx: {
+    pluginId: string;
+    id: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "invalid_scheduled_task_id",
+      `Plugin "${ctx.pluginId}" registered a scheduled task with invalid id ` +
+        `"${ctx.id}" — must be alphanum + dash/underscore/slash, 1..64 chars.`,
+      ctx,
+    );
+  }
+
+  static scheduledTaskHandlerMissing(ctx: {
+    pluginId: string;
+    id: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "scheduled_task_handler_missing",
+      `Plugin "${ctx.pluginId}" registered scheduled task "${ctx.id}" without ` +
+        `a handler function.`,
+      ctx,
+    );
+  }
+
+  static invalidLoginLinkKey(ctx: {
+    pluginId: string;
+    key: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "invalid_login_link_key",
+      `Plugin "${ctx.pluginId}" registered a login link with invalid key ` +
+        `"${ctx.key}" — must be lowercase alphanum + dash/underscore, ` +
+        `1..32 chars.`,
+      ctx,
+    );
+  }
+
+  static loginLinkEmptyLabel(ctx: {
+    pluginId: string;
+    key: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "login_link_empty_label",
+      `Plugin "${ctx.pluginId}" registered login link "${ctx.key}" with ` +
+        `an empty label.`,
+      ctx,
+    );
+  }
+
+  static loginLinkLabelHasCrLf(ctx: {
+    pluginId: string;
+    key: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "login_link_label_has_crlf",
+      `Plugin "${ctx.pluginId}" registered login link "${ctx.key}" with ` +
+        `a label containing CR/LF.`,
+      ctx,
+    );
+  }
+
+  static invalidLoginLinkHref(ctx: {
+    pluginId: string;
+    key: string;
+    href: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "invalid_login_link_href",
+      `Plugin "${ctx.pluginId}" registered login link "${ctx.key}" with ` +
+        `href "${ctx.href}" — must start with "/" (same-origin path) ` +
+        `or "https://".`,
+      ctx,
+    );
+  }
+
+  static invalidNavGroupIdLength(ctx: {
+    pluginId: string;
+    id: string;
+    maxLength: number;
+  }): PluginContextError {
+    return new PluginContextError(
+      "invalid_nav_group_id_length",
+      `Plugin "${ctx.pluginId}" registered admin nav group with invalid id ` +
+        `"${ctx.id}" — length must be 1..${String(ctx.maxLength)}.`,
+      ctx,
+    );
+  }
+
+  static invalidNavGroupIdShape(ctx: {
+    pluginId: string;
+    id: string;
+    pattern: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "invalid_nav_group_id_shape",
+      `Plugin "${ctx.pluginId}" registered admin nav group with invalid id ` +
+        `"${ctx.id}" — must match /${ctx.pattern}/.`,
+      ctx,
+    );
+  }
+
+  static pathMustStartWithSlash(ctx: {
+    pluginId: string;
+    kind: string;
+    path: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "path_must_start_with_slash",
+      `Plugin "${ctx.pluginId}" ${ctx.kind} path "${ctx.path}" must start with "/".`,
+      ctx,
+    );
+  }
+
+  static pathContainsTraversal(ctx: {
+    pluginId: string;
+    kind: string;
+    path: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "path_contains_traversal",
+      `Plugin "${ctx.pluginId}" ${ctx.kind} path "${ctx.path}" contains "//" or "..".`,
+      ctx,
+    );
+  }
+
+  static pathContainsQueryOrFragment(ctx: {
+    pluginId: string;
+    kind: string;
+    path: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "path_contains_query_or_fragment",
+      `Plugin "${ctx.pluginId}" ${ctx.kind} path "${ctx.path}" must not include a query ` +
+        `string or fragment — match on the pathname only.`,
+      ctx,
+    );
+  }
+
+  static adminPagePathContainsWildcard(ctx: {
+    pluginId: string;
+    path: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "admin_page_path_contains_wildcard",
+      `Plugin "${ctx.pluginId}" admin page path "${ctx.path}" must not contain "*" ` +
+        `— register nested routes via TanStack Router children inside the ` +
+        `page component rather than a wildcard suffix.`,
+      ctx,
+    );
+  }
+
+  static routePathWildcardNotAtEnd(ctx: {
+    pluginId: string;
+    path: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "route_path_wildcard_not_at_end",
+      `Plugin "${ctx.pluginId}" route path "${ctx.path}" may only contain "*" ` +
+        `as a trailing wildcard (e.g. "/storage/*").`,
+      ctx,
+    );
+  }
+
+  static routePathWildcardNotAfterSlash(ctx: {
+    pluginId: string;
+    path: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "route_path_wildcard_not_after_slash",
+      `Plugin "${ctx.pluginId}" route path "${ctx.path}" must place the trailing ` +
+        `wildcard after a "/" ("/prefix/*", not "/prefix*").`,
+      ctx,
+    );
+  }
+
+  static identifierTooLong(ctx: {
+    kind: string;
+    name: string;
+    maxLength: number;
+  }): PluginContextError {
+    return new PluginContextError(
+      "identifier_too_long",
+      `Invalid ${ctx.kind} name "${ctx.name}" — names are capped at ` +
+        `${String(ctx.maxLength)} characters to match the RPC ` +
+        `input schema.`,
+      {
+        kind: ctx.kind,
+        identifierName: ctx.name,
+        maxLength: ctx.maxLength,
+      },
+    );
+  }
+
+  static identifierShapeInvalid(ctx: {
+    kind: string;
+    name: string;
+    pattern: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "identifier_shape_invalid",
+      `Invalid ${ctx.kind} name "${ctx.name}" — expected lowercase ASCII ` +
+        `/${ctx.pattern}/ so storage keys, testids, and URLs stay portable.`,
+      {
+        kind: ctx.kind,
+        identifierName: ctx.name,
+        pattern: ctx.pattern,
+      },
+    );
+  }
+
+  static metaBoxTooManyFields(ctx: {
+    kind: string;
+    id: string;
+    count: number;
+    maxFields: number;
+  }): PluginContextError {
+    return new PluginContextError(
+      "meta_box_too_many_fields",
+      `${ctx.kind} "${ctx.id}" declares ${String(ctx.count)} fields; the admin caps ` +
+        `a single box at ${String(ctx.maxFields)}. Split into multiple boxes.`,
+      ctx,
+    );
+  }
+
+  static metaBoxFieldInvalidKey(ctx: {
+    kind: string;
+    id: string;
+    fieldKey: string;
+    pattern: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "meta_box_field_invalid_key",
+      `${ctx.kind} "${ctx.id}" declares field with invalid key "${ctx.fieldKey}" — ` +
+        `meta keys must match /${ctx.pattern}/.`,
+      ctx,
+    );
+  }
+
+  static metaBoxFieldDuplicateKey(ctx: {
+    kind: string;
+    id: string;
+    fieldKey: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "meta_box_field_duplicate_key",
+      `${ctx.kind} "${ctx.id}" declares field "${ctx.fieldKey}" more than once.`,
+      ctx,
+    );
+  }
+}
+
+type PluginDefinitionErrorCode =
+  | "invalid_plugin_id_length"
+  | "invalid_plugin_id_shape"
+  | "define_plugin_legacy_third_arg"
+  | "duplicate_plugin_id_in_config"
+  | "meta_field_clash_across_boxes"
+  | "meta_box_references_unknown_scope"
+  | "settings_page_references_unknown_group"
+  | "admin_slug_derivation_failed"
+  | "admin_manifest_placeholder_missing";
+
+interface PluginDefinitionErrorFields {
+  pluginId?: string;
+  pluginIdMaxLength?: number;
+  pattern?: string;
+  kind?: string;
+  fieldKey?: string;
+  firstBoxId?: string;
+  secondBoxId?: string;
+  scope?: string;
+  boxKind?: string;
+  boxId?: string;
+  scopeKind?: string;
+  pageName?: string;
+  groupName?: string;
+  entryTypeName?: string;
+  from?: string;
+  scriptId?: string;
+}
+
+export class PluginDefinitionError extends Error {
+  static {
+    PluginDefinitionError.prototype.name = "PluginDefinitionError";
+  }
+
+  readonly code: PluginDefinitionErrorCode;
+  readonly pluginId: string | undefined;
+  readonly pluginIdMaxLength: number | undefined;
+  readonly pattern: string | undefined;
+  readonly kind: string | undefined;
+  readonly fieldKey: string | undefined;
+  readonly firstBoxId: string | undefined;
+  readonly secondBoxId: string | undefined;
+  readonly scope: string | undefined;
+  readonly boxKind: string | undefined;
+  readonly boxId: string | undefined;
+  readonly scopeKind: string | undefined;
+  readonly pageName: string | undefined;
+  readonly groupName: string | undefined;
+  readonly entryTypeName: string | undefined;
+  readonly from: string | undefined;
+  readonly scriptId: string | undefined;
+
+  private constructor(
+    code: PluginDefinitionErrorCode,
+    message: string,
+    fields: PluginDefinitionErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.pluginId = fields.pluginId;
+    this.pluginIdMaxLength = fields.pluginIdMaxLength;
+    this.pattern = fields.pattern;
+    this.kind = fields.kind;
+    this.fieldKey = fields.fieldKey;
+    this.firstBoxId = fields.firstBoxId;
+    this.secondBoxId = fields.secondBoxId;
+    this.scope = fields.scope;
+    this.boxKind = fields.boxKind;
+    this.boxId = fields.boxId;
+    this.scopeKind = fields.scopeKind;
+    this.pageName = fields.pageName;
+    this.groupName = fields.groupName;
+    this.entryTypeName = fields.entryTypeName;
+    this.from = fields.from;
+    this.scriptId = fields.scriptId;
+  }
+
+  static invalidPluginIdLength(ctx: {
+    pluginId: string;
+    pluginIdMaxLength: number;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "invalid_plugin_id_length",
+      `Plugin id "${ctx.pluginId}" must be between 1 and ${String(ctx.pluginIdMaxLength)} ` +
+        `characters.`,
+      ctx,
+    );
+  }
+
+  static invalidPluginIdShape(ctx: {
+    pluginId: string;
+    pattern: string;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "invalid_plugin_id_shape",
+      `Plugin id "${ctx.pluginId}" must match /${ctx.pattern}/ (lowercase ASCII ` +
+        `starting with a letter; alphanumerics, hyphens, and underscores).`,
+      ctx,
+    );
+  }
+
+  static definePluginLegacyThirdArg(ctx: {
+    pluginId: string;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "define_plugin_legacy_third_arg",
+      `definePlugin("${ctx.pluginId}", input) — pass options inside the input ` +
+        `object (\`setup\`, \`provides\`, \`schema\`, ...) instead of the ` +
+        `legacy third argument.`,
+      ctx,
+    );
+  }
+
+  static duplicatePluginIdInConfig(ctx: {
+    pluginId: string;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "duplicate_plugin_id_in_config",
+      `Plugin id "${ctx.pluginId}" appears more than once in ` +
+        `config.plugins — each plugin id must be unique.`,
+      ctx,
+    );
+  }
+
+  static metaFieldClashAcrossBoxes(ctx: {
+    kind: string;
+    fieldKey: string;
+    firstBoxId: string;
+    secondBoxId: string;
+    scope: string;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "meta_field_clash_across_boxes",
+      `Meta field "${ctx.fieldKey}" is declared by ${ctx.kind} meta ` +
+        `boxes "${ctx.firstBoxId}" and "${ctx.secondBoxId}" on the same scope ` +
+        `"${ctx.scope}". Each key may appear in at most one box ` +
+        `per scope.`,
+      ctx,
+    );
+  }
+
+  static metaBoxReferencesUnknownScope(ctx: {
+    boxKind: string;
+    boxId: string;
+    scopeKind: string;
+    scope: string;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "meta_box_references_unknown_scope",
+      `${ctx.boxKind} "${ctx.boxId}" references ${ctx.scopeKind} "${ctx.scope}" ` +
+        `which hasn't been registered.`,
+      ctx,
+    );
+  }
+
+  static settingsPageReferencesUnknownGroup(ctx: {
+    pageName: string;
+    groupName: string;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "settings_page_references_unknown_group",
+      `Settings page "${ctx.pageName}" references group "${ctx.groupName}" ` +
+        `which hasn't been registered. Call ` +
+        `ctx.registerSettingsGroup("${ctx.groupName}", {...}) before the page.`,
+      ctx,
+    );
+  }
+
+  static adminSlugDerivationFailed(ctx: {
+    entryTypeName: string;
+    from: string;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "admin_slug_derivation_failed",
+      `Cannot derive an admin slug for post type "${ctx.entryTypeName}" from ${ctx.from} — result was empty.`,
+      ctx,
+    );
+  }
+
+  static adminManifestPlaceholderMissing(ctx: {
+    scriptId: string;
+  }): PluginDefinitionError {
+    return new PluginDefinitionError(
+      "admin_manifest_placeholder_missing",
+      `Admin index.html is missing the <script id="${ctx.scriptId}"> ` +
+        `placeholder. Rebuild @plumix/admin.`,
+      ctx,
+    );
+  }
+}

--- a/packages/core/src/plugin/fields/color.ts
+++ b/packages/core/src/plugin/fields/color.ts
@@ -42,6 +42,7 @@ export function color(options: ColorFieldOptions): ColorMetaBoxField {
 
 function defaultColorSanitize(value: unknown): string {
   if (typeof value !== "string" || !HEX_COLOR.test(value)) {
+    // eslint-disable-next-line no-restricted-syntax -- sanitizer flow-control sentinel; migrated in the field-sanitizer-error slice
     throw new Error("invalid_value");
   }
   return value.toLowerCase();

--- a/packages/core/src/plugin/fields/errors.test.ts
+++ b/packages/core/src/plugin/fields/errors.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+
+import { FieldConfigError } from "./errors.js";
+
+describe("FieldConfigError.rangeMinGreaterThanMax", () => {
+  test("class identity, code, and exposed fields", () => {
+    const err = FieldConfigError.rangeMinGreaterThanMax({
+      fieldKey: "score",
+      min: 10,
+      max: 5,
+    });
+    expect(err).toBeInstanceOf(FieldConfigError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("FieldConfigError");
+    expect(err.code).toBe("range_min_greater_than_max");
+    expect(err.fieldKey).toBe("score");
+    expect(err.min).toBe(10);
+    expect(err.max).toBe(5);
+  });
+
+  test("message interpolates fieldKey, min, and max", () => {
+    const err = FieldConfigError.rangeMinGreaterThanMax({
+      fieldKey: "score",
+      min: 10,
+      max: 5,
+    });
+    expect(err.message).toContain('range field "score"');
+    expect(err.message).toContain("min (10)");
+    expect(err.message).toContain("max (5)");
+  });
+});
+
+describe("FieldConfigError — repeater factories", () => {
+  test("repeaterNestedNotSupported", () => {
+    const err = FieldConfigError.repeaterNestedNotSupported({
+      repeaterKey: "items",
+      subFieldKey: "nested",
+    });
+    expect(err.code).toBe("repeater_nested_not_supported");
+    expect(err.repeaterKey).toBe("items");
+    expect(err.subFieldKey).toBe("nested");
+    expect(err.message).toContain(
+      'repeater("items") subFields contains a nested repeater',
+    );
+    expect(err.message).toContain('"nested"');
+  });
+
+  test("repeaterSubFieldKeyForbidden", () => {
+    const err = FieldConfigError.repeaterSubFieldKeyForbidden({
+      repeaterKey: "items",
+      subFieldKey: "__proto__",
+    });
+    expect(err.code).toBe("repeater_sub_field_key_forbidden");
+    expect(err.message).toContain(
+      'repeater("items") subField key "__proto__" is forbidden',
+    );
+    expect(err.message).toContain("prototype-pollution risk");
+  });
+
+  test("repeaterSubFieldKeyInvalid", () => {
+    const err = FieldConfigError.repeaterSubFieldKeyInvalid({
+      repeaterKey: "items",
+      subFieldKey: "bad key!",
+      pattern: "^[a-zA-Z0-9_:-]+$",
+    });
+    expect(err.code).toBe("repeater_sub_field_key_invalid");
+    expect(err.pattern).toBe("^[a-zA-Z0-9_:-]+$");
+    expect(err.message).toContain(
+      'repeater("items") subField key "bad key!" must match',
+    );
+    expect(err.message).toContain("^[a-zA-Z0-9_:-]+$");
+  });
+
+  test("repeaterSubFieldDuplicate", () => {
+    const err = FieldConfigError.repeaterSubFieldDuplicate({
+      repeaterKey: "items",
+      subFieldKey: "title",
+    });
+    expect(err.code).toBe("repeater_sub_field_duplicate");
+    expect(err.message).toContain(
+      'repeater("items") declares subField "title" more than once',
+    );
+  });
+});

--- a/packages/core/src/plugin/fields/errors.ts
+++ b/packages/core/src/plugin/fields/errors.ts
@@ -1,0 +1,104 @@
+type FieldConfigErrorCode =
+  | "range_min_greater_than_max"
+  | "repeater_nested_not_supported"
+  | "repeater_sub_field_key_forbidden"
+  | "repeater_sub_field_key_invalid"
+  | "repeater_sub_field_duplicate";
+
+interface FieldConfigErrorFields {
+  fieldKey?: string;
+  repeaterKey?: string;
+  subFieldKey?: string;
+  min?: number;
+  max?: number;
+  pattern?: string;
+}
+
+export class FieldConfigError extends Error {
+  static {
+    FieldConfigError.prototype.name = "FieldConfigError";
+  }
+
+  readonly code: FieldConfigErrorCode;
+  readonly fieldKey: string | undefined;
+  readonly repeaterKey: string | undefined;
+  readonly subFieldKey: string | undefined;
+  readonly min: number | undefined;
+  readonly max: number | undefined;
+  readonly pattern: string | undefined;
+
+  private constructor(
+    code: FieldConfigErrorCode,
+    message: string,
+    fields: FieldConfigErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.fieldKey = fields.fieldKey;
+    this.repeaterKey = fields.repeaterKey;
+    this.subFieldKey = fields.subFieldKey;
+    this.min = fields.min;
+    this.max = fields.max;
+    this.pattern = fields.pattern;
+  }
+
+  static rangeMinGreaterThanMax(ctx: {
+    fieldKey: string;
+    min: number;
+    max: number;
+  }): FieldConfigError {
+    return new FieldConfigError(
+      "range_min_greater_than_max",
+      `range field "${ctx.fieldKey}": min (${String(ctx.min)}) must be <= max (${String(ctx.max)})`,
+      ctx,
+    );
+  }
+
+  static repeaterNestedNotSupported(ctx: {
+    repeaterKey: string;
+    subFieldKey: string;
+  }): FieldConfigError {
+    return new FieldConfigError(
+      "repeater_nested_not_supported",
+      `repeater("${ctx.repeaterKey}") subFields contains a nested repeater ` +
+        `("${ctx.subFieldKey}"); nested repeaters are not supported in v0.1.`,
+      ctx,
+    );
+  }
+
+  static repeaterSubFieldKeyForbidden(ctx: {
+    repeaterKey: string;
+    subFieldKey: string;
+  }): FieldConfigError {
+    return new FieldConfigError(
+      "repeater_sub_field_key_forbidden",
+      `repeater("${ctx.repeaterKey}") subField key "${ctx.subFieldKey}" is forbidden ` +
+        `(prototype-pollution risk).`,
+      ctx,
+    );
+  }
+
+  static repeaterSubFieldKeyInvalid(ctx: {
+    repeaterKey: string;
+    subFieldKey: string;
+    pattern: string;
+  }): FieldConfigError {
+    return new FieldConfigError(
+      "repeater_sub_field_key_invalid",
+      `repeater("${ctx.repeaterKey}") subField key "${ctx.subFieldKey}" must match ` +
+        `/${ctx.pattern}/.`,
+      ctx,
+    );
+  }
+
+  static repeaterSubFieldDuplicate(ctx: {
+    repeaterKey: string;
+    subFieldKey: string;
+  }): FieldConfigError {
+    return new FieldConfigError(
+      "repeater_sub_field_duplicate",
+      `repeater("${ctx.repeaterKey}") declares subField "${ctx.subFieldKey}" more than once.`,
+      ctx,
+    );
+  }
+}

--- a/packages/core/src/plugin/fields/multiselect.ts
+++ b/packages/core/src/plugin/fields/multiselect.ts
@@ -43,11 +43,13 @@ function buildOptionSanitizer(
 ): (value: unknown) => readonly string[] {
   const allowed = new Set(optionList.map((opt) => opt.value));
   return (value) => {
+    // eslint-disable-next-line no-restricted-syntax -- sanitizer flow-control sentinel; migrated in the field-sanitizer-error slice
     if (!Array.isArray(value)) throw new Error("invalid_value");
     const out: string[] = [];
     const seen = new Set<string>();
     for (const item of value) {
       if (typeof item !== "string" || !allowed.has(item)) {
+        // eslint-disable-next-line no-restricted-syntax -- sanitizer flow-control sentinel; migrated in the field-sanitizer-error slice
         throw new Error("invalid_value");
       }
       if (!seen.has(item)) {

--- a/packages/core/src/plugin/fields/range.ts
+++ b/packages/core/src/plugin/fields/range.ts
@@ -1,4 +1,5 @@
 import type { MetaBoxFieldSpan, RangeMetaBoxField } from "../manifest.js";
+import { FieldConfigError } from "./errors.js";
 
 export interface RangeFieldOptions {
   readonly key: string;
@@ -26,9 +27,11 @@ export interface RangeFieldOptions {
  */
 export function range(options: RangeFieldOptions): RangeMetaBoxField {
   if (options.min > options.max) {
-    throw new Error(
-      `range field "${options.key}": min (${options.min}) must be <= max (${options.max})`,
-    );
+    throw FieldConfigError.rangeMinGreaterThanMax({
+      fieldKey: options.key,
+      min: options.min,
+      max: options.max,
+    });
   }
   const { min, max } = options;
   return {
@@ -53,9 +56,11 @@ function buildBoundsSanitizer(
 ): (value: unknown) => number {
   return (value) => {
     if (typeof value !== "number" || !Number.isFinite(value)) {
+      // eslint-disable-next-line no-restricted-syntax -- sanitizer flow-control sentinel; migrated in the field-sanitizer-error slice
       throw new Error("invalid_value");
     }
     if (value < min || value > max) {
+      // eslint-disable-next-line no-restricted-syntax -- sanitizer flow-control sentinel; migrated in the field-sanitizer-error slice
       throw new Error("invalid_value");
     }
     return value;

--- a/packages/core/src/plugin/fields/repeater.ts
+++ b/packages/core/src/plugin/fields/repeater.ts
@@ -3,6 +3,7 @@ import type {
   MetaBoxFieldSpan,
   RepeaterMetaBoxField,
 } from "../manifest.js";
+import { FieldConfigError } from "./errors.js";
 import { walkRepeaterRows } from "./repeater-validate.js";
 
 export interface RepeaterFieldOptions {
@@ -39,27 +40,29 @@ export function repeater(options: RepeaterFieldOptions): RepeaterMetaBoxField {
   const seen = new Set<string>();
   for (const sf of options.subFields) {
     if (sf.inputType === "repeater") {
-      throw new Error(
-        `repeater("${options.key}") subFields contains a nested repeater ` +
-          `("${sf.key}"); nested repeaters are not supported in v0.1.`,
-      );
+      throw FieldConfigError.repeaterNestedNotSupported({
+        repeaterKey: options.key,
+        subFieldKey: sf.key,
+      });
     }
     if (FORBIDDEN_SUBFIELD_KEYS.has(sf.key)) {
-      throw new Error(
-        `repeater("${options.key}") subField key "${sf.key}" is forbidden ` +
-          `(prototype-pollution risk).`,
-      );
+      throw FieldConfigError.repeaterSubFieldKeyForbidden({
+        repeaterKey: options.key,
+        subFieldKey: sf.key,
+      });
     }
     if (!REPEATER_SUBFIELD_KEY_RE.test(sf.key)) {
-      throw new Error(
-        `repeater("${options.key}") subField key "${sf.key}" must match ` +
-          `${REPEATER_SUBFIELD_KEY_RE}.`,
-      );
+      throw FieldConfigError.repeaterSubFieldKeyInvalid({
+        repeaterKey: options.key,
+        subFieldKey: sf.key,
+        pattern: REPEATER_SUBFIELD_KEY_RE.source,
+      });
     }
     if (seen.has(sf.key)) {
-      throw new Error(
-        `repeater("${options.key}") declares subField "${sf.key}" more than once.`,
-      );
+      throw FieldConfigError.repeaterSubFieldDuplicate({
+        repeaterKey: options.key,
+        subFieldKey: sf.key,
+      });
     }
     seen.add(sf.key);
   }

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -6,6 +6,7 @@ import type { AppContext } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { RouteIntent } from "../route/intent.js";
 import type { RegisteredLookupAdapter } from "./lookup.js";
+import { PluginDefinitionError } from "./errors.js";
 
 export interface EntryTypeOptions {
   readonly label: string;
@@ -1757,12 +1758,13 @@ function assertUniqueFieldKeysPerScope<
         const scopedKey = `${scope}:${field.key}`;
         const existing = seen.get(scopedKey);
         if (existing !== undefined && existing !== box.id) {
-          throw new Error(
-            `Meta field "${field.key}" is declared by ${kind} meta ` +
-              `boxes "${existing}" and "${box.id}" on the same scope ` +
-              `"${scope}". Each key may appear in at most one box ` +
-              `per scope.`,
-          );
+          throw PluginDefinitionError.metaFieldClashAcrossBoxes({
+            kind,
+            fieldKey: field.key,
+            firstBoxId: existing,
+            secondBoxId: box.id,
+            scope,
+          });
         }
         seen.set(scopedKey, box.id);
       }
@@ -1785,10 +1787,12 @@ function assertMetaBoxScopesExist<TBox extends { readonly id: string }>(
   for (const box of boxes) {
     for (const scope of getScopes(box)) {
       if (!known.has(scope)) {
-        throw new Error(
-          `${boxKind} "${box.id}" references ${scopeKind} "${scope}" ` +
-            `which hasn't been registered.`,
-        );
+        throw PluginDefinitionError.metaBoxReferencesUnknownScope({
+          boxKind,
+          boxId: box.id,
+          scopeKind,
+          scope,
+        });
       }
     }
   }
@@ -1805,11 +1809,10 @@ function assertSettingsPageGroupsExist(
   for (const page of pages) {
     for (const groupName of page.groups) {
       if (!groups.has(groupName)) {
-        throw new Error(
-          `Settings page "${page.name}" references group "${groupName}" ` +
-            `which hasn't been registered. Call ` +
-            `ctx.registerSettingsGroup("${groupName}", {...}) before the page.`,
-        );
+        throw PluginDefinitionError.settingsPageReferencesUnknownGroup({
+          pageName: page.name,
+          groupName,
+        });
       }
     }
   }
@@ -1852,9 +1855,10 @@ export function deriveAdminSlug(name: string, plural?: string): string {
   const slug = slugify(source);
   if (slug.length === 0) {
     const from = plural === undefined ? "its name" : `plural="${plural}"`;
-    throw new Error(
-      `Cannot derive an admin slug for post type "${name}" from ${from} — result was empty.`,
-    );
+    throw PluginDefinitionError.adminSlugDerivationFailed({
+      entryTypeName: name,
+      from,
+    });
   }
   return slug;
 }
@@ -2169,10 +2173,9 @@ export function injectManifestIntoHtml(
   manifest: PlumixManifest,
 ): string {
   if (!MANIFEST_SCRIPT_RE.test(html)) {
-    throw new Error(
-      `Admin index.html is missing the <script id="${MANIFEST_SCRIPT_ID}"> ` +
-        `placeholder. Rebuild @plumix/admin.`,
-    );
+    throw PluginDefinitionError.adminManifestPlaceholderMissing({
+      scriptId: MANIFEST_SCRIPT_ID,
+    });
   }
   return html.replace(MANIFEST_SCRIPT_RE, serializeManifestScript(manifest));
 }

--- a/packages/core/src/plugin/register.ts
+++ b/packages/core/src/plugin/register.ts
@@ -7,6 +7,7 @@ import {
   createPluginSetupContext,
 } from "./context.js";
 import { assertValidPluginId } from "./define.js";
+import { PluginDefinitionError } from "./errors.js";
 import { createPluginRegistry } from "./manifest.js";
 
 export interface PluginInstallResult {
@@ -39,10 +40,9 @@ export async function installPlugins({
     // Re-check in case the descriptor was hand-rolled.
     assertValidPluginId(descriptor.id);
     if (seenIds.has(descriptor.id)) {
-      throw new Error(
-        `Plugin id "${descriptor.id}" appears more than once in ` +
-          `config.plugins — each plugin id must be unique.`,
-      );
+      throw PluginDefinitionError.duplicatePluginIdInConfig({
+        pluginId: descriptor.id,
+      });
     }
     seenIds.add(descriptor.id);
   }


### PR DESCRIPTION
Slice #237 of the named-errors convention. Adds three factory-pattern error classes (`PluginContextError`, `PluginDefinitionError`, `FieldConfigError`) covering 46 bare `throw new Error(...)` sites across `context.ts`, `define.ts`, `manifest.ts`, `register.ts`, and `fields/{range,repeater}.ts` — the largest concentration of bare throws in core. Existing call-site test assertions pass verbatim; 1344 → 1391 tests (+47 new factory contracts).

**Class layout: one class per area, one factory per cause**

| Class | Throws | Factories | Notes |
|---|---|---|---|
| `PluginContextError` | 31 | 31 | All 31 distinct registration-time validations on `PluginSetupContext` |
| `PluginDefinitionError` | 9 | 9 | `define.ts` + `manifest.ts` + `register.ts:42` (duplicate plugin id in config — not in the umbrella's task list, semantically belongs here, +1 throw) |
| `FieldConfigError` | 5 | 5 | `range.ts` `min > max` + 4 repeater subfield validations |

`PluginContextError` is large because `context.ts` validates many distinct concerns through one factory function. Splitting by sub-domain (e.g. `PluginLoginLinkError`, `PluginPathError`) was considered and rejected — the umbrella's "one class per area" granularity is the right cut for the convention.

**`identifierName` field instead of `name`**

The class carries ~20 readonly context fields covering every factory's payload. The original draft used `name` for the generic-identifier kinds (`settingsPageDuplicateGroup`, `identifierTooLong`, `identifierShapeInvalid`), which collided with `Error.name` and silently overrode the prototype-set `"PluginContextError"` value. Renamed the field to `identifierName`; `Error.name` stays on the prototype. Worth flagging because future error classes accumulating many fields will hit this same gotcha — any field named `name` or `message` will shadow Error's own slots.

**Sanitizer flow-control throws deferred to a separate slice**

Five `throw new Error("invalid_value")` sentinels live inside per-value sanitizers in `fields/{color,multiselect,range}.ts`. They're caught by an upstream sanitizer runner and translated into structured field-level validation errors — flow-control, not user-facing errors. They get inline `eslint-disable-next-line` with a TODO ref to a future `FieldSanitizerError` slice. Semantically distinct domain from `FieldConfigError` (per-value vs. registration-time config); wrapping them in the same class would muddle the discriminator.

**Existing `DuplicateRegistrationError` / `DuplicateAdminSlugError` untouched**

Per the umbrella's PR 1 scope, the existing 19 error classes (including these two in `manifest.ts`) stay on their old constructor shape. PR 2 (#234) migrates them to the factory pattern.

**ESLint scope extends to `src/plugin/**`**

`packages/core/eslint.config.ts` adds `src/plugin/**/*.ts` to `noBareThrowErrorFor`'s glob list. Verified empirically via `pnpm eslint --print-config` that the rule fires inside the plugin tree and stays inactive in `src/auth/**` (which still has bare throws pending #243).

Refs #232
Refs #233
Refs #237