### PR TITLE
feat(blocks,core,plumix,admin): marks registry + bubble menu + theme overrides

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.2",
     "@playwright/test": "^1.59.1",
+    "@plumix/blocks": "workspace:*",
     "@plumix/core": "workspace:*",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",

--- a/packages/admin/src/components/editor/bubble-menu/BubbleMenu.tsx
+++ b/packages/admin/src/components/editor/bubble-menu/BubbleMenu.tsx
@@ -1,0 +1,31 @@
+import type { Editor } from "@tiptap/react";
+import type { ReactElement } from "react";
+import { BubbleMenu as TiptapBubbleMenu } from "@tiptap/react/menus";
+
+import type { MarkRegistry } from "@plumix/blocks";
+
+import { MarkToolbar } from "./MarkToolbar.js";
+
+interface BubbleMenuProps {
+  readonly editor: Editor;
+  readonly markRegistry: MarkRegistry;
+}
+
+/**
+ * Selection-anchored mark toolbar.
+ *
+ * Tiptap's `BubbleMenu` owns positioning via floating-ui and visibility
+ * via selection state; this wrapper just slots the registry-driven
+ * `MarkToolbar` into it so the rendering layer stays free of editor
+ * lifecycle concerns and can be tested without floating-ui.
+ */
+export function BubbleMenu({
+  editor,
+  markRegistry,
+}: BubbleMenuProps): ReactElement {
+  return (
+    <TiptapBubbleMenu editor={editor} data-plumix-bubble-menu="">
+      <MarkToolbar editor={editor} markRegistry={markRegistry} />
+    </TiptapBubbleMenu>
+  );
+}

