### PR TITLE
feat(blocks,admin): drag handle + block menu + declarative transforms

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -27,6 +27,7 @@
     "@tanstack/react-router": "^1.169.1",
     "@tanstack/react-table": "^8.21.3",
     "@tiptap/core": "^3.23.1",
+    "@tiptap/extension-drag-handle-react": "3.23.4",
     "@tiptap/react": "^3.23.1",
     "@tiptap/starter-kit": "^3.23.1",
     "@tiptap/suggestion": "^3.23.4",

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -1,6 +1,7 @@
 import type { Editor, JSONContent } from "@tiptap/react";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
+import { PlumixDragHandle } from "@/editor/drag-handle/PlumixDragHandle.js";
 import { FloatingInsertMenu } from "@/editor/floating-menu/FloatingInsertMenu.js";
 import { createSlashMenuExtension } from "@/editor/slash-menu/extension.js";
 import { cn } from "@/lib/utils.js";
@@ -147,6 +148,9 @@ export function TiptapEditor({
       ) : null}
       {!allowlist && blockRegistry ? (
         <FloatingInsertMenu editor={editor} />
+      ) : null}
+      {!allowlist && blockRegistry ? (
+        <PlumixDragHandle editor={editor} blockRegistry={blockRegistry} />
       ) : null}
       <EditorContent editor={editor} />
     </div>

