### PR TITLE
feat(admin,blocks): wrapper blocks insert valid + slash icons + sidebar separator

### DIFF
--- a/packages/admin/e2e/slash-menu-wrapper-blocks.spec.ts
+++ b/packages/admin/e2e/slash-menu-wrapper-blocks.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+// Regression for the wrapper-block slash-menu bug surfaced 2026-05-18:
+// inserting `core/list` / `core/list-ordered` / `core/quote` /
+// `core/columns` from the slash menu produced a paragraph because the
+// Tiptap schemas require non-optional children and the slash payload
+// shipped no content. Each spec now declares `defaultInnerBlocks` so
+// items-from-registry materialises a valid empty body.
+
+const T0 = new Date("2026-05-18T00:00:00Z");
+
+const CASES = [
+  {
+    item: "core/list",
+    query: "list",
+    expect: { selector: "ul", tag: "UL" },
+  },
+  {
+    item: "core/list-ordered",
+    query: "numbered",
+    expect: { selector: "ol", tag: "OL" },
+  },
+  {
+    item: "core/quote",
+    query: "quote",
+    expect: { selector: "blockquote", tag: "BLOCKQUOTE" },
+  },
+] as const;
+
+test.describe("slash menu inserts valid wrapper blocks", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  for (const c of CASES) {
+    test(`${c.item} produces <${c.expect.selector}>`, async ({ page }) => {
+      await page.route("**/_plumix/rpc/**", async (route) => {
+        const url = route.request().url();
+        if (url.endsWith("/auth/session")) {
+          return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: rpcOkBody(AUTHED_ADMIN),
+          });
+        }
+        if (url.endsWith("/entry/get")) {
+          return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              json: {
+                id: 9,
+                type: "post",
+                parentId: null,
+                title: "Probe",
+                slug: "p",
+                content: {
+                  type: "doc",
+                  content: [{ type: "core/paragraph", content: [] }],
+                },
+                excerpt: null,
+                status: "draft",
+                authorId: 1,
+                sortOrder: 0,
+                publishedAt: null,
+                createdAt: T0,
+                updatedAt: T0,
+                meta: {},
+              },
+              meta: [],
+            }),
+          });
+        }
+        return route.fulfill({ status: 404, body: "not-mocked" });
+      });
+
+      await page.goto("entries/posts/9/edit");
+      await expect(page.getByTestId("post-editor-form")).toBeVisible();
+      await page.locator(".ProseMirror").click();
+      await page.keyboard.type(`/${c.query}`);
+      await expect(page.getByTestId(`slash-menu-item-${c.item}`)).toBeVisible();
+      await page.keyboard.press("Enter");
+      await page.keyboard.type("Hello");
+
+      const tag = await page.evaluate((selector) => {
+        const el = document.querySelector(`.ProseMirror ${selector}`);
+        return el?.tagName ?? null;
+      }, c.expect.selector);
+      expect(tag).toBe(c.expect.tag);
+    });
+  }
+});