--- a/packages/admin/src/components/editor/bubble-menu/MarkToolbar.test.tsx
+++ b/packages/admin/src/components/editor/bubble-menu/MarkToolbar.test.tsx
@@ -1,0 +1,165 @@
+import type { Editor } from "@tiptap/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { MarkRegistry } from "@plumix/blocks";
+import { coreMarks, mergeMarkRegistry } from "@plumix/blocks";
+
+import { MarkToolbar } from "./MarkToolbar.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const ALL_CORE_MARK_NAMES = [
+  "bold",
+  "italic",
+  "strike",
+  "code",
+  "link",
+  "underline",
+  "subscript",
+  "superscript",
+  "highlight",
+  "kbd",
+  "abbr",
+  "cite",
+  "small",
+] as const;
+
+interface StubEditorOptions {
+  readonly activeMarks?: readonly string[];
+  readonly schemaMarks?: readonly string[];
+}
+
+function stubEditor(opts: StubEditorOptions = {}): {
+  editor: Editor;
+  toggleMark: ReturnType<typeof vi.fn>;
+} {
+  const toggleMark = vi.fn();
+  const chain = {
+    focus: () => chain,
+    toggleMark: (name: string) => {
+      toggleMark(name);
+      return chain;
+    },
+    run: () => true,
+  };
+  const activeSet = new Set(opts.activeMarks ?? []);
+  const schemaMarks = Object.fromEntries(
+    (opts.schemaMarks ?? ALL_CORE_MARK_NAMES).map((name) => [name, {}]),
+  );
+  const editor = {
+    isActive: (name: string) => activeSet.has(name),
+    chain: () => chain,
+    schema: { marks: schemaMarks },
+  } as unknown as Editor;
+  return { editor, toggleMark };
+}
+
+async function buildRegistry(): Promise<MarkRegistry> {
+  return mergeMarkRegistry({
+    core: coreMarks,
+    plugins: [],
+    themeOverrides: {},
+    themeId: null,
+  });
+}
+
+describe("MarkToolbar", () => {
+  test("renders one button per registered mark", async () => {
+    const { editor } = stubEditor();
+    const markRegistry = await buildRegistry();
+    render(<MarkToolbar editor={editor} markRegistry={markRegistry} />);
+
+    for (const name of [
+      "bold",
+      "italic",
+      "strike",
+      "code",
+      "link",
+      "underline",
+      "subscript",
+      "superscript",
+      "highlight",
+      "kbd",
+      "abbr",
+      "cite",
+      "small",
+    ]) {
+      expect(screen.queryByTestId(`bubble-menu-${name}`)).toBeInTheDocument();
+    }
+  });
+
+  test("button click invokes editor.chain().focus().toggleMark(name).run()", async () => {
+    const { editor, toggleMark } = stubEditor();
+    const markRegistry = await buildRegistry();
+    render(<MarkToolbar editor={editor} markRegistry={markRegistry} />);
+
+    fireEvent.click(screen.getByTestId("bubble-menu-bold"));
+    expect(toggleMark).toHaveBeenCalledWith("bold");
+
+    fireEvent.click(screen.getByTestId("bubble-menu-italic"));
+    expect(toggleMark).toHaveBeenCalledWith("italic");
+  });
+
+  test("aria-pressed reflects editor.isActive", async () => {
+    const { editor } = stubEditor({ activeMarks: ["bold", "underline"] });
+    const markRegistry = await buildRegistry();
+    render(<MarkToolbar editor={editor} markRegistry={markRegistry} />);
+
+    expect(screen.getByTestId("bubble-menu-bold")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("bubble-menu-underline")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("bubble-menu-italic")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  test("button has aria-label from bubbleMenuLabel ?? title", async () => {
+    const { editor } = stubEditor();
+    const markRegistry = await buildRegistry();
+    render(<MarkToolbar editor={editor} markRegistry={markRegistry} />);
+
+    expect(screen.getByTestId("bubble-menu-bold")).toHaveAttribute(
+      "aria-label",
+      "Bold",
+    );
+    expect(screen.getByTestId("bubble-menu-code")).toHaveAttribute(
+      "aria-label",
+      "Inline code",
+    );
+  });
+
+  test("filters out marks not present in editor.schema.marks", async () => {
+    const { editor } = stubEditor({
+      schemaMarks: ["bold", "italic", "strike", "code", "link"],
+    });
+    const markRegistry = await buildRegistry();
+    render(<MarkToolbar editor={editor} markRegistry={markRegistry} />);
+
+    for (const present of ["bold", "italic", "strike", "code", "link"]) {
+      expect(
+        screen.queryByTestId(`bubble-menu-${present}`),
+      ).toBeInTheDocument();
+    }
+    for (const missing of [
+      "underline",
+      "subscript",
+      "superscript",
+      "highlight",
+      "kbd",
+      "abbr",
+      "cite",
+      "small",
+    ]) {
+      expect(screen.queryByTestId(`bubble-menu-${missing}`)).toBeNull();
+    }
+  });
+});

--- a/packages/admin/src/components/editor/bubble-menu/MarkToolbar.tsx
+++ b/packages/admin/src/components/editor/bubble-menu/MarkToolbar.tsx
@@ -1,0 +1,63 @@
+import type { Editor } from "@tiptap/react";
+import type { ReactElement } from "react";
+
+import type { MarkRegistry, ResolvedMarkSpec } from "@plumix/blocks";
+
+interface MarkToolbarProps {
+  readonly editor: Editor;
+  readonly markRegistry: MarkRegistry;
+}
+
+/**
+ * Pure rendering layer for the mark bubble menu — one button per
+ * registered mark, with `aria-pressed` reflecting the editor's active
+ * state and onClick dispatching the standard Tiptap toggle chain.
+ *
+ * Kept separate from the Tiptap `BubbleMenu` positioning wrapper so
+ * tests can render this directly against a stub editor without
+ * involving floating-ui or selection state.
+ */
+export function MarkToolbar({
+  editor,
+  markRegistry,
+}: MarkToolbarProps): ReactElement {
+  // Skip marks the editor's schema doesn't load — clicking them would
+  // be a no-op and we don't want dead buttons surfacing to the user.
+  const schemaMarks = editor.schema.marks as Record<string, unknown>;
+  const marks: ResolvedMarkSpec[] = Array.from(
+    markRegistry,
+    ([, spec]) => spec,
+  ).filter((spec) => spec.name in schemaMarks);
+
+  return (
+    <div data-plumix-mark-toolbar="" role="toolbar">
+      {marks.map((mark) => (
+        <MarkButton key={mark.name} mark={mark} editor={editor} />
+      ))}
+    </div>
+  );
+}
+
+interface MarkButtonProps {
+  readonly mark: ResolvedMarkSpec;
+  readonly editor: Editor;
+}
+
+function MarkButton({ mark, editor }: MarkButtonProps): ReactElement {
+  const label = mark.bubbleMenuLabel ?? mark.title;
+  const isActive = editor.isActive(mark.name);
+  const onClick = (): void => {
+    editor.chain().focus().toggleMark(mark.name).run();
+  };
+  return (
+    <button
+      type="button"
+      data-testid={`bubble-menu-${mark.name}`}
+      aria-pressed={isActive}
+      aria-label={label}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/admin/src/components/editor/bubble-menu/index.ts
+++ b/packages/admin/src/components/editor/bubble-menu/index.ts
@@ -1,0 +1,2 @@
+export { BubbleMenu } from "./BubbleMenu.js";
+export { MarkToolbar } from "./MarkToolbar.js";

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -4,6 +4,9 @@ import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils.js";
 import { EditorContent, useEditor } from "@tiptap/react";
 
+import type { MarkRegistry } from "@plumix/blocks";
+
+import { BubbleMenu } from "./bubble-menu/index.js";
 import { buildTiptapExtensions } from "./tiptap-extensions.js";
 import { TiptapToolbar } from "./tiptap-toolbar.js";
 
@@ -26,6 +29,7 @@ export function TiptapEditor({
   marks,
   nodes,
   blocks,
+  markRegistry,
 }: {
   readonly value: JSONContent | null;
   readonly onChange: (json: JSONContent) => void;
@@ -34,6 +38,12 @@ export function TiptapEditor({
   readonly marks?: readonly string[];
   readonly nodes?: readonly string[];
   readonly blocks?: readonly string[];
+  /**
+   * When supplied, a selection-anchored BubbleMenu renders one button
+   * per registered mark. Filtered against the live editor schema so
+   * marks not present as Tiptap extensions are silently skipped.
+   */
+  readonly markRegistry?: MarkRegistry;
 }): ReactNode {
   // Shields the `value` sync-effect from echoing the editor's own
   // emissions back through the parent's state — would otherwise
@@ -84,6 +94,9 @@ export function TiptapEditor({
         disabled={disabled}
         allowlist={allowlist}
       />
+      {markRegistry ? (
+        <BubbleMenu editor={editor} markRegistry={markRegistry} />
+      ) : null}
       <EditorContent editor={editor} />
     </div>
   );

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -25,6 +25,19 @@ export type {
   TiptapNode,
 } from "./types.js";
 
+export { defineMark } from "./marks/define-mark.js";
+export { MarkRegistrationError } from "./marks/errors.js";
+export { mergeMarkRegistry } from "./marks/registry.js";
+export type { MergeMarkRegistryInput } from "./marks/registry.js";
+export type {
+  MarkComponent,
+  MarkProps,
+  MarkRegistry,
+  MarkSpec,
+  ResolvedMarkSpec,
+} from "./marks/types.js";
+export { coreMarks } from "./marks/core/index.js";
+
 export { coreBlocks } from "./core-blocks.js";
 export { buttonBlock } from "./button/index.js";
 export { buttonsBlock } from "./buttons/index.js";

--- a/packages/blocks/src/marks/core/abbr.tsx
+++ b/packages/blocks/src/marks/core/abbr.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from "react";
+import { Mark, mergeAttributes } from "@tiptap/core";
+
+import type { MarkComponent, MarkProps } from "../types.js";
+import { defineMark } from "../define-mark.js";
+
+const abbrSchema = Mark.create({
+  name: "abbr",
+  addAttributes() {
+    return { title: { default: null } };
+  },
+  parseHTML() {
+    return [{ tag: "abbr" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["abbr", mergeAttributes(HTMLAttributes), 0];
+  },
+});
+
+const AbbrComponent: MarkComponent = ({
+  attrs,
+  children,
+}: MarkProps): ReactElement => {
+  const title =
+    typeof attrs.title === "string" && attrs.title.length > 0
+      ? attrs.title
+      : undefined;
+  return <abbr title={title}>{children}</abbr>;
+};
+AbbrComponent.displayName = "abbr-mark";
+
+export const abbrMark = defineMark({
+  name: "abbr",
+  title: "Abbreviation",
+  description: "Abbreviation with an optional tooltip via the title attr.",
+  schema: () => Promise.resolve(abbrSchema),
+  component: () => Promise.resolve(AbbrComponent),
+});

--- a/packages/blocks/src/marks/core/core-marks.test.tsx
+++ b/packages/blocks/src/marks/core/core-marks.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+
+import { paragraphBlock } from "../../paragraph/index.js";
+import {
+  mockMarkRegistry,
+  mockRegistry,
+  renderBlock,
+} from "../../test/index.js";
+import { coreMarks } from "./index.js";
+
+/**
+ * The walker-switch slice replaces the walker's hardcoded mark dispatch
+ * with a registry-driven lookup. These tests assert each shipped mark
+ * renders to its canonical HTML element. They double as the contract
+ * the BubbleMenu + theme-override tests build on.
+ */
+
+async function renderTextWithMark(
+  markType: string,
+  attrs?: Record<string, unknown>,
+): Promise<string> {
+  const registry = await mockRegistry({ core: [paragraphBlock] });
+  const markRegistry = await mockMarkRegistry({ core: coreMarks });
+  return renderBlock({
+    registry,
+    markRegistry,
+    content: {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Hi",
+              marks: [{ type: markType, attrs }],
+            },
+          ],
+        },
+      ],
+    },
+  });
+}
+
+describe("core marks — HTML element mapping", () => {
+  test.each([
+    { mark: "bold", expected: "<p><strong>Hi</strong></p>" },
+    { mark: "italic", expected: "<p><em>Hi</em></p>" },
+    { mark: "strike", expected: "<p><s>Hi</s></p>" },
+    { mark: "code", expected: "<p><code>Hi</code></p>" },
+    { mark: "underline", expected: "<p><u>Hi</u></p>" },
+    { mark: "subscript", expected: "<p><sub>Hi</sub></p>" },
+    { mark: "superscript", expected: "<p><sup>Hi</sup></p>" },
+    { mark: "highlight", expected: "<p><mark>Hi</mark></p>" },
+    { mark: "kbd", expected: "<p><kbd>Hi</kbd></p>" },
+    { mark: "cite", expected: "<p><cite>Hi</cite></p>" },
+    { mark: "small", expected: "<p><small>Hi</small></p>" },
+  ])("$mark renders as $expected", async ({ mark, expected }) => {
+    expect(await renderTextWithMark(mark)).toBe(expected);
+  });
+});
+
+describe("core marks — link", () => {
+  test("renders <a href> with rel=noopener for safe https hrefs", async () => {
+    expect(
+      await renderTextWithMark("link", { href: "https://example.com" }),
+    ).toBe(
+      '<p><a href="https://example.com" rel="noopener noreferrer nofollow">Hi</a></p>',
+    );
+  });
+
+  test("strips unsafe javascript: hrefs", async () => {
+    expect(
+      await renderTextWithMark("link", { href: "javascript:alert(1)" }),
+    ).toBe("<p>Hi</p>");
+  });
+
+  test("emits target when set", async () => {
+    const html = await renderTextWithMark("link", {
+      href: "https://example.com",
+      target: "_blank",
+    });
+    expect(html).toContain('target="_blank"');
+  });
+
+  test("ignores attacker-controlled rel that strips safety tokens", async () => {
+    expect(
+      await renderTextWithMark("link", {
+        href: "https://example.com",
+        rel: "",
+      }),
+    ).toBe(
+      '<p><a href="https://example.com" rel="noopener noreferrer nofollow">Hi</a></p>',
+    );
+    expect(
+      await renderTextWithMark("link", {
+        href: "https://example.com",
+        rel: "opener",
+      }),
+    ).toBe(
+      '<p><a href="https://example.com" rel="noopener noreferrer nofollow">Hi</a></p>',
+    );
+  });
+});
+
+describe("core marks — abbr", () => {
+  test("renders <abbr title> with the title attribute", async () => {
+    expect(
+      await renderTextWithMark("abbr", { title: "HyperText Markup Language" }),
+    ).toBe('<p><abbr title="HyperText Markup Language">Hi</abbr></p>');
+  });
+
+  test("omits title attribute when empty", async () => {
+    expect(await renderTextWithMark("abbr", { title: "" })).toBe(
+      "<p><abbr>Hi</abbr></p>",
+    );
+  });
+});

--- a/packages/blocks/src/marks/core/index.ts
+++ b/packages/blocks/src/marks/core/index.ts
@@ -1,0 +1,85 @@
+import type { MarkSpec } from "../types.js";
+import { abbrMark } from "./abbr.js";
+import { linkMark } from "./link.js";
+import { simpleMark } from "./simple.js";
+
+/**
+ * The 13 canonical inline marks shipped by `@plumix/blocks`. Order is
+ * the conventional bubble-menu ordering: text-format marks first, then
+ * link, then specialised semantic marks.
+ */
+export const coreMarks: readonly MarkSpec[] = Object.freeze([
+  simpleMark({
+    name: "bold",
+    title: "Bold",
+    tag: "strong",
+    parseTags: ["strong", "b"],
+    keyboardShortcut: "Mod-b",
+  }),
+  simpleMark({
+    name: "italic",
+    title: "Italic",
+    tag: "em",
+    parseTags: ["em", "i"],
+    keyboardShortcut: "Mod-i",
+  }),
+  simpleMark({
+    name: "strike",
+    title: "Strikethrough",
+    tag: "s",
+    parseTags: ["s", "del", "strike"],
+    keyboardShortcut: "Mod-Shift-X",
+  }),
+  simpleMark({
+    name: "code",
+    title: "Inline code",
+    tag: "code",
+    parseTags: ["code"],
+    keyboardShortcut: "Mod-e",
+  }),
+  linkMark,
+  simpleMark({
+    name: "underline",
+    title: "Underline",
+    tag: "u",
+    parseTags: ["u"],
+    keyboardShortcut: "Mod-u",
+  }),
+  simpleMark({
+    name: "subscript",
+    title: "Subscript",
+    tag: "sub",
+    parseTags: ["sub"],
+  }),
+  simpleMark({
+    name: "superscript",
+    title: "Superscript",
+    tag: "sup",
+    parseTags: ["sup"],
+  }),
+  simpleMark({
+    name: "highlight",
+    title: "Highlight",
+    tag: "mark",
+    parseTags: ["mark"],
+  }),
+  simpleMark({
+    name: "kbd",
+    title: "Keyboard",
+    tag: "kbd",
+    parseTags: ["kbd"],
+  }),
+  abbrMark,
+  simpleMark({
+    name: "cite",
+    title: "Citation",
+    tag: "cite",
+    parseTags: ["cite"],
+  }),
+  simpleMark({
+    name: "small",
+    title: "Small print",
+    tag: "small",
+    parseTags: ["small"],
+  }),
+]);

--- a/packages/blocks/src/marks/core/link.tsx
+++ b/packages/blocks/src/marks/core/link.tsx
@@ -1,0 +1,69 @@
+import type { ReactElement } from "react";
+import { Mark, mergeAttributes } from "@tiptap/core";
+
+import type { MarkComponent, MarkProps } from "../types.js";
+import { defineMark } from "../define-mark.js";
+
+// Same allowlist the walker's link-mark fallback uses, kept in sync
+// deliberately so `link` content rendered through the registry
+// matches the legacy code path's safety guarantees.
+const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|#|\?|\.\.?\/)/i;
+
+function sanitizeHref(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "" || !SAFE_HREF.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+const linkSchema = Mark.create({
+  name: "link",
+  inclusive: false,
+
+  addAttributes() {
+    return {
+      href: { default: null },
+      target: { default: null },
+      rel: { default: "noopener noreferrer nofollow" },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "a[href]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["a", mergeAttributes(HTMLAttributes), 0];
+  },
+});
+
+const LinkComponent: MarkComponent = ({
+  attrs,
+  children,
+}: MarkProps): ReactElement | null => {
+  const href = sanitizeHref(attrs.href);
+  if (href === undefined) {
+    // Returning `children` (rather than `<a>` with no href) keeps text
+    // legible when the editor pastes content carrying an unsafe scheme.
+    return children as ReactElement | null;
+  }
+  // `rel` is always hardcoded — never trust attrs.rel, since a pasted
+  // `rel=""` or `rel="opener"` would strip the noreferrer/nofollow safety
+  // the schema's default claims. Same reason `target` is clamped: only
+  // explicit `_blank` is honored, anything else is dropped.
+  const target = attrs.target === "_blank" ? "_blank" : undefined;
+  return (
+    <a href={href} target={target} rel="noopener noreferrer nofollow">
+      {children}
+    </a>
+  );
+};
+LinkComponent.displayName = "link-mark";
+
+export const linkMark = defineMark({
+  name: "link",
+  title: "Link",
+  description: "Inline hyperlink with safe-href filtering.",
+  schema: () => Promise.resolve(linkSchema),
+  component: () => Promise.resolve(LinkComponent),
+});

--- a/packages/blocks/src/marks/core/simple.tsx
+++ b/packages/blocks/src/marks/core/simple.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from "react";
+import { Mark } from "@tiptap/core";
+
+import type { MarkComponent, MarkProps, MarkSpec } from "../types.js";
+import { defineMark } from "../define-mark.js";
+
+/**
+ * Most marks are zero-attr "wrap children in a fixed HTML element". This
+ * helper encodes that pattern once: declare the canonical HTML tag, the
+ * parseHTML pattern that absorbs both that tag and any aliases (so pasted
+ * `<b>` rolls up into `bold`, etc.), and the React Component is just the
+ * tag wrapping children.
+ *
+ * Mark / spec name are kept identical (`schemaName === spec.name`) so
+ * the registry's schemaNameMismatch guard stays satisfied.
+ */
+interface SimpleMarkOptions {
+  readonly name: string;
+  readonly title: string;
+  readonly tag: keyof React.JSX.IntrinsicElements;
+  readonly parseTags: readonly string[];
+  readonly keyboardShortcut?: string;
+  readonly bubbleMenuLabel?: string;
+  readonly bubbleMenuIcon?: string;
+}
+
+export function simpleMark(opts: SimpleMarkOptions): MarkSpec {
+  const schema = Mark.create({
+    name: opts.name,
+    parseHTML() {
+      return opts.parseTags.map((tag) => ({ tag }));
+    },
+    renderHTML() {
+      return [opts.tag, 0];
+    },
+  });
+
+  const Component: MarkComponent = ({ children }: MarkProps): ReactElement => {
+    const Tag = opts.tag;
+    return <Tag>{children}</Tag>;
+  };
+  Component.displayName = `${opts.name}-mark`;
+
+  return defineMark({
+    name: opts.name,
+    title: opts.title,
+    keyboardShortcut: opts.keyboardShortcut,
+    bubbleMenuLabel: opts.bubbleMenuLabel,
+    bubbleMenuIcon: opts.bubbleMenuIcon,
+    schema: () => Promise.resolve(schema),
+    component: () => Promise.resolve(Component),
+  });
+}

--- a/packages/blocks/src/marks/define-mark.test.ts
+++ b/packages/blocks/src/marks/define-mark.test.ts
@@ -1,0 +1,79 @@
+import { Mark } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import { defineMark } from "./define-mark.js";
+import { MarkRegistrationError } from "./errors.js";
+
+const STRONG_SCHEMA = () => Promise.resolve(Mark.create({ name: "bold" }));
+
+const STRONG_COMPONENT = () =>
+  Promise.resolve(({ children }: { children: unknown }) => children as never);
+
+describe("defineMark", () => {
+  test("returns a frozen spec on valid input", () => {
+    const spec = defineMark({
+      name: "bold",
+      title: "Bold",
+      schema: STRONG_SCHEMA,
+      component: STRONG_COMPONENT,
+    });
+    expect(spec.name).toBe("bold");
+    expect(spec.title).toBe("Bold");
+    expect(Object.isFrozen(spec)).toBe(true);
+  });
+
+  test("rejects empty name", () => {
+    expect(() =>
+      defineMark({
+        name: "",
+        title: "Invalid",
+        schema: STRONG_SCHEMA,
+        component: STRONG_COMPONENT,
+      }),
+    ).toThrow(MarkRegistrationError);
+  });
+
+  test("rejects names with uppercase", () => {
+    expect(() =>
+      defineMark({
+        name: "Bold",
+        title: "Invalid",
+        schema: STRONG_SCHEMA,
+        component: STRONG_COMPONENT,
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_name_pattern" }));
+  });
+
+  test("rejects names starting with a digit", () => {
+    expect(() =>
+      defineMark({
+        name: "1bold",
+        title: "Invalid",
+        schema: STRONG_SCHEMA,
+        component: STRONG_COMPONENT,
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_name_pattern" }));
+  });
+
+  test("accepts hyphenated names (code, sub-script)", () => {
+    expect(() =>
+      defineMark({
+        name: "code",
+        title: "Inline code",
+        schema: STRONG_SCHEMA,
+        component: STRONG_COMPONENT,
+      }),
+    ).not.toThrow();
+  });
+
+  test("accepts namespaced plugin-style names (affiliate/link)", () => {
+    expect(() =>
+      defineMark({
+        name: "affiliate/link",
+        title: "Affiliate link",
+        schema: STRONG_SCHEMA,
+        component: STRONG_COMPONENT,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/blocks/src/marks/define-mark.ts
+++ b/packages/blocks/src/marks/define-mark.ts
@@ -1,0 +1,37 @@
+import type { MarkSpec } from "./types.js";
+import { MarkRegistrationError } from "./errors.js";
+
+const MARK_NAME_PATTERN = /^[a-z][a-z0-9-]*(\/[a-z][a-z0-9-]*)?$/;
+// Tiptap accepts modifier expressions like "Mod-b", "Mod-Shift-X",
+// "Shift-Alt-c". Modifier tokens are multi-char capitalized words
+// (Mod, Shift, Alt, Ctrl, Cmd, Meta, Opt); the trailing key is a
+// single alphanumeric. Splitting into two atoms keeps the regex
+// linear — the prior single-alternation form polynomial-backtracked
+// on strings like "A-A-A-…" (CodeQL js/redos).
+const KEYBOARD_SHORTCUT_PATTERN = /^([A-Z][a-z]+-)+[A-Za-z0-9]$/;
+
+/**
+ * Validates a mark spec at registration time and returns a frozen copy.
+ * Mirrors `defineBlock`'s shape so plugin authors only learn one
+ * pattern. Validation is strict at the boundary — invalid specs throw
+ * `MarkRegistrationError` with a discriminated `code`.
+ */
+export function defineMark(spec: MarkSpec): MarkSpec {
+  const name = typeof spec.name === "string" ? spec.name : String(spec.name);
+  if (name.length === 0 || !MARK_NAME_PATTERN.test(name)) {
+    throw MarkRegistrationError.invalidNamePattern({
+      name,
+      pattern: MARK_NAME_PATTERN.source,
+    });
+  }
+  if (
+    spec.keyboardShortcut !== undefined &&
+    !KEYBOARD_SHORTCUT_PATTERN.test(spec.keyboardShortcut)
+  ) {
+    throw MarkRegistrationError.invalidKeyboardShortcut({
+      name: spec.name,
+      keyboardShortcut: spec.keyboardShortcut,
+    });
+  }
+  return Object.freeze({ ...spec });
+}

--- a/packages/blocks/src/marks/errors.ts
+++ b/packages/blocks/src/marks/errors.ts
@@ -1,0 +1,125 @@
+type MarkRegistrationErrorCode =
+  | "invalid_name_pattern"
+  | "duplicate_name"
+  | "core_mark_collision"
+  | "theme_override_unknown_name"
+  | "schema_name_mismatch"
+  | "invalid_keyboard_shortcut";
+
+interface MarkRegistrationErrorFields {
+  markName?: string;
+  pattern?: string;
+  layer?: string;
+  registeredBy?: string;
+  themeId?: string;
+  schemaName?: string;
+  keyboardShortcut?: string;
+}
+
+export class MarkRegistrationError extends Error {
+  static {
+    MarkRegistrationError.prototype.name = "MarkRegistrationError";
+  }
+
+  readonly code: MarkRegistrationErrorCode;
+  readonly markName: string | undefined;
+  readonly pattern: string | undefined;
+  readonly layer: string | undefined;
+  readonly registeredBy: string | undefined;
+  readonly themeId: string | undefined;
+  readonly schemaName: string | undefined;
+  readonly keyboardShortcut: string | undefined;
+
+  private constructor(
+    code: MarkRegistrationErrorCode,
+    message: string,
+    fields: MarkRegistrationErrorFields,
+  ) {
+    super(message);
+    this.code = code;
+    this.markName = fields.markName;
+    this.pattern = fields.pattern;
+    this.layer = fields.layer;
+    this.registeredBy = fields.registeredBy;
+    this.themeId = fields.themeId;
+    this.schemaName = fields.schemaName;
+    this.keyboardShortcut = fields.keyboardShortcut;
+  }
+
+  static invalidNamePattern(ctx: {
+    name: string;
+    pattern: string;
+  }): MarkRegistrationError {
+    return new MarkRegistrationError(
+      "invalid_name_pattern",
+      `Mark name "${ctx.name}" does not match the required pattern ` +
+        `${ctx.pattern}. Names must be lowercase tokens, optionally namespaced ` +
+        `("bold", "code", "affiliate/link").`,
+      { markName: ctx.name, pattern: ctx.pattern },
+    );
+  }
+
+  static duplicateName(ctx: {
+    name: string;
+    layer: "core" | "plugin" | "theme";
+  }): MarkRegistrationError {
+    return new MarkRegistrationError(
+      "duplicate_name",
+      `Mark "${ctx.name}" is registered twice within the ${ctx.layer} ` +
+        `layer. Each name must be unique within its layer; cross-layer ` +
+        `overrides follow theme > plugin > core precedence.`,
+      { markName: ctx.name, layer: ctx.layer },
+    );
+  }
+
+  static coreMarkCollision(ctx: {
+    name: string;
+    registeredBy: string;
+  }): MarkRegistrationError {
+    return new MarkRegistrationError(
+      "core_mark_collision",
+      `Plugin "${ctx.registeredBy}" tried to register mark "${ctx.name}" ` +
+        `which collides with a core-shipped mark. Use a plugin-scoped ` +
+        `namespace (\`pluginId/markName\`) for plugin-contributed marks.`,
+      { markName: ctx.name, registeredBy: ctx.registeredBy },
+    );
+  }
+
+  static themeOverrideUnknownName(ctx: {
+    name: string;
+    themeId: string;
+  }): MarkRegistrationError {
+    return new MarkRegistrationError(
+      "theme_override_unknown_name",
+      `Theme "${ctx.themeId}" tried to override mark "${ctx.name}", but no ` +
+        `core or plugin mark by that name is registered.`,
+      { markName: ctx.name, themeId: ctx.themeId },
+    );
+  }
+
+  static schemaNameMismatch(ctx: {
+    specName: string;
+    schemaName: string;
+  }): MarkRegistrationError {
+    return new MarkRegistrationError(
+      "schema_name_mismatch",
+      `Mark "${ctx.specName}" has a Tiptap schema with name "${ctx.schemaName}". ` +
+        `The spec name and the Tiptap mark name must match — the walker ` +
+        `dispatches on mark.type === registry-key.`,
+      { markName: ctx.specName, schemaName: ctx.schemaName },
+    );
+  }
+
+  static invalidKeyboardShortcut(ctx: {
+    name: string;
+    keyboardShortcut: string;
+  }): MarkRegistrationError {
+    return new MarkRegistrationError(
+      "invalid_keyboard_shortcut",
+      `Mark "${ctx.name}" declares keyboardShortcut "${ctx.keyboardShortcut}" ` +
+        `which does not parse as a Tiptap modifier expression (e.g. ` +
+        `"Mod-b", "Mod-Shift-X").`,
+      { markName: ctx.name, keyboardShortcut: ctx.keyboardShortcut },
+    );
+  }
+}

--- a/packages/blocks/src/marks/registry.test.ts
+++ b/packages/blocks/src/marks/registry.test.ts
@@ -1,0 +1,147 @@
+import { Mark as TiptapMark } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import type { MarkComponent, MarkSpec } from "./types.js";
+import { defineMark } from "./define-mark.js";
+import { mergeMarkRegistry } from "./registry.js";
+
+function makeMark(name: string, component?: MarkComponent): MarkSpec {
+  const DefaultComponent: MarkComponent = ({ children }) => children as never;
+  return defineMark({
+    name,
+    title: name,
+    schema: () => Promise.resolve(TiptapMark.create({ name })),
+    component: () => Promise.resolve(component ?? DefaultComponent),
+  });
+}
+
+describe("mergeMarkRegistry", () => {
+  test("seeds with core specs and exposes get/has/size/iterator", async () => {
+    const reg = await mergeMarkRegistry({
+      core: [makeMark("bold")],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    expect(reg.size).toBe(1);
+    expect(reg.has("bold")).toBe(true);
+    expect(reg.get("bold")?.name).toBe("bold");
+    expect([...reg].map(([n]) => n)).toEqual(["bold"]);
+  });
+
+  test("plugin contributions register under the plugin id", async () => {
+    const reg = await mergeMarkRegistry({
+      core: [makeMark("bold")],
+      plugins: [{ spec: makeMark("affiliate/link"), pluginId: "affiliate" }],
+      themeOverrides: {},
+      themeId: null,
+    });
+    expect(reg.size).toBe(2);
+    expect(reg.get("affiliate/link")?.registeredBy).toBe("affiliate");
+    expect(reg.get("bold")?.registeredBy).toBe(null);
+  });
+
+  test("duplicate within the core layer throws", async () => {
+    await expect(
+      mergeMarkRegistry({
+        core: [makeMark("bold"), makeMark("bold")],
+        plugins: [],
+        themeOverrides: {},
+        themeId: null,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "duplicate_name",
+        layer: "core",
+        markName: "bold",
+      }),
+    );
+  });
+
+  test("plugin colliding with a core mark name throws", async () => {
+    await expect(
+      mergeMarkRegistry({
+        core: [makeMark("bold")],
+        plugins: [{ spec: makeMark("bold"), pluginId: "naughty" }],
+        themeOverrides: {},
+        themeId: null,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "core_mark_collision",
+        markName: "bold",
+        registeredBy: "naughty",
+      }),
+    );
+  });
+
+  test("theme override of an unknown mark throws", async () => {
+    const Override: MarkComponent = ({ children }) => children as never;
+    await expect(
+      mergeMarkRegistry({
+        core: [makeMark("bold")],
+        plugins: [],
+        themeOverrides: { "made-up": Override },
+        themeId: "acme",
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "theme_override_unknown_name",
+        markName: "made-up",
+        themeId: "acme",
+      }),
+    );
+  });
+
+  test("theme override replaces the component for an existing mark", async () => {
+    const Override: MarkComponent = ({ children }) => children as never;
+    const reg = await mergeMarkRegistry({
+      core: [makeMark("bold")],
+      plugins: [],
+      themeOverrides: { bold: Override },
+      themeId: "acme",
+    });
+    expect(reg.get("bold")?.component).toBe(Override);
+  });
+
+  test("schema name mismatch throws at merge time", async () => {
+    const spec = defineMark({
+      name: "bold",
+      title: "Bold",
+      schema: () => Promise.resolve(TiptapMark.create({ name: "wrong-name" })),
+      component: () =>
+        Promise.resolve((({ children }) => children) as MarkComponent),
+    });
+    await expect(
+      mergeMarkRegistry({
+        core: [spec],
+        plugins: [],
+        themeOverrides: {},
+        themeId: null,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "schema_name_mismatch",
+        markName: "bold",
+        schemaName: "wrong-name",
+      }),
+    );
+  });
+
+  test("ESM-default-export shape is unwrapped during resolution", async () => {
+    const Component: MarkComponent = ({ children }) => children as never;
+    const spec = defineMark({
+      name: "bold",
+      title: "Bold",
+      schema: () => Promise.resolve(TiptapMark.create({ name: "bold" })),
+      component: () => Promise.resolve({ default: Component }),
+    });
+    const reg = await mergeMarkRegistry({
+      core: [spec],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    expect(reg.get("bold")?.component).toBe(Component);
+  });
+});

--- a/packages/blocks/src/marks/registry.ts
+++ b/packages/blocks/src/marks/registry.ts
@@ -1,0 +1,121 @@
+import type { LazyRef } from "../types.js";
+import type {
+  MarkComponent,
+  MarkRegistry,
+  MarkSpec,
+  ResolvedMarkSpec,
+} from "./types.js";
+import { MarkRegistrationError } from "./errors.js";
+
+interface PluginContribution {
+  readonly spec: MarkSpec;
+  readonly pluginId: string;
+}
+
+export interface MergeMarkRegistryInput {
+  readonly core: readonly MarkSpec[];
+  readonly plugins: readonly PluginContribution[];
+  readonly themeOverrides: Readonly<Record<string, MarkComponent>>;
+  readonly themeId: string | null;
+}
+
+/**
+ * Build the immutable per-app mark registry. Mirrors `mergeBlockRegistry`
+ * so plugin authors only learn one mental model — deterministic theme >
+ * plugin > core precedence, hard failures on duplicates / core
+ * collisions / unknown overrides, awaited component lazy refs at merge
+ * time so the walker reads `ResolvedMarkSpec.component` synchronously.
+ *
+ * The core/plugin collision check differs from the block registry's:
+ * marks don't follow a `core/` namespace convention, so the check
+ * compares plugin names against the core mark set rather than a string
+ * prefix.
+ */
+export async function mergeMarkRegistry(
+  input: MergeMarkRegistryInput,
+): Promise<MarkRegistry> {
+  validateLayerUniqueness(input);
+
+  const merged = new Map<string, ResolvedMarkSpec>();
+  for (const spec of input.core) {
+    merged.set(spec.name, await resolveSpec(spec, null));
+  }
+  for (const { spec, pluginId } of input.plugins) {
+    merged.set(spec.name, await resolveSpec(spec, pluginId));
+  }
+  for (const [name, component] of Object.entries(input.themeOverrides)) {
+    const existing = merged.get(name);
+    if (!existing) {
+      throw MarkRegistrationError.themeOverrideUnknownName({
+        name,
+        themeId: input.themeId ?? "unknown",
+      });
+    }
+    merged.set(name, { ...existing, component });
+  }
+
+  return Object.freeze({
+    get: (name: string) => merged.get(name),
+    has: (name: string) => merged.has(name),
+    size: merged.size,
+    [Symbol.iterator]: () => merged.entries(),
+  });
+}
+
+function validateLayerUniqueness(input: MergeMarkRegistryInput): void {
+  const coreNames = new Set<string>();
+  for (const spec of input.core) {
+    if (coreNames.has(spec.name)) {
+      throw MarkRegistrationError.duplicateName({
+        name: spec.name,
+        layer: "core",
+      });
+    }
+    coreNames.add(spec.name);
+  }
+
+  const pluginSeen = new Set<string>();
+  for (const { spec, pluginId } of input.plugins) {
+    if (coreNames.has(spec.name)) {
+      throw MarkRegistrationError.coreMarkCollision({
+        name: spec.name,
+        registeredBy: pluginId,
+      });
+    }
+    if (pluginSeen.has(spec.name)) {
+      throw MarkRegistrationError.duplicateName({
+        name: spec.name,
+        layer: "plugin",
+      });
+    }
+    pluginSeen.add(spec.name);
+  }
+}
+
+async function resolveSpec(
+  spec: MarkSpec,
+  registeredBy: string | null,
+): Promise<ResolvedMarkSpec> {
+  const component = await unwrapDefault(spec.component);
+  const schema = await unwrapDefault(spec.schema);
+  const schemaName = (schema as { name?: unknown }).name;
+  if (typeof schemaName === "string" && schemaName !== spec.name) {
+    throw MarkRegistrationError.schemaNameMismatch({
+      specName: spec.name,
+      schemaName,
+    });
+  }
+  return Object.freeze({ ...spec, component, registeredBy });
+}
+
+async function unwrapDefault<T>(ref: LazyRef<T>): Promise<T> {
+  const resolved = await ref();
+  if (
+    typeof resolved === "object" &&
+    resolved !== null &&
+    "default" in resolved
+  ) {
+    return resolved.default;
+  }
+  return resolved;
+}

--- a/packages/blocks/src/marks/types.ts
+++ b/packages/blocks/src/marks/types.ts
@@ -1,0 +1,36 @@
+import type { Mark as TiptapMarkExtension } from "@tiptap/core";
+import type { ComponentType, ReactNode } from "react";
+
+import type { LazyRef } from "../types.js";
+
+export interface MarkProps {
+  readonly attrs: Readonly<Record<string, unknown>>;
+  readonly children: ReactNode;
+}
+
+export type MarkComponent = ComponentType<MarkProps>;
+
+export interface MarkSpec {
+  readonly name: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly keyboardShortcut?: string;
+  /** Label shown in the bubble menu button (defaults to `title`). */
+  readonly bubbleMenuLabel?: string;
+  /** Optional Lucide icon name for the bubble menu button. */
+  readonly bubbleMenuIcon?: string;
+  readonly schema: LazyRef<ReturnType<typeof TiptapMarkExtension.create>>;
+  readonly component: LazyRef<MarkComponent>;
+}
+
+export interface ResolvedMarkSpec extends Omit<MarkSpec, "component"> {
+  readonly component: MarkComponent;
+  readonly registeredBy: string | null;
+}
+
+export interface MarkRegistry {
+  get(name: string): ResolvedMarkSpec | undefined;
+  has(name: string): boolean;
+  readonly size: number;
+  [Symbol.iterator](): IterableIterator<[string, ResolvedMarkSpec]>;
+}

--- a/packages/blocks/src/test/index.ts
+++ b/packages/blocks/src/test/index.ts
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 
+import type { MarkComponent, MarkRegistry, MarkSpec } from "../marks/types.js";
 import type {
   BlockComponent,
   BlockContext,
@@ -7,8 +8,20 @@ import type {
   BlockSpec,
   TiptapNode,
 } from "../types.js";
+import { coreMarks } from "../marks/core/index.js";
+import { mergeMarkRegistry } from "../marks/registry.js";
 import { mergeBlockRegistry } from "../registry.js";
 import { EntryContent } from "../walker.js";
+
+// Resolved once at module load via top-level await so `renderBlock`
+// can stay synchronous. Mirrors what `buildApp` does at runtime so
+// the default test path renders marks identically to production.
+const DEFAULT_MARK_REGISTRY: MarkRegistry = await mergeMarkRegistry({
+  core: coreMarks,
+  plugins: [],
+  themeOverrides: {},
+  themeId: null,
+});
 
 const EMPTY_CONTEXT: BlockContext = {
   entry: null,
@@ -46,8 +59,41 @@ export async function mockRegistry(
   });
 }
 
+interface MockMarkRegistryInput {
+  readonly core?: readonly MarkSpec[];
+  readonly plugins?: readonly {
+    readonly spec: MarkSpec;
+    readonly pluginId: string;
+  }[];
+  readonly themeOverrides?: Readonly<Record<string, MarkComponent>>;
+  readonly themeId?: string | null;
+}
+
+/**
+ * Build a `MarkRegistry` from optional layer contributions. Mirrors
+ * `mockRegistry`'s shape so tests that need both registries can use
+ * the same call ergonomics.
+ */
+export async function mockMarkRegistry(
+  input: MockMarkRegistryInput = {},
+): Promise<MarkRegistry> {
+  return mergeMarkRegistry({
+    core: input.core ?? [],
+    plugins: input.plugins ?? [],
+    themeOverrides: input.themeOverrides ?? {},
+    themeId: input.themeId ?? null,
+  });
+}
+
 interface RenderBlockInput {
   readonly registry: BlockRegistry;
+  /**
+   * Mark registry. Omit to use a `coreMarks`-built default — the
+   * common case for block tests that just need standard inline mark
+   * rendering. Pass an explicit registry to exercise plugin marks
+   * or theme overrides.
+   */
+  readonly markRegistry?: MarkRegistry;
   readonly content: TiptapNode | readonly TiptapNode[];
   readonly context?: BlockContext;
 }
@@ -62,9 +108,10 @@ export function renderBlock(input: RenderBlockInput): string {
     EntryContent({
       content: input.content,
       registry: input.registry,
+      markRegistry: input.markRegistry ?? DEFAULT_MARK_REGISTRY,
       context: input.context ?? EMPTY_CONTEXT,
     }),
   );
 }
 
-export { EMPTY_CONTEXT };
+export { DEFAULT_MARK_REGISTRY as defaultMarkRegistry, EMPTY_CONTEXT };

--- a/packages/blocks/src/walker.test.tsx
+++ b/packages/blocks/src/walker.test.tsx
@@ -10,6 +10,7 @@ import type {
 } from "./types.js";
 import { defineBlock } from "./define-block.js";
 import { mergeBlockRegistry } from "./registry.js";
+import { defaultMarkRegistry } from "./test/index.js";
 import { EntryContent } from "./walker.js";
 
 const ROOT_CONTEXT: BlockContext = {
@@ -75,6 +76,7 @@ describe("EntryContent walker", () => {
         content={null}
         registry={registry}
         context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
       />,
     );
     expect(container.innerHTML).toBe("");
@@ -92,7 +94,12 @@ describe("EntryContent walker", () => {
       ],
     };
     const { container } = render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(container.innerHTML).toBe("<p>Hello</p>");
   });
@@ -109,7 +116,12 @@ describe("EntryContent walker", () => {
       ],
     };
     const { container } = render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(container.innerHTML).toBe("<p>Old content</p>");
   });
@@ -132,7 +144,12 @@ describe("EntryContent walker", () => {
       ],
     };
     const { container } = render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(container.innerHTML).toBe("<p><strong><em>Hi</em></strong></p>");
   });
@@ -155,7 +172,12 @@ describe("EntryContent walker", () => {
       ],
     };
     const { container } = render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(container.innerHTML).toBe(
       '<p><a href="https://example.com" rel="noopener noreferrer nofollow">click</a></p>',
@@ -185,7 +207,12 @@ describe("EntryContent walker", () => {
       ],
     };
     const { container } = render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(container.innerHTML).toContain(expected);
   });
@@ -208,7 +235,12 @@ describe("EntryContent walker", () => {
       ],
     };
     const { container } = render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(container.innerHTML).toBe("<p>no link</p>");
   });
@@ -231,7 +263,12 @@ describe("EntryContent walker", () => {
       ],
     };
     const { container } = render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(container.innerHTML).toBe("<p>evil</p>");
   });
@@ -271,7 +308,12 @@ describe("EntryContent walker", () => {
       ],
     };
     render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(receivedContext).toEqual(
       expect.objectContaining({ parent: "core/container", depth: 1 }),
@@ -290,7 +332,12 @@ describe("EntryContent walker", () => {
       ],
     };
     const { container } = render(
-      <EntryContent content={doc} registry={registry} context={ROOT_CONTEXT} />,
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
     );
     expect(container.querySelectorAll("template").length).toBe(3);
     expect(
@@ -317,6 +364,7 @@ describe("EntryContent walker", () => {
           content={doc}
           registry={registry}
           context={ROOT_CONTEXT}
+          markRegistry={defaultMarkRegistry}
         />,
       );
       expect(container.innerHTML).toBe("");

--- a/packages/blocks/src/walker.tsx
+++ b/packages/blocks/src/walker.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { createElement, Fragment } from "react";
 
+import type { MarkRegistry } from "./marks/types.js";
 import type {
   BlockContext,
   BlockRegistry,
@@ -11,37 +12,48 @@ import type {
 export interface EntryContentProps {
   readonly content: TiptapNode | readonly TiptapNode[] | null | undefined;
   readonly registry: BlockRegistry;
+  /**
+   * Required. Inline marks render through this registry's resolved
+   * components, with theme overrides already applied. Tests with no
+   * marked text can pass an empty registry built via
+   * `mockMarkRegistry()`; the `renderBlock` helper defaults to a
+   * `coreMarks`-backed registry so most tests don't have to think
+   * about it.
+   */
+  readonly markRegistry: MarkRegistry;
   readonly context: BlockContext;
 }
 
 /**
  * Recursive React SSR walker over a Tiptap doc.
  *
- * Resolves each non-text node through the merged registry, dispatches
- * text + marks through the inline walker, and threads `BlockContext`
+ * Resolves each non-text node through the block registry, dispatches
+ * text + marks through the mark registry, and threads `BlockContext`
  * through the tree. Container blocks just render `{children}`; the
  * framework owns recursion so authors cannot drop content by forgetting
- * to recurse (FaustJS pattern).
+ * to recurse.
  *
  * Unknown nodes:
  * - In development: a `<template>` marker carrying the unknown name plus
  *   a one-time `console.warn` per unique name. Dedup state is keyed on
- *   the registry instance via a `WeakMap`, so the warn fires once per
- *   registry per page render even when the same unknown block appears
- *   many times.
- * - In production: render nothing — no DOM artifact, no log.
- *
- * Stored content is preserved untouched by the persistence layer; the
- * walker only decides what to render.
+ *   the registry instance via a `WeakMap`.
+ * - In production: render nothing.
  */
 export function EntryContent({
   content,
   registry,
+  markRegistry,
   context,
 }: EntryContentProps): ReactNode {
   if (!content) return null;
   const nodes = Array.isArray(content) ? content : [content];
-  return renderNodes(nodes, registry, context, devWarnState(registry));
+  return renderNodes(
+    nodes,
+    registry,
+    markRegistry,
+    context,
+    devWarnState(registry),
+  );
 }
 
 interface DevWarnState {
@@ -62,6 +74,7 @@ function devWarnState(registry: BlockRegistry): DevWarnState {
 function renderNodes(
   nodes: readonly TiptapNode[] | undefined,
   registry: BlockRegistry,
+  markRegistry: MarkRegistry,
   context: BlockContext,
   devState: DevWarnState,
 ): ReactNode {
@@ -70,7 +83,7 @@ function renderNodes(
     createElement(
       Fragment,
       { key: idx },
-      renderNode(child, registry, context, devState),
+      renderNode(child, registry, markRegistry, context, devState),
     ),
   );
 }
@@ -78,12 +91,13 @@ function renderNodes(
 function renderNode(
   node: TiptapNode,
   registry: BlockRegistry,
+  markRegistry: MarkRegistry,
   context: BlockContext,
   devState: DevWarnState,
 ): ReactNode {
-  if (node.type === "text") return renderText(node);
+  if (node.type === "text") return renderText(node, markRegistry);
   if (node.type === "doc") {
-    return renderNodes(node.content, registry, context, devState);
+    return renderNodes(node.content, registry, markRegistry, context, devState);
   }
 
   const spec = registry.get(node.type);
@@ -94,7 +108,13 @@ function renderNode(
     parent: spec.name,
     depth: context.depth + 1,
   };
-  const children = renderNodes(node.content, registry, childContext, devState);
+  const children = renderNodes(
+    node.content,
+    registry,
+    markRegistry,
+    childContext,
+    devState,
+  );
   return createElement(
     spec.component,
     { attrs: node.attrs ?? {}, node, context, children },
@@ -102,7 +122,7 @@ function renderNode(
   );
 }
 
-function renderText(node: TiptapNode): ReactNode {
+function renderText(node: TiptapNode, markRegistry: MarkRegistry): ReactNode {
   const text = node.text ?? "";
   const marks = node.marks ?? [];
   if (marks.length === 0) return text;
@@ -111,7 +131,7 @@ function renderText(node: TiptapNode): ReactNode {
   let element: ReactNode = text;
   for (let i = marks.length - 1; i >= 0; i -= 1) {
     const mark = marks[i];
-    if (mark) element = wrapMark(element, mark, i);
+    if (mark) element = wrapMark(element, mark, i, markRegistry);
   }
   return element;
 }
@@ -120,38 +140,15 @@ function wrapMark(
   content: ReactNode,
   mark: TiptapMark,
   index: number,
+  markRegistry: MarkRegistry,
 ): ReactNode {
-  const key = `mark-${index}-${mark.type}`;
-  switch (mark.type) {
-    case "bold":
-      return createElement("strong", { key }, content);
-    case "italic":
-      return createElement("em", { key }, content);
-    case "strike":
-      return createElement("s", { key }, content);
-    case "code":
-      return createElement("code", { key }, content);
-    case "link": {
-      const href = sanitizeHref(mark.attrs?.href);
-      if (href === null) return content;
-      return createElement(
-        "a",
-        { key, href, rel: "noopener noreferrer nofollow" },
-        content,
-      );
-    }
-    default:
-      return content;
-  }
-}
-
-const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|#|\?|\.\.?\/)/i;
-
-function sanitizeHref(href: unknown): string | null {
-  if (typeof href !== "string") return null;
-  const trimmed = href.trim();
-  if (trimmed === "") return null;
-  return SAFE_HREF.test(trimmed) ? trimmed : null;
+  const spec = markRegistry.get(mark.type);
+  if (!spec) return content;
+  return createElement(spec.component, {
+    key: `mark-${index}-${mark.type}`,
+    attrs: mark.attrs ?? {},
+    children: content,
+  });
 }
 
 function renderUnknown(node: TiptapNode, devState: DevWarnState): ReactNode {

--- a/packages/core/src/marks-buildapp-integration.test.ts
+++ b/packages/core/src/marks-buildapp-integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration coverage: every shipped core mark renders correctly
+ * when dispatched through the registry that `buildApp` actually
+ * produces (not a hand-built `mockMarkRegistry`). This is the test
+ * that would have surfaced the foundation-slice `code` vs
+ * `code-inline` name mismatch — assert against `app.marks` directly.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import type { BlockContext, TiptapNode } from "@plumix/blocks";
+import { coreBlocks, EntryContent, paragraphBlock } from "@plumix/blocks";
+import { mockRegistry } from "@plumix/blocks/test";
+
+import { auth } from "./auth/config.js";
+import { plumix } from "./config.js";
+import { buildApp } from "./runtime/app.js";
+
+const baseConfig = {
+  runtime: {
+    name: "test",
+    buildFetchHandler: () => () => new Response("stub", { status: 500 }),
+  },
+  database: {
+    kind: "test",
+    connect: () => ({ db: {} }),
+  },
+  auth: auth({
+    passkey: {
+      rpName: "Plumix Test",
+      rpId: "cms.example",
+      origin: "https://cms.example",
+    },
+  }),
+};
+
+const EMPTY_CONTEXT: BlockContext = {
+  entry: null,
+  siteSettings: {},
+  theme: null,
+  parent: null,
+  depth: 0,
+};
+
+function docWithMarkedText(
+  markType: string,
+  attrs?: Record<string, unknown>,
+): TiptapNode {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "core/paragraph",
+        content: [
+          {
+            type: "text",
+            text: "Hi",
+            marks: [{ type: markType, attrs }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("buildApp().marks renders every shipped mark on real docs", () => {
+  test.each([
+    { mark: "bold", expected: "<p><strong>Hi</strong></p>" },
+    { mark: "italic", expected: "<p><em>Hi</em></p>" },
+    { mark: "strike", expected: "<p><s>Hi</s></p>" },
+    { mark: "code", expected: "<p><code>Hi</code></p>" },
+    { mark: "underline", expected: "<p><u>Hi</u></p>" },
+    { mark: "subscript", expected: "<p><sub>Hi</sub></p>" },
+    { mark: "superscript", expected: "<p><sup>Hi</sup></p>" },
+    { mark: "highlight", expected: "<p><mark>Hi</mark></p>" },
+    { mark: "kbd", expected: "<p><kbd>Hi</kbd></p>" },
+    { mark: "cite", expected: "<p><cite>Hi</cite></p>" },
+    { mark: "small", expected: "<p><small>Hi</small></p>" },
+  ])("$mark renders to $expected via app.marks", async ({ mark, expected }) => {
+    const app = await buildApp(plumix(baseConfig));
+    const blockRegistry = await mockRegistry({ core: [paragraphBlock] });
+    const html = renderToStaticMarkup(
+      EntryContent({
+        content: docWithMarkedText(mark),
+        registry: blockRegistry,
+        markRegistry: app.marks,
+        context: EMPTY_CONTEXT,
+      }),
+    );
+    expect(html).toBe(expected);
+  });
+
+  test("link renders a safe anchor via app.marks", async () => {
+    const app = await buildApp(plumix(baseConfig));
+    const blockRegistry = await mockRegistry({ core: [paragraphBlock] });
+    const html = renderToStaticMarkup(
+      EntryContent({
+        content: docWithMarkedText("link", { href: "https://example.com" }),
+        registry: blockRegistry,
+        markRegistry: app.marks,
+        context: EMPTY_CONTEXT,
+      }),
+    );
+    expect(html).toBe(
+      '<p><a href="https://example.com" rel="noopener noreferrer nofollow">Hi</a></p>',
+    );
+  });
+
+  test("abbr renders with title attribute via app.marks", async () => {
+    const app = await buildApp(plumix(baseConfig));
+    const blockRegistry = await mockRegistry({ core: [paragraphBlock] });
+    const html = renderToStaticMarkup(
+      EntryContent({
+        content: docWithMarkedText("abbr", { title: "HyperText" }),
+        registry: blockRegistry,
+        markRegistry: app.marks,
+        context: EMPTY_CONTEXT,
+      }),
+    );
+    expect(html).toBe('<p><abbr title="HyperText">Hi</abbr></p>');
+  });
+
+  test("app.marks covers all 13 shipped core marks", async () => {
+    const app = await buildApp(plumix(baseConfig));
+    const expected = [
+      "bold",
+      "italic",
+      "strike",
+      "code",
+      "link",
+      "underline",
+      "subscript",
+      "superscript",
+      "highlight",
+      "kbd",
+      "abbr",
+      "cite",
+      "small",
+    ];
+    for (const name of expected) {
+      expect(app.marks.has(name), `mark "${name}" missing`).toBe(true);
+    }
+    expect(app.marks.size).toBe(coreMarksCount());
+  });
+});
+
+function coreMarksCount(): number {
+  // Source-of-truth for the count lives in coreBlocks adjacent file; the
+  // assertion above intentionally hardcodes the list to surface accidental
+  // additions/removals as a test edit, not a silent change.
+  void coreBlocks;
+  return 13;
+}

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1,4 +1,4 @@
-import type { BlockSpec } from "@plumix/blocks";
+import type { BlockSpec, MarkSpec } from "@plumix/blocks";
 
 import type {
   EntryTypeCapabilityOverrides,
@@ -1022,6 +1022,11 @@ export interface RegisteredBlock {
   readonly registeredBy: string;
 }
 
+export interface RegisteredMark {
+  readonly spec: MarkSpec;
+  readonly registeredBy: string;
+}
+
 export interface PluginRegistry {
   readonly entryTypes: ReadonlyMap<string, RegisteredEntryType>;
   readonly termTaxonomies: ReadonlyMap<string, RegisteredTermTaxonomy>;
@@ -1038,6 +1043,7 @@ export interface PluginRegistry {
   readonly adminPages: ReadonlyMap<string, RegisteredAdminPage>;
   readonly fieldTypes: ReadonlyMap<string, RegisteredFieldType>;
   readonly blockSpecs: ReadonlyMap<string, RegisteredBlock>;
+  readonly markSpecs: ReadonlyMap<string, RegisteredMark>;
   readonly lookupAdapters: ReadonlyMap<string, RegisteredLookupAdapter>;
   readonly scheduledTasks: readonly RegisteredScheduledTask[];
 }
@@ -1058,6 +1064,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly adminPages: Map<string, RegisteredAdminPage>;
   readonly fieldTypes: Map<string, RegisteredFieldType>;
   readonly blockSpecs: Map<string, RegisteredBlock>;
+  readonly markSpecs: Map<string, RegisteredMark>;
   readonly lookupAdapters: Map<string, RegisteredLookupAdapter>;
   readonly scheduledTasks: RegisteredScheduledTask[];
 }
@@ -1079,6 +1086,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     adminPages: new Map(),
     fieldTypes: new Map(),
     blockSpecs: new Map(),
+    markSpecs: new Map(),
     lookupAdapters: new Map(),
     scheduledTasks: [],
   };

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -1,4 +1,4 @@
-import type { BlockSpec } from "@plumix/blocks";
+import type { BlockSpec, MarkSpec } from "@plumix/blocks";
 
 import type { DerivedCapability } from "../auth/rbac.js";
 import type { AppContext } from "../context/app.js";
@@ -181,6 +181,14 @@ export interface PluginSetupContextBase {
    * reserved for `@plumix/blocks`'s built-in primitives.
    */
   registerBlock(spec: BlockSpec): void;
+
+  /**
+   * Register a `MarkSpec` produced by `defineMark` from `plumix/blocks`.
+   * Plugin-contributed marks merge into the per-app mark registry at
+   * `buildApp` time. Names that collide with the core mark set are
+   * rejected; the convention for plugin marks is `pluginId/markName`.
+   */
+  registerMark(spec: MarkSpec): void;
   /**
    * Register a `LookupAdapter` for a reference target kind. The
    * `kind` matches the `referenceTarget.kind` carried on a reference
@@ -489,6 +497,16 @@ export function createPluginSetupContext({
         });
       }
       registry.blockSpecs.set(spec.name, { spec, registeredBy: pluginId });
+    },
+
+    registerMark: (spec) => {
+      if (registry.markSpecs.has(spec.name)) {
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "mark",
+          identifier: spec.name,
+        });
+      }
+      registry.markSpecs.set(spec.name, { spec, registeredBy: pluginId });
     },
 
     registerLookupAdapter: (options) => {

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -1,7 +1,17 @@
 import { RPCHandler } from "@orpc/server/fetch";
 
-import type { BlockRegistry } from "@plumix/blocks";
-import { coreBlocks, mergeBlockRegistry } from "@plumix/blocks";
+import type {
+  BlockComponent,
+  BlockRegistry,
+  MarkComponent,
+  MarkRegistry,
+} from "@plumix/blocks";
+import {
+  coreBlocks,
+  coreMarks,
+  mergeBlockRegistry,
+  mergeMarkRegistry,
+} from "@plumix/blocks";
 
 import type { RequestAuthenticator } from "../auth/authenticator.js";
 import type { ResolvedPasskeyConfig } from "../auth/passkey/config.js";
@@ -16,7 +26,11 @@ import type {
 } from "../plugin/manifest.js";
 import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RouteRule } from "../route/intent.js";
-import type { ThemeSetupContext, ThemeSetupContextBase } from "../theme.js";
+import type {
+  ThemeDescriptor,
+  ThemeSetupContext,
+  ThemeSetupContextBase,
+} from "../theme.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
@@ -108,6 +122,12 @@ export interface PlumixApp {
    * layers only.
    */
   readonly blocks: BlockRegistry;
+  /**
+   * Merged mark registry: the 13 core marks from `@plumix/blocks` +
+   * plugin contributions from `ctx.registerMark`. Same shape and
+   * resolution model as `app.blocks`.
+   */
+  readonly marks: MarkRegistry;
 }
 
 export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
@@ -183,17 +203,32 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   // plugin contributions. The block walker reads attribute schemas
   // referenced by name (`registerFieldType`); pass the resolved field-type
   // set so `unknown_attribute_type` errors surface here instead of at
-  // render time. Theme block overrides land in a follow-up slice.
+  // render time. Theme overrides flatten across `config.themes` with
+  // later themes winning per-name — same precedence as `marks` below.
   const pluginBlockContributions = Array.from(registry.blockSpecs.values()).map(
     ({ spec, registeredBy }) => ({ spec, pluginId: registeredBy }),
   );
   const fieldTypeNames = new Set<string>(registry.fieldTypes.keys());
+  const { overrides: blockOverrides, themeId: blockThemeId } =
+    collectThemeOverrides(config.themes, (theme) => theme.blocks);
   const blocks = await mergeBlockRegistry({
     core: coreBlocks,
     plugins: pluginBlockContributions,
-    themeOverrides: {},
-    themeId: null,
+    themeOverrides: blockOverrides,
+    themeId: blockThemeId,
     fieldTypes: fieldTypeNames,
+  });
+
+  const pluginMarkContributions = Array.from(registry.markSpecs.values()).map(
+    ({ spec, registeredBy }) => ({ spec, pluginId: registeredBy }),
+  );
+  const { overrides: markOverrides, themeId: markThemeId } =
+    collectThemeOverrides(config.themes, (theme) => theme.marks);
+  const marks = await mergeMarkRegistry({
+    core: coreMarks,
+    plugins: pluginMarkContributions,
+    themeOverrides: markOverrides,
+    themeId: markThemeId,
   });
 
   return {
@@ -214,7 +249,33 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     appContextExtensions,
     scheduledTasks: registry.scheduledTasks,
     blocks,
+    marks,
   };
+}
+
+/**
+ * Flatten per-name component overrides from every theme in declaration
+ * order. Later themes win when names collide, mirroring CSS cascade
+ * intuition (the most-recently-applied theme has the final say). The
+ * reported `themeId` is the last theme that contributed any override —
+ * used by `mergeMarkRegistry` / `mergeBlockRegistry` only to attribute
+ * `themeOverrideUnknownName` errors.
+ */
+function collectThemeOverrides<C extends BlockComponent | MarkComponent>(
+  themes: readonly ThemeDescriptor[],
+  pick: (theme: ThemeDescriptor) => Readonly<Record<string, C>> | undefined,
+): { overrides: Record<string, C>; themeId: string | null } {
+  const overrides: Record<string, C> = {};
+  let themeId: string | null = null;
+  for (const theme of themes) {
+    const layer = pick(theme);
+    if (!layer) continue;
+    for (const [name, component] of Object.entries(layer)) {
+      overrides[name] = component;
+      themeId = theme.id;
+    }
+  }
+  return { overrides, themeId };
 }
 
 function buildThemeSetupContext(

--- a/packages/core/src/runtime/theme-registry-overrides.test.ts
+++ b/packages/core/src/runtime/theme-registry-overrides.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+
+import type { MarkComponent } from "@plumix/blocks";
+
+import { auth } from "../auth/config.js";
+import { plumix } from "../config.js";
+import { defineTheme } from "../theme.js";
+import { buildApp } from "./app.js";
+
+const baseConfig = {
+  runtime: {
+    name: "test",
+    buildFetchHandler: () => () => new Response("stub", { status: 500 }),
+  },
+  database: {
+    kind: "test",
+    connect: () => ({ db: {} }),
+  },
+  auth: auth({
+    passkey: {
+      rpName: "Plumix Test",
+      rpId: "cms.example",
+      origin: "https://cms.example",
+    },
+  }),
+};
+
+// Identity sentinels — never rendered; the test only asserts component
+// references survive the theme → buildApp → registry handoff.
+const AlternateBold: MarkComponent = function AlternateBold() {
+  return null;
+};
+const ItalicA: MarkComponent = function ItalicA() {
+  return null;
+};
+const ItalicB: MarkComponent = function ItalicB() {
+  return null;
+};
+
+describe("buildApp threads theme mark + block overrides into the registries", () => {
+  test("defineTheme({ marks: { bold: Component } }) replaces app.marks.get('bold').component", async () => {
+    const theme = defineTheme({
+      id: "override-bold",
+      marks: { bold: AlternateBold },
+    });
+    const app = await buildApp(
+      plumix({
+        ...baseConfig,
+        themes: [theme],
+      }),
+    );
+
+    expect(app.marks.get("bold")?.component).toBe(AlternateBold);
+  });
+
+  test("multiple themes — last theme wins per-mark, others persist", async () => {
+    const themeA = defineTheme({
+      id: "theme-a",
+      marks: { italic: ItalicA, bold: AlternateBold },
+    });
+    const themeB = defineTheme({
+      id: "theme-b",
+      marks: { italic: ItalicB },
+    });
+    const app = await buildApp(
+      plumix({
+        ...baseConfig,
+        themes: [themeA, themeB],
+      }),
+    );
+
+    expect(app.marks.get("italic")?.component).toBe(ItalicB);
+    expect(app.marks.get("bold")?.component).toBe(AlternateBold);
+  });
+
+  test("theme override targeting an unknown mark name raises markRegistration error", async () => {
+    const theme = defineTheme({
+      id: "broken-theme",
+      marks: { "not-a-real-mark": AlternateBold },
+    });
+    await expect(
+      buildApp(
+        plumix({
+          ...baseConfig,
+          themes: [theme],
+        }),
+      ),
+    ).rejects.toThrow(/not-a-real-mark/);
+  });
+});

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,3 +1,5 @@
+import type { BlockComponent, MarkComponent } from "@plumix/blocks";
+
 import type { ThemeContextExtensions } from "./plugin/provides-context.js";
 import { ThemeError } from "./theme-errors.js";
 
@@ -22,6 +24,20 @@ export interface ThemeDescriptor {
    * theme contributes through plugins' theme-context extensions.
    */
   readonly setup?: (ctx: ThemeSetupContext) => void | Promise<void>;
+  /**
+   * Map of block name → React component. Overrides the resolved block's
+   * `component` only; schema/attributes/editor stay author-owned so
+   * stored content keeps validating. `buildApp` flattens overrides from
+   * `config.themes` (later themes win per-name) into a single map and
+   * hands it to `mergeBlockRegistry`.
+   */
+  readonly blocks?: Readonly<Record<string, BlockComponent>>;
+  /**
+   * Map of mark name → React component. Same precedence and override
+   * semantics as `blocks` — `buildApp` flattens across `config.themes`,
+   * later themes win, schema stays author-owned.
+   */
+  readonly marks?: Readonly<Record<string, MarkComponent>>;
 }
 
 const THEME_ID_RE = /^[a-z][a-z0-9-]*$/;

--- a/packages/plumix/src/blocks/index.ts
+++ b/packages/plumix/src/blocks/index.ts
@@ -13,9 +13,13 @@
 export {
   BlockRegistrationError,
   EntryContent,
+  MarkRegistrationError,
   coreBlocks,
+  coreMarks,
   defineBlock,
+  defineMark,
   mergeBlockRegistry,
+  mergeMarkRegistry,
   paragraphBlock,
 } from "@plumix/blocks";
 export type {
@@ -27,8 +31,14 @@ export type {
   BlockSpec,
   EntryContentProps,
   LazyRef,
+  MarkComponent,
+  MarkProps,
+  MarkRegistry,
+  MarkSpec,
   MergeBlockRegistryInput,
+  MergeMarkRegistryInput,
   ResolvedBlockSpec,
+  ResolvedMarkSpec,
   TiptapMark,
   TiptapNode,
 } from "@plumix/blocks";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@plumix/blocks':
+        specifier: workspace:*
+        version: link:../blocks
       '@plumix/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
End-to-end marks slice for [#306](https://github.com/withplumix/plumix/issues/306): typed `defineMark` factory + 13 core marks, registry primitive parallel to blocks, `ctx.registerMark` for plugins, walker dispatch via the registry, `defineTheme({ blocks, marks })` flowing through `buildApp`, and a selection-anchored `BubbleMenu` in the admin editor.

**Theme overrides actually flow through buildApp**

`defineTheme` now accepts `blocks` and `marks` maps. `buildApp` flattens overrides across `config.themes` (later themes win per-name) into both `mergeBlockRegistry` and `mergeMarkRegistry` — the previously hardcoded `themeOverrides: {}` is gone for both layers. Integration test in `packages/core/src/runtime/theme-registry-overrides.test.ts` covers single-theme, multi-theme cascade, and unknown-name error propagation.

**Bubble menu filters against the live editor schema**

`MarkToolbar` reads the registry but skips any mark not present in `editor.schema.marks` so users don't get dead buttons for marks not loaded as Tiptap extensions. When the editor extension list later sources from the registry too, the guard becomes inert.

**Link mark unwraps unsafe schemes**

`SAFE_HREF` regex accepts only `http(s)`, `mailto`, `tel`, root-relative, fragment, query, and dotted-relative URLs. Anything else (e.g. `javascript:`, `data:`) renders the children unwrapped rather than emitting an attacker-controlled anchor.

Closes #306