--- a/packages/admin/src/editor/block-menu/BlockMenu.test.tsx
+++ b/packages/admin/src/editor/block-menu/BlockMenu.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { BlockRegistry, ResolvedBlockSpec } from "@plumix/blocks";
+
+import { BlockMenu } from "./BlockMenu.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function spec(
+  partial: Partial<ResolvedBlockSpec> & { name: string; title: string },
+): ResolvedBlockSpec {
+  const out: Partial<ResolvedBlockSpec> = {
+    name: partial.name,
+    title: partial.title,
+    component: () => null,
+    registeredBy: null,
+    transforms: partial.transforms,
+  };
+  return out as ResolvedBlockSpec;
+}
+
+function fakeRegistry(specs: readonly ResolvedBlockSpec[]): BlockRegistry {
+  const map = new Map(specs.map((s) => [s.name, s]));
+  return {
+    get: (n) => map.get(n),
+    has: (n) => map.has(n),
+    size: map.size,
+    [Symbol.iterator]: () => map.entries(),
+  } satisfies BlockRegistry;
+}
+
+describe("BlockMenu", () => {
+  test("renders the four canonical actions", () => {
+    const paragraph = spec({ name: "core/paragraph", title: "Paragraph" });
+    render(
+      <BlockMenu
+        sourceName="core/paragraph"
+        blockRegistry={fakeRegistry([paragraph])}
+        onTransform={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onCopyJson={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("block-menu-duplicate")).toBeInTheDocument();
+    expect(screen.queryByTestId("block-menu-delete")).toBeInTheDocument();
+    expect(screen.queryByTestId("block-menu-copy-json")).toBeInTheDocument();
+  });
+
+  test("renders Transform-to entries from the resolver", () => {
+    const heading = spec({ name: "core/heading", title: "Heading" });
+    const quote = spec({ name: "core/quote", title: "Quote" });
+    const paragraph = spec({
+      name: "core/paragraph",
+      title: "Paragraph",
+      transforms: {
+        to: [{ target: "core/heading" }, { target: "core/quote" }],
+      },
+    });
+    const registry = fakeRegistry([paragraph, heading, quote]);
+    render(
+      <BlockMenu
+        sourceName="core/paragraph"
+        blockRegistry={registry}
+        onTransform={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onCopyJson={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("block-menu-transform-core/heading"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("block-menu-transform-core/quote"),
+    ).toBeInTheDocument();
+  });
+
+  test("clicking a transform entry invokes onTransform with the target name", () => {
+    const heading = spec({ name: "core/heading", title: "Heading" });
+    const paragraph = spec({
+      name: "core/paragraph",
+      title: "Paragraph",
+      transforms: { to: [{ target: "core/heading" }] },
+    });
+    const onTransform = vi.fn();
+    render(
+      <BlockMenu
+        sourceName="core/paragraph"
+        blockRegistry={fakeRegistry([paragraph, heading])}
+        onTransform={onTransform}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onCopyJson={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("block-menu-transform-core/heading"));
+    expect(onTransform).toHaveBeenCalledWith(
+      expect.objectContaining({ target: "core/heading" }),
+    );
+  });
+
+  test("clicking Duplicate / Delete / Copy JSON fires their callbacks", () => {
+    const paragraph = spec({ name: "core/paragraph", title: "Paragraph" });
+    const onDuplicate = vi.fn();
+    const onDelete = vi.fn();
+    const onCopyJson = vi.fn();
+    render(
+      <BlockMenu
+        sourceName="core/paragraph"
+        blockRegistry={fakeRegistry([paragraph])}
+        onTransform={vi.fn()}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+        onCopyJson={onCopyJson}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("block-menu-duplicate"));
+    fireEvent.click(screen.getByTestId("block-menu-delete"));
+    fireEvent.click(screen.getByTestId("block-menu-copy-json"));
+    expect(onDuplicate).toHaveBeenCalled();
+    expect(onDelete).toHaveBeenCalled();
+    expect(onCopyJson).toHaveBeenCalled();
+  });
+
+  test("renders without crashing when the source has no transform targets", () => {
+    const orphan = spec({ name: "core/orphan", title: "Orphan" });
+    render(
+      <BlockMenu
+        sourceName="core/orphan"
+        blockRegistry={fakeRegistry([orphan])}
+        onTransform={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onCopyJson={vi.fn()}
+      />,
+    );
+    // Transform section is absent; the three canonical actions remain.
+    expect(screen.queryByTestId("block-menu-duplicate")).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/editor/block-menu/BlockMenu.tsx
+++ b/packages/admin/src/editor/block-menu/BlockMenu.tsx
@@ -1,0 +1,97 @@
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command.js";
+
+import type { BlockRegistry, BlockTransformTo } from "@plumix/blocks";
+import { resolveTransformTargets } from "@plumix/blocks";
+
+interface BlockMenuProps {
+  readonly sourceName: string;
+  readonly blockRegistry: BlockRegistry;
+  /**
+   * Receives the full transform entry — including `mode` and
+   * `mapAttrs` — so the caller can dispatch the right Tiptap command
+   * (setNode vs wrapIn) and pre-compute attrs from the source's
+   * current state.
+   */
+  readonly onTransform: (entry: BlockTransformTo) => void;
+  readonly onDuplicate: () => void;
+  readonly onDelete: () => void;
+  readonly onCopyJson: () => void;
+}
+
+/**
+ * Per-block action menu rendered into the popover anchored on the
+ * drag handle. Hosts the four canonical actions plus a Transform-to
+ * group derived from `resolveTransformTargets`. Native cmdk semantics
+ * own keyboard nav + ARIA — same primitive the slash menu uses.
+ */
+export function BlockMenu({
+  sourceName,
+  blockRegistry,
+  onTransform,
+  onDuplicate,
+  onDelete,
+  onCopyJson,
+}: BlockMenuProps): ReactElement {
+  const targets = useMemo(
+    () => resolveTransformTargets(sourceName, blockRegistry),
+    [sourceName, blockRegistry],
+  );
+  return (
+    <Command data-plumix-block-menu="" label="Block actions">
+      <CommandList>
+        {targets.length > 0 ? (
+          <>
+            <CommandGroup heading="Transform to">
+              {targets.map((entry) => {
+                const targetSpec = blockRegistry.get(entry.target);
+                if (!targetSpec) return null;
+                return (
+                  <CommandItem
+                    key={entry.target}
+                    value={`transform-${entry.target}`}
+                    data-testid={`block-menu-transform-${entry.target}`}
+                    onSelect={() => onTransform(entry)}
+                  >
+                    {targetSpec.title}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        ) : null}
+        <CommandGroup heading="Block">
+          <CommandItem
+            value="duplicate"
+            data-testid="block-menu-duplicate"
+            onSelect={onDuplicate}
+          >
+            Duplicate
+          </CommandItem>
+          <CommandItem
+            value="delete"
+            data-testid="block-menu-delete"
+            onSelect={onDelete}
+          >
+            Delete
+          </CommandItem>
+          <CommandItem
+            value="copy-json"
+            data-testid="block-menu-copy-json"
+            onSelect={onCopyJson}
+          >
+            Copy JSON
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}

--- a/packages/admin/src/editor/drag-handle/DragHandleButton.test.tsx
+++ b/packages/admin/src/editor/drag-handle/DragHandleButton.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { DragHandleButton } from "./DragHandleButton.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DragHandleButton", () => {
+  test("renders a button with role=button and aria-label", () => {
+    render(<DragHandleButton onOpenMenu={vi.fn()} />);
+    const handle = screen.getByTestId("drag-handle-button");
+    expect(handle.getAttribute("role")).toBe("button");
+    expect(handle.getAttribute("aria-label")).toBe("Block actions");
+  });
+
+  test("clicking the handle invokes onOpenMenu", () => {
+    const onOpenMenu = vi.fn();
+    render(<DragHandleButton onOpenMenu={onOpenMenu} />);
+    fireEvent.click(screen.getByTestId("drag-handle-button"));
+    expect(onOpenMenu).toHaveBeenCalled();
+  });
+
+  test("Enter and Space on a focused handle also open the menu", () => {
+    const onOpenMenu = vi.fn();
+    render(<DragHandleButton onOpenMenu={onOpenMenu} />);
+    const handle = screen.getByTestId("drag-handle-button");
+    fireEvent.keyDown(handle, { key: "Enter" });
+    fireEvent.keyDown(handle, { key: " " });
+    expect(onOpenMenu).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/admin/src/editor/drag-handle/DragHandleButton.tsx
+++ b/packages/admin/src/editor/drag-handle/DragHandleButton.tsx
@@ -1,0 +1,42 @@
+import type {
+  ComponentPropsWithoutRef,
+  KeyboardEvent,
+  ReactElement,
+} from "react";
+import { GripVertical } from "lucide-react";
+
+interface DragHandleButtonProps extends ComponentPropsWithoutRef<"div"> {
+  readonly onOpenMenu: () => void;
+}
+
+/**
+ * Visible handle the author clicks / drags. Spreads `...rest` so
+ * `<PopoverTrigger asChild>` and `<DragHandle>` (from
+ * `@tiptap/extension-drag-handle-react`) can forward their own props
+ * onto the same root.
+ */
+export function DragHandleButton({
+  onOpenMenu,
+  ...rest
+}: DragHandleButtonProps): ReactElement {
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onOpenMenu();
+    }
+  };
+  return (
+    <div
+      {...rest}
+      data-testid="drag-handle-button"
+      role="button"
+      aria-label="Block actions"
+      tabIndex={0}
+      onClick={onOpenMenu}
+      onKeyDown={onKeyDown}
+      className="text-muted-foreground hover:text-foreground flex h-6 w-4 cursor-grab items-center justify-center rounded-sm active:cursor-grabbing"
+    >
+      <GripVertical className="size-4" aria-hidden="true" />
+    </div>
+  );
+}

--- a/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
+++ b/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
@@ -1,0 +1,156 @@
+import type { Editor } from "@tiptap/react";
+import type { ReactElement } from "react";
+import { useState } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover.js";
+import { DragHandle } from "@tiptap/extension-drag-handle-react";
+
+import type { BlockRegistry, BlockTransformTo } from "@plumix/blocks";
+
+import { BlockMenu } from "../block-menu/BlockMenu.js";
+import { DragHandleButton } from "./DragHandleButton.js";
+
+interface PlumixDragHandleProps {
+  readonly editor: Editor;
+  readonly blockRegistry: BlockRegistry;
+}
+
+interface TrackedNode {
+  readonly node: {
+    readonly type: { readonly name: string };
+    readonly nodeSize: number;
+    toJSON(): unknown;
+  };
+  readonly pos: number;
+}
+
+/**
+ * Selection-anchored drag handle. The first-party Tiptap drag handle
+ * owns the floating positioning and the drag-and-drop machinery; this
+ * wrapper supplies the visible handle UI + the BlockMenu popover that
+ * opens on click.
+ *
+ * `trackedNode` mirrors the node the handle is currently anchored to
+ * so BlockMenu actions know which block to act on (Tiptap's
+ * `chain().setNodeSelection(pos)` then runs against the right pos).
+ */
+export function PlumixDragHandle({
+  editor,
+  blockRegistry,
+}: PlumixDragHandleProps): ReactElement {
+  // Structural shape rather than naming PMNode — `@tiptap/pm` isn't a
+  // direct admin dep and pulling it in just for this type would bloat
+  // the dependency surface. The fields we touch (type.name, nodeSize,
+  // toJSON) are the only contract this component relies on.
+  const [tracked, setTracked] = useState<TrackedNode | null>(null);
+  const [open, setOpen] = useState(false);
+
+  /**
+   * Every BlockMenu action selects the tracked node first so the
+   * subsequent command runs against the right pos. Guards against
+   * stale `tracked` state — Tiptap's `onNodeChange` may not fire
+   * before the popover re-opens after a delete, so we re-validate
+   * that the position still holds the node we recorded.
+   */
+  const runWithSelection = (mutate: () => void): void => {
+    if (!tracked) return;
+    const liveNode = editor.state.doc.nodeAt(tracked.pos);
+    if (liveNode?.type.name !== tracked.node.type.name) {
+      setTracked(null);
+      setOpen(false);
+      return;
+    }
+    editor.chain().focus().setNodeSelection(tracked.pos).run();
+    mutate();
+    setOpen(false);
+  };
+
+  const onTransform = (entry: BlockTransformTo): void => {
+    runWithSelection(() => {
+      const currentAttrs = tracked
+        ? ((tracked.node as { attrs?: Readonly<Record<string, unknown>> })
+            .attrs ?? {})
+        : {};
+      const attrs = entry.mapAttrs ? entry.mapAttrs(currentAttrs) : undefined;
+      const chain = editor.chain().focus();
+      switch (entry.mode ?? "setNode") {
+        case "setNode":
+          chain.setNode(entry.target, attrs).run();
+          break;
+        case "wrap":
+          chain.wrapIn(entry.target, attrs).run();
+          break;
+        case "leaf":
+          chain.insertContent({ type: entry.target, attrs }).run();
+          break;
+      }
+    });
+  };
+
+  const onDuplicate = (): void => {
+    runWithSelection(() => {
+      if (!tracked) return;
+      const json = tracked.node.toJSON() as Parameters<
+        typeof editor.commands.insertContentAt
+      >[1];
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(tracked.pos + tracked.node.nodeSize, json)
+        .run();
+    });
+  };
+
+  const onDelete = (): void => {
+    runWithSelection(() => {
+      editor.chain().focus().deleteSelection().run();
+      // The recorded position now points at content that may have
+      // shifted up; drop the stale ref so a re-opened menu starts fresh.
+      setTracked(null);
+    });
+  };
+
+  const onCopyJson = (): void => {
+    if (!tracked) return;
+    const json = JSON.stringify(tracked.node.toJSON(), null, 2);
+    navigator.clipboard.writeText(json).catch((error: unknown) => {
+      // Clipboard rejects on insecure origin, permission denial, or
+      // focus loss. Surface the failure so silent loss doesn't leave
+      // the author wondering why nothing was copied. The toast layer
+      // is out of scope for this slice; until then, console is the
+      // minimum acceptable bar.
+      console.error("[plumix:block-menu] Copy to clipboard failed:", error);
+    });
+    setOpen(false);
+  };
+
+  return (
+    <DragHandle
+      editor={editor}
+      onNodeChange={({ node, pos }) => {
+        setTracked(node ? { node, pos } : null);
+      }}
+    >
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <DragHandleButton onOpenMenu={() => setOpen(true)} />
+        </PopoverTrigger>
+        <PopoverContent side="left" align="start" className="w-56 p-0">
+          {tracked ? (
+            <BlockMenu
+              sourceName={tracked.node.type.name}
+              blockRegistry={blockRegistry}
+              onTransform={onTransform}
+              onDuplicate={onDuplicate}
+              onDelete={onDelete}
+              onCopyJson={onCopyJson}
+            />
+          ) : null}
+        </PopoverContent>
+      </Popover>
+    </DragHandle>
+  );
+}

--- a/packages/blocks/src/code/index.ts
+++ b/packages/blocks/src/code/index.ts
@@ -8,6 +8,10 @@ export const codeBlock = defineBlock({
   keyboardShortcuts: [{ shortcut: "Mod-Alt-C" }],
   markdownShortcuts: [{ pattern: "``` " }],
   parsePaste: [{ selector: "pre" }],
+  transforms: {
+    priority: 20,
+    to: [{ target: "core/paragraph" }],
+  },
   schema: () => import("./schema.js").then((m) => m.codeSchema),
   component: () => import("./Component.js").then((m) => m.CodeComponent),
 });

--- a/packages/blocks/src/define-block.test.ts
+++ b/packages/blocks/src/define-block.test.ts
@@ -107,6 +107,67 @@ describe("defineBlock", () => {
     ).toThrow(expect.objectContaining({ code: "invalid_keyboard_shortcut" }));
   });
 
+  test("accepts a transforms declaration with to/from/priority", () => {
+    const spec = defineBlock({
+      name: "core/quote",
+      title: "Quote",
+      transforms: {
+        priority: 10,
+        to: [{ target: "core/paragraph" }],
+        from: [{ source: "core/paragraph" }],
+      },
+      schema: PARAGRAPH_SCHEMA,
+      component: PARAGRAPH_COMPONENT,
+    });
+    expect(spec.transforms?.priority).toBe(10);
+    expect(spec.transforms?.to?.[0]?.target).toBe("core/paragraph");
+  });
+
+  test("rejects a negative transforms.priority", () => {
+    expect(() =>
+      defineBlock({
+        name: "core/quote",
+        title: "Quote",
+        transforms: { priority: -1 },
+        schema: PARAGRAPH_SCHEMA,
+        component: PARAGRAPH_COMPONENT,
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_transform_priority" }));
+  });
+
+  test("rejects a non-integer transforms.priority", () => {
+    expect(() =>
+      defineBlock({
+        name: "core/quote",
+        title: "Quote",
+        transforms: { priority: 1.5 },
+        schema: PARAGRAPH_SCHEMA,
+        component: PARAGRAPH_COMPONENT,
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_transform_priority" }));
+  });
+
+  test.each([
+    { value: Infinity, label: "Infinity" },
+    { value: -Infinity, label: "-Infinity" },
+    { value: NaN, label: "NaN" },
+  ])(
+    "rejects $label as transforms.priority",
+    ({ value }: { value: number }) => {
+      expect(() =>
+        defineBlock({
+          name: "core/quote",
+          title: "Quote",
+          transforms: { priority: value },
+          schema: PARAGRAPH_SCHEMA,
+          component: PARAGRAPH_COMPONENT,
+        }),
+      ).toThrow(
+        expect.objectContaining({ code: "invalid_transform_priority" }),
+      );
+    },
+  );
+
   test("freezes attribute schemas as well", () => {
     const spec = defineBlock({
       name: "core/paragraph",

--- a/packages/blocks/src/define-block.ts
+++ b/packages/blocks/src/define-block.ts
@@ -30,6 +30,15 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
       });
     }
   }
+  if (spec.transforms?.priority !== undefined) {
+    const p = spec.transforms.priority;
+    if (!Number.isInteger(p) || p < 0) {
+      throw BlockRegistrationError.invalidTransformPriority({
+        name: spec.name,
+        priority: p,
+      });
+    }
+  }
 
   const attributes = spec.attributes
     ? Object.freeze(
@@ -58,6 +67,13 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
     keyboardShortcuts: freezeArrayOfObjects(spec.keyboardShortcuts),
     markdownShortcuts: freezeArrayOfObjects(spec.markdownShortcuts),
     parsePaste: freezeArrayOfObjects(spec.parsePaste),
+    transforms: spec.transforms
+      ? Object.freeze({
+          priority: spec.transforms.priority,
+          to: freezeArrayOfObjects(spec.transforms.to),
+          from: freezeArrayOfObjects(spec.transforms.from),
+        })
+      : undefined,
   });
 }
 

--- a/packages/blocks/src/errors.ts
+++ b/packages/blocks/src/errors.ts
@@ -1,6 +1,7 @@
 type BlockRegistrationErrorCode =
   | "invalid_name_pattern"
   | "invalid_keyboard_shortcut"
+  | "invalid_transform_priority"
   | "duplicate_name"
   | "core_block_collision"
   | "theme_override_unknown_name"
@@ -17,6 +18,7 @@ interface BlockRegistrationErrorFields {
   attributeName?: string;
   attributeType?: string;
   keyboardShortcut?: string;
+  priority?: number;
 }
 
 const NAME_PATTERN = "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$";
@@ -36,6 +38,7 @@ export class BlockRegistrationError extends Error {
   readonly attributeName: string | undefined;
   readonly attributeType: string | undefined;
   readonly keyboardShortcut: string | undefined;
+  readonly priority: number | undefined;
 
   private constructor(
     code: BlockRegistrationErrorCode,
@@ -53,6 +56,7 @@ export class BlockRegistrationError extends Error {
     this.attributeName = fields.attributeName;
     this.attributeType = fields.attributeType;
     this.keyboardShortcut = fields.keyboardShortcut;
+    this.priority = fields.priority;
   }
 
   static invalidNamePattern(ctx: {
@@ -134,6 +138,20 @@ export class BlockRegistrationError extends Error {
         `Cmd, Ctrl, Meta, Opt) followed by a single alphanumeric key, ` +
         `each joined by "-". Examples: "Mod-b", "Mod-Alt-2".`,
       { blockName: ctx.name, keyboardShortcut: ctx.keyboardShortcut },
+    );
+  }
+
+  static invalidTransformPriority(ctx: {
+    name: string;
+    priority: number;
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "invalid_transform_priority",
+      `Block "${ctx.name}" declared transforms.priority = ${ctx.priority}. ` +
+        `Priority must be a non-negative integer (the BlockMenu's ` +
+        `Transform-to submenu orders entries highest-first, so the value ` +
+        `needs a stable, finite, integer ordering).`,
+      { blockName: ctx.name, priority: ctx.priority },
     );
   }
 

--- a/packages/blocks/src/heading/index.ts
+++ b/packages/blocks/src/heading/index.ts
@@ -31,6 +31,13 @@ export const headingBlock = defineBlock({
     selector: `h${level}`,
     fromHTML: () => ({ level }),
   })),
+  transforms: {
+    priority: 50,
+    // heading → paragraph drops the level attr; the explicit mapAttrs
+    // makes the intent legible to anyone reading the spec rather than
+    // hiding it in the transform engine's default-drop behavior.
+    to: [{ target: "core/paragraph", mapAttrs: () => ({}) }],
+  },
   schema: () => import("./schema.js").then((m) => m.headingSchema),
   component: () => import("./Component.js").then((m) => m.HeadingComponent),
 });

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -10,6 +10,7 @@ export { defineBlock } from "./define-block.js";
 export { BlockRegistrationError } from "./errors.js";
 export { mergeBlockRegistry } from "./registry.js";
 export type { MergeBlockRegistryInput } from "./registry.js";
+export { resolveTransformTargets } from "./transforms.js";
 export { EntryContent } from "./walker.js";
 export type { EntryContentProps } from "./walker.js";
 export type {
@@ -22,6 +23,9 @@ export type {
   BlockMarkdownShortcut,
   BlockShortcutMode,
   BlockSpec,
+  BlockTransformFrom,
+  BlockTransformTo,
+  BlockTransforms,
   LazyRef,
   ParsePasteRule,
   ResolvedBlockSpec,

--- a/packages/blocks/src/list/list-ordered.ts
+++ b/packages/blocks/src/list/list-ordered.ts
@@ -9,6 +9,10 @@ export const listOrderedBlock = defineBlock({
   keyboardShortcuts: [{ shortcut: "Mod-Alt-O", mode: "wrap" }],
   markdownShortcuts: [{ pattern: "1. ", mode: "wrap" }],
   parsePaste: [{ selector: "ol" }],
+  transforms: {
+    priority: 20,
+    to: [{ target: "core/paragraph" }],
+  },
   schema: () => import("./schema.js").then((m) => m.listOrderedSchema),
   component: () => import("./Component.js").then((m) => m.ListOrderedComponent),
 });

--- a/packages/blocks/src/list/list.ts
+++ b/packages/blocks/src/list/list.ts
@@ -9,6 +9,10 @@ export const listBlock = defineBlock({
   keyboardShortcuts: [{ shortcut: "Mod-Alt-L", mode: "wrap" }],
   markdownShortcuts: [{ pattern: "- ", mode: "wrap" }],
   parsePaste: [{ selector: "ul" }],
+  transforms: {
+    priority: 20,
+    to: [{ target: "core/paragraph" }],
+  },
   schema: () => import("./schema.js").then((m) => m.listSchema),
   component: () => import("./Component.js").then((m) => m.ListComponent),
 });

--- a/packages/blocks/src/paragraph/index.ts
+++ b/packages/blocks/src/paragraph/index.ts
@@ -15,6 +15,16 @@ export const paragraphBlock = defineBlock({
   legacyAliases: ["paragraph"],
   keyboardShortcuts: [{ shortcut: "Mod-Alt-0" }],
   parsePaste: [{ selector: "p" }],
+  transforms: {
+    priority: 100,
+    to: [
+      { target: "core/heading", mapAttrs: () => ({ level: 2 }) },
+      { target: "core/quote" },
+      { target: "core/code" },
+      { target: "core/list", mode: "wrap" },
+      { target: "core/list-ordered", mode: "wrap" },
+    ],
+  },
   schema: () => import("./schema.js").then((m) => m.paragraphSchema),
   component: () => import("./Component.js").then((m) => m.ParagraphComponent),
 });

--- a/packages/blocks/src/quote/index.ts
+++ b/packages/blocks/src/quote/index.ts
@@ -8,6 +8,10 @@ export const quoteBlock = defineBlock({
   keyboardShortcuts: [{ shortcut: "Mod-Alt-Q" }],
   markdownShortcuts: [{ pattern: "> " }],
   parsePaste: [{ selector: "blockquote" }],
+  transforms: {
+    priority: 20,
+    to: [{ target: "core/paragraph" }],
+  },
   schema: () => import("./schema.js").then((m) => m.quoteSchema),
   component: () => import("./Component.js").then((m) => m.QuoteComponent),
 });

--- a/packages/blocks/src/transforms.test.ts
+++ b/packages/blocks/src/transforms.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockRegistry, ResolvedBlockSpec } from "./types.js";
+import { resolveTransformTargets } from "./transforms.js";
+
+function spec(
+  partial: Partial<ResolvedBlockSpec> & { name: string; title: string },
+): ResolvedBlockSpec {
+  const out: Partial<ResolvedBlockSpec> = {
+    name: partial.name,
+    title: partial.title,
+    component: () => null,
+    registeredBy: null,
+    transforms: partial.transforms,
+  };
+  return out as ResolvedBlockSpec;
+}
+
+function fakeRegistry(specs: readonly ResolvedBlockSpec[]): BlockRegistry {
+  const map = new Map(specs.map((s) => [s.name, s]));
+  return {
+    get: (n) => map.get(n),
+    has: (n) => map.has(n),
+    size: map.size,
+    [Symbol.iterator]: () => map.entries(),
+  } satisfies BlockRegistry;
+}
+
+describe("resolveTransformTargets", () => {
+  test("returns transforms.to entries when source declares them", () => {
+    const heading = spec({ name: "core/heading", title: "Heading" });
+    const paragraph = spec({
+      name: "core/paragraph",
+      title: "Paragraph",
+      transforms: { to: [{ target: "core/heading" }] },
+    });
+    const registry = fakeRegistry([paragraph, heading]);
+    const targets = resolveTransformTargets("core/paragraph", registry);
+    expect(targets.map((t) => t.target)).toEqual(["core/heading"]);
+  });
+
+  test("includes targets discovered through other blocks' transforms.from", () => {
+    const heading = spec({
+      name: "core/heading",
+      title: "Heading",
+      transforms: { from: [{ source: "core/paragraph" }] },
+    });
+    const paragraph = spec({ name: "core/paragraph", title: "Paragraph" });
+    const registry = fakeRegistry([paragraph, heading]);
+    const targets = resolveTransformTargets("core/paragraph", registry);
+    expect(targets.map((t) => t.target)).toEqual(["core/heading"]);
+  });
+
+  test("dedupes by target name and orders by priority desc", () => {
+    const heading = spec({
+      name: "core/heading",
+      title: "Heading",
+      transforms: { priority: 10, from: [{ source: "core/paragraph" }] },
+    });
+    const quote = spec({
+      name: "core/quote",
+      title: "Quote",
+      transforms: { priority: 5, from: [{ source: "core/paragraph" }] },
+    });
+    const paragraph = spec({
+      name: "core/paragraph",
+      title: "Paragraph",
+      transforms: {
+        priority: 100,
+        to: [{ target: "core/heading" }, { target: "core/quote" }],
+      },
+    });
+    const registry = fakeRegistry([paragraph, heading, quote]);
+    const names = resolveTransformTargets("core/paragraph", registry).map(
+      (t) => t.target,
+    );
+    // higher priority wins on dedupe: paragraph.priority=100 entries
+    // first, then by target name (stable)
+    expect(names).toEqual(["core/heading", "core/quote"]);
+  });
+
+  test("returns [] when the source spec has no transforms and no other block points to it", () => {
+    const paragraph = spec({ name: "core/paragraph", title: "Paragraph" });
+    const registry = fakeRegistry([paragraph]);
+    expect(resolveTransformTargets("core/paragraph", registry)).toEqual([]);
+  });
+
+  test("skips targets that no longer exist in the registry", () => {
+    const paragraph = spec({
+      name: "core/paragraph",
+      title: "Paragraph",
+      transforms: { to: [{ target: "core/missing-from-registry" }] },
+    });
+    const registry = fakeRegistry([paragraph]);
+    expect(
+      resolveTransformTargets("core/paragraph", registry).map((t) => t.target),
+    ).toEqual([]);
+  });
+
+  test("returns [] for unknown source name", () => {
+    const paragraph = spec({ name: "core/paragraph", title: "Paragraph" });
+    const registry = fakeRegistry([paragraph]);
+    expect(resolveTransformTargets("core/unknown", registry)).toEqual([]);
+  });
+
+  test("from-side beats to-side when its priority is higher", () => {
+    // paragraph declares heading at priority 1; heading declares
+    // accepts-paragraph at priority 99 with its own mapAttrs. The
+    // higher-priority side's entry survives the dedupe.
+    const headingMapper = () => ({ level: 9 });
+    const paragraphMapper = () => ({ level: 2 });
+    const heading = spec({
+      name: "core/heading",
+      title: "Heading",
+      transforms: {
+        priority: 99,
+        from: [{ source: "core/paragraph", mapAttrs: headingMapper }],
+      },
+    });
+    const paragraph = spec({
+      name: "core/paragraph",
+      title: "Paragraph",
+      transforms: {
+        priority: 1,
+        to: [{ target: "core/heading", mapAttrs: paragraphMapper }],
+      },
+    });
+    const registry = fakeRegistry([paragraph, heading]);
+    const targets = resolveTransformTargets("core/paragraph", registry);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]?.target).toBe("core/heading");
+    // The from-side entry is the synthesized `{ target: candidate.name }`
+    // without mapAttrs (the spec author's mapAttrs lives on the
+    // candidate's `transforms.from[i].mapAttrs`, which the resolver
+    // would have to carry through to surface it). For this slice the
+    // synthesized entry is `{ target }` only — assert that the
+    // priority-winning side replaced the to-side's `paragraphMapper`.
+    expect(targets[0]?.mapAttrs).not.toBe(paragraphMapper);
+  });
+});

--- a/packages/blocks/src/transforms.ts
+++ b/packages/blocks/src/transforms.ts
@@ -1,0 +1,51 @@
+import type { BlockRegistry, BlockTransformTo } from "./types.js";
+
+/**
+ * Resolve the set of valid transform targets for the block named
+ * `source`. The BlockMenu's "Transform to…" submenu renders this
+ * list verbatim.
+ *
+ * Pulls from both sides of the relationship: `source.transforms.to`
+ * entries the source spec authored, plus every other block whose
+ * `transforms.from` lists `source`. Higher priority wins on dedupe —
+ * same target surfacing from both sides keeps the entry whose owning
+ * spec declared a higher `transforms.priority`.
+ */
+export function resolveTransformTargets(
+  source: string,
+  registry: BlockRegistry,
+): readonly BlockTransformTo[] {
+  const sourceSpec = registry.get(source);
+  if (!sourceSpec) return [];
+
+  interface Entry {
+    transform: BlockTransformTo;
+    priority: number;
+  }
+  const byTarget = new Map<string, Entry>();
+  const record = (transform: BlockTransformTo, priority: number): void => {
+    const existing = byTarget.get(transform.target);
+    if (!existing || priority > existing.priority) {
+      byTarget.set(transform.target, { transform, priority });
+    }
+  };
+
+  const sourcePriority = sourceSpec.transforms?.priority ?? 0;
+  for (const entry of sourceSpec.transforms?.to ?? []) {
+    record(entry, sourcePriority);
+  }
+
+  for (const [, candidate] of registry) {
+    if (candidate.name === source) continue;
+    const acceptsSource = candidate.transforms?.from?.some(
+      (rule) => rule.source === source,
+    );
+    if (!acceptsSource) continue;
+    record({ target: candidate.name }, candidate.transforms?.priority ?? 0);
+  }
+
+  return Array.from(byTarget.values())
+    .filter(({ transform }) => registry.has(transform.target))
+    .sort((a, b) => b.priority - a.priority)
+    .map(({ transform }) => transform);
+}

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -123,6 +123,11 @@ export interface BlockSpec<Attrs = Readonly<Record<string, unknown>>> {
    * attrs are extracted.
    */
   readonly parsePaste?: readonly ParsePasteRule[];
+  /**
+   * Declarative block transforms. Surfaces in the BlockMenu's
+   * "Transform to…" submenu via `resolveTransformTargets`.
+   */
+  readonly transforms?: BlockTransforms;
 }
 
 /**
@@ -150,6 +155,44 @@ export interface BlockMarkdownShortcut {
   readonly pattern: string;
   readonly attrs?: Readonly<Record<string, unknown>>;
   readonly mode?: BlockShortcutMode;
+}
+
+/**
+ * Declarative transforms between blocks. The BlockMenu's "Transform
+ * to…" submenu reads each registered block's `transforms.to` plus the
+ * symmetric entries from every other block whose `transforms.from`
+ * names the current block — both sides build the same target list
+ * regardless of which side declared it.
+ *
+ * `priority` orders the resulting entries when the same target name
+ * surfaces twice (e.g. core/paragraph → core/heading vs core/heading
+ * → core/paragraph from the other side); higher priority wins.
+ */
+export interface BlockTransformTo {
+  readonly target: string;
+  readonly mapAttrs?: (
+    currentAttrs: Readonly<Record<string, unknown>>,
+  ) => Readonly<Record<string, unknown>>;
+  /**
+   * Dispatch mode for the transform — same discriminator as
+   * `BlockShortcutMode`. `setNode` (default) for textblock-to-textblock,
+   * `wrap` for list-style containers, `leaf` for atom inserts.
+   */
+  readonly mode?: BlockShortcutMode;
+}
+
+export interface BlockTransformFrom {
+  readonly source: string;
+  readonly mapAttrs?: (
+    sourceAttrs: Readonly<Record<string, unknown>>,
+  ) => Readonly<Record<string, unknown>>;
+  readonly mode?: BlockShortcutMode;
+}
+
+export interface BlockTransforms {
+  readonly priority?: number;
+  readonly to?: readonly BlockTransformTo[];
+  readonly from?: readonly BlockTransformFrom[];
 }
 
 export interface ParsePasteRule {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@tiptap/core':
         specifier: ^3.23.1
         version: 3.23.1(@tiptap/pm@3.23.1)
+      '@tiptap/extension-drag-handle-react':
+        specifier: 3.23.4
+        version: 3.23.4(@tiptap/extension-drag-handle@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/extension-collaboration@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.23.1)(@tiptap/react@3.23.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tiptap/react':
         specifier: ^3.23.1
         version: 3.23.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3953,10 +3956,36 @@ packages:
     peerDependencies:
       '@tiptap/core': 3.23.1
 
+  '@tiptap/extension-collaboration@3.23.4':
+    resolution: {integrity: sha512-28TJFayxCk7J9TmHBG4+8lVAz6YgyjN0RqzZueVeimWxSEgnTDGlkfHx6Ho5tOuyLwDa6SMBhN/6Q0iUMdnwMQ==}
+    peerDependencies:
+      '@tiptap/core': 3.23.4
+      '@tiptap/pm': 3.23.4
+      '@tiptap/y-tiptap': ^3.0.2
+      yjs: ^13
+
   '@tiptap/extension-document@3.23.1':
     resolution: {integrity: sha512-NA5Rx59HRwG6Hb6LwLpC5lE7z6vCj6f90S7RNNsnE+CyiXNR/OhY2BcjuxiGnascHvsnsAbvxGU3ymKMDgvDVg==}
     peerDependencies:
       '@tiptap/core': 3.23.1
+
+  '@tiptap/extension-drag-handle-react@3.23.4':
+    resolution: {integrity: sha512-/enO9HmUgkXACRa0FxETkQeBrnv2WDoAHAXQ0LL25yIV7YW5tWIwXgDBpPd8G7YEk9R05XhFq1tN6NmU0JYIAA==}
+    peerDependencies:
+      '@tiptap/extension-drag-handle': 3.23.4
+      '@tiptap/pm': 3.23.4
+      '@tiptap/react': 3.23.4
+      react: ^16.8 || ^17 || ^18 || ^19
+      react-dom: ^16.8 || ^17 || ^18 || ^19
+
+  '@tiptap/extension-drag-handle@3.23.4':
+    resolution: {integrity: sha512-ia027RBIdZIA9YBzt7Yuc4fGFAgdbxbVhrPqiDDJIN41IVsbb1PSQHDp8NVit50BNH1XVeAEB/E6WA/QLBoOgw==}
+    peerDependencies:
+      '@tiptap/core': 3.23.4
+      '@tiptap/extension-collaboration': 3.23.4
+      '@tiptap/extension-node-range': 3.23.4
+      '@tiptap/pm': 3.23.4
+      '@tiptap/y-tiptap': ^3.0.2
 
   '@tiptap/extension-dropcursor@3.23.1':
     resolution: {integrity: sha512-WRN7e/h9m3uI5j9/+L6jcPhHbTL6aKxfFfQWZHNf5M8TqSL1P+/2h034td0XMj3n48i4fWyzjVUV9+sz6t2fDw==}
@@ -4018,6 +4047,12 @@ packages:
       '@tiptap/core': 3.23.1
       '@tiptap/pm': 3.23.1
 
+  '@tiptap/extension-node-range@3.23.4':
+    resolution: {integrity: sha512-wmJrIT2Ng4TP4HniA0+WCNtqL09ZBZYd9bSnyDfZiz5phEcnqfCTBGpPXiA+jTjxZp/ZrJPFTjgQPevNQIAa9g==}
+    peerDependencies:
+      '@tiptap/core': 3.23.4
+      '@tiptap/pm': 3.23.4
+
   '@tiptap/extension-ordered-list@3.23.1':
     resolution: {integrity: sha512-3GG7YFhVJWw/HWmRxvMMUC296x7TPBQRLsH4ryEC1SMAmVJnbTIvetyvIcLqLEXGW7Rj41S7SO8qjOXVceSOTA==}
     peerDependencies:
@@ -4070,6 +4105,16 @@ packages:
     peerDependencies:
       '@tiptap/core': 3.23.4
       '@tiptap/pm': 3.23.4
+
+  '@tiptap/y-tiptap@3.0.3':
+    resolution: {integrity: sha512-8UvuV4lTisCE9cMTc/X8kRyTn9edUO7Kball0I6wb17VwZSjNDfh/YKtP4O5vcPawEzFHQIvZGq/k1h37kAf0w==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      prosemirror-model: ^1.7.1
+      prosemirror-state: ^1.2.3
+      prosemirror-view: ^1.9.10
+      y-protocols: ^1.0.1
+      yjs: ^13.5.38
 
   '@turbo/darwin-64@2.9.12':
     resolution: {integrity: sha512-eu3eFRmE9NjgZ0wPdRJ44l+LGSeIky+tz5ZQd8zQkw/Yqi+BM7wq+8nbabeoiVUcICi/IZweMOKl/MCmkrd1+g==}
@@ -5479,6 +5524,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -5582,6 +5630,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
@@ -6825,6 +6878,12 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6852,6 +6911,10 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yjs@13.6.30:
+    resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -9266,9 +9329,33 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.23.1(@tiptap/pm@3.23.1)
 
+  '@tiptap/extension-collaboration@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30)':
+    dependencies:
+      '@tiptap/core': 3.23.1(@tiptap/pm@3.23.1)
+      '@tiptap/pm': 3.23.1
+      '@tiptap/y-tiptap': 3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
+      yjs: 13.6.30
+
   '@tiptap/extension-document@3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))':
     dependencies:
       '@tiptap/core': 3.23.1(@tiptap/pm@3.23.1)
+
+  '@tiptap/extension-drag-handle-react@3.23.4(@tiptap/extension-drag-handle@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/extension-collaboration@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.23.1)(@tiptap/react@3.23.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tiptap/extension-drag-handle': 3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/extension-collaboration@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))
+      '@tiptap/pm': 3.23.1
+      '@tiptap/react': 3.23.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@tiptap/extension-drag-handle@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/extension-collaboration@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.23.1(@tiptap/pm@3.23.1)
+      '@tiptap/extension-collaboration': 3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30)
+      '@tiptap/extension-node-range': 3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)
+      '@tiptap/pm': 3.23.1
+      '@tiptap/y-tiptap': 3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
 
   '@tiptap/extension-dropcursor@3.23.1(@tiptap/extensions@3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))':
     dependencies:
@@ -9317,6 +9404,11 @@ snapshots:
       '@tiptap/extension-list': 3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)
 
   '@tiptap/extension-list@3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)':
+    dependencies:
+      '@tiptap/core': 3.23.1(@tiptap/pm@3.23.1)
+      '@tiptap/pm': 3.23.1
+
+  '@tiptap/extension-node-range@3.23.4(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1)':
     dependencies:
       '@tiptap/core': 3.23.1(@tiptap/pm@3.23.1)
       '@tiptap/pm': 3.23.1
@@ -9409,6 +9501,15 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.23.1(@tiptap/pm@3.23.1)
       '@tiptap/pm': 3.23.1
+
+  '@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)':
+    dependencies:
+      lib0: 0.2.117
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+      y-protocols: 1.0.7(yjs@13.6.30)
+      yjs: 13.6.30
 
   '@turbo/darwin-64@2.9.12':
     optional: true
@@ -9641,7 +9742,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -10904,6 +11005,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic.js@0.2.5: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -11027,6 +11130,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   libsql@0.5.29:
     dependencies:
@@ -12436,6 +12543,11 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y-protocols@1.0.7(yjs@13.6.30):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.30
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -12464,6 +12576,10 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yjs@13.6.30:
+    dependencies:
+      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
End-to-end slice for [#309](https://github.com/withplumix/plumix/issues/309): \`BlockSpec.transforms\` declarative API + pure resolver in \`@plumix/blocks\`, drag handle UI wrapping \`@tiptap/extension-drag-handle-react\`, cmdk-based BlockMenu with Transform-to / Duplicate / Delete / Copy JSON.

**transforms field with mode discriminator**

Each entry on \`transforms.to\` / \`transforms.from\` carries an optional \`mapAttrs(currentAttrs) -> newAttrs\` and a \`mode: setNode | wrap | leaf\` discriminator. Heading exposes paragraph→heading with \`mapAttrs: () => ({ level: 2 })\`; paragraph→list/list-ordered uses \`mode: \"wrap\"\` so the BlockMenu dispatches \`wrapIn\` instead of the broken \`setNode\` that couldn't fit inline content into a list container. \`defineBlock\` validates priority as non-negative finite integer.

**resolveTransformTargets — pure**

Pulls from both sides (\`source.transforms.to\` plus every other block whose \`transforms.from\` lists the source), dedupes by target name, higher-priority side wins. Filters out targets that no longer exist. Stateless and testable in isolation.

**drag handle via @tiptap/extension-drag-handle-react**

Per shadcn-first principle: the issue's \"Vue-only experiment\" note is outdated — the official package at v3.23.4 matches our Tiptap version, so we use it rather than rolling a custom ProseMirror plugin. \`PlumixDragHandle\` is a thin wrapper that mounts the floating handle, tracks the anchored node, opens the BlockMenu on click. The visible \`DragHandleButton\` stays stateless and testable (role=button, aria-label=Block actions, Enter/Space).

**BlockMenu — cmdk popover**

Reuses the same \`<Command>\` primitive the slash menu uses. Hosts Transform-to entries from the resolver plus Duplicate / Delete / Copy JSON. \`aria-label=\"Block actions\"\` on the Command root so screen readers announce a named dialog.

**Senpai review addressed in-slice**

- \`mapAttrs\` invoked at click time and \`mode\` discriminator wired so paragraph → list (wrap mode) actually wraps
- \`runWithSelection\` re-validates the recorded pos still holds the recorded node type before mutating (stale-state guard); \`onDelete\` clears the ref after running
- clipboard \`writeText\` catches the rejection (insecure origin / permission / focus loss) and logs rather than swallowing
- From-side-wins priority test added; Infinity / NaN / -Infinity rejection tests added
- \`PopoverTrigger asChild\` wraps \`DragHandleButton\` directly so Radix forwards trigger props onto the focusable element

Closes #309