### PR TITLE
feat(plugin-media): six media blocks — image, gallery, video, audio, file, embed

### DIFF
--- a/packages/plugins/media/package.json
+++ b/packages/plugins/media/package.json
@@ -56,6 +56,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.99.2",
+    "@tiptap/core": "^3.23.1",
     "plumix": "workspace:*",
     "react": "catalog:"
   },
@@ -68,6 +69,7 @@
     "@plumix/typescript-config": "workspace:*",
     "@plumix/vitest-config": "workspace:*",
     "@tanstack/react-query": "^5.99.2",
+    "@tiptap/core": "^3.23.1",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/packages/plugins/media/playground/tsconfig.json
+++ b/packages/plugins/media/playground/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "@plumix/typescript-config/base.json",
   "compilerOptions": {
+    // Media plugin source includes block Component `.tsx` files,
+    // resolved through the path alias below — TS needs JSX enabled
+    // to typecheck those.
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node", "@cloudflare/workers-types"],
     // Resolve the workspace packages directly from `src/` rather than
     // their built `dist/`. Otherwise the playground's typecheck

--- a/packages/plugins/media/src/blocks/audio/Component.tsx
+++ b/packages/plugins/media/src/blocks/audio/Component.tsx
@@ -1,0 +1,15 @@
+import type { BlockProps } from "plumix/blocks";
+import type { ReactElement } from "react";
+
+export function AudioComponent({ attrs }: BlockProps): ReactElement {
+  const src = typeof attrs.src === "string" ? attrs.src : "";
+  return (
+    <audio
+      data-plumix-block="media/audio"
+      src={src}
+      controls={attrs.controls !== false}
+      autoPlay={attrs.autoplay === true}
+      loop={attrs.loop === true}
+    />
+  );
+}

--- a/packages/plugins/media/src/blocks/audio/index.ts
+++ b/packages/plugins/media/src/blocks/audio/index.ts
@@ -1,0 +1,23 @@
+import { defineBlock } from "plumix/blocks";
+
+export const audioBlock = defineBlock({
+  name: "media/audio",
+  title: "Audio",
+  category: "media",
+  description: "HTML <audio> with browser controls.",
+  keywords: ["sound", "music", "podcast"],
+  attributes: {
+    mediaId: { type: "text", label: "Media id", default: "" },
+    src: { type: "url", label: "Source URL", default: "" },
+    controls: { type: "boolean", label: "Show controls", default: true },
+    autoplay: { type: "boolean", label: "Autoplay", default: false },
+    loop: { type: "boolean", label: "Loop", default: false },
+  },
+  supports: {
+    spacing: { padding: true, margin: true },
+    anchor: true,
+    customClassName: true,
+  },
+  schema: () => import("./schema.js").then((m) => m.audioSchema),
+  component: () => import("./Component.js").then((m) => m.AudioComponent),
+});

--- a/packages/plugins/media/src/blocks/audio/schema.ts
+++ b/packages/plugins/media/src/blocks/audio/schema.ts
@@ -1,0 +1,30 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const audioSchema = Node.create({
+  name: "media/audio",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      mediaId: { default: null },
+      src: { default: null },
+      controls: { default: true },
+      autoplay: { default: false },
+      loop: { default: false },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "audio[data-plumix-block='media/audio']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "audio",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "media/audio" }),
+    ];
+  },
+});

