### PR TITLE
chore(admin): mobile sheet a11y + grabber affordance

### DIFF
--- a/packages/admin/e2e/mobile-inspector-sheet.spec.ts
+++ b/packages/admin/e2e/mobile-inspector-sheet.spec.ts
@@ -89,10 +89,29 @@ test.describe("Mobile Inspector bottom sheet (#314)", () => {
     // The Inspector inside the sheet still drives `updateAttributes`
     // through the same editor — changing level retargets the tag in
     // the live canvas behind the sheet.
+    // The grabber gives the visual "this is a dismissable sheet" cue
+    // alongside the X button shadcn ships at top-right. It carries
+    // aria-hidden (decorative), so assert presence by count rather
+    // than visibility — Playwright treats aria-hidden as hidden.
+    await expect(
+      sheet.getByTestId("mobile-inspector-sheet-grabber"),
+    ).toHaveCount(1);
+    // Verify aria wiring — trigger declares the disclosure target.
+    await expect(trigger).toHaveAttribute(
+      "aria-controls",
+      "plumix-mobile-inspector-sheet",
+    );
+    await expect(trigger).toHaveAttribute("aria-expanded", "true");
+
     const levelSelect = sheet.getByTestId("inspector-field-level");
     await expect(levelSelect).toBeVisible();
     await levelSelect.selectOption({ value: "4" });
     await expect(page.locator(".ProseMirror h4")).toHaveCount(1);
+
+    // Escape dismisses — Radix dialog default.
+    await page.keyboard.press("Escape");
+    await expect(sheet).toBeHidden();
+    await expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
 
   test("sheet hosts the document panel — meta boxes + permalink + status live alongside the Inspector", async ({

--- a/packages/admin/src/editor/drag-handle/MobileInspectorTrigger.tsx
+++ b/packages/admin/src/editor/drag-handle/MobileInspectorTrigger.tsx
@@ -1,18 +1,24 @@
 import type { ReactElement } from "react";
 import { Settings2 } from "lucide-react";
 
+export const MOBILE_INSPECTOR_SHEET_ID = "plumix-mobile-inspector-sheet";
+
 interface MobileInspectorTriggerProps {
   readonly onOpen: () => void;
+  readonly open: boolean;
 }
 
 export function MobileInspectorTrigger({
   onOpen,
+  open,
 }: MobileInspectorTriggerProps): ReactElement {
   return (
     <button
       type="button"
       data-testid="mobile-inspector-trigger"
       aria-label="Block settings"
+      aria-expanded={open}
+      aria-controls={MOBILE_INSPECTOR_SHEET_ID}
       onClick={onOpen}
       className="text-muted-foreground hover:text-foreground flex h-6 w-6 items-center justify-center rounded-sm"
     >

--- a/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
+++ b/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
@@ -206,7 +206,10 @@ export function PlumixDragHandle({
     <DragHandle editor={editor} onNodeChange={onNodeChange}>
       <div className="flex items-center gap-0.5">
         {isMobile ? (
-          <MobileInspectorTrigger onOpen={() => mobileSheet.setOpen(true)} />
+          <MobileInspectorTrigger
+            open={mobileSheet.open}
+            onOpen={() => mobileSheet.setOpen(true)}
+          />
         ) : null}
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>

--- a/packages/admin/src/editor/inspector/mobile-inspector-sheet.tsx
+++ b/packages/admin/src/editor/inspector/mobile-inspector-sheet.tsx
@@ -12,6 +12,7 @@ import { useIsMobile } from "@/hooks/use-mobile.js";
 
 import type { BlockRegistry } from "@plumix/blocks";
 
+import { MOBILE_INSPECTOR_SHEET_ID } from "../drag-handle/MobileInspectorTrigger.js";
 import { Inspector } from "./Inspector.js";
 
 interface MobileInspectorSheetContextValue {
@@ -75,9 +76,18 @@ export function MobileInspectorSheet({
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetContent
         side="bottom"
+        id={MOBILE_INSPECTOR_SHEET_ID}
         className="h-[80vh] overflow-y-auto"
         data-testid="mobile-inspector-sheet"
       >
+        {/* Drag affordance — visual hint that the surface is a sheet.
+            Functional dismiss already happens via Esc, the X button,
+            and overlay tap (Radix defaults via the shadcn Sheet). */}
+        <div
+          aria-hidden="true"
+          data-testid="mobile-inspector-sheet-grabber"
+          className="bg-muted-foreground/30 mx-auto mt-2 h-1.5 w-10 rounded-full"
+        />
         <SheetHeader>
           <SheetTitle>Document</SheetTitle>
           <SheetDescription className="sr-only">


### PR DESCRIPTION
## Summary

Two #314 follow-up cleanups flagged during senpai reviews on #357:

- **A11y**: `MobileInspectorTrigger` declares `aria-expanded={open}` + `aria-controls=<sheet-id>` so screen readers announce the disclosure state.
- **Grabber**: a small horizontal pill at the top of the `SheetContent` — visual cue that the surface is a dismissable bottom sheet. Functional dismiss is unchanged (Esc / X-button / overlay-tap — all Radix defaults).

## Test plan

- [x] E2E asserts `aria-controls` / `aria-expanded` transitions, grabber present in DOM (decorative, aria-hidden), Escape dismiss
- [x] All 287 admin unit + 85 admin e2e pass
- [x] typecheck / lint / format clean

Refs GH-314