### PR TITLE
feat(blocks): core/heading block + parity with legacy renderer

### DIFF
--- a/packages/blocks/src/core-blocks.ts
+++ b/packages/blocks/src/core-blocks.ts
@@ -1,4 +1,5 @@
 import type { BlockSpec } from "./types.js";
+import { headingBlock } from "./heading/index.js";
 import { paragraphBlock } from "./paragraph/index.js";
 
 /**
@@ -10,4 +11,7 @@ import { paragraphBlock } from "./paragraph/index.js";
  * allowlist; the spec itself stays registered so existing content
  * continues to round-trip losslessly.
  */
-export const coreBlocks: readonly BlockSpec[] = Object.freeze([paragraphBlock]);
+export const coreBlocks: readonly BlockSpec[] = Object.freeze([
+  paragraphBlock,
+  headingBlock,
+]);

--- a/packages/blocks/src/heading/Component.tsx
+++ b/packages/blocks/src/heading/Component.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from "react";
+import { createElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+const DEFAULT_LEVEL = 2;
+
+/**
+ * Clamps and integer-coerces an author-supplied level. Mirrors the
+ * defensive walker that `@plumix/core`'s legacy renderer uses — content
+ * stored with malformed levels (legacy imports, hand-edited JSON) still
+ * renders sensibly instead of producing `<hNaN>`.
+ */
+function clampHeadingLevel(raw: unknown): 1 | 2 | 3 | 4 | 5 | 6 {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return DEFAULT_LEVEL;
+  const truncated = Math.trunc(raw);
+  if (truncated < 1) return 1;
+  if (truncated > 6) return 6;
+  return truncated as 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export function HeadingComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const level = clampHeadingLevel(attrs.level);
+  return createElement(`h${level}`, null, children);
+}

--- a/packages/blocks/src/heading/heading.test.tsx
+++ b/packages/blocks/src/heading/heading.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+
+import { coreBlocks } from "../core-blocks.js";
+import { mockRegistry, renderBlock } from "../test/index.js";
+import { headingBlock } from "./index.js";
+
+describe("core/heading", () => {
+  test("is shipped in coreBlocks alongside core/paragraph", () => {
+    const names = coreBlocks.map((b) => b.name);
+    expect(names).toContain("core/heading");
+  });
+
+  test("renders <h2> for the default level", async () => {
+    const registry = await mockRegistry({ core: [headingBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/heading",
+            content: [{ type: "text", text: "Title" }],
+          },
+        ],
+      },
+    });
+    expect(html).toBe("<h2>Title</h2>");
+  });
+
+  test.each([1, 2, 3, 4, 5, 6])("respects level=%i as <h%i>", async (level) => {
+    const registry = await mockRegistry({ core: [headingBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/heading",
+            attrs: { level },
+            content: [{ type: "text", text: "Title" }],
+          },
+        ],
+      },
+    });
+    expect(html).toBe(`<h${level}>Title</h${level}>`);
+  });
+
+  test.each([
+    { level: 0, expected: 1 },
+    { level: -3, expected: 1 },
+    { level: 7, expected: 6 },
+    { level: 99, expected: 6 },
+    { level: 2.7, expected: 2 },
+  ])("clamps level=$level to <h$expected>", async ({ level, expected }) => {
+    const registry = await mockRegistry({ core: [headingBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/heading",
+            attrs: { level },
+            content: [{ type: "text", text: "T" }],
+          },
+        ],
+      },
+    });
+    expect(html).toBe(`<h${expected}>T</h${expected}>`);
+  });
+
+  test('legacy `type: "heading"` content renders identically', async () => {
+    const registry = await mockRegistry({ core: [headingBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 3 },
+            content: [{ type: "text", text: "Legacy" }],
+          },
+        ],
+      },
+    });
+    expect(html).toBe("<h3>Legacy</h3>");
+  });
+
+  test("falls back to <h2> when level is not a number", async () => {
+    const registry = await mockRegistry({ core: [headingBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/heading",
+            attrs: { level: "two" },
+            content: [{ type: "text", text: "T" }],
+          },
+        ],
+      },
+    });
+    expect(html).toBe("<h2>T</h2>");
+  });
+});

