### PR TITLE
feat(blocks): introduce blocks system foundation

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -38,11 +38,6 @@ const config: KnipConfig = {
     "packages/plugins/pages/playground": {
       entry: ["plumix.config.ts"],
     },
-    // @plumix/core is a dependency but has no real imports yet (empty skeleton).
-    // Remove these once packages have actual code importing from core.
-    "packages/blocks": {
-      ignoreDependencies: ["@plumix/core"],
-    },
     // - drizzle-kit is invoked by consumers as a CLI hint, not imported.
     // - @plumix/admin is consumed via filesystem copy (scripts/copy-admin.mjs)
     //   at build time, not as a TypeScript import.
@@ -69,6 +64,7 @@ const config: KnipConfig = {
         // path is a static import knip can follow.
         "src/admin/theme.css",
         "src/blocks/index.ts",
+        "src/blocks/test.ts",
         "src/cli/index.ts",
         "src/fields/index.ts",
         "src/i18n/index.ts",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -7,25 +7,45 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./src/index.ts"
+    },
+    "./test": {
+      "types": "./dist/test/index.d.ts",
+      "default": "./src/test/index.ts"
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@plumix/core": "workspace:*"
+    "@plumix/core": "workspace:*",
+    "@tiptap/core": "^3.23.1"
+  },
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
+    "@plumix/vitest-config": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
+    "jsdom": "^29.1.1",
     "prettier": "catalog:",
-    "typescript": "catalog:"
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "prettier": "@plumix/prettier-config"
 }

--- a/packages/blocks/src/core-blocks.ts
+++ b/packages/blocks/src/core-blocks.ts
@@ -1,0 +1,13 @@
+import type { BlockSpec } from "./types.js";
+import { paragraphBlock } from "./paragraph/index.js";
+
+/**
+ * The canonical list of blocks shipped by `@plumix/blocks`.
+ *
+ * `buildApp` imports this and seeds the registry — the user's config
+ * does not list core blocks because they are always present. To opt
+ * out of a core block on a specific field, narrow the per-field
+ * allowlist; the spec itself stays registered so existing content
+ * continues to round-trip losslessly.
+ */
+export const coreBlocks: readonly BlockSpec[] = Object.freeze([paragraphBlock]);

