### PR TITLE
feat(blocks): interactive primitives — button, buttons, callout, details

### DIFF
--- a/packages/blocks/src/button/Component.tsx
+++ b/packages/blocks/src/button/Component.tsx
@@ -1,0 +1,49 @@
+import type { ReactElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+const VARIANTS = ["primary", "secondary", "outline", "ghost"] as const;
+const SIZES = ["sm", "md", "lg"] as const;
+
+// Shared with the walker's link sanitizer — kept verbatim so behaviour
+// stays in lockstep across the two surfaces. If this list ever drifts
+// from `walker.tsx`'s SAFE_HREF, the parity test in @plumix/core will
+// catch it.
+const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|#|\?|\.\.?\/)/i;
+
+function asAllowed<T extends string>(
+  raw: unknown,
+  allowed: readonly T[],
+): T | undefined {
+  return typeof raw === "string" && (allowed as readonly string[]).includes(raw)
+    ? (raw as T)
+    : undefined;
+}
+
+function sanitizeHref(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "" || !SAFE_HREF.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+export function ButtonComponent({ attrs }: BlockProps): ReactElement {
+  const href = sanitizeHref(attrs.href);
+  const text = typeof attrs.text === "string" ? attrs.text : "";
+  const variant = asAllowed(attrs.variant, VARIANTS);
+  const size = asAllowed(attrs.size, SIZES);
+  const target = attrs.target === "_blank" ? "_blank" : undefined;
+  const rel = target === "_blank" ? "noopener noreferrer" : undefined;
+  return (
+    <a
+      href={href}
+      target={target}
+      rel={rel}
+      data-plumix-block="core/button"
+      data-variant={variant}
+      data-size={size}
+    >
+      {text}
+    </a>
+  );
+}

--- a/packages/blocks/src/button/button.test.tsx
+++ b/packages/blocks/src/button/button.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "vitest";
+
+import { mockRegistry, renderBlock } from "../test/index.js";
+import { buttonBlock } from "./index.js";
+
+describe("core/button", () => {
+  test("renders as <a> when href is set", async () => {
+    const registry = await mockRegistry({ core: [buttonBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/button",
+            attrs: { href: "https://example.com", text: "Open" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toBe(
+      '<a href="https://example.com" data-plumix-block="core/button">Open</a>',
+    );
+  });
+
+  test.each(["primary", "secondary", "outline", "ghost"])(
+    "exposes variant=%s as data-variant",
+    async (variant) => {
+      const registry = await mockRegistry({ core: [buttonBlock] });
+      const html = renderBlock({
+        registry,
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "core/button",
+              attrs: { href: "/x", text: "Go", variant },
+              content: [],
+            },
+          ],
+        },
+      });
+      expect(html).toContain(`data-variant="${variant}"`);
+    },
+  );
+
+  test("ignores unknown variant values", async () => {
+    const registry = await mockRegistry({ core: [buttonBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/button",
+            attrs: { href: "/x", text: "Go", variant: "rainbow" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("data-variant");
+  });
+
+  test.each(["sm", "md", "lg"])(
+    "exposes size=%s as data-size",
+    async (size) => {
+      const registry = await mockRegistry({ core: [buttonBlock] });
+      const html = renderBlock({
+        registry,
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "core/button",
+              attrs: { href: "/x", text: "Go", size },
+              content: [],
+            },
+          ],
+        },
+      });
+      expect(html).toContain(`data-size="${size}"`);
+    },
+  );
+
+  test("emits rel=noopener noreferrer when target=_blank", async () => {
+    const registry = await mockRegistry({ core: [buttonBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/button",
+            attrs: {
+              href: "https://example.com",
+              text: "External",
+              target: "_blank",
+            },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  test("strips unsafe javascript: hrefs", async () => {
+    const registry = await mockRegistry({ core: [buttonBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/button",
+            attrs: { href: "javascript:alert(1)", text: "evil" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("href=");
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain(">evil</a>");
+  });
+
+  test("renders empty text as an empty anchor body", async () => {
+    const registry = await mockRegistry({ core: [buttonBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/button",
+            attrs: { href: "/x" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toBe('<a href="/x" data-plumix-block="core/button"></a>');
+  });
+});

--- a/packages/blocks/src/button/index.ts
+++ b/packages/blocks/src/button/index.ts
@@ -1,0 +1,10 @@
+import { defineBlock } from "../define-block.js";
+
+export const buttonBlock = defineBlock({
+  name: "core/button",
+  title: "Button",
+  category: "interactive",
+  description: "Call-to-action link styled as a button.",
+  schema: () => import("./schema.js").then((m) => m.buttonSchema),
+  component: () => import("./Component.js").then((m) => m.ButtonComponent),
+});

--- a/packages/blocks/src/button/schema.ts
+++ b/packages/blocks/src/button/schema.ts
@@ -1,0 +1,30 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const buttonSchema = Node.create({
+  name: "core/button",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      href: { default: null },
+      text: { default: "" },
+      variant: { default: "primary" },
+      size: { default: "md" },
+      target: { default: null },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "a[data-plumix-block='core/button']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "a",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/button" }),
+    ];
+  },
+});

--- a/packages/blocks/src/buttons/Component.tsx
+++ b/packages/blocks/src/buttons/Component.tsx
@@ -1,0 +1,30 @@
+import type { ReactElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+const ALIGNS = ["start", "center", "end", "between"] as const;
+
+function pickAlign(raw: unknown): (typeof ALIGNS)[number] | undefined {
+  return typeof raw === "string" && (ALIGNS as readonly string[]).includes(raw)
+    ? (raw as (typeof ALIGNS)[number])
+    : undefined;
+}
+
+function normalizeGap(raw: unknown): string | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw)) return `${raw}px`;
+  if (typeof raw === "string" && raw.length > 0) return raw;
+  return undefined;
+}
+
+export function ButtonsComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const align = pickAlign(attrs.align);
+  const gap = normalizeGap(attrs.gap);
+  return (
+    <div data-plumix-block="core/buttons" data-align={align} data-gap={gap}>
+      {children}
+    </div>
+  );
+}

--- a/packages/blocks/src/buttons/buttons.test.tsx
+++ b/packages/blocks/src/buttons/buttons.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+
+import { buttonBlock } from "../button/index.js";
+import { mockRegistry, renderBlock } from "../test/index.js";
+import { buttonsBlock } from "./index.js";
+
+describe("core/buttons", () => {
+  test("renders as a <div> wrapping button children", async () => {
+    const registry = await mockRegistry({
+      core: [buttonsBlock, buttonBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/buttons", content: [] }],
+      },
+    });
+    expect(html).toBe('<div data-plumix-block="core/buttons"></div>');
+  });
+
+  test.each(["start", "center", "end", "between"])(
+    "exposes align=%s as data-align",
+    async (align) => {
+      const registry = await mockRegistry({
+        core: [buttonsBlock, buttonBlock],
+      });
+      const html = renderBlock({
+        registry,
+        content: {
+          type: "doc",
+          content: [{ type: "core/buttons", attrs: { align }, content: [] }],
+        },
+      });
+      expect(html).toContain(`data-align="${align}"`);
+    },
+  );
+
+  test("rejects unknown align values", async () => {
+    const registry = await mockRegistry({
+      core: [buttonsBlock, buttonBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          { type: "core/buttons", attrs: { align: "diagonal" }, content: [] },
+        ],
+      },
+    });
+    expect(html).not.toContain("data-align");
+  });
+
+  test("normalises numeric gap to a px string", async () => {
+    const registry = await mockRegistry({
+      core: [buttonsBlock, buttonBlock],
+    });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          { type: "core/buttons", attrs: { gap: 12 }, content: [] },
+          { type: "core/buttons", attrs: { gap: "1rem" }, content: [] },
+        ],
+      },
+    });
+    expect(html).toContain('data-gap="12px"');
+    expect(html).toContain('data-gap="1rem"');
+  });
+});

--- a/packages/blocks/src/buttons/index.ts
+++ b/packages/blocks/src/buttons/index.ts
@@ -1,0 +1,10 @@
+import { defineBlock } from "../define-block.js";
+
+export const buttonsBlock = defineBlock({
+  name: "core/buttons",
+  title: "Buttons",
+  category: "interactive",
+  description: "Container for a row of call-to-action buttons.",
+  schema: () => import("./schema.js").then((m) => m.buttonsSchema),
+  component: () => import("./Component.js").then((m) => m.ButtonsComponent),
+});

--- a/packages/blocks/src/buttons/schema.ts
+++ b/packages/blocks/src/buttons/schema.ts
@@ -1,0 +1,20 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const buttonsSchema = Node.create({
+  name: "core/buttons",
+  group: "block",
+  content: "block*",
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: "div[data-plumix-block='core/buttons']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/buttons" }),
+      0,
+    ];
+  },
+});

--- a/packages/blocks/src/callout/Component.tsx
+++ b/packages/blocks/src/callout/Component.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+const VARIANTS = ["info", "warn", "error", "success", "note"] as const;
+type CalloutVariant = (typeof VARIANTS)[number];
+
+function pickVariant(raw: unknown): CalloutVariant {
+  return typeof raw === "string" &&
+    (VARIANTS as readonly string[]).includes(raw)
+    ? (raw as CalloutVariant)
+    : "info";
+}
+
+export function CalloutComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const variant = pickVariant(attrs.variant);
+  const icon = typeof attrs.icon === "string" ? attrs.icon : undefined;
+  return (
+    <aside
+      role="note"
+      data-plumix-block="core/callout"
+      data-variant={variant}
+      data-icon={icon}
+    >
+      {children}
+    </aside>
+  );
+}

