### PR TITLE
fix(admin): suppress block-menu shortcut while slash menu is open

### DIFF
--- a/packages/admin/e2e/editor-keyboard.spec.ts
+++ b/packages/admin/e2e/editor-keyboard.spec.ts
@@ -152,4 +152,65 @@ test.describe("Keyboard-only editor flow (a11y)", () => {
       page.locator(".ProseMirror h1, .ProseMirror h2, .ProseMirror h3"),
     ).toHaveCount(1);
   });
+
+  test("Mod-Alt-ArrowLeft is a no-op while the slash menu is open", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 9,
+              type: "post",
+              parentId: null,
+              title: "Empty",
+              slug: "e",
+              content: {
+                type: "doc",
+                content: [{ type: "core/paragraph", content: [] }],
+              },
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              sortOrder: 0,
+              publishedAt: null,
+              createdAt: NOW,
+              updatedAt: NOW,
+              meta: {},
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/9/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    await page.locator(".ProseMirror").click();
+    await page.keyboard.type("/");
+    const slashMount = page.locator("[data-plumix-slash-menu-mount]");
+    await expect(slashMount).toBeVisible();
+
+    // While the slash menu is open the keyboard extension bails so
+    // it doesn't stack the BlockMenu popover on top. The BlockMenu's
+    // cmdk Command root carries `data-plumix-block-menu` — assert it
+    // never mounts.
+    const isMac = await page.evaluate(() => /Mac/i.test(navigator.platform));
+    await page.keyboard.press(`${isMac ? "Meta" : "Control"}+Alt+ArrowLeft`);
+    await expect(slashMount).toBeVisible();
+    await expect(page.locator("[data-plumix-block-menu]")).toHaveCount(0);
+  });
 });

--- a/packages/admin/src/editor/drag-handle/block-menu-keyboard.test.ts
+++ b/packages/admin/src/editor/drag-handle/block-menu-keyboard.test.ts
@@ -68,4 +68,28 @@ describe("createBlockMenuKeyboardExtension", () => {
     );
     editor.destroy();
   });
+
+  test("no-op when the slash-menu mount is already in the DOM", () => {
+    const editor = bootEditor();
+    editor.commands.setTextSelection(10);
+    const captured: BlockMenuOpenDetail[] = [];
+    editor.view.dom.addEventListener(BLOCK_MENU_OPEN_EVENT, (event) => {
+      captured.push((event as CustomEvent<BlockMenuOpenDetail>).detail);
+    });
+
+    // Simulate the slash-menu mount being present (suggestion plugin
+    // has opened it). The shortcut should bow out so we don't stack a
+    // second popover over the first.
+    const slashMount = document.createElement("div");
+    slashMount.setAttribute("data-plumix-slash-menu-mount", "");
+    document.body.appendChild(slashMount);
+    try {
+      const handled = editor.commands.openBlockMenuAtCaret();
+      expect(handled).toBe(false);
+      expect(captured).toHaveLength(0);
+    } finally {
+      slashMount.remove();
+      editor.destroy();
+    }
+  });
 });

--- a/packages/admin/src/editor/drag-handle/block-menu-keyboard.ts
+++ b/packages/admin/src/editor/drag-handle/block-menu-keyboard.ts
@@ -33,6 +33,13 @@ export function createBlockMenuKeyboardExtension(): Extension {
         openBlockMenuAtCaret:
           () =>
           ({ editor }) => {
+            // Suppress while the slash menu is open — the suggestion
+            // plugin's mount lives in the document until onExit fires.
+            // Stacking a second popover over it confuses focus +
+            // dismiss semantics for both surfaces.
+            if (document.querySelector("[data-plumix-slash-menu-mount]")) {
+              return false;
+            }
             const { $from } = editor.state.selection;
             let depth = $from.depth;
             while (depth > 0 && !$from.node(depth).type.isBlock) depth -= 1;


### PR DESCRIPTION
## Summary

Closes a known follow-up flagged in #356: pressing `Mod-Alt-ArrowLeft` while the slash menu is open stacked the BlockMenu popover over it. `openBlockMenuAtCaret` now bails (returns false) when the slash-menu mount is present, letting Tiptap fall through to the slash menu's own keymap.

## Test plan

- [x] Unit (`block-menu-keyboard.test.ts`): inserts a `data-plumix-slash-menu-mount` div, runs the command, asserts `handled === false` and no event dispatched
- [x] E2E (`editor-keyboard.spec.ts`): types `/`, fires the shortcut, asserts no `[data-plumix-block-menu]` appears
- [x] `pnpm exec turbo run typecheck lint --filter @plumix/admin` clean
- [x] `pnpm format` clean
- [x] 271/271 admin tests pass

Refs GH-314