### PR TITLE
feat(admin): long-press on touch opens the BlockMenu

### DIFF
--- a/packages/admin/e2e/touch-long-press-block-menu.spec.ts
+++ b/packages/admin/e2e/touch-long-press-block-menu.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+// Touch long-press wiring lives in unit + integration tests
+// (`long-press.test.ts`, `long-press-extension.test.ts`). This spec
+// confirms the production editor exposes the same contract end-to-end
+// against the real React tree under a 480px viewport with `hasTouch`.
+// We listen on the editor's view.dom for the BLOCK_MENU_OPEN_EVENT the
+// extension dispatches; rendering the BlockMenu popover at this width
+// has its own anchoring story tracked separately.
+
+const T0 = new Date("2026-05-18T00:00:00Z");
+
+test.describe("Touch long-press dispatches the BlockMenu open event (#314)", () => {
+  test.use({ viewport: { width: 480, height: 800 }, hasTouch: true });
+
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  test("touchstart held for >500ms fires plumix:block-menu-open", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              id: 33,
+              type: "post",
+              parentId: null,
+              title: "Touch",
+              slug: "t",
+              content: {
+                type: "doc",
+                content: [
+                  {
+                    type: "core/heading",
+                    attrs: { level: 2 },
+                    content: [{ type: "text", text: "Title" }],
+                  },
+                ],
+              },
+              excerpt: null,
+              status: "draft",
+              authorId: 1,
+              sortOrder: 0,
+              publishedAt: null,
+              createdAt: T0,
+              updatedAt: T0,
+              meta: {},
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/33/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    // Place the caret inside the heading so the command resolves
+    // a non-null pos when long-press triggers it.
+    await page.locator(".ProseMirror h2").click();
+
+    // Install a sentinel on view.dom, then synthesise a held touch
+    // (Playwright's touchscreen lacks a "hold" primitive). The
+    // attachLongPressHandler timer fires after 500ms regardless of
+    // touchend.
+    const captured = await page.evaluate(
+      async () =>
+        new Promise<number>((resolve) => {
+          const dom = document.querySelector<HTMLElement>(".ProseMirror");
+          if (!dom) throw new Error(".ProseMirror not found");
+          const onOpen = (e: Event): void => {
+            const detail = (e as CustomEvent<{ pos: number }>).detail;
+            resolve(detail.pos);
+          };
+          dom.addEventListener("plumix:block-menu-open", onOpen, {
+            once: true,
+          });
+          const rect = dom.getBoundingClientRect();
+          const event = new Event("touchstart", { bubbles: true });
+          Object.defineProperty(event, "touches", {
+            value: [{ clientX: rect.left + 20, clientY: rect.top + 20 }],
+          });
+          dom.dispatchEvent(event);
+        }),
+    );
+
+    // pos=0 is the heading's containing position — proves the command
+    // resolved the caret-block and dispatched the open event.
+    expect(captured).toBe(0);
+  });
+});

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -6,6 +6,7 @@ import { createBlockMenuKeyboardExtension } from "@/editor/drag-handle/block-men
 import { PlumixDragHandle } from "@/editor/drag-handle/PlumixDragHandle.js";
 import { FloatingInsertMenu } from "@/editor/floating-menu/FloatingInsertMenu.js";
 import { createSlashMenuExtension } from "@/editor/slash-menu/extension.js";
+import { createLongPressBlockMenuExtension } from "@/editor/touch/long-press-extension.js";
 import { cn } from "@/lib/utils.js";
 import { EditorContent, useEditor } from "@tiptap/react";
 
@@ -137,6 +138,7 @@ export function TiptapEditor({
         },
       }),
       createBlockMenuKeyboardExtension(),
+      createLongPressBlockMenuExtension(),
     ];
   }, [allowlist, blockRegistry, markRegistry]);
 