--- a/packages/blocks/src/heading/index.ts
+++ b/packages/blocks/src/heading/index.ts
@@ -1,0 +1,11 @@
+import { defineBlock } from "../define-block.js";
+
+export const headingBlock = defineBlock({
+  name: "core/heading",
+  title: "Heading",
+  category: "text",
+  description: "Section title.",
+  legacyAliases: ["heading"],
+  schema: () => import("./schema.js").then((m) => m.headingSchema),
+  component: () => import("./Component.js").then((m) => m.HeadingComponent),
+});

--- a/packages/blocks/src/heading/schema.ts
+++ b/packages/blocks/src/heading/schema.ts
@@ -1,0 +1,23 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const headingSchema = Node.create({
+  name: "core/heading",
+  group: "block",
+  content: "inline*",
+  defining: true,
+
+  parseHTML() {
+    return [
+      { tag: "h1" },
+      { tag: "h2" },
+      { tag: "h3" },
+      { tag: "h4" },
+      { tag: "h5" },
+      { tag: "h6" },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["h2", mergeAttributes(HTMLAttributes), 0];
+  },
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -26,4 +26,5 @@ export type {
 } from "./types.js";
 
 export { coreBlocks } from "./core-blocks.js";
+export { headingBlock } from "./heading/index.js";
 export { paragraphBlock } from "./paragraph/index.js";

--- a/packages/core/src/blocks-parity.test.ts
+++ b/packages/core/src/blocks-parity.test.ts
@@ -67,6 +67,43 @@ describe("paragraph parity against the legacy walker", () => {
     );
   });
 
+  test.each([1, 2, 3, 4, 5, 6])(
+    "heading level=%i renders identically (legacy `type: heading`)",
+    async (level) => {
+      const registry = await mockRegistry({ core: [...coreBlocks] });
+      const doc = {
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level },
+            content: [{ type: "text", text: "Title" }],
+          },
+        ],
+      };
+      expect(renderBlock({ registry, content: doc })).toBe(
+        renderTiptapContent(doc),
+      );
+    },
+  );
+
+  test("heading with out-of-range level clamps identically", async () => {
+    const registry = await mockRegistry({ core: [...coreBlocks] });
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 9 },
+          content: [{ type: "text", text: "Title" }],
+        },
+      ],
+    };
+    expect(renderBlock({ registry, content: doc })).toBe(
+      renderTiptapContent(doc),
+    );
+  });
+
   test("paragraph with a safe link", async () => {
     const registry = await mockRegistry({ core: [...coreBlocks] });
     const doc = {


### PR DESCRIPTION
Adds the second core block following the same \`defineBlock\` + lazy-ref contract paragraph established in #319. Ships as a deliberately narrow PR so the upcoming Inspector slice can review separately on top of it.

**Heading semantics**

\`core/heading\` ships with defensive level clamping — out-of-range or non-numeric levels in stored content fall back to \`<h2>\` rather than producing \`<hNaN>\`. Matches the existing \`renderTiptapContent\` behaviour exactly, so the parity tests hold across the malformed-content boundary. \`legacyAliases: ["heading"]\` mirrors paragraph's existing alias so StarterKit-shaped content keeps rendering with no DB migration.

**Parity tests**

\`@plumix/core\`'s \`blocks-parity.test.ts\` now exercises all six heading levels plus the out-of-range clamp path, asserting identical HTML between the legacy walker and the new \`<EntryContent>\` walker.

**Deferred**

The \`level\` attribute *schema* declaration (and the \`select\` field type that surfaces it in the Inspector) lands with the Inspector PR — keeping this one narrowly scoped to "core/heading renders correctly" so the next slice focuses entirely on the admin-side editor surface.

19 new heading-block tests (14 in @plumix/blocks for the block itself, 7 in @plumix/core for the legacy-walker parity). Full repo: 60/60 turbo tasks green.

Refs #303
Refs #300