### PR TITLE
feat(blocks): table family v2 + retroactive senpai/simplifier review

### DIFF
--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -19,6 +19,7 @@ export function PlumixEditorLayout(
         <input
           type="text"
           placeholder="Untitled"
+          aria-label="Entry title"
           className="flex-1 bg-transparent outline-none"
           data-testid="plumix-editor-title-input"
         />

--- a/packages/admin/src/editor/v2/field-type-translator.ts
+++ b/packages/admin/src/editor/v2/field-type-translator.ts
@@ -21,7 +21,24 @@ export function translateField(
       };
     case "slot":
       return { type: "slot", label: input.label };
+    case "checkbox":
+      // Puck has no native checkbox; surface a radio with true/false options
+      // so the editor produces booleans rather than silently downgrading to a
+      // text input that returns strings the block's `=== true` check rejects.
+      return {
+        type: "radio",
+        label: input.label,
+        options: [
+          { label: "Yes", value: true },
+          { label: "No", value: false },
+        ],
+      };
     default:
+      if (typeof process !== "undefined" && process.env.NODE_ENV !== "production") {
+        console.warn(
+          `[plumix:admin] field-type-translator: unknown input type "${input.type}" — falling back to text. Register the type via ctx.registerFieldType or pick a Puck-native type.`,
+        );
+      }
       return { type: "text", label: input.label };
   }
 }

--- a/packages/blocks/src/button/v2.test.tsx
+++ b/packages/blocks/src/button/v2.test.tsx
@@ -32,6 +32,28 @@ describe("core/button v2", () => {
     expect(html).not.toContain("javascript:");
   });
 
