### PR TITLE
feat(blocks,core): render hooks + client-island plumbing

### DIFF
--- a/packages/blocks/src/define-block.ts
+++ b/packages/blocks/src/define-block.ts
@@ -39,6 +39,12 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
       });
     }
   }
+  if (spec.client) {
+    validateClientIslandField(spec.name, "src", spec.client.src, true);
+    if (spec.client.export !== undefined) {
+      validateClientIslandField(spec.name, "export", spec.client.export, false);
+    }
+  }
 
   const attributes = spec.attributes
     ? Object.freeze(
@@ -75,6 +81,46 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
         })
       : undefined,
   });
+}
+
+// Block characters that could break out of a JSON-embedded
+// `<script type="module">` body emitted by `<PlumixIslandBootstrap>`:
+// - `<` / `>` / `&` close out of `</script>`, `<!--`, HTML entities;
+// - C0 controls and DEL (`\x00`-`\x1f`, `\x7f`) close out of a JS string;
+// - U+2028 / U+2029 are line terminators in JS source even though JSON
+//   leaves them unescaped — historically the prime XSS-via-JSON vector.
+const CLIENT_FIELD_FORBIDDEN_CHARS =
+  // eslint-disable-next-line no-control-regex, no-misleading-character-class
+  /[<>&\u0000-\u001f\u007f\u2028\u2029]/;
+const DANGEROUS_URL_SCHEME = /^\s*(javascript|data|vbscript):/i;
+
+function validateClientIslandField(
+  blockName: string,
+  field: "src" | "export",
+  value: string,
+  isUrl: boolean,
+): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw BlockRegistrationError.invalidClientIsland({
+      name: blockName,
+      field,
+      value: String(value),
+    });
+  }
+  if (CLIENT_FIELD_FORBIDDEN_CHARS.test(value)) {
+    throw BlockRegistrationError.invalidClientIsland({
+      name: blockName,
+      field,
+      value,
+    });
+  }
+  if (isUrl && DANGEROUS_URL_SCHEME.test(value)) {
+    throw BlockRegistrationError.invalidClientIsland({
+      name: blockName,
+      field,
+      value,
+    });
+  }
 }
 
 function freezeArray<T>(

--- a/packages/blocks/src/errors.ts
+++ b/packages/blocks/src/errors.ts
@@ -2,6 +2,7 @@ type BlockRegistrationErrorCode =
   | "invalid_name_pattern"
   | "invalid_keyboard_shortcut"
   | "invalid_transform_priority"
+  | "invalid_client_island"
   | "duplicate_name"
   | "core_block_collision"
   | "theme_override_unknown_name"
@@ -19,6 +20,8 @@ interface BlockRegistrationErrorFields {
   attributeType?: string;
   keyboardShortcut?: string;
   priority?: number;
+  field?: string;
+  value?: string;
 }
 
 const NAME_PATTERN = "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$";
@@ -39,6 +42,8 @@ export class BlockRegistrationError extends Error {
   readonly attributeType: string | undefined;
   readonly keyboardShortcut: string | undefined;
   readonly priority: number | undefined;
+  readonly field: string | undefined;
+  readonly value: string | undefined;
 
   private constructor(
     code: BlockRegistrationErrorCode,
@@ -57,6 +62,8 @@ export class BlockRegistrationError extends Error {
     this.attributeType = fields.attributeType;
     this.keyboardShortcut = fields.keyboardShortcut;
     this.priority = fields.priority;
+    this.field = fields.field;
+    this.value = fields.value;
   }
 
   static invalidNamePattern(ctx: {
@@ -152,6 +159,23 @@ export class BlockRegistrationError extends Error {
         `Transform-to submenu orders entries highest-first, so the value ` +
         `needs a stable, finite, integer ordering).`,
       { blockName: ctx.name, priority: ctx.priority },
+    );
+  }
+
+  static invalidClientIsland(ctx: {
+    name: string;
+    field: "src" | "export";
+    value: string;
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "invalid_client_island",
+      `Block "${ctx.name}" declared client.${ctx.field} = ${JSON.stringify(ctx.value)}. ` +
+        `The value flows into a server-rendered <script type="module"> body ` +
+        `and must not contain characters that could break out of the script ` +
+        `element (<, >, &, control characters) or use a dangerous scheme ` +
+        `(javascript:, data:). Use a plain module URL — e.g. ` +
+        `"/assets/widget.js" or "https://example.com/widget.mjs".`,
+      { blockName: ctx.name, field: ctx.field, value: ctx.value },
     );
   }
 

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -24,7 +24,15 @@ export type {
   BlockContentValidationIssue,
 } from "./validation-errors.js";
 export { EntryContent } from "./walker.js";
-export type { EntryContentProps } from "./walker.js";
+export type {
+  BlockRenderHookContext,
+  EntryContentProps,
+  SyncFilterExecutor,
+} from "./walker.js";
+export { collectActiveIslands } from "./islands.js";
+export type { ActiveIsland } from "./islands.js";
+export { PlumixIslandBootstrap } from "./island-bootstrap.js";
+export type { PlumixIslandBootstrapProps } from "./island-bootstrap.js";
 export type {
   BlockAttributeSchema,
   BlockComponent,
@@ -38,6 +46,7 @@ export type {
   BlockTransformFrom,
   BlockTransformTo,
   BlockTransforms,
+  ClientIslandRef,
   LazyRef,
   ParsePasteRule,
   ResolvedBlockSpec,

--- a/packages/blocks/src/island-bootstrap.test.tsx
+++ b/packages/blocks/src/island-bootstrap.test.tsx
@@ -1,0 +1,146 @@
+import { render } from "@testing-library/react";
+import { Node as TiptapNode } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import type { BlockProps, TiptapNode as TiptapNodeJson } from "./types.js";
+import { defineBlock } from "./define-block.js";
+import { jsonForScriptTag, PlumixIslandBootstrap } from "./island-bootstrap.js";
+import { mergeBlockRegistry } from "./registry.js";
+
+function islandSpec(name: string, src: string, exp?: string) {
+  return defineBlock({
+    name,
+    title: name,
+    schema: () => Promise.resolve(TiptapNode.create({ name, group: "block" })),
+    component: () => Promise.resolve(({ children }: BlockProps) => children),
+    client: { src, ...(exp !== undefined && { export: exp }) },
+  });
+}
+
+describe("PlumixIslandBootstrap", () => {
+  test("emits one script tag that imports each unique active island", async () => {
+    const registry = await mergeBlockRegistry({
+      core: [
+        islandSpec("core/widget", "/assets/widget.js"),
+        islandSpec("core/gallery", "/assets/gallery.js", "mount"),
+      ],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        { type: "core/widget" },
+        { type: "core/gallery" },
+        { type: "core/widget" },
+      ],
+    };
+    const { container } = render(
+      <PlumixIslandBootstrap content={doc} registry={registry} />,
+    );
+    const scripts = container.querySelectorAll('script[type="module"]');
+    expect(scripts.length).toBe(1);
+    const body = scripts[0]?.textContent ?? "";
+    // One import per unique island, dedup preserved.
+    expect(body).toContain('"/assets/widget.js"');
+    expect(body).toContain('"/assets/gallery.js"');
+    // Default vs named export both reachable.
+    expect(body).toContain('"core/widget"');
+    expect(body).toContain('"core/gallery"');
+    expect(body).toContain('"mount"');
+  });
+
+  test("escapes script-breakout characters in the embedded manifest", async () => {
+    // `defineBlock` already rejects `<` / `>` / `&` in `client.src`, so a
+    // hostile spec can't reach the bootstrap directly — but the manifest
+    // also embeds `name`, which is a separate path (block names use a
+    // restricted pattern but the bootstrap should still belt-and-brace).
+    const registry = await mergeBlockRegistry({
+      core: [islandSpec("core/widget", "/assets/widget.js")],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [{ type: "core/widget" }],
+    };
+    const { container } = render(
+      <PlumixIslandBootstrap content={doc} registry={registry} />,
+    );
+    const body = container.querySelector('script[type="module"]')?.textContent;
+    // Even though the inputs here are benign, the encoder should be in
+    // play: no raw `<` / `>` / `&` should appear inside the JSON literal
+    // (they'd be hex-escaped as `<` etc.). The bootstrap code below
+    // legitimately contains `<` from the template-literal tick + `${...}`
+    // — the assertion is on the JSON segment alone.
+    const jsonMatch = body?.match(/const islands = (\[.*?\]);/u);
+    expect(jsonMatch).not.toBeNull();
+    expect(jsonMatch?.[1]).not.toMatch(/[<>&]/);
+  });
+
+  test("jsonForScriptTag escapes `</script>` and JS line-terminator bytes", () => {
+    // Drive the encoder directly so the defense is verified in
+    // isolation from `defineBlock`'s upstream rejection. Embedding any
+    // of these bytes raw into a `<script>` body would break out.
+    const out = jsonForScriptTag({
+      script: "</script><img src=x onerror=alert(1)>",
+      htmlComment: "<!-- escape -->",
+      ampersand: "a&b",
+      lineSep: " ",
+      paraSep: " ",
+    });
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+    expect(out).not.toContain("&");
+    expect(out).not.toContain(" ");
+    expect(out).not.toContain(" ");
+    // Round-trips back to the original payload.
+    expect(JSON.parse(out)).toEqual({
+      script: "</script><img src=x onerror=alert(1)>",
+      htmlComment: "<!-- escape -->",
+      ampersand: "a&b",
+      lineSep: " ",
+      paraSep: " ",
+    });
+  });
+
+  test("rejects an island registered with `</script>` in src at defineBlock time", () => {
+    expect(() =>
+      islandSpec("core/evil", "/x</script><img src=x onerror=alert(1)>"),
+    ).toThrow(/invalid_client_island|client\.src/);
+  });
+
+  test("rejects an island registered with javascript: scheme", () => {
+    expect(() => islandSpec("core/evil", "javascript:alert(1)")).toThrow(
+      /invalid_client_island|client\.src/,
+    );
+  });
+
+  test("emits nothing when content has no client-bearing blocks", async () => {
+    const plain = defineBlock({
+      name: "core/plain",
+      title: "Plain",
+      schema: () =>
+        Promise.resolve(
+          TiptapNode.create({ name: "core/plain", group: "block" }),
+        ),
+      component: () => Promise.resolve(({ children }: BlockProps) => children),
+    });
+    const registry = await mergeBlockRegistry({
+      core: [plain],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [{ type: "core/plain" }],
+    };
+    const { container } = render(
+      <PlumixIslandBootstrap content={doc} registry={registry} />,
+    );
+    expect(container.querySelectorAll("script").length).toBe(0);
+  });
+});

--- a/packages/blocks/src/island-bootstrap.tsx
+++ b/packages/blocks/src/island-bootstrap.tsx
@@ -1,0 +1,72 @@
+import type { ReactElement } from "react";
+
+import type { ActiveIsland } from "./islands.js";
+import type { BlockRegistry, TiptapNode } from "./types.js";
+import { collectActiveIslands } from "./islands.js";
+
+export interface PlumixIslandBootstrapProps {
+  readonly content: TiptapNode | readonly TiptapNode[] | null | undefined;
+  readonly registry: BlockRegistry;
+}
+
+/**
+ * SSR-only script-tag emitter. Pre-walks the content + registry to find
+ * every active client-island module, then renders a single
+ * `<script type="module">` whose bootstrap dynamically imports each
+ * unique island and invokes its init export on every matching
+ * placeholder element the walker emitted (`[data-plumix-island="..."]`).
+ *
+ * Returns `null` when no island is active so SSR shells can mount this
+ * unconditionally without bloating empty pages with an inert script.
+ */
+export function PlumixIslandBootstrap({
+  content,
+  registry,
+}: PlumixIslandBootstrapProps): ReactElement | null {
+  const islands = collectActiveIslands(content, registry);
+  if (islands.length === 0) return null;
+  return (
+    <script
+      type="module"
+      dangerouslySetInnerHTML={{ __html: buildBootstrap(islands) }}
+    />
+  );
+}
+
+function buildBootstrap(islands: readonly ActiveIsland[]): string {
+  const manifest = jsonForScriptTag(
+    islands.map((i) => ({
+      name: i.name,
+      src: i.src,
+      export: i.export ?? "default",
+    })),
+  );
+  return [
+    `const islands = ${manifest};`,
+    `for (const i of islands) {`,
+    `  const mod = await import(i.src);`,
+    `  const init = mod[i.export];`,
+    `  if (typeof init !== "function") continue;`,
+    `  for (const el of document.querySelectorAll(\`[data-plumix-island="\${i.name}"]\`)) {`,
+    `    const raw = el.getAttribute("data-plumix-island-attrs");`,
+    `    init(el, raw ? JSON.parse(raw) : {});`,
+    `  }`,
+    `}`,
+  ].join("\n");
+}
+
+// Escape every character JSON.stringify leaves bare but that can
+// terminate a `<script>` body or a JS string literal. Defense in
+// depth — `defineBlock` already rejects these in `client.src` /
+// `client.export`, and React escapes them in attrs — but the
+// bootstrap is the one place JSON lands directly in executable
+// JS source, so we belt-and-brace it here.
+// Exported for direct unit testing — `buildBootstrap` is private and
+// `defineBlock` rejects hostile values upstream, so the only way to drive
+// the encoder with `</script>` etc. is to call it in isolation.
+export function jsonForScriptTag(value: unknown): string {
+  return JSON.stringify(value).replace(
+    /[<>&\u2028\u2029]/g,
+    (ch) => `\\u${ch.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}

--- a/packages/blocks/src/islands.test.ts
+++ b/packages/blocks/src/islands.test.ts
@@ -1,0 +1,92 @@
+import { Node as TiptapNode } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import type { BlockProps, TiptapNode as TiptapNodeJson } from "./types.js";
+import { defineBlock } from "./define-block.js";
+import { collectActiveIslands } from "./islands.js";
+import { mergeBlockRegistry } from "./registry.js";
+
+function islandSpec(name: string, src: string) {
+  return defineBlock({
+    name,
+    title: name,
+    schema: () => Promise.resolve(TiptapNode.create({ name, group: "block" })),
+    component: () => Promise.resolve(({ children }: BlockProps) => children),
+    client: { src },
+  });
+}
+
+function plainSpec(name: string) {
+  return defineBlock({
+    name,
+    title: name,
+    schema: () => Promise.resolve(TiptapNode.create({ name, group: "block" })),
+    component: () => Promise.resolve(({ children }: BlockProps) => children),
+  });
+}
+
+function deeplyNested(
+  containerType: string,
+  innerType: string,
+  depth: number,
+): TiptapNodeJson {
+  let current: TiptapNodeJson = { type: innerType };
+  for (let i = 0; i < depth; i += 1) {
+    current = { type: containerType, content: [current] };
+  }
+  return { type: "doc", content: [current] };
+}
+
+describe("collectActiveIslands", () => {
+  test("dedupes active islands across multiple instances of the same block", async () => {
+    const registry = await mergeBlockRegistry({
+      core: [
+        islandSpec("core/widget", "/assets/widget.js"),
+        plainSpec("core/plain"),
+      ],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        { type: "core/widget" },
+        { type: "core/plain" },
+        { type: "core/widget" },
+      ],
+    };
+    const islands = collectActiveIslands(doc, registry);
+    expect(islands).toEqual([
+      { name: "core/widget", src: "/assets/widget.js" },
+    ]);
+  });
+
+  test("does not overflow the stack on deeply nested content", async () => {
+    const containerSpec = defineBlock({
+      name: "core/container",
+      title: "Container",
+      schema: () =>
+        Promise.resolve(
+          TiptapNode.create({
+            name: "core/container",
+            group: "block",
+            content: "block+",
+          }),
+        ),
+      component: () => Promise.resolve(({ children }: BlockProps) => children),
+    });
+    const registry = await mergeBlockRegistry({
+      core: [containerSpec, islandSpec("core/widget", "/assets/widget.js")],
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    // 10k of nesting would blow a recursive walker on most V8 builds.
+    const doc = deeplyNested("core/container", "core/widget", 10_000);
+    const islands = collectActiveIslands(doc, registry);
+    expect(islands).toEqual([
+      { name: "core/widget", src: "/assets/widget.js" },
+    ]);
+  });
+});

--- a/packages/blocks/src/islands.ts
+++ b/packages/blocks/src/islands.ts
@@ -1,0 +1,66 @@
+import type { BlockRegistry, TiptapNode } from "./types.js";
+
+/**
+ * Static descriptor of one active client island in a rendered entry —
+ * the slice the SSR shell needs to emit one `<script type="module">`
+ * bootstrap entry. The per-instance attrs travel on the DOM placeholder
+ * the walker emits; this descriptor is the (deduped) per-block-type
+ * import contract.
+ */
+export interface ActiveIsland {
+  readonly name: string;
+  readonly src: string;
+  readonly export?: string;
+}
+
+/**
+ * Pure pre-walk over a Tiptap doc + registry returning every active
+ * client-island module — deduped by block name, preserving the order
+ * the walker first encounters them. Used by `<PlumixIslandBootstrap>`
+ * to emit one import per unique island; the `<EntryContent>` walker
+ * still renders the SSR placeholder for each instance separately.
+ *
+ * Pure (no DOM, no hooks, no React) — safe to call inside the SSR shell
+ * before `renderToReadableStream`.
+ */
+export function collectActiveIslands(
+  content: TiptapNode | readonly TiptapNode[] | null | undefined,
+  registry: BlockRegistry,
+): readonly ActiveIsland[] {
+  if (!content) return [];
+  const seen = new Map<string, ActiveIsland>();
+  const initial: readonly TiptapNode[] = Array.isArray(content)
+    ? content
+    : [content];
+  // Explicit stack instead of recursion: a pathologically nested doc
+  // (legacy import, migration bug) shouldn't blow the SSR call stack.
+  // Push children in reverse so the pop order matches sibling order.
+  const stack: TiptapNode[] = [];
+  for (let i = initial.length - 1; i >= 0; i -= 1) {
+    const n = initial[i];
+    if (n) stack.push(n);
+  }
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node || node.type === "text") continue;
+    if (node.type !== "doc") {
+      const spec = registry.get(node.type);
+      if (spec?.client && !seen.has(spec.name)) {
+        seen.set(spec.name, {
+          name: spec.name,
+          src: spec.client.src,
+          ...(spec.client.export !== undefined && {
+            export: spec.client.export,
+          }),
+        });
+      }
+    }
+    if (node.content) {
+      for (let i = node.content.length - 1; i >= 0; i -= 1) {
+        const child = node.content[i];
+        if (child) stack.push(child);
+      }
+    }
+  }
+  return Array.from(seen.values());
+}

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -74,6 +74,18 @@ export interface BlockAttributeSchema {
 export type LazyRef<T> = () => Promise<{ default: T } | T>;
 
 /**
+ * Declarative client-island descriptor. `src` is the public module
+ * specifier the bootstrap script imports at hydration time. `export`
+ * names the init function within that module (default `"default"`).
+ * The init function is invoked once per placeholder element with the
+ * placeholder DOM node and parsed attrs.
+ */
+export interface ClientIslandRef {
+  readonly src: string;
+  readonly export?: string;
+}
+
+/**
  * The unresolved spec returned by `defineBlock`.
  *
  * Editor and Component are lazy refs so the workers bundle can tree-shake
@@ -92,7 +104,20 @@ export interface BlockSpec<Attrs = Readonly<Record<string, unknown>>> {
   readonly schema: LazyRef<ReturnType<typeof TiptapNodeFactory.create>>;
   readonly component: LazyRef<BlockComponent<Attrs>>;
   readonly editor?: LazyRef<ComponentType<unknown>>;
-  readonly client?: LazyRef<unknown>;
+  /**
+   * Marks this block as a client island. SSR emits a wrapper carrying
+   * `data-plumix-island="<spec.name>"` plus a serialised attrs blob; the
+   * island-bootstrap script (`<PlumixIslandBootstrap>`) imports `src`
+   * once per unique island name and invokes the named export
+   * (default `"default"`), passing the placeholder element.
+   *
+   * `src` must be a browser-resolvable module specifier the SSR shell
+   * can stringify into `<script type="module">`. Authors typically pass
+   * the URL their build pipeline produces (e.g. via `new URL(...,
+   * import.meta.url)` rewriting). Closures (`() => import("…")`) hide
+   * the URL from SSR and are deliberately rejected.
+   */
+  readonly client?: ClientIslandRef;
   /**
    * Tiptap-node names this block accepts as input from legacy content.
    * The walker maps these aliases back to the canonical spec `name` when

--- a/packages/blocks/src/walker.test.tsx
+++ b/packages/blocks/src/walker.test.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from "react";
+import { createElement } from "react";
 import { render } from "@testing-library/react";
 import { Node as TiptapNode } from "@tiptap/core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -8,6 +10,7 @@ import type {
   BlockProps,
   TiptapNode as TiptapNodeJson,
 } from "./types.js";
+import type { SyncFilterExecutor } from "./walker.js";
 import { defineBlock } from "./define-block.js";
 import { mergeBlockRegistry } from "./registry.js";
 import { defaultMarkRegistry } from "./test/index.js";
@@ -318,6 +321,237 @@ describe("EntryContent walker", () => {
     expect(receivedContext).toEqual(
       expect.objectContaining({ parent: "core/container", depth: 1 }),
     );
+  });
+
+  test("block:before_render wraps every rendered block element", async () => {
+    const registry = await buildRegistry();
+    const hooks: SyncFilterExecutor = {
+      applyFilterSync<T>(name: string, value: T): T {
+        if (name !== "block:before_render") return value;
+        const element = value as unknown as ReactElement;
+        return createElement(
+          "div",
+          { "data-traced": "" },
+          element,
+        ) as unknown as T;
+      },
+    };
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        { type: "core/paragraph", content: [{ type: "text", text: "one" }] },
+        { type: "core/paragraph", content: [{ type: "text", text: "two" }] },
+        { type: "core/paragraph", content: [{ type: "text", text: "three" }] },
+      ],
+    };
+    const { container } = render(
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+        hooks={hooks}
+      />,
+    );
+    expect(container.querySelectorAll("div[data-traced]").length).toBe(3);
+    expect(container.innerHTML).toContain("<p>one</p>");
+  });
+
+  test("block:after_render receives block:before_render's output (order)", async () => {
+    const registry = await buildRegistry();
+    const calls: string[] = [];
+    const hooks: SyncFilterExecutor = {
+      applyFilterSync<T>(name: string, value: T): T {
+        if (name === "block:before_render") {
+          calls.push("before");
+          return createElement(
+            "section",
+            { "data-before": "1" },
+            value as unknown as ReactElement,
+          ) as unknown as T;
+        }
+        if (name === "block:after_render") {
+          calls.push("after");
+          return createElement(
+            "article",
+            { "data-after": "1" },
+            value as unknown as ReactElement,
+          ) as unknown as T;
+        }
+        return value;
+      },
+    };
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        { type: "core/paragraph", content: [{ type: "text", text: "x" }] },
+      ],
+    };
+    const { container } = render(
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+        hooks={hooks}
+      />,
+    );
+    expect(calls).toEqual(["before", "after"]);
+    // after wraps the before-wrapped element → article > section > p
+    expect(container.innerHTML).toBe(
+      '<article data-after="1"><section data-before="1"><p>x</p></section></article>',
+    );
+  });
+
+  test("theme block override surfaces on EntryContent output", async () => {
+    const ThemeParagraph: BlockComponent = ({ children }: BlockProps) => (
+      <p className="theme-mark">{children}</p>
+    );
+    const registry = await mergeBlockRegistry({
+      core: [paragraphSpec()],
+      plugins: [],
+      themeOverrides: { "core/paragraph": ThemeParagraph },
+      themeId: "test-theme",
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          content: [{ type: "text", text: "themed" }],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
+    );
+    expect(container.innerHTML).toBe('<p class="theme-mark">themed</p>');
+  });
+
+  test("render hooks also fire for the unknown-block fallback", async () => {
+    const registry = await buildRegistry();
+    const seen: string[] = [];
+    const hooks: SyncFilterExecutor = {
+      applyFilterSync<T>(name: string, value: T, ...rest: unknown[]): T {
+        if (name === "block:before_render") {
+          const [ctx] = rest as [{ node: TiptapNodeJson }];
+          seen.push(ctx.node.type);
+        }
+        return value;
+      },
+    };
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        { type: "core/paragraph", content: [{ type: "text", text: "ok" }] },
+        { type: "missing/x" },
+      ],
+    };
+    render(
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+        hooks={hooks}
+      />,
+    );
+    expect(seen).toEqual(["core/paragraph", "missing/x"]);
+  });
+
+  test("client-island block wraps SSR output in data-plumix-island placeholder", async () => {
+    const widgetSpec = defineBlock({
+      name: "demo/widget",
+      title: "Widget",
+      schema: () =>
+        Promise.resolve(
+          TiptapNode.create({ name: "demo/widget", group: "block" }),
+        ),
+      component: () =>
+        Promise.resolve(({ children }: BlockProps) => (
+          <span data-widget="">widget-ssr{children}</span>
+        )),
+      client: { src: "/assets/widget.js" },
+    });
+    const registry = await mergeBlockRegistry({
+      core: [paragraphSpec()],
+      plugins: [{ spec: widgetSpec, pluginId: "demo" }],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [{ type: "demo/widget", attrs: { size: 42, title: "Hi" } }],
+    };
+    const { container } = render(
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
+    );
+    const placeholder = container.querySelector(
+      '[data-plumix-island="demo/widget"]',
+    );
+    expect(placeholder).not.toBeNull();
+    const rawAttrs = placeholder?.getAttribute("data-plumix-island-attrs");
+    expect(rawAttrs).not.toBeNull();
+    expect(JSON.parse(rawAttrs ?? "{}")).toEqual({ size: 42, title: "Hi" });
+    expect(placeholder?.querySelector("[data-widget]")).not.toBeNull();
+  });
+
+  test("client-island attrs survive an attribute-breakout attempt via JSON", async () => {
+    // React escapes `"` / `<` / `>` / `&` inside HTML attribute values, so
+    // an attrs payload whose values contain `" onclick="alert(1)` stays
+    // confined inside `data-plumix-island-attrs` and round-trips through
+    // JSON.parse on the client side. The regression here is to ensure
+    // that contract is preserved if we ever swap the wrapper element or
+    // serialisation strategy.
+    const widgetSpec = defineBlock({
+      name: "demo/widget2",
+      title: "Widget",
+      schema: () =>
+        Promise.resolve(
+          TiptapNode.create({ name: "demo/widget2", group: "block" }),
+        ),
+      component: () =>
+        Promise.resolve(({ children }: BlockProps) => <span>{children}</span>),
+      client: { src: "/assets/widget.js" },
+    });
+    const registry = await mergeBlockRegistry({
+      core: [paragraphSpec()],
+      plugins: [{ spec: widgetSpec, pluginId: "demo" }],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const hostile = '" onclick="alert(1)';
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [{ type: "demo/widget2", attrs: { title: hostile } }],
+    };
+    const { container } = render(
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
+    );
+    const placeholder = container.querySelector(
+      '[data-plumix-island="demo/widget2"]',
+    );
+    expect(placeholder).not.toBeNull();
+    expect(placeholder?.hasAttribute("onclick")).toBe(false);
+    const parsed = JSON.parse(
+      placeholder?.getAttribute("data-plumix-island-attrs") ?? "{}",
+    ) as Record<string, unknown>;
+    expect(parsed.title).toBe(hostile);
   });
 
   test("unknown block in dev mode emits one-time warn + template marker", async () => {

--- a/packages/blocks/src/walker.tsx
+++ b/packages/blocks/src/walker.tsx
@@ -11,6 +11,22 @@ import type {
 } from "./types.js";
 import { HtmlAllowlistProvider } from "./html/context.js";
 
+/**
+ * Minimum surface the walker needs from a hook executor: a synchronous
+ * filter pipeline keyed by hook name. Defined structurally here so
+ * `@plumix/blocks` stays free of a `@plumix/core` dependency — the core
+ * package augments `FilterRegistry` for typed plugin authoring; the walker
+ * just calls the structural method at render time.
+ */
+export interface SyncFilterExecutor {
+  applyFilterSync<T>(name: string, value: T, ...rest: unknown[]): T;
+}
+
+export interface BlockRenderHookContext {
+  readonly node: TiptapNode;
+  readonly context: BlockContext;
+}
+
 export interface EntryContentProps {
   readonly content: TiptapNode | readonly TiptapNode[] | null | undefined;
   readonly registry: BlockRegistry;
@@ -33,6 +49,15 @@ export interface EntryContentProps {
    * through here.
    */
   readonly htmlAllowlist?: HtmlAllowlist;
+  /**
+   * Optional hook executor invoked around each block render. When supplied
+   * the walker fires `block:before_render` and `block:after_render` filter
+   * hooks per block (in that order), threading
+   * `{ node, context }: BlockRenderHookContext` as the second argument.
+   * Hooks fire for the unknown-block fallback too — plugins can decorate
+   * or replace whatever the walker is about to render.
+   */
+  readonly hooks?: SyncFilterExecutor;
 }
 
 /**
@@ -56,6 +81,7 @@ export function EntryContent({
   markRegistry,
   context,
   htmlAllowlist,
+  hooks,
 }: EntryContentProps): ReactNode {
   if (!content) return null;
   const nodes = Array.isArray(content) ? content : [content];
@@ -65,6 +91,7 @@ export function EntryContent({
     markRegistry,
     context,
     devWarnState(registry),
+    hooks,
   );
   if (htmlAllowlist === undefined) return tree;
   return createElement(HtmlAllowlistProvider, { value: htmlAllowlist }, tree);
@@ -91,13 +118,14 @@ function renderNodes(
   markRegistry: MarkRegistry,
   context: BlockContext,
   devState: DevWarnState,
+  hooks: SyncFilterExecutor | undefined,
 ): ReactNode {
   if (!nodes || nodes.length === 0) return null;
   return nodes.map((child, idx) =>
     createElement(
       Fragment,
       { key: idx },
-      renderNode(child, registry, markRegistry, context, devState),
+      renderNode(child, registry, markRegistry, context, devState, hooks),
     ),
   );
 }
@@ -108,14 +136,29 @@ function renderNode(
   markRegistry: MarkRegistry,
   context: BlockContext,
   devState: DevWarnState,
+  hooks: SyncFilterExecutor | undefined,
 ): ReactNode {
   if (node.type === "text") return renderText(node, markRegistry);
   if (node.type === "doc") {
-    return renderNodes(node.content, registry, markRegistry, context, devState);
+    return renderNodes(
+      node.content,
+      registry,
+      markRegistry,
+      context,
+      devState,
+      hooks,
+    );
   }
 
   const spec = registry.get(node.type);
-  if (!spec) return renderUnknown(node, devState);
+  if (!spec) {
+    return applyRenderHooks(
+      renderUnknown(node, devState),
+      node,
+      context,
+      hooks,
+    );
+  }
 
   const childContext: BlockContext = {
     ...context,
@@ -128,12 +171,40 @@ function renderNode(
     markRegistry,
     childContext,
     devState,
+    hooks,
   );
-  return createElement(
+  const inner = createElement(
     spec.component,
     { attrs: node.attrs ?? {}, node, context, children },
     children,
   );
+  const element = spec.client
+    ? createElement(
+        "div",
+        {
+          "data-plumix-island": spec.name,
+          "data-plumix-island-attrs": JSON.stringify(node.attrs ?? {}),
+        },
+        inner,
+      )
+    : inner;
+  return applyRenderHooks(element, node, context, hooks);
+}
+
+function applyRenderHooks(
+  element: ReactNode,
+  node: TiptapNode,
+  context: BlockContext,
+  hooks: SyncFilterExecutor | undefined,
+): ReactNode {
+  if (!hooks) return element;
+  const ctx: BlockRenderHookContext = { node, context };
+  const before = hooks.applyFilterSync<ReactNode>(
+    "block:before_render",
+    element,
+    ctx,
+  );
+  return hooks.applyFilterSync<ReactNode>("block:after_render", before, ctx);
 }
 
 function renderText(node: TiptapNode, markRegistry: MarkRegistry): ReactNode {

--- a/packages/core/src/hooks/block-render.ts
+++ b/packages/core/src/hooks/block-render.ts
@@ -1,0 +1,35 @@
+/**
+ * Sync filter hooks fired by `<EntryContent>` around every block render.
+ *
+ * Plugins decorate or replace the React element the walker is about to
+ * render: `block:before_render` runs first, `block:after_render` second,
+ * with the second receiving the first's return value. Both fire for the
+ * unknown-block fallback too (so plugins can wrap unregistered content).
+ *
+ * Augments `FilterRegistry` so `setupContext.addFilter("block:before_render", ...)`
+ * is type-safe at plugin-authoring time. The walker itself reads through a
+ * structural `SyncFilterExecutor` in `@plumix/blocks` — that package has no
+ * dependency on `@plumix/core`.
+ */
+
+import type { ReactNode } from "react";
+
+import type { BlockContext, TiptapNode } from "@plumix/blocks";
+
+export interface BlockRenderHookContext {
+  readonly node: TiptapNode;
+  readonly context: BlockContext;
+}
+
+declare module "./types.js" {
+  interface FilterRegistry {
+    "block:before_render": (
+      element: ReactNode,
+      ctx: BlockRenderHookContext,
+    ) => ReactNode;
+    "block:after_render": (
+      element: ReactNode,
+      ctx: BlockRenderHookContext,
+    ) => ReactNode;
+  }
+}

--- a/packages/core/src/hooks/errors.ts
+++ b/packages/core/src/hooks/errors.ts
@@ -1,0 +1,29 @@
+export class HookExecutionError extends Error {
+  static {
+    HookExecutionError.prototype.name = "HookExecutionError";
+  }
+
+  readonly code: "async_handler_in_sync_filter";
+  readonly hookName: string;
+
+  private constructor(
+    code: "async_handler_in_sync_filter",
+    message: string,
+    hookName: string,
+  ) {
+    super(message);
+    this.code = code;
+    this.hookName = hookName;
+  }
+
+  static asyncHandlerInSyncFilter(ctx: { name: string }): HookExecutionError {
+    return new HookExecutionError(
+      "async_handler_in_sync_filter",
+      `Hook "${ctx.name}" registered an async handler but is invoked ` +
+        `synchronously. Render-time filters must return a value (no Promise) ` +
+        `because React rendering is synchronous and the registry skips ` +
+        `awaiting on the sync path.`,
+      ctx.name,
+    );
+  }
+}

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,2 +1,5 @@
+import "./block-render.js";
+
 export * from "./registry.js";
 export * from "./types.js";
+export type { BlockRenderHookContext } from "./block-render.js";

--- a/packages/core/src/hooks/registry.test.ts
+++ b/packages/core/src/hooks/registry.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 
+import type { FilterFn } from "./types.js";
+import { HookExecutionError } from "./errors.js";
 import { HookRegistry } from "./registry.js";
 
 // Augment the empty registries with test-only hook names so the real type
@@ -78,6 +80,49 @@ describe("applyFilter", () => {
     registry.addFilter("test:with_rest", (v, mul) => v + mul);
     const out = await registry.applyFilter("test:with_rest", 3, 10);
     expect(out).toBe(40); // (3 * 10) + 10
+  });
+});
+
+describe("applyFilterSync", () => {
+  test("returns input unchanged when no filters are registered", () => {
+    const registry = new HookRegistry();
+    const result = registry.applyFilterSync("test:passthrough", "unchanged");
+    expect(result).toBe("unchanged");
+  });
+
+  test("runs filters in priority order (lower first), stable on ties", () => {
+    const registry = new HookRegistry();
+    registry.addFilter("test:passthrough", (v) => v + "-b", { priority: 100 });
+    registry.addFilter("test:passthrough", (v) => v + "-a", { priority: 50 });
+    registry.addFilter("test:passthrough", (v) => v + "-c", { priority: 100 });
+    const result = registry.applyFilterSync("test:passthrough", "start");
+    expect(result).toBe("start-a-b-c");
+  });
+
+  test("rejects a non-Promise thenable too (anything with `.then`)", () => {
+    const registry = new HookRegistry();
+    const thenable = (() => ({
+      then() {
+        /* never called — sync path must reject before invoking */
+      },
+    })) as unknown as FilterFn<"test:passthrough">;
+    registry.addFilter("test:passthrough", thenable);
+    expect(() => registry.applyFilterSync("test:passthrough", "x")).toThrow(
+      HookExecutionError,
+    );
+  });
+
+  test("rejects an async handler registered against a sync invocation", () => {
+    const registry = new HookRegistry();
+    // The misuse: a filter signature whose return is `string`, but the
+    // registered handler returns `Promise<string>`. Sync path must reject
+    // at the call site instead of leaking a rejected value downstream.
+    const asyncMisuse = ((v: string) =>
+      Promise.resolve(v)) as unknown as FilterFn<"test:passthrough">;
+    registry.addFilter("test:passthrough", asyncMisuse);
+    expect(() => registry.applyFilterSync("test:passthrough", "x")).toThrow(
+      HookExecutionError,
+    );
   });
 });
 

--- a/packages/core/src/hooks/registry.ts
+++ b/packages/core/src/hooks/registry.ts
@@ -9,6 +9,7 @@ import type {
   HookOptions,
 } from "./types.js";
 import { hookStore } from "../context/stores.js";
+import { HookExecutionError } from "./errors.js";
 import { DEFAULT_HOOK_PRIORITY } from "./types.js";
 
 interface FilterEntry {
@@ -31,6 +32,19 @@ export interface HookExecutor {
     input: FilterInput<TName>,
     ...rest: FilterRest<TName>
   ): Promise<FilterInput<TName>>;
+  /**
+   * Synchronous filter pipeline for hooks that fire inside React render
+   * (e.g. `block:before_render`). Skips the structured-clone step the
+   * async path performs — React elements are not structured-cloneable —
+   * so handlers must treat the value as read-only by convention. Throws
+   * if a registered handler returns a Promise so async-in-sync misuse
+   * surfaces immediately instead of leaking a rejected value downstream.
+   */
+  applyFilterSync<TName extends FilterName>(
+    name: TName,
+    input: FilterInput<TName>,
+    ...rest: FilterRest<TName>
+  ): FilterInput<TName>;
   doAction<TName extends ActionName>(
     name: TName,
     ...args: ActionArgs<TName>
@@ -115,6 +129,26 @@ export class HookRegistry implements HookExecutor {
     return current as FilterInput<TName>;
   }
 
+  applyFilterSync<TName extends FilterName>(
+    name: TName,
+    input: FilterInput<TName>,
+    ...rest: FilterRest<TName>
+  ): FilterInput<TName> {
+    const entries = this.#filters.get(name);
+    if (!entries || entries.length === 0) return input;
+
+    const sorted = sortEntries(entries);
+    let current: unknown = input;
+    for (const entry of sorted) {
+      const next = entry.fn(current, ...(rest as unknown[]));
+      if (isPromiseLike(next)) {
+        throw HookExecutionError.asyncHandlerInSyncFilter({ name });
+      }
+      current = next;
+    }
+    return current as FilterInput<TName>;
+  }
+
   async doAction<TName extends ActionName>(
     name: TName,
     ...args: ActionArgs<TName>
@@ -144,6 +178,14 @@ export class HookRegistry implements HookExecutor {
       }
     }
   }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
 }
 
 function sortEntries<T extends { priority: number; insertOrder: number }>(

--- a/packages/plugins/blog/e2e/blog.spec.ts
+++ b/packages/plugins/blog/e2e/blog.spec.ts
@@ -31,13 +31,13 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
 
     await expect(page.getByTestId("post-editor-form")).toBeVisible();
     await page.getByTestId("post-editor-title-input").fill("Hello world");
+    // Arm the navigation waiter BEFORE the click so we never miss a
+    // fast post-create redirect — playwright's `waitForURL` only matches
+    // navigations that start after it's armed, and the create RPC can
+    // resolve in <10ms against a warm worker.
+    const navigated = page.waitForURL(/\/entries\/posts\/\d+\/edit/);
     await page.getByTestId("post-editor-submit").click();
-
-    // On successful create the editor navigates from
-    // `/entries/posts/create` to `/entries/posts/<id>/edit` — wait for
-    // that URL change before navigating away so we don't race the
-    // create RPC.
-    await page.waitForURL(/\/entries\/posts\/\d+\/edit/);
+    await navigated;
 
     await page.goto("entries/posts");
     // `content-list-row-*` matches the row plus the per-row actions
@@ -67,12 +67,15 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
     await page
       .getByTestId("post-editor-status-select")
       .selectOption("published");
-    await page.getByTestId("post-editor-submit").click();
-
-    // Wait for the update RPC to settle before reload.
-    await page.waitForResponse(
+    // Arm the response waiter BEFORE the click so we never miss a fast
+    // update RPC — `waitForResponse` only matches responses that arrive
+    // after it's armed, and the update can resolve in <10ms against a
+    // warm worker.
+    const updated = page.waitForResponse(
       (r) => r.url().endsWith("/entry/update") && r.status() === 200,
     );
+    await page.getByTestId("post-editor-submit").click();
+    await updated;
 
     await page.reload();
     await expect(page.getByTestId("post-editor-form")).toBeVisible();


### PR DESCRIPTION
Adds the remaining surface from issue #311: render-time filter hooks fired by `<EntryContent>` around every block, and end-to-end client-island plumbing (declarative `client.src`, DOM placeholders, and a single SSR `<script type="module">` bootstrap that dedup-imports each active island).

**Sync filter pipeline on `HookRegistry`**

`applyFilterSync` is a sibling of the existing async `applyFilter` — same `addFilter` registration, but skips `structuredClone` (React elements are not cloneable) and runs synchronously. Handlers that return a Promise are rejected at the call site via the new `HookExecutionError` factory so async-in-sync misuse surfaces immediately. The two hooks `block:before_render` / `block:after_render` augment `FilterRegistry` from `@plumix/core`; the walker reads them through a structural `SyncFilterExecutor` so `@plumix/blocks` keeps zero dependency on `@plumix/core`.

**Client-island declarative shape**

The previously-unused `client?: LazyRef<unknown>` is replaced with `client?: { src: string; export?: string }`. Authors pass a browser-resolvable module URL; the bootstrap stringifies it into a `<script type="module">` that dynamically imports each unique module and invokes its init export on every matching `[data-plumix-island="<name>"]` placeholder. Per-instance attrs travel as `data-plumix-island-attrs` JSON on the placeholder for the init function to parse.

**Script-tag XSS defenses**

`defineBlock` rejects `<` / `>` / `&` / C0 controls / U+2028 / U+2029 in `client.src` and `client.export`, and rejects `javascript:` / `data:` / `vbscript:` schemes in `src`. As defense-in-depth the bootstrap also routes `JSON.stringify` output through a script-tag-safe encoder so any future caller bypassing `defineBlock` still cannot break out. Regression tests cover the encoder in isolation, registration-time rejection of `</script>` in `src`, and attribute-breakout payloads in `data-plumix-island-attrs`.

**SSR stack-overflow resilience**

`collectActiveIslands` uses an explicit pre-order stack walk instead of recursion. A 10,000-deep nesting regression test confirms no overflow.

Refs GH-311