### PR TITLE
feat(blocks,core,plumix,admin): supports + design tokens + virtual tokens.css

### DIFF
--- a/packages/admin/src/editor/inspector/Inspector.test.tsx
+++ b/packages/admin/src/editor/inspector/Inspector.test.tsx
@@ -20,6 +20,7 @@ function spec(
     category: partial.category ?? "typography",
     keywords: partial.keywords,
     attributes: partial.attributes,
+    supports: partial.supports,
     component: () => null,
     legacyAliases: undefined,
     schema: undefined,
@@ -213,5 +214,47 @@ describe("Inspector", () => {
     );
     if (!checkbox) throw new Error("inspector-field-enabled not rendered");
     expect(checkbox.checked).toBe(false);
+  });
+
+  test("hides the Supports section when the spec declares no supports", () => {
+    const noSupports = spec({
+      name: "core/plain",
+      title: "Plain",
+      attributes: { level: { type: "select", label: "Level", default: 1 } },
+    });
+    const registry = fakeRegistry([noSupports]);
+    const { editor } = stubEditor({
+      nodeType: "core/plain",
+      attrs: { level: 1 },
+    });
+    const { queryByTestId } = render(
+      <Inspector editor={editor} blockRegistry={registry} />,
+    );
+    expect(queryByTestId("inspector-supports-section")).toBeNull();
+  });
+
+  test("renders an anchor input when the spec opts into supports.anchor", () => {
+    const withAnchor = spec({
+      name: "core/heading",
+      title: "Heading",
+      attributes: { level: { type: "select", label: "Level", default: 2 } },
+      supports: { anchor: true },
+    });
+    const registry = fakeRegistry([withAnchor]);
+    const { editor, updateAttributes } = stubEditor({
+      nodeType: "core/heading",
+      attrs: { level: 2, style: { anchor: "intro" } },
+    });
+    const { getByTestId } = render(
+      <Inspector editor={editor} blockRegistry={registry} />,
+    );
+    expect(getByTestId("inspector-supports-section")).toBeInTheDocument();
+    const input = getByTestId("inspector-supports-anchor") as HTMLInputElement;
+    expect(input.value).toBe("intro");
+
+    fireEvent.change(input, { target: { value: "section-2" } });
+    expect(updateAttributes).toHaveBeenCalledWith("core/heading", {
+      style: { anchor: "section-2" },
+    });
   });
 });

--- a/packages/admin/src/editor/inspector/Inspector.tsx
+++ b/packages/admin/src/editor/inspector/Inspector.tsx
@@ -2,9 +2,14 @@ import type { Editor } from "@tiptap/react";
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
-import type { BlockRegistry, ResolvedBlockSpec } from "@plumix/blocks";
+import type {
+  BlockRegistry,
+  BlockStyleSlot,
+  ResolvedBlockSpec,
+} from "@plumix/blocks";
 
 import { InspectorField } from "./InspectorField.js";
