### PR TITLE
feat(blocks,admin): layout block attributes + variations machinery

### DIFF
--- a/packages/admin/src/components/editor/slash-menu-insert.test.ts
+++ b/packages/admin/src/components/editor/slash-menu-insert.test.ts
@@ -1,0 +1,73 @@
+import type { SlashMenuItem } from "@/editor/slash-menu/items-from-registry.js";
+import { describe, expect, test } from "vitest";
+
+import { slashMenuItemToContent } from "./tiptap-editor.js";
+
+describe("slashMenuItemToContent", () => {
+  test("block items insert as a bare node of the block's type", () => {
+    const item: SlashMenuItem = {
+      name: "core/paragraph",
+      title: "Paragraph",
+      category: "text",
+    };
+    expect(slashMenuItemToContent(item)).toEqual({ type: "core/paragraph" });
+  });
+
+  test("variation items insert as the parent's node type with preset attrs", () => {
+    const item: SlashMenuItem = {
+      name: "core/group:row",
+      title: "Row",
+      category: "layout",
+      parent: "core/group",
+      attributes: { layout: "flex-row" },
+    };
+    expect(slashMenuItemToContent(item)).toEqual({
+      type: "core/group",
+      attrs: { layout: "flex-row" },
+    });
+  });
+
+  test("variation innerBlocks template materialises into Tiptap content", () => {
+    const item: SlashMenuItem = {
+      name: "core/columns:50-50",
+      title: "Two columns 50/50",
+      category: "layout",
+      parent: "core/columns",
+      attributes: { ratio: "1:1" },
+      innerBlocks: [{ name: "core/column" }, { name: "core/column" }],
+    };
+    expect(slashMenuItemToContent(item)).toEqual({
+      type: "core/columns",
+      attrs: { ratio: "1:1" },
+      content: [{ type: "core/column" }, { type: "core/column" }],
+    });
+  });
+
+  test("recursively materialises nested innerBlocks", () => {
+    const item: SlashMenuItem = {
+      name: "core/columns:nested",
+      title: "Nested",
+      category: "layout",
+      parent: "core/columns",
+      attributes: { ratio: "1:1" },
+      innerBlocks: [
+        {
+          name: "core/column",
+          innerBlocks: [
+            { name: "core/paragraph", attributes: { align: "left" } },
+          ],
+        },
+      ],
+    };
+    expect(slashMenuItemToContent(item)).toEqual({
+      type: "core/columns",
+      attrs: { ratio: "1:1" },
+      content: [
+        {
+          type: "core/column",
+          content: [{ type: "core/paragraph", attrs: { align: "left" } }],
+        },
+      ],
+    });
+  });
+});

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -1,3 +1,4 @@
+import type { SlashMenuItem } from "@/editor/slash-menu/items-from-registry.js";
 import type { Editor, JSONContent } from "@tiptap/react";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
@@ -7,10 +8,46 @@ import { createSlashMenuExtension } from "@/editor/slash-menu/extension.js";
 import { cn } from "@/lib/utils.js";
 import { EditorContent, useEditor } from "@tiptap/react";
 
-import type { BlockRegistry, MarkRegistry } from "@plumix/blocks";
+import type {
+  BlockRegistry,
+  BlockVariationInnerBlock,
+  MarkRegistry,
+} from "@plumix/blocks";
 
 import { BubbleMenu } from "./bubble-menu/index.js";
 import { buildTiptapExtensions } from "./tiptap-extensions.js";
+
+/**
+ * Translate a slash-menu item into Tiptap's `insertContent` payload.
+ * Block items insert as a bare empty node of their type; variation
+ * items insert the parent block's node type with the variation's
+ * preset attrs and the variation's `innerBlocks` template materialised
+ * (recursively) as `content`.
+ */
+export function slashMenuItemToContent(item: SlashMenuItem): JSONContent {
+  if (item.parent !== undefined) {
+    return {
+      type: item.parent,
+      ...(item.attributes !== undefined && { attrs: { ...item.attributes } }),
+      ...(item.innerBlocks !== undefined &&
+        item.innerBlocks.length > 0 && {
+          content: item.innerBlocks.map(innerBlockToContent),
+        }),
+    };
+  }
+  return { type: item.name };
+}
+
+function innerBlockToContent(inner: BlockVariationInnerBlock): JSONContent {
+  return {
+    type: inner.name,
+    ...(inner.attributes !== undefined && { attrs: { ...inner.attributes } }),
+    ...(inner.innerBlocks !== undefined &&
+      inner.innerBlocks.length > 0 && {
+        content: inner.innerBlocks.map(innerBlockToContent),
+      }),
+  };
+}
 
 // Two render modes:
 //   - canvas mode (no allowlist props): full StarterKit + slash menu +
