### PR TITLE
refactor(core): migrate non-auth error classes to factory pattern

### DIFF
--- a/packages/core/src/cli/errors.ts
+++ b/packages/core/src/cli/errors.ts
@@ -1,18 +1,192 @@
-export interface CliErrorOptions {
-  readonly code: string;
-  readonly hint?: string;
-  readonly cause?: unknown;
-}
+type CliErrorCode =
+  | "spawn_failed"
+  | "spawn_nonzero_exit"
+  | "unknown_command"
+  | "unknown_subcommand"
+  | "runtime_commands_not_found"
+  | "runtime_commands_load_failed"
+  | "migrate_generate_no_drizzle_kit"
+  | "migrate_apply_missing_db"
+  | "migrate_apply_no_d1"
+  | "migrate_apply_ambiguous_db"
+  | "config_not_found_explicit"
+  | "config_not_found_default"
+  | "config_load_failed"
+  | "config_invalid";
 
 export class CliError extends Error {
-  readonly code: string;
+  static {
+    CliError.prototype.name = "CliError";
+  }
+
+  readonly code: CliErrorCode;
   readonly hint: string | undefined;
 
-  constructor(message: string, options: CliErrorOptions) {
-    super(message, options.cause ? { cause: options.cause } : undefined);
-    this.name = "CliError";
-    this.code = options.code;
-    this.hint = options.hint;
+  private constructor(
+    code: CliErrorCode,
+    message: string,
+    hint: string | undefined,
+    cause: unknown,
+  ) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.code = code;
+    this.hint = hint;
+  }
+
+  static spawnFailed(ctx: { command: string; cause: unknown }): CliError {
+    return new CliError(
+      "spawn_failed",
+      `Failed to start ${ctx.command}`,
+      `Is ${ctx.command} installed and on PATH?`,
+      ctx.cause,
+    );
+  }
+
+  static spawnNonzeroExit(ctx: {
+    command: string;
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+  }): CliError {
+    const detail = ctx.signal
+      ? `signal ${ctx.signal}`
+      : `code ${ctx.exitCode ?? "unknown"}`;
+    return new CliError(
+      "spawn_nonzero_exit",
+      `${ctx.command} exited with ${detail}`,
+      undefined,
+      undefined,
+    );
+  }
+
+  static unknownCommand(ctx: { command: string }): CliError {
+    return new CliError(
+      "unknown_command",
+      `Unknown command: ${ctx.command}`,
+      "Run `plumix help` to see available commands.",
+      undefined,
+    );
+  }
+
+  static unknownSubcommand(ctx: {
+    command: string;
+    subcommand: string | undefined;
+    supported: readonly string[];
+  }): CliError {
+    const supported = ctx.supported
+      .map((n) => `\`plumix ${ctx.command} ${n}\``)
+      .join(", ");
+    return new CliError(
+      "unknown_subcommand",
+      `Unknown subcommand: ${ctx.command} ${String(ctx.subcommand)}`,
+      `Supported: ${supported}.`,
+      undefined,
+    );
+  }
+
+  static runtimeCommandsNotFound(ctx: {
+    commandsModule: string;
+    cwd: string;
+    cause: unknown;
+  }): CliError {
+    return new CliError(
+      "runtime_commands_not_found",
+      `Runtime commands module not found: "${ctx.commandsModule}"`,
+      `Install the runtime adapter package in ${ctx.cwd}.`,
+      ctx.cause,
+    );
+  }
+
+  static runtimeCommandsLoadFailed(ctx: {
+    commandsModule: string;
+    cause: unknown;
+  }): CliError {
+    return new CliError(
+      "runtime_commands_load_failed",
+      `Failed to load runtime commands from "${ctx.commandsModule}"`,
+      "Check the runtime adapter's commands module for import errors.",
+      ctx.cause,
+    );
+  }
+
+  static migrateGenerateNoDrizzleKit(): CliError {
+    return new CliError(
+      "migrate_generate_no_drizzle_kit",
+      "drizzle-kit could not be resolved",
+      "drizzle-kit ships with plumix; rerun `pnpm install` to restore node_modules, or pin a specific version as a devDependency to override.",
+      undefined,
+    );
+  }
+
+  static migrateApplyMissingDb(): CliError {
+    return new CliError(
+      "migrate_apply_missing_db",
+      "Missing D1 database name",
+      "Pass the database name: `plumix migrate apply <database-name>`. Or add a wrangler.jsonc / wrangler.toml with a `d1_databases` entry so Plumix can auto-discover it.",
+      undefined,
+    );
+  }
+
+  static migrateApplyNoD1(ctx: { filename: string }): CliError {
+    return new CliError(
+      "migrate_apply_no_d1",
+      `No d1_databases entries with a database_name in ${ctx.filename}`,
+      "Add a `d1_databases` entry with a `database_name`, or pass the name explicitly: `plumix migrate apply <database-name>`.",
+      undefined,
+    );
+  }
+
+  static migrateApplyAmbiguousDb(ctx: {
+    filename: string;
+    names: readonly string[];
+  }): CliError {
+    return new CliError(
+      "migrate_apply_ambiguous_db",
+      `Multiple D1 databases found in ${ctx.filename}: ${ctx.names.join(", ")}`,
+      "Pass the name explicitly: `plumix migrate apply <database-name>`.",
+      undefined,
+    );
+  }
+
+  static configNotFoundExplicit(ctx: {
+    explicit: string;
+    absolute: string;
+  }): CliError {
+    return new CliError(
+      "config_not_found_explicit",
+      `Config file not found: ${ctx.explicit}`,
+      `Checked ${ctx.absolute}`,
+      undefined,
+    );
+  }
+
+  static configNotFoundDefault(ctx: { cwd: string }): CliError {
+    return new CliError(
+      "config_not_found_default",
+      "No plumix.config.{ts,js,mjs} found",
+      `Create plumix.config.ts in ${ctx.cwd} or pass --config <path>.`,
+      undefined,
+    );
+  }
+
+  static configLoadFailed(ctx: {
+    configPath: string;
+    cause: unknown;
+  }): CliError {
+    return new CliError(
+      "config_load_failed",
+      `Failed to load ${ctx.configPath}`,
+      "Check the file for syntax errors and ensure every import resolves.",
+      ctx.cause,
+    );
+  }
+
+  static configInvalid(ctx: { configPath: string }): CliError {
+    return new CliError(
+      "config_invalid",
+      `Invalid config shape in ${ctx.configPath}`,
+      "Default export must be the return value of plumix({ ... }) or defineConfig({ ... }).",
+      undefined,
+    );
   }
 }
 

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,5 +1,4 @@
 export { CliError, isCliError } from "./errors.js";
-export type { CliErrorOptions } from "./errors.js";
 export { CORE_SCHEMA_MODULE, generateSchemaSource } from "./schema-codegen.js";
 export type { SchemaSource } from "./schema-codegen.js";
 export { spawnInherit } from "./spawn.js";

