### PR TITLE
feat(runtime-cloudflare): explicit workerd inspector port

### DIFF
--- a/packages/core/src/test/playwright/playwright-config.test.ts
+++ b/packages/core/src/test/playwright/playwright-config.test.ts
@@ -97,6 +97,16 @@ describe("definePlumixE2EConfig", () => {
     );
   });
 
+  test("rejects inspectorPort paired with a custom webServerCommand", () => {
+    expect(() =>
+      definePlumixE2EConfig({
+        port: 3040,
+        inspectorPort: 9340,
+        webServerCommand: "custom",
+      }),
+    ).toThrow(/inspectorPort.*webServerCommand/i);
+  });
+
   test("webServer readiness defaults to URL-based polling against baseURL", () => {
     const config = definePlumixE2EConfig({
       port: 3040,
@@ -122,5 +132,32 @@ describe("definePlumixE2EConfig", () => {
         ? config.webServer.port
         : undefined;
     expect(port).toBe(3040);
+  });
+
+  test("inspectorPort threads through as --inspector-port on plumix dev", () => {
+    const config = definePlumixE2EConfig({
+      port: 3020,
+      inspectorPort: 9320,
+      playground: "../playground",
+    });
+
+    const cmd =
+      config.webServer && "command" in config.webServer
+        ? config.webServer.command
+        : "";
+    expect(cmd).toContain("plumix dev --port 3020 --inspector-port 9320");
+  });
+
+  test("inspectorPort omitted leaves the dev command flag-free (auto-allocation default)", () => {
+    const config = definePlumixE2EConfig({
+      port: 3020,
+      playground: "../playground",
+    });
+
+    const cmd =
+      config.webServer && "command" in config.webServer
+        ? config.webServer.command
+        : "";
+    expect(cmd).not.toContain("--inspector-port");
   });
 });

--- a/packages/core/src/test/playwright/playwright-config.ts
+++ b/packages/core/src/test/playwright/playwright-config.ts
@@ -12,6 +12,15 @@ export interface PlumixE2EConfigOptions {
    */
   readonly port?: number;
   /**
+   * Explicit workerd inspector port baked into `plumix dev
+   * --inspector-port <port>`. `@cloudflare/vite-plugin` otherwise
+   * auto-allocates from 9229 upward, which collides when multiple
+   * worker-driven e2e suites boot in parallel under turbo. Suites
+   * should pick distinct ports (convention: mirror the HTTP port —
+   * 3010 ↔ 9310, 3020 ↔ 9320, …). Ignored when `playground` is unset.
+   */
+  readonly inspectorPort?: number;
+  /**
    * Optional path to a playground workspace (relative to the playwright
    * config file). When set, `definePlumixE2EConfig` bakes the standard
    * worker-driven webServer setup: wipe `.wrangler/state` → apply D1
@@ -65,6 +74,7 @@ const DEFAULT_PORT = 5173;
 function bakePlaygroundCommand(
   playground: string,
   port: number,
+  inspectorPort: number | undefined,
   extraSetup: string | undefined,
 ): string {
   const steps = [
@@ -74,7 +84,11 @@ function bakePlaygroundCommand(
     `pnpm exec wrangler d1 migrations apply ${DEFAULT_BINDING} --local`,
   ];
   if (extraSetup) steps.push(extraSetup);
-  steps.push(`pnpm exec plumix dev --port ${String(port)}`);
+  const devFlags = [`--port ${String(port)}`];
+  if (inspectorPort !== undefined) {
+    devFlags.push(`--inspector-port ${String(inspectorPort)}`);
+  }
+  steps.push(`pnpm exec plumix dev ${devFlags.join(" ")}`);
   return steps.join(" && ");
 }
 
@@ -113,6 +127,14 @@ export function definePlumixE2EConfig(
       "definePlumixE2EConfig: must provide either `playground` (worker-driven) or `webServerCommand` (custom).",
     );
   }
+  if (
+    options.inspectorPort !== undefined &&
+    options.webServerCommand !== undefined
+  ) {
+    throw new Error(
+      "definePlumixE2EConfig: `inspectorPort` only affects the baked `plumix dev` command and is incompatible with a custom `webServerCommand`.",
+    );
+  }
 
   const port = options.port ?? DEFAULT_PORT;
   const baseURL =
@@ -122,7 +144,12 @@ export function definePlumixE2EConfig(
   const webServerCommand =
     options.webServerCommand ??
     (options.playground !== undefined
-      ? bakePlaygroundCommand(options.playground, port, options.extraSetup)
+      ? bakePlaygroundCommand(
+          options.playground,
+          port,
+          options.inspectorPort,
+          options.extraSetup,
+        )
       : "");
 
   return defineConfig({

--- a/packages/plugins/audit-log/e2e/playwright.config.ts
+++ b/packages/plugins/audit-log/e2e/playwright.config.ts
@@ -1,8 +1,12 @@
 import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 export default definePlumixE2EConfig({
-  // Distinct per-plugin port so the suite can run in parallel with
-  // menu (3040) and media (3030) under turbo.
+  // Distinct per-plugin HTTP port + workerd inspector port so the
+  // suite can run in parallel with the other plugin playgrounds under
+  // turbo. Convention: HTTP 30N0 ↔ inspector 93N0 (3010↔9310,
+  // 3020↔9320, …). `@cloudflare/vite-plugin` otherwise auto-allocates
+  // inspector ports from 9229 upward and collides under parallelism.
   port: 3010,
+  inspectorPort: 9310,
   playground: "../playground",
 });

--- a/packages/plugins/blog/e2e/playwright.config.ts
+++ b/packages/plugins/blog/e2e/playwright.config.ts
@@ -1,8 +1,9 @@
 import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 export default definePlumixE2EConfig({
-  // Distinct per-plugin port so the suite can run in parallel with
-  // audit-log (3010), media (3030), and menu (3040) under turbo.
+  // See `packages/plugins/audit-log/e2e/playwright.config.ts` for why
+  // each playground assigns its own HTTP + inspector port.
   port: 3020,
+  inspectorPort: 9320,
   playground: "../playground",
 });

--- a/packages/plugins/media/e2e/playwright.config.ts
+++ b/packages/plugins/media/e2e/playwright.config.ts
@@ -1,8 +1,9 @@
 import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 export default definePlumixE2EConfig({
-  // Distinct per-plugin port so the suite can run in parallel with
-  // menu (3040) and audit-log (3010) under turbo.
+  // See `packages/plugins/audit-log/e2e/playwright.config.ts` for why
+  // each playground assigns its own HTTP + inspector port.
   port: 3030,
+  inspectorPort: 9330,
   playground: "../playground",
 });

--- a/packages/plugins/menu/e2e/playwright.config.ts
+++ b/packages/plugins/menu/e2e/playwright.config.ts
@@ -1,8 +1,9 @@
 import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 export default definePlumixE2EConfig({
-  // Distinct per-plugin port so the suite can run in parallel with
-  // media (3030) and audit-log (3010) under turbo.
+  // See `packages/plugins/audit-log/e2e/playwright.config.ts` for why
+  // each playground assigns its own HTTP + inspector port.
   port: 3040,
+  inspectorPort: 9340,
   playground: "../playground",
 });

--- a/packages/plugins/pages/e2e/playwright.config.ts
+++ b/packages/plugins/pages/e2e/playwright.config.ts
@@ -1,9 +1,9 @@
 import { definePlumixE2EConfig } from "plumix/test/playwright";
 
 export default definePlumixE2EConfig({
-  // Distinct per-plugin port so the suite can run in parallel with
-  // audit-log (3010), blog (3020), media (3030), and menu (3040)
-  // under turbo.
+  // See `packages/plugins/audit-log/e2e/playwright.config.ts` for why
+  // each playground assigns its own HTTP + inspector port.
   port: 3050,
+  inspectorPort: 9350,
   playground: "../playground",
 });

--- a/packages/runtimes/cloudflare/src/commands/dev.test.ts
+++ b/packages/runtimes/cloudflare/src/commands/dev.test.ts
@@ -28,4 +28,38 @@ describe("parseDevArgs", () => {
   test("throws when --port has no value following it", () => {
     expect(() => parseDevArgs(["--port"])).toThrow(/--port.*requires a value/i);
   });
+
+  test("extracts --inspector-port followed by a numeric value", () => {
+    expect(parseDevArgs(["--inspector-port", "9320"])).toEqual({
+      inspectorPort: 9320,
+    });
+  });
+
+  test("accepts the --inspector-port=N equals form", () => {
+    expect(parseDevArgs(["--inspector-port=9320"])).toEqual({
+      inspectorPort: 9320,
+    });
+  });
+
+  test("parses --port and --inspector-port together", () => {
+    expect(
+      parseDevArgs(["--port", "3020", "--inspector-port", "9320"]),
+    ).toEqual({ port: 3020, inspectorPort: 9320 });
+    // Reverse order should also work.
+    expect(
+      parseDevArgs(["--inspector-port", "9320", "--port", "3020"]),
+    ).toEqual({ port: 3020, inspectorPort: 9320 });
+  });
+
+  test("throws on a non-numeric --inspector-port value", () => {
+    expect(() => parseDevArgs(["--inspector-port", "abc"])).toThrow(
+      /--inspector-port.*must be a number/i,
+    );
+  });
+
+  test("throws when --inspector-port has no value following it", () => {
+    expect(() => parseDevArgs(["--inspector-port"])).toThrow(
+      /--inspector-port.*requires a value/i,
+    );
+  });
 });

--- a/packages/runtimes/cloudflare/src/commands/dev.ts
+++ b/packages/runtimes/cloudflare/src/commands/dev.ts
@@ -4,9 +4,11 @@ import { createCloudflareVite } from "./vite.js";
 
 interface DevArgs {
   readonly port?: number;
+  readonly inspectorPort?: number;
 }
 
 export function parseDevArgs(argv: readonly string[]): DevArgs {
+  const args: { port?: number; inspectorPort?: number } = {};
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
     if (token === "--port") {
@@ -17,32 +19,57 @@ export function parseDevArgs(argv: readonly string[]): DevArgs {
           "plumix dev: --port requires a value (e.g. --port 3030)",
         );
       }
-      return { port: parsePort(raw) };
+      args.port = parsePort("--port", raw);
+      i += 1;
+      continue;
     }
     if (token?.startsWith("--port=")) {
-      return { port: parsePort(token.slice("--port=".length)) };
+      args.port = parsePort("--port", token.slice("--port=".length));
+      continue;
+    }
+    if (token === "--inspector-port") {
+      const raw = argv[i + 1];
+      if (raw === undefined) {
+        // eslint-disable-next-line no-restricted-syntax -- DevCommandError factory to land in a follow-up CLI-errors slice
+        throw new Error(
+          "plumix dev: --inspector-port requires a value (e.g. --inspector-port 9320)",
+        );
+      }
+      args.inspectorPort = parsePort("--inspector-port", raw);
+      i += 1;
+      continue;
+    }
+    if (token?.startsWith("--inspector-port=")) {
+      args.inspectorPort = parsePort(
+        "--inspector-port",
+        token.slice("--inspector-port=".length),
+      );
+      continue;
     }
   }
-  return {};
+  return args;
 }
 
-function parsePort(raw: string): number {
+function parsePort(flag: string, raw: string): number {
   const port = Number(raw);
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     // eslint-disable-next-line no-restricted-syntax -- DevCommandError factory to land in a follow-up CLI-errors slice
     throw new Error(
-      `plumix dev: --port value "${raw}" must be a number between 1 and 65535`,
+      `plumix dev: ${flag} value "${raw}" must be a number between 1 and 65535`,
     );
   }
   return port;
 }
 
 export const devCommand: CommandDefinition = {
-  describe: "Start the Workers dev server (vite + @cloudflare/vite-plugin)",
+  describe:
+    "Start the Workers dev server (vite + @cloudflare/vite-plugin). Accepts --port and --inspector-port.",
   async run(ctx) {
-    const { port } = parseDevArgs(ctx.argv);
+    const { port, inspectorPort } = parseDevArgs(ctx.argv);
     const vite = await import("vite");
-    const { plugins, root } = await createCloudflareVite(ctx);
+    const { plugins, root } = await createCloudflareVite(ctx, {
+      inspectorPort,
+    });
 
     // `strictPort: true` when --port is explicit: e2e harnesses point
     // playwright at the requested port and need a fail-fast if it's

--- a/packages/runtimes/cloudflare/src/commands/vite.ts
+++ b/packages/runtimes/cloudflare/src/commands/vite.ts
@@ -3,6 +3,14 @@ import type { Plugin } from "vite";
 
 export async function createCloudflareVite(
   ctx: CommandContext,
+  options: {
+    /**
+     * Explicit workerd inspector port. When omitted, `@cloudflare/vite-plugin`
+     * auto-allocates from 9229 upward, which collides when multiple worker-
+     * driven e2e suites boot in parallel under turbo.
+     */
+    readonly inspectorPort?: number;
+  } = {},
 ): Promise<{ plugins: Plugin[]; root: string }> {
   const { emitPlumixSources, plumix } = await import("plumix/vite");
   const { cloudflare } = await import("@cloudflare/vite-plugin");
@@ -11,7 +19,11 @@ export async function createCloudflareVite(
   // wrangler.jsonc validation finds the `main` file.
   await emitPlumixSources(ctx.cwd, ctx.configPath);
 
-  const cfResult = cloudflare() as unknown;
+  const cfResult = cloudflare(
+    options.inspectorPort !== undefined
+      ? { inspectorPort: options.inspectorPort }
+      : undefined,
+  ) as unknown;
   const plugins: Plugin[] = [plumix({ configFile: ctx.configPath })];
   if (Array.isArray(cfResult)) {
     plugins.push(...(cfResult as Plugin[]));


### PR DESCRIPTION
Threads `--inspector-port` end-to-end so workerd's debugger port doesn't collide when multiple worker-driven plugin e2e suites boot in parallel under turbo. `@cloudflare/vite-plugin` otherwise auto-allocates from 9229 upward; concurrent suites race and one loses with `EADDRINUSE 127.0.0.1:9231` (seen on PR #299's plugin-menu run). Refs the e2e-flake context surfaced while shipping #287.

**plumix dev CLI**

`parseDevArgs` walks the full argv now instead of early-returning on the first match, and handles `--inspector-port N` / `--inspector-port=N` alongside the existing `--port`. `createCloudflareVite` accepts an optional `inspectorPort` and forwards to `cloudflare({inspectorPort})`. Backwards-compatible — omitting the flag preserves the original `cloudflare()` call. Five new unit tests cover the parsing paths.

**E2E harness**

`PlumixE2EConfigOptions.inspectorPort?: number`; `bakePlaygroundCommand` appends `--inspector-port` when set. New mutual-exclusivity guard rejects pairing `inspectorPort` with a custom `webServerCommand` (since `inspectorPort` only affects the baked playground path). Three new tests cover the thread-through, the omission default, and the guard.

**Per-playground port assignments**

Mirror the existing HTTP scheme (30N0 ↔ 93N0):

| Plugin    | HTTP | Inspector |
|-----------|------|-----------|
| audit-log | 3010 | 9310      |
| blog      | 3020 | 9320      |
| media     | 3030 | 9330      |
| menu      | 3040 | 9340      |
| pages     | 3050 | 9350      |

The 4 non-anchor configs reference audit-log's anchor comment for the rationale instead of duplicating it five times.

**Scope**

Eliminates one class of e2e flake — concurrent inspector-port collisions on parallel worker boots — not all of them. The blog publish-test mystery and other test-state-leak categories remain in scope for follow-up PRs.

**Verification**

- `pnpm exec turbo run lint typecheck test format --filter @plumix/core --filter @plumix/runtime-cloudflare` — 12/12 tasks green
- `pnpm boundaries` — clean (1596 modules)
- `pnpm knip` — clean for this PR's files

Refs #287.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>