### PR TITLE
feat(admin): a11y ARIA polish + axe-core smoke harness

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -64,6 +64,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "axe-core": "^4.11.3",
     "esbuild": "0.27.7",
     "eslint": "catalog:",
     "jsdom": "^29.1.1",

--- a/packages/admin/src/components/editor/bubble-menu/MarkToolbar.test.tsx
+++ b/packages/admin/src/components/editor/bubble-menu/MarkToolbar.test.tsx
@@ -162,4 +162,33 @@ describe("MarkToolbar", () => {
       expect(screen.queryByTestId(`bubble-menu-${missing}`)).toBeNull();
     }
   });
+
+  test("ArrowRight moves focus to the next button; ArrowLeft moves back; wraps at the ends", async () => {
+    const { editor } = stubEditor({
+      schemaMarks: ["bold", "italic", "strike"],
+    });
+    const markRegistry = await buildRegistry();
+    render(<MarkToolbar editor={editor} markRegistry={markRegistry} />);
+
+    const bold = screen.getByTestId("bubble-menu-bold");
+    const italic = screen.getByTestId("bubble-menu-italic");
+    const strike = screen.getByTestId("bubble-menu-strike");
+
+    bold.focus();
+    expect(document.activeElement).toBe(bold);
+
+    fireEvent.keyDown(bold, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(italic);
+
+    fireEvent.keyDown(italic, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(strike);
+
+    // Wrap forward
+    fireEvent.keyDown(strike, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(bold);
+
+    // Wrap backward
+    fireEvent.keyDown(bold, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(strike);
+  });
 });

--- a/packages/admin/src/components/editor/bubble-menu/MarkToolbar.tsx
+++ b/packages/admin/src/components/editor/bubble-menu/MarkToolbar.tsx
@@ -1,5 +1,6 @@
 import type { Editor } from "@tiptap/react";
-import type { ReactElement } from "react";
+import type { KeyboardEvent, ReactElement } from "react";
+import { useRef } from "react";
 
 import type { MarkRegistry, ResolvedMarkSpec } from "@plumix/blocks";
 
@@ -7,6 +8,11 @@ interface MarkToolbarProps {
   readonly editor: Editor;
   readonly markRegistry: MarkRegistry;
 }
+
+const ARROW_DELTAS: Record<string, number | undefined> = {
+  ArrowRight: 1,
+  ArrowLeft: -1,
+};
 
 /**
  * Pure rendering layer for the mark bubble menu — one button per
@@ -29,8 +35,34 @@ export function MarkToolbar({
     ([, spec]) => spec,
   ).filter((spec) => spec.name in schemaMarks);
 
+  // Roving-focus arrow navigation: ArrowRight/Left moves focus within
+  // the toolbar, wrapping at the ends. Tab/Shift-Tab still escape to
+  // surrounding focusable elements — standard WAI-ARIA toolbar pattern.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    const delta = ARROW_DELTAS[event.key];
+    if (delta === undefined) return;
+    const root = rootRef.current;
+    if (!root) return;
+    const buttons = root.querySelectorAll<HTMLButtonElement>(
+      "button[data-testid]",
+    );
+    if (buttons.length === 0) return;
+    const active = root.ownerDocument.activeElement;
+    const current = Array.from(buttons).indexOf(active as HTMLButtonElement);
+    if (current === -1) return;
+    event.preventDefault();
+    const next = (current + delta + buttons.length) % buttons.length;
+    buttons[next]?.focus();
+  };
+
   return (
-    <div data-plumix-mark-toolbar="" role="toolbar">
+    <div
+      ref={rootRef}
+      data-plumix-mark-toolbar=""
+      role="toolbar"
+      onKeyDown={handleKeyDown}
+    >
       {marks.map((mark) => (
         <MarkButton key={mark.name} mark={mark} editor={editor} />
       ))}

--- a/packages/admin/src/editor/a11y-smoke-helpers.ts
+++ b/packages/admin/src/editor/a11y-smoke-helpers.ts
@@ -1,0 +1,38 @@
+import axe from "axe-core";
+
+export class AxeViolationError extends Error {
+  static {
+    AxeViolationError.prototype.name = "AxeViolationError";
+  }
+
+  static forViolations(violations: readonly axe.Result[]): AxeViolationError {
+    const summary = violations
+      .map((v) => `${v.id}: ${v.help} (${v.nodes.length} node(s))`)
+      .join("\n");
+    return new AxeViolationError(
+      `axe-core found ${violations.length} violations:\n${summary}`,
+    );
+  }
+}
+
+/**
+ * Runs axe against a rendered DOM container and fails the test with a
+ * legible list of violations when any rule fires. Targets the WCAG
+ * 2.1 AA ruleset which lines up with the editor's compliance target.
+ *
+ * Used as a smoke check — unit tests still assert the specific ARIA
+ * properties we care about; axe catches regressions in adjacent areas
+ * (label/labelledby pairing, contrast on bundled styles, duplicate
+ * ids when a Component is rendered twice in the same test).
+ */
+export async function runAxeSmokeTest(container: HTMLElement): Promise<void> {
+  const results = await axe.run(container, {
+    runOnly: { type: "tag", values: ["wcag2a", "wcag2aa"] },
+    // Color-contrast on jsdom is unreliable (no real layout / computed
+    // colour); we cover contrast via the Playwright + @axe-core/playwright
+    // e2e path. Disable here to keep vitest deterministic.
+    rules: { "color-contrast": { enabled: false } },
+  });
+  if (results.violations.length === 0) return;
+  throw AxeViolationError.forViolations(results.violations);
+}

--- a/packages/admin/src/editor/a11y-smoke.test.tsx
+++ b/packages/admin/src/editor/a11y-smoke.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, test, vi } from "vitest";
+
+import type { BlockRegistry, ResolvedBlockSpec } from "@plumix/blocks";
+
+import { runAxeSmokeTest } from "./a11y-smoke-helpers.js";
+import { Inspector } from "./inspector/Inspector.js";
+import { SlashMenuPanel } from "./slash-menu/SlashMenuPanel.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function spec(
+  partial: Partial<ResolvedBlockSpec> & { name: string; title: string },
+): ResolvedBlockSpec {
+  return {
+    name: partial.name,
+    title: partial.title,
+    description: partial.description,
+    category: partial.category ?? "typography",
+    attributes: partial.attributes,
+    supports: partial.supports,
+    component: () => null,
+    legacyAliases: undefined,
+    schema: undefined,
+    registeredBy: null,
+    editor: undefined,
+    client: undefined,
+  } as unknown as ResolvedBlockSpec;
+}
+
+function fakeBlockRegistry(specs: readonly ResolvedBlockSpec[]): BlockRegistry {
+  const map = new Map(specs.map((s) => [s.name, s]));
+  return {
+    get: (n) => map.get(n),
+    has: (n) => map.has(n),
+    size: map.size,
+    [Symbol.iterator]: () => map.entries(),
+  } satisfies BlockRegistry;
+}
+
+function stubEditor(nodeType: string, attrs: Record<string, unknown>) {
+  const chain = {
+    focus: () => chain,
+    updateAttributes: () => chain,
+    run: () => true,
+  };
+  return {
+    chain: () => chain,
+    on: () => undefined,
+    off: () => undefined,
+    state: {
+      selection: {
+        $from: { parent: { type: { name: nodeType }, attrs } },
+      },
+    },
+  } as unknown as Parameters<typeof Inspector>[0]["editor"];
+}
+
+describe("editor surface a11y smoke", () => {
+  test("Inspector with attributes + supports passes axe baseline", async () => {
+    const sectionSpec = spec({
+      name: "core/section",
+      title: "Section",
+      attributes: {
+        level: {
+          type: "select",
+          label: "Level",
+          default: 2,
+          options: [
+            { value: 1, label: "H1" },
+            { value: 2, label: "H2" },
+          ],
+        },
+      },
+      supports: { anchor: true, color: { background: true } },
+    });
+    const registry = fakeBlockRegistry([sectionSpec]);
+    const editor = stubEditor("core/section", { level: 2, style: {} });
+    const { container } = render(
+      <Inspector editor={editor} blockRegistry={registry} />,
+    );
+    await runAxeSmokeTest(container);
+  });
+
+  test("SlashMenuPanel passes axe baseline", async () => {
+    const { container } = render(
+      <SlashMenuPanel
+        items={[
+          {
+            name: "core/paragraph",
+            title: "Paragraph",
+            category: "typography",
+          },
+          { name: "core/heading", title: "Heading", category: "typography" },
+        ]}
+        query=""
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    await runAxeSmokeTest(container);
+  });
+});

--- a/packages/admin/src/editor/inspector/Inspector.test.tsx
+++ b/packages/admin/src/editor/inspector/Inspector.test.tsx
@@ -233,6 +233,29 @@ describe("Inspector", () => {
     expect(queryByTestId("inspector-supports-section")).toBeNull();
   });
 
+  test("groups attributes and supports in semantic <fieldset> blocks with <legend>", () => {
+    const withBoth = spec({
+      name: "core/section",
+      title: "Section",
+      attributes: { level: { type: "select", label: "Level", default: 1 } },
+      supports: { anchor: true, color: { background: true } },
+    });
+    const registry = fakeRegistry([withBoth]);
+    const { editor } = stubEditor({
+      nodeType: "core/section",
+      attrs: { level: 1, style: {} },
+    });
+    const { container } = render(
+      <Inspector editor={editor} blockRegistry={registry} />,
+    );
+    const fieldsets = container.querySelectorAll("fieldset");
+    expect(fieldsets.length).toBe(2);
+    const legends = Array.from(container.querySelectorAll("legend")).map(
+      (el) => el.textContent,
+    );
+    expect(legends).toEqual(expect.arrayContaining(["Attributes", "Supports"]));
+  });
+
   test("renders an anchor input when the spec opts into supports.anchor", () => {
     const withAnchor = spec({
       name: "core/heading",

--- a/packages/admin/src/editor/inspector/Inspector.tsx
+++ b/packages/admin/src/editor/inspector/Inspector.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { useEffect, useState } from "react";
 
 import type {
@@ -80,35 +80,60 @@ export function Inspector({
   return (
     <div data-plumix-inspector="" aria-label={`${spec.title} attributes`}>
       <h3 data-plumix-inspector-title="">{spec.title}</h3>
-      {attributeEntries.map(([attrName, schema]) => (
-        <InspectorField
-          key={attrName}
-          name={attrName}
-          schema={schema}
-          value={attrName in attrs ? attrs[attrName] : schema.default}
-          onChange={(next) => {
-            editor
-              .chain()
-              .focus()
-              .updateAttributes(spec.name, { [attrName]: next })
-              .run();
-          }}
-        />
-      ))}
+      {attributeEntries.length > 0 ? (
+        <InspectorSection id="attributes" legend="Attributes">
+          {attributeEntries.map(([attrName, schema]) => (
+            <InspectorField
+              key={attrName}
+              name={attrName}
+              schema={schema}
+              value={attrName in attrs ? attrs[attrName] : schema.default}
+              onChange={(next) => {
+                editor
+                  .chain()
+                  .focus()
+                  .updateAttributes(spec.name, { [attrName]: next })
+                  .run();
+              }}
+            />
+          ))}
+        </InspectorSection>
+      ) : null}
       {spec.supports ? (
-        <SupportsSection
-          supports={spec.supports}
-          style={slot}
-          onChange={(nextSlot) => {
-            editor
-              .chain()
-              .focus()
-              .updateAttributes(spec.name, { style: nextSlot })
-              .run();
-          }}
-        />
+        <InspectorSection id="supports" legend="Supports">
+          <SupportsSection
+            supports={spec.supports}
+            style={slot}
+            onChange={(nextSlot) => {
+              editor
+                .chain()
+                .focus()
+                .updateAttributes(spec.name, { style: nextSlot })
+                .run();
+            }}
+          />
+        </InspectorSection>
       ) : null}
     </div>
+  );
+}
+
+interface InspectorSectionProps {
+  readonly id: "attributes" | "supports";
+  readonly legend: string;
+  readonly children: ReactNode;
+}
+
+function InspectorSection({
+  id,
+  legend,
+  children,
+}: InspectorSectionProps): ReactElement {
+  return (
+    <fieldset data-plumix-inspector-section={id}>
+      <legend>{legend}</legend>
+      {children}
+    </fieldset>
   );
 }
 

--- a/packages/admin/src/editor/inspector/SupportsSection.tsx
+++ b/packages/admin/src/editor/inspector/SupportsSection.tsx
@@ -28,7 +28,6 @@ export function SupportsSection({
   if (rows.length === 0) return null;
   return (
     <div data-testid="inspector-supports-section" data-plumix-supports="">
-      <h3>Supports</h3>
       {rows.map((row) => (
         <label key={row.path} data-plumix-supports-row={row.path}>
           <span>{row.label}</span>

--- a/packages/admin/src/editor/slash-menu/SlashMenuPanel.test.tsx
+++ b/packages/admin/src/editor/slash-menu/SlashMenuPanel.test.tsx
@@ -180,4 +180,62 @@ describe("SlashMenuPanel", () => {
       ref.current?.onKeyDown(new KeyboardEvent("keydown", { key: "a" })),
     ).toBe(false);
   });
+
+  test("renders an aria-live region announcing the filtered count", () => {
+    render(
+      <SlashMenuPanel
+        items={items}
+        query=""
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    const live = screen.getByTestId("slash-menu-live-region");
+    expect(live).toHaveAttribute("aria-live", "polite");
+    expect(live.textContent).toMatch(/3 result/);
+  });
+
+  test("live region announces the QUERY-filtered count, not the unfiltered items length", () => {
+    // Reflects what cmdk shows the user. The previous shape announced
+    // the unfiltered count and stayed stuck at "3 results" while the
+    // visible list shrank to 1 on the user's keystroke.
+    render(
+      <SlashMenuPanel
+        items={items}
+        query="quote"
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("slash-menu-live-region").textContent).toMatch(
+      /1 result/,
+    );
+  });
+
+  test("live region updates when items array shrinks", () => {
+    const { rerender } = render(
+      <SlashMenuPanel
+        items={items}
+        query=""
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("slash-menu-live-region").textContent).toMatch(
+      /3 result/,
+    );
+    const [firstItem] = items;
+    if (!firstItem) throw new Error("expected at least one fixture item");
+    rerender(
+      <SlashMenuPanel
+        items={[firstItem]}
+        query="head"
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("slash-menu-live-region").textContent).toMatch(
+      /1 result/,
+    );
+  });
 });

--- a/packages/admin/src/editor/slash-menu/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/slash-menu/SlashMenuPanel.tsx
@@ -75,6 +75,21 @@ export const SlashMenuPanel = forwardRef<
     groups[0]?.members[0]?.value ?? "",
   );
 
+  // Mirror the same predicate cmdk uses (`value.includes(search)`)
+  // against the joined value the parent builds. Without this the SR
+  // announces `items.length` while cmdk's filter has already shrunk
+  // the visible list — defeats the live-region's purpose.
+  const visibleCount = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (needle === "") return items.length;
+    return groups.reduce(
+      (total, group) =>
+        total +
+        group.members.filter(({ value }) => value.includes(needle)).length,
+      0,
+    );
+  }, [groups, items.length, query]);
+
   // Scoping the key bridge to this panel's own root prevents cross-talk
   // when two editors (e.g., canvas + meta-box richtext field) are open
   // simultaneously — `document.querySelector` would have returned the
@@ -126,6 +141,14 @@ export const SlashMenuPanel = forwardRef<
         aria-hidden="true"
         tabIndex={-1}
       />
+      <div
+        data-testid="slash-menu-live-region"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {visibleCount} result{visibleCount === 1 ? "" : "s"}
+      </div>
       <CommandList>
         <CommandEmpty data-testid="slash-menu-empty">
           No blocks found

--- a/packages/admin/src/editor/unknown-block/HtmlBadgeNodeView.tsx
+++ b/packages/admin/src/editor/unknown-block/HtmlBadgeNodeView.tsx
@@ -12,6 +12,8 @@ export function HtmlBadgeNodeView({ node }: NodeViewProps): ReactElement {
     <NodeViewWrapper
       data-testid="html-block-editor"
       data-plumix-block="core/html"
+      role="region"
+      aria-label="Raw HTML block"
       className="my-2 rounded-md border border-amber-500/40 bg-amber-50/40 p-3"
     >
       <div

--- a/packages/admin/src/editor/unknown-block/UnknownBlockNodeView.tsx
+++ b/packages/admin/src/editor/unknown-block/UnknownBlockNodeView.tsx
@@ -17,6 +17,8 @@ export function UnknownBlockNodeView({ node }: NodeViewProps): ReactElement {
     <NodeViewWrapper
       data-testid="unknown-block"
       data-plumix-unknown-block={originalType}
+      role="region"
+      aria-label={`Unregistered block: ${originalType}`}
       className="border-muted-foreground/40 bg-muted/30 my-2 rounded-md border border-dashed p-3"
     >
       <div className="text-muted-foreground flex items-center gap-2 text-xs font-medium">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.5(vitest@4.1.5)
+      axe-core:
+        specifier: ^4.11.3
+        version: 4.11.3
       esbuild:
         specifier: 0.27.7
         version: 0.27.7


### PR DESCRIPTION
Tightens accessibility on the editor surfaces the block system landed in earlier slices:

- **Inspector** wraps the attributes list and the supports list in `<fieldset><legend>` so screen readers announce grouped headings; the duplicate `<h3>Supports</h3>` inside `<SupportsSection>` was dropped to avoid re-announcing the same label.
- **MarkToolbar** adds roving-focus ArrowLeft/ArrowRight navigation between buttons (wraps at the ends). Tab/Shift-Tab still escape to surrounding focusable elements. `aria-pressed` and per-button `aria-label` were already in place.
- **SlashMenuPanel** renders an `aria-live="polite" aria-atomic="true"` sr-only region that announces "N result(s)". The count mirrors cmdk's own filter predicate against the query, so screen-reader users hear the **actual visible count** when typing — not the unfiltered items length.
- **UnknownBlockNodeView + HtmlBadgeNodeView** declare `role="region"` + descriptive `aria-label` so assistive tech announces the out-of-band content the placeholders represent.

**Axe smoke harness**

Adds a vitest + axe-core helper (`runAxeSmokeTest`) running against jsdom DOM with `wcag2a + wcag2aa` rules; color-contrast disabled because jsdom has no real layout. Throws a named `AxeViolationError` factory on rule fires. Locks baseline a11y on `<Inspector>` and `<SlashMenuPanel>`.

**Deferred**

Mobile bottom-sheet Inspector and Playwright keyboard-only / screen-reader E2E flows from #314 are intentionally deferred to a separate slice — the issue body flagged the mobile UX as a HITL design decision (breakpoint, gesture model). This PR ships the parts of #314 that don't require a design pass.

Refs GH-314