### PR TITLE
refactor(blocks): co-locate per-block CSS, drop module imports

### DIFF
--- a/packages/admin/src/styles/globals.css
+++ b/packages/admin/src/styles/globals.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+/* Per-block visual styles ship with each block via @plumix/blocks.
+   The aggregate import keeps admin globals free of block-aware
+   selectors so plugins can ship their own CSS the same way. */
+@import "@plumix/blocks/styles.css";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -125,120 +129,3 @@
   }
 }
 
-/* Editor canvas typography. Tailwind's `prose` plugin isn't installed
-   in this admin, so we ship a scoped baseline so authors can tell
-   blocks apart while typing. Frontend themes own production styling;
-   these only apply inside `.ProseMirror` (the editor view). */
-.ProseMirror {
-  /* Headings — clear size hierarchy without going as large as
-     a theme would. Keeps the editor compact at prose-sm scale. */
-  h1 {
-    @apply mb-3 text-3xl leading-tight font-bold;
-  }
-  h2 {
-    @apply mt-6 mb-3 text-2xl leading-tight font-bold;
-  }
-  h3 {
-    @apply mt-5 mb-2 text-xl leading-snug font-semibold;
-  }
-  h4 {
-    @apply mt-4 mb-2 text-lg leading-snug font-semibold;
-  }
-  h5,
-  h6 {
-    @apply mt-3 mb-1 text-base font-semibold;
-  }
-
-  /* Body */
-  p {
-    @apply my-2 leading-relaxed;
-  }
-
-  /* Lists — Tailwind preflight zeroes list-style and padding; we
-     opt our editor lists back in so authors see real bullets. */
-  ul[data-plumix-block="core/list"] {
-    @apply my-2 list-disc pl-6;
-  }
-  ol[data-plumix-block="core/list-ordered"] {
-    @apply my-2 list-decimal pl-6;
-  }
-  ul[data-plumix-block="core/list"] li,
-  ol[data-plumix-block="core/list-ordered"] li {
-    @apply my-1;
-  }
-
-  /* Quote */
-  blockquote[data-plumix-block="core/quote"] {
-    @apply border-muted-foreground/30 text-muted-foreground my-3 border-l-4 pl-4 italic;
-  }
-
-  /* Inline code */
-  p code,
-  li code {
-    @apply bg-muted rounded px-1 py-0.5 font-mono text-[0.875em];
-  }
-
-  /* Code block */
-  pre[data-plumix-block="core/code"] {
-    @apply bg-muted my-3 overflow-x-auto rounded-md p-3 font-mono text-sm;
-  }
-
-  /* Separator */
-  hr[data-plumix-block="core/separator"] {
-    @apply border-border my-6 border-t;
-  }
-
-  /* Columns — explicit grid by ratio. The block writes `data-ratio`
-     in the rendered DOM; CSS expands the canonical ratios. Plugin
-     ratios outside this list fall back to equal-width via the
-     default `grid-cols-2`. */
-  div[data-plumix-block="core/columns"] {
-    @apply my-3 grid grid-cols-2 gap-3;
-  }
-  div[data-plumix-block="core/columns"][data-ratio="1:2"] {
-    grid-template-columns: 1fr 2fr;
-  }
-  div[data-plumix-block="core/columns"][data-ratio="2:1"] {
-    grid-template-columns: 2fr 1fr;
-  }
-  div[data-plumix-block="core/columns"][data-ratio="1:1:1"] {
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-  div[data-plumix-block="core/columns"][data-ratio="1:2:1"] {
-    grid-template-columns: 1fr 2fr 1fr;
-  }
-  div[data-plumix-block="core/columns"][data-ratio="2:1:2"] {
-    grid-template-columns: 2fr 1fr 2fr;
-  }
-  div[data-plumix-block="core/columns"][data-ratio="1:1:1:1"] {
-    grid-template-columns: repeat(4, 1fr);
-  }
-  div[data-plumix-block="core/column"] {
-    @apply border-border/40 min-h-12 rounded border border-dashed p-2;
-  }
-
-  /* Callout */
-  aside[data-plumix-block="core/callout"] {
-    @apply bg-muted/40 border-muted-foreground/20 my-3 rounded-md border p-3;
-  }
-
-  /* Buttons row */
-  div[data-plumix-block="core/buttons"] {
-    @apply my-3 flex flex-wrap gap-2;
-  }
-  a[data-plumix-block="core/button"] {
-    @apply bg-primary text-primary-foreground inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium no-underline;
-  }
-
-  /* Table */
-  table[data-plumix-block="core/table"] {
-    @apply border-border my-3 w-full border-collapse border;
-  }
-  table[data-plumix-block="core/table"] th,
-  table[data-plumix-block="core/table"] td {
-    @apply border-border border px-2 py-1;
-  }
-  table[data-plumix-block="core/table"] th {
-    @apply bg-muted/50 text-left font-semibold;
-  }
-}

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -11,10 +11,11 @@
     "./test": {
       "types": "./dist/test/index.d.ts",
       "default": "./dist/test/index.js"
-    }
+    },
+    "./styles.css": "./dist/styles.css"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node ../../scripts/copy-styles.mjs",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",

--- a/packages/blocks/src/button/Component.tsx
+++ b/packages/blocks/src/button/Component.tsx
@@ -40,6 +40,7 @@ export function ButtonComponent({ attrs }: BlockProps): ReactElement {
       target={target}
       rel={rel}
       data-plumix-block="core/button"
+      className="plumix-button"
       data-variant={variant}
       data-size={size}
     >

--- a/packages/blocks/src/button/button.test.tsx
+++ b/packages/blocks/src/button/button.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { buttonBlock } from "./index.js";
 
 describe("core/button", () => {
@@ -19,8 +19,8 @@ describe("core/button", () => {
         ],
       },
     });
-    expect(html).toBe(
-      '<a href="https://example.com" data-plumix-block="core/button">Open</a>',
+    expect(stripBlockMarkers(html)).toBe(
+      '<a href="https://example.com">Open</a>',
     );
   });
 
@@ -41,7 +41,7 @@ describe("core/button", () => {
           ],
         },
       });
-      expect(html).toContain(`data-variant="${variant}"`);
+      expect(stripBlockMarkers(html)).toContain(`data-variant="${variant}"`);
     },
   );
 
@@ -60,7 +60,7 @@ describe("core/button", () => {
         ],
       },
     });
-    expect(html).not.toContain("data-variant");
+    expect(stripBlockMarkers(html)).not.toContain("data-variant");
   });
 
   test.each(["sm", "md", "lg"])(
@@ -80,7 +80,7 @@ describe("core/button", () => {
           ],
         },
       });
-      expect(html).toContain(`data-size="${size}"`);
+      expect(stripBlockMarkers(html)).toContain(`data-size="${size}"`);
     },
   );
 
@@ -103,8 +103,8 @@ describe("core/button", () => {
         ],
       },
     });
-    expect(html).toContain('target="_blank"');
-    expect(html).toContain('rel="noopener noreferrer"');
+    expect(stripBlockMarkers(html)).toContain('target="_blank"');
+    expect(stripBlockMarkers(html)).toContain('rel="noopener noreferrer"');
   });
 
   test("strips unsafe javascript: hrefs", async () => {
@@ -122,9 +122,9 @@ describe("core/button", () => {
         ],
       },
     });
-    expect(html).not.toContain("href=");
-    expect(html).not.toContain("javascript:");
-    expect(html).toContain(">evil</a>");
+    expect(stripBlockMarkers(html)).not.toContain("href=");
+    expect(stripBlockMarkers(html)).not.toContain("javascript:");
+    expect(stripBlockMarkers(html)).toContain(">evil</a>");
   });
 
   test("renders empty text as an empty anchor body", async () => {
@@ -142,7 +142,7 @@ describe("core/button", () => {
         ],
       },
     });
