### PR TITLE
fix(core): set MetaSanitizationError.name on prototype

### DIFF
--- a/packages/core/src/rpc/meta/core.test.ts
+++ b/packages/core/src/rpc/meta/core.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest";
+
+import { MetaSanitizationError } from "./core.js";
+
+describe("MetaSanitizationError", () => {
+  test("error.name is the class name, not 'Error'", () => {
+    const err = new MetaSanitizationError("tag", "not_registered");
+    expect(err).toBeInstanceOf(MetaSanitizationError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("MetaSanitizationError");
+  });
+});

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -53,6 +53,10 @@ type MetaSanitizationReason =
   | "value_too_large";
 
 export class MetaSanitizationError extends Error {
+  static {
+    MetaSanitizationError.prototype.name = "MetaSanitizationError";
+  }
+
   readonly key: string;
   readonly reason: MetaSanitizationReason;
   constructor(key: string, reason: MetaSanitizationReason) {


### PR DESCRIPTION
## Summary

- `MetaSanitizationError` extended `Error` but never set `name`, so `error.name` resolved to `"Error"` instead of `"MetaSanitizationError"` — a latent bug that distorted log output and would silently break any future name-based dispatch.
- Adds a `static {}` block setting `prototype.name`, matching the convention used by `AppBootError`, `ThemeError`, `RouteCompileError`, and `OAuthError`.
- Adds a colocated regression test in `packages/core/src/rpc/meta/core.test.ts` so a future refactor that strips the block fails loudly.

## Test plan

- [x] Failing test confirmed before fix (`.name === "Error"`)
- [x] Test passes after fix
- [x] `pnpm exec turbo run test --filter @plumix/core` — 1430 / 1430 green
- [x] `pnpm exec turbo run lint typecheck --filter @plumix/core` — clean

Closes #246.