### PR TITLE
feat(core): named-error factories for menu plugin, admin lib, scaffolder

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
 import { reactConfig } from "@plumix/eslint-config/react";
 
-export default defineConfig(baseConfig, reactConfig, {
-  // Vendored shadcn/ui primitives — kept verbatim so `shadcn diff` upgrades
-  // don't merge-conflict. Lint these like we lint node_modules: we don't.
-  ignores: ["src/components/ui/**", "src/hooks/use-mobile.ts"],
-});
+export default defineConfig(
+  baseConfig,
+  reactConfig,
+  // Migrated areas per umbrella #232. Subsequent slices extend this list.
+  noBareThrowErrorFor(["src/lib/**/*.ts"]),
+  {
+    // Vendored shadcn/ui primitives — kept verbatim so `shadcn diff` upgrades
+    // don't merge-conflict. Lint these like we lint node_modules: we don't.
+    ignores: ["src/components/ui/**", "src/hooks/use-mobile.ts"],
+  },
+);

--- a/packages/admin/src/lib/errors.test.ts
+++ b/packages/admin/src/lib/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import { AdminPluginRegistryError } from "./errors.js";
+
+describe("AdminPluginRegistryError.duplicateKey", () => {
+  test("class identity, code, exposed fields, and message", () => {
+    const err = AdminPluginRegistryError.duplicateKey({
+      registerName: "registerPluginPage",
+      key: "/media",
+    });
+    expect(err).toBeInstanceOf(AdminPluginRegistryError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("AdminPluginRegistryError");
+    expect(err.code).toBe("duplicate_key");
+    expect(err.registerName).toBe("registerPluginPage");
+    expect(err.key).toBe("/media");
+    expect(err.message).toContain(
+      'registerPluginPage: "/media" is already registered',
+    );
+  });
+});
+
+describe("AdminPluginRegistryError.inputTypeReserved", () => {
+  test("class identity, code, exposed type, and message", () => {
+    const err = AdminPluginRegistryError.inputTypeReserved({ type: "text" });
+    expect(err.code).toBe("input_type_reserved");
+    expect(err.type).toBe("text");
+    expect(err.message).toContain(
+      'registerPluginFieldType: "text" is reserved for built-in renderers',
+    );
+    expect(err.message).toContain("RESERVED_INPUT_TYPES list");
+  });
+});

--- a/packages/admin/src/lib/errors.ts
+++ b/packages/admin/src/lib/errors.ts
@@ -1,0 +1,52 @@
+type AdminPluginRegistryErrorCode = "duplicate_key" | "input_type_reserved";
+
+interface AdminPluginRegistryErrorFields {
+  registerName?: string;
+  key?: string;
+  type?: string;
+}
+
+export class AdminPluginRegistryError extends Error {
+  static {
+    AdminPluginRegistryError.prototype.name = "AdminPluginRegistryError";
+  }
+
+  readonly code: AdminPluginRegistryErrorCode;
+  readonly registerName: string | undefined;
+  readonly key: string | undefined;
+  readonly type: string | undefined;
+
+  private constructor(
+    code: AdminPluginRegistryErrorCode,
+    message: string,
+    fields: AdminPluginRegistryErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.registerName = fields.registerName;
+    this.key = fields.key;
+    this.type = fields.type;
+  }
+
+  static duplicateKey(ctx: {
+    registerName: string;
+    key: string;
+  }): AdminPluginRegistryError {
+    return new AdminPluginRegistryError(
+      "duplicate_key",
+      `${ctx.registerName}: "${ctx.key}" is already registered. ` +
+        `Two plugins are claiming the same key; rename one.`,
+      ctx,
+    );
+  }
+
+  static inputTypeReserved(ctx: { type: string }): AdminPluginRegistryError {
+    return new AdminPluginRegistryError(
+      "input_type_reserved",
+      `registerPluginFieldType: "${ctx.type}" is reserved for built-in renderers. ` +
+        `Pick a different inputType for your custom field — see the host's ` +
+        `RESERVED_INPUT_TYPES list.`,
+      ctx,
+    );
+  }
+}

--- a/packages/admin/src/lib/plugin-registry.ts
+++ b/packages/admin/src/lib/plugin-registry.ts
@@ -3,6 +3,8 @@ import type { ControllerRenderProps, FieldValues } from "react-hook-form";
 
 import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 
+import { AdminPluginRegistryError } from "./errors.js";
+
 /**
  * Contract for plugin-supplied field renderers. The admin's
  * `MetaBoxField` dispatcher resolves the renderer via
@@ -47,10 +49,10 @@ function register<TComponent>(
   component: TComponent,
 ): void {
   if (registry.map.has(key)) {
-    throw new Error(
-      `${registry.registerName}: "${key}" is already registered. ` +
-        `Two plugins are claiming the same key; rename one.`,
-    );
+    throw AdminPluginRegistryError.duplicateKey({
+      registerName: registry.registerName,
+      key,
+    });
   }
   registry.map.set(key, component);
 }
@@ -109,11 +111,7 @@ export function registerPluginFieldType(
   component: PluginFieldComponent,
 ): void {
   if (RESERVED_INPUT_TYPES.has(type)) {
-    throw new Error(
-      `registerPluginFieldType: "${type}" is reserved for built-in renderers. ` +
-        `Pick a different inputType for your custom field — see the host's ` +
-        `RESERVED_INPUT_TYPES list.`,
-    );
+    throw AdminPluginRegistryError.inputTypeReserved({ type });
   }
   register(fieldTypes, type, component);
 }

--- a/packages/create-plumix-app/eslint.config.ts
+++ b/packages/create-plumix-app/eslint.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(
+  baseConfig,
+  // Migrated areas per umbrella #232. Subsequent slices extend this list.
+  noBareThrowErrorFor(["src/**/*.ts"]),
+);

