### PR TITLE
feat(blocks,admin): block adapter, field translator, style-slot CSS emitter

### DIFF
--- a/packages/admin/src/editor/v2/block-adapter.test.ts
+++ b/packages/admin/src/editor/v2/block-adapter.test.ts
@@ -1,0 +1,86 @@
+import type { BlockSpecV2 as BlockSpec } from "@plumix/blocks";
+import { describe, expect, test } from "vitest";
+
+import { blockSpecsToPuckComponents } from "./block-adapter.js";
+
+const noopRender: BlockSpec["render"] = () => null;
+
+describe("blockSpecsToPuckComponents", () => {
+  test("keys components by spec.name and surfaces the spec title as label", () => {
+    const components = blockSpecsToPuckComponents([
+      { name: "core/heading", title: "Heading", render: noopRender },
+      { name: "core/paragraph", title: "Paragraph", render: noopRender },
+    ]);
+
+    expect(Object.keys(components)).toEqual(["core/heading", "core/paragraph"]);
+    expect(components["core/heading"]?.label).toBe("Heading");
+    expect(components["core/paragraph"]?.label).toBe("Paragraph");
+  });
+
+  test("falls back to spec.name as label when title is absent", () => {
+    const components = blockSpecsToPuckComponents([
+      { name: "acme/widget", render: noopRender },
+    ]);
+
+    expect(components["acme/widget"]?.label).toBe("acme/widget");
+  });
+
+  test("translates inputs to Puck fields", () => {
+    const components = blockSpecsToPuckComponents([
+      {
+        name: "core/heading",
+        title: "Heading",
+        inputs: [
+          { name: "text", type: "text" },
+          {
+            name: "level",
+            type: "select",
+            options: [
+              { label: "H1", value: 1 },
+              { label: "H2", value: 2 },
+            ],
+          },
+        ],
+        render: noopRender,
+      },
+    ]);
+
+    const fields = components["core/heading"]?.fields ?? {};
+    expect(Object.keys(fields)).toEqual(["text", "level"]);
+    expect(fields.text?.type).toBe("text");
+    expect(fields.level?.type).toBe("select");
+  });
+
+  test("forwards defaults to Puck defaultProps", () => {
+    const components = blockSpecsToPuckComponents([
+      {
+        name: "core/heading",
+        title: "Heading",
+        defaults: { level: 2, text: "" },
+        render: noopRender,
+      },
+    ]);
+
+    expect(components["core/heading"]?.defaultProps).toEqual({
+      level: 2,
+      text: "",
+    });
+  });
+
+  test("the synthesized render bridges Puck props → Plumix BlockNodeRenderProps", () => {
+    let receivedAttrs: Readonly<Record<string, unknown>> | undefined;
+    const components = blockSpecsToPuckComponents([
+      {
+        name: "acme/probe",
+        render: ({ attrs }) => {
+          receivedAttrs = attrs;
+          return null;
+        },
+      },
+    ]);
+
+    components["acme/probe"]?.render({ text: "Hi" } as never);
+
+    expect(receivedAttrs).toEqual({ text: "Hi" });
+  });
+});

--- a/packages/admin/src/editor/v2/block-adapter.ts
+++ b/packages/admin/src/editor/v2/block-adapter.ts
@@ -1,0 +1,29 @@
+import type { BlockSpecV2 as BlockSpec } from "@plumix/blocks";
+import type { Config } from "@puckeditor/core";
+import { DEFAULT_BLOCK_CONTEXT } from "@plumix/blocks";
+import { createElement, Fragment } from "react";
+
+import { translateFields } from "./field-type-translator.js";
+
+export function blockSpecsToPuckComponents(
+  specs: readonly BlockSpec[],
+): Config["components"] {
+  const out: Config["components"] = {};
+  for (const spec of specs) {
+    out[spec.name] = {
+      label: spec.title ?? spec.name,
+      fields: spec.inputs ? translateFields(spec.inputs) : {},
+      defaultProps: spec.defaults,
+      render: (props) =>
+        createElement(
+          Fragment,
+          null,
+          spec.render({
+            attrs: props,
+            context: DEFAULT_BLOCK_CONTEXT,
+          }),
+        ),
+    };
+  }
+  return out;
+}

