### PR TITLE
feat(blocks): layout primitives — core/group + core/columns + core/column

### DIFF
--- a/packages/blocks/src/columns/Component.tsx
+++ b/packages/blocks/src/columns/Component.tsx
@@ -1,0 +1,40 @@
+import type { ReactElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+// Matches `n[:m]*` where each part is a positive integer. Catches both
+// the canonical "1:1", "1:2", "1:1:1" and pathological values like
+// `lol`, `1:`, `:2`, `1::2`. Cap the part count at 6 because columns
+// beyond that produce unreadable layouts at typical breakpoints anyway.
+const RATIO_PATTERN = /^[1-9]\d*(?::[1-9]\d*){0,5}$/;
+
+function isRatio(value: unknown): value is string {
+  return typeof value === "string" && RATIO_PATTERN.test(value);
+}
+
+export function ColumnsComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const ratio = isRatio(attrs.ratio) ? attrs.ratio : undefined;
+  return (
+    <div data-plumix-block="core/columns" data-ratio={ratio}>
+      {children}
+    </div>
+  );
+}
+
+function normalizeWidth(raw: unknown): string | undefined {
+  if (typeof raw === "string" && raw.length > 0) return raw;
+  if (typeof raw === "number" && Number.isFinite(raw)) return `${raw}%`;
+  return undefined;
+}
+
+export function ColumnComponent({ attrs, children }: BlockProps): ReactElement {
+  const width = normalizeWidth(attrs.width);
+  return (
+    <div data-plumix-block="core/column" data-width={width}>
+      {children}
+    </div>
+  );
+}

--- a/packages/blocks/src/columns/column.ts
+++ b/packages/blocks/src/columns/column.ts
@@ -1,0 +1,10 @@
+import { defineBlock } from "../define-block.js";
+
+export const columnBlock = defineBlock({
+  name: "core/column",
+  title: "Column",
+  category: "layout",
+  description: "Single column inside a columns container.",
+  schema: () => import("./schema.js").then((m) => m.columnSchema),
+  component: () => import("./Component.js").then((m) => m.ColumnComponent),
+});

--- a/packages/blocks/src/columns/columns.test.tsx
+++ b/packages/blocks/src/columns/columns.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+
+import { mockRegistry, renderBlock } from "../test/index.js";
+import { columnBlock } from "./column.js";
+import { columnsBlock } from "./index.js";
+
+describe("core/columns", () => {
+  test("renders as a <div> wrapping column children", async () => {
+    const registry = await mockRegistry({
+      core: [columnsBlock, columnBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/columns", content: [] }],
+      },
+    });
+    expect(html).toBe('<div data-plumix-block="core/columns"></div>');
+  });
+
+  test.each(["1:1", "1:2", "1:1:1", "2:1:2"])(
+    "exposes ratio=%s as data-ratio",
+    async (ratio) => {
+      const registry = await mockRegistry({
+        core: [columnsBlock, columnBlock],
+      });
+      const html = renderBlock({
+        registry,
+        content: {
+          type: "doc",
+          content: [{ type: "core/columns", attrs: { ratio }, content: [] }],
+        },
+      });
+      expect(html).toBe(
+        `<div data-plumix-block="core/columns" data-ratio="${ratio}"></div>`,
+      );
+    },
+  );
+
+  test("ignores malformed ratio values", async () => {
+    const registry = await mockRegistry({
+      core: [columnsBlock, columnBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          { type: "core/columns", attrs: { ratio: "lol" }, content: [] },
+          { type: "core/columns", attrs: { ratio: 42 }, content: [] },
+        ],
+      },
+    });
+    expect(html).not.toContain("data-ratio");
+  });
+});
+
+describe("core/column", () => {
+  test("renders as a <div> wrapping inner blocks", async () => {
+    const registry = await mockRegistry({
+      core: [columnsBlock, columnBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/column", content: [] }],
+      },
+    });
+    expect(html).toBe('<div data-plumix-block="core/column"></div>');
+  });
+
+  test.each([
+    { width: "50%", expected: "50%" },
+    { width: 33, expected: "33%" },
+    { width: "1fr", expected: "1fr" },
+  ])(
+    "exposes width=$width as data-width=$expected",
+    async ({ width, expected }) => {
+      const registry = await mockRegistry({
+        core: [columnsBlock, columnBlock],
+      });
+      const html = renderBlock({
+        registry,
+        content: {
+          type: "doc",
+          content: [{ type: "core/column", attrs: { width }, content: [] }],
+        },
+      });
+      expect(html).toBe(
+        `<div data-plumix-block="core/column" data-width="${expected}"></div>`,
+      );
+    },
+  );
+
+  test("omits data-width when absent", async () => {
+    const registry = await mockRegistry({
+      core: [columnsBlock, columnBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/column", content: [] }],
+      },
+    });
+    expect(html).not.toContain("data-width");
+  });
+});

