### PR TITLE
feat(admin): host the document panel inside the mobile Inspector sheet

### DIFF
--- a/packages/admin/e2e/mobile-inspector-sheet.spec.ts
+++ b/packages/admin/e2e/mobile-inspector-sheet.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   AUTHED_ADMIN,
+  MANIFEST_WITH_META_BOXES,
   MANIFEST_WITH_POST,
   mockManifest,
   rpcOkBody,
@@ -92,5 +93,74 @@ test.describe("Mobile Inspector bottom sheet (#314)", () => {
     await expect(levelSelect).toBeVisible();
     await levelSelect.selectOption({ value: "4" });
     await expect(page.locator(".ProseMirror h4")).toHaveCount(1);
+  });
+
+  test("sheet hosts the document panel — meta boxes + permalink + status live alongside the Inspector", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_META_BOXES);
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 22,
+              type: "post",
+              parentId: null,
+              title: "Mobile",
+              slug: "m",
+              content: {
+                type: "doc",
+                content: [
+                  {
+                    type: "core/heading",
+                    attrs: { level: 2 },
+                    content: [{ type: "text", text: "Title" }],
+                  },
+                ],
+              },
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              sortOrder: 0,
+              publishedAt: null,
+              createdAt: T0,
+              updatedAt: T0,
+              meta: {},
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/22/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    // SidebarTrigger is hidden below md — the per-block trigger is
+    // the only entry-point into the document panel on mobile.
+    await page.locator(".ProseMirror h2").click();
+    await page.getByTestId("mobile-inspector-trigger").click();
+
+    const sheet = page.getByTestId("mobile-inspector-sheet");
+    await expect(sheet).toBeVisible();
+
+    // Inspector still resolves the heading's level field.
+    await expect(sheet.getByTestId("inspector-field-level")).toBeVisible();
+    // Meta box from MANIFEST_WITH_META_BOXES — proves the document
+    // panel reached the sheet, not just the Inspector.
+    await expect(sheet.getByTestId("meta-box-seo")).toBeVisible();
+    await expect(sheet.getByTestId("meta-box-featured")).toBeVisible();
   });
 });

