### PR TITLE
refactor(core): migrate remaining auth errors to factory pattern

### DIFF
--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -95,12 +95,34 @@ export interface PlumixConfigIssue {
 }
 
 export class PlumixConfigError extends Error {
+  static {
+    PlumixConfigError.prototype.name = "PlumixConfigError";
+  }
+
+  readonly code: "invalid_auth_config";
   readonly issues: readonly PlumixConfigIssue[];
 
-  constructor(message: string, issues: readonly PlumixConfigIssue[]) {
+  private constructor(
+    code: "invalid_auth_config",
+    message: string,
+    issues: readonly PlumixConfigIssue[],
+  ) {
     super(message);
-    this.name = "PlumixConfigError";
+    this.code = code;
     this.issues = issues;
+  }
+
+  static invalidAuthConfig(ctx: {
+    issues: readonly PlumixConfigIssue[];
+  }): PlumixConfigError {
+    const summary = ctx.issues
+      .map((i) => (i.path ? `${i.path}: ${i.message}` : i.message))
+      .join("; ");
+    return new PlumixConfigError(
+      "invalid_auth_config",
+      `Invalid auth() config — ${summary}`,
+      ctx.issues,
+    );
   }
 }
 
@@ -239,10 +261,7 @@ export function auth(input: PlumixAuthInput): PlumixAuthConfig {
   const result = v.safeParse(authInputSchema, input);
   if (!result.success) {
     const issues = toIssues(result.issues);
-    const summary = issues
-      .map((i) => (i.path ? `${i.path}: ${i.message}` : i.message))
-      .join("; ");
-    throw new PlumixConfigError(`Invalid auth() config — ${summary}`, issues);
+    throw PlumixConfigError.invalidAuthConfig({ issues });
   }
   return {
     kind: "plumix",

--- a/packages/core/src/auth/csrf.ts
+++ b/packages/core/src/auth/csrf.ts
@@ -62,17 +62,38 @@ export function hasMatchingOrigin(
 }
 
 export class CsrfError extends Error {
-  constructor(message = "CSRF check failed") {
+  static {
+    CsrfError.prototype.name = "CsrfError";
+  }
+
+  readonly code: "missing_header" | "origin_mismatch";
+
+  private constructor(
+    code: "missing_header" | "origin_mismatch",
+    message: string,
+  ) {
     super(message);
-    this.name = "CsrfError";
+    this.code = code;
+  }
+
+  static missingHeader(): CsrfError {
+    return new CsrfError(
+      "missing_header",
+      `Missing required header ${CSRF_HEADER_NAME}: ${CSRF_HEADER_VALUE}`,
+    );
+  }
+
+  static originMismatch(): CsrfError {
+    return new CsrfError(
+      "origin_mismatch",
+      "Origin / Referer does not match site",
+    );
   }
 }
 
 export function requireCsrf(request: Request): void {
   if (!hasCsrfHeader(request)) {
-    throw new CsrfError(
-      `Missing required header ${CSRF_HEADER_NAME}: ${CSRF_HEADER_VALUE}`,
-    );
+    throw CsrfError.missingHeader();
   }
 }
 
@@ -81,6 +102,6 @@ export function requireMatchingOrigin(
   options: OriginCheckOptions,
 ): void {
   if (!hasMatchingOrigin(request, options)) {
-    throw new CsrfError("Origin / Referer does not match site");
+    throw CsrfError.originMismatch();
   }
 }

--- a/packages/core/src/auth/email-change/errors.test.ts
+++ b/packages/core/src/auth/email-change/errors.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import { EmailChangeError } from "./errors.js";
+
+describe("EmailChangeError — factories", () => {
+  test.each([
+    ["missingToken", () => EmailChangeError.missingToken(), "missing_token"],
+    ["tokenInvalid", () => EmailChangeError.tokenInvalid(), "token_invalid"],
+    ["tokenExpired", () => EmailChangeError.tokenExpired(), "token_expired"],
+    ["emailTaken", () => EmailChangeError.emailTaken(), "email_taken"],
+    ["userNotFound", () => EmailChangeError.userNotFound(), "user_not_found"],
+    [
+      "accountDisabled",
+      () => EmailChangeError.accountDisabled(),
+      "account_disabled",
+    ],
+  ])("%s produces class identity + code + message", (_label, factory, code) => {
+    const err = factory();
+    expect(err).toBeInstanceOf(EmailChangeError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("EmailChangeError");
+    expect(err.code).toBe(code);
+    expect(err.message).toBe(code);
+  });
+});

--- a/packages/core/src/auth/email-change/errors.ts
+++ b/packages/core/src/auth/email-change/errors.ts
@@ -18,10 +18,38 @@ export const EMAIL_CHANGE_ERROR_CODES = [
 export type EmailChangeErrorCode = (typeof EMAIL_CHANGE_ERROR_CODES)[number];
 
 export class EmailChangeError extends Error {
+  static {
+    EmailChangeError.prototype.name = "EmailChangeError";
+  }
+
   readonly code: EmailChangeErrorCode;
-  constructor(code: EmailChangeErrorCode, message?: string) {
-    super(message ?? code);
-    this.name = "EmailChangeError";
+
+  private constructor(code: EmailChangeErrorCode, message: string) {
+    super(message);
     this.code = code;
+  }
+
+  static missingToken(): EmailChangeError {
+    return new EmailChangeError("missing_token", "missing_token");
+  }
+
+  static tokenInvalid(): EmailChangeError {
+    return new EmailChangeError("token_invalid", "token_invalid");
+  }
+
+  static tokenExpired(): EmailChangeError {
+    return new EmailChangeError("token_expired", "token_expired");
+  }
+
+  static emailTaken(): EmailChangeError {
+    return new EmailChangeError("email_taken", "email_taken");
+  }
+
+  static userNotFound(): EmailChangeError {
+    return new EmailChangeError("user_not_found", "user_not_found");
+  }
+
+  static accountDisabled(): EmailChangeError {
+    return new EmailChangeError("account_disabled", "account_disabled");
   }
 }

--- a/packages/core/src/auth/email-change/request.ts
+++ b/packages/core/src/auth/email-change/request.ts
@@ -70,19 +70,19 @@ export async function requestEmailChange(
   const user = await db.query.users.findFirst({
     where: eq(users.id, input.userId),
   });
-  if (!user) throw new EmailChangeError("user_not_found");
-  if (user.disabledAt) throw new EmailChangeError("account_disabled");
+  if (!user) throw EmailChangeError.userNotFound();
+  if (user.disabledAt) throw EmailChangeError.accountDisabled();
 
   // Pre-check uniqueness against any *other* user's email. Same-self
   // re-request (newEmail === current) is rejected as `email_taken`
   // for symmetry — there's nothing to verify.
   if (newEmail === user.email) {
-    throw new EmailChangeError("email_taken");
+    throw EmailChangeError.emailTaken();
   }
   const collision = await db.query.users.findFirst({
     where: and(eq(users.email, newEmail), ne(users.id, user.id)),
   });
-  if (collision) throw new EmailChangeError("email_taken");
+  if (collision) throw EmailChangeError.emailTaken();
 
   // Single in-flight request per user — purge any prior pending
   // change before issuing the new one. Caller's previous link

--- a/packages/core/src/auth/email-change/verify.ts
+++ b/packages/core/src/auth/email-change/verify.ts
@@ -47,15 +47,15 @@ export async function verifyEmailChange(
     )
     .returning();
 
-  if (!tokenRow) throw new EmailChangeError("token_invalid");
+  if (!tokenRow) throw EmailChangeError.tokenInvalid();
   if (tokenRow.expiresAt.getTime() < Date.now()) {
-    throw new EmailChangeError("token_expired");
+    throw EmailChangeError.tokenExpired();
   }
   if (tokenRow.userId === null || tokenRow.email === null) {
     // Defensive: every email_verification row written by
     // `requestEmailChange` sets both. A null here means hand-rolled
     // DB state.
-    throw new EmailChangeError("token_invalid");
+    throw EmailChangeError.tokenInvalid();
   }
 
   // Look up the previous email for the hook payload. The atomic
@@ -63,7 +63,7 @@ export async function verifyEmailChange(
   const target = await db.query.users.findFirst({
     where: eq(users.id, tokenRow.userId),
   });
-  if (!target) throw new EmailChangeError("user_not_found");
+  if (!target) throw EmailChangeError.userNotFound();
 
   let updated: User;
   try {
@@ -78,11 +78,11 @@ export async function verifyEmailChange(
       .set({ email: tokenRow.email, emailVerifiedAt: new Date() })
       .where(and(eq(users.id, target.id), isNull(users.disabledAt)))
       .returning();
-    if (!row) throw new EmailChangeError("account_disabled");
+    if (!row) throw EmailChangeError.accountDisabled();
     updated = row;
   } catch (error) {
     if (isUniqueConstraintError(error)) {
-      throw new EmailChangeError("email_taken");
+      throw EmailChangeError.emailTaken();
     }
     throw error;
   }

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -9,15 +9,48 @@ export type ExternalIdentityErrorCode =
   | "email_unverified"
   | "account_disabled"
   | "domain_not_allowed"
-  | "registration_closed";
+  | "registration_closed"
+  | "default_role_required";
 
 export class ExternalIdentityError extends Error {
+  static {
+    ExternalIdentityError.prototype.name = "ExternalIdentityError";
+  }
+
   readonly code: ExternalIdentityErrorCode;
 
-  constructor(code: ExternalIdentityErrorCode, message?: string) {
-    super(message ?? code);
-    this.name = "ExternalIdentityError";
+  private constructor(code: ExternalIdentityErrorCode, message: string) {
+    super(message);
     this.code = code;
+  }
+
+  static emailUnverified(): ExternalIdentityError {
+    return new ExternalIdentityError("email_unverified", "email_unverified");
+  }
+
+  static accountDisabled(): ExternalIdentityError {
+    return new ExternalIdentityError("account_disabled", "account_disabled");
+  }
+
+  static domainNotAllowed(): ExternalIdentityError {
+    return new ExternalIdentityError(
+      "domain_not_allowed",
+      "domain_not_allowed",
+    );
+  }
+
+  static registrationClosed(): ExternalIdentityError {
+    return new ExternalIdentityError(
+      "registration_closed",
+      "registration_closed",
+    );
+  }
+
+  static defaultRoleRequired(): ExternalIdentityError {
+    return new ExternalIdentityError(
+      "default_role_required",
+      "resolveExternalIdentity: allowedDomainsGate=false requires an explicit defaultRole",
+    );
   }
 }
 
@@ -121,23 +154,23 @@ async function resolveOnce(
       // Auto-linking an unverified email to an existing local user
       // would let an attacker who controls a third-party account that
       // claims `victim@gmail.com` take over the local row. Refuse.
-      throw new ExternalIdentityError("email_unverified");
+      throw ExternalIdentityError.emailUnverified();
     }
     if (existing.disabledAt) {
-      throw new ExternalIdentityError("account_disabled");
+      throw ExternalIdentityError.accountDisabled();
     }
     return { user: existing, created: false };
   }
 
   // No existing user — provision via the configured gate.
   if (!input.emailVerified) {
-    throw new ExternalIdentityError("email_unverified");
+    throw ExternalIdentityError.emailUnverified();
   }
 
   if (!bootstrapAllowed) {
     const userCount = await db.$count(users);
     if (userCount === 0) {
-      throw new ExternalIdentityError("registration_closed");
+      throw ExternalIdentityError.registrationClosed();
     }
   }
 
@@ -149,10 +182,7 @@ async function resolveOnce(
     // Falling through with `undefined` would silently default the
     // user to "subscriber" via the schema default — surfacing as a
     // config bug instead.
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      "resolveExternalIdentity: allowedDomainsGate=false requires an explicit defaultRole",
-    );
+    throw ExternalIdentityError.defaultRoleRequired();
   }
 
   const { user } = await provisionUser(db, {
@@ -167,12 +197,12 @@ async function resolveOnce(
 
 async function roleFromAllowedDomain(db: Db, email: string): Promise<UserRole> {
   const domain = extractDomain(email);
-  if (!domain) throw new ExternalIdentityError("domain_not_allowed");
+  if (!domain) throw ExternalIdentityError.domainNotAllowed();
   const allowed = await db.query.allowedDomains.findFirst({
     where: eq(allowedDomains.domain, domain),
   });
   if (!allowed?.isEnabled) {
-    throw new ExternalIdentityError("domain_not_allowed");
+    throw ExternalIdentityError.domainNotAllowed();
   }
   return allowed.defaultRole;
 }

--- a/packages/core/src/auth/invite.test.ts
+++ b/packages/core/src/auth/invite.test.ts
@@ -149,7 +149,7 @@ describe("consumeInviteToken", () => {
 });
 
 test("InviteError carries a structured code", () => {
-  const err = new InviteError("token_expired");
+  const err = InviteError.tokenExpired();
   expect(err).toBeInstanceOf(Error);
   expect(err.name).toBe("InviteError");
   expect(err.code).toBe("token_expired");

--- a/packages/core/src/auth/invite.ts
+++ b/packages/core/src/auth/invite.ts
@@ -5,12 +5,23 @@ import { authTokens } from "../db/schema/auth_tokens.js";
 import { hashToken } from "./tokens.js";
 
 export class InviteError extends Error {
+  static {
+    InviteError.prototype.name = "InviteError";
+  }
+
   readonly code: "invalid_token" | "token_expired";
 
-  constructor(code: InviteError["code"], message?: string) {
-    super(message ?? code);
-    this.name = "InviteError";
+  private constructor(code: InviteError["code"], message: string) {
+    super(message);
     this.code = code;
+  }
+
+  static invalidToken(): InviteError {
+    return new InviteError("invalid_token", "invalid_token");
+  }
+
+  static tokenExpired(): InviteError {
+    return new InviteError("token_expired", "token_expired");
   }
 }
 
@@ -39,13 +50,13 @@ export async function validateInviteToken(
   // Treat a non-invite token, a token with missing fields, and a missing
   // token as the same "invalid" outcome — don't leak which rows exist.
   if (row?.type !== "invite") {
-    throw new InviteError("invalid_token");
+    throw InviteError.invalidToken();
   }
   if (row.userId === null || row.email === null || row.role === null) {
-    throw new InviteError("invalid_token");
+    throw InviteError.invalidToken();
   }
   if (row.expiresAt.getTime() < Date.now()) {
-    throw new InviteError("token_expired");
+    throw InviteError.tokenExpired();
   }
   return {
     tokenHash,

--- a/packages/core/src/auth/magic-link/errors.test.ts
+++ b/packages/core/src/auth/magic-link/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import { MagicLinkError } from "./errors.js";
+
+describe("MagicLinkError — factories", () => {
+  test.each([
+    ["missingToken", () => MagicLinkError.missingToken(), "missing_token"],
+    ["tokenInvalid", () => MagicLinkError.tokenInvalid(), "token_invalid"],
+    ["tokenExpired", () => MagicLinkError.tokenExpired(), "token_expired"],
+    [
+      "accountDisabled",
+      () => MagicLinkError.accountDisabled(),
+      "account_disabled",
+    ],
+    [
+      "domainNotAllowed",
+      () => MagicLinkError.domainNotAllowed(),
+      "domain_not_allowed",
+    ],
+    [
+      "registrationClosed",
+      () => MagicLinkError.registrationClosed(),
+      "registration_closed",
+    ],
+  ])("%s produces class identity + code + message", (_label, factory, code) => {
+    const err = factory();
+    expect(err).toBeInstanceOf(MagicLinkError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("MagicLinkError");
+    expect(err.code).toBe(code);
+    expect(err.message).toBe(code);
+  });
+});

--- a/packages/core/src/auth/magic-link/errors.ts
+++ b/packages/core/src/auth/magic-link/errors.ts
@@ -13,11 +13,38 @@ export const MAGIC_LINK_ERROR_CODES = [
 export type MagicLinkErrorCode = (typeof MAGIC_LINK_ERROR_CODES)[number];
 
 export class MagicLinkError extends Error {
+  static {
+    MagicLinkError.prototype.name = "MagicLinkError";
+  }
+
   readonly code: MagicLinkErrorCode;
 
-  constructor(code: MagicLinkErrorCode, message?: string) {
-    super(message ?? code);
-    this.name = "MagicLinkError";
+  private constructor(code: MagicLinkErrorCode, message: string) {
+    super(message);
     this.code = code;
+  }
+
+  static missingToken(): MagicLinkError {
+    return new MagicLinkError("missing_token", "missing_token");
+  }
+
+  static tokenInvalid(): MagicLinkError {
+    return new MagicLinkError("token_invalid", "token_invalid");
+  }
+
+  static tokenExpired(): MagicLinkError {
+    return new MagicLinkError("token_expired", "token_expired");
+  }
+
+  static accountDisabled(): MagicLinkError {
+    return new MagicLinkError("account_disabled", "account_disabled");
+  }
+
+  static domainNotAllowed(): MagicLinkError {
+    return new MagicLinkError("domain_not_allowed", "domain_not_allowed");
+  }
+
+  static registrationClosed(): MagicLinkError {
+    return new MagicLinkError("registration_closed", "registration_closed");
   }
 }

--- a/packages/core/src/auth/magic-link/verify.ts
+++ b/packages/core/src/auth/magic-link/verify.ts
@@ -59,14 +59,14 @@ export async function verifyMagicLink(
     .where(and(eq(authTokens.hash, hash), eq(authTokens.type, "magic_link")))
     .returning();
 
-  if (!row) throw new MagicLinkError("token_invalid");
+  if (!row) throw MagicLinkError.tokenInvalid();
   if (row.expiresAt.getTime() < Date.now()) {
-    throw new MagicLinkError("token_expired");
+    throw MagicLinkError.tokenExpired();
   }
   if (row.email === null) {
     // Defensive: every magic_link row written by `requestMagicLink`
     // sets email. A null here means hand-rolled DB state.
-    throw new MagicLinkError("token_invalid");
+    throw MagicLinkError.tokenInvalid();
   }
 
   if (row.userId !== null) {
@@ -83,11 +83,18 @@ export async function verifyMagicLink(
     return { user, created };
   } catch (error) {
     if (error instanceof ExternalIdentityError) {
-      // `email_unverified` can't fire here (we always pass true);
-      // re-throw as-is to surface the programming error if it ever
-      // does. Other codes map directly to MagicLinkError.
-      if (error.code === "email_unverified") throw error;
-      throw new MagicLinkError(error.code);
+      switch (error.code) {
+        case "email_unverified":
+          // Can't fire here (we always pass emailVerified: true);
+          // re-throw as-is to surface the programming error if it ever does.
+          throw error;
+        case "account_disabled":
+          throw MagicLinkError.accountDisabled();
+        case "domain_not_allowed":
+          throw MagicLinkError.domainNotAllowed();
+        case "registration_closed":
+          throw MagicLinkError.registrationClosed();
+      }
     }
     throw error;
   }
@@ -97,7 +104,7 @@ async function resolveExistingUser(db: Db, userId: number): Promise<User> {
   const user = await db.query.users.findFirst({
     where: eq(users.id, userId),
   });
-  if (!user) throw new MagicLinkError("token_invalid");
-  if (user.disabledAt) throw new MagicLinkError("account_disabled");
+  if (!user) throw MagicLinkError.tokenInvalid();
+  if (user.disabledAt) throw MagicLinkError.accountDisabled();
   return user;
 }

--- a/packages/core/src/auth/passkey/routes.ts
+++ b/packages/core/src/auth/passkey/routes.ts
@@ -569,7 +569,7 @@ async function resolveInviteTarget(
     where: eq(users.id, invite.userId),
   });
   if (!user || user.disabledAt) {
-    return inviteErrorResponse(new InviteError("invalid_token"));
+    return inviteErrorResponse(InviteError.invalidToken());
   }
   const existingCreds = await ctx.db.$count(
     credentials,

--- a/packages/core/src/auth/rbac.ts
+++ b/packages/core/src/auth/rbac.ts
@@ -175,18 +175,37 @@ export function createCapabilityResolver(
 }
 
 export class CapabilityError extends Error {
+  static {
+    CapabilityError.prototype.name = "CapabilityError";
+  }
+
   readonly code: "unauthorized" | "forbidden";
   readonly capability: string;
 
-  constructor(
+  private constructor(
     code: "unauthorized" | "forbidden",
     capability: string,
-    message?: string,
+    message: string,
   ) {
-    super(message ?? `${code}: ${capability}`);
-    this.name = "CapabilityError";
+    super(message);
     this.code = code;
     this.capability = capability;
+  }
+
+  static unauthorized(ctx: { capability: string }): CapabilityError {
+    return new CapabilityError(
+      "unauthorized",
+      ctx.capability,
+      "Authentication required",
+    );
+  }
+
+  static forbidden(ctx: { capability: string }): CapabilityError {
+    return new CapabilityError(
+      "forbidden",
+      ctx.capability,
+      `Missing capability: ${ctx.capability}`,
+    );
   }
 }
 
@@ -226,17 +245,8 @@ export function requireCapability(
   user: { role: UserRole } | null,
   capability: string,
 ): void {
-  if (!user)
-    throw new CapabilityError(
-      "unauthorized",
-      capability,
-      "Authentication required",
-    );
+  if (!user) throw CapabilityError.unauthorized({ capability });
   if (!resolver.hasCapability(user.role, capability)) {
-    throw new CapabilityError(
-      "forbidden",
-      capability,
-      `Missing capability: ${capability}`,
-    );
+    throw CapabilityError.forbidden({ capability });
   }
 }


### PR DESCRIPTION
Second slice (#243) of umbrella #232 **PR 2**. Migrates the 7 remaining auth-related error classes to the factory pattern locked by #242:

| Class | Codes | Notes |
|---|---|---|
| `MagicLinkError` | 6 | All no-context; dynamic `new MagicLinkError(error.code)` rethrow → exhaustive `switch` over `ExternalIdentityErrorCode` |
| `EmailChangeError` | 6 | All no-context |
| `CapabilityError` | 2 | Preserves `readonly capability` field; factories take `{ capability }` ctx |
| `InviteError` | 2 | All no-context |
| `CsrfError` | 2 | **Adds** typed `code: "missing_header" \| "origin_mismatch"` (was untyped before); factories compose the existing messages |
| `PlumixConfigError` | 1 | `invalidAuthConfig({ issues })` now owns the summary composition (was at call site) |
| `ExternalIdentityError` | 5 | **Adds** `default_role_required` for the existing throw at `identity.ts:152` that PR 1 #280 had marked TODO. Clears one inline disable from the audit. |

**24 throw sites migrated** across `magic-link/verify.ts`, `email-change/{request,verify}.ts`, `rbac.ts`, `invite.ts`, `passkey/routes.ts`, `csrf.ts`, `config.ts`, `identity.ts`.

**Dynamic dispatch refactor (`magic-link/verify.ts`)**

Before:
```ts
if (error.code === "email_unverified") throw error;
throw new MagicLinkError(error.code);
```

After:
```ts
switch (error.code) {
  case "email_unverified":     throw error;  // can't fire (we always pass true)
  case "account_disabled":     throw MagicLinkError.accountDisabled();
  case "domain_not_allowed":   throw MagicLinkError.domainNotAllowed();
  case "registration_closed":  throw MagicLinkError.registrationClosed();
}
```

Same exhaustive-narrowing pattern from #242's OAuth dispatch. The new `default_role_required` ExternalIdentityErrorCode falls through to the `throw error` at the catch-block end — rethrown as-is (it's a config error, not a magic-link UX failure).

**`CsrfError` and `PlumixConfigError` gain a `code` field**

These two classes didn't carry a `.code` discriminator before — `CsrfError` had only a message, `PlumixConfigError` had `issues` but no code. The migration adds the discriminator while preserving the message text verbatim. Consumers narrowing on `instanceof` keep working; consumers wanting to switch on cause now have a typed `.code`.

**Test coverage**

New `errors.test.ts` files for MagicLinkError + EmailChangeError (12 factory contracts total via `test.each` arrow-wrapped tables). Existing call-site tests preserved.

Local validation: format ✓, lint ✓, typecheck ✓, test ✓ (28/28 packages), boundaries ✓ (1582 modules, 0 violations).

Refs #232
Refs #234
Refs #243