### PR TITLE
feat(admin): keyboard-only authoring narrative for #314

### DIFF
--- a/packages/admin/e2e/keyboard-only-save-and-reload.spec.ts
+++ b/packages/admin/e2e/keyboard-only-save-and-reload.spec.ts
@@ -8,11 +8,9 @@ import {
 } from "./support/rpc-mock.js";
 
 // Keyboard-only narrative for #314: insert a heading via the slash
-// menu, retarget the heading level via the Inspector, save, reload,
-// and assert the persisted state still reflects the keyboard-only
-// edits. The drag-handle → BlockMenu → transform-to leg of the AC
-// is covered in `keyboard-only-block-transform.spec.ts` once the
-// drag-handle keyboard plumbing lands.
+// menu, retarget the heading level via the Inspector, transform the
+// block via the keyboard-driven BlockMenu, save, reload, and assert
+// the persisted state still reflects the keyboard-only edits.
 
 const T0 = new Date("2026-05-18T00:00:00Z");
 const T1 = new Date("2026-05-18T00:01:00Z");
@@ -137,21 +135,121 @@ test.describe("Keyboard-only: insert via slash menu, save, reload", () => {
     // Filter for the level-3 update specifically so a stray autosave
     // (or any other write the editor decides to dispatch) doesn't
     // satisfy "length > 0" before the save we care about lands.
-    const isLevelThreeUpdate = (
-      input: unknown,
-    ): input is {
-      content: { content: ReadonlyArray<{ attrs?: { level?: number } }> };
-    } => {
-      const first = (input as { content?: { content?: unknown[] } })?.content
+    const isLevelThreeUpdate = (input: unknown): boolean => {
+      const first = (input as { content?: { content?: unknown[] } }).content
         ?.content?.[0] as { attrs?: { level?: number } } | undefined;
       return first?.attrs?.level === 3;
     };
-    await expect
-      .poll(() => updateInputs.some(isLevelThreeUpdate))
-      .toBe(true);
+    await expect.poll(() => updateInputs.some(isLevelThreeUpdate)).toBe(true);
 
     await page.reload();
     await expect(page.getByTestId("post-editor-form")).toBeVisible();
     await expect(page.locator(".ProseMirror h3")).toHaveCount(1);
+  });
+
+  test("Mod-Alt-ArrowLeft opens the BlockMenu and the keyboard transform persists", async ({
+    page,
+  }) => {
+    const updateInputs: unknown[] = [];
+    let getCalls = 0;
+
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        getCalls += 1;
+        const lastUpdate = updateInputs.at(-1) as
+          | { content?: unknown }
+          | undefined;
+        const isReload = getCalls > 1;
+        const content = isReload
+          ? lastUpdate?.content
+          : {
+              type: "doc",
+              content: [
+                {
+                  type: "core/heading",
+                  attrs: { level: 2 },
+                  content: [{ type: "text", text: "Title" }],
+                },
+              ],
+            };
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: entryBody({
+            id: 12,
+            content,
+            updatedAt: isReload ? T1 : T0,
+          }),
+        });
+      }
+      if (url.endsWith("/entry/update")) {
+        const body = route.request().postDataJSON() as { json?: unknown };
+        updateInputs.push(body.json);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: entryBody({
+            id: 12,
+            content: (body.json as { content?: unknown }).content,
+            updatedAt: T1,
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/12/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    // Land the caret inside the loaded heading.
+    await page.locator(".ProseMirror h2").click();
+
+    // Mod-Alt-ArrowLeft (Cmd on darwin, Ctrl elsewhere) dispatches
+    // `openBlockMenuAtCaret` which surfaces the popover anchored on
+    // the caret-containing block. cmdk owns the popover's keyboard
+    // navigation from here.
+    // Tiptap resolves `Mod` against the browser's view of the
+    // platform, which is what `navigator.platform` reports inside
+    // the page — not the host OS. Reading it via `page.evaluate`
+    // keeps the test correct under cross-platform CI where the
+    // host and the browser may disagree (e.g. linux runner serving
+    // a macOS-emulating WebKit).
+    const isMac = await page.evaluate(() => /Mac/i.test(navigator.platform));
+    const mod = isMac ? "Meta" : "Control";
+    await page.keyboard.press(`${mod}+Alt+ArrowLeft`);
+    const transformParagraph = page.getByTestId(
+      "block-menu-transform-core/paragraph",
+    );
+    await expect(transformParagraph).toBeVisible();
+    // cmdk auto-selects the first CommandItem when focus lands on the
+    // hidden CommandInput, so Enter commits transform-paragraph
+    // directly. ArrowDown would skip past it to the Duplicate row.
+    await expect(transformParagraph).toHaveAttribute("aria-selected", "true");
+    await page.keyboard.press("Enter");
+    await expect(page.locator(".ProseMirror h2")).toHaveCount(0);
+    await expect(page.locator(".ProseMirror p")).toHaveCount(1);
+
+    await page.getByTestId("post-editor-submit").focus();
+    await page.keyboard.press("Enter");
+
+    const isParagraphUpdate = (input: unknown): boolean => {
+      const first = (input as { content?: { content?: unknown[] } }).content
+        ?.content?.[0] as { type?: string } | undefined;
+      return first?.type === "core/paragraph";
+    };
+    await expect.poll(() => updateInputs.some(isParagraphUpdate)).toBe(true);
+
+    await page.reload();
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+    await expect(page.locator(".ProseMirror h2")).toHaveCount(0);
+    await expect(page.locator(".ProseMirror p")).toHaveCount(1);
   });
 });

