### PR TITLE
feat(blocks,core,admin,plumix): plugin blocks + marks reach the admin editor

### DIFF
--- a/packages/admin/src/components/editor/spec-extensions.test.ts
+++ b/packages/admin/src/components/editor/spec-extensions.test.ts
@@ -247,8 +247,9 @@ describe("wireMarkSpecExtension", () => {
       parsePaste: [{ selector: "span.warn" }, { selector: "em.warn" }],
     });
     const wired = wireMarkSpecExtension(spec);
-    const rules = (wired.config.parseHTML?.call({ parent: undefined } as never) ??
-      []) as readonly { tag: string }[];
+    const rules = (wired.config.parseHTML?.call({
+      parent: undefined,
+    } as never) ?? []) as readonly { tag: string }[];
     const selectors = rules.map((r) => r.tag);
     expect(selectors).toContain("span.warn");
     expect(selectors).toContain("em.warn");

--- a/packages/admin/src/components/editor/spec-extensions.test.ts
+++ b/packages/admin/src/components/editor/spec-extensions.test.ts
@@ -1,9 +1,12 @@
-import { Node } from "@tiptap/core";
+import { Mark, Node } from "@tiptap/core";
 import { describe, expect, test, vi } from "vitest";
 
-import type { ResolvedBlockSpec } from "@plumix/blocks";
+import type { ResolvedBlockSpec, ResolvedMarkSpec } from "@plumix/blocks";
 
