### PR TITLE
test(core): plugin block + mark round-trip integration test

### DIFF
--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "vitest";
 
+import { defineBlock, defineMark } from "@plumix/blocks";
+
 import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
+import { HookRegistry } from "../../../hooks/registry.js";
+import { definePlugin } from "../../../plugin/define.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { installPlugins } from "../../../plugin/register.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 import { registerCoreLookupAdapters } from "../lookup-adapters.js";
 
@@ -16,6 +21,81 @@ describe("entry.create", () => {
     expect(created.status).toBe("draft");
     expect(created.authorId).toBe(h.user.id);
     expect(created.publishedAt).toBeNull();
+  });
+
+  describe("with a fixture plugin contributing a block + mark", () => {
+    const PLUGIN_CONTENT = {
+      type: "doc",
+      content: [
+        {
+          type: "acme/callout",
+          content: [
+            {
+              type: "text",
+              text: "warn",
+              marks: [{ type: "acme/highlight-warning" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    async function pluginHarness() {
+      const plugin = definePlugin("acme", (ctx) => {
+        ctx.registerBlock(
+          defineBlock({
+            name: "acme/callout",
+            title: "Callout",
+            schema: () =>
+              Promise.resolve({
+                name: "acme/callout",
+                parseHTML: () => [],
+                renderHTML: () => ["div", 0],
+              } as never),
+            component: () => Promise.resolve(() => null),
+          }),
+        );
+        ctx.registerMark(
+          defineMark({
+            name: "acme/highlight-warning",
+            title: "Warning highlight",
+            schema: () =>
+              Promise.resolve({
+                name: "acme/highlight-warning",
+                parseHTML: () => [],
+                renderHTML: () => ["mark", 0],
+              } as never),
+            component: () => Promise.resolve(() => null),
+          }),
+        );
+      });
+      const { registry } = await installPlugins({
+        hooks: new HookRegistry(),
+        plugins: [plugin],
+      });
+      return createRpcHarness({ authAs: "contributor", plugins: registry });
+    }
+
+    test("entry.create accepts content carrying the plugin block + mark", async () => {
+      const h = await pluginHarness();
+      const created = await h.client.entry.create({
+        title: "p",
+        slug: "p",
+        content: PLUGIN_CONTENT,
+      });
+      expect(created.status).toBe("draft");
+    });
+
+    test("entry.get round-trips the plugin block + mark content unchanged", async () => {
+      const h = await pluginHarness();
+      const created = await h.client.entry.create({
+        title: "p",
+        slug: "p",
+        content: PLUGIN_CONTENT,
+      });
+      const fetched = await h.client.entry.get({ id: created.id });
+      expect(fetched.content).toEqual(PLUGIN_CONTENT);
+    });
   });
 
   test("INVALID_BLOCK_CONTENT when content carries an unknown block type", async () => {

--- a/packages/core/src/test/rpc.ts
+++ b/packages/core/src/test/rpc.ts
@@ -40,6 +40,12 @@ type TestDb = Awaited<ReturnType<typeof createTestDb>>;
 
 export interface BaseRpcHarnessOptions {
   readonly hooks?: HookRegistry;
+  /**
+   * Plugin registry seed. Anything contributed via `ctx.registerBlock` /
+   * `ctx.registerMark` lands in the validator's merged registries —
+   * pass a registry produced by `installPlugins` to exercise plugin
+   * block / mark content end-to-end through `entry.update`.
+   */
   readonly plugins?: PluginRegistry;
   readonly request?: Request;
   /**
@@ -242,15 +248,21 @@ export async function createRpcHarness(
   const oauthProviders = options.oauthProviders ?? [];
   // Build the same default registries `buildApp` would so the RPC
   // harness exercises validation against the real core specs.
+  const pluginBlockContributions = Array.from(plugins.blockSpecs.values()).map(
+    ({ spec, registeredBy }) => ({ spec, pluginId: registeredBy }),
+  );
+  const pluginMarkContributions = Array.from(plugins.markSpecs.values()).map(
+    ({ spec, registeredBy }) => ({ spec, pluginId: registeredBy }),
+  );
   const blocks = await mergeBlockRegistry({
     core: coreBlocks,
-    plugins: [],
+    plugins: pluginBlockContributions,
     themeOverrides: {},
     themeId: null,
   });
   const marks = await mergeMarkRegistry({
     core: coreMarks,
-    plugins: [],
+    plugins: pluginMarkContributions,
     themeOverrides: {},
     themeId: null,
   });


### PR DESCRIPTION
Closes the last two open ACs on GH-341 (integration test + persistence) by exercising the full validator path with a plugin-contributed block and mark. The third remaining AC — StarterKit removal — stays a separate follow-up.

**Harness now threads plugin contributions into the validator**

`createRpcHarness` previously seeded the validator's block / mark registries from `coreBlocks` / `coreMarks` only — any specs contributed via `ctx.registerBlock` / `ctx.registerMark` on the supplied `plugins: PluginRegistry` were dropped before the merge. The change pulls `plugins.blockSpecs` / `plugins.markSpecs` through into `mergeBlock/MarkRegistry`'s `plugins` input so the validator behaves identically to `buildApp` in production.

**Behaviour-preserving for every other test**

Every other test passing a custom `plugins` registry (`entry/create`, `entry/read`, `entry/update`, `term`, `meta`, `auth`) only mutates `entryMetaBoxes` / `termMetaBoxes` / `lookupAdapters` / `settingsGroups` — `blockSpecs.values()` is empty for them, so `mergeBlock/MarkRegistry({ plugins: [] })` is byte-identical to the prior call. Full core suite (1537 tests) still passes.

**Two new tests**

`describe("with a fixture plugin contributing a block + mark")` in `entry/create.test.ts`:
- `entry.create` accepts content carrying `acme/callout` (block) + `acme/highlight-warning` (mark)
- `entry.get` round-trips the saved JSON unchanged

These cover distinct invariants: the create test gates the validator path, the round-trip catches future filter / serializer regressions on the read path. Reusable `pluginHarness()` helper since both tests share the fixture.

Refs GH-341