### PR TITLE
fix(plumix): keep class names through esbuild minification

### DIFF
--- a/packages/core/src/test/playwright/build-admin-chunk.ts
+++ b/packages/core/src/test/playwright/build-admin-chunk.ts
@@ -54,6 +54,10 @@ export async function buildAdminPluginChunkForE2E(
     target: "es2022",
     jsx: "automatic",
     minify: true,
+    // Match the production plugin-chunk builder (admin-plugin-bundle.ts):
+    // preserve class identifiers so e2e fixtures see the same
+    // `error.constructor.name` value the host build would produce.
+    keepNames: true,
     legalComments: "none",
     logLevel: "warning",
     define: { "process.env.NODE_ENV": '"production"' },

--- a/packages/plumix/src/vite/admin-plugin-bundle.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.ts
@@ -114,6 +114,11 @@ export async function assemblePluginAdminBundle({
     platform: "browser",
     target: "es2022",
     minify: true,
+    // Preserves class identifiers through minification. The error-class
+    // `static {}` blocks already pin `error.name` to a string literal,
+    // but `error.constructor.name` would otherwise surface the mangled
+    // identifier (`class PasskeyError` → `class e`).
+    keepNames: true,
     legalComments: "none",
     logLevel: "warning",
     define: { "process.env.NODE_ENV": '"production"' },


### PR DESCRIPTION
Adds `keepNames: true` to both explicit `esbuild.build()` invocations so named-error classes survive minification with their identifiers intact. Closes #248 (audit slice of umbrella #232 PR 3).

**Audit finding: class names are mangled**

The admin bundle shows `class PasskeyError extends Error` minifying to `class e extends Error`. The `static { Cls.prototype.name = "Cls" }` blocks added in PRs #275–#286 already pin `error.name` to a string literal that survives mangling, so log output and `getPasskeyErrorMessage(code)` lookups stay correct regardless. The leak is `error.constructor.name`, which would surface the mangled identifier. No current caller branches on that property, but the fix is one config line per build site.

**Patched**

- `packages/plumix/src/vite/admin-plugin-bundle.ts` — per-plugin admin chunk built by consumers' `plumix dev`. The primary target the issue calls out.
- `packages/core/src/test/playwright/build-admin-chunk.ts` — e2e fixture chunk builder. Matches the production builder so fixtures see the same `error.constructor.name` shape.

**Out of scope: Vite's internal minify pass**

`pnpm --filter @plumix/admin build` produces a host admin SPA where Vite-managed esbuild minify also mangles class names. Vite's `esbuild` config option propagates only to the transform pass, not the minify pass — fixing it would require either switching `build.minify` to `terser` (with `keep_classnames: true`) or wiring a custom rollup/vite plugin. Both are larger decisions than this audit slice and are deferred to a follow-up. The operational impact is the same: `error.name` is correct (static-block trick), only `error.constructor.name` leaks the mangled identifier.

**Verification**

`pnpm exec turbo run test lint typecheck format --filter plumix --filter @plumix/core --filter @plumix/admin` — 15/15 tasks green.

Closes #248.