### PR TITLE
feat(admin): mobile Inspector as bottom sheet at <768px

### DIFF
--- a/packages/admin/e2e/mobile-inspector-sheet.spec.ts
+++ b/packages/admin/e2e/mobile-inspector-sheet.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+// Mobile (< 768px) flow for #314: the right-rail Inspector folds into
+// a bottom Sheet. Authors open it via the per-block "Block settings"
+// trigger that sits next to the drag handle on touch widths. Desktop
+// is unchanged and covered by the existing keyboard suite.
+
+const T0 = new Date("2026-05-18T00:00:00Z");
+
+test.describe("Mobile Inspector bottom sheet (#314)", () => {
+  test.use({ viewport: { width: 480, height: 800 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  test("trigger opens the sheet; level change reflects in the editor", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 21,
+              type: "post",
+              parentId: null,
+              title: "Mobile",
+              slug: "m",
+              content: {
+                type: "doc",
+                content: [
+                  {
+                    type: "core/heading",
+                    attrs: { level: 2 },
+                    content: [{ type: "text", text: "Title" }],
+                  },
+                ],
+              },
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              sortOrder: 0,
+              publishedAt: null,
+              createdAt: T0,
+              updatedAt: T0,
+              meta: {},
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/21/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    // Select the heading — the drag-handle wrapper anchors to it and
+    // the mobile-only Inspector trigger renders alongside.
+    await page.locator(".ProseMirror h2").click();
+    const trigger = page.getByTestId("mobile-inspector-trigger");
+    await expect(trigger).toBeVisible();
+
+    // Tap opens the bottom sheet. The right-rail Inspector remains
+    // hidden at this width — the Sheet is the only Inspector surface.
+    await trigger.click();
+    const sheet = page.getByTestId("mobile-inspector-sheet");
+    await expect(sheet).toBeVisible();
+
+    // The Inspector inside the sheet still drives `updateAttributes`
+    // through the same editor — changing level retargets the tag in
+    // the live canvas behind the sheet.
+    const levelSelect = sheet.getByTestId("inspector-field-level");
+    await expect(levelSelect).toBeVisible();
+    await levelSelect.selectOption({ value: "4" });
+    await expect(page.locator(".ProseMirror h4")).toHaveCount(1);
+  });
+});

--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -41,9 +41,14 @@ import {
 import { EditorProvider, useActiveEditor } from "@/editor/editor-context.js";
 import { Inspector } from "@/editor/inspector/Inspector.js";
 import {
+  MobileInspectorSheet,
+  MobileInspectorSheetProvider,
+} from "@/editor/inspector/mobile-inspector-sheet.js";
+import {
   useAdminBlockRegistry,
   useAdminMarkRegistry,
 } from "@/editor/registries.js";
+import { useIsMobile } from "@/hooks/use-mobile.js";
 import { orpc } from "@/lib/orpc.js";
 import { buildEditorTermOptions } from "@/lib/terms.js";
 import { cn } from "@/lib/utils";
@@ -288,139 +293,142 @@ export function PostEditorForm({
   return (
     <Form {...form}>
       <EditorProvider value={activeEditor}>
-        {/* `contents` makes the form invisible in the flex flow so
-          SidebarProvider owns the layout; fields in the rail still
-          submit via Controller (rhf state, not DOM form semantics). */}
-        <form
-          id="entry-editor-form"
-          data-testid="post-editor-form"
-          onSubmit={handleSubmit}
-          className="contents"
-        >
-          <SidebarProvider defaultOpen className="flex-1">
-            <SidebarInset className="flex min-w-0 flex-col">
-              <header className="bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center justify-between gap-3 border-b px-4">
-                <div className="flex min-w-0 items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={onCancel}
-                    disabled={isSubmitting}
-                    data-testid="post-editor-cancel"
-                    aria-label="Back"
-                  >
-                    <ArrowLeft />
-                  </Button>
-                  <span
-                    className="truncate text-sm font-medium"
-                    data-testid="post-editor-headline"
-                  >
-                    {headline}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    type="submit"
-                    disabled={isSubmitting}
-                    data-testid="post-editor-submit"
-                  >
-                    {isSubmitting ? "Saving…" : submitLabel}
-                  </Button>
-                  {/* `type="button"` is load-bearing: shadcn's `Button`
+        <MobileInspectorSheetProvider>
+          <MobileInspectorSheetMount editor={activeEditor} />
+          {/* `contents` makes the form invisible in the flex flow so
+            SidebarProvider owns the layout; fields in the rail still
+            submit via Controller (rhf state, not DOM form semantics). */}
+          <form
+            id="entry-editor-form"
+            data-testid="post-editor-form"
+            onSubmit={handleSubmit}
+            className="contents"
+          >
+            <SidebarProvider defaultOpen className="flex-1">
+              <SidebarInset className="flex min-w-0 flex-col">
+                <header className="bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center justify-between gap-3 border-b px-4">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={onCancel}
+                      disabled={isSubmitting}
+                      data-testid="post-editor-cancel"
+                      aria-label="Back"
+                    >
+                      <ArrowLeft />
+                    </Button>
+                    <span
+                      className="truncate text-sm font-medium"
+                      data-testid="post-editor-headline"
+                    >
+                      {headline}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="submit"
+                      disabled={isSubmitting}
+                      data-testid="post-editor-submit"
+                    >
+                      {isSubmitting ? "Saving…" : submitLabel}
+                    </Button>
+                    {/* `type="button"` is load-bearing: shadcn's `Button`
                     doesn't default it, and an un-typed button inside
                     `<form>` inherits `submit` — clicking the toggle
                     would otherwise fire the form's onSubmit + mutate. */}
-                  <SidebarTrigger type="button" />
-                </div>
-              </header>
+                    <SidebarTrigger type="button" />
+                  </div>
+                </header>
 
-              {serverError ? (
-                <div className="border-b px-4 py-2">
-                  <Alert variant="destructive">
-                    <AlertDescription>{serverError}</AlertDescription>
-                  </Alert>
-                </div>
-              ) : null}
+                {serverError ? (
+                  <div className="border-b px-4 py-2">
+                    <Alert variant="destructive">
+                      <AlertDescription>{serverError}</AlertDescription>
+                    </Alert>
+                  </div>
+                ) : null}
 
-              <main className="flex-1 overflow-auto">
-                <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-8 py-10">
-                  {showTitle ? <TitleField disabled={isSubmitting} /> : null}
-                  {showEditor ? (
-                    <ContentField
-                      disabled={isSubmitting}
-                      onEditorReady={setActiveEditor}
-                    />
-                  ) : null}
-                  {!showTitle && !showEditor ? (
-                    <p
-                      className="text-muted-foreground text-sm"
-                      data-testid="post-editor-empty-canvas"
-                    >
-                      This entry type has no title or editor. Use the panels on
-                      the right to manage its content.
-                    </p>
-                  ) : null}
-                </div>
-              </main>
-            </SidebarInset>
+                <main className="flex-1 overflow-auto">
+                  <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-8 py-10">
+                    {showTitle ? <TitleField disabled={isSubmitting} /> : null}
+                    {showEditor ? (
+                      <ContentField
+                        disabled={isSubmitting}
+                        onEditorReady={setActiveEditor}
+                      />
+                    ) : null}
+                    {!showTitle && !showEditor ? (
+                      <p
+                        className="text-muted-foreground text-sm"
+                        data-testid="post-editor-empty-canvas"
+                      >
+                        This entry type has no title or editor. Use the panels
+                        on the right to manage its content.
+                      </p>
+                    ) : null}
+                  </div>
+                </main>
+              </SidebarInset>
 
-            <Sidebar
-              side="right"
-              collapsible="offcanvas"
-              data-testid="meta-boxes-sidebar"
-            >
-              <SidebarHeader className="flex h-14 shrink-0 flex-row items-center border-b px-4 text-sm font-semibold">
-                Document
-              </SidebarHeader>
-              <SidebarContent>
-                <InspectorSection />
-                <Accordion
-                  type="multiple"
-                  defaultValue={openSections}
-                  className="divide-y"
-                >
-                  {showSlug ? (
-                    <PermalinkSection
-                      disabled={isSubmitting}
-                      onSlugEdit={() => {
-                        setSlugLocked(true);
-                      }}
-                    />
-                  ) : null}
-                  <StatusSection
-                    availableStatuses={availableStatuses}
-                    disabled={isSubmitting}
-                  />
-                  {isHierarchical ? (
-                    <ParentSection
-                      parentOptions={parentOptions}
+              <Sidebar
+                side="right"
+                collapsible="offcanvas"
+                data-testid="meta-boxes-sidebar"
+              >
+                <SidebarHeader className="flex h-14 shrink-0 flex-row items-center border-b px-4 text-sm font-semibold">
+                  Document
+                </SidebarHeader>
+                <SidebarContent>
+                  <InspectorSection />
+                  <Accordion
+                    type="multiple"
+                    defaultValue={openSections}
+                    className="divide-y"
+                  >
+                    {showSlug ? (
+                      <PermalinkSection
+                        disabled={isSubmitting}
+                        onSlugEdit={() => {
+                          setSlugLocked(true);
+                        }}
+                      />
+                    ) : null}
+                    <StatusSection
+                      availableStatuses={availableStatuses}
                       disabled={isSubmitting}
                     />
-                  ) : null}
-                  {showExcerpt ? (
-                    <ExcerptSection disabled={isSubmitting} />
-                  ) : null}
-                  {taxonomies.map((tax) => (
-                    <TaxonomySection
-                      key={tax.name}
-                      taxonomy={tax}
-                      disabled={isSubmitting}
-                    />
-                  ))}
-                  {metaBoxes.map((box) => (
-                    <MetaBoxAccordionItem
-                      key={box.id}
-                      box={box}
-                      basePath="meta"
-                      disabled={isSubmitting}
-                    />
-                  ))}
-                </Accordion>
-              </SidebarContent>
-            </Sidebar>
-          </SidebarProvider>
-        </form>
+                    {isHierarchical ? (
+                      <ParentSection
+                        parentOptions={parentOptions}
+                        disabled={isSubmitting}
+                      />
+                    ) : null}
+                    {showExcerpt ? (
+                      <ExcerptSection disabled={isSubmitting} />
+                    ) : null}
+                    {taxonomies.map((tax) => (
+                      <TaxonomySection
+                        key={tax.name}
+                        taxonomy={tax}
+                        disabled={isSubmitting}
+                      />
+                    ))}
+                    {metaBoxes.map((box) => (
+                      <MetaBoxAccordionItem
+                        key={box.id}
+                        box={box}
+                        basePath="meta"
+                        disabled={isSubmitting}
+                      />
+                    ))}
+                  </Accordion>
+                </SidebarContent>
+              </Sidebar>
+            </SidebarProvider>
+          </form>
+        </MobileInspectorSheetProvider>
       </EditorProvider>
 
       <AlertDialog
@@ -487,9 +495,23 @@ function TitleField({ disabled }: { readonly disabled: boolean }): ReactNode {
   );
 }
 
+function MobileInspectorSheetMount({
+  editor,
+}: {
+  readonly editor: Editor | null;
+}): ReactNode {
+  const blockRegistry = useAdminBlockRegistry();
+  return <MobileInspectorSheet editor={editor} blockRegistry={blockRegistry} />;
+}
+
 function InspectorSection(): ReactNode {
+  // On mobile the Inspector renders inside `MobileInspectorSheet`
+  // instead; skipping here avoids double-binding `updateAttributes`
+  // handlers to the same editor.
+  const isMobile = useIsMobile();
   const editor = useActiveEditor();
   const blockRegistry = useAdminBlockRegistry();
+  if (isMobile) return null;
   if (!editor) return null;
   return <Inspector editor={editor} blockRegistry={blockRegistry} />;
 }

--- a/packages/admin/src/editor/drag-handle/MobileInspectorTrigger.tsx
+++ b/packages/admin/src/editor/drag-handle/MobileInspectorTrigger.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from "react";
+import { Settings2 } from "lucide-react";
+
+interface MobileInspectorTriggerProps {
+  readonly onOpen: () => void;
+}
+
+export function MobileInspectorTrigger({
+  onOpen,
+}: MobileInspectorTriggerProps): ReactElement {
+  return (
+    <button
+      type="button"
+      data-testid="mobile-inspector-trigger"
+      aria-label="Block settings"
+      onClick={onOpen}
+      className="text-muted-foreground hover:text-foreground flex h-6 w-6 items-center justify-center rounded-sm"
+    >
+      <Settings2 className="size-4" aria-hidden="true" />
+    </button>
+  );
+}

--- a/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
+++ b/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
@@ -6,14 +6,17 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover.js";
+import { useIsMobile } from "@/hooks/use-mobile.js";
 import { DragHandle } from "@tiptap/extension-drag-handle-react";
 
 import type { BlockRegistry, BlockTransformTo } from "@plumix/blocks";
 
 import type { BlockMenuOpenDetail } from "./block-menu-keyboard.js";
 import { BlockMenu } from "../block-menu/BlockMenu.js";
+import { useMobileInspectorSheet } from "../inspector/mobile-inspector-sheet.js";
 import { BLOCK_MENU_OPEN_EVENT } from "./block-menu-keyboard.js";
 import { DragHandleButton } from "./DragHandleButton.js";
+import { MobileInspectorTrigger } from "./MobileInspectorTrigger.js";
 
 interface PlumixDragHandleProps {
   readonly editor: Editor;
@@ -54,6 +57,8 @@ export function PlumixDragHandle({
   // toJSON) are the only contract this component relies on.
   const [tracked, setTracked] = useState<TrackedNode | null>(null);
   const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const mobileSheet = useMobileInspectorSheet();
 
   /**
    * Every BlockMenu action selects the tracked node first so the
@@ -178,41 +183,46 @@ export function PlumixDragHandle({
 
   return (
     <DragHandle editor={editor} onNodeChange={onNodeChange}>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <DragHandleButton onOpenMenu={() => setOpen(true)} />
-        </PopoverTrigger>
-        <PopoverContent
-          side="left"
-          align="start"
-          className="w-56 p-0"
-          onOpenAutoFocus={(event) => {
-            // Radix defaults to focusing the first tab-stop in the
-            // content; BlockMenu has none (cmdk items aren't tabbable).
-            // Route focus onto the hidden cmdk input so it receives
-            // ArrowDown / Enter for keyboard-only authors. The explicit
-            // `data-plumix-block-menu-input` selector survives future
-            // additions of unrelated <input> elements to the popover.
-            event.preventDefault();
-            const content = event.currentTarget as HTMLElement | null;
-            const input = content?.querySelector<HTMLElement>(
-              "[data-plumix-block-menu-input]",
-            );
-            input?.focus();
-          }}
-        >
-          {tracked ? (
-            <BlockMenu
-              sourceName={tracked.node.type.name}
-              blockRegistry={blockRegistry}
-              onTransform={onTransform}
-              onDuplicate={onDuplicate}
-              onDelete={onDelete}
-              onCopyJson={onCopyJson}
-            />
-          ) : null}
-        </PopoverContent>
-      </Popover>
+      <div className="flex items-center gap-0.5">
+        {isMobile ? (
+          <MobileInspectorTrigger onOpen={() => mobileSheet.setOpen(true)} />
+        ) : null}
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <DragHandleButton onOpenMenu={() => setOpen(true)} />
+          </PopoverTrigger>
+          <PopoverContent
+            side="left"
+            align="start"
+            className="w-56 p-0"
+            onOpenAutoFocus={(event) => {
+              // Radix defaults to focusing the first tab-stop in the
+              // content; BlockMenu has none (cmdk items aren't tabbable).
+              // Route focus onto the hidden cmdk input so it receives
+              // ArrowDown / Enter for keyboard-only authors. The explicit
+              // `data-plumix-block-menu-input` selector survives future
+              // additions of unrelated <input> elements to the popover.
+              event.preventDefault();
+              const content = event.currentTarget as HTMLElement | null;
+              const input = content?.querySelector<HTMLElement>(
+                "[data-plumix-block-menu-input]",
+              );
+              input?.focus();
+            }}
+          >
+            {tracked ? (
+              <BlockMenu
+                sourceName={tracked.node.type.name}
+                blockRegistry={blockRegistry}
+                onTransform={onTransform}
+                onDuplicate={onDuplicate}
+                onDelete={onDelete}
+                onCopyJson={onCopyJson}
+              />
+            ) : null}
+          </PopoverContent>
+        </Popover>
+      </div>
     </DragHandle>
   );
 }

--- a/packages/admin/src/editor/inspector/mobile-inspector-sheet.tsx
+++ b/packages/admin/src/editor/inspector/mobile-inspector-sheet.tsx
@@ -1,0 +1,88 @@
+import type { Editor } from "@tiptap/react";
+import type { ReactElement, ReactNode } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet.js";
+import { useIsMobile } from "@/hooks/use-mobile.js";
+
+import type { BlockRegistry } from "@plumix/blocks";
+
+import { Inspector } from "./Inspector.js";
+
+interface MobileInspectorSheetContextValue {
+  readonly open: boolean;
+  readonly setOpen: (open: boolean) => void;
+}
+
+const MobileInspectorSheetContext =
+  createContext<MobileInspectorSheetContextValue | null>(null);
+
+// Coordinates the open state across the trigger (rendered next to the
+// drag handle) and the Sheet (rendered alongside the editor canvas).
+export function MobileInspectorSheetProvider({
+  children,
+}: {
+  readonly children: ReactNode;
+}): ReactElement {
+  const [open, setOpen] = useState(false);
+  const value = useMemo<MobileInspectorSheetContextValue>(
+    () => ({ open, setOpen }),
+    [open],
+  );
+  return (
+    <MobileInspectorSheetContext.Provider value={value}>
+      {children}
+    </MobileInspectorSheetContext.Provider>
+  );
+}
+
+export function useMobileInspectorSheet(): MobileInspectorSheetContextValue {
+  const value = useContext(MobileInspectorSheetContext);
+  if (!value) {
+    // eslint-disable-next-line no-restricted-syntax -- React hook-misuse guard; convention exception per umbrella #232
+    throw new Error(
+      "useMobileInspectorSheet must be used inside MobileInspectorSheetProvider",
+    );
+  }
+  return value;
+}
+
+interface MobileInspectorSheetProps {
+  readonly editor: Editor | null;
+  readonly blockRegistry: BlockRegistry;
+}
+
+// Renders nothing on desktop; on mobile (<768px) the bottom Sheet
+// hosts the block Inspector. Trigger lives next to the drag handle.
+export function MobileInspectorSheet({
+  editor,
+  blockRegistry,
+}: MobileInspectorSheetProps): ReactElement | null {
+  const isMobile = useIsMobile();
+  const { open, setOpen } = useMobileInspectorSheet();
+  if (!isMobile) return null;
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetContent
+        side="bottom"
+        className="h-[80vh] overflow-y-auto"
+        data-testid="mobile-inspector-sheet"
+      >
+        <SheetHeader>
+          <SheetTitle>Block settings</SheetTitle>
+          <SheetDescription className="sr-only">
+            Attributes and styles for the selected block.
+          </SheetDescription>
+        </SheetHeader>
+        {editor ? (
+          <Inspector editor={editor} blockRegistry={blockRegistry} />
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary

First leg of #314's mobile-responsive scope. At < 768px viewports the right-rail Inspector folds into a bottom Sheet; authors open it via a new per-block "Block settings" button rendered alongside the drag handle.

Design HITL decisions baked in:
- **Breakpoint: 768px** (reuses shadcn's `useIsMobile`)
- **Trigger: per-block button** in the drag-handle area (`MobileInspectorTrigger`)
- **Touch handle tap behavior**: deferred to a focused follow-up slice (current tap → BlockMenu via the existing button stays)

## What's new

- `MobileInspectorSheetProvider` + `useMobileInspectorSheet` hook coordinate open state
- `MobileInspectorSheet` short-circuits on `!isMobile` — desktop pays one context read + one Suspense-resolved registry hook
- `InspectorSection` gated on `!isMobile` so `updateAttributes` doesn't double-bind to the same editor
- 480px Playwright spec exercises trigger → sheet open → level=4 → asserts h4 in the canvas

## Out of scope (queued follow-ups)

1. Slash-menu viewport clamping at small viewports
2. Touch tap/long-press drag-handle redesign (long-press → BlockMenu per design)
3. Right-rail meta-boxes integration into the mobile sheet

## Test plan

- [x] `pnpm --filter @plumix/admin test` (270/270)
- [x] `pnpm exec turbo run typecheck lint --filter @plumix/admin` clean
- [x] `pnpm format` clean
- [x] `pnpm knip` no new flagged exports
- [x] Mobile + desktop e2e: 5/5 (`mobile-inspector-sheet`, `keyboard-only-save-and-reload` ×2, `editor-keyboard` ×2)

Refs GH-314