### PR TITLE
refactor(admin): migrate mirror error classes to factory pattern

### DIFF
--- a/packages/admin/src/lib/magic-link.ts
+++ b/packages/admin/src/lib/magic-link.ts
@@ -22,13 +22,13 @@ export async function requestMagicLink(
   });
 
   if (response.status === 503) {
-    throw new MagicLinkRequestError("not_configured");
+    throw MagicLinkRequestError.notConfigured();
   }
   if (response.status === 400) {
-    throw new MagicLinkRequestError("invalid_input");
+    throw MagicLinkRequestError.invalidInput();
   }
   if (!response.ok) {
-    throw new MagicLinkRequestError("network");
+    throw MagicLinkRequestError.network();
   }
 
   return (await response.json()) as MagicLinkRequestResponse;
@@ -37,12 +37,27 @@ export async function requestMagicLink(
 type MagicLinkRequestErrorCode = "not_configured" | "invalid_input" | "network";
 
 export class MagicLinkRequestError extends Error {
+  static {
+    MagicLinkRequestError.prototype.name = "MagicLinkRequestError";
+  }
+
   readonly code: MagicLinkRequestErrorCode;
 
-  constructor(code: MagicLinkRequestErrorCode, message?: string) {
-    super(message ?? code);
-    this.name = "MagicLinkRequestError";
+  private constructor(code: MagicLinkRequestErrorCode) {
+    super(code);
     this.code = code;
+  }
+
+  static notConfigured(): MagicLinkRequestError {
+    return new MagicLinkRequestError("not_configured");
+  }
+
+  static invalidInput(): MagicLinkRequestError {
+    return new MagicLinkRequestError("invalid_input");
+  }
+
+  static network(): MagicLinkRequestError {
+    return new MagicLinkRequestError("network");
   }
 }
 

--- a/packages/admin/src/lib/passkey-errors.ts
+++ b/packages/admin/src/lib/passkey-errors.ts
@@ -36,11 +36,32 @@ type PasskeyClientErrorCode =
 export type PasskeyErrorCode = PasskeyServerErrorCode | PasskeyClientErrorCode;
 
 export class PasskeyError extends Error {
+  static {
+    PasskeyError.prototype.name = "PasskeyError";
+  }
+
   readonly code: PasskeyErrorCode;
-  constructor(code: PasskeyErrorCode, message?: string) {
-    super(message ?? code);
-    this.name = "PasskeyError";
+
+  private constructor(code: PasskeyErrorCode) {
+    super(code);
     this.code = code;
+  }
+
+  static networkError(): PasskeyError {
+    return new PasskeyError("network_error");
+  }
+
+  static userCancelled(): PasskeyError {
+    return new PasskeyError("user_cancelled");
+  }
+
+  // Dispatch entry for codes derived from a server response or DOMException
+  // mapping. The 23 server codes and two browser-side codes
+  // (`no_authenticator`, `unknown`) have no literal admin throw sites — every
+  // one of them arrives via a dispatched path, so a single dispatcher beats
+  // listing 25 unused per-code factories.
+  static ofCode(ctx: { code: PasskeyErrorCode }): PasskeyError {
+    return new PasskeyError(ctx.code);
   }
 }
 

--- a/packages/admin/src/lib/passkey.ts
+++ b/packages/admin/src/lib/passkey.ts
@@ -54,7 +54,7 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
       body: JSON.stringify(body),
     });
   } catch {
-    throw new PasskeyError("network_error");
+    throw PasskeyError.networkError();
   }
   if (!response.ok) {
     let code: PasskeyErrorCode = "unknown";
@@ -66,7 +66,7 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
     } catch {
       // body wasn't JSON; fall through with "unknown"
     }
-    throw new PasskeyError(code);
+    throw PasskeyError.ofCode({ code });
   }
   return (await response.json()) as T;
 }
@@ -80,7 +80,7 @@ async function postJsonNoBody<T>(path: string): Promise<T> {
       headers: PLUMIX_CSRF_HEADER,
     });
   } catch {
-    throw new PasskeyError("network_error");
+    throw PasskeyError.networkError();
   }
   return (await response.json()) as T;
 }
@@ -109,9 +109,9 @@ async function callCredentialsApi(
       err instanceof DOMException
         ? (DOM_EXCEPTION_CODE[err.name] ?? "unknown")
         : "unknown";
-    throw new PasskeyError(code);
+    throw PasskeyError.ofCode({ code });
   }
-  if (!raw) throw new PasskeyError("user_cancelled");
+  if (!raw) throw PasskeyError.userCancelled();
   return raw as PublicKeyCredential;
 }
 


### PR DESCRIPTION
Slice #245 of umbrella #232 PR 2. Migrates admin's two mirror error classes (`PasskeyError`, `MagicLinkRequestError`) to the factory pattern. Closes the admin-side migrations on PR 2; only #247 (HITL reconciliation of admin↔core `PasskeyError` unions) remains on the existing-class track.

| Class | File | Throw sites |
|---|---|---|
| `PasskeyError` | `packages/admin/src/lib/passkey-errors.ts` | 5 |
| `MagicLinkRequestError` | `packages/admin/src/lib/magic-link.ts` | 3 |

**Factory shape diverges from core's `PasskeyError` by design**

Core's `PasskeyError` has 23 per-code factories because every code has a literal server-side throw. Admin's class has 27 codes in the union (23 server + 4 client) but only two are constructed at literal admin throw sites: `network_error` (2 sites) and `user_cancelled` (1 site). The other 25 codes only arrive via dispatched paths — server error-payload + `DOMException` mapping in `callCredentialsApi`.

Listing 25 unused per-code factories would be dead-code noise, so admin gets:

- `PasskeyError.networkError()` — literal cause
- `PasskeyError.userCancelled()` — literal cause
- `PasskeyError.ofCode({ code })` — single dispatcher for the wire path

An inline comment on `ofCode` documents this divergence so future contributors don't ask "why no `challengeNotFound()` factory?".

`MagicLinkRequestError` has 3 codes, all literal, all factories used (`notConfigured`, `invalidInput`, `network`) — straight per-cause shape.

**Hand-maintained mirror status unchanged**

The two `PasskeyErrorCode` unions remain hand-maintained mirrors of core's after this slice. Reconciliation (dedupe via cross-package import vs. compile-time sync assertion) is slice #247 — explicitly HITL because it depends on Vite + esbuild bundle-size verification.

**Verification**

`pnpm exec turbo run test lint typecheck format --filter @plumix/admin` — all green. 166/166 admin tests pass. Existing assertions on `instanceof X` and `.code` survive unchanged.

Closes #245.