### PR TITLE
feat(admin): puck editor chrome — header + left tabs + Puck.Preview + Fields

### DIFF
--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -1,0 +1,79 @@
+import type { ReactElement, ReactNode } from "react";
+import { Puck } from "@puckeditor/core";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.js";
+
+interface PlumixEditorLayoutProps {
+  readonly children?: ReactNode;
+}
+
+export function PlumixEditorLayout(
+  _props: PlumixEditorLayoutProps,
+): ReactElement {
+  return (
+    <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
+      <header
+        className="flex items-center gap-3 border-b px-4 py-2"
+        data-testid="plumix-editor-header"
+      >
+        <input
+          type="text"
+          placeholder="Untitled"
+          className="flex-1 bg-transparent outline-none"
+          data-testid="plumix-editor-title-input"
+        />
+        <span
+          className="rounded bg-muted px-2 py-1 text-xs"
+          data-testid="plumix-editor-status-pill"
+        >
+          Draft
+        </span>
+        <button
+          type="button"
+          className="rounded border px-3 py-1 text-sm"
+          data-testid="plumix-editor-publish-button"
+        >
+          Publish
+        </button>
+      </header>
+      <div
+        className="grid flex-1 grid-cols-[260px_1fr_320px] overflow-hidden"
+        data-testid="plumix-editor-cols"
+      >
+        <aside
+          className="overflow-y-auto border-r"
+          data-testid="plumix-editor-left"
+        >
+          <Tabs defaultValue="blocks" className="h-full">
+            <TabsList className="w-full">
+              <TabsTrigger value="blocks" data-testid="plumix-editor-tab-blocks">
+                Blocks
+              </TabsTrigger>
+              <TabsTrigger value="outline" data-testid="plumix-editor-tab-outline">
+                Outline
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="blocks">
+              <Puck.Components />
+            </TabsContent>
+            <TabsContent value="outline">
+              <Puck.Outline />
+            </TabsContent>
+          </Tabs>
+        </aside>
+        <main
+          className="overflow-auto"
+          data-testid="plumix-editor-canvas"
+        >
+          <Puck.Preview />
+        </main>
+        <aside
+          className="overflow-y-auto border-l"
+          data-testid="plumix-editor-right"
+        >
+          <Puck.Fields />
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -4,6 +4,8 @@ import { Puck } from "@puckeditor/core";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 
+import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
+
 import "@puckeditor/core/puck.css";
 
 interface HeadingProps {
@@ -53,6 +55,7 @@ function PuckSpikeRoute(): ReactNode {
       data={data}
       onPublish={setData}
       onChange={setData}
+      overrides={{ puck: PlumixEditorLayout }}
     />
   );
 }


### PR DESCRIPTION
Land the minimum-viable editor chrome for slice #383 of the page-builder rearchitecture (PRD #379).

\`PlumixEditorLayout\` wires into Puck via \`overrides.puck\` on the spike route. Three-column grid under a fixed top header — every container carries a \`data-testid\` so the Playwright suites that arrive with #15 (a11y) and #18 (media block screenshots) target the chrome structurally:

\`\`\`
┌──────────── plumix-editor-header ────────────┐
│  [ title input ]  [Draft]  [Publish]         │
├──────────────────────────────────────────────┤
│ plumix-editor-left │ canvas │ plumix-…right  │
│  ┌──────────────┐  │        │  ┌──────────┐  │
│  │Blocks │Outline│  │ Puck   │  │ Puck     │  │
│  ├──────────────┤  │.Preview│  │.Fields   │  │
│  │ <Components>│  │        │  └──────────┘  │
│  │  or Outline │  │        │                │
│  └──────────────┘  │        │                │
└──────────────────────────────────────────────┘
\`\`\`

**Slice carve-outs** (each tracked in its own follow-up):

- Audit tab body (heading-structure analyzer) — slice #389
- Block / Style right-tab split + token-driven Style controls — slice #387
- Save / Publish wiring + revisions dropdown — slice #391
- Viewport relabel to Mobile/Tablet/Desktop/Wide + active-viewport ↔ Style-bucket binding — slice #387 (composes with the Style tab)
- Screenshot baseline tests for the chrome — slice #15 (a11y pass)

Refs #383