--- a/packages/admin/e2e/keyboard-only-save-and-reload.spec.ts
+++ b/packages/admin/e2e/keyboard-only-save-and-reload.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+// Keyboard-only narrative for #314: insert a heading via the slash
+// menu, retarget the heading level via the Inspector, save, reload,
+// and assert the persisted state still reflects the keyboard-only
+// edits. The drag-handle → BlockMenu → transform-to leg of the AC
+// is covered in `keyboard-only-block-transform.spec.ts` once the
+// drag-handle keyboard plumbing lands.
+
+const T0 = new Date("2026-05-18T00:00:00Z");
+const T1 = new Date("2026-05-18T00:01:00Z");
+
+interface EntryRecord {
+  readonly id: number;
+  readonly content: unknown;
+  readonly updatedAt: Date;
+}
+
+function entryBody(record: EntryRecord): string {
+  return JSON.stringify({
+    json: {
+      id: record.id,
+      type: "post",
+      parentId: null,
+      title: "Empty",
+      slug: "e",
+      content: record.content,
+      excerpt: null,
+      status: "draft",
+      authorId: 1,
+      sortOrder: 0,
+      publishedAt: null,
+      createdAt: T0,
+      updatedAt: record.updatedAt,
+      meta: {},
+    },
+    meta: [],
+  });
+}
+
+test.describe("Keyboard-only: insert via slash menu, save, reload", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  test("typing `/heading` + Inspector level change persists across reload", async ({
+    page,
+  }) => {
+    const updateInputs: unknown[] = [];
+    let getCalls = 0;
+
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        getCalls += 1;
+        const lastUpdate = updateInputs.at(-1) as
+          | { content?: unknown }
+          | undefined;
+        const isReload = getCalls > 1;
+        const content = isReload
+          ? lastUpdate?.content
+          : {
+              type: "doc",
+              content: [{ type: "core/paragraph", content: [] }],
+            };
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: entryBody({
+            id: 9,
+            content,
+            updatedAt: isReload ? T1 : T0,
+          }),
+        });
+      }
+      if (url.endsWith("/entry/update")) {
+        const body = route.request().postDataJSON() as { json?: unknown };
+        updateInputs.push(body.json);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: entryBody({
+            id: 9,
+            content: (body.json as { content?: unknown }).content,
+            updatedAt: T1,
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/9/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    // Editor focus uses a click — the existing keyboard suite
+    // treats `.ProseMirror` click as the mount affordance, not a
+    // flow step. Every subsequent interaction is keyboard-only.
+    await page.locator(".ProseMirror").click();
+    await page.keyboard.type("/heading");
+    await expect(page.locator("[data-plumix-slash-menu-mount]")).toBeVisible();
+    await expect(
+      page.getByTestId("slash-menu-item-core/heading"),
+    ).toBeVisible();
+    await page.keyboard.press("Enter");
+    await expect(page.locator(".ProseMirror h2")).toHaveCount(1);
+
+    // `selectOption` dispatches the same `input`+`change` events a
+    // real ArrowDown on the focused native `<select>` would — the
+    // AC bars mouse events, not the equivalent keyboard semantics
+    // expressed through the Playwright API.
+    const levelSelect = page.getByTestId("inspector-field-level");
+    await expect(levelSelect).toBeVisible();
+    await levelSelect.selectOption({ value: "3" });
+    await expect(page.locator(".ProseMirror h3")).toHaveCount(1);
+
+    // Save: focus the submit button, Enter. The form's
+    // `<button type="submit">` fires onSubmit on Enter regardless
+    // of which control has focus, so landing on it via keyboard
+    // and pressing Enter is the canonical model.
+    await page.getByTestId("post-editor-submit").focus();
+    await page.keyboard.press("Enter");
+
+    // Filter for the level-3 update specifically so a stray autosave
+    // (or any other write the editor decides to dispatch) doesn't
+    // satisfy "length > 0" before the save we care about lands.
+    const isLevelThreeUpdate = (
+      input: unknown,
+    ): input is {
+      content: { content: ReadonlyArray<{ attrs?: { level?: number } }> };
+    } => {
+      const first = (input as { content?: { content?: unknown[] } })?.content
+        ?.content?.[0] as { attrs?: { level?: number } } | undefined;
+      return first?.attrs?.level === 3;
+    };
+    await expect
+      .poll(() => updateInputs.some(isLevelThreeUpdate))
+      .toBe(true);
+
+    await page.reload();
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+    await expect(page.locator(".ProseMirror h3")).toHaveCount(1);
+  });
+});

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -2,6 +2,7 @@ import type { SlashMenuItem } from "@/editor/slash-menu/items-from-registry.js";
 import type { Editor, JSONContent } from "@tiptap/react";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
