### PR TITLE
fix(admin): keep tracked block alive while BlockMenu popover is open

### DIFF
--- a/packages/admin/e2e/block-menu-mobile-render.spec.ts
+++ b/packages/admin/e2e/block-menu-mobile-render.spec.ts
@@ -1,0 +1,117 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+// Regression guard for the mobile popover-render bug surfaced during
+// #361: Tiptap's drag-handle plugin fires `onNodeChange(null)` (mouse
+// left the block area) right after our keyboard/touch handler sets
+// the tracked node, clobbering it before the popover renders BlockMenu.
+// PlumixDragHandle now ignores the plugin's anchor updates while
+// `open` is true.
+
+const T0 = new Date("2026-05-18T00:00:00Z");
+
+async function mockEntry(page: Page, id: number): Promise<void> {
+  await page.route("**/_plumix/rpc/**", async (route) => {
+    const url = route.request().url();
+    if (url.endsWith("/auth/session")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(AUTHED_ADMIN),
+      });
+    }
+    if (url.endsWith("/entry/get")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          json: {
+            id,
+            type: "post",
+            parentId: null,
+            title: "Mobile",
+            slug: "m",
+            content: {
+              type: "doc",
+              content: [
+                {
+                  type: "core/heading",
+                  attrs: { level: 2 },
+                  content: [{ type: "text", text: "Title" }],
+                },
+              ],
+            },
+            excerpt: null,
+            status: "draft",
+            authorId: 1,
+            sortOrder: 0,
+            publishedAt: null,
+            createdAt: T0,
+            updatedAt: T0,
+            meta: {},
+          },
+          meta: [],
+        }),
+      });
+    }
+    return route.fulfill({ status: 404, body: "not-mocked" });
+  });
+}
+
+test.describe("BlockMenu popover renders at <768px (#314)", () => {
+  test.use({ viewport: { width: 480, height: 800 }, hasTouch: true });
+
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  test("Mod-Alt-ArrowLeft surfaces the BlockMenu over the caret block", async ({
+    page,
+  }) => {
+    await mockEntry(page, 44);
+    await page.goto("entries/posts/44/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    await page.locator(".ProseMirror h2").click();
+
+    const isMac = await page.evaluate(() => /Mac/i.test(navigator.platform));
+    await page.keyboard.press(`${isMac ? "Meta" : "Control"}+Alt+ArrowLeft`);
+
+    await expect(page.locator("[data-plumix-block-menu]")).toBeVisible();
+    await expect(
+      page.getByTestId("block-menu-transform-core/paragraph"),
+    ).toBeVisible();
+  });
+
+  test("touch long-press surfaces the BlockMenu over the caret block", async ({
+    page,
+  }) => {
+    await mockEntry(page, 45);
+    await page.goto("entries/posts/45/edit");
+    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+
+    await page.locator(".ProseMirror h2").click();
+
+    // Synthesise touchstart on .ProseMirror — the long-press timer
+    // fires after 500ms regardless of touchend.
+    await page.evaluate(() => {
+      const dom = document.querySelector<HTMLElement>(".ProseMirror");
+      if (!dom) throw new Error(".ProseMirror not found");
+      const rect = dom.getBoundingClientRect();
+      const event = new Event("touchstart", { bubbles: true });
+      Object.defineProperty(event, "touches", {
+        value: [{ clientX: rect.left + 20, clientY: rect.top + 20 }],
+      });
+      dom.dispatchEvent(event);
+    });
+
+    await expect(page.locator("[data-plumix-block-menu]")).toBeVisible();
+  });
+});

--- a/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
+++ b/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
@@ -1,6 +1,6 @@
 import type { Editor } from "@tiptap/react";
 import type { ReactElement } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Popover,
   PopoverContent,
@@ -139,10 +139,31 @@ export function PlumixDragHandle({
     setOpen(false);
   };
 
+  // `openRef` is the source of truth for the `onNodeChange` guard;
+  // setters that open the popover flip it imperatively *before*
+  // scheduling React state so a synchronous `onNodeChange(null)`
+  // following `setOpen(true)` can't clobber `tracked` between the
+  // state update and React's next commit. Closing happens through
+  // Radix → setOpen, which the effect mirrors back into the ref.
+  const openRef = useRef(open);
+  useEffect(() => {
+    openRef.current = open;
+  });
+  const openPopover = useCallback((): void => {
+    openRef.current = true;
+    setOpen(true);
+  }, []);
+
   // Pinned identity: `DragHandle` lists `onNodeChange` in its effect
   // deps, so a fresh callback per render re-registers the ProseMirror
   // plugin and tears down the slash-menu mount mid-typing (#342).
+  // While the popover is open we intentionally freeze the anchor —
+  // matches Notion/Linear behavior where open menus don't re-target
+  // on hover — and also avoids the plugin's `onNodeChange(null)`
+  // (pointer leaves the block area) clobbering a keyboard-set
+  // tracked node before the menu can render.
   const onNodeChange = useCallback(({ node, pos }: OnNodeChangeArgs) => {
+    if (openRef.current) return;
     setTracked(node ? { node, pos } : null);
   }, []);
 
@@ -158,7 +179,7 @@ export function PlumixDragHandle({
       const node = editor.state.doc.nodeAt(pos);
       if (!node) return;
       setTracked({ node, pos });
-      setOpen(true);
+      openPopover();
     };
     const attach = ({ editor: ed }: { editor: typeof editor }): void => {
       if (dom) return;
@@ -189,7 +210,7 @@ export function PlumixDragHandle({
         ) : null}
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
-            <DragHandleButton onOpenMenu={() => setOpen(true)} />
+            <DragHandleButton onOpenMenu={openPopover} />
           </PopoverTrigger>
           <PopoverContent
             side="left"


### PR DESCRIPTION
## Summary

Closes the last engineering follow-up from #314 (surfaced during #361 debugging). At <768px viewports — and on touch — the BlockMenu popover opened with empty content. Root cause: Tiptap's drag-handle plugin fires `onNodeChange(null)` (pointer left the block area) right *after* our handler set `tracked` from the `BLOCK_MENU_OPEN_EVENT`, clobbering the keyboard/touch-set node before React's next commit.

Fix: `openRef` + `openPopover()` callback flips the ref *imperatively* before scheduling `setOpen(true)`. The `onNodeChange` guard (still `useCallback([])`-pinned per #342) early-returns whenever `openRef.current` is true, freezing the plugin's mouse-driven anchor while the menu is on screen — also matches Notion/Linear's "open menus don't re-target on hover" behavior. Closing the popover clears `open` and the effect mirrors it back; hover re-anchoring resumes normally.

## Test plan

- [x] New `block-menu-mobile-render.spec.ts` at 480px + hasTouch — both keyboard `Mod-Alt-ArrowLeft` and touch long-press surface the BlockMenu with a transform-target visible
- [x] All 85 admin e2e specs pass (no desktop regression)
- [x] 287 admin unit tests pass
- [x] typecheck / lint / format clean

Refs GH-314