### PR TITLE
feat(plugin-audit-log): persist filter state in URL search params

### DIFF
--- a/packages/plugins/audit-log/e2e/audit-log.spec.ts
+++ b/packages/plugins/audit-log/e2e/audit-log.spec.ts
@@ -117,4 +117,31 @@ test.describe
       .locator("[data-testid^='audit-log-row-']");
     await expect(rows).toHaveCount(3);
   });
+
+  test("filter state survives a page reload via URL params", async ({
+    page,
+  }) => {
+    await page.goto("pages/audit-log");
+    await page
+      .getByTestId("audit-log-filter-event-prefix")
+      .selectOption("user:");
+    const filtered = page
+      .getByTestId("audit-log-table")
+      .locator("[data-testid^='audit-log-row-']");
+    await expect(filtered).toHaveCount(2);
+
+    // The URL should carry the filter so the next render can rebuild it.
+    await expect(page).toHaveURL(/eventPrefix=user/);
+
+    await page.reload();
+
+    // Same filter applied + same narrowed list. No re-selection needed.
+    await expect(page.getByTestId("audit-log-filter-event-prefix")).toHaveValue(
+      "user:",
+    );
+    const afterReload = page
+      .getByTestId("audit-log-table")
+      .locator("[data-testid^='audit-log-row-']");
+    await expect(afterReload).toHaveCount(2);
+  });
 });

--- a/packages/plugins/audit-log/src/admin/AuditLogShell.test.tsx
+++ b/packages/plugins/audit-log/src/admin/AuditLogShell.test.tsx
@@ -80,6 +80,10 @@ describe("AuditLogShell", () => {
   beforeEach(() => {
     fetchMock = vi.fn();
     calls = [];
+    // URL-state lives in window.location.search; isolate each test from
+    // bleed-over by resetting the URL to a clean baseline path. Without
+    // this, a filter set in one test would re-hydrate in the next.
+    window.history.replaceState(null, "", "/pages/audit-log");
   });
 
   afterEach(() => {
@@ -225,6 +229,68 @@ describe("AuditLogShell", () => {
 
     await waitFor(() => {
       expect(lastJson()?.subjectType).toBeUndefined();
+    });
+  });
+
+  test("URL search params hydrate the initial filter state on mount", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/pages/audit-log?eventPrefix=user%3A&actorId=7&subjectType=user&preset=last7",
+    );
+    mockListPages([{ rows: [], nextCursor: null }]);
+    renderShell();
+
+    await screen.findByTestId("audit-log-empty");
+
+    const json = lastJson();
+    expect(json).toMatchObject({
+      eventPrefix: "user:",
+      actorId: 7,
+      subjectType: "user",
+    });
+    // The preset translates to an occurredAfter epoch — we don't pin the
+    // exact value (depends on `now`), but it must be set, which proves the
+    // preset survived the URL round-trip.
+    expect(typeof json?.occurredAfter).toBe("number");
+
+    expect(
+      screen.getByTestId<HTMLSelectElement>("audit-log-filter-event-prefix")
+        .value,
+    ).toBe("user:");
+    expect(
+      screen.getByTestId<HTMLInputElement>("audit-log-filter-actor").value,
+    ).toBe("7");
+  });
+
+  test("changing a filter updates the URL search params", async () => {
+    mockListPages([{ rows: [], nextCursor: null }]);
+    renderShell();
+    await screen.findByTestId("audit-log-empty");
+
+    fireEvent.change(screen.getByTestId("audit-log-filter-event-prefix"), {
+      target: { value: "user:" },
+    });
+
+    await waitFor(() => {
+      expect(window.location.search).toContain("eventPrefix=user");
+    });
+  });
+
+  test("reset clears the URL search params", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/pages/audit-log?eventPrefix=user%3A",
+    );
+    mockListPages([{ rows: [], nextCursor: null }]);
+    renderShell();
+    await screen.findByTestId("audit-log-empty");
+
+    fireEvent.click(screen.getByTestId("audit-log-filter-reset"));
+
+    await waitFor(() => {
+      expect(window.location.search).toBe("");
     });
   });
 });

--- a/packages/plugins/audit-log/src/admin/AuditLogShell.tsx
+++ b/packages/plugins/audit-log/src/admin/AuditLogShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 import type { AuditLogFilter, AuditLogRowDTO, DateRangePreset } from "./rpc.js";
 import { presetToRange, useAuditLogList } from "./rpc.js";
@@ -45,6 +45,40 @@ const EMPTY_FILTERS: FilterState = {
   eventPrefix: "",
 };
 
