### PR TITLE
refactor(core): extract shared auth-flow helpers

### DIFF
--- a/packages/core/src/auth/email-change/routes.ts
+++ b/packages/core/src/auth/email-change/routes.ts
@@ -1,5 +1,7 @@
 import type { AppContext } from "../../context/app.js";
 import type { PlumixApp } from "../../runtime/app.js";
+import type { EmailChangeErrorCode } from "./errors.js";
+import { loginErrorRedirect, redirectTo } from "../../runtime/http.js";
 import { EmailChangeError } from "./errors.js";
 import { verifyEmailChange } from "./verify.js";
 
@@ -62,15 +64,6 @@ export async function handleEmailChangeVerify(
   return redirectTo(`${LOGIN_PATH}?email_change_success=1`);
 }
 
-function redirectTo(
-  location: string,
-  extraHeaders: Record<string, string> = {},
-): Response {
-  const headers = new Headers({ Location: location, ...extraHeaders });
-  return new Response(null, { status: 302, headers });
-}
-
-function loginError(code: string): Response {
-  const params = new URLSearchParams({ email_change_error: code });
-  return redirectTo(`${LOGIN_PATH}?${params.toString()}`);
+function loginError(code: EmailChangeErrorCode): Response {
+  return loginErrorRedirect(LOGIN_PATH, "email_change_error", code);
 }

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -11,4 +11,5 @@ export * from "./oauth/index.js";
 export * from "./passkey/index.js";
 export * from "./rbac.js";
 export * from "./sessions.js";
+export * from "./sign-in.js";
 export * from "./tokens.js";

--- a/packages/core/src/auth/magic-link/routes.ts
+++ b/packages/core/src/auth/magic-link/routes.ts
@@ -3,9 +3,12 @@ import * as v from "valibot";
 import type { AppContext } from "../../context/app.js";
 import type { PlumixApp } from "../../runtime/app.js";
 import type { MagicLinkErrorCode } from "./errors.js";
-import { jsonResponse } from "../../runtime/http.js";
-import { buildSessionCookie, isSecureRequest } from "../cookies.js";
-import { createSession, readRequestMeta } from "../sessions.js";
+import {
+  jsonResponse,
+  loginErrorRedirect,
+  redirectTo,
+} from "../../runtime/http.js";
+import { mintSessionAndCookie } from "../sign-in.js";
 import { MagicLinkError } from "./errors.js";
 import { requestMagicLink } from "./request.js";
 import { verifyMagicLink } from "./verify.js";
@@ -112,21 +115,12 @@ export async function handleMagicLinkVerify(
     const { user, created } = await verifyMagicLink(ctx.db, token, {
       bootstrapAllowed: ctx.bootstrapAllowed,
     });
-    const { token: sessionToken } = await createSession(
-      ctx.db,
-      { userId: user.id, ...readRequestMeta(ctx.request) },
-      app.sessionPolicy,
-    );
+    const { cookieHeader } = await mintSessionAndCookie(ctx, app, user.id);
     await ctx.hooks.doAction("user:signed_in", user, {
       method: "magic_link",
       firstSignIn: created,
     });
-    const cookie = buildSessionCookie(sessionToken, {
-      maxAgeSeconds: app.sessionPolicy.maxAgeSeconds,
-      secure: isSecureRequest(ctx.request),
-      sameSite: "Lax",
-    });
-    return redirectTo(ADMIN_PATH, { "set-cookie": cookie });
+    return redirectTo(ADMIN_PATH, { "set-cookie": cookieHeader });
   } catch (error) {
     if (error instanceof MagicLinkError) {
       ctx.logger.warn("magic_link_verify_rejected", { code: error.code });
@@ -141,15 +135,6 @@ function invalidInput(): Response {
   return jsonResponse({ error: "invalid_input" }, { status: 400 });
 }
 
-function redirectTo(
-  location: string,
-  extraHeaders: Record<string, string> = {},
-): Response {
-  const headers = new Headers({ Location: location, ...extraHeaders });
-  return new Response(null, { status: 302, headers });
-}
-
 function loginError(code: MagicLinkErrorCode): Response {
-  const params = new URLSearchParams({ magic_link_error: code });
-  return redirectTo(`${LOGIN_PATH}?${params.toString()}`);
+  return loginErrorRedirect(LOGIN_PATH, "magic_link_error", code);
 }

--- a/packages/core/src/auth/oauth/routes.ts
+++ b/packages/core/src/auth/oauth/routes.ts
@@ -3,8 +3,8 @@ import type { PlumixApp } from "../../runtime/app.js";
 import type { OAuthErrorCode } from "./errors.js";
 import type { OAuthProviderClient } from "./types.js";
 import { users } from "../../db/schema/users.js";
-import { buildSessionCookie, isSecureRequest } from "../cookies.js";
-import { createSession, readRequestMeta } from "../sessions.js";
+import { loginErrorRedirect, redirectTo } from "../../runtime/http.js";
+import { mintSessionAndCookie } from "../sign-in.js";
 import { buildAuthorizeUrl, exchangeAndFetchProfile } from "./consumer.js";
 import { OAuthError } from "./errors.js";
 import { resolveOAuthUser } from "./signup.js";
@@ -126,11 +126,7 @@ export async function handleOAuthCallback(
       bootstrapAllowed: ctx.bootstrapAllowed,
     });
 
-    const { token } = await createSession(
-      ctx.db,
-      { userId: user.id, ...readRequestMeta(ctx.request) },
-      app.sessionPolicy,
-    );
+    const { cookieHeader } = await mintSessionAndCookie(ctx, app, user.id);
 
     await ctx.hooks.doAction("user:signed_in", user, {
       method: "oauth",
@@ -138,13 +134,7 @@ export async function handleOAuthCallback(
       firstSignIn: created,
     });
 
-    const cookie = buildSessionCookie(token, {
-      maxAgeSeconds: app.sessionPolicy.maxAgeSeconds,
-      secure: isSecureRequest(ctx.request),
-      sameSite: "Lax",
-    });
-
-    return redirectTo(ADMIN_PATH, { "set-cookie": cookie });
+    return redirectTo(ADMIN_PATH, { "set-cookie": cookieHeader });
   } catch (error) {
     if (error instanceof OAuthError) {
       ctx.logger.warn("oauth_callback_rejected", {
@@ -178,17 +168,8 @@ function oauthCallbackUrl(app: PlumixApp, providerKey: string): string {
   return `${app.origin}/_plumix/auth/oauth/${providerKey}/callback`;
 }
 
-function redirectTo(
-  location: string,
-  extraHeaders: Record<string, string> = {},
-): Response {
-  const headers = new Headers({ Location: location, ...extraHeaders });
-  return new Response(null, { status: 302, headers });
-}
-
 function loginError(code: OAuthErrorCode): Response {
-  const params = new URLSearchParams({ oauth_error: code });
   // Relative location — keeps the same scheme/host/port the browser
   // already used to reach us, no need to know the canonical origin.
-  return redirectTo(`${LOGIN_PATH}?${params.toString()}`);
+  return loginErrorRedirect(LOGIN_PATH, "oauth_error", code);
 }

--- a/packages/core/src/auth/passkey/routes.ts
+++ b/packages/core/src/auth/passkey/routes.ts
@@ -11,7 +11,6 @@ import { users } from "../../db/schema/users.js";
 import { jsonResponse } from "../../runtime/http.js";
 import { provisionUser } from "../bootstrap.js";
 import {
-  buildSessionCookie,
   buildSessionDeletionCookie,
   isSecureRequest,
   readSessionCookie,
@@ -21,12 +20,8 @@ import {
   InviteError,
   validateInviteToken,
 } from "../invite.js";
-import {
-  createSession,
-  invalidateSession,
-  readRequestMeta,
-  validateSession,
-} from "../sessions.js";
+import { invalidateSession, validateSession } from "../sessions.js";
+import { mintSessionAndCookie } from "../sign-in.js";
 import { beginAuthentication, finishAuthentication } from "./authenticate.js";
 import { PasskeyError } from "./errors.js";
 import {
@@ -118,18 +113,6 @@ async function parseJson<
 
 function invalidInput(): Response {
   return jsonResponse({ error: "invalid_input" }, { status: 400 });
-}
-
-function sessionCookieHeader(
-  ctx: AppContext,
-  app: PlumixApp,
-  token: string,
-): string {
-  return buildSessionCookie(token, {
-    maxAgeSeconds: app.sessionPolicy.maxAgeSeconds,
-    secure: isSecureRequest(ctx.request),
-    sameSite: "Lax",
-  });
 }
 
 function passkeyError(ctx: AppContext, error: PasskeyError): Response {
@@ -262,10 +245,10 @@ export async function handlePasskeyRegisterVerify(
       where: eq(users.id, verified.userId),
     });
 
-    const { token } = await createSession(
-      ctx.db,
-      { userId: verified.userId, ...readRequestMeta(ctx.request) },
-      app.sessionPolicy,
+    const { cookieHeader } = await mintSessionAndCookie(
+      ctx,
+      app,
+      verified.userId,
     );
 
     if (user) {
@@ -298,7 +281,7 @@ export async function handlePasskeyRegisterVerify(
       { userId: verified.userId },
       {
         status: 200,
-        headers: { "set-cookie": sessionCookieHeader(ctx, app, token) },
+        headers: { "set-cookie": cookieHeader },
       },
     );
   } catch (error) {
@@ -350,13 +333,10 @@ export async function handlePasskeyLoginVerify(
       .set({ counter: verified.newSignatureCounter })
       .where(eq(credentials.id, verified.credential.id));
 
-    const { token } = await createSession(
-      ctx.db,
-      {
-        userId: verified.credential.userId,
-        ...readRequestMeta(ctx.request),
-      },
-      app.sessionPolicy,
+    const { cookieHeader } = await mintSessionAndCookie(
+      ctx,
+      app,
+      verified.credential.userId,
     );
 
     const user = await ctx.db.query.users.findFirst({
@@ -373,7 +353,7 @@ export async function handlePasskeyLoginVerify(
       { userId: verified.credential.userId },
       {
         status: 200,
-        headers: { "set-cookie": sessionCookieHeader(ctx, app, token) },
+        headers: { "set-cookie": cookieHeader },
       },
     );
   } catch (error) {
@@ -502,11 +482,7 @@ export async function handleInviteRegisterVerify(
       maxPerUser: app.passkey.maxCredentialsPerUser,
     });
     await consumeInviteToken(ctx.db, invite.tokenHash);
-    const { token } = await createSession(
-      ctx.db,
-      { userId: user.id, ...readRequestMeta(ctx.request) },
-      app.sessionPolicy,
-    );
+    const { cookieHeader } = await mintSessionAndCookie(ctx, app, user.id);
     // User is fully enrolled (credential persisted, token consumed,
     // session created). Fire after the session exists so handlers that
     // hit the DB can rely on the user being in a stable post-invite
@@ -531,7 +507,7 @@ export async function handleInviteRegisterVerify(
       { userId: user.id },
       {
         status: 200,
-        headers: { "set-cookie": sessionCookieHeader(ctx, app, token) },
+        headers: { "set-cookie": cookieHeader },
       },
     );
   } catch (error) {

--- a/packages/core/src/auth/sign-in.ts
+++ b/packages/core/src/auth/sign-in.ts
@@ -1,0 +1,39 @@
+import type { AppContext } from "../context/app.js";
+import type { PlumixApp } from "../runtime/app.js";
+import { buildSessionCookie, isSecureRequest } from "./cookies.js";
+import { createSession, readRequestMeta } from "./sessions.js";
+
+interface MintedSession {
+  /** Raw session token — same value the cookie carries. */
+  readonly token: string;
+  /** Ready-to-set `Set-Cookie` header value. */
+  readonly cookieHeader: string;
+}
+
+/**
+ * Compose the four steps every successful sign-in shares: read request
+ * meta, create the session row, derive the secure-context flag, and
+ * build the `Set-Cookie` header from the configured `sessionPolicy`.
+ *
+ * Every auth flow that mints a session for the user (magic-link, oauth,
+ * passkey register/login/invite-accept) calls this — cookie attribute
+ * policy lives here so a change to `SameSite`, `Secure`, or `Max-Age`
+ * applies uniformly without scanning five call sites.
+ */
+export async function mintSessionAndCookie(
+  ctx: AppContext,
+  app: PlumixApp,
+  userId: number,
+): Promise<MintedSession> {
+  const { token } = await createSession(
+    ctx.db,
+    { userId, ...readRequestMeta(ctx.request) },
+    app.sessionPolicy,
+  );
+  const cookieHeader = buildSessionCookie(token, {
+    maxAgeSeconds: app.sessionPolicy.maxAgeSeconds,
+    secure: isSecureRequest(ctx.request),
+    sameSite: "Lax",
+  });
+  return { token, cookieHeader };
+}

--- a/packages/core/src/runtime/http.ts
+++ b/packages/core/src/runtime/http.ts
@@ -25,3 +25,20 @@ export function methodNotAllowed(allowed: readonly string[]): Response {
 export function forbidden(reason: string): Response {
   return jsonResponse({ error: "forbidden", reason }, { status: 403 });
 }
+
+export function redirectTo(
+  location: string,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  const headers = new Headers({ Location: location, ...extraHeaders });
+  return new Response(null, { status: 302, headers });
+}
+
+export function loginErrorRedirect(
+  loginPath: string,
+  paramName: string,
+  code: string,
+): Response {
+  const params = new URLSearchParams({ [paramName]: code });
+  return redirectTo(`${loginPath}?${params.toString()}`);
+}


### PR DESCRIPTION
Closes #273 by pulling three helpers out of the four `auth/*/routes.ts` files so cookie-attribute policy and login-error redirect shape have one place to live.

**Three helpers, scoped exactly**

- `redirectTo(location, extraHeaders?)` and `loginErrorRedirect(loginPath, paramName, code)` join `jsonResponse` in `runtime/http.ts` — pure response-shape utilities.
- `mintSessionAndCookie(ctx, app, userId)` is the new primitive in `auth/sign-in.ts`. It wraps `createSession` + `readRequestMeta` + the `buildSessionCookie(...)` policy block that was duplicated at five call sites and returns `{ token, cookieHeader }`. Passkey's private `sessionCookieHeader` helper is deleted and absorbed.
- Each flow keeps a 1-line typed wrapper around `loginErrorRedirect` so its handlers still call `loginError(code: MagicLinkErrorCode)` / `OAuthErrorCode` / `EmailChangeErrorCode` with compile-time enforcement at the call site.

**No state-machine refactoring, no behavior change**

Every endpoint's status, headers, error codes, hook payloads, JSON shapes, cookie attributes, and redirect targets are identical. The acceptance criterion is that every existing routes test passes unmodified — and they do.

**Diff size**

| File | Net |
|---|---|
| `auth/email-change/routes.ts` | -9 |
| `auth/magic-link/routes.ts` | -19 |
| `auth/oauth/routes.ts` | -19 |
| `auth/passkey/routes.ts` | -25 |
| `auth/sign-in.ts` (new) | +39 |
| `runtime/http.ts` | +17 |

**Verification**

- `pnpm exec turbo run typecheck test lint format --filter @plumix/core` — 5/5 tasks, 1430/1430 tests pass
- `pnpm exec turbo run typecheck` — 29/29 packages green
- `pnpm boundaries`, `pnpm knip` — clean

Refs #273.