-    expect(html).toBe('<a href="/x" data-plumix-block="core/button"></a>');
+    expect(stripBlockMarkers(html)).toBe('<a href="/x"></a>');
   });
 
   test("declares the text/href/variant/size/target attribute schema for the Inspector", () => {

--- a/packages/blocks/src/button/schema.ts
+++ b/packages/blocks/src/button/schema.ts
@@ -31,7 +31,10 @@ export const buttonSchema = Node.create({
     // shows the button label instead of an empty link.
     return [
       "a",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/button" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/button",
+        class: "plumix-button",
+      }),
       typeof node.attrs.text === "string" ? node.attrs.text : "",
     ];
   },

--- a/packages/blocks/src/button/styles.css
+++ b/packages/blocks/src/button/styles.css
@@ -1,0 +1,44 @@
+/* Button anchor — variant + size modifiers selected via data-* so a
+   single class works for both the editor renderHTML path and the
+   Component path. */
+.plumix-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+.plumix-button[data-size="sm"] {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.875rem;
+}
+.plumix-button[data-size="md"] {
+  padding: 0.375rem 0.875rem;
+  font-size: 0.9375rem;
+}
+.plumix-button[data-size="lg"] {
+  padding: 0.5rem 1.125rem;
+  font-size: 1rem;
+}
+.plumix-button[data-variant="primary"] {
+  background: oklch(0.205 0 0);
+  color: oklch(0.985 0 0);
+}
+.plumix-button[data-variant="secondary"] {
+  background: oklch(0.97 0 0);
+  color: oklch(0.205 0 0);
+}
+.plumix-button[data-variant="outline"] {
+  background: transparent;
+  border-color: oklch(0.85 0 0);
+  color: oklch(0.205 0 0);
+}
+.plumix-button[data-variant="ghost"] {
+  background: transparent;
+  color: oklch(0.205 0 0);
+}

--- a/packages/blocks/src/buttons/Component.tsx
+++ b/packages/blocks/src/buttons/Component.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import type { CSSProperties, ReactElement } from "react";
 
 import type { BlockProps } from "../types.js";
 
@@ -23,7 +23,15 @@ export function ButtonsComponent({
   const align = pickAlign(attrs.align);
   const gap = normalizeGap(attrs.gap);
   return (
-    <div data-plumix-block="core/buttons" data-align={align} data-gap={gap}>
+    <div
+      data-plumix-block="core/buttons"
+      className="plumix-buttons"
+      data-align={align}
+      data-gap={gap}
+      style={
+        gap ? ({ "--plumix-buttons-gap": gap } as CSSProperties) : undefined
+      }
+    >
       {children}
     </div>
   );

--- a/packages/blocks/src/buttons/buttons.test.tsx
+++ b/packages/blocks/src/buttons/buttons.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { buttonBlock } from "../button/index.js";
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { buttonsBlock } from "./index.js";
 
 describe("core/buttons", () => {
@@ -16,7 +16,7 @@ describe("core/buttons", () => {
         content: [{ type: "core/buttons", content: [] }],
       },
     });
-    expect(html).toBe('<div data-plumix-block="core/buttons"></div>');
+    expect(stripBlockMarkers(html)).toBe('<div></div>');
   });
 
   test.each(["start", "center", "end", "between"])(
@@ -32,7 +32,7 @@ describe("core/buttons", () => {
           content: [{ type: "core/buttons", attrs: { align }, content: [] }],
         },
       });
-      expect(html).toContain(`data-align="${align}"`);
+      expect(stripBlockMarkers(html)).toContain(`data-align="${align}"`);
     },
   );
 
@@ -49,7 +49,7 @@ describe("core/buttons", () => {
         ],
       },
     });
-    expect(html).not.toContain("data-align");
+    expect(stripBlockMarkers(html)).not.toContain("data-align");
   });
 
   test("normalises numeric gap to a px string", async () => {
@@ -66,8 +66,8 @@ describe("core/buttons", () => {
         ],
       },
     });
-    expect(html).toContain('data-gap="12px"');
-    expect(html).toContain('data-gap="1rem"');
+    expect(stripBlockMarkers(html)).toContain('data-gap="12px"');
+    expect(stripBlockMarkers(html)).toContain('data-gap="1rem"');
   });
 
   test("declares align (select) + gap (text) attributes for the Inspector", () => {

--- a/packages/blocks/src/buttons/schema.ts
+++ b/packages/blocks/src/buttons/schema.ts
@@ -17,7 +17,10 @@ export const buttonsSchema = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       "div",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/buttons" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/buttons",
+        class: "plumix-buttons",
+      }),
       0,
     ];
   },

--- a/packages/blocks/src/buttons/styles.css
+++ b/packages/blocks/src/buttons/styles.css
@@ -1,0 +1,19 @@
+/* Buttons container — flex row with author-controlled alignment + gap. */
+.plumix-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--plumix-buttons-gap, 0.5rem);
+  margin-block: 0.5rem;
+}
+.plumix-buttons[data-align="start"] {
+  justify-content: flex-start;
+}
+.plumix-buttons[data-align="center"] {
+  justify-content: center;
+}
+.plumix-buttons[data-align="end"] {
+  justify-content: flex-end;
+}
+.plumix-buttons[data-align="between"] {
+  justify-content: space-between;
+}

--- a/packages/blocks/src/callout/Component.tsx
+++ b/packages/blocks/src/callout/Component.tsx
@@ -22,6 +22,7 @@ export function CalloutComponent({
     <aside
       role="note"
       data-plumix-block="core/callout"
+      className="plumix-callout"
       data-variant={variant}
       data-icon={icon}
     >

--- a/packages/blocks/src/callout/callout.test.tsx
+++ b/packages/blocks/src/callout/callout.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { calloutBlock } from "./index.js";
 
 describe("core/callout", () => {
@@ -13,8 +13,8 @@ describe("core/callout", () => {
         content: [{ type: "core/callout", content: [] }],
       },
     });
-    expect(html).toBe(
-      '<aside role="note" data-plumix-block="core/callout" data-variant="info"></aside>',
+    expect(stripBlockMarkers(html)).toBe(
+      '<aside role="note" data-variant="info"></aside>',
     );
   });
 
@@ -29,7 +29,7 @@ describe("core/callout", () => {
           content: [{ type: "core/callout", attrs: { variant }, content: [] }],
         },
       });
-      expect(html).toContain(`data-variant="${variant}"`);
+      expect(stripBlockMarkers(html)).toContain(`data-variant="${variant}"`);
     },
   );
 
@@ -48,7 +48,7 @@ describe("core/callout", () => {
         ],
       },
     });
-    expect(html).toContain('data-variant="info"');
+    expect(stripBlockMarkers(html)).toContain('data-variant="info"');
   });
 
   test("exposes icon attr as data-icon", async () => {
@@ -66,7 +66,7 @@ describe("core/callout", () => {
         ],
       },
     });
-    expect(html).toContain('data-icon="lightbulb"');
+    expect(stripBlockMarkers(html)).toContain('data-icon="lightbulb"');
   });
 
   test("omits data-icon when icon attr is absent or non-string", async () => {
@@ -81,7 +81,7 @@ describe("core/callout", () => {
         ],
       },
     });
-    expect(html).not.toContain("data-icon");
+    expect(stripBlockMarkers(html)).not.toContain("data-icon");
   });
 
   test("declares variant (select) + icon (text) attributes for the Inspector", () => {

--- a/packages/blocks/src/callout/schema.ts
+++ b/packages/blocks/src/callout/schema.ts
@@ -16,6 +16,7 @@ export const calloutSchema = Node.create({
       mergeAttributes(HTMLAttributes, {
         role: "note",
         "data-plumix-block": "core/callout",
+        class: "plumix-callout",
       }),
       0,
     ];

--- a/packages/blocks/src/callout/styles.css
+++ b/packages/blocks/src/callout/styles.css
@@ -1,0 +1,7 @@
+.plumix-callout {
+  border: 1px solid rgb(0 0 0 / 0.12);
+  background: rgb(0 0 0 / 0.025);
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  margin-block: 0.75rem;
+}

--- a/packages/blocks/src/code/Component.tsx
+++ b/packages/blocks/src/code/Component.tsx
@@ -8,7 +8,11 @@ export function CodeComponent({ attrs, children }: BlockProps): ReactElement {
       ? attrs.language
       : null;
   return (
-    <pre data-plumix-block="core/code" data-language={language ?? undefined}>
+    <pre
+      data-plumix-block="core/code"
+      className="plumix-code"
+      data-language={language ?? undefined}
+    >
       {language === null ? (
         children
       ) : (

--- a/packages/blocks/src/code/code.test.tsx
+++ b/packages/blocks/src/code/code.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { codeBlock } from "./index.js";
 
 describe("core/code", () => {
@@ -19,8 +19,8 @@ describe("core/code", () => {
         ],
       },
     });
-    expect(html).toBe(
-      '<pre data-plumix-block="core/code" data-language="typescript"><code data-language="typescript">const x = 1;</code></pre>',
+    expect(stripBlockMarkers(html)).toBe(
+      '<pre data-language="typescript"><code data-language="typescript">const x = 1;</code></pre>',
     );
   });
 
@@ -39,7 +39,7 @@ describe("core/code", () => {
         ],
       },
     });
-    expect(html).toBe('<pre data-plumix-block="core/code">raw text</pre>');
+    expect(stripBlockMarkers(html)).toBe('<pre>raw text</pre>');
   });
 
   test("treats non-string language as null (no inner <code>)", async () => {
@@ -57,6 +57,6 @@ describe("core/code", () => {
         ],
       },
     });
-    expect(html).not.toContain("<code");
+    expect(stripBlockMarkers(html)).not.toContain("<code");
   });
 });

--- a/packages/blocks/src/code/schema.ts
+++ b/packages/blocks/src/code/schema.ts
@@ -21,7 +21,10 @@ export const codeSchema = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       "pre",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/code" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/code",
+        class: "plumix-code",
+      }),
       0,
     ];
   },

--- a/packages/blocks/src/code/styles.css
+++ b/packages/blocks/src/code/styles.css
@@ -1,0 +1,9 @@
+.plumix-code {
+  background: rgb(0 0 0 / 0.05);
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  margin-block: 0.75rem;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  font-size: 0.875rem;
+}

--- a/packages/blocks/src/columns/Component.tsx
+++ b/packages/blocks/src/columns/Component.tsx
@@ -18,7 +18,11 @@ export function ColumnsComponent({
 }: BlockProps): ReactElement {
   const ratio = isRatio(attrs.ratio) ? attrs.ratio : undefined;
   return (
-    <div data-plumix-block="core/columns" data-ratio={ratio}>
+    <div
+      data-plumix-block="core/columns"
+      className="plumix-columns"
+      data-ratio={ratio}
+    >
       {children}
     </div>
   );

--- a/packages/blocks/src/columns/columns.test.tsx
+++ b/packages/blocks/src/columns/columns.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { columnBlock } from "./column.js";
 import { columnsBlock } from "./index.js";
 
@@ -16,7 +16,7 @@ describe("core/columns", () => {
         content: [{ type: "core/columns", content: [] }],
       },
     });
