### PR TITLE
feat(blocks): baseline sanitize-html allowlist for core/html

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@tiptap/core": "^3.23.1"
+    "@tiptap/core": "^3.23.1",
+    "sanitize-html": "^2.17.4"
   },
   "peerDependencies": {
     "react": "catalog:",
@@ -37,6 +38,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@types/sanitize-html": "^2.16.1",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "jsdom": "^29.1.1",

--- a/packages/blocks/src/core-blocks.ts
+++ b/packages/blocks/src/core-blocks.ts
@@ -32,10 +32,12 @@ import { spacerBlock } from "./spacer/index.js";
  * interactive → structured, in the order slices land.
  *
  * Note: `htmlBlock` is exported from `./html/index.js` but deliberately
- * NOT included here — it renders raw HTML via `dangerouslySetInnerHTML`
- * with no sanitisation (DOMPurify lands in #312). Auto-installing it
- * would be a stored-XSS regression. Themes / plugins that need the
- * escape hatch can register it explicitly via `ctx.registerBlock`.
+ * NOT included here. The renderer applies a baseline `sanitize-html`
+ * allowlist (no script / style / iframe / object / on* handlers; anchors
+ * limited to http(s) / mailto / tel / root-relative), but operators
+ * should still opt in explicitly via `ctx.registerBlock` after deciding
+ * whether they want the escape hatch at all. The operator-configurable
+ * allowlist lands in #312.
  */
 export const coreBlocks: readonly BlockSpec[] = Object.freeze([
   paragraphBlock,

--- a/packages/blocks/src/html/Component.tsx
+++ b/packages/blocks/src/html/Component.tsx
@@ -1,22 +1,13 @@
 import type { ReactElement } from "react";
 
 import type { BlockProps } from "../types.js";
+import { sanitizeHtml } from "./sanitize.js";
 
-/**
- * SECURITY TODO (issue #312): the raw `html` attribute is passed
- * through `dangerouslySetInnerHTML` verbatim today. That is acceptable
- * only because slice #305 ships this block behind the same trust
- * boundary the legacy walker had — author content. Slice #312 wires
- * DOMPurify with an operator-configurable allowlist; until then,
- * surfaces that accept unauthenticated submissions MUST NOT enable
- * `core/html` in their field allowlist.
- */
 export function HtmlComponent({ attrs }: BlockProps): ReactElement {
-  const raw = typeof attrs.html === "string" ? attrs.html : "";
   return (
     <div
       data-plumix-block="core/html"
-      dangerouslySetInnerHTML={{ __html: raw }}
+      dangerouslySetInnerHTML={{ __html: sanitizeHtml(attrs.html) }}
     />
   );
 }

--- a/packages/blocks/src/html/html.test.tsx
+++ b/packages/blocks/src/html/html.test.tsx
@@ -4,7 +4,7 @@ import { mockRegistry, renderBlock } from "../test/index.js";
 import { htmlBlock } from "./index.js";
 
 describe("core/html", () => {
-  test("emits the html attribute verbatim inside a marker div", async () => {
+  test("preserves allowlisted markup verbatim inside the marker div", async () => {
     const registry = await mockRegistry({ core: [htmlBlock] });
     const html = renderBlock({
       registry,
@@ -13,14 +13,31 @@ describe("core/html", () => {
         content: [
           {
             type: "core/html",
-            attrs: { html: "<custom-widget data-x='1'></custom-widget>" },
+            attrs: { html: "<p><strong>Bold</strong></p>" },
           },
         ],
       },
     });
     expect(html).toBe(
-      "<div data-plumix-block=\"core/html\"><custom-widget data-x='1'></custom-widget></div>",
+      '<div data-plumix-block="core/html"><p><strong>Bold</strong></p></div>',
     );
+  });
+
+  test("routes the html attr through the sanitizer", async () => {
+    const registry = await mockRegistry({ core: [htmlBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/html",
+            attrs: { html: "<p>safe</p><script>alert(1)</script>" },
+          },
+        ],
+      },
+    });
+    expect(html).toBe('<div data-plumix-block="core/html"><p>safe</p></div>');
   });
 
   test("renders an empty marker div when html attr is missing or non-string", async () => {

--- a/packages/blocks/src/html/sanitize.test.ts
+++ b/packages/blocks/src/html/sanitize.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "vitest";
+
+import { sanitizeHtml } from "./sanitize.js";
+
+describe("sanitizeHtml — baseline allowlist", () => {
+  test("returns empty string when input is empty", () => {
+    expect(sanitizeHtml("")).toBe("");
+  });
+
+  test("strips <script> tags entirely", () => {
+    expect(sanitizeHtml("<p>hi</p><script>alert(1)</script>")).toBe(
+      "<p>hi</p>",
+    );
+  });
+
+  test("strips on* event-handler attributes", () => {
+    expect(sanitizeHtml('<p onclick="alert(1)">hi</p>')).toBe("<p>hi</p>");
+    expect(sanitizeHtml('<a href="/x" onmouseover="evil()">x</a>')).toBe(
+      '<a href="/x">x</a>',
+    );
+  });
+
+  test("strips javascript: and data: URLs from anchors", () => {
+    expect(sanitizeHtml('<a href="javascript:alert(1)">x</a>')).toBe(
+      "<a>x</a>",
+    );
+    expect(
+      sanitizeHtml('<a href="data:text/html,<script>alert(1)</script>">x</a>'),
+    ).toBe("<a>x</a>");
+  });
+
+  test("strips <iframe>, <object>, <embed>", () => {
+    expect(sanitizeHtml('<iframe src="//evil"></iframe>hi')).toBe("hi");
+    expect(sanitizeHtml('<object data="//evil"></object>hi')).toBe("hi");
+    expect(sanitizeHtml('<embed src="//evil">hi')).toBe("hi");
+  });
+
+  test("preserves safe formatting tags", () => {
+    const safe =
+      '<p><strong>Bold</strong> and <em>italic</em> and <a href="https://example.com">link</a>.</p>';
+    expect(sanitizeHtml(safe)).toBe(safe);
+  });
+
+  test("preserves heading + list structure", () => {
+    const safe = "<h2>Title</h2><ul><li>one</li><li>two</li></ul>";
+    expect(sanitizeHtml(safe)).toBe(safe);
+  });
+
+  test("strips <style> blocks (CSS-based attacks)", () => {
+    expect(
+      sanitizeHtml(
+        "<style>body { background: url(javascript:alert(1)) }</style>hi",
+      ),
+    ).toBe("hi");
+  });
+
+  test("non-string input returns empty string", () => {
+    expect(sanitizeHtml(undefined)).toBe("");
+    expect(sanitizeHtml(null)).toBe("");
+    expect(sanitizeHtml(42)).toBe("");
+  });
+
+  // Regression tests for vectors that pass today only because of the
+  // current allowlist config — without explicit tests, a future tweak
+  // could silently regress one without anyone noticing.
+
+  test("strips protocol-relative hrefs (`//evil` can't smuggle a scheme)", () => {
+    expect(sanitizeHtml('<a href="//evil.example/x">x</a>')).toBe("<a>x</a>");
+  });
+
+  test.each([
+    "JaVaScRiPt:alert(1)",
+    "java\tscript:alert(1)",
+    "javas&#99;ript:alert(1)",
+    " javascript:alert(1)",
+  ])("strips case- / whitespace- / entity-obfuscated %s", (href) => {
+    const out = sanitizeHtml(`<a href="${href}">x</a>`);
+    expect(out.toLowerCase()).not.toContain("javascript:");
+  });
+
+  test("preserves root-relative, fragment, and query-only hrefs", () => {
+    expect(sanitizeHtml('<a href="/internal">x</a>')).toBe(
+      '<a href="/internal">x</a>',
+    );
+    expect(sanitizeHtml('<a href="#section">x</a>')).toBe(
+      '<a href="#section">x</a>',
+    );
+    expect(sanitizeHtml('<a href="?page=2">x</a>')).toBe(
+      '<a href="?page=2">x</a>',
+    );
+  });
+
+  test("strips target / rel from anchors (no reverse-tabnabbing surface)", () => {
+    expect(
+      sanitizeHtml('<a href="https://x.example" target="_blank">x</a>'),
+    ).toBe('<a href="https://x.example">x</a>');
+    expect(
+      sanitizeHtml('<a href="https://x.example" rel="opener noreferrer">x</a>'),
+    ).toBe('<a href="https://x.example">x</a>');
+  });
+
+  test("strips non-allowlisted heading levels (h1, h5, h6) to text", () => {
+    expect(sanitizeHtml("<h1>title</h1>")).toBe("title");
+    expect(sanitizeHtml("<h5>title</h5>")).toBe("title");
+    expect(sanitizeHtml("<h6>title</h6>")).toBe("title");
+  });
+
+  test("strips <svg> / <math> containers used as XSS smuggling vectors", () => {
+    expect(
+      sanitizeHtml("<svg><script>alert(1)</script></svg>hi"),
+    ).not.toContain("script");
+    expect(
+      sanitizeHtml(
+        '<math><mglyph href="javascript:alert(1)">x</mglyph></math>hi',
+      ),
+    ).not.toContain("javascript");
+  });
+
+  test("strips data-* on <span> (no behavior-injection vector)", () => {
+    expect(
+      sanitizeHtml(
+        '<span data-onclick="alert(1)" data-controller="evil">x</span>',
+      ),
+    ).toBe("<span>x</span>");
+  });
+});

--- a/packages/blocks/src/html/sanitize.ts
+++ b/packages/blocks/src/html/sanitize.ts
@@ -1,0 +1,60 @@
+import sanitize from "sanitize-html";
+
+/**
+ * Baseline `core/html` sanitizer. `sanitize-html` is pure-JS
+ * (htmlparser2) so it runs on Workers as well as the admin browser.
+ * The operator-configurable allowlist lands in #312; this function
+ * becomes the default for that config rather than the only option.
+ */
+export function sanitizeHtml(raw: unknown): string {
+  if (typeof raw !== "string" || raw === "") return "";
+  return sanitize(raw, {
+    allowedTags: [
+      "p",
+      "h2",
+      "h3",
+      "h4",
+      "blockquote",
+      "pre",
+      "code",
+      "hr",
+      "br",
+      "ul",
+      "ol",
+      "li",
+      "figure",
+      "figcaption",
+      "strong",
+      "em",
+      "s",
+      "u",
+      "mark",
+      "sub",
+      "sup",
+      "kbd",
+      "small",
+      "cite",
+      "abbr",
+      "a",
+      "span",
+    ],
+    allowedAttributes: {
+      // `target` / `rel` deliberately omitted — allowing `target="_blank"`
+      // without forcing `rel="noopener noreferrer"` opens reverse-tabnabbing
+      // on older WebKit and embedded webviews. Authored anchors render
+      // same-tab; the operator-configurable allowlist (#312) can add the
+      // rel-rewriting transform when target is genuinely needed.
+      a: ["href", "title"],
+      abbr: ["title"],
+      code: ["data-language"],
+      // No `data-*` wildcard — a JS framework that treats data-attrs as
+      // event bindings (Stimulus, Alpine, htmx hx-on:* aliases) would
+      // turn authored HTML into a behavior-injection vector. Add specific
+      // attrs explicitly when the editor actually emits them.
+    },
+    // Override default (which includes `ftp`); drop protocol-relative
+    // so `//evil.example` can't smuggle a scheme past the allowlist.
+    allowedSchemes: ["http", "https", "mailto", "tel"],
+    allowProtocolRelative: false,
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,15 @@ settings:
 
 catalogs:
   default:
+    '@arethetypeswrong/cli':
+      specifier: ^0.18.2
+      version: 0.18.2
+    '@cloudflare/workers-types':
+      specifier: ^4.20260421.1
+      version: 4.20260421.1
+    '@types/node':
+      specifier: ^24.12.2
+      version: 24.12.2
     '@types/react':
       specifier: ^19.2.14
       version: 19.2.14
@@ -18,12 +27,24 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: ^4.1.5
       version: 4.1.5
+    drizzle-kit:
+      specifier: ^0.31.10
+      version: 0.31.10
+    drizzle-orm:
+      specifier: ^0.45.2
+      version: 0.45.2
+    drizzle-valibot:
+      specifier: ^0.4.2
+      version: 0.4.2
     eslint:
       specifier: ^10.3.0
       version: 10.3.0
     prettier:
       specifier: ^3.8.3
       version: 3.8.3
+    publint:
+      specifier: ^0.3.18
+      version: 0.3.18
     react:
       specifier: ^19.2.6
       version: 19.2.6
@@ -42,6 +63,9 @@ catalogs:
     vitest:
       specifier: ^4.1.5
       version: 4.1.5
+    wrangler:
+      specifier: ^4.86.0
+      version: 4.86.0
 
 overrides:
   esbuild@<0.25.0: '>=0.25.0'
@@ -311,6 +335,9 @@ importers:
       '@tiptap/core':
         specifier: ^3.23.1
         version: 3.23.1(@tiptap/pm@3.23.1)
+      sanitize-html:
+        specifier: ^2.17.4
+        version: 2.17.4
     devDependencies:
       '@plumix/eslint-config':
         specifier: workspace:*
@@ -336,6 +363,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.5(vitest@4.1.5)
@@ -4106,6 +4136,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -4661,6 +4694,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -4675,6 +4711,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -4720,6 +4760,19 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -4854,6 +4907,14 @@ packages:
   enhanced-resolve@5.21.3:
     resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -5224,6 +5285,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -5354,6 +5418,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -5507,6 +5575,9 @@ packages:
     resolution: {integrity: sha512-IT1YDiHyRctYYsuZNBd/ZiGoa7HmCaxs+ZrWxCfYjQKPG6QyRqMfkteqC+rBuMymBJeLXyBnRa7hn95O+sGG8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -5791,6 +5862,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -6130,6 +6204,9 @@ packages:
 
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
+
+  sanitize-html@2.17.4:
+    resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -9387,6 +9464,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
@@ -9560,7 +9641,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -9984,6 +10065,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dayjs@1.11.20: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -9991,6 +10074,8 @@ snapshots:
   decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
+
+  deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -10045,6 +10130,24 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -10091,6 +10194,10 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 
@@ -10622,6 +10729,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -10736,6 +10850,8 @@ snapshots:
   is-plain-obj@2.1.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -10902,6 +11018,10 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.20
 
   levn@0.4.1:
     dependencies:
@@ -11231,6 +11351,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-srcset@1.0.2: {}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
@@ -11610,6 +11732,16 @@ snapshots:
   safe-regex@2.1.1:
     dependencies:
       regexp-tree: 0.1.27
+
+  sanitize-html@2.17.4:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.10
 
   saxes@6.0.0:
     dependencies:


### PR DESCRIPTION
Removes the unsanitized-rendering footgun left by [#305](https://github.com/withplumix/plumix/issues/305) on the \`core/html\` block. The full operator-configurable allowlist still ships in [#312](https://github.com/withplumix/plumix/issues/312); this slice adds the hardcoded baseline so opt-in consumers don't accept stored XSS.

**Sanitizer choice**

\`sanitize-html\` (pure-JS htmlparser2) runs on Cloudflare Workers as well as the admin browser — no DOM shim needed, unlike DOMPurify on Workers. Wrapped in a small \`sanitizeHtml\` helper with a hardcoded allowlist; this same function becomes the default config for #312 rather than getting refactored away.

**Anchors are same-tab only**

\`target\` and \`rel\` are NOT in the anchor attribute allowlist. Allowing \`target=\"_blank\"\` without forcing \`rel=\"noopener noreferrer\"\` opens reverse-tabnabbing on older WebKit and embedded webviews — the rel-rewriting transform belongs in the operator-configurable path (#312).

**No \`data-*\` wildcard**

Removed the \`data-*\` allowance on \`<span>\` — a JS framework that treats data-attrs as event bindings (Stimulus, Alpine, htmx hx-on:* aliases) would turn authored HTML into a behavior-injection vector. Specific data attrs can be added explicitly when the editor actually emits them.

**Regression tests for brittle vectors**

Beyond script / iframe / \`javascript:\`, this slice pins: protocol-relative URLs, case-obfuscated \`JaVaScRiPt:\`, whitespace + entity-encoded obfuscation, \`<svg>\` / \`<math>\` XSS smuggling containers, h1/h5/h6 stripping to text, target/rel removal, and data-* removal. Each passes today only because of specific config choices; the tests catch silent regressions when #312 reshapes the config.

Refs #312