### PR TITLE
feat(blocks): migrate details/callout to v2 defineBlock surface

### DIFF
--- a/packages/blocks/src/callout/v2.test.tsx
+++ b/packages/blocks/src/callout/v2.test.tsx
@@ -1,0 +1,50 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "../test/index.js";
+import { paragraphBlockV2 } from "../paragraph/v2.js";
+import { calloutBlockV2 } from "./v2.js";
+
+describe("core/callout v2", () => {
+  test("renders an <aside role=note> with the info variant by default", () => {
+    const html = renderBlockSpecToHtml(calloutBlockV2, {});
+
+    expect(html).toContain('role="note"');
+    expect(html).toContain('data-variant="info"');
+  });
+
+  test("renders the declared variant when valid", () => {
+    const html = renderBlockSpecToHtml(calloutBlockV2, { variant: "warn" });
+
+    expect(html).toContain('data-variant="warn"');
+  });
+
+  test("falls back to info for an unknown variant", () => {
+    const html = renderBlockSpecToHtml(calloutBlockV2, { variant: "destructive" });
+
+    expect(html).toContain('data-variant="info"');
+  });
+
+  test("renders the icon attribute when provided", () => {
+    const html = renderBlockSpecToHtml(calloutBlockV2, { icon: "alert" });
+
+    expect(html).toContain('data-icon="alert"');
+  });
+
+  test("renders nested blocks from the content slot", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "c1",
+        name: "core/callout",
+        attrs: {
+          variant: "warn",
+          content: [{ id: "p1", name: "core/paragraph", attrs: { text: "Heads up" } }],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml([calloutBlockV2, paragraphBlockV2], tree);
+
+    expect(html).toContain("<p>Heads up</p>");
+  });
+});

--- a/packages/blocks/src/callout/v2.tsx
+++ b/packages/blocks/src/callout/v2.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+const VARIANTS = ["info", "warn", "error", "success", "note"] as const;
+type CalloutVariant = (typeof VARIANTS)[number];
+
+function pickVariant(raw: unknown): CalloutVariant {
+  return typeof raw === "string" && (VARIANTS as readonly string[]).includes(raw)
+    ? (raw as CalloutVariant)
+    : "info";
+}
+
+export const calloutBlockV2 = defineBlock({
+  name: "core/callout",
+  title: "Callout",
+  icon: "Megaphone",
+  category: "layout",
+  inputs: [
+    {
+      name: "variant",
+      type: "select",
+      label: "Variant",
+      options: VARIANTS.map((v) => ({ label: v, value: v })),
+    },
+    { name: "icon", type: "text", label: "Icon" },
+    { name: "content", type: "slot", label: "Content" },
+  ],
+  defaults: { variant: "info" },
+  render: ({ attrs }): ReactNode => {
+    const variant = pickVariant(attrs.variant);
+    const iconRaw = attrs.icon as string | undefined;
+    const icon = typeof iconRaw === "string" && iconRaw.length > 0 ? iconRaw : undefined;
+    const Content = attrs.content as (() => ReactNode) | undefined;
+    return (
+      <aside role="note" data-variant={variant} data-icon={icon}>
+        {Content ? <Content /> : null}
+      </aside>
+    );
+  },
+});

--- a/packages/blocks/src/details/v2.test.tsx
+++ b/packages/blocks/src/details/v2.test.tsx
@@ -1,0 +1,42 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "../test/index.js";
+import { paragraphBlockV2 } from "../paragraph/v2.js";
+import { detailsBlockV2 } from "./v2.js";
+
+describe("core/details v2", () => {
+  test("falls back to 'Details' summary when summary is empty", () => {
+    const html = renderBlockSpecToHtml(detailsBlockV2, {});
+
+    expect(html).toContain("<summary>Details</summary>");
+    expect(html).not.toContain("open=");
+  });
+
+  test("renders the declared summary and opens when open=true", () => {
+    const html = renderBlockSpecToHtml(detailsBlockV2, {
+      summary: "Long version",
+      open: true,
+    });
+
+    expect(html).toContain("<summary>Long version</summary>");
+    expect(html).toContain('<details open=""');
+  });
+
+  test("renders nested blocks from the content slot", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "d1",
+        name: "core/details",
+        attrs: {
+          summary: "More",
+          content: [{ id: "p1", name: "core/paragraph", attrs: { text: "Hidden" } }],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml([detailsBlockV2, paragraphBlockV2], tree);
+
+    expect(html).toContain("<p>Hidden</p>");
+  });
+});

--- a/packages/blocks/src/details/v2.tsx
+++ b/packages/blocks/src/details/v2.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+const DEFAULT_SUMMARY = "Details";
+
+export const detailsBlockV2 = defineBlock({
+  name: "core/details",
+  title: "Details",
+  icon: "ChevronDown",
+  category: "layout",
+  inputs: [
+    { name: "summary", type: "text", label: "Summary" },
+    { name: "open", type: "checkbox", label: "Open by default" },
+    { name: "content", type: "slot", label: "Content" },
+  ],
+  defaults: { summary: "", open: false },
+  render: ({ attrs }): ReactNode => {
+    const summaryRaw = attrs.summary as string | undefined;
+    const summary =
+      typeof summaryRaw === "string" && summaryRaw.length > 0
+        ? summaryRaw
+        : DEFAULT_SUMMARY;
+    const open = attrs.open === true;
+    const Content = attrs.content as (() => ReactNode) | undefined;
+    return (
+      <details open={open}>
+        <summary>{summary}</summary>
+        {Content ? <Content /> : null}
+      </details>
+    );
+  },
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -77,6 +77,8 @@ export { codeBlockV2 } from "./code/v2.js";
 export { separatorBlockV2 } from "./separator/v2.js";
 export { groupBlockV2 } from "./group/v2.js";
 export { columnsBlockV2 } from "./columns/v2.js";
+export { detailsBlockV2 } from "./details/v2.js";
+export { calloutBlockV2 } from "./callout/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";
 export { PlumixIslandBootstrap } from "./island-bootstrap.js";


### PR DESCRIPTION
Land slice #17b (layout blocks) of the page-builder rearchitecture (PRD #379).

Two layout-category core blocks ported via the \`paragraph/v2.tsx\` coexistence pattern. Both use a content slot for nested blocks:

- \`core/details\` → \`<details open?><summary>{summary}</summary>{children}</details>\`
- \`core/callout\` → \`<aside role=\"note\" data-variant data-icon>{children}</aside>\`

Eight tests across both blocks cover defaults, invalid-input fallback, slot rendering with paragraph-v2 children, and the role/data attribute output.

Refs #17b (issue tracked under the layout-blocks slice in PRD #379)