--- a/packages/admin/src/editor/v2/field-type-translator.test.ts
+++ b/packages/admin/src/editor/v2/field-type-translator.test.ts
@@ -1,0 +1,63 @@
+import type { BlockInput } from "@plumix/blocks";
+import { describe, expect, test } from "vitest";
+
+import { translateField, translateFields } from "./field-type-translator.js";
+
+describe("translateField", () => {
+  test("identity-maps native Puck types: text, textarea, number", () => {
+    expect(translateField({ name: "x", type: "text" })).toEqual({
+      type: "text",
+      label: undefined,
+    });
+    expect(translateField({ name: "x", type: "textarea" })).toEqual({
+      type: "textarea",
+      label: undefined,
+    });
+    expect(translateField({ name: "x", type: "number" })).toEqual({
+      type: "number",
+      label: undefined,
+    });
+  });
+
+  test("translates select with options", () => {
+    const input: BlockInput = {
+      name: "level",
+      type: "select",
+      label: "Level",
+      options: [
+        { label: "H1", value: 1 },
+        { label: "H2", value: 2 },
+      ],
+    };
+
+    expect(translateField(input)).toEqual({
+      type: "select",
+      label: "Level",
+      options: [
+        { label: "H1", value: 1 },
+        { label: "H2", value: 2 },
+      ],
+    });
+  });
+
+  test("falls back to text for unknown field types", () => {
+    expect(
+      translateField({ name: "x", type: "wat", label: "Unknown" }),
+    ).toEqual({ type: "text", label: "Unknown" });
+  });
+});
+
+describe("translateFields", () => {
+  test("maps an array of inputs to a Puck fields record keyed by name", () => {
+    const inputs: readonly BlockInput[] = [
+      { name: "text", type: "text" },
+      { name: "level", type: "number" },
+    ];
+
+    const fields = translateFields(inputs);
+
+    expect(Object.keys(fields)).toEqual(["text", "level"]);
+    expect(fields.text).toEqual({ type: "text", label: undefined });
+    expect(fields.level).toEqual({ type: "number", label: undefined });
+  });
+});

--- a/packages/admin/src/editor/v2/field-type-translator.ts
+++ b/packages/admin/src/editor/v2/field-type-translator.ts
@@ -1,0 +1,35 @@
+import type { BlockInput } from "@plumix/blocks";
+import type { Fields } from "@puckeditor/core";
+
+export function translateField(
+  input: BlockInput,
+): Fields[string] {
+  switch (input.type) {
+    case "text":
+    case "textarea":
+    case "number":
+      return { type: input.type, label: input.label };
+    case "select":
+    case "radio":
+      return {
+        type: input.type,
+        label: input.label,
+        options: (input.options ?? []).map((opt) => ({
+          label: opt.label,
+          value: opt.value,
+        })),
+      };
+    default:
+      return { type: "text", label: input.label };
+  }
+}
+
+export function translateFields(
+  inputs: readonly BlockInput[],
+): Fields {
+  const out: Record<string, Fields[string]> = {};
+  for (const input of inputs) {
+    out[input.name] = translateField(input);
+  }
+  return out;
+}

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -1,5 +1,17 @@
 import type { BlockNodeComponent } from "./render-block-tree.js";
 
+export interface BlockInputOption {
+  readonly label: string;
+  readonly value: string | number | boolean;
+}
+
+export interface BlockInput {
+  readonly name: string;
+  readonly type: string;
+  readonly label?: string;
+  readonly options?: readonly BlockInputOption[];
+}
+
 export interface BlockSpec<
   Attrs extends Readonly<Record<string, unknown>> = Readonly<
     Record<string, unknown>
@@ -9,6 +21,7 @@ export interface BlockSpec<
   readonly title?: string;
   readonly icon?: string;
   readonly category?: string;
+  readonly inputs?: readonly BlockInput[];
   readonly render: BlockNodeComponent<Attrs>;
   readonly inline?: boolean;
   readonly defaults?: Readonly<Partial<Attrs>>;

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -46,17 +46,30 @@ export type {
   EntryContentProps,
   SyncFilterExecutor,
 } from "./walker.js";
