### PR TITLE
feat(core): optimistic concurrency on entry.update

### DIFF
--- a/packages/admin/e2e/content.spec.ts
+++ b/packages/admin/e2e/content.spec.ts
@@ -409,6 +409,111 @@ test.describe("/entries/$slug/$id/edit", () => {
       .toBe("Edited title");
     expect((updateInputs.at(-1) as { id?: number } | undefined)?.id).toBe(7);
   });
+
+  test("stale-token save raises the conflict dialog and resolves via Compare → Take theirs", async ({
+    page,
+  }) => {
+    const t0 = new Date("2026-04-21T00:00:00Z");
+    const t1 = new Date("2026-04-21T01:00:00Z");
+    let getCalls = 0;
+    const updateInputs: unknown[] = [];
+
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        getCalls += 1;
+        // First load: t0 / original title.
+        // Refetch after conflict: t1 / new live title.
+        const isFresh = getCalls > 1;
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 7,
+              type: "post",
+              parentId: null,
+              title: isFresh ? "Their edit" : "Original title",
+              slug: "original",
+              content:
+                '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Body"}]}]}',
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              sortOrder: 0,
+              publishedAt: null,
+              createdAt: t0,
+              updatedAt: isFresh ? t1 : t0,
+              meta: {},
+            },
+            meta: [],
+          }),
+        });
+      }
+      if (url.endsWith("/entry/update")) {
+        const body = route.request().postDataJSON() as { json?: unknown };
+        updateInputs.push(body.json);
+        // First save: stale token rejected.
+        return route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              defined: true,
+              code: "CONFLICT",
+              status: 409,
+              message: "Resource conflict",
+              data: { reason: "stale_expected_updated_at" },
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/7/edit");
+    await expect(page.getByTestId("post-editor-title-input")).toHaveValue(
+      "Original title",
+    );
+
+    await page.getByTestId("post-editor-title-input").fill("My edit");
+    await page.getByTestId("post-editor-submit").click();
+
+    const dialog = page.getByTestId("entry-editor-conflict-dialog");
+    await expect(dialog).toBeVisible();
+
+    await page.getByTestId("entry-editor-conflict-compare").click();
+    await expect(page.getByTestId("entry-editor-conflict-mine-title")).toHaveText(
+      "My edit",
+    );
+    await expect(
+      page.getByTestId("entry-editor-conflict-theirs-title"),
+    ).toHaveText("Their edit");
+
+    await page.getByTestId("entry-editor-conflict-take-theirs").click();
+
+    await expect(dialog).toBeHidden();
+    // Form remounts (keyed on updatedAt) with the fresh server values.
+    await expect(page.getByTestId("post-editor-title-input")).toHaveValue(
+      "Their edit",
+    );
+
+    // Sanity: the first save attempt did go out with the stale token, and the
+    // conflict path didn't re-send it.
+    expect(updateInputs).toHaveLength(1);
+    expect(
+      (updateInputs[0] as { expectedLiveUpdatedAt?: unknown })
+        .expectedLiveUpdatedAt,
+    ).toBeDefined();
+  });
 });
 
 test.describe("meta-box sidebar", () => {

--- a/packages/admin/e2e/content.spec.ts
+++ b/packages/admin/e2e/content.spec.ts
@@ -491,9 +491,9 @@ test.describe("/entries/$slug/$id/edit", () => {
     await expect(dialog).toBeVisible();
 
     await page.getByTestId("entry-editor-conflict-compare").click();
-    await expect(page.getByTestId("entry-editor-conflict-mine-title")).toHaveText(
-      "My edit",
-    );
+    await expect(
+      page.getByTestId("entry-editor-conflict-mine-title"),
+    ).toHaveText("My edit");
     await expect(
       page.getByTestId("entry-editor-conflict-theirs-title"),
     ).toHaveText("Their edit");

--- a/packages/admin/src/components/editor/entry-conflict-dialog.tsx
+++ b/packages/admin/src/components/editor/entry-conflict-dialog.tsx
@@ -53,8 +53,8 @@ export function EntryConflictDialog({
                 Someone else updated this {singularLabel}
               </AlertDialogTitle>
               <AlertDialogDescription>
-                Your version is out of date. Keep your changes, take the
-                latest, or compare side-by-side first.
+                Your version is out of date. Keep your changes, take the latest,
+                or compare side-by-side first.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter className="flex-col sm:flex-col">
@@ -149,7 +149,7 @@ function ComparePanel({
 }): ReactNode {
   return (
     <section className="flex flex-col gap-2">
-      <h3 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+      <h3 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
         {title}
       </h3>
       {values === null ? (

--- a/packages/admin/src/components/editor/entry-conflict-dialog.tsx
+++ b/packages/admin/src/components/editor/entry-conflict-dialog.tsx
@@ -1,0 +1,203 @@
+import type { PostEditorValues } from "@/components/editor/entry-editor-form.js";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog.js";
+import { Button } from "@/components/ui/button.js";
+
+import type { Entry } from "@plumix/core/schema";
+
+interface EntryConflictDialogProps {
+  readonly open: boolean;
+  readonly singularLabel: string;
+  readonly mine: PostEditorValues | null;
+  readonly theirs: Entry | null;
+  readonly onKeepMine: () => void;
+  readonly onTakeTheirs: () => void;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+export function EntryConflictDialog({
+  open,
+  singularLabel,
+  mine,
+  theirs,
+  onKeepMine,
+  onTakeTheirs,
+  onOpenChange,
+}: EntryConflictDialogProps): ReactNode {
+  const [showCompare, setShowCompare] = useState(false);
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setShowCompare(false);
+        onOpenChange(next);
+      }}
+    >
+      <AlertDialogContent
+        className={showCompare ? "max-w-3xl" : undefined}
+        data-testid="entry-editor-conflict-dialog"
+      >
+        {!showCompare ? (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                Someone else updated this {singularLabel}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                Your version is out of date. Keep your changes, take the
+                latest, or compare side-by-side first.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter className="flex-col gap-2 sm:flex-col sm:gap-2 sm:space-x-0">
+              <Button
+                data-testid="entry-editor-conflict-keep-mine"
+                onClick={onKeepMine}
+              >
+                Keep my changes
+              </Button>
+              <Button
+                data-testid="entry-editor-conflict-take-theirs"
+                variant="secondary"
+                onClick={onTakeTheirs}
+              >
+                Discard and reload
+              </Button>
+              <Button
+                data-testid="entry-editor-conflict-compare"
+                variant="ghost"
+                onClick={() => setShowCompare(true)}
+              >
+                Compare side-by-side
+              </Button>
+            </AlertDialogFooter>
+          </>
+        ) : (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                Compare your changes vs the live {singularLabel}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                Pick which version to keep.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="grid grid-cols-2 gap-4 py-2 text-sm">
+              <ComparePanel
+                title="Your changes"
+                testIdPrefix="entry-editor-conflict-mine"
+                values={mine}
+              />
+              <ComparePanel
+                title="Live version"
+                testIdPrefix="entry-editor-conflict-theirs"
+                values={theirs ? entryToCompareValues(theirs) : null}
+              />
+            </div>
+            <AlertDialogFooter>
+              <Button
+                variant="ghost"
+                onClick={() => setShowCompare(false)}
+                data-testid="entry-editor-conflict-back"
+              >
+                Back
+              </Button>
+              <Button
+                data-testid="entry-editor-conflict-keep-mine"
+                onClick={onKeepMine}
+              >
+                Keep mine
+              </Button>
+              <Button
+                data-testid="entry-editor-conflict-take-theirs"
+                variant="secondary"
+                onClick={onTakeTheirs}
+              >
+                Take theirs
+              </Button>
+            </AlertDialogFooter>
+          </>
+        )}
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+interface CompareValues {
+  readonly title: string;
+  readonly slug: string;
+  readonly status: string;
+  readonly excerpt: string;
+}
+
+function ComparePanel({
+  title,
+  testIdPrefix,
+  values,
+}: {
+  readonly title: string;
+  readonly testIdPrefix: string;
+  readonly values: CompareValues | null;
+}): ReactNode {
+  return (
+    <section className="flex flex-col gap-2">
+      <h3 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+        {title}
+      </h3>
+      {values === null ? (
+        <p className="text-muted-foreground italic">Loading…</p>
+      ) : (
+        <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1.5">
+          <CompareRow label="Title" testId={`${testIdPrefix}-title`}>
+            {values.title}
+          </CompareRow>
+          <CompareRow label="Slug" testId={`${testIdPrefix}-slug`}>
+            {values.slug}
+          </CompareRow>
+          <CompareRow label="Status" testId={`${testIdPrefix}-status`}>
+            {values.status}
+          </CompareRow>
+          <CompareRow label="Excerpt" testId={`${testIdPrefix}-excerpt`}>
+            {values.excerpt.length === 0 ? "—" : values.excerpt}
+          </CompareRow>
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function CompareRow({
+  label,
+  testId,
+  children,
+}: {
+  readonly label: string;
+  readonly testId: string;
+  readonly children: ReactNode;
+}): ReactNode {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="break-words" data-testid={testId}>
+        {children}
+      </dd>
+    </>
+  );
+}
+
+function entryToCompareValues(entry: Entry): CompareValues {
+  return {
+    title: entry.title,
+    slug: entry.slug,
+    status: entry.status,
+    excerpt: entry.excerpt ?? "",
+  };
+}

--- a/packages/admin/src/components/editor/entry-conflict-dialog.tsx
+++ b/packages/admin/src/components/editor/entry-conflict-dialog.tsx
@@ -57,7 +57,7 @@ export function EntryConflictDialog({
                 latest, or compare side-by-side first.
               </AlertDialogDescription>
             </AlertDialogHeader>
-            <AlertDialogFooter className="flex-col gap-2 sm:flex-col sm:gap-2 sm:space-x-0">
+            <AlertDialogFooter className="flex-col sm:flex-col">
               <Button
                 data-testid="entry-editor-conflict-keep-mine"
                 onClick={onKeepMine}

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -32,10 +32,8 @@ interface ConflictState {
   readonly theirs: Entry | null;
 }
 
-// Narrows an unknown thrown value to "the server rejected our save
-// because our expectedLiveUpdatedAt token was stale". oRPC's
-// `ORPCError.data` is typed `any`, so the helper does one cast in
-// one place rather than scattering narrowing logic at the call site.
+// oRPC types `ORPCError.data` as `any`, so the structural cast lives
+// in one place rather than at every call site.
 function isStaleConflictError(err: unknown): boolean {
   if (!(err instanceof ORPCError)) return false;
   if (err.code !== "CONFLICT") return false;

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -1,6 +1,7 @@
 import type { PostEditorValues } from "@/components/editor/entry-editor-form.js";
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { EntryConflictDialog } from "@/components/editor/entry-conflict-dialog.js";
 import {
   POST_EDITOR_STATUSES,
   PostEditorForm,
@@ -13,6 +14,7 @@ import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import { findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { filterTermsForEntryType } from "@/lib/terms.js";
+import { ORPCError } from "@orpc/client";
 import {
   useMutation,
   useQueryClient,
@@ -24,6 +26,22 @@ import * as v from "valibot";
 import type { EntryTypeManifestEntry } from "@plumix/core/manifest";
 import type { Entry } from "@plumix/core/schema";
 import { idPathParam } from "@plumix/core/validation";
+
+interface ConflictState {
+  readonly mine: PostEditorValues;
+  readonly theirs: Entry | null;
+}
+
+// Narrows an unknown thrown value to "the server rejected our save
+// because our expectedLiveUpdatedAt token was stale". oRPC's
+// `ORPCError.data` is typed `any`, so the helper does one cast in
+// one place rather than scattering narrowing logic at the call site.
+function isStaleConflictError(err: unknown): boolean {
+  if (!(err instanceof ORPCError)) return false;
+  if (err.code !== "CONFLICT") return false;
+  const data = err.data as { reason?: unknown };
+  return data.reason === "stale_expected_updated_at";
+}
 
 export const Route = createFileRoute("/_editor/entries/$slug/$id/edit")({
   // Reject invalid ids as a router 404 before `beforeLoad` / `loader`
@@ -86,6 +104,7 @@ function EditPostRoute(): ReactNode {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [serverError, setServerError] = useState<string | null>(null);
+  const [conflict, setConflict] = useState<ConflictState | null>(null);
 
   const { data: post } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id: entryId } }),
@@ -94,22 +113,30 @@ function EditPostRoute(): ReactNode {
   const isHierarchical = entryType.isHierarchical === true;
 
   const updatePost = useMutation({
-    mutationFn: (input: PostEditorValues) =>
+    mutationFn: ({
+      values,
+      expectedLiveUpdatedAt,
+    }: {
+      values: PostEditorValues;
+      expectedLiveUpdatedAt: Date | undefined;
+    }) =>
       orpc.entry.update.call({
         id: entryId,
-        title: input.title,
-        slug: input.slug,
-        content: input.content,
-        excerpt: input.excerpt.length > 0 ? input.excerpt : null,
-        status: input.status,
-        meta: input.meta,
-        terms: filterTermsForEntryType(input.terms, entryType.termTaxonomies),
-        ...(isHierarchical ? { parentId: input.parentId } : {}),
+        title: values.title,
+        slug: values.slug,
+        content: values.content,
+        excerpt: values.excerpt.length > 0 ? values.excerpt : null,
+        status: values.status,
+        meta: values.meta,
+        terms: filterTermsForEntryType(values.terms, entryType.termTaxonomies),
+        ...(isHierarchical ? { parentId: values.parentId } : {}),
+        ...(expectedLiveUpdatedAt ? { expectedLiveUpdatedAt } : {}),
       }),
     onMutate: () => {
       setServerError(null);
     },
     onSuccess: async () => {
+      setConflict(null);
       // List variants are scoped by `type` so sibling post types
       // don't needlessly refetch.
       await Promise.all([
@@ -122,10 +149,41 @@ function EditPostRoute(): ReactNode {
         }),
       ]);
     },
-    onError: (err) => {
+    onError: (err, variables) => {
+      if (isStaleConflictError(err)) {
+        setConflict({ mine: variables.values, theirs: null });
+        void queryClient
+          .fetchQuery(orpc.entry.get.queryOptions({ input: { id: entryId } }))
+          .then((fresh) => {
+            setConflict((prev) =>
+              prev === null ? prev : { ...prev, theirs: fresh },
+            );
+          })
+          .catch(() => {
+            // Best-effort: the dialog still works without "theirs"; the
+            // Compare panel renders a Loading state for the missing side.
+          });
+        return;
+      }
       setServerError(err instanceof Error ? err.message : "Couldn't save.");
     },
   });
+
+  function handleKeepMine(): void {
+    if (conflict === null) return;
+    updatePost.mutate({
+      values: conflict.mine,
+      expectedLiveUpdatedAt: undefined,
+    });
+  }
+
+  async function handleTakeTheirs(): Promise<void> {
+    setConflict(null);
+    await queryClient.invalidateQueries({
+      queryKey: orpc.entry.get.queryOptions({ input: { id: entryId } })
+        .queryKey,
+    });
+  }
 
   const singularLower = (
     entryType.labels?.singular ?? entryType.label
@@ -158,45 +216,63 @@ function EditPostRoute(): ReactNode {
   const initialValues: PostEditorValues = toEditorValues(post, entryType);
 
   return (
-    <PostEditorForm
-      // Key on `updatedAt` so a successful update (which bumps the
-      // server's updatedAt and triggers a refetch) remounts the form
-      // with fresh initial values — clears isDirty and re-arms the
-      // blocker cleanly. Switching entries (different id → different
-      // updatedAt) resets state the same way.
-      key={
-        post.updatedAt instanceof Date
-          ? post.updatedAt.toISOString()
-          : String(post.updatedAt)
-      }
-      initialValues={initialValues}
-      slugLocked
-      availableStatuses={POST_EDITOR_STATUSES}
-      supports={entryType.supports}
-      metaBoxes={metaBoxes}
-      taxonomies={taxonomies}
-      isHierarchical={isHierarchical}
-      parentOptions={parentOptions}
-      headline={`Edit ${singularLower}`}
-      submitLabel="Save"
-      // For the edit path, the post-save remount (keyed on
-      // `updatedAt`) resets the form's isDirty to false — so the
-      // blocker naturally stops prompting once the mutation settles.
-      // No need to carry `isSuccess` across, unlike the new-post
-      // route which has a navigation to bridge.
-      isSubmitting={updatePost.isPending}
-      serverError={updatePost.isPending ? null : serverError}
-      onSubmit={(values) => {
-        updatePost.mutate(values);
-      }}
-      onCancel={() => {
-        void navigate({
-          to: "/entries/$slug",
-          params: { slug },
-          search: ENTRIES_LIST_DEFAULT_SEARCH,
-        });
-      }}
-    />
+    <>
+      <PostEditorForm
+        // Key on `updatedAt` so a successful update (which bumps the
+        // server's updatedAt and triggers a refetch) remounts the form
+        // with fresh initial values — clears isDirty and re-arms the
+        // blocker cleanly. Switching entries (different id → different
+        // updatedAt) resets state the same way.
+        key={
+          post.updatedAt instanceof Date
+            ? post.updatedAt.toISOString()
+            : String(post.updatedAt)
+        }
+        initialValues={initialValues}
+        slugLocked
+        availableStatuses={POST_EDITOR_STATUSES}
+        supports={entryType.supports}
+        metaBoxes={metaBoxes}
+        taxonomies={taxonomies}
+        isHierarchical={isHierarchical}
+        parentOptions={parentOptions}
+        headline={`Edit ${singularLower}`}
+        submitLabel="Save"
+        // For the edit path, the post-save remount (keyed on
+        // `updatedAt`) resets the form's isDirty to false — so the
+        // blocker naturally stops prompting once the mutation settles.
+        // No need to carry `isSuccess` across, unlike the new-post
+        // route which has a navigation to bridge.
+        isSubmitting={updatePost.isPending}
+        serverError={updatePost.isPending ? null : serverError}
+        onSubmit={(values) => {
+          updatePost.mutate({
+            values,
+            expectedLiveUpdatedAt: post.updatedAt,
+          });
+        }}
+        onCancel={() => {
+          void navigate({
+            to: "/entries/$slug",
+            params: { slug },
+            search: ENTRIES_LIST_DEFAULT_SEARCH,
+          });
+        }}
+      />
+      <EntryConflictDialog
+        open={conflict !== null}
+        singularLabel={singularLower}
+        mine={conflict?.mine ?? null}
+        theirs={conflict?.theirs ?? null}
+        onKeepMine={handleKeepMine}
+        onTakeTheirs={() => {
+          void handleTakeTheirs();
+        }}
+        onOpenChange={(open) => {
+          if (!open) setConflict(null);
+        }}
+      />
+    </>
   );
 }
 

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -150,8 +150,12 @@ function EditPostRoute(): ReactNode {
     onError: (err, variables) => {
       if (isStaleConflictError(err)) {
         setConflict({ mine: variables.values, theirs: null });
-        void queryClient
-          .fetchQuery(orpc.entry.get.queryOptions({ input: { id: entryId } }))
+        // Raw client bypasses the React Query cache so the fresh server
+        // state shows up in the Compare panel — `fetchQuery` would
+        // dedupe against the suspense query that loaded the entry on
+        // mount and return the same `post` we already have in memory.
+        void orpc.entry.get
+          .call({ id: entryId })
           .then((fresh) => {
             setConflict((prev) =>
               prev === null ? prev : { ...prev, theirs: fresh },

--- a/packages/core/src/rpc/procedures/entry/concurrency.test.ts
+++ b/packages/core/src/rpc/procedures/entry/concurrency.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { assertExpectedLiveUpdatedAt } from "./concurrency.js";
+
+describe("assertExpectedLiveUpdatedAt", () => {
+  test("undefined expected token is a no-op (legacy callers)", () => {
+    const stale = vi.fn(() => {
+      throw new Error("should not be called");
+    });
+    expect(() =>
+      assertExpectedLiveUpdatedAt(undefined, new Date(), { stale }),
+    ).not.toThrow();
+    expect(stale).not.toHaveBeenCalled();
+  });
+
+  test("matching timestamps are a no-op even when Date identity differs", () => {
+    const t = new Date("2026-01-01T12:00:00Z");
+    const stale = vi.fn(() => {
+      throw new Error("should not be called");
+    });
+    expect(() =>
+      assertExpectedLiveUpdatedAt(t, new Date(t.getTime()), { stale }),
+    ).not.toThrow();
+    expect(stale).not.toHaveBeenCalled();
+  });
+
+  test("mismatched timestamps invoke the stale guard", () => {
+    const expected = new Date("2026-01-01T12:00:00Z");
+    const current = new Date("2026-01-01T12:00:01Z");
+    const stale = vi.fn(() => {
+      throw new Error("CONFLICT");
+    });
+    expect(() =>
+      assertExpectedLiveUpdatedAt(expected, current, { stale }),
+    ).toThrow("CONFLICT");
+    expect(stale).toHaveBeenCalledTimes(1);
+  });
+
+  test("one-millisecond difference is a mismatch", () => {
+    const expected = new Date(1_700_000_000_000);
+    const current = new Date(1_700_000_000_001);
+    const stale = vi.fn(() => {
+      throw new Error("CONFLICT");
+    });
+    expect(() =>
+      assertExpectedLiveUpdatedAt(expected, current, { stale }),
+    ).toThrow("CONFLICT");
+    expect(stale).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/concurrency.ts
+++ b/packages/core/src/rpc/procedures/entry/concurrency.ts
@@ -1,12 +1,9 @@
-// Optimistic-concurrency guard for live-row writes. Compares the
-// caller's loaded `updatedAt` token against the server's current
-// `updatedAt`; if they disagree, another write landed in between and
-// the caller should resolve before clobbering.
-//
-// Pure value comparison — no oRPC, no DB. Callers wire the staleness
-// signal to whatever surface they expose (typed RPC CONFLICT here;
-// future callers may surface as something else). Matches the
-// guards-as-callbacks style used elsewhere in `update.ts`.
+// Optimistic-concurrency guard for live-row writes. Compares the caller's
+// loaded `updatedAt` token against the server's current `updatedAt`; on
+// disagreement another write landed first and the caller should resolve.
+// Point-in-time check, not transactional — concurrent writes between this
+// call and the eventual UPDATE can still slip through; tighten via a
+// `WHERE id = ? AND updatedAt = ?` clause if that window matters.
 export function assertExpectedLiveUpdatedAt(
   expected: Date | undefined,
   current: Date,

--- a/packages/core/src/rpc/procedures/entry/concurrency.ts
+++ b/packages/core/src/rpc/procedures/entry/concurrency.ts
@@ -1,0 +1,17 @@
+// Optimistic-concurrency guard for live-row writes. Compares the
+// caller's loaded `updatedAt` token against the server's current
+// `updatedAt`; if they disagree, another write landed in between and
+// the caller should resolve before clobbering.
+//
+// Pure value comparison — no oRPC, no DB. Callers wire the staleness
+// signal to whatever surface they expose (typed RPC CONFLICT here;
+// future callers may surface as something else). Matches the
+// guards-as-callbacks style used elsewhere in `update.ts`.
+export function assertExpectedLiveUpdatedAt(
+  expected: Date | undefined,
+  current: Date,
+  guards: { readonly stale: () => never },
+): void {
+  if (expected === undefined) return;
+  if (expected.getTime() !== current.getTime()) guards.stale();
+}

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -94,6 +94,13 @@ export const entryUpdateInputSchema = v.object({
   sortOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
   terms: v.optional(postTermsSchema),
   meta: v.optional(entryMetaInputSchema),
+  /**
+   * Optimistic-concurrency token: the live entry's `updatedAt` at the
+   * moment the caller loaded it. When provided, the server rejects
+   * with `CONFLICT { reason: "stale_expected_updated_at" }` if another
+   * write landed in between. Absent ⇒ legacy last-write-wins.
+   */
+  expectedLiveUpdatedAt: v.optional(v.date()),
 });
 
 // Upper bound on the term-slug list per termTaxonomy clause. Mirrors the

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -441,4 +441,87 @@ describe("entry.update", () => {
       _derived: "always-there",
     });
   });
+
+  describe("optimistic concurrency (expectedLiveUpdatedAt)", () => {
+    test("matching token: update succeeds", async () => {
+      const h = await createRpcHarness({ authAs: "author" });
+      const own = await h.factory.draft.create({
+        authorId: h.user.id,
+        slug: "oc-match",
+      });
+      const loaded = await h.client.entry.get({ id: own.id });
+      const updated = await h.client.entry.update({
+        id: own.id,
+        title: "renamed",
+        expectedLiveUpdatedAt: loaded.updatedAt,
+      });
+      expect(updated.title).toBe("renamed");
+    });
+
+    test("stale token: rejects with CONFLICT { stale_expected_updated_at }", async () => {
+      const h = await createRpcHarness({ authAs: "author" });
+      const own = await h.factory.draft.create({
+        authorId: h.user.id,
+        slug: "oc-stale",
+      });
+      await expect(
+        h.client.entry.update({
+          id: own.id,
+          title: "lost-race",
+          expectedLiveUpdatedAt: new Date("2020-01-01T00:00:00Z"),
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        data: { reason: "stale_expected_updated_at" },
+      });
+    });
+
+    test("absent token: preserves legacy last-write-wins behavior", async () => {
+      const h = await createRpcHarness({ authAs: "author" });
+      const own = await h.factory.draft.create({
+        authorId: h.user.id,
+        slug: "oc-legacy",
+      });
+      const updated = await h.client.entry.update({
+        id: own.id,
+        title: "no-token",
+      });
+      expect(updated.title).toBe("no-token");
+    });
+
+    test("stale token + empty patch: still CONFLICT (no short-circuit bypass)", async () => {
+      const h = await createRpcHarness({ authAs: "author" });
+      const own = await h.factory.draft.create({
+        authorId: h.user.id,
+        slug: "oc-empty",
+      });
+      await expect(
+        h.client.entry.update({
+          id: own.id,
+          expectedLiveUpdatedAt: new Date("2020-01-01T00:00:00Z"),
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        data: { reason: "stale_expected_updated_at" },
+      });
+    });
+
+    test("unauthorised caller with stale token still gets FORBIDDEN (no CONFLICT oracle)", async () => {
+      const h = await createRpcHarness({ authAs: "subscriber" });
+      const own = await h.factory.draft.create({
+        authorId: h.user.id,
+        slug: "oc-no-oracle",
+      });
+      await expect(
+        h.client.entry.update({
+          id: own.id,
+          title: "x",
+          expectedLiveUpdatedAt: new Date("2020-01-01T00:00:00Z"),
+        }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        data: { capability: "entry:post:edit_any" },
+      });
+    });
+  });
 });

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -5,8 +5,8 @@ import { entries } from "../../../db/schema/entries.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { isEmptyMetaPatch } from "../../meta/core.js";
-import { assertContentWithinByteCap } from "./content.js";
 import { assertExpectedLiveUpdatedAt } from "./concurrency.js";
+import { assertContentWithinByteCap } from "./content.js";
 import { stripUndefined } from "./helpers.js";
 import {
   applyEntryBeforeSave,

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -6,6 +6,7 @@ import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { isEmptyMetaPatch } from "../../meta/core.js";
 import { assertContentWithinByteCap } from "./content.js";
+import { assertExpectedLiveUpdatedAt } from "./concurrency.js";
 import { stripUndefined } from "./helpers.js";
 import {
   applyEntryBeforeSave,
@@ -153,6 +154,20 @@ export const update = base
     };
     assertCanEditEntry(context, existing, accessGuards);
 
+    // Optimistic-concurrency check sits after auth so an unauthorised
+    // caller with a stale token still gets FORBIDDEN, not CONFLICT.
+    assertExpectedLiveUpdatedAt(
+      filtered.expectedLiveUpdatedAt,
+      existing.updatedAt,
+      {
+        stale: () => {
+          throw errors.CONFLICT({
+            data: { reason: "stale_expected_updated_at" },
+          });
+        },
+      },
+    );
+
     const isPublishTransition =
       filtered.status === "published" && existing.status !== "published";
     if (isPublishTransition) {
@@ -175,13 +190,14 @@ export const update = base
       );
     }
 
-    // `terms` and `meta` aren't entries.* columns — split them out and
-    // validate up front so a bad taxonomy/cap/meta key fails fast,
-    // before any write happens.
+    // `terms`, `meta`, and `expectedLiveUpdatedAt` aren't entries.* columns
+    // — split them out and validate up front so a bad taxonomy/cap/meta key
+    // fails fast, before any write happens.
     const {
       id: _id,
       terms: termsPatch,
       meta: metaInput,
+      expectedLiveUpdatedAt: _expectedLiveUpdatedAt,
       ...changes
     } = filtered;
     const metaPatch = sanitizeMetaForRpc(


### PR DESCRIPTION
Adds an opt-in optimistic-concurrency token so live-row writes can detect silent overwrites and surface a resolve-or-clobber dialog instead of last-write-wins. The token is `entries.updatedAt` at the moment the caller loaded the row, echoed back on `entry.update`. The server compares it to the current row's `updatedAt` after auth and throws a typed `CONFLICT { reason: "stale_expected_updated_at" }` on mismatch. Absent token preserves today's exact behavior.

This slice ships standalone value before any drafts/revisions infrastructure exists (parent PRD #285): even entry types that never opt into drafts (e.g. menu items today) now get a safety net on concurrent edits.

**Server**

`packages/core/src/rpc/procedures/entry/concurrency.ts` is a new pure `assertExpectedLiveUpdatedAt(expected, current, { stale })` guard that matches the guards-as-callbacks style used elsewhere in `update.ts`. Tested directly without oRPC/DB coupling. `entryUpdateInputSchema` gains optional `expectedLiveUpdatedAt: v.date()`; the handler runs the guard after `assertCanEditEntry` so an unauthorised caller with a stale token still gets `FORBIDDEN`, not `CONFLICT` (no oracle). On staleness, the guard's callback throws the procedure's typed `CONFLICT` with the existing `data: { reason }` shape so callers can distinguish it from `slug_taken` / `parent_cycle` / `update_failed`.

**Admin**

The editor route at `_editor/entries/$slug/$id/edit.tsx` passes `expectedLiveUpdatedAt: post.updatedAt` on every save and detects the typed CONFLICT via a small `isStaleConflictError(err)` helper. New `EntryConflictDialog` surfaces three actions: **Keep my changes** (re-submits without the token, last-write-wins), **Discard and reload** (invalidates the query, form remounts on the fresh server values), **Compare side-by-side** (flips to a two-column panel showing title/slug/status/excerpt for both my edits and the live version re-fetched on conflict). All selectors via `data-testid`.

**Typed-error narrowing**

oRPC's `ORPCError.data` types as `any` without a generic, so the helper does one cast in one place rather than scattering structural narrowing at the call site. The alternative path — migrating the mutation to `orpc.entry.update.mutationOptions({...})` to thread a typed `TError` through `useMutation` — would require reshaping the custom `{values, expectedLiveUpdatedAt}` call wrapper and isn't done by other admin call sites. Happy to migrate if reviewers prefer the stricter contract.

**Tests**

- 4 unit tests for the guard module — matching token, undefined token, mismatched timestamps, 1ms mismatch.
- 5 integration tests through the RPC harness — matching token → success; stale token → `CONFLICT`; absent token → legacy pass-through; stale + empty patch → still `CONFLICT` (no short-circuit bypass); unauthorised caller with stale token → `FORBIDDEN` (no `CONFLICT` oracle).
- 1 Playwright e2e — stale-token save raises the dialog, Compare panels show both sides, Take theirs closes the dialog and remounts the form with the live version.

**Limitation**

`entries.updatedAt` is stamped via SQLite `unixepoch()` (second-granularity). Two writes within the same second can produce identical tokens and miss the guard. The PRD's design uses `updatedAt` as the token and accepts this granularity for the 0.1.x slice; tightening to ms-precision is out of scope here.

**Verification**

`pnpm exec turbo run lint typecheck test --filter @plumix/core --filter @plumix/admin` — 8/8 tasks green, 1439/1439 core tests pass, admin tests pass. `pnpm boundaries` — clean (1596 modules, 0 violations). `pnpm knip` — clean for this PR's files.

Closes #287.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>