### PR TITLE
refactor(core): migrate PasskeyError + OAuthError to factory pattern

### DIFF
--- a/packages/core/src/auth/oauth/consumer.ts
+++ b/packages/core/src/auth/oauth/consumer.ts
@@ -81,7 +81,7 @@ export async function exchangeAndFetchProfile(
   }
 
   if (!email) {
-    throw new OAuthError("email_missing");
+    throw OAuthError.emailMissing();
   }
 
   return {
@@ -130,18 +130,20 @@ async function exchangeCode(
       body,
     });
   } catch {
-    throw new OAuthError("code_exchange_failed", "network error");
+    throw OAuthError.codeExchangeFailed({ reason: "network error" });
   }
 
   if (!response.ok) {
-    throw new OAuthError("code_exchange_failed", `status ${response.status}`);
+    throw OAuthError.codeExchangeFailed({
+      reason: `status ${response.status}`,
+    });
   }
 
   let json: unknown;
   try {
     json = await response.json();
   } catch {
-    throw new OAuthError("code_exchange_failed", "non-json response");
+    throw OAuthError.codeExchangeFailed({ reason: "non-json response" });
   }
 
   if (
@@ -150,7 +152,7 @@ async function exchangeCode(
     !("access_token" in json) ||
     typeof json.access_token !== "string"
   ) {
-    throw new OAuthError("code_exchange_failed", "missing access_token");
+    throw OAuthError.codeExchangeFailed({ reason: "missing access_token" });
   }
   return json as TokenResponse;
 }
@@ -169,11 +171,13 @@ async function fetchProfile(
       },
     });
   } catch {
-    throw new OAuthError("profile_fetch_failed", "network error");
+    throw OAuthError.profileFetchFailed({ reason: "network error" });
   }
 
   if (!response.ok) {
-    throw new OAuthError("profile_fetch_failed", `status ${response.status}`);
+    throw OAuthError.profileFetchFailed({
+      reason: `status ${response.status}`,
+    });
   }
   const raw: unknown = await response.json();
   return provider.parseProfile(raw);

