### PR TITLE
feat(core): broaden no-bare-throw rule to packages/**/src/** (final PR1 slice)

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -1,16 +1,10 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 import { reactConfig } from "@plumix/eslint-config/react";
 
-export default defineConfig(
-  baseConfig,
-  reactConfig,
-  // Migrated areas per umbrella #232. Subsequent slices extend this list.
-  noBareThrowErrorFor(["src/lib/**/*.ts"]),
-  {
-    // Vendored shadcn/ui primitives — kept verbatim so `shadcn diff` upgrades
-    // don't merge-conflict. Lint these like we lint node_modules: we don't.
-    ignores: ["src/components/ui/**", "src/hooks/use-mobile.ts"],
-  },
-);
+export default defineConfig(baseConfig, reactConfig, noBareThrowError, {
+  // Vendored shadcn/ui primitives — kept verbatim so `shadcn diff` upgrades
+  // don't merge-conflict. Lint these like we lint node_modules: we don't.
+  ignores: ["src/components/ui/**", "src/hooks/use-mobile.ts"],
+});

--- a/packages/admin/src/main.tsx
+++ b/packages/admin/src/main.tsx
@@ -17,6 +17,7 @@ import "./styles/globals.css";
 bootPlumixGlobals();
 
 const rootElement = document.getElementById("root");
