### PR TITLE
refactor(core): split plugin/context into setup, provides, validation

### DIFF
--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -1,5 +1,6 @@
-import type { PluginProvidesContext, PluginSetupContext } from "./context.js";
 import { PluginDefinitionError } from "./errors.js";
+import type { PluginProvidesContext } from "./provides-context.js";
+import type { PluginSetupContext } from "./setup-context.js";
 
 export type PluginSetup<TConfig> = (
   ctx: PluginSetupContext,

--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -1,6 +1,6 @@
-import { PluginDefinitionError } from "./errors.js";
 import type { PluginProvidesContext } from "./provides-context.js";
 import type { PluginSetupContext } from "./setup-context.js";
+import { PluginDefinitionError } from "./errors.js";
 
 export type PluginSetup<TConfig> = (
   ctx: PluginSetupContext,

--- a/packages/core/src/plugin/fields/repeater.ts
+++ b/packages/core/src/plugin/fields/repeater.ts
@@ -18,7 +18,7 @@ export interface RepeaterFieldOptions {
   readonly max?: number;
 }
 
-// Mirrors `META_FIELD_KEY_RE` in plugin/context.ts. The top-level
+// Mirrors `META_FIELD_KEY_RE` in plugin/validation/meta-box-fields.ts. The top-level
 // registrar validates field keys against this regex but doesn't
 // recurse into subFields, so the repeater builder enforces it locally
 // — guards row-object shape and protects against duplicate-key clobber.

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -1,5 +1,6 @@
-export * from "./context.js";
 export * from "./define.js";
 export * from "./lookup.js";
 export * from "./manifest.js";
+export * from "./provides-context.js";
 export * from "./register.js";
+export * from "./setup-context.js";

--- a/packages/core/src/plugin/provides-context.ts
+++ b/packages/core/src/plugin/provides-context.ts
@@ -34,7 +34,7 @@ export interface PluginProvidesContext {
   ): void;
 }
 
-export interface CreateProvidesContextArgs {
+interface CreateProvidesContextArgs {
   readonly pluginId: string;
   readonly pluginExtensions: Map<string, ContextExtensionEntry>;
   readonly themeExtensions: Map<string, ContextExtensionEntry>;

--- a/packages/core/src/plugin/provides-context.ts
+++ b/packages/core/src/plugin/provides-context.ts
@@ -1,0 +1,132 @@
+import type { AppContextExtensions } from "../context/app.js";
+import { PluginContextError } from "./errors.js";
+
+export interface ContextExtensionEntry {
+  readonly value: unknown;
+  readonly pluginId: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface PluginContextExtensions {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ThemeContextExtensions {}
+
+export interface PluginProvidesContext {
+  readonly id: string;
+  extendPluginContext<TKey extends keyof PluginContextExtensions>(
+    key: TKey,
+    value: PluginContextExtensions[TKey],
+  ): void;
+  extendThemeContext<TKey extends keyof ThemeContextExtensions>(
+    key: TKey,
+    value: ThemeContextExtensions[TKey],
+  ): void;
+  /**
+   * Register a runtime helper on every per-request `AppContext`. Reads
+   * are typed via the `AppContextExtensions` declaration-merge target —
+   * a plugin augments it once and `ctx.<key>` is autocompleted in
+   * every RPC/route/hook handler. Duplicate keys throw.
+   */
+  extendAppContext<TKey extends keyof AppContextExtensions>(
+    key: TKey,
+    value: AppContextExtensions[TKey],
+  ): void;
+}
+
+export interface CreateProvidesContextArgs {
+  readonly pluginId: string;
+  readonly pluginExtensions: Map<string, ContextExtensionEntry>;
+  readonly themeExtensions: Map<string, ContextExtensionEntry>;
+  readonly appExtensions: Map<string, ContextExtensionEntry>;
+}
+
+// Names that would corrupt the per-request `AppContext` if a plugin
+// tried to register them. `__proto__` triggers the Object.prototype
+// setter and reparents the ctx; `constructor` / `prototype` shadow
+// inherited members and confuse downstream introspection.
+const RESERVED_EXTENSION_KEYS: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+// Built-in `AppContextBase` members. extendAppContext rejects these so
+// a plugin can't silently replace `db`, `auth`, etc. at request time.
+// Mirrors the `key in target` shadow check `extendPluginContext`
+// runs against the constructed PluginSetupContext at install.
+const APP_CONTEXT_BASE_KEYS: ReadonlySet<string> = new Set([
+  "db",
+  "env",
+  "request",
+  "user",
+  "tokenScopes",
+  "hooks",
+  "plugins",
+  "logger",
+  "auth",
+  "authenticator",
+  "bootstrapAllowed",
+  "oauthProviders",
+  "after",
+  "assets",
+  "storage",
+  "imageDelivery",
+  "mailer",
+  "origin",
+  "siteName",
+  "resolvedEntity",
+]);
+
+export function createPluginProvidesContext({
+  pluginId,
+  pluginExtensions,
+  themeExtensions,
+  appExtensions,
+}: CreateProvidesContextArgs): PluginProvidesContext {
+  const stash = (
+    target: Map<string, ContextExtensionEntry>,
+    kind: "Plugin" | "Theme" | "App",
+    key: string,
+    value: unknown,
+  ): void => {
+    if (typeof key !== "string" || key.length === 0) {
+      throw PluginContextError.extendContextInvalidKey({ pluginId, kind });
+    }
+    if (RESERVED_EXTENSION_KEYS.has(key)) {
+      throw PluginContextError.extendContextReservedKey({
+        pluginId,
+        kind,
+        key,
+      });
+    }
+    if (kind === "App" && APP_CONTEXT_BASE_KEYS.has(key)) {
+      throw PluginContextError.extendAppContextBuiltinCollision({
+        pluginId,
+        key,
+      });
+    }
+    const existing = target.get(key);
+    if (existing) {
+      throw PluginContextError.extendContextDuplicate({
+        pluginId,
+        kind,
+        key,
+        existingOwner: existing.pluginId,
+      });
+    }
+    target.set(key, { value, pluginId });
+  };
+  return {
+    id: pluginId,
+    extendPluginContext: (key, value) => {
+      stash(pluginExtensions, "Plugin", key, value);
+    },
+    extendThemeContext: (key, value) => {
+      stash(themeExtensions, "Theme", key, value);
+    },
+    extendAppContext: (key, value) => {
+      stash(appExtensions, "App", key, value);
+    },
+  };
+}

--- a/packages/core/src/plugin/provides.test.ts
+++ b/packages/core/src/plugin/provides.test.ts
@@ -7,7 +7,7 @@ import { HookRegistry } from "../hooks/registry.js";
 import { definePlugin } from "./define.js";
 import { installPlugins } from "./register.js";
 
-declare module "./context.js" {
+declare module "./provides-context.js" {
   interface PluginContextExtensions {
     registerMenuItemType(type: string, opts: { readonly label: string }): void;
     media: {

--- a/packages/core/src/plugin/register.ts
+++ b/packages/core/src/plugin/register.ts
@@ -1,14 +1,12 @@
 import type { AnyPluginDescriptor } from "../config.js";
 import type { HookRegistry } from "../hooks/registry.js";
-import type { ContextExtensionEntry } from "./context.js";
 import type { MutablePluginRegistry, PluginRegistry } from "./manifest.js";
-import {
-  createPluginProvidesContext,
-  createPluginSetupContext,
-} from "./context.js";
+import type { ContextExtensionEntry } from "./provides-context.js";
 import { assertValidPluginId } from "./define.js";
 import { PluginDefinitionError } from "./errors.js";
 import { createPluginRegistry } from "./manifest.js";
+import { createPluginProvidesContext } from "./provides-context.js";
+import { createPluginSetupContext } from "./setup-context.js";
 
 export interface PluginInstallResult {
   readonly hooks: HookRegistry;

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -1,5 +1,5 @@
 import type { DerivedCapability } from "../auth/rbac.js";
-import type { AppContext, AppContextExtensions } from "../context/app.js";
+import type { AppContext } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { HookRegistry } from "../hooks/registry.js";
 import type {
@@ -32,47 +32,26 @@ import type {
   TermTaxonomyOptions,
   UserMetaBoxOptions,
 } from "./manifest.js";
+import type { PluginContextExtensions } from "./provides-context.js";
 import {
   deriveEntryTypeCapabilities,
   deriveTermTaxonomyCapabilities,
 } from "../auth/rbac.js";
 import { DEFAULT_REWRITE_RULE_PRIORITY } from "../route/compile.js";
-import { MAX_PLUGIN_ID_LENGTH, PLUGIN_ID_RE } from "./define.js";
 import { DuplicateRegistrationError, PluginContextError } from "./errors.js";
 import { CORE_RPC_NAMESPACES } from "./manifest.js";
-
-export interface ContextExtensionEntry {
-  readonly value: unknown;
-  readonly pluginId: string;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface PluginContextExtensions {}
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ThemeContextExtensions {}
-
-export interface PluginProvidesContext {
-  readonly id: string;
-  extendPluginContext<TKey extends keyof PluginContextExtensions>(
-    key: TKey,
-    value: PluginContextExtensions[TKey],
-  ): void;
-  extendThemeContext<TKey extends keyof ThemeContextExtensions>(
-    key: TKey,
-    value: ThemeContextExtensions[TKey],
-  ): void;
-  /**
-   * Register a runtime helper on every per-request `AppContext`. Reads
-   * are typed via the `AppContextExtensions` declaration-merge target —
-   * a plugin augments it once and `ctx.<key>` is autocompleted in
-   * every RPC/route/hook handler. Duplicate keys throw.
-   */
-  extendAppContext<TKey extends keyof AppContextExtensions>(
-    key: TKey,
-    value: AppContextExtensions[TKey],
-  ): void;
-}
+import {
+  assertComponentRef,
+  assertMetaBoxFields,
+  assertValidAdminPagePath,
+  assertValidFieldTypeName,
+  assertValidIdentifier,
+  assertValidLoginLink,
+  assertValidLookupAdapterKind,
+  assertValidNavGroupId,
+  assertValidPluginRoutePath,
+  assertValidScheduledTask,
+} from "./validation/index.js";
 
 export interface PluginSetupContextBase {
   readonly id: string;
@@ -235,103 +214,6 @@ interface CreatePluginContextArgs {
   readonly hooks: HookRegistry;
   readonly registry: MutablePluginRegistry;
   readonly extensions?: ReadonlyMap<string, unknown>;
-}
-
-interface CreateProvidesContextArgs {
-  readonly pluginId: string;
-  readonly pluginExtensions: Map<string, ContextExtensionEntry>;
-  readonly themeExtensions: Map<string, ContextExtensionEntry>;
-  readonly appExtensions: Map<string, ContextExtensionEntry>;
-}
-
-// Names that would corrupt the per-request `AppContext` if a plugin
-// tried to register them. `__proto__` triggers the Object.prototype
-// setter and reparents the ctx; `constructor` / `prototype` shadow
-// inherited members and confuse downstream introspection.
-const RESERVED_EXTENSION_KEYS: ReadonlySet<string> = new Set([
-  "__proto__",
-  "constructor",
-  "prototype",
-]);
-
-// Built-in `AppContextBase` members. extendAppContext rejects these so
-// a plugin can't silently replace `db`, `auth`, etc. at request time.
-// Mirrors the `key in target` shadow check `extendPluginContext`
-// runs against the constructed PluginSetupContext at install.
-const APP_CONTEXT_BASE_KEYS: ReadonlySet<string> = new Set([
-  "db",
-  "env",
-  "request",
-  "user",
-  "tokenScopes",
-  "hooks",
-  "plugins",
-  "logger",
-  "auth",
-  "authenticator",
-  "bootstrapAllowed",
-  "oauthProviders",
-  "after",
-  "assets",
-  "storage",
-  "imageDelivery",
-  "mailer",
-  "origin",
-  "siteName",
-  "resolvedEntity",
-]);
-
-export function createPluginProvidesContext({
-  pluginId,
-  pluginExtensions,
-  themeExtensions,
-  appExtensions,
-}: CreateProvidesContextArgs): PluginProvidesContext {
-  const stash = (
-    target: Map<string, ContextExtensionEntry>,
-    kind: "Plugin" | "Theme" | "App",
-    key: string,
-    value: unknown,
-  ): void => {
-    if (typeof key !== "string" || key.length === 0) {
-      throw PluginContextError.extendContextInvalidKey({ pluginId, kind });
-    }
-    if (RESERVED_EXTENSION_KEYS.has(key)) {
-      throw PluginContextError.extendContextReservedKey({
-        pluginId,
-        kind,
-        key,
-      });
-    }
-    if (kind === "App" && APP_CONTEXT_BASE_KEYS.has(key)) {
-      throw PluginContextError.extendAppContextBuiltinCollision({
-        pluginId,
-        key,
-      });
-    }
-    const existing = target.get(key);
-    if (existing) {
-      throw PluginContextError.extendContextDuplicate({
-        pluginId,
-        kind,
-        key,
-        existingOwner: existing.pluginId,
-      });
-    }
-    target.set(key, { value, pluginId });
-  };
-  return {
-    id: pluginId,
-    extendPluginContext: (key, value) => {
-      stash(pluginExtensions, "Plugin", key, value);
-    },
-    extendThemeContext: (key, value) => {
-      stash(themeExtensions, "Theme", key, value);
-    },
-    extendAppContext: (key, value) => {
-      stash(appExtensions, "App", key, value);
-    },
-  };
 }
 
 export function createPluginSetupContext({
@@ -680,236 +562,6 @@ function makeMetaBoxRegistrar<
       registeredBy: pluginId,
     });
   };
-}
-
-function assertComponentRef(
-  pluginId: string,
-  descriptor: string,
-  ref: unknown,
-): void {
-  if (typeof ref !== "string" || ref.length === 0) {
-    throw PluginContextError.invalidComponentRef({ pluginId, descriptor });
-  }
-}
-
-const IDENTIFIER_NAME_RE = /^[a-z][a-z0-9_-]*$/;
-
-function assertValidFieldTypeName(pluginId: string, type: string): void {
-  if (!IDENTIFIER_NAME_RE.test(type) || type.length > 64) {
-    throw PluginContextError.invalidFieldTypeName({
-      pluginId,
-      type,
-      pattern: IDENTIFIER_NAME_RE.source,
-      maxLength: 64,
-    });
-  }
-}
-
-function assertValidLookupAdapterKind(pluginId: string, kind: string): void {
-  if (!IDENTIFIER_NAME_RE.test(kind) || kind.length > 64) {
-    throw PluginContextError.invalidLookupAdapterKind({
-      pluginId,
-      kind,
-      pattern: IDENTIFIER_NAME_RE.source,
-      maxLength: 64,
-    });
-  }
-}
-
-// Lowercase alphanum + dash/underscore, 1–32 chars, must start with a
-// letter. Matches `OAUTH_PROVIDER_KEY_PATTERN` exactly so keys read
-// consistently across login-button surfaces. Leading-letter constraint
-// keeps the wire id `${pluginId}:${key}` from looking like an opaque
-// numeric identifier in logs.
-const LOGIN_LINK_KEY_RE = /^[a-z][a-z0-9_-]{0,31}$/;
-
-const SCHEDULED_TASK_ID_RE = /^[a-z0-9][a-z0-9_/-]{0,63}$/i;
-
-function assertValidScheduledTask(pluginId: string, task: ScheduledTask): void {
-  if (!SCHEDULED_TASK_ID_RE.test(task.id)) {
-    throw PluginContextError.invalidScheduledTaskId({ pluginId, id: task.id });
-  }
-  if (typeof task.handler !== "function") {
-    throw PluginContextError.scheduledTaskHandlerMissing({
-      pluginId,
-      id: task.id,
-    });
-  }
-}
-
-function assertValidLoginLink(
-  pluginId: string,
-  options: LoginLinkOptions,
-): void {
-  if (!LOGIN_LINK_KEY_RE.test(options.key)) {
-    throw PluginContextError.invalidLoginLinkKey({
-      pluginId,
-      key: options.key,
-    });
-  }
-  if (options.label.length === 0) {
-    throw PluginContextError.loginLinkEmptyLabel({
-      pluginId,
-      key: options.key,
-    });
-  }
-  // CR/LF defense: label is rendered into HTML by the admin, but a
-  // future logger / audit-trail consumer might splice it into a
-  // line-oriented format. Block at the boundary.
-  if (/[\r\n]/.test(options.label)) {
-    throw PluginContextError.loginLinkLabelHasCrLf({
-      pluginId,
-      key: options.key,
-    });
-  }
-  // href must be a same-origin path or an https:// URL — block
-  // `javascript:`, `data:`, protocol-relative `//`, and other schemes
-  // a misconfigured or hostile plugin might surface.
-  const isSameOriginPath =
-    options.href.startsWith("/") && !options.href.startsWith("//");
-  const isHttps = options.href.startsWith("https://");
-  if (!isSameOriginPath && !isHttps) {
-    throw PluginContextError.invalidLoginLinkHref({
-      pluginId,
-      key: options.key,
-      href: options.href,
-    });
-  }
-}
-
-function assertValidNavGroupId(pluginId: string, id: string): void {
-  if (id.length === 0 || id.length > MAX_PLUGIN_ID_LENGTH) {
-    throw PluginContextError.invalidNavGroupIdLength({
-      pluginId,
-      id,
-      maxLength: MAX_PLUGIN_ID_LENGTH,
-    });
-  }
-  if (!PLUGIN_ID_RE.test(id)) {
-    throw PluginContextError.invalidNavGroupIdShape({
-      pluginId,
-      id,
-      pattern: PLUGIN_ID_RE.source,
-    });
-  }
-}
-
-// Shared `/`-anchored path validation: must start with /, no `//` or
-// `..` traversal, no `?` / `#` (we match on pathname only). The
-// admin-page and plugin-route validators diverge after this on how
-// they handle `*`, so the wildcard rule stays at each call site.
-function assertValidPathPrefix(
-  pluginId: string,
-  path: string,
-  kind: string,
-): void {
-  if (!path.startsWith("/")) {
-    throw PluginContextError.pathMustStartWithSlash({ pluginId, kind, path });
-  }
-  if (path.includes("//") || path.includes("..")) {
-    throw PluginContextError.pathContainsTraversal({ pluginId, kind, path });
-  }
-  if (path.includes("?") || path.includes("#")) {
-    throw PluginContextError.pathContainsQueryOrFragment({
-      pluginId,
-      kind,
-      path,
-    });
-  }
-}
-
-function assertValidAdminPagePath(pluginId: string, path: string): void {
-  assertValidPathPrefix(pluginId, path, "admin page");
-  if (path.includes("*")) {
-    throw PluginContextError.adminPagePathContainsWildcard({ pluginId, path });
-  }
-}
-
-function assertValidPluginRoutePath(pluginId: string, path: string): void {
-  assertValidPathPrefix(pluginId, path, "route");
-  // Allow exactly `/*` at the very end. Any other `*` is ambiguous.
-  const starIndex = path.indexOf("*");
-  if (starIndex !== -1 && starIndex !== path.length - 1) {
-    throw PluginContextError.routePathWildcardNotAtEnd({ pluginId, path });
-  }
-  if (
-    path.endsWith("*") &&
-    (path.length < 2 || path[path.length - 2] !== "/")
-  ) {
-    throw PluginContextError.routePathWildcardNotAfterSlash({ pluginId, path });
-  }
-}
-
-// Keep page / group / field names portable: ASCII identifier that
-// starts with a letter, then letters/digits/underscores. Hyphens /
-// dots are excluded so testids, URL params, and storage keys stay
-// portable across SQLite / future MySQL without quoting. Length cap
-// mirrors the valibot `settingsIdentifierSchema` on the RPC side so a
-// plugin can't register a name its own `settings.get` / `.upsert`
-// calls would then reject.
-const SETTINGS_NAME_RE = /^[a-z][a-z0-9_]*$/;
-const MAX_SETTINGS_IDENTIFIER_LENGTH = 64;
-
-function assertValidIdentifier(kind: string, name: string): void {
-  if (name.length > MAX_SETTINGS_IDENTIFIER_LENGTH) {
-    throw PluginContextError.identifierTooLong({
-      kind,
-      name,
-      maxLength: MAX_SETTINGS_IDENTIFIER_LENGTH,
-    });
-  }
-  if (!SETTINGS_NAME_RE.test(name)) {
-    throw PluginContextError.identifierShapeInvalid({
-      kind,
-      name,
-      pattern: SETTINGS_NAME_RE.source,
-    });
-  }
-}
-
-// Must match the RPC input-schema regex for meta keys — any key that
-// doesn't match is dead code (the write path rejects it), so catch it
-// at registration instead of letting the admin discover it later.
-const META_FIELD_KEY_RE = /^[a-zA-Z0-9_:-]+$/;
-
-// Cap on fields per box — keeps the admin's per-request payload
-// bounded and signals a modeling problem if a plugin wants to pile
-// hundreds of fields into one card. Matches the RPC input-schema cap
-// on the meta/upsert request surface.
-const MAX_FIELDS_PER_META_BOX = 200;
-
-function assertMetaBoxFields(
-  kind: string,
-  id: string,
-  fields: readonly MetaBoxField[],
-): void {
-  if (fields.length > MAX_FIELDS_PER_META_BOX) {
-    throw PluginContextError.metaBoxTooManyFields({
-      kind,
-      id,
-      count: fields.length,
-      maxFields: MAX_FIELDS_PER_META_BOX,
-    });
-  }
-  const seen = new Set<string>();
-  for (const field of fields) {
-    if (!META_FIELD_KEY_RE.test(field.key)) {
-      throw PluginContextError.metaBoxFieldInvalidKey({
-        kind,
-        id,
-        fieldKey: field.key,
-        pattern: META_FIELD_KEY_RE.source,
-      });
-    }
-    if (seen.has(field.key)) {
-      throw PluginContextError.metaBoxFieldDuplicateKey({
-        kind,
-        id,
-        fieldKey: field.key,
-      });
-    }
-    seen.add(field.key);
-  }
 }
 
 // Re-exported from our local FilterRest helper so the type used by hook wrapper

--- a/packages/core/src/plugin/validation/component-ref.ts
+++ b/packages/core/src/plugin/validation/component-ref.ts
@@ -1,0 +1,11 @@
+import { PluginContextError } from "../errors.js";
+
+export function assertComponentRef(
+  pluginId: string,
+  descriptor: string,
+  ref: unknown,
+): void {
+  if (typeof ref !== "string" || ref.length === 0) {
+    throw PluginContextError.invalidComponentRef({ pluginId, descriptor });
+  }
+}

--- a/packages/core/src/plugin/validation/identifiers.ts
+++ b/packages/core/src/plugin/validation/identifiers.ts
@@ -1,0 +1,73 @@
+import { MAX_PLUGIN_ID_LENGTH, PLUGIN_ID_RE } from "../define.js";
+import { PluginContextError } from "../errors.js";
+
+const IDENTIFIER_NAME_RE = /^[a-z][a-z0-9_-]*$/;
+
+export function assertValidFieldTypeName(pluginId: string, type: string): void {
+  if (!IDENTIFIER_NAME_RE.test(type) || type.length > 64) {
+    throw PluginContextError.invalidFieldTypeName({
+      pluginId,
+      type,
+      pattern: IDENTIFIER_NAME_RE.source,
+      maxLength: 64,
+    });
+  }
+}
+
+export function assertValidLookupAdapterKind(
+  pluginId: string,
+  kind: string,
+): void {
+  if (!IDENTIFIER_NAME_RE.test(kind) || kind.length > 64) {
+    throw PluginContextError.invalidLookupAdapterKind({
+      pluginId,
+      kind,
+      pattern: IDENTIFIER_NAME_RE.source,
+      maxLength: 64,
+    });
+  }
+}
+
+// Keep page / group / field names portable: ASCII identifier that
+// starts with a letter, then letters/digits/underscores. Hyphens /
+// dots are excluded so testids, URL params, and storage keys stay
+// portable across SQLite / future MySQL without quoting. Length cap
+// mirrors the valibot `settingsIdentifierSchema` on the RPC side so a
+// plugin can't register a name its own `settings.get` / `.upsert`
+// calls would then reject.
+export const SETTINGS_NAME_RE = /^[a-z][a-z0-9_]*$/;
+const MAX_SETTINGS_IDENTIFIER_LENGTH = 64;
+
+export function assertValidIdentifier(kind: string, name: string): void {
+  if (name.length > MAX_SETTINGS_IDENTIFIER_LENGTH) {
+    throw PluginContextError.identifierTooLong({
+      kind,
+      name,
+      maxLength: MAX_SETTINGS_IDENTIFIER_LENGTH,
+    });
+  }
+  if (!SETTINGS_NAME_RE.test(name)) {
+    throw PluginContextError.identifierShapeInvalid({
+      kind,
+      name,
+      pattern: SETTINGS_NAME_RE.source,
+    });
+  }
+}
+
+export function assertValidNavGroupId(pluginId: string, id: string): void {
+  if (id.length === 0 || id.length > MAX_PLUGIN_ID_LENGTH) {
+    throw PluginContextError.invalidNavGroupIdLength({
+      pluginId,
+      id,
+      maxLength: MAX_PLUGIN_ID_LENGTH,
+    });
+  }
+  if (!PLUGIN_ID_RE.test(id)) {
+    throw PluginContextError.invalidNavGroupIdShape({
+      pluginId,
+      id,
+      pattern: PLUGIN_ID_RE.source,
+    });
+  }
+}

--- a/packages/core/src/plugin/validation/index.ts
+++ b/packages/core/src/plugin/validation/index.ts
@@ -1,0 +1,6 @@
+export * from "./component-ref.js";
+export * from "./identifiers.js";
+export * from "./login-link.js";
+export * from "./meta-box-fields.js";
+export * from "./paths.js";
+export * from "./scheduled-task.js";

--- a/packages/core/src/plugin/validation/login-link.ts
+++ b/packages/core/src/plugin/validation/login-link.ts
@@ -1,0 +1,49 @@
+import { PluginContextError } from "../errors.js";
+import type { LoginLinkOptions } from "../manifest.js";
+
+// Lowercase alphanum + dash/underscore, 1–32 chars, must start with a
+// letter. Matches `OAUTH_PROVIDER_KEY_PATTERN` exactly so keys read
+// consistently across login-button surfaces. Leading-letter constraint
+// keeps the wire id `${pluginId}:${key}` from looking like an opaque
+// numeric identifier in logs.
+const LOGIN_LINK_KEY_RE = /^[a-z][a-z0-9_-]{0,31}$/;
+
+export function assertValidLoginLink(
+  pluginId: string,
+  options: LoginLinkOptions,
+): void {
+  if (!LOGIN_LINK_KEY_RE.test(options.key)) {
+    throw PluginContextError.invalidLoginLinkKey({
+      pluginId,
+      key: options.key,
+    });
+  }
+  if (options.label.length === 0) {
+    throw PluginContextError.loginLinkEmptyLabel({
+      pluginId,
+      key: options.key,
+    });
+  }
+  // CR/LF defense: label is rendered into HTML by the admin, but a
+  // future logger / audit-trail consumer might splice it into a
+  // line-oriented format. Block at the boundary.
+  if (/[\r\n]/.test(options.label)) {
+    throw PluginContextError.loginLinkLabelHasCrLf({
+      pluginId,
+      key: options.key,
+    });
+  }
+  // href must be a same-origin path or an https:// URL — block
+  // `javascript:`, `data:`, protocol-relative `//`, and other schemes
+  // a misconfigured or hostile plugin might surface.
+  const isSameOriginPath =
+    options.href.startsWith("/") && !options.href.startsWith("//");
+  const isHttps = options.href.startsWith("https://");
+  if (!isSameOriginPath && !isHttps) {
+    throw PluginContextError.invalidLoginLinkHref({
+      pluginId,
+      key: options.key,
+      href: options.href,
+    });
+  }
+}

--- a/packages/core/src/plugin/validation/login-link.ts
+++ b/packages/core/src/plugin/validation/login-link.ts
@@ -1,5 +1,5 @@
-import { PluginContextError } from "../errors.js";
 import type { LoginLinkOptions } from "../manifest.js";
+import { PluginContextError } from "../errors.js";
 
 // Lowercase alphanum + dash/underscore, 1–32 chars, must start with a
 // letter. Matches `OAUTH_PROVIDER_KEY_PATTERN` exactly so keys read

--- a/packages/core/src/plugin/validation/meta-box-fields.ts
+++ b/packages/core/src/plugin/validation/meta-box-fields.ts
@@ -1,0 +1,47 @@
+import { PluginContextError } from "../errors.js";
+import type { MetaBoxField } from "../manifest.js";
+
+// Must match the RPC input-schema regex for meta keys — any key that
+// doesn't match is dead code (the write path rejects it), so catch it
+// at registration instead of letting the admin discover it later.
+export const META_FIELD_KEY_RE = /^[a-zA-Z0-9_:-]+$/;
+
+// Cap on fields per box — keeps the admin's per-request payload
+// bounded and signals a modeling problem if a plugin wants to pile
+// hundreds of fields into one card. Matches the RPC input-schema cap
+// on the meta/upsert request surface.
+export const MAX_FIELDS_PER_META_BOX = 200;
+
+export function assertMetaBoxFields(
+  kind: string,
+  id: string,
+  fields: readonly MetaBoxField[],
+): void {
+  if (fields.length > MAX_FIELDS_PER_META_BOX) {
+    throw PluginContextError.metaBoxTooManyFields({
+      kind,
+      id,
+      count: fields.length,
+      maxFields: MAX_FIELDS_PER_META_BOX,
+    });
+  }
+  const seen = new Set<string>();
+  for (const field of fields) {
+    if (!META_FIELD_KEY_RE.test(field.key)) {
+      throw PluginContextError.metaBoxFieldInvalidKey({
+        kind,
+        id,
+        fieldKey: field.key,
+        pattern: META_FIELD_KEY_RE.source,
+      });
+    }
+    if (seen.has(field.key)) {
+      throw PluginContextError.metaBoxFieldDuplicateKey({
+        kind,
+        id,
+        fieldKey: field.key,
+      });
+    }
+    seen.add(field.key);
+  }
+}

--- a/packages/core/src/plugin/validation/meta-box-fields.ts
+++ b/packages/core/src/plugin/validation/meta-box-fields.ts
@@ -1,5 +1,5 @@
-import { PluginContextError } from "../errors.js";
 import type { MetaBoxField } from "../manifest.js";
+import { PluginContextError } from "../errors.js";
 
 // Must match the RPC input-schema regex for meta keys — any key that
 // doesn't match is dead code (the write path rejects it), so catch it

--- a/packages/core/src/plugin/validation/paths.ts
+++ b/packages/core/src/plugin/validation/paths.ts
@@ -1,0 +1,50 @@
+import { PluginContextError } from "../errors.js";
+
+// Shared `/`-anchored path validation: must start with /, no `//` or
+// `..` traversal, no `?` / `#` (we match on pathname only). The
+// admin-page and plugin-route validators diverge after this on how
+// they handle `*`, so the wildcard rule stays at each call site.
+function assertValidPathPrefix(
+  pluginId: string,
+  path: string,
+  kind: string,
+): void {
+  if (!path.startsWith("/")) {
+    throw PluginContextError.pathMustStartWithSlash({ pluginId, kind, path });
+  }
+  if (path.includes("//") || path.includes("..")) {
+    throw PluginContextError.pathContainsTraversal({ pluginId, kind, path });
+  }
+  if (path.includes("?") || path.includes("#")) {
+    throw PluginContextError.pathContainsQueryOrFragment({
+      pluginId,
+      kind,
+      path,
+    });
+  }
+}
+
+export function assertValidAdminPagePath(pluginId: string, path: string): void {
+  assertValidPathPrefix(pluginId, path, "admin page");
+  if (path.includes("*")) {
+    throw PluginContextError.adminPagePathContainsWildcard({ pluginId, path });
+  }
+}
+
+export function assertValidPluginRoutePath(
+  pluginId: string,
+  path: string,
+): void {
+  assertValidPathPrefix(pluginId, path, "route");
+  // Allow exactly `/*` at the very end. Any other `*` is ambiguous.
+  const starIndex = path.indexOf("*");
+  if (starIndex !== -1 && starIndex !== path.length - 1) {
+    throw PluginContextError.routePathWildcardNotAtEnd({ pluginId, path });
+  }
+  if (
+    path.endsWith("*") &&
+    (path.length < 2 || path[path.length - 2] !== "/")
+  ) {
+    throw PluginContextError.routePathWildcardNotAfterSlash({ pluginId, path });
+  }
+}

--- a/packages/core/src/plugin/validation/scheduled-task.ts
+++ b/packages/core/src/plugin/validation/scheduled-task.ts
@@ -1,0 +1,19 @@
+import { PluginContextError } from "../errors.js";
+import type { ScheduledTask } from "../manifest.js";
+
+const SCHEDULED_TASK_ID_RE = /^[a-z0-9][a-z0-9_/-]{0,63}$/i;
+
+export function assertValidScheduledTask(
+  pluginId: string,
+  task: ScheduledTask,
+): void {
+  if (!SCHEDULED_TASK_ID_RE.test(task.id)) {
+    throw PluginContextError.invalidScheduledTaskId({ pluginId, id: task.id });
+  }
+  if (typeof task.handler !== "function") {
+    throw PluginContextError.scheduledTaskHandlerMissing({
+      pluginId,
+      id: task.id,
+    });
+  }
+}

--- a/packages/core/src/plugin/validation/scheduled-task.ts
+++ b/packages/core/src/plugin/validation/scheduled-task.ts
@@ -1,5 +1,5 @@
-import { PluginContextError } from "../errors.js";
 import type { ScheduledTask } from "../manifest.js";
+import { PluginContextError } from "../errors.js";
 
 const SCHEDULED_TASK_ID_RE = /^[a-z0-9][a-z0-9_/-]{0,63}$/i;
 

--- a/packages/core/src/rpc/procedures/settings/get.ts
+++ b/packages/core/src/rpc/procedures/settings/get.ts
@@ -7,7 +7,7 @@ import { settingsGetInputSchema } from "./schemas.js";
 const CAPABILITY = "settings:manage";
 // Hard ceiling on rows returned per group. Registered-field count per
 // group is already capped at 200 (`MAX_FIELDS_PER_SETTINGS_GROUP` in
-// plugin/context); doubling it here gives headroom for orphan keys
+// plugin/validation/meta-box-fields); doubling it here gives headroom for orphan keys
 // left by uninstalled plugins while still bounding response size.
 const MAX_GROUP_ROWS_PER_READ = 500;
 

--- a/packages/core/src/rpc/procedures/settings/schemas.ts
+++ b/packages/core/src/rpc/procedures/settings/schemas.ts
@@ -3,7 +3,7 @@ import * as v from "valibot";
 // Group / page identifiers stay tight — lowercase snake_case ASCII so
 // they're safe in URLs (`/settings/<page>`), testids, and future
 // storage backends that may quote differently. Matches the
-// registration-time `SETTINGS_NAME_RE` in `plugin/context.ts`.
+// registration-time `SETTINGS_NAME_RE` in `plugin/validation/identifiers.ts`.
 const settingsNameSchema = v.pipe(
   v.string(),
   v.trim(),
@@ -15,7 +15,7 @@ const settingsNameSchema = v.pipe(
 // Field-value keys share the permissive meta regex (`og:title`,
 // `my-field`, `2fa_enabled` all valid) so a plugin registering a
 // `MetaBoxField` via `registerSettingsGroup` isn't rejected at the
-// RPC boundary. Matches `META_FIELD_KEY_RE` in `plugin/context.ts`.
+// RPC boundary. Matches `META_FIELD_KEY_RE` in `plugin/validation/meta-box-fields.ts`.
 const settingsValueKeySchema = v.pipe(
   v.string(),
   v.trim(),

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -6,12 +6,12 @@ import type { CapabilityResolver } from "../auth/rbac.js";
 import type { SessionPolicy } from "../auth/sessions.js";
 import type { PlumixConfig } from "../config.js";
 import type { AppContext } from "../context/app.js";
-import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type {
   PluginRegistry,
   RegisteredRawRoute,
   RegisteredScheduledTask,
 } from "../plugin/manifest.js";
+import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RouteRule } from "../route/intent.js";
 import type { ThemeSetupContext, ThemeSetupContextBase } from "../theme.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -6,7 +6,7 @@ import type { CapabilityResolver } from "../auth/rbac.js";
 import type { SessionPolicy } from "../auth/sessions.js";
 import type { PlumixConfig } from "../config.js";
 import type { AppContext } from "../context/app.js";
-import type { ContextExtensionEntry } from "../plugin/context.js";
+import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type {
   PluginRegistry,
   RegisteredRawRoute,

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,4 +1,4 @@
-import type { ThemeContextExtensions } from "./plugin/context.js";
+import type { ThemeContextExtensions } from "./plugin/provides-context.js";
 import { ThemeError } from "./theme-errors.js";
 
 export interface ThemeSetupContextBase {


### PR DESCRIPTION
Closes #272 by splitting `packages/core/src/plugin/context.ts` (913 LOC) into three cohesive modules. Pure refactor — every `register*` signature, every error message, every throw condition is preserved verbatim. Public plugin-author API is unchanged.

**File layout after the split**

- `plugin/setup-context.ts` — `createPluginSetupContext` and its supporting types (the 22 `register*` closures stay co-located, since they share the `MutablePluginRegistry` argument by design).
- `plugin/provides-context.ts` — `createPluginProvidesContext` plus its types, constants, and `stash` helper. Mirrors the pre-existing `provides.test.ts` / `register.test.ts` test-side split.
- `plugin/validation/` — per-concept `assert*` helpers with their regex/cap constants colocated: `paths.ts`, `identifiers.ts`, `login-link.ts`, `scheduled-task.ts`, `meta-box-fields.ts`, `component-ref.ts`, re-exported via a barrel.

**Visibility unchanged**

Validators are exported from the validation barrel so other modules inside `@plumix/core` can import them (preparation for unifying the RPC-side mirror constants in a follow-up), but nothing re-exports from the package root. Plugin authors gain no new public API surface.

**Drift markers retargeted**

Three RPC-side comments that previously pointed at `plugin/context.ts` (in `rpc/procedures/settings/{get,schemas}.ts` and `plugin/fields/repeater.ts`) now point at their new validator locations so the follow-up mirror-constant unification still has a signpost to follow.

**Verification**

- `pnpm exec turbo run typecheck` — 29/29 packages green
- `pnpm exec turbo run test lint --filter @plumix/core` — 1430/1430 tests pass, lint clean
- `pnpm boundaries` — no dependency violations
- `pnpm knip` — no new findings

Refs #272.