### PR TITLE
chore: fold senpai + code-simplifier findings from spike PR #406

### DIFF
--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -51,12 +51,8 @@ function PuckSpikeRoute(): ReactNode {
     <Puck
       config={config}
       data={data}
-      onPublish={(next) => {
-        setData(next);
-      }}
-      onChange={(next) => {
-        setData(next);
-      }}
+      onPublish={setData}
+      onChange={setData}
     />
   );
 }

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -1,8 +1,18 @@
 import type { BlockNode, BlockNodeRegistry } from "./render-block-tree.js";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { renderBlockTree } from "./render-block-tree.js";
+
+function withProductionEnv<T>(fn: () => T): T {
+  const previous = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+  try {
+    return fn();
+  } finally {
+    process.env.NODE_ENV = previous;
+  }
+}
 
 const headingRegistry: BlockNodeRegistry = new Map([
   [
@@ -47,15 +57,15 @@ describe("renderBlockTree", () => {
     expect(html).toBe("<h2>First</h2><h3>Second</h3><h2>Third</h2>");
   });
 
-  test("renders nothing for an unknown block name", () => {
+  test("renders nothing for an unknown block name in production", () => {
     const unknown: BlockNode = {
       id: "x",
       name: "acme/missing",
       attrs: { foo: "bar" },
     };
 
-    const html = renderToStaticMarkup(
-      renderBlockTree([unknown], headingRegistry),
+    const html = withProductionEnv(() =>
+      renderToStaticMarkup(renderBlockTree([unknown], headingRegistry)),
     );
 
     expect(html).toBe("");
@@ -67,17 +77,41 @@ describe("renderBlockTree", () => {
     expect(html).toBe("");
   });
 
-  test("known blocks render even when interleaved with unknown blocks", () => {
+  test("known blocks render around unknown blocks in production", () => {
     const blocks: readonly BlockNode[] = [
       { id: "1", name: "core/heading", attrs: { text: "Before", level: 2 } },
       { id: "2", name: "acme/missing", attrs: {} },
       { id: "3", name: "core/heading", attrs: { text: "After", level: 2 } },
     ];
 
-    const html = renderToStaticMarkup(
-      renderBlockTree(blocks, headingRegistry),
+    const html = withProductionEnv(() =>
+      renderToStaticMarkup(renderBlockTree(blocks, headingRegistry)),
     );
 
     expect(html).toBe("<h2>Before</h2><h2>After</h2>");
+  });
+
+  describe("in development", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test("emits an unknown-block template marker and warns once per name", () => {
+      const warn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      const blocks: readonly BlockNode[] = [
+        { id: "1", name: "acme/missing", attrs: {} },
+        { id: "2", name: "acme/missing", attrs: {} },
+        { id: "3", name: "acme/other", attrs: {} },
+      ];
+      const registry: BlockNodeRegistry = new Map();
+
+      const html = renderToStaticMarkup(renderBlockTree(blocks, registry));
+
+      expect(html).toContain('data-plumix-unknown-block="acme/missing"');
+      expect(html).toContain('data-plumix-unknown-block="acme/other"');
+      expect(warn).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { createElement } from "react";
+import { createElement, Fragment } from "react";
 
 import type { BlockContext } from "./types.js";
 
@@ -30,13 +30,49 @@ const DEFAULT_CONTEXT: BlockContext = Object.freeze({
   depth: 0,
 });
 
+interface DevWarnState {
+  readonly seen: Set<string>;
+}
+
+const devWarnStates = new WeakMap<object, DevWarnState>();
+
+function devWarnState(registry: BlockNodeRegistry): DevWarnState {
+  let existing = devWarnStates.get(registry);
+  if (!existing) {
+    existing = { seen: new Set() };
+    devWarnStates.set(registry, existing);
+  }
+  return existing;
+}
+
+function renderUnknown(name: string, devState: DevWarnState): ReactNode {
+  if (!isDevMode()) return null;
+  if (!devState.seen.has(name)) {
+    devState.seen.add(name);
+    console.warn(`[plumix:blocks] Unregistered block name: ${name}`);
+  }
+  return createElement("template", { "data-plumix-unknown-block": name });
+}
+
+function isDevMode(): boolean {
+  if (typeof process === "undefined") return false;
+  return process.env.NODE_ENV !== "production";
+}
+
 export function renderBlockTree(
   nodes: readonly BlockNode[],
   registry: BlockNodeRegistry,
 ): ReactNode {
+  const devState = devWarnState(registry);
   return nodes.map((node) => {
     const Component = registry.get(node.name);
-    if (!Component) return null;
+    if (!Component) {
+      return createElement(
+        Fragment,
+        { key: node.id },
+        renderUnknown(node.name, devState),
+      );
+    }
     return createElement(Component, {
       key: node.id,
       attrs: node.attrs ?? {},

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -22,13 +22,13 @@ export type BlockNodeComponent<Attrs = Readonly<Record<string, unknown>>> = (
 
 export type BlockNodeRegistry = ReadonlyMap<string, BlockNodeComponent>;
 
-const DEFAULT_CONTEXT: BlockContext = {
+const DEFAULT_CONTEXT: BlockContext = Object.freeze({
   entry: null,
-  siteSettings: {},
+  siteSettings: Object.freeze({}),
   theme: null,
   parent: null,
   depth: 0,
-};
+});
 
 export function renderBlockTree(
   nodes: readonly BlockNode[],


### PR DESCRIPTION
## Summary

Follow-up to spike PR #406 (squash-merged as c4daca8). Senpai and code-simplifier review of the merged spike surfaced three concrete code changes; folding them in before slice #381 starts so they don't drift.

## Commits

1. `refactor(admin): inline setData in puck spike route handlers` — useState's setter has the same `SetStateAction` signature Puck's `onChange`/`onPublish` expect, so the wrapping arrow callbacks were redundant. Code-simplifier suggestion.
2. `refactor(blocks): freeze DEFAULT_CONTEXT in renderBlockTree` — runtime guard against accidental shared mutation. TypeScript already prevents this at compile time (`readonly` fields on `BlockContext`), but `Object.freeze` locks the runtime shape too. Senpai should-fix.
3. `fix(blocks): emit dev-marker + warn-once for unknown blocks in renderBlockTree` — mirrors the existing `EntryContent` walker's contract: in development emit a `<template data-plumix-unknown-block>` marker and `console.warn` once per unique name; in production render nothing. The spike's initial impl returned null unconditionally, dropping the dev affordance. Senpai should-fix.

## Findings explicitly NOT applied (with reason)

- **`BlockNode.id` uniqueness** (senpai should-fix #1) — slice #381 territory; that's where the BlockNode schema gets validation
- **Adapter boundary around `@puckeditor/core`** (senpai should-fix #3) — sequencing flag, not a code change. Slice #382 introduces the adapter
- **Test runner choice (`renderToStaticMarkup` vs `renderToString`)** (senpai nice-to-have #5) — will revisit when style-slot / island work lands (slice #382 / #388)
- **`BlockNodeRegistry` generic erasure** (senpai nice-to-have #6) — feed into slice #382 adapter design, no change now
- **Cross-package symbol extraction** (multiple simplifier rejections) — would create surface that vanishes when slice #381 unifies the walkers

## Test plan

- [x] `pnpm exec turbo run typecheck test --filter @plumix/admin --filter @plumix/blocks` — all green
- [x] `pnpm --filter @plumix/blocks lint` — clean
- [x] 6 tests pass on the walker (was 5; added one for the dev-marker + warn-once contract)
- [ ] CI green

Refs #379, #380