### PR TITLE
feat(blocks): migrate quote/code/separator to v2 defineBlock surface

### DIFF
--- a/packages/blocks/src/code/v2.test.tsx
+++ b/packages/blocks/src/code/v2.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml } from "../test/index.js";
+import { codeBlockV2 } from "./v2.js";
+
+describe("core/code v2", () => {
+  test("renders a <pre> with the code text when no language is set", () => {
+    const html = renderBlockSpecToHtml(codeBlockV2, {
+      text: "const x = 1;",
+    });
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/code"><pre>const x = 1;</pre></div>',
+    );
+  });
+
+  test("wraps the text in <code data-language> when a language is provided", () => {
+    const html = renderBlockSpecToHtml(codeBlockV2, {
+      text: "fn main() {}",
+      language: "rust",
+    });
+
+    expect(html).toContain('data-language="rust"');
+    expect(html).toContain('<code data-language="rust">fn main() {}</code>');
+  });
+
+  test("treats whitespace-only language as no language", () => {
+    const html = renderBlockSpecToHtml(codeBlockV2, {
+      text: "noop",
+      language: "   ",
+    });
+
+    expect(html).not.toContain("<code");
+    expect(html).not.toContain("data-language");
+  });
+});

--- a/packages/blocks/src/code/v2.tsx
+++ b/packages/blocks/src/code/v2.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+export const codeBlockV2 = defineBlock({
+  name: "core/code",
+  title: "Code",
+  icon: "Code",
+  category: "text",
+  inputs: [
+    { name: "text", type: "textarea", label: "Code" },
+    { name: "language", type: "text", label: "Language" },
+  ],
+  defaults: { text: "", language: "" },
+  render: ({ attrs }): ReactNode => {
+    const { text = "", language = "" } = attrs as {
+      readonly text?: string;
+      readonly language?: string;
+    };
+    const trimmed = language.trim();
+    return (
+      <pre data-language={trimmed.length > 0 ? trimmed : undefined}>
+        {trimmed.length > 0 ? (
+          <code data-language={trimmed}>{text}</code>
+        ) : (
+          text
+        )}
+      </pre>
+    );
+  },
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -71,6 +71,9 @@ export type {
   TokenCategory,
 } from "./styles/style-emitter.js";
 export { paragraphBlockV2 } from "./paragraph/v2.js";
+export { quoteBlockV2 } from "./quote/v2.js";
+export { codeBlockV2 } from "./code/v2.js";
+export { separatorBlockV2 } from "./separator/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";
 export { PlumixIslandBootstrap } from "./island-bootstrap.js";

--- a/packages/blocks/src/quote/v2.test.tsx
+++ b/packages/blocks/src/quote/v2.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml } from "../test/index.js";
+import { quoteBlockV2 } from "./v2.js";
+
+describe("core/quote v2", () => {
+  test("renders a blockquote with the text", () => {
+    const html = renderBlockSpecToHtml(quoteBlockV2, {
+      text: "To be or not to be",
+    });
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/quote"><blockquote>To be or not to be</blockquote></div>',
+    );
+  });
+
+  test("renders the cite attribute when citation is provided", () => {
+    const html = renderBlockSpecToHtml(quoteBlockV2, {
+      text: "I think therefore I am",
+      citation: "https://example.com/descartes",
+    });
+
+    expect(html).toContain('cite="https://example.com/descartes"');
+    expect(html).toContain("I think therefore I am");
+  });
+
+  test("omits cite when citation is empty", () => {
+    const html = renderBlockSpecToHtml(quoteBlockV2, { text: "Quiet" });
+
+    expect(html).not.toContain("cite=");
+  });
+});

--- a/packages/blocks/src/quote/v2.tsx
+++ b/packages/blocks/src/quote/v2.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+export const quoteBlockV2 = defineBlock({
+  name: "core/quote",
+  title: "Quote",
+  icon: "Quote",
+  category: "text",
+  inputs: [
+    { name: "text", type: "text", label: "Quote" },
+    { name: "citation", type: "text", label: "Citation" },
+  ],
+  defaults: { text: "", citation: "" },
+  render: ({ attrs }): ReactNode => {
+    const { text = "", citation = "" } = attrs as {
+      readonly text?: string;
+      readonly citation?: string;
+    };
+    return (
+      <blockquote cite={citation.length > 0 ? citation : undefined}>
+        {text}
+      </blockquote>
+    );
+  },
+});

--- a/packages/blocks/src/separator/v2.test.tsx
+++ b/packages/blocks/src/separator/v2.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml } from "../test/index.js";
+import { separatorBlockV2 } from "./v2.js";
+
+describe("core/separator v2", () => {
+  test("renders an <hr> with the solid variant by default", () => {
+    const html = renderBlockSpecToHtml(separatorBlockV2, {});
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/separator"><hr data-variant="solid"/></div>',
+    );
+  });
+
+  test("renders the declared variant when valid", () => {
+    const html = renderBlockSpecToHtml(separatorBlockV2, {
+      variant: "dashed",
+    });
+
+    expect(html).toContain('data-variant="dashed"');
+  });
+
+  test("falls back to solid for an unknown variant", () => {
+    const html = renderBlockSpecToHtml(separatorBlockV2, {
+      variant: "wavy",
+    });
+
+    expect(html).toContain('data-variant="solid"');
+  });
+});

--- a/packages/blocks/src/separator/v2.tsx
+++ b/packages/blocks/src/separator/v2.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+const VARIANTS = ["solid", "dashed", "dotted", "wide"] as const;
+type SeparatorVariant = (typeof VARIANTS)[number];
+
+function pickVariant(raw: unknown): SeparatorVariant {
+  return typeof raw === "string" && (VARIANTS as readonly string[]).includes(raw)
+    ? (raw as SeparatorVariant)
+    : "solid";
+}
+
+export const separatorBlockV2 = defineBlock({
+  name: "core/separator",
+  title: "Separator",
+  icon: "Minus",
+  category: "text",
+  inputs: [
+    {
+      name: "variant",
+      type: "select",
+      label: "Variant",
+      options: VARIANTS.map((v) => ({ label: v, value: v })),
+    },
+  ],
+  defaults: { variant: "solid" },
+  render: ({ attrs }): ReactNode => {
+    return <hr data-variant={pickVariant(attrs.variant)} />;
+  },
+});


### PR DESCRIPTION
Land slice #392 of the page-builder rearchitecture (PRD #379).

Three text-category core blocks ported to the new \`defineBlock\` surface, each in a \`v2.tsx\` file parallel to the legacy implementation (same pattern as \`paragraph/v2.tsx\`; full deletion at cutover #405):

- \`core/quote\` → \`<blockquote cite={…}>{text}</blockquote>\`
- \`core/code\` → \`<pre>{text}</pre>\` or \`<pre><code data-language=…>{text}</code></pre>\` when a language is set
- \`core/separator\` → \`<hr data-variant=…>\`, with variant defaulting to \`solid\` and falling back to it for unknown values

Three colocated v2.test.tsx suites exercise each block end-to-end through \`renderBlockSpecToHtml\`. The richtext mark surface (inline bold/italic/etc.) inside quote and code tracks with Puck's richtext field integration in a later slice; the v2 blocks accept plain text via their \`text\` attr until then.

Refs #392