-    expect(html).toBe('<div data-plumix-block="core/columns"></div>');
+    expect(stripBlockMarkers(html)).toBe('<div></div>');
   });
 
   test.each(["1:1", "1:2", "1:1:1", "2:1:2"])(
@@ -32,8 +32,8 @@ describe("core/columns", () => {
           content: [{ type: "core/columns", attrs: { ratio }, content: [] }],
         },
       });
-      expect(html).toBe(
-        `<div data-plumix-block="core/columns" data-ratio="${ratio}"></div>`,
+      expect(stripBlockMarkers(html)).toBe(
+        `<div data-ratio="${ratio}"></div>`,
       );
     },
   );
@@ -52,7 +52,7 @@ describe("core/columns", () => {
         ],
       },
     });
-    expect(html).not.toContain("data-ratio");
+    expect(stripBlockMarkers(html)).not.toContain("data-ratio");
   });
 });
 
@@ -68,7 +68,7 @@ describe("core/column", () => {
         content: [{ type: "core/column", content: [] }],
       },
     });
-    expect(html).toBe('<div data-plumix-block="core/column"></div>');
+    expect(stripBlockMarkers(html)).toBe('<div></div>');
   });
 
   test.each([
@@ -88,8 +88,8 @@ describe("core/column", () => {
           content: [{ type: "core/column", attrs: { width }, content: [] }],
         },
       });
-      expect(html).toBe(
-        `<div data-plumix-block="core/column" data-width="${expected}"></div>`,
+      expect(stripBlockMarkers(html)).toBe(
+        `<div data-width="${expected}"></div>`,
       );
     },
   );
@@ -105,7 +105,7 @@ describe("core/column", () => {
         content: [{ type: "core/column", content: [] }],
       },
     });
-    expect(html).not.toContain("data-width");
+    expect(stripBlockMarkers(html)).not.toContain("data-width");
   });
 
   test("columnBlock declares a `width` text attribute the Inspector renders", () => {

--- a/packages/blocks/src/columns/index.ts
+++ b/packages/blocks/src/columns/index.ts
@@ -14,8 +14,19 @@ const RATIO_OPTIONS = [
   { value: "1:1:1:1", label: "Four equal columns" },
 ] as const;
 
-function emptyColumns(count: number): readonly { name: "core/column" }[] {
-  return Array.from({ length: count }, () => ({ name: "core/column" }));
+// Each column seeds a paragraph so authors have a textblock to land
+// the caret in. Without inner content the column renders as an empty
+// `<div>` that ProseMirror won't focus, so authors can't type into it.
+function emptyColumns(
+  count: number,
+): readonly {
+  name: "core/column";
+  innerBlocks: readonly [{ name: "core/paragraph" }];
+}[] {
+  return Array.from({ length: count }, () => ({
+    name: "core/column" as const,
+    innerBlocks: [{ name: "core/paragraph" as const }] as const,
+  }));
 }
 
 export const columnsBlock = defineBlock({

--- a/packages/blocks/src/columns/schema.ts
+++ b/packages/blocks/src/columns/schema.ts
@@ -15,6 +15,21 @@ export const columnsSchema = Node.create({
   content: "coreColumn+",
   defining: true,
 
+  addAttributes() {
+    return {
+      // `data-ratio` is what the block's CSS module keys off to set
+      // `grid-template-columns`. Without addAttributes the schema
+      // wouldn't accept `ratio` from Inspector updateAttributes, and
+      // the rendered DOM wouldn't carry the attribute the CSS reads.
+      ratio: {
+        default: "1:1",
+        parseHTML: (el) => el.getAttribute("data-ratio") ?? "1:1",
+        renderHTML: (attrs: { ratio?: string }) =>
+          attrs.ratio ? { "data-ratio": attrs.ratio } : {},
+      },
+    };
+  },
+
   parseHTML() {
     return [{ tag: "div[data-plumix-block='core/columns']" }];
   },
@@ -22,7 +37,10 @@ export const columnsSchema = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       "div",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/columns" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/columns",
+        class: "plumix-columns",
+      }),
       0,
     ];
   },

--- a/packages/blocks/src/columns/styles.css
+++ b/packages/blocks/src/columns/styles.css
@@ -1,0 +1,24 @@
+.plumix-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-block: 0.75rem;
+}
+.plumix-columns[data-ratio="1:2"] {
+  grid-template-columns: 1fr 2fr;
+}
+.plumix-columns[data-ratio="2:1"] {
+  grid-template-columns: 2fr 1fr;
+}
+.plumix-columns[data-ratio="1:1:1"] {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+.plumix-columns[data-ratio="1:2:1"] {
+  grid-template-columns: 1fr 2fr 1fr;
+}
+.plumix-columns[data-ratio="2:1:2"] {
+  grid-template-columns: 2fr 1fr 2fr;
+}
+.plumix-columns[data-ratio="1:1:1:1"] {
+  grid-template-columns: repeat(4, 1fr);
+}

--- a/packages/blocks/src/description-list/Component.tsx
+++ b/packages/blocks/src/description-list/Component.tsx
@@ -5,17 +5,17 @@ import type { BlockProps } from "../types.js";
 export function DescriptionListComponent({
   children,
 }: BlockProps): ReactElement {
-  return <dl>{children}</dl>;
+  return <dl className="plumix-descriptionList">{children}</dl>;
 }
 
 export function DescriptionTermComponent({
   children,
 }: BlockProps): ReactElement {
-  return <dt>{children}</dt>;
+  return <dt className="plumix-descriptionTerm">{children}</dt>;
 }
 
 export function DescriptionDetailComponent({
   children,
 }: BlockProps): ReactElement {
-  return <dd>{children}</dd>;
+  return <dd className="plumix-descriptionDetail">{children}</dd>;
 }

--- a/packages/blocks/src/description-list/description-list.test.tsx
+++ b/packages/blocks/src/description-list/description-list.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { descriptionDetailBlock } from "./description-detail.js";
 import { descriptionTermBlock } from "./description-term.js";
 import { descriptionListBlock } from "./index.js";
@@ -36,7 +36,7 @@ describe("core/description-list", () => {
         ],
       },
     });
-    expect(html).toBe(
+    expect(stripBlockMarkers(html)).toBe(
       "<dl><dt>HTTP</dt><dd>Hypertext Transfer Protocol</dd></dl>",
     );
   });
@@ -68,7 +68,7 @@ describe("core/description-list", () => {
         ],
       },
     });
-    expect(html).toBe(
+    expect(stripBlockMarkers(html)).toBe(
       "<dl><dt>A</dt><dt>B</dt><dd>shared definition</dd></dl>",
     );
   });
@@ -89,7 +89,7 @@ describe("core/description-term", () => {
         ],
       },
     });
-    expect(html).toBe("<dt>Term</dt>");
+    expect(stripBlockMarkers(html)).toBe("<dt>Term</dt>");
   });
 });
 
@@ -108,6 +108,6 @@ describe("core/description-detail", () => {
         ],
       },
     });
-    expect(html).toBe("<dd>Definition</dd>");
+    expect(stripBlockMarkers(html)).toBe("<dd>Definition</dd>");
   });
 });

--- a/packages/blocks/src/description-list/schema.ts
+++ b/packages/blocks/src/description-list/schema.ts
@@ -24,6 +24,7 @@ export const descriptionListSchema = Node.create({
       "dl",
       mergeAttributes(HTMLAttributes, {
         "data-plumix-block": "core/description-list",
+        class: "plumix-descriptionList",
       }),
       0,
     ];
@@ -41,7 +42,11 @@ export const descriptionTermSchema = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    return ["dt", mergeAttributes(HTMLAttributes), 0];
+    return [
+      "dt",
+      mergeAttributes(HTMLAttributes, { class: "plumix-descriptionTerm" }),
+      0,
+    ];
   },
 });
 
@@ -56,6 +61,10 @@ export const descriptionDetailSchema = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    return ["dd", mergeAttributes(HTMLAttributes), 0];
+    return [
+      "dd",
+      mergeAttributes(HTMLAttributes, { class: "plumix-descriptionDetail" }),
+      0,
+    ];
   },
 });

--- a/packages/blocks/src/description-list/styles.css
+++ b/packages/blocks/src/description-list/styles.css
@@ -1,0 +1,13 @@
+/* Description list — term/detail spacing. Class names are
+   block-specific so the dl doesn't inherit list/ul rules. */
+.plumix-descriptionList {
+  margin-block: 0.75rem;
+}
+.plumix-descriptionTerm {
+  font-weight: 600;
+  margin-block: 0.25rem 0;
+}
+.plumix-descriptionDetail {
+  margin-block: 0 0.375rem;
+  margin-inline-start: 1rem;
+}

