### PR TITLE
feat(blocks,admin): interactive block attributes + core/table

### DIFF
--- a/packages/admin/src/editor/slash-menu/items-from-registry.test.ts
+++ b/packages/admin/src/editor/slash-menu/items-from-registry.test.ts
@@ -96,6 +96,23 @@ describe("itemsFromRegistry", () => {
     expect(row?.attributes).toEqual({ layout: "flex-row" });
   });
 
+  test("skips blocks marked `inserter: false` so content-only children stay out of the slash menu", () => {
+    const tableSpec = spec({
+      name: "core/table",
+      title: "Table",
+      category: "interactive",
+    });
+    const cellSpec = spec({
+      name: "core/table-cell",
+      title: "Table cell",
+      category: "interactive",
+    });
+    (cellSpec as unknown as { inserter: boolean }).inserter = false;
+    const registry = fakeRegistry([tableSpec, cellSpec]);
+    const items = itemsFromRegistry(registry);
+    expect(items.map((i) => i.name)).toEqual(["core/table"]);
+  });
+
   test("skips blocks that are content-only (children of another block)", () => {
     const child = spec({
       name: "core/column",

--- a/packages/admin/src/editor/slash-menu/items-from-registry.ts
+++ b/packages/admin/src/editor/slash-menu/items-from-registry.ts
@@ -44,6 +44,10 @@ export function itemsFromRegistry(
   for (const [, spec] of registry) {
     const parent = (spec as unknown as { parent?: unknown }).parent;
     if (typeof parent === "string") continue;
+    // `inserter: false` keeps content-only children (table rows,
+    // table cells) out of the standalone slash menu — they enter
+    // the document through a parent's variation template.
+    if (spec.inserter === false) continue;
     items.push({
       name: spec.name,
       title: spec.title,

--- a/packages/blocks/src/button/button.test.tsx
+++ b/packages/blocks/src/button/button.test.tsx
@@ -144,4 +144,27 @@ describe("core/button", () => {
     });
     expect(html).toBe('<a href="/x" data-plumix-block="core/button"></a>');
   });
+
+  test("declares the text/href/variant/size/target attribute schema for the Inspector", () => {
+    expect(buttonBlock.attributes?.text).toMatchObject({ type: "text" });
+    expect(buttonBlock.attributes?.href).toMatchObject({ type: "url" });
+    expect(buttonBlock.attributes?.variant).toMatchObject({
+      type: "select",
+      default: "primary",
+    });
+    expect(buttonBlock.attributes?.size).toMatchObject({
+      type: "select",
+      default: "md",
+    });
+  });
+
+  test("declares supports for color/spacing/border/customClassName/anchor", () => {
+    expect(buttonBlock.supports).toEqual({
+      color: { background: true, text: true },
+      spacing: { padding: true, margin: true },
+      border: { radius: true },
+      anchor: true,
+      customClassName: true,
+    });
+  });
 });

--- a/packages/blocks/src/button/index.ts
+++ b/packages/blocks/src/button/index.ts
@@ -1,10 +1,57 @@
 import { defineBlock } from "../define-block.js";
 
+const VARIANT_OPTIONS = [
+  { value: "primary", label: "Primary" },
+  { value: "secondary", label: "Secondary" },
+  { value: "outline", label: "Outline" },
+  { value: "ghost", label: "Ghost" },
+] as const;
+
+const SIZE_OPTIONS = [
+  { value: "sm", label: "Small" },
+  { value: "md", label: "Medium" },
+  { value: "lg", label: "Large" },
+] as const;
+
+const TARGET_OPTIONS = [
+  { value: "", label: "Same window" },
+  { value: "_blank", label: "New window" },
+] as const;
+
 export const buttonBlock = defineBlock({
   name: "core/button",
   title: "Button",
   category: "interactive",
   description: "Call-to-action link styled as a button.",
+  attributes: {
+    text: { type: "text", label: "Label", default: "" },
+    href: { type: "url", label: "Link target", default: "" },
+    variant: {
+      type: "select",
+      label: "Variant",
+      default: "primary",
+      options: VARIANT_OPTIONS,
+    },
+    size: {
+      type: "select",
+      label: "Size",
+      default: "md",
+      options: SIZE_OPTIONS,
+    },
+    target: {
+      type: "select",
+      label: "Open in",
+      default: "",
+      options: TARGET_OPTIONS,
+    },
+  },
+  supports: {
+    color: { background: true, text: true },
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
   schema: () => import("./schema.js").then((m) => m.buttonSchema),
   component: () => import("./Component.js").then((m) => m.ButtonComponent),
 });

--- a/packages/blocks/src/buttons/buttons.test.tsx
+++ b/packages/blocks/src/buttons/buttons.test.tsx
@@ -69,4 +69,21 @@ describe("core/buttons", () => {
     expect(html).toContain('data-gap="12px"');
     expect(html).toContain('data-gap="1rem"');
   });
+
+  test("declares align (select) + gap (text) attributes for the Inspector", () => {
+    expect(buttonsBlock.attributes?.align).toMatchObject({
+      type: "select",
+      default: "start",
+    });
+    expect(buttonsBlock.attributes?.gap).toMatchObject({ type: "text" });
+  });
+
+  test("declares supports for color/spacing/customClassName/anchor", () => {
+    expect(buttonsBlock.supports).toEqual({
+      color: { background: true },
+      spacing: { padding: true, margin: true },
+      anchor: true,
+      customClassName: true,
+    });
+  });
 });

--- a/packages/blocks/src/buttons/index.ts
+++ b/packages/blocks/src/buttons/index.ts
@@ -1,10 +1,32 @@
 import { defineBlock } from "../define-block.js";
 
+const ALIGN_OPTIONS = [
+  { value: "start", label: "Start" },
+  { value: "center", label: "Centre" },
+  { value: "end", label: "End" },
+  { value: "between", label: "Space between" },
+] as const;
+
 export const buttonsBlock = defineBlock({
   name: "core/buttons",
   title: "Buttons",
   category: "interactive",
   description: "Container for a row of call-to-action buttons.",
+  attributes: {
+    align: {
+      type: "select",
+      label: "Alignment",
+      default: "start",
+      options: ALIGN_OPTIONS,
+    },
+    gap: { type: "text", label: "Gap", default: "" },
+  },
+  supports: {
+    color: { background: true },
+    spacing: { padding: true, margin: true },
+    anchor: true,
+    customClassName: true,
+  },
   schema: () => import("./schema.js").then((m) => m.buttonsSchema),
   component: () => import("./Component.js").then((m) => m.ButtonsComponent),
 });

--- a/packages/blocks/src/callout/callout.test.tsx
+++ b/packages/blocks/src/callout/callout.test.tsx
@@ -83,4 +83,32 @@ describe("core/callout", () => {
     });
     expect(html).not.toContain("data-icon");
   });
+
+  test("declares variant (select) + icon (text) attributes for the Inspector", () => {
+    expect(calloutBlock.attributes?.variant).toMatchObject({
+      type: "select",
+      default: "info",
+    });
+    const options = (calloutBlock.attributes?.variant?.options ?? []) as {
+      value: string;
+    }[];
+    expect(options.map((o) => o.value)).toEqual([
+      "info",
+      "warn",
+      "error",
+      "success",
+      "note",
+    ]);
+    expect(calloutBlock.attributes?.icon).toMatchObject({ type: "text" });
+  });
+
+  test("declares supports for color/spacing/border/anchor/customClassName", () => {
+    expect(calloutBlock.supports).toEqual({
+      color: { background: true, text: true },
+      spacing: { padding: true, margin: true },
+      border: { radius: true },
+      anchor: true,
+      customClassName: true,
+    });
+  });
 });