+import { createBlockMenuKeyboardExtension } from "@/editor/drag-handle/block-menu-keyboard.js";
 import { PlumixDragHandle } from "@/editor/drag-handle/PlumixDragHandle.js";
 import { FloatingInsertMenu } from "@/editor/floating-menu/FloatingInsertMenu.js";
 import { createSlashMenuExtension } from "@/editor/slash-menu/extension.js";
@@ -135,6 +136,7 @@ export function TiptapEditor({
           ed.chain().focus().insertContent(slashMenuItemToContent(item)).run();
         },
       }),
+      createBlockMenuKeyboardExtension(),
     ];
   }, [allowlist, blockRegistry, markRegistry]);
 

--- a/packages/admin/src/editor/block-menu/BlockMenu.tsx
+++ b/packages/admin/src/editor/block-menu/BlockMenu.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import {
   Command,
   CommandGroup,
+  CommandInput,
   CommandItem,
   CommandList,
   CommandSeparator,
@@ -46,6 +47,18 @@ export function BlockMenu({
   );
   return (
     <Command data-plumix-block-menu="" label="Block actions">
+      {/*
+        Hidden CommandInput exists to give cmdk a focusable surface so
+        keyboard-only authors can drive the menu with ArrowDown / Enter
+        — without it, radix's Popover autoFocus has nothing to land on
+        and the editor keeps focus, swallowing Enter.
+      */}
+      <CommandInput
+        className="sr-only"
+        tabIndex={-1}
+        aria-label="Filter block actions"
+        data-plumix-block-menu-input=""
+      />
       <CommandList>
         {targets.length > 0 ? (
           <>

--- a/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
+++ b/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
@@ -1,6 +1,6 @@
 import type { Editor } from "@tiptap/react";
 import type { ReactElement } from "react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Popover,
   PopoverContent,
@@ -10,7 +10,9 @@ import { DragHandle } from "@tiptap/extension-drag-handle-react";
 
 import type { BlockRegistry, BlockTransformTo } from "@plumix/blocks";
 
+import type { BlockMenuOpenDetail } from "./block-menu-keyboard.js";
 import { BlockMenu } from "../block-menu/BlockMenu.js";
+import { BLOCK_MENU_OPEN_EVENT } from "./block-menu-keyboard.js";
 import { DragHandleButton } from "./DragHandleButton.js";
 
 interface PlumixDragHandleProps {
@@ -139,13 +141,66 @@ export function PlumixDragHandle({
     setTracked(node ? { node, pos } : null);
   }, []);
 
+  // Keyboard-only path: the drag-handle plugin is mouse-driven, so
+  // pressing the keyboard shortcut dispatches a CustomEvent on the
+  // editor's `view.dom`. Scoping to `view.dom` (not `document`)
+  // prevents crosstalk if a second editor mounts on the same page —
+  // each PlumixDragHandle resolves `pos` against its own editor's doc.
+  useEffect(() => {
+    let dom: HTMLElement | null = null;
+    const handler = (event: Event): void => {
+      const { pos } = (event as CustomEvent<BlockMenuOpenDetail>).detail;
+      const node = editor.state.doc.nodeAt(pos);
+      if (!node) return;
+      setTracked({ node, pos });
+      setOpen(true);
+    };
+    const attach = ({ editor: ed }: { editor: typeof editor }): void => {
+      if (dom) return;
+      dom = ed.view.dom;
+      dom.addEventListener(BLOCK_MENU_OPEN_EVENT, handler);
+    };
+    editor.on("create", attach);
+    // Editor may already be mounted when this effect runs (StrictMode
+    // remount, or this effect's first run after the create event has
+    // already fired). The view-access guard in Tiptap throws synchronously
+    // pre-mount, so catch and let `create` handle the attach later.
+    try {
+      attach({ editor });
+    } catch {
+      /* view not ready; the `create` handler covers it */
+    }
+    return () => {
+      editor.off("create", attach);
+      dom?.removeEventListener(BLOCK_MENU_OPEN_EVENT, handler);
+    };
+  }, [editor]);
+
   return (
     <DragHandle editor={editor} onNodeChange={onNodeChange}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <DragHandleButton onOpenMenu={() => setOpen(true)} />
         </PopoverTrigger>
-        <PopoverContent side="left" align="start" className="w-56 p-0">
+        <PopoverContent
+          side="left"
+          align="start"
+          className="w-56 p-0"
+          onOpenAutoFocus={(event) => {
+            // Radix defaults to focusing the first tab-stop in the
+            // content; BlockMenu has none (cmdk items aren't tabbable).
+            // Route focus onto the hidden cmdk input so it receives
+            // ArrowDown / Enter for keyboard-only authors. The explicit
+            // `data-plumix-block-menu-input` selector survives future
+            // additions of unrelated <input> elements to the popover.
+            event.preventDefault();
+            const content = event.currentTarget as HTMLElement | null;
+            const input = content?.querySelector<HTMLElement>(
+              "[data-plumix-block-menu-input]",
+            );
+            input?.focus();
+          }}
+        >
           {tracked ? (
             <BlockMenu
               sourceName={tracked.node.type.name}

--- a/packages/admin/src/editor/drag-handle/block-menu-keyboard.test.ts
+++ b/packages/admin/src/editor/drag-handle/block-menu-keyboard.test.ts
@@ -1,0 +1,71 @@
+import { Editor, Node } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import type { BlockMenuOpenDetail } from "./block-menu-keyboard.js";
+import {
+  BLOCK_MENU_OPEN_EVENT,
+  createBlockMenuKeyboardExtension,
+} from "./block-menu-keyboard.js";
+
+const Doc = Node.create({ name: "doc", topNode: true, content: "block+" });
+const Text = Node.create({ name: "text", group: "inline" });
+const Para = Node.create({
+  name: "paragraph",
+  group: "block",
+  content: "inline*",
+  parseHTML() {
+    return [{ tag: "p" }];
+  },
+  renderHTML() {
+    return ["p", 0];
+  },
+});
+
+function bootEditor(): Editor {
+  return new Editor({
+    extensions: [Doc, Text, Para, createBlockMenuKeyboardExtension()],
+    content: "<p>First</p><p>Second</p>",
+  });
+}
+
+describe("createBlockMenuKeyboardExtension", () => {
+  test("Mod-Alt-ArrowLeft dispatches BLOCK_MENU_OPEN_EVENT with the caret block's pos", () => {
+    const editor = bootEditor();
+    editor.commands.setTextSelection(10); // inside "Second"
+    const captured: BlockMenuOpenDetail[] = [];
+    editor.view.dom.addEventListener(BLOCK_MENU_OPEN_EVENT, (event) => {
+      captured.push((event as CustomEvent<BlockMenuOpenDetail>).detail);
+    });
+
+    const handled = editor.commands.openBlockMenuAtCaret();
+
+    expect(handled).toBe(true);
+    expect(captured).toHaveLength(1);
+    // First p occupies positions 0..6 (nodeSize 7); the second p
+    // begins at pos 7, which is what doc.nodeAt() resolves to.
+    expect(captured[0]?.pos).toBe(7);
+    const node = editor.state.doc.nodeAt(captured[0]?.pos ?? -1);
+    expect(node?.type.name).toBe("paragraph");
+    editor.destroy();
+  });
+
+  test("empty paragraph — command still resolves to the enclosing block", () => {
+    const editor = new Editor({
+      extensions: [Doc, Text, Para, createBlockMenuKeyboardExtension()],
+      content: "<p></p>",
+    });
+    const captured: BlockMenuOpenDetail[] = [];
+    editor.view.dom.addEventListener(BLOCK_MENU_OPEN_EVENT, (event) => {
+      captured.push((event as CustomEvent<BlockMenuOpenDetail>).detail);
+    });
+
+    const handled = editor.commands.openBlockMenuAtCaret();
+
+    expect(handled).toBe(true);
+    expect(captured).toHaveLength(1);
+    expect(editor.state.doc.nodeAt(captured[0]?.pos ?? -1)?.type.name).toBe(
+      "paragraph",
+    );
+    editor.destroy();
+  });
+});

--- a/packages/admin/src/editor/drag-handle/block-menu-keyboard.ts
+++ b/packages/admin/src/editor/drag-handle/block-menu-keyboard.ts
@@ -1,0 +1,59 @@
+import { Extension } from "@tiptap/core";
+
+export const BLOCK_MENU_OPEN_EVENT = "plumix:block-menu-open";
+
+export interface BlockMenuOpenDetail {
+  readonly pos: number;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    plumixBlockMenuKeyboard: {
+      openBlockMenuAtCaret: () => ReturnType;
+    };
+  }
+}
+
+/**
+ * Keyboard affordance for the BlockMenu. The drag-handle plugin from
+ * `@tiptap/extension-drag-handle-react` only anchors on hover, which
+ * leaves keyboard-only authors with no path to the block actions. This
+ * extension bridges the caret position to React via a DOM custom event
+ * so the listener (PlumixDragHandle) can open the menu against the
+ * containing block — radix's Popover handles the rest.
+ *
+ * Mod-Alt-ArrowLeft was chosen for consistency with the #314 AC and
+ * because no shipped block keyboard shortcut occupies it.
+ */
+export function createBlockMenuKeyboardExtension(): Extension {
+  return Extension.create({
+    name: "plumixBlockMenuKeyboard",
+    addCommands() {
+      return {
+        openBlockMenuAtCaret:
+          () =>
+          ({ editor }) => {
+            const { $from } = editor.state.selection;
+            let depth = $from.depth;
+            while (depth > 0 && !$from.node(depth).type.isBlock) depth -= 1;
+            const pos = depth === 0 ? 0 : $from.before(depth);
+            // Dispatch on `editor.view.dom` (per-editor) so two editor
+            // mounts on one page don't crosstalk. The command only runs
+            // after the editor is fully mounted, so `view` is safe.
+            editor.view.dom.dispatchEvent(
+              new CustomEvent(BLOCK_MENU_OPEN_EVENT, {
+                detail: { pos } satisfies BlockMenuOpenDetail,
+                bubbles: false,
+              }),
+            );
+            return true;
+          },
+      };
+    },
+    addKeyboardShortcuts() {
+      return {
+        "Mod-Alt-ArrowLeft": () => this.editor.commands.openBlockMenuAtCaret(),
+      };
+    },
+  });
+}

--- a/packages/blocks/src/heading/schema.test.ts
+++ b/packages/blocks/src/heading/schema.test.ts
@@ -6,7 +6,9 @@ import { headingSchema } from "./schema.js";
 const Doc = Node.create({ name: "doc", topNode: true, content: "block+" });
 const Text = Node.create({ name: "text", group: "inline" });
 
-function bootEditor(json: Parameters<Editor["commands"]["setContent"]>[0]): Editor {
+function bootEditor(
+  json: Parameters<Editor["commands"]["setContent"]>[0],
+): Editor {
   return new Editor({
     extensions: [Doc, Text, headingSchema],
     content: json,
@@ -28,23 +30,20 @@ describe("core/heading editor schema honors the level attribute", () => {
     editor.destroy();
   });
 
-  test.each([1, 2, 3, 4, 5, 6])(
-    "level=%i renders as <h%i>",
-    (level) => {
-      const editor = bootEditor({
-        type: "doc",
-        content: [
-          {
-            type: "core/heading",
-            attrs: { level },
-            content: [{ type: "text", text: "Hi" }],
-          },
-        ],
-      });
-      expect(editor.getHTML()).toContain(`<h${level}>`);
-      editor.destroy();
-    },
-  );
+  test.each([1, 2, 3, 4, 5, 6])("level=%i renders as <h%i>", (level) => {
+    const editor = bootEditor({
+      type: "doc",
+      content: [
+        {
+          type: "core/heading",
+          attrs: { level },
+          content: [{ type: "text", text: "Hi" }],
+        },
+      ],
+    });
+    expect(editor.getHTML()).toContain(`<h${level}>`);
+    editor.destroy();
+  });
 
   test("parseHTML round-trips the level from h1..h6 tags", () => {
     const editor = bootEditor("<h3>Section</h3>");

--- a/packages/blocks/src/heading/schema.test.ts
+++ b/packages/blocks/src/heading/schema.test.ts
@@ -1,3 +1,4 @@
+import type { Content } from "@tiptap/core";
 import { Editor, Node } from "@tiptap/core";
 import { describe, expect, test } from "vitest";
 
@@ -6,12 +7,10 @@ import { headingSchema } from "./schema.js";
 const Doc = Node.create({ name: "doc", topNode: true, content: "block+" });
 const Text = Node.create({ name: "text", group: "inline" });
 
-function bootEditor(
-  json: Parameters<Editor["commands"]["setContent"]>[0],
-): Editor {
+function bootEditor(content: Content): Editor {
   return new Editor({
     extensions: [Doc, Text, headingSchema],
-    content: json,
+    content,
   });
 }
 

--- a/packages/blocks/src/heading/schema.test.ts
+++ b/packages/blocks/src/heading/schema.test.ts
@@ -1,0 +1,99 @@
+import { Editor, Node } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import { headingSchema } from "./schema.js";
+
+const Doc = Node.create({ name: "doc", topNode: true, content: "block+" });
+const Text = Node.create({ name: "text", group: "inline" });
+
+function bootEditor(json: Parameters<Editor["commands"]["setContent"]>[0]): Editor {
+  return new Editor({
+    extensions: [Doc, Text, headingSchema],
+    content: json,
+  });
+}
+
+describe("core/heading editor schema honors the level attribute", () => {
+  test("default level renders as <h2>", () => {
+    const editor = bootEditor({
+      type: "doc",
+      content: [
+        {
+          type: "core/heading",
+          content: [{ type: "text", text: "Hi" }],
+        },
+      ],
+    });
+    expect(editor.getHTML()).toContain("<h2>");
+    editor.destroy();
+  });
+
+  test.each([1, 2, 3, 4, 5, 6])(
+    "level=%i renders as <h%i>",
+    (level) => {
+      const editor = bootEditor({
+        type: "doc",
+        content: [
+          {
+            type: "core/heading",
+            attrs: { level },
+            content: [{ type: "text", text: "Hi" }],
+          },
+        ],
+      });
+      expect(editor.getHTML()).toContain(`<h${level}>`);
+      editor.destroy();
+    },
+  );
+
+  test("parseHTML round-trips the level from h1..h6 tags", () => {
+    const editor = bootEditor("<h3>Section</h3>");
+    const first = editor.state.doc.firstChild;
+    expect(first?.type.name).toBe("core/heading");
+    expect(first?.attrs.level).toBe(3);
+    editor.destroy();
+  });
+
+  // Mirrors the Frontend Component's clamp contract (heading.test.tsx).
+  // Both surfaces share semantics so out-of-bounds attrs render as <h1>
+  // / <h6> regardless of how the doc got that way.
+  test.each([
+    { level: 0, expected: 1 },
+    { level: -3, expected: 1 },
+    { level: 7, expected: 6 },
+    { level: 99, expected: 6 },
+    { level: 2.7, expected: 2 },
+    { level: "two", expected: 2 },
+  ])("clamps level=$level to <h$expected>", ({ level, expected }) => {
+    const editor = bootEditor({
+      type: "doc",
+      content: [
+        {
+          type: "core/heading",
+          attrs: { level },
+          content: [{ type: "text", text: "Hi" }],
+        },
+      ],
+    });
+    expect(editor.getHTML()).toContain(`<h${expected}>`);
+    editor.destroy();
+  });
+
+  test("renderHTML emits the tag only — no leaked `level` attribute", () => {
+    const editor = bootEditor({
+      type: "doc",
+      content: [
+        {
+          type: "core/heading",
+          attrs: { level: 4 },
+          content: [{ type: "text", text: "Hi" }],
+        },
+      ],
+    });
+    // The level is encoded by the tag itself; serializing it as an
+    // attribute would clobber arbitrary HTMLAttributes and confuse the
+    // server-side renderer which round-trips via the same DOM.
+    expect(editor.getHTML()).toBe("<h4>Hi</h4>");
+    editor.destroy();
+  });
+});

--- a/packages/blocks/src/heading/schema.ts
+++ b/packages/blocks/src/heading/schema.ts
@@ -35,6 +35,10 @@ export const headingSchema = Node.create({
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    return [`h${clampLevel(node.attrs.level)}`, mergeAttributes(HTMLAttributes), 0];
+    return [
+      `h${clampLevel(node.attrs.level)}`,
+      mergeAttributes(HTMLAttributes),
+      0,
+    ];
   },
 });

--- a/packages/blocks/src/heading/schema.ts
+++ b/packages/blocks/src/heading/schema.ts
@@ -1,23 +1,40 @@
 import { mergeAttributes, Node } from "@tiptap/core";
 
+const LEVELS = [1, 2, 3, 4, 5, 6] as const;
+type Level = (typeof LEVELS)[number];
+const DEFAULT_LEVEL: Level = 2;
+
+function clampLevel(raw: unknown): Level {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n)) return DEFAULT_LEVEL;
+  const rounded = Math.trunc(n);
+  if (rounded < 1) return 1;
+  if (rounded > 6) return 6;
+  return rounded as Level;
+}
+
 export const headingSchema = Node.create({
   name: "core/heading",
   group: "block",
   content: "inline*",
   defining: true,
 
-  parseHTML() {
-    return [
-      { tag: "h1" },
-      { tag: "h2" },
-      { tag: "h3" },
-      { tag: "h4" },
-      { tag: "h5" },
-      { tag: "h6" },
-    ];
+  addAttributes() {
+    return {
+      level: {
+        default: DEFAULT_LEVEL,
+        parseHTML: (el) => clampLevel(el.tagName.replace(/^H/i, "")),
+        // Suppress the default `level="N"` HTML attribute — the tag itself encodes it.
+        renderHTML: () => ({}),
+      },
+    };
   },
 
-  renderHTML({ HTMLAttributes }) {
-    return ["h2", mergeAttributes(HTMLAttributes), 0];
+  parseHTML() {
+    return LEVELS.map((level) => ({ tag: `h${level}` }));
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [`h${clampLevel(node.attrs.level)}`, mergeAttributes(HTMLAttributes), 0];
   },
 });


### PR DESCRIPTION
## Summary

Closes the three remaining engineering follow-ups on #314 in one branch (two commits):

1. **`fix(blocks)`** — `core/heading`'s Tiptap node schema didn't declare `level` as an attribute and hardcoded `<h2>` in renderHTML. The Inspector's level select called `updateAttributes` but the editor kept rendering `h2` and `parseHTML` threw the level away on reload. The frontend `<EntryContent>` Component already clamped + honored level; this brings the editor surface to parity.
2. **`feat(admin)`** — new `createBlockMenuKeyboardExtension` adds `Mod-Alt-ArrowLeft` → opens the BlockMenu over the caret-containing block. cmdk owns ArrowDown/Enter navigation, so the existing transform-to / duplicate / delete actions all flow through the keyboard. Cross-editor crosstalk avoided by dispatching on `editor.view.dom`. BlockMenu gains a hidden, labelled CommandInput so cmdk has a focus target.
3. **e2e** — `keyboard-only-save-and-reload.spec.ts` covers two narratives end-to-end:
   - `/heading` → Inspector level=3 → save (Enter on submit) → reload → asserts persisted `h3`
   - `Mod-Alt-ArrowLeft` → cmdk auto-selects transform-paragraph → Enter → save → reload → asserts paragraph persisted

Mod modifier is detected via `navigator.platform` inside the page (not host OS) so it matches Tiptap's own resolution.

## Test plan

- [x] `pnpm --filter @plumix/blocks test heading` (23/23 inc. 15 new schema tests)
- [x] `pnpm --filter @plumix/admin test` (270/270 inc. 2 new block-menu-keyboard tests)
- [x] `pnpm exec turbo run typecheck lint --filter @plumix/admin` clean
- [x] `pnpm format` clean
- [x] `pnpm knip` no new flagged exports
- [x] `pnpm exec playwright test keyboard-only-save-and-reload.spec.ts` (2/2)

## Known follow-up

Mod-Alt-ArrowLeft while the slash menu is open stacks the BlockMenu popover over it. Edge case in UI layering, not the transform path itself. Worth a focused fix in a follow-up.

Refs GH-314