### PR TITLE
refactor(core): richtext validator accepts both legacy and namespaced node names

### DIFF
--- a/packages/core/src/plugin/fields/richtext-validate.test.ts
+++ b/packages/core/src/plugin/fields/richtext-validate.test.ts
@@ -297,3 +297,54 @@ describe("walkRichtextDoc — shape errors", () => {
     expect(() => validate(root)).not.toThrow();
   });
 });
+
+describe("walkRichtextDoc — registry alias parity", () => {
+  test("`nodes: ['heading']` also accepts the canonical `core/heading` the editor saves", () => {
+    const validate = walkRichtextDoc({ nodes: ["heading"] });
+    expect(() =>
+      validate({
+        type: "doc",
+        content: [
+          {
+            type: "core/heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "ok" }],
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  test("core/paragraph is implicit alongside the legacy `paragraph`", () => {
+    // Mirrors `FIELD_MODE_IMPLICIT_BLOCK` in the admin editor wiring —
+    // the editor saves `core/paragraph` even when the field allowlist
+    // declares no nodes.
+    const validate = walkRichtextDoc({});
+    const doc = {
+      type: "doc",
+      content: [
+        { type: "core/paragraph", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    expect(validate(doc)).toBe(doc);
+  });
+
+  test("namespaced names declared in the allowlist also accept their legacy aliases", () => {
+    // Symmetric: if a field author migrates to the namespaced contract
+    // by declaring `nodes: ["core/heading"]`, legacy stored content
+    // with `type: "heading"` must still round-trip cleanly.
+    const validate = walkRichtextDoc({ nodes: ["core/heading"] });
+    expect(() =>
+      validate({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "ok" }],
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/plugin/fields/richtext-validate.ts
+++ b/packages/core/src/plugin/fields/richtext-validate.ts
@@ -1,3 +1,5 @@
+import { coreBlocks } from "@plumix/blocks";
+
 // Server-side Tiptap ProseMirror JSON validator. Walks a saved doc
 // against the field's `marks` / `nodes` / `blocks` allowlist and
 // rejects any disallowed type/mark name with a JSON-path pointer to
@@ -21,16 +23,35 @@ interface TiptapNodeShape {
 }
 
 /**
- * Always-allowed type names. ProseMirror requires these for any
- * document to parse, and the editor crashes at mount if they're
- * missing. Treat them as implicit; the field's allowlists declare
- * everything *else*.
+ * Always-allowed type names. ProseMirror requires `doc` / `text`; the
+ * editor mounts an implicit paragraph regardless of the field's
+ * `nodes` allowlist — mirrors `FIELD_MODE_IMPLICIT_BLOCK` in admin's
+ * `tiptap-extensions.ts`. Both `paragraph` and `core/paragraph` are
+ * accepted so docs from either editor era round-trip unchanged.
  */
 const IMPLICIT_NODES: ReadonlySet<string> = new Set([
   "doc",
   "paragraph",
+  "core/paragraph",
   "text",
 ]);
+
+/**
+ * Bi-directional alias map: every core block's canonical name and
+ * its `legacyAliases` resolve to the same equivalence group, so an
+ * allowlist declared in either dialect (`"heading"` or
+ * `"core/heading"`) accepts saved docs in the other.
+ */
+const ALIAS_GROUPS: ReadonlyMap<string, readonly string[]> = new Map(
+  coreBlocks.flatMap((block) => {
+    const names = [block.name, ...(block.legacyAliases ?? [])];
+    return names.map((n) => [n, names] as const);
+  }),
+);
+
+function expandAliases(allowlist: readonly string[]): readonly string[] {
+  return allowlist.flatMap((name) => ALIAS_GROUPS.get(name) ?? [name]);
+}
 
 /**
  * Final href gate. Mirrors the regex in `route/render/tiptap.ts`'s
@@ -76,12 +97,14 @@ export function walkRichtextDoc(
   // them on every node.
   const allowedNodeTypes = new Set<string>([
     ...IMPLICIT_NODES,
-    ...(allowlist.nodes ?? []),
-    ...(allowlist.blocks ?? []),
+    ...expandAliases(allowlist.nodes ?? []),
+    ...expandAliases(allowlist.blocks ?? []),
   ]);
   const allowedMarkTypes = new Set<string>([
-    ...(allowlist.marks ?? []),
-    ...(allowlist.blocks ?? []),
+    // `MarkSpec` has no `legacyAliases` today so `expandAliases` is a
+    // no-op for marks — kept symmetric for the eventual mark namespacing.
+    ...expandAliases(allowlist.marks ?? []),
+    ...expandAliases(allowlist.blocks ?? []),
   ]);
   return (value) => {
     if (value === null || value === undefined) return value;


### PR DESCRIPTION
Picks up senpai's follow-up from PR #352. After the StarterKit-removal series, the admin editor saves namespaced node types (`core/heading`, `core/quote`, …) but the server-side richtext validator built its `allowedNodeTypes` straight from the StarterKit-era unnamespaced contract (`"heading"`, `"bulletList"`). The validator would reject the editor's output once any production `richtext()` callsite ships.

**Alias-aware allowlist expansion**

Derives `ALIAS_GROUPS` from `coreBlocks` at module load — every core block's canonical name + `legacyAliases` form an equivalence group. A new `expandAliases()` pulls each declared allowlist entry through the map so both dialects round-trip:

- `nodes: ["heading"]` accepts saved `core/heading` (editor's current output)
- `nodes: ["core/heading"]` accepts saved `heading` (legacy DB content)

Mirrors the editor-side `matchesAllowlist` semantics in `tiptap-extensions.ts:82-88` — identical bi-directional acceptance, so a field declared in either dialect stays consistent server- and client-side.

**`IMPLICIT_NODES` widened**

Now accepts both `paragraph` and `core/paragraph`. The asymmetry vs admin (`FIELD_MODE_IMPLICIT_BLOCK = "core/paragraph"` only) is intentional: the editor mounts the new canonical name; the validator round-trips both eras of stored content.

**No behaviour change for live callsites**

There are no live `richtext()` callsites in production today — the field validator was unreachable. This slice unblocks the field-mode richtext input from being wired into a real route without the editor/validator disagreement.

Refs GH-341