### PR TITLE
feat(blocks): add block:before/after_render hooks + verify round-trip

### DIFF
--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -51,6 +51,7 @@ export type {
   BlockNode,
   BlockNodeComponent,
   BlockNodeRenderProps,
+  BlockRenderHooks,
   RenderBlockTreeOptions,
 } from "./render-block-tree.js";
 export { createBlockRegistry, defineBlock as defineBlockSpec } from "./block-registry.js";

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -301,6 +301,128 @@ describe("renderBlockTree", () => {
     expect(html).not.toContain("data-plumix-block");
   });
 
+  describe("render hooks", () => {
+    test("fires beforeRender and afterRender around each block render", () => {
+      const events: { phase: "before" | "after"; nodeName: string }[] = [];
+      const tree: readonly BlockNode[] = [
+        { id: "1", name: "core/heading", attrs: { text: "Hi", level: 2 } },
+      ];
+
+      renderToStaticMarkup(
+        renderBlockTree(tree, headingRegistry, {
+          hooks: {
+            beforeRender: (node) =>
+              events.push({ phase: "before", nodeName: node.name }),
+            afterRender: (node) =>
+              events.push({ phase: "after", nodeName: node.name }),
+          },
+        }),
+      );
+
+      expect(events).toEqual([
+        { phase: "before", nodeName: "core/heading" },
+        { phase: "after", nodeName: "core/heading" },
+      ]);
+    });
+
+    test("fires hooks for unknown blocks too", () => {
+      const events: string[] = [];
+      const tree: readonly BlockNode[] = [
+        { id: "1", name: "acme/missing", attrs: {} },
+      ];
+
+      withProductionEnv(() =>
+        renderToStaticMarkup(
+          renderBlockTree(tree, headingRegistry, {
+            hooks: {
+              beforeRender: (node) => events.push(`before:${node.name}`),
+              afterRender: (node) => events.push(`after:${node.name}`),
+            },
+          }),
+        ),
+      );
+
+      expect(events).toEqual(["before:acme/missing", "after:acme/missing"]);
+    });
+
+    test("threads the parent's context into hooks for slot children", () => {
+      const captured: { name: string; parent: string | null; depth: number }[] =
+        [];
+      const registry = createBlockRegistry([
+        {
+          name: "core/section",
+          render: ({ attrs }) => {
+            const Content = attrs.content as () => React.ReactNode;
+            return <section><Content /></section>;
+          },
+        },
+        {
+          name: "core/heading",
+          render: ({ attrs }) => {
+            const { text, level } = attrs as {
+              readonly text: string;
+              readonly level: 1 | 2 | 3 | 4 | 5 | 6;
+            };
+            const Tag = `h${level}` as const;
+            return <Tag>{text}</Tag>;
+          },
+        },
+      ]);
+      const tree: readonly BlockNode[] = [
+        {
+          id: "1",
+          name: "core/section",
+          attrs: {
+            content: [
+              {
+                id: "2",
+                name: "core/heading",
+                attrs: { text: "Inside", level: 2 },
+              },
+            ],
+          },
+        },
+      ];
+
+      renderToStaticMarkup(
+        renderBlockTree(tree, registry, {
+          hooks: {
+            beforeRender: (node, context) => {
+              captured.push({
+                name: node.name,
+                parent: context.parent,
+                depth: context.depth,
+              });
+            },
+          },
+        }),
+      );
+
+      expect(captured).toEqual([
+        { name: "core/section", parent: null, depth: 0 },
+        { name: "core/heading", parent: "core/section", depth: 1 },
+      ]);
+    });
+  });
+
+  describe("BlockNode serialization", () => {
+    test("preserves unknown nodes byte-identical through JSON round-trip", () => {
+      const tree: readonly BlockNode[] = [
+        { id: "1", name: "core/heading", attrs: { text: "Known", level: 2 } },
+        {
+          id: "2",
+          name: "acme/unknown",
+          attrs: { foo: "bar", nested: { x: 1 } },
+        },
+        { id: "3", name: "core/heading", attrs: { text: "After", level: 2 } },
+      ];
+
+      const roundtripped = JSON.parse(JSON.stringify(tree)) as readonly BlockNode[];
+
+      expect(roundtripped).toEqual(tree);
+    });
+  });
+
   describe("in development", () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -14,8 +14,14 @@ export interface BlockNode {
   readonly style?: ResponsiveStyleSlot;
 }
 
+export interface BlockRenderHooks {
+  readonly beforeRender?: (node: BlockNode, context: BlockContext) => void;
+  readonly afterRender?: (node: BlockNode, context: BlockContext) => void;
+}
+
 export interface RenderBlockTreeOptions {
   readonly tokens?: ThemeTokens;
+  readonly hooks?: BlockRenderHooks;
 }
 
 export interface BlockNodeRenderProps<
@@ -85,13 +91,21 @@ function materializeSlots(
   devState: DevWarnState,
   childContext: BlockContext,
   tokens: ThemeTokens | undefined,
+  hooks: BlockRenderHooks | undefined,
 ): Readonly<Record<string, unknown>> {
   let materialized: Record<string, unknown> | undefined;
   for (const [key, value] of Object.entries(attrs)) {
     if (isBlockNodeArray(value)) {
       materialized ??= { ...attrs };
       materialized[key] = function SlotComponent() {
-        return renderNodes(value, registry, devState, childContext, tokens);
+        return renderNodes(
+          value,
+          registry,
+          devState,
+          childContext,
+          tokens,
+          hooks,
+        );
       };
     }
   }
@@ -104,15 +118,19 @@ function renderNodes(
   devState: DevWarnState,
   context: BlockContext,
   tokens: ThemeTokens | undefined,
+  hooks: BlockRenderHooks | undefined,
 ): ReactNode {
   return nodes.map((node) => {
+    hooks?.beforeRender?.(node, context);
     const spec = registry.get(node.name);
     if (!spec) {
-      return createElement(
+      const unknownNode = createElement(
         Fragment,
         { key: node.id },
         renderUnknown(node.name, devState),
       );
+      hooks?.afterRender?.(node, context);
+      return unknownNode;
     }
     const childContext: BlockContext = {
       ...context,
@@ -125,10 +143,13 @@ function renderNodes(
       devState,
       childContext,
       tokens,
+      hooks,
     );
     const rendered = createElement(spec.render, { attrs, context });
     if (spec.inline) {
-      return createElement(Fragment, { key: node.id }, rendered);
+      const inlineEl = createElement(Fragment, { key: node.id }, rendered);
+      hooks?.afterRender?.(node, context);
+      return inlineEl;
     }
     const safeId = SAFE_ID_RE.test(node.id) ? node.id : null;
     const styleCss =
@@ -139,7 +160,7 @@ function renderNodes(
     const styleTag = styleCss
       ? createElement("style", { key: "style" }, styleCss)
       : null;
-    return createElement(
+    const wrappedEl = createElement(
       "div",
       {
         key: node.id,
@@ -149,6 +170,8 @@ function renderNodes(
       styleTag,
       rendered,
     );
+    hooks?.afterRender?.(node, context);
+    return wrappedEl;
   });
 }
 
@@ -163,5 +186,6 @@ export function renderBlockTree(
     devWarnState(registry),
     DEFAULT_BLOCK_CONTEXT,
     options?.tokens,
+    options?.hooks,
   );
 }


### PR DESCRIPTION
Land slice #393 of the page-builder rearchitecture (PRD #379).

\`renderBlockTree\` accepts \`options.hooks\` with optional \`beforeRender\` and \`afterRender\` callbacks that fire around every block render — known and unknown alike. Hooks receive the current \`BlockNode\` and the parent's \`BlockContext\` (parent name + depth), so plugins (audit-log attribution, A/B test wrapping, image-optimization rewriting) can observe placement without re-walking the tree.

Three new hook tests + one round-trip invariant test. 12 turbo tasks pass.

**Hooks contract**

\`\`\`ts
renderBlockTree(tree, registry, {
  hooks: {
    beforeRender: (node, context) => { ... },
    afterRender: (node, context) => { ... },
  },
});
\`\`\`

Hooks fire in walker traversal order (depth-first), not in React commit order — appropriate for SSR plugins that need to inspect the tree as it's emitted. Both phases also fire for unknown blocks so plugins can detect and react to them.

**Out of scope**

- DOMPurify integration with the new walker — tracks with the html block migration in slice #399; the allowlist composition module already exists in \`packages/blocks/src/html/\`
- Hook return-value composition (decorate output, wrap with extra elements) — the current hook signature is observation-only; decoration semantics design in a later slice if real plugin demand emerges

Refs #393