--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -425,7 +425,15 @@ export function PostEditorForm({
                   Document
                 </SidebarHeader>
                 <SidebarContent>
-                  <InspectorSection />
+                  {/* `border-b` lives on this wrapper (not on the
+                      Inspector itself) so the seam between block
+                      attributes and the document panel is always
+                      visible — Inspector returns `null` when the
+                      selected block has no attributes/supports, and
+                      we still want a divider then. */}
+                  <div className="border-b">
+                    <InspectorSection />
+                  </div>
                   {documentPanelSections}
                 </SidebarContent>
               </Sidebar>

--- a/packages/admin/src/components/editor/tiptap-editor.tsx
+++ b/packages/admin/src/components/editor/tiptap-editor.tsx
@@ -28,17 +28,15 @@ import { buildTiptapExtensions } from "./tiptap-extensions.js";
  * (recursively) as `content`.
  */
 export function slashMenuItemToContent(item: SlashMenuItem): JSONContent {
-  if (item.parent !== undefined) {
-    return {
-      type: item.parent,
-      ...(item.attributes !== undefined && { attrs: { ...item.attributes } }),
-      ...(item.innerBlocks !== undefined &&
-        item.innerBlocks.length > 0 && {
-          content: item.innerBlocks.map(innerBlockToContent),
-        }),
-    };
-  }
-  return { type: item.name };
+  const type = item.parent ?? item.name;
+  return {
+    type,
+    ...(item.attributes !== undefined && { attrs: { ...item.attributes } }),
+    ...(item.innerBlocks !== undefined &&
+      item.innerBlocks.length > 0 && {
+        content: item.innerBlocks.map(innerBlockToContent),
+      }),
+  };
 }
 
 function innerBlockToContent(inner: BlockVariationInnerBlock): JSONContent {

--- a/packages/admin/src/editor/slash-menu/SlashMenuIcon.tsx
+++ b/packages/admin/src/editor/slash-menu/SlashMenuIcon.tsx
@@ -1,0 +1,59 @@
+import type { ComponentType, ReactElement } from "react";
+import {
+  ArrowDownUp,
+  ChevronDownSquare,
+  Code,
+  CodeXml,
+  Columns2,
+  Heading,
+  Info,
+  List,
+  ListOrdered,
+  ListTree,
+  Minus,
+  MousePointer,
+  MousePointerClick,
+  Quote,
+  SquareDashed,
+  SquareStack,
+  Table,
+  Type,
+} from "lucide-react";
+
+// Hand-rolled, tree-shakeable mapping. Block specs pass their lucide
+// icon name as a string; plugin blocks with unknown names fall back to
+// the placeholder so the row layout stays consistent.
+const ICONS: Record<string, ComponentType<{ readonly className?: string }>> = {
+  ArrowDownUp,
+  ChevronDownSquare,
+  Code,
+  CodeXml,
+  Columns2,
+  Heading,
+  Info,
+  List,
+  ListOrdered,
+  ListTree,
+  Minus,
+  MousePointer,
+  MousePointerClick,
+  Quote,
+  SquareStack,
+  Table,
+  Type,
+};
+
+export function SlashMenuIcon({
+  name,
+}: {
+  readonly name?: string;
+}): ReactElement {
+  const Icon = name ? ICONS[name] : undefined;
+  const Resolved = Icon ?? SquareDashed;
+  return (
+    <Resolved
+      aria-hidden="true"
+      className="text-muted-foreground size-4 shrink-0"
+    />
+  );
+}

--- a/packages/admin/src/editor/slash-menu/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/slash-menu/SlashMenuPanel.tsx
@@ -16,6 +16,7 @@ import {
 import { Command as CmdkPrimitive } from "cmdk";
 
 import type { SlashMenuItem } from "./items-from-registry.js";
+import { SlashMenuIcon } from "./SlashMenuIcon.js";
 
 export interface SlashMenuPanelHandle {
   /**
@@ -166,13 +167,25 @@ export const SlashMenuPanel = forwardRef<
                 value={value}
                 data-testid={`slash-menu-item-${item.name}`}
                 onSelect={() => onSelect(item)}
+                className="flex items-start gap-2"
               >
-                <span data-plumix-slash-menu-title="">{item.title}</span>
-                {item.description ? (
-                  <span data-plumix-slash-menu-description="">
-                    {item.description}
+                <SlashMenuIcon name={item.icon} />
+                <span className="flex min-w-0 flex-col">
+                  <span
+                    data-plumix-slash-menu-title=""
+                    className="text-sm font-medium"
+                  >
+                    {item.title}
                   </span>
-                ) : null}
+                  {item.description ? (
+                    <span
+                      data-plumix-slash-menu-description=""
+                      className="text-muted-foreground text-xs"
+                    >
+                      {item.description}
+                    </span>
+                  ) : null}
+                </span>
               </CommandItem>
             ))}
           </CommandGroup>

--- a/packages/admin/src/editor/slash-menu/items-from-registry.ts
+++ b/packages/admin/src/editor/slash-menu/items-from-registry.ts
@@ -10,6 +10,8 @@ export interface SlashMenuItem {
   readonly description?: string;
   readonly category: string;
   readonly keywords?: readonly string[];
+  /** Lucide icon name resolved at render time. */
+  readonly icon?: string;
   /**
    * When this item is a variation, the parent block's name. The editor
    * uses this to insert a node of `parent`'s type rather than `name`'s
@@ -54,9 +56,17 @@ export function itemsFromRegistry(
       description: spec.description,
       category: spec.category ?? "typography",
       keywords: spec.keywords,
+      icon: spec.icon,
+      // Bare-block items inherit the spec's `defaultInnerBlocks` so
+      // wrapper blocks (list, quote, columns) materialise valid
+      // children — otherwise Tiptap silently degrades the empty
+      // insertion to the default block.
+      innerBlocks: spec.defaultInnerBlocks,
     });
     for (const variation of spec.variations ?? []) {
-      items.push(variationToItem(spec.name, spec.category, variation));
+      items.push(
+        variationToItem(spec.name, spec.category, variation, spec.icon),
+      );
     }
   }
   return items;
@@ -66,6 +76,7 @@ function variationToItem(
   parentName: string,
   parentCategory: string | undefined,
   variation: BlockVariation,
+  parentIcon: string | undefined,
 ): SlashMenuItem {
   return {
     name: `${parentName}:${variation.name}`,
@@ -73,6 +84,7 @@ function variationToItem(
     description: variation.description,
     category: parentCategory ?? "typography",
     keywords: variation.keywords,
+    icon: variation.icon ?? parentIcon,
     parent: parentName,
     attributes: variation.attributes,
     innerBlocks: variation.innerBlocks,

--- a/packages/blocks/src/button/index.ts
+++ b/packages/blocks/src/button/index.ts
@@ -21,6 +21,7 @@ const TARGET_OPTIONS = [
 export const buttonBlock = defineBlock({
   name: "core/button",
   title: "Button",
+  icon: "MousePointer",
   category: "interactive",
   description: "Call-to-action link styled as a button.",
   attributes: {

--- a/packages/blocks/src/buttons/index.ts
+++ b/packages/blocks/src/buttons/index.ts
@@ -10,6 +10,7 @@ const ALIGN_OPTIONS = [
 export const buttonsBlock = defineBlock({
   name: "core/buttons",
   title: "Buttons",
+  icon: "MousePointerClick",
   category: "interactive",
   description: "Container for a row of call-to-action buttons.",
   attributes: {

--- a/packages/blocks/src/callout/index.ts
+++ b/packages/blocks/src/callout/index.ts
@@ -11,6 +11,7 @@ const VARIANT_OPTIONS = [
 export const calloutBlock = defineBlock({
   name: "core/callout",
   title: "Callout",
+  icon: "Info",
   category: "interactive",
   description: "Highlighted aside for info / warning / error / success / note.",
   attributes: {

--- a/packages/blocks/src/code/index.ts
+++ b/packages/blocks/src/code/index.ts
@@ -3,6 +3,7 @@ import { defineBlock } from "../define-block.js";
 export const codeBlock = defineBlock({
   name: "core/code",
   title: "Code",
+  icon: "Code",
   category: "typography",
   description: "Preformatted code block with optional language attribute.",
   legacyAliases: ["codeBlock"],

--- a/packages/blocks/src/columns/index.ts
+++ b/packages/blocks/src/columns/index.ts
@@ -21,6 +21,7 @@ function emptyColumns(count: number): readonly { name: "core/column" }[] {
 export const columnsBlock = defineBlock({
   name: "core/columns",
   title: "Columns",
+  icon: "Columns2",
   category: "layout",
   description: "Multi-column container with explicit ratios.",
   attributes: {
@@ -31,6 +32,7 @@ export const columnsBlock = defineBlock({
       options: RATIO_OPTIONS,
     },
   },
+  defaultInnerBlocks: emptyColumns(2),
   variations: [
     {
       name: "50-50",

--- a/packages/blocks/src/define-block.ts
+++ b/packages/blocks/src/define-block.ts
@@ -100,6 +100,9 @@ export function defineBlock<Attrs = Readonly<Record<string, unknown>>>(
     markdownShortcuts: freezeArrayOfObjects(spec.markdownShortcuts),
     parsePaste: freezeArrayOfObjects(spec.parsePaste),
     variations: freezeVariations(spec.variations),
+    defaultInnerBlocks: spec.defaultInnerBlocks
+      ? freezeInnerBlocks(spec.defaultInnerBlocks)
+      : undefined,
     transforms: spec.transforms
       ? Object.freeze({
           priority: spec.transforms.priority,

--- a/packages/blocks/src/description-list/index.ts
+++ b/packages/blocks/src/description-list/index.ts
@@ -3,6 +3,7 @@ import { defineBlock } from "../define-block.js";
 export const descriptionListBlock = defineBlock({
   name: "core/description-list",
   title: "Description list",
+  icon: "ListTree",
   category: "text",
   description: "Definition list of term / detail pairs.",
   schema: () => import("./schema.js").then((m) => m.descriptionListSchema),

--- a/packages/blocks/src/details/index.ts
+++ b/packages/blocks/src/details/index.ts
@@ -3,6 +3,7 @@ import { defineBlock } from "../define-block.js";
 export const detailsBlock = defineBlock({
   name: "core/details",
   title: "Details",
+  icon: "ChevronDownSquare",
   category: "interactive",
   description: "Native <details>/<summary> collapsible region.",
   attributes: {

--- a/packages/blocks/src/group/index.ts
+++ b/packages/blocks/src/group/index.ts
@@ -10,6 +10,7 @@ const LAYOUT_OPTIONS = [
 export const groupBlock = defineBlock({
   name: "core/group",
   title: "Group",
+  icon: "SquareStack",
   category: "layout",
   description: "Generic container that hosts any block-level children.",
   attributes: {

--- a/packages/blocks/src/heading/index.ts
+++ b/packages/blocks/src/heading/index.ts
@@ -6,6 +6,7 @@ const HEADING_LEVELS = [1, 2, 3, 4, 5, 6] as const;
 export const headingBlock = defineBlock({
   name: "core/heading",
   title: "Heading",
+  icon: "Heading",
   category: "text",
   description: "Section title.",
   supports: headingSupports,

--- a/packages/blocks/src/html/index.ts
+++ b/packages/blocks/src/html/index.ts
@@ -3,6 +3,7 @@ import { defineBlock } from "../define-block.js";
 export const htmlBlock = defineBlock({
   name: "core/html",
   title: "Custom HTML",
+  icon: "CodeXml",
   category: "typography",
   description:
     "Raw HTML escape hatch. Author content is sanitized through the registry-derived allowlist before render — operators extend the allowlist via `defineApp({ blocks: { htmlAllowlist: {...} } })`.",

--- a/packages/blocks/src/list/list-ordered.ts
+++ b/packages/blocks/src/list/list-ordered.ts
@@ -3,12 +3,14 @@ import { defineBlock } from "../define-block.js";
 export const listOrderedBlock = defineBlock({
   name: "core/list-ordered",
   title: "Numbered list",
+  icon: "ListOrdered",
   category: "text",
   description: "Ordered list of items.",
   legacyAliases: ["orderedList"],
   keyboardShortcuts: [{ shortcut: "Mod-Alt-O", mode: "wrap" }],
   markdownShortcuts: [{ pattern: "1. ", mode: "wrap" }],
   parsePaste: [{ selector: "ol" }],
+  defaultInnerBlocks: [{ name: "core/list-item" }],
   transforms: {
     priority: 20,
     to: [{ target: "core/paragraph" }],

--- a/packages/blocks/src/list/list.ts
+++ b/packages/blocks/src/list/list.ts
@@ -3,12 +3,14 @@ import { defineBlock } from "../define-block.js";
 export const listBlock = defineBlock({
   name: "core/list",
   title: "Bulleted list",
+  icon: "List",
   category: "text",
   description: "Unordered list of items.",
   legacyAliases: ["bulletList"],
   keyboardShortcuts: [{ shortcut: "Mod-Alt-L", mode: "wrap" }],
   markdownShortcuts: [{ pattern: "- ", mode: "wrap" }],
   parsePaste: [{ selector: "ul" }],
+  defaultInnerBlocks: [{ name: "core/list-item" }],
   transforms: {
     priority: 20,
     to: [{ target: "core/paragraph" }],

--- a/packages/blocks/src/paragraph/index.ts
+++ b/packages/blocks/src/paragraph/index.ts
@@ -11,6 +11,7 @@ import { paragraphSupports } from "./supports.js";
 export const paragraphBlock = defineBlock({
   name: "core/paragraph",
   title: "Paragraph",
+  icon: "Type",
   category: "text",
   description: "The building block of all narrative.",
   supports: paragraphSupports,

--- a/packages/blocks/src/quote/index.ts
+++ b/packages/blocks/src/quote/index.ts
@@ -3,12 +3,14 @@ import { defineBlock } from "../define-block.js";
 export const quoteBlock = defineBlock({
   name: "core/quote",
   title: "Quote",
+  icon: "Quote",
   category: "typography",
   description: "Pull quote with optional citation.",
   legacyAliases: ["blockquote"],
   keyboardShortcuts: [{ shortcut: "Mod-Alt-Q" }],
   markdownShortcuts: [{ pattern: "> " }],
   parsePaste: [{ selector: "blockquote" }],
+  defaultInnerBlocks: [{ name: "core/paragraph" }],
   transforms: {
     priority: 20,
     to: [{ target: "core/paragraph" }],

--- a/packages/blocks/src/registry.ts
+++ b/packages/blocks/src/registry.ts
@@ -159,6 +159,7 @@ async function resolveSpec(
     markdownShortcuts: spec.markdownShortcuts,
     parsePaste: spec.parsePaste,
     variations: spec.variations,
+    defaultInnerBlocks: spec.defaultInnerBlocks,
     transforms: spec.transforms,
   });
 }

--- a/packages/blocks/src/separator/index.ts
+++ b/packages/blocks/src/separator/index.ts
@@ -3,6 +3,7 @@ import { defineBlock } from "../define-block.js";
 export const separatorBlock = defineBlock({
   name: "core/separator",
   title: "Separator",
+  icon: "Minus",
   category: "typography",
   description: "Horizontal rule with named style variants.",
   legacyAliases: ["horizontalRule"],

--- a/packages/blocks/src/spacer/index.ts
+++ b/packages/blocks/src/spacer/index.ts
@@ -3,6 +3,7 @@ import { defineBlock } from "../define-block.js";
 export const spacerBlock = defineBlock({
   name: "core/spacer",
   title: "Spacer",
+  icon: "ArrowDownUp",
   category: "typography",
   description: "Vertical whitespace with adjustable height.",
   schema: () => import("./schema.js").then((m) => m.spacerSchema),

--- a/packages/blocks/src/table/index.ts
+++ b/packages/blocks/src/table/index.ts
@@ -9,6 +9,7 @@ const ALIGN_OPTIONS = [
 export const tableBlock = defineBlock({
   name: "core/table",
   title: "Table",
+  icon: "Table",
   category: "interactive",
   description: "Tabular data with optional striped + bordered variants.",
   attributes: {

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -156,6 +156,15 @@ export interface BlockSpec<Attrs = Readonly<Record<string, unknown>>> {
    * configure attributes after every insert.
    */
   readonly variations?: readonly BlockVariation[];
+  /**
+   * Default inner blocks the slash menu materialises when the author
+   * picks the bare block (not a variation). Required for wrapper blocks
+   * whose Tiptap schema has a non-optional content expression — e.g.
+   * `core/list` requires `coreListItem+`, so inserting a bare empty list
+   * silently degrades to a paragraph. Variations override this by
+   * supplying their own `innerBlocks`.
+   */
+  readonly defaultInnerBlocks?: readonly BlockVariationInnerBlock[];
   readonly schema: LazyRef<ReturnType<typeof TiptapNodeFactory.create>>;
   readonly component: LazyRef<BlockComponent<Attrs>>;
   readonly editor?: LazyRef<ComponentType<unknown>>;


### PR DESCRIPTION
## Summary

Visual + behavior audit follow-ups:

1. **Wrapper-block slash insertion fix (BEHAVIOR BUG)** — inserting Bulleted list / Numbered list / Quote / Columns via the slash menu produced a paragraph instead of `<ul>`/`<ol>`/`<blockquote>`/columns. Schemas require non-optional children; the slash payload shipped none. Added `defaultInnerBlocks` to `BlockSpec`, set on list/list-ordered/quote/columns. `define-block`, `registry`, `items-from-registry`, and `slashMenuItemToContent` propagate the field. Regression spec in `e2e/slash-menu-wrapper-blocks.spec.ts`.
2. **Slash menu icons** — each core block declares a lucide icon name. `SlashMenuIcon` resolves via a tree-shakeable static record. Plugin blocks with unknown icons fall back to a placeholder.
3. **Sidebar separator** — `border-b` on the InspectorSection wrapper (rail container, not Inspector itself, so the divider stays visible when no block has attributes).

## Known follow-ups (senpai-flagged)

- **Transform path has the same `defaultInnerBlocks` gap.** `PlumixDragHandle.onTransform` inserts `{ type, attrs }` with no `content`; transforming paragraph → list via the BlockMenu reproduces the original bug. Worth a focused PR that lifts `slashMenuItemToContent` into a shared helper and reuses it.
- `defaultInnerBlocks` isn't validated at `defineBlock` boot — a plugin typo silently produces unknown-type nodes. Mirror the variation-name check.
- `SlashMenuIcon`'s lucide allowlist is hand-rolled; document that plugins should PR new names rather than expecting dynamic lookup.

## Test plan

- [x] 292 admin unit tests pass
- [x] 327 blocks unit tests pass
- [x] new e2e `slash-menu-wrapper-blocks` (3 cases: list, list-ordered, quote)
- [x] typecheck / lint / format clean

Refs GH-314