--- a/packages/admin/src/editor/touch/long-press-extension.test.ts
+++ b/packages/admin/src/editor/touch/long-press-extension.test.ts
@@ -1,0 +1,81 @@
+import { Editor, Node } from "@tiptap/core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  BLOCK_MENU_OPEN_EVENT,
+  createBlockMenuKeyboardExtension,
+} from "../drag-handle/block-menu-keyboard.js";
+import { createLongPressBlockMenuExtension } from "./long-press-extension.js";
+
+const Doc = Node.create({ name: "doc", topNode: true, content: "block+" });
+const Text = Node.create({ name: "text", group: "inline" });
+const Para = Node.create({
+  name: "paragraph",
+  group: "block",
+  content: "inline*",
+  parseHTML() {
+    return [{ tag: "p" }];
+  },
+  renderHTML() {
+    return ["p", 0];
+  },
+});
+
+function dispatchTouch(
+  target: HTMLElement,
+  type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+  touches: readonly { clientX: number; clientY: number }[],
+): void {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, "touches", { value: touches });
+  target.dispatchEvent(event);
+}
+
+describe("createLongPressBlockMenuExtension", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    editor = new Editor({
+      extensions: [
+        Doc,
+        Text,
+        Para,
+        createBlockMenuKeyboardExtension(),
+        createLongPressBlockMenuExtension(),
+      ],
+      content: "<p>First</p>",
+    });
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    vi.useRealTimers();
+  });
+
+  test("a long press on the editor view triggers openBlockMenuAtCaret", () => {
+    const dom = editor.view.dom;
+    const captured: number[] = [];
+    dom.addEventListener(BLOCK_MENU_OPEN_EVENT, (event) => {
+      captured.push((event as CustomEvent<{ pos: number }>).detail.pos);
+    });
+
+    dispatchTouch(dom, "touchstart", [{ clientX: 50, clientY: 50 }]);
+    vi.advanceTimersByTime(500);
+
+    expect(captured).toHaveLength(1);
+  });
+
+  test("a short tap does not trigger the command", () => {
+    const dom = editor.view.dom;
+    const spy = vi.fn();
+    dom.addEventListener(BLOCK_MENU_OPEN_EVENT, spy);
+
+    dispatchTouch(dom, "touchstart", [{ clientX: 50, clientY: 50 }]);
+    vi.advanceTimersByTime(150);
+    dispatchTouch(dom, "touchend", []);
+    vi.advanceTimersByTime(500);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/editor/touch/long-press-extension.ts
+++ b/packages/admin/src/editor/touch/long-press-extension.ts
@@ -1,0 +1,48 @@
+import { Extension } from "@tiptap/core";
+
+import { attachLongPressHandler } from "./long-press.js";
+
+/**
+ * Routes a long-press on the editor view to `openBlockMenuAtCaret`.
+ * On touch devices the drag-handle plugin's hover model doesn't give
+ * authors a discoverable way to surface block actions; long-press is
+ * the canonical mobile gesture for "show contextual actions on this
+ * thing." Desktop pointer interactions ignore touch events, so this
+ * is a zero-cost addition outside the mobile path.
+ */
+export function createLongPressBlockMenuExtension(): Extension {
+  return Extension.create({
+    name: "plumixLongPressBlockMenu",
+    addProseMirrorPlugins() {
+      const { editor } = this;
+      let detach: (() => void) | null = null;
+      const attach = (): void => {
+        if (detach) return;
+        detach = attachLongPressHandler(editor.view.dom, () => {
+          editor.commands.openBlockMenuAtCaret();
+        });
+      };
+      editor.on("create", attach);
+      // `create` may have already fired by the time addProseMirrorPlugins
+      // returns when the editor is constructed synchronously (vitest);
+      // attach immediately if the view is reachable. Tiptap v3 throws on
+      // pre-mount view access — catch ONLY the view-access error so any
+      // bug inside `attachLongPressHandler` still propagates.
+      try {
+        attach();
+      } catch (error) {
+        if (
+          !(error instanceof Error) ||
+          !error.message.includes("editor view is not available")
+        ) {
+          throw error;
+        }
+      }
+      editor.on("destroy", () => {
+        detach?.();
+        detach = null;
+      });
+      return [];
+    },
+  });
+}

--- a/packages/admin/src/editor/touch/long-press.test.ts
+++ b/packages/admin/src/editor/touch/long-press.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { attachLongPressHandler } from "./long-press.js";
+
+function dispatchTouch(
+  target: HTMLElement,
+  type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+  touches: readonly { clientX: number; clientY: number }[],
+): void {
+  // jsdom lacks a usable TouchEvent constructor — synthesise a plain
+  // Event and graft the `touches` shape the handler reads. dispatching
+  // through the real EventTarget keeps the listener wiring exercised.
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, "touches", { value: touches });
+  target.dispatchEvent(event);
+}
+
+describe("attachLongPressHandler", () => {
+  let target: HTMLElement;
+  let onLongPress: ReturnType<typeof vi.fn<() => void>>;
+  let detach: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    target = document.createElement("div");
+    document.body.appendChild(target);
+    onLongPress = vi.fn<() => void>();
+    detach = attachLongPressHandler(target, onLongPress);
+  });
+
+  afterEach(() => {
+    detach();
+    target.remove();
+    vi.useRealTimers();
+  });
+
+  test("fires onLongPress after the threshold elapses without movement", () => {
+    dispatchTouch(target, "touchstart", [{ clientX: 50, clientY: 50 }]);
+    vi.advanceTimersByTime(500);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fire on a quick tap (touchend before threshold)", () => {
+    dispatchTouch(target, "touchstart", [{ clientX: 50, clientY: 50 }]);
+    vi.advanceTimersByTime(200);
+    dispatchTouch(target, "touchend", []);
+    vi.advanceTimersByTime(500);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  test("cancels when the finger moves beyond the slop threshold", () => {
+    dispatchTouch(target, "touchstart", [{ clientX: 50, clientY: 50 }]);
+    vi.advanceTimersByTime(100);
+    dispatchTouch(target, "touchmove", [{ clientX: 80, clientY: 50 }]);
+    vi.advanceTimersByTime(500);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  test("tolerates small movement inside the slop threshold", () => {
+    dispatchTouch(target, "touchstart", [{ clientX: 50, clientY: 50 }]);
+    vi.advanceTimersByTime(100);
+    dispatchTouch(target, "touchmove", [{ clientX: 52, clientY: 51 }]);
+    vi.advanceTimersByTime(500);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  test("touchcancel aborts the long-press timer", () => {
+    dispatchTouch(target, "touchstart", [{ clientX: 50, clientY: 50 }]);
+    vi.advanceTimersByTime(100);
+    dispatchTouch(target, "touchcancel", []);
+    vi.advanceTimersByTime(500);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  test("detach removes the listeners and disarms pending timers", () => {
+    dispatchTouch(target, "touchstart", [{ clientX: 50, clientY: 50 }]);
+    vi.advanceTimersByTime(100);
+    detach();
+    vi.advanceTimersByTime(500);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/editor/touch/long-press.ts
+++ b/packages/admin/src/editor/touch/long-press.ts
@@ -1,0 +1,78 @@
+interface LongPressOptions {
+  /** Milliseconds the finger must stay down to register as a long press. */
+  readonly thresholdMs?: number;
+  /** Pixel slop the finger can drift before the gesture cancels. */
+  readonly slopPx?: number;
+}
+
+const DEFAULT_THRESHOLD_MS = 500;
+const DEFAULT_SLOP_PX = 8;
+
+/**
+ * Wires touchstart / touchmove / touchend / touchcancel listeners onto
+ * `target` and invokes `onLongPress` once the gesture completes — finger
+ * down for at least `thresholdMs`, drift no further than `slopPx`. Returns
+ * a detacher that removes the listeners and disarms any pending timer.
+ *
+ * Lives outside the Tiptap extension so the gesture logic is testable in
+ * isolation with `vi.useFakeTimers()`.
+ */
+export function attachLongPressHandler(
+  target: HTMLElement,
+  onLongPress: () => void,
+  options: LongPressOptions = {},
+): () => void {
+  const threshold = options.thresholdMs ?? DEFAULT_THRESHOLD_MS;
+  const slop = options.slopPx ?? DEFAULT_SLOP_PX;
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let startX = 0;
+  let startY = 0;
+
+  const clear = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const onTouchStart = (event: TouchEvent): void => {
+    const t = event.touches[0];
+    if (!t) return;
+    startX = t.clientX;
+    startY = t.clientY;
+    clear();
+    timer = setTimeout(() => {
+      timer = null;
+      onLongPress();
+    }, threshold);
+  };
+
+  const onTouchMove = (event: TouchEvent): void => {
+    if (timer === null) return;
+    const t = event.touches[0];
+    if (!t) return;
+    if (
+      Math.abs(t.clientX - startX) > slop ||
+      Math.abs(t.clientY - startY) > slop
+    ) {
+      clear();
+    }
+  };
+
+  // Passive: the handler never calls preventDefault, and being explicit
+  // avoids Chrome's "scroll-blocking listener" performance warning.
+  const passive = { passive: true } as const;
+  target.addEventListener("touchstart", onTouchStart, passive);
+  target.addEventListener("touchmove", onTouchMove, passive);
+  target.addEventListener("touchend", clear, passive);
+  target.addEventListener("touchcancel", clear, passive);
+
+  return () => {
+    clear();
+    target.removeEventListener("touchstart", onTouchStart);
+    target.removeEventListener("touchmove", onTouchMove);
+    target.removeEventListener("touchend", clear);
+    target.removeEventListener("touchcancel", clear);
+  };
+}


### PR DESCRIPTION
## Summary

#314 follow-up. Touch authors had no path to the BlockMenu — the drag-handle plugin is hover-driven and the `Mod-Alt-ArrowLeft` shortcut requires a physical keyboard. Long-press is the canonical mobile gesture; this slice wires it to `openBlockMenuAtCaret`.

- Pure `attachLongPressHandler` with configurable threshold (default 500ms) + slop (default 8px). Passive listeners. Cleanup tears down pending timers.
- `createLongPressBlockMenuExtension` attaches the handler to `editor.view.dom` via Tiptap's `create` / `destroy` lifecycle; the immediate-attach try/catch is scoped to the pre-mount view-access error so unrelated handler bugs still propagate.
- Wired into canvas-mode extensions in `tiptap-editor.tsx`.

## Test plan

- [x] vitest `long-press.test.ts` — 6 cases with fake timers (fire, quick-tap, slop cancel, slop tolerance, touchcancel, detach)
- [x] vitest `long-press-extension.test.ts` — 2 cases verifying the command runs end-to-end via the BLOCK_MENU_OPEN_EVENT dispatch
- [x] Playwright `touch-long-press-block-menu.spec.ts` at 480px viewport with `hasTouch: true` — synthesises touchstart on `.ProseMirror`, asserts the open event fires with `pos=0`
- [x] All gates green: typecheck / lint / format / 287 admin tests

## Known follow-up

The visual BlockMenu popover doesn't render at <768px viewport — surfaced during this slice. The keyboard path (`Mod-Alt-ArrowLeft`) also fails to render at mobile widths. Both paths set state correctly; the popover content stays empty. Likely a `tracked` state-update timing issue specific to mobile React rendering. Tracked separately.

Refs GH-314