### PR TITLE
feat(blocks,core,admin): block inspector + core field-type seed

### DIFF
--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -1,4 +1,4 @@
-import type { JSONContent } from "@tiptap/react";
+import type { Editor, JSONContent } from "@tiptap/react";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { MultiSelect } from "@/components/form/multi-select.js";
@@ -38,6 +38,8 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar.js";
+import { EditorProvider, useActiveEditor } from "@/editor/editor-context.js";
+import { Inspector } from "@/editor/inspector/Inspector.js";
 import {
   useAdminBlockRegistry,
   useAdminMarkRegistry,
@@ -235,6 +237,11 @@ export function PostEditorForm({
   // from the title. Standard WP auto-slug behavior.
   const [slugLocked, setSlugLocked] = useState(initialSlugLocked);
 
+  // Hoisted so the right-rail Inspector can subscribe to selection
+  // changes without prop-drilling through the FormField tree. Set by
+  // `ContentEditor` via `onEditorReady`, exposed through context.
+  const [activeEditor, setActiveEditor] = useState<Editor | null>(null);
+
   const form = useForm({
     resolver: valibotResolver(postEditorSchema),
     defaultValues: initialValues,
@@ -280,133 +287,141 @@ export function PostEditorForm({
 
   return (
     <Form {...form}>
-      {/* `contents` makes the form invisible in the flex flow so
+      <EditorProvider value={activeEditor}>
+        {/* `contents` makes the form invisible in the flex flow so
           SidebarProvider owns the layout; fields in the rail still
           submit via Controller (rhf state, not DOM form semantics). */}
-      <form
-        id="entry-editor-form"
-        data-testid="post-editor-form"
-        onSubmit={handleSubmit}
-        className="contents"
-      >
-        <SidebarProvider defaultOpen className="flex-1">
-          <SidebarInset className="flex min-w-0 flex-col">
-            <header className="bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center justify-between gap-3 border-b px-4">
-              <div className="flex min-w-0 items-center gap-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={onCancel}
-                  disabled={isSubmitting}
-                  data-testid="post-editor-cancel"
-                  aria-label="Back"
-                >
-                  <ArrowLeft />
-                </Button>
-                <span
-                  className="truncate text-sm font-medium"
-                  data-testid="post-editor-headline"
-                >
-                  {headline}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button
-                  type="submit"
-                  disabled={isSubmitting}
-                  data-testid="post-editor-submit"
-                >
-                  {isSubmitting ? "Saving…" : submitLabel}
-                </Button>
-                {/* `type="button"` is load-bearing: shadcn's `Button`
+        <form
+          id="entry-editor-form"
+          data-testid="post-editor-form"
+          onSubmit={handleSubmit}
+          className="contents"
+        >
+          <SidebarProvider defaultOpen className="flex-1">
+            <SidebarInset className="flex min-w-0 flex-col">
+              <header className="bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center justify-between gap-3 border-b px-4">
+                <div className="flex min-w-0 items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={onCancel}
+                    disabled={isSubmitting}
+                    data-testid="post-editor-cancel"
+                    aria-label="Back"
+                  >
+                    <ArrowLeft />
+                  </Button>
+                  <span
+                    className="truncate text-sm font-medium"
+                    data-testid="post-editor-headline"
+                  >
+                    {headline}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="submit"
+                    disabled={isSubmitting}
+                    data-testid="post-editor-submit"
+                  >
+                    {isSubmitting ? "Saving…" : submitLabel}
+                  </Button>
+                  {/* `type="button"` is load-bearing: shadcn's `Button`
                     doesn't default it, and an un-typed button inside
                     `<form>` inherits `submit` — clicking the toggle
                     would otherwise fire the form's onSubmit + mutate. */}
-                <SidebarTrigger type="button" />
-              </div>
-            </header>
+                  <SidebarTrigger type="button" />
+                </div>
+              </header>
 
-            {serverError ? (
-              <div className="border-b px-4 py-2">
-                <Alert variant="destructive">
-                  <AlertDescription>{serverError}</AlertDescription>
-                </Alert>
-              </div>
-            ) : null}
+              {serverError ? (
+                <div className="border-b px-4 py-2">
+                  <Alert variant="destructive">
+                    <AlertDescription>{serverError}</AlertDescription>
+                  </Alert>
+                </div>
+              ) : null}
 
-            <main className="flex-1 overflow-auto">
-              <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-8 py-10">
-                {showTitle ? <TitleField disabled={isSubmitting} /> : null}
-                {showEditor ? <ContentField disabled={isSubmitting} /> : null}
-                {!showTitle && !showEditor ? (
-                  <p
-                    className="text-muted-foreground text-sm"
-                    data-testid="post-editor-empty-canvas"
-                  >
-                    This entry type has no title or editor. Use the panels on
-                    the right to manage its content.
-                  </p>
-                ) : null}
-              </div>
-            </main>
-          </SidebarInset>
+              <main className="flex-1 overflow-auto">
+                <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-8 py-10">
+                  {showTitle ? <TitleField disabled={isSubmitting} /> : null}
+                  {showEditor ? (
+                    <ContentField
+                      disabled={isSubmitting}
+                      onEditorReady={setActiveEditor}
+                    />
+                  ) : null}
+                  {!showTitle && !showEditor ? (
+                    <p
+                      className="text-muted-foreground text-sm"
+                      data-testid="post-editor-empty-canvas"
+                    >
+                      This entry type has no title or editor. Use the panels on
+                      the right to manage its content.
+                    </p>
+                  ) : null}
+                </div>
+              </main>
+            </SidebarInset>
 
-          <Sidebar
-            side="right"
-            collapsible="offcanvas"
-            data-testid="meta-boxes-sidebar"
-          >
-            <SidebarHeader className="flex h-14 shrink-0 flex-row items-center border-b px-4 text-sm font-semibold">
-              Document
-            </SidebarHeader>
-            <SidebarContent>
-              <Accordion
-                type="multiple"
-                defaultValue={openSections}
-                className="divide-y"
-              >
-                {showSlug ? (
-                  <PermalinkSection
-                    disabled={isSubmitting}
-                    onSlugEdit={() => {
-                      setSlugLocked(true);
-                    }}
-                  />
-                ) : null}
-                <StatusSection
-                  availableStatuses={availableStatuses}
-                  disabled={isSubmitting}
-                />
-                {isHierarchical ? (
-                  <ParentSection
-                    parentOptions={parentOptions}
+            <Sidebar
+              side="right"
+              collapsible="offcanvas"
+              data-testid="meta-boxes-sidebar"
+            >
+              <SidebarHeader className="flex h-14 shrink-0 flex-row items-center border-b px-4 text-sm font-semibold">
+                Document
+              </SidebarHeader>
+              <SidebarContent>
+                <InspectorSection />
+                <Accordion
+                  type="multiple"
+                  defaultValue={openSections}
+                  className="divide-y"
+                >
+                  {showSlug ? (
+                    <PermalinkSection
+                      disabled={isSubmitting}
+                      onSlugEdit={() => {
+                        setSlugLocked(true);
+                      }}
+                    />
+                  ) : null}
+                  <StatusSection
+                    availableStatuses={availableStatuses}
                     disabled={isSubmitting}
                   />
-                ) : null}
-                {showExcerpt ? (
-                  <ExcerptSection disabled={isSubmitting} />
-                ) : null}
-                {taxonomies.map((tax) => (
-                  <TaxonomySection
-                    key={tax.name}
-                    taxonomy={tax}
-                    disabled={isSubmitting}
-                  />
-                ))}
-                {metaBoxes.map((box) => (
-                  <MetaBoxAccordionItem
-                    key={box.id}
-                    box={box}
-                    basePath="meta"
-                    disabled={isSubmitting}
-                  />
-                ))}
-              </Accordion>
-            </SidebarContent>
-          </Sidebar>
-        </SidebarProvider>
-      </form>
+                  {isHierarchical ? (
+                    <ParentSection
+                      parentOptions={parentOptions}
+                      disabled={isSubmitting}
+                    />
+                  ) : null}
+                  {showExcerpt ? (
+                    <ExcerptSection disabled={isSubmitting} />
+                  ) : null}
+                  {taxonomies.map((tax) => (
+                    <TaxonomySection
+                      key={tax.name}
+                      taxonomy={tax}
+                      disabled={isSubmitting}
+                    />
+                  ))}
+                  {metaBoxes.map((box) => (
+                    <MetaBoxAccordionItem
+                      key={box.id}
+                      box={box}
+                      basePath="meta"
+                      disabled={isSubmitting}
+                    />
+                  ))}
+                </Accordion>
+              </SidebarContent>
+            </Sidebar>
+          </SidebarProvider>
+        </form>
+      </EditorProvider>
 
       <AlertDialog
         open={blocker.status === "blocked"}
@@ -472,14 +487,23 @@ function TitleField({ disabled }: { readonly disabled: boolean }): ReactNode {
   );
 }
 
+function InspectorSection(): ReactNode {
+  const editor = useActiveEditor();
+  const blockRegistry = useAdminBlockRegistry();
+  if (!editor) return null;
+  return <Inspector editor={editor} blockRegistry={blockRegistry} />;
+}
+
 function ContentEditor({
   value,
   onChange,
   disabled,
+  onEditorReady,
 }: {
   readonly value: JSONContent | null;
   readonly onChange: (json: JSONContent) => void;
   readonly disabled: boolean;
+  readonly onEditorReady: (editor: Editor | null) => void;
 }): ReactNode {
   // Hooks unwrap the lazy registries via React's `use()` + Suspense —
   // the parent renders a fallback while they resolve (one-shot per
@@ -494,11 +518,18 @@ function ContentEditor({
       ariaLabel="Entry content"
       blockRegistry={blockRegistry}
       markRegistry={markRegistry}
+      onEditorReady={onEditorReady}
     />
   );
 }
 
-function ContentField({ disabled }: { readonly disabled: boolean }): ReactNode {
+function ContentField({
+  disabled,
+  onEditorReady,
+}: {
+  readonly disabled: boolean;
+  readonly onEditorReady: (editor: Editor | null) => void;
+}): ReactNode {
   const { control } = useFormContext<PostEditorValues>();
   return (
     <FormField
@@ -518,6 +549,7 @@ function ContentField({ disabled }: { readonly disabled: boolean }): ReactNode {
                 value={field.value}
                 onChange={field.onChange}
                 disabled={disabled}
+                onEditorReady={onEditorReady}
               />
             </div>
           </FormControl>

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -1,4 +1,4 @@
-import type { JSONContent } from "@tiptap/react";
+import type { Editor, JSONContent } from "@tiptap/react";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
 import { FloatingInsertMenu } from "@/editor/floating-menu/FloatingInsertMenu.js";
@@ -32,6 +32,7 @@ export function TiptapEditor({
   blocks,
   markRegistry,
   blockRegistry,
+  onEditorReady,
 }: {
   readonly value: JSONContent | null;
   readonly onChange: (json: JSONContent) => void;
@@ -50,6 +51,13 @@ export function TiptapEditor({
    * `/` to insert a block; omit in field mode (no slash menu shown).
    */
   readonly blockRegistry?: BlockRegistry;
+  /**
+   * Called once with the editor instance after mount, and again with
+   * `null` on unmount. Lets the rail Inspector (or future Block menu)
+   * subscribe to selection state without prop-drilling the editor
+   * down the form tree.
+   */
+  readonly onEditorReady?: (editor: Editor | null) => void;
 }): ReactNode {
   // Shields the `value` sync-effect from echoing the editor's own
   // emissions back through the parent's state — would otherwise
@@ -114,6 +122,23 @@ export function TiptapEditor({
   useEffect(() => {
     editor.setEditable(!disabled);
   }, [editor, disabled]);
+
+  // Ref-pin the callback so the publish/unpublish effect only fires
+  // when the editor instance itself changes (mount/unmount) — not on
+  // every parent re-render that might hand us a new inline lambda.
+  // Without this, the Inspector context value would flicker null →
+  // editor on unrelated re-renders.
+  const onEditorReadyRef = useRef(onEditorReady);
+  useEffect(() => {
+    onEditorReadyRef.current = onEditorReady;
+  });
+
+  useEffect(() => {
+    onEditorReadyRef.current?.(editor);
+    return () => {
+      onEditorReadyRef.current?.(null);
+    };
+  }, [editor]);
 
   return (
     <div className={cn("bg-background", disabled && "opacity-60")}>

--- a/packages/admin/src/editor/editor-context.ts
+++ b/packages/admin/src/editor/editor-context.ts
@@ -1,0 +1,16 @@
+import type { Editor } from "@tiptap/react";
+import { createContext, useContext } from "react";
+
+/**
+ * Lets sibling panels (Inspector, Block menu) reach the live Tiptap
+ * editor without prop-drilling through the form/field tree that owns
+ * it. `TiptapEditor` publishes itself via `onEditorReady`; the form
+ * stores the instance in state and exposes it through this context.
+ */
+const EditorContext = createContext<Editor | null>(null);
+
+export const EditorProvider = EditorContext.Provider;
+
+export function useActiveEditor(): Editor | null {
+  return useContext(EditorContext);
+}

--- a/packages/admin/src/editor/inspector/Inspector.test.tsx
+++ b/packages/admin/src/editor/inspector/Inspector.test.tsx
@@ -1,0 +1,217 @@
+import type { Editor } from "@tiptap/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { BlockRegistry, ResolvedBlockSpec } from "@plumix/blocks";
+
+import { Inspector } from "./Inspector.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function spec(
+  partial: Partial<ResolvedBlockSpec> & { name: string; title: string },
+): ResolvedBlockSpec {
+  return {
+    name: partial.name,
+    title: partial.title,
+    description: partial.description,
+    category: partial.category ?? "typography",
+    keywords: partial.keywords,
+    attributes: partial.attributes,
+    component: () => null,
+    legacyAliases: undefined,
+    schema: undefined,
+    registeredBy: null,
+    editor: undefined,
+    client: undefined,
+  } as unknown as ResolvedBlockSpec;
+}
+
+function fakeRegistry(specs: readonly ResolvedBlockSpec[]): BlockRegistry {
+  const map = new Map(specs.map((s) => [s.name, s]));
+  return {
+    get: (n) => map.get(n),
+    has: (n) => map.has(n),
+    size: map.size,
+    [Symbol.iterator]: () => map.entries(),
+  } satisfies BlockRegistry;
+}
+
+interface SelectionState {
+  readonly nodeType: string | null;
+  readonly attrs: Record<string, unknown>;
+}
+
+function stubEditor(selection: SelectionState) {
+  const updateAttributes = vi.fn();
+  const chain = {
+    focus: () => chain,
+    updateAttributes: (type: string, attrs: Record<string, unknown>) => {
+      updateAttributes(type, attrs);
+      return chain;
+    },
+    run: () => true,
+  };
+  const listeners = new Map<string, Set<() => void>>();
+  const editor = {
+    chain: () => chain,
+    on: (event: string, fn: () => void) => {
+      const bucket = listeners.get(event) ?? new Set();
+      bucket.add(fn);
+      listeners.set(event, bucket);
+      return editor;
+    },
+    off: (event: string, fn: () => void) => {
+      listeners.get(event)?.delete(fn);
+      return editor;
+    },
+    state: {
+      get selection() {
+        if (selection.nodeType === null) {
+          return { $from: { parent: { type: { name: "doc" }, attrs: {} } } };
+        }
+        return {
+          $from: {
+            parent: {
+              type: { name: selection.nodeType },
+              attrs: selection.attrs,
+            },
+          },
+        };
+      },
+    },
+  } as unknown as Editor;
+  return {
+    editor,
+    updateAttributes,
+    listenerCount: (event: string) => listeners.get(event)?.size ?? 0,
+  };
+}
+
+describe("Inspector", () => {
+  test("renders nothing when selection is in a node without a registered spec", () => {
+    const registry = fakeRegistry([]);
+    const { editor } = stubEditor({ nodeType: null, attrs: {} });
+    const { container } = render(
+      <Inspector editor={editor} blockRegistry={registry} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders one InspectorField per declared attribute, preserving order", () => {
+    const headingSpec = spec({
+      name: "core/heading",
+      title: "Heading",
+      attributes: {
+        level: {
+          type: "select",
+          label: "Heading level",
+          default: 2,
+          options: [
+            { value: 1, label: "H1" },
+            { value: 2, label: "H2" },
+            { value: 3, label: "H3" },
+          ],
+        },
+        anchor: {
+          type: "link",
+          label: "Anchor",
+          default: "",
+        },
+      },
+    });
+    const registry = fakeRegistry([headingSpec]);
+    const { editor } = stubEditor({
+      nodeType: "core/heading",
+      attrs: { level: 2 },
+    });
+    render(<Inspector editor={editor} blockRegistry={registry} />);
+    expect(screen.getByTestId("inspector-field-level")).toBeInTheDocument();
+    expect(screen.getByTestId("inspector-field-anchor")).toBeInTheDocument();
+  });
+
+  test("changing a field calls editor.chain().focus().updateAttributes()", () => {
+    const headingSpec = spec({
+      name: "core/heading",
+      title: "Heading",
+      attributes: {
+        level: {
+          type: "select",
+          label: "Heading level",
+          default: 2,
+          options: [
+            { value: 1, label: "H1" },
+            { value: 2, label: "H2" },
+            { value: 3, label: "H3" },
+          ],
+        },
+      },
+    });
+    const registry = fakeRegistry([headingSpec]);
+    const { editor, updateAttributes } = stubEditor({
+      nodeType: "core/heading",
+      attrs: { level: 2 },
+    });
+    render(<Inspector editor={editor} blockRegistry={registry} />);
+    fireEvent.change(screen.getByTestId("inspector-field-level"), {
+      target: { value: "3" },
+    });
+    expect(updateAttributes).toHaveBeenCalledWith("core/heading", {
+      level: 3,
+    });
+  });
+
+  test("renders nothing when the selected node's spec has no attributes", () => {
+    const paragraph = spec({
+      name: "core/paragraph",
+      title: "Paragraph",
+      attributes: undefined,
+    });
+    const registry = fakeRegistry([paragraph]);
+    const { editor } = stubEditor({
+      nodeType: "core/paragraph",
+      attrs: {},
+    });
+    const { container } = render(
+      <Inspector editor={editor} blockRegistry={registry} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("registers a transaction listener on mount and removes it on unmount", () => {
+    const registry = fakeRegistry([]);
+    const { editor, listenerCount } = stubEditor({
+      nodeType: null,
+      attrs: {},
+    });
+    const { unmount } = render(
+      <Inspector editor={editor} blockRegistry={registry} />,
+    );
+    expect(listenerCount("transaction")).toBe(1);
+    unmount();
+    expect(listenerCount("transaction")).toBe(0);
+  });
+
+  test("shows attr=false rather than the schema default (no `??` swallow)", () => {
+    const boolSpec = spec({
+      name: "core/probe",
+      title: "Probe",
+      attributes: {
+        enabled: { type: "boolean", label: "Enabled", default: true },
+      },
+    });
+    const registry = fakeRegistry([boolSpec]);
+    const { editor } = stubEditor({
+      nodeType: "core/probe",
+      attrs: { enabled: false },
+    });
+    render(<Inspector editor={editor} blockRegistry={registry} />);
+    const checkbox = document.querySelector<HTMLInputElement>(
+      '[data-testid="inspector-field-enabled"]',
+    );
+    if (!checkbox) throw new Error("inspector-field-enabled not rendered");
+    expect(checkbox.checked).toBe(false);
+  });
+});

--- a/packages/admin/src/editor/inspector/Inspector.tsx
+++ b/packages/admin/src/editor/inspector/Inspector.tsx
@@ -1,0 +1,104 @@
+import type { Editor } from "@tiptap/react";
+import type { ReactElement } from "react";
+import { useEffect, useState } from "react";
+
+import type { BlockRegistry, ResolvedBlockSpec } from "@plumix/blocks";
+
+import { InspectorField } from "./InspectorField.js";
+
+interface InspectorProps {
+  readonly editor: Editor;
+  readonly blockRegistry: BlockRegistry;
+}
+
+interface SelectedNode {
+  readonly spec: ResolvedBlockSpec;
+  readonly attrs: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Block Inspector — subscribes to the editor's selection and, when the
+ * caret is inside a registered block with declared `attributes`,
+ * renders one `InspectorField` per attribute. Field changes flow
+ * through `editor.chain().focus().updateAttributes(nodeName, ...)`
+ * so the editor's own undo / collaboration / history pipeline owns
+ * the mutation.
+ *
+ * Renders nothing when no spec is found OR the spec declares no
+ * attributes — keeps the rail clean when the user is editing plain
+ * paragraphs.
+ */
+export function Inspector({
+  editor,
+  blockRegistry,
+}: InspectorProps): ReactElement | null {
+  const [selected, setSelected] = useState<SelectedNode | null>(() =>
+    resolveSelection(editor, blockRegistry),
+  );
+
+  useEffect(() => {
+    // `transaction` covers selection moves AND attribute updates;
+    // `selectionUpdate` alone would miss `updateAttributes` mutations
+    // that don't move the caret.
+    //
+    // The handler fires on every keystroke inside the editor, so we
+    // bail out when neither the spec identity nor the attrs object
+    // changed. Without this check, every keystroke produces a new
+    // `{ spec, attrs }` object → React re-renders the Inspector even
+    // when there's nothing to redraw.
+    const sync = (): void => {
+      setSelected((prev) => {
+        const next = resolveSelection(editor, blockRegistry);
+        if (!prev && !next) return prev;
+        if (prev?.spec === next?.spec && prev?.attrs === next?.attrs) {
+          return prev;
+        }
+        return next;
+      });
+    };
+    editor.on("transaction", sync);
+    return () => {
+      editor.off("transaction", sync);
+    };
+  }, [editor, blockRegistry]);
+
+  if (!selected) return null;
+  const { spec, attrs } = selected;
+  if (!spec.attributes) return null;
+  const entries = Object.entries(spec.attributes);
+  if (entries.length === 0) return null;
+
+  return (
+    <div data-plumix-inspector="" aria-label={`${spec.title} attributes`}>
+      <h3 data-plumix-inspector-title="">{spec.title}</h3>
+      {entries.map(([attrName, schema]) => (
+        <InspectorField
+          key={attrName}
+          name={attrName}
+          schema={schema}
+          value={attrName in attrs ? attrs[attrName] : schema.default}
+          onChange={(next) => {
+            editor
+              .chain()
+              .focus()
+              .updateAttributes(spec.name, { [attrName]: next })
+              .run();
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function resolveSelection(
+  editor: Editor,
+  blockRegistry: BlockRegistry,
+): SelectedNode | null {
+  const node = editor.state.selection.$from.parent;
+  const spec = blockRegistry.get(node.type.name);
+  if (!spec) return null;
+  return {
+    spec,
+    attrs: node.attrs,
+  };
+}

--- a/packages/admin/src/editor/inspector/InspectorField.test.tsx
+++ b/packages/admin/src/editor/inspector/InspectorField.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { BlockAttributeSchema } from "@plumix/blocks";
+
+import { InspectorField } from "./InspectorField.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("InspectorField — select", () => {
+  const selectAttr: BlockAttributeSchema = {
+    type: "select",
+    label: "Heading level",
+    default: 2,
+    options: [
+      { value: 1, label: "H1" },
+      { value: 2, label: "H2" },
+      { value: 3, label: "H3" },
+    ],
+  };
+
+  test("renders a select with one option per entry, reflecting the current value", () => {
+    render(
+      <InspectorField
+        name="level"
+        schema={selectAttr}
+        value={2}
+        onChange={vi.fn()}
+      />,
+    );
+    const field = document.querySelector<HTMLSelectElement>(
+      '[data-testid="inspector-field-level"]',
+    );
+    if (!field) throw new Error("inspector-field-level not rendered");
+    expect(field.tagName).toBe("SELECT");
+    expect(field.value).toBe("2");
+    expect(field.querySelectorAll("option")).toHaveLength(3);
+  });
+
+  test("changing the select fires onChange with the coerced value", () => {
+    const onChange = vi.fn();
+    render(
+      <InspectorField
+        name="level"
+        schema={selectAttr}
+        value={2}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("inspector-field-level"), {
+      target: { value: "3" },
+    });
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("InspectorField — boolean", () => {
+  const boolAttr: BlockAttributeSchema = {
+    type: "boolean",
+    label: "Numbered",
+    default: false,
+  };
+
+  test("renders a checkbox reflecting the current value", () => {
+    render(
+      <InspectorField
+        name="numbered"
+        schema={boolAttr}
+        value={true}
+        onChange={vi.fn()}
+      />,
+    );
+    const field = document.querySelector<HTMLInputElement>(
+      '[data-testid="inspector-field-numbered"]',
+    );
+    if (!field) throw new Error("inspector-field-numbered not rendered");
+    expect(field.type).toBe("checkbox");
+    expect(field.checked).toBe(true);
+  });
+
+  test("toggling the checkbox fires onChange with the new boolean", () => {
+    const onChange = vi.fn();
+    render(
+      <InspectorField
+        name="numbered"
+        schema={boolAttr}
+        value={false}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("inspector-field-numbered"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe("InspectorField — link", () => {
+  const linkAttr: BlockAttributeSchema = {
+    type: "link",
+    label: "Destination",
+    default: "",
+  };
+
+  test("renders a url input reflecting the current value", () => {
+    render(
+      <InspectorField
+        name="href"
+        schema={linkAttr}
+        value="https://example.com"
+        onChange={vi.fn()}
+      />,
+    );
+    const field = document.querySelector<HTMLInputElement>(
+      '[data-testid="inspector-field-href"]',
+    );
+    if (!field) throw new Error("inspector-field-href not rendered");
+    expect(field.type).toBe("url");
+    expect(field.value).toBe("https://example.com");
+  });
+
+  test("typing in the url input fires onChange with the string value", () => {
+    const onChange = vi.fn();
+    render(
+      <InspectorField
+        name="href"
+        schema={linkAttr}
+        value=""
+        onChange={onChange}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("inspector-field-href"), {
+      target: { value: "https://x.example" },
+    });
+    expect(onChange).toHaveBeenCalledWith("https://x.example");
+  });
+});
+
+describe("InspectorField — unknown type", () => {
+  test("renders nothing for an unsupported schema.type (no crash)", () => {
+    const { container } = render(
+      <InspectorField
+        name="exotic"
+        schema={{ type: "color-wheel-3d" }}
+        value="unused"
+        onChange={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/admin/src/editor/inspector/InspectorField.tsx
+++ b/packages/admin/src/editor/inspector/InspectorField.tsx
@@ -1,0 +1,114 @@
+import type { ChangeEvent, ReactElement } from "react";
+import { Input } from "@/components/ui/input.js";
+import { Label } from "@/components/ui/label.js";
+
+import type { BlockAttributeSchema } from "@plumix/blocks";
+
+interface InspectorFieldProps {
+  readonly name: string;
+  readonly schema: BlockAttributeSchema;
+  readonly value: unknown;
+  readonly onChange: (next: unknown) => void;
+}
+
+interface SelectOption {
+  readonly value: string | number;
+  readonly label: string;
+}
+
+const SELECT_CLASS =
+  "border-input focus-visible:ring-ring h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none";
+
+function stringifyScalar(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+/**
+ * Per-attribute input renderer for the block Inspector. Dispatches on
+ * `schema.type` to a small set of canonical controls. Native form
+ * elements rather than Radix popovers — the Inspector lives in a
+ * persistent right-rail and a native `<select>` plays nicer with
+ * keyboard nav, screen readers, and jsdom unit tests than a Radix
+ * Select popover that needs floating-ui to render.
+ */
+export function InspectorField({
+  name,
+  schema,
+  value,
+  onChange,
+}: InspectorFieldProps): ReactElement | null {
+  const id = `inspector-field-${name}`;
+  const label = schema.label ?? name;
+
+  switch (schema.type) {
+    case "select": {
+      const options = Array.isArray(schema.options)
+        ? (schema.options as readonly SelectOption[])
+        : [];
+      // Numeric options round-trip through the DOM as strings; coerce
+      // back when the schema declared numbers so `updateAttributes`
+      // receives the original type.
+      const isNumeric = typeof options[0]?.value === "number";
+      return (
+        <div data-plumix-inspector-field={name}>
+          <Label htmlFor={id}>{label}</Label>
+          <select
+            id={id}
+            data-testid={id}
+            value={stringifyScalar(value)}
+            onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+              const raw = event.target.value;
+              onChange(isNumeric ? Number(raw) : raw);
+            }}
+            className={SELECT_CLASS}
+          >
+            {options.map((opt) => (
+              <option key={String(opt.value)} value={String(opt.value)}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      );
+    }
+
+    case "boolean":
+    case "checkbox":
+      return (
+        <div data-plumix-inspector-field={name}>
+          <Label htmlFor={id} className="flex items-center gap-2">
+            <input
+              id={id}
+              data-testid={id}
+              type="checkbox"
+              checked={value === true}
+              onChange={(event) => onChange(event.target.checked)}
+            />
+            {label}
+          </Label>
+        </div>
+      );
+
+    case "link":
+    case "url":
+      return (
+        <div data-plumix-inspector-field={name}>
+          <Label htmlFor={id}>{label}</Label>
+          <Input
+            id={id}
+            data-testid={id}
+            type="url"
+            value={typeof value === "string" ? value : ""}
+            onChange={(event) => onChange(event.target.value)}
+          />
+        </div>
+      );
+
+    default:
+      return null;
+  }
+}

--- a/packages/blocks/src/heading/index.ts
+++ b/packages/blocks/src/heading/index.ts
@@ -6,6 +6,21 @@ export const headingBlock = defineBlock({
   category: "text",
   description: "Section title.",
   legacyAliases: ["heading"],
+  attributes: {
+    level: {
+      type: "select",
+      label: "Heading level",
+      default: 2,
+      options: [
+        { value: 1, label: "H1" },
+        { value: 2, label: "H2" },
+        { value: 3, label: "H3" },
+        { value: 4, label: "H4" },
+        { value: 5, label: "H5" },
+        { value: 6, label: "H6" },
+      ],
+    },
+  },
   schema: () => import("./schema.js").then((m) => m.headingSchema),
   component: () => import("./Component.js").then((m) => m.HeadingComponent),
 });

--- a/packages/core/src/plugin/core-field-types.ts
+++ b/packages/core/src/plugin/core-field-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Seed set for `mergeBlockRegistry`'s attribute-type validation so
+ * core blocks can declare `type: "select"` etc. without registering a
+ * plugin. Mirrors the admin `MetaBoxField` dispatcher's native variants
+ * plus block-specific aliases (`boolean`, `link`). Plugins extend this
+ * via `ctx.registerFieldType`.
+ */
+export const CORE_FIELD_TYPES: readonly string[] = Object.freeze([
+  "text",
+  "textarea",
+  "number",
+  "range",
+  "select",
+  "multiselect",
+  "checkbox",
+  "boolean",
+  "url",
+  "link",
+  "email",
+  "password",
+  "color",
+  "date",
+  "datetime",
+  "time",
+  "json",
+  "richtext",
+  "repeater",
+  "entry",
+  "entry-list",
+  "term",
+  "term-list",
+  "user",
+  "user-list",
+  "radio",
+]);

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -37,6 +37,7 @@ import { createCapabilityResolver } from "../auth/rbac.js";
 import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
 import * as coreSchema from "../db/schema/index.js";
 import { HookRegistry } from "../hooks/registry.js";
+import { CORE_FIELD_TYPES } from "../plugin/core-field-types.js";
 import {
   CORE_RPC_NAMESPACES,
   createPluginRegistry,
@@ -208,7 +209,10 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   const pluginBlockContributions = Array.from(registry.blockSpecs.values()).map(
     ({ spec, registeredBy }) => ({ spec, pluginId: registeredBy }),
   );
-  const fieldTypeNames = new Set<string>(registry.fieldTypes.keys());
+  const fieldTypeNames = new Set<string>([
+    ...CORE_FIELD_TYPES,
+    ...registry.fieldTypes.keys(),
+  ]);
   const { overrides: blockOverrides, themeId: blockThemeId } =
     collectThemeOverrides(config.themes, (theme) => theme.blocks);
   const blocks = await mergeBlockRegistry({

--- a/packages/core/src/runtime/core-field-types.test.ts
+++ b/packages/core/src/runtime/core-field-types.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+
+import { defineBlock } from "@plumix/blocks";
+
+import { auth } from "../auth/config.js";
+import { plumix } from "../config.js";
+import { definePlugin } from "../plugin/define.js";
+import { buildApp } from "./app.js";
+
+const baseConfig = {
+  runtime: {
+    name: "test",
+    buildFetchHandler: () => () => new Response("stub", { status: 500 }),
+  },
+  database: {
+    kind: "test",
+    connect: () => ({ db: {} }),
+  },
+  auth: auth({
+    passkey: {
+      rpName: "Plumix Test",
+      rpId: "cms.example",
+      origin: "https://cms.example",
+    },
+  }),
+};
+
+function pluginWithBlock(name: string, attrType: string) {
+  const id = `test-plugin-${name.replace(/[^a-z0-9]/g, "")}`;
+  return definePlugin(id, (ctx) => {
+    ctx.registerBlock(
+      defineBlock({
+        name,
+        title: name,
+        attributes: {
+          sample: { type: attrType, default: null },
+        },
+        schema: () =>
+          Promise.resolve({
+            name,
+            parseHTML: () => [],
+            renderHTML: () => ["div", 0],
+          } as never),
+        component: () => Promise.resolve(() => null),
+      }),
+    );
+  });
+}
+
+describe("buildApp accepts canonical core field types on block attributes", () => {
+  test("core/heading's level: { type: 'select', ... } passes validation", async () => {
+    // `headingBlock` is in `coreBlocks` with `attributes.level.type = "select"`.
+    // Without the core-field-types seed in the validation set, buildApp would
+    // throw `unknown_attribute_type` here.
+    await expect(buildApp(plumix(baseConfig))).resolves.toBeDefined();
+  });
+
+  test.each(["boolean", "link", "url", "checkbox", "number"])(
+    "core type %s is accepted on a plugin block attribute",
+    async (type) => {
+      await expect(
+        buildApp(
+          plumix({
+            ...baseConfig,
+            plugins: [pluginWithBlock(`test/${type}-block`, type)],
+          }),
+        ),
+      ).resolves.toBeDefined();
+    },
+  );
+
+  test("an unknown attribute type still throws unknown_attribute_type", async () => {
+    await expect(
+      buildApp(
+        plumix({
+          ...baseConfig,
+          plugins: [pluginWithBlock("test/exotic-block", "color-wheel-3d")],
+        }),
+      ),
+    ).rejects.toThrow(/unknown_attribute_type|color-wheel-3d/);
+  });
+});


### PR DESCRIPTION
End-to-end slice for [#303](https://github.com/withplumix/plumix/issues/303): right-rail block Inspector that renders one input per declared block attribute, native select/boolean/link field renderers, \`level\` declared as a select attribute on \`core/heading\`, and a canonical core-field-type seed so block authors can declare \`type: \"select\"\` without registering a plugin.

**Inspector**

\`<Inspector editor blockRegistry />\` subscribes to \`editor.on(\"transaction\")\`, finds the parent node's spec via the registry, and renders one \`<InspectorField>\` per declared attribute. Field changes flow through \`editor.chain().focus().updateAttributes(spec.name, ...)\` so undo / collaboration / history own the mutation. Sits at the top of the right rail above the existing meta-box stack and renders nothing when no spec-bearing block is selected.

Reaches the live editor instance via \`EditorProvider\` + \`useActiveEditor\` (React context) to avoid prop-drilling through the form / FormField tree.

**Field renderers — native, not Radix**

The Inspector lives in a persistent rail rather than a popover, so native \`<select>\` / \`<input type=\"checkbox\">\` / shadcn \`<Input type=\"url\">\` play nicer with keyboard nav, screen readers, and jsdom unit tests than Radix Select / Switch popovers that need floating-ui. Documented in \`InspectorField.tsx\`.

**Core field-type seed**

\`CORE_FIELD_TYPES\` constant lists every type the admin's \`MetaBoxField\` dispatcher handles natively plus the block-specific aliases (\`boolean\`, \`link\`). \`buildApp\` seeds these into the validation set passed to \`mergeBlockRegistry\`. Without the seed, every block author would have to register a plugin to declare \`type: \"select\"\` on an attribute.

**Senpai review addressed in-slice**

- Bail out of \`setSelected\` when spec + attrs identity unchanged (was rendering on every keystroke)
- \`attrName in attrs\` instead of \`??\` (was swallowing \`attr = false\` and showing the schema default)
- Ref-pin \`onEditorReady\` so unrelated parent re-renders don't flicker the Inspector's editor context value
- Listener-removal symmetry test pins the cleanup contract
- core-field-types test adds parameterized positives for boolean/link/url/checkbox/number plus a negative for unknown types

Closes #303