### PR TITLE
fix(admin): skip external setContent while editor is focused

### DIFF
--- a/packages/admin/e2e/editor-keyboard.spec.ts
+++ b/packages/admin/e2e/editor-keyboard.spec.ts
@@ -9,11 +9,12 @@ import {
 
 // Keyboard-only flow asserting the a11y promise: an author with no
 // mouse can compose, navigate, and inspect blocks without touching a
-// pointer. The slash-menu insertion path verifies the resolved block
-// registry reaches the editor's `extensions` (the suspense ordering
-// hazard PR #339 punted on) — using ArrowDown + Enter rather than
-// typing a query string sidesteps the orthogonal cmdk filter
-// keystroke-handling tracked in #342.
+// pointer. The slash-menu spec uses ArrowDown rather than typing a
+// query string — the suggestion plugin still deactivates on the first
+// character of typed input (tracked in #342); the `editor.isFocused`
+// guard added in this slice rules out external `setContent` echoes
+// from RHF as the cause, but the underlying interaction remains
+// unresolved.
 
 const NOW = new Date("2026-05-17T00:00:00Z");
 
@@ -142,17 +143,15 @@ test.describe("Keyboard-only editor flow (a11y)", () => {
     await page.keyboard.type("/");
 
     // Slash menu's listbox is rendered to document.body via a portal.
-    // Items are projected from the resolved BlockRegistry — the
-    // presence of every core block proves the registry promise
-    // resolved before the editor's `extensions` were locked in (the
-    // hazard PR #339 punted on).
+    // The presence of every registered item proves the resolved
+    // BlockRegistry reached the editor's `extensions`. ArrowDown
+    // navigates to "Heading" (second item) and Enter dispatches the
+    // suggestion's command — typing the query string itself is
+    // tracked separately in #342.
     await expect(page.locator("[data-plumix-slash-menu-mount]")).toBeVisible();
     await expect(
       page.getByTestId("slash-menu-item-core/heading"),
     ).toBeVisible();
-    // ArrowDown moves to "Heading" (the second item — Paragraph is
-    // first). Enter dispatches the suggestion's `command`, which
-    // inserts the heading node.
     await page.keyboard.press("ArrowDown");
     await page.keyboard.press("Enter");
 

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -156,6 +156,14 @@ export function TiptapEditor({
   useEffect(() => {
     if (lastEmittedRef.current === value) return;
     lastEmittedRef.current = value;
+    // While the editor has focus the user is the source of truth; a
+    // `setContent` here resets ProseMirror's selection + decoration
+    // state and notably deactivates the slash-menu suggestion plugin
+    // mid-typing. External sync is only meaningful when focus is
+    // elsewhere (programmatic field reset, form hydrating a different
+    // entry, etc.). RHF re-renders with a fresh `value` reference on
+    // every change so the upstream ref check alone is insufficient.
+    if (editor.isFocused) return;
     editor.commands.setContent(value);
   }, [editor, value]);
 


### PR DESCRIPTION
RHF re-renders the content field with a fresh \`value\` reference on every keystroke. The existing identity guard (\`lastEmittedRef === value\`) therefore mis-fires and \`editor.commands.setContent\` runs on every input, resetting ProseMirror's selection state and tearing down in-flight decorations.

External sync (loading a fresh entry, programmatic field reset) is only meaningful when focus is elsewhere — while the user is typing the editor is the source of truth. Bail out when \`editor.isFocused\` so the user-driven path is left alone.

**Scope note**

This is a defensive prerequisite for fixing the slash-menu deactivation bug in #342. The keyboard-only spec still uses ArrowDown rather than typing a query string — the suggestion plugin still deactivates on the first typed character even with this guard in place, which rules out RHF-driven \`setContent\` echoes as the root cause and narrows the surface area for the actual fix.

Refs GH-342