--- a/packages/blocks/src/callout/index.ts
+++ b/packages/blocks/src/callout/index.ts
@@ -1,10 +1,34 @@
 import { defineBlock } from "../define-block.js";
 
+const VARIANT_OPTIONS = [
+  { value: "info", label: "Info" },
+  { value: "warn", label: "Warning" },
+  { value: "error", label: "Error" },
+  { value: "success", label: "Success" },
+  { value: "note", label: "Note" },
+] as const;
+
 export const calloutBlock = defineBlock({
   name: "core/callout",
   title: "Callout",
   category: "interactive",
   description: "Highlighted aside for info / warning / error / success / note.",
+  attributes: {
+    variant: {
+      type: "select",
+      label: "Variant",
+      default: "info",
+      options: VARIANT_OPTIONS,
+    },
+    icon: { type: "text", label: "Lucide icon name", default: "" },
+  },
+  supports: {
+    color: { background: true, text: true },
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
   schema: () => import("./schema.js").then((m) => m.calloutSchema),
   component: () => import("./Component.js").then((m) => m.CalloutComponent),
 });

--- a/packages/blocks/src/core-blocks.ts
+++ b/packages/blocks/src/core-blocks.ts
@@ -18,6 +18,13 @@ import { paragraphBlock } from "./paragraph/index.js";
 import { quoteBlock } from "./quote/index.js";
 import { separatorBlock } from "./separator/index.js";
 import { spacerBlock } from "./spacer/index.js";
+import {
+  tableBlock,
+  tableBodyRowBlock,
+  tableCellBlock,
+  tableHeaderCellBlock,
+  tableHeaderRowBlock,
+} from "./table/index.js";
 
 /**
  * The canonical list of blocks shipped by `@plumix/blocks`.
@@ -59,4 +66,9 @@ export const coreBlocks: readonly BlockSpec[] = Object.freeze([
   buttonBlock,
   detailsBlock,
   calloutBlock,
+  tableBlock,
+  tableHeaderRowBlock,
+  tableBodyRowBlock,
+  tableHeaderCellBlock,
+  tableCellBlock,
 ]);

--- a/packages/blocks/src/define-block.ts
+++ b/packages/blocks/src/define-block.ts
@@ -88,6 +88,7 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
     keywords: freezeArray(spec.keywords),
     attributes,
     supports: freezeSupports(spec.supports),
+    inserter: spec.inserter,
     schema: spec.schema,
     component: spec.component,
     editor: spec.editor,

--- a/packages/blocks/src/details/details.test.tsx
+++ b/packages/blocks/src/details/details.test.tsx
@@ -73,4 +73,22 @@ describe("core/details", () => {
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
   });
+
+  test("declares summary (text) + open (boolean) attributes for the Inspector", () => {
+    expect(detailsBlock.attributes?.summary).toMatchObject({ type: "text" });
+    expect(detailsBlock.attributes?.open).toMatchObject({
+      type: "boolean",
+      default: false,
+    });
+  });
+
+  test("declares supports for color/spacing/border/anchor/customClassName", () => {
+    expect(detailsBlock.supports).toEqual({
+      color: { background: true },
+      spacing: { padding: true, margin: true },
+      border: { radius: true },
+      anchor: true,
+      customClassName: true,
+    });
+  });
 });

--- a/packages/blocks/src/details/index.ts
+++ b/packages/blocks/src/details/index.ts
@@ -5,6 +5,17 @@ export const detailsBlock = defineBlock({
   title: "Details",
   category: "interactive",
   description: "Native <details>/<summary> collapsible region.",
+  attributes: {
+    summary: { type: "text", label: "Summary", default: "" },
+    open: { type: "boolean", label: "Open by default", default: false },
+  },
+  supports: {
+    color: { background: true },
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
   schema: () => import("./schema.js").then((m) => m.detailsSchema),
   component: () => import("./Component.js").then((m) => m.DetailsComponent),
 });

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -106,3 +106,10 @@ export { paragraphBlock } from "./paragraph/index.js";
 export { quoteBlock } from "./quote/index.js";
 export { separatorBlock } from "./separator/index.js";
 export { spacerBlock } from "./spacer/index.js";
+export {
+  tableBlock,
+  tableBodyRowBlock,
+  tableCellBlock,
+  tableHeaderCellBlock,
+  tableHeaderRowBlock,
+} from "./table/index.js";

--- a/packages/blocks/src/registry.ts
+++ b/packages/blocks/src/registry.ts
@@ -148,6 +148,7 @@ async function resolveSpec(
     keywords: spec.keywords,
     attributes: spec.attributes,
     supports: spec.supports,
+    inserter: spec.inserter,
     schema,
     editor: spec.editor,
     client: spec.client,

--- a/packages/blocks/src/table/Component.tsx
+++ b/packages/blocks/src/table/Component.tsx
@@ -1,0 +1,68 @@
+import type { ReactElement } from "react";
+
+import type { BlockProps } from "../types.js";
+
+const ALIGNS = ["left", "center", "right"] as const;
+type Align = (typeof ALIGNS)[number];
+
+function pickAlign(raw: unknown): Align | undefined {
+  return typeof raw === "string" && (ALIGNS as readonly string[]).includes(raw)
+    ? (raw as Align)
+    : undefined;
+}
+
+export function TableComponent({ attrs, children }: BlockProps): ReactElement {
+  const striped = attrs.striped === true || undefined;
+  const bordered = attrs.bordered === true || undefined;
+  return (
+    <table
+      data-plumix-block="core/table"
+      data-striped={striped}
+      data-bordered={bordered}
+    >
+      {children}
+    </table>
+  );
+}
+
+export function TableHeaderRowComponent({
+  children,
+}: BlockProps): ReactElement {
+  return (
+    <tr data-plumix-block="core/table-header-row" data-header="">
+      {children}
+    </tr>
+  );
+}
+
+export function TableBodyRowComponent({ children }: BlockProps): ReactElement {
+  return <tr data-plumix-block="core/table-body-row">{children}</tr>;
+}
+
+export function TableCellComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const align = pickAlign(attrs.align);
+  return (
+    <td data-plumix-block="core/table-cell" data-align={align}>
+      {children}
+    </td>
+  );
+}
+
+export function TableHeaderCellComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const align = pickAlign(attrs.align);
+  return (
+    <th
+      scope="col"
+      data-plumix-block="core/table-header-cell"
+      data-align={align}
+    >
+      {children}
+    </th>
+  );
+}

--- a/packages/blocks/src/table/index.ts
+++ b/packages/blocks/src/table/index.ts
@@ -1,0 +1,86 @@
+import { defineBlock } from "../define-block.js";
+
+const ALIGN_OPTIONS = [
+  { value: "left", label: "Left" },
+  { value: "center", label: "Centre" },
+  { value: "right", label: "Right" },
+] as const;
+
+export const tableBlock = defineBlock({
+  name: "core/table",
+  title: "Table",
+  category: "interactive",
+  description: "Tabular data with optional striped + bordered variants.",
+  attributes: {
+    striped: { type: "boolean", label: "Striped rows", default: false },
+    bordered: { type: "boolean", label: "Bordered cells", default: false },
+  },
+  supports: {
+    color: { background: true },
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
+  schema: () => import("./schema.js").then((m) => m.tableSchema),
+  component: () => import("./Component.js").then((m) => m.TableComponent),
+});
+
+export const tableHeaderRowBlock = defineBlock({
+  name: "core/table-header-row",
+  title: "Header row",
+  category: "interactive",
+  description: "Header row in a table; children render as <th>.",
+  inserter: false,
+  schema: () => import("./schema.js").then((m) => m.tableHeaderRowSchema),
+  component: () =>
+    import("./Component.js").then((m) => m.TableHeaderRowComponent),
+});
+
+export const tableBodyRowBlock = defineBlock({
+  name: "core/table-body-row",
+  title: "Body row",
+  category: "interactive",
+  description: "Body row in a table.",
+  inserter: false,
+  schema: () => import("./schema.js").then((m) => m.tableBodyRowSchema),
+  component: () =>
+    import("./Component.js").then((m) => m.TableBodyRowComponent),
+});
+
+export const tableCellBlock = defineBlock({
+  name: "core/table-cell",
+  title: "Table cell",
+  category: "interactive",
+  description: "Cell inside a table row.",
+  inserter: false,
+  attributes: {
+    align: {
+      type: "select",
+      label: "Alignment",
+      default: "left",
+      options: ALIGN_OPTIONS,
+    },
+  },
+  schema: () => import("./schema.js").then((m) => m.tableCellSchema),
+  component: () => import("./Component.js").then((m) => m.TableCellComponent),
+});
+
+export const tableHeaderCellBlock = defineBlock({
+  name: "core/table-header-cell",
+  title: "Table header cell",
+  category: "interactive",
+  description: "Header cell inside a table header row.",
+  inserter: false,
+  attributes: {
+    align: {
+      type: "select",
+      label: "Alignment",
+      default: "left",
+      options: ALIGN_OPTIONS,
+    },
+  },
+  schema: () => import("./schema.js").then((m) => m.tableHeaderCellSchema),
+  component: () =>
+    import("./Component.js").then((m) => m.TableHeaderCellComponent),
+});

--- a/packages/blocks/src/table/schema.ts
+++ b/packages/blocks/src/table/schema.ts
@@ -1,0 +1,137 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+/**
+ * Tiptap nodes for the `core/table` family. Modelled as four
+ * cooperating node types so the editor can validate structure
+ * (`table > header-row | body-row > cell`) at the schema layer rather
+ * than relying on runtime checks in the Component. Each row type
+ * carries the row's column alignments as an attr so the cell child
+ * can read its index against the parent row's `alignments` array.
+ */
+
+export const tableSchema = Node.create({
+  name: "core/table",
+  group: "block",
+  // Optional single header row followed by zero or more body rows —
+  // models <thead>/<tbody> conventions at the schema level and
+  // prevents stored content from interleaving them.
+  content: "coreTableHeaderRow? coreTableBodyRow*",
+  defining: true,
+
+  addAttributes() {
+    return {
+      striped: { default: false },
+      bordered: { default: false },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "table[data-plumix-block='core/table']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "table",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/table" }),
+      0,
+    ];
+  },
+});
+
+export const tableHeaderRowSchema = Node.create({
+  name: "core/table-header-row",
+  group: "coreTableHeaderRow",
+  // Header rows contain header cells specifically, so the renderer
+  // can emit <th> without parent-context lookup and stored content
+  // can't mix header / body cell semantics inside a single row.
+  content: "coreTableHeaderCell*",
+  defining: true,
+
+  addAttributes() {
+    return {
+      alignments: { default: [] },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "tr[data-plumix-block='core/table-header-row']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "tr",
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/table-header-row",
+      }),
+      0,
+    ];
+  },
+});
+
+export const tableBodyRowSchema = Node.create({
+  name: "core/table-body-row",
+  group: "coreTableBodyRow",
+  content: "coreTableCell*",
+  defining: true,
+
+  addAttributes() {
+    return {
+      alignments: { default: [] },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "tr[data-plumix-block='core/table-body-row']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "tr",
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/table-body-row",
+      }),
+      0,
+    ];
+  },
+});
+
+export const tableCellSchema = Node.create({
+  name: "core/table-cell",
+  group: "coreTableCell",
+  content: "inline*",
+
+  parseHTML() {
+    return [{ tag: "td[data-plumix-block='core/table-cell']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "td",
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/table-cell",
+      }),
+      0,
+    ];
+  },
+});
+
+export const tableHeaderCellSchema = Node.create({
+  name: "core/table-header-cell",
+  group: "coreTableHeaderCell",
+  content: "inline*",
+
+  parseHTML() {
+    return [{ tag: "th[data-plumix-block='core/table-header-cell']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "th",
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/table-header-cell",
+        scope: "col",
+      }),
+      0,
+    ];
+  },
+});

