### PR TITLE
feat(blocks,admin): slot field translator + columns/group v2 migrations

### DIFF
--- a/packages/admin/src/editor/v2/field-type-translator.test.ts
+++ b/packages/admin/src/editor/v2/field-type-translator.test.ts
@@ -40,6 +40,13 @@ describe("translateField", () => {
     });
   });
 
+  test("maps slot to Puck's slot field type", () => {
+    expect(translateField({ name: "content", type: "slot", label: "Body" })).toEqual({
+      type: "slot",
+      label: "Body",
+    });
+  });
+
   test("falls back to text for unknown field types", () => {
     expect(
       translateField({ name: "x", type: "wat", label: "Unknown" }),

--- a/packages/admin/src/editor/v2/field-type-translator.ts
+++ b/packages/admin/src/editor/v2/field-type-translator.ts
@@ -19,6 +19,8 @@ export function translateField(
           value: opt.value,
         })),
       };
+    case "slot":
+      return { type: "slot", label: input.label };
     default:
       return { type: "text", label: input.label };
   }

--- a/packages/blocks/src/columns/v2.test.tsx
+++ b/packages/blocks/src/columns/v2.test.tsx
@@ -1,0 +1,60 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { describe, expect, test } from "vitest";
+
+import { renderBlockTreeToHtml } from "../test/index.js";
+import { paragraphBlockV2 } from "../paragraph/v2.js";
+import { columnsBlockV2 } from "./v2.js";
+
+describe("core/columns v2", () => {
+  test("renders an empty two-column layout with the default gap", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "c1", name: "core/columns", attrs: {} },
+    ];
+
+    const html = renderBlockTreeToHtml([columnsBlockV2], tree);
+
+    expect(html).toContain('data-plumix-columns="true"');
+    expect(html).toContain('data-gap="md"');
+    expect(html).toContain('data-plumix-column="left"');
+    expect(html).toContain('data-plumix-column="right"');
+  });
+
+  test("renders the declared gap when valid", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "c1", name: "core/columns", attrs: { gap: "lg" } },
+    ];
+
+    const html = renderBlockTreeToHtml([columnsBlockV2], tree);
+
+    expect(html).toContain('data-gap="lg"');
+  });
+
+  test("renders nested blocks in their respective slot columns", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "c1",
+        name: "core/columns",
+        attrs: {
+          left: [
+            { id: "p1", name: "core/paragraph", attrs: { text: "L" } },
+          ],
+          right: [
+            { id: "p2", name: "core/paragraph", attrs: { text: "R" } },
+          ],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml(
+      [columnsBlockV2, paragraphBlockV2],
+      tree,
+    );
+
+    expect(html).toContain(
+      '<div data-plumix-column="left"><div data-plumix-block="core/paragraph"><p>L</p></div></div>',
+    );
+    expect(html).toContain(
+      '<div data-plumix-column="right"><div data-plumix-block="core/paragraph"><p>R</p></div></div>',
+    );
+  });
+});

--- a/packages/blocks/src/columns/v2.tsx
+++ b/packages/blocks/src/columns/v2.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+const GAPS = ["sm", "md", "lg"] as const;
+type Gap = (typeof GAPS)[number];
+
+function pickGap(raw: unknown): Gap {
+  return typeof raw === "string" && (GAPS as readonly string[]).includes(raw)
+    ? (raw as Gap)
+    : "md";
+}
+
+export const columnsBlockV2 = defineBlock({
+  name: "core/columns",
+  title: "Columns",
+  icon: "Columns",
+  category: "layout",
+  inputs: [
+    {
+      name: "gap",
+      type: "select",
+      label: "Gap",
+      options: GAPS.map((v) => ({ label: v, value: v })),
+    },
+    { name: "left", type: "slot", label: "Left column" },
+    { name: "right", type: "slot", label: "Right column" },
+  ],
+  defaults: { gap: "md" },
+  render: ({ attrs }): ReactNode => {
+    const gap = pickGap(attrs.gap);
+    const Left = attrs.left as (() => ReactNode) | undefined;
+    const Right = attrs.right as (() => ReactNode) | undefined;
+    return (
+      <div data-plumix-columns data-gap={gap}>
+        <div data-plumix-column="left">{Left ? <Left /> : null}</div>
+        <div data-plumix-column="right">{Right ? <Right /> : null}</div>
+      </div>
+    );
+  },
+});