+// Filter state in `window.location.search` enables reload + shared-link
+// hydration. Empty fields are skipped so EMPTY_FILTERS produces a clean URL
+// instead of `?preset=all&actorId=&...`.
+function filtersToSearchParams(state: FilterState): URLSearchParams {
+  const params = new URLSearchParams();
+  if (state.preset !== "all") params.set("preset", state.preset);
+  if (state.actorId !== "") params.set("actorId", state.actorId);
+  if (state.subjectType !== "") params.set("subjectType", state.subjectType);
+  if (state.eventPrefix !== "") params.set("eventPrefix", state.eventPrefix);
+  return params;
+}
+
+function parsePreset(raw: string | null): FilterState["preset"] {
+  switch (raw) {
+    case "today":
+    case "last7":
+    case "last30":
+    case "custom":
+      return raw;
+    default:
+      return "all";
+  }
+}
+
+function filtersFromSearchParams(search: string): FilterState {
+  const params = new URLSearchParams(search);
+  return {
+    preset: parsePreset(params.get("preset")),
+    actorId: params.get("actorId") ?? "",
+    subjectType: params.get("subjectType") ?? "",
+    eventPrefix: params.get("eventPrefix") ?? "",
+  };
+}
+
 function filterToRpcInput(state: FilterState): AuditLogFilter {
   const out: {
     actorId?: number;
@@ -69,8 +103,50 @@ function filterToRpcInput(state: FilterState): AuditLogFilter {
   return out;
 }
 
+// `popstate` covers browser back/forward; for our own writes we dispatch
+// the event explicitly after `replaceState` since neither push/replace fire
+// it natively. Module-scoped so `useSyncExternalStore` sees a stable ref.
+function subscribeToHistory(onChange: () => void): () => void {
+  window.addEventListener("popstate", onChange);
+  return () => {
+    window.removeEventListener("popstate", onChange);
+  };
+}
+
+function readSearchSnapshot(): string {
+  return window.location.search;
+}
+
+function ssrSearchSnapshot(): string {
+  return "";
+}
+
+function useFilterUrlState(): readonly [
+  FilterState,
+  (next: FilterState) => void,
+] {
+  const search = useSyncExternalStore(
+    subscribeToHistory,
+    readSearchSnapshot,
+    ssrSearchSnapshot,
+  );
+  const filters = filtersFromSearchParams(search);
+
+  const setFilters = useCallback((next: FilterState) => {
+    const params = filtersToSearchParams(next);
+    const query = params.toString();
+    const nextUrl = `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`;
+    // `replaceState` not `pushState` — each keystroke / select-change
+    // shouldn't pollute the back-stack with one entry per filter combo.
+    window.history.replaceState(window.history.state, "", nextUrl);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, []);
+
+  return [filters, setFilters] as const;
+}
+
 export function AuditLogShell(): ReactNode {
-  const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
+  const [filters, setFilters] = useFilterUrlState();
   const list = useAuditLogList(filterToRpcInput(filters));
 
   const rows = list.data?.pages.flatMap((p) => p.rows) ?? [];
@@ -81,7 +157,9 @@ export function AuditLogShell(): ReactNode {
       <FilterRow
         filters={filters}
         onChange={setFilters}
-        onReset={() => setFilters(EMPTY_FILTERS)}
+        onReset={() => {
+          setFilters(EMPTY_FILTERS);
+        }}
       />
       {list.isLoading ? (
         <div data-testid="audit-log-loading" />


### PR DESCRIPTION
Closes #263. `AuditLogShell` migrates filter state from local `useState` into `window.location.search`. Filters now reload-stable and shareable via link — the assertion the existing e2e spec dropped now passes.

URL shape: `/_plumix/admin/pages/audit-log?eventPrefix=user%3A&actorId=1&subjectType=user&preset=last7`. Empty fields are omitted so the default `EMPTY_FILTERS` state renders a clean path rather than a noisy `?preset=all&actorId=&...`.

**Implementation**

Self-contained `useFilterUrlState` hook built on `useSyncExternalStore` + `popstate` subscription. Writes go through `replaceState` (not `pushState` — each keystroke / select-change shouldn't pollute the back-stack with one history entry per intermediate filter combination). After a write we dispatch a synthetic `popstate` event since neither `pushState` nor `replaceState` fire it natively. Module-scoped subscribe/snapshot functions keep the hook's `useSyncExternalStore` args reference-stable across renders.

**TanStack Router coexistence (deferred concern)**

The hook bypasses TanStack Router's history abstraction and manipulates `window.history` directly. Plugin pages render inside `/_authenticated/pages/$.tsx`; the router will see the popstate and re-evaluate its match tree, but the route *path* is unchanged so the route match is unchanged — only `useSearch`/`useLocation` consumers in the surrounding shell re-render. There are none today, so the cost is theoretical.

Switching to `useNavigate({ from }) + to: '.' + search: …` would couple to TanStack Router and require `{ strict: false }` ergonomics since the splat route doesn't declare typed search params. Deferred until wasted re-renders materialize as a measurable concern.

**Tests**

- 3 new unit tests in `AuditLogShell.test.tsx` cover URL hydration on mount, write-on-change, and reset-clears-URL.
- 1 new Playwright spec in `e2e/audit-log.spec.ts` asserts filter state survives `page.reload()`. The existing spec dropped this assertion when filter state was a local `useState`; #263 was filed to re-enable it.
- All `beforeEach` blocks reset `window.history` to a clean baseline so URL state from one test doesn't bleed into the next.

**Verification**

`pnpm exec turbo run test lint typecheck format --filter @plumix/plugin-audit-log` — 9/9 tasks green, 115/115 tests pass.

Closes #263.
Refs #253, #262.