--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -246,6 +246,7 @@ export function PostEditorForm({
   // changes without prop-drilling through the FormField tree. Set by
   // `ContentEditor` via `onEditorReady`, exposed through context.
   const [activeEditor, setActiveEditor] = useState<Editor | null>(null);
+  const blockRegistry = useAdminBlockRegistry();
 
   const form = useForm({
     resolver: valibotResolver(postEditorSchema),
@@ -290,11 +291,59 @@ export function PostEditorForm({
     metaBoxes,
   });
 
+  const documentPanelSections = (
+    <Accordion
+      type="multiple"
+      defaultValue={openSections}
+      className="divide-y"
+    >
+      {showSlug ? (
+        <PermalinkSection
+          disabled={isSubmitting}
+          onSlugEdit={() => {
+            setSlugLocked(true);
+          }}
+        />
+      ) : null}
+      <StatusSection
+        availableStatuses={availableStatuses}
+        disabled={isSubmitting}
+      />
+      {isHierarchical ? (
+        <ParentSection
+          parentOptions={parentOptions}
+          disabled={isSubmitting}
+        />
+      ) : null}
+      {showExcerpt ? <ExcerptSection disabled={isSubmitting} /> : null}
+      {taxonomies.map((tax) => (
+        <TaxonomySection
+          key={tax.name}
+          taxonomy={tax}
+          disabled={isSubmitting}
+        />
+      ))}
+      {metaBoxes.map((box) => (
+        <MetaBoxAccordionItem
+          key={box.id}
+          box={box}
+          basePath="meta"
+          disabled={isSubmitting}
+        />
+      ))}
+    </Accordion>
+  );
+
   return (
     <Form {...form}>
       <EditorProvider value={activeEditor}>
         <MobileInspectorSheetProvider>
-          <MobileInspectorSheetMount editor={activeEditor} />
+          <MobileInspectorSheet
+            editor={activeEditor}
+            blockRegistry={blockRegistry}
+          >
+            {documentPanelSections}
+          </MobileInspectorSheet>
           {/* `contents` makes the form invisible in the flex flow so
             SidebarProvider owns the layout; fields in the rail still
             submit via Controller (rhf state, not DOM form semantics). */}
@@ -337,8 +386,10 @@ export function PostEditorForm({
                     {/* `type="button"` is load-bearing: shadcn's `Button`
                     doesn't default it, and an un-typed button inside
                     `<form>` inherits `submit` — clicking the toggle
-                    would otherwise fire the form's onSubmit + mutate. */}
-                    <SidebarTrigger type="button" />
+                    would otherwise fire the form's onSubmit + mutate.
+                    Hidden below md — the mobile sheet covers the same
+                    content via the per-block trigger. */}
+                    <SidebarTrigger type="button" className="hidden md:flex" />
                   </div>
                 </header>
 
@@ -382,48 +433,7 @@ export function PostEditorForm({
                 </SidebarHeader>
                 <SidebarContent>
                   <InspectorSection />
-                  <Accordion
-                    type="multiple"
-                    defaultValue={openSections}
-                    className="divide-y"
-                  >
-                    {showSlug ? (
-                      <PermalinkSection
-                        disabled={isSubmitting}
-                        onSlugEdit={() => {
-                          setSlugLocked(true);
-                        }}
-                      />
-                    ) : null}
-                    <StatusSection
-                      availableStatuses={availableStatuses}
-                      disabled={isSubmitting}
-                    />
-                    {isHierarchical ? (
-                      <ParentSection
-                        parentOptions={parentOptions}
-                        disabled={isSubmitting}
-                      />
-                    ) : null}
-                    {showExcerpt ? (
-                      <ExcerptSection disabled={isSubmitting} />
-                    ) : null}
-                    {taxonomies.map((tax) => (
-                      <TaxonomySection
-                        key={tax.name}
-                        taxonomy={tax}
-                        disabled={isSubmitting}
-                      />
-                    ))}
-                    {metaBoxes.map((box) => (
-                      <MetaBoxAccordionItem
-                        key={box.id}
-                        box={box}
-                        basePath="meta"
-                        disabled={isSubmitting}
-                      />
-                    ))}
-                  </Accordion>
+                  {documentPanelSections}
                 </SidebarContent>
               </Sidebar>
             </SidebarProvider>
@@ -493,15 +503,6 @@ function TitleField({ disabled }: { readonly disabled: boolean }): ReactNode {
       )}
     />
   );
-}
-
-function MobileInspectorSheetMount({
-  editor,
-}: {
-  readonly editor: Editor | null;
-}): ReactNode {
-  const blockRegistry = useAdminBlockRegistry();
-  return <MobileInspectorSheet editor={editor} blockRegistry={blockRegistry} />;
 }
 
 function InspectorSection(): ReactNode {

--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -292,11 +292,7 @@ export function PostEditorForm({
   });
 
   const documentPanelSections = (
-    <Accordion
-      type="multiple"
-      defaultValue={openSections}
-      className="divide-y"
-    >
+    <Accordion type="multiple" defaultValue={openSections} className="divide-y">
       {showSlug ? (
         <PermalinkSection
           disabled={isSubmitting}
@@ -310,10 +306,7 @@ export function PostEditorForm({
         disabled={isSubmitting}
       />
       {isHierarchical ? (
-        <ParentSection
-          parentOptions={parentOptions}
-          disabled={isSubmitting}
-        />
+        <ParentSection parentOptions={parentOptions} disabled={isSubmitting} />
       ) : null}
       {showExcerpt ? <ExcerptSection disabled={isSubmitting} /> : null}
       {taxonomies.map((tax) => (

--- a/packages/admin/src/editor/inspector/mobile-inspector-sheet.tsx
+++ b/packages/admin/src/editor/inspector/mobile-inspector-sheet.tsx
@@ -1,6 +1,6 @@
 import type { Editor } from "@tiptap/react";
 import type { ReactElement, ReactNode } from "react";
-import { createContext, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useState } from "react";
 import {
   Sheet,
   SheetContent,
@@ -30,12 +30,8 @@ export function MobileInspectorSheetProvider({
   readonly children: ReactNode;
 }): ReactElement {
   const [open, setOpen] = useState(false);
-  const value = useMemo<MobileInspectorSheetContextValue>(
-    () => ({ open, setOpen }),
-    [open],
-  );
   return (
-    <MobileInspectorSheetContext.Provider value={value}>
+    <MobileInspectorSheetContext.Provider value={{ open, setOpen }}>
       {children}
     </MobileInspectorSheetContext.Provider>
   );
@@ -55,13 +51,22 @@ export function useMobileInspectorSheet(): MobileInspectorSheetContextValue {
 interface MobileInspectorSheetProps {
   readonly editor: Editor | null;
   readonly blockRegistry: BlockRegistry;
+  /**
+   * Rendered below the Inspector. The caller passes the same document
+   * panel sections (permalink, status, taxonomies, meta boxes) the
+   * right-rail Sidebar uses on desktop so mobile authors don't have
+   * to context-switch between two surfaces.
+   */
+  readonly children?: ReactNode;
 }
 
 // Renders nothing on desktop; on mobile (<768px) the bottom Sheet
-// hosts the block Inspector. Trigger lives next to the drag handle.
+// hosts the block Inspector + the document panel. Trigger lives next
+// to the drag handle.
 export function MobileInspectorSheet({
   editor,
   blockRegistry,
+  children,
 }: MobileInspectorSheetProps): ReactElement | null {
   const isMobile = useIsMobile();
   const { open, setOpen } = useMobileInspectorSheet();
@@ -74,14 +79,16 @@ export function MobileInspectorSheet({
         data-testid="mobile-inspector-sheet"
       >
         <SheetHeader>
-          <SheetTitle>Block settings</SheetTitle>
+          <SheetTitle>Document</SheetTitle>
           <SheetDescription className="sr-only">
-            Attributes and styles for the selected block.
+            Block attributes, permalink, status, and meta boxes for
+            this entry.
           </SheetDescription>
         </SheetHeader>
         {editor ? (
           <Inspector editor={editor} blockRegistry={blockRegistry} />
         ) : null}
+        {children}
       </SheetContent>
     </Sheet>
   );

--- a/packages/admin/src/editor/inspector/mobile-inspector-sheet.tsx
+++ b/packages/admin/src/editor/inspector/mobile-inspector-sheet.tsx
@@ -81,8 +81,7 @@ export function MobileInspectorSheet({
         <SheetHeader>
           <SheetTitle>Document</SheetTitle>
           <SheetDescription className="sr-only">
-            Block attributes, permalink, status, and meta boxes for
-            this entry.
+            Block attributes, permalink, status, and meta boxes for this entry.
           </SheetDescription>
         </SheetHeader>
         {editor ? (


### PR DESCRIPTION
## Summary

#314 follow-up. The mobile bottom Inspector sheet now hosts the *full* document panel — Inspector at the top, then the same Permalink / Status / Parent / Excerpt / Taxonomies / MetaBoxes Accordion the desktop sidebar shows. Mobile authors stop bouncing between the per-block trigger and the sidebar trigger.

- `MobileInspectorSheet` accepts `children` rendered below the Inspector
- Extracted the inline Accordion into a `documentPanelSections` JSX variable, reused by the desktop `<Sidebar>` AND passed as children on mobile
- `SidebarTrigger` hidden below `md` — the per-block trigger is the only mobile entry-point
- Sheet title: "Block settings" → "Document" to match the broader scope

## Test plan

- [x] 279/279 admin unit tests pass
- [x] 16/16 e2e (`content.spec.ts` ×14 + `mobile-inspector-sheet.spec.ts` ×2) — including the new assertion that `meta-box-seo` / `meta-box-featured` live inside the sheet
- [x] typecheck / lint / format / knip clean

Senpai cleared (form-context resolution at render is correct, no double-mount on desktop, testid scoping is collision-free, a11y narrative consistent).

Refs GH-314