-export { renderBlockTree } from "./render-block-tree.js";
+export { DEFAULT_BLOCK_CONTEXT, renderBlockTree } from "./render-block-tree.js";
 export type {
   BlockNode,
   BlockNodeComponent,
   BlockNodeRenderProps,
+  RenderBlockTreeOptions,
 } from "./render-block-tree.js";
 export { createBlockRegistry, defineBlock as defineBlockSpec } from "./block-registry.js";
 export type {
-  BlockSpec as BlockSpecV2,
+  BlockInput,
+  BlockInputOption,
   BlockRegistry as BlockRegistryV2,
+  BlockSpec as BlockSpecV2,
 } from "./block-registry.js";
+export {
+  emitBlockStyleCss,
+  tokenIdToCssVar,
+} from "./styles/style-emitter.js";
+export type {
+  ResponsiveStyleBucket,
+  ResponsiveStyleSlot,
+  TokenCategory,
+} from "./styles/style-emitter.js";
+export { paragraphBlockV2 } from "./paragraph/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";
 export { PlumixIslandBootstrap } from "./island-bootstrap.js";

--- a/packages/blocks/src/paragraph/v2.test.tsx
+++ b/packages/blocks/src/paragraph/v2.test.tsx
@@ -1,0 +1,58 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry } from "../block-registry.js";
+import { renderBlockTree } from "../render-block-tree.js";
+import { paragraphBlockV2 } from "./v2.js";
+
+describe("core/paragraph end-to-end through new defineBlock + walker + style emitter", () => {
+  test("renders a <p> wrapped in data-plumix-block", () => {
+    const registry = createBlockRegistry([paragraphBlockV2]);
+    const tree: readonly BlockNode[] = [
+      {
+        id: "p1",
+        name: "core/paragraph",
+        attrs: { text: "Hello, world" },
+      },
+    ];
+
+    const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/paragraph"><p>Hello, world</p></div>',
+    );
+  });
+
+  test("renders the desktop-first responsive @media cascade for a style slot override", () => {
+    const registry = createBlockRegistry([paragraphBlockV2]);
+    const tree: readonly BlockNode[] = [
+      {
+        id: "p1",
+        name: "core/paragraph",
+        attrs: { text: "Cascading" },
+        style: {
+          large: { padding: "lg" },
+          small: { padding: "sm" },
+        },
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      renderBlockTree(tree, registry, {
+        tokens: {
+          spacing: { lg: { value: "24px" }, sm: { value: "8px" } },
+        },
+      }),
+    );
+
+    expect(html).toContain('class="plumix-block-p1"');
+    expect(html).toContain(
+      ".plumix-block-p1 { padding: var(--plumix-spacing-lg, 24px); }",
+    );
+    expect(html).toContain(
+      "@media (max-width: 640px) { .plumix-block-p1 { padding: var(--plumix-spacing-sm, 8px); } }",
+    );
+    expect(html).toContain("<p>Cascading</p>");
+  });
+});

--- a/packages/blocks/src/paragraph/v2.tsx
+++ b/packages/blocks/src/paragraph/v2.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+export const paragraphBlockV2 = defineBlock({
+  name: "core/paragraph",
+  title: "Paragraph",
+  icon: "Paragraph",
+  category: "text",
+  inputs: [{ name: "text", type: "text", label: "Text" }],
+  defaults: { text: "" },
+  render: ({ attrs }): ReactNode => {
+    const { text = "" } = attrs as { readonly text?: string };
+    return <p>{text}</p>;
+  },
+});

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -188,6 +188,101 @@ describe("renderBlockTree", () => {
     );
   });
 