--- a/packages/blocks/src/table/table.test.tsx
+++ b/packages/blocks/src/table/table.test.tsx
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "vitest";
+
+import { mockRegistry, renderBlock } from "../test/index.js";
+import {
+  tableBlock,
+  tableBodyRowBlock,
+  tableCellBlock,
+  tableHeaderCellBlock,
+  tableHeaderRowBlock,
+} from "./index.js";
+
+const TABLE_REGISTRY_INPUT = {
+  core: [
+    tableBlock,
+    tableHeaderRowBlock,
+    tableBodyRowBlock,
+    tableHeaderCellBlock,
+    tableCellBlock,
+  ],
+};
+
+describe("core/table", () => {
+  test("renders empty table as <table>", async () => {
+    const registry = await mockRegistry(TABLE_REGISTRY_INPUT);
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "core/table", content: [] }],
+      },
+    });
+    expect(html).toBe('<table data-plumix-block="core/table"></table>');
+  });
+
+  test("renders header row with <th scope='col'> cells and body rows with <td>", async () => {
+    const registry = await mockRegistry(TABLE_REGISTRY_INPUT);
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/table",
+            content: [
+              {
+                type: "core/table-header-row",
+                content: [
+                  {
+                    type: "core/table-header-cell",
+                    content: [{ type: "text", text: "Name" }],
+                  },
+                  {
+                    type: "core/table-header-cell",
+                    content: [{ type: "text", text: "Role" }],
+                  },
+                ],
+              },
+              {
+                type: "core/table-body-row",
+                content: [
+                  {
+                    type: "core/table-cell",
+                    content: [{ type: "text", text: "Ada" }],
+                  },
+                  {
+                    type: "core/table-cell",
+                    content: [{ type: "text", text: "Founder" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('<th scope="col"');
+    expect(html).toContain('data-plumix-block="core/table-header-cell"');
+    expect(html).toContain("Name");
+    expect(html).toContain("Role");
+    expect(html).toContain('data-plumix-block="core/table-body-row"');
+    expect(html).toContain("<td");
+    expect(html).toContain("Ada");
+    expect(html).toContain("Founder");
+  });
+
+  test("omits data-striped when the attr is false (no leaky empty attribute)", async () => {
+    const registry = await mockRegistry(TABLE_REGISTRY_INPUT);
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/table",
+            attrs: { striped: false, bordered: false },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("data-striped");
+    expect(html).not.toContain("data-bordered");
+  });
+
+  test("exposes data-striped and data-bordered when attrs are set", async () => {
+    const registry = await mockRegistry(TABLE_REGISTRY_INPUT);
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/table",
+            attrs: { striped: true, bordered: true },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-striped="true"');
+    expect(html).toContain('data-bordered="true"');
+  });
+
+  test("cell exposes data-align from its align attribute", async () => {
+    const registry = await mockRegistry(TABLE_REGISTRY_INPUT);
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/table-cell",
+            attrs: { align: "center" },
+            content: [{ type: "text", text: "centred" }],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-align="center"');
+    expect(html).toContain("centred");
+  });
+
+  test("rejects invalid align values rather than leaking them", async () => {
+    const registry = await mockRegistry(TABLE_REGISTRY_INPUT);
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "core/table-cell",
+            attrs: { align: "bogus" },
+            content: [{ type: "text", text: "x" }],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("data-align");
+    expect(html).toContain("x");
+  });
+
+  test("tableBlock + tableCellBlock declare attributes and supports", () => {
+    expect(tableBlock.attributes?.striped).toMatchObject({ type: "boolean" });
+    expect(tableBlock.attributes?.bordered).toMatchObject({ type: "boolean" });
+    expect(tableCellBlock.attributes?.align).toMatchObject({
+      type: "select",
+      default: "left",
+    });
+    expect(tableBlock.supports?.color?.background).toBe(true);
+  });
+});

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -140,6 +140,13 @@ export interface BlockSpec<Attrs = Readonly<Record<string, unknown>>> {
    */
   readonly supports?: BlockSupports;
   /**
+   * Whether the slash menu / Inserter should surface this block as a
+   * standalone insertable. `false` for content-only children (table
+   * rows, table cells, column children) that the user inserts through
+   * a parent's variation template, not directly. Default `true`.
+   */
+  readonly inserter?: boolean;
+  /**
    * Preset insertion entries for the slash menu / Inserter. Each
    * variation surfaces as a separate slash-menu item using this
    * block's schema but with the variation's `attributes` preset and


### PR DESCRIPTION
Declares the missing attribute schemas + supports on the four existing skeleton interactive blocks so the Inspector exposes controls and the Components have a stable contract to read from:

- `core/button` — text + href + variant + size + target (selects with curated options); full supports.
- `core/buttons` — align + gap; supports.
- `core/details` — summary (text) + open (boolean); supports.
- `core/callout` — variant (info/warn/error/success/note) + icon; supports.

**New `core/table` family** — modelled as five cooperating Tiptap nodes so structure is enforced at the schema layer:

- `core/table` with striped + bordered booleans. Content expression `coreTableHeaderRow? coreTableBodyRow*` requires headers to come before body rows.
- `core/table-header-row` whose schema requires `coreTableHeaderCell*` children so the renderer can emit `<th>` without parent-context lookup and stored content cannot mix header / body cell semantics inside one row.
- `core/table-body-row` containing `coreTableCell*`.
- `core/table-header-cell` renders `<th scope="col">` with align.
- `core/table-cell` renders `<td>` with align.

**New `BlockSpec.inserter?: boolean`** — defaults to `true`. Table rows + cells set `inserter: false` so they never surface in the slash menu as standalone insertables; they enter the document only through a parent's content/variation template. `itemsFromRegistry` filters on it.

Senpai-flagged fixes addressed in-slice: header cells now render `<th scope="col">` (critical a11y), header-row schema requires distinct header-cell children (no mixed semantics), table content expression rejects interleaved header/body rows, table children stay out of the slash menu.

Refs GH-308