### PR TITLE
feat(blocks): walker emits hydration script for client-descriptor blocks

### DIFF
--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -12,6 +12,10 @@ export interface BlockInput {
   readonly options?: readonly BlockInputOption[];
 }
 
+export interface ClientIslandDescriptor {
+  readonly script: string;
+}
+
 export interface BlockSpec<
   Attrs extends Readonly<Record<string, unknown>> = Readonly<
     Record<string, unknown>
@@ -27,6 +31,7 @@ export interface BlockSpec<
   readonly defaults?: Readonly<Partial<Attrs>>;
   readonly placeholder?: string;
   readonly capability?: string;
+  readonly client?: ClientIslandDescriptor;
 }
 
 export interface BlockRegistry {

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -60,6 +60,7 @@ export type {
   BlockInputOption,
   BlockRegistry as BlockRegistryV2,
   BlockSpec as BlockSpecV2,
+  ClientIslandDescriptor,
 } from "./block-registry.js";
 export {
   emitBlockStyleCss,

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -301,6 +301,61 @@ describe("renderBlockTree", () => {
     expect(html).not.toContain("data-plumix-block");
   });
 
+  describe("client islands", () => {
+    test("emits a <script type='module'> next to the wrapper when spec.client is declared", () => {
+      const registry = createBlockRegistry([
+        {
+          name: "acme/carousel",
+          render: () => <div className="carousel" />,
+          client: { script: "/assets/carousel.js" },
+        },
+      ]);
+      const tree: readonly BlockNode[] = [
+        { id: "c1", name: "acme/carousel", attrs: {} },
+      ];
+
+      const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+      expect(html).toContain('data-plumix-block="acme/carousel"');
+      expect(html).toContain(
+        '<script type="module" src="/assets/carousel.js"></script>',
+      );
+    });
+
+    test("emits one script per block instance for multiple instances of the same client block", () => {
+      const registry = createBlockRegistry([
+        {
+          name: "acme/carousel",
+          render: () => <div />,
+          client: { script: "/assets/carousel.js" },
+        },
+      ]);
+      const tree: readonly BlockNode[] = [
+        { id: "c1", name: "acme/carousel", attrs: {} },
+        { id: "c2", name: "acme/carousel", attrs: {} },
+      ];
+
+      const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+      const scriptMatches = html.match(/<script[^>]*src="\/assets\/carousel.js"/g);
+      expect(scriptMatches).toHaveLength(2);
+    });
+
+    test("does not emit a script for blocks without spec.client", () => {
+      const heading: BlockNode = {
+        id: "h1",
+        name: "core/heading",
+        attrs: { text: "no js", level: 2 },
+      };
+
+      const html = renderToStaticMarkup(
+        renderBlockTree([heading], headingRegistry),
+      );
+
+      expect(html).not.toContain("<script");
+    });
+  });
+
   describe("render hooks", () => {
     test("fires beforeRender and afterRender around each block render", () => {
       const events: { phase: "before" | "after"; nodeName: string }[] = [];

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -170,6 +170,20 @@ function renderNodes(
       styleTag,
       rendered,
     );
+    if (spec.client) {
+      const hydrationScript = createElement("script", {
+        key: "client-island",
+        type: "module",
+        src: spec.client.script,
+      });
+      hooks?.afterRender?.(node, context);
+      return createElement(
+        Fragment,
+        { key: node.id },
+        wrappedEl,
+        hydrationScript,
+      );
+    }
     hooks?.afterRender?.(node, context);
     return wrappedEl;
   });


### PR DESCRIPTION
Lock the walker-side contract for slice #388 (client islands) in PRD #379.

\`BlockSpec\` gains \`client?: ClientIslandDescriptor { script: string }\`. When set, \`renderBlockTree\` emits a \`<script type=\"module\" src={…}>\` next to each block instance's wrapper:

\`\`\`tsx
defineBlock({
  name: \"acme/carousel\",
  client: { script: \"/assets/carousel.js\" },
  render: () => <div className=\"carousel\" />,
});
\`\`\`

becomes:

\`\`\`html
<div data-plumix-block=\"acme/carousel\"><div class=\"carousel\"></div></div>
<script type=\"module\" src=\"/assets/carousel.js\"></script>
\`\`\`

Per-instance script emission (N instances → N script tags) is the contract that lets each block hydrate independently. Three tests cover this.

**Scope split** — full \`media/embed\` migration (URL-safelist, parsePaste handlers, the four other media blocks) lives in slice #401 where the whole \`@plumix/plugin-media\` block surface ports together. The walker contract this slice locks in is what #401 builds against.

Refs #388