### PR TITLE
fix(admin): clamp slash-menu mount inside viewport at small widths

### DIFF
--- a/packages/admin/e2e/slash-menu-viewport-clamp.spec.ts
+++ b/packages/admin/e2e/slash-menu-viewport-clamp.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+const NOW = new Date("2026-05-18T00:00:00Z");
+
+test.describe("Slash menu — viewport clamping at small widths (#314)", () => {
+  test.use({ viewport: { width: 480, height: 800 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  test("mount stays inside the 480px viewport", async ({ page }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 9,
+              type: "post",
+              parentId: null,
+              title: "Empty",
+              slug: "e",
+              content: {
+                type: "doc",
+                content: [{ type: "core/paragraph", content: [] }],
+              },
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              sortOrder: 0,
+              publishedAt: null,
+              createdAt: NOW,
+              updatedAt: NOW,
+              meta: {},
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/9/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+    await page.locator(".ProseMirror").click();
+    await page.keyboard.type("/");
+
+    const mount = page.locator("[data-plumix-slash-menu-mount]");
+    await expect(mount).toBeVisible();
+
+    const box = await mount.boundingBox();
+    if (!box) throw new Error("slash-menu mount has no bounding box");
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(480);
+    expect(box.y).toBeGreaterThanOrEqual(0);
+    expect(box.y + box.height).toBeLessThanOrEqual(800);
+  });
+});

--- a/packages/admin/src/editor/slash-menu/extension.ts
+++ b/packages/admin/src/editor/slash-menu/extension.ts
@@ -13,6 +13,7 @@ import type { BlockRegistry } from "@plumix/blocks";
 import type { SlashMenuItem } from "./items-from-registry.js";
 import type { SlashMenuPanelHandle } from "./SlashMenuPanel.js";
 import { itemsFromRegistry } from "./items-from-registry.js";
+import { clampMenuPosition } from "./position.js";
 import { SlashMenuPanel } from "./SlashMenuPanel.js";
 
 interface CreateSlashMenuExtensionOptions {
@@ -133,6 +134,20 @@ function positionMount(
 ): void {
   const rect = props.clientRect?.();
   if (!rect) return;
-  mount.style.top = `${rect.bottom + window.scrollY + 4}px`;
-  mount.style.left = `${rect.left + window.scrollX}px`;
+  // Mount wrapper measures 0×0 on the first onStart before layout;
+  // fall back to the panel child so the clamp has a real width.
+  const child = mount.firstElementChild as HTMLElement | null;
+  const menuRect = (child ?? mount).getBoundingClientRect();
+  const { top, left } = clampMenuPosition({
+    caret: { top: rect.top, bottom: rect.bottom, left: rect.left },
+    viewport: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+      scrollX: window.scrollX,
+      scrollY: window.scrollY,
+    },
+    menu: { width: menuRect.width, height: menuRect.height },
+  });
+  mount.style.top = `${top}px`;
+  mount.style.left = `${left}px`;
 }

--- a/packages/admin/src/editor/slash-menu/position.test.ts
+++ b/packages/admin/src/editor/slash-menu/position.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+
+import { clampMenuPosition } from "./position.js";
+
+const VIEWPORT = {
+  width: 480,
+  height: 800,
+  scrollX: 0,
+  scrollY: 0,
+};
+
+const MENU = { width: 240, height: 320 };
+
+describe("clampMenuPosition", () => {
+  test("places the mount below the caret with a 4px gap by default", () => {
+    const pos = clampMenuPosition({
+      caret: { top: 100, bottom: 120, left: 50 },
+      viewport: VIEWPORT,
+      menu: MENU,
+    });
+    expect(pos.top).toBe(124);
+    expect(pos.left).toBe(50);
+  });
+
+  test("flips above the caret when the menu would clip the bottom edge", () => {
+    const pos = clampMenuPosition({
+      caret: { top: 600, bottom: 620, left: 50 },
+      viewport: VIEWPORT,
+      menu: MENU,
+    });
+    // 600 - 4 - 320 = 276 above the caret
+    expect(pos.top).toBe(276);
+  });
+
+  test("shifts left when the caret is near the right edge", () => {
+    // Caret at left=400 with menu width 240 would land at 400..640 —
+    // right edge clips at viewport 480. Should clamp to 480 - 240 = 240.
+    const pos = clampMenuPosition({
+      caret: { top: 100, bottom: 120, left: 400 },
+      viewport: VIEWPORT,
+      menu: MENU,
+    });
+    expect(pos.left).toBe(240);
+  });
+
+  test("pins to the left edge when the caret is off-screen left", () => {
+    const pos = clampMenuPosition({
+      caret: { top: 100, bottom: 120, left: -20 },
+      viewport: VIEWPORT,
+      menu: MENU,
+    });
+    expect(pos.left).toBe(0);
+  });
+
+  test("page-space top accounts for window scrollY", () => {
+    const pos = clampMenuPosition({
+      caret: { top: 100, bottom: 120, left: 50 },
+      viewport: { ...VIEWPORT, scrollY: 200 },
+      menu: MENU,
+    });
+    expect(pos.top).toBe(324);
+  });
+
+  test("page-space left accounts for window scrollX", () => {
+    const pos = clampMenuPosition({
+      caret: { top: 100, bottom: 120, left: 50 },
+      viewport: { ...VIEWPORT, scrollX: 30 },
+      menu: MENU,
+    });
+    expect(pos.left).toBe(80);
+  });
+
+  test("pins top=0 when flipping above would push the menu off the top", () => {
+    // Caret at top=50 with no room below (height=200, viewport=200);
+    // menu.height=320 — flip-above would land at 50 - 4 - 320 = -274.
+    const pos = clampMenuPosition({
+      caret: { top: 50, bottom: 70, left: 50 },
+      viewport: { width: 480, height: 200, scrollX: 0, scrollY: 0 },
+      menu: MENU,
+    });
+    expect(pos.top).toBe(0);
+  });
+
+  test("pins to left=0 when the menu is wider than the viewport", () => {
+    const pos = clampMenuPosition({
+      caret: { top: 100, bottom: 120, left: 100 },
+      viewport: { ...VIEWPORT, width: 200 },
+      menu: { width: 240, height: 320 },
+    });
+    expect(pos.left).toBe(0);
+  });
+});

--- a/packages/admin/src/editor/slash-menu/position.ts
+++ b/packages/admin/src/editor/slash-menu/position.ts
@@ -1,0 +1,42 @@
+const GAP = 4;
+
+interface CaretRect {
+  readonly top: number;
+  readonly bottom: number;
+  readonly left: number;
+}
+
+interface Viewport {
+  readonly width: number;
+  readonly height: number;
+  readonly scrollX: number;
+  readonly scrollY: number;
+}
+
+interface MenuSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+interface MenuPosition {
+  readonly top: number;
+  readonly left: number;
+}
+
+export function clampMenuPosition(input: {
+  readonly caret: CaretRect;
+  readonly viewport: Viewport;
+  readonly menu: MenuSize;
+}): MenuPosition {
+  const { caret, viewport, menu } = input;
+  const fitsBelow = caret.bottom + GAP + menu.height <= viewport.height;
+  const topViewport = fitsBelow
+    ? caret.bottom + GAP
+    : Math.max(caret.top - GAP - menu.height, 0);
+  const maxLeft = Math.max(viewport.width - menu.width, 0);
+  const clampedLeft = Math.min(Math.max(caret.left, 0), maxLeft);
+  return {
+    top: topViewport + viewport.scrollY,
+    left: clampedLeft + viewport.scrollX,
+  };
+}


### PR DESCRIPTION
## Summary

#314 follow-up. Below 480px viewports the slash menu overflowed the right edge whenever the caret sat past `viewport.width - menu.width`. Extracted a pure `clampMenuPosition` so `positionMount` gets viewport-aware placement:

- Below-caret by default (legacy behavior at desktop widths)
- Flip above when the bottom would clip
- Clamp top to 0 when flipping above itself would overflow
- Clamp left to `[0, viewport.width - menu.width]`
- Page-space scroll accounted for on both axes

## Test plan

- [x] vitest `position.test.ts` — 8 cases (default below, flip-above, right-clip, off-screen-left, scroll axes, menu-wider-than-viewport, top clamp on flip)
- [x] Playwright `slash-menu-viewport-clamp.spec.ts` at 480px viewport asserts the mount's bounding box stays inside the visible viewport on all four sides
- [x] All 7 related e2e specs still pass (`slash-menu-typed-query`, `editor-keyboard` ×3, `keyboard-only-save-and-reload` ×2, `mobile-inspector-sheet`)
- [x] typecheck / lint / format / 31 slash-menu tests clean

Refs GH-314