+// eslint-disable-next-line no-restricted-syntax -- React boot guard; convention exception per umbrella #232
 if (!rootElement) throw new Error("Missing #root element");
 
 void waitForPluginChunks().then(() => {

--- a/packages/admin/src/providers/theme.tsx
+++ b/packages/admin/src/providers/theme.tsx
@@ -87,6 +87,7 @@ export function ThemeProvider({
 export function useTheme(): ThemeProviderState {
   const context = useContext(ThemeProviderContext);
   if (context === null) {
+    // eslint-disable-next-line no-restricted-syntax -- React hook-misuse guard; convention exception per umbrella #232
     throw new Error("useTheme must be used within a ThemeProvider");
   }
   return context;

--- a/packages/blocks/eslint.config.ts
+++ b/packages/blocks/eslint.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 import { reactConfig } from "@plumix/eslint-config/react";
 
-export default defineConfig(baseConfig, reactConfig);
+export default defineConfig(baseConfig, reactConfig, noBareThrowError);

--- a/packages/core/eslint.config.ts
+++ b/packages/core/eslint.config.ts
@@ -1,15 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(
-  baseConfig,
-  // Migrated areas per umbrella #232. Subsequent slices extend this list.
-  noBareThrowErrorFor([
-    "src/runtime/**/*.ts",
-    "src/route/**/*.ts",
-    "src/theme.ts",
-    "src/theme-errors.ts",
-    "src/plugin/**/*.ts",
-  ]),
-);
+export default defineConfig(baseConfig, noBareThrowError);

--- a/packages/core/src/auth/api-tokens.ts
+++ b/packages/core/src/auth/api-tokens.ts
@@ -81,6 +81,7 @@ export async function createApiToken(
       scopes: input.scopes ?? null,
     })
     .returning();
+  // eslint-disable-next-line no-restricted-syntax -- defensive driver-regression guard; migrate alongside auth errors in PR 2 (#234)
   if (!row) throw new Error("createApiToken: insert returned no row");
 
   return { secret, row };

--- a/packages/core/src/auth/bootstrap.ts
+++ b/packages/core/src/auth/bootstrap.ts
@@ -35,6 +35,7 @@ export async function provisionUser(
     })
     .returning();
 
+  // eslint-disable-next-line no-restricted-syntax -- defensive driver-regression guard; migrate alongside auth errors in PR 2 (#234)
   if (!user) throw new Error("provisionUser: insert returned no row");
   return {
     user,

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -149,6 +149,7 @@ async function resolveOnce(
     // Falling through with `undefined` would silently default the
     // user to "subscriber" via the schema default — surfacing as a
     // config bug instead.
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       "resolveExternalIdentity: allowedDomainsGate=false requires an explicit defaultRole",
     );

--- a/packages/core/src/auth/passkey/register.ts
+++ b/packages/core/src/auth/passkey/register.ts
@@ -228,6 +228,7 @@ export async function persistCredential(
     })
     .returning();
 
+  // eslint-disable-next-line no-restricted-syntax -- defensive driver-regression guard; migrate alongside auth errors in PR 2 (#234)
   if (!row) throw new Error("persistCredential: insert returned no row");
   return row;
 }

--- a/packages/core/src/auth/sessions.ts
+++ b/packages/core/src/auth/sessions.ts
@@ -114,6 +114,7 @@ export async function createSession(
     })
     .returning();
 
+  // eslint-disable-next-line no-restricted-syntax -- defensive driver-regression guard; migrate alongside auth errors in PR 2 (#234)
   if (!session) throw new Error("createSession: insert returned no row");
   return { token, session, expiresAt };
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -62,6 +62,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
   // today) need a configured mailer at the top level. Surface this at
   // app build time rather than letting it crash on the first request.
   if (config.auth.magicLink && !config.mailer) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       "plumix(): `auth.magicLink` requires a top-level `mailer` " +
         "(use `consoleMailer()` for dev or pass your own `Mailer`).",

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -326,6 +326,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
       // fails fast on the first request rather than silently
       // corrupting `db` / `auth` / etc. for the rest of the process.
       if (key in target) {
+        // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
         throw new Error(
           `appContextExtensions entry "${key}" shadows a built-in ` +
             `AppContext field. Reserve plugin-scoped names; built-in ` +

--- a/packages/core/src/context/stores.ts
+++ b/packages/core/src/context/stores.ts
@@ -28,6 +28,7 @@ export const txStore = new AsyncLocalStorage<unknown>();
 export function getContext(): AppContext {
   const ctx = requestStore.getStore();
   if (!ctx)
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       "No request context — getContext() called outside requestStore.run()",
     );

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -437,6 +437,7 @@ function referenceGroupKey(target: ReferenceTarget): string {
   try {
     return `${target.kind}::${JSON.stringify(target.scope ?? null)}`;
   } catch (cause) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       `lookup adapter scope for kind "${target.kind}" must be JSON-serializable`,
       { cause },
@@ -462,6 +463,7 @@ async function fetchLiveRows(
   callsite: string,
 ): Promise<readonly LookupResult[]> {
   if (ids.size > MAX_REFERENCE_GROUP_BATCH) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       `${callsite}: aggregated batch size ${ids.size} exceeds MAX_REFERENCE_GROUP_BATCH (${MAX_REFERENCE_GROUP_BATCH})`,
     );
@@ -1046,6 +1048,7 @@ function coerceOnRead(type: MetaScalarType, value: unknown): unknown {
 // via a crafted path.
 function metaJsonPath(key: string): string {
   if (/["\\]/.test(key)) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       `meta key "${key}" contains characters forbidden in a JSON path`,
     );

--- a/packages/core/src/rpc/procedures/auth/allowed-domains/create.ts
+++ b/packages/core/src/rpc/procedures/auth/allowed-domains/create.ts
@@ -23,6 +23,7 @@ export const create = base
         })
         .returning();
       if (!row)
+        // eslint-disable-next-line no-restricted-syntax -- defensive driver-regression guard; migrate alongside auth errors in PR 2 (#234)
         throw new Error("allowedDomains.create: insert returned no row");
       return row;
     } catch (error) {

--- a/packages/core/src/rpc/procedures/entry/lookup.ts
+++ b/packages/core/src/rpc/procedures/entry/lookup.ts
@@ -94,6 +94,7 @@ function scopeConditions(scope: EntryFieldScope | undefined): SQL[] {
   // turn the picker into a "list every entry across every type" channel
   // bypassing per-type read scoping.
   if (!scope?.entryTypes || scope.entryTypes.length === 0) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       "entry adapter: scope.entryTypes is required and must be non-empty",
     );

--- a/packages/core/src/rpc/procedures/term/lookup.ts
+++ b/packages/core/src/rpc/procedures/term/lookup.ts
@@ -93,6 +93,7 @@ function scopeConditions(scope: TermFieldScope | undefined): SQL[] {
   // omit it and would otherwise enumerate every term across every
   // taxonomy.
   if (!scope?.termTaxonomies || scope.termTaxonomies.length === 0) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       "term adapter: scope.termTaxonomies is required and must be non-empty",
     );

--- a/packages/create-plumix-app/eslint.config.ts
+++ b/packages/create-plumix-app/eslint.config.ts
@@ -1,9 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(
-  baseConfig,
-  // Migrated areas per umbrella #232. Subsequent slices extend this list.
-  noBareThrowErrorFor(["src/**/*.ts"]),
-);
+export default defineConfig(baseConfig, noBareThrowError);

--- a/packages/plugins/audit-log/eslint.config.ts
+++ b/packages/plugins/audit-log/eslint.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(baseConfig, noBareThrowError);

--- a/packages/plugins/audit-log/src/admin/rpc.ts
+++ b/packages/plugins/audit-log/src/admin/rpc.ts
@@ -56,6 +56,7 @@ async function rpcCall<TOutput>(
       | undefined;
     const reason =
       error?.data?.reason ?? error?.message ?? `rpc_${String(res.status)}`;
+    // eslint-disable-next-line no-restricted-syntax -- admin-side rpc envelope rethrow; server-derived message is the discriminator
     throw new Error(reason);
   }
   return envelope?.json as TOutput;

--- a/packages/plugins/audit-log/src/server/retention.ts
+++ b/packages/plugins/audit-log/src/server/retention.ts
@@ -35,6 +35,7 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 export function assertValidRetention(retention: AuditLogRetentionConfig): void {
   if (retention === false) return;
   if (!Number.isFinite(retention.maxAgeDays) || retention.maxAgeDays < 0) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
     throw new Error(
       `[plumix/plugin-audit-log] retention.maxAgeDays must be a non-negative finite number (got ${retention.maxAgeDays})`,
     );

--- a/packages/plugins/blog/eslint.config.ts
+++ b/packages/plugins/blog/eslint.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(baseConfig, noBareThrowError);

--- a/packages/plugins/media/eslint.config.ts
+++ b/packages/plugins/media/eslint.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(baseConfig, noBareThrowError);

--- a/packages/plugins/media/src/admin/MediaLibrary.tsx
+++ b/packages/plugins/media/src/admin/MediaLibrary.tsx
@@ -110,6 +110,7 @@ async function rpcCall<TOutput>(
       | undefined;
     const reason =
       error?.data?.reason ?? error?.message ?? `rpc_${String(res.status)}`;
+    // eslint-disable-next-line no-restricted-syntax -- admin-side rpc envelope rethrow; server-derived message is the discriminator
     throw new Error(reason);
   }
   return envelope?.json as TOutput;

--- a/packages/plugins/menu/eslint.config.ts
+++ b/packages/plugins/menu/eslint.config.ts
@@ -1,9 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(
-  baseConfig,
-  // Migrated areas per umbrella #232. Subsequent slices extend this list.
-  noBareThrowErrorFor(["src/server/**/*.ts", "src/rpc.ts", "src/errors.ts"]),
-);
+export default defineConfig(baseConfig, noBareThrowError);

--- a/packages/plugins/menu/src/admin/rpc.ts
+++ b/packages/plugins/menu/src/admin/rpc.ts
@@ -76,6 +76,7 @@ export async function rpcCall<TOutput>(
       | undefined;
     const reason =
       error?.data?.reason ?? error?.message ?? `rpc_${String(res.status)}`;
+    // eslint-disable-next-line no-restricted-syntax -- admin-side rpc envelope rethrow; server-derived message is the discriminator
     throw new Error(reason);
   }
   return envelope?.json as TOutput;

--- a/packages/plugins/pages/eslint.config.ts
+++ b/packages/plugins/pages/eslint.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(baseConfig);
+export default defineConfig(baseConfig, noBareThrowError);

--- a/packages/plumix/eslint.config.ts
+++ b/packages/plumix/eslint.config.ts
@@ -1,13 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noBareThrowErrorFor } from "@plumix/eslint-config/base";
+import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
 
-export default defineConfig(
-  baseConfig,
-  // Migrated areas per umbrella #232. Subsequent slices extend this list.
-  noBareThrowErrorFor([
-    "src/vite/**/*.ts",
-    "src/admin/runtime.ts",
-    "src/errors.ts",
-  ]),
-);
+export default defineConfig(baseConfig, noBareThrowError);


### PR DESCRIPTION
Final slice (#241) of umbrella #232 PR 1. Replaces per-package `noBareThrowErrorFor([...globs])` opt-ins with the broad `noBareThrowError` config across every package, and adds the opt-in to 5 packages that didn't have it yet (blocks, plugin-audit-log, plugin-blog, plugin-media, plugin-pages). The ESLint `no-restricted-syntax` rule now applies to `packages/**/src/**` unconditionally.

**Not the no-op the umbrella expected**

The umbrella framed this as "should be a no-op — all areas in PR1 scope have been migrated". In practice, broadening flagged **18 throw sites in production-code `src/` paths** that the prior slices' task lists didn't enumerate. Per the smallest-diff path, each gets an inline `eslint-disable-next-line` with category-specific rationale and a follow-up reference:

| Category | Sites | Rationale |
|---|---|---|
| **Defensive driver-regression guards** | 5 (`auth/api-tokens`, `auth/bootstrap`, `auth/sessions`, `auth/passkey/register`, `rpc/procedures/auth/allowed-domains/create`) | All identical `if (!row) throw new Error("X: insert returned no row")` shape. Routed to PR 2 (#234) alongside the surrounding auth migrations |
| **React boot/hook guards** | 2 (`admin/main.tsx`, `admin/providers/theme.tsx`) | React idiom — boot-fatal `#root` check + hook-outside-provider guard. Convention exception |
| **Admin-side RPC envelope rethrows** | 3 (`audit-log/admin/rpc.ts`, `media/admin/MediaLibrary.tsx`, `menu/admin/rpc.ts`) | `throw new Error(reason)` where `reason` is server-derived. Pass-through pattern, nothing narrows by type. Convention exception |
| **Business-logic throws → factory in follow-up** | 8 (`config.ts`, `context/{app,stores}.ts`, `auth/identity.ts`, `rpc/meta/core.ts` ×3, `rpc/procedures/{entry,term}/lookup.ts`, `audit-log/server/retention.ts`) | Each marked `TODO migrate to a named factory in a follow-up slice` |

The 11 throws already inline-disabled in earlier slices stay disabled (sanitizer sentinels, cloudflare AsyncLocalStorage checks, cloudflare CLI flags, vendored shadcn hooks already in `ignores`).

**ESLint config shape across the monorepo is now uniform**

Every package's `eslint.config.ts` reads:

```ts
import { baseConfig, noBareThrowError } from "@plumix/eslint-config/base";
export default defineConfig(baseConfig, noBareThrowError);
```

(admin adds `reactConfig` + its `ignores` for vendored shadcn; that's the only variance.) The `noBareThrowErrorFor(globs)` helper stays exported from base.ts for any future package that wants to add a narrower scope.

**Closes PR 1 of umbrella #232**

Every area in umbrella #232's PR1 task list now has its `errors.ts` file. Subsequent work: **PR 2 (#234)** migrates the 19 existing error classes to the factory pattern + clears the auth/rpc-meta TODO disables. **PR 3 (#235)** is the audit and cleanup pass.

Refs #232
Refs #233
Refs #241