### PR TITLE
fix(admin): hide visible CommandInput chrome in slash + BlockMenu

### DIFF
--- a/packages/admin/src/editor/block-menu/BlockMenu.tsx
+++ b/packages/admin/src/editor/block-menu/BlockMenu.tsx
@@ -3,11 +3,11 @@ import { useMemo } from "react";
 import {
   Command,
   CommandGroup,
-  CommandInput,
   CommandItem,
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command.js";
+import { Command as CmdkPrimitive } from "cmdk";
 
 import type { BlockRegistry, BlockTransformTo } from "@plumix/blocks";
 import { resolveTransformTargets } from "@plumix/blocks";
@@ -47,13 +47,11 @@ export function BlockMenu({
   );
   return (
     <Command data-plumix-block-menu="" label="Block actions">
-      {/*
-        Hidden CommandInput exists to give cmdk a focusable surface so
-        keyboard-only authors can drive the menu with ArrowDown / Enter
-        — without it, radix's Popover autoFocus has nothing to land on
-        and the editor keeps focus, swallowing Enter.
-      */}
-      <CommandInput
+      {/* Hidden cmdk input — gives keyboard-only authors a focus
+          target so ArrowDown / Enter route through cmdk. Use the
+          primitive directly: shadcn's `CommandInput` wraps the input
+          in a div with a SearchIcon that `sr-only` doesn't hide. */}
+      <CmdkPrimitive.Input
         className="sr-only"
         tabIndex={-1}
         aria-label="Filter block actions"

--- a/packages/admin/src/editor/slash-menu/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/slash-menu/SlashMenuPanel.tsx
@@ -10,10 +10,10 @@ import {
   Command,
   CommandEmpty,
   CommandGroup,
-  CommandInput,
   CommandItem,
   CommandList,
 } from "@/components/ui/command.js";
+import { Command as CmdkPrimitive } from "cmdk";
 
 import type { SlashMenuItem } from "./items-from-registry.js";
 
@@ -131,8 +131,13 @@ export const SlashMenuPanel = forwardRef<
       filter={(value, search) =>
         value.includes(search.trim().toLowerCase()) ? 1 : 0
       }
+      className="w-72 max-w-full border shadow-md"
     >
-      <CommandInput
+      {/* Use cmdk's primitive directly — shadcn's `CommandInput`
+          wraps the input in a div with a SearchIcon that `sr-only`
+          on the input doesn't hide. We just need cmdk's filter
+          wire-up; the query comes from Tiptap. */}
+      <CmdkPrimitive.Input
         value={query}
         onValueChange={() => {
           /* search is driven by Tiptap's query, not user typing here */


### PR DESCRIPTION
## Summary

Visual audit follow-up after #365 (the bubble-menu polish). Captured screenshots of every editor surface and found two more:

1. **Slash menu** — the cmdk `<Command>` had no border or shadow; items rendered as bare text on the page background.
2. **Slash menu + BlockMenu** — both wrapped a "hidden" `CommandInput` with `sr-only`, but shadcn's `CommandInput` wraps the input in a div containing a `SearchIcon`. The wrapper stayed visible, leaking a magnifier icon at the top of both popovers.

Fix:
- SlashMenuPanel's `<Command>` gets `border shadow-md w-72`.
- Both surfaces import cmdk's `Command.Input` primitive directly. The cmdk filter wiring is unchanged; the shadcn chrome (icon + container) is bypassed.

Before/after screenshots posted in the chat.

## Test plan

- [x] 292 admin unit tests pass
- [x] typecheck / lint / format clean
- [x] Visual recapture confirms both surfaces no longer leak the icon and slash menu has proper panel chrome

Refs GH-314