### PR TITLE
feat(blocks): renderBlockSpecToHtml + renderBlockTreeToHtml test helpers

### DIFF
--- a/packages/blocks/src/test/index.ts
+++ b/packages/blocks/src/test/index.ts
@@ -117,3 +117,45 @@ export function mockEditor(input: MockEditorInput = {}): Editor {
 }
 
 export { DEFAULT_MARK_REGISTRY as defaultMarkRegistry, EMPTY_CONTEXT };
+
+// ─── New-walker helpers (slice #394) ────────────────────────────────────────
+//
+// These wrap the new BlockNode/BlockRegistry surface so block authors can
+// unit-test their `defineBlock` specs in isolation without touching the
+// legacy EntryContent path above. Once the legacy walker is deleted at
+// cutover (#405), the helpers above are removed and these become the
+// sole public surface.
+
+import type { BlockNode, BlockSpecV2, RenderBlockTreeOptions } from "../index.js";
+import { createBlockRegistry, renderBlockTree } from "../index.js";
+
+/**
+ * Render a single block spec in isolation and return its HTML output.
+ * Useful for asserting `defineBlock.render` output against attrs fixtures.
+ */
+export function renderBlockSpecToHtml(
+  spec: BlockSpecV2,
+  attrs?: Readonly<Record<string, unknown>>,
+  options?: RenderBlockTreeOptions,
+): string {
+  const registry = createBlockRegistry([spec]);
+  const node: BlockNode = {
+    id: "test-block",
+    name: spec.name,
+    attrs,
+  };
+  return renderToStaticMarkup(renderBlockTree([node], registry, options));
+}
+
+/**
+ * Render a tree of BlockNodes against a list of specs and return the HTML.
+ * Use for testing multi-block compositions (slots, ordering, context).
+ */
+export function renderBlockTreeToHtml(
+  specs: readonly BlockSpecV2[],
+  tree: readonly BlockNode[],
+  options?: RenderBlockTreeOptions,
+): string {
+  const registry = createBlockRegistry(specs);
+  return renderToStaticMarkup(renderBlockTree(tree, registry, options));
+}

--- a/packages/blocks/src/test/v2-helpers.test.tsx
+++ b/packages/blocks/src/test/v2-helpers.test.tsx
@@ -1,0 +1,73 @@
+import type { BlockNode, BlockSpecV2 } from "../index.js";
+import type { ReactNode } from "react";
+import { describe, expect, test } from "vitest";
+
+import { defineBlockSpec } from "../index.js";
+import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "./index.js";
+
+const sampleHeading: BlockSpecV2 = defineBlockSpec({
+  name: "sample/heading",
+  title: "Sample Heading",
+  defaults: { level: 2, text: "" },
+  render: ({ attrs }): ReactNode => {
+    const { level = 2, text = "" } = attrs as {
+      readonly level?: number;
+      readonly text?: string;
+    };
+    const tag = `h${level}`;
+    return <span data-test-tag={tag}>{text}</span>;
+  },
+});
+
+describe("renderBlockSpecToHtml", () => {
+  test("renders the spec's component wrapped in the universal data-plumix-block div", () => {
+    const html = renderBlockSpecToHtml(sampleHeading, {
+      level: 2,
+      text: "Hello",
+    });
+
+    expect(html).toBe(
+      '<div data-plumix-block="sample/heading">' +
+        '<span data-test-tag="h2">Hello</span>' +
+        "</div>",
+    );
+  });
+
+  test("threads RenderBlockTreeOptions.tokens through to style emission", () => {
+    const sampleWithStyle: BlockSpecV2 = defineBlockSpec({
+      name: "sample/styled",
+      render: () => <span>x</span>,
+    });
+
+    const html = renderBlockSpecToHtml(
+      sampleWithStyle,
+      {},
+      { tokens: { spacing: { lg: { value: "24px" } } } },
+    );
+
+    // No style declared on the node; nothing emitted regardless of tokens.
+    expect(html).toBe('<div data-plumix-block="sample/styled"><span>x</span></div>');
+  });
+});
+
+describe("renderBlockTreeToHtml", () => {
+  test("renders multiple blocks against a multi-spec registry", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "1",
+        name: "sample/heading",
+        attrs: { level: 2, text: "First" },
+      },
+      {
+        id: "2",
+        name: "sample/heading",
+        attrs: { level: 3, text: "Second" },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml([sampleHeading], tree);
+
+    expect(html).toContain('data-test-tag="h2">First');
+    expect(html).toContain('data-test-tag="h3">Second');
+  });
+});

--- a/packages/plumix/src/blocks/test.ts
+++ b/packages/plumix/src/blocks/test.ts
@@ -4,5 +4,7 @@ export {
   mockMarkRegistry,
   mockRegistry,
   renderBlock,
+  renderBlockSpecToHtml,
+  renderBlockTreeToHtml,
   validateContent,
 } from "@plumix/blocks/test";


### PR DESCRIPTION
Land slice #394 of the page-builder rearchitecture (PRD #379).

Two new helpers in \`@plumix/blocks/test\` (re-exported via \`plumix/blocks/test\`) so block authors can assert their \`defineBlock\` specs without hand-rolling a registry + walker invocation each test:

\`\`\`ts
import { defineBlockSpec } from "plumix/blocks";
import { renderBlockSpecToHtml } from "plumix/blocks/test";

const myBlock = defineBlockSpec({
  name: "acme/widget",
  render: ({ attrs }) => <span>{(attrs as { label?: string }).label}</span>,
});

test("renders the widget", () => {
  expect(renderBlockSpecToHtml(myBlock, { label: "hi" })).toBe(
    '<div data-plumix-block="acme/widget"><span>hi</span></div>',
  );
});
\`\`\`

\`renderBlockTreeToHtml(specs, tree, options?)\` covers multi-block compositions, slot rendering, and BlockContext threading.

Legacy \`mockRegistry\` / \`renderBlock\` / \`mockMarkRegistry\` helpers stay until cutover (#405). The umbrella \`plumix/blocks/test\` subpath re-exports both old and new.

Refs #394