### PR TITLE
feat(plumix): named-error factories for vite plugin + admin runtime

### DIFF
--- a/packages/plumix/eslint.config.ts
+++ b/packages/plumix/eslint.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(
+  baseConfig,
+  // Migrated areas per umbrella #232. Subsequent slices extend this list.
+  noBareThrowErrorFor([
+    "src/vite/**/*.ts",
+    "src/admin/runtime.ts",
+    "src/errors.ts",
+  ]),
+);

--- a/packages/plumix/src/admin/runtime.ts
+++ b/packages/plumix/src/admin/runtime.ts
@@ -13,6 +13,8 @@ import type * as ReactDomNs from "react-dom";
 import type * as ReactDomClientNs from "react-dom/client";
 import type * as ReactJsxRuntimeNs from "react/jsx-runtime";
 
+import { AdminRuntimeError } from "../errors.js";
+
 export interface PlumixAdminRuntime {
   readonly react: typeof ReactNs;
   readonly reactJsxRuntime: typeof ReactJsxRuntimeNs;
@@ -32,9 +34,7 @@ export interface PlumixGlobal {
 export function getRuntime(): PlumixAdminRuntime {
   const rt = (globalThis as { plumix?: PlumixGlobal }).plumix?.runtime;
   if (!rt) {
-    throw new Error(
-      "plumix admin runtime not initialised — plugin chunk loaded before host bundle.",
-    );
+    throw AdminRuntimeError.notInitialised();
   }
   return rt;
 }

--- a/packages/plumix/src/errors.test.ts
+++ b/packages/plumix/src/errors.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+
+import { AdminRuntimeError } from "./errors.js";
+
+describe("AdminRuntimeError.notInitialised", () => {
+  test("class identity, code, and message", () => {
+    const err = AdminRuntimeError.notInitialised();
+    expect(err).toBeInstanceOf(AdminRuntimeError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("AdminRuntimeError");
+    expect(err.code).toBe("not_initialised");
+    expect(err.message).toContain(
+      "plumix admin runtime not initialised — plugin chunk loaded before host bundle.",
+    );
+  });
+});

--- a/packages/plumix/src/errors.ts
+++ b/packages/plumix/src/errors.ts
@@ -1,0 +1,19 @@
+export class AdminRuntimeError extends Error {
+  static {
+    AdminRuntimeError.prototype.name = "AdminRuntimeError";
+  }
+
+  readonly code: "not_initialised";
+
+  private constructor(code: "not_initialised", message: string) {
+    super(message);
+    this.code = code;
+  }
+
+  static notInitialised(): AdminRuntimeError {
+    return new AdminRuntimeError(
+      "not_initialised",
+      "plumix admin runtime not initialised — plugin chunk loaded before host bundle.",
+    );
+  }
+}

--- a/packages/plumix/src/vite/admin-plugin-bundle.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.ts
@@ -16,6 +16,8 @@ import {
   SHARED_ADMIN_RUNTIME_SPECIFIERS,
 } from "@plumix/core";
 
+import { VitePluginError } from "./errors.js";
+
 // Bare imports of `react` etc. in the plugin source get aliased to
 // `plumix/admin/<lib>` shims that read from `window.plumix.runtime.*`
 // — single React instance across host + plugin.
@@ -68,10 +70,7 @@ export async function assemblePluginAdminBundle({
 
   for (const p of withEntry) {
     if (p.adminChunk) {
-      throw new Error(
-        `[plumix] plugin "${p.id}" sets both adminEntry and adminChunk. ` +
-          `Pick one — adminEntry (TS source) is preferred.`,
-      );
+      throw VitePluginError.adminEntryAndChunkBothSet({ pluginId: p.id });
     }
   }
 
@@ -278,20 +277,21 @@ export async function resolveAndValidateEntry(
   // or buggy `adminEntry` values pulling in arbitrary files.
   const rel = relative(projectRoot, resolved);
   if (rel.startsWith("..") || isAbsolute(rel)) {
-    throw new Error(
-      `[plumix] plugin "${plugin.id}" adminEntry "${plugin.adminEntry}" ` +
-        `resolves outside the project root (${resolved}). Plugin admin ` +
-        `entries must live inside the consumer site's directory tree.`,
-    );
+    throw VitePluginError.adminEntryOutsideProjectRoot({
+      pluginId: plugin.id,
+      adminEntry: plugin.adminEntry,
+      resolved,
+    });
   }
 
   try {
     await stat(resolved);
   } catch {
-    throw new Error(
-      `[plumix] plugin "${plugin.id}" declares adminEntry ` +
-        `"${plugin.adminEntry}" but the file was not found at ${resolved}.`,
-    );
+    throw VitePluginError.adminEntryNotFound({
+      pluginId: plugin.id,
+      adminEntry: plugin.adminEntry,
+      resolved,
+    });
   }
 
   return resolved;

--- a/packages/plumix/src/vite/errors.test.ts
+++ b/packages/plumix/src/vite/errors.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+
+import { VitePluginError } from "./errors.js";
+
+describe("VitePluginError.adminAssetNotFound", () => {
+  test("class identity, code, exposed fields, and message", () => {
+    const err = VitePluginError.adminAssetNotFound({
+      pluginId: "blog",
+      field: "adminCss",
+      declared: "./dist/admin.css",
+      resolved: "/abs/dist/admin.css",
+    });
+    expect(err).toBeInstanceOf(VitePluginError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("VitePluginError");
+    expect(err.code).toBe("admin_asset_not_found");
+    expect(err.pluginId).toBe("blog");
+    expect(err.field).toBe("adminCss");
+    expect(err.declared).toBe("./dist/admin.css");
+    expect(err.resolved).toBe("/abs/dist/admin.css");
+    expect(err.message).toContain(
+      '[plumix] plugin "blog" declares adminCss "./dist/admin.css"',
+    );
+    expect(err.message).toContain(
+      "the file was not found at /abs/dist/admin.css",
+    );
+  });
+});
+
+describe("VitePluginError.adminEntryAndChunkBothSet", () => {
+  test("class identity, code, exposed pluginId, and message", () => {
+    const err = VitePluginError.adminEntryAndChunkBothSet({ pluginId: "blog" });
+    expect(err).toBeInstanceOf(VitePluginError);
+    expect(err.name).toBe("VitePluginError");
+    expect(err.code).toBe("admin_entry_and_chunk_both_set");
+    expect(err.pluginId).toBe("blog");
+    expect(err.message).toContain(
+      '[plumix] plugin "blog" sets both adminEntry and adminChunk.',
+    );
+    expect(err.message).toContain("adminEntry (TS source) is preferred");
+  });
+});
+
+describe("VitePluginError.adminEntryOutsideProjectRoot", () => {
+  test("class identity, code, exposed fields, and message", () => {
+    const err = VitePluginError.adminEntryOutsideProjectRoot({
+      pluginId: "blog",
+      adminEntry: "../outside.ts",
+      resolved: "/abs/outside.ts",
+    });
+    expect(err.code).toBe("admin_entry_outside_project_root");
+    expect(err.pluginId).toBe("blog");
+    expect(err.adminEntry).toBe("../outside.ts");
+    expect(err.resolved).toBe("/abs/outside.ts");
+    expect(err.message).toContain(
+      '[plumix] plugin "blog" adminEntry "../outside.ts"',
+    );
+    expect(err.message).toContain("resolves outside the project root");
+    expect(err.message).toContain("/abs/outside.ts");
+  });
+});
+
+describe("VitePluginError.adminEntryNotFound", () => {
+  test("class identity, code, exposed fields, and message", () => {
+    const err = VitePluginError.adminEntryNotFound({
+      pluginId: "blog",
+      adminEntry: "./src/admin.tsx",
+      resolved: "/abs/src/admin.tsx",
+    });
+    expect(err.code).toBe("admin_entry_not_found");
+    expect(err.adminEntry).toBe("./src/admin.tsx");
+    expect(err.resolved).toBe("/abs/src/admin.tsx");
+    expect(err.message).toContain(
+      '[plumix] plugin "blog" declares adminEntry "./src/admin.tsx"',
+    );
+    expect(err.message).toContain(
+      "the file was not found at /abs/src/admin.tsx",
+    );
+  });
+});

--- a/packages/plumix/src/vite/errors.ts
+++ b/packages/plumix/src/vite/errors.ts
@@ -1,0 +1,91 @@
+type VitePluginErrorCode =
+  | "admin_asset_not_found"
+  | "admin_entry_and_chunk_both_set"
+  | "admin_entry_outside_project_root"
+  | "admin_entry_not_found";
+
+interface VitePluginErrorFields {
+  pluginId?: string;
+  field?: string;
+  declared?: string;
+  resolved?: string;
+  adminEntry?: string;
+}
+
+export class VitePluginError extends Error {
+  static {
+    VitePluginError.prototype.name = "VitePluginError";
+  }
+
+  readonly code: VitePluginErrorCode;
+  readonly pluginId: string | undefined;
+  readonly field: string | undefined;
+  readonly declared: string | undefined;
+  readonly resolved: string | undefined;
+  readonly adminEntry: string | undefined;
+
+  private constructor(
+    code: VitePluginErrorCode,
+    message: string,
+    fields: VitePluginErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.pluginId = fields.pluginId;
+    this.field = fields.field;
+    this.declared = fields.declared;
+    this.resolved = fields.resolved;
+    this.adminEntry = fields.adminEntry;
+  }
+
+  static adminAssetNotFound(ctx: {
+    pluginId: string;
+    field: string;
+    declared: string;
+    resolved: string;
+  }): VitePluginError {
+    return new VitePluginError(
+      "admin_asset_not_found",
+      `[plumix] plugin "${ctx.pluginId}" declares ${ctx.field} "${ctx.declared}" but ` +
+        `the file was not found at ${ctx.resolved}. Build the plugin's admin ` +
+        `assets before running \`plumix build\`.`,
+      ctx,
+    );
+  }
+
+  static adminEntryAndChunkBothSet(ctx: { pluginId: string }): VitePluginError {
+    return new VitePluginError(
+      "admin_entry_and_chunk_both_set",
+      `[plumix] plugin "${ctx.pluginId}" sets both adminEntry and adminChunk. ` +
+        `Pick one — adminEntry (TS source) is preferred.`,
+      ctx,
+    );
+  }
+
+  static adminEntryOutsideProjectRoot(ctx: {
+    pluginId: string;
+    adminEntry: string;
+    resolved: string;
+  }): VitePluginError {
+    return new VitePluginError(
+      "admin_entry_outside_project_root",
+      `[plumix] plugin "${ctx.pluginId}" adminEntry "${ctx.adminEntry}" ` +
+        `resolves outside the project root (${ctx.resolved}). Plugin admin ` +
+        `entries must live inside the consumer site's directory tree.`,
+      ctx,
+    );
+  }
+
+  static adminEntryNotFound(ctx: {
+    pluginId: string;
+    adminEntry: string;
+    resolved: string;
+  }): VitePluginError {
+    return new VitePluginError(
+      "admin_entry_not_found",
+      `[plumix] plugin "${ctx.pluginId}" declares adminEntry ` +
+        `"${ctx.adminEntry}" but the file was not found at ${ctx.resolved}.`,
+      ctx,
+    );
+  }
+}

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -31,6 +31,7 @@ import {
   ADMIN_URL_PREFIX,
   assemblePluginAdminBundle,
 } from "./admin-plugin-bundle.js";
+import { VitePluginError } from "./errors.js";
 
 // `import.meta.url` for this module lives at plumix/dist/vite/index.js in
 // consumer installs, so the pre-compiled admin artifact is a sibling at
@@ -285,11 +286,12 @@ async function resolvePluginAsset(
   try {
     await stat(source);
   } catch {
-    throw new Error(
-      `[plumix] plugin "${pluginId}" declares ${field} "${relOrAbs}" but ` +
-        `the file was not found at ${source}. Build the plugin's admin ` +
-        `assets before running \`plumix build\`.`,
-    );
+    throw VitePluginError.adminAssetNotFound({
+      pluginId,
+      field,
+      declared: relOrAbs,
+      resolved: source,
+    });
   }
   return source;
 }


### PR DESCRIPTION
Slice #239 of the named-errors convention. Adds two factory-pattern error classes (`VitePluginError`, `AdminRuntimeError`) covering 5 bare `throw new Error(...)` sites in `plumix/src/vite/{index,admin-plugin-bundle}.ts` and `plumix/src/admin/runtime.ts`. Existing call-site regex assertions still pass verbatim. 41 → 45 tests.

**`VitePluginError` covers admin-asset + adminEntry validation**

Four factories — `adminAssetNotFound`, `adminEntryAndChunkBothSet`, `adminEntryOutsideProjectRoot`, `adminEntryNotFound` — covering the 4 throws in `vite/`. Each carries typed context (`pluginId`, `field`, `declared`, `resolved`, `adminEntry`) on the instance.

**`AdminRuntimeError` is a single-factory class**

One throw, one factory (`notInitialised()`). No context fields needed — the message is fixed (plugin chunk loaded before host bundle). Tiny class, but matches the umbrella's "one class per area" convention and gives consumers a typed catch surface for the admin-bootstrap failure mode.

**ESLint scope extends to plumix's vite + admin/runtime + errors**

`packages/plumix/eslint.config.ts` opts into `noBareThrowErrorFor` with three globs: `src/vite/**/*.ts`, `src/admin/runtime.ts`, `src/errors.ts`. Other plumix subtrees (`src/cli/`, `src/blocks/`, `src/fields/`, etc.) remain unscoped pending future slices.

Refs #232
Refs #233
Refs #239