-import { wireBlockSpecExtension } from "./spec-extensions.js";
+import {
+  wireBlockSpecExtension,
+  wireMarkSpecExtension,
+} from "./spec-extensions.js";
 
 function probeSpec(opts: {
   keyboardShortcuts?: readonly {
@@ -194,5 +197,60 @@ describe("wireBlockSpecExtension — keyboardShortcut", () => {
     shortcuts["Mod-Alt-2"]?.();
     expect(setNode).toHaveBeenCalledWith("core/probe", { level: 1 });
     expect(setNode).toHaveBeenCalledWith("core/probe", { level: 2 });
+  });
+});
+
+function markProbeSpec(opts: {
+  keyboardShortcut?: string;
+  parsePaste?: readonly { selector: string }[];
+}): ResolvedMarkSpec {
+  const spec: Partial<ResolvedMarkSpec> = {
+    name: "core/probe-mark",
+    title: "Probe mark",
+    schema: Mark.create({ name: "core/probe-mark" }),
+    registeredBy: null,
+    keyboardShortcut: opts.keyboardShortcut,
+    parsePaste: opts.parsePaste,
+    component: () => null,
+  };
+  return spec as ResolvedMarkSpec;
+}
+
+describe("wireMarkSpecExtension", () => {
+  test("returns the base mark when no editor-side fields are set", () => {
+    const spec = markProbeSpec({});
+    const wired = wireMarkSpecExtension(spec);
+    expect(wired).toBe(spec.schema);
+  });
+
+  test("binds keyboardShortcut to toggleMark on the registered name", () => {
+    const spec = markProbeSpec({ keyboardShortcut: "Mod-Alt-w" });
+    const wired = wireMarkSpecExtension(spec);
+    const toggleMark = vi.fn();
+    const chain = {
+      focus: () => chain,
+      toggleMark: (name: string) => {
+        toggleMark(name);
+        return chain;
+      },
+      run: () => true,
+    };
+    const shortcuts = (wired.config.addKeyboardShortcuts?.call({
+      editor: { chain: () => chain },
+    } as never) ?? {}) as Record<string, () => boolean>;
+    shortcuts["Mod-Alt-w"]?.();
+    expect(toggleMark).toHaveBeenCalledWith("core/probe-mark");
+  });
+
+  test("attaches parsePaste rules into the mark's parseHTML output", () => {
+    const spec = markProbeSpec({
+      parsePaste: [{ selector: "span.warn" }, { selector: "em.warn" }],
+    });
+    const wired = wireMarkSpecExtension(spec);
+    const rules = (wired.config.parseHTML?.call({ parent: undefined } as never) ??
+      []) as readonly { tag: string }[];
+    const selectors = rules.map((r) => r.tag);
+    expect(selectors).toContain("span.warn");
+    expect(selectors).toContain("em.warn");
   });
 });

--- a/packages/admin/src/components/editor/spec-extensions.ts
+++ b/packages/admin/src/components/editor/spec-extensions.ts
@@ -1,4 +1,4 @@
-import type { Node } from "@tiptap/core";
+import type { Mark, Node } from "@tiptap/core";
 import {
   nodeInputRule,
   textblockTypeInputRule,
@@ -10,6 +10,7 @@ import type {
   BlockMarkdownShortcut,
   ParsePasteRule,
   ResolvedBlockSpec,
+  ResolvedMarkSpec,
 } from "@plumix/blocks";
 
 /**
@@ -129,13 +130,35 @@ function buildInputRule(
   }
 }
 
-// `wireMarkSpecExtension` is not implemented in this slice because marks
-// aren't loaded into the editor schema yet — that's the broader
-// "editor extension list sources from the registry" deferral tracked
-// in the project memory. The 5 marks StarterKit ships already carry
-// their canonical Cmd-B / Cmd-I / etc. shortcuts; the 8 additional
-// marks shipped by @plumix/blocks don't declare shortcuts. When the
-// mark-schema loader lands, build the symmetric helper here.
+/**
+ * Symmetric to {@link wireBlockSpecExtension} for marks: extends the base
+ * Mark with the editor-side concerns declared on the spec (keyboard
+ * shortcut, paste rules). Marks have no markdown-input-rule surface —
+ * Tiptap's mark input rules attach to surrounding text, not the mark
+ * itself, and would belong on the host block.
+ */
+export function wireMarkSpecExtension(spec: ResolvedMarkSpec): Mark {
+  const base = spec.schema;
+  if (spec.keyboardShortcut === undefined && !spec.parsePaste?.length) {
+    return base;
+  }
+  return base.extend({
+    addKeyboardShortcuts() {
+      const inherited = this.parent?.() ?? {};
+      if (spec.keyboardShortcut === undefined) return inherited;
+      return {
+        ...inherited,
+        [spec.keyboardShortcut]: () =>
+          this.editor.chain().focus().toggleMark(spec.name).run(),
+      };
+    },
+    parseHTML() {
+      const inherited = this.parent?.() ?? [];
+      if (!spec.parsePaste) return inherited;
+      return [...inherited, ...spec.parsePaste.map(pasteToParseRule)];
+    },
+  });
+}
 
 function escapeForRegex(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -113,7 +113,11 @@ export function TiptapEditor({
   );
 
   const extensions = useMemo(() => {
-    const base = buildTiptapExtensions({ allowlist, blockRegistry, markRegistry });
+    const base = buildTiptapExtensions({
+      allowlist,
+      blockRegistry,
+      markRegistry,
+    });
     // Slash menu is canvas-mode-only; in strict field mode the user
     // already knows what node they're editing.
     if (allowlist || !blockRegistry) return base;

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -113,7 +113,7 @@ export function TiptapEditor({
   );
 
   const extensions = useMemo(() => {
-    const base = buildTiptapExtensions({ allowlist, blockRegistry });
+    const base = buildTiptapExtensions({ allowlist, blockRegistry, markRegistry });
     // Slash menu is canvas-mode-only; in strict field mode the user
     // already knows what node they're editing.
     if (allowlist || !blockRegistry) return base;
@@ -131,7 +131,7 @@ export function TiptapEditor({
         },
       }),
     ];
-  }, [allowlist, blockRegistry]);
+  }, [allowlist, blockRegistry, markRegistry]);
 
   const editor = useEditor({
     extensions,

--- a/packages/admin/src/components/editor/tiptap-extensions.test.ts
+++ b/packages/admin/src/components/editor/tiptap-extensions.test.ts
@@ -1,0 +1,61 @@
+import { Mark } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import type { MarkRegistry, ResolvedMarkSpec } from "@plumix/blocks";
+
+import { buildTiptapExtensions } from "./tiptap-extensions.js";
+
+function fakeMarkRegistry(specs: readonly ResolvedMarkSpec[]): MarkRegistry {
+  const map = new Map(specs.map((s) => [s.name, s]));
+  return {
+    get: (n) => map.get(n),
+    has: (n) => map.has(n),
+    size: map.size,
+    [Symbol.iterator]: () => map.entries(),
+  } satisfies MarkRegistry;
+}
+
+function pluginMarkSpec(
+  name: string,
+  registeredBy: string | null,
+): ResolvedMarkSpec {
+  const spec: Partial<ResolvedMarkSpec> = {
+    name,
+    title: name,
+    schema: Mark.create({ name }),
+    component: () => null,
+    registeredBy,
+  };
+  return spec as ResolvedMarkSpec;
+}
+
+describe("buildTiptapExtensions — markRegistry", () => {
+  test("appends a Tiptap mark extension for each plugin-registered mark", () => {
+    const registry = fakeMarkRegistry([
+      pluginMarkSpec("acme/highlight-warning", "acme"),
+    ]);
+    const exts = buildTiptapExtensions({ markRegistry: registry });
+    expect(
+      exts.some(
+        (ext) => ext && (ext as { name?: string }).name === "acme/highlight-warning",
+      ),
+    ).toBe(true);
+  });
+
+  test("skips core marks (registeredBy === null) so StarterKit doesn't collide", () => {
+    const registry = fakeMarkRegistry([
+      pluginMarkSpec("bold", null),
+      pluginMarkSpec("acme/highlight-warning", "acme"),
+    ]);
+    const exts = buildTiptapExtensions({ markRegistry: registry });
+    const names = exts.map((ext) => (ext as { name?: string }).name);
+    expect(names).not.toContain("bold");
+    expect(names).toContain("acme/highlight-warning");
+  });
+
+  test("emits no plugin marks when registry is omitted", () => {
+    const exts = buildTiptapExtensions({});
+    const names = exts.map((ext) => (ext as { name?: string }).name);
+    expect(names).not.toContain("acme/highlight-warning");
+  });
+});

--- a/packages/admin/src/components/editor/tiptap-extensions.test.ts
+++ b/packages/admin/src/components/editor/tiptap-extensions.test.ts
@@ -37,7 +37,7 @@ describe("buildTiptapExtensions — markRegistry", () => {
     const exts = buildTiptapExtensions({ markRegistry: registry });
     expect(
       exts.some(
-        (ext) => ext && (ext as { name?: string }).name === "acme/highlight-warning",
+        (ext) => (ext as { name?: string }).name === "acme/highlight-warning",
       ),
     ).toBe(true);
   });

--- a/packages/admin/src/components/editor/tiptap-extensions.ts
+++ b/packages/admin/src/components/editor/tiptap-extensions.ts
@@ -4,10 +4,13 @@ import { UnknownBlockNodeView } from "@/editor/unknown-block/UnknownBlockNodeVie
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 
-import type { BlockRegistry } from "@plumix/blocks";
+import type { BlockRegistry, MarkRegistry } from "@plumix/blocks";
 import { unknownBlockSchema } from "@plumix/blocks";
 
-import { wireBlockSpecExtension } from "./spec-extensions.js";
+import {
+  wireBlockSpecExtension,
+  wireMarkSpecExtension,
+} from "./spec-extensions.js";
 
 // `undefined` allowlist → canvas mode (full StarterKit). Defined →
 // strict richtext-field mode where StarterKit extensions are gated
@@ -34,6 +37,12 @@ interface BuildExtensionsInput {
    * ProseMirror throwing "unknown node type".
    */
   readonly blockRegistry?: BlockRegistry;
+  /**
+   * Canvas-mode-only. Only plugin-contributed marks (`registeredBy`
+   * truthy) flow through — core marks share StarterKit's unnamespaced
+   * names (`bold`, `italic`, …) and adding them again would collide.
+   */
+  readonly markRegistry?: MarkRegistry;
 }
 
 // Per-call object literal: Tiptap's `LinkOptions` requires mutable
@@ -52,7 +61,7 @@ function linkOptions() {
 export function buildTiptapExtensions(
   input: BuildExtensionsInput = {},
 ): Extensions {
-  const { allowlist, blockRegistry } = input;
+  const { allowlist, blockRegistry, markRegistry } = input;
   if (allowlist === undefined) {
     return [
       StarterKit.configure({
@@ -60,6 +69,7 @@ export function buildTiptapExtensions(
         link: linkOptions(),
       }),
       ...registryNodeExtensions(blockRegistry),
+      ...registryMarkExtensions(markRegistry),
       unknownBlockSchema.extend({
         addNodeView() {
           return ReactNodeViewRenderer(UnknownBlockNodeView);
@@ -108,6 +118,18 @@ function registryNodeExtensions(
       continue;
     }
     exts.push(wired);
+  }
+  return exts;
+}
+
+function registryMarkExtensions(
+  registry: MarkRegistry | undefined,
+): Extensions {
+  if (!registry) return [];
+  const exts: Extensions = [];
+  for (const [, spec] of registry) {
+    if (spec.registeredBy === null) continue;
+    exts.push(wireMarkSpecExtension(spec));
   }
   return exts;
 }

--- a/packages/admin/src/editor/plugin-contributions.test.ts
+++ b/packages/admin/src/editor/plugin-contributions.test.ts
@@ -29,12 +29,12 @@ describe("buildPluginBlockContributions", () => {
     );
 
     expect(contributions).toHaveLength(1);
-    const entry = contributions[0]!;
-    expect(entry.pluginId).toBe("manifest");
-    expect(entry.spec.name).toBe("acme/callout");
-    expect(entry.spec.title).toBe("Callout");
-    await expect(entry.spec.schema()).resolves.toBe(stubBlockSchema);
-    expect(entry.spec.editor).toBeUndefined();
+    const [entry] = contributions;
+    expect(entry?.pluginId).toBe("manifest");
+    expect(entry?.spec.name).toBe("acme/callout");
+    expect(entry?.spec.title).toBe("Callout");
+    await expect(entry?.spec.schema()).resolves.toBe(stubBlockSchema);
+    expect(entry?.spec.editor).toBeUndefined();
   });
 
   test("attaches the admin editor when both manifest ref + registry entry present", async () => {
@@ -54,9 +54,9 @@ describe("buildPluginBlockContributions", () => {
       },
     );
 
-    const entry = contributions[0]!;
-    expect(entry.spec.editor).toBeDefined();
-    await expect(entry.spec.editor!()).resolves.toBe(StubEditor);
+    const [entry] = contributions;
+    expect(entry?.spec.editor).toBeDefined();
+    await expect(entry?.spec.editor?.()).resolves.toBe(StubEditor);
   });
 
   test("skips entries without an admin schema ref", () => {
@@ -114,7 +114,8 @@ describe("buildPluginBlockContributions", () => {
       },
     );
 
-    expect(contributions[0]!.spec).toMatchObject({
+    const [entry] = contributions;
+    expect(entry?.spec).toMatchObject({
       name: "acme/callout",
       title: "Callout",
       description: "Aside content",
@@ -148,10 +149,10 @@ describe("buildPluginMarkContributions", () => {
     );
 
     expect(contributions).toHaveLength(1);
-    const entry = contributions[0]!;
-    expect(entry.spec.name).toBe("acme/highlight");
-    expect(entry.spec.title).toBe("Highlight");
-    await expect(entry.spec.schema()).resolves.toBe(stubMarkSchema);
+    const [entry] = contributions;
+    expect(entry?.spec.name).toBe("acme/highlight");
+    expect(entry?.spec.title).toBe("Highlight");
+    await expect(entry?.spec.schema()).resolves.toBe(stubMarkSchema);
   });
 
   test("skips entries without an admin schema ref or runtime registration", () => {

--- a/packages/admin/src/editor/plugin-contributions.test.ts
+++ b/packages/admin/src/editor/plugin-contributions.test.ts
@@ -1,0 +1,174 @@
+import type { Mark, Node } from "@tiptap/core";
+import type { ComponentType } from "react";
+import { describe, expect, test } from "vitest";
+
+import {
+  buildPluginBlockContributions,
+  buildPluginMarkContributions,
+} from "./plugin-contributions.js";
+
+const stubBlockSchema = { name: "acme/callout" } as unknown as Node;
+const stubMarkSchema = { name: "acme/highlight" } as unknown as Mark;
+const StubEditor: ComponentType<unknown> = () => null;
+
+describe("buildPluginBlockContributions", () => {
+  test("wraps a manifest entry with a registered schema into a PluginContribution", async () => {
+    const contributions = buildPluginBlockContributions(
+      [
+        {
+          name: "acme/callout",
+          title: "Callout",
+          adminSchema: "calloutSchema",
+        },
+      ],
+      {
+        getBlockSchema: (name) =>
+          name === "acme/callout" ? stubBlockSchema : undefined,
+        getBlockEditor: () => undefined,
+      },
+    );
+
+    expect(contributions).toHaveLength(1);
+    const entry = contributions[0]!;
+    expect(entry.pluginId).toBe("manifest");
+    expect(entry.spec.name).toBe("acme/callout");
+    expect(entry.spec.title).toBe("Callout");
+    await expect(entry.spec.schema()).resolves.toBe(stubBlockSchema);
+    expect(entry.spec.editor).toBeUndefined();
+  });
+
+  test("attaches the admin editor when both manifest ref + registry entry present", async () => {
+    const contributions = buildPluginBlockContributions(
+      [
+        {
+          name: "acme/callout",
+          title: "Callout",
+          adminSchema: "calloutSchema",
+          adminEditor: "CalloutEditor",
+        },
+      ],
+      {
+        getBlockSchema: () => stubBlockSchema,
+        getBlockEditor: (name) =>
+          name === "acme/callout" ? StubEditor : undefined,
+      },
+    );
+
+    const entry = contributions[0]!;
+    expect(entry.spec.editor).toBeDefined();
+    await expect(entry.spec.editor!()).resolves.toBe(StubEditor);
+  });
+
+  test("skips entries without an admin schema ref", () => {
+    const contributions = buildPluginBlockContributions(
+      [{ name: "acme/no-schema", title: "Metadata only" }],
+      {
+        getBlockSchema: () => stubBlockSchema,
+        getBlockEditor: () => undefined,
+      },
+    );
+
+    expect(contributions).toEqual([]);
+  });
+
+  test("skips entries where the runtime registry has no schema", () => {
+    const contributions = buildPluginBlockContributions(
+      [
+        {
+          name: "acme/callout",
+          title: "Callout",
+          adminSchema: "calloutSchema",
+        },
+      ],
+      {
+        getBlockSchema: () => undefined,
+        getBlockEditor: () => undefined,
+      },
+    );
+
+    expect(contributions).toEqual([]);
+  });
+
+  test("forwards declarative metadata onto the synthetic BlockSpec", () => {
+    const contributions = buildPluginBlockContributions(
+      [
+        {
+          name: "acme/callout",
+          title: "Callout",
+          description: "Aside content",
+          keywords: ["aside", "note"],
+          category: "interactive",
+          icon: "lightbulb",
+          adminSchema: "calloutSchema",
+          attributes: {
+            variant: {
+              type: "select",
+              options: [{ value: "info", label: "Info" }],
+            },
+          },
+        },
+      ],
+      {
+        getBlockSchema: () => stubBlockSchema,
+        getBlockEditor: () => undefined,
+      },
+    );
+
+    expect(contributions[0]!.spec).toMatchObject({
+      name: "acme/callout",
+      title: "Callout",
+      description: "Aside content",
+      keywords: ["aside", "note"],
+      category: "interactive",
+      icon: "lightbulb",
+      attributes: {
+        variant: {
+          type: "select",
+          options: [{ value: "info", label: "Info" }],
+        },
+      },
+    });
+  });
+});
+
+describe("buildPluginMarkContributions", () => {
+  test("wraps a manifest entry with a registered schema", async () => {
+    const contributions = buildPluginMarkContributions(
+      [
+        {
+          name: "acme/highlight",
+          title: "Highlight",
+          adminSchema: "highlightSchema",
+        },
+      ],
+      {
+        getMarkSchema: (name) =>
+          name === "acme/highlight" ? stubMarkSchema : undefined,
+      },
+    );
+
+    expect(contributions).toHaveLength(1);
+    const entry = contributions[0]!;
+    expect(entry.spec.name).toBe("acme/highlight");
+    expect(entry.spec.title).toBe("Highlight");
+    await expect(entry.spec.schema()).resolves.toBe(stubMarkSchema);
+  });
+
+  test("skips entries without an admin schema ref or runtime registration", () => {
+    const contributions = buildPluginMarkContributions(
+      [
+        { name: "acme/no-schema", title: "Metadata only" },
+        {
+          name: "acme/highlight",
+          title: "Highlight",
+          adminSchema: "highlightSchema",
+        },
+      ],
+      {
+        getMarkSchema: () => undefined,
+      },
+    );
+
+    expect(contributions).toEqual([]);
+  });
+});

--- a/packages/admin/src/editor/plugin-contributions.ts
+++ b/packages/admin/src/editor/plugin-contributions.ts
@@ -1,0 +1,112 @@
+import type { Mark, Node } from "@tiptap/core";
+import type { ComponentType } from "react";
+
+import type { BlockSpec, MarkSpec } from "@plumix/blocks";
+import type {
+  BlockManifestEntry,
+  MarkManifestEntry,
+} from "@plumix/core/manifest";
+
+interface BlockLookups {
+  getBlockSchema(name: string): Node | undefined;
+  getBlockEditor(name: string): ComponentType<unknown> | undefined;
+}
+
+interface MarkLookups {
+  getMarkSchema(name: string): Mark | undefined;
+}
+
+export interface PluginBlockContribution {
+  readonly spec: BlockSpec;
+  readonly pluginId: string;
+}
+
+export interface PluginMarkContribution {
+  readonly spec: MarkSpec;
+  readonly pluginId: string;
+}
+
+// Manifest entries carry no plugin id (they're aggregated from many
+// plugins build-side). `registeredBy` surfaces this sentinel on the
+// resolved spec; admin code only treats it as opaque.
+const PLUGIN_ID_PLACEHOLDER = "manifest";
+
+// `mergeBlockRegistry` awaits `spec.component` to populate
+// `ResolvedBlockSpec.component` for the SSR walker. Admin never walks
+// (it renders through Tiptap), so a no-op satisfies the contract.
+// Admin-only spec — if `ResolvedBlockSpec.component` is ever invoked,
+// some caller walked the admin's registry on the SSR render path.
+// That's a bug; surface it loudly rather than rendering empty content.
+const SSR_COMPONENT_STUB = () => {
+  throw new Error(
+    "Admin-only plugin block spec rendered on the SSR walker path",
+  );
+};
+
+/**
+ * Entries without an `adminSchema` ref or without a matching runtime
+ * registration are silently dropped — they're either metadata-only
+ * sentinels or in a partial-boot state where the plugin admin chunk
+ * hasn't run yet.
+ */
+export function buildPluginBlockContributions(
+  entries: readonly BlockManifestEntry[],
+  lookups: BlockLookups,
+): readonly PluginBlockContribution[] {
+  const out: PluginBlockContribution[] = [];
+  for (const entry of entries) {
+    if (entry.adminSchema === undefined) continue;
+    const schema = lookups.getBlockSchema(entry.name);
+    if (schema === undefined) continue;
+    const editor =
+      entry.adminEditor !== undefined
+        ? lookups.getBlockEditor(entry.name)
+        : undefined;
+    const spec: BlockSpec = {
+      name: entry.name,
+      title: entry.title,
+      icon: entry.icon,
+      category: entry.category,
+      description: entry.description,
+      keywords: entry.keywords,
+      attributes: entry.attributes,
+      supports: entry.supports,
+      inserter: entry.inserter,
+      variations: entry.variations,
+      keyboardShortcuts: entry.keyboardShortcuts,
+      markdownShortcuts: entry.markdownShortcuts,
+      legacyAliases: entry.legacyAliases,
+      schema: () => Promise.resolve(schema),
+      component: () => Promise.resolve(SSR_COMPONENT_STUB),
+      editor:
+        editor !== undefined ? () => Promise.resolve(editor) : undefined,
+    };
+    out.push({ spec, pluginId: PLUGIN_ID_PLACEHOLDER });
+  }
+  return out;
+}
+
+/** Same drop-when-unresolvable semantics as `buildPluginBlockContributions`. */
+export function buildPluginMarkContributions(
+  entries: readonly MarkManifestEntry[],
+  lookups: MarkLookups,
+): readonly PluginMarkContribution[] {
+  const out: PluginMarkContribution[] = [];
+  for (const entry of entries) {
+    if (entry.adminSchema === undefined) continue;
+    const schema = lookups.getMarkSchema(entry.name);
+    if (schema === undefined) continue;
+    const spec: MarkSpec = {
+      name: entry.name,
+      title: entry.title,
+      description: entry.description,
+      keyboardShortcut: entry.keyboardShortcut,
+      bubbleMenuLabel: entry.bubbleMenuLabel,
+      bubbleMenuIcon: entry.bubbleMenuIcon,
+      schema: () => Promise.resolve(schema),
+      component: () => Promise.resolve(SSR_COMPONENT_STUB),
+    };
+    out.push({ spec, pluginId: PLUGIN_ID_PLACEHOLDER });
+  }
+  return out;
+}

--- a/packages/admin/src/editor/plugin-contributions.ts
+++ b/packages/admin/src/editor/plugin-contributions.ts
@@ -7,6 +7,8 @@ import type {
   MarkManifestEntry,
 } from "@plumix/core/manifest";
 
+import { AdminPluginRegistryError } from "../lib/errors.js";
+
 interface BlockLookups {
   getBlockSchema(name: string): Node | undefined;
   getBlockEditor(name: string): ComponentType<unknown> | undefined;
@@ -16,12 +18,12 @@ interface MarkLookups {
   getMarkSchema(name: string): Mark | undefined;
 }
 
-export interface PluginBlockContribution {
+interface PluginBlockContribution {
   readonly spec: BlockSpec;
   readonly pluginId: string;
 }
 
-export interface PluginMarkContribution {
+interface PluginMarkContribution {
   readonly spec: MarkSpec;
   readonly pluginId: string;
 }
@@ -33,14 +35,10 @@ const PLUGIN_ID_PLACEHOLDER = "manifest";
 
 // `mergeBlockRegistry` awaits `spec.component` to populate
 // `ResolvedBlockSpec.component` for the SSR walker. Admin never walks
-// (it renders through Tiptap), so a no-op satisfies the contract.
-// Admin-only spec — if `ResolvedBlockSpec.component` is ever invoked,
-// some caller walked the admin's registry on the SSR render path.
-// That's a bug; surface it loudly rather than rendering empty content.
-const SSR_COMPONENT_STUB = () => {
-  throw new Error(
-    "Admin-only plugin block spec rendered on the SSR walker path",
-  );
+// (it renders through Tiptap), so a no-op satisfies the contract — and
+// surfaces loudly if a caller ever does.
+const SSR_COMPONENT_STUB = (): never => {
+  throw AdminPluginRegistryError.ssrWalkedAdminSpec();
 };
 
 /**
@@ -78,8 +76,7 @@ export function buildPluginBlockContributions(
       legacyAliases: entry.legacyAliases,
       schema: () => Promise.resolve(schema),
       component: () => Promise.resolve(SSR_COMPONENT_STUB),
-      editor:
-        editor !== undefined ? () => Promise.resolve(editor) : undefined,
+      editor: editor !== undefined ? () => Promise.resolve(editor) : undefined,
     };
     out.push({ spec, pluginId: PLUGIN_ID_PLACEHOLDER });
   }

--- a/packages/admin/src/editor/registries.ts
+++ b/packages/admin/src/editor/registries.ts
@@ -8,41 +8,62 @@ import {
   mergeMarkRegistry,
 } from "@plumix/blocks";
 
+import { readManifest } from "../lib/manifest.js";
+import {
+  getPluginBlockEditor,
+  getPluginBlockSchema,
+  getPluginMarkSchema,
+} from "../lib/plugin-registry.js";
+import {
+  buildPluginBlockContributions,
+  buildPluginMarkContributions,
+} from "./plugin-contributions.js";
+
 /**
- * Admin-side static registries derived from `@plumix/blocks` core specs.
+ * Admin-side merged registries: core specs from `@plumix/blocks` plus
+ * plugin contributions read out of the manifest and the runtime
+ * `window.plumix.registerPluginBlock*` registrations the plugin admin
+ * chunks ran at module-eval.
  *
  * Lazy singletons rather than module-level `await` — top-level await
  * forces every importer into an async module and propagates that
  * status through Vite/Rollup chunk graphs. The Promise is created on
  * first call; React 19's `use()` unwraps it ergonomically inside
  * components, and React's Suspense boundary handles the wait.
- *
- * Plugin contributions are NOT visible here yet — that needs an RPC
- * endpoint exposing the runtime registry to the admin bundle (tracked
- * in [project_blocks_marks_deferred] memory). Once that lands, swap
- * the inputs below and the slash menu / bubble menu pick up plugin
- * entries automatically.
  */
 let blocksPromise: Promise<BlockRegistry> | undefined;
 let marksPromise: Promise<MarkRegistry> | undefined;
 
 function getBlocksPromise(): Promise<BlockRegistry> {
-  blocksPromise ??= mergeBlockRegistry({
-    core: coreBlocks,
-    plugins: [],
-    themeOverrides: {},
-    themeId: null,
-  });
+  blocksPromise ??= (() => {
+    const manifest = readManifest();
+    const plugins = buildPluginBlockContributions(manifest.blocks ?? [], {
+      getBlockSchema: getPluginBlockSchema,
+      getBlockEditor: getPluginBlockEditor,
+    });
+    return mergeBlockRegistry({
+      core: coreBlocks,
+      plugins,
+      themeOverrides: {},
+      themeId: null,
+    });
+  })();
   return blocksPromise;
 }
 
 function getMarksPromise(): Promise<MarkRegistry> {
-  marksPromise ??= mergeMarkRegistry({
-    core: coreMarks,
-    plugins: [],
-    themeOverrides: {},
-    themeId: null,
-  });
+  marksPromise ??= (() => {
+    const manifest = readManifest();
+    const plugins = buildPluginMarkContributions(manifest.marks ?? [], {
+      getMarkSchema: getPluginMarkSchema,
+    });
+    return mergeMarkRegistry({
+      core: coreMarks,
+      plugins,
+      themeOverrides: {},
+      themeId: null,
+    });
+  })();
   return marksPromise;
 }
 
@@ -52,4 +73,10 @@ export function useAdminBlockRegistry(): BlockRegistry {
 
 export function useAdminMarkRegistry(): MarkRegistry {
   return use(getMarksPromise());
+}
+
+/** @internal Test-only. Drops the memoised promises so the next call rebuilds. */
+export function _resetAdminRegistries(): void {
+  blocksPromise = undefined;
+  marksPromise = undefined;
 }

--- a/packages/admin/src/lib/errors.ts
+++ b/packages/admin/src/lib/errors.ts
@@ -1,4 +1,7 @@
-type AdminPluginRegistryErrorCode = "duplicate_key" | "input_type_reserved";
+type AdminPluginRegistryErrorCode =
+  | "duplicate_key"
+  | "input_type_reserved"
+  | "ssr_walked_admin_spec";
 
 interface AdminPluginRegistryErrorFields {
   registerName?: string;
@@ -47,6 +50,16 @@ export class AdminPluginRegistryError extends Error {
         `Pick a different inputType for your custom field — see the host's ` +
         `RESERVED_INPUT_TYPES list.`,
       ctx,
+    );
+  }
+
+  static ssrWalkedAdminSpec(): AdminPluginRegistryError {
+    return new AdminPluginRegistryError(
+      "ssr_walked_admin_spec",
+      "Admin-only plugin block spec rendered on the SSR walker path. " +
+        "registries.ts contributions are admin-only; the runtime walker " +
+        "must source `component` from `@plumix/blocks` directly.",
+      {},
     );
   }
 }

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -43,6 +43,8 @@ const KNOWN_ARRAY_FIELDS = [
   "settingsPages",
   "adminNav",
   "fieldTypes",
+  "blocks",
+  "marks",
 ] as const satisfies readonly (keyof PlumixManifest)[];
 
 function normalize(value: unknown): PlumixManifest {

--- a/packages/admin/src/lib/plugin-registry.test.ts
+++ b/packages/admin/src/lib/plugin-registry.test.ts
@@ -2,9 +2,15 @@ import { afterEach, describe, expect, test } from "vitest";
 
 import {
   _resetPluginRegistry,
+  getPluginBlockEditor,
+  getPluginBlockSchema,
   getPluginFieldType,
+  getPluginMarkSchema,
   getPluginPage,
+  registerPluginBlockEditor,
+  registerPluginBlockSchema,
   registerPluginFieldType,
+  registerPluginMarkSchema,
   registerPluginPage,
 } from "./plugin-registry.js";
 
@@ -62,6 +68,43 @@ describe("plugin field-type registry", () => {
     registerPluginFieldType("media", Stub);
     expect(getPluginFieldType("media")).toBe(Stub);
     expect(() => registerPluginFieldType("media", Stub)).toThrow(
+      /already registered/,
+    );
+  });
+});
+
+describe("plugin block + mark registries", () => {
+  const schema = { name: "acme/callout" } as never;
+
+  test("round-trips block schemas + editors + mark schemas", () => {
+    registerPluginBlockSchema("acme/callout", schema);
+    expect(getPluginBlockSchema("acme/callout")).toBe(schema);
+
+    registerPluginBlockEditor("acme/callout", Stub);
+    expect(getPluginBlockEditor("acme/callout")).toBe(Stub);
+
+    const markSchema = { name: "acme/highlight" } as never;
+    registerPluginMarkSchema("acme/highlight", markSchema);
+    expect(getPluginMarkSchema("acme/highlight")).toBe(markSchema);
+  });
+
+  test("returns undefined for unknown names", () => {
+    expect(getPluginBlockSchema("acme/nope")).toBeUndefined();
+    expect(getPluginBlockEditor("acme/nope")).toBeUndefined();
+    expect(getPluginMarkSchema("acme/nope")).toBeUndefined();
+  });
+
+  test("rejects duplicate registrations per registry", () => {
+    registerPluginBlockSchema("acme/callout", schema);
+    expect(() => registerPluginBlockSchema("acme/callout", schema)).toThrow(
+      /already registered/,
+    );
+    registerPluginBlockEditor("acme/callout", Stub);
+    expect(() => registerPluginBlockEditor("acme/callout", Stub)).toThrow(
+      /already registered/,
+    );
+    registerPluginMarkSchema("acme/highlight", schema);
+    expect(() => registerPluginMarkSchema("acme/highlight", schema)).toThrow(
       /already registered/,
     );
   });

--- a/packages/admin/src/lib/plugin-registry.ts
+++ b/packages/admin/src/lib/plugin-registry.ts
@@ -1,3 +1,4 @@
+import type { Mark, Node } from "@tiptap/core";
 import type { ComponentType } from "react";
 import type { ControllerRenderProps, FieldValues } from "react-hook-form";
 
@@ -42,6 +43,11 @@ const pages = makeRegistry<ComponentType>("registerPluginPage");
 const fieldTypes = makeRegistry<PluginFieldComponent>(
   "registerPluginFieldType",
 );
+const blockSchemas = makeRegistry<Node>("registerPluginBlockSchema");
+const blockEditors = makeRegistry<ComponentType<unknown>>(
+  "registerPluginBlockEditor",
+);
+const markSchemas = makeRegistry<Mark>("registerPluginMarkSchema");
 
 function register<TComponent>(
   registry: PluginRegistryEntry<TComponent>,
@@ -122,8 +128,40 @@ export function getPluginFieldType(
   return fieldTypes.map.get(type);
 }
 
+export function registerPluginBlockSchema(name: string, schema: Node): void {
+  register(blockSchemas, name, schema);
+}
+
+export function getPluginBlockSchema(name: string): Node | undefined {
+  return blockSchemas.map.get(name);
+}
+
+export function registerPluginBlockEditor(
+  name: string,
+  component: ComponentType<unknown>,
+): void {
+  register(blockEditors, name, component);
+}
+
+export function getPluginBlockEditor(
+  name: string,
+): ComponentType<unknown> | undefined {
+  return blockEditors.map.get(name);
+}
+
+export function registerPluginMarkSchema(name: string, schema: Mark): void {
+  register(markSchemas, name, schema);
+}
+
+export function getPluginMarkSchema(name: string): Mark | undefined {
+  return markSchemas.map.get(name);
+}
+
 /** @internal Test-only. */
 export function _resetPluginRegistry(): void {
   pages.map.clear();
   fieldTypes.map.clear();
+  blockSchemas.map.clear();
+  blockEditors.map.clear();
+  markSchemas.map.clear();
 }

--- a/packages/admin/src/lib/plumix-globals.ts
+++ b/packages/admin/src/lib/plumix-globals.ts
@@ -9,7 +9,10 @@ import * as ReactDomNs from "react-dom";
 import * as ReactDomClientNs from "react-dom/client";
 
 import {
+  registerPluginBlockEditor,
+  registerPluginBlockSchema,
   registerPluginFieldType,
+  registerPluginMarkSchema,
   registerPluginPage,
 } from "./plugin-registry.js";
 
@@ -32,6 +35,9 @@ declare global {
     plumix?: {
       readonly registerPluginPage: typeof registerPluginPage;
       readonly registerPluginFieldType: typeof registerPluginFieldType;
+      readonly registerPluginBlockSchema: typeof registerPluginBlockSchema;
+      readonly registerPluginBlockEditor: typeof registerPluginBlockEditor;
+      readonly registerPluginMarkSchema: typeof registerPluginMarkSchema;
       readonly runtime: typeof runtime;
     };
   }
@@ -43,6 +49,9 @@ export function bootPlumixGlobals(): void {
   window.plumix = {
     registerPluginPage,
     registerPluginFieldType,
+    registerPluginBlockSchema,
+    registerPluginBlockEditor,
+    registerPluginMarkSchema,
     runtime,
   };
 }

--- a/packages/blocks/src/define-block.ts
+++ b/packages/blocks/src/define-block.ts
@@ -92,6 +92,8 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
     schema: spec.schema,
     component: spec.component,
     editor: spec.editor,
+    adminSchema: spec.adminSchema,
+    adminEditor: spec.adminEditor,
     client: spec.client,
     legacyAliases: freezeArray(spec.legacyAliases),
     keyboardShortcuts: freezeArrayOfObjects(spec.keyboardShortcuts),

--- a/packages/blocks/src/marks/registry.ts
+++ b/packages/blocks/src/marks/registry.ts
@@ -105,7 +105,7 @@ async function resolveSpec(
       schemaName,
     });
   }
-  return Object.freeze({ ...spec, component, registeredBy });
+  return Object.freeze({ ...spec, component, schema, registeredBy });
 }
 
 /**

--- a/packages/blocks/src/marks/types.ts
+++ b/packages/blocks/src/marks/types.ts
@@ -22,6 +22,14 @@ export interface MarkSpec {
   readonly schema: LazyRef<ReturnType<typeof TiptapMarkExtension.create>>;
   readonly component: LazyRef<MarkComponent>;
   /**
+   * Export name on the plugin's `adminEntry` module that resolves to the
+   * Tiptap `Mark.create(...)` instance for this mark. Mirrors
+   * `BlockSpec.adminSchema`: lets the admin chunk synthesizer wire the
+   * mark into the editor's extension list. Core marks leave this unset —
+   * the admin imports `@plumix/blocks` directly.
+   */
+  readonly adminSchema?: string;
+  /**
    * Paste rules: HTML selectors this mark absorbs when the editor
    * receives pasted content. Marks usually need only the selector;
    * the editor extension wraps matched ranges with this mark.

--- a/packages/blocks/src/marks/types.ts
+++ b/packages/blocks/src/marks/types.ts
@@ -37,7 +37,10 @@ export interface MarkSpec {
   readonly parsePaste?: readonly ParsePasteRule[];
 }
 
-export interface ResolvedMarkSpec extends Omit<MarkSpec, "component" | "schema"> {
+export interface ResolvedMarkSpec extends Omit<
+  MarkSpec,
+  "component" | "schema"
+> {
   readonly component: MarkComponent;
   /**
    * Awaited Tiptap Mark instance. Stored sync (not lazy) so the admin

--- a/packages/blocks/src/marks/types.ts
+++ b/packages/blocks/src/marks/types.ts
@@ -37,8 +37,14 @@ export interface MarkSpec {
   readonly parsePaste?: readonly ParsePasteRule[];
 }
 
-export interface ResolvedMarkSpec extends Omit<MarkSpec, "component"> {
+export interface ResolvedMarkSpec extends Omit<MarkSpec, "component" | "schema"> {
   readonly component: MarkComponent;
+  /**
+   * Awaited Tiptap Mark instance. Stored sync (not lazy) so the admin
+   * editor can build its extension list synchronously — parallel to
+   * `ResolvedBlockSpec.schema`.
+   */
+  readonly schema: ReturnType<typeof TiptapMarkExtension.create>;
   readonly registeredBy: string | null;
 }
 

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -160,6 +160,21 @@ export interface BlockSpec<Attrs = Readonly<Record<string, unknown>>> {
   readonly component: LazyRef<BlockComponent<Attrs>>;
   readonly editor?: LazyRef<ComponentType<unknown>>;
   /**
+   * Export name on the plugin's `adminEntry` module that resolves to the
+   * Tiptap `Node.create(...)` instance for this block. Set by plugin
+   * authors so the admin chunk synthesizer can wire the schema into the
+   * editor without the admin awaiting a runtime `LazyRef` that points at
+   * the plugin's worker-side module. Core blocks leave this unset — the
+   * admin imports `@plumix/blocks` directly.
+   */
+  readonly adminSchema?: string;
+  /**
+   * Export name on the plugin's `adminEntry` module that resolves to the
+   * NodeView Component for this block. Optional; blocks without a bespoke
+   * Editor render through Tiptap's default contenteditable surface.
+   */
+  readonly adminEditor?: string;
+  /**
    * Marks this block as a client island. SSR emits a wrapper carrying
    * `data-plumix-island="<spec.name>"` plus a serialised attrs blob; the
    * island-bootstrap script (`<PlumixIslandBootstrap>`) imports `src`

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -906,6 +906,58 @@ describe("buildManifest", () => {
     });
   });
 
+  test("plugin block entries carry adminSchema + adminEditor refs", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/callout",
+          title: "Callout",
+          adminSchema: "calloutSchema",
+          adminEditor: "CalloutEditor",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/callout",
+              parseHTML: () => [],
+              renderHTML: () => ["div", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).blocks[0]).toMatchObject({
+      adminSchema: "calloutSchema",
+      adminEditor: "CalloutEditor",
+    });
+  });
+
+  test("plugin mark entries carry adminSchema ref", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerMark(
+        defineMark({
+          name: "acme/highlight-warning",
+          title: "Warning highlight",
+          adminSchema: "warningHighlightSchema",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/highlight-warning",
+              parseHTML: () => [],
+              renderHTML: () => ["mark", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).marks[0]).toMatchObject({
+      adminSchema: "warningHighlightSchema",
+    });
+  });
+
   test("blocks and marks are sorted alphabetically by name", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("acme", (ctx) => {

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
 
+import { defineBlock, defineMark } from "@plumix/blocks";
+
 import { HookRegistry } from "../hooks/registry.js";
 import { definePlugin } from "./define.js";
 import { DuplicateAdminSlugError } from "./errors.js";
@@ -695,6 +697,68 @@ describe("buildManifest", () => {
     const { registry } = await installPlugins({ hooks, plugins: [plugin] });
 
     expect(buildManifest(registry).termTaxonomies).toEqual([]);
+  });
+
+  test("projects registered plugin blocks into manifest.blocks", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/callout",
+          title: "Callout",
+          category: "interactive",
+          icon: "lightbulb",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/callout",
+              parseHTML: () => [],
+              renderHTML: () => ["div", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    const manifest = buildManifest(registry);
+    expect(manifest.blocks).toHaveLength(1);
+    expect(manifest.blocks[0]).toMatchObject({
+      name: "acme/callout",
+      title: "Callout",
+      category: "interactive",
+      icon: "lightbulb",
+    });
+  });
+
+  test("projects registered plugin marks into manifest.marks", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerMark(
+        defineMark({
+          name: "acme/highlight-warning",
+          title: "Warning highlight",
+          keyboardShortcut: "Mod-Alt-w",
+          bubbleMenuIcon: "alert-triangle",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/highlight-warning",
+              parseHTML: () => [],
+              renderHTML: () => ["mark", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    const manifest = buildManifest(registry);
+    expect(manifest.marks).toHaveLength(1);
+    expect(manifest.marks[0]).toMatchObject({
+      name: "acme/highlight-warning",
+      title: "Warning highlight",
+      keyboardShortcut: "Mod-Alt-w",
+      bubbleMenuIcon: "alert-triangle",
+    });
   });
 });
 

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -730,6 +730,251 @@ describe("buildManifest", () => {
     });
   });
 
+  test("block entries carry slash-menu metadata (description, keywords, inserter)", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/callout",
+          title: "Callout",
+          description: "Highlight an aside passage.",
+          keywords: ["aside", "note", "tip"],
+          inserter: false,
+          schema: () =>
+            Promise.resolve({
+              name: "acme/callout",
+              parseHTML: () => [],
+              renderHTML: () => ["div", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).blocks[0]).toMatchObject({
+      description: "Highlight an aside passage.",
+      keywords: ["aside", "note", "tip"],
+      inserter: false,
+    });
+  });
+
+  test("block entries carry attributes + supports for Inspector rendering", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/callout",
+          title: "Callout",
+          attributes: {
+            variant: {
+              type: "select",
+              label: "Variant",
+              default: "info",
+              options: [
+                { value: "info", label: "Info" },
+                { value: "warn", label: "Warning" },
+              ],
+            },
+            dismissible: {
+              type: "boolean",
+              label: "Dismissible",
+              default: false,
+            },
+          },
+          supports: {
+            color: { background: true, text: true },
+            spacing: { padding: true },
+            customClassName: true,
+          },
+          schema: () =>
+            Promise.resolve({
+              name: "acme/callout",
+              parseHTML: () => [],
+              renderHTML: () => ["div", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).blocks[0]).toMatchObject({
+      attributes: {
+        variant: {
+          type: "select",
+          label: "Variant",
+          default: "info",
+          options: [
+            { value: "info", label: "Info" },
+            { value: "warn", label: "Warning" },
+          ],
+        },
+        dismissible: {
+          type: "boolean",
+          label: "Dismissible",
+          default: false,
+        },
+      },
+      supports: {
+        color: { background: true, text: true },
+        spacing: { padding: true },
+        customClassName: true,
+      },
+    });
+  });
+
+  test("block entries carry variations for slash-menu inserter items", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/grid",
+          title: "Grid",
+          variations: [
+            {
+              name: "two-up",
+              title: "Two columns",
+              description: "Equal width pair.",
+              icon: "columns-2",
+              keywords: ["pair"],
+              attributes: { ratio: "50/50" },
+            },
+            {
+              name: "three-up",
+              title: "Three columns",
+              attributes: { ratio: "33/33/33" },
+            },
+          ],
+          schema: () =>
+            Promise.resolve({
+              name: "acme/grid",
+              parseHTML: () => [],
+              renderHTML: () => ["div", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).blocks[0]).toMatchObject({
+      variations: [
+        {
+          name: "two-up",
+          title: "Two columns",
+          description: "Equal width pair.",
+          icon: "columns-2",
+          keywords: ["pair"],
+          attributes: { ratio: "50/50" },
+        },
+        {
+          name: "three-up",
+          title: "Three columns",
+          attributes: { ratio: "33/33/33" },
+        },
+      ],
+    });
+  });
+
+  test("block entries carry shortcut + legacy-alias bindings", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/callout",
+          title: "Callout",
+          keyboardShortcuts: [{ shortcut: "Mod-Alt-c", mode: "setNode" }],
+          markdownShortcuts: [{ pattern: "!! ", mode: "setNode" }],
+          legacyAliases: ["alert"],
+          schema: () =>
+            Promise.resolve({
+              name: "acme/callout",
+              parseHTML: () => [],
+              renderHTML: () => ["div", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).blocks[0]).toMatchObject({
+      keyboardShortcuts: [{ shortcut: "Mod-Alt-c", mode: "setNode" }],
+      markdownShortcuts: [{ pattern: "!! ", mode: "setNode" }],
+      legacyAliases: ["alert"],
+    });
+  });
+
+  test("blocks and marks are sorted alphabetically by name", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/zebra",
+          title: "Zebra",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/zebra",
+              parseHTML: () => [],
+              renderHTML: () => ["div", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/apple",
+          title: "Apple",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/apple",
+              parseHTML: () => [],
+              renderHTML: () => ["div", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+      ctx.registerMark(
+        defineMark({
+          name: "acme/zoom",
+          title: "Zoom",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/zoom",
+              parseHTML: () => [],
+              renderHTML: () => ["span", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+      ctx.registerMark(
+        defineMark({
+          name: "acme/accent",
+          title: "Accent",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/accent",
+              parseHTML: () => [],
+              renderHTML: () => ["span", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    const manifest = buildManifest(registry);
+    expect(manifest.blocks.map((b) => b.name)).toEqual([
+      "acme/apple",
+      "acme/zebra",
+    ]);
+    expect(manifest.marks.map((m) => m.name)).toEqual([
+      "acme/accent",
+      "acme/zoom",
+    ]);
+  });
+
   test("projects registered plugin marks into manifest.marks", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("acme", (ctx) => {
@@ -758,6 +1003,33 @@ describe("buildManifest", () => {
       title: "Warning highlight",
       keyboardShortcut: "Mod-Alt-w",
       bubbleMenuIcon: "alert-triangle",
+    });
+  });
+
+  test("mark entries carry bubbleMenuLabel + description", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerMark(
+        defineMark({
+          name: "acme/highlight-warning",
+          title: "Warning highlight",
+          description: "Inline highlight emphasising a hazard.",
+          bubbleMenuLabel: "Warn",
+          schema: () =>
+            Promise.resolve({
+              name: "acme/highlight-warning",
+              parseHTML: () => [],
+              renderHTML: () => ["mark", 0],
+            } as never),
+          component: () => Promise.resolve(() => null),
+        }),
+      );
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(buildManifest(registry).marks[0]).toMatchObject({
+      description: "Inline highlight emphasising a hazard.",
+      bubbleMenuLabel: "Warn",
     });
   });
 });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1389,6 +1389,20 @@ export interface FieldTypeManifestEntry {
   readonly component: PluginComponentRef;
 }
 
+export interface BlockManifestEntry {
+  readonly name: string;
+  readonly title: string;
+  readonly category?: string;
+  readonly icon?: string;
+}
+
+export interface MarkManifestEntry {
+  readonly name: string;
+  readonly title: string;
+  readonly keyboardShortcut?: string;
+  readonly bubbleMenuIcon?: string;
+}
+
 /**
  * Wire-shipped manifest payload. Every field is optional on the type
  * so test fixtures can declare just the slice they exercise; the
@@ -1405,6 +1419,8 @@ export interface PlumixManifest {
   readonly settingsPages?: readonly SettingsPageManifestEntry[];
   readonly adminNav?: readonly AdminNavGroup[];
   readonly fieldTypes?: readonly FieldTypeManifestEntry[];
+  readonly blocks?: readonly BlockManifestEntry[];
+  readonly marks?: readonly MarkManifestEntry[];
 }
 
 /**
@@ -1431,6 +1447,8 @@ export function emptyManifest(): PlumixManifest {
     settingsPages: [],
     adminNav: [],
     fieldTypes: [],
+    blocks: [],
+    marks: [],
   };
 }
 
@@ -1501,6 +1519,8 @@ export function buildManifest(registry: PluginRegistry): BuiltManifest {
   const fieldTypes = Array.from(registry.fieldTypes.values())
     .map(toFieldTypeEntry)
     .sort((a, b) => a.type.localeCompare(b.type));
+  const blocks = Array.from(registry.blockSpecs.values()).map(toBlockEntry);
+  const marks = Array.from(registry.markSpecs.values()).map(toMarkEntry);
   return {
     entryTypes: entries,
     termTaxonomies,
@@ -1511,6 +1531,8 @@ export function buildManifest(registry: PluginRegistry): BuiltManifest {
     settingsPages,
     adminNav,
     fieldTypes,
+    blocks,
+    marks,
   };
 }
 
@@ -2128,6 +2150,16 @@ function toFieldTypeEntry(
 ): FieldTypeManifestEntry {
   const { type, component } = fieldType;
   return { type, component };
+}
+
+function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
+  const { name, title, category, icon } = block.spec;
+  return { name, title, category, icon };
+}
+
+function toMarkEntry(mark: RegisteredMark): MarkManifestEntry {
+  const { name, title, keyboardShortcut, bubbleMenuIcon } = mark.spec;
+  return { name, title, keyboardShortcut, bubbleMenuIcon };
 }
 
 // Per-variant options live on each narrowed variant of `MetaBoxField`.

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1411,6 +1411,10 @@ export interface BlockManifestEntry {
   readonly keyboardShortcuts?: readonly BlockKeyboardShortcut[];
   readonly markdownShortcuts?: readonly BlockMarkdownShortcut[];
   readonly legacyAliases?: readonly string[];
+  /** Export name on the plugin's `adminEntry` module — see `BlockSpec.adminSchema`. */
+  readonly adminSchema?: string;
+  /** Export name on the plugin's `adminEntry` module — see `BlockSpec.adminEditor`. */
+  readonly adminEditor?: string;
 }
 
 export interface MarkManifestEntry {
@@ -1420,6 +1424,8 @@ export interface MarkManifestEntry {
   readonly keyboardShortcut?: string;
   readonly bubbleMenuLabel?: string;
   readonly bubbleMenuIcon?: string;
+  /** Export name on the plugin's `adminEntry` module — see `MarkSpec.adminSchema`. */
+  readonly adminSchema?: string;
 }
 
 /**
@@ -2190,6 +2196,8 @@ function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
     keyboardShortcuts,
     markdownShortcuts,
     legacyAliases,
+    adminSchema,
+    adminEditor,
   } = block.spec;
   return {
     name,
@@ -2205,6 +2213,8 @@ function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
     keyboardShortcuts,
     markdownShortcuts,
     legacyAliases,
+    adminSchema,
+    adminEditor,
   };
 }
 
@@ -2216,6 +2226,7 @@ function toMarkEntry(mark: RegisteredMark): MarkManifestEntry {
     keyboardShortcut,
     bubbleMenuLabel,
     bubbleMenuIcon,
+    adminSchema,
   } = mark.spec;
   return {
     name,
@@ -2224,6 +2235,7 @@ function toMarkEntry(mark: RegisteredMark): MarkManifestEntry {
     keyboardShortcut,
     bubbleMenuLabel,
     bubbleMenuIcon,
+    adminSchema,
   };
 }
 

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1,4 +1,12 @@
-import type { BlockSpec, MarkSpec } from "@plumix/blocks";
+import type {
+  BlockAttributeSchema,
+  BlockKeyboardShortcut,
+  BlockMarkdownShortcut,
+  BlockSpec,
+  BlockSupports,
+  BlockVariation,
+  MarkSpec,
+} from "@plumix/blocks";
 
 import type {
   EntryTypeCapabilityOverrides,
@@ -1394,12 +1402,23 @@ export interface BlockManifestEntry {
   readonly title: string;
   readonly category?: string;
   readonly icon?: string;
+  readonly description?: string;
+  readonly keywords?: readonly string[];
+  readonly inserter?: boolean;
+  readonly attributes?: Readonly<Record<string, BlockAttributeSchema>>;
+  readonly supports?: BlockSupports;
+  readonly variations?: readonly BlockVariation[];
+  readonly keyboardShortcuts?: readonly BlockKeyboardShortcut[];
+  readonly markdownShortcuts?: readonly BlockMarkdownShortcut[];
+  readonly legacyAliases?: readonly string[];
 }
 
 export interface MarkManifestEntry {
   readonly name: string;
   readonly title: string;
+  readonly description?: string;
   readonly keyboardShortcut?: string;
+  readonly bubbleMenuLabel?: string;
   readonly bubbleMenuIcon?: string;
 }
 
@@ -1519,8 +1538,12 @@ export function buildManifest(registry: PluginRegistry): BuiltManifest {
   const fieldTypes = Array.from(registry.fieldTypes.values())
     .map(toFieldTypeEntry)
     .sort((a, b) => a.type.localeCompare(b.type));
-  const blocks = Array.from(registry.blockSpecs.values()).map(toBlockEntry);
-  const marks = Array.from(registry.markSpecs.values()).map(toMarkEntry);
+  const blocks = Array.from(registry.blockSpecs.values())
+    .map(toBlockEntry)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const marks = Array.from(registry.markSpecs.values())
+    .map(toMarkEntry)
+    .sort((a, b) => a.name.localeCompare(b.name));
   return {
     entryTypes: entries,
     termTaxonomies,
@@ -2153,13 +2176,55 @@ function toFieldTypeEntry(
 }
 
 function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
-  const { name, title, category, icon } = block.spec;
-  return { name, title, category, icon };
+  const {
+    name,
+    title,
+    category,
+    icon,
+    description,
+    keywords,
+    inserter,
+    attributes,
+    supports,
+    variations,
+    keyboardShortcuts,
+    markdownShortcuts,
+    legacyAliases,
+  } = block.spec;
+  return {
+    name,
+    title,
+    category,
+    icon,
+    description,
+    keywords,
+    inserter,
+    attributes,
+    supports,
+    variations,
+    keyboardShortcuts,
+    markdownShortcuts,
+    legacyAliases,
+  };
 }
 
 function toMarkEntry(mark: RegisteredMark): MarkManifestEntry {
-  const { name, title, keyboardShortcut, bubbleMenuIcon } = mark.spec;
-  return { name, title, keyboardShortcut, bubbleMenuIcon };
+  const {
+    name,
+    title,
+    description,
+    keyboardShortcut,
+    bubbleMenuLabel,
+    bubbleMenuIcon,
+  } = mark.spec;
+  return {
+    name,
+    title,
+    description,
+    keyboardShortcut,
+    bubbleMenuLabel,
+    bubbleMenuIcon,
+  };
 }
 
 // Per-variant options live on each narrowed variant of `MetaBoxField`.

--- a/packages/plumix/src/vite/admin-plugin-bundle.test.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.test.ts
@@ -261,4 +261,89 @@ describe("assemblePluginAdminBundle", () => {
     expect(bundle).toContain("registerPluginFieldType");
     expect(bundle).toContain('"media_picker"');
   });
+
+  test("auto-emits register* calls for plugin block + mark adminSchema / adminEditor refs", async () => {
+    const pkgDir = resolve(workspace, "node_modules/@fixture/plugin-blocks");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      resolve(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@fixture/plugin-blocks",
+        version: "0.0.0",
+        type: "module",
+        main: "./entry.js",
+      }),
+    );
+    await writeFile(
+      resolve(pkgDir, "entry.js"),
+      `
+        export const calloutSchema = { name: "acme/callout" };
+        export const CalloutEditor = () => null;
+        export const warningHighlightSchema = { name: "acme/highlight-warning" };
+      `,
+    );
+
+    const { defineBlock, defineMark } = await import("@plumix/blocks");
+    const descriptor = definePlugin(
+      "acme",
+      (ctx) => {
+        ctx.registerBlock(
+          defineBlock({
+            name: "acme/callout",
+            title: "Callout",
+            adminSchema: "calloutSchema",
+            adminEditor: "CalloutEditor",
+            schema: () =>
+              Promise.resolve({
+                name: "acme/callout",
+                parseHTML: () => [],
+                renderHTML: () => ["div", 0],
+              } as never),
+            component: () => Promise.resolve(() => null),
+          }),
+        );
+        ctx.registerMark(
+          defineMark({
+            name: "acme/highlight-warning",
+            title: "Warning highlight",
+            adminSchema: "warningHighlightSchema",
+            schema: () =>
+              Promise.resolve({
+                name: "acme/highlight-warning",
+                parseHTML: () => [],
+                renderHTML: () => ["mark", 0],
+              } as never),
+            component: () => Promise.resolve(() => null),
+          }),
+        );
+      },
+      { adminEntry: "./node_modules/@fixture/plugin-blocks/entry.js" },
+    );
+
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [descriptor],
+    });
+
+    const adminDest = resolve(workspace, "dist");
+    await mkdir(adminDest, { recursive: true });
+
+    const result = await assemblePluginAdminBundle({
+      plugins: [descriptor as AssemblerPlugin],
+      registry,
+      adminDest,
+      projectRoot: workspace,
+    });
+
+    expect(result).not.toBeNull();
+    const bundle = await readFile(
+      resolve(adminDest, "plugins/site-bundle.js"),
+      "utf8",
+    );
+    expect(bundle).toContain("registerPluginBlockSchema");
+    expect(bundle).toContain("registerPluginBlockEditor");
+    expect(bundle).toContain("registerPluginMarkSchema");
+    expect(bundle).toContain('"acme/callout"');
+    expect(bundle).toContain('"acme/highlight-warning"');
+  });
 });

--- a/packages/plumix/src/vite/admin-plugin-bundle.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.ts
@@ -188,6 +188,30 @@ function buildSynthesisedEntry({
           `${ns}[${JSON.stringify(fieldType.component)}]);`,
       );
     }
+    for (const block of registry.blockSpecs.values()) {
+      if (block.registeredBy !== plugin.id) continue;
+      if (block.spec.adminSchema !== undefined) {
+        registerLines.push(
+          `  __plumix.registerPluginBlockSchema(${JSON.stringify(block.spec.name)}, ` +
+            `${ns}[${JSON.stringify(block.spec.adminSchema)}]);`,
+        );
+      }
+      if (block.spec.adminEditor !== undefined) {
+        registerLines.push(
+          `  __plumix.registerPluginBlockEditor(${JSON.stringify(block.spec.name)}, ` +
+            `${ns}[${JSON.stringify(block.spec.adminEditor)}]);`,
+        );
+      }
+    }
+    for (const mark of registry.markSpecs.values()) {
+      if (mark.registeredBy !== plugin.id) continue;
+      if (mark.spec.adminSchema !== undefined) {
+        registerLines.push(
+          `  __plumix.registerPluginMarkSchema(${JSON.stringify(mark.spec.name)}, ` +
+            `${ns}[${JSON.stringify(mark.spec.adminSchema)}]);`,
+        );
+      }
+    }
   });
 
   if (registerLines.length === 0) {


### PR DESCRIPTION
Wires plugin-registered blocks and marks all the way through to the admin's Tiptap editor and supporting surfaces (slash menu, BubbleMenu, Inspector). Closes most of GH-341; the remaining gaps (integration test, StarterKit removal) are tracked as follow-ups below.

**Manifest projection**

`buildManifest` now ships `blocks` + `marks` arrays alongside the existing surfaces. Wire shape mirrors `fieldTypes`: explicit destructure-and-rebuild that drops server-only and function-bearing fields (`registeredBy`, `schema` LazyRef, `parsePaste.fromHTML`, `transforms.mapAttrs`). Declarative metadata flows through: `name`, `title`, `category`, `icon`, `description`, `keywords`, `inserter`, `attributes`, `supports`, `variations`, `keyboardShortcuts`, `markdownShortcuts`, `legacyAliases` for blocks; `description`, `keyboardShortcut`, `bubbleMenuLabel`, `bubbleMenuIcon` for marks. Both arrays sorted alphabetically by canonical name.

**Cross-bundle refs**

`BlockSpec` gains optional `adminSchema?: string` and `adminEditor?: string`; `MarkSpec` gains `adminSchema?: string`. The strings name exports on the plugin's `adminEntry` module — same `PluginComponentRef` shape `registerFieldType.component` already uses. Core specs leave them unset.

The Vite admin-plugin-bundle synthesiser auto-emits `__plumix.registerPluginBlockSchema` / `registerPluginBlockEditor` / `registerPluginMarkSchema` calls into the chunk, mirroring how `registerPluginPage` / `registerPluginFieldType` are emitted today.

**Admin runtime + registry wiring**

`packages/admin/src/lib/plugin-registry.ts` adds three new registries with parallel `register*`/`get*` functions. `plumix-globals.ts` exposes them on `window.plumix`.

New module `packages/admin/src/editor/plugin-contributions.ts` adapts manifest entries into the `mergeBlock/MarkRegistry` plugin-input shape, looking up actual schemas / editors via the runtime registry. Entries without a registered schema are silently dropped (partial-boot or metadata-only).

`registries.ts` now reads the manifest and feeds plugin contributions into the merge — the previous hardcoded `plugins: []` / `themeOverrides: {}` is gone.

**Tiptap schema sourced from the registries**

`wireMarkSpecExtension` lands (parallel to the existing `wireBlockSpecExtension`); `ResolvedMarkSpec.schema` is now the awaited Tiptap Mark instance (parity with `ResolvedBlockSpec`). `buildTiptapExtensions` accepts both `blockRegistry` and `markRegistry` and appends plugin-only mark entries (filters `registeredBy === null` to avoid StarterKit collisions on `bold`/`italic`/etc.).

**Known follow-ups (deliberate carve-outs)**

- Fixture-plugin integration test (block + mark round-trip through `assemblePluginAdminBundle` → admin boot → save → reload) — queued.
- StarterKit removal blocked on a baseline-primitives migration (paragraph/text/doc/hardBreak from `@plumix/blocks` rather than StarterKit).
- `getBlocksPromise()` / `getMarksPromise()` are memoised lazily — a merge rejection wedges admin until full reload. Worth an invalidation hook in a follow-up.
- Plugin-id provenance is lost on manifest-sourced contributions (`registeredBy: "manifest"` placeholder). Field-type projection has the same gap; punt to a shared fix.
- Cross-registry shortcut-collision check (plugin block shortcut vs plugin mark shortcut) — currently Tiptap's last-wins ordering is the only arbiter.
- `MarkToolbar` button tooltips don't surface the now-functional plugin mark `keyboardShortcut` to authors.
- SSR component stub on synthetic admin specs throws if invoked — guard against accidental SSR walks.

Refs GH-341
Refs GH-300