### PR TITLE
fix(admin): stop the drag-handle plugin from re-registering on every render

### DIFF
--- a/packages/admin/e2e/editor-keyboard.spec.ts
+++ b/packages/admin/e2e/editor-keyboard.spec.ts
@@ -7,13 +7,9 @@ import {
   rpcOkBody,
 } from "./support/rpc-mock.js";
 
-// Keyboard-only flow asserting the a11y promise: an author with no
-// mouse can compose, navigate, and inspect blocks without touching a
-// pointer. The slash-menu spec uses ArrowDown rather than typing a
-// query string — the suggestion plugin still deactivates on the first
-// character of typed input (tracked in #342); the value-sync deep
-// compare added in #344+ is a defensive improvement but doesn't
-// resolve the typed-query path on its own.
+// Keyboard-only flow asserting the a11y promise: compose, navigate,
+// and inspect blocks without a pointer. Slash-menu ArrowDown nav is
+// covered here; typed-query path lives in slash-menu-typed-query.spec.ts.
 
 const NOW = new Date("2026-05-17T00:00:00Z");
 

--- a/packages/admin/e2e/slash-menu-typed-query.spec.ts
+++ b/packages/admin/e2e/slash-menu-typed-query.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+const NOW = new Date("2026-05-17T00:00:00Z");
+
+test.describe("Slash menu — typed query keeps the mount alive (#342)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  test("typing `/heading` keeps the mount visible across every keystroke", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 9,
+              type: "post",
+              parentId: null,
+              title: "Empty",
+              slug: "e",
+              content: {
+                type: "doc",
+                content: [{ type: "core/paragraph", content: [] }],
+              },
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              sortOrder: 0,
+              publishedAt: null,
+              createdAt: NOW,
+              updatedAt: NOW,
+              meta: {},
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/9/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    await page.locator(".ProseMirror").click();
+
+    // Per-keystroke visibility — the regression was a mount-disappears
+    // mid-typing, so the assertion needs to fire on every character to
+    // pinpoint the offending keystroke if it ever reappears.
+    const mount = page.locator("[data-plumix-slash-menu-mount]");
+    for (const ch of "/heading") {
+      await page.keyboard.press(ch === "/" ? "Slash" : ch);
+      await expect(mount).toBeVisible();
+    }
+    await expect(
+      page.getByTestId("slash-menu-item-core/heading"),
+    ).toBeVisible();
+    await page.keyboard.press("Enter");
+    await expect(
+      page.locator(".ProseMirror h1, .ProseMirror h2, .ProseMirror h3"),
+    ).toHaveCount(1);
+  });
+});

--- a/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
+++ b/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
@@ -135,12 +135,9 @@ export function PlumixDragHandle({
   // Pinned identity: `DragHandle` lists `onNodeChange` in its effect
   // deps, so a fresh callback per render re-registers the ProseMirror
   // plugin and tears down the slash-menu mount mid-typing (#342).
-  const onNodeChange = useCallback(
-    ({ node, pos }: OnNodeChangeArgs) => {
-      setTracked(node ? { node, pos } : null);
-    },
-    [],
-  );
+  const onNodeChange = useCallback(({ node, pos }: OnNodeChangeArgs) => {
+    setTracked(node ? { node, pos } : null);
+  }, []);
 
   return (
     <DragHandle editor={editor} onNodeChange={onNodeChange}>

--- a/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
+++ b/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
@@ -1,6 +1,6 @@
 import type { Editor } from "@tiptap/react";
 import type { ReactElement } from "react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import {
   Popover,
   PopoverContent,
@@ -24,6 +24,11 @@ interface TrackedNode {
     readonly nodeSize: number;
     toJSON(): unknown;
   };
+  readonly pos: number;
+}
+
+interface OnNodeChangeArgs {
+  readonly node: TrackedNode["node"] | null;
   readonly pos: number;
 }
 
@@ -127,13 +132,18 @@ export function PlumixDragHandle({
     setOpen(false);
   };
 
+  // Pinned identity: `DragHandle` lists `onNodeChange` in its effect
+  // deps, so a fresh callback per render re-registers the ProseMirror
+  // plugin and tears down the slash-menu mount mid-typing (#342).
+  const onNodeChange = useCallback(
+    ({ node, pos }: OnNodeChangeArgs) => {
+      setTracked(node ? { node, pos } : null);
+    },
+    [],
+  );
+
   return (
-    <DragHandle
-      editor={editor}
-      onNodeChange={({ node, pos }) => {
-        setTracked(node ? { node, pos } : null);
-      }}
-    >
+    <DragHandle editor={editor} onNodeChange={onNodeChange}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <DragHandleButton onOpenMenu={() => setOpen(true)} />


### PR DESCRIPTION
Fixes GH-342. The defensive helper in PR #347 closed a separate bug class (the value-sync echo loop), but the typed-query path still broke in the real browser — typing `/heading` after `/` always removed the slash-menu mount mid-typing.

**Root cause**

`PlumixDragHandle` rendered the third-party `<DragHandle onNodeChange={({node,pos})=>...}>` with an inline arrow function. That library's internal `useEffect` lists `onNodeChange` in its dependency array, so every parent re-render (e.g. RHF's `setValue` after `onUpdate` emits new content → React re-render → cascades into `TiptapEditor` → `PlumixDragHandle` re-renders with a fresh callback identity) ran:

1. `useEffect` cleanup → `editor.unregisterPlugin(dragHandleKey)`
2. `useEffect` re-run → `editor.registerPlugin(dragHandle)`

Both mutate `state.plugins`, ProseMirror's `view.updateState` runs `updatePluginViews`, *every* plugin view is destroyed and recreated, including the slash-menu suggestion's view. Renderer's `onExit` fires from the plugin-view destroy and removes the mount.

Confirmed via Playwright stack-trace instrumentation showing `onExit ← Object.destroy ← destroyPluginViews ← updatePluginViews` on every keystroke transaction.

**Fix**

`useCallback`-pin `onNodeChange` in `PlumixDragHandle` with empty deps. The closure only references `setTracked`, which React guarantees is stable.

**Regression spec**

`packages/admin/e2e/slash-menu-typed-query.spec.ts` types `/heading` character-by-character and asserts the mount stays visible after *each* keystroke — without the fix it fails on the second keystroke. Per-char assertion + `Slash` keypress for the `/` character gives a clean failure signature if this ever regresses.

The pre-existing keyboard-only spec (`editor-keyboard.spec.ts`) keeps its ArrowDown path as the keyboard-nav fallback — header comment updated to point at the new typed-query spec.

**Out-of-scope but noted by senpai**

Other admin sites that render `@tiptap/*` React components were audited — `BubbleMenu` and `FloatingInsertMenu` only pass `editor` (stable) and the library ref-pins their plugin props internally. The `DragHandle` family is uniquely bad because the library author put callback props directly into the registration `useEffect`. A `usePinnedCallback` workspace helper would be a belt-and-suspenders option but isn't needed for this fix.

Fixes GH-342