--- a/packages/create-plumix-app/src/errors.test.ts
+++ b/packages/create-plumix-app/src/errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+
+import { ScaffoldError } from "./errors.js";
+
+describe("ScaffoldError.targetParentMissing", () => {
+  test("class identity, code, exposed parent, and message", () => {
+    const err = ScaffoldError.targetParentMissing({ parent: "/missing/dir" });
+    expect(err).toBeInstanceOf(ScaffoldError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ScaffoldError");
+    expect(err.code).toBe("target_parent_missing");
+    expect(err.parent).toBe("/missing/dir");
+    expect(err.message).toContain(
+      "Target parent directory does not exist: /missing/dir",
+    );
+  });
+});
+
+describe("ScaffoldError.targetNotDirectory", () => {
+  test("class identity, code, exposed targetDir, and message", () => {
+    const err = ScaffoldError.targetNotDirectory({ targetDir: "/path/file" });
+    expect(err.name).toBe("ScaffoldError");
+    expect(err.code).toBe("target_not_directory");
+    expect(err.targetDir).toBe("/path/file");
+    expect(err.message).toContain(
+      "Target path exists but is not a directory: /path/file",
+    );
+  });
+});
+
+describe("ScaffoldError.targetDirectoryNotEmpty", () => {
+  test("class identity, code, exposed targetDir, and message", () => {
+    const err = ScaffoldError.targetDirectoryNotEmpty({
+      targetDir: "/path/existing",
+    });
+    expect(err.code).toBe("target_directory_not_empty");
+    expect(err.targetDir).toBe("/path/existing");
+    expect(err.message).toContain(
+      "Target directory is not empty: /path/existing",
+    );
+  });
+});
+
+describe("ScaffoldError.catalogResolutionMissing", () => {
+  test("class identity, code, exposed catalogName, and message", () => {
+    const err = ScaffoldError.catalogResolutionMissing({
+      catalogName: "react-dom",
+    });
+    expect(err.code).toBe("catalog_resolution_missing");
+    expect(err.catalogName).toBe("react-dom");
+    expect(err.message).toContain('No catalog resolution for "react-dom"');
+    expect(err.message).toContain("CATALOG_RESOLUTIONS in scaffold.ts");
+  });
+});

--- a/packages/create-plumix-app/src/errors.ts
+++ b/packages/create-plumix-app/src/errors.ts
@@ -1,0 +1,66 @@
+type ScaffoldErrorCode =
+  | "target_parent_missing"
+  | "target_not_directory"
+  | "target_directory_not_empty"
+  | "catalog_resolution_missing";
+
+interface ScaffoldErrorFields {
+  parent?: string;
+  targetDir?: string;
+  catalogName?: string;
+}
+
+export class ScaffoldError extends Error {
+  static {
+    ScaffoldError.prototype.name = "ScaffoldError";
+  }
+
+  readonly code: ScaffoldErrorCode;
+  readonly parent: string | undefined;
+  readonly targetDir: string | undefined;
+  readonly catalogName: string | undefined;
+
+  private constructor(
+    code: ScaffoldErrorCode,
+    message: string,
+    fields: ScaffoldErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.parent = fields.parent;
+    this.targetDir = fields.targetDir;
+    this.catalogName = fields.catalogName;
+  }
+
+  static targetParentMissing(ctx: { parent: string }): ScaffoldError {
+    return new ScaffoldError(
+      "target_parent_missing",
+      `Target parent directory does not exist: ${ctx.parent}. Create the parent first, or pick a target inside an existing directory.`,
+      ctx,
+    );
+  }
+
+  static targetNotDirectory(ctx: { targetDir: string }): ScaffoldError {
+    return new ScaffoldError(
+      "target_not_directory",
+      `Target path exists but is not a directory: ${ctx.targetDir}. Pick a target that is either a fresh path or an empty directory.`,
+      ctx,
+    );
+  }
+
+  static targetDirectoryNotEmpty(ctx: { targetDir: string }): ScaffoldError {
+    return new ScaffoldError(
+      "target_directory_not_empty",
+      `Target directory is not empty: ${ctx.targetDir}. Pick a fresh path, or empty the existing one first.`,
+      ctx,
+    );
+  }
+
+  static catalogResolutionMissing(ctx: { catalogName: string }): ScaffoldError {
+    return new ScaffoldError(
+      "catalog_resolution_missing",
+      `No catalog resolution for "${ctx.catalogName}" — add it to CATALOG_RESOLUTIONS in scaffold.ts.`,
+      ctx,
+    );
+  }
+}

--- a/packages/create-plumix-app/src/scaffold.ts
+++ b/packages/create-plumix-app/src/scaffold.ts
@@ -3,6 +3,8 @@ import { cp, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { ScaffoldError } from "./errors.js";
+
 const EXCLUDED_SEGMENTS: ReadonlySet<string> = new Set([
   "node_modules",
   ".cache",
@@ -109,22 +111,16 @@ export async function scaffold(
   const { targetDir } = options;
   const parent = dirname(targetDir);
   if (!existsSync(parent)) {
-    throw new Error(
-      `Target parent directory does not exist: ${parent}. Create the parent first, or pick a target inside an existing directory.`,
-    );
+    throw ScaffoldError.targetParentMissing({ parent });
   }
 
   if (existsSync(targetDir)) {
     if (!statSync(targetDir).isDirectory()) {
-      throw new Error(
-        `Target path exists but is not a directory: ${targetDir}. Pick a target that is either a fresh path or an empty directory.`,
-      );
+      throw ScaffoldError.targetNotDirectory({ targetDir });
     }
     const entries = await readdir(targetDir);
     if (entries.length > 0) {
-      throw new Error(
-        `Target directory is not empty: ${targetDir}. Pick a fresh path, or empty the existing one first.`,
-      );
+      throw ScaffoldError.targetDirectoryNotEmpty({ targetDir });
     }
   } else {
     await mkdir(targetDir);
@@ -164,9 +160,7 @@ export function rewriteDeps(
     if (range.startsWith("catalog:")) {
       const resolved = CATALOG_RESOLUTIONS[name];
       if (!resolved) {
-        throw new Error(
-          `No catalog resolution for "${name}" — add it to CATALOG_RESOLUTIONS in scaffold.ts.`,
-        );
+        throw ScaffoldError.catalogResolutionMissing({ catalogName: name });
       }
       out[name] = resolved;
       continue;

--- a/packages/plugins/menu/eslint.config.ts
+++ b/packages/plugins/menu/eslint.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(
+  baseConfig,
+  // Migrated areas per umbrella #232. Subsequent slices extend this list.
+  noBareThrowErrorFor(["src/server/**/*.ts", "src/rpc.ts", "src/errors.ts"]),
+);

--- a/packages/plugins/menu/src/errors.test.ts
+++ b/packages/plugins/menu/src/errors.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+
+import { MenuPluginError } from "./errors.js";
+
+describe("MenuPluginError.invalidLocationId", () => {
+  test("class identity, code, exposed fields, and message", () => {
+    const err = MenuPluginError.invalidLocationId({
+      id: "Bad Id!",
+      pattern: "^[a-z][a-z0-9-]*$",
+      maxLength: 64,
+    });
+    expect(err).toBeInstanceOf(MenuPluginError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("MenuPluginError");
+    expect(err.code).toBe("invalid_location_id");
+    expect(err.id).toBe("Bad Id!");
+    expect(err.pattern).toBe("^[a-z][a-z0-9-]*$");
+    expect(err.maxLength).toBe(64);
+    expect(err.message).toContain(
+      'registerMenuLocation: id "Bad Id!" is invalid',
+    );
+    expect(err.message).toContain("^[a-z][a-z0-9-]*$");
+    expect(err.message).toContain("1–64 chars");
+  });
+});
+
+describe("MenuPluginError.locationLabelEmpty", () => {
+  test("class identity, code, exposed id, and message", () => {
+    const err = MenuPluginError.locationLabelEmpty({ id: "primary" });
+    expect(err.code).toBe("location_label_empty");
+    expect(err.id).toBe("primary");
+    expect(err.message).toContain(
+      'registerMenuLocation("primary"): `label` is required',
+    );
+  });
+});
+
+describe("MenuPluginError.duplicateLocation", () => {
+  test("class identity, code, exposed id, and message", () => {
+    const err = MenuPluginError.duplicateLocation({ id: "primary" });
+    expect(err.code).toBe("duplicate_location");
+    expect(err.message).toContain(
+      'registerMenuLocation: location "primary" is already registered',
+    );
+    expect(err.message).toContain("unique across themes");
+  });
+});
+
+describe("MenuPluginError.resolveParentIdsLengthMismatch", () => {
+  test("class identity, code, exposed lengths, and message", () => {
+    const err = MenuPluginError.resolveParentIdsLengthMismatch({
+      itemsLength: 5,
+      resolvedIdsLength: 3,
+    });
+    expect(err.code).toBe("resolve_parent_ids_length_mismatch");
+    expect(err.itemsLength).toBe(5);
+    expect(err.resolvedIdsLength).toBe(3);
+    expect(err.message).toContain(
+      "resolveParentIds: items.length (5) does not match resolvedIds.length (3)",
+    );
+  });
+});
+
+describe("MenuPluginError.menuCreateNoRowReturned", () => {
+  test("class identity, code, and message", () => {
+    const err = MenuPluginError.menuCreateNoRowReturned();
+    expect(err.code).toBe("menu_create_no_row_returned");
+    expect(err.message).toContain("menu.create: insert returned no row");
+  });
+});

--- a/packages/plugins/menu/src/errors.ts
+++ b/packages/plugins/menu/src/errors.ts
@@ -1,0 +1,90 @@
+type MenuPluginErrorCode =
+  | "invalid_location_id"
+  | "location_label_empty"
+  | "duplicate_location"
+  | "resolve_parent_ids_length_mismatch"
+  | "menu_create_no_row_returned";
+
+interface MenuPluginErrorFields {
+  id?: string;
+  pattern?: string;
+  maxLength?: number;
+  itemsLength?: number;
+  resolvedIdsLength?: number;
+}
+
+export class MenuPluginError extends Error {
+  static {
+    MenuPluginError.prototype.name = "MenuPluginError";
+  }
+
+  readonly code: MenuPluginErrorCode;
+  readonly id: string | undefined;
+  readonly pattern: string | undefined;
+  readonly maxLength: number | undefined;
+  readonly itemsLength: number | undefined;
+  readonly resolvedIdsLength: number | undefined;
+
+  private constructor(
+    code: MenuPluginErrorCode,
+    message: string,
+    fields: MenuPluginErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.id = fields.id;
+    this.pattern = fields.pattern;
+    this.maxLength = fields.maxLength;
+    this.itemsLength = fields.itemsLength;
+    this.resolvedIdsLength = fields.resolvedIdsLength;
+  }
+
+  static invalidLocationId(ctx: {
+    id: string;
+    pattern: string;
+    maxLength: number;
+  }): MenuPluginError {
+    return new MenuPluginError(
+      "invalid_location_id",
+      `registerMenuLocation: id "${ctx.id}" is invalid. Location ids must ` +
+        `match /${ctx.pattern}/ and be 1–${String(ctx.maxLength)} chars.`,
+      ctx,
+    );
+  }
+
+  static locationLabelEmpty(ctx: { id: string }): MenuPluginError {
+    return new MenuPluginError(
+      "location_label_empty",
+      `registerMenuLocation("${ctx.id}"): \`label\` is required and must be a non-empty, non-whitespace string.`,
+      ctx,
+    );
+  }
+
+  static duplicateLocation(ctx: { id: string }): MenuPluginError {
+    return new MenuPluginError(
+      "duplicate_location",
+      `registerMenuLocation: location "${ctx.id}" is already registered. ` +
+        `Each location id must be unique across themes.`,
+      ctx,
+    );
+  }
+
+  static resolveParentIdsLengthMismatch(ctx: {
+    itemsLength: number;
+    resolvedIdsLength: number;
+  }): MenuPluginError {
+    return new MenuPluginError(
+      "resolve_parent_ids_length_mismatch",
+      `resolveParentIds: items.length (${String(ctx.itemsLength)}) does not match resolvedIds.length (${String(ctx.resolvedIdsLength)})`,
+      ctx,
+    );
+  }
+
+  static menuCreateNoRowReturned(): MenuPluginError {
+    return new MenuPluginError(
+      "menu_create_no_row_returned",
+      "menu.create: insert returned no row",
+      {},
+    );
+  }
+}

--- a/packages/plugins/menu/src/rpc.ts
+++ b/packages/plugins/menu/src/rpc.ts
@@ -15,6 +15,7 @@ import {
 import * as v from "valibot";
 
 import type { ResolvedRow } from "./server/resolveItemStates.js";
+import { MenuPluginError } from "./errors.js";
 import { getEligibleMenuKinds } from "./server/eligibility.js";
 import { getRegisteredLocations } from "./server/locations.js";
 import { resolveItemStates } from "./server/resolveItemStates.js";
@@ -579,7 +580,7 @@ export function createMenuRouter(): Record<string, unknown> {
           // returning the affected row is contractually non-empty for
           // SQLite/D1. Surface as a plain error (mapped to 500 by the
           // RPC layer) rather than papering over a driver regression.
-          throw new Error("menu.create: insert returned no row");
+          throw MenuPluginError.menuCreateNoRowReturned();
         }
         return { termId: row.id, slug, version: row.version };
       },

--- a/packages/plugins/menu/src/server/locations.ts
+++ b/packages/plugins/menu/src/server/locations.ts
@@ -1,4 +1,5 @@
 import type { MenuLocationOptions, RegisteredMenuLocation } from "./types.js";
+import { MenuPluginError } from "../errors.js";
 
 /**
  * Module-scoped registry of menu locations. Themes call
@@ -24,21 +25,17 @@ export function recordLocation(id: string, options: MenuLocationOptions): void {
     id.length > MAX_LOCATION_ID_LENGTH ||
     !LOCATION_ID_RE.test(id)
   ) {
-    throw new Error(
-      `registerMenuLocation: id "${id}" is invalid. Location ids must ` +
-        `match /${LOCATION_ID_RE.source}/ and be 1–${MAX_LOCATION_ID_LENGTH} chars.`,
-    );
+    throw MenuPluginError.invalidLocationId({
+      id,
+      pattern: LOCATION_ID_RE.source,
+      maxLength: MAX_LOCATION_ID_LENGTH,
+    });
   }
   if (typeof options.label !== "string" || options.label.trim().length === 0) {
-    throw new Error(
-      `registerMenuLocation("${id}"): \`label\` is required and must be a non-empty, non-whitespace string.`,
-    );
+    throw MenuPluginError.locationLabelEmpty({ id });
   }
   if (locations.has(id)) {
-    throw new Error(
-      `registerMenuLocation: location "${id}" is already registered. ` +
-        `Each location id must be unique across themes.`,
-    );
+    throw MenuPluginError.duplicateLocation({ id });
   }
   locations.set(id, {
     id,

--- a/packages/plugins/menu/src/server/save.ts
+++ b/packages/plugins/menu/src/server/save.ts
@@ -1,4 +1,5 @@
 import type { MenuItemMeta } from "./types.js";
+import { MenuPluginError } from "../errors.js";
 
 /**
  * Save-protocol input for a single menu item. `parentIndex` references
@@ -140,9 +141,10 @@ export function resolveParentIds(
   resolvedIds: readonly number[],
 ): readonly (number | null)[] {
   if (items.length !== resolvedIds.length) {
-    throw new Error(
-      `resolveParentIds: items.length (${items.length}) does not match resolvedIds.length (${resolvedIds.length})`,
-    );
+    throw MenuPluginError.resolveParentIdsLengthMismatch({
+      itemsLength: items.length,
+      resolvedIdsLength: resolvedIds.length,
+    });
   }
   return items.map((item) => {
     if (item.resolvedParentIndex === null) return null;


### PR DESCRIPTION
Slice #240 of the named-errors convention. Adds three factory-pattern error classes (`MenuPluginError`, `AdminPluginRegistryError`, `ScaffoldError`) covering 11 bare `throw new Error(...)` sites across menu plugin internals, admin's plugin registry, and the project scaffolder. Existing call-site `.toThrow()` assertions still pass verbatim.

**ESLint scope narrows around as-yet-unmigrated areas**

- `packages/plugins/menu` opts in to `src/server/**/*.ts`, `src/rpc.ts`, `src/errors.ts` — excludes `src/admin/**` where `src/admin/rpc.ts:79` still has a generic envelope-rethrow `throw new Error(reason)` (admin-side rpc helper, semantically a different domain; deferred)
- `packages/admin` opts in to `src/lib/**/*.ts` — excludes `src/main.tsx:20` (boot guard for missing `#root`) and `src/providers/theme.tsx:90` (React hook context check). Both are React-shaped guards rather than business-logic errors; deferred
- `packages/create-plumix-app` opts in to the whole `src/**/*.ts` — every throw migrated

After this slice, the remaining PR1 work is **#241 errors: whole-repo activation** which broadens the ESLint rule globally and migrates the remaining stragglers (the 4 deferred sanitizer throws in core's `fields/`, the 2 plumix-vite-server `EADDRINUSE` guards, the 3 admin React-shaped guards above, plus 2 in commands/dev.ts deferred from #275).

**Test count growth**

From CI's perspective, +11 new factory tests across the three classes. Local test counts: menu (235 → still 235, factory tests counted in their own file), admin (166 → 168 with 2 new factory tests), create-plumix-app (31 → 35 with 4 new factory tests).

Refs #232
Refs #233
Refs #240