--- a/packages/plugins/media/src/blocks/embed/Component.tsx
+++ b/packages/plugins/media/src/blocks/embed/Component.tsx
@@ -1,0 +1,54 @@
+import type { BlockProps } from "plumix/blocks";
+import type { ReactElement } from "react";
+
+import { resolveOEmbed } from "./safelist.js";
+
+// Generic sandbox for non-safelist URLs. Deliberately omits
+// `allow-same-origin` — together with `allow-scripts` it lets the
+// iframe call `parent.document` if the URL is same-origin and lets it
+// rewrite its own sandbox via DOM mutation. For unknown third-party
+// hosts we keep the iframe in a fully sandboxed origin (`null`).
+const GENERIC_SANDBOX = "allow-scripts allow-presentation";
+
+export function EmbedComponent({ attrs }: BlockProps): ReactElement | null {
+  const url = typeof attrs.url === "string" ? attrs.url : "";
+  if (url.length === 0) return null;
+  const title =
+    typeof attrs.title === "string" ? attrs.title : "Embedded content";
+  const resolved = resolveOEmbed(url);
+  if (resolved) {
+    return (
+      <div
+        data-plumix-block="media/embed"
+        data-provider={resolved.provider}
+        data-loading="lazy"
+      >
+        <iframe
+          src={resolved.embedUrl}
+          title={title}
+          loading="lazy"
+          referrerPolicy="strict-origin-when-cross-origin"
+          {...(resolved.allow.length > 0 && { allow: resolved.allow })}
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+  // Non-safelist URL: fully sandboxed iframe so untrusted hosts can't
+  // escape via the `allow-scripts`+`allow-same-origin` footgun.
+  return (
+    <div
+      data-plumix-block="media/embed"
+      data-provider="generic"
+      data-loading="lazy"
+    >
+      <iframe
+        src={url}
+        title={title}
+        loading="lazy"
+        sandbox={GENERIC_SANDBOX}
+        referrerPolicy="strict-origin-when-cross-origin"
+      />
+    </div>
+  );
+}

--- a/packages/plugins/media/src/blocks/embed/embed.test.tsx
+++ b/packages/plugins/media/src/blocks/embed/embed.test.tsx
@@ -1,0 +1,166 @@
+import { mockRegistry, renderBlock } from "plumix/blocks/test";
+import { describe, expect, test } from "vitest";
+
+import { embedBlock } from "./index.js";
+import { resolveOEmbed } from "./safelist.js";
+
+describe("resolveOEmbed", () => {
+  test.each([
+    [
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "youtube",
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+    ],
+    [
+      "https://youtu.be/dQw4w9WgXcQ",
+      "youtube",
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+    ],
+    [
+      "https://vimeo.com/76979871",
+      "vimeo",
+      "https://player.vimeo.com/video/76979871",
+    ],
+    [
+      "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp",
+      "spotify",
+      "https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp",
+    ],
+    [
+      "https://codepen.io/withplumix/pen/abc123",
+      "codepen",
+      "https://codepen.io/withplumix/embed/abc123",
+    ],
+    [
+      "https://www.loom.com/share/abc123def",
+      "loom",
+      "https://www.loom.com/embed/abc123def",
+    ],
+  ])("recognises canonical share URL %s", (input, provider, embedUrl) => {
+    const result = resolveOEmbed(input);
+    expect(result?.provider).toBe(provider);
+    expect(result?.embedUrl).toBe(embedUrl);
+    // Every provider declares an `allow` (possibly empty for the
+    // ones that need zero Permissions-Policy features).
+    expect(typeof result?.allow).toBe("string");
+  });
+
+  test("rejects path-traversal in YouTube `v=` (id pattern blocks `../`)", () => {
+    expect(
+      resolveOEmbed("https://www.youtube.com/watch?v=../evil"),
+    ).toBeUndefined();
+  });
+
+  test("rejects path-traversal in Spotify/CodePen/Loom ids", () => {
+    expect(
+      resolveOEmbed("https://open.spotify.com/track/../bad"),
+    ).toBeUndefined();
+    expect(
+      resolveOEmbed("https://codepen.io/withplumix/pen/../escape"),
+    ).toBeUndefined();
+    expect(
+      resolveOEmbed("https://www.loom.com/share/../escape"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for an unrecognised host", () => {
+    expect(resolveOEmbed("https://example.com/video")).toBeUndefined();
+  });
+
+  test("rejects host look-alikes that prefix a safelist host", () => {
+    // CodeQL flagged this — `hostname.includes("player.vimeo.com")`
+    // would match `player.vimeo.com.evil.example`. The lookup uses
+    // exact hostname matching against the provider's `hosts` array,
+    // so the look-alike doesn't resolve to a safelist provider.
+    expect(
+      resolveOEmbed("https://player.vimeo.com.evil.example/76979871"),
+    ).toBeUndefined();
+    expect(
+      resolveOEmbed("https://youtu.be.evil.example/dQw4w9WgXcQ"),
+    ).toBeUndefined();
+  });
+
+  test("rejects non-http(s) protocols", () => {
+    expect(resolveOEmbed("javascript:alert(1)")).toBeUndefined();
+    expect(resolveOEmbed("file:///etc/passwd")).toBeUndefined();
+  });
+
+  test("returns undefined for a YouTube channel page (not embeddable)", () => {
+    expect(resolveOEmbed("https://www.youtube.com/@plumix")).toBeUndefined();
+  });
+});
+
+describe("media/embed Component", () => {
+  test("renders a safelist iframe with the provider-specific embed URL and minimal allow directive", async () => {
+    const registry = await mockRegistry({ core: [embedBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/embed",
+            attrs: { url: "https://youtu.be/dQw4w9WgXcQ" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-provider="youtube"');
+    expect(html).toContain('src="https://www.youtube.com/embed/dQw4w9WgXcQ"');
+    // YouTube allow set is minimal — no `clipboard-write`, `web-share`, etc.
+    expect(html).toContain(
+      'allow="autoplay; encrypted-media; picture-in-picture; fullscreen"',
+    );
+    // Safelist providers run without a sandbox (`null` origin would
+    // break the embed JS); the trust comes from the hostname allowlist.
+    expect(html).not.toContain("sandbox");
+  });
+
+  test("non-safelist URLs render through a sandboxed iframe WITHOUT allow-same-origin", async () => {
+    // `allow-scripts` + `allow-same-origin` is the spec-documented
+    // escape-the-sandbox combo for same-origin embeds. The generic
+    // fallback must omit `allow-same-origin` so unknown hosts stay
+    // in the `null` origin even if same-origin with the host site.
+    const registry = await mockRegistry({ core: [embedBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/embed",
+            attrs: { url: "https://example.com/widget" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-provider="generic"');
+    expect(html).toContain('src="https://example.com/widget"');
+    expect(html).toContain('sandbox="allow-scripts allow-presentation"');
+    expect(html).not.toContain("allow-same-origin");
+  });
+
+  test("renders no iframe when url attr is empty", async () => {
+    // The walker wraps client-bearing blocks in a data-plumix-island
+    // placeholder; that wrapper survives but its inner content is null
+    // — the public site sees an empty island that the bootstrap can
+    // populate when the editor later sets a url.
+    const registry = await mockRegistry({ core: [embedBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [{ type: "media/embed", attrs: { url: "" }, content: [] }],
+      },
+    });
+    expect(html).not.toContain("<iframe");
+  });
+
+  test("declares a client island for lazy loading", () => {
+    expect(embedBlock.client?.src).toBe(
+      "/_plumix/admin/assets/media-embed.client.js",
+    );
+  });
+});

--- a/packages/plugins/media/src/blocks/embed/index.ts
+++ b/packages/plugins/media/src/blocks/embed/index.ts
@@ -1,0 +1,28 @@
+import { defineBlock } from "plumix/blocks";
+
+import { embedParsePasteRules } from "./schema.js";
+
+export const embedBlock = defineBlock({
+  name: "media/embed",
+  title: "Embed",
+  category: "media",
+  description:
+    "oEmbed-style embed for YouTube, Vimeo, Twitter/X, Spotify, CodePen, Loom.",
+  keywords: ["video", "tweet", "iframe", "oembed"],
+  attributes: {
+    url: { type: "url", label: "Share URL", default: "" },
+    title: { type: "text", label: "Accessible title", default: "" },
+  },
+  supports: {
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
+  parsePaste: embedParsePasteRules,
+  client: {
+    src: "/_plumix/admin/assets/media-embed.client.js",
+  },
+  schema: () => import("./schema.js").then((m) => m.embedSchema),
+  component: () => import("./Component.js").then((m) => m.EmbedComponent),
+});

--- a/packages/plugins/media/src/blocks/embed/safelist.ts
+++ b/packages/plugins/media/src/blocks/embed/safelist.ts
@@ -1,0 +1,163 @@
+/**
+ * oEmbed safelist for `media/embed`. Each provider maps a recognised
+ * share URL into the embeddable iframe URL the public site renders.
+ *
+ * Each provider exposes:
+ *   - `name`: stable id used as `data-provider` and in the embed attr
+ *   - `hosts`: hostnames the provider canonically serves on
+ *   - `toEmbed(url)`: pure URL → iframe-URL; returns `undefined` for
+ *     URLs that match the host but aren't embeddable (e.g. a YouTube
+ *     channel page rather than a watch URL).
+ *   - `allow`: minimal Permissions Policy directive list the embed
+ *     genuinely needs. Avoids handing every provider the union of
+ *     dangerous permissions — `clipboard-write`, for instance, only
+ *     belongs on providers that pop a copy-link UI.
+ *
+ * Non-safelist URLs fall through to the strict-sandbox iframe path
+ * in `EmbedComponent`. Adding a new provider here is the only step
+ * required to support it — no schema change needed.
+ */
+
+interface OEmbedProvider {
+  readonly name: string;
+  readonly hosts: readonly string[];
+  readonly allow: string;
+  toEmbed(url: URL): string | undefined;
+}
+
+// Path-regex provider: match `url.pathname` against `pattern` and feed
+// the capture groups into `build`. Each builder validates its capture
+// against an id-pattern so a normalisation oddity (path traversal,
+// arbitrary characters) can't leak into the constructed embed URL.
+function pathRewrite(
+  pattern: RegExp,
+  build: (groups: readonly string[]) => string | undefined,
+): (url: URL) => string | undefined {
+  return (url) => {
+    const match = pattern.exec(url.pathname);
+    return match ? build(match.slice(1)) : undefined;
+  };
+}
+
+// Common id shape — alphanumerics + `_` + `-`. Strict enough to block
+// path-traversal (`../`) and URL-component characters that would let
+// a hostile share URL rewrite the host or path of the embed iframe.
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+function validId(raw: string | undefined): string | undefined {
+  return raw && ID_PATTERN.test(raw) ? raw : undefined;
+}
+
+export const OEMBED_PROVIDERS: readonly OEmbedProvider[] = [
+  {
+    name: "youtube",
+    hosts: ["youtube.com", "www.youtube.com", "youtu.be"],
+    allow: "autoplay; encrypted-media; picture-in-picture; fullscreen",
+    toEmbed(url) {
+      if (url.hostname === "youtu.be") {
+        const id = validId(url.pathname.replace(/^\//, "").split("/")[0]);
+        return id ? `https://www.youtube.com/embed/${id}` : undefined;
+      }
+      if (url.pathname === "/watch") {
+        const id = validId(url.searchParams.get("v") ?? undefined);
+        return id ? `https://www.youtube.com/embed/${id}` : undefined;
+      }
+      const shorts = /^\/shorts\/([^/]+)/.exec(url.pathname);
+      const id = validId(shorts?.[1]);
+      return id ? `https://www.youtube.com/embed/${id}` : undefined;
+    },
+  },
+  {
+    name: "vimeo",
+    hosts: ["vimeo.com", "www.vimeo.com", "player.vimeo.com"],
+    allow: "autoplay; encrypted-media; picture-in-picture; fullscreen",
+    toEmbed(url) {
+      // Already-embed URLs pass through. Exact-match on the hostname
+      // rejects look-alikes like `player.vimeo.com.evil.example`.
+      if (url.hostname === "player.vimeo.com") return url.toString();
+      const raw = url.pathname.replace(/^\//, "").split("/")[0] ?? "";
+      return /^\d{1,16}$/.test(raw)
+        ? `https://player.vimeo.com/video/${raw}`
+        : undefined;
+    },
+  },
+  {
+    name: "twitter",
+    hosts: ["twitter.com", "www.twitter.com", "x.com", "www.x.com"],
+    allow: "",
+    // Twitter / X embed via publish.twitter.com — the canonical
+    // share URL is the embed identifier.
+    toEmbed: (url) =>
+      /\/status\/\d{1,32}$/.test(url.pathname)
+        ? `https://platform.twitter.com/embed/Tweet.html?url=${encodeURIComponent(url.toString())}`
+        : undefined,
+  },
+  {
+    name: "spotify",
+    hosts: ["open.spotify.com"],
+    allow: "encrypted-media",
+    // /track/ID, /album/ID, /playlist/ID, /episode/ID, /show/ID
+    toEmbed: pathRewrite(
+      /^\/(track|album|playlist|episode|show)\/([^/]+)/,
+      ([kind, raw]) => {
+        const id = validId(raw);
+        return id && kind
+          ? `https://open.spotify.com/embed/${kind}/${id}`
+          : undefined;
+      },
+    ),
+  },
+  {
+    name: "codepen",
+    hosts: ["codepen.io"],
+    // CodePen runs untrusted user JS — keep it sandboxed by allowing
+    // nothing beyond the iframe's own scripts.
+    allow: "",
+    toEmbed: pathRewrite(/^\/([^/]+)\/pen\/([^/]+)/, ([user, raw]) => {
+      const userId = validId(user);
+      const penId = validId(raw);
+      return userId && penId
+        ? `https://codepen.io/${userId}/embed/${penId}`
+        : undefined;
+    }),
+  },
+  {
+    name: "loom",
+    hosts: ["loom.com", "www.loom.com"],
+    allow: "fullscreen; picture-in-picture",
+    toEmbed: pathRewrite(/^\/share\/([^/]+)/, ([raw]) => {
+      const id = validId(raw);
+      return id ? `https://www.loom.com/embed/${id}` : undefined;
+    }),
+  },
+];
+
+/**
+ * Resolve a share URL through the safelist. Returns the provider name,
+ * the iframe URL, and the provider's Permissions-Policy `allow`
+ * directive list when matched; `undefined` falls through to the
+ * generic strict-sandbox iframe path.
+ */
+export function resolveOEmbed(raw: string):
+  | {
+      provider: string;
+      embedUrl: string;
+      allow: string;
+    }
+  | undefined {
+  if (typeof raw !== "string") return undefined;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
+  const provider = OEMBED_PROVIDERS.find((p) =>
+    p.hosts.includes(url.hostname.toLowerCase()),
+  );
+  if (!provider) return undefined;
+  const embedUrl = provider.toEmbed(url);
+  return embedUrl
+    ? { provider: provider.name, embedUrl, allow: provider.allow }
+    : undefined;
+}

--- a/packages/plugins/media/src/blocks/embed/schema.ts
+++ b/packages/plugins/media/src/blocks/embed/schema.ts
@@ -1,0 +1,49 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+import { OEMBED_PROVIDERS, resolveOEmbed } from "./safelist.js";
+
+export const embedSchema = Node.create({
+  name: "media/embed",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      url: { default: "" },
+      title: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[data-plumix-block='media/embed']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "media/embed" }),
+    ];
+  },
+});
+
+/**
+ * `parsePaste` rules so the editor recognises share URLs and converts
+ * them into `media/embed` blocks. The rule's `fromHTML` maps the
+ * `<a>` href to the block's `url` attr; the Component does the
+ * provider-specific URL → iframe-URL mapping at render time.
+ */
+export const embedParsePasteRules = OEMBED_PROVIDERS.flatMap((provider) =>
+  provider.hosts.map((host) => ({
+    selector: `a[href*='${host}']`,
+    fromHTML(
+      element: HTMLElement,
+    ): Readonly<Record<string, unknown>> | undefined {
+      const href = element.getAttribute("href") ?? "";
+      const match = resolveOEmbed(href);
+      if (!match) return undefined;
+      return { url: href };
+    },
+  })),
+);

--- a/packages/plugins/media/src/blocks/file/Component.tsx
+++ b/packages/plugins/media/src/blocks/file/Component.tsx
@@ -1,0 +1,54 @@
+import type { BlockProps } from "plumix/blocks";
+import type { ReactElement } from "react";
+
+// Accepts http(s), root-relative, parent-relative, mailto:, and tel:.
+// File blocks legitimately link to contact addresses for "email me
+// the pdf" flows. Other schemes (javascript:, data:, vbscript:) are
+// silently stripped so a hostile href never reaches the rendered `<a>`.
+const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|\.\.?\/)/i;
+
+function sanitizeHref(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "" || !SAFE_HREF.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+function formatSize(bytes: unknown): string | undefined {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) {
+    return undefined;
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  let size = bytes;
+  let i = 0;
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024;
+    i += 1;
+  }
+  return `${size.toFixed(size >= 100 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+export function FileComponent({ attrs }: BlockProps): ReactElement {
+  const href = sanitizeHref(attrs.href);
+  const filename =
+    typeof attrs.filename === "string" && attrs.filename.length > 0
+      ? attrs.filename
+      : "Download";
+  const sizeLabel = formatSize(attrs.size);
+  const mime = typeof attrs.mime === "string" ? attrs.mime : "";
+  return (
+    <a
+      data-plumix-block="media/file"
+      href={href}
+      download={filename}
+      rel="noopener noreferrer"
+    >
+      <span data-plumix-file-name="">{filename}</span>
+      {sizeLabel || mime.length > 0 ? (
+        <span data-plumix-file-meta="">
+          {[sizeLabel, mime].filter(Boolean).join(" · ")}
+        </span>
+      ) : null}
+    </a>
+  );
+}

--- a/packages/plugins/media/src/blocks/file/file.test.tsx
+++ b/packages/plugins/media/src/blocks/file/file.test.tsx
@@ -1,0 +1,76 @@
+import { mockRegistry, renderBlock } from "plumix/blocks/test";
+import { describe, expect, test } from "vitest";
+
+import { fileBlock } from "./index.js";
+
+describe("media/file", () => {
+  test("renders as download anchor with filename + size + mime label", async () => {
+    const registry = await mockRegistry({ core: [fileBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/file",
+            attrs: {
+              href: "/_plumix/media/abc/report.pdf",
+              filename: "report.pdf",
+              size: 2_048_576,
+              mime: "application/pdf",
+            },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-plumix-block="media/file"');
+    expect(html).toContain('href="/_plumix/media/abc/report.pdf"');
+    expect(html).toContain('download="report.pdf"');
+    expect(html).toContain("report.pdf");
+    expect(html).toContain("2.0 MB");
+    expect(html).toContain("application/pdf");
+  });
+
+  test("accepts mailto: and tel: hrefs (contact-card flows)", async () => {
+    const registry = await mockRegistry({ core: [fileBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/file",
+            attrs: { href: "mailto:author@example.com", filename: "Contact" },
+            content: [],
+          },
+          {
+            type: "media/file",
+            attrs: { href: "tel:+15551234", filename: "Phone" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('href="mailto:author@example.com"');
+    expect(html).toContain('href="tel:+15551234"');
+  });
+
+  test("strips dangerous hrefs (javascript:) rather than leaking them", async () => {
+    const registry = await mockRegistry({ core: [fileBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/file",
+            attrs: { href: "javascript:alert(1)", filename: "x" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("javascript:");
+  });
+});

--- a/packages/plugins/media/src/blocks/file/index.ts
+++ b/packages/plugins/media/src/blocks/file/index.ts
@@ -1,0 +1,26 @@
+import { defineBlock } from "plumix/blocks";
+
+export const fileBlock = defineBlock({
+  name: "media/file",
+  title: "File",
+  category: "media",
+  description: "Downloadable file with size + MIME label.",
+  keywords: ["download", "attachment"],
+  attributes: {
+    mediaId: { type: "text", label: "Media id", default: "" },
+    href: { type: "url", label: "Download URL", default: "" },
+    filename: { type: "text", label: "Filename", default: "" },
+    size: { type: "number", label: "Size (bytes)", default: 0 },
+    mime: { type: "text", label: "MIME type", default: "" },
+    thumbnail: { type: "url", label: "Preview thumbnail URL", default: "" },
+  },
+  supports: {
+    color: { background: true },
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
+  schema: () => import("./schema.js").then((m) => m.fileSchema),
+  component: () => import("./Component.js").then((m) => m.FileComponent),
+});

--- a/packages/plugins/media/src/blocks/file/schema.ts
+++ b/packages/plugins/media/src/blocks/file/schema.ts
@@ -1,0 +1,31 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const fileSchema = Node.create({
+  name: "media/file",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      mediaId: { default: null },
+      href: { default: null },
+      filename: { default: "" },
+      size: { default: null },
+      mime: { default: "" },
+      thumbnail: { default: null },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "a[data-plumix-block='media/file']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "a",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "media/file" }),
+    ];
+  },
+});

--- a/packages/plugins/media/src/blocks/gallery/Component.tsx
+++ b/packages/plugins/media/src/blocks/gallery/Component.tsx
@@ -1,0 +1,43 @@
+import type { BlockProps } from "plumix/blocks";
+import type { ReactElement } from "react";
+
+function clampColumns(raw: unknown): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return 3;
+  const truncated = Math.trunc(raw);
+  if (truncated < 1) return 1;
+  if (truncated > 8) return 8;
+  return truncated;
+}
+
+function pickAspect(raw: unknown): string | undefined {
+  // Accepts `n:m` ratio or `auto`. Mirrors the columns ratio regex.
+  if (raw === "auto") return "auto";
+  return typeof raw === "string" && /^[1-9]\d*:[1-9]\d*$/.test(raw)
+    ? raw
+    : undefined;
+}
+
+function normalizeGap(raw: unknown): string | undefined {
+  if (typeof raw === "string" && raw.length > 0) return raw;
+  if (typeof raw === "number" && Number.isFinite(raw)) return `${raw}px`;
+  return undefined;
+}
+
+export function GalleryComponent({
+  attrs,
+  children,
+}: BlockProps): ReactElement {
+  const columns = clampColumns(attrs.columns);
+  const aspect = pickAspect(attrs.aspect);
+  const gap = normalizeGap(attrs.gap);
+  return (
+    <div
+      data-plumix-block="media/gallery"
+      data-columns={columns}
+      data-aspect={aspect}
+      data-gap={gap}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/plugins/media/src/blocks/gallery/gallery.test.tsx
+++ b/packages/plugins/media/src/blocks/gallery/gallery.test.tsx
@@ -1,0 +1,69 @@
+import { mockRegistry, renderBlock } from "plumix/blocks/test";
+import { describe, expect, test } from "vitest";
+
+import { imageBlock } from "../image/index.js";
+import { galleryBlock } from "./index.js";
+
+describe("media/gallery", () => {
+  test("renders a div wrapping image children with data-columns/data-aspect/data-gap", async () => {
+    const registry = await mockRegistry({ core: [galleryBlock, imageBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/gallery",
+            attrs: { columns: 4, aspect: "16:9", gap: "1rem" },
+            content: [
+              { type: "media/image", attrs: { src: "/a.jpg", alt: "" } },
+              { type: "media/image", attrs: { src: "/b.jpg", alt: "" } },
+            ],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-plumix-block="media/gallery"');
+    expect(html).toContain('data-columns="4"');
+    expect(html).toContain('data-aspect="16:9"');
+    expect(html).toContain('data-gap="1rem"');
+    // Children: two img tags.
+    expect(html.match(/<img/g)?.length).toBe(2);
+  });
+
+  test("clamps columns into [1, 8]", async () => {
+    const registry = await mockRegistry({ core: [galleryBlock, imageBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/gallery",
+            attrs: { columns: 99 },
+            content: [{ type: "media/image", attrs: { src: "/a.jpg" } }],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-columns="8"');
+  });
+
+  test("ignores malformed aspect strings rather than leaking them", async () => {
+    const registry = await mockRegistry({ core: [galleryBlock, imageBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/gallery",
+            attrs: { aspect: "lol" },
+            content: [{ type: "media/image", attrs: { src: "/a.jpg" } }],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("data-aspect");
+  });
+});

--- a/packages/plugins/media/src/blocks/gallery/index.ts
+++ b/packages/plugins/media/src/blocks/gallery/index.ts
@@ -1,0 +1,46 @@
+import { defineBlock } from "plumix/blocks";
+
+const COLUMN_OPTIONS = [
+  { value: 2, label: "2 columns" },
+  { value: 3, label: "3 columns" },
+  { value: 4, label: "4 columns" },
+  { value: 6, label: "6 columns" },
+] as const;
+
+const ASPECT_OPTIONS = [
+  { value: "1:1", label: "Square" },
+  { value: "4:3", label: "4:3" },
+  { value: "3:2", label: "3:2" },
+  { value: "16:9", label: "16:9" },
+  { value: "auto", label: "Auto (image-native)" },
+] as const;
+
+export const galleryBlock = defineBlock({
+  name: "media/gallery",
+  title: "Gallery",
+  category: "media",
+  description: "Grid of images with explicit column count and aspect ratio.",
+  keywords: ["images", "grid", "photos"],
+  attributes: {
+    columns: {
+      type: "select",
+      label: "Columns",
+      default: 3,
+      options: COLUMN_OPTIONS,
+    },
+    aspect: {
+      type: "select",
+      label: "Aspect ratio",
+      default: "1:1",
+      options: ASPECT_OPTIONS,
+    },
+    gap: { type: "text", label: "Gap", default: "0.5rem" },
+  },
+  supports: {
+    spacing: { padding: true, margin: true },
+    anchor: true,
+    customClassName: true,
+  },
+  schema: () => import("./schema.js").then((m) => m.gallerySchema),
+  component: () => import("./Component.js").then((m) => m.GalleryComponent),
+});

--- a/packages/plugins/media/src/blocks/gallery/schema.ts
+++ b/packages/plugins/media/src/blocks/gallery/schema.ts
@@ -1,0 +1,32 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const gallerySchema = Node.create({
+  name: "media/gallery",
+  group: "block",
+  // Children restricted to `media/image` at the schema level — the
+  // Inspector's "add image" affordance is the only way authors compose
+  // a gallery, and pasted content from other rich-text sources can't
+  // smuggle non-image siblings into a gallery container.
+  content: "mediaImage+",
+  defining: true,
+
+  addAttributes() {
+    return {
+      columns: { default: 3 },
+      gap: { default: "0.5rem" },
+      aspect: { default: "1:1" },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[data-plumix-block='media/gallery']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "media/gallery" }),
+      0,
+    ];
+  },
+});

--- a/packages/plugins/media/src/blocks/image/Component.tsx
+++ b/packages/plugins/media/src/blocks/image/Component.tsx
@@ -1,0 +1,76 @@
+import type { BlockProps } from "plumix/blocks";
+import type { ReactElement } from "react";
+
+interface FocalPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+function normalizeFocalPoint(raw: unknown): FocalPoint | undefined {
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const { x, y } = raw as { x?: unknown; y?: unknown };
+  if (
+    typeof x !== "number" ||
+    typeof y !== "number" ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y)
+  ) {
+    return undefined;
+  }
+  return { x: clamp01(x), y: clamp01(y) };
+}
+
+function clamp01(n: number): number {
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+const SIZING = ["full", "wide", "narrow", "thumbnail"] as const;
+
+function pickSizing(raw: unknown): (typeof SIZING)[number] | undefined {
+  return typeof raw === "string" && (SIZING as readonly string[]).includes(raw)
+    ? (raw as (typeof SIZING)[number])
+    : undefined;
+}
+
+/**
+ * `media/image` frontend Component.
+ *
+ * Emits `<figure><img><figcaption?></figure>`. The `src` is resolved by
+ * the caller via the existing media serve route; `srcset` is left to
+ * a theme wrapper or the image-delivery integration to override
+ * (themes can replace this Component entirely via `defineTheme`).
+ *
+ * Focal point is encoded as `object-position: <x*100>% <y*100>%`
+ * inline style so cropped variants align around the author-picked
+ * focus.
+ */
+export function ImageComponent({ attrs }: BlockProps): ReactElement {
+  const src = typeof attrs.src === "string" ? attrs.src : "";
+  const alt = typeof attrs.alt === "string" ? attrs.alt : "";
+  const caption = typeof attrs.caption === "string" ? attrs.caption : "";
+  const srcset = typeof attrs.srcset === "string" ? attrs.srcset : undefined;
+  const sizing = pickSizing(attrs.sizing);
+  const focal = normalizeFocalPoint(attrs.focalPoint);
+  const objectPosition = focal
+    ? `${(focal.x * 100).toFixed(0)}% ${(focal.y * 100).toFixed(0)}%`
+    : undefined;
+  return (
+    <figure
+      data-plumix-block="media/image"
+      data-sizing={sizing}
+      data-loading="lazy"
+    >
+      <img
+        src={src}
+        srcSet={srcset}
+        alt={alt}
+        loading="lazy"
+        decoding="async"
+        {...(objectPosition && { style: { objectPosition } })}
+      />
+      {caption.length > 0 ? <figcaption>{caption}</figcaption> : null}
+    </figure>
+  );
+}

--- a/packages/plugins/media/src/blocks/image/image.test.tsx
+++ b/packages/plugins/media/src/blocks/image/image.test.tsx
@@ -1,0 +1,87 @@
+import { mockRegistry, renderBlock } from "plumix/blocks/test";
+import { describe, expect, test } from "vitest";
+
+import { imageBlock } from "./index.js";
+
+describe("media/image", () => {
+  test("renders <figure><img alt><figcaption /> with the supplied attrs", async () => {
+    const registry = await mockRegistry({ core: [imageBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/image",
+            attrs: {
+              src: "/_plumix/media/abc/cover.jpg",
+              alt: "Cover photo",
+              caption: "Photo by Ada",
+            },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-plumix-block="media/image"');
+    expect(html).toContain('alt="Cover photo"');
+    expect(html).toContain('src="/_plumix/media/abc/cover.jpg"');
+    expect(html).toContain("<figcaption>Photo by Ada</figcaption>");
+  });
+
+  test("omits the figcaption when caption is empty", async () => {
+    const registry = await mockRegistry({ core: [imageBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/image",
+            attrs: { src: "/x.jpg", alt: "" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("figcaption");
+  });
+
+  test("encodes focalPoint into object-position inline style", async () => {
+    const registry = await mockRegistry({ core: [imageBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/image",
+            attrs: {
+              src: "/x.jpg",
+              alt: "x",
+              focalPoint: { x: 0.25, y: 0.75 },
+            },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain("object-position");
+    expect(html).toContain("25% 75%");
+  });
+
+  test("declares a client island module so the SSR shell emits a bootstrap", () => {
+    expect(imageBlock.client?.src).toBe(
+      "/_plumix/admin/assets/media-image.client.js",
+    );
+  });
+
+  test("declares supports for spacing/border/anchor/customClassName", () => {
+    expect(imageBlock.supports).toMatchObject({
+      spacing: { padding: true, margin: true },
+      border: { radius: true },
+      anchor: true,
+      customClassName: true,
+    });
+  });
+});

--- a/packages/plugins/media/src/blocks/image/index.ts
+++ b/packages/plugins/media/src/blocks/image/index.ts
@@ -1,0 +1,48 @@
+import { defineBlock } from "plumix/blocks";
+
+const SIZING_OPTIONS = [
+  { value: "full", label: "Full width" },
+  { value: "wide", label: "Wide" },
+  { value: "narrow", label: "Narrow" },
+  { value: "thumbnail", label: "Thumbnail" },
+] as const;
+
+export const imageBlock = defineBlock({
+  name: "media/image",
+  title: "Image",
+  category: "media",
+  description: "Image with alt text, caption, and focal-point cropping.",
+  keywords: ["picture", "photo", "media"],
+  attributes: {
+    mediaId: { type: "text", label: "Media id", default: "" },
+    src: { type: "url", label: "Source URL", default: "" },
+    srcset: { type: "text", label: "Source set", default: "" },
+    alt: { type: "text", label: "Alternative text", default: "" },
+    caption: { type: "text", label: "Caption", default: "" },
+    sizing: {
+      type: "select",
+      label: "Sizing",
+      default: "full",
+      options: SIZING_OPTIONS,
+    },
+    // focalPoint is a structured `{ x, y }` slot edited via the
+    // NodeView's focal-point picker; the Inspector doesn't render a
+    // direct control for it.
+    focalPoint: {
+      type: "json",
+      label: "Focal point",
+      default: { x: 0.5, y: 0.5 },
+    },
+  },
+  supports: {
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
+  client: {
+    src: "/_plumix/admin/assets/media-image.client.js",
+  },
+  schema: () => import("./schema.js").then((m) => m.imageSchema),
+  component: () => import("./Component.js").then((m) => m.ImageComponent),
+});

--- a/packages/plugins/media/src/blocks/image/schema.ts
+++ b/packages/plugins/media/src/blocks/image/schema.ts
@@ -1,0 +1,35 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const imageSchema = Node.create({
+  name: "media/image",
+  group: "block mediaImage",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      // The media-row id this block references. The serve-route
+      // resolves the id to a URL at SSR time; storing the id keeps
+      // content portable across deploys / R2 buckets.
+      mediaId: { default: null },
+      src: { default: null },
+      srcset: { default: null },
+      alt: { default: "" },
+      caption: { default: "" },
+      sizing: { default: "full" },
+      focalPoint: { default: { x: 0.5, y: 0.5 } },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "figure[data-plumix-block='media/image']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "figure",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "media/image" }),
+    ];
+  },
+});

--- a/packages/plugins/media/src/blocks/video-audio.test.tsx
+++ b/packages/plugins/media/src/blocks/video-audio.test.tsx
@@ -1,0 +1,80 @@
+import { mockRegistry, renderBlock } from "plumix/blocks/test";
+import { describe, expect, test } from "vitest";
+
+import { audioBlock } from "./audio/index.js";
+import { videoBlock } from "./video/index.js";
+
+describe("media/video", () => {
+  test("renders <video> with src + controls", async () => {
+    const registry = await mockRegistry({ core: [videoBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/video",
+            attrs: { src: "/clip.mp4" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-plumix-block="media/video"');
+    expect(html).toContain('src="/clip.mp4"');
+    expect(html).toContain("controls");
+  });
+
+  test("autoplay + loop + muted + poster attributes round-trip", async () => {
+    const registry = await mockRegistry({ core: [videoBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/video",
+            attrs: {
+              src: "/clip.mp4",
+              poster: "/cover.jpg",
+              autoplay: true,
+              loop: true,
+              muted: true,
+            },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('poster="/cover.jpg"');
+    // React's SSR preserves camelCase here even though the browser
+    // normalises the attributes to lowercase at the DOM level. We
+    // check the HTML stream — they round-trip to the real <video>
+    // attributes on the client side.
+    expect(html).toContain("autoPlay");
+    expect(html).toContain("loop");
+    expect(html).toContain("muted");
+  });
+});
+
+describe("media/audio", () => {
+  test("renders <audio> with src + controls", async () => {
+    const registry = await mockRegistry({ core: [audioBlock] });
+    const html = renderBlock({
+      registry,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "media/audio",
+            attrs: { src: "/song.mp3" },
+            content: [],
+          },
+        ],
+      },
+    });
+    expect(html).toContain('data-plumix-block="media/audio"');
+    expect(html).toContain('src="/song.mp3"');
+    expect(html).toContain("controls");
+  });
+});

--- a/packages/plugins/media/src/blocks/video/Component.tsx
+++ b/packages/plugins/media/src/blocks/video/Component.tsx
@@ -1,0 +1,22 @@
+import type { BlockProps } from "plumix/blocks";
+import type { ReactElement } from "react";
+
+export function VideoComponent({ attrs }: BlockProps): ReactElement {
+  const src = typeof attrs.src === "string" ? attrs.src : "";
+  const poster =
+    typeof attrs.poster === "string" && attrs.poster.length > 0
+      ? attrs.poster
+      : undefined;
+  return (
+    <video
+      data-plumix-block="media/video"
+      src={src}
+      poster={poster}
+      controls={attrs.controls !== false}
+      autoPlay={attrs.autoplay === true}
+      loop={attrs.loop === true}
+      muted={attrs.muted === true}
+      playsInline={attrs.playsinline !== false}
+    />
+  );
+}

--- a/packages/plugins/media/src/blocks/video/index.ts
+++ b/packages/plugins/media/src/blocks/video/index.ts
@@ -1,0 +1,31 @@
+import { defineBlock } from "plumix/blocks";
+
+export const videoBlock = defineBlock({
+  name: "media/video",
+  title: "Video",
+  category: "media",
+  description: "HTML <video> with browser controls.",
+  keywords: ["movie", "clip", "media"],
+  attributes: {
+    mediaId: { type: "text", label: "Media id", default: "" },
+    src: { type: "url", label: "Source URL", default: "" },
+    poster: { type: "url", label: "Poster image URL", default: "" },
+    controls: { type: "boolean", label: "Show controls", default: true },
+    autoplay: { type: "boolean", label: "Autoplay", default: false },
+    loop: { type: "boolean", label: "Loop", default: false },
+    muted: { type: "boolean", label: "Muted", default: false },
+    playsinline: {
+      type: "boolean",
+      label: "Plays inline (iOS)",
+      default: true,
+    },
+  },
+  supports: {
+    spacing: { padding: true, margin: true },
+    border: { radius: true },
+    anchor: true,
+    customClassName: true,
+  },
+  schema: () => import("./schema.js").then((m) => m.videoSchema),
+  component: () => import("./Component.js").then((m) => m.VideoComponent),
+});

--- a/packages/plugins/media/src/blocks/video/schema.ts
+++ b/packages/plugins/media/src/blocks/video/schema.ts
@@ -1,0 +1,33 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const videoSchema = Node.create({
+  name: "media/video",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      mediaId: { default: null },
+      src: { default: null },
+      poster: { default: null },
+      controls: { default: true },
+      autoplay: { default: false },
+      loop: { default: false },
+      muted: { default: false },
+      playsinline: { default: true },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "video[data-plumix-block='media/video']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "video",
+      mergeAttributes(HTMLAttributes, { "data-plumix-block": "media/video" }),
+    ];
+  },
+});

--- a/packages/plugins/media/src/index.test.ts
+++ b/packages/plugins/media/src/index.test.ts
@@ -9,6 +9,34 @@ async function install() {
 }
 
 describe("@plumix/plugin-media — registration", () => {
+  test("contributes six media/* block specs", async () => {
+    const { registry } = await install();
+    const blockNames = Array.from(registry.blockSpecs.keys()).sort();
+    expect(blockNames).toEqual([
+      "media/audio",
+      "media/embed",
+      "media/file",
+      "media/gallery",
+      "media/image",
+      "media/video",
+    ]);
+  });
+
+  test("each media block is attributed to the media plugin", async () => {
+    const { registry } = await install();
+    for (const name of [
+      "media/image",
+      "media/gallery",
+      "media/video",
+      "media/audio",
+      "media/file",
+      "media/embed",
+    ]) {
+      const entry = registry.blockSpecs.get(name);
+      expect(entry?.registeredBy).toBe("media");
+    }
+  });
+
   test("registers the media entry type with attribution", async () => {
     const { registry } = await install();
     const m = registry.entryTypes.get("media");

--- a/packages/plugins/media/src/index.ts
+++ b/packages/plugins/media/src/index.ts
@@ -1,6 +1,12 @@
 import type { PluginDescriptor } from "plumix/plugin";
 import { definePlugin } from "plumix/plugin";
 
+import { audioBlock } from "./blocks/audio/index.js";
+import { embedBlock } from "./blocks/embed/index.js";
+import { fileBlock } from "./blocks/file/index.js";
+import { galleryBlock } from "./blocks/gallery/index.js";
+import { imageBlock } from "./blocks/image/index.js";
+import { videoBlock } from "./blocks/video/index.js";
 import { mediaLookupAdapter } from "./lookup.js";
 import { DEFAULT_ACCEPTED_TYPES } from "./mime.js";
 import { createMediaRouter } from "./rpc.js";
@@ -87,6 +93,15 @@ export function media(
   return definePlugin(
     "media",
     (ctx) => {
+      // Six media blocks contributed under the `media/` namespace.
+      // Order is just for readability; the registry is keyed by name.
+      ctx.registerBlock(imageBlock);
+      ctx.registerBlock(galleryBlock);
+      ctx.registerBlock(videoBlock);
+      ctx.registerBlock(audioBlock);
+      ctx.registerBlock(fileBlock);
+      ctx.registerBlock(embedBlock);
+
       ctx.registerEntryType("media", {
         label: "Media",
         labels: { singular: "Asset", plural: "Media" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,6 +746,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.99.2
         version: 5.99.2(react@19.2.6)
+      '@tiptap/core':
+        specifier: ^3.23.1
+        version: 3.23.1(@tiptap/pm@3.23.1)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2


### PR DESCRIPTION
Ships the full media block set to `@plumix/plugin-media`. Six new blocks each with Tiptap schema, frontend Component, attribute schema for the Inspector, supports declarations, and the plugin's `setup(ctx)` calling `ctx.registerBlock(...)` for each.

- **`media/image`** — `<figure><img loading=lazy decoding=async><figcaption?>` with focal-point encoded as `object-position`. Atom node; mediaId/src/srcset/alt/caption/sizing/focalPoint attrs. Declares a client island for lazy-load.
- **`media/gallery`** — grid over `media/image` children. Children restricted to `media/image` at the schema level (`content: "mediaImage+"`). Columns clamped to [1, 8].
- **`media/video` + `media/audio`** — native `<video>` / `<audio>` with browser controls; autoplay / loop / muted / playsinline / poster.
- **`media/file`** — download card with size + MIME label. SAFE_HREF allowlist covers http(s), root/parent-relative, **`mailto:`, `tel:`** (contact-card flows). `rel="noopener noreferrer"`.
- **`media/embed`** — oEmbed safelist for YouTube / Vimeo / Twitter+X / Spotify / CodePen / Loom. Each provider has:
  - A strict id regex (`[A-Za-z0-9_-]{1,64}`) — path-traversal can't smuggle into the embed URL.
  - A **per-provider** `allow` Permissions-Policy directive list. YouTube gets `autoplay; encrypted-media; picture-in-picture; fullscreen`; CodePen gets nothing; replacing the previous union-of-permissions blanket allow.
  - A `parsePaste` rule so authors pasting a share URL get a `media/embed` block automatically.

**Sandbox hardening (senpai-flagged HIGH)**

Non-safelist URLs render with sandbox `allow-scripts allow-presentation` — critically **without** `allow-same-origin`. The `allow-scripts` + `allow-same-origin` combination is the spec-documented escape-the-sandbox footgun whenever the embed URL is same-origin with the host site; dropping `allow-same-origin` keeps unknown hosts in the `null` origin.

Refs GH-313