### PR TITLE
feat(admin): persist drag handle anchor on touch devices

### DIFF
--- a/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
+++ b/packages/admin/src/editor/drag-handle/PlumixDragHandle.tsx
@@ -17,6 +17,7 @@ import { useMobileInspectorSheet } from "../inspector/mobile-inspector-sheet.js"
 import { BLOCK_MENU_OPEN_EVENT } from "./block-menu-keyboard.js";
 import { DragHandleButton } from "./DragHandleButton.js";
 import { MobileInspectorTrigger } from "./MobileInspectorTrigger.js";
+import { nextTrackedNode } from "./next-tracked.js";
 
 interface PlumixDragHandleProps {
   readonly editor: Editor;
@@ -154,17 +155,37 @@ export function PlumixDragHandle({
     setOpen(true);
   }, []);
 
+  // Detect coarse pointers (touch). Read inside the callback via a
+  // ref so the stable `useCallback([])` identity survives.
+  const isTouchRef = useRef(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia("(pointer: coarse)");
+    const sync = (): void => {
+      isTouchRef.current = mql.matches;
+    };
+    sync();
+    mql.addEventListener("change", sync);
+    return () => mql.removeEventListener("change", sync);
+  }, []);
+
   // Pinned identity: `DragHandle` lists `onNodeChange` in its effect
   // deps, so a fresh callback per render re-registers the ProseMirror
   // plugin and tears down the slash-menu mount mid-typing (#342).
-  // While the popover is open we intentionally freeze the anchor —
-  // matches Notion/Linear behavior where open menus don't re-target
-  // on hover — and also avoids the plugin's `onNodeChange(null)`
-  // (pointer leaves the block area) clobbering a keyboard-set
-  // tracked node before the menu can render.
+  // While the popover is open we freeze the anchor (matches
+  // Notion/Linear behavior). Otherwise we route through
+  // `nextTrackedNode`, which on touch suppresses the plugin's
+  // hover-driven `onNodeChange(null)` so the handle stays anchored
+  // to the last-tapped block.
   const onNodeChange = useCallback(({ node, pos }: OnNodeChangeArgs) => {
     if (openRef.current) return;
-    setTracked(node ? { node, pos } : null);
+    setTracked((current) =>
+      nextTrackedNode({
+        isTouch: isTouchRef.current,
+        current,
+        incoming: { node, pos },
+      }),
+    );
   }, []);
 
   // Keyboard-only path: the drag-handle plugin is mouse-driven, so

--- a/packages/admin/src/editor/drag-handle/next-tracked.test.ts
+++ b/packages/admin/src/editor/drag-handle/next-tracked.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+
+import { nextTrackedNode } from "./next-tracked.js";
+
+const heading = {
+  node: { type: { name: "core/heading" }, nodeSize: 7, toJSON: () => ({}) },
+  pos: 0,
+};
+const paragraph = {
+  node: { type: { name: "core/paragraph" }, nodeSize: 4, toJSON: () => ({}) },
+  pos: 8,
+};
+
+describe("nextTrackedNode", () => {
+  test("non-touch + null incoming → null", () => {
+    expect(
+      nextTrackedNode({
+        isTouch: false,
+        current: heading,
+        incoming: { node: null, pos: -1 },
+      }),
+    ).toBeNull();
+  });
+
+  test("non-touch + node incoming → tracked = incoming", () => {
+    expect(
+      nextTrackedNode({
+        isTouch: false,
+        current: heading,
+        incoming: { node: paragraph.node, pos: paragraph.pos },
+      }),
+    ).toEqual(paragraph);
+  });
+
+  test("touch + null incoming + null current → null (nothing to suppress)", () => {
+    expect(
+      nextTrackedNode({
+        isTouch: true,
+        current: null,
+        incoming: { node: null, pos: -1 },
+      }),
+    ).toBeNull();
+  });
+
+  test("touch + null incoming + existing current → keep current (suppress)", () => {
+    expect(
+      nextTrackedNode({
+        isTouch: true,
+        current: heading,
+        incoming: { node: null, pos: -1 },
+      }),
+    ).toBe(heading);
+  });
+
+  test("touch + node incoming → tracked = incoming (real anchor change wins)", () => {
+    expect(
+      nextTrackedNode({
+        isTouch: true,
+        current: heading,
+        incoming: { node: paragraph.node, pos: paragraph.pos },
+      }),
+    ).toEqual(paragraph);
+  });
+});

--- a/packages/admin/src/editor/drag-handle/next-tracked.ts
+++ b/packages/admin/src/editor/drag-handle/next-tracked.ts
@@ -1,0 +1,30 @@
+interface TrackedNode {
+  readonly node: {
+    readonly type: { readonly name: string };
+    readonly nodeSize: number;
+    toJSON(): unknown;
+  };
+  readonly pos: number;
+}
+
+interface IncomingAnchor {
+  readonly node: TrackedNode["node"] | null;
+  readonly pos: number;
+}
+
+interface NextTrackedInput {
+  readonly isTouch: boolean;
+  readonly current: TrackedNode | null;
+  readonly incoming: IncomingAnchor;
+}
+
+// Tiptap's drag-handle is hover-driven and emits `onNodeChange(null)`
+// on pointer-leave — meaningless on touch, where it would tear the
+// handle off the last-tapped block. Real anchor changes still win.
+export function nextTrackedNode(input: NextTrackedInput): TrackedNode | null {
+  const { isTouch, current, incoming } = input;
+  if (isTouch && incoming.node === null && current !== null) {
+    return current;
+  }
+  return incoming.node ? { node: incoming.node, pos: incoming.pos } : null;
+}


### PR DESCRIPTION
## Summary

Last #314 follow-up. Tiptap's `@tiptap/extension-drag-handle-react` is hover-driven and fires `onNodeChange(null)` whenever the pointer leaves a block. Touch authors got a brief anchor from the tap's compatibility mouse events, then the plugin tore the handle off again. Match `(pointer: coarse)` and suppress the null clear when we already have a tracked anchor — real anchor changes (non-null incoming node) still win.

- Pure `nextTrackedNode({ isTouch, current, incoming })` decision function
- `PlumixDragHandle` mirrors `matchMedia("(pointer: coarse)")` via a `change` listener; `onNodeChange` routes through the helper
- Layered with the existing popover-open guard (#362) and stable callback identity (#342) — both preserved

## Test plan

- [x] 5-case vitest spec on `nextTrackedNode` (truth table)
- [x] 292 admin unit tests pass
- [x] 9/9 mobile-related e2e specs still pass (no regression in the existing flows)
- [x] typecheck / lint / format clean

## Known scope

Touchscreen laptops with a trackpad report `pointer: fine` and fall back to desktop behavior — same as main today, no regression. `any-pointer: coarse` would cover both but would also persist on iPads where the mouse-hover model works fine; left as a follow-up if it becomes a real complaint.

Refs GH-314