--- a/packages/blocks/src/callout/callout.test.tsx
+++ b/packages/blocks/src/callout/callout.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+
+import { mockRegistry, renderBlock } from "../test/index.js";
+import { calloutBlock } from "./index.js";
+
+describe("core/callout", () => {
+  test('renders as <aside role="note"> wrapping children', async () => {
+    const registry = await mockRegistry({ core: [calloutBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/callout", content: [] }],
+      },
+    });
+    expect(html).toBe(
+      '<aside role="note" data-plumix-block="core/callout" data-variant="info"></aside>',
+    );
+  });
+
+  test.each(["info", "warn", "error", "success", "note"])(
+    "exposes variant=%s as data-variant",
+    async (variant) => {
+      const registry = await mockRegistry({ core: [calloutBlock] });
+      const html = renderBlock({
+        registry,
+        content: {
+          type: "doc",
+          content: [{ type: "core/callout", attrs: { variant }, content: [] }],
+        },
+      });
+      expect(html).toContain(`data-variant="${variant}"`);
+    },
+  );
+
+  test("falls back to data-variant=info on unknown variants", async () => {
+    const registry = await mockRegistry({ core: [calloutBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/callout",
+            attrs: { variant: "rainbow" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-variant="info"');
+  });
+
+  test("exposes icon attr as data-icon", async () => {
+    const registry = await mockRegistry({ core: [calloutBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/callout",
+            attrs: { icon: "lightbulb" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-icon="lightbulb"');
+  });
+
+  test("omits data-icon when icon attr is absent or non-string", async () => {
+    const registry = await mockRegistry({ core: [calloutBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          { type: "core/callout", content: [] },
+          { type: "core/callout", attrs: { icon: 42 }, content: [] },
+        ],
+      },
+    });
+    expect(html).not.toContain("data-icon");
+  });
+});

--- a/packages/blocks/src/callout/index.ts
+++ b/packages/blocks/src/callout/index.ts
@@ -1,0 +1,10 @@
+import { defineBlock } from "../define-block.js";
+
+export const calloutBlock = defineBlock({
+  name: "core/callout",
+  title: "Callout",
+  category: "interactive",
+  description: "Highlighted aside for info / warning / error / success / note.",
+  schema: () => import("./schema.js").then((m) => m.calloutSchema),
+  component: () => import("./Component.js").then((m) => m.CalloutComponent),
+});

--- a/packages/blocks/src/callout/schema.ts
+++ b/packages/blocks/src/callout/schema.ts
@@ -1,0 +1,23 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const calloutSchema = Node.create({
+  name: "core/callout",
+  group: "block",
+  content: "block*",
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: "aside[data-plumix-block='core/callout']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "aside",
+      mergeAttributes(HTMLAttributes, {
+        role: "note",
+        "data-plumix-block": "core/callout",
+      }),
+      0,
+    ];
+  },
+});

--- a/packages/blocks/src/core-blocks.test.ts
+++ b/packages/blocks/src/core-blocks.test.ts
@@ -23,4 +23,19 @@ describe("coreBlocks catalogue", () => {
       expect.arrayContaining(["core/group", "core/columns", "core/column"]),
     );
   });
+
+  test("interactive blocks declare the `interactive` category", () => {
+    const interactiveBlocks = coreBlocks.filter(
+      (b) => b.category === "interactive",
+    );
+    const names = interactiveBlocks.map((b) => b.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "core/buttons",
+        "core/button",
+        "core/details",
+        "core/callout",
+      ]),
+    );
+  });
 });

