### PR TITLE
feat(blocks): migrate list family to v2 defineBlock surface

### DIFF
--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -96,6 +96,11 @@ export {
   tableHeaderCellBlockV2,
   tableHeaderRowBlockV2,
 } from "./table/v2.js";
+export {
+  listBlockV2,
+  listItemBlockV2,
+  listOrderedBlockV2,
+} from "./list/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";
 export { PlumixIslandBootstrap } from "./island-bootstrap.js";

--- a/packages/blocks/src/list/v2.test.tsx
+++ b/packages/blocks/src/list/v2.test.tsx
@@ -1,0 +1,97 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "../test/index.js";
+import {
+  listBlockV2,
+  listItemBlockV2,
+  listOrderedBlockV2,
+} from "./v2.js";
+
+describe("core/list family v2", () => {
+  test("renders an empty <ul> for the bulleted list", () => {
+    const html = renderBlockSpecToHtml(listBlockV2, {});
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/list"><ul></ul></div>',
+    );
+  });
+
+  test("renders an empty <ol> with no start attribute when no attrs are supplied", () => {
+    const html = renderBlockSpecToHtml(listOrderedBlockV2, {});
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/list-ordered"><ol></ol></div>',
+    );
+  });
+
+  test("renders the start attribute on <ol> when greater than the implicit default of 1", () => {
+    const html = renderBlockSpecToHtml(listOrderedBlockV2, { start: 5 });
+
+    expect(html).toContain('<ol start="5">');
+  });
+
+  test("drops the start attribute when it equals the canonical default of 1 (legacy parity)", () => {
+    const html = renderBlockSpecToHtml(listOrderedBlockV2, { start: 1 });
+
+    expect(html).not.toContain("start=");
+  });
+
+  test("ignores invalid start values (zero, negative, fractional, NaN, Infinity, non-number)", () => {
+    for (const start of [0, -3, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const html = renderBlockSpecToHtml(listOrderedBlockV2, { start });
+      expect(html).not.toContain("start=");
+    }
+    expect(
+      renderBlockSpecToHtml(listOrderedBlockV2, { start: "5" }),
+    ).not.toContain("start=");
+  });
+
+  test("renders a list-item as inline <li> (no universal wrapper)", () => {
+    const html = renderBlockSpecToHtml(listItemBlockV2, { text: "Bullet" });
+
+    expect(html).toBe("<li>Bullet</li>");
+  });
+
+  test("li nests as a direct child of <ul> via the items slot", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "l1",
+        name: "core/list",
+        attrs: {
+          items: [
+            { id: "i1", name: "core/list-item", attrs: { text: "A" } },
+            { id: "i2", name: "core/list-item", attrs: { text: "B" } },
+          ],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml(
+      [listBlockV2, listItemBlockV2],
+      tree,
+    );
+
+    expect(html).toContain("<ul><li>A</li><li>B</li></ul>");
+  });
+
+  test("li nests as a direct child of <ol> with start attribute preserved", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "o1",
+        name: "core/list-ordered",
+        attrs: {
+          start: 3,
+          items: [{ id: "i1", name: "core/list-item", attrs: { text: "x" } }],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml(
+      [listOrderedBlockV2, listItemBlockV2],
+      tree,
+    );
+
+    expect(html).toContain('<ol start="3"><li>x</li></ol>');
+  });
+});

--- a/packages/blocks/src/list/v2.tsx
+++ b/packages/blocks/src/list/v2.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+export const listBlockV2 = defineBlock({
+  name: "core/list",
+  title: "Bulleted list",
+  icon: "List",
+  category: "text",
+  inputs: [{ name: "items", type: "slot", label: "Items" }],
+  defaults: {},
+  render: ({ attrs }): ReactNode => {
+    const Items = attrs.items as (() => ReactNode) | undefined;
+    return <ul>{Items ? <Items /> : null}</ul>;
+  },
+});
+
+export const listOrderedBlockV2 = defineBlock({
+  name: "core/list-ordered",
+  title: "Numbered list",
+  icon: "ListOrdered",
+  category: "text",
+  inputs: [
+    { name: "start", type: "number", label: "Start" },
+    { name: "items", type: "slot", label: "Items" },
+  ],
+  defaults: {},
+  render: ({ attrs }): ReactNode => {
+    const startRaw = attrs.start as number | undefined;
+    // Drop start when it equals the canonical default of 1 — matches the
+    // legacy walker, which omits the attribute so the rendered HTML stays
+    // identical to the implicit <ol>.
+    const start =
+      typeof startRaw === "number" && Number.isInteger(startRaw) && startRaw > 1
+        ? startRaw
+        : undefined;
+    const Items = attrs.items as (() => ReactNode) | undefined;
+    return <ol start={start}>{Items ? <Items /> : null}</ol>;
+  },
+});
+
+export const listItemBlockV2 = defineBlock({
+  name: "core/list-item",
+  title: "List item",
+  category: "text",
+  inline: true,
+  inputs: [{ name: "text", type: "text", label: "Item" }],
+  defaults: { text: "" },
+  render: ({ attrs }): ReactNode => {
+    const { text = "" } = attrs as { readonly text?: string };
+    return <li>{text}</li>;
+  },
+});


### PR DESCRIPTION
Migrates the list family (\`core/list\`, \`core/list-ordered\`, \`core/list-item\`) to v2 via the established coexistence pattern.

**Specs**

- \`listBlockV2\` → \`<ul>\` with items slot
- \`listOrderedBlockV2\` → \`<ol start?>\` with positive-integer-greater-than-1 validation. Drops \`start\` when it equals the canonical default of 1 so the rendered HTML matches the legacy walker's behavior.
- \`listItemBlockV2\` → \`<li>\`, \`inline: true\` so the universal \`<div data-plumix-block>\` wrapper doesn't reparent it out of \`<ul>/<ol>\` (same pattern as dt/dd/tr/th/td)

**Senpai findings folded in before commit**

- \`start=1\` now dropped on render (was leaking; broke legacy walker parity)
- \`defaults: { start: 1 }\` removed (the walker doesn't merge \`defaults\` into attrs at render time, so the declaration was dead signal that contradicted the \`start=1\` drop)
- \`transforms.to: \"core/paragraph\"\` dropped from \`list\` and \`list-ordered\` — the conversion is fundamentally lossy (slot of BlockNodes → string text) and the v2 declarations had no \`mapAttrs\`. Returns once slot-aware transforms are designed.
- Test expansion: NaN / Infinity / non-numbers added to invalid-start coverage; \`start=1\` boundary test added; empty-\`<ol>\` assertion tightened from \`toContain\` to byte-exact \`toBe\`
- \`listItem\` icon dropped (\`\"Minus\"\` was an outlier vs sibling inline blocks which keep no icon)

Simplifier: nothing to simplify. Sibling v2 specs (table family, description-list family) follow the same one-spec-per-block pattern; cross-family extraction is premature per spike scope.

Refs #17a