--- a/packages/blocks/src/details/Component.tsx
+++ b/packages/blocks/src/details/Component.tsx
@@ -14,7 +14,11 @@ export function DetailsComponent({
       : DEFAULT_SUMMARY;
   const open = attrs.open === true;
   return (
-    <details open={open} data-plumix-block="core/details">
+    <details
+      open={open}
+      data-plumix-block="core/details"
+      className="plumix-details"
+    >
       <summary>{summary}</summary>
       {children}
     </details>

--- a/packages/blocks/src/details/details.test.tsx
+++ b/packages/blocks/src/details/details.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { detailsBlock } from "./index.js";
 
 describe("core/details", () => {
@@ -19,8 +19,8 @@ describe("core/details", () => {
         ],
       },
     });
-    expect(html).toBe(
-      '<details data-plumix-block="core/details"><summary>Click to expand</summary></details>',
+    expect(stripBlockMarkers(html)).toBe(
+      '<details><summary>Click to expand</summary></details>',
     );
   });
 
@@ -33,7 +33,7 @@ describe("core/details", () => {
         content: [{ type: "core/details", content: [] }],
       },
     });
-    expect(html).toContain("<summary>Details</summary>");
+    expect(stripBlockMarkers(html)).toContain("<summary>Details</summary>");
   });
 
   test("emits open attribute when open=true", async () => {
@@ -51,8 +51,8 @@ describe("core/details", () => {
         ],
       },
     });
-    expect(html).toContain("<details");
-    expect(html).toContain("open=");
+    expect(stripBlockMarkers(html)).toContain("<details");
+    expect(stripBlockMarkers(html)).toContain("open=");
   });
 
   test("escapes summary HTML — no XSS via summary attr", async () => {
@@ -70,8 +70,8 @@ describe("core/details", () => {
         ],
       },
     });
-    expect(html).not.toContain("<script>");
-    expect(html).toContain("&lt;script&gt;");
+    expect(stripBlockMarkers(html)).not.toContain("<script>");
+    expect(stripBlockMarkers(html)).toContain("&lt;script&gt;");
   });
 
   test("declares summary (text) + open (boolean) attributes for the Inspector", () => {

--- a/packages/blocks/src/details/schema.ts
+++ b/packages/blocks/src/details/schema.ts
@@ -20,7 +20,10 @@ export const detailsSchema = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       "details",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/details" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/details",
+        class: "plumix-details",
+      }),
       0,
     ];
   },

--- a/packages/blocks/src/details/styles.css
+++ b/packages/blocks/src/details/styles.css
@@ -1,0 +1,16 @@
+/* Details disclosure — border + padding so the collapsed/expanded
+   states look like a card. */
+.plumix-details {
+  border: 1px solid oklch(0.9 0 0);
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  margin-block: 0.75rem;
+}
+.plumix-details > summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: revert;
+}
+.plumix-details[open] > summary {
+  margin-bottom: 0.5rem;
+}

--- a/packages/blocks/src/group/Component.tsx
+++ b/packages/blocks/src/group/Component.tsx
@@ -20,7 +20,11 @@ function isGroupLayout(value: unknown): value is GroupLayout {
 export function GroupComponent({ attrs, children }: BlockProps): ReactElement {
   const layout = isGroupLayout(attrs.layout) ? attrs.layout : undefined;
   return (
-    <div data-plumix-block="core/group" data-layout={layout}>
+    <div
+      data-plumix-block="core/group"
+      className="plumix-group"
+      data-layout={layout}
+    >
       {children}
     </div>
   );

--- a/packages/blocks/src/group/group.test.tsx
+++ b/packages/blocks/src/group/group.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { groupBlock } from "./index.js";
 
 describe("core/group", () => {
@@ -15,7 +15,7 @@ describe("core/group", () => {
         content: [{ type: "core/group", content: [] }],
       },
     });
-    expect(html).toBe('<div data-plumix-block="core/group"></div>');
+    expect(stripBlockMarkers(html)).toBe('<div></div>');
   });
 
   test.each(["flow", "flex-row", "flex-column", "grid"])(
@@ -31,8 +31,8 @@ describe("core/group", () => {
           content: [{ type: "core/group", attrs: { layout }, content: [] }],
         },
       });
-      expect(html).toBe(
-        `<div data-plumix-block="core/group" data-layout="${layout}"></div>`,
+      expect(stripBlockMarkers(html)).toBe(
+        `<div data-layout="${layout}"></div>`,
       );
     },
   );
@@ -48,7 +48,7 @@ describe("core/group", () => {
         content: [{ type: "core/group", content: [] }],
       },
     });
-    expect(html).not.toContain("data-layout");
+    expect(stripBlockMarkers(html)).not.toContain("data-layout");
   });
 
   test("ignores unknown layout values rather than leaking them", async () => {
@@ -64,7 +64,7 @@ describe("core/group", () => {
         ],
       },
     });
-    expect(html).not.toContain("data-layout");
+    expect(stripBlockMarkers(html)).not.toContain("data-layout");
   });
 
   test("groupBlock declares Row + Stack variations presetting layout", () => {

--- a/packages/blocks/src/group/schema.ts
+++ b/packages/blocks/src/group/schema.ts
@@ -19,7 +19,10 @@ export const groupSchema = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       "div",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/group" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/group",
+        class: "plumix-group",
+      }),
       0,
     ];
   },

--- a/packages/blocks/src/group/styles.css
+++ b/packages/blocks/src/group/styles.css
@@ -1,0 +1,20 @@
+/* Group container — layout chosen via data-layout. */
+.plumix-group {
+  margin-block: 0.5rem;
+}
+.plumix-group[data-layout="flex-row"] {
+  display: flex;
+  flex-direction: row;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.plumix-group[data-layout="flex-column"] {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.plumix-group[data-layout="grid"] {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.75rem;
+}

--- a/packages/blocks/src/heading/Component.tsx
+++ b/packages/blocks/src/heading/Component.tsx
@@ -29,5 +29,9 @@ export function HeadingComponent({
   const level = clampHeadingLevel(attrs.level);
   const slot = (attrs.style ?? {}) as BlockStyleSlot;
   const resolved = useBlockStyles(slot, headingSupports);
-  return createElement(`h${level}`, blockElementProps(resolved), children);
+  const props = blockElementProps(resolved, {
+    name: "core/heading",
+    moduleClass: `plumix-heading plumix-h${level}`,
+  });
+  return createElement(`h${level}`, props, children);
 }

--- a/packages/blocks/src/heading/heading.test.tsx
+++ b/packages/blocks/src/heading/heading.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { coreBlocks } from "../core-blocks.js";
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { headingBlock } from "./index.js";
 
 describe("core/heading", () => {
@@ -24,7 +24,7 @@ describe("core/heading", () => {
         ],
       },
     });
-    expect(html).toBe("<h2>Title</h2>");
+    expect(stripBlockMarkers(html)).toBe("<h2>Title</h2>");
   });
 
   test.each([1, 2, 3, 4, 5, 6])("respects level=%i as <h%i>", async (level) => {
@@ -42,7 +42,7 @@ describe("core/heading", () => {
         ],
       },
     });
-    expect(html).toBe(`<h${level}>Title</h${level}>`);
+    expect(stripBlockMarkers(html)).toBe(`<h${level}>Title</h${level}>`);
   });
 
   test.each([
@@ -66,7 +66,7 @@ describe("core/heading", () => {
         ],
       },
     });
-    expect(html).toBe(`<h${expected}>T</h${expected}>`);
+    expect(stripBlockMarkers(html)).toBe(`<h${expected}>T</h${expected}>`);
   });
 
   test('legacy `type: "heading"` content renders identically', async () => {
@@ -84,7 +84,7 @@ describe("core/heading", () => {
         ],
       },
     });
-    expect(html).toBe("<h3>Legacy</h3>");
+    expect(stripBlockMarkers(html)).toBe("<h3>Legacy</h3>");
   });
 
   test("falls back to <h2> when level is not a number", async () => {
@@ -102,6 +102,6 @@ describe("core/heading", () => {
         ],
       },
     });
-    expect(html).toBe("<h2>T</h2>");
+    expect(stripBlockMarkers(html)).toBe("<h2>T</h2>");
   });
 });

--- a/packages/blocks/src/heading/schema.test.ts
+++ b/packages/blocks/src/heading/schema.test.ts
@@ -2,6 +2,7 @@ import type { Content } from "@tiptap/core";
 import { Editor, Node } from "@tiptap/core";
 import { describe, expect, test } from "vitest";
 
+import { stripBlockMarkers } from "../test/index.js";
 import { headingSchema } from "./schema.js";
 
 const Doc = Node.create({ name: "doc", topNode: true, content: "block+" });
@@ -25,7 +26,7 @@ describe("core/heading editor schema honors the level attribute", () => {
         },
       ],
     });
-    expect(editor.getHTML()).toContain("<h2>");
+    expect(stripBlockMarkers(editor.getHTML())).toContain("<h2>");
     editor.destroy();
   });
 
@@ -40,7 +41,7 @@ describe("core/heading editor schema honors the level attribute", () => {
         },
       ],
     });
-    expect(editor.getHTML()).toContain(`<h${level}>`);
+    expect(stripBlockMarkers(editor.getHTML())).toContain(`<h${level}>`);
     editor.destroy();
   });
 
@@ -73,7 +74,7 @@ describe("core/heading editor schema honors the level attribute", () => {
         },
       ],
     });
-    expect(editor.getHTML()).toContain(`<h${expected}>`);
+    expect(stripBlockMarkers(editor.getHTML())).toContain(`<h${expected}>`);
     editor.destroy();
   });
 