+  test("emits per-instance <style> + class when BlockNode has a style slot and tokens are provided", () => {
+    const registry = createBlockRegistry([
+      {
+        name: "core/paragraph",
+        render: ({ attrs }) => {
+          const { text } = attrs as { readonly text?: string };
+          return <p>{text}</p>;
+        },
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      {
+        id: "p1",
+        name: "core/paragraph",
+        attrs: { text: "Hello" },
+        style: { large: { padding: "lg" } },
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      renderBlockTree(tree, registry, {
+        tokens: { spacing: { lg: { value: "24px" } } },
+      }),
+    );
+
+    expect(html).toContain('class="plumix-block-p1"');
+    expect(html).toContain(
+      "<style>.plumix-block-p1 { padding: var(--plumix-spacing-lg, 24px); }</style>",
+    );
+    expect(html).toContain("<p>Hello</p>");
+  });
+
+  test("omits the per-instance class when style is set but tokens are not provided", () => {
+    const registry = createBlockRegistry([
+      {
+        name: "core/paragraph",
+        render: () => <p>x</p>,
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      {
+        id: "p1",
+        name: "core/paragraph",
+        attrs: {},
+        style: { large: { padding: "lg" } },
+      },
+    ];
+
+    const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+    expect(html).toBe('<div data-plumix-block="core/paragraph"><p>x</p></div>');
+  });
+
+  test("skips style emission when node.id contains unsafe characters", () => {
+    const registry = createBlockRegistry([
+      {
+        name: "core/paragraph",
+        render: () => <p>x</p>,
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      {
+        id: "p1</style><script>alert(1)</script>",
+        name: "core/paragraph",
+        attrs: {},
+        style: { large: { padding: "lg" } },
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      renderBlockTree(tree, registry, {
+        tokens: { spacing: { lg: { value: "24px" } } },
+      }),
+    );
+
+    expect(html).not.toContain("<style>");
+    expect(html).not.toContain("<script>");
+  });
+
+  test("omits the per-instance class when no style slot is declared", () => {
+    const heading: BlockNode = {
+      id: "h1",
+      name: "core/heading",
+      attrs: { text: "No style", level: 2 },
+    };
+
+    const html = renderToStaticMarkup(
+      renderBlockTree([heading], headingRegistry),
+    );
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/heading"><h2>No style</h2></div>',
+    );
+  });
+
   test("skips the universal wrapper for blocks with inline: true", () => {
     const registry = createBlockRegistry([
       {

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -2,12 +2,20 @@ import type { ReactNode } from "react";
 import { createElement, Fragment } from "react";
 
 import type { BlockRegistry } from "./block-registry.js";
+import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
+import type { ThemeTokens } from "./styles/types.js";
 import type { BlockContext } from "./types.js";
+import { emitBlockStyleCss } from "./styles/style-emitter.js";
 
 export interface BlockNode {
   readonly id: string;
   readonly name: string;
   readonly attrs?: Readonly<Record<string, unknown>>;
+  readonly style?: ResponsiveStyleSlot;
+}
+
+export interface RenderBlockTreeOptions {
+  readonly tokens?: ThemeTokens;
 }
 
 export interface BlockNodeRenderProps<
@@ -21,7 +29,7 @@ export type BlockNodeComponent<Attrs = Readonly<Record<string, unknown>>> = (
   props: BlockNodeRenderProps<Attrs>,
 ) => ReactNode;
 
-const DEFAULT_CONTEXT: BlockContext = Object.freeze({
+export const DEFAULT_BLOCK_CONTEXT: BlockContext = Object.freeze({
   entry: null,
   siteSettings: Object.freeze({}),
   theme: null,
@@ -34,6 +42,8 @@ interface DevWarnState {
 }
 
 const devWarnStates = new WeakMap<object, DevWarnState>();
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
 
 function devWarnState(registry: BlockRegistry): DevWarnState {
   let existing = devWarnStates.get(registry);
@@ -74,14 +84,14 @@ function materializeSlots(
   registry: BlockRegistry,
   devState: DevWarnState,
   childContext: BlockContext,
+  tokens: ThemeTokens | undefined,
 ): Readonly<Record<string, unknown>> {
   let materialized: Record<string, unknown> | undefined;
   for (const [key, value] of Object.entries(attrs)) {
     if (isBlockNodeArray(value)) {
       materialized ??= { ...attrs };
-      const children = value;
       materialized[key] = function SlotComponent() {
-        return renderNodes(children, registry, devState, childContext);
+        return renderNodes(value, registry, devState, childContext, tokens);
       };
     }
   }
@@ -93,6 +103,7 @@ function renderNodes(
   registry: BlockRegistry,
   devState: DevWarnState,
   context: BlockContext,
+  tokens: ThemeTokens | undefined,
 ): ReactNode {
   return nodes.map((node) => {
     const spec = registry.get(node.name);
@@ -113,14 +124,29 @@ function renderNodes(
       registry,
       devState,
       childContext,
+      tokens,
     );
     const rendered = createElement(spec.render, { attrs, context });
     if (spec.inline) {
       return createElement(Fragment, { key: node.id }, rendered);
     }
+    const safeId = SAFE_ID_RE.test(node.id) ? node.id : null;
+    const styleCss =
+      safeId && node.style && tokens
+        ? emitBlockStyleCss(`plumix-block-${safeId}`, node.style, tokens)
+        : "";
+    const className = styleCss ? `plumix-block-${safeId ?? ""}` : undefined;
+    const styleTag = styleCss
+      ? createElement("style", { key: "style" }, styleCss)
+      : null;
     return createElement(
       "div",
-      { key: node.id, "data-plumix-block": node.name },
+      {
+        key: node.id,
+        "data-plumix-block": node.name,
+        className,
+      },
+      styleTag,
       rendered,
     );
   });
@@ -129,6 +155,13 @@ function renderNodes(
 export function renderBlockTree(
   nodes: readonly BlockNode[],
   registry: BlockRegistry,
+  options?: RenderBlockTreeOptions,
 ): ReactNode {
-  return renderNodes(nodes, registry, devWarnState(registry), DEFAULT_CONTEXT);
+  return renderNodes(
+    nodes,
+    registry,
+    devWarnState(registry),
+    DEFAULT_BLOCK_CONTEXT,
+    options?.tokens,
+  );
 }

--- a/packages/blocks/src/styles/style-emitter.test.ts
+++ b/packages/blocks/src/styles/style-emitter.test.ts
@@ -1,4 +1,4 @@
-import type { BlockStyleSlot } from "./style-emitter.js";
+import type { ResponsiveStyleSlot } from "./style-emitter.js";
 import type { ThemeTokens } from "./types.js";
 import { describe, expect, test } from "vitest";
 
@@ -29,7 +29,7 @@ describe("emitBlockStyleCss", () => {
   };
 
   test("emits base CSS for the large bucket without a media-query wrapper", () => {
-    const style: BlockStyleSlot = { large: { padding: "lg" } };
+    const style: ResponsiveStyleSlot = { large: { padding: "lg" } };
 
     expect(emitBlockStyleCss("block-1", style, tokens)).toBe(
       ".block-1 { padding: var(--plumix-spacing-lg, 24px); }",
@@ -37,19 +37,58 @@ describe("emitBlockStyleCss", () => {
   });
 
   test("emits desktop-first cascade with @media wrappers for medium and small", () => {
-    const style: BlockStyleSlot = {
+    const style: ResponsiveStyleSlot = {
       large: { padding: "lg" },
+      medium: { padding: "md" },
       small: { padding: "sm" },
     };
+    const tokensWithMedium: ThemeTokens = {
+      spacing: {
+        lg: { value: "24px" },
+        md: { value: "16px" },
+        sm: { value: "8px" },
+      },
+    };
 
-    const css = emitBlockStyleCss("block-1", style, tokens);
+    const css = emitBlockStyleCss("block-1", style, tokensWithMedium);
 
     expect(css).toContain(
       ".block-1 { padding: var(--plumix-spacing-lg, 24px); }",
     );
     expect(css).toContain(
+      "@media (max-width: 991px) { .block-1 { padding: var(--plumix-spacing-md, 16px); } }",
+    );
+    expect(css).toContain(
       "@media (max-width: 640px) { .block-1 { padding: var(--plumix-spacing-sm, 8px); } }",
     );
+  });
+
+  test("skips unmapped CSS properties without emitting raw token ids as literal CSS values", () => {
+    const style: ResponsiveStyleSlot = {
+      large: { padding: "lg", width: "lg" },
+    };
+
+    const css = emitBlockStyleCss("block-1", style, tokens);
+
+    expect(css).toContain("padding: var(--plumix-spacing-lg, 24px);");
+    expect(css).not.toContain("width: lg");
+    expect(css).not.toContain("width:");
+  });
+
+  test("skips style emission when the property or token name contains unsafe characters", () => {
+    const style: ResponsiveStyleSlot = {
+      large: {
+        padding: "lg",
+        "<script>": "lg",
+        margin: "</style><script>alert(1)</script>",
+      },
+    };
+
+    const css = emitBlockStyleCss("block-1", style, tokens);
+
+    expect(css).toContain("padding: var(--plumix-spacing-lg, 24px);");
+    expect(css).not.toContain("<script>");
+    expect(css).not.toContain("</style>");
   });
 
   test("returns an empty string for missing or empty style slot", () => {
@@ -58,7 +97,7 @@ describe("emitBlockStyleCss", () => {
   });
 
   test("converts camelCase CSS properties to kebab-case", () => {
-    const style: BlockStyleSlot = { large: { fontSize: "lg" } };
+    const style: ResponsiveStyleSlot = { large: { fontSize: "lg" } };
 
     expect(emitBlockStyleCss("b", style, { typography: { lg: { value: "20px" } } })).toBe(
       ".b { font-size: var(--plumix-typography-lg, 20px); }",

--- a/packages/blocks/src/styles/style-emitter.test.ts
+++ b/packages/blocks/src/styles/style-emitter.test.ts
@@ -1,0 +1,67 @@
+import type { BlockStyleSlot } from "./style-emitter.js";
+import type { ThemeTokens } from "./types.js";
+import { describe, expect, test } from "vitest";
+
+import { emitBlockStyleCss, tokenIdToCssVar } from "./style-emitter.js";
+
+describe("tokenIdToCssVar", () => {
+  test("resolves a registered token to a CSS variable reference with the token's literal as fallback", () => {
+    const tokens: ThemeTokens = {
+      spacing: { lg: { value: "24px" } },
+    };
+
+    expect(tokenIdToCssVar("lg", "spacing", tokens)).toBe(
+      "var(--plumix-spacing-lg, 24px)",
+    );
+  });
+
+  test("returns a CSS variable reference without fallback when the token is unregistered", () => {
+    expect(tokenIdToCssVar("xl", "spacing", {})).toBe(
+      "var(--plumix-spacing-xl)",
+    );
+  });
+});
+
+describe("emitBlockStyleCss", () => {
+  const tokens: ThemeTokens = {
+    spacing: { lg: { value: "24px" }, sm: { value: "8px" } },
+    colors: { primary: { value: "#0c2238" } },
+  };
+
+  test("emits base CSS for the large bucket without a media-query wrapper", () => {
+    const style: BlockStyleSlot = { large: { padding: "lg" } };
+
+    expect(emitBlockStyleCss("block-1", style, tokens)).toBe(
+      ".block-1 { padding: var(--plumix-spacing-lg, 24px); }",
+    );
+  });
+
+  test("emits desktop-first cascade with @media wrappers for medium and small", () => {
+    const style: BlockStyleSlot = {
+      large: { padding: "lg" },
+      small: { padding: "sm" },
+    };
+
+    const css = emitBlockStyleCss("block-1", style, tokens);
+
+    expect(css).toContain(
+      ".block-1 { padding: var(--plumix-spacing-lg, 24px); }",
+    );
+    expect(css).toContain(
+      "@media (max-width: 640px) { .block-1 { padding: var(--plumix-spacing-sm, 8px); } }",
+    );
+  });
+
+  test("returns an empty string for missing or empty style slot", () => {
+    expect(emitBlockStyleCss("block-1", undefined, tokens)).toBe("");
+    expect(emitBlockStyleCss("block-1", {}, tokens)).toBe("");
+  });
+
+  test("converts camelCase CSS properties to kebab-case", () => {
+    const style: BlockStyleSlot = { large: { fontSize: "lg" } };
+
+    expect(emitBlockStyleCss("b", style, { typography: { lg: { value: "20px" } } })).toBe(
+      ".b { font-size: var(--plumix-typography-lg, 20px); }",
+    );
+  });
+});

--- a/packages/blocks/src/styles/style-emitter.ts
+++ b/packages/blocks/src/styles/style-emitter.ts
@@ -1,0 +1,86 @@
+import type { ThemeTokens } from "./types.js";
+
+export type TokenCategory = keyof ThemeTokens;
+
+export type BlockStyleBucket = Readonly<Record<string, string>>;
+
+export interface BlockStyleSlot {
+  readonly large?: BlockStyleBucket;
+  readonly medium?: BlockStyleBucket;
+  readonly small?: BlockStyleBucket;
+}
+
+const PROPERTY_TO_CATEGORY: Readonly<Record<string, TokenCategory>> = {
+  padding: "spacing",
+  margin: "spacing",
+  gap: "spacing",
+  background: "colors",
+  color: "colors",
+  borderColor: "colors",
+  fontSize: "typography",
+  fontFamily: "typography",
+};
+
+const VIEWPORT_MAX_PX: Readonly<Record<"medium" | "small", number>> = {
+  medium: 991,
+  small: 640,
+};
+
+export function tokenIdToCssVar(
+  id: string,
+  category: TokenCategory,
+  tokens: ThemeTokens,
+): string {
+  const cssVar = `--plumix-${categoryToSegment(category)}-${id}`;
+  const entry = tokens[category]?.[id];
+  if (entry?.value !== undefined) {
+    return `var(${cssVar}, ${entry.value})`;
+  }
+  return `var(${cssVar})`;
+}
+
+export function emitBlockStyleCss(
+  className: string,
+  style: BlockStyleSlot | undefined,
+  tokens: ThemeTokens,
+): string {
+  if (!style) return "";
+  const parts: string[] = [];
+  if (style.large) {
+    const decls = bucketToDeclarations(style.large, tokens);
+    if (decls) parts.push(`.${className} { ${decls} }`);
+  }
+  for (const viewport of ["medium", "small"] as const) {
+    const bucket = style[viewport];
+    if (!bucket) continue;
+    const decls = bucketToDeclarations(bucket, tokens);
+    if (decls)
+      parts.push(
+        `@media (max-width: ${VIEWPORT_MAX_PX[viewport]}px) { .${className} { ${decls} } }`,
+      );
+  }
+  return parts.join(" ");
+}
+
+function bucketToDeclarations(
+  bucket: BlockStyleBucket,
+  tokens: ThemeTokens,
+): string {
+  const decls: string[] = [];
+  for (const [property, tokenId] of Object.entries(bucket)) {
+    const category = PROPERTY_TO_CATEGORY[property];
+    const value = category
+      ? tokenIdToCssVar(tokenId, category, tokens)
+      : tokenId;
+    decls.push(`${propertyToCss(property)}: ${value};`);
+  }
+  return decls.join(" ");
+}
+
+function propertyToCss(property: string): string {
+  return property.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+function categoryToSegment(category: TokenCategory): string {
+  return category === "colors" ? "color" : category;
+}

--- a/packages/blocks/src/styles/style-emitter.ts
+++ b/packages/blocks/src/styles/style-emitter.ts
@@ -2,12 +2,12 @@ import type { ThemeTokens } from "./types.js";
 
 export type TokenCategory = keyof ThemeTokens;
 
-export type BlockStyleBucket = Readonly<Record<string, string>>;
+export type ResponsiveStyleBucket = Readonly<Record<string, string>>;
 
-export interface BlockStyleSlot {
-  readonly large?: BlockStyleBucket;
-  readonly medium?: BlockStyleBucket;
-  readonly small?: BlockStyleBucket;
+export interface ResponsiveStyleSlot {
+  readonly large?: ResponsiveStyleBucket;
+  readonly medium?: ResponsiveStyleBucket;
+  readonly small?: ResponsiveStyleBucket;
 }
 
 const PROPERTY_TO_CATEGORY: Readonly<Record<string, TokenCategory>> = {
@@ -16,10 +16,11 @@ const PROPERTY_TO_CATEGORY: Readonly<Record<string, TokenCategory>> = {
   gap: "spacing",
   background: "colors",
   color: "colors",
-  borderColor: "colors",
   fontSize: "typography",
   fontFamily: "typography",
 };
+
+const SAFE_CSS_TOKEN_RE = /^[A-Za-z0-9_-]+$/;
 
 const VIEWPORT_MAX_PX: Readonly<Record<"medium" | "small", number>> = {
   medium: 991,
@@ -41,7 +42,7 @@ export function tokenIdToCssVar(
 
 export function emitBlockStyleCss(
   className: string,
-  style: BlockStyleSlot | undefined,
+  style: ResponsiveStyleSlot | undefined,
   tokens: ThemeTokens,
 ): string {
   if (!style) return "";
@@ -63,16 +64,19 @@ export function emitBlockStyleCss(
 }
 
 function bucketToDeclarations(
-  bucket: BlockStyleBucket,
+  bucket: ResponsiveStyleBucket,
   tokens: ThemeTokens,
 ): string {
   const decls: string[] = [];
   for (const [property, tokenId] of Object.entries(bucket)) {
+    if (!SAFE_CSS_TOKEN_RE.test(property) || !SAFE_CSS_TOKEN_RE.test(tokenId)) {
+      continue;
+    }
     const category = PROPERTY_TO_CATEGORY[property];
-    const value = category
-      ? tokenIdToCssVar(tokenId, category, tokens)
-      : tokenId;
-    decls.push(`${propertyToCss(property)}: ${value};`);
+    if (!category) continue;
+    decls.push(
+      `${propertyToCss(property)}: ${tokenIdToCssVar(tokenId, category, tokens)};`,
+    );
   }
   return decls.join(" ");
 }


### PR DESCRIPTION
Land slice #382 of the page-builder rearchitecture (PRD #379). Three pure deep modules + walker integration + \`core/paragraph\` migrated to the new shape with a working responsive style override end-to-end.

23 tests across the new code (6 emitter, 4 translator, 5 adapter, 4 walker-style, 2 paragraph-v2, 2 sanitization). All 12 turbo tasks (typecheck/lint/test/build across \`@plumix/admin\`, \`@plumix/blocks\`, \`@plumix/core\`) pass.

**Style emission**

\`emitBlockStyleCss\` produces desktop-first cascaded CSS from a \`ResponsiveStyleSlot\`:

\`\`\`ts
{
  large: { padding: "lg" },
  medium: { padding: "md" },
  small: { padding: "sm" },
}
\`\`\`

becomes:

\`\`\`css
.plumix-block-<id> { padding: var(--plumix-spacing-lg, 24px); }
@media (max-width: 991px) { .plumix-block-<id> { padding: var(--plumix-spacing-md, 16px); } }
@media (max-width: 640px) { .plumix-block-<id> { padding: var(--plumix-spacing-sm, 8px); } }
\`\`\`

Walker emits one \`<style>\` tag per block instance with the cascade scoped to a \`plumix-block-<id>\` class. \`node.id\`, property names, and token ids must all match \`[A-Za-z0-9_-]+\` or the emission is skipped — defends against \`<style>\` injection via stored content.

**Block adapter + field translator**

\`packages/admin/src/editor/v2/block-adapter.ts\` exposes \`blockSpecsToPuckComponents(specs)\` → Puck \`Config.components\`. Each Plumix \`BlockSpec\` becomes a Puck \`ComponentConfig\` with translated fields (\`field-type-translator.ts\`), \`defaultProps\` from \`spec.defaults\`, and a render closure bridging Puck's props to Plumix's \`BlockNodeRenderProps\` shape (\`attrs\` + shared \`DEFAULT_BLOCK_CONTEXT\` for SSR/admin parity).

Field translator covers Puck-native types directly (\`text\`, \`textarea\`, \`number\`, \`select\`, \`radio\`); image, entry, term, user, and other plugin field types arrive in their respective slices.

**Out of scope**

- Input-driven TypeScript inference for \`defineBlock\`'s render attrs (variance design lands later)
- Plugin-extensible field-type translator (\`registerFieldType\` integration with the Puck adapter): #401, #402
- Full text-block migration (paragraph stays parallel to legacy via \`paragraph/v2.tsx\`; replacement in #392)
- Property-to-category map expansion (\`borderColor\`, \`boxShadow\`, etc.) tracks with the categories themes actually declare

Refs #382