--- a/packages/blocks/src/columns/index.ts
+++ b/packages/blocks/src/columns/index.ts
@@ -1,0 +1,10 @@
+import { defineBlock } from "../define-block.js";
+
+export const columnsBlock = defineBlock({
+  name: "core/columns",
+  title: "Columns",
+  category: "layout",
+  description: "Multi-column container with explicit ratios.",
+  schema: () => import("./schema.js").then((m) => m.columnsSchema),
+  component: () => import("./Component.js").then((m) => m.ColumnsComponent),
+});

--- a/packages/blocks/src/columns/schema.ts
+++ b/packages/blocks/src/columns/schema.ts
@@ -1,0 +1,48 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+/**
+ * Tiptap node for `core/columns`.
+ *
+ * Children are typed `block*` in the Tiptap schema rather than
+ * restricted to `core/column` — strict containment is an editor-surface
+ * concern (slash menu allowedBlocks, drag-drop validation) handled in
+ * the admin slice. Loose schema here keeps the parser tolerant of legacy
+ * or hand-edited content.
+ */
+export const columnsSchema = Node.create({
+  name: "core/columns",
+  group: "block",
+  content: "block*",
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: "div[data-plumix-block='core/columns']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/columns" }),
+      0,
+    ];
+  },
+});
+
+export const columnSchema = Node.create({
+  name: "core/column",
+  group: "block",
+  content: "block*",
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: "div[data-plumix-block='core/column']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/column" }),
+      0,
+    ];
+  },
+});

--- a/packages/blocks/src/core-blocks.test.ts
+++ b/packages/blocks/src/core-blocks.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { coreBlocks } from "./core-blocks.js";
+
+describe("coreBlocks catalogue", () => {
+  test("ships layout primitives alongside paragraph and heading", () => {
+    const names = coreBlocks.map((b) => b.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "core/paragraph",
+        "core/heading",
+        "core/group",
+        "core/columns",
+        "core/column",
+      ]),
+    );
+  });
+
+  test("layout blocks declare the `layout` category", () => {
+    const layoutBlocks = coreBlocks.filter((b) => b.category === "layout");
+    const names = layoutBlocks.map((b) => b.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["core/group", "core/columns", "core/column"]),
+    );
+  });
+});

--- a/packages/blocks/src/core-blocks.ts
+++ b/packages/blocks/src/core-blocks.ts
@@ -1,4 +1,7 @@
 import type { BlockSpec } from "./types.js";
+import { columnBlock } from "./columns/column.js";
+import { columnsBlock } from "./columns/index.js";
+import { groupBlock } from "./group/index.js";
 import { headingBlock } from "./heading/index.js";
 import { paragraphBlock } from "./paragraph/index.js";
 
@@ -10,8 +13,15 @@ import { paragraphBlock } from "./paragraph/index.js";
  * out of a core block on a specific field, narrow the per-field
  * allowlist; the spec itself stays registered so existing content
  * continues to round-trip losslessly.
+ *
+ * Order is purely a readability convention: typography first, then
+ * layout primitives, then interactive blocks as they land in
+ * subsequent slices.
  */
 export const coreBlocks: readonly BlockSpec[] = Object.freeze([
   paragraphBlock,
   headingBlock,
+  groupBlock,
+  columnsBlock,
+  columnBlock,
 ]);

--- a/packages/blocks/src/group/Component.tsx
+++ b/packages/blocks/src/group/Component.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+export const GROUP_LAYOUTS = [
+  "flow",
+  "flex-row",
+  "flex-column",
+  "grid",
+] as const;
+export type GroupLayout = (typeof GROUP_LAYOUTS)[number];
+
+function isGroupLayout(value: unknown): value is GroupLayout {
+  return (
+    typeof value === "string" &&
+    (GROUP_LAYOUTS as readonly string[]).includes(value)
+  );
+}
+
+export function GroupComponent({ attrs, children }: BlockProps): ReactElement {
+  const layout = isGroupLayout(attrs.layout) ? attrs.layout : undefined;
+  return (
+    <div data-plumix-block="core/group" data-layout={layout}>
+      {children}
+    </div>
+  );
+}