--- a/packages/core/src/cli/spawn.ts
+++ b/packages/core/src/cli/spawn.ts
@@ -19,25 +19,14 @@ export function spawnInherit(
       stdio: "inherit",
     });
     child.once("error", (cause) => {
-      reject(
-        new CliError(`Failed to start ${command}`, {
-          code: "SPAWN_FAILED",
-          hint: `Is ${command} installed and on PATH?`,
-          cause,
-        }),
-      );
+      reject(CliError.spawnFailed({ command, cause }));
     });
     child.once("exit", (code, signal) => {
       if (code === 0) {
         resolve();
         return;
       }
-      reject(
-        new CliError(
-          `${command} exited with ${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`}`,
-          { code: "SPAWN_NONZERO_EXIT" },
-        ),
-      );
+      reject(CliError.spawnNonzeroExit({ command, exitCode: code, signal }));
     });
   });
 }

--- a/packages/core/src/plugin/context.ts
+++ b/packages/core/src/plugin/context.ts
@@ -38,8 +38,8 @@ import {
 } from "../auth/rbac.js";
 import { DEFAULT_REWRITE_RULE_PRIORITY } from "../route/compile.js";
 import { MAX_PLUGIN_ID_LENGTH, PLUGIN_ID_RE } from "./define.js";
-import { PluginContextError } from "./errors.js";
-import { CORE_RPC_NAMESPACES, DuplicateRegistrationError } from "./manifest.js";
+import { DuplicateRegistrationError, PluginContextError } from "./errors.js";
+import { CORE_RPC_NAMESPACES } from "./manifest.js";
 
 export interface ContextExtensionEntry {
   readonly value: unknown;
@@ -391,7 +391,10 @@ export function createPluginSetupContext({
 
     registerEntryType: (name, options) => {
       if (registry.entryTypes.has(name))
-        throw new DuplicateRegistrationError("entry type", name);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "entry type",
+          identifier: name,
+        });
       registry.entryTypes.set(name, {
         ...options,
         name,
@@ -402,7 +405,10 @@ export function createPluginSetupContext({
 
     registerTermTaxonomy: (name, options) => {
       if (registry.termTaxonomies.has(name))
-        throw new DuplicateRegistrationError("termTaxonomy", name);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "termTaxonomy",
+          identifier: name,
+        });
       registry.termTaxonomies.set(name, {
         ...options,
         name,
@@ -434,7 +440,10 @@ export function createPluginSetupContext({
         | { minRole: UserRole; defaultGrants?: readonly UserRole[] },
     ) => {
       if (registry.capabilities.has(name)) {
-        throw new DuplicateRegistrationError("capability", name);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "capability",
+          identifier: name,
+        });
       }
       const resolved =
         typeof minRoleOrOptions === "string"
@@ -456,7 +465,10 @@ export function createPluginSetupContext({
     registerSettingsGroup: (name, options) => {
       assertValidIdentifier("settings group", name);
       if (registry.settingsGroups.has(name)) {
-        throw new DuplicateRegistrationError("settings group", name);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "settings group",
+          identifier: name,
+        });
       }
       assertMetaBoxFields("settings group", name, options.fields);
       registry.settingsGroups.set(name, {
@@ -469,7 +481,10 @@ export function createPluginSetupContext({
     registerSettingsPage: (name, options) => {
       assertValidIdentifier("settings page", name);
       if (registry.settingsPages.has(name)) {
-        throw new DuplicateRegistrationError("settings page", name);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "settings page",
+          identifier: name,
+        });
       }
       for (const groupName of options.groups) {
         assertValidIdentifier("settings group reference", groupName);
@@ -501,7 +516,10 @@ export function createPluginSetupContext({
         });
       }
       if (registry.rpcRouters.has(pluginId)) {
-        throw new DuplicateRegistrationError("plugin RPC router", pluginId);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "plugin RPC router",
+          identifier: pluginId,
+        });
       }
       registry.rpcRouters.set(pluginId, router);
     },
@@ -529,7 +547,10 @@ export function createPluginSetupContext({
     registerAdminPage: (options) => {
       assertValidAdminPagePath(pluginId, options.path);
       if (registry.adminPages.has(options.path)) {
-        throw new DuplicateRegistrationError("admin page", options.path);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "admin page",
+          identifier: options.path,
+        });
       }
       assertComponentRef(
         pluginId,
@@ -552,7 +573,10 @@ export function createPluginSetupContext({
     registerFieldType: (options) => {
       assertValidFieldTypeName(pluginId, options.type);
       if (registry.fieldTypes.has(options.type)) {
-        throw new DuplicateRegistrationError("field type", options.type);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "field type",
+          identifier: options.type,
+        });
       }
       assertComponentRef(
         pluginId,
@@ -568,7 +592,10 @@ export function createPluginSetupContext({
     registerLookupAdapter: (options) => {
       assertValidLookupAdapterKind(pluginId, options.kind);
       if (registry.lookupAdapters.has(options.kind)) {
-        throw new DuplicateRegistrationError("lookup adapter", options.kind);
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "lookup adapter",
+          identifier: options.kind,
+        });
       }
       // Spread to preserve plugin-contributed option fields (e.g. the
       // `menuPicker` field that @plumix/plugin-menu adds via declaration
@@ -587,10 +614,10 @@ export function createPluginSetupContext({
           existing.registeredBy === pluginId &&
           existing.key === options.key
         ) {
-          throw new DuplicateRegistrationError(
-            "login link",
-            `${pluginId}:${options.key}`,
-          );
+          throw DuplicateRegistrationError.alreadyRegistered({
+            kind: "login link",
+            identifier: `${pluginId}:${options.key}`,
+          });
         }
       }
       registry.loginLinks.push({
@@ -603,10 +630,10 @@ export function createPluginSetupContext({
       assertValidScheduledTask(pluginId, task);
       for (const existing of registry.scheduledTasks) {
         if (existing.registeredBy === pluginId && existing.id === task.id) {
-          throw new DuplicateRegistrationError(
-            "scheduled task",
-            `${pluginId}:${task.id}`,
-          );
+          throw DuplicateRegistrationError.alreadyRegistered({
+            kind: "scheduled task",
+            identifier: `${pluginId}:${task.id}`,
+          });
         }
       }
       registry.scheduledTasks.push({
@@ -641,7 +668,11 @@ function makeMetaBoxRegistrar<
   pluginId: string,
 ): (id: string, options: Omit<T, "id">) => void {
   return (id, options) => {
-    if (map.has(id)) throw new DuplicateRegistrationError(kind, id);
+    if (map.has(id))
+      throw DuplicateRegistrationError.alreadyRegistered({
+        kind,
+        identifier: id,
+      });
     assertMetaBoxFields(kind, id, options.fields);
     map.set(id, {
       ...(options as unknown as T),

--- a/packages/core/src/plugin/errors.ts
+++ b/packages/core/src/plugin/errors.ts
@@ -712,3 +712,62 @@ export class PluginDefinitionError extends Error {
     );
   }
 }
+
+export class DuplicateRegistrationError extends Error {
+  static {
+    DuplicateRegistrationError.prototype.name = "DuplicateRegistrationError";
+  }
+
+  readonly kind: string;
+  readonly identifier: string;
+
+  private constructor(kind: string, identifier: string) {
+    super(`${kind} "${identifier}" is already registered`);
+    this.kind = kind;
+    this.identifier = identifier;
+  }
+
+  static alreadyRegistered(ctx: {
+    kind: string;
+    identifier: string;
+  }): DuplicateRegistrationError {
+    return new DuplicateRegistrationError(ctx.kind, ctx.identifier);
+  }
+}
+
+export class DuplicateAdminSlugError extends Error {
+  static {
+    DuplicateAdminSlugError.prototype.name = "DuplicateAdminSlugError";
+  }
+
+  readonly firstPostType: string;
+  readonly secondPostType: string;
+  readonly slug: string;
+
+  private constructor(
+    firstPostType: string,
+    secondPostType: string,
+    slug: string,
+  ) {
+    super(
+      `Entry types "${firstPostType}" and "${secondPostType}" both resolve ` +
+        `to the admin slug "${slug}". Set \`labels.plural\` on one of them ` +
+        `to disambiguate.`,
+    );
+    this.firstPostType = firstPostType;
+    this.secondPostType = secondPostType;
+    this.slug = slug;
+  }
+
+  static slugCollision(ctx: {
+    firstPostType: string;
+    secondPostType: string;
+    slug: string;
+  }): DuplicateAdminSlugError {
+    return new DuplicateAdminSlugError(
+      ctx.firstPostType,
+      ctx.secondPostType,
+      ctx.slug,
+    );
+  }
+}