@@ -91,7 +92,7 @@ describe("core/heading editor schema honors the level attribute", () => {
     // The level is encoded by the tag itself; serializing it as an
     // attribute would clobber arbitrary HTMLAttributes and confuse the
     // server-side renderer which round-trips via the same DOM.
-    expect(editor.getHTML()).toBe("<h4>Hi</h4>");
+    expect(stripBlockMarkers(editor.getHTML())).toBe("<h4>Hi</h4>");
     editor.destroy();
   });
 });

--- a/packages/blocks/src/heading/schema.ts
+++ b/packages/blocks/src/heading/schema.ts
@@ -35,9 +35,13 @@ export const headingSchema = Node.create({
   },
 
   renderHTML({ node, HTMLAttributes }) {
+    const level = clampLevel(node.attrs.level);
     return [
-      `h${clampLevel(node.attrs.level)}`,
-      mergeAttributes(HTMLAttributes),
+      `h${level}`,
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/heading",
+        class: `plumix-heading plumix-h${level}`,
+      }),
       0,
     ];
   },

--- a/packages/blocks/src/heading/styles.css
+++ b/packages/blocks/src/heading/styles.css
@@ -1,0 +1,28 @@
+/* Heading visual identity — frontend themes override. */
+.plumix-heading {
+  font-weight: 600;
+  line-height: 1.2;
+}
+.plumix-h1 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  margin-block: 0.75rem;
+}
+.plumix-h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-block: 0.75rem 0.5rem;
+}
+.plumix-h3 {
+  font-size: 1.25rem;
+  margin-block: 0.625rem 0.375rem;
+}
+.plumix-h4 {
+  font-size: 1.125rem;
+  margin-block: 0.5rem 0.25rem;
+}
+.plumix-h5,
+.plumix-h6 {
+  font-size: 1rem;
+  margin-block: 0.375rem 0.25rem;
+}

--- a/packages/blocks/src/html/html.test.tsx
+++ b/packages/blocks/src/html/html.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { htmlBlock } from "./index.js";
 
 describe("core/html", () => {
@@ -18,8 +18,8 @@ describe("core/html", () => {
         ],
       },
     });
-    expect(html).toBe(
-      '<div data-plumix-block="core/html"><p><strong>Bold</strong></p></div>',
+    expect(stripBlockMarkers(html)).toBe(
+      '<div><p><strong>Bold</strong></p></div>',
     );
   });
 
@@ -37,7 +37,7 @@ describe("core/html", () => {
         ],
       },
     });
-    expect(html).toBe('<div data-plumix-block="core/html"><p>safe</p></div>');
+    expect(stripBlockMarkers(html)).toBe('<div><p>safe</p></div>');
   });
 
   test("renders an empty marker div when html attr is missing or non-string", async () => {
@@ -52,8 +52,8 @@ describe("core/html", () => {
         ],
       },
     });
-    expect(html).toBe(
-      '<div data-plumix-block="core/html"></div><div data-plumix-block="core/html"></div>',
+    expect(stripBlockMarkers(html)).toBe(
+      '<div></div><div></div>',
     );
   });
 });

--- a/packages/blocks/src/list/Component.tsx
+++ b/packages/blocks/src/list/Component.tsx
@@ -3,7 +3,11 @@ import type { ReactElement } from "react";
 import type { BlockProps } from "../types.js";
 
 export function ListComponent({ children }: BlockProps): ReactElement {
-  return <ul>{children}</ul>;
+  return (
+    <ul data-plumix-block="core/list" className="plumix-list">
+      {children}
+    </ul>
+  );
 }
 
 export function ListOrderedComponent({
@@ -21,12 +25,17 @@ export function ListOrderedComponent({
       : undefined;
   const reversed = attrs.reversed === true ? true : undefined;
   return (
-    <ol start={start} reversed={reversed}>
+    <ol
+      data-plumix-block="core/list-ordered"
+      className="plumix-listOrdered"
+      start={start}
+      reversed={reversed}
+    >
       {children}
     </ol>
   );
 }
 
 export function ListItemComponent({ children }: BlockProps): ReactElement {
-  return <li>{children}</li>;
+  return <li className="plumix-listItem">{children}</li>;
 }

--- a/packages/blocks/src/list/list.test.tsx
+++ b/packages/blocks/src/list/list.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { listItemBlock } from "./list-item.js";
 import { listOrderedBlock } from "./list-ordered.js";
 import { listBlock } from "./list.js";
@@ -31,7 +31,7 @@ describe("core/list (bullet)", () => {
         ],
       },
     });
-    expect(html).toBe("<ul><li>one</li><li>two</li></ul>");
+    expect(stripBlockMarkers(html)).toBe("<ul><li>one</li><li>two</li></ul>");
   });
 
   test('legacy `type: "bulletList"` content renders identically', async () => {
@@ -55,7 +55,7 @@ describe("core/list (bullet)", () => {
         ],
       },
     });
-    expect(html).toBe("<ul><li>Legacy</li></ul>");
+    expect(stripBlockMarkers(html)).toBe("<ul><li>Legacy</li></ul>");
   });
 });
 
@@ -81,7 +81,7 @@ describe("core/list-ordered", () => {
         ],
       },
     });
-    expect(html).toBe("<ol><li>one</li></ol>");
+    expect(stripBlockMarkers(html)).toBe("<ol><li>one</li></ol>");
   });
 
   test("propagates start attribute", async () => {
@@ -106,7 +106,7 @@ describe("core/list-ordered", () => {
         ],
       },
     });
-    expect(html).toContain('start="5"');
+    expect(stripBlockMarkers(html)).toContain('start="5"');
   });
 
   test("propagates reversed attribute when true", async () => {
@@ -131,7 +131,7 @@ describe("core/list-ordered", () => {
         ],
       },
     });
-    expect(html).toContain("reversed");
+    expect(stripBlockMarkers(html)).toContain("reversed");
   });
 
   test("omits start attribute when 1 (default)", async () => {
@@ -156,7 +156,7 @@ describe("core/list-ordered", () => {
         ],
       },
     });
-    expect(html).not.toContain("start=");
+    expect(stripBlockMarkers(html)).not.toContain("start=");
   });
 
   test('legacy `type: "orderedList"` content renders identically', async () => {
@@ -181,7 +181,7 @@ describe("core/list-ordered", () => {
         ],
       },
     });
-    expect(html).toBe('<ol start="3"><li>Legacy</li></ol>');
+    expect(stripBlockMarkers(html)).toBe('<ol start="3"><li>Legacy</li></ol>');
   });
 });
 
@@ -202,6 +202,6 @@ describe("core/list-item", () => {
         ],
       },
     });
-    expect(html).toBe("<li>hello</li>");
+    expect(stripBlockMarkers(html)).toBe("<li>hello</li>");
   });
 });

--- a/packages/blocks/src/list/schema.ts
+++ b/packages/blocks/src/list/schema.ts
@@ -18,7 +18,10 @@ export const listSchema = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       "ul",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/list" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/list",
+        class: "plumix-list",
+      }),
       0,
     ];
   },
@@ -60,6 +63,7 @@ export const listOrderedSchema = Node.create({
       "ol",
       mergeAttributes(HTMLAttributes, {
         "data-plumix-block": "core/list-ordered",
+        class: "plumix-listOrdered",
       }),
       0,
     ];
@@ -91,6 +95,10 @@ export const listItemSchema = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    return ["li", mergeAttributes(HTMLAttributes), 0];
+    return [
+      "li",
+      mergeAttributes(HTMLAttributes, { class: "plumix-listItem" }),
+      0,
+    ];
   },
 });

--- a/packages/blocks/src/list/styles.css
+++ b/packages/blocks/src/list/styles.css
@@ -1,0 +1,13 @@
+.plumix-list {
+  list-style: disc;
+  padding-inline-start: 1.5rem;
+  margin-block: 0.5rem;
+}
+.plumix-listOrdered {
+  list-style: decimal;
+  padding-inline-start: 1.5rem;
+  margin-block: 0.5rem;
+}
+.plumix-listItem {
+  margin-block: 0.25rem;
+}

--- a/packages/blocks/src/marks/core/core-marks.test.tsx
+++ b/packages/blocks/src/marks/core/core-marks.test.tsx
@@ -5,6 +5,7 @@ import {
   mockMarkRegistry,
   mockRegistry,
   renderBlock,
+  stripBlockMarkers,
 } from "../../test/index.js";
 import { coreMarks } from "./index.js";
 