--- a/packages/blocks/src/core-blocks.ts
+++ b/packages/blocks/src/core-blocks.ts
@@ -1,6 +1,10 @@
 import type { BlockSpec } from "./types.js";
+import { buttonBlock } from "./button/index.js";
+import { buttonsBlock } from "./buttons/index.js";
+import { calloutBlock } from "./callout/index.js";
 import { columnBlock } from "./columns/column.js";
 import { columnsBlock } from "./columns/index.js";
+import { detailsBlock } from "./details/index.js";
 import { groupBlock } from "./group/index.js";
 import { headingBlock } from "./heading/index.js";
 import { paragraphBlock } from "./paragraph/index.js";
@@ -14,9 +18,8 @@ import { paragraphBlock } from "./paragraph/index.js";
  * allowlist; the spec itself stays registered so existing content
  * continues to round-trip losslessly.
  *
- * Order is purely a readability convention: typography first, then
- * layout primitives, then interactive blocks as they land in
- * subsequent slices.
+ * Order is purely a readability convention: typography → layout →
+ * interactive → structured, in the order slices land.
  */
 export const coreBlocks: readonly BlockSpec[] = Object.freeze([
   paragraphBlock,
@@ -24,4 +27,8 @@ export const coreBlocks: readonly BlockSpec[] = Object.freeze([
   groupBlock,
   columnsBlock,
   columnBlock,
+  buttonsBlock,
+  buttonBlock,
+  detailsBlock,
+  calloutBlock,
 ]);

--- a/packages/blocks/src/details/Component.tsx
+++ b/packages/blocks/src/details/Component.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+const DEFAULT_SUMMARY = "Details";
+
+export function DetailsComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const summary =
+    typeof attrs.summary === "string" && attrs.summary.length > 0
+      ? attrs.summary
+      : DEFAULT_SUMMARY;
+  const open = attrs.open === true;
+  return (
+    <details open={open} data-plumix-block="core/details">
+      <summary>{summary}</summary>
+      {children}
+    </details>
+  );
+}

--- a/packages/blocks/src/details/details.test.tsx
+++ b/packages/blocks/src/details/details.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+
+import { mockRegistry, renderBlock } from "../test/index.js";
+import { detailsBlock } from "./index.js";
+
+describe("core/details", () => {
+  test("renders <details><summary> with the summary attribute", async () => {
+    const registry = await mockRegistry({ core: [detailsBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/details",
+            attrs: { summary: "Click to expand" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toBe(
+      '<details data-plumix-block="core/details"><summary>Click to expand</summary></details>',
+    );
+  });
+
+  test("falls back to a default summary when summary attr is missing", async () => {
+    const registry = await mockRegistry({ core: [detailsBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/details", content: [] }],
+      },
+    });
+    expect(html).toContain("<summary>Details</summary>");
+  });
+
+  test("emits open attribute when open=true", async () => {
+    const registry = await mockRegistry({ core: [detailsBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/details",
+            attrs: { open: true, summary: "Open by default" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain("<details");
+    expect(html).toContain("open=");
+  });
+
+  test("escapes summary HTML — no XSS via summary attr", async () => {
+    const registry = await mockRegistry({ core: [detailsBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/details",
+            attrs: { summary: "<script>alert(1)</script>" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/packages/blocks/src/details/index.ts
+++ b/packages/blocks/src/details/index.ts
@@ -1,0 +1,10 @@
+import { defineBlock } from "../define-block.js";
+
+export const detailsBlock = defineBlock({
+  name: "core/details",
+  title: "Details",
+  category: "interactive",
+  description: "Native <details>/<summary> collapsible region.",
+  schema: () => import("./schema.js").then((m) => m.detailsSchema),
+  component: () => import("./Component.js").then((m) => m.DetailsComponent),
+});

--- a/packages/blocks/src/details/schema.ts
+++ b/packages/blocks/src/details/schema.ts
@@ -1,0 +1,27 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const detailsSchema = Node.create({
+  name: "core/details",
+  group: "block",
+  content: "block*",
+  defining: true,
+
+  addAttributes() {
+    return {
+      summary: { default: "" },
+      open: { default: false },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "details[data-plumix-block='core/details']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "details",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/details" }),
+      0,
+    ];
+  },
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -26,8 +26,12 @@ export type {
 } from "./types.js";
 
 export { coreBlocks } from "./core-blocks.js";
+export { buttonBlock } from "./button/index.js";
+export { buttonsBlock } from "./buttons/index.js";
+export { calloutBlock } from "./callout/index.js";
 export { columnBlock } from "./columns/column.js";
 export { columnsBlock } from "./columns/index.js";
+export { detailsBlock } from "./details/index.js";
 export { groupBlock } from "./group/index.js";
 export { headingBlock } from "./heading/index.js";
 export { paragraphBlock } from "./paragraph/index.js";


### PR DESCRIPTION
Adds four of the five interactive containers from slice #308. \`core/table\` is deferred to its own PR — table's Tiptap schema (rows, cells, headers, per-column alignment) is heavier than the rest combined and deserves focused review.

**Button safety**

\`core/button\` reuses the same \`SAFE_HREF\` regex the walker uses for link marks — \`javascript:\`, \`data:\`, and other unsafe schemes drop silently. \`target="_blank"\` automatically pulls \`rel="noopener noreferrer"\` so theme authors can't accidentally tab-nap visitors. \`text\` flows through React's auto-escaping so summary-style XSS attempts produce escaped output.

**Allowlist guards, not passthrough**

\`variant\`, \`size\`, \`align\`, \`callout.variant\` all use allowlist-then-data-attr pattern: unknown values drop rather than pass through, so theme CSS only ever sees the canonical set. Same shape as \`core/group.layout\` from #307.

**Native semantics where they exist**

\`core/details\` uses native \`<details>\`/\`<summary>\` — zero JS, zero ARIA hacks. \`core/callout\` uses \`<aside role="note">\` so screen readers get a sensible default before themes layer presentation. \`core/button\` is an \`<a>\` not a \`<button>\` — these are link-style CTAs; form-submit buttons aren't part of the v1 set.

**Loose schema, strict UI** (same pattern as #307)

Tiptap schemas use \`content: "block*"\` rather than \`core/buttons\` → \`core/button\` only. Strict containment is an editor-surface concern (allowedBlocks in the slash menu) that lands with the admin slice.

33 new tests across the four blocks plus updated coreBlocks catalogue assertions for the \`interactive\` category. Full repo: 60/60 turbo tasks green.

Refs #308
Refs #300