--- a/packages/core/src/plugin/fields/repeater-validate.ts
+++ b/packages/core/src/plugin/fields/repeater-validate.ts
@@ -24,18 +24,10 @@ export function walkRepeaterRows(
   return (value) => {
     if (value === null || value === undefined) return value;
     if (!Array.isArray(value)) {
-      throw new RepeaterValidationError(
-        "invalid_shape",
-        "<root>",
-        "repeater value must be an array of rows",
-      );
+      throw RepeaterValidationError.rootNotArray();
     }
     if (value.length > MAX_REPEATER_ROWS) {
-      throw new RepeaterValidationError(
-        "invalid_shape",
-        "<root>",
-        `repeater input exceeds ${MAX_REPEATER_ROWS} rows`,
-      );
+      throw RepeaterValidationError.tooManyRows({ maxRows: MAX_REPEATER_ROWS });
     }
     const rows: Record<string, unknown>[] = [];
     value.forEach((rawRow, i) => {
@@ -44,11 +36,7 @@ export function walkRepeaterRows(
         typeof rawRow !== "object" ||
         Array.isArray(rawRow)
       ) {
-        throw new RepeaterValidationError(
-          "invalid_shape",
-          `[${i}]`,
-          "repeater row must be a plain object",
-        );
+        throw RepeaterValidationError.rowNotPlainObject({ path: `[${i}]` });
       }
       const inputRow = rawRow as Record<string, unknown>;
       const next: Record<string, unknown> = {};
@@ -66,38 +54,101 @@ export function walkRepeaterRows(
       if (hasValue) rows.push(next);
     });
     if (options.min !== undefined && rows.length < options.min) {
-      throw new RepeaterValidationError(
-        "below_min",
-        "<root>",
-        `repeater requires at least ${options.min} non-empty row(s); got ${rows.length}`,
-      );
+      throw RepeaterValidationError.belowMin({
+        min: options.min,
+        rowCount: rows.length,
+      });
     }
     if (options.max !== undefined && rows.length > options.max) {
-      throw new RepeaterValidationError(
-        "above_max",
-        "<root>",
-        `repeater allows at most ${options.max} row(s); got ${rows.length}`,
-      );
+      throw RepeaterValidationError.aboveMax({
+        max: options.max,
+        rowCount: rows.length,
+      });
     }
     return rows;
   };
 }
 
+type RepeaterValidationReason =
+  | "invalid_shape"
+  | "below_min"
+  | "above_max"
+  | "subfield_invalid";
+
 export class RepeaterValidationError extends Error {
+  static {
+    RepeaterValidationError.prototype.name = "RepeaterValidationError";
+  }
+
   readonly path: string;
-  readonly reason:
-    | "invalid_shape"
-    | "below_min"
-    | "above_max"
-    | "subfield_invalid";
-  constructor(
-    reason: RepeaterValidationError["reason"],
+  readonly reason: RepeaterValidationReason;
+
+  private constructor(
+    reason: RepeaterValidationReason,
     path: string,
     message: string,
   ) {
     super(message);
     this.path = path;
     this.reason = reason;
+  }
+
+  static rootNotArray(): RepeaterValidationError {
+    return new RepeaterValidationError(
+      "invalid_shape",
+      "<root>",
+      "repeater value must be an array of rows",
+    );
+  }
+
+  static tooManyRows(ctx: { maxRows: number }): RepeaterValidationError {
+    return new RepeaterValidationError(
+      "invalid_shape",
+      "<root>",
+      `repeater input exceeds ${String(ctx.maxRows)} rows`,
+    );
+  }
+
+  static rowNotPlainObject(ctx: { path: string }): RepeaterValidationError {
+    return new RepeaterValidationError(
+      "invalid_shape",
+      ctx.path,
+      "repeater row must be a plain object",
+    );
+  }
+
+  static belowMin(ctx: {
+    min: number;
+    rowCount: number;
+  }): RepeaterValidationError {
+    return new RepeaterValidationError(
+      "below_min",
+      "<root>",
+      `repeater requires at least ${String(ctx.min)} non-empty row(s); got ${String(ctx.rowCount)}`,
+    );
+  }
+
+  static aboveMax(ctx: {
+    max: number;
+    rowCount: number;
+  }): RepeaterValidationError {
+    return new RepeaterValidationError(
+      "above_max",
+      "<root>",
+      `repeater allows at most ${String(ctx.max)} row(s); got ${String(ctx.rowCount)}`,
+    );
+  }
+
+  static subfieldInvalid(ctx: {
+    path: string;
+    fieldKey: string;
+    detail: string;
+  }): RepeaterValidationError {
+    return new RepeaterValidationError(
+      "subfield_invalid",
+      ctx.path,
+      `repeater subfield "${ctx.fieldKey}" rejected value: ${ctx.detail}`,
+    );
   }
 }
 
@@ -112,10 +163,10 @@ function runSubSanitize(
     return sanitize(value);
   } catch (cause) {
     const detail = cause instanceof Error ? cause.message : String(cause);
-    throw new RepeaterValidationError(
-      "subfield_invalid",
+    throw RepeaterValidationError.subfieldInvalid({
       path,
-      `repeater subfield "${field.key}" rejected value: ${detail}`,
-    );
+      fieldKey: field.key,
+      detail,
+    });
   }
 }

--- a/packages/core/src/plugin/fields/richtext-validate.ts
+++ b/packages/core/src/plugin/fields/richtext-validate.ts
@@ -90,6 +90,12 @@ export function walkRichtextDoc(
   };
 }
 