@@ -56,14 +57,16 @@ describe("core marks — HTML element mapping", () => {
     { mark: "cite", expected: "<p><cite>Hi</cite></p>" },
     { mark: "small", expected: "<p><small>Hi</small></p>" },
   ])("$mark renders as $expected", async ({ mark, expected }) => {
-    expect(await renderTextWithMark(mark)).toBe(expected);
+    expect(stripBlockMarkers(await renderTextWithMark(mark))).toBe(expected);
   });
 });
 
 describe("core marks — link", () => {
   test("renders <a href> with rel=noopener for safe https hrefs", async () => {
     expect(
-      await renderTextWithMark("link", { href: "https://example.com" }),
+      stripBlockMarkers(
+        await renderTextWithMark("link", { href: "https://example.com" }),
+      ),
     ).toBe(
       '<p><a href="https://example.com" rel="noopener noreferrer nofollow">Hi</a></p>',
     );
@@ -71,7 +74,9 @@ describe("core marks — link", () => {
 
   test("strips unsafe javascript: hrefs", async () => {
     expect(
-      await renderTextWithMark("link", { href: "javascript:alert(1)" }),
+      stripBlockMarkers(
+        await renderTextWithMark("link", { href: "javascript:alert(1)" }),
+      ),
     ).toBe("<p>Hi</p>");
   });
 
@@ -80,23 +85,27 @@ describe("core marks — link", () => {
       href: "https://example.com",
       target: "_blank",
     });
-    expect(html).toContain('target="_blank"');
+    expect(stripBlockMarkers(html)).toContain('target="_blank"');
   });
 
   test("ignores attacker-controlled rel that strips safety tokens", async () => {
     expect(
-      await renderTextWithMark("link", {
-        href: "https://example.com",
-        rel: "",
-      }),
+      stripBlockMarkers(
+        await renderTextWithMark("link", {
+          href: "https://example.com",
+          rel: "",
+        }),
+      ),
     ).toBe(
       '<p><a href="https://example.com" rel="noopener noreferrer nofollow">Hi</a></p>',
     );
     expect(
-      await renderTextWithMark("link", {
-        href: "https://example.com",
-        rel: "opener",
-      }),
+      stripBlockMarkers(
+        await renderTextWithMark("link", {
+          href: "https://example.com",
+          rel: "opener",
+        }),
+      ),
     ).toBe(
       '<p><a href="https://example.com" rel="noopener noreferrer nofollow">Hi</a></p>',
     );
@@ -106,13 +115,17 @@ describe("core marks — link", () => {
 describe("core marks — abbr", () => {
   test("renders <abbr title> with the title attribute", async () => {
     expect(
-      await renderTextWithMark("abbr", { title: "HyperText Markup Language" }),
+      stripBlockMarkers(
+        await renderTextWithMark("abbr", {
+          title: "HyperText Markup Language",
+        }),
+      ),
     ).toBe('<p><abbr title="HyperText Markup Language">Hi</abbr></p>');
   });
 
   test("omits title attribute when empty", async () => {
-    expect(await renderTextWithMark("abbr", { title: "" })).toBe(
-      "<p><abbr>Hi</abbr></p>",
-    );
+    expect(
+      stripBlockMarkers(await renderTextWithMark("abbr", { title: "" })),
+    ).toBe("<p><abbr>Hi</abbr></p>");
   });
 });

--- a/packages/blocks/src/paragraph/Component.tsx
+++ b/packages/blocks/src/paragraph/Component.tsx
@@ -17,5 +17,14 @@ export function ParagraphComponent({
 }: BlockProps): ReactElement {
   const slot = (attrs.style ?? {}) as BlockStyleSlot;
   const resolved = useBlockStyles(slot, paragraphSupports);
-  return <p {...blockElementProps(resolved)}>{children}</p>;
+  return (
+    <p
+      {...blockElementProps(resolved, {
+        name: "core/paragraph",
+        moduleClass: "plumix-paragraph",
+      })}
+    >
+      {children}
+    </p>
+  );
 }

--- a/packages/blocks/src/paragraph/paragraph.test.tsx
+++ b/packages/blocks/src/paragraph/paragraph.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { paragraphBlock } from "./index.js";
 
 describe("core/paragraph", () => {
@@ -25,7 +25,7 @@ describe("core/paragraph", () => {
         ],
       },
     });
-    expect(html).toBe("<p>Hello world</p>");
+    expect(stripBlockMarkers(html)).toBe("<p>Hello world</p>");
   });
 
   test("legacy `paragraph` content renders identically", async () => {
@@ -42,6 +42,6 @@ describe("core/paragraph", () => {
         ],
       },
     });
-    expect(html).toBe("<p>Legacy content</p>");
+    expect(stripBlockMarkers(html)).toBe("<p>Legacy content</p>");
   });
 });

--- a/packages/blocks/src/paragraph/schema.ts
+++ b/packages/blocks/src/paragraph/schema.ts
@@ -20,6 +20,13 @@ export const paragraphSchema = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    return ["p", mergeAttributes(HTMLAttributes), 0];
+    return [
+      "p",
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/paragraph",
+        class: "plumix-paragraph",
+      }),
+      0,
+    ];
   },
 });

--- a/packages/blocks/src/paragraph/styles.css
+++ b/packages/blocks/src/paragraph/styles.css
@@ -1,0 +1,4 @@
+.plumix-paragraph {
+  margin-block: 0.5rem;
+  line-height: 1.6;
+}

--- a/packages/blocks/src/quote/Component.tsx
+++ b/packages/blocks/src/quote/Component.tsx
@@ -8,7 +8,11 @@ export function QuoteComponent({ attrs, children }: BlockProps): ReactElement {
       ? attrs.citation
       : undefined;
   return (
-    <blockquote data-plumix-block="core/quote" cite={cite}>
+    <blockquote
+      data-plumix-block="core/quote"
+      className="plumix-quote"
+      cite={cite}
+    >
       {children}
     </blockquote>
   );

--- a/packages/blocks/src/quote/quote.test.tsx
+++ b/packages/blocks/src/quote/quote.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { paragraphBlock } from "../paragraph/index.js";
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { quoteBlock } from "./index.js";
 
 describe("core/quote", () => {
@@ -27,7 +27,7 @@ describe("core/quote", () => {
         ],
       },
     });
-    expect(html).toContain('cite="https://example.com/source"');
+    expect(stripBlockMarkers(html)).toContain('cite="https://example.com/source"');
   });
 
   test("omits cite when citation attr is empty or non-string", async () => {
@@ -62,7 +62,7 @@ describe("core/quote", () => {
         ],
       },
     });
-    expect(html).not.toContain("cite=");
+    expect(stripBlockMarkers(html)).not.toContain("cite=");
   });
 
   test("renders as <blockquote> wrapping children", async () => {
@@ -86,8 +86,8 @@ describe("core/quote", () => {
         ],
       },
     });
-    expect(html).toBe(
-      '<blockquote data-plumix-block="core/quote"><p>Wisdom</p></blockquote>',
+    expect(stripBlockMarkers(html)).toBe(
+      "<blockquote><p>Wisdom</p></blockquote>",
     );
   });
 });

--- a/packages/blocks/src/quote/schema.ts
+++ b/packages/blocks/src/quote/schema.ts
@@ -19,7 +19,10 @@ export const quoteSchema = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       "blockquote",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/quote" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/quote",
+        class: "plumix-quote",
+      }),
       0,
     ];
   },

--- a/packages/blocks/src/quote/styles.css
+++ b/packages/blocks/src/quote/styles.css
@@ -1,0 +1,7 @@
+.plumix-quote {
+  border-inline-start: 4px solid rgb(0 0 0 / 0.15);
+  padding-inline-start: 1rem;
+  margin-block: 0.75rem;
+  font-style: italic;
+  color: rgb(0 0 0 / 0.7);
+}

--- a/packages/blocks/src/separator/Component.tsx
+++ b/packages/blocks/src/separator/Component.tsx
@@ -16,6 +16,7 @@ export function SeparatorComponent({ attrs }: BlockProps): ReactElement {
   return (
     <hr
       data-plumix-block="core/separator"
+      className="plumix-separator"
       data-variant={pickVariant(attrs.variant)}
     />
   );

--- a/packages/blocks/src/separator/schema.ts
+++ b/packages/blocks/src/separator/schema.ts
@@ -21,6 +21,7 @@ export const separatorSchema = Node.create({
       "hr",
       mergeAttributes(HTMLAttributes, {
         "data-plumix-block": "core/separator",
+        class: "plumix-separator",
       }),
     ];
   },

--- a/packages/blocks/src/separator/separator.test.tsx
+++ b/packages/blocks/src/separator/separator.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import { separatorBlock } from "./index.js";
 
 describe("core/separator", () => {
@@ -13,8 +13,8 @@ describe("core/separator", () => {
         content: [{ type: "core/separator" }],
       },
     });
-    expect(html).toBe(
-      '<hr data-plumix-block="core/separator" data-variant="solid"/>',
+    expect(stripBlockMarkers(html)).toBe(
+      '<hr data-variant="solid"/>',
     );
   });
 
@@ -29,7 +29,7 @@ describe("core/separator", () => {
           content: [{ type: "core/separator", attrs: { variant } }],
         },
       });
-      expect(html).toContain(`data-variant="${variant}"`);
+      expect(stripBlockMarkers(html)).toContain(`data-variant="${variant}"`);
     },
   );
 
@@ -42,6 +42,6 @@ describe("core/separator", () => {
         content: [{ type: "core/separator", attrs: { variant: "rainbow" } }],
       },
     });
-    expect(html).toContain('data-variant="solid"');
+    expect(stripBlockMarkers(html)).toContain('data-variant="solid"');
   });
 });

--- a/packages/blocks/src/separator/styles.css
+++ b/packages/blocks/src/separator/styles.css
@@ -1,0 +1,5 @@
+.plumix-separator {
+  border: 0;
+  border-top: 1px solid rgb(0 0 0 / 0.12);
+  margin-block: 1.5rem;
+}