+import { SupportsSection } from "./SupportsSection.js";
 
 interface InspectorProps {
   readonly editor: Editor;
@@ -64,14 +69,18 @@ export function Inspector({
 
   if (!selected) return null;
   const { spec, attrs } = selected;
-  if (!spec.attributes) return null;
-  const entries = Object.entries(spec.attributes);
-  if (entries.length === 0) return null;
+  const attributeEntries = spec.attributes
+    ? Object.entries(spec.attributes)
+    : [];
+  const hasSupports = Boolean(spec.supports);
+  if (attributeEntries.length === 0 && !hasSupports) return null;
+
+  const slot = (attrs.style ?? {}) as BlockStyleSlot;
 
   return (
     <div data-plumix-inspector="" aria-label={`${spec.title} attributes`}>
       <h3 data-plumix-inspector-title="">{spec.title}</h3>
-      {entries.map(([attrName, schema]) => (
+      {attributeEntries.map(([attrName, schema]) => (
         <InspectorField
           key={attrName}
           name={attrName}
@@ -86,6 +95,19 @@ export function Inspector({
           }}
         />
       ))}
+      {spec.supports ? (
+        <SupportsSection
+          supports={spec.supports}
+          style={slot}
+          onChange={(nextSlot) => {
+            editor
+              .chain()
+              .focus()
+              .updateAttributes(spec.name, { style: nextSlot })
+              .run();
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/admin/src/editor/inspector/SupportsSection.tsx
+++ b/packages/admin/src/editor/inspector/SupportsSection.tsx
@@ -1,0 +1,179 @@
+import type { ReactElement } from "react";
+
+import type { BlockStyleSlot, BlockSupports } from "@plumix/blocks";
+
+interface SupportsSectionProps {
+  readonly supports: BlockSupports;
+  readonly style: BlockStyleSlot;
+  readonly onChange: (next: BlockStyleSlot) => void;
+}
+
+/**
+ * Inspector controls for the supports axes a spec opts into. Each
+ * declared axis renders one input that writes to `attrs.style.<axis>`.
+ * Renders `null` when no axis is declared so the Inspector can mount
+ * `<SupportsSection>` unconditionally and stay clean when off.
+ *
+ * v1 keeps controls minimal — text inputs for token-slug fields and
+ * the anchor / customClassName slots. A follow-up Inspector polish
+ * pass swaps the slug fields for token-aware pickers; the data flow
+ * (one axis → one slot path) is the stable contract.
+ */
+export function SupportsSection({
+  supports,
+  style,
+  onChange,
+}: SupportsSectionProps): ReactElement | null {
+  const rows = collectRows(supports, style);
+  if (rows.length === 0) return null;
+  return (
+    <div data-testid="inspector-supports-section" data-plumix-supports="">
+      <h3>Supports</h3>
+      {rows.map((row) => (
+        <label key={row.path} data-plumix-supports-row={row.path}>
+          <span>{row.label}</span>
+          <input
+            data-testid={`inspector-supports-${row.path}`}
+            value={row.value}
+            onChange={(e) =>
+              onChange(setSlotValue(style, row.path, e.target.value))
+            }
+          />
+        </label>
+      ))}
+    </div>
+  );
+}
+
+interface SupportsRow {
+  readonly path: string;
+  readonly label: string;
+  readonly value: string;
+}
+
+interface RowDef {
+  readonly path: string;
+  readonly label: string;
+  readonly enabled: (s: BlockSupports) => boolean | undefined;
+  readonly value: (s: BlockStyleSlot) => string | undefined;
+}
+
+// Ordering here drives Inspector row order — keep in sync with
+// `resolveBlockStyles`' axis order so what authors see top-to-bottom
+// matches what the renderer applies.
+const ROW_DEFS: readonly RowDef[] = [
+  {
+    path: "color.background",
+    label: "Background color",
+    enabled: (s) => s.color?.background,
+    value: (s) => s.color?.background,
+  },
+  {
+    path: "color.text",
+    label: "Text color",
+    enabled: (s) => s.color?.text,
+    value: (s) => s.color?.text,
+  },
+  {
+    path: "spacing.padding",
+    label: "Padding",
+    enabled: (s) => s.spacing?.padding,
+    value: (s) => s.spacing?.padding,
+  },
+  {
+    path: "spacing.margin",
+    label: "Margin",
+    enabled: (s) => s.spacing?.margin,
+    value: (s) => s.spacing?.margin,
+  },
+  {
+    path: "typography.fontSize",
+    label: "Font size",
+    enabled: (s) => s.typography?.fontSize,
+    value: (s) => s.typography?.fontSize,
+  },
+  {
+    path: "typography.lineHeight",
+    label: "Line height",
+    enabled: (s) => s.typography?.lineHeight,
+    value: (s) => s.typography?.lineHeight,
+  },
+  {
+    path: "typography.fontWeight",
+    label: "Font weight",
+    enabled: (s) => s.typography?.fontWeight,
+    value: (s) => s.typography?.fontWeight,
+  },
+  {
+    path: "typography.textAlign",
+    label: "Text align",
+    enabled: (s) => s.typography?.textAlign,
+    value: (s) => s.typography?.textAlign,
+  },
+  {
+    path: "border.radius",
+    label: "Border radius",
+    enabled: (s) => s.border?.radius,
+    value: (s) => s.border?.radius,
+  },
+  {
+    path: "align",
+    label: "Align",
+    enabled: (s) => s.align,
+    value: (s) => s.align,
+  },
+  {
+    path: "anchor",
+    label: "HTML anchor",
+    enabled: (s) => s.anchor,
+    value: (s) => s.anchor,
+  },
+  {
+    path: "customClassName",
+    label: "Additional CSS class",
+    enabled: (s) => s.customClassName,
+    value: (s) => s.customClassName,
+  },
+];
+
+function collectRows(
+  supports: BlockSupports,
+  style: BlockStyleSlot,
+): SupportsRow[] {
+  const rows: SupportsRow[] = [];
+  for (const def of ROW_DEFS) {
+    if (!def.enabled(supports)) continue;
+    rows.push({
+      path: def.path,
+      label: def.label,
+      value: def.value(style) ?? "",
+    });
+  }
+  return rows;
+}
+
+function setSlotValue(
+  slot: BlockStyleSlot,
+  path: string,
+  value: string,
+): BlockStyleSlot {
+  const [head, tail] = path.split(".") as [string, string | undefined];
+  if (tail === undefined) {
+    // Top-level path (anchor, align, customClassName). An empty string
+    // clears the slot so the resolver doesn't emit an empty class.
+    const next = { ...(slot as Record<string, unknown>) };
+    if (value === "") delete next[head];
+    else next[head] = value;
+    return next;
+  }
+  const nested =
+    (slot as Record<string, Record<string, unknown> | undefined>)[head] ?? {};
+  const updatedNested = { ...nested };
+  if (value === "") delete updatedNested[tail];
+  else updatedNested[tail] = value;
+  const next = {
+    ...(slot as Record<string, unknown>),
+    [head]: updatedNested,
+  };
+  return next;
+}

--- a/packages/blocks/src/define-block.test.ts
+++ b/packages/blocks/src/define-block.test.ts
@@ -181,4 +181,27 @@ describe("defineBlock", () => {
     expect(Object.isFrozen(spec.attributes)).toBe(true);
     expect(Object.isFrozen(spec.attributes?.align)).toBe(true);
   });
+
+  test("accepts a supports declaration and freezes it through", () => {
+    const spec = defineBlock({
+      name: "core/paragraph",
+      title: "Paragraph",
+      schema: PARAGRAPH_SCHEMA,
+      component: PARAGRAPH_COMPONENT,
+      supports: {
+        color: { background: true, text: true },
+        spacing: { padding: true },
+        anchor: true,
+        customClassName: true,
+      },
+    });
+    expect(spec.supports).toEqual({
+      color: { background: true, text: true },
+      spacing: { padding: true },
+      anchor: true,
+      customClassName: true,
+    });
+    expect(Object.isFrozen(spec.supports)).toBe(true);
+    expect(Object.isFrozen(spec.supports?.color)).toBe(true);
+  });
 });

--- a/packages/blocks/src/define-block.ts
+++ b/packages/blocks/src/define-block.ts
@@ -65,6 +65,7 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
     description: spec.description,
     keywords: freezeArray(spec.keywords),
     attributes,
+    supports: freezeSupports(spec.supports),
     schema: spec.schema,
     component: spec.component,
     editor: spec.editor,
@@ -90,7 +91,7 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
 // - U+2028 / U+2029 are line terminators in JS source even though JSON
 //   leaves them unescaped — historically the prime XSS-via-JSON vector.
 const CLIENT_FIELD_FORBIDDEN_CHARS =
-  // eslint-disable-next-line no-control-regex, no-misleading-character-class
+  // eslint-disable-next-line no-control-regex
   /[<>&\u0000-\u001f\u007f\u2028\u2029]/;
 const DANGEROUS_URL_SCHEME = /^\s*(javascript|data|vbscript):/i;
 
@@ -121,6 +122,19 @@ function validateClientIslandField(
       value,
     });
   }
+}
+
+function freezeSupports<T>(supports: T | undefined): T | undefined {
+  if (supports === undefined) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(supports as Record<string, unknown>)) {
+    if (v !== null && typeof v === "object") {
+      out[k] = Object.freeze({ ...(v as Record<string, unknown>) });
+    } else {
+      out[k] = v;
+    }
+  }
+  return Object.freeze(out) as T;
 }
 
 function freezeArray<T>(

--- a/packages/blocks/src/heading/Component.tsx
+++ b/packages/blocks/src/heading/Component.tsx
@@ -1,7 +1,10 @@
 import type { ReactElement } from "react";
 import { createElement } from "react";
 
+import type { BlockStyleSlot } from "../styles/types.js";
 import type { BlockProps } from "../types.js";
+import { blockElementProps, useBlockStyles } from "../styles/hooks.js";
+import { headingSupports } from "./supports.js";
 
 const DEFAULT_LEVEL = 2;
 
@@ -24,5 +27,7 @@ export function HeadingComponent({
   children,
 }: BlockProps): ReactElement {
   const level = clampHeadingLevel(attrs.level);
-  return createElement(`h${level}`, null, children);
+  const slot = (attrs.style ?? {}) as BlockStyleSlot;
+  const resolved = useBlockStyles(slot, headingSupports);
+  return createElement(`h${level}`, blockElementProps(resolved), children);
 }

--- a/packages/blocks/src/heading/index.ts
+++ b/packages/blocks/src/heading/index.ts
@@ -1,4 +1,5 @@
 import { defineBlock } from "../define-block.js";
+import { headingSupports } from "./supports.js";
 
 const HEADING_LEVELS = [1, 2, 3, 4, 5, 6] as const;
 
@@ -7,6 +8,7 @@ export const headingBlock = defineBlock({
   title: "Heading",
   category: "text",
   description: "Section title.",
+  supports: headingSupports,
   legacyAliases: ["heading"],
   attributes: {
     level: {

--- a/packages/blocks/src/heading/supports.ts
+++ b/packages/blocks/src/heading/supports.ts
@@ -1,0 +1,19 @@
+import type { BlockSupports } from "../styles/types.js";
+
+/**
+ * `core/heading` opts into the same supports surface as paragraph,
+ * minus margin (most theme designs control heading vertical rhythm
+ * via the typography scale, not per-instance margin).
+ */
+export const headingSupports: BlockSupports = {
+  color: { background: true, text: true },
+  spacing: { padding: true },
+  typography: {
+    fontSize: true,
+    lineHeight: true,
+    fontWeight: true,
+    textAlign: true,
+  },
+  anchor: true,
+  customClassName: true,
+};

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -23,6 +23,22 @@ export type {
   BlockContentValidationCode,
   BlockContentValidationIssue,
 } from "./validation-errors.js";
+export { resolveBlockStyles } from "./styles/resolve-block-styles.js";
+export type { ResolvedBlockStyles } from "./styles/resolve-block-styles.js";
+export {
+  ThemeTokensProvider,
+  useBlockStyles,
+  useThemeTokens,
+} from "./styles/hooks.js";
+export type { ThemeTokensProviderProps } from "./styles/hooks.js";
+export { tokensToCss } from "./styles/tokens-to-css.js";
+export type {
+  BlockStyleSlot,
+  BlockSupports,
+  ThemeTokenEntry,
+  ThemeTokenGroup,
+  ThemeTokens,
+} from "./styles/types.js";
 export { EntryContent } from "./walker.js";
 export type {
   BlockRenderHookContext,

--- a/packages/blocks/src/paragraph/Component.tsx
+++ b/packages/blocks/src/paragraph/Component.tsx
@@ -1,6 +1,9 @@
 import type { ReactElement } from "react";
 
+import type { BlockStyleSlot } from "../styles/types.js";
 import type { BlockProps } from "../types.js";
+import { blockElementProps, useBlockStyles } from "../styles/hooks.js";
+import { paragraphSupports } from "./supports.js";
 
 /**
  * Default frontend rendering for `core/paragraph`.
@@ -8,6 +11,11 @@ import type { BlockProps } from "../types.js";
  * Themes override by supplying a different component via
  * `defineTheme({ blocks: { "core/paragraph": MyParagraph } })`.
  */
-export function ParagraphComponent({ children }: BlockProps): ReactElement {
-  return <p>{children}</p>;
+export function ParagraphComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const slot = (attrs.style ?? {}) as BlockStyleSlot;
+  const resolved = useBlockStyles(slot, paragraphSupports);
+  return <p {...blockElementProps(resolved)}>{children}</p>;
 }

--- a/packages/blocks/src/paragraph/index.ts
+++ b/packages/blocks/src/paragraph/index.ts
@@ -1,4 +1,5 @@
 import { defineBlock } from "../define-block.js";
+import { paragraphSupports } from "./supports.js";
 
 /**
  * Spec for the first core block. Lazy refs keep admin-only imports out
@@ -12,6 +13,7 @@ export const paragraphBlock = defineBlock({
   title: "Paragraph",
   category: "text",
   description: "The building block of all narrative.",
+  supports: paragraphSupports,
   legacyAliases: ["paragraph"],
   keyboardShortcuts: [{ shortcut: "Mod-Alt-0" }],
   parsePaste: [{ selector: "p" }],

--- a/packages/blocks/src/paragraph/supports.ts
+++ b/packages/blocks/src/paragraph/supports.ts
@@ -1,0 +1,19 @@
+import type { BlockSupports } from "../styles/types.js";
+
+/**
+ * `core/paragraph` opts into every Inspector control path. Used by
+ * both the spec declaration and the frontend Component so the Inspector
+ * and the renderer agree on which axes to resolve.
+ */
+export const paragraphSupports: BlockSupports = {
+  color: { background: true, text: true },
+  spacing: { padding: true, margin: true },
+  typography: {
+    fontSize: true,
+    lineHeight: true,
+    fontWeight: true,
+    textAlign: true,
+  },
+  anchor: true,
+  customClassName: true,
+};

--- a/packages/blocks/src/registry.ts
+++ b/packages/blocks/src/registry.ts
@@ -147,6 +147,7 @@ async function resolveSpec(
     description: spec.description,
     keywords: spec.keywords,
     attributes: spec.attributes,
+    supports: spec.supports,
     schema,
     editor: spec.editor,
     client: spec.client,

--- a/packages/blocks/src/styles/hooks.test.tsx
+++ b/packages/blocks/src/styles/hooks.test.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { ThemeTokens } from "./types.js";
+import {
+  ThemeTokensProvider,
+  useBlockStyles,
+  useThemeTokens,
+} from "./hooks.js";
+
+function wrapper(tokens: ThemeTokens) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <ThemeTokensProvider value={tokens}>{children}</ThemeTokensProvider>;
+  };
+}
+
+describe("useThemeTokens / useBlockStyles", () => {
+  test("useThemeTokens returns empty tokens by default (no provider)", () => {
+    const { result } = renderHook(() => useThemeTokens());
+    expect(result.current).toEqual({});
+  });
+
+  test("useThemeTokens returns the provided tokens through context", () => {
+    const tokens: ThemeTokens = {
+      colors: { primary: { value: "#0066cc" } },
+    };
+    const { result } = renderHook(() => useThemeTokens(), {
+      wrapper: wrapper(tokens),
+    });
+    expect(result.current).toBe(tokens);
+  });
+
+  test("useBlockStyles resolves through useThemeTokens output", () => {
+    const tokens: ThemeTokens = {
+      colors: { primary: { value: "#0066cc" } },
+    };
+    const { result } = renderHook(
+      () =>
+        useBlockStyles(
+          { color: { background: "primary" } },
+          { color: { background: true } },
+        ),
+      { wrapper: wrapper(tokens) },
+    );
+    expect(result.current.className).toBe("has-primary-background-color");
+    expect(result.current.style).toEqual({});
+  });
+});

--- a/packages/blocks/src/styles/hooks.tsx
+++ b/packages/blocks/src/styles/hooks.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties, ReactElement, ReactNode } from "react";
+import { createContext, useContext, useMemo } from "react";
+
+import type { ResolvedBlockStyles } from "./resolve-block-styles.js";
+import type { BlockStyleSlot, BlockSupports, ThemeTokens } from "./types.js";
+import { resolveBlockStyles } from "./resolve-block-styles.js";
+
+const EMPTY_TOKENS: ThemeTokens = Object.freeze({});
+
+const ThemeTokensContext = createContext<ThemeTokens>(EMPTY_TOKENS);
+
+export interface ThemeTokensProviderProps {
+  readonly value: ThemeTokens;
+  readonly children: ReactNode;
+}
+
+/**
+ * Provides the active theme's tokens to descendant blocks. The SSR
+ * shell mounts this once around `<EntryContent>` so every block can
+ * resolve its style slot through `useBlockStyles`. Themes without
+ * tokens declared just don't mount a provider — defaults fall through
+ * to empty tokens and the resolver degrades to inline `style` only.
+ */
+export function ThemeTokensProvider({
+  value,
+  children,
+}: ThemeTokensProviderProps): ReactElement {
+  return (
+    <ThemeTokensContext.Provider value={value}>
+      {children}
+    </ThemeTokensContext.Provider>
+  );
+}
+
+/**
+ * Returns the active theme's tokens. Without a provider the default
+ * is the frozen empty tokens object — callers can safely read groups
+ * (`tokens.colors`) without nil-checking the parent.
+ */
+export function useThemeTokens(): ThemeTokens {
+  return useContext(ThemeTokensContext);
+}
+
+/**
+ * Convenience hook over `resolveBlockStyles` that pulls tokens from
+ * context. The memo dependency on `slot` / `supports` / `tokens`
+ * keeps the resolver output stable for spread onto a memoised root.
+ */
+export function useBlockStyles(
+  slot: BlockStyleSlot,
+  supports: BlockSupports,
+): ResolvedBlockStyles {
+  const tokens = useThemeTokens();
+  return useMemo(
+    () => resolveBlockStyles(slot, supports, tokens),
+    [slot, supports, tokens],
+  );
+}
+
+/**
+ * Picks only the non-empty fields from a `ResolvedBlockStyles` so the
+ * spread on a JSX root doesn't emit `className=""` or `style={}` — the
+ * walker's snapshot tests assert exact HTML without empty attributes.
+ */
+export function blockElementProps(resolved: ResolvedBlockStyles): {
+  id?: string;
+  className?: string;
+  style?: CSSProperties;
+} {
+  const props: { id?: string; className?: string; style?: CSSProperties } = {};
+  if (resolved.id !== undefined) props.id = resolved.id;
+  if (resolved.className.length > 0) props.className = resolved.className;
+  if (Object.keys(resolved.style).length > 0) props.style = resolved.style;
+  return props;
+}

--- a/packages/blocks/src/styles/integration.test.tsx
+++ b/packages/blocks/src/styles/integration.test.tsx
@@ -1,0 +1,80 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { BlockContext, TiptapNode as TiptapNodeJson } from "../types.js";
+import { coreBlocks } from "../core-blocks.js";
+import { mergeBlockRegistry } from "../registry.js";
+import { defaultMarkRegistry } from "../test/index.js";
+import { EntryContent } from "../walker.js";
+
+const ROOT_CONTEXT: BlockContext = {
+  entry: null,
+  siteSettings: {},
+  theme: null,
+  parent: null,
+  depth: 0,
+};
+
+describe("blocks + supports + tokens end-to-end", () => {
+  test("paragraph with attrs.style.color.background='primary' renders has-primary-background-color under a theme declaring the token", async () => {
+    const registry = await mergeBlockRegistry({
+      core: coreBlocks,
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/paragraph",
+          attrs: { style: { color: { background: "primary" } } },
+          content: [{ type: "text", text: "themed" }],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+        themeTokens={{
+          colors: { primary: { value: "#0066cc", label: "Primary" } },
+        }}
+      />,
+    );
+    const p = container.querySelector("p");
+    expect(p?.className).toBe("has-primary-background-color");
+    expect(p?.textContent).toBe("themed");
+  });
+
+  test("heading anchor slot surfaces as the `id` attribute", async () => {
+    const registry = await mergeBlockRegistry({
+      core: coreBlocks,
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const doc: TiptapNodeJson = {
+      type: "doc",
+      content: [
+        {
+          type: "core/heading",
+          attrs: { level: 2, style: { anchor: "intro" } },
+          content: [{ type: "text", text: "Hello" }],
+        },
+      ],
+    };
+    const { container } = render(
+      <EntryContent
+        content={doc}
+        registry={registry}
+        context={ROOT_CONTEXT}
+        markRegistry={defaultMarkRegistry}
+      />,
+    );
+    const h2 = container.querySelector("h2");
+    expect(h2?.id).toBe("intro");
+  });
+});

--- a/packages/blocks/src/styles/resolve-block-styles.test.ts
+++ b/packages/blocks/src/styles/resolve-block-styles.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveBlockStyles } from "./resolve-block-styles.js";
+
+describe("resolveBlockStyles", () => {
+  test("returns empty className and style when both inputs are empty", () => {
+    const result = resolveBlockStyles(
+      {},
+      {},
+      { colors: {}, spacing: {}, typography: {}, border: {} },
+    );
+    expect(result).toEqual({ className: "", style: {} });
+  });
+
+  test("named color-background token resolves to has-<slug>-background-color class", () => {
+    const result = resolveBlockStyles(
+      { color: { background: "primary" } },
+      { color: { background: true } },
+      {
+        colors: { primary: { value: "#0066cc", label: "Primary" } },
+      },
+    );
+    expect(result.className).toBe("has-primary-background-color");
+    expect(result.style).toEqual({});
+  });
+
+  test("raw color value falls through to inline backgroundColor style", () => {
+    const result = resolveBlockStyles(
+      { color: { background: "#abcdef" } },
+      { color: { background: true } },
+      { colors: { primary: { value: "#0066cc" } } },
+    );
+    expect(result.className).toBe("");
+    expect(result.style).toEqual({ backgroundColor: "#abcdef" });
+  });
+
+  test("missing color-token slug degrades to inline style with literal slug", () => {
+    const result = resolveBlockStyles(
+      { color: { background: "primary" } },
+      { color: { background: true } },
+      { colors: {} },
+    );
+    expect(result.className).toBe("");
+    expect(result.style).toEqual({ backgroundColor: "primary" });
+  });
+
+  test("ignores style values for axes the spec does not opt into via supports", () => {
+    // The reserved attrs.style slot can hold values for axes the
+    // block hasn't opted into (e.g. legacy content from before the
+    // spec dropped an axis). The resolver must NOT leak those into
+    // the rendered output — that would let content silently re-acquire
+    // a styling power the spec author removed.
+    const result = resolveBlockStyles(
+      {
+        color: { background: "primary" },
+        spacing: { padding: "md" },
+      },
+      { color: { background: true } },
+      {
+        colors: { primary: { value: "#0066cc" } },
+        spacing: { md: { value: "1rem" } },
+      },
+    );
+    expect(result.className).toBe("has-primary-background-color");
+    expect(result.style).toEqual({});
+  });
+
+  test("named spacing-padding token resolves to has-<slug>-padding class", () => {
+    const result = resolveBlockStyles(
+      { spacing: { padding: "md" } },
+      { spacing: { padding: true } },
+      { spacing: { md: { value: "1rem" } } },
+    );
+    expect(result.className).toBe("has-md-padding");
+    expect(result.style).toEqual({});
+  });
+
+  test("anchor slot surfaces as a top-level `id` field on the result", () => {
+    // Anchor is special: it's not a class or style, it's an HTML `id`
+    // on the rendered element. The resolver exposes it via a dedicated
+    // return field so block components can spread it cleanly.
+    const result = resolveBlockStyles(
+      { anchor: "section-1" },
+      { anchor: true },
+      {},
+    );
+    expect(result.id).toBe("section-1");
+    expect(result.className).toBe("");
+  });
+
+  test("customClassName slot appends raw class verbatim (no token lookup)", () => {
+    // customClassName intentionally bypasses the token machinery —
+    // it's the explicit escape hatch for one-off Tailwind / utility
+    // classes the design system hasn't promoted to tokens yet.
+    const result = resolveBlockStyles(
+      { customClassName: "alert alert-info" },
+      { customClassName: true },
+      {},
+    );
+    expect(result.className).toBe("alert alert-info");
+    expect(result.style).toEqual({});
+  });
+
+  // Table-driven coverage for the symmetric token-resolving axes. Each
+  // row exercises one (slot, supports) pair through the same resolver
+  // branch, asserting the slug → `has-<slug>-<suffix>` class mapping.
+  // Keeps the spec for "named tokens become utility classes" readable
+  // as a single table instead of one identical-shape test per axis.
+  test.each([
+    {
+      axis: "color.text",
+      slot: { color: { text: "primary" } },
+      supports: { color: { text: true } },
+      group: "colors",
+      slug: "primary",
+      expectedClass: "has-primary-color",
+    },
+    {
+      axis: "spacing.margin",
+      slot: { spacing: { margin: "lg" } },
+      supports: { spacing: { margin: true } },
+      group: "spacing",
+      slug: "lg",
+      expectedClass: "has-lg-margin",
+    },
+    {
+      axis: "typography.fontSize",
+      slot: { typography: { fontSize: "xl" } },
+      supports: { typography: { fontSize: true } },
+      group: "typography",
+      slug: "xl",
+      expectedClass: "has-xl-font-size",
+    },
+    {
+      axis: "typography.lineHeight",
+      slot: { typography: { lineHeight: "tight" } },
+      supports: { typography: { lineHeight: true } },
+      group: "typography",
+      slug: "tight",
+      expectedClass: "has-tight-line-height",
+    },
+    {
+      axis: "typography.fontWeight",
+      slot: { typography: { fontWeight: "bold" } },
+      supports: { typography: { fontWeight: true } },
+      group: "typography",
+      slug: "bold",
+      expectedClass: "has-bold-font-weight",
+    },
+    {
+      axis: "border.radius",
+      slot: { border: { radius: "md" } },
+      supports: { border: { radius: true } },
+      group: "border",
+      slug: "md",
+      expectedClass: "has-md-border-radius",
+    },
+  ] as const)(
+    "named $axis token resolves to `$expectedClass`",
+    ({ slot, supports, group, slug, expectedClass }) => {
+      const tokens = { [group]: { [slug]: { value: "x" } } };
+      const result = resolveBlockStyles(slot, supports, tokens);
+      expect(result.className).toBe(expectedClass);
+      expect(result.style).toEqual({});
+    },
+  );
+
+  // Raw-value coverage for the same axes — unknown slug or non-token
+  // value falls through to inline `style`. Guards against the resolver
+  // silently dropping author-provided values when the theme hasn't
+  // declared a matching token, and against accidentally widening the
+  // class-emission path to non-tokenizable axes.
+  test.each([
+    {
+      axis: "color.text",
+      slot: { color: { text: "#abcdef" } },
+      supports: { color: { text: true } },
+      expectedStyle: { color: "#abcdef" },
+    },
+    {
+      axis: "spacing.margin",
+      slot: { spacing: { margin: "8px" } },
+      supports: { spacing: { margin: true } },
+      expectedStyle: { margin: "8px" },
+    },
+    {
+      axis: "typography.fontSize",
+      slot: { typography: { fontSize: "1.25rem" } },
+      supports: { typography: { fontSize: true } },
+      expectedStyle: { fontSize: "1.25rem" },
+    },
+    {
+      axis: "typography.lineHeight",
+      slot: { typography: { lineHeight: "1.4" } },
+      supports: { typography: { lineHeight: true } },
+      expectedStyle: { lineHeight: "1.4" },
+    },
+    {
+      axis: "typography.fontWeight",
+      slot: { typography: { fontWeight: "700" } },
+      supports: { typography: { fontWeight: true } },
+      expectedStyle: { fontWeight: "700" },
+    },
+    {
+      axis: "border.radius",
+      slot: { border: { radius: "4px" } },
+      supports: { border: { radius: true } },
+      expectedStyle: { borderRadius: "4px" },
+    },
+  ] as const)(
+    "raw $axis value falls through to inline style",
+    ({ slot, supports, expectedStyle }) => {
+      const result = resolveBlockStyles(slot, supports, {});
+      expect(result.className).toBe("");
+      expect(result.style).toEqual(expectedStyle);
+    },
+  );
+
+  test("typography.textAlign and align surface as classes without token lookup", () => {
+    // Alignment is enumerated (left/center/right/justify), not
+    // token-driven — the class encodes the choice directly.
+    const result = resolveBlockStyles(
+      { typography: { textAlign: "center" }, align: "wide" },
+      { typography: { textAlign: true }, align: true },
+      {},
+    );
+    expect(result.className).toBe("has-text-align-center align-wide");
+    expect(result.style).toEqual({});
+  });
+
+  test("combines color class + raw spacing inline style on a single call", () => {
+    const result = resolveBlockStyles(
+      {
+        color: { background: "primary" },
+        spacing: { padding: "8px" },
+      },
+      { color: { background: true }, spacing: { padding: true } },
+      { colors: { primary: { value: "#0066cc" } } },
+    );
+    expect(result.className).toBe("has-primary-background-color");
+    expect(result.style).toEqual({ padding: "8px" });
+  });
+});

--- a/packages/blocks/src/styles/resolve-block-styles.ts
+++ b/packages/blocks/src/styles/resolve-block-styles.ts
@@ -1,0 +1,128 @@
+import type { CSSProperties } from "react";
+
+import type { BlockStyleSlot, BlockSupports, ThemeTokens } from "./types.js";
+
+export interface ResolvedBlockStyles {
+  readonly className: string;
+  readonly style: CSSProperties;
+  readonly id?: string;
+}
+
+interface TokenAxis {
+  readonly enabled: (s: BlockSupports) => boolean | undefined;
+  readonly value: (s: BlockStyleSlot) => string | undefined;
+  readonly group: (t: ThemeTokens) => ThemeTokens[keyof ThemeTokens];
+  readonly classSuffix: string;
+  readonly styleProperty: string;
+}
+
+const TOKEN_AXES: readonly TokenAxis[] = [
+  {
+    enabled: (s) => s.color?.background,
+    value: (s) => s.color?.background,
+    group: (t) => t.colors,
+    classSuffix: "background-color",
+    styleProperty: "backgroundColor",
+  },
+  {
+    enabled: (s) => s.color?.text,
+    value: (s) => s.color?.text,
+    group: (t) => t.colors,
+    classSuffix: "color",
+    styleProperty: "color",
+  },
+  {
+    enabled: (s) => s.spacing?.padding,
+    value: (s) => s.spacing?.padding,
+    group: (t) => t.spacing,
+    classSuffix: "padding",
+    styleProperty: "padding",
+  },
+  {
+    enabled: (s) => s.spacing?.margin,
+    value: (s) => s.spacing?.margin,
+    group: (t) => t.spacing,
+    classSuffix: "margin",
+    styleProperty: "margin",
+  },
+  {
+    enabled: (s) => s.typography?.fontSize,
+    value: (s) => s.typography?.fontSize,
+    group: (t) => t.typography,
+    classSuffix: "font-size",
+    styleProperty: "fontSize",
+  },
+  {
+    enabled: (s) => s.typography?.lineHeight,
+    value: (s) => s.typography?.lineHeight,
+    group: (t) => t.typography,
+    classSuffix: "line-height",
+    styleProperty: "lineHeight",
+  },
+  {
+    enabled: (s) => s.typography?.fontWeight,
+    value: (s) => s.typography?.fontWeight,
+    group: (t) => t.typography,
+    classSuffix: "font-weight",
+    styleProperty: "fontWeight",
+  },
+  {
+    enabled: (s) => s.border?.radius,
+    value: (s) => s.border?.radius,
+    group: (t) => t.border,
+    classSuffix: "border-radius",
+    styleProperty: "borderRadius",
+  },
+];
+
+/**
+ * Pure mapper from author-picked style values + the block's `supports`
+ * declaration + the theme's tokens to a `{ className, style, id? }`
+ * triple. Named-token slugs resolve to `has-<slug>-<suffix>` utility
+ * classes; raw or missing-token values fall through to inline `style`
+ * so a theme swap doesn't silently break stored content.
+ */
+export function resolveBlockStyles(
+  slot: BlockStyleSlot,
+  supports: BlockSupports,
+  tokens: ThemeTokens,
+): ResolvedBlockStyles {
+  const classes: string[] = [];
+  const style: Record<string, string> = {};
+
+  for (const axis of TOKEN_AXES) {
+    if (!axis.enabled(supports)) continue;
+    const raw = axis.value(slot);
+    if (raw === undefined) continue;
+    if (axis.group(tokens)?.[raw]) {
+      classes.push(`has-${raw}-${axis.classSuffix}`);
+    } else {
+      style[axis.styleProperty] = raw;
+    }
+  }
+
+  // textAlign / align are enumerated (left|center|right|justify, wide|full):
+  // emit the class directly, no token lookup.
+  if (
+    supports.typography?.textAlign &&
+    slot.typography?.textAlign !== undefined
+  ) {
+    classes.push(`has-text-align-${slot.typography.textAlign}`);
+  }
+  if (supports.align && slot.align !== undefined) {
+    classes.push(`align-${slot.align}`);
+  }
+  // customClassName is the explicit escape hatch — raw class appended verbatim.
+  if (supports.customClassName && slot.customClassName !== undefined) {
+    classes.push(slot.customClassName);
+  }
+
+  const out: { className: string; style: CSSProperties; id?: string } = {
+    className: classes.join(" "),
+    style,
+  };
+  if (supports.anchor && slot.anchor !== undefined && slot.anchor.length > 0) {
+    out.id = slot.anchor;
+  }
+  return out;
+}

--- a/packages/blocks/src/styles/tokens-to-css.test.ts
+++ b/packages/blocks/src/styles/tokens-to-css.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+import { tokensToCss } from "./tokens-to-css.js";
+
+describe("tokensToCss", () => {
+  test("returns an empty string for empty tokens", () => {
+    expect(tokensToCss({})).toBe("");
+  });
+
+  test("emits CSS variables for declared color tokens under :root", () => {
+    const css = tokensToCss({
+      colors: {
+        primary: { value: "#0066cc" },
+        accent: { value: "#ff6600" },
+      },
+    });
+    expect(css).toContain(":root {");
+    expect(css).toContain("--plumix-color-primary: #0066cc;");
+    expect(css).toContain("--plumix-color-accent: #ff6600;");
+  });
+
+  test("emits utility classes consuming the CSS variables", () => {
+    const css = tokensToCss({
+      colors: { primary: { value: "#0066cc" } },
+    });
+    expect(css).toContain(".has-primary-background-color");
+    expect(css).toContain("background-color: var(--plumix-color-primary)");
+    expect(css).toContain(".has-primary-color");
+    expect(css).toContain("color: var(--plumix-color-primary)");
+  });
+
+  test("emits spacing + typography + border utility classes", () => {
+    const css = tokensToCss({
+      spacing: { md: { value: "1rem" } },
+      typography: { lg: { value: "1.25rem" } },
+      border: { md: { value: "0.5rem" } },
+    });
+    expect(css).toContain("--plumix-spacing-md: 1rem;");
+    expect(css).toContain(".has-md-padding");
+    expect(css).toContain(".has-md-margin");
+    expect(css).toContain("--plumix-typography-lg: 1.25rem;");
+    expect(css).toContain(".has-lg-font-size");
+    expect(css).toContain("--plumix-border-md: 0.5rem;");
+    expect(css).toContain(".has-md-border-radius");
+  });
+});

--- a/packages/blocks/src/styles/tokens-to-css.ts
+++ b/packages/blocks/src/styles/tokens-to-css.ts
@@ -1,0 +1,67 @@
+import type { ThemeTokenGroup, ThemeTokens } from "./types.js";
+
+interface GroupConfig {
+  readonly varPrefix: string;
+  readonly utilities: readonly { suffix: string; cssProperty: string }[];
+}
+
+const GROUPS: Readonly<Record<keyof ThemeTokens, GroupConfig>> = {
+  colors: {
+    varPrefix: "--plumix-color",
+    utilities: [
+      { suffix: "background-color", cssProperty: "background-color" },
+      { suffix: "color", cssProperty: "color" },
+    ],
+  },
+  spacing: {
+    varPrefix: "--plumix-spacing",
+    utilities: [
+      { suffix: "padding", cssProperty: "padding" },
+      { suffix: "margin", cssProperty: "margin" },
+    ],
+  },
+  typography: {
+    varPrefix: "--plumix-typography",
+    utilities: [
+      { suffix: "font-size", cssProperty: "font-size" },
+      { suffix: "line-height", cssProperty: "line-height" },
+      { suffix: "font-weight", cssProperty: "font-weight" },
+    ],
+  },
+  border: {
+    varPrefix: "--plumix-border",
+    utilities: [{ suffix: "border-radius", cssProperty: "border-radius" }],
+  },
+};
+
+/**
+ * Pure CSS-string generator: turns a `ThemeTokens` value into a single
+ * stylesheet declaring CSS custom properties on `:root` and the
+ * utility classes `resolveBlockStyles` emits. The Vite plugin's
+ * `virtual:plumix/blocks/tokens.css` virtual module returns this
+ * string at build time so the bundle ships exactly the variables the
+ * active theme declared — empty groups produce no output, missing
+ * groups skip cleanly.
+ */
+export function tokensToCss(tokens: ThemeTokens): string {
+  const varDecls: string[] = [];
+  const utilityBlocks: string[] = [];
+  for (const [groupKey, config] of Object.entries(GROUPS) as [
+    keyof ThemeTokens,
+    GroupConfig,
+  ][]) {
+    const group: ThemeTokenGroup | undefined = tokens[groupKey];
+    if (!group) continue;
+    for (const [slug, entry] of Object.entries(group)) {
+      const varName = `${config.varPrefix}-${slug}`;
+      varDecls.push(`  ${varName}: ${entry.value};`);
+      for (const util of config.utilities) {
+        utilityBlocks.push(
+          `.has-${slug}-${util.suffix} { ${util.cssProperty}: var(${varName}); }`,
+        );
+      }
+    }
+  }
+  if (varDecls.length === 0) return "";
+  return [":root {", ...varDecls, "}", ...utilityBlocks].join("\n");
+}

--- a/packages/blocks/src/styles/types.ts
+++ b/packages/blocks/src/styles/types.ts
@@ -1,0 +1,86 @@
+/**
+ * One entry in a token group. `value` is the CSS value the browser
+ * receives (hex/rgb for colors, length string for spacing, etc.).
+ * `label` is the human-readable name the Inspector picker shows;
+ * defaults to the slug when omitted.
+ */
+export interface ThemeTokenEntry {
+  readonly value: string;
+  readonly label?: string;
+}
+
+export type ThemeTokenGroup = Readonly<Record<string, ThemeTokenEntry>>;
+
+/**
+ * The theme's design vocabulary. Each group is a slug-keyed map of
+ * `{ value, label? }`. All groups are optional — a theme that doesn't
+ * declare a group just falls through to inline-style for that axis.
+ */
+export interface ThemeTokens {
+  readonly colors?: ThemeTokenGroup;
+  readonly spacing?: ThemeTokenGroup;
+  readonly typography?: ThemeTokenGroup;
+  readonly border?: ThemeTokenGroup;
+}
+
+/**
+ * Per-block declaration of which supports axes the spec opts into.
+ * Each axis is independently optional. Authors flip the sub-axes they
+ * want exposed in the Inspector and resolved by `resolveBlockStyles`.
+ */
+export interface BlockSupports {
+  readonly color?: {
+    readonly background?: boolean;
+    readonly text?: boolean;
+  };
+  readonly spacing?: {
+    readonly padding?: boolean;
+    readonly margin?: boolean;
+  };
+  readonly typography?: {
+    readonly fontSize?: boolean;
+    readonly lineHeight?: boolean;
+    readonly textAlign?: boolean;
+    readonly fontWeight?: boolean;
+  };
+  readonly border?: {
+    readonly radius?: boolean;
+    readonly width?: boolean;
+    readonly color?: boolean;
+  };
+  readonly align?: boolean;
+  readonly anchor?: boolean;
+  readonly customClassName?: boolean;
+}
+
+/**
+ * Reserved `attrs.style.*` slot the Inspector and resolver read. Each
+ * entry is either a token slug (`"primary"`, `"md"`) — which resolves
+ * to a utility class — or a raw CSS value, which lands in inline
+ * `style`. Both shapes coexist so authors can pick a theme token or
+ * one-off value per attribute.
+ */
+export interface BlockStyleSlot {
+  readonly color?: {
+    readonly background?: string;
+    readonly text?: string;
+  };
+  readonly spacing?: {
+    readonly padding?: string;
+    readonly margin?: string;
+  };
+  readonly typography?: {
+    readonly fontSize?: string;
+    readonly lineHeight?: string;
+    readonly textAlign?: string;
+    readonly fontWeight?: string;
+  };
+  readonly border?: {
+    readonly radius?: string;
+    readonly width?: string;
+    readonly color?: string;
+  };
+  readonly align?: string;
+  readonly anchor?: string;
+  readonly customClassName?: string;
+}

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -1,6 +1,8 @@
 import type { Node as TiptapNodeFactory } from "@tiptap/core";
 import type { ComponentType, ReactNode } from "react";
 
+import type { BlockSupports } from "./styles/types.js";
+
 /**
  * The persisted ProseMirror JSON shape Tiptap produces.
  *
@@ -101,6 +103,15 @@ export interface BlockSpec<Attrs = Readonly<Record<string, unknown>>> {
   readonly description?: string;
   readonly keywords?: readonly string[];
   readonly attributes?: Readonly<Record<string, BlockAttributeSchema>>;
+  /**
+   * Declarative opt-in for the supports axes (color, spacing,
+   * typography, border, align, anchor, customClassName) the Inspector
+   * should expose and `resolveBlockStyles` should fold into the
+   * rendered output. Axes the spec doesn't opt into are silently
+   * ignored at render time even if the persisted `attrs.style.*` slot
+   * carries values for them.
+   */
+  readonly supports?: BlockSupports;
   readonly schema: LazyRef<ReturnType<typeof TiptapNodeFactory.create>>;
   readonly component: LazyRef<BlockComponent<Attrs>>;
   readonly editor?: LazyRef<ComponentType<unknown>>;

--- a/packages/blocks/src/walker.tsx
+++ b/packages/blocks/src/walker.tsx
@@ -3,6 +3,7 @@ import { createElement, Fragment } from "react";
 
 import type { HtmlAllowlist } from "./html/sanitize.js";
 import type { MarkRegistry } from "./marks/types.js";
+import type { ThemeTokens } from "./styles/types.js";
 import type {
   BlockContext,
   BlockRegistry,
@@ -10,6 +11,7 @@ import type {
   TiptapNode,
 } from "./types.js";
 import { HtmlAllowlistProvider } from "./html/context.js";
+import { ThemeTokensProvider } from "./styles/hooks.js";
 
 /**
  * Minimum surface the walker needs from a hook executor: a synchronous
@@ -50,6 +52,13 @@ export interface EntryContentProps {
    */
   readonly htmlAllowlist?: HtmlAllowlist;
   /**
+   * Active theme's design tokens. When supplied the walker wraps its
+   * render tree in `<ThemeTokensProvider>` so descendant blocks can
+   * resolve their style slot through `useBlockStyles`. SSR shells
+   * thread `app.themeTokens` through here.
+   */
+  readonly themeTokens?: ThemeTokens;
+  /**
    * Optional hook executor invoked around each block render. When supplied
    * the walker fires `block:before_render` and `block:after_render` filter
    * hooks per block (in that order), threading
@@ -81,11 +90,12 @@ export function EntryContent({
   markRegistry,
   context,
   htmlAllowlist,
+  themeTokens,
   hooks,
 }: EntryContentProps): ReactNode {
   if (!content) return null;
   const nodes = Array.isArray(content) ? content : [content];
-  const tree = renderNodes(
+  let tree: ReactNode = renderNodes(
     nodes,
     registry,
     markRegistry,
@@ -93,8 +103,16 @@ export function EntryContent({
     devWarnState(registry),
     hooks,
   );
-  if (htmlAllowlist === undefined) return tree;
-  return createElement(HtmlAllowlistProvider, { value: htmlAllowlist }, tree);
+  if (htmlAllowlist !== undefined) {
+    tree = createElement(HtmlAllowlistProvider, { value: htmlAllowlist }, tree);
+  }
+  if (themeTokens !== undefined) {
+    tree = createElement(ThemeTokensProvider, {
+      value: themeTokens,
+      children: tree,
+    });
+  }
+  return tree;
 }
 
 interface DevWarnState {

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -6,6 +6,7 @@ import type {
   HtmlAllowlist,
   MarkComponent,
   MarkRegistry,
+  ThemeTokens,
 } from "@plumix/blocks";
 import {
   buildHtmlAllowlist,
@@ -139,6 +140,13 @@ export interface PlumixApp {
    * output rather than being silently swapped with the baseline.
    */
   readonly htmlAllowlist: HtmlAllowlist;
+  /**
+   * Active theme's design tokens, flattened across `config.themes`
+   * with later themes winning per-group. `undefined` when no theme
+   * declared `tokens` — the SSR shell skips `<ThemeTokensProvider>`
+   * in that case and `useBlockStyles` degrades to inline `style` only.
+   */
+  readonly themeTokens: ThemeTokens | undefined;
 }
 
 export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
@@ -250,6 +258,12 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     config.blocks?.htmlAllowlist,
   );
 
+  // Per-group merge across themes: a theme that declares only `colors`
+  // doesn't wipe `spacing` / `typography` from an earlier base theme.
+  // Within a group, later themes win per-slug — same precedence as the
+  // block/mark override flatten above.
+  const themeTokens = mergeThemeTokens(config.themes);
+
   return {
     config,
     hooks,
@@ -270,6 +284,7 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     blocks,
     marks,
     htmlAllowlist,
+    themeTokens,
   };
 }
 
@@ -281,6 +296,34 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
  * used by `mergeMarkRegistry` / `mergeBlockRegistry` only to attribute
  * `themeOverrideUnknownName` errors.
  */
+function mergeThemeTokens(
+  themes: readonly ThemeDescriptor[],
+): ThemeTokens | undefined {
+  let merged: ThemeTokens | undefined;
+  for (const theme of themes) {
+    if (!theme.tokens) continue;
+    merged = {
+      ...(merged ?? {}),
+      ...(theme.tokens.colors !== undefined && {
+        colors: { ...(merged?.colors ?? {}), ...theme.tokens.colors },
+      }),
+      ...(theme.tokens.spacing !== undefined && {
+        spacing: { ...(merged?.spacing ?? {}), ...theme.tokens.spacing },
+      }),
+      ...(theme.tokens.typography !== undefined && {
+        typography: {
+          ...(merged?.typography ?? {}),
+          ...theme.tokens.typography,
+        },
+      }),
+      ...(theme.tokens.border !== undefined && {
+        border: { ...(merged?.border ?? {}), ...theme.tokens.border },
+      }),
+    };
+  }
+  return merged;
+}
+
 function collectThemeOverrides<C extends BlockComponent | MarkComponent>(
   themes: readonly ThemeDescriptor[],
   pick: (theme: ThemeDescriptor) => Readonly<Record<string, C>> | undefined,

--- a/packages/core/src/theme-errors.test.ts
+++ b/packages/core/src/theme-errors.test.ts
@@ -43,3 +43,34 @@ describe("ThemeError.setupNotAFunction", () => {
     expect(err.message).toContain("`setup` must be a function");
   });
 });
+
+describe("ThemeError.invalidTokenSlug", () => {
+  test("class identity, code, group, slug", () => {
+    const err = ThemeError.invalidTokenSlug({
+      themeId: "blog",
+      group: "colors",
+      slug: "x } body",
+    });
+    expect(err).toBeInstanceOf(ThemeError);
+    expect(err.code).toBe("invalid_token_slug");
+    expect(err.group).toBe("colors");
+    expect(err.slug).toBe("x } body");
+    expect(err.message).toContain("tokens.colors");
+  });
+});
+
+describe("ThemeError.invalidTokenValue", () => {
+  test("class identity, code, group, slug", () => {
+    const err = ThemeError.invalidTokenValue({
+      themeId: "blog",
+      group: "colors",
+      slug: "primary",
+      value: "#fff; } body { display:none",
+    });
+    expect(err).toBeInstanceOf(ThemeError);
+    expect(err.code).toBe("invalid_token_value");
+    expect(err.group).toBe("colors");
+    expect(err.slug).toBe("primary");
+    expect(err.message).toContain("tokens.colors.primary");
+  });
+});

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -3,17 +3,30 @@ export class ThemeError extends Error {
     ThemeError.prototype.name = "ThemeError";
   }
 
-  readonly code: "invalid_theme_id" | "setup_not_a_function";
+  readonly code:
+    | "invalid_theme_id"
+    | "setup_not_a_function"
+    | "invalid_token_slug"
+    | "invalid_token_value";
   readonly themeId: string;
+  readonly group: string | undefined;
+  readonly slug: string | undefined;
 
   private constructor(
-    code: "invalid_theme_id" | "setup_not_a_function",
+    code:
+      | "invalid_theme_id"
+      | "setup_not_a_function"
+      | "invalid_token_slug"
+      | "invalid_token_value",
     message: string,
     themeId: string,
+    extra?: { group?: string; slug?: string },
   ) {
     super(message);
     this.code = code;
     this.themeId = themeId;
+    this.group = extra?.group;
+    this.slug = extra?.slug;
   }
 
   static invalidThemeId(ctx: {
@@ -34,6 +47,45 @@ export class ThemeError extends Error {
       "setup_not_a_function",
       `defineTheme("${ctx.themeId}"): \`setup\` must be a function when provided.`,
       ctx.themeId,
+    );
+  }
+
+  static invalidTokenSlug(ctx: {
+    themeId: string;
+    group: string;
+    slug: string;
+  }): ThemeError {
+    return new ThemeError(
+      "invalid_token_slug",
+      `defineTheme("${ctx.themeId}"): tokens.${ctx.group} slug ${JSON.stringify(
+        ctx.slug,
+      )} is invalid. Token slugs must match /^[a-z][a-z0-9-]*$/ — they ` +
+        `are concatenated into CSS class names (e.g. "has-<slug>-padding") ` +
+        `and CSS custom-property names (e.g. "--plumix-color-<slug>"), so ` +
+        `whitespace, braces, or other CSS-delimiter characters break the ` +
+        `stylesheet at build time.`,
+      ctx.themeId,
+      { group: ctx.group, slug: ctx.slug },
+    );
+  }
+
+  static invalidTokenValue(ctx: {
+    themeId: string;
+    group: string;
+    slug: string;
+    value: string;
+  }): ThemeError {
+    return new ThemeError(
+      "invalid_token_value",
+      `defineTheme("${ctx.themeId}"): tokens.${ctx.group}.${ctx.slug} value ` +
+        `${JSON.stringify(ctx.value)} contains characters that would break ` +
+        `out of a CSS declaration value (semicolons, braces, comment ` +
+        `delimiters, or newlines). The Vite plugin emits this value ` +
+        `verbatim into ` +
+        `\`virtual:plumix/blocks/tokens.css\`, so any of those bytes lets ` +
+        `the token rewrite arbitrary rules in the bundle.`,
+      ctx.themeId,
+      { group: ctx.group, slug: ctx.slug },
     );
   }
 }

--- a/packages/core/src/theme-tokens.test.ts
+++ b/packages/core/src/theme-tokens.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+
+import { ThemeError } from "./theme-errors.js";
+import { defineTheme } from "./theme.js";
+
+describe("defineTheme tokens validation", () => {
+  test("accepts valid tokens", () => {
+    expect(() =>
+      defineTheme({
+        id: "blog",
+        tokens: {
+          colors: { primary: { value: "#0066cc", label: "Primary" } },
+          spacing: { md: { value: "1rem" } },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects a slug with CSS-breaking characters", () => {
+    expect(() =>
+      defineTheme({
+        id: "blog",
+        tokens: {
+          colors: {
+            "x } body": { value: "#fff" },
+          },
+        },
+      }),
+    ).toThrow(ThemeError);
+  });
+
+  test("rejects a slug starting with a digit", () => {
+    expect(() =>
+      defineTheme({
+        id: "blog",
+        tokens: { colors: { "1bad": { value: "#fff" } } },
+      }),
+    ).toThrow(ThemeError);
+  });
+
+  test("rejects a value with `;` (declaration breakout)", () => {
+    expect(() =>
+      defineTheme({
+        id: "blog",
+        tokens: {
+          colors: {
+            primary: { value: "#fff; } body { display:none" },
+          },
+        },
+      }),
+    ).toThrow(ThemeError);
+  });
+
+  test("rejects a value with `*/` (comment breakout)", () => {
+    expect(() =>
+      defineTheme({
+        id: "blog",
+        tokens: {
+          colors: { primary: { value: "#fff */ body { x: 1 } /*" } },
+        },
+      }),
+    ).toThrow(ThemeError);
+  });
+
+  test("rejects a value with embedded newline", () => {
+    expect(() =>
+      defineTheme({
+        id: "blog",
+        tokens: { colors: { primary: { value: "#fff\nbody { x: 1 }" } } },
+      }),
+    ).toThrow(ThemeError);
+  });
+});

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,4 +1,8 @@
-import type { BlockComponent, MarkComponent } from "@plumix/blocks";
+import type {
+  BlockComponent,
+  MarkComponent,
+  ThemeTokens,
+} from "@plumix/blocks";
 
 import type { ThemeContextExtensions } from "./plugin/provides-context.js";
 import { ThemeError } from "./theme-errors.js";
@@ -38,10 +42,30 @@ export interface ThemeDescriptor {
    * later themes win, schema stays author-owned.
    */
   readonly marks?: Readonly<Record<string, MarkComponent>>;
+  /**
+   * Design-token vocabulary the theme exposes to block style picks.
+   * Authored values like `attrs.style.color.background = "primary"`
+   * resolve through this map at render time via `resolveBlockStyles` —
+   * a registered slug produces a stable utility class, a missing slug
+   * degrades to inline `style` carrying the literal slug. The Vite
+   * plugin also reads this at build time to populate
+   * `virtual:plumix/blocks/tokens.css` with CSS variables and the
+   * matching utility classes the resolver emits.
+   */
+  readonly tokens?: ThemeTokens;
 }
 
 const THEME_ID_RE = /^[a-z][a-z0-9-]*$/;
 const MAX_THEME_ID_LENGTH = 64;
+const TOKEN_SLUG_RE = /^[a-z][a-z0-9-]*$/;
+// Bytes that close out of a CSS declaration value or comment context.
+// `;` ends the declaration; `{` `}` close out of the surrounding rule;
+// `/* */` is comment delimiter; newlines + `\` break the CSS lexer's
+// string state. Operator-controlled tokens still flow into the bundle
+// verbatim, so any of these would let a hostile/careless theme rewrite
+// arbitrary rules.
+// eslint-disable-next-line no-control-regex
+const TOKEN_VALUE_FORBIDDEN_CHARS = /[;{}\\\n\r]|\/\*|\*\//;
 
 export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
   if (
@@ -62,5 +86,31 @@ export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
   ) {
     throw ThemeError.setupNotAFunction({ themeId: descriptor.id });
   }
+  if (descriptor.tokens) {
+    validateTokens(descriptor.id, descriptor.tokens);
+  }
   return descriptor;
+}
+
+function validateTokens(themeId: string, tokens: ThemeTokens): void {
+  for (const group of ["colors", "spacing", "typography", "border"] as const) {
+    const entries = tokens[group];
+    if (!entries) continue;
+    for (const [slug, entry] of Object.entries(entries)) {
+      if (!TOKEN_SLUG_RE.test(slug)) {
+        throw ThemeError.invalidTokenSlug({ themeId, group, slug });
+      }
+      if (
+        typeof entry.value !== "string" ||
+        TOKEN_VALUE_FORBIDDEN_CHARS.test(entry.value)
+      ) {
+        throw ThemeError.invalidTokenValue({
+          themeId,
+          group,
+          slug,
+          value: String(entry.value),
+        });
+      }
+    }
+  }
 }

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -12,6 +12,7 @@ import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Plugin } from "vite";
 
+import type { ThemeTokens } from "@plumix/blocks";
 import type {
   AnyPluginDescriptor,
   PluginRegistry,
@@ -32,6 +33,7 @@ import {
   assemblePluginAdminBundle,
 } from "./admin-plugin-bundle.js";
 import { VitePluginError } from "./errors.js";
+import { loadTokensVirtual, resolveTokensVirtualId } from "./tokens-virtual.js";
 
 // `import.meta.url` for this module lives at plumix/dist/vite/index.js in
 // consumer installs, so the pre-compiled admin artifact is a sibling at
@@ -49,6 +51,11 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
   let root = process.cwd();
   let publicDir = "";
   let configPath: string | undefined;
+  // Active theme tokens captured at each regenerate. The virtual
+  // `virtual:plumix/blocks/tokens.css` module reads this every time
+  // Vite loads it; on config change the watcher refreshes it and
+  // sends a `full-reload` so the CSS imports pick up the new tokens.
+  let activeThemeTokens: ThemeTokens | undefined;
 
   return {
     name: "plumix",
@@ -80,6 +87,7 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     async buildStart() {
       const emitted = await regenerate(root, options.configFile);
       configPath = emitted.configPath;
+      activeThemeTokens = emitted.themeTokens;
       warnOnPluginAdminMismatch(emitted.plugins, this.warn.bind(this));
       await stageAdminAssets(
         publicDir,
@@ -89,11 +97,18 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
         root,
       );
     },
+    resolveId(id) {
+      return resolveTokensVirtualId(id);
+    },
+    load(id) {
+      return loadTokensVirtual(id, activeThemeTokens);
+    },
     configureServer(server) {
       server.watcher.on("change", (path) => {
         if (!configPath || resolve(path) !== configPath) return;
         void regenerate(root, options.configFile)
           .then(async (emitted) => {
+            activeThemeTokens = emitted.themeTokens;
             await stageAdminAssets(
               publicDir,
               emitted.manifest,
@@ -137,6 +152,7 @@ async function regenerate(
   manifest: PlumixManifest;
   registry: PluginRegistry;
   plugins: readonly AnyPluginDescriptor[];
+  themeTokens: ThemeTokens | undefined;
 }> {
   const { config, configPath } = await loadConfig(cwd, explicitConfig);
 
@@ -152,7 +168,40 @@ async function regenerate(
     config.plugins,
   );
 
-  return { configPath, manifest, registry, plugins: config.plugins };
+  // Per-group merge across themes — a theme adding only `colors`
+  // doesn't wipe `spacing` / `typography` from a base theme. Mirrors
+  // `mergeThemeTokens` in `buildApp` so the virtual module's CSS
+  // matches the runtime resolver's tokens.
+  let themeTokens: ThemeTokens | undefined;
+  for (const theme of config.themes) {
+    if (!theme.tokens) continue;
+    themeTokens = {
+      ...(themeTokens ?? {}),
+      ...(theme.tokens.colors !== undefined && {
+        colors: { ...(themeTokens?.colors ?? {}), ...theme.tokens.colors },
+      }),
+      ...(theme.tokens.spacing !== undefined && {
+        spacing: { ...(themeTokens?.spacing ?? {}), ...theme.tokens.spacing },
+      }),
+      ...(theme.tokens.typography !== undefined && {
+        typography: {
+          ...(themeTokens?.typography ?? {}),
+          ...theme.tokens.typography,
+        },
+      }),
+      ...(theme.tokens.border !== undefined && {
+        border: { ...(themeTokens?.border ?? {}), ...theme.tokens.border },
+      }),
+    };
+  }
+
+  return {
+    configPath,
+    manifest,
+    registry,
+    plugins: config.plugins,
+    themeTokens,
+  };
 }
 
 type PluginDescriptors = Parameters<typeof installPlugins>[0]["plugins"];

--- a/packages/plumix/src/vite/tokens-virtual.test.ts
+++ b/packages/plumix/src/vite/tokens-virtual.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  loadTokensVirtual,
+  resolveTokensVirtualId,
+  TOKENS_RESOLVED_ID,
+  TOKENS_VIRTUAL_ID,
+} from "./tokens-virtual.js";
+
+describe("tokens virtual module", () => {
+  test("resolves the public id to a stable resolved id", () => {
+    expect(resolveTokensVirtualId(TOKENS_VIRTUAL_ID)).toBe(TOKENS_RESOLVED_ID);
+    expect(resolveTokensVirtualId("some/other/module")).toBeUndefined();
+  });
+
+  test("emits the active theme's tokens.css when loaded", () => {
+    const css = loadTokensVirtual(TOKENS_RESOLVED_ID, {
+      colors: { primary: { value: "#0066cc" } },
+    });
+    expect(css).toContain("--plumix-color-primary: #0066cc;");
+    expect(css).toContain(".has-primary-background-color");
+  });
+
+  test("returns an empty stylesheet when no theme has declared tokens", () => {
+    expect(loadTokensVirtual(TOKENS_RESOLVED_ID, undefined)).toBe("");
+    expect(loadTokensVirtual(TOKENS_RESOLVED_ID, {})).toBe("");
+  });
+
+  test("returns undefined for a non-matching id", () => {
+    expect(loadTokensVirtual("\0virtual:something-else", {})).toBeUndefined();
+  });
+});

--- a/packages/plumix/src/vite/tokens-virtual.ts
+++ b/packages/plumix/src/vite/tokens-virtual.ts
@@ -1,0 +1,29 @@
+import type { ThemeTokens } from "@plumix/blocks";
+import { tokensToCss } from "@plumix/blocks";
+
+/**
+ * Public id consumers import: `import "virtual:plumix/blocks/tokens.css"`.
+ * The Vite plugin's `resolveId` hook turns this into the resolved id
+ * below (prefixed with `\0` so Vite skips other resolvers).
+ */
+export const TOKENS_VIRTUAL_ID = "virtual:plumix/blocks/tokens.css";
+export const TOKENS_RESOLVED_ID = "\0virtual:plumix/blocks/tokens.css";
+
+export function resolveTokensVirtualId(id: string): string | undefined {
+  return id === TOKENS_VIRTUAL_ID ? TOKENS_RESOLVED_ID : undefined;
+}
+
+/**
+ * Produce the stylesheet contents at load time from the active theme's
+ * tokens. Empty tokens (or absent theme) emit an empty string so the
+ * `.css` import always succeeds — the active theme just contributes
+ * nothing to the bundle.
+ */
+export function loadTokensVirtual(
+  id: string,
+  tokens: ThemeTokens | undefined,
+): string | undefined {
+  if (id !== TOKENS_RESOLVED_ID) return undefined;
+  if (!tokens) return "";
+  return tokensToCss(tokens);
+}


### PR DESCRIPTION
Adds the `supports` declaration to `BlockSpec`, the matching theme-side `tokens` field to `defineTheme`, and the runtime + build-time glue that folds author-picked style values into theme-aware utility classes.

`resolveBlockStyles(style, supports, tokens) → { className, style, id? }` is the pure mapper covering color (background/text), spacing (padding/margin), typography (fontSize/lineHeight/fontWeight/textAlign), border.radius, align, anchor, and customClassName. Named-token slugs resolve to predictable utility classes; raw values land in inline `style`; missing tokens degrade to inline style carrying the literal slug so a theme swap cannot silently break stored content.

**Theme provider + per-group merge**

`useBlockStyles` / `useThemeTokens` hooks read from a new `<ThemeTokensProvider>` mounted by `<EntryContent themeTokens={...}>`, the SSR-shell counterpart to the existing `htmlAllowlist` prop. Tokens flow `defineTheme({ tokens })` → `buildApp` → `app.themeTokens` → the provider. Per-group merge across themes — a theme adding only `colors` no longer wipes `spacing`/`typography` from a base theme.

**Virtual `tokens.css` module**

`tokensToCss(tokens)` is the pure CSS-string generator the new Vite virtual module `virtual:plumix/blocks/tokens.css` serves. The plumix plugin captures the merged token set during config regeneration and re-emits the stylesheet on watcher-driven config reloads.

**Token validation (CSS-injection defense)**

`defineTheme` rejects token slugs that don't match `[a-z][a-z0-9-]*` and token values containing semicolons, braces, comment delimiters, or newlines. Without this gate a hostile or careless theme could close the `:root` block and inject arbitrary rules once `tokens.css` ships into the bundle.

**Inspector + core block retrofit**

Inspector renders a Supports section below the attributes section, one input per declared axis writing to `attrs.style.<path>`. `core/paragraph` and `core/heading` declare full supports and read `useBlockStyles` so editor preview and public output stay aligned — a paragraph with `attrs.style.color.background = "primary"` under a theme that declares `tokens.colors.primary` renders with `class="has-primary-background-color"`.

Refs GH-304