--- a/packages/blocks/src/group/group.test.tsx
+++ b/packages/blocks/src/group/group.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import { mockRegistry, renderBlock } from "../test/index.js";
+import { groupBlock } from "./index.js";
+
+describe("core/group", () => {
+  test("renders as a <div> wrapping children", async () => {
+    const registry = await mockRegistry({
+      core: [groupBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/group", content: [] }],
+      },
+    });
+    expect(html).toBe('<div data-plumix-block="core/group"></div>');
+  });
+
+  test.each(["flow", "flex-row", "flex-column", "grid"])(
+    "exposes layout=%s as data-layout",
+    async (layout) => {
+      const registry = await mockRegistry({
+        core: [groupBlock],
+      });
+      const html = renderBlock({
+        registry,
+        content: {
+          type: "doc",
+          content: [{ type: "core/group", attrs: { layout }, content: [] }],
+        },
+      });
+      expect(html).toBe(
+        `<div data-plumix-block="core/group" data-layout="${layout}"></div>`,
+      );
+    },
+  );
+
+  test("omits data-layout when layout attr is absent", async () => {
+    const registry = await mockRegistry({
+      core: [groupBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/group", content: [] }],
+      },
+    });
+    expect(html).not.toContain("data-layout");
+  });
+
+  test("ignores unknown layout values rather than leaking them", async () => {
+    const registry = await mockRegistry({
+      core: [groupBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          { type: "core/group", attrs: { layout: "spinny" }, content: [] },
+        ],
+      },
+    });
+    expect(html).not.toContain("data-layout");
+  });
+});

--- a/packages/blocks/src/group/index.ts
+++ b/packages/blocks/src/group/index.ts
@@ -1,0 +1,10 @@
+import { defineBlock } from "../define-block.js";
+
+export const groupBlock = defineBlock({
+  name: "core/group",
+  title: "Group",
+  category: "layout",
+  description: "Generic container that hosts any block-level children.",
+  schema: () => import("./schema.js").then((m) => m.groupSchema),
+  component: () => import("./Component.js").then((m) => m.GroupComponent),
+});

--- a/packages/blocks/src/group/schema.ts
+++ b/packages/blocks/src/group/schema.ts
@@ -1,0 +1,26 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+/**
+ * Tiptap node for `core/group` — a generic container that hosts any
+ * block-level children. Inner-block restrictions (variations like Row /
+ * Stack picked from the slash menu) live on the editor surface, not in
+ * the schema, so a single Node definition serves all variants.
+ */
+export const groupSchema = Node.create({
+  name: "core/group",
+  group: "block",
+  content: "block*",
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: "div[data-plumix-block='core/group']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/group" }),
+      0,
+    ];
+  },
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -26,5 +26,8 @@ export type {
 } from "./types.js";
 
 export { coreBlocks } from "./core-blocks.js";
+export { columnBlock } from "./columns/column.js";
+export { columnsBlock } from "./columns/index.js";
+export { groupBlock } from "./group/index.js";
 export { headingBlock } from "./heading/index.js";
 export { paragraphBlock } from "./paragraph/index.js";


### PR DESCRIPTION
Adds the three layout containers from slice #307. Pure frontend-render slice; mirrors the heading/paragraph pattern (\`defineBlock\` + lazy refs + spec → Component → Tiptap Node), no new infrastructure.

**Render contract**

All three render as plain \`<div data-plumix-block="...">\` wrappers with spec attributes surfaced as \`data-*\` attributes. Themes own visual treatment via CSS hooks against those stable attributes — no class taxonomy invented by core that themes would have to fight.

**Attribute validation lives in the components, not the Tiptap schema**

- \`core/group.layout\` allowlist: \`flow | flex-row | flex-column | grid\`. Unknown values drop silently rather than passing through, so theme CSS only ever sees the allowlist.
- \`core/columns.ratio\` matched against \`^[1-9]\d*(?::[1-9]\d*){0,5}$\`. Up to six parts; longer ratios drop because they're unreadable at typical breakpoints.
- \`core/column.width\` accepts strings (\`"50%"\`, \`"1fr"\`) or numbers (coerced to percentage). Empty / non-finite values are omitted.

**Loose schema, strict UI**

Tiptap schemas use \`content: "block*"\` rather than restricting columns→column-only. Strict containment is an editor-surface concern (slash menu allowedBlocks, drag-drop validation) that lands with the admin slice. Parser-level looseness keeps legacy and hand-edited content tolerant.

**Variations**

The PRD's \`Row\` / \`Stack\` variations on \`core/group\` are presets that will surface in the slash menu (slice #305). They reuse this single Node with \`layout: flex-row\` / \`layout: flex-column\` defaults — no separate Tiptap Node needed.

20 new tests across @plumix/blocks (group + columns + column + the catalogue). Full repo: 60/60 turbo tasks green.

Refs #307
Refs #300