--- a/packages/blocks/src/group/v2.test.tsx
+++ b/packages/blocks/src/group/v2.test.tsx
@@ -1,0 +1,57 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { describe, expect, test } from "vitest";
+
+import { renderBlockTreeToHtml } from "../test/index.js";
+import { paragraphBlockV2 } from "../paragraph/v2.js";
+import { groupBlockV2 } from "./v2.js";
+
+describe("core/group v2", () => {
+  test("renders an empty group with the default flow layout", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "g1", name: "core/group", attrs: {} },
+    ];
+
+    const html = renderBlockTreeToHtml([groupBlockV2], tree);
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/group"><div data-layout="flow"></div></div>',
+    );
+  });
+
+  test("renders the declared layout when valid", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "g1", name: "core/group", attrs: { layout: "flex-row" } },
+    ];
+
+    const html = renderBlockTreeToHtml([groupBlockV2], tree);
+
+    expect(html).toContain('data-layout="flex-row"');
+  });
+
+  test("renders nested blocks from the content slot", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "g1",
+        name: "core/group",
+        attrs: {
+          content: [
+            {
+              id: "p1",
+              name: "core/paragraph",
+              attrs: { text: "Inside group" },
+            },
+          ],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml(
+      [groupBlockV2, paragraphBlockV2],
+      tree,
+    );
+
+    expect(html).toContain(
+      '<div data-plumix-block="core/paragraph"><p>Inside group</p></div>',
+    );
+  });
+});

--- a/packages/blocks/src/group/v2.tsx
+++ b/packages/blocks/src/group/v2.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+const LAYOUTS = ["flow", "flex-row", "flex-column", "grid"] as const;
+type GroupLayout = (typeof LAYOUTS)[number];
+
+function pickLayout(raw: unknown): GroupLayout {
+  return typeof raw === "string" && (LAYOUTS as readonly string[]).includes(raw)
+    ? (raw as GroupLayout)
+    : "flow";
+}
+
+export const groupBlockV2 = defineBlock({
+  name: "core/group",
+  title: "Group",
+  icon: "Group",
+  category: "layout",
+  inputs: [
+    {
+      name: "layout",
+      type: "select",
+      label: "Layout",
+      options: LAYOUTS.map((v) => ({ label: v, value: v })),
+    },
+    { name: "content", type: "slot", label: "Content" },
+  ],
+  defaults: { layout: "flow" },
+  render: ({ attrs }): ReactNode => {
+    const layout = pickLayout(attrs.layout);
+    const Content = attrs.content as (() => ReactNode) | undefined;
+    return (
+      <div data-layout={layout}>{Content ? <Content /> : null}</div>
+    );
+  },
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -75,6 +75,8 @@ export { paragraphBlockV2 } from "./paragraph/v2.js";
 export { quoteBlockV2 } from "./quote/v2.js";
 export { codeBlockV2 } from "./code/v2.js";
 export { separatorBlockV2 } from "./separator/v2.js";
+export { groupBlockV2 } from "./group/v2.js";
+export { columnsBlockV2 } from "./columns/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";
 export { PlumixIslandBootstrap } from "./island-bootstrap.js";


### PR DESCRIPTION
Land slice #384 of the page-builder rearchitecture (PRD #379).

Two pieces:

**Admin — slot field translator.** \`field-type-translator.ts\` maps \`type: \"slot\"\` block inputs to Puck's native slot field. Slot-typed inputs declared on \`defineBlock\` now flow straight through the adapter into Puck without further glue.

**Blocks — \`core/columns\` + \`core/group\` v2.** Following the \`paragraph/v2.tsx\` coexistence pattern (legacy files unchanged; both retire at cutover #405):

\`\`\`tsx
defineBlock({
  name: \"core/columns\",
  inputs: [
    { name: \"gap\", type: \"select\", options: [...] },
    { name: \"left\", type: \"slot\", label: \"Left column\" },
    { name: \"right\", type: \"slot\", label: \"Right column\" },
  ],
  render: ({ attrs }) => {
    const Left = attrs.left as (() => ReactNode) | undefined;
    const Right = attrs.right as (() => ReactNode) | undefined;
    return (
      <div data-plumix-columns data-gap={gap}>
        <div data-plumix-column=\"left\">{Left ? <Left /> : null}</div>
        <div data-plumix-column=\"right\">{Right ? <Right /> : null}</div>
      </div>
    );
  },
});
\`\`\`

Six new tests cover the empty-block case, attr-driven variants (\`layout\` / \`gap\`), and end-to-end slot-rendering with paragraph-v2 children inside.

**Out of scope (slice carve-outs)**

- \`allow\` / \`disallow\` slot restrictions — needs a separate walker-side gate and the Puck slot field's prop forwarding. Tracks in a smaller follow-up.
- A standalone \`section\` block — the existing codebase doesn't ship one; the group with \`flow\` layout already covers single-slot wrapping.
- Editor-side drag-into-slot screenshot tests — slice #15 / #16 (a11y + mobile responsive screenshots).

Refs #384