### PR TITLE
refactor(admin): drop StarterKit's node duplicates from canvas mode

### DIFF
--- a/packages/admin/src/components/editor/tiptap-extensions.test.ts
+++ b/packages/admin/src/components/editor/tiptap-extensions.test.ts
@@ -1,7 +1,13 @@
-import { Mark } from "@tiptap/core";
-import { describe, expect, test } from "vitest";
+import { Editor, Mark } from "@tiptap/core";
+import { afterEach, describe, expect, test } from "vitest";
 
 import type { MarkRegistry, ResolvedMarkSpec } from "@plumix/blocks";
+import {
+  coreBlocks,
+  coreMarks,
+  mergeBlockRegistry,
+  mergeMarkRegistry,
+} from "@plumix/blocks";
 
 import { buildTiptapExtensions } from "./tiptap-extensions.js";
 
@@ -57,5 +63,60 @@ describe("buildTiptapExtensions — markRegistry", () => {
     const exts = buildTiptapExtensions({});
     const names = exts.map((ext) => (ext as { name?: string }).name);
     expect(names).not.toContain("acme/highlight-warning");
+  });
+});
+
+const editors: Editor[] = [];
+
+afterEach(() => {
+  while (editors.length > 0) editors.pop()?.destroy();
+  document.body.innerHTML = "";
+});
+
+describe("buildTiptapExtensions — canvas-mode schema is registry-sourced", () => {
+  test("StarterKit's node duplicates are dropped; namespaced core blocks remain", async () => {
+    const blockRegistry = await mergeBlockRegistry({
+      core: coreBlocks,
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const markRegistry = await mergeMarkRegistry({
+      core: coreMarks,
+      plugins: [],
+      themeOverrides: {},
+      themeId: null,
+    });
+    const exts = buildTiptapExtensions({ blockRegistry, markRegistry });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const editor = new Editor({ element: host, extensions: exts });
+    editors.push(editor);
+    const shadowed = [
+      "paragraph",
+      "heading",
+      "bulletList",
+      "orderedList",
+      "listItem",
+      "blockquote",
+      "codeBlock",
+      "horizontalRule",
+    ];
+    for (const name of shadowed) {
+      expect(editor.schema.nodes[name]).toBeUndefined();
+    }
+    expect(editor.schema.nodes["core/paragraph"]).toBeDefined();
+    expect(editor.schema.nodes["core/heading"]).toBeDefined();
+    expect(editor.schema.nodes.doc).toBeDefined();
+    expect(editor.schema.nodes.text).toBeDefined();
+    expect(editor.schema.nodes.hardBreak).toBeDefined();
+    // Empty-doc auto-fill must land on core/paragraph — production
+    // callsites pass null content (e.g. the "create entry" route)
+    // and ProseMirror's defaultType resolves by schema-registration
+    // order. Locks in coreBlocks ordering.
+    expect(editor.getJSON()).toEqual({
+      type: "doc",
+      content: [{ type: "core/paragraph" }],
+    });
   });
 });

--- a/packages/admin/src/components/editor/tiptap-extensions.ts
+++ b/packages/admin/src/components/editor/tiptap-extensions.ts
@@ -64,13 +64,24 @@ export function buildTiptapExtensions(
   const { allowlist, blockRegistry, markRegistry } = input;
   if (allowlist === undefined) {
     return [
+      // StarterKit retained only for primitives ProseMirror requires
+      // (`doc` / `text` / `hardBreak`) + history; every node/mark with
+      // a registry equivalent is disabled so the registry stays the
+      // single source of truth.
       StarterKit.configure({
-        heading: { levels: [2, 3] },
         bold: false,
         italic: false,
         strike: false,
         code: false,
         link: false,
+        heading: false,
+        paragraph: false,
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+        blockquote: false,
+        codeBlock: false,
+        horizontalRule: false,
       }),
       ...registryNodeExtensions(blockRegistry),
       ...registryMarkExtensions(markRegistry),
@@ -90,7 +101,10 @@ export function buildTiptapExtensions(
       strike: marks.has("strike") ? {} : false,
       code: marks.has("code") ? {} : false,
       link: marks.has("link") ? linkOptions() : false,
-      // `paragraph`, `text`, `doc` are baseline (ProseMirror requires them).
+      // Richtext-field mode keeps StarterKit's `paragraph`/`text`/`doc`
+      // because field content predates the registry namespacing and
+      // gets validated against the legacy allowlist; canvas mode (the
+      // branch above) sources those from the registry instead.
       heading: nodes.has("heading") ? { levels: [2, 3] } : false,
       bulletList: nodes.has("bulletList") ? {} : false,
       orderedList: nodes.has("orderedList") ? {} : false,


### PR DESCRIPTION
Slice B of 4 toward the StarterKit-removal AC on GH-341. Slice A merged in #350.

Canvas-mode `StarterKit.configure(...)` now disables every node that has a `core/*` registry equivalent — `paragraph`, `heading`, `bulletList`, `orderedList`, `listItem`, `blockquote`, `codeBlock`, `horizontalRule`. StarterKit narrows to providing `doc` / `text` / `hardBreak` + history (the irreducible baseline + undo/redo). The registry becomes the only source of block-level schema in the canvas.

**Empty-doc behaviour preserved**

ProseMirror's `block+` content match fills via `ContentMatch.defaultType`, which walks the schema in registration order. `core/paragraph` is the first block-group node after StarterKit's nodeless primitives, so an empty editor still auto-fills with a `{type: "core/paragraph"}` block. Locked in by a new `editor.getJSON()` assertion in `tiptap-extensions.test.ts` — guards against future regressions if `coreBlocks` order shifts.

**Out of scope**

- Slice C: replace StarterKit's history with `@tiptap/extension-history` direct.
- Slice D: drop the `@tiptap/starter-kit` dependency entirely once `doc`/`text`/`hardBreak`/history have direct equivalents.
- Richtext-field mode unchanged — it keeps StarterKit's `paragraph`/`text`/`doc` because field content predates the registry namespacing and rides the legacy allowlist. Will switch in slice D.

Refs GH-341