### PR TITLE
refactor(core): drift-guard admin's passkey error union against core

### DIFF
--- a/packages/admin/src/lib/passkey-errors.ts
+++ b/packages/admin/src/lib/passkey-errors.ts
@@ -1,8 +1,8 @@
-// Server-side `PasskeyErrorCode` string union, kept in sync with
-// packages/core/src/auth/passkey/errors.ts. We can't import the type — admin
-// is a SPA build and @plumix/core is devDep-only for type-probe purposes —
-// but the string literals are the wire contract.
-type PasskeyServerErrorCode =
+import type { PasskeyErrorCode as CorePasskeyErrorCode } from "@plumix/core";
+
+// Codes thrown from core's `PasskeyError` class. Drift-guarded
+// against core's `PasskeyErrorCode` by the assertion below.
+type PasskeyClassErrorCode =
   | "challenge_not_found"
   | "invalid_client_data"
   | "invalid_origin"
@@ -17,7 +17,14 @@ type PasskeyServerErrorCode =
   | "invalid_signature"
   | "counter_replay"
   | "user_not_found"
-  | "invalid_response"
+  | "invalid_response";
+
+// Wire codes the passkey UI's `postJson` can receive that core does
+// not name in a single union: route-inline strings from
+// `passkey/routes.ts` and sibling-flow codes that arrive when the user
+// came in via an invite or hit RPC input validation. Admin owns this
+// union outright.
+type PasskeyWireExtraErrorCode =
   | "challenge_not_bound_to_user"
   | "challenge_mismatch"
   | "registration_closed"
@@ -25,6 +32,8 @@ type PasskeyServerErrorCode =
   | "invalid_token"
   | "token_expired"
   | "invalid_input";
+
+type PasskeyServerErrorCode = PasskeyClassErrorCode | PasskeyWireExtraErrorCode;
 
 // Browser-side failures we distinguish ourselves before/after the server call.
 type PasskeyClientErrorCode =
@@ -34,6 +43,19 @@ type PasskeyClientErrorCode =
   | "unknown";
 
 export type PasskeyErrorCode = PasskeyServerErrorCode | PasskeyClientErrorCode;
+
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+type Assert<T extends true> = T;
+
+// If core's `PasskeyErrorCode` adds, removes, or renames a code,
+// `Equals` resolves to `false` and `Assert<false>` fails the
+// constraint here. Purely type-level — no runtime cost.
+type _PasskeyClassErrorCodeSync = Assert<
+  Equals<PasskeyClassErrorCode, CorePasskeyErrorCode>
+>;
 
 export class PasskeyError extends Error {
   static {
@@ -56,10 +78,8 @@ export class PasskeyError extends Error {
   }
 
   // Dispatch entry for codes derived from a server response or DOMException
-  // mapping. The 23 server codes and two browser-side codes
-  // (`no_authenticator`, `unknown`) have no literal admin throw sites — every
-  // one of them arrives via a dispatched path, so a single dispatcher beats
-  // listing 25 unused per-code factories.
+  // mapping. Most codes have no literal throw site — they arrive via
+  // dispatch, so a single entry beats per-code factories.
   static ofCode(ctx: { code: PasskeyErrorCode }): PasskeyError {
     return new PasskeyError(ctx.code);
   }

--- a/packages/core/src/auth/passkey/errors.ts
+++ b/packages/core/src/auth/passkey/errors.ts
@@ -1,24 +1,29 @@
 // challenge_expired is folded into challenge_not_found — `consumeChallenge`
 // returns null whether the row was missing or just expired, since the
 // distinction is meaningless to the caller (and leaking it would help
-// timing-distinguish stale from never-issued). Admin maintains its own
-// mirror union (admin/src/lib/passkey-errors.ts) — keep them in sync.
-type PasskeyErrorCode =
-  | "challenge_not_found"
-  | "invalid_client_data"
-  | "invalid_origin"
-  | "invalid_rp_id"
-  | "user_presence_missing"
-  | "unsupported_attestation_format"
-  | "unsupported_algorithm"
-  | "credential_already_registered"
-  | "credential_limit_reached"
-  | "credential_not_found"
-  | "credential_storage_corrupt"
-  | "invalid_signature"
-  | "counter_replay"
-  | "user_not_found"
-  | "invalid_response";
+// timing-distinguish stale from never-issued).
+//
+// Admin's `passkey-errors.ts` mirrors this tuple via a compile-time
+// assertion; changing it will trip an admin typecheck failure.
+export const PASSKEY_ERROR_CODES = [
+  "challenge_not_found",
+  "invalid_client_data",
+  "invalid_origin",
+  "invalid_rp_id",
+  "user_presence_missing",
+  "unsupported_attestation_format",
+  "unsupported_algorithm",
+  "credential_already_registered",
+  "credential_limit_reached",
+  "credential_not_found",
+  "credential_storage_corrupt",
+  "invalid_signature",
+  "counter_replay",
+  "user_not_found",
+  "invalid_response",
+] as const;
+
+export type PasskeyErrorCode = (typeof PASSKEY_ERROR_CODES)[number];
 
 // Structured diagnostic payload. Never returned to clients — the dispatcher
 // pulls it off via `error.detail` for server-side logging only.


### PR DESCRIPTION
Closes #247 via option 2 — keep admin's mirror, add a compile-time `Equals` assertion that fails typecheck when core's `PasskeyErrorCode` and admin's class-subset diverge.

Admin's `PasskeyServerErrorCode` claimed to mirror core's `PasskeyError` but had silently diverged: it includes route-inline strings (`challenge_not_bound_to_user`, `challenge_mismatch`, `registration_closed`, `email_mismatch`) and sibling-flow codes (`invalid_token`, `token_expired`, `invalid_input`) the admin passkey UI's `postJson` happens to surface from invite acceptance and RPC input validation. The "kept in sync" comment was already wrong, and nothing forced the parts that genuinely should mirror to stay in lockstep.

**Core: const-tuple-derived `PasskeyErrorCode`**

`packages/core/src/auth/passkey/errors.ts` converts `PasskeyErrorCode` from an inline unexported `type` to a `PASSKEY_ERROR_CODES` const tuple driving the type, both exported. Mirrors the existing magic-link / oauth / email-change pattern. `PasskeyError` class signature is unchanged.

**Admin: split union + drift guard**

`packages/admin/src/lib/passkey-errors.ts` splits the union into `PasskeyClassErrorCode` (the part that mirrors core's class) and `PasskeyWireExtraErrorCode` (the seven admin-owned codes core doesn't name). Adds the standard TS `Equals<A, B>` and `Assert<T extends true>` helpers and pins `PasskeyClassErrorCode` to the imported core type. Drift now fails `tsc --noEmit` at the assertion site:

```
src/lib/passkey-errors.ts(63,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

**Bundle-size impact: zero**

The import is `import type { PasskeyErrorCode } from "@plumix/core"`, erased at compile time. `@plumix/core` is already an admin `devDependency` for the existing magic-link / oauth / email-change error type imports, so no new dependency edge.

**Verification**

- `pnpm exec turbo run lint typecheck test --filter @plumix/core --filter @plumix/admin` — 8/8 tasks green, 1430/1430 core tests pass.
- Drift canary: temporarily added `"drift_canary"` to core's `PASSKEY_ERROR_CODES` and re-ran admin typecheck; got the expected `TS2344` at `passkey-errors.ts(63,3)`. Reverted before commit.

Closes #247.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>