### PR TITLE
build: close admin#test:e2e vs plumix#build copy race in turbo graph

### DIFF
--- a/packages/admin/turbo.json
+++ b/packages/admin/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test:e2e": {
+      "dependsOn": ["build", "^build", "plumix#build"],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Fixes the bidirectional copy race that's been causing intermittent blog/pages e2e failures on main since #319. Adds an explicit turbo dep so `@plumix/admin#test:e2e` can't run in parallel with `plumix#build`'s `copy-admin.mjs`.

**The race**

Turbo's dep graph had `plumix#build` and `@plumix/admin#test:e2e` as parallel siblings — both depend only on `admin#build`. That left two writers fighting over `packages/admin/dist/`:

1. `plumix#build` → `copy-admin.mjs` reads `admin/dist/` → writes `packages/plumix/dist/admin-app/`
2. `admin#test:e2e`'s webServer fixture step → writes `site-bundle.js` + patches `index.html` under `admin/dist/`

When (2) finished before (1) started reading, `plumix/dist/admin-app/index.html` inherited the e2e-specific `<script src="/_plumix/admin/plugins/site-bundle.js">` tag. Plugin playgrounds (blog/pages/media/menu/audit-log) booting via `plumix dev` then served that polluted HTML and 404'd the script — admin SPA failed silently, form submits never fired, Playwright timed out on `waitForURL` / `waitForResponse`.

#319's retry-with-backoff in `copy-admin.mjs` handles transient `ENOENT`/`EBUSY` during cp but doesn't address the read-after-pollution case where the copy succeeds against contaminated input.

**The fix**

```jsonc
"@plumix/admin#test:e2e": {
  "dependsOn": ["build", "^build", "plumix#build"],
  "cache": false
}
```

After this, the conflicting paths fully serialize:

1. `admin#build` (level 1)
2. `plumix#build` (level 2) — copy completes against a clean `admin/dist`
3. `admin#test:e2e` + every `<plugin>#test:e2e` (level 3) — admin's fixture writes happen, but `plumix/dist/admin-app/` is already final; plugins serve from the clean copy

The retry-with-backoff in `copy-admin.mjs` stays as defense in depth.

**Verification**

`pnpm exec turbo run test:e2e --force` — 24/24 tasks green, all 6 e2e suites running with the new ordering in 28s.

Refs #287, #316, #318, #319.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>