@@ -85,10 +122,12 @@ export function TiptapEditor({
       createSlashMenuExtension({
         blockRegistry,
         onPick: (item, ed) => {
-          // Minimal default: insert the block as an empty node. Block
-          // authors can extend by supplying a `defaults` template
-          // (wired through in a follow-up slice).
-          ed.chain().focus().insertContent({ type: item.name }).run();
+          // Variation items carry the parent block's actual Tiptap
+          // node type as `item.parent` — `item.name` is the
+          // `<parent>:<slug>` composite which is NOT a registered node
+          // type. Block items leave `parent` undefined and the block
+          // name IS the node type.
+          ed.chain().focus().insertContent(slashMenuItemToContent(item)).run();
         },
       }),
     ];

--- a/packages/admin/src/editor/slash-menu/items-from-registry.test.ts
+++ b/packages/admin/src/editor/slash-menu/items-from-registry.test.ts
@@ -63,6 +63,39 @@ describe("itemsFromRegistry", () => {
     expect(item?.keywords).toEqual(["blockquote"]);
   });
 
+  test("emits one item per variation in addition to the parent block", () => {
+    const groupSpec = spec({
+      name: "core/group",
+      title: "Group",
+      category: "layout",
+    });
+    (groupSpec as unknown as { variations: unknown }).variations = [
+      {
+        name: "row",
+        title: "Row",
+        description: "Horizontal flex container.",
+        attributes: { layout: "flex-row" },
+      },
+      {
+        name: "stack",
+        title: "Stack",
+        attributes: { layout: "flex-column" },
+      },
+    ];
+    const registry = fakeRegistry([groupSpec]);
+    const items = itemsFromRegistry(registry);
+    expect(items.map((i) => i.name).sort()).toEqual([
+      "core/group",
+      "core/group:row",
+      "core/group:stack",
+    ]);
+    const row = items.find((i) => i.name === "core/group:row");
+    expect(row?.title).toBe("Row");
+    expect(row?.description).toBe("Horizontal flex container.");
+    expect(row?.parent).toBe("core/group");
+    expect(row?.attributes).toEqual({ layout: "flex-row" });
+  });
+
   test("skips blocks that are content-only (children of another block)", () => {
     const child = spec({
       name: "core/column",

--- a/packages/admin/src/editor/slash-menu/items-from-registry.ts
+++ b/packages/admin/src/editor/slash-menu/items-from-registry.ts
@@ -1,4 +1,8 @@
-import type { BlockRegistry } from "@plumix/blocks";
+import type {
+  BlockRegistry,
+  BlockVariation,
+  BlockVariationInnerBlock,
+} from "@plumix/blocks";
 
 export interface SlashMenuItem {
   readonly name: string;
@@ -6,10 +10,28 @@ export interface SlashMenuItem {
   readonly description?: string;
   readonly category: string;
   readonly keywords?: readonly string[];
+  /**
+   * When this item is a variation, the parent block's name. The editor
+   * uses this to insert a node of `parent`'s type rather than `name`'s
+   * (since variation items don't have their own Tiptap schema).
+   */
+  readonly parent?: string;
+  /**
+   * Preset attrs for the inserted node (variation only).
+   */
+  readonly attributes?: Readonly<Record<string, unknown>>;
+  /**
+   * Templated children to materialise under the inserted node
+   * (variation only).
+   */
+  readonly innerBlocks?: readonly BlockVariationInnerBlock[];
 }
 
 /**
- * Project the block registry into the SlashMenuItem shape.
+ * Project the block registry into SlashMenuItem entries — one per
+ * block, plus one per variation declared on each block. Variation
+ * items carry their parent block's name so the editor knows which
+ * Tiptap node to insert.
  *
  * Skips child-only specs (those carrying a `parent` declaration) since
  * the user inserts them through the parent's own template, not as a
@@ -29,6 +51,26 @@ export function itemsFromRegistry(
       category: spec.category ?? "typography",
       keywords: spec.keywords,
     });
+    for (const variation of spec.variations ?? []) {
+      items.push(variationToItem(spec.name, spec.category, variation));
+    }
   }
   return items;
+}
+
+function variationToItem(
+  parentName: string,
+  parentCategory: string | undefined,
+  variation: BlockVariation,
+): SlashMenuItem {
+  return {
+    name: `${parentName}:${variation.name}`,
+    title: variation.title,
+    description: variation.description,
+    category: parentCategory ?? "typography",
+    keywords: variation.keywords,
+    parent: parentName,
+    attributes: variation.attributes,
+    innerBlocks: variation.innerBlocks,
+  };
 }

--- a/packages/blocks/src/columns/column.ts
+++ b/packages/blocks/src/columns/column.ts
@@ -5,6 +5,17 @@ export const columnBlock = defineBlock({
   title: "Column",
   category: "layout",
   description: "Single column inside a columns container.",
+  attributes: {
+    // Free-form so authors can express CSS lengths (`33%`, `1fr`, `20rem`)
+    // — the parent columns ratio drives the default layout; this is the
+    // override knob for one-off column sizing.
+    width: { type: "text", label: "Width", default: "" },
+  },
+  supports: {
+    color: { background: true },
+    spacing: { padding: true, margin: true },
+    customClassName: true,
+  },
   schema: () => import("./schema.js").then((m) => m.columnSchema),
   component: () => import("./Component.js").then((m) => m.ColumnComponent),
 });

--- a/packages/blocks/src/columns/columns.test.tsx
+++ b/packages/blocks/src/columns/columns.test.tsx
@@ -107,4 +107,45 @@ describe("core/column", () => {
     });
     expect(html).not.toContain("data-width");
   });
+
+  test("columnBlock declares a `width` text attribute the Inspector renders", () => {
+    expect(columnBlock.attributes?.width).toMatchObject({ type: "text" });
+  });
+});
+
+describe("core/columns variations", () => {
+  test("declares 50/50, 33/67, 25/50/25, and 25/25/25/25 as separate slash-menu entries", () => {
+    const slugs = (columnsBlock.variations ?? []).map((v) => v.name);
+    expect(slugs).toEqual(
+      expect.arrayContaining(["50-50", "33-67", "25-50-25", "25-25-25-25"]),
+    );
+  });
+
+  test("each variation presets the parent ratio and templates the right number of empty column children", () => {
+    const fifty = columnsBlock.variations?.find((v) => v.name === "50-50");
+    expect(fifty?.attributes).toEqual({ ratio: "1:1" });
+    expect(fifty?.innerBlocks).toHaveLength(2);
+    expect(fifty?.innerBlocks?.[0]?.name).toBe("core/column");
+
+    const threeUneven = columnsBlock.variations?.find(
+      (v) => v.name === "25-50-25",
+    );
+    expect(threeUneven?.attributes).toEqual({ ratio: "1:2:1" });
+    expect(threeUneven?.innerBlocks).toHaveLength(3);
+  });
+});
+
+describe("core/columns attribute schema", () => {
+  test("columnsBlock declares a `ratio` select attribute with canonical options", () => {
+    expect(columnsBlock.attributes?.ratio).toMatchObject({
+      type: "select",
+      default: "1:1",
+    });
+    const options = (columnsBlock.attributes?.ratio?.options ?? []) as {
+      value: string;
+    }[];
+    expect(options.map((o) => o.value)).toEqual(
+      expect.arrayContaining(["1:1", "1:2", "2:1", "1:1:1", "1:2:1"]),
+    );
+  });
 });

--- a/packages/blocks/src/columns/index.ts
+++ b/packages/blocks/src/columns/index.ts
@@ -1,10 +1,85 @@
 import { defineBlock } from "../define-block.js";
 
+// Canonical ratios the Inspector exposes. Authors typing a raw ratio
+// at the persistence layer still work because the Component validates
+// against the same `n[:m]*` regex; this list controls the dropdown
+// only, not the parser.
+const RATIO_OPTIONS = [
+  { value: "1:1", label: "Two equal columns (1:1)" },
+  { value: "1:2", label: "Narrow + wide (1:2)" },
+  { value: "2:1", label: "Wide + narrow (2:1)" },
+  { value: "1:1:1", label: "Three equal columns (1:1:1)" },
+  { value: "1:2:1", label: "Three columns 1:2:1" },
+  { value: "2:1:2", label: "Three columns 2:1:2" },
+  { value: "1:1:1:1", label: "Four equal columns" },
+] as const;
+
+function emptyColumns(count: number): readonly { name: "core/column" }[] {
+  return Array.from({ length: count }, () => ({ name: "core/column" }));
+}
+
 export const columnsBlock = defineBlock({
   name: "core/columns",
   title: "Columns",
   category: "layout",
   description: "Multi-column container with explicit ratios.",
+  attributes: {
+    ratio: {
+      type: "select",
+      label: "Ratio",
+      default: "1:1",
+      options: RATIO_OPTIONS,
+    },
+  },
+  variations: [
+    {
+      name: "50-50",
+      title: "Two columns 50/50",
+      description: "Equal-width pair.",
+      keywords: ["two", "equal", "halves"],
+      attributes: { ratio: "1:1" },
+      innerBlocks: emptyColumns(2),
+    },
+    {
+      name: "33-67",
+      title: "Two columns 33/67",
+      description: "Narrow + wide.",
+      keywords: ["two", "asymmetric"],
+      attributes: { ratio: "1:2" },
+      innerBlocks: emptyColumns(2),
+    },
+    {
+      name: "67-33",
+      title: "Two columns 67/33",
+      description: "Wide + narrow.",
+      keywords: ["two", "asymmetric"],
+      attributes: { ratio: "2:1" },
+      innerBlocks: emptyColumns(2),
+    },
+    {
+      name: "25-50-25",
+      title: "Three columns 25/50/25",
+      description: "Centred wide column flanked by two narrow.",
+      keywords: ["three", "centred"],
+      attributes: { ratio: "1:2:1" },
+      innerBlocks: emptyColumns(3),
+    },
+    {
+      name: "25-25-25-25",
+      title: "Four equal columns",
+      description: "Four equal-width siblings.",
+      keywords: ["four", "equal", "quarters"],
+      attributes: { ratio: "1:1:1:1" },
+      innerBlocks: emptyColumns(4),
+    },
+  ],
+  supports: {
+    color: { background: true },
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
   schema: () => import("./schema.js").then((m) => m.columnsSchema),
   component: () => import("./Component.js").then((m) => m.ColumnsComponent),
 });

--- a/packages/blocks/src/define-block.test.ts
+++ b/packages/blocks/src/define-block.test.ts
@@ -182,6 +182,104 @@ describe("defineBlock", () => {
     expect(Object.isFrozen(spec.attributes?.align)).toBe(true);
   });
 
+  test("accepts a variations declaration and freezes it through", () => {
+    const spec = defineBlock({
+      name: "core/group",
+      title: "Group",
+      schema: PARAGRAPH_SCHEMA,
+      component: PARAGRAPH_COMPONENT,
+      variations: [
+        {
+          name: "row",
+          title: "Row",
+          description: "Horizontal flex container.",
+          attributes: { layout: "flex-row" },
+        },
+        {
+          name: "stack",
+          title: "Stack",
+          attributes: { layout: "flex-column" },
+        },
+      ],
+    });
+    expect(spec.variations).toHaveLength(2);
+    expect(spec.variations?.[0]).toMatchObject({
+      name: "row",
+      title: "Row",
+      attributes: { layout: "flex-row" },
+    });
+    expect(Object.isFrozen(spec.variations)).toBe(true);
+    expect(Object.isFrozen(spec.variations?.[0])).toBe(true);
+  });
+
+  test("rejects a variation with a slug containing uppercase or whitespace", () => {
+    expect(() =>
+      defineBlock({
+        name: "core/group",
+        title: "Group",
+        schema: PARAGRAPH_SCHEMA,
+        component: PARAGRAPH_COMPONENT,
+        variations: [{ name: "Bad Slug!", title: "Bad" }],
+      }),
+    ).toThrow(BlockRegistrationError);
+  });
+
+  test("deep-freezes variation innerBlocks so plugins cannot mutate templates after registration", () => {
+    const spec = defineBlock({
+      name: "core/columns",
+      title: "Columns",
+      schema: PARAGRAPH_SCHEMA,
+      component: PARAGRAPH_COMPONENT,
+      variations: [
+        {
+          name: "50-50",
+          title: "Two columns 50/50",
+          innerBlocks: [
+            { name: "core/column" },
+            {
+              name: "core/column",
+              innerBlocks: [{ name: "core/paragraph" }],
+            },
+          ],
+        },
+      ],
+    });
+    const inners = spec.variations?.[0]?.innerBlocks;
+    expect(Object.isFrozen(inners)).toBe(true);
+    expect(Object.isFrozen(inners?.[0])).toBe(true);
+    expect(Object.isFrozen(inners?.[1])).toBe(true);
+    expect(Object.isFrozen(inners?.[1]?.innerBlocks)).toBe(true);
+    expect(Object.isFrozen(inners?.[1]?.innerBlocks?.[0])).toBe(true);
+  });
+
+  test("accepts a variation slug starting with a digit (ratio-style)", () => {
+    // Layout variations commonly encode ratios like "50-50" or "25-50-25";
+    // requiring a leading letter would force ugly slugs like "two-50-50".
+    const spec = defineBlock({
+      name: "core/columns",
+      title: "Columns",
+      schema: PARAGRAPH_SCHEMA,
+      component: PARAGRAPH_COMPONENT,
+      variations: [{ name: "50-50", title: "Two columns 50/50" }],
+    });
+    expect(spec.variations?.[0]?.name).toBe("50-50");
+  });
+
+  test("rejects two variations with the same slug", () => {
+    expect(() =>
+      defineBlock({
+        name: "core/group",
+        title: "Group",
+        schema: PARAGRAPH_SCHEMA,
+        component: PARAGRAPH_COMPONENT,
+        variations: [
+          { name: "row", title: "Row" },
+          { name: "row", title: "Row again" },
+        ],
+      }),
+    ).toThrow(BlockRegistrationError);
+  });
+
   test("accepts a supports declaration and freezes it through", () => {
     const spec = defineBlock({
       name: "core/paragraph",

--- a/packages/blocks/src/define-block.ts
+++ b/packages/blocks/src/define-block.ts
@@ -3,6 +3,10 @@ import { BlockRegistrationError } from "./errors.js";
 import { KEYBOARD_SHORTCUT_PATTERN } from "./keyboard-shortcut.js";
 
 const BLOCK_NAME_PATTERN = /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/;
+// Variation slugs may start with a digit because layout variations
+// commonly encode ratios (`50-50`, `33-67`, `25-50-25`). Hyphens
+// inside the slug are still required to be flanked by alphanumerics.
+const VARIATION_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 
 /**
  * Validates a block spec at registration time and returns a frozen copy.
@@ -45,6 +49,24 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
       validateClientIslandField(spec.name, "export", spec.client.export, false);
     }
   }
+  if (spec.variations) {
+    const seenSlugs = new Set<string>();
+    for (const variation of spec.variations) {
+      if (!VARIATION_NAME_PATTERN.test(variation.name)) {
+        throw BlockRegistrationError.invalidVariationName({
+          name: spec.name,
+          variationName: variation.name,
+        });
+      }
+      if (seenSlugs.has(variation.name)) {
+        throw BlockRegistrationError.duplicateVariationName({
+          name: spec.name,
+          variationName: variation.name,
+        });
+      }
+      seenSlugs.add(variation.name);
+    }
+  }
 
   const attributes = spec.attributes
     ? Object.freeze(
@@ -74,6 +96,7 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
     keyboardShortcuts: freezeArrayOfObjects(spec.keyboardShortcuts),
     markdownShortcuts: freezeArrayOfObjects(spec.markdownShortcuts),
     parsePaste: freezeArrayOfObjects(spec.parsePaste),
+    variations: freezeVariations(spec.variations),
     transforms: spec.transforms
       ? Object.freeze({
           priority: spec.transforms.priority,
@@ -135,6 +158,64 @@ function freezeSupports<T>(supports: T | undefined): T | undefined {
     }
   }
   return Object.freeze(out) as T;
+}
+
+function freezeVariations<T>(
+  variations: readonly T[] | undefined,
+): readonly T[] | undefined {
+  if (!variations) return undefined;
+  return Object.freeze(
+    variations.map((variation) =>
+      Object.freeze({
+        ...(variation as Record<string, unknown>),
+        ...(hasInnerBlocks(variation) && {
+          innerBlocks: freezeInnerBlocks(variation.innerBlocks),
+        }),
+      }),
+    ),
+  ) as readonly T[];
+}
+
+interface InnerBlockShape {
+  readonly name: string;
+  readonly attributes?: Readonly<Record<string, unknown>>;
+  readonly innerBlocks?: readonly InnerBlockShape[];
+}
+
+function hasInnerBlocks(
+  v: unknown,
+): v is { readonly innerBlocks: readonly InnerBlockShape[] } {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Array.isArray((v as { innerBlocks?: unknown }).innerBlocks)
+  );
+}
+
+/**
+ * Deep-freezes `innerBlocks` recursively so a plugin holding a registry
+ * reference can't mutate the templated children that `<SlashMenu>` will
+ * materialise on every variation insert. Without this, freezing only
+ * stops at the variation object and the template arrays under it stay
+ * writeable — a misbehaving plugin could rewrite "core/column" to
+ * "core/evil" after registration.
+ */
+function freezeInnerBlocks(
+  inners: readonly InnerBlockShape[],
+): readonly InnerBlockShape[] {
+  return Object.freeze(
+    inners.map((inner) =>
+      Object.freeze({
+        ...inner,
+        ...(inner.attributes !== undefined && {
+          attributes: Object.freeze({ ...inner.attributes }),
+        }),
+        ...(inner.innerBlocks !== undefined && {
+          innerBlocks: freezeInnerBlocks(inner.innerBlocks),
+        }),
+      }),
+    ),
+  );
 }
 
 function freezeArray<T>(

--- a/packages/blocks/src/errors.ts
+++ b/packages/blocks/src/errors.ts
@@ -3,6 +3,8 @@ type BlockRegistrationErrorCode =
   | "invalid_keyboard_shortcut"
   | "invalid_transform_priority"
   | "invalid_client_island"
+  | "invalid_variation_name"
+  | "duplicate_variation_name"
   | "duplicate_name"
   | "core_block_collision"
   | "theme_override_unknown_name"
@@ -22,6 +24,7 @@ interface BlockRegistrationErrorFields {
   priority?: number;
   field?: string;
   value?: string;
+  variationName?: string;
 }
 
 const NAME_PATTERN = "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$";
@@ -44,6 +47,7 @@ export class BlockRegistrationError extends Error {
   readonly priority: number | undefined;
   readonly field: string | undefined;
   readonly value: string | undefined;
+  readonly variationName: string | undefined;
 
   private constructor(
     code: BlockRegistrationErrorCode,
@@ -64,6 +68,7 @@ export class BlockRegistrationError extends Error {
     this.priority = fields.priority;
     this.field = fields.field;
     this.value = fields.value;
+    this.variationName = fields.variationName;
   }
 
   static invalidNamePattern(ctx: {
@@ -176,6 +181,35 @@ export class BlockRegistrationError extends Error {
         `(javascript:, data:). Use a plain module URL — e.g. ` +
         `"/assets/widget.js" or "https://example.com/widget.mjs".`,
       { blockName: ctx.name, field: ctx.field, value: ctx.value },
+    );
+  }
+
+  static invalidVariationName(ctx: {
+    name: string;
+    variationName: string;
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "invalid_variation_name",
+      `Block "${ctx.name}" declared variation ${JSON.stringify(
+        ctx.variationName,
+      )}. Variation slugs must be lowercase alphanumerics, optionally ` +
+        `separated by hyphens (e.g. "row", "50-50", "25-50-25") — they ` +
+        `surface as slash-menu item names and may end up in serialized ` +
+        `content.`,
+      { blockName: ctx.name, variationName: ctx.variationName },
+    );
+  }
+
+  static duplicateVariationName(ctx: {
+    name: string;
+    variationName: string;
+  }): BlockRegistrationError {
+    return new BlockRegistrationError(
+      "duplicate_variation_name",
+      `Block "${ctx.name}" declared variation "${ctx.variationName}" twice. ` +
+        `Each variation slug must be unique within its parent block — the ` +
+        `slash menu de-duplicates by slug.`,
+      { blockName: ctx.name, variationName: ctx.variationName },
     );
   }
 

--- a/packages/blocks/src/group/group.test.tsx
+++ b/packages/blocks/src/group/group.test.tsx
@@ -66,4 +66,29 @@ describe("core/group", () => {
     });
     expect(html).not.toContain("data-layout");
   });
+
+  test("groupBlock declares Row + Stack variations presetting layout", () => {
+    const slugs = (groupBlock.variations ?? []).map((v) => v.name);
+    expect(slugs).toEqual(["row", "stack"]);
+    const row = groupBlock.variations?.find((v) => v.name === "row");
+    expect(row?.attributes).toEqual({ layout: "flex-row" });
+    const stack = groupBlock.variations?.find((v) => v.name === "stack");
+    expect(stack?.attributes).toEqual({ layout: "flex-column" });
+  });
+
+  test("groupBlock declares a `layout` select attribute with the four canonical options", () => {
+    expect(groupBlock.attributes?.layout).toMatchObject({
+      type: "select",
+      default: "flow",
+    });
+    const options = (groupBlock.attributes?.layout?.options ?? []) as {
+      value: string;
+    }[];
+    expect(options.map((o) => o.value)).toEqual([
+      "flow",
+      "flex-row",
+      "flex-column",
+      "grid",
+    ]);
+  });
 });

--- a/packages/blocks/src/group/index.ts
+++ b/packages/blocks/src/group/index.ts
@@ -1,10 +1,48 @@
 import { defineBlock } from "../define-block.js";
 
+const LAYOUT_OPTIONS = [
+  { value: "flow", label: "Flow" },
+  { value: "flex-row", label: "Row (flex)" },
+  { value: "flex-column", label: "Stack (flex)" },
+  { value: "grid", label: "Grid" },
+] as const;
+
 export const groupBlock = defineBlock({
   name: "core/group",
   title: "Group",
   category: "layout",
   description: "Generic container that hosts any block-level children.",
+  attributes: {
+    layout: {
+      type: "select",
+      label: "Layout",
+      default: "flow",
+      options: LAYOUT_OPTIONS,
+    },
+  },
+  variations: [
+    {
+      name: "row",
+      title: "Row",
+      description: "Horizontal flex container — siblings flow left to right.",
+      keywords: ["row", "horizontal", "flex"],
+      attributes: { layout: "flex-row" },
+    },
+    {
+      name: "stack",
+      title: "Stack",
+      description: "Vertical flex container — siblings stack top to bottom.",
+      keywords: ["stack", "vertical", "column", "flex"],
+      attributes: { layout: "flex-column" },
+    },
+  ],
+  supports: {
+    color: { background: true },
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
   schema: () => import("./schema.js").then((m) => m.groupSchema),
   component: () => import("./Component.js").then((m) => m.GroupComponent),
 });

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -62,6 +62,8 @@ export type {
   BlockTransformFrom,
   BlockTransformTo,
   BlockTransforms,
+  BlockVariation,
+  BlockVariationInnerBlock,
   ClientIslandRef,
   LazyRef,
   ParsePasteRule,

--- a/packages/blocks/src/registry.ts
+++ b/packages/blocks/src/registry.ts
@@ -157,6 +157,7 @@ async function resolveSpec(
     keyboardShortcuts: spec.keyboardShortcuts,
     markdownShortcuts: spec.markdownShortcuts,
     parsePaste: spec.parsePaste,
+    variations: spec.variations,
     transforms: spec.transforms,
   });
 }

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -76,6 +76,33 @@ export interface BlockAttributeSchema {
 export type LazyRef<T> = () => Promise<{ default: T } | T>;
 
 /**
+ * Templated child for a variation's `innerBlocks`. Inserted verbatim
+ * as a Tiptap node with the named block type and the supplied attrs
+ * — recursively, so nested templates compose.
+ */
+export interface BlockVariationInnerBlock {
+  readonly name: string;
+  readonly attributes?: Readonly<Record<string, unknown>>;
+  readonly innerBlocks?: readonly BlockVariationInnerBlock[];
+}
+
+/**
+ * Preset insertion entry. The slash menu shows one item per variation
+ * alongside the block itself; selecting an item creates a node of the
+ * parent block's type with the variation's `attributes` preset and
+ * the `innerBlocks` template materialised under it.
+ */
+export interface BlockVariation {
+  readonly name: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly icon?: string;
+  readonly keywords?: readonly string[];
+  readonly attributes?: Readonly<Record<string, unknown>>;
+  readonly innerBlocks?: readonly BlockVariationInnerBlock[];
+}
+
+/**
  * Declarative client-island descriptor. `src` is the public module
  * specifier the bootstrap script imports at hydration time. `export`
  * names the init function within that module (default `"default"`).
@@ -112,6 +139,16 @@ export interface BlockSpec<Attrs = Readonly<Record<string, unknown>>> {
    * carries values for them.
    */
   readonly supports?: BlockSupports;
+  /**
+   * Preset insertion entries for the slash menu / Inserter. Each
+   * variation surfaces as a separate slash-menu item using this
+   * block's schema but with the variation's `attributes` preset and
+   * the variation's optional `innerBlocks` template materialised as
+   * the inserted children. Used for layouts (Row / Stack on group;
+   * 50/50 / 33/67 / 25/50/25 on columns) so authors don't have to
+   * configure attributes after every insert.
+   */
+  readonly variations?: readonly BlockVariation[];
   readonly schema: LazyRef<ReturnType<typeof TiptapNodeFactory.create>>;
   readonly component: LazyRef<BlockComponent<Attrs>>;
   readonly editor?: LazyRef<ComponentType<unknown>>;


### PR DESCRIPTION
Declares the missing attributes on the three layout primitives so the Inspector and Component agree on the shape: `ratio` (select) on `core/columns`, `width` (text) on `core/column`, `layout` (select with flow / flex-row / flex-column / grid) on `core/group`. All three also declare full `supports` so the Inspector exposes color / spacing / border / anchor / customClassName controls.

**New `variations` field on `BlockSpec`**

Preset insertion entries the slash menu surfaces alongside the block itself. Each variation optionally presets `attributes` and templates `innerBlocks`.

- `core/group` ships **Row** and **Stack** variations that preset `layout: flex-row` / `flex-column` — authors don't reach for the Inspector after every insert.
- `core/columns` ships **50/50, 33/67, 67/33, 25/50/25, 25/25/25/25** variations that preset the matching ratio AND template N empty `core/column` children. Picking "Two columns 50/50" from the slash menu produces a ready-to-fill columns container.

**Slash menu plumbing**

`itemsFromRegistry` now emits one item per block plus one per variation. Variation items carry the parent block's actual Tiptap node type as `parent`, the preset `attributes`, and the `innerBlocks` template; `slashMenuItemToContent` translates that into Tiptap's `insertContent` payload with recursive materialisation for nested templates. Without this glue, the editor would crash on every variation pick because `core/group:row` is not a registered Tiptap node type.

**Defense**

`defineBlock` validates variation slugs against `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$` (digits allowed at the start so ratio variations like `50-50` work), rejects duplicate slugs, and deep-freezes the `innerBlocks` template tree so a plugin holding a registry reference can't mutate the templated children between registration and slash-menu insert.

Refs GH-307