--- a/packages/blocks/src/styles.css
+++ b/packages/blocks/src/styles.css
@@ -1,0 +1,17 @@
+/* Aggregate CSS for every core block. Consumers (admin + sites)
+   import this single file once; per-block stylesheets co-locate with
+   the block schema/Component so a plugin author can ship the same way. */
+@import "./paragraph/styles.css";
+@import "./heading/styles.css";
+@import "./list/styles.css";
+@import "./quote/styles.css";
+@import "./code/styles.css";
+@import "./separator/styles.css";
+@import "./columns/styles.css";
+@import "./callout/styles.css";
+@import "./table/styles.css";
+@import "./buttons/styles.css";
+@import "./button/styles.css";
+@import "./details/styles.css";
+@import "./group/styles.css";
+@import "./description-list/styles.css";

--- a/packages/blocks/src/styles/hooks.tsx
+++ b/packages/blocks/src/styles/hooks.tsx
@@ -61,15 +61,34 @@ export function useBlockStyles(
  * Picks only the non-empty fields from a `ResolvedBlockStyles` so the
  * spread on a JSX root doesn't emit `className=""` or `style={}` — the
  * walker's snapshot tests assert exact HTML without empty attributes.
+ *
+ * `name` stamps the canonical `data-plumix-block` identity attribute
+ * (load-bearing for `parseHTML` round-trip + walker dispatch).
+ * `moduleClass` is the block's own static class string (e.g.
+ * `"plumix-heading plumix-h2"`) so the visual identity ships with the
+ * block, not with the host.
  */
-export function blockElementProps(resolved: ResolvedBlockStyles): {
+export function blockElementProps(
+  resolved: ResolvedBlockStyles,
+  opts: { readonly name?: string; readonly moduleClass?: string } = {},
+): {
   id?: string;
   className?: string;
   style?: CSSProperties;
+  "data-plumix-block"?: string;
 } {
-  const props: { id?: string; className?: string; style?: CSSProperties } = {};
+  const props: {
+    id?: string;
+    className?: string;
+    style?: CSSProperties;
+    "data-plumix-block"?: string;
+  } = {};
   if (resolved.id !== undefined) props.id = resolved.id;
-  if (resolved.className.length > 0) props.className = resolved.className;
+  const merged = [opts.moduleClass, resolved.className]
+    .filter((c): c is string => Boolean(c && c.length > 0))
+    .join(" ");
+  if (merged.length > 0) props.className = merged;
   if (Object.keys(resolved.style).length > 0) props.style = resolved.style;
+  if (opts.name !== undefined) props["data-plumix-block"] = opts.name;
   return props;
 }

--- a/packages/blocks/src/styles/integration.test.tsx
+++ b/packages/blocks/src/styles/integration.test.tsx
@@ -45,7 +45,7 @@ describe("blocks + supports + tokens end-to-end", () => {
       />,
     );
     const p = container.querySelector("p");
-    expect(p?.className).toBe("has-primary-background-color");
+    expect(p?.className).toContain("has-primary-background-color");
     expect(p?.textContent).toBe("themed");
   });
 

--- a/packages/blocks/src/table/Component.tsx
+++ b/packages/blocks/src/table/Component.tsx
@@ -17,6 +17,7 @@ export function TableComponent({ attrs, children }: BlockProps): ReactElement {
   return (
     <table
       data-plumix-block="core/table"
+      className="plumix-table"
       data-striped={striped}
       data-bordered={bordered}
     >
@@ -45,7 +46,11 @@ export function TableCellComponent({
 }: BlockProps): ReactElement {
   const align = pickAlign(attrs.align);
   return (
-    <td data-plumix-block="core/table-cell" data-align={align}>
+    <td
+      data-plumix-block="core/table-cell"
+      className="plumix-cell"
+      data-align={align}
+    >
       {children}
     </td>
   );
@@ -60,6 +65,7 @@ export function TableHeaderCellComponent({
     <th
       scope="col"
       data-plumix-block="core/table-header-cell"
+      className="plumix-headerCell"
       data-align={align}
     >
       {children}

--- a/packages/blocks/src/table/schema.ts
+++ b/packages/blocks/src/table/schema.ts
@@ -19,9 +19,21 @@ export const tableSchema = Node.create({
   defining: true,
 
   addAttributes() {
+    // CSS selectors target `data-striped` / `data-bordered`, but
+    // Tiptap's default attribute renderer emits the raw attr name.
+    // Mirror the columns/spacer pattern so the editor canvas styles
+    // the table the same way the SSR Component does.
     return {
-      striped: { default: false },
-      bordered: { default: false },
+      striped: {
+        default: false,
+        renderHTML: (attrs: { readonly striped?: boolean }) =>
+          attrs.striped === true ? { "data-striped": "true" } : {},
+      },
+      bordered: {
+        default: false,
+        renderHTML: (attrs: { readonly bordered?: boolean }) =>
+          attrs.bordered === true ? { "data-bordered": "true" } : {},
+      },
     };
   },
 
@@ -32,7 +44,10 @@ export const tableSchema = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       "table",
-      mergeAttributes(HTMLAttributes, { "data-plumix-block": "core/table" }),
+      mergeAttributes(HTMLAttributes, {
+        "data-plumix-block": "core/table",
+        class: "plumix-table",
+      }),
       0,
     ];
   },
@@ -109,6 +124,7 @@ export const tableCellSchema = Node.create({
       "td",
       mergeAttributes(HTMLAttributes, {
         "data-plumix-block": "core/table-cell",
+        class: "plumix-cell",
       }),
       0,
     ];
@@ -130,6 +146,7 @@ export const tableHeaderCellSchema = Node.create({
       mergeAttributes(HTMLAttributes, {
         "data-plumix-block": "core/table-header-cell",
         scope: "col",
+        class: "plumix-headerCell",
       }),
       0,
     ];

--- a/packages/blocks/src/table/styles.css
+++ b/packages/blocks/src/table/styles.css
@@ -1,0 +1,35 @@
+/* Table visual identity — frontend themes override. Cells get
+   padding + border so empty cells stay visible (a freshly inserted
+   table is otherwise zero-height because every cell is empty). */
+.plumix-table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-block: 0.75rem;
+}
+.plumix-table[data-striped="true"] tbody tr:nth-child(odd) {
+  background: oklch(0.97 0 0);
+}
+.plumix-table[data-bordered="true"] .plumix-cell,
+.plumix-table[data-bordered="true"] .plumix-headerCell {
+  border: 1px solid oklch(0.85 0 0);
+}
+.plumix-cell,
+.plumix-headerCell {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid oklch(0.9 0 0);
+  vertical-align: top;
+  min-width: 4rem;
+}
+.plumix-headerCell {
+  font-weight: 600;
+  text-align: left;
+  background: oklch(0.98 0 0);
+}
+.plumix-cell[data-align="center"],
+.plumix-headerCell[data-align="center"] {
+  text-align: center;
+}
+.plumix-cell[data-align="right"],
+.plumix-headerCell[data-align="right"] {
+  text-align: right;
+}

--- a/packages/blocks/src/table/table.test.tsx
+++ b/packages/blocks/src/table/table.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { mockRegistry, renderBlock } from "../test/index.js";
+import { mockRegistry, renderBlock, stripBlockMarkers } from "../test/index.js";
 import {
   tableBlock,
   tableBodyRowBlock,
@@ -29,7 +29,7 @@ describe("core/table", () => {
         content: [{ type: "core/table", content: [] }],
       },
     });
-    expect(html).toBe('<table data-plumix-block="core/table"></table>');
+    expect(stripBlockMarkers(html)).toBe('<table></table>');
   });
 
   test("renders header row with <th scope='col'> cells and body rows with <td>", async () => {
@@ -75,12 +75,12 @@ describe("core/table", () => {
     });
     expect(html).toContain('<th scope="col"');
     expect(html).toContain('data-plumix-block="core/table-header-cell"');
-    expect(html).toContain("Name");
-    expect(html).toContain("Role");
+    expect(stripBlockMarkers(html)).toContain("Name");
+    expect(stripBlockMarkers(html)).toContain("Role");
     expect(html).toContain('data-plumix-block="core/table-body-row"');
-    expect(html).toContain("<td");
-    expect(html).toContain("Ada");
-    expect(html).toContain("Founder");
+    expect(stripBlockMarkers(html)).toContain("<td");
+    expect(stripBlockMarkers(html)).toContain("Ada");
+    expect(stripBlockMarkers(html)).toContain("Founder");
   });
 
   test("omits data-striped when the attr is false (no leaky empty attribute)", async () => {
@@ -98,8 +98,8 @@ describe("core/table", () => {
         ],
       },
     });
-    expect(html).not.toContain("data-striped");
-    expect(html).not.toContain("data-bordered");
+    expect(stripBlockMarkers(html)).not.toContain("data-striped");
+    expect(stripBlockMarkers(html)).not.toContain("data-bordered");
   });
 
   test("exposes data-striped and data-bordered when attrs are set", async () => {
@@ -117,8 +117,8 @@ describe("core/table", () => {
         ],
       },
     });
-    expect(html).toContain('data-striped="true"');
-    expect(html).toContain('data-bordered="true"');
+    expect(stripBlockMarkers(html)).toContain('data-striped="true"');
+    expect(stripBlockMarkers(html)).toContain('data-bordered="true"');
   });
 
   test("cell exposes data-align from its align attribute", async () => {
@@ -136,8 +136,8 @@ describe("core/table", () => {
         ],
       },
     });
-    expect(html).toContain('data-align="center"');
-    expect(html).toContain("centred");
+    expect(stripBlockMarkers(html)).toContain('data-align="center"');
+    expect(stripBlockMarkers(html)).toContain("centred");
   });
 
   test("rejects invalid align values rather than leaking them", async () => {
@@ -155,8 +155,8 @@ describe("core/table", () => {
         ],
       },
     });