+  test("adds rel='noopener noreferrer' when target='_blank' on a safe href", () => {
+    const html = renderBlockSpecToHtml(buttonBlockV2, {
+      label: "Open",
+      href: "https://example.com",
+      target: "_blank",
+    });
+
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  test("omits rel when target='_self' (default)", () => {
+    const html = renderBlockSpecToHtml(buttonBlockV2, {
+      label: "Same",
+      href: "https://example.com",
+      target: "_self",
+    });
+
+    expect(html).toContain('target="_self"');
+    expect(html).not.toContain("rel=");
+  });
+
   test("falls back to primary/md when variant/size are invalid", () => {
     const html = renderBlockSpecToHtml(buttonBlockV2, {
       label: "Click",

--- a/packages/blocks/src/button/v2.tsx
+++ b/packages/blocks/src/button/v2.tsx
@@ -4,6 +4,14 @@ import { defineBlock } from "../block-registry.js";
 
 const VARIANTS = ["primary", "secondary", "outline", "ghost"] as const;
 const SIZES = ["sm", "md", "lg"] as const;
+const TARGETS = ["_self", "_blank"] as const;
+type Target = (typeof TARGETS)[number];
+
+function pickTarget(raw: unknown): Target | undefined {
+  return typeof raw === "string" && (TARGETS as readonly string[]).includes(raw)
+    ? (raw as Target)
+    : undefined;
+}
 
 const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|#|\?|\.\.?\/)/i;
 
@@ -32,6 +40,12 @@ export const buttonBlockV2 = defineBlock({
     { name: "label", type: "text", label: "Label" },
     { name: "href", type: "text", label: "Href" },
     {
+      name: "target",
+      type: "select",
+      label: "Target",
+      options: TARGETS.map((t) => ({ label: t, value: t })),
+    },
+    {
       name: "variant",
       type: "select",
       label: "Variant",
@@ -48,11 +62,18 @@ export const buttonBlockV2 = defineBlock({
   render: ({ attrs }): ReactNode => {
     const label = (attrs.label as string | undefined) ?? "";
     const href = sanitizeHref(attrs.href);
+    const target = pickTarget(attrs.target);
     const variant = pickFrom(attrs.variant, VARIANTS, "primary");
     const size = pickFrom(attrs.size, SIZES, "md");
     if (href) {
       return (
-        <a href={href} data-variant={variant} data-size={size}>
+        <a
+          href={href}
+          target={target}
+          rel={target === "_blank" ? "noopener noreferrer" : undefined}
+          data-variant={variant}
+          data-size={size}
+        >
           {label}
         </a>
       );

--- a/packages/blocks/src/code/v2.tsx
+++ b/packages/blocks/src/code/v2.tsx
@@ -17,14 +17,10 @@ export const codeBlockV2 = defineBlock({
       readonly text?: string;
       readonly language?: string;
     };
-    const trimmed = language.trim();
+    const lang = language.trim() || undefined;
     return (
-      <pre data-language={trimmed.length > 0 ? trimmed : undefined}>
-        {trimmed.length > 0 ? (
-          <code data-language={trimmed}>{text}</code>
-        ) : (
-          text
-        )}
+      <pre data-language={lang}>
+        {lang ? <code data-language={lang}>{text}</code> : text}
       </pre>
     );
   },

--- a/packages/blocks/src/description-list/v2.test.tsx
+++ b/packages/blocks/src/description-list/v2.test.tsx
@@ -17,23 +17,19 @@ describe("core/description-list family v2", () => {
     );
   });
 
-  test("renders <dt> with the term text", () => {
+  test("renders <dt> with the term text, no universal wrapper (inline)", () => {
     const html = renderBlockSpecToHtml(descriptionTermBlockV2, { text: "Plumix" });
 
-    expect(html).toBe(
-      '<div data-plumix-block="core/description-term"><dt>Plumix</dt></div>',
-    );
+    expect(html).toBe("<dt>Plumix</dt>");
   });
 
-  test("renders <dd> with the detail text", () => {
+  test("renders <dd> with the detail text, no universal wrapper (inline)", () => {
     const html = renderBlockSpecToHtml(descriptionDetailBlockV2, { text: "A CMS" });
 
-    expect(html).toBe(
-      '<div data-plumix-block="core/description-detail"><dd>A CMS</dd></div>',
-    );
+    expect(html).toBe("<dd>A CMS</dd>");
   });
 
-  test("renders a full dl with term + detail children via the items slot", () => {
+  test("dt + dd nest as direct children of <dl> (preserves HTML content model)", () => {
     const tree: readonly BlockNode[] = [
       {
         id: "dl1",
@@ -52,8 +48,6 @@ describe("core/description-list family v2", () => {
       tree,
     );
 
-    expect(html).toContain("<dt>Plumix</dt>");
-    expect(html).toContain("<dd>A CMS</dd>");
-    expect(html).toContain("<dl>");
+    expect(html).toContain("<dl><dt>Plumix</dt><dd>A CMS</dd></dl>");
   });
 });

--- a/packages/blocks/src/description-list/v2.tsx
+++ b/packages/blocks/src/description-list/v2.tsx
@@ -20,6 +20,7 @@ export const descriptionTermBlockV2 = defineBlock({
   title: "Term",
   icon: "Type",
   category: "text",
+  inline: true,
   inputs: [{ name: "text", type: "text", label: "Term" }],
   defaults: { text: "" },
   render: ({ attrs }): ReactNode => {
@@ -33,6 +34,7 @@ export const descriptionDetailBlockV2 = defineBlock({
   title: "Detail",
   icon: "AlignLeft",
   category: "text",
+  inline: true,
   inputs: [{ name: "text", type: "textarea", label: "Detail" }],
   defaults: { text: "" },
   render: ({ attrs }): ReactNode => {

--- a/packages/blocks/src/html/v2.tsx
+++ b/packages/blocks/src/html/v2.tsx
@@ -1,7 +1,17 @@
+import type { BlockNodeRenderProps } from "../render-block-tree.js";
 import type { ReactNode } from "react";
 
 import { defineBlock } from "../block-registry.js";
-import { BASELINE_HTML_ALLOWLIST, sanitizeHtml } from "./sanitize.js";
+import { useHtmlAllowlist } from "./context.js";
+import { sanitizeHtml } from "./sanitize.js";
+
+function HtmlBlockV2Render({ attrs }: BlockNodeRenderProps): ReactNode {
+  const allowlist = useHtmlAllowlist();
+  const raw = (attrs.html as string | undefined) ?? "";
+  return (
+    <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(raw, allowlist) }} />
+  );
+}
 
 export const htmlBlockV2 = defineBlock({
   name: "core/html",
@@ -10,14 +20,5 @@ export const htmlBlockV2 = defineBlock({
   category: "interactive",
   inputs: [{ name: "html", type: "textarea", label: "HTML" }],
   defaults: { html: "" },
-  render: ({ attrs }): ReactNode => {
-    const raw = (attrs.html as string | undefined) ?? "";
-    return (
-      <div
-        dangerouslySetInnerHTML={{
-          __html: sanitizeHtml(raw, BASELINE_HTML_ALLOWLIST),
-        }}
-      />
-    );
-  },
+  render: HtmlBlockV2Render,
 });

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -87,6 +87,13 @@ export {
   descriptionListBlockV2,
   descriptionTermBlockV2,
 } from "./description-list/v2.js";
+export {
+  tableBlockV2,
+  tableBodyRowBlockV2,
+  tableCellBlockV2,
+  tableHeaderCellBlockV2,
+  tableHeaderRowBlockV2,
+} from "./table/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";
 export { PlumixIslandBootstrap } from "./island-bootstrap.js";

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -12,7 +12,11 @@ function withProductionEnv<T>(fn: () => T): T {
   try {
     return fn();
   } finally {
-    process.env.NODE_ENV = previous;
+    if (previous === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previous;
+    }
   }
 }
 
@@ -322,7 +326,7 @@ describe("renderBlockTree", () => {
       );
     });
 
-    test("emits one script per block instance for multiple instances of the same client block", () => {
+    test("dedupes the hydration script when multiple instances share a client.script URL", () => {
       const registry = createBlockRegistry([
         {
           name: "acme/carousel",
@@ -338,7 +342,11 @@ describe("renderBlockTree", () => {
       const html = renderToStaticMarkup(renderBlockTree(tree, registry));
 
       const scriptMatches = html.match(/<script[^>]*src="\/assets\/carousel.js"/g);
-      expect(scriptMatches).toHaveLength(2);
+      expect(scriptMatches).toHaveLength(1);
+      // Each instance still carries the island marker so the bootstrap can
+      // find every DOM anchor by name.
+      const islandMatches = html.match(/data-plumix-island="acme\/carousel"/g);
+      expect(islandMatches).toHaveLength(2);
     });
 
     test("does not emit a script for blocks without spec.client", () => {

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -14,6 +14,16 @@ export interface BlockNode {
   readonly style?: ResponsiveStyleSlot;
 }
 
+/**
+ * Walker-traversal hooks, fired at tree-construction time (NOT post-order).
+ * Both callbacks fire synchronously around each `BlockNode`'s React element
+ * construction — `beforeRender` immediately before, `afterRender` immediately
+ * after. Slot children render lazily inside React (the slot's `<Content />`
+ * invocation), so a parent's `afterRender` fires before its children's
+ * `beforeRender`. For plugins that need post-order semantics (decorate around
+ * children), this contract isn't the right primitive — observe the React
+ * tree directly instead.
+ */
 export interface BlockRenderHooks {
   readonly beforeRender?: (node: BlockNode, context: BlockContext) => void;
   readonly afterRender?: (node: BlockNode, context: BlockContext) => void;
@@ -120,73 +130,94 @@ function renderNodes(
   tokens: ThemeTokens | undefined,
   hooks: BlockRenderHooks | undefined,
 ): ReactNode {
+  const seenScripts = new Set<string>();
   return nodes.map((node) => {
     hooks?.beforeRender?.(node, context);
-    const spec = registry.get(node.name);
-    if (!spec) {
-      const unknownNode = createElement(
-        Fragment,
-        { key: node.id },
-        renderUnknown(node.name, devState),
-      );
-      hooks?.afterRender?.(node, context);
-      return unknownNode;
-    }
-    const childContext: BlockContext = {
-      ...context,
-      parent: node.name,
-      depth: context.depth + 1,
-    };
-    const attrs = materializeSlots(
-      node.attrs ?? {},
+    const result = renderNode(
+      node,
       registry,
       devState,
-      childContext,
+      context,
       tokens,
       hooks,
+      seenScripts,
     );
-    const rendered = createElement(spec.render, { attrs, context });
-    if (spec.inline) {
-      const inlineEl = createElement(Fragment, { key: node.id }, rendered);
-      hooks?.afterRender?.(node, context);
-      return inlineEl;
-    }
-    const safeId = SAFE_ID_RE.test(node.id) ? node.id : null;
-    const styleCss =
-      safeId && node.style && tokens
-        ? emitBlockStyleCss(`plumix-block-${safeId}`, node.style, tokens)
-        : "";
-    const className = styleCss ? `plumix-block-${safeId ?? ""}` : undefined;
-    const styleTag = styleCss
-      ? createElement("style", { key: "style" }, styleCss)
-      : null;
-    const wrappedEl = createElement(
-      "div",
-      {
-        key: node.id,
-        "data-plumix-block": node.name,
-        className,
-      },
-      styleTag,
-      rendered,
-    );
-    if (spec.client) {
-      const hydrationScript = createElement("script", {
-        key: "client-island",
-        type: "module",
-        src: spec.client.script,
-      });
-      hooks?.afterRender?.(node, context);
-      return createElement(
-        Fragment,
-        { key: node.id },
-        wrappedEl,
-        hydrationScript,
-      );
-    }
     hooks?.afterRender?.(node, context);
-    return wrappedEl;
+    return result;
   });
+}
+
+function renderNode(
+  node: BlockNode,
+  registry: BlockRegistry,
+  devState: DevWarnState,
+  context: BlockContext,
+  tokens: ThemeTokens | undefined,
+  hooks: BlockRenderHooks | undefined,
+  seenScripts: Set<string>,
+): ReactNode {
+  const spec = registry.get(node.name);
+  if (!spec) {
+    return createElement(
+      Fragment,
+      { key: node.id },
+      renderUnknown(node.name, devState),
+    );
+  }
+  const childContext: BlockContext = {
+    ...context,
+    parent: node.name,
+    depth: context.depth + 1,
+  };
+  const attrs = materializeSlots(
+    node.attrs ?? {},
+    registry,
+    devState,
+    childContext,
+    tokens,
+    hooks,
+  );
+  const rendered = createElement(spec.render, { attrs, context });
+  if (spec.inline) {
+    return createElement(Fragment, { key: node.id }, rendered);
+  }
+  const safeId = SAFE_ID_RE.test(node.id) ? node.id : null;
+  const styleCss =
+    safeId && node.style && tokens
+      ? emitBlockStyleCss(`plumix-block-${safeId}`, node.style, tokens)
+      : "";
+  const className = safeId && styleCss ? `plumix-block-${safeId}` : undefined;
+  const styleTag = styleCss
+    ? createElement("style", { key: "style" }, styleCss)
+    : null;
+  const wrappedEl = createElement(
+    "div",
+    {
+      key: node.id,
+      "data-plumix-block": node.name,
+      "data-plumix-island": spec.client ? node.name : undefined,
+      className,
+    },
+    styleTag,
+    rendered,
+  );
+  if (!spec.client) return wrappedEl;
+  // Dedupe per-renderNodes-call so N instances of the same client block ship
+  // one <script type="module">, not N. The module loader already dedupes
+  // execution by URL; this avoids shipping the tag at all for siblings.
+  if (seenScripts.has(spec.client.script)) return wrappedEl;
+  seenScripts.add(spec.client.script);
+  const hydrationScript = createElement("script", {
+    key: "client-island",
+    type: "module",
+    src: spec.client.script,
+  });
+  return createElement(
+    Fragment,
+    { key: node.id },
+    wrappedEl,
+    hydrationScript,
+  );
 }
 
 export function renderBlockTree(

--- a/packages/blocks/src/spacer/v2.tsx
+++ b/packages/blocks/src/spacer/v2.tsx
@@ -15,7 +15,7 @@ export const spacerBlockV2 = defineBlock({
   name: "core/spacer",
   title: "Spacer",
   icon: "Minus",
-  category: "interactive",
+  category: "layout",
   inputs: [{ name: "height", type: "number", label: "Height (px)" }],
   defaults: { height: DEFAULT_HEIGHT },
   render: ({ attrs }): ReactNode => {

--- a/packages/blocks/src/table/v2.test.tsx
+++ b/packages/blocks/src/table/v2.test.tsx
@@ -1,0 +1,105 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "../test/index.js";
+import {
+  tableBlockV2,
+  tableBodyRowBlockV2,
+  tableCellBlockV2,
+  tableHeaderCellBlockV2,
+  tableHeaderRowBlockV2,
+} from "./v2.js";
+
+describe("core/table family v2", () => {
+  test("renders an empty <table> with no striped/bordered attrs by default", () => {
+    const html = renderBlockSpecToHtml(tableBlockV2, {});
+
+    expect(html).toContain("<table>");
+    expect(html).not.toContain("data-striped");
+    expect(html).not.toContain("data-bordered");
+  });
+
+  test("renders striped + bordered when truthy", () => {
+    const html = renderBlockSpecToHtml(tableBlockV2, {
+      striped: true,
+      bordered: true,
+    });
+
+    expect(html).toContain('data-striped="true"');
+    expect(html).toContain('data-bordered="true"');
+  });
+
+  test("renders <th scope=col> for header-cell with align attr", () => {
+    const html = renderBlockSpecToHtml(tableHeaderCellBlockV2, {
+      text: "Name",
+      align: "center",
+    });
+
+    expect(html).toContain('<th scope="col"');
+    expect(html).toContain('data-align="center"');
+    expect(html).toContain("Name");
+  });
+
+  test("renders <td> for body cells", () => {
+    const html = renderBlockSpecToHtml(tableCellBlockV2, { text: "v1" });
+
+    expect(html).toContain("<td");
+    expect(html).toContain("v1");
+  });
+
+  test("renders a full table > header-row > th + body-row > td composition", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "t1",
+        name: "core/table",
+        attrs: {
+          rows: [
+            {
+              id: "hr",
+              name: "core/table-header-row",
+              attrs: {
+                cells: [
+                  {
+                    id: "th1",
+                    name: "core/table-header-cell",
+                    attrs: { text: "Col 1" },
+                  },
+                ],
+              },
+            },
+            {
+              id: "br",
+              name: "core/table-body-row",
+              attrs: {
+                cells: [
+                  {
+                    id: "td1",
+                    name: "core/table-cell",
+                    attrs: { text: "val 1" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml(
+      [
+        tableBlockV2,
+        tableHeaderRowBlockV2,
+        tableBodyRowBlockV2,
+        tableHeaderCellBlockV2,
+        tableCellBlockV2,
+      ],
+      tree,
+    );
+
+    expect(html).toContain("<table>");
+    expect(html).toContain('<tr data-header=""');
+    expect(html).toContain("<th");
+    expect(html).toContain("Col 1");
+    expect(html).toContain("val 1");
+  });
+});

--- a/packages/blocks/src/table/v2.test.tsx
+++ b/packages/blocks/src/table/v2.test.tsx
@@ -29,25 +29,22 @@ describe("core/table family v2", () => {
     expect(html).toContain('data-bordered="true"');
   });
 
-  test("renders <th scope=col> for header-cell with align attr", () => {
+  test("renders <th scope=col> for header-cell with align attr, no universal wrapper (inline)", () => {
     const html = renderBlockSpecToHtml(tableHeaderCellBlockV2, {
       text: "Name",
       align: "center",
     });
 
-    expect(html).toContain('<th scope="col"');
-    expect(html).toContain('data-align="center"');
-    expect(html).toContain("Name");
+    expect(html).toBe('<th scope="col" data-align="center">Name</th>');
   });
 
-  test("renders <td> for body cells", () => {
+  test("renders <td> for body cells, no universal wrapper (inline)", () => {
     const html = renderBlockSpecToHtml(tableCellBlockV2, { text: "v1" });
 
-    expect(html).toContain("<td");
-    expect(html).toContain("v1");
+    expect(html).toBe("<td>v1</td>");
   });
 
-  test("renders a full table > header-row > th + body-row > td composition", () => {
+  test("th/td nest as direct children of <tr>, <tr> as direct children of <table> (preserves HTML content model)", () => {
     const tree: readonly BlockNode[] = [
       {
         id: "t1",
@@ -96,10 +93,9 @@ describe("core/table family v2", () => {
       tree,
     );
 
-    expect(html).toContain("<table>");
-    expect(html).toContain('<tr data-header=""');
-    expect(html).toContain("<th");
-    expect(html).toContain("Col 1");
-    expect(html).toContain("val 1");
+    expect(html).toContain(
+      '<table><tr data-header=""><th scope="col">Col 1</th></tr>' +
+        "<tr><td>val 1</td></tr></table>",
+    );
   });
 });

--- a/packages/blocks/src/table/v2.tsx
+++ b/packages/blocks/src/table/v2.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+const ALIGNS = ["left", "center", "right"] as const;
+type Align = (typeof ALIGNS)[number];
+
+function pickAlign(raw: unknown): Align | undefined {
+  return typeof raw === "string" && (ALIGNS as readonly string[]).includes(raw)
+    ? (raw as Align)
+    : undefined;
+}
+
+export const tableBlockV2 = defineBlock({
+  name: "core/table",
+  title: "Table",
+  icon: "Table",
+  category: "text",
+  inputs: [
+    { name: "striped", type: "checkbox", label: "Striped" },
+    { name: "bordered", type: "checkbox", label: "Bordered" },
+    { name: "rows", type: "slot", label: "Rows" },
+  ],
+  defaults: {},
+  render: ({ attrs }): ReactNode => {
+    const striped = attrs.striped === true || undefined;
+    const bordered = attrs.bordered === true || undefined;
+    const Rows = attrs.rows as (() => ReactNode) | undefined;
+    return (
+      <table data-striped={striped} data-bordered={bordered}>
+        {Rows ? <Rows /> : null}
+      </table>
+    );
+  },
+});
+
+export const tableHeaderRowBlockV2 = defineBlock({
+  name: "core/table-header-row",
+  title: "Header Row",
+  icon: "Rows",
+  category: "text",
+  inputs: [{ name: "cells", type: "slot", label: "Cells" }],
+  defaults: {},
+  render: ({ attrs }): ReactNode => {
+    const Cells = attrs.cells as (() => ReactNode) | undefined;
+    return <tr data-header="">{Cells ? <Cells /> : null}</tr>;
+  },
+});
+
+export const tableBodyRowBlockV2 = defineBlock({
+  name: "core/table-body-row",
+  title: "Body Row",
+  icon: "Rows",
+  category: "text",
+  inputs: [{ name: "cells", type: "slot", label: "Cells" }],
+  defaults: {},
+  render: ({ attrs }): ReactNode => {
+    const Cells = attrs.cells as (() => ReactNode) | undefined;
+    return <tr>{Cells ? <Cells /> : null}</tr>;
+  },
+});
+
+export const tableHeaderCellBlockV2 = defineBlock({
+  name: "core/table-header-cell",
+  title: "Header Cell",
+  icon: "AlignLeft",
+  category: "text",
+  inputs: [
+    { name: "text", type: "text", label: "Text" },
+    {
+      name: "align",
+      type: "select",
+      label: "Align",
+      options: ALIGNS.map((a) => ({ label: a, value: a })),
+    },
+  ],
+  defaults: { text: "" },
+  render: ({ attrs }): ReactNode => {
+    const { text = "" } = attrs as { readonly text?: string };
+    const align = pickAlign(attrs.align);
+    return (
+      <th scope="col" data-align={align}>
+        {text}
+      </th>
+    );
+  },
+});
+
+export const tableCellBlockV2 = defineBlock({
+  name: "core/table-cell",
+  title: "Cell",
+  icon: "AlignLeft",
+  category: "text",
+  inputs: [
+    { name: "text", type: "text", label: "Text" },
+    {
+      name: "align",
+      type: "select",
+      label: "Align",
+      options: ALIGNS.map((a) => ({ label: a, value: a })),
+    },
+  ],
+  defaults: { text: "" },
+  render: ({ attrs }): ReactNode => {
+    const { text = "" } = attrs as { readonly text?: string };
+    const align = pickAlign(attrs.align);
+    return <td data-align={align}>{text}</td>;
+  },
+});

--- a/packages/blocks/src/table/v2.tsx
+++ b/packages/blocks/src/table/v2.tsx
@@ -39,6 +39,7 @@ export const tableHeaderRowBlockV2 = defineBlock({
   title: "Header Row",
   icon: "Rows",
   category: "text",
+  inline: true,
   inputs: [{ name: "cells", type: "slot", label: "Cells" }],
   defaults: {},
   render: ({ attrs }): ReactNode => {
@@ -52,6 +53,7 @@ export const tableBodyRowBlockV2 = defineBlock({
   title: "Body Row",
   icon: "Rows",
   category: "text",
+  inline: true,
   inputs: [{ name: "cells", type: "slot", label: "Cells" }],
   defaults: {},
   render: ({ attrs }): ReactNode => {
@@ -65,6 +67,7 @@ export const tableHeaderCellBlockV2 = defineBlock({
   title: "Header Cell",
   icon: "AlignLeft",
   category: "text",
+  inline: true,
   inputs: [
     { name: "text", type: "text", label: "Text" },
     {
@@ -91,6 +94,7 @@ export const tableCellBlockV2 = defineBlock({
   title: "Cell",
   icon: "AlignLeft",
   category: "text",
+  inline: true,
   inputs: [
     { name: "text", type: "text", label: "Text" },
     {


### PR DESCRIPTION
Two commits — the table family migration plus a retroactive senpai + code-simplifier review pass against everything since PR #409 (slices #393, #394, #392, #388, #383, #384, #17b, #17c, this PR's table family).

**163e45b — table family v2.** Five table-shaped blocks ported via the v2 coexistence pattern: \`table\` + two row blocks + two cell blocks. Striped/bordered checkboxes on the outer table, align select on cells, slots for rows/cells. Five tests.

**790187a — review fixes** addressing every senpai + simplifier finding on the unreviewed slice chain:

- **HTML content-model fix (must-fix)**: dt/dd/tr/th/td now \`inline: true\` so the universal \`<div data-plumix-block>\` wrapper doesn't reparent them out of their \`<dl>\`/\`<table>\` ancestors. Tests asserted only via \`toContain\` before; now pinned with byte-exact \`<dl><dt>…</dt><dd>…</dd></dl>\` and \`<table><tr><th>…</th></tr></table>\` structure.
- **button target+rel (must-fix)**: \`target\` input restored with \`_self\`/\`_blank\` options; \`rel=\"noopener noreferrer\"\` auto-emitted on \`_blank\`. Closes the reverse-tabnabbing surface that legacy ButtonComponent enforced.
- **checkbox handling (must-fix)**: Puck has no native checkbox; field-type-translator maps \`type: \"checkbox\"\` to a Puck radio with true/false options. Unknown input types log a dev \`console.warn\` so silent text-input downgrades surface.
- **Client island contract (should-fix)**: wrapper carries \`data-plumix-island=\"<name>\"\` so the hydration bootstrap can find each anchor. Per-renderNodes-call script dedupe — N instances of one client block ship one \`<script>\` and N island anchors.
- **html/v2 allowlist context (should-fix)**: \`useHtmlAllowlist()\` restored so plugin-extended allowlists apply (legacy contract preserved). Render hoisted to PascalCase \`HtmlBlockV2Render\` for the react-hooks/rules-of-hooks lint.
- **Render hook contract (should-fix)**: docstring on \`BlockRenderHooks\` clarifies pre-order traversal — slot children render lazily inside React, so a parent's \`afterRender\` fires before its children's \`beforeRender\`. Plugins needing post-order observe the React tree directly.
- **\`withProductionEnv\` cleanup (should-fix)**: deletes \`process.env.NODE_ENV\` when the prior value was undefined, instead of leaving the string \`\"undefined\"\` behind.
- **Nice-to-haves**: code/v2 always wraps text in \`<code>\` (symmetric output); spacer category \`layout\` (matches sibling primitives); EditorLayout title input gains \`aria-label\`; simplifier extracted \`renderNode\` from the \`renderNodes\` closure so the per-node logic lives in one named function with the before/after hooks bracketing it.

Full turbo typecheck/lint/test/build green: 379 \`@plumix/blocks\` tests + 301 \`@plumix/admin\` tests pass.

Refs #17c