### PR TITLE
feat(admin,blocks): bubble menu icons + floating panel styling

### DIFF
--- a/packages/admin/src/components/editor/bubble-menu/MarkToolbar.tsx
+++ b/packages/admin/src/components/editor/bubble-menu/MarkToolbar.tsx
@@ -1,6 +1,23 @@
 import type { Editor } from "@tiptap/react";
-import type { KeyboardEvent, ReactElement } from "react";
+import type { ComponentType, KeyboardEvent, ReactElement } from "react";
 import { useRef } from "react";
+import { Toggle } from "@/components/ui/toggle.js";
+import { cn } from "@/lib/utils";
+import {
+  Bold,
+  Code,
+  Highlighter,
+  Italic,
+  Keyboard,
+  Link as LinkIcon,
+  Quote,
+  Strikethrough,
+  Subscript,
+  Superscript,
+  TextQuote,
+  Underline,
+  WholeWord,
+} from "lucide-react";
 
 import type { MarkRegistry, ResolvedMarkSpec } from "@plumix/blocks";
 
@@ -14,15 +31,25 @@ const ARROW_DELTAS: Record<string, number | undefined> = {
   ArrowLeft: -1,
 };
 
-/**
- * Pure rendering layer for the mark bubble menu — one button per
- * registered mark, with `aria-pressed` reflecting the editor's active
- * state and onClick dispatching the standard Tiptap toggle chain.
- *
- * Kept separate from the Tiptap `BubbleMenu` positioning wrapper so
- * tests can render this directly against a stub editor without
- * involving floating-ui or selection state.
- */
+// Hand-rolled, tree-shakeable mapping — bundling lucide via dynamic
+// keys would pull every icon in (~1MB). Plugin marks fall back to the
+// title text below when their `bubbleMenuIcon` isn't in this map.
+const ICONS: Record<string, ComponentType<{ readonly className?: string }>> = {
+  Bold,
+  Italic,
+  Strikethrough,
+  Code,
+  Link: LinkIcon,
+  Underline,
+  Subscript,
+  Superscript,
+  Highlighter,
+  Keyboard,
+  Quote,
+  TextQuote,
+  WholeWord,
+};
+
 export function MarkToolbar({
   editor,
   markRegistry,
@@ -61,7 +88,9 @@ export function MarkToolbar({
       ref={rootRef}
       data-plumix-mark-toolbar=""
       role="toolbar"
+      aria-label="Inline formatting"
       onKeyDown={handleKeyDown}
+      className="bg-popover text-popover-foreground flex items-center gap-0.5 rounded-md border p-1 shadow-md"
     >
       {marks.map((mark) => (
         <MarkButton key={mark.name} mark={mark} editor={editor} />
@@ -78,18 +107,20 @@ interface MarkButtonProps {
 function MarkButton({ mark, editor }: MarkButtonProps): ReactElement {
   const label = mark.bubbleMenuLabel ?? mark.title;
   const isActive = editor.isActive(mark.name);
-  const onClick = (): void => {
-    editor.chain().focus().toggleMark(mark.name).run();
-  };
+  const Icon = mark.bubbleMenuIcon ? ICONS[mark.bubbleMenuIcon] : undefined;
   return (
-    <button
-      type="button"
+    <Toggle
       data-testid={`bubble-menu-${mark.name}`}
-      aria-pressed={isActive}
+      size="sm"
+      pressed={isActive}
       aria-label={label}
-      onClick={onClick}
+      title={label}
+      onPressedChange={() => {
+        editor.chain().focus().toggleMark(mark.name).run();
+      }}
+      className={cn(Icon ? "px-1.5" : "px-2 text-xs")}
     >
-      {label}
-    </button>
+      {Icon ? <Icon className="size-4" /> : label}
+    </Toggle>
   );
 }

--- a/packages/blocks/src/marks/core/abbr.tsx
+++ b/packages/blocks/src/marks/core/abbr.tsx
@@ -33,6 +33,7 @@ export const abbrMark = defineMark({
   name: "abbr",
   title: "Abbreviation",
   description: "Abbreviation with an optional tooltip via the title attr.",
+  bubbleMenuIcon: "WholeWord",
   schema: () => Promise.resolve(abbrSchema),
   component: () => Promise.resolve(AbbrComponent),
 });

--- a/packages/blocks/src/marks/core/index.ts
+++ b/packages/blocks/src/marks/core/index.ts
@@ -15,6 +15,7 @@ export const coreMarks: readonly MarkSpec[] = Object.freeze([
     tag: "strong",
     parseTags: ["strong", "b"],
     keyboardShortcut: "Mod-b",
+    bubbleMenuIcon: "Bold",
   }),
   simpleMark({
     name: "italic",
@@ -22,6 +23,7 @@ export const coreMarks: readonly MarkSpec[] = Object.freeze([
     tag: "em",
     parseTags: ["em", "i"],
     keyboardShortcut: "Mod-i",
+    bubbleMenuIcon: "Italic",
   }),
   simpleMark({
     name: "strike",
@@ -29,6 +31,7 @@ export const coreMarks: readonly MarkSpec[] = Object.freeze([
     tag: "s",
     parseTags: ["s", "del", "strike"],
     keyboardShortcut: "Mod-Shift-X",
+    bubbleMenuIcon: "Strikethrough",
   }),
   simpleMark({
     name: "code",
@@ -36,6 +39,7 @@ export const coreMarks: readonly MarkSpec[] = Object.freeze([
     tag: "code",
     parseTags: ["code"],
     keyboardShortcut: "Mod-e",
+    bubbleMenuIcon: "Code",
   }),
   linkMark,
   simpleMark({
@@ -44,30 +48,35 @@ export const coreMarks: readonly MarkSpec[] = Object.freeze([
     tag: "u",
     parseTags: ["u"],
     keyboardShortcut: "Mod-u",
+    bubbleMenuIcon: "Underline",
   }),
   simpleMark({
     name: "subscript",
     title: "Subscript",
     tag: "sub",
     parseTags: ["sub"],
+    bubbleMenuIcon: "Subscript",
   }),
   simpleMark({
     name: "superscript",
     title: "Superscript",
     tag: "sup",
     parseTags: ["sup"],
+    bubbleMenuIcon: "Superscript",
   }),
   simpleMark({
     name: "highlight",
     title: "Highlight",
     tag: "mark",
     parseTags: ["mark"],
+    bubbleMenuIcon: "Highlighter",
   }),
   simpleMark({
     name: "kbd",
     title: "Keyboard",
     tag: "kbd",
     parseTags: ["kbd"],
+    bubbleMenuIcon: "Keyboard",
   }),
   abbrMark,
   simpleMark({
@@ -75,11 +84,13 @@ export const coreMarks: readonly MarkSpec[] = Object.freeze([
     title: "Citation",
     tag: "cite",
     parseTags: ["cite"],
+    bubbleMenuIcon: "Quote",
   }),
   simpleMark({
     name: "small",
     title: "Small print",
     tag: "small",
     parseTags: ["small"],
+    bubbleMenuIcon: "TextQuote",
   }),
 ]);

--- a/packages/blocks/src/marks/core/link.tsx
+++ b/packages/blocks/src/marks/core/link.tsx
@@ -64,6 +64,7 @@ export const linkMark = defineMark({
   name: "link",
   title: "Link",
   description: "Inline hyperlink with safe-href filtering.",
+  bubbleMenuIcon: "Link",
   schema: () => Promise.resolve(linkSchema),
   component: () => Promise.resolve(LinkComponent),
 });


### PR DESCRIPTION
## Summary

User flagged that the inline (Bold/Italic/...) toolbar rendered as a row of bare browser buttons with plain-text labels. Confirmed via screenshot — there was no panel, no icons, no spacing. Polish pass:

- All 13 core marks declare `bubbleMenuIcon` (`Bold`/`Italic`/`Strikethrough`/...)
- `MarkToolbar` renders shadcn `Toggle` with lucide icons via a static tree-shakeable `ICONS` record. Plugin marks without a known icon fall back to the title text
- Toolbar wrapped in a proper floating panel — `bg-popover`, border, shadow, rounded corners. `data-state=on` styling shows active marks; `aria-pressed` exposed natively by Radix Toggle

## Test plan

- [x] 292 admin unit tests pass (`MarkToolbar.test.tsx` covers the active-state contract)
- [x] 327 blocks unit tests pass (existing mark specs revalidated)
- [x] typecheck / lint / format clean
- [x] Visual review via screenshot — before/after sent in chat

Refs GH-314