### PR TITLE
refactor(admin): make the mark registry the source of truth for inline marks

### DIFF
--- a/packages/admin/src/components/editor/tiptap-extensions.test.ts
+++ b/packages/admin/src/components/editor/tiptap-extensions.test.ts
@@ -42,14 +42,14 @@ describe("buildTiptapExtensions — markRegistry", () => {
     ).toBe(true);
   });
 
-  test("skips core marks (registeredBy === null) so StarterKit doesn't collide", () => {
+  test("loads every registered mark — core + plugin — so the registry is the source of truth", () => {
     const registry = fakeMarkRegistry([
       pluginMarkSpec("bold", null),
       pluginMarkSpec("acme/highlight-warning", "acme"),
     ]);
     const exts = buildTiptapExtensions({ markRegistry: registry });
     const names = exts.map((ext) => (ext as { name?: string }).name);
-    expect(names).not.toContain("bold");
+    expect(names).toContain("bold");
     expect(names).toContain("acme/highlight-warning");
   });
 

--- a/packages/admin/src/components/editor/tiptap-extensions.ts
+++ b/packages/admin/src/components/editor/tiptap-extensions.ts
@@ -38,9 +38,9 @@ interface BuildExtensionsInput {
    */
   readonly blockRegistry?: BlockRegistry;
   /**
-   * Canvas-mode-only. Only plugin-contributed marks (`registeredBy`
-   * truthy) flow through — core marks share StarterKit's unnamespaced
-   * names (`bold`, `italic`, …) and adding them again would collide.
+   * Canvas-mode-only. Every mark in the registry — core + plugin —
+   * lands in the editor schema; StarterKit's duplicate marks are
+   * disabled so the registry stays the single source of truth.
    */
   readonly markRegistry?: MarkRegistry;
 }
@@ -66,7 +66,11 @@ export function buildTiptapExtensions(
     return [
       StarterKit.configure({
         heading: { levels: [2, 3] },
-        link: linkOptions(),
+        bold: false,
+        italic: false,
+        strike: false,
+        code: false,
+        link: false,
       }),
       ...registryNodeExtensions(blockRegistry),
       ...registryMarkExtensions(markRegistry),
@@ -128,7 +132,6 @@ function registryMarkExtensions(
   if (!registry) return [];
   const exts: Extensions = [];
   for (const [, spec] of registry) {
-    if (spec.registeredBy === null) continue;
     exts.push(wireMarkSpecExtension(spec));
   }
   return exts;


### PR DESCRIPTION
Slice A of 4 toward the StarterKit-removal AC on GH-341. Canvas mode's `StarterKit.configure(...)` now disables `bold` / `italic` / `strike` / `code` / `link`, and `registryMarkExtensions` no longer skips core marks (`registeredBy === null`). The merged mark registry is now the single source the editor schema reads from.

Net schema parity for the common case — same 5 core marks land, just via the registry path. Plugin marks already flowed through.

**Known behavior deltas worth flagging**

StarterKit's `@tiptap/extension-link` shipped two affordances the bare `Mark.create` schema in `packages/blocks/src/marks/core/link.tsx` doesn't replicate:

- **`autolink: true`** — typing or pasting a URL inside the editor auto-wraps it as a link. The registry's link schema has no autolink plugin, so this is a real authoring-side regression. Tracked for a dedicated autolink slice on the link mark spec.
- **`HTMLAttributes.target = "_blank"`** default on newly-inserted links. The frontend `LinkComponent` already clamps `target` on render based on the stored `attrs.target`, so public-site output is unaffected; the regression is limited to the in-editor `<a>` element for newly created links.

Both deltas are by-design carve-outs of this slice — the goal is "registry is source of truth," not "preserve every StarterKit affordance." Restoring autolink / setting `target` default belong with the link mark spec, not the editor wiring.

**Follow-up slices on this branch series**

- Slice B: baseline primitives (doc / text / hardBreak) out of StarterKit, into @plumix/blocks or admin's editor module
- Slice C: `@tiptap/extension-history` direct dependency for undo/redo
- Slice D: drop StarterKit from admin's package.json, ensure parser handles legacy unnamespaced content via the existing `legacyAliases` mechanism

Refs GH-341