+type RichtextValidationReason =
+  | "disallowed_node"
+  | "disallowed_mark"
+  | "unsafe_href"
+  | "invalid_shape";
+
 /**
  * Error thrown when the validator encounters a disallowed type or
  * unsafe attribute. Carries the JSON path so the editor (or test
@@ -98,20 +104,99 @@ export function walkRichtextDoc(
  * third paragraph's first text run's second mark.
  */
 export class RichtextValidationError extends Error {
+  static {
+    RichtextValidationError.prototype.name = "RichtextValidationError";
+  }
+
   readonly path: string;
-  readonly reason:
-    | "disallowed_node"
-    | "disallowed_mark"
-    | "unsafe_href"
-    | "invalid_shape";
-  constructor(
-    reason: RichtextValidationError["reason"],
+  readonly reason: RichtextValidationReason;
+
+  private constructor(
+    reason: RichtextValidationReason,
     path: string,
     message: string,
   ) {
     super(message);
     this.path = path;
     this.reason = reason;
+  }
+
+  static nestingExceeded(ctx: {
+    path: string;
+    maxDepth: number;
+  }): RichtextValidationError {
+    return new RichtextValidationError(
+      "invalid_shape",
+      ctx.path,
+      `richtext nesting exceeds ${String(ctx.maxDepth)} levels`,
+    );
+  }
+
+  static nodeNotPlainObject(ctx: { path: string }): RichtextValidationError {
+    return new RichtextValidationError(
+      "invalid_shape",
+      ctx.path,
+      "richtext node must be a plain object",
+    );
+  }
+
+  static nodeMissingType(ctx: { path: string }): RichtextValidationError {
+    return new RichtextValidationError(
+      "invalid_shape",
+      ctx.path,
+      "richtext node missing string `type`",
+    );
+  }
+
+  static disallowedNode(ctx: {
+    path: string;
+    nodeType: string;
+  }): RichtextValidationError {
+    return new RichtextValidationError(
+      "disallowed_node",
+      ctx.path,
+      `richtext node type "${ctx.nodeType}" not in field allowlist`,
+    );
+  }
+
+  static markNotPlainObject(ctx: { path: string }): RichtextValidationError {
+    return new RichtextValidationError(
+      "invalid_shape",
+      ctx.path,
+      "richtext mark must be a plain object",
+    );
+  }
+
+  static markMissingType(ctx: { path: string }): RichtextValidationError {
+    return new RichtextValidationError(
+      "invalid_shape",
+      ctx.path,
+      "richtext mark missing string `type`",
+    );
+  }
+
+  static disallowedMark(ctx: {
+    path: string;
+    markType: string;
+  }): RichtextValidationError {
+    return new RichtextValidationError(
+      "disallowed_mark",
+      ctx.path,
+      `richtext mark type "${ctx.markType}" not in field allowlist`,
+    );
+  }
+
+  static unsafeHref(ctx: {
+    path: string;
+    hrefType: string;
+  }): RichtextValidationError {
+    // `href` shape is unknown; describe by typeof so we don't tempt a
+    // `[object Object]` stringification in the error.
+    return new RichtextValidationError(
+      "unsafe_href",
+      ctx.path,
+      `richtext link mark href (${ctx.hrefType}) is not a safe URL`,
+    );
   }
 }
 
@@ -122,34 +207,25 @@ function walkNode(
   allowedNodeTypes: ReadonlySet<string>,
   allowedMarkTypes: ReadonlySet<string>,
 ): void {
+  const normalizedPath = path === "" ? "<root>" : path;
   if (depth > MAX_RICHTEXT_DEPTH) {
-    throw new RichtextValidationError(
-      "invalid_shape",
-      path === "" ? "<root>" : path,
-      `richtext nesting exceeds ${MAX_RICHTEXT_DEPTH} levels`,
-    );
+    throw RichtextValidationError.nestingExceeded({
+      path: normalizedPath,
+      maxDepth: MAX_RICHTEXT_DEPTH,
+    });
   }
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new RichtextValidationError(
-      "invalid_shape",
-      path === "" ? "<root>" : path,
-      "richtext node must be a plain object",
-    );
+    throw RichtextValidationError.nodeNotPlainObject({ path: normalizedPath });
   }
   const node = value as TiptapNodeShape;
   if (typeof node.type !== "string" || node.type === "") {
-    throw new RichtextValidationError(
-      "invalid_shape",
-      path === "" ? "<root>" : path,
-      "richtext node missing string `type`",
-    );
+    throw RichtextValidationError.nodeMissingType({ path: normalizedPath });
   }
   if (!allowedNodeTypes.has(node.type)) {
-    throw new RichtextValidationError(
-      "disallowed_node",
-      path === "" ? "<root>" : path,
-      `richtext node type "${node.type}" not in field allowlist`,
-    );
+    throw RichtextValidationError.disallowedNode({
+      path: normalizedPath,
+      nodeType: node.type,
+    });
   }
   if (Array.isArray(node.marks)) {
     node.marks.forEach((mark, i) => {
@@ -175,26 +251,17 @@ function walkMark(
   allowedMarkTypes: ReadonlySet<string>,
 ): void {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new RichtextValidationError(
-      "invalid_shape",
-      path,
-      "richtext mark must be a plain object",
-    );
+    throw RichtextValidationError.markNotPlainObject({ path });
   }
   const mark = value as TiptapNodeShape;
   if (typeof mark.type !== "string" || mark.type === "") {
-    throw new RichtextValidationError(
-      "invalid_shape",
-      path,
-      "richtext mark missing string `type`",
-    );
+    throw RichtextValidationError.markMissingType({ path });
   }
   if (!allowedMarkTypes.has(mark.type)) {
-    throw new RichtextValidationError(
-      "disallowed_mark",
+    throw RichtextValidationError.disallowedMark({
       path,
-      `richtext mark type "${mark.type}" not in field allowlist`,
-    );
+      markType: mark.type,
+    });
   }
   // `link` is the only attr we gate at this layer — its `href` is
   // user-supplied and reaches rendered HTML. Unsafe schemes
@@ -206,13 +273,10 @@ function walkMark(
     const href = attrs.href;
     if (href !== undefined && href !== null && href !== "") {
       if (typeof href !== "string" || !SAFE_HREF_RE.test(href.trim())) {
-        // `href` shape is unknown; describe by typeof so we don't
-        // tempt a `[object Object]` stringification in the error.
-        throw new RichtextValidationError(
-          "unsafe_href",
+        throw RichtextValidationError.unsafeHref({
           path,
-          `richtext link mark href (${typeof href}) is not a safe URL`,
-        );
+          hrefType: typeof href,
+        });
       }
     }
   }

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "vitest";
 
 import { HookRegistry } from "../hooks/registry.js";
 import { definePlugin } from "./define.js";
+import { DuplicateAdminSlugError } from "./errors.js";
 import {
   buildManifest,
   createPluginRegistry,
   deriveAdminSlug,
-  DuplicateAdminSlugError,
   emptyManifest,
   injectManifestIntoHtml,
   MANIFEST_SCRIPT_ID,

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -6,7 +6,7 @@ import type { AppContext } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { RouteIntent } from "../route/intent.js";
 import type { RegisteredLookupAdapter } from "./lookup.js";
-import { PluginDefinitionError } from "./errors.js";
+import { DuplicateAdminSlugError, PluginDefinitionError } from "./errors.js";
 
 export interface EntryTypeOptions {
   readonly label: string;
@@ -1127,13 +1127,6 @@ export function findUserMetaField(
   return undefined;
 }
 
-export class DuplicateRegistrationError extends Error {
-  constructor(kind: string, name: string) {
-    super(`${kind} "${name}" is already registered`);
-    this.name = "DuplicateRegistrationError";
-  }
-}
-
 /**
  * Shape serialised into the admin's `<script id="plumix-manifest">` payload.
  * Intentionally a strict subset of `RegisteredEntryType`: drops
@@ -1825,20 +1818,13 @@ function assertUniqueAdminSlugs(
   for (const entry of entries) {
     const existing = seen.get(entry.adminSlug);
     if (existing !== undefined) {
-      throw new DuplicateAdminSlugError(existing, entry.name, entry.adminSlug);
+      throw DuplicateAdminSlugError.slugCollision({
+        firstPostType: existing,
+        secondPostType: entry.name,
+        slug: entry.adminSlug,
+      });
     }
     seen.set(entry.adminSlug, entry.name);
-  }
-}
-
-export class DuplicateAdminSlugError extends Error {
-  constructor(firstPostType: string, secondPostType: string, slug: string) {
-    super(
-      `Entry types "${firstPostType}" and "${secondPostType}" both resolve ` +
-        `to the admin slug "${slug}". Set \`labels.plural\` on one of them ` +
-        `to disambiguate.`,
-    );
-    this.name = "DuplicateAdminSlugError";
   }
 }
 

--- a/packages/core/src/plugin/register.test.ts
+++ b/packages/core/src/plugin/register.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { HookRegistry } from "../hooks/registry.js";
 import { definePlugin } from "./define.js";
-import { DuplicateRegistrationError } from "./manifest.js";
+import { DuplicateRegistrationError } from "./errors.js";
 import { installPlugins } from "./register.js";
 
 import "../rpc/hooks.js";

--- a/packages/core/src/rpc/meta/core.test.ts
+++ b/packages/core/src/rpc/meta/core.test.ts
@@ -4,7 +4,7 @@ import { MetaSanitizationError } from "./core.js";
 
 describe("MetaSanitizationError", () => {
   test("error.name is the class name, not 'Error'", () => {
-    const err = new MetaSanitizationError("tag", "not_registered");
+    const err = MetaSanitizationError.notRegistered({ key: "tag" });
     expect(err).toBeInstanceOf(MetaSanitizationError);
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("MetaSanitizationError");

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -59,10 +59,23 @@ export class MetaSanitizationError extends Error {
 
   readonly key: string;
   readonly reason: MetaSanitizationReason;
-  constructor(key: string, reason: MetaSanitizationReason) {
+
+  private constructor(key: string, reason: MetaSanitizationReason) {
     super(`meta key "${key}" failed sanitization: ${reason}`);
     this.key = key;
     this.reason = reason;
+  }
+
+  static notRegistered(ctx: { key: string }): MetaSanitizationError {
+    return new MetaSanitizationError(ctx.key, "not_registered");
+  }
+
+  static invalidValue(ctx: { key: string }): MetaSanitizationError {
+    return new MetaSanitizationError(ctx.key, "invalid_value");
+  }
+
+  static valueTooLarge(ctx: { key: string }): MetaSanitizationError {
+    return new MetaSanitizationError(ctx.key, "value_too_large");
   }
 }
 
@@ -103,7 +116,7 @@ export function sanitizeMetaInput(
   for (const [key, rawValue] of Object.entries(input)) {
     const field = findField(key);
     if (!field) {
-      throw new MetaSanitizationError(key, "not_registered");
+      throw MetaSanitizationError.notRegistered({ key });
     }
     if (rawValue === null || rawValue === undefined) {
       deletes.push(key);
@@ -146,7 +159,7 @@ function runSanitize(
       `[plumix] sanitize callback for meta key ${JSON.stringify(key)} threw:`,
       error,
     );
-    throw new MetaSanitizationError(key, "invalid_value");
+    throw MetaSanitizationError.invalidValue({ key });
   }
 }
 
@@ -201,7 +214,7 @@ export async function validateMetaReferences(
     if (target) {
       const registered = ctx.plugins.lookupAdapters.get(target.kind);
       if (!registered) {
-        throw new MetaSanitizationError(key, "invalid_value");
+        throw MetaSanitizationError.invalidValue({ key });
       }
       const ids = referenceIdsForValidation(
         key,
@@ -269,10 +282,9 @@ export async function validateMetaReferences(
                 `references missing id ${JSON.stringify(id)}`,
             );
           }
-          throw new MetaSanitizationError(
-            contribution.errorKey,
-            "invalid_value",
-          );
+          throw MetaSanitizationError.invalidValue({
+            key: contribution.errorKey,
+          });
         }
       }
       contribution.applyNormalize(rowsById);
@@ -313,7 +325,7 @@ function collectRepeaterReferences(
       if (subValue === undefined || subValue === null) continue;
       const registered = ctx.plugins.lookupAdapters.get(target.kind);
       if (!registered) {
-        throw new MetaSanitizationError(topKey, "invalid_value");
+        throw MetaSanitizationError.invalidValue({ key: topKey });
       }
       const ids = referenceIdsForValidation(
         topKey,
@@ -509,13 +521,13 @@ function referenceIdsForValidation(
 ): readonly string[] {
   if (target.multiple) {
     if (!Array.isArray(value)) {
-      throw new MetaSanitizationError(key, "invalid_value");
+      throw MetaSanitizationError.invalidValue({ key });
     }
     if (value.length > HARD_MULTI_REFERENCE_LIMIT) {
-      throw new MetaSanitizationError(key, "value_too_large");
+      throw MetaSanitizationError.valueTooLarge({ key });
     }
     if (max !== undefined && value.length > max) {
-      throw new MetaSanitizationError(key, "invalid_value");
+      throw MetaSanitizationError.invalidValue({ key });
     }
     if (target.valueShape === "object") {
       // Lenient on input: each item can be `"42"` (first-write
@@ -532,13 +544,13 @@ function referenceIdsForValidation(
           ids.push(id);
           continue;
         }
-        throw new MetaSanitizationError(key, "invalid_value");
+        throw MetaSanitizationError.invalidValue({ key });
       }
       return ids;
     }
     for (const item of value) {
       if (typeof item !== "string" || item === "") {
-        throw new MetaSanitizationError(key, "invalid_value");
+        throw MetaSanitizationError.invalidValue({ key });
       }
     }
     return value as readonly string[];
@@ -550,10 +562,10 @@ function referenceIdsForValidation(
     if (typeof value === "string" && value !== "") return [value];
     const id = extractStringId(value);
     if (id !== null && id !== "") return [id];
-    throw new MetaSanitizationError(key, "invalid_value");
+    throw MetaSanitizationError.invalidValue({ key });
   }
   if (typeof value !== "string") {
-    throw new MetaSanitizationError(key, "invalid_value");
+    throw MetaSanitizationError.invalidValue({ key });
   }
   return [value];
 }
@@ -960,7 +972,7 @@ function coerceString(key: string, value: unknown): string {
   if (typeof value === "string") return value;
   if (typeof value === "number" && Number.isFinite(value)) return String(value);
   if (typeof value === "boolean") return String(value);
-  throw new MetaSanitizationError(key, "invalid_value");
+  throw MetaSanitizationError.invalidValue({ key });
 }
 
 function coerceNumber(key: string, value: unknown): number {
@@ -970,20 +982,20 @@ function coerceNumber(key: string, value: unknown): number {
     // already sends `null` for those, but a direct RPC caller might send
     // "" — reject here so we don't silently coerce to 0 (`Number("") === 0`).
     if (value.trim() === "") {
-      throw new MetaSanitizationError(key, "invalid_value");
+      throw MetaSanitizationError.invalidValue({ key });
     }
     const parsed = Number(value);
     if (Number.isFinite(parsed)) return parsed;
   }
   if (typeof value === "boolean") return value ? 1 : 0;
-  throw new MetaSanitizationError(key, "invalid_value");
+  throw MetaSanitizationError.invalidValue({ key });
 }
 
 function coerceBoolean(key: string, value: unknown): boolean {
   if (typeof value === "boolean") return value;
   if (value === 1 || value === "1" || value === "true") return true;
   if (value === 0 || value === "0" || value === "false") return false;
-  throw new MetaSanitizationError(key, "invalid_value");
+  throw MetaSanitizationError.invalidValue({ key });
 }
 
 function coerceJson(key: string, value: unknown): unknown {
@@ -996,11 +1008,11 @@ function coerceJson(key: string, value: unknown): unknown {
   try {
     const encoded = JSON.stringify(value) as string | undefined;
     if (encoded === undefined) {
-      throw new MetaSanitizationError(key, "invalid_value");
+      throw MetaSanitizationError.invalidValue({ key });
     }
     return JSON.parse(encoded);
   } catch {
-    throw new MetaSanitizationError(key, "invalid_value");
+    throw MetaSanitizationError.invalidValue({ key });
   }
 }
 
@@ -1009,7 +1021,7 @@ function assertEncodedSize(key: string, value: unknown): void {
   if (encoded === undefined) return; // already caught in coerceJson
   const byteLength = new TextEncoder().encode(encoded).length;
   if (byteLength > MAX_META_VALUE_BYTES) {
-    throw new MetaSanitizationError(key, "value_too_large");
+    throw MetaSanitizationError.valueTooLarge({ key });
   }
 }
 

--- a/packages/core/src/rpc/procedures/entry/meta.test.ts
+++ b/packages/core/src/rpc/procedures/entry/meta.test.ts
@@ -211,7 +211,7 @@ describe("sanitizeMetaInput", () => {
       tag: {
         type: "string",
         sanitize: () => {
-          throw new MetaSanitizationError("tag", "value_too_large");
+          throw MetaSanitizationError.valueTooLarge({ key: "tag" });
         },
       },
     });

--- a/packages/plugins/audit-log/src/rpc.test.ts
+++ b/packages/plugins/audit-log/src/rpc.test.ts
@@ -171,7 +171,7 @@ describe("auditLog.list RPC", () => {
       query: (_ctx, filter) => {
         calls.push(filter);
         // Storage simulates cursor.decodeCursor() failure.
-        return Promise.reject(new CursorError("malformed cursor"));
+        return Promise.reject(CursorError.malformed());
       },
     };
     const router = createAuditLogRouter(failingStorage);

--- a/packages/plugins/audit-log/src/server/cursor.ts
+++ b/packages/plugins/audit-log/src/server/cursor.ts
@@ -10,10 +10,26 @@
 // `CursorError` branch in the RPC layer and surfaces as a typed
 // `INVALID_CURSOR` to the caller.
 
+type CursorErrorCode = "empty" | "malformed";
+
 export class CursorError extends Error {
-  constructor(reason: string) {
-    super(reason);
-    this.name = "CursorError";
+  static {
+    CursorError.prototype.name = "CursorError";
+  }
+
+  readonly code: CursorErrorCode;
+
+  private constructor(code: CursorErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+
+  static empty(): CursorError {
+    return new CursorError("empty", "empty cursor");
+  }
+
+  static malformed(): CursorError {
+    return new CursorError("malformed", "malformed cursor");
   }
 }
 
@@ -28,26 +44,26 @@ export function encodeCursor(position: CursorPosition): string {
 }
 
 export function decodeCursor(encoded: string): CursorPosition {
-  if (encoded === "") throw new CursorError("empty cursor");
+  if (encoded === "") throw CursorError.empty();
   let raw: string;
   try {
     raw = fromUrlSafeBase64(encoded);
   } catch {
-    throw new CursorError("malformed cursor");
+    throw CursorError.malformed();
   }
   const parts = raw.split(".");
-  if (parts.length !== 2) throw new CursorError("malformed cursor");
+  if (parts.length !== 2) throw CursorError.malformed();
   const occurredAt = Number(parts[0]);
   const id = Number(parts[1]);
   if (!Number.isInteger(occurredAt) || !Number.isInteger(id)) {
-    throw new CursorError("malformed cursor");
+    throw CursorError.malformed();
   }
   // Audit rows have positive auto-increment ids and non-negative
   // occurredAt (unix epoch). A cursor outside that range is either
   // tampering or an upstream bug — treat as malformed so the RPC
   // returns a typed BAD_REQUEST instead of silently returning 0 rows.
   if (occurredAt < 0 || id <= 0) {
-    throw new CursorError("malformed cursor");
+    throw CursorError.malformed();
   }
   return { occurredAt, id };
 }

--- a/packages/plumix/src/cli/commands/migrate.test.ts
+++ b/packages/plumix/src/cli/commands/migrate.test.ts
@@ -79,16 +79,16 @@ describe("migrate dispatch", () => {
         }),
       ),
     ).rejects.toMatchObject({
-      code: "UNKNOWN_SUBCOMMAND",
+      code: "unknown_subcommand",
       hint: expect.stringContaining("plumix migrate apply") as unknown,
     });
   });
 
-  test("inherited prototype names fall through to UNKNOWN_SUBCOMMAND", async () => {
+  test("inherited prototype names fall through to unknown_subcommand", async () => {
     for (const sub of ["__proto__", "constructor", "toString"]) {
       await expect(
         migrateCommand.run(ctx({ cwd: dir, argv: [sub] })),
-      ).rejects.toMatchObject({ code: "UNKNOWN_SUBCOMMAND" });
+      ).rejects.toMatchObject({ code: "unknown_subcommand" });
     }
   });
 });
@@ -157,7 +157,7 @@ describe("migrate generate", () => {
     await expect(
       migrateCommand.run(ctx({ cwd: dir, argv: ["generate"] })),
     ).rejects.toMatchObject({
-      code: "MIGRATE_GENERATE_NO_DRIZZLE_KIT",
+      code: "migrate_generate_no_drizzle_kit",
       hint: expect.stringContaining("ships with plumix") as unknown,
     });
     expect(spawn).not.toHaveBeenCalled();
@@ -169,13 +169,13 @@ describe("migrate generate", () => {
     );
     vi.spyOn(migrateGenerateDeps, "spawnInherit").mockRejectedValue(
       Object.assign(new Error("drizzle-kit exited with code 1"), {
-        code: "SPAWN_NONZERO_EXIT",
+        code: "spawn_nonzero_exit",
       }),
     );
 
     await expect(
       migrateCommand.run(ctx({ cwd: dir, argv: ["generate"] })),
-    ).rejects.toMatchObject({ code: "SPAWN_NONZERO_EXIT" });
+    ).rejects.toMatchObject({ code: "spawn_nonzero_exit" });
   });
 });
 

--- a/packages/plumix/src/cli/commands/migrate.ts
+++ b/packages/plumix/src/cli/commands/migrate.ts
@@ -26,12 +26,10 @@ export const migrateCommand: CommandDefinition = {
         return;
       }
     }
-    const supported = ["generate", ...Object.keys(ctx.runtimeMigrate)]
-      .map((n) => `\`plumix migrate ${n}\``)
-      .join(", ");
-    throw new CliError(`Unknown subcommand: migrate ${sub}`, {
-      code: "UNKNOWN_SUBCOMMAND",
-      hint: `Supported: ${supported}.`,
+    throw CliError.unknownSubcommand({
+      command: "migrate",
+      subcommand: sub,
+      supported: ["generate", ...Object.keys(ctx.runtimeMigrate)],
     });
   },
 };
@@ -42,10 +40,7 @@ async function migrateGenerate(ctx: CommandContext): Promise<void> {
 
   const bin = migrateGenerateDeps.resolveDrizzleKitBin(cwd);
   if (bin === null) {
-    throw new CliError("drizzle-kit could not be resolved", {
-      code: "MIGRATE_GENERATE_NO_DRIZZLE_KIT",
-      hint: "drizzle-kit ships with plumix; rerun `pnpm install` to restore node_modules, or pin a specific version as a devDependency to override.",
-    });
+    throw CliError.migrateGenerateNoDrizzleKit();
   }
 
   report.info("Running drizzle-kit generate…");

--- a/packages/plumix/src/cli/index.ts
+++ b/packages/plumix/src/cli/index.ts
@@ -118,10 +118,7 @@ export async function run(argv: readonly string[]): Promise<void> {
   );
   const command = resolveCommand(runtimeModule.commands, args.command);
   if (!command) {
-    throw new CliError(`Unknown command: ${args.command}`, {
-      code: "UNKNOWN_COMMAND",
-      hint: "Run `plumix help` to see available commands.",
-    });
+    throw CliError.unknownCommand({ command: args.command });
   }
 
   const app = await buildApp(loaded.config);
@@ -185,14 +182,11 @@ async function loadRuntimeCommands(
   try {
     resolved = require.resolve(adapter.commandsModule);
   } catch (cause) {
-    throw new CliError(
-      `Runtime commands module not found: "${adapter.commandsModule}"`,
-      {
-        code: "RUNTIME_COMMANDS_NOT_FOUND",
-        hint: `Install the runtime adapter package in ${cwd}.`,
-        cause,
-      },
-    );
+    throw CliError.runtimeCommandsNotFound({
+      commandsModule: adapter.commandsModule,
+      cwd,
+      cause,
+    });
   }
   try {
     const mod = (await import(pathToFileURL(resolved).href)) as {
@@ -205,14 +199,10 @@ async function loadRuntimeCommands(
       migrate: mod.migrate ?? {},
     };
   } catch (cause) {
-    throw new CliError(
-      `Failed to load runtime commands from "${adapter.commandsModule}"`,
-      {
-        code: "RUNTIME_COMMANDS_LOAD_FAILED",
-        hint: "Check the runtime adapter's commands module for import errors.",
-        cause,
-      },
-    );
+    throw CliError.runtimeCommandsLoadFailed({
+      commandsModule: adapter.commandsModule,
+      cause,
+    });
   }
 }
 

--- a/packages/plumix/src/cli/load-config.ts
+++ b/packages/plumix/src/cli/load-config.ts
@@ -32,18 +32,11 @@ export async function loadConfig(
   try {
     imported = await jiti.import(configPath, { default: true });
   } catch (cause) {
-    throw new CliError(`Failed to load ${configPath}`, {
-      code: "CONFIG_LOAD_FAILED",
-      hint: "Check the file for syntax errors and ensure every import resolves.",
-      cause,
-    });
+    throw CliError.configLoadFailed({ configPath, cause });
   }
 
   if (!isPlumixConfig(imported)) {
-    throw new CliError(`Invalid config shape in ${configPath}`, {
-      code: "CONFIG_INVALID",
-      hint: "Default export must be the return value of plumix({ ... }) or defineConfig({ ... }).",
-    });
+    throw CliError.configInvalid({ configPath });
   }
 
   return { config: imported, configPath };
@@ -53,10 +46,7 @@ export function resolveConfigPath(cwd: string, explicit?: string): string {
   if (explicit) {
     const absolute = isAbsolute(explicit) ? explicit : resolve(cwd, explicit);
     if (!existsSync(absolute)) {
-      throw new CliError(`Config file not found: ${explicit}`, {
-        code: "CONFIG_NOT_FOUND",
-        hint: `Checked ${absolute}`,
-      });
+      throw CliError.configNotFoundExplicit({ explicit, absolute });
     }
     return absolute;
   }
@@ -66,10 +56,7 @@ export function resolveConfigPath(cwd: string, explicit?: string): string {
     if (existsSync(absolute)) return absolute;
   }
 
-  throw new CliError("No plumix.config.{ts,js,mjs} found", {
-    code: "CONFIG_NOT_FOUND",
-    hint: `Create plumix.config.ts in ${cwd} or pass --config <path>.`,
-  });
+  throw CliError.configNotFoundDefault({ cwd });
 }
 
 function isPlumixConfig(value: unknown): value is PlumixConfig {

--- a/packages/plumix/test/cli.test.ts
+++ b/packages/plumix/test/cli.test.ts
@@ -76,9 +76,9 @@ describe("plumix CLI dispatch", () => {
     expect(exitCode).toBeUndefined();
   });
 
-  test("unknown command throws CliError with UNKNOWN_COMMAND", async () => {
+  test("unknown command throws CliError with unknown_command", async () => {
     await expect(run(["--cwd", dir, "nonsense-command"])).rejects.toMatchObject(
-      { code: "UNKNOWN_COMMAND" },
+      { code: "unknown_command" },
     );
   });
 

--- a/packages/plumix/test/load-config.test.ts
+++ b/packages/plumix/test/load-config.test.ts
@@ -28,11 +28,11 @@ describe("resolveConfigPath", () => {
     expect(resolveConfigPath(dir, "custom.config.ts")).toBe(path);
   });
 
-  test("throws CONFIG_NOT_FOUND when no candidate exists", () => {
+  test("throws config_not_found_default when no candidate exists", () => {
     expect(() => resolveConfigPath(dir)).toThrow(/No plumix\.config/);
   });
 
-  test("throws CONFIG_NOT_FOUND for a missing explicit path", () => {
+  test("throws config_not_found_explicit for a missing explicit path", () => {
     expect(() => resolveConfigPath(dir, "absent.ts")).toThrow(
       /Config file not found/,
     );
@@ -50,25 +50,25 @@ describe("loadConfig", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("CONFIG_INVALID when default export lacks required fields", async () => {
+  test("config_invalid when default export lacks required fields", async () => {
     writeFileSync(
       join(dir, "plumix.config.mjs"),
       "export default { runtime: { name: 'x' } };",
       "utf8",
     );
     await expect(loadConfig(dir)).rejects.toMatchObject({
-      code: "CONFIG_INVALID",
+      code: "config_invalid",
     });
   });
 
-  test("CONFIG_LOAD_FAILED when the config throws on import", async () => {
+  test("config_load_failed when the config throws on import", async () => {
     writeFileSync(
       join(dir, "plumix.config.mjs"),
       "throw new Error('boom');",
       "utf8",
     );
     await expect(loadConfig(dir)).rejects.toMatchObject({
-      code: "CONFIG_LOAD_FAILED",
+      code: "config_load_failed",
     });
   });
 });

--- a/packages/runtimes/cloudflare/src/adapter.test.ts
+++ b/packages/runtimes/cloudflare/src/adapter.test.ts
@@ -347,7 +347,7 @@ describe("cloudflare adapter — binding validation", () => {
     expect(response.status).toBe(500);
     const body: unknown = await response.json();
     expect(body).toMatchObject({
-      error: "plumix_runtime_config_error",
+      error: "bindings_missing",
       missing: ["DB", "CACHE"],
     });
   });
@@ -366,7 +366,7 @@ describe("cloudflare adapter — binding validation", () => {
     expect(response.status).toBe(500);
     const body: unknown = await response.json();
     expect(body).toMatchObject({
-      error: "plumix_runtime_config_error",
+      error: "bindings_missing",
       missing: ["DB"],
     });
   });
@@ -385,7 +385,7 @@ describe("cloudflare adapter — binding validation", () => {
     expect(response.status).toBe(500);
     const body: unknown = await response.json();
     expect(body).toMatchObject({
-      error: "plumix_runtime_config_error",
+      error: "bindings_missing",
       missing: ["DB"],
     });
   });

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -17,6 +17,8 @@ import {
   runScheduledTasks,
 } from "plumix";
 
+import { PlumixRuntimeConfigError } from "./errors.js";
+
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 /**
@@ -69,29 +71,6 @@ function collectBindingsFrom(slot: unknown, into: string[]): void {
   if (bindings) into.push(...bindings);
 }
 
-/**
- * Thrown when the runtime adapter detects a missing env binding at boot.
- * Dedicated class so the request handler can surface the actionable
- * message in the response body, rather than swallowing it as a generic
- * "internal_error" 500 (the operator may not have wrangler tail open).
- *
- * Internal: consumers interact via the HTTP response body
- * (`{"error": "plumix_runtime_config_error", ...}`), not by catching the
- * class directly. Keeping it non-exported avoids adding a stable API
- * surface for something that's effectively implementation detail.
- */
-class PlumixRuntimeConfigError extends Error {
-  readonly code = "plumix_runtime_config_error";
-  readonly missing: readonly string[];
-  constructor(missing: readonly string[]) {
-    super(
-      `@plumix/runtime-cloudflare: missing required env bindings: ${missing.join(", ")}. Declare them in wrangler.toml and ensure the names match the adapter config.`,
-    );
-    this.name = "PlumixRuntimeConfigError";
-    this.missing = missing;
-  }
-}
-
 function validateBindings(app: PlumixApp, env: unknown): void {
   const required: string[] = [];
   const { database, kv, storage } = app.config;
@@ -108,7 +87,7 @@ function validateBindings(app: PlumixApp, env: unknown): void {
   // hands us a plain object — but produces a useful error instead of a
   // TypeError from property access on undefined.
   if (env == null || typeof env !== "object") {
-    throw new PlumixRuntimeConfigError(required);
+    throw PlumixRuntimeConfigError.bindingsMissing({ missing: required });
   }
   const envRecord = env as Record<string, unknown>;
   // `== null` catches both undefined and null — a binding explicitly set
@@ -116,7 +95,7 @@ function validateBindings(app: PlumixApp, env: unknown): void {
   // just as broken as an unset one.
   const missing = required.filter((name) => envRecord[name] == null);
   if (missing.length > 0) {
-    throw new PlumixRuntimeConfigError(missing);
+    throw PlumixRuntimeConfigError.bindingsMissing({ missing });
   }
 }
 
@@ -150,10 +129,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
   // stubbed symbol (some edge-runtime shims do) the cryptic error bubbles up
   // from the first AsyncLocalStorage.run() call. Fail fast with a useful hint.
   if (typeof AsyncLocalStorage !== "function") {
-    // eslint-disable-next-line no-restricted-syntax -- migrated alongside PlumixRuntimeConfigError in PR 2 (#234)
-    throw new Error(
-      '@plumix/runtime-cloudflare requires AsyncLocalStorage. Add `compatibility_flags = ["nodejs_compat"]` to wrangler.toml.',
-    );
+    throw PlumixRuntimeConfigError.asyncLocalStorageMissing();
   }
 
   const dispatcher = createPlumixDispatcher(app);
@@ -239,10 +215,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
 
 function buildScheduled(app: PlumixApp): ScheduledHandler {
   if (typeof AsyncLocalStorage !== "function") {
-    // eslint-disable-next-line no-restricted-syntax -- migrated alongside PlumixRuntimeConfigError in PR 2 (#234)
-    throw new Error(
-      '@plumix/runtime-cloudflare requires AsyncLocalStorage. Add `compatibility_flags = ["nodejs_compat"]` to wrangler.toml.',
-    );
+    throw PlumixRuntimeConfigError.asyncLocalStorageMissing();
   }
 
   let bindingsValidated = false;

--- a/packages/runtimes/cloudflare/src/commands/migrate-apply.test.ts
+++ b/packages/runtimes/cloudflare/src/commands/migrate-apply.test.ts
@@ -72,19 +72,19 @@ describe("migrate apply", () => {
     expect(args).toEqual(["d1", "migrations", "apply", "only-db"]);
   });
 
-  test("throws MIGRATE_APPLY_MISSING_DB when no name and no wrangler config", async () => {
+  test("throws migrate_apply_missing_db when no name and no wrangler config", async () => {
     vi.spyOn(migrateApplyDeps, "spawnInherit").mockResolvedValue();
     vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue(null);
 
     await expect(
       migrateApplyCommand.run(ctx({ argv: [] })),
     ).rejects.toMatchObject({
-      code: "MIGRATE_APPLY_MISSING_DB",
+      code: "migrate_apply_missing_db",
       hint: expect.stringContaining("wrangler.jsonc") as unknown,
     });
   });
 
-  test("throws MIGRATE_APPLY_NO_D1 when config has no d1_databases", async () => {
+  test("throws migrate_apply_no_d1 when config has no d1_databases", async () => {
     vi.spyOn(migrateApplyDeps, "spawnInherit").mockResolvedValue();
     vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue({
       filename: "wrangler.jsonc",
@@ -93,10 +93,10 @@ describe("migrate apply", () => {
 
     await expect(
       migrateApplyCommand.run(ctx({ argv: [] })),
-    ).rejects.toMatchObject({ code: "MIGRATE_APPLY_NO_D1" });
+    ).rejects.toMatchObject({ code: "migrate_apply_no_d1" });
   });
 
-  test("throws MIGRATE_APPLY_AMBIGUOUS_DB when config has multiple D1 dbs", async () => {
+  test("throws migrate_apply_ambiguous_db when config has multiple D1 dbs", async () => {
     vi.spyOn(migrateApplyDeps, "spawnInherit").mockResolvedValue();
     vi.spyOn(migrateApplyDeps, "loadWranglerConfig").mockReturnValue({
       filename: "wrangler.jsonc",
@@ -109,7 +109,7 @@ describe("migrate apply", () => {
     await expect(
       migrateApplyCommand.run(ctx({ argv: [] })),
     ).rejects.toMatchObject({
-      code: "MIGRATE_APPLY_AMBIGUOUS_DB",
+      code: "migrate_apply_ambiguous_db",
       message: expect.stringContaining("alpha") as unknown,
     });
   });

--- a/packages/runtimes/cloudflare/src/commands/migrate-apply.ts
+++ b/packages/runtimes/cloudflare/src/commands/migrate-apply.ts
@@ -30,10 +30,7 @@ function resolveDatabaseName(
 
   const config = migrateApplyDeps.loadWranglerConfig(cwd);
   if (config === null) {
-    throw new CliError("Missing D1 database name", {
-      code: "MIGRATE_APPLY_MISSING_DB",
-      hint: "Pass the database name: `plumix migrate apply <database-name>`. Or add a wrangler.jsonc / wrangler.toml with a `d1_databases` entry so Plumix can auto-discover it.",
-    });
+    throw CliError.migrateApplyMissingDb();
   }
 
   const [firstName, ...moreNames] = config.d1Databases
@@ -43,22 +40,13 @@ function resolveDatabaseName(
     );
 
   if (firstName === undefined) {
-    throw new CliError(
-      `No d1_databases entries with a database_name in ${config.filename}`,
-      {
-        code: "MIGRATE_APPLY_NO_D1",
-        hint: "Add a `d1_databases` entry with a `database_name`, or pass the name explicitly: `plumix migrate apply <database-name>`.",
-      },
-    );
+    throw CliError.migrateApplyNoD1({ filename: config.filename });
   }
   if (moreNames.length > 0) {
-    throw new CliError(
-      `Multiple D1 databases found in ${config.filename}: ${[firstName, ...moreNames].join(", ")}`,
-      {
-        code: "MIGRATE_APPLY_AMBIGUOUS_DB",
-        hint: "Pass the name explicitly: `plumix migrate apply <database-name>`.",
-      },
-    );
+    throw CliError.migrateApplyAmbiguousDb({
+      filename: config.filename,
+      names: [firstName, ...moreNames],
+    });
   }
   return { databaseName: firstName, passthroughArgs: argv };
 }

--- a/packages/runtimes/cloudflare/src/errors.ts
+++ b/packages/runtimes/cloudflare/src/errors.ts
@@ -127,6 +127,47 @@ export class SigV4Error extends Error {
   }
 }
 
+type PlumixRuntimeConfigErrorCode =
+  | "bindings_missing"
+  | "async_local_storage_missing";
+
+export class PlumixRuntimeConfigError extends Error {
+  static {
+    PlumixRuntimeConfigError.prototype.name = "PlumixRuntimeConfigError";
+  }
+
+  readonly code: PlumixRuntimeConfigErrorCode;
+  readonly missing: readonly string[];
+
+  private constructor(
+    code: PlumixRuntimeConfigErrorCode,
+    message: string,
+    missing: readonly string[],
+  ) {
+    super(message);
+    this.code = code;
+    this.missing = missing;
+  }
+
+  static bindingsMissing(ctx: {
+    missing: readonly string[];
+  }): PlumixRuntimeConfigError {
+    return new PlumixRuntimeConfigError(
+      "bindings_missing",
+      `@plumix/runtime-cloudflare: missing required env bindings: ${ctx.missing.join(", ")}. Declare them in wrangler.toml and ensure the names match the adapter config.`,
+      ctx.missing,
+    );
+  }
+
+  static asyncLocalStorageMissing(): PlumixRuntimeConfigError {
+    return new PlumixRuntimeConfigError(
+      "async_local_storage_missing",
+      '@plumix/runtime-cloudflare requires AsyncLocalStorage. Add `compatibility_flags = ["nodejs_compat"]` to wrangler.toml.',
+      [],
+    );
+  }
+}
+
 export class WranglerConfigError extends Error {
   static {
     WranglerConfigError.prototype.name = "WranglerConfigError";


### PR DESCRIPTION
Slice #244 of umbrella #232 PR 2. Migrates the seven remaining non-auth error classes to the factory pattern locked by #275–#282 (private constructor, static factories per cause, `static {}` prototype-name). Closes the largest single slice on the existing-class side of PR 2.

| Class | File | Throw sites |
|---|---|---|
| `CliError` | `packages/core/src/cli/errors.ts` | 14 (across 5 files) |
| `DuplicateRegistrationError` | moved into `packages/core/src/plugin/errors.ts` | 13 |
| `DuplicateAdminSlugError` | moved into `packages/core/src/plugin/errors.ts` | 1 |
| `RichtextValidationError` | `packages/core/src/plugin/fields/richtext-validate.ts` | 8 |
| `RepeaterValidationError` | `packages/core/src/plugin/fields/repeater-validate.ts` | 6 |
| `MetaSanitizationError` | `packages/core/src/rpc/meta/core.ts` | 22 |
| `CursorError` | `packages/plugins/audit-log/src/server/cursor.ts` | 5 |
| `PlumixRuntimeConfigError` | moved into `packages/runtimes/cloudflare/src/errors.ts` | 4 (incl. 2 AsyncLocalStorage guards) |

**Scope was bigger than the issue estimated**

The issue's "~15 throw sites" estimate was off by ~5×. `CliError` alone had 14 sites across `core/cli/spawn.ts` + `plumix/cli/{index,load-config,commands/migrate}.ts` + `runtimes/cloudflare/.../migrate-apply.ts`. `MetaSanitizationError` had 22 sites inside `rpc/meta/core.ts`. The total landed at ~70 throw-site rewrites. Diff size is a faithful reflection of the actual surface — not bloat.

**Consolidations**

`DuplicateRegistrationError` + `DuplicateAdminSlugError` move from `plugin/manifest.ts` into `plugin/errors.ts` (the module that slice #237 created). `PlumixRuntimeConfigError` moves from `runtimes/cloudflare/src/adapter.ts` into `runtimes/cloudflare/src/errors.ts` (the module that slice #236 created) and now also owns the two `AsyncLocalStorage`-missing guards in `buildFetch` / `buildScheduled` — clears the two `eslint-disable-next-line` TODOs that #280 left behind.

**Breaking wire-format changes (pre-1.0; no published consumers)**

1. `CliError.code` flips from uppercase snake to lowercase snake. `report.ts` writes the code to stderr, so CLI output changes from `SPAWN_FAILED: …` to `spawn_failed: …`. 8 test assertions updated.

   ```diff
   - { code: "MIGRATE_APPLY_AMBIGUOUS_DB" }
   + { code: "migrate_apply_ambiguous_db" }
   ```

2. `PlumixRuntimeConfigError` HTTP 500 response body changes:

   ```diff
   - { "error": "plumix_runtime_config_error", "missing": [...] }
   + { "error": "bindings_missing", "missing": [...] }
   ```

   …or `async_local_storage_missing` for the boot-time guard. The JSDoc on the old non-exported class explicitly called the wire `error` value "implementation detail" — but worth flagging. 3 adapter tests updated.

3. The single `CONFIG_NOT_FOUND` code splits into `config_not_found_explicit` (when `--config <path>` doesn't exist) vs `config_not_found_default` (when no `plumix.config.*` candidate exists). The two existing tests assert on `.message` regex, not `.code`, so they pass unchanged.

**Export changes**

`CliErrorOptions` removed from the public `@plumix/core` exports — it was an open-shape options bag that the factory pattern obviates. `PlumixRuntimeConfigError` class now exported from `@plumix/runtime-cloudflare`'s `errors.ts` (was non-exported in `adapter.ts`).

**Small parallel cleanup**

`DuplicateRegistrationError`'s constructor param renamed from `name` to `identifier`. `name` shadowed `Error.name` and would have silently overridden the prototype-set value — the same gotcha that #277 already flagged for `PluginContextError`.

**Verification**

`pnpm exec turbo run test lint typecheck format --filter @plumix/core --filter plumix --filter @plumix/runtime-cloudflare --filter @plumix/plugin-audit-log` — all green. 1,430 (core) + 144 (cloudflare) + 112 (audit-log) + plumix tests pass.

Closes #244.