### PR TITLE
feat(blocks): migrate description-list family to v2 defineBlock

### DIFF
--- a/packages/blocks/src/description-list/v2.test.tsx
+++ b/packages/blocks/src/description-list/v2.test.tsx
@@ -1,0 +1,59 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "../test/index.js";
+import {
+  descriptionDetailBlockV2,
+  descriptionListBlockV2,
+  descriptionTermBlockV2,
+} from "./v2.js";
+
+describe("core/description-list family v2", () => {
+  test("renders an empty <dl> when no items are provided", () => {
+    const html = renderBlockSpecToHtml(descriptionListBlockV2, {});
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/description-list"><dl></dl></div>',
+    );
+  });
+
+  test("renders <dt> with the term text", () => {
+    const html = renderBlockSpecToHtml(descriptionTermBlockV2, { text: "Plumix" });
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/description-term"><dt>Plumix</dt></div>',
+    );
+  });
+
+  test("renders <dd> with the detail text", () => {
+    const html = renderBlockSpecToHtml(descriptionDetailBlockV2, { text: "A CMS" });
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/description-detail"><dd>A CMS</dd></div>',
+    );
+  });
+
+  test("renders a full dl with term + detail children via the items slot", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "dl1",
+        name: "core/description-list",
+        attrs: {
+          items: [
+            { id: "t1", name: "core/description-term", attrs: { text: "Plumix" } },
+            { id: "d1", name: "core/description-detail", attrs: { text: "A CMS" } },
+          ],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml(
+      [descriptionListBlockV2, descriptionTermBlockV2, descriptionDetailBlockV2],
+      tree,
+    );
+
+    expect(html).toContain("<dt>Plumix</dt>");
+    expect(html).toContain("<dd>A CMS</dd>");
+    expect(html).toContain("<dl>");
+  });
+});

--- a/packages/blocks/src/description-list/v2.tsx
+++ b/packages/blocks/src/description-list/v2.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+export const descriptionListBlockV2 = defineBlock({
+  name: "core/description-list",
+  title: "Description List",
+  icon: "List",
+  category: "text",
+  inputs: [{ name: "items", type: "slot", label: "Items" }],
+  defaults: {},
+  render: ({ attrs }): ReactNode => {
+    const Items = attrs.items as (() => ReactNode) | undefined;
+    return <dl>{Items ? <Items /> : null}</dl>;
+  },
+});
+
+export const descriptionTermBlockV2 = defineBlock({
+  name: "core/description-term",
+  title: "Term",
+  icon: "Type",
+  category: "text",
+  inputs: [{ name: "text", type: "text", label: "Term" }],
+  defaults: { text: "" },
+  render: ({ attrs }): ReactNode => {
+    const { text = "" } = attrs as { readonly text?: string };
+    return <dt>{text}</dt>;
+  },
+});
+
+export const descriptionDetailBlockV2 = defineBlock({
+  name: "core/description-detail",
+  title: "Detail",
+  icon: "AlignLeft",
+  category: "text",
+  inputs: [{ name: "text", type: "textarea", label: "Detail" }],
+  defaults: { text: "" },
+  render: ({ attrs }): ReactNode => {
+    const { text = "" } = attrs as { readonly text?: string };
+    return <dd>{text}</dd>;
+  },
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -82,6 +82,11 @@ export { calloutBlockV2 } from "./callout/v2.js";
 export { buttonBlockV2 } from "./button/v2.js";
 export { spacerBlockV2 } from "./spacer/v2.js";
 export { htmlBlockV2 } from "./html/v2.js";
+export {
+  descriptionDetailBlockV2,
+  descriptionListBlockV2,
+  descriptionTermBlockV2,
+} from "./description-list/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";
 export { PlumixIslandBootstrap } from "./island-bootstrap.js";


### PR DESCRIPTION
Continue slice #17c with the structured-text description-list family.

Three new specs in \`description-list/v2.tsx\`:

- \`descriptionListBlockV2\` — \`<dl>\` container with an \`items\` slot
- \`descriptionTermBlockV2\` — \`<dt>\` leaf, text input
- \`descriptionDetailBlockV2\` — \`<dd>\` leaf, textarea input

A nested composition test exercises \`dl > dt + dd\` end-to-end through the new walker + slot rendering.

Refs #17c