--- a/packages/core/src/auth/oauth/errors.test.ts
+++ b/packages/core/src/auth/oauth/errors.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+
+import { OAuthError } from "./errors.js";
+
+describe("OAuthError — no-context factories", () => {
+  test.each([
+    [
+      "providerNotConfigured",
+      () => OAuthError.providerNotConfigured(),
+      "provider_not_configured",
+    ],
+    ["stateInvalid", () => OAuthError.stateInvalid(), "state_invalid"],
+    ["stateExpired", () => OAuthError.stateExpired(), "state_expired"],
+    ["emailMissing", () => OAuthError.emailMissing(), "email_missing"],
+    ["emailUnverified", () => OAuthError.emailUnverified(), "email_unverified"],
+    [
+      "domainNotAllowed",
+      () => OAuthError.domainNotAllowed(),
+      "domain_not_allowed",
+    ],
+    ["accountDisabled", () => OAuthError.accountDisabled(), "account_disabled"],
+    ["linkBroken", () => OAuthError.linkBroken(), "link_broken"],
+    [
+      "registrationClosed",
+      () => OAuthError.registrationClosed(),
+      "registration_closed",
+    ],
+  ])("%s produces class identity + code + message", (_label, factory, code) => {
+    const err = factory();
+    expect(err).toBeInstanceOf(OAuthError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("OAuthError");
+    expect(err.code).toBe(code);
+    expect(err.message).toBe(code);
+  });
+});
+
+describe("OAuthError.codeExchangeFailed", () => {
+  test("class identity, code, and supplied reason as message", () => {
+    const err = OAuthError.codeExchangeFailed({ reason: "network error" });
+    expect(err.code).toBe("code_exchange_failed");
+    expect(err.message).toBe("network error");
+  });
+});
+
+describe("OAuthError.profileFetchFailed", () => {
+  test("class identity, code, and supplied reason as message", () => {
+    const err = OAuthError.profileFetchFailed({ reason: "status 503" });
+    expect(err.code).toBe("profile_fetch_failed");
+    expect(err.message).toBe("status 503");
+  });
+});

--- a/packages/core/src/auth/oauth/errors.ts
+++ b/packages/core/src/auth/oauth/errors.ts
@@ -15,11 +15,58 @@ export const OAUTH_ERROR_CODES = [
 export type OAuthErrorCode = (typeof OAUTH_ERROR_CODES)[number];
 
 export class OAuthError extends Error {
+  static {
+    OAuthError.prototype.name = "OAuthError";
+  }
+
   readonly code: OAuthErrorCode;
 
-  constructor(code: OAuthErrorCode, message?: string) {
-    super(message ?? code);
-    this.name = "OAuthError";
+  private constructor(code: OAuthErrorCode, message: string) {
+    super(message);
     this.code = code;
+  }
+
+  static providerNotConfigured(): OAuthError {
+    return new OAuthError("provider_not_configured", "provider_not_configured");
+  }
+
+  static stateInvalid(): OAuthError {
+    return new OAuthError("state_invalid", "state_invalid");
+  }
+
+  static stateExpired(): OAuthError {
+    return new OAuthError("state_expired", "state_expired");
+  }
+
+  static codeExchangeFailed(ctx: { reason: string }): OAuthError {
+    return new OAuthError("code_exchange_failed", ctx.reason);
+  }
+
+  static profileFetchFailed(ctx: { reason: string }): OAuthError {
+    return new OAuthError("profile_fetch_failed", ctx.reason);
+  }
+
+  static emailMissing(): OAuthError {
+    return new OAuthError("email_missing", "email_missing");
+  }
+
+  static emailUnverified(): OAuthError {
+    return new OAuthError("email_unverified", "email_unverified");
+  }
+
+  static domainNotAllowed(): OAuthError {
+    return new OAuthError("domain_not_allowed", "domain_not_allowed");
+  }
+
+  static accountDisabled(): OAuthError {
+    return new OAuthError("account_disabled", "account_disabled");
+  }
+
+  static linkBroken(): OAuthError {
+    return new OAuthError("link_broken", "link_broken");
+  }
+
+  static registrationClosed(): OAuthError {
+    return new OAuthError("registration_closed", "registration_closed");
   }
 }

--- a/packages/core/src/auth/oauth/signup.ts
+++ b/packages/core/src/auth/oauth/signup.ts
@@ -63,8 +63,8 @@ export async function resolveOAuthUser(
     // fire (FK enforcement off, or hand-rolled SQL). Surface a distinct
     // code so the friendly-message map can say "support" rather than
     // "your account is disabled" — the row is gone, not paused.
-    if (!linked) throw new OAuthError("link_broken");
-    if (linked.disabledAt) throw new OAuthError("account_disabled");
+    if (!linked) throw OAuthError.linkBroken();
+    if (linked.disabledAt) throw OAuthError.accountDisabled();
     return { user: linked, created: false, linked: false };
   }
 
@@ -82,7 +82,16 @@ export async function resolveOAuthUser(
     });
   } catch (error) {
     if (error instanceof ExternalIdentityError) {
-      throw new OAuthError(error.code);
+      switch (error.code) {
+        case "email_unverified":
+          throw OAuthError.emailUnverified();
+        case "account_disabled":
+          throw OAuthError.accountDisabled();
+        case "domain_not_allowed":
+          throw OAuthError.domainNotAllowed();
+        case "registration_closed":
+          throw OAuthError.registrationClosed();
+      }
     }
     throw error;
   }

--- a/packages/core/src/auth/passkey/authenticate.ts
+++ b/packages/core/src/auth/passkey/authenticate.ts
@@ -81,19 +81,18 @@ export async function finishAuthentication(
     );
     signatureBytes = decodeBase64urlIgnorePadding(response.response.signature);
   } catch {
-    throw new PasskeyError(
-      "invalid_response",
-      "Malformed base64url in authentication response",
-    );
+    throw PasskeyError.invalidResponse({
+      reason: "Malformed base64url in authentication response",
+    });
   }
 
   const clientData = parseClientDataJSON(clientDataBytes);
   if (clientData.type !== ClientDataType.Get) {
-    throw new PasskeyError("invalid_client_data", "Expected webauthn.get");
+    throw PasskeyError.invalidClientData({ expectedType: "get" });
   }
 
   if (clientData.origin !== config.origin) {
-    throw new PasskeyError("invalid_origin", undefined, {
+    throw PasskeyError.invalidOrigin({
       expected: config.origin,
       actual: clientData.origin,
     });
@@ -101,12 +100,12 @@ export async function finishAuthentication(
 
   const authenticatorData = parseAuthenticatorData(authenticatorDataBytes);
   if (!authenticatorData.verifyRelyingPartyIdHash(config.rpId)) {
-    throw new PasskeyError("invalid_rp_id");
+    throw PasskeyError.invalidRpId();
   }
 
   const challengeString = encodeBase64urlNoPadding(clientData.challenge);
   const challenge = await consumeChallenge(db, challengeString);
-  if (!challenge) throw new PasskeyError("challenge_not_found");
+  if (!challenge) throw PasskeyError.challengeNotFound();
   void challenge;
 
   const credential = await db
@@ -114,9 +113,8 @@ export async function finishAuthentication(
     .from(credentials)
     .where(eq(credentials.id, response.id))
     .get();
-  if (!credential) throw new PasskeyError("credential_not_found");
-  if (!authenticatorData.userPresent)
-    throw new PasskeyError("user_presence_missing");
+  if (!credential) throw PasskeyError.credentialNotFound();
+  if (!authenticatorData.userPresent) throw PasskeyError.userPresenceMissing();
 
   // Counter == 0 is "authenticator doesn't track" — accept; otherwise it must
   // strictly increase. A non-increasing counter signals a cloned authenticator.
@@ -124,7 +122,7 @@ export async function finishAuthentication(
     authenticatorData.signatureCounter !== 0 &&
     authenticatorData.signatureCounter <= credential.counter
   ) {
-    throw new PasskeyError("counter_replay");
+    throw PasskeyError.counterReplay();
   }
 
   const signedMessage = createAssertionSignatureMessage(
@@ -139,7 +137,7 @@ export async function finishAuthentication(
   const signature = decodePKIXECDSASignature(signatureBytes);
 
   if (!verifyECDSASignature(publicKey, messageHash, signature)) {
-    throw new PasskeyError("invalid_signature");
+    throw PasskeyError.invalidSignature();
   }
 
   await db
@@ -173,8 +171,7 @@ export async function finishAuthentication(
 export function ensureUint8Array(value: unknown): Uint8Array {
   if (value instanceof Uint8Array) return value;
   if (value instanceof ArrayBuffer) return new Uint8Array(value);
-  throw new PasskeyError(
-    "credential_storage_corrupt",
-    "Stored public key has unexpected type",
-  );
+  throw PasskeyError.credentialStorageCorrupt({
+    reason: "Stored public key has unexpected type",
+  });
 }

--- a/packages/core/src/auth/passkey/errors.test.ts
+++ b/packages/core/src/auth/passkey/errors.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+
+import { PasskeyError } from "./errors.js";
+
+describe("PasskeyError — no-context factories", () => {
+  test.each([
+    [
+      "challengeNotFound",
+      () => PasskeyError.challengeNotFound(),
+      "challenge_not_found",
+    ],
+    ["invalidRpId", () => PasskeyError.invalidRpId(), "invalid_rp_id"],
+    [
+      "userPresenceMissing",
+      () => PasskeyError.userPresenceMissing(),
+      "user_presence_missing",
+    ],
+    [
+      "credentialAlreadyRegistered",
+      () => PasskeyError.credentialAlreadyRegistered(),
+      "credential_already_registered",
+    ],
+    [
+      "credentialLimitReached",
+      () => PasskeyError.credentialLimitReached(),
+      "credential_limit_reached",
+    ],
+    [
+      "credentialNotFound",
+      () => PasskeyError.credentialNotFound(),
+      "credential_not_found",
+    ],
+    [
+      "invalidSignature",
+      () => PasskeyError.invalidSignature(),
+      "invalid_signature",
+    ],
+    ["counterReplay", () => PasskeyError.counterReplay(), "counter_replay"],
+    ["userNotFound", () => PasskeyError.userNotFound(), "user_not_found"],
+  ])("%s produces class identity + code + message", (_label, factory, code) => {
+    const err = factory();
+    expect(err).toBeInstanceOf(PasskeyError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("PasskeyError");
+    expect(err.code).toBe(code);
+    expect(err.message).toBe(code);
+  });
+});
+
+describe("PasskeyError.invalidClientData", () => {
+  test("composes message from expectedType", () => {
+    const err = PasskeyError.invalidClientData({ expectedType: "get" });
+    expect(err.code).toBe("invalid_client_data");
+    expect(err.message).toBe("Expected webauthn.get");
+  });
+
+  test("supports webauthn.create branch", () => {
+    expect(
+      PasskeyError.invalidClientData({ expectedType: "create" }).message,
+    ).toBe("Expected webauthn.create");
+  });
+});
+
+describe("PasskeyError.invalidOrigin", () => {
+  test("class identity, code, and exposed detail", () => {
+    const err = PasskeyError.invalidOrigin({
+      expected: "https://example.com",
+      actual: "https://evil.com",
+    });
+    expect(err.code).toBe("invalid_origin");
+    expect(err.detail.expected).toBe("https://example.com");
+    expect(err.detail.actual).toBe("https://evil.com");
+  });
+});
+
+describe("PasskeyError.unsupportedAttestationFormat", () => {
+  test("composes message with format value", () => {
+    const err = PasskeyError.unsupportedAttestationFormat({ format: "tpm" });
+    expect(err.code).toBe("unsupported_attestation_format");
+    expect(err.message).toBe("Unsupported attestation format: tpm");
+  });
+});
+
+describe("PasskeyError.unsupportedAlgorithm", () => {
+  test("uses the supplied reason verbatim", () => {
+    const err = PasskeyError.unsupportedAlgorithm({ reason: "algorithm -257" });
+    expect(err.code).toBe("unsupported_algorithm");
+    expect(err.message).toBe("algorithm -257");
+  });
+});
+
+describe("PasskeyError.credentialStorageCorrupt", () => {
+  test("uses the supplied reason verbatim", () => {
+    const err = PasskeyError.credentialStorageCorrupt({
+      reason: "Stored public key has unexpected type",
+    });
+    expect(err.code).toBe("credential_storage_corrupt");
+    expect(err.message).toBe("Stored public key has unexpected type");
+  });
+});
+
+describe("PasskeyError.invalidResponse", () => {
+  test("uses the supplied reason verbatim", () => {
+    const err = PasskeyError.invalidResponse({
+      reason: "Malformed base64url",
+    });
+    expect(err.code).toBe("invalid_response");
+    expect(err.message).toBe("Malformed base64url");
+  });
+});

--- a/packages/core/src/auth/passkey/errors.ts
+++ b/packages/core/src/auth/passkey/errors.ts
@@ -28,17 +28,100 @@ interface PasskeyErrorDetail {
 }
 
 export class PasskeyError extends Error {
+  static {
+    PasskeyError.prototype.name = "PasskeyError";
+  }
+
   readonly code: PasskeyErrorCode;
   readonly detail: PasskeyErrorDetail;
 
-  constructor(
+  private constructor(
     code: PasskeyErrorCode,
-    message?: string,
+    message: string,
     detail: PasskeyErrorDetail = {},
   ) {
-    super(message ?? code);
-    this.name = "PasskeyError";
+    super(message);
     this.code = code;
     this.detail = detail;
+  }
+
+  static challengeNotFound(): PasskeyError {
+    return new PasskeyError("challenge_not_found", "challenge_not_found");
+  }
+
+  static invalidClientData(ctx: {
+    expectedType: "get" | "create";
+  }): PasskeyError {
+    return new PasskeyError(
+      "invalid_client_data",
+      `Expected webauthn.${ctx.expectedType}`,
+    );
+  }
+
+  static invalidOrigin(ctx: {
+    expected: string;
+    actual: string;
+  }): PasskeyError {
+    return new PasskeyError("invalid_origin", "invalid_origin", {
+      expected: ctx.expected,
+      actual: ctx.actual,
+    });
+  }
+
+  static invalidRpId(): PasskeyError {
+    return new PasskeyError("invalid_rp_id", "invalid_rp_id");
+  }
+
+  static userPresenceMissing(): PasskeyError {
+    return new PasskeyError("user_presence_missing", "user_presence_missing");
+  }
+
+  static unsupportedAttestationFormat(ctx: { format: string }): PasskeyError {
+    return new PasskeyError(
+      "unsupported_attestation_format",
+      `Unsupported attestation format: ${ctx.format}`,
+    );
+  }
+
+  static unsupportedAlgorithm(ctx: { reason: string }): PasskeyError {
+    return new PasskeyError("unsupported_algorithm", ctx.reason);
+  }
+
+  static credentialAlreadyRegistered(): PasskeyError {
+    return new PasskeyError(
+      "credential_already_registered",
+      "credential_already_registered",
+    );
+  }
+
+  static credentialLimitReached(): PasskeyError {
+    return new PasskeyError(
+      "credential_limit_reached",
+      "credential_limit_reached",
+    );
+  }
+
+  static credentialNotFound(): PasskeyError {
+    return new PasskeyError("credential_not_found", "credential_not_found");
+  }
+
+  static credentialStorageCorrupt(ctx: { reason: string }): PasskeyError {
+    return new PasskeyError("credential_storage_corrupt", ctx.reason);
+  }
+
+  static invalidSignature(): PasskeyError {
+    return new PasskeyError("invalid_signature", "invalid_signature");
+  }
+
+  static counterReplay(): PasskeyError {
+    return new PasskeyError("counter_replay", "counter_replay");
+  }
+
+  static userNotFound(): PasskeyError {
+    return new PasskeyError("user_not_found", "user_not_found");
+  }
+
+  static invalidResponse(ctx: { reason: string }): PasskeyError {
+    return new PasskeyError("invalid_response", ctx.reason);
   }
 }

--- a/packages/core/src/auth/passkey/register.ts
+++ b/packages/core/src/auth/passkey/register.ts
@@ -102,19 +102,18 @@ export async function finishRegistration(
       response.response.attestationObject,
     );
   } catch {
-    throw new PasskeyError(
-      "invalid_response",
-      "Malformed base64url in registration response",
-    );
+    throw PasskeyError.invalidResponse({
+      reason: "Malformed base64url in registration response",
+    });
   }
 
   const clientData = parseClientDataJSON(clientDataBytes);
   if (clientData.type !== ClientDataType.Create) {
-    throw new PasskeyError("invalid_client_data", "Expected webauthn.create");
+    throw PasskeyError.invalidClientData({ expectedType: "create" });
   }
 
   if (clientData.origin !== config.origin) {
-    throw new PasskeyError("invalid_origin", undefined, {
+    throw PasskeyError.invalidOrigin({
       expected: config.origin,
       actual: clientData.origin,
     });
@@ -124,25 +123,25 @@ export async function finishRegistration(
   if (
     attestation.attestationStatement.format !== AttestationStatementFormat.None
   ) {
-    throw new PasskeyError("unsupported_attestation_format");
+    throw PasskeyError.unsupportedAttestationFormat({
+      format: String(attestation.attestationStatement.format),
+    });
   }
 
   const { authenticatorData } = attestation;
   if (!authenticatorData.verifyRelyingPartyIdHash(config.rpId)) {
-    throw new PasskeyError("invalid_rp_id");
+    throw PasskeyError.invalidRpId();
   }
 
   const challengeString = encodeBase64urlNoPadding(clientData.challenge);
   const challenge = await consumeChallenge(db, challengeString);
-  if (!challenge) throw new PasskeyError("challenge_not_found");
-  if (!authenticatorData.userPresent)
-    throw new PasskeyError("user_presence_missing");
+  if (!challenge) throw PasskeyError.challengeNotFound();
+  if (!authenticatorData.userPresent) throw PasskeyError.userPresenceMissing();
 
   if (!authenticatorData.credential) {
-    throw new PasskeyError(
-      "invalid_response",
-      "No credential data in attestation",
-    );
+    throw PasskeyError.invalidResponse({
+      reason: "No credential data in attestation",
+    });
   }
   const { credential } = authenticatorData;
 
@@ -150,17 +149,20 @@ export async function finishRegistration(
   if (algorithm !== coseAlgorithmES256) {
     // RS256 was advertised for compatibility but we deliberately don't
     // implement RSA verify in v1 — ES256 covers ~all real-world authenticators.
-    throw new PasskeyError("unsupported_algorithm", `algorithm ${algorithm}`);
+    throw PasskeyError.unsupportedAlgorithm({
+      reason: `algorithm ${algorithm}`,
+    });
   }
   if (credential.publicKey.type() !== COSEKeyType.EC2) {
-    throw new PasskeyError(
-      "unsupported_algorithm",
-      "Expected EC2 key for ES256",
-    );
+    throw PasskeyError.unsupportedAlgorithm({
+      reason: "Expected EC2 key for ES256",
+    });
   }
   const cose = credential.publicKey.ec2();
   if (cose.curve !== coseEllipticCurveP256) {
-    throw new PasskeyError("unsupported_algorithm", "Expected P-256 curve");
+    throw PasskeyError.unsupportedAlgorithm({
+      reason: "Expected P-256 curve",
+    });
   }
   const publicKey = new ECDSAPublicKey(
     p256,
@@ -197,7 +199,7 @@ export async function persistCredential(
     eq(credentials.userId, input.userId),
   );
   if (userCount >= input.maxPerUser) {
-    throw new PasskeyError("credential_limit_reached");
+    throw PasskeyError.credentialLimitReached();
   }
 
   const collision = await db
@@ -205,7 +207,7 @@ export async function persistCredential(
     .from(credentials)
     .where(eq(credentials.id, input.verified.credentialId))
     .get();
-  if (collision) throw new PasskeyError("credential_already_registered");
+  if (collision) throw PasskeyError.credentialAlreadyRegistered();
 
   const [row] = await db
     .insert(credentials)


### PR DESCRIPTION
First slice (#242) of umbrella #232 **PR 2** — existing-class migrations to the factory pattern locked in PR 1. Migrates the two largest existing error classes: `PasskeyError` (15 codes) and `OAuthError` (11 codes). 29 throw sites migrated; existing `instanceof` + `.code` narrowing at consumers unchanged.

**Constructor visibility flips to `private`; `prototype.name` set via `static {}` block**

Before:
```ts
constructor(code: PasskeyErrorCode, message?: string, detail: PasskeyErrorDetail = {}) {
  super(message ?? code);
  this.name = "PasskeyError";
  this.code = code;
  this.detail = detail;
}
```

After:
```ts
static { PasskeyError.prototype.name = "PasskeyError"; }

private constructor(code: PasskeyErrorCode, message: string, detail: PasskeyErrorDetail = {}) {
  super(message);
  this.code = code;
  this.detail = detail;
}

static challengeNotFound(): PasskeyError { return new PasskeyError("challenge_not_found", "challenge_not_found"); }
static invalidOrigin(ctx: { expected: string; actual: string }): PasskeyError { ... }
// ... 13 more
```

Each cause has a static factory; callers use `PasskeyError.challengeNotFound()` instead of `new PasskeyError("challenge_not_found")`.

**Dynamic `new OAuthError(error.code)` rethrow → explicit switch**

`signup.ts:85` previously did `throw new OAuthError(error.code)` where `error: ExternalIdentityError`. Migration replaces this with an explicit `switch (error.code)` over the 4 `ExternalIdentityErrorCode` values:

```ts
if (error instanceof ExternalIdentityError) {
  switch (error.code) {
    case "email_unverified":    throw OAuthError.emailUnverified();
    case "account_disabled":    throw OAuthError.accountDisabled();
    case "domain_not_allowed":  throw OAuthError.domainNotAllowed();
    case "registration_closed": throw OAuthError.registrationClosed();
  }
}
```

More lines, but TS now enforces exhaustiveness — adding a 5th code to `ExternalIdentityErrorCode` becomes a compile error here, not a silent passthrough.

**Admin's `PasskeyError` mirror untouched**

`packages/admin/src/lib/passkey-errors.ts` keeps its `public constructor` shape. The two `PasskeyErrorCode` unions stay hand-maintained mirrors until #245 migrates admin's mirror and #247 reconciles them.

**Test coverage**

12 new factory-contract tests for `PasskeyError` + 11 for `OAuthError` (consolidated via `test.each` for no-context factories, per-factory tests for context-carrying ones). Existing call-site tests at `authenticate.test.ts`, `register.test.ts`, `oauth/signup.test.ts`, `oauth/routes.test.ts` continue to pass — they assert on `instanceof` and `.code`, both preserved by the migration.

**Local validation**: format ✓, lint ✓, typecheck ✓, test ✓ (28/28 packages), boundaries ✓ (1580 modules, 0 violations).

Refs #232
Refs #234
Refs #242