--- a/packages/blocks/src/define-block.test.ts
+++ b/packages/blocks/src/define-block.test.ts
@@ -1,0 +1,100 @@
+import { Node as TiptapNode } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import { defineBlock } from "./define-block.js";
+import { BlockRegistrationError } from "./errors.js";
+
+const PARAGRAPH_SCHEMA = () =>
+  Promise.resolve(
+    TiptapNode.create({
+      name: "core/paragraph",
+      group: "block",
+      content: "inline*",
+    }),
+  );
+
+const PARAGRAPH_COMPONENT = () =>
+  Promise.resolve(({ children }: { children: unknown }) => children as never);
+
+describe("defineBlock", () => {
+  test("returns a frozen spec on a valid input", () => {
+    const spec = defineBlock({
+      name: "core/paragraph",
+      title: "Paragraph",
+      schema: PARAGRAPH_SCHEMA,
+      component: PARAGRAPH_COMPONENT,
+    });
+
+    expect(spec.name).toBe("core/paragraph");
+    expect(spec.title).toBe("Paragraph");
+    expect(Object.isFrozen(spec)).toBe(true);
+  });
+
+  test("rejects empty name", () => {
+    expect(() =>
+      defineBlock({
+        name: "",
+        title: "Invalid",
+        schema: PARAGRAPH_SCHEMA,
+        component: PARAGRAPH_COMPONENT,
+      }),
+    ).toThrow(BlockRegistrationError);
+  });
+
+  test("rejects name without namespace separator", () => {
+    expect(() =>
+      defineBlock({
+        name: "paragraph",
+        title: "Invalid",
+        schema: PARAGRAPH_SCHEMA,
+        component: PARAGRAPH_COMPONENT,
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_name_pattern" }));
+  });
+
+  test("rejects name with uppercase characters", () => {
+    expect(() =>
+      defineBlock({
+        name: "core/Paragraph",
+        title: "Invalid",
+        schema: PARAGRAPH_SCHEMA,
+        component: PARAGRAPH_COMPONENT,
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_name_pattern" }));
+  });
+
+  test("rejects namespace starting with a digit", () => {
+    expect(() =>
+      defineBlock({
+        name: "1core/paragraph",
+        title: "Invalid",
+        schema: PARAGRAPH_SCHEMA,
+        component: PARAGRAPH_COMPONENT,
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_name_pattern" }));
+  });
+
+  test("accepts a name with hyphens in both segments", () => {
+    const spec = defineBlock({
+      name: "media-extra/full-bleed-image",
+      title: "Full bleed image",
+      schema: PARAGRAPH_SCHEMA,
+      component: PARAGRAPH_COMPONENT,
+    });
+    expect(spec.name).toBe("media-extra/full-bleed-image");
+  });
+
+  test("freezes attribute schemas as well", () => {
+    const spec = defineBlock({
+      name: "core/paragraph",
+      title: "Paragraph",
+      attributes: {
+        align: { type: "select", default: "left" },
+      },
+      schema: PARAGRAPH_SCHEMA,
+      component: PARAGRAPH_COMPONENT,
+    });
+    expect(Object.isFrozen(spec.attributes)).toBe(true);
+    expect(Object.isFrozen(spec.attributes?.align)).toBe(true);
+  });
+});

--- a/packages/blocks/src/define-block.ts
+++ b/packages/blocks/src/define-block.ts
@@ -1,0 +1,63 @@
+import type { BlockAttributeSchema, BlockSpec } from "./types.js";
+import { BlockRegistrationError } from "./errors.js";
+
+const BLOCK_NAME_PATTERN = /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/;
+
+/**
+ * Validates a block spec at registration time and returns a frozen copy.
+ *
+ * Validation is strict at the boundary — invalid specs throw
+ * `BlockRegistrationError` with a discriminated `code` so the failure is
+ * actionable from a test or a CLI doctor command.
+ *
+ * Schema / name consistency between the spec and the underlying Tiptap
+ * node is checked lazily at registry-merge time (the spec's `schema`
+ * field is a `() => import(...)` ref; awaiting it here would force the
+ * admin-only schema module into the workers bundle).
+ */
+export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
+  spec: BlockSpec<Attrs>,
+): BlockSpec<Attrs> {
+  if (typeof spec.name !== "string" || spec.name.length === 0) {
+    throw BlockRegistrationError.invalidNamePattern({
+      name: String(spec.name),
+    });
+  }
+  if (!BLOCK_NAME_PATTERN.test(spec.name)) {
+    throw BlockRegistrationError.invalidNamePattern({ name: spec.name });
+  }
+
+  const attributes = spec.attributes
+    ? Object.freeze(
+        Object.fromEntries(
+          Object.entries(spec.attributes).map(([attrName, schema]) => [
+            attrName,
+            Object.freeze({ ...schema }) as BlockAttributeSchema,
+          ]),
+        ),
+      )
+    : undefined;
+
+  const keywords = spec.keywords
+    ? Object.freeze([...spec.keywords] as readonly string[])
+    : undefined;
+
+  const legacyAliases = spec.legacyAliases
+    ? Object.freeze([...spec.legacyAliases] as readonly string[])
+    : undefined;
+
+  return Object.freeze<BlockSpec<Attrs>>({
+    name: spec.name,
+    title: spec.title,
+    icon: spec.icon,
+    category: spec.category,
+    description: spec.description,
+    keywords,
+    attributes,
+    schema: spec.schema,
+    component: spec.component,
+    editor: spec.editor,
+    client: spec.client,
+    legacyAliases,
+  });
+}

--- a/packages/blocks/src/errors.test.ts
+++ b/packages/blocks/src/errors.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+
+import { BlockRegistrationError } from "./errors.js";
+
+describe("BlockRegistrationError", () => {
+  test("name is BlockRegistrationError on every instance", () => {
+    const err = BlockRegistrationError.invalidNamePattern({
+      name: "BAD",
+      pattern: "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$",
+    });
+    expect(err.name).toBe("BlockRegistrationError");
+  });
+
+  test("is throwable and catchable by class", () => {
+    expect(() => {
+      throw BlockRegistrationError.duplicateName({
+        name: "core/paragraph",
+        layer: "core",
+      });
+    }).toThrow(BlockRegistrationError);
+  });
+
+  test("invalidNamePattern carries code and fields", () => {
+    const err = BlockRegistrationError.invalidNamePattern({
+      name: "BAD",
+      pattern: "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$",
+    });
+    expect(err.code).toBe("invalid_name_pattern");
+    expect(err.blockName).toBe("BAD");
+    expect(err.pattern).toBe("^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$");
+    expect(err.message).toContain("BAD");
+    expect(err.message).toContain("namespace/name");
+  });
+
+  test("duplicateName carries code and layer", () => {
+    const err = BlockRegistrationError.duplicateName({
+      name: "core/paragraph",
+      layer: "core",
+    });
+    expect(err.code).toBe("duplicate_name");
+    expect(err.blockName).toBe("core/paragraph");
+    expect(err.layer).toBe("core");
+    expect(err.message).toContain("core/paragraph");
+  });
+
+  test("coreBlockCollision when plugin uses core namespace", () => {
+    const err = BlockRegistrationError.coreBlockCollision({
+      name: "core/something",
+      registeredBy: "my-plugin",
+    });
+    expect(err.code).toBe("core_block_collision");
+    expect(err.blockName).toBe("core/something");
+    expect(err.registeredBy).toBe("my-plugin");
+  });
+
+  test("themeOverrideUnknownName", () => {
+    const err = BlockRegistrationError.themeOverrideUnknownName({
+      name: "made-up/block",
+      themeId: "acme",
+    });
+    expect(err.code).toBe("theme_override_unknown_name");
+    expect(err.blockName).toBe("made-up/block");
+    expect(err.themeId).toBe("acme");
+  });
+
+  test("schemaNameMismatch when spec.name != schema.name", () => {
+    const err = BlockRegistrationError.schemaNameMismatch({
+      specName: "core/paragraph",
+      schemaName: "paragraph",
+    });
+    expect(err.code).toBe("schema_name_mismatch");
+    expect(err.blockName).toBe("core/paragraph");
+    expect(err.schemaName).toBe("paragraph");
+  });
+
+  test("unknownAttributeType", () => {
+    const err = BlockRegistrationError.unknownAttributeType({
+      name: "core/paragraph",
+      attributeName: "weird",
+      attributeType: "non-existent-type",
+    });
+    expect(err.code).toBe("unknown_attribute_type");
+    expect(err.blockName).toBe("core/paragraph");
+    expect(err.attributeName).toBe("weird");
+    expect(err.attributeType).toBe("non-existent-type");
+  });
+});

--- a/packages/blocks/src/errors.ts
+++ b/packages/blocks/src/errors.ts
@@ -1,0 +1,139 @@
+type BlockRegistrationErrorCode =
+  | "invalid_name_pattern"
+  | "duplicate_name"
+  | "core_block_collision"
+  | "theme_override_unknown_name"
+  | "schema_name_mismatch"
+  | "unknown_attribute_type";
+
+interface BlockRegistrationErrorFields {
+  blockName?: string;
+  pattern?: string;
+  layer?: string;
+  registeredBy?: string;
+  themeId?: string;
+  schemaName?: string;
+  attributeName?: string;
+  attributeType?: string;
+}
+
+const NAME_PATTERN = "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$";
+
+export class BlockRegistrationError extends Error {
+  static {
+    BlockRegistrationError.prototype.name = "BlockRegistrationError";
+  }
+
+  readonly code: BlockRegistrationErrorCode;
+  readonly blockName: string | undefined;
+  readonly pattern: string | undefined;
+  readonly layer: string | undefined;
+  readonly registeredBy: string | undefined;
+  readonly themeId: string | undefined;
+  readonly schemaName: string | undefined;
+  readonly attributeName: string | undefined;
+  readonly attributeType: string | undefined;
+
+  private constructor(
+    code: BlockRegistrationErrorCode,
+    message: string,
+    fields: BlockRegistrationErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.blockName = fields.blockName;
+    this.pattern = fields.pattern;
+    this.layer = fields.layer;
+    this.registeredBy = fields.registeredBy;
+    this.themeId = fields.themeId;
+    this.schemaName = fields.schemaName;
+    this.attributeName = fields.attributeName;
+    this.attributeType = fields.attributeType;
+  }
+
+  static invalidNamePattern(ctx: {
+    name: string;
+    pattern?: string;
+  }): BlockRegistrationError {
+    const pattern = ctx.pattern ?? NAME_PATTERN;
+    return new BlockRegistrationError(
+      "invalid_name_pattern",
+      `Block name "${ctx.name}" does not match the required namespace/name ` +
+        `pattern ${pattern}. Names must be lowercase, namespaced ` +
+        `(e.g. "core/paragraph", "media/image", "acme/testimonial").`,
+      { blockName: ctx.name, pattern },
+    );
+  }
+
+  static duplicateName(ctx: {
+    name: string;
+    layer: "core" | "plugin" | "theme";
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "duplicate_name",
+      `Block "${ctx.name}" is registered twice within the ${ctx.layer} ` +
+        `layer. Each block name must be unique within its layer; ` +
+        `theme > plugin > core precedence handles cross-layer overrides.`,
+      { blockName: ctx.name, layer: ctx.layer },
+    );
+  }
+
+  static coreBlockCollision(ctx: {
+    name: string;
+    registeredBy: string;
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "core_block_collision",
+      `Plugin "${ctx.registeredBy}" tried to register block "${ctx.name}" ` +
+        `using the "core/" namespace, which is reserved for blocks shipped ` +
+        `with @plumix/blocks. Use a plugin-scoped namespace instead.`,
+      { blockName: ctx.name, registeredBy: ctx.registeredBy },
+    );
+  }
+
+  static themeOverrideUnknownName(ctx: {
+    name: string;
+    themeId: string;
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "theme_override_unknown_name",
+      `Theme "${ctx.themeId}" tried to override block "${ctx.name}", but no ` +
+        `core or plugin block by that name is registered. Themes can only ` +
+        `override existing blocks or register entirely new theme-namespaced ` +
+        `blocks via ctx.registerBlock.`,
+      { blockName: ctx.name, themeId: ctx.themeId },
+    );
+  }
+
+  static schemaNameMismatch(ctx: {
+    specName: string;
+    schemaName: string;
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "schema_name_mismatch",
+      `Block "${ctx.specName}" has a Tiptap schema with name "${ctx.schemaName}". ` +
+        `The spec name and the Tiptap node name must match — otherwise ` +
+        `the walker cannot resolve nodes through the registry.`,
+      { blockName: ctx.specName, schemaName: ctx.schemaName },
+    );
+  }
+
+  static unknownAttributeType(ctx: {
+    name: string;
+    attributeName: string;
+    attributeType: string;
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "unknown_attribute_type",
+      `Block "${ctx.name}" declares attribute "${ctx.attributeName}" with ` +
+        `type "${ctx.attributeType}", which is not registered in the ` +
+        `field-type registry. Register the field type via ` +
+        `ctx.registerFieldType before referencing it from a block.`,
+      {
+        blockName: ctx.name,
+        attributeName: ctx.attributeName,
+        attributeType: ctx.attributeType,
+      },
+    );
+  }
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,1 +1,29 @@
-export {};
+/**
+ * Public API of `@plumix/blocks`.
+ *
+ * Re-exported from `plumix/blocks` (see `packages/plumix/src/blocks/`).
+ * Consumers should import from `plumix/blocks`, not from this package
+ * directly — `@plumix/blocks` is workspace-internal and unpublished.
+ */
+
+export { defineBlock } from "./define-block.js";
+export { BlockRegistrationError } from "./errors.js";
+export { mergeBlockRegistry } from "./registry.js";
+export type { MergeBlockRegistryInput } from "./registry.js";
+export { EntryContent } from "./walker.js";
+export type { EntryContentProps } from "./walker.js";
+export type {
+  BlockAttributeSchema,
+  BlockComponent,
+  BlockContext,
+  BlockProps,
+  BlockRegistry,
+  BlockSpec,
+  LazyRef,
+  ResolvedBlockSpec,
+  TiptapMark,
+  TiptapNode,
+} from "./types.js";
+
+export { coreBlocks } from "./core-blocks.js";
+export { paragraphBlock } from "./paragraph/index.js";

--- a/packages/blocks/src/integration.test.ts
+++ b/packages/blocks/src/integration.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+
+import { renderTiptapContent } from "@plumix/core";
+
+import { coreBlocks } from "./core-blocks.js";
+import { mockRegistry, renderBlock } from "./test/index.js";
+
+/**
+ * Parity check: paragraph content authored against the legacy
+ * StarterKit schema (`type: "paragraph"`) renders to the same HTML
+ * through the new walker as through the existing
+ * `renderTiptapContent` walker shipped in `@plumix/core`.
+ *
+ * This is the foundation tracer-bullet's load-bearing claim: the new
+ * pipeline does not silently break existing entries.
+ */
+describe("paragraph parity against the legacy walker", () => {
+  test("plain paragraph", async () => {
+    const registry = await mockRegistry({ core: [...coreBlocks] });
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello" }],
+        },
+      ],
+    };
+    const legacy = renderTiptapContent(doc);
+    const next = renderBlock({ registry, content: doc });
+    expect(next).toBe(legacy);
+  });
+
+  test("paragraph with bold + italic marks", async () => {
+    const registry = await mockRegistry({ core: [...coreBlocks] });
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Hi",
+              marks: [{ type: "bold" }, { type: "italic" }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(renderBlock({ registry, content: doc })).toBe(
+      renderTiptapContent(doc),
+    );
+  });
+
+  test("paragraph with a safe link", async () => {
+    const registry = await mockRegistry({ core: [...coreBlocks] });
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "click",
+              marks: [{ type: "link", attrs: { href: "https://example.com" } }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(renderBlock({ registry, content: doc })).toBe(
+      renderTiptapContent(doc),
+    );
+  });
+});

--- a/packages/blocks/src/paragraph/Component.tsx
+++ b/packages/blocks/src/paragraph/Component.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+/**
+ * Default frontend rendering for `core/paragraph`.
+ *
+ * Themes override by supplying a different component via
+ * `defineTheme({ blocks: { "core/paragraph": MyParagraph } })`.
+ */
+export function ParagraphComponent({ children }: BlockProps): ReactElement {
+  return <p>{children}</p>;
+}

--- a/packages/blocks/src/paragraph/index.ts
+++ b/packages/blocks/src/paragraph/index.ts
@@ -1,0 +1,18 @@
+import { defineBlock } from "../define-block.js";
+
+/**
+ * Spec for the first core block. Lazy refs keep admin-only imports out
+ * of the workers bundle and frontend-only renderers out of the admin
+ * bundle. `legacyAliases: ["paragraph"]` lets the walker resolve
+ * StarterKit-shaped content (entries authored before the namespaced
+ * registry shipped) to this spec.
+ */
+export const paragraphBlock = defineBlock({
+  name: "core/paragraph",
+  title: "Paragraph",
+  category: "text",
+  description: "The building block of all narrative.",
+  legacyAliases: ["paragraph"],
+  schema: () => import("./schema.js").then((m) => m.paragraphSchema),
+  component: () => import("./Component.js").then((m) => m.ParagraphComponent),
+});

--- a/packages/blocks/src/paragraph/paragraph.test.tsx
+++ b/packages/blocks/src/paragraph/paragraph.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+
+import { mockRegistry, renderBlock } from "../test/index.js";
+import { paragraphBlock } from "./index.js";
+
+describe("core/paragraph", () => {
+  test("spec metadata", () => {
+    expect(paragraphBlock.name).toBe("core/paragraph");
+    expect(paragraphBlock.title).toBe("Paragraph");
+    expect(paragraphBlock.category).toBe("text");
+    expect(paragraphBlock.legacyAliases).toEqual(["paragraph"]);
+  });
+
+  test("renders <p> with text content", async () => {
+    const registry = await mockRegistry({ core: [paragraphBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/paragraph",
+            content: [{ type: "text", text: "Hello world" }],
+          },
+        ],
+      },
+    });
+    expect(html).toBe("<p>Hello world</p>");
+  });
+
+  test("legacy `paragraph` content renders identically", async () => {
+    const registry = await mockRegistry({ core: [paragraphBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Legacy content" }],
+          },
+        ],
+      },
+    });
+    expect(html).toBe("<p>Legacy content</p>");
+  });
+});

--- a/packages/blocks/src/paragraph/schema.ts
+++ b/packages/blocks/src/paragraph/schema.ts
@@ -1,0 +1,23 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+/**
+ * Tiptap node for `core/paragraph`.
+ *
+ * Schema name matches the spec name (the walker dispatches on
+ * `node.type === registry-name`). Existing StarterKit-shaped content
+ * with `type: "paragraph"` is mapped here via the spec's `legacyAliases`.
+ */
+export const paragraphSchema = Node.create({
+  name: "core/paragraph",
+  group: "block",
+  content: "inline*",
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: "p" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["p", mergeAttributes(HTMLAttributes), 0];
+  },
+});

--- a/packages/blocks/src/registry.test.ts
+++ b/packages/blocks/src/registry.test.ts
@@ -1,0 +1,186 @@
+import { Node as TiptapNode } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import type { BlockComponent, BlockSpec } from "./types.js";
+import { defineBlock } from "./define-block.js";
+import { mergeBlockRegistry } from "./registry.js";
+
+function paragraph(opts: {
+  name: string;
+  component?: BlockComponent;
+}): BlockSpec {
+  const DefaultComponent: BlockComponent = ({ children }) => children as never;
+  return defineBlock({
+    name: opts.name,
+    title: opts.name,
+    schema: () =>
+      Promise.resolve(
+        TiptapNode.create({
+          name: opts.name,
+          group: "block",
+          content: "inline*",
+        }),
+      ),
+    component: () => Promise.resolve(opts.component ?? DefaultComponent),
+  });
+}
+
+describe("mergeBlockRegistry", () => {
+  test("seeds with core specs and exposes get/has/size/iterator", async () => {
+    const reg = await mergeBlockRegistry({
+      core: [paragraph({ name: "core/paragraph" })],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    expect(reg.size).toBe(1);
+    expect(reg.has("core/paragraph")).toBe(true);
+    expect(reg.get("core/paragraph")?.name).toBe("core/paragraph");
+    expect([...reg].map(([name]) => name)).toEqual(["core/paragraph"]);
+  });
+
+  test("plugin layer adds blocks to the merged registry", async () => {
+    const reg = await mergeBlockRegistry({
+      core: [paragraph({ name: "core/paragraph" })],
+      plugins: [
+        { spec: paragraph({ name: "media/image" }), pluginId: "media" },
+      ],
+      themeOverrides: {},
+      themeId: null,
+    });
+    expect(reg.size).toBe(2);
+    expect(reg.get("media/image")?.registeredBy).toBe("media");
+    expect(reg.get("core/paragraph")?.registeredBy).toBe(null);
+  });
+
+  test("duplicate within the core layer throws", async () => {
+    await expect(
+      mergeBlockRegistry({
+        core: [
+          paragraph({ name: "core/paragraph" }),
+          paragraph({ name: "core/paragraph" }),
+        ],
+        plugins: [],
+        themeOverrides: {},
+        themeId: null,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "duplicate_name",
+        layer: "core",
+        blockName: "core/paragraph",
+      }),
+    );
+  });
+
+  test("duplicate within the plugin layer throws", async () => {
+    await expect(
+      mergeBlockRegistry({
+        core: [],
+        plugins: [
+          { spec: paragraph({ name: "media/image" }), pluginId: "media" },
+          { spec: paragraph({ name: "media/image" }), pluginId: "media-extra" },
+        ],
+        themeOverrides: {},
+        themeId: null,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "duplicate_name",
+        layer: "plugin",
+        blockName: "media/image",
+      }),
+    );
+  });
+
+  test("plugin using the core/ namespace throws", async () => {
+    await expect(
+      mergeBlockRegistry({
+        core: [],
+        plugins: [
+          {
+            spec: paragraph({ name: "core/sneaky" }),
+            pluginId: "naughty",
+          },
+        ],
+        themeOverrides: {},
+        themeId: null,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "core_block_collision",
+        blockName: "core/sneaky",
+        registeredBy: "naughty",
+      }),
+    );
+  });
+
+  test("theme override of an unknown name throws", async () => {
+    const overrideComponent: BlockComponent = ({ children }) =>
+      children as never;
+    await expect(
+      mergeBlockRegistry({
+        core: [paragraph({ name: "core/paragraph" })],
+        plugins: [],
+        themeOverrides: { "made-up/block": overrideComponent },
+        themeId: "acme",
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "theme_override_unknown_name",
+        blockName: "made-up/block",
+        themeId: "acme",
+      }),
+    );
+  });
+
+  test("theme override replaces the component for an existing block", async () => {
+    const Override: BlockComponent = ({ children }) => children as never;
+    const reg = await mergeBlockRegistry({
+      core: [paragraph({ name: "core/paragraph" })],
+      plugins: [],
+      themeOverrides: { "core/paragraph": Override },
+      themeId: "acme",
+    });
+    expect(reg.get("core/paragraph")?.component).toBe(Override);
+  });
+
+  test("theme override does not touch non-overridden blocks", async () => {
+    const Override: BlockComponent = ({ children }) => children as never;
+    const reg = await mergeBlockRegistry({
+      core: [
+        paragraph({ name: "core/paragraph" }),
+        paragraph({ name: "core/heading" }),
+      ],
+      plugins: [],
+      themeOverrides: { "core/paragraph": Override },
+      themeId: "acme",
+    });
+    expect(reg.get("core/heading")?.component).not.toBe(Override);
+    expect(reg.get("core/heading")?.registeredBy).toBe(null);
+  });
+
+  test("ESM-default-export shape is unwrapped during resolution", async () => {
+    const Component: BlockComponent = ({ children }) => children as never;
+    const spec = defineBlock({
+      name: "core/paragraph",
+      title: "Paragraph",
+      schema: () =>
+        Promise.resolve(
+          TiptapNode.create({
+            name: "core/paragraph",
+            group: "block",
+            content: "inline*",
+          }),
+        ),
+      component: () => Promise.resolve({ default: Component }),
+    });
+    const reg = await mergeBlockRegistry({
+      core: [spec],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    expect(reg.get("core/paragraph")?.component).toBe(Component);
+  });
+});

--- a/packages/blocks/src/registry.ts
+++ b/packages/blocks/src/registry.ts
@@ -1,0 +1,153 @@
+import type {
+  BlockComponent,
+  BlockRegistry,
+  BlockSpec,
+  LazyRef,
+  ResolvedBlockSpec,
+} from "./types.js";
+import { BlockRegistrationError } from "./errors.js";
+
+const CORE_NAMESPACE_PREFIX = "core/";
+
+interface PluginContribution {
+  readonly spec: BlockSpec;
+  readonly pluginId: string;
+}
+
+export interface MergeBlockRegistryInput {
+  readonly core: readonly BlockSpec[];
+  readonly plugins: readonly PluginContribution[];
+  readonly themeOverrides: Readonly<Record<string, BlockComponent>>;
+  readonly themeId: string | null;
+}
+
+/**
+ * Build the immutable per-app block registry from the three contribution
+ * layers, with deterministic precedence theme > plugin > core.
+ *
+ * Hard failures (thrown synchronously, before any async work):
+ * - duplicate name within any single layer;
+ * - plugin spec with a `core/` namespace;
+ * - theme override targeting a name no layer registered.
+ *
+ * Theme overrides only replace the resolved spec's `component` — the
+ * schema, attributes, and editor are owned by the block author and
+ * cannot be swapped by a theme without invalidating stored content.
+ *
+ * Async because each spec's `component` lazy ref is awaited once at
+ * boot; afterwards the walker reads `registry.get(name).component`
+ * synchronously, matching React SSR's render contract.
+ */
+export async function mergeBlockRegistry(
+  input: MergeBlockRegistryInput,
+): Promise<BlockRegistry> {
+  validateLayerUniqueness(input);
+
+  const merged = new Map<string, ResolvedBlockSpec>();
+  const aliases = new Map<string, string>();
+
+  for (const spec of input.core) {
+    const resolved = await resolveSpec(spec, null);
+    merged.set(spec.name, resolved);
+    indexAliases(spec, aliases);
+  }
+  for (const { spec, pluginId } of input.plugins) {
+    const resolved = await resolveSpec(spec, pluginId);
+    merged.set(spec.name, resolved);
+    indexAliases(spec, aliases);
+  }
+  for (const [name, component] of Object.entries(input.themeOverrides)) {
+    const existing = merged.get(name);
+    if (!existing) {
+      throw BlockRegistrationError.themeOverrideUnknownName({
+        name,
+        themeId: input.themeId ?? "unknown",
+      });
+    }
+    merged.set(name, { ...existing, component });
+  }
+
+  const get = (name: string): ResolvedBlockSpec | undefined => {
+    const direct = merged.get(name);
+    if (direct) return direct;
+    const canonical = aliases.get(name);
+    return canonical === undefined ? undefined : merged.get(canonical);
+  };
+
+  return Object.freeze({
+    get,
+    has: (name: string) => get(name) !== undefined,
+    size: merged.size,
+    [Symbol.iterator]: () => merged.entries(),
+  });
+}
+
+function validateLayerUniqueness(input: MergeBlockRegistryInput): void {
+  const coreSeen = new Set<string>();
+  for (const spec of input.core) {
+    if (coreSeen.has(spec.name)) {
+      throw BlockRegistrationError.duplicateName({
+        name: spec.name,
+        layer: "core",
+      });
+    }
+    coreSeen.add(spec.name);
+  }
+
+  const pluginSeen = new Set<string>();
+  for (const { spec, pluginId } of input.plugins) {
+    if (spec.name.startsWith(CORE_NAMESPACE_PREFIX)) {
+      throw BlockRegistrationError.coreBlockCollision({
+        name: spec.name,
+        registeredBy: pluginId,
+      });
+    }
+    if (pluginSeen.has(spec.name)) {
+      throw BlockRegistrationError.duplicateName({
+        name: spec.name,
+        layer: "plugin",
+      });
+    }
+    pluginSeen.add(spec.name);
+  }
+}
+
+async function resolveSpec(
+  spec: BlockSpec,
+  registeredBy: string | null,
+): Promise<ResolvedBlockSpec> {
+  const component = await unwrapDefault(spec.component);
+  return Object.freeze({
+    name: spec.name,
+    title: spec.title,
+    icon: spec.icon,
+    category: spec.category,
+    description: spec.description,
+    keywords: spec.keywords,
+    attributes: spec.attributes,
+    schema: spec.schema,
+    editor: spec.editor,
+    client: spec.client,
+    component,
+    registeredBy,
+  });
+}
+
+function indexAliases(spec: BlockSpec, aliases: Map<string, string>): void {
+  if (!spec.legacyAliases) return;
+  for (const alias of spec.legacyAliases) {
+    aliases.set(alias, spec.name);
+  }
+}
+
+async function unwrapDefault<T>(ref: LazyRef<T>): Promise<T> {
+  const resolved = await ref();
+  if (
+    typeof resolved === "object" &&
+    resolved !== null &&
+    "default" in resolved
+  ) {
+    return resolved.default;
+  }
+  return resolved;
+}

--- a/packages/blocks/src/test/index.ts
+++ b/packages/blocks/src/test/index.ts
@@ -1,0 +1,70 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type {
+  BlockComponent,
+  BlockContext,
+  BlockRegistry,
+  BlockSpec,
+  TiptapNode,
+} from "../types.js";
+import { mergeBlockRegistry } from "../registry.js";
+import { EntryContent } from "../walker.js";
+
+const EMPTY_CONTEXT: BlockContext = {
+  entry: null,
+  siteSettings: {},
+  theme: null,
+  parent: null,
+  depth: 0,
+};
+
+interface MockRegistryInput {
+  readonly core?: readonly BlockSpec[];
+  readonly plugins?: readonly {
+    readonly spec: BlockSpec;
+    readonly pluginId: string;
+  }[];
+  readonly themeOverrides?: Readonly<Record<string, BlockComponent>>;
+  readonly themeId?: string | null;
+}
+
+/**
+ * Build a `BlockRegistry` from optional layer contributions. Defaults
+ * everything to empty so callers only supply the layer(s) they need.
+ *
+ * Returns the same merged registry shape the runtime uses, with the
+ * async resolution awaited so test bodies can stay synchronous.
+ */
+export async function mockRegistry(
+  input: MockRegistryInput = {},
+): Promise<BlockRegistry> {
+  return mergeBlockRegistry({
+    core: input.core ?? [],
+    plugins: input.plugins ?? [],
+    themeOverrides: input.themeOverrides ?? {},
+    themeId: input.themeId ?? null,
+  });
+}
+
+interface RenderBlockInput {
+  readonly registry: BlockRegistry;
+  readonly content: TiptapNode | readonly TiptapNode[];
+  readonly context?: BlockContext;
+}
+
+/**
+ * Server-render a Tiptap doc through `<EntryContent>` into an HTML
+ * string. Useful for asserting expected output without spinning up a
+ * full React testing-library harness.
+ */
+export function renderBlock(input: RenderBlockInput): string {
+  return renderToStaticMarkup(
+    EntryContent({
+      content: input.content,
+      registry: input.registry,
+      context: input.context ?? EMPTY_CONTEXT,
+    }),
+  );
+}
+
+export { EMPTY_CONTEXT };

--- a/packages/blocks/src/test/test.test.ts
+++ b/packages/blocks/src/test/test.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import { paragraphBlock } from "../paragraph/index.js";
+import { mockRegistry, renderBlock } from "./index.js";
+
+describe("mockRegistry", () => {
+  test("returns an empty registry with no input", async () => {
+    const reg = await mockRegistry();
+    expect(reg.size).toBe(0);
+    expect(reg.get("anything")).toBeUndefined();
+  });
+
+  test("seeds a single core block when supplied", async () => {
+    const reg = await mockRegistry({ core: [paragraphBlock] });
+    expect(reg.size).toBe(1);
+    expect(reg.get("core/paragraph")?.name).toBe("core/paragraph");
+  });
+});
+
+describe("renderBlock", () => {
+  test("renders a paragraph to HTML", async () => {
+    const registry = await mockRegistry({ core: [paragraphBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/paragraph",
+            content: [{ type: "text", text: "Hi" }],
+          },
+        ],
+      },
+    });
+    expect(html).toBe("<p>Hi</p>");
+  });
+
+  test("accepts a custom context", async () => {
+    const registry = await mockRegistry({ core: [paragraphBlock] });
+    const html = renderBlock({
+      registry,
+      content: { type: "core/paragraph", content: [] },
+      context: {
+        entry: null,
+        siteSettings: {},
+        theme: { id: "acme" },
+        parent: null,
+        depth: 0,
+      },
+    });
+    expect(html).toBe("<p></p>");
+  });
+});

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -1,0 +1,138 @@
+import type { Node as TiptapNodeFactory } from "@tiptap/core";
+import type { ComponentType, ReactNode } from "react";
+
+/**
+ * The persisted ProseMirror JSON shape Tiptap produces.
+ *
+ * Walker reads `type` to dispatch into the registry, `attrs` to feed the
+ * resolved component, and `content` to recurse. `marks` only appears on
+ * text leaves. Loose typing on `attrs` is deliberate — each block's
+ * Component supplies its own typed `Attrs`.
+ */
+export interface TiptapNode {
+  readonly type: string;
+  readonly attrs?: Readonly<Record<string, unknown>>;
+  readonly content?: readonly TiptapNode[];
+  readonly text?: string;
+  readonly marks?: readonly TiptapMark[];
+}
+
+export interface TiptapMark {
+  readonly type: string;
+  readonly attrs?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Threaded through `<EntryContent>` recursion. Block Components introspect
+ * it for placement-aware rendering — a media/image inside a core/columns
+ * inside a single-post template knows its full ancestry without prop drilling.
+ */
+export interface BlockContext {
+  readonly entry: Readonly<Record<string, unknown>> | null;
+  readonly siteSettings: Readonly<Record<string, unknown>>;
+  readonly theme: { readonly id: string } | null;
+  /** Type name of the immediate parent block, or `null` at the document root. */
+  readonly parent: string | null;
+  /** 0 at root, incremented for each container traversal. */
+  readonly depth: number;
+}
+
+/**
+ * Props every block Component receives. `children` is the framework's
+ * pre-rendered subtree (95% path); `node` exposes the raw subtree for
+ * the rare slot-based composition case.
+ */
+export interface BlockProps<Attrs = Readonly<Record<string, unknown>>> {
+  readonly attrs: Attrs;
+  readonly children: ReactNode;
+  readonly node: TiptapNode;
+  readonly context: BlockContext;
+}
+
+export type BlockComponent<Attrs = Readonly<Record<string, unknown>>> =
+  ComponentType<BlockProps<Attrs>>;
+
+/**
+ * A single attribute on a block. `type` resolves through the existing
+ * registerFieldType registry; the field-type-specific extras (`options`,
+ * `min`, `max`, etc.) flow through unchanged.
+ */
+export interface BlockAttributeSchema {
+  readonly type: string;
+  readonly label?: string;
+  readonly description?: string;
+  readonly default?: unknown;
+  readonly optional?: boolean;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * Lazy reference used for cross-bundle code: workers runtime never
+ * evaluates admin-only modules and admin never evaluates runtime-only
+ * renderers. `buildApp` awaits the side-appropriate refs once at boot.
+ */
+export type LazyRef<T> = () => Promise<{ default: T } | T>;
+
+/**
+ * The unresolved spec returned by `defineBlock`.
+ *
+ * Editor and Component are lazy refs so the workers bundle can tree-shake
+ * admin-only imports (MediaPicker, react-dropzone, etc.) and the admin
+ * bundle can tree-shake runtime-only renderers. The registry resolves
+ * them once at boot.
+ */
+export interface BlockSpec<Attrs = Readonly<Record<string, unknown>>> {
+  readonly name: string;
+  readonly title: string;
+  readonly icon?: string;
+  readonly category?: string;
+  readonly description?: string;
+  readonly keywords?: readonly string[];
+  readonly attributes?: Readonly<Record<string, BlockAttributeSchema>>;
+  readonly schema: LazyRef<ReturnType<typeof TiptapNodeFactory.create>>;
+  readonly component: LazyRef<BlockComponent<Attrs>>;
+  readonly editor?: LazyRef<ComponentType<unknown>>;
+  readonly client?: LazyRef<unknown>;
+  /**
+   * Tiptap-node names this block accepts as input from legacy content.
+   * The walker maps these aliases back to the canonical spec `name` when
+   * resolving a stored node. Used to migrate StarterKit-shaped content
+   * (`type: "paragraph"`) into the namespaced registry (`core/paragraph`)
+   * without rewriting the database.
+   */
+  readonly legacyAliases?: readonly string[];
+}
+
+/**
+ * The post-merge view of a `BlockSpec`.
+ *
+ * `component` is awaited during registry merge and replaced with the
+ * resolved (sync) component — theme override if present, otherwise the
+ * spec's default. This keeps the SSR walker synchronous; React's
+ * `renderToReadableStream` can't await arbitrary promises during render.
+ *
+ * `editor` and `client` remain lazy refs: they're only evaluated in the
+ * admin bundle and the browser respectively, so the runtime bundle never
+ * needs to await them.
+ */
+export interface ResolvedBlockSpec<
+  Attrs = Readonly<Record<string, unknown>>,
+> extends Omit<BlockSpec<Attrs>, "component"> {
+  readonly component: BlockComponent<Attrs>;
+  readonly registeredBy: string | null;
+}
+
+/**
+ * Immutable lookup map produced by the registry merge. Read-only at
+ * runtime; the only entry points are `get(name)` and iteration.
+ */
+export interface BlockRegistry {
+  /**
+   * Resolve a block spec by canonical name OR registered legacy alias.
+   * Returns undefined when neither matches.
+   */
+  get(name: string): ResolvedBlockSpec | undefined;
+  has(name: string): boolean;
+  readonly size: number;
+  [Symbol.iterator](): IterableIterator<[string, ResolvedBlockSpec]>;
+}

--- a/packages/blocks/src/walker.test.tsx
+++ b/packages/blocks/src/walker.test.tsx
@@ -1,0 +1,337 @@
+import { render } from "@testing-library/react";
+import { Node as TiptapNode } from "@tiptap/core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type {
+  BlockComponent,
+  BlockContext,
+  BlockProps,
+  TiptapNode as TiptapNodeJson,
+} from "./types.js";
+import { defineBlock } from "./define-block.js";
+import { mergeBlockRegistry } from "./registry.js";
+import { EntryContent } from "./walker.js";
+
+const ROOT_CONTEXT: BlockContext = {
+  entry: null,
+  siteSettings: {},
+  theme: null,
+  parent: null,
+  depth: 0,
+};
+
+function specForTag(opts: { name: string; tag: string; alias?: string }) {
+  const Component: BlockComponent = ({ children }: BlockProps) => {
+    return <div data-block={opts.name}>{children}</div>;
+  };
+  return defineBlock({
+    name: opts.name,
+    title: opts.name,
+    schema: () =>
+      Promise.resolve(
+        TiptapNode.create({
+          name: opts.name,
+          group: "block",
+          content: "inline*",
+        }),
+      ),
+    component: () => Promise.resolve(Component),
+    legacyAliases: opts.alias ? [opts.alias] : undefined,
+  });
+}
+
+function paragraphSpec() {
+  return defineBlock({
+    name: "core/paragraph",
+    title: "Paragraph",
+    schema: () =>
+      Promise.resolve(
+        TiptapNode.create({
+          name: "core/paragraph",
+          group: "block",
+          content: "inline*",
+        }),
+      ),
+    component: () =>
+      Promise.resolve(({ children }: BlockProps) => <p>{children}</p>),
+    legacyAliases: ["paragraph"],
+  });
+}
+
+async function buildRegistry() {
+  return mergeBlockRegistry({
+    core: [paragraphSpec()],
+    plugins: [],
+    themeOverrides: {},
+    themeId: null,
+  });
+}
+
+describe("EntryContent walker", () => {
+  test("renders null for empty content", async () => {
+    const registry = await buildRegistry();
+    const { container } = render(
+      <EntryContent
+        content={null}
+        registry={registry}
+        context={ROOT_CONTEXT}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("renders a paragraph through the resolved component", async () => {
+    const registry = await buildRegistry();
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          content: [{ type: "text", text: "Hello" }],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(container.innerHTML).toBe("<p>Hello</p>");
+  });
+
+  test("resolves legacy alias `paragraph` to canonical `core/paragraph`", async () => {
+    const registry = await buildRegistry();
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Old content" }],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(container.innerHTML).toBe("<p>Old content</p>");
+  });
+
+  test("wraps marks outside-in: bold + italic produce <strong><em>text</em></strong>", async () => {
+    const registry = await buildRegistry();
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Hi",
+              marks: [{ type: "bold" }, { type: "italic" }],
+            },
+          ],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(container.innerHTML).toBe("<p><strong><em>Hi</em></strong></p>");
+  });
+
+  test("link mark renders an anchor with safe rel attribute", async () => {
+    const registry = await buildRegistry();
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          content: [
+            {
+              type: "text",
+              text: "click",
+              marks: [{ type: "link", attrs: { href: "https://example.com" } }],
+            },
+          ],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(container.innerHTML).toBe(
+      '<p><a href="https://example.com" rel="noopener noreferrer nofollow">click</a></p>',
+    );
+  });
+
+  test.each([
+    { href: "mailto:a@b.com", expected: 'href="mailto:a@b.com"' },
+    { href: "tel:+15551234", expected: 'href="tel:+15551234"' },
+    { href: "/internal", expected: 'href="/internal"' },
+    { href: "#section", expected: 'href="#section"' },
+  ])("link mark allows safe scheme: $href", async ({ href, expected }) => {
+    const registry = await buildRegistry();
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          content: [
+            {
+              type: "text",
+              text: "go",
+              marks: [{ type: "link", attrs: { href } }],
+            },
+          ],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(container.innerHTML).toContain(expected);
+  });
+
+  test("link mark with empty href is stripped (renders bare text)", async () => {
+    const registry = await buildRegistry();
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          content: [
+            {
+              type: "text",
+              text: "no link",
+              marks: [{ type: "link", attrs: { href: "" } }],
+            },
+          ],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(container.innerHTML).toBe("<p>no link</p>");
+  });
+
+  test("link mark with javascript: href is stripped (renders bare text)", async () => {
+    const registry = await buildRegistry();
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          content: [
+            {
+              type: "text",
+              text: "evil",
+              marks: [{ type: "link", attrs: { href: "javascript:alert(1)" } }],
+            },
+          ],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(container.innerHTML).toBe("<p>evil</p>");
+  });
+
+  test("threads parent and depth into nested block context", async () => {
+    let receivedContext: BlockContext | null = null;
+    const InspectingChild: BlockComponent = ({ context }) => {
+      receivedContext = context;
+      return null;
+    };
+    const childSpec = defineBlock({
+      name: "core/leaf",
+      title: "Leaf",
+      schema: () =>
+        Promise.resolve(
+          TiptapNode.create({ name: "core/leaf", group: "block" }),
+        ),
+      component: () => Promise.resolve(InspectingChild),
+    });
+    const containerSpec = specForTag({
+      name: "core/container",
+      tag: "div",
+    });
+    const registry = await mergeBlockRegistry({
+      core: [containerSpec, childSpec],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/container",
+          content: [{ type: "core/leaf" }],
+        },
+      ],
+    };
+    render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(receivedContext).toEqual(
+      expect.objectContaining({ parent: "core/container", depth: 1 }),
+    );
+  });
+
+  test("unknown block in dev mode emits one-time warn + template marker", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const registry = await buildRegistry();
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        { type: "missing/x" },
+        { type: "missing/x" },
+        { type: "missing/y" },
+      ],
+    };
+    const { container } = render(
+      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+    );
+    expect(container.querySelectorAll("template").length).toBe(3);
+    expect(
+      container.querySelector(
+        'template[data-plumix-unknown-block="missing/x"]',
+      ),
+    ).not.toBeNull();
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  test("unknown block in production renders nothing", async () => {
+    const previousEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const registry = await buildRegistry();
+      const doc: TiptapNodeJson = {
+        type: "doc",
+        content: [{ type: "missing/z" }],
+      };
+      const { container } = render(
+        <EntryContent
+          content={doc}
+          registry={registry}
+          context={ROOT_CONTEXT}
+        />,
+      );
+      expect(container.innerHTML).toBe("");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = previousEnv;
+      warn.mockRestore();
+    }
+  });
+});
+
+beforeEach(() => {
+  process.env.NODE_ENV = "test";
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = "test";
+});

--- a/packages/blocks/src/walker.tsx
+++ b/packages/blocks/src/walker.tsx
@@ -1,0 +1,178 @@
+import type { ReactNode } from "react";
+import { createElement, Fragment } from "react";
+
+import type {
+  BlockContext,
+  BlockRegistry,
+  TiptapMark,
+  TiptapNode,
+} from "./types.js";
+
+export interface EntryContentProps {
+  readonly content: TiptapNode | readonly TiptapNode[] | null | undefined;
+  readonly registry: BlockRegistry;
+  readonly context: BlockContext;
+}
+
+/**
+ * Recursive React SSR walker over a Tiptap doc.
+ *
+ * Resolves each non-text node through the merged registry, dispatches
+ * text + marks through the inline walker, and threads `BlockContext`
+ * through the tree. Container blocks just render `{children}`; the
+ * framework owns recursion so authors cannot drop content by forgetting
+ * to recurse (FaustJS pattern).
+ *
+ * Unknown nodes:
+ * - In development: a `<template>` marker carrying the unknown name plus
+ *   a one-time `console.warn` per unique name. Dedup state is keyed on
+ *   the registry instance via a `WeakMap`, so the warn fires once per
+ *   registry per page render even when the same unknown block appears
+ *   many times.
+ * - In production: render nothing — no DOM artifact, no log.
+ *
+ * Stored content is preserved untouched by the persistence layer; the
+ * walker only decides what to render.
+ */
+export function EntryContent({
+  content,
+  registry,
+  context,
+}: EntryContentProps): ReactNode {
+  if (!content) return null;
+  const nodes = Array.isArray(content) ? content : [content];
+  return renderNodes(nodes, registry, context, devWarnState(registry));
+}
+
+interface DevWarnState {
+  readonly seen: Set<string>;
+}
+
+const devWarnStates = new WeakMap<object, DevWarnState>();
+
+function devWarnState(registry: BlockRegistry): DevWarnState {
+  let existing = devWarnStates.get(registry);
+  if (!existing) {
+    existing = { seen: new Set() };
+    devWarnStates.set(registry, existing);
+  }
+  return existing;
+}
+
+function renderNodes(
+  nodes: readonly TiptapNode[] | undefined,
+  registry: BlockRegistry,
+  context: BlockContext,
+  devState: DevWarnState,
+): ReactNode {
+  if (!nodes || nodes.length === 0) return null;
+  return nodes.map((child, idx) =>
+    createElement(
+      Fragment,
+      { key: idx },
+      renderNode(child, registry, context, devState),
+    ),
+  );
+}
+
+function renderNode(
+  node: TiptapNode,
+  registry: BlockRegistry,
+  context: BlockContext,
+  devState: DevWarnState,
+): ReactNode {
+  if (node.type === "text") return renderText(node);
+  if (node.type === "doc") {
+    return renderNodes(node.content, registry, context, devState);
+  }
+
+  const spec = registry.get(node.type);
+  if (!spec) return renderUnknown(node, devState);
+
+  const childContext: BlockContext = {
+    ...context,
+    parent: spec.name,
+    depth: context.depth + 1,
+  };
+  const children = renderNodes(node.content, registry, childContext, devState);
+  return createElement(
+    spec.component,
+    { attrs: node.attrs ?? {}, node, context, children },
+    children,
+  );
+}
+
+function renderText(node: TiptapNode): ReactNode {
+  const text = node.text ?? "";
+  const marks = node.marks ?? [];
+  if (marks.length === 0) return text;
+  // Marks are stored outside-in; wrap inside-out so the innermost element
+  // matches the first mark in the array.
+  let element: ReactNode = text;
+  for (let i = marks.length - 1; i >= 0; i -= 1) {
+    const mark = marks[i];
+    if (mark) element = wrapMark(element, mark, i);
+  }
+  return element;
+}
+
+function wrapMark(
+  content: ReactNode,
+  mark: TiptapMark,
+  index: number,
+): ReactNode {
+  const key = `mark-${index}-${mark.type}`;
+  switch (mark.type) {
+    case "bold":
+      return createElement("strong", { key }, content);
+    case "italic":
+      return createElement("em", { key }, content);
+    case "strike":
+      return createElement("s", { key }, content);
+    case "code":
+      return createElement("code", { key }, content);
+    case "link": {
+      const href = sanitizeHref(mark.attrs?.href);
+      if (href === null) return content;
+      return createElement(
+        "a",
+        { key, href, rel: "noopener noreferrer nofollow" },
+        content,
+      );
+    }
+    default:
+      return content;
+  }
+}
+
+const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|#|\?|\.\.?\/)/i;
+
+function sanitizeHref(href: unknown): string | null {
+  if (typeof href !== "string") return null;
+  const trimmed = href.trim();
+  if (trimmed === "") return null;
+  return SAFE_HREF.test(trimmed) ? trimmed : null;
+}
+
+function renderUnknown(node: TiptapNode, devState: DevWarnState): ReactNode {
+  if (isDevMode()) {
+    if (!devState.seen.has(node.type)) {
+      devState.seen.add(node.type);
+
+      console.warn(`[plumix:blocks] Unregistered block type: ${node.type}`);
+    }
+    return createElement("template", {
+      "data-plumix-unknown-block": node.type,
+    });
+  }
+  return null;
+}
+
+function isDevMode(): boolean {
+  // Cloudflare Workers may not expose `process` natively; guard the
+  // access so the walker stays safe regardless of bundler / runtime.
+  // Vite (the admin/runtime bundler) replaces this expression at build
+  // time when it is processing the module.
+  if (typeof process === "undefined") return false;
+  return process.env.NODE_ENV !== "production";
+}

--- a/packages/blocks/tsconfig.build.json
+++ b/packages/blocks/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "stripInternal": true
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/blocks/tsconfig.json
+++ b/packages/blocks/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "@plumix/typescript-config/internal-package.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
   "include": ["src"]
 }

--- a/packages/blocks/vitest.config.ts
+++ b/packages/blocks/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import { baseConfig } from "@plumix/vitest-config/base";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export type {
   TaxonomyArchiveProps,
 } from "./route/render/archive-props.js";
 export type { ResolvedNode } from "./route/render/template-hierarchy.js";
+export { renderTiptapContent } from "./route/render/tiptap.js";
 export * from "./rpc/index.js";
 export type * from "./runtime/adapter.js";
 export { buildApp } from "./runtime/app.js";

--- a/packages/plumix/package.json
+++ b/packages/plumix/package.json
@@ -87,6 +87,10 @@
       "types": "./dist/blocks/index.d.ts",
       "default": "./dist/blocks/index.js"
     },
+    "./blocks/test": {
+      "types": "./dist/blocks/test.d.ts",
+      "default": "./dist/blocks/test.js"
+    },
     "./schema": {
       "types": "./dist/schema/index.d.ts",
       "default": "./dist/schema/index.js"
@@ -128,6 +132,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@plumix/blocks": "workspace:*",
     "@plumix/core": "workspace:*",
     "@tailwindcss/node": "4.3.0",
     "@tailwindcss/oxide": "4.3.0",

--- a/packages/plumix/src/blocks/index.ts
+++ b/packages/plumix/src/blocks/index.ts
@@ -1,1 +1,34 @@
-export {};
+/**
+ * Public `plumix/blocks` surface.
+ *
+ * Re-exports the curated public API from the workspace-internal
+ * `@plumix/blocks` package. Consumers (plugins, themes, the user's app)
+ * import from `plumix/blocks`; `@plumix/blocks` is never a direct
+ * dependency in their `package.json`.
+ *
+ * Mirrors the convention already used by `plumix/theme` re-exporting
+ * `defineTheme` from `@plumix/core`.
+ */
+
+export {
+  BlockRegistrationError,
+  EntryContent,
+  coreBlocks,
+  defineBlock,
+  mergeBlockRegistry,
+  paragraphBlock,
+} from "@plumix/blocks";
+export type {
+  BlockAttributeSchema,
+  BlockComponent,
+  BlockContext,
+  BlockProps,
+  BlockRegistry,
+  BlockSpec,
+  EntryContentProps,
+  LazyRef,
+  MergeBlockRegistryInput,
+  ResolvedBlockSpec,
+  TiptapMark,
+  TiptapNode,
+} from "@plumix/blocks";

--- a/packages/plumix/src/blocks/test.ts
+++ b/packages/plumix/src/blocks/test.ts
@@ -1,0 +1,10 @@
+/**
+ * Test utilities for plugin and theme authors writing blocks.
+ *
+ * Imported as `plumix/blocks/test`. Re-exports `renderBlock` and
+ * `mockRegistry` from the workspace-internal `@plumix/blocks/test`
+ * surface so consumers can unit-test their custom blocks without
+ * spinning up a full admin app.
+ */
+
+export { mockRegistry, renderBlock, EMPTY_CONTEXT } from "@plumix/blocks/test";

--- a/packages/plumix/tsconfig.json
+++ b/packages/plumix/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@plumix/typescript-config/library.json",
   "compilerOptions": {
     "types": ["node"],
-    "rootDir": "."
+    "rootDir": ".",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": ["src", "test"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
       '@plumix/core':
         specifier: workspace:*
         version: link:../core
+      '@tiptap/core':
+        specifier: ^3.23.1
+        version: 3.23.1(@tiptap/pm@3.23.1)
     devDependencies:
       '@plumix/eslint-config':
         specifier: workspace:*
@@ -339,15 +342,45 @@ importers:
       '@plumix/typescript-config':
         specifier: workspace:*
         version: link:../../tooling/typescript
+      '@plumix/vitest-config':
+        specifier: workspace:*
+        version: link:../../tooling/vitest
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.7.0)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -939,6 +972,9 @@ importers:
 
   packages/plumix:
     dependencies:
+      '@plumix/blocks':
+        specifier: workspace:*
+        version: link:../blocks
       '@plumix/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Lays the foundation for the blocks system from PRD #300: a registry-driven walker that takes Tiptap ProseMirror JSON, dispatches each node through a typed `BlockSpec`, and renders React. End-to-end paragraph round-trip works through the new pipeline and renders identically to the legacy `renderTiptapContent` walker — proving the remaining 12 slices can build on this without disturbing existing content.

**The contract**

`defineBlock(spec)` validates the namespace/name pattern, freezes the spec, and throws `BlockRegistrationError` with a discriminated `code` on invalid input. Specs hold lazy refs (`() => import(...)`) for `schema`, `component`, and `editor` so the workers bundle never executes admin-only modules and the admin never executes runtime-only renderers. `BlockSpec.legacyAliases` lets a namespaced spec absorb StarterKit-shaped content; `core/paragraph` aliases `paragraph` so existing entries render identically.

**The walker**

`<EntryContent>` is the React SSR walker exported from `plumix/blocks`. It dispatches text, marks, and blocks; recurses through `node.content` automatically so container components just render `{children}` (avoiding the FaustJS-style manual-recursion footgun); threads `BlockContext` (entry, siteSettings, theme, parent, depth) through the tree. Unknown blocks render a `<template>` marker plus a one-time `console.warn` per unique name in development, and nothing at all in production. `mergeBlockRegistry` is async because each spec's `component` lazy ref is awaited once at boot — afterwards the walker reads `ResolvedBlockSpec.component` synchronously (React `renderToReadableStream` cannot await arbitrary promises during render).

**Public surface**

`plumix/blocks` is the consumer-facing subpath (re-export plumbing in `packages/plumix/src/blocks/`); `@plumix/blocks` is workspace-internal and never appears in plugin or theme `package.json`. `plumix/blocks/test` exports `renderBlock` and `mockRegistry` so plugin and theme authors can unit-test custom blocks without standing up the full admin app.

48 tests across 7 files cover validation paths, registry precedence and ESM-default unwrap, walker recursion + depth/parent propagation, mark wrapping + href sanitisation, unknown-block dev/prod divergence, and parity with the legacy walker. Two acceptance items on #302 are deferred to follow-up PRs to keep this one reviewable: `buildApp` registry seeding (touches `packages/core/src/runtime/app.ts`) and the schema-name-mismatch / unknown-attribute-type validation paths. Both are small patches built on this contract.

Refs #302
Refs #300