-    expect(html).not.toContain("data-align");
-    expect(html).toContain("x");
+    expect(stripBlockMarkers(html)).not.toContain("data-align");
+    expect(stripBlockMarkers(html)).toContain("x");
   });
 
   test("tableBlock + tableCellBlock declare attributes and supports", () => {

--- a/packages/blocks/src/test/index.ts
+++ b/packages/blocks/src/test/index.ts
@@ -117,3 +117,13 @@ export function mockEditor(input: MockEditorInput = {}): Editor {
 }
 
 export { DEFAULT_MARK_REGISTRY as defaultMarkRegistry, EMPTY_CONTEXT };
+
+// Block specs now own their CSS Module class + `data-plumix-block`
+// identity attribute, but most assertion fixtures pre-date both. Strip
+// them before comparison so the structural shape stays under test
+// without coupling each fixture to a per-block class name.
+export function stripBlockMarkers(html: string): string {
+  return html
+    .replace(/ class="[^"]*"/g, "")
+    .replace(/ data-plumix-block="[^"]*"/g, "");
+}

--- a/packages/blocks/src/test/test.test.ts
+++ b/packages/blocks/src/test/test.test.ts
@@ -6,6 +6,7 @@ import {
   mockMarkRegistry,
   mockRegistry,
   renderBlock,
+  stripBlockMarkers,
   validateContent,
 } from "./index.js";
 
@@ -38,7 +39,7 @@ describe("renderBlock", () => {
         ],
       },
     });
-    expect(html).toBe("<p>Hi</p>");
+    expect(stripBlockMarkers(html)).toBe("<p>Hi</p>");
   });
 
   test("accepts a custom context", async () => {
@@ -54,7 +55,7 @@ describe("renderBlock", () => {
         depth: 0,
       },
     });
-    expect(html).toBe("<p></p>");
+    expect(stripBlockMarkers(html)).toBe("<p></p>");
   });
 });
 

--- a/packages/core/src/blocks-parity.test.ts
+++ b/packages/core/src/blocks-parity.test.ts
@@ -10,7 +10,11 @@
 import { describe, expect, test } from "vitest";
 
 import { coreBlocks } from "@plumix/blocks";
-import { mockRegistry, renderBlock } from "@plumix/blocks/test";
+import {
+  mockRegistry,
+  renderBlock,
+  stripBlockMarkers,
+} from "@plumix/blocks/test";
 
 import { renderTiptapContent } from "./route/render/tiptap.js";
 
@@ -42,7 +46,7 @@ describe("paragraph parity against the legacy walker", () => {
     };
     const legacy = renderTiptapContent(doc);
     const next = renderBlock({ registry, content: doc });
-    expect(next).toBe(legacy);
+    expect(stripBlockMarkers(next)).toBe(legacy);
   });
 
   test("paragraph with bold + italic marks", async () => {
@@ -62,7 +66,7 @@ describe("paragraph parity against the legacy walker", () => {
         },
       ],
     };
-    expect(renderBlock({ registry, content: doc })).toBe(
+    expect(stripBlockMarkers(renderBlock({ registry, content: doc }))).toBe(
       renderTiptapContent(doc),
     );
   });
@@ -81,7 +85,7 @@ describe("paragraph parity against the legacy walker", () => {
           },
         ],
       };
-      expect(renderBlock({ registry, content: doc })).toBe(
+      expect(stripBlockMarkers(renderBlock({ registry, content: doc }))).toBe(
         renderTiptapContent(doc),
       );
     },
@@ -107,7 +111,7 @@ describe("paragraph parity against the legacy walker", () => {
         },
       ],
     };
-    expect(renderBlock({ registry, content: doc })).toBe(
+    expect(stripBlockMarkers(renderBlock({ registry, content: doc }))).toBe(
       renderTiptapContent(doc),
     );
   });
@@ -132,7 +136,7 @@ describe("paragraph parity against the legacy walker", () => {
         },
       ],
     };
-    expect(renderBlock({ registry, content: doc })).toBe(
+    expect(stripBlockMarkers(renderBlock({ registry, content: doc }))).toBe(
       renderTiptapContent(doc),
     );
   });
@@ -149,7 +153,7 @@ describe("paragraph parity against the legacy walker", () => {
         },
       ],
     };
-    expect(renderBlock({ registry, content: doc })).toBe(
+    expect(stripBlockMarkers(renderBlock({ registry, content: doc }))).toBe(
       renderTiptapContent(doc),
     );
   });
@@ -171,7 +175,7 @@ describe("paragraph parity against the legacy walker", () => {
         },
       ],
     };
-    expect(renderBlock({ registry, content: doc })).toBe(
+    expect(stripBlockMarkers(renderBlock({ registry, content: doc }))).toBe(
       renderTiptapContent(doc),
     );
   });

--- a/packages/core/src/marks-buildapp-integration.test.ts
+++ b/packages/core/src/marks-buildapp-integration.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, test } from "vitest";
 
 import type { BlockContext, TiptapNode } from "@plumix/blocks";
 import { coreBlocks, EntryContent, paragraphBlock } from "@plumix/blocks";
-import { mockRegistry } from "@plumix/blocks/test";
+import { mockRegistry, stripBlockMarkers } from "@plumix/blocks/test";
 
 import { auth } from "./auth/config.js";
 import { plumix } from "./config.js";
@@ -89,7 +89,7 @@ describe("buildApp().marks renders every shipped mark on real docs", () => {
         context: EMPTY_CONTEXT,
       }),
     );
-    expect(html).toBe(expected);
+    expect(stripBlockMarkers(html)).toBe(expected);
   });
 
   test("link renders a safe anchor via app.marks", async () => {
@@ -103,7 +103,7 @@ describe("buildApp().marks renders every shipped mark on real docs", () => {
         context: EMPTY_CONTEXT,
       }),
     );
-    expect(html).toBe(
+    expect(stripBlockMarkers(html)).toBe(
       '<p><a href="https://example.com" rel="noopener noreferrer nofollow">Hi</a></p>',
     );
   });
@@ -119,7 +119,7 @@ describe("buildApp().marks renders every shipped mark on real docs", () => {
         context: EMPTY_CONTEXT,
       }),
     );
-    expect(html).toBe('<p><abbr title="HyperText">Hi</abbr></p>');
+    expect(stripBlockMarkers(html)).toBe('<p><abbr title="HyperText">Hi</abbr></p>');
   });
 
   test("app.marks covers all 13 shipped core marks", async () => {

--- a/scripts/copy-styles.mjs
+++ b/scripts/copy-styles.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Copies every `*.css` from `src/` into the matching `dist/` path so
+// the aggregate `src/styles.css` (which `@import`s each per-block
+// stylesheet) resolves at consume time. tsc only compiles .ts, so we
+// shadow the source layout for CSS as well — that way Vite (admin) and
+// future SSR bundles can `import "@plumix/blocks/styles.css"` and
+// follow the same relative `@import` paths the source used.
+
+import { readdirSync, cpSync, mkdirSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+const ROOT = process.cwd();
+const SRC = join(ROOT, "src");
+const DIST = join(ROOT, "dist");
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else if (entry.isFile()) yield full;
+  }
+}
+
+let copied = 0;
+try {
+  statSync(SRC);
+} catch {
+  console.error(`copy-styles: ${SRC} not found`);
+  process.exit(1);
+}
+
+for (const file of walk(SRC)) {
+  if (!file.endsWith(".css")) continue;
+  const dest = join(DIST, relative(SRC, file));
+  mkdirSync(dirname(dest), { recursive: true });
+  cpSync(file, dest);
+  copied += 1;
+}
+
+console.log(`copy-styles: copied ${copied} CSS file(s)`);


### PR DESCRIPTION
Block-specific styles previously lived in admin's `globals.css` and were referenced from `schema.ts` / `Component.tsx` via JS-side CSS Module imports. That coupled the host to every block and broke SSR consumers (Cloudflare worker, `plumix build`, `@plumix/core` tests) because Node can't load `.css`.

Each block now ships a sibling `styles.css` and emits literal `plumix-*` class strings from its schema + Component. An aggregate stylesheet at `packages/blocks/src/styles.css` `@import`s every per-block file and is exported as `@plumix/blocks/styles.css`; admin imports it once from `globals.css`. Plugins ship custom-block CSS the same way.

**Editor canvas now reflects table modifiers**

`core/table` declared `striped` / `bordered` attrs but Tiptap's default attribute serializer emitted them as raw HTML attributes, not `data-striped` / `data-bordered`. The CSS selectors target the `data-*` form, so the editor canvas silently ignored the toggles. Per-attribute `renderHTML` now mirrors the SSR Component.

**Empty inline shells are visible / authorable**

A freshly-inserted `<table>` was zero-height because every cell was empty; the slash-menu coverage e2e flagged it as \"hidden\". Cells now get padding + border. Each `<column>` in `core/columns` seeds a `core/paragraph` child so authors have a textblock to land the caret in.

**Test helper for structural assertions**

`stripBlockMarkers(html)` in `@plumix/blocks/test` strips `class=\"…\"` and `data-plumix-block=\"…\"` so existing structural fixtures (paragraph/heading/list/marks/parity suites) stay valid without coupling to per-block class names.

Refs GH-314