### PR TITLE
feat(blocks): migrate core/buttons to v2 defineBlock surface

### DIFF
--- a/packages/blocks/src/buttons/v2.test.tsx
+++ b/packages/blocks/src/buttons/v2.test.tsx
@@ -1,0 +1,76 @@
+import type { BlockNode } from "../render-block-tree.js";
+import { describe, expect, test } from "vitest";
+
+import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "../test/index.js";
+import { buttonBlockV2 } from "../button/v2.js";
+import { buttonsBlockV2 } from "./v2.js";
+
+describe("core/buttons v2", () => {
+  test("renders empty <div data-align='start'> by default (v1 parity)", () => {
+    const html = renderBlockSpecToHtml(buttonsBlockV2, {});
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/buttons"><div data-align="start"></div></div>',
+    );
+  });
+
+  test("renders align + gap when valid", () => {
+    const html = renderBlockSpecToHtml(buttonsBlockV2, {
+      align: "center",
+      gap: "16px",
+    });
+
+    expect(html).toContain('data-align="center"');
+    expect(html).toContain('data-gap="16px"');
+  });
+
+  test("coerces a positive number gap to px", () => {
+    const html = renderBlockSpecToHtml(buttonsBlockV2, { gap: 24 });
+
+    expect(html).toContain('data-gap="24px"');
+  });
+
+  test("falls back to align='start' for invalid align; ignores invalid gap", () => {
+    const html = renderBlockSpecToHtml(buttonsBlockV2, {
+      align: "wibble",
+      gap: 0,
+    });
+
+    expect(html).toContain('data-align="start"');
+    expect(html).not.toContain("data-gap");
+  });
+
+  test("accepts non-px string gap values verbatim (1rem, calc(), etc.)", () => {
+    expect(renderBlockSpecToHtml(buttonsBlockV2, { gap: "1rem" })).toContain(
+      'data-gap="1rem"',
+    );
+    expect(
+      renderBlockSpecToHtml(buttonsBlockV2, { gap: "calc(1rem + 4px)" }),
+    ).toContain('data-gap="calc(1rem + 4px)"');
+  });
+
+  test("renders nested button children via the items slot", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "btns",
+        name: "core/buttons",
+        attrs: {
+          align: "end",
+          items: [
+            { id: "b1", name: "core/button", attrs: { label: "Save" } },
+            { id: "b2", name: "core/button", attrs: { label: "Cancel" } },
+          ],
+        },
+      },
+    ];
+
+    const html = renderBlockTreeToHtml(
+      [buttonsBlockV2, buttonBlockV2],
+      tree,
+    );
+
+    expect(html).toContain('data-align="end"');
+    expect(html).toContain("Save");
+    expect(html).toContain("Cancel");
+  });
+});

--- a/packages/blocks/src/buttons/v2.tsx
+++ b/packages/blocks/src/buttons/v2.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+const ALIGNS = ["start", "center", "end", "between"] as const;
+type Align = (typeof ALIGNS)[number];
+
+function pickAlign(raw: unknown): Align {
+  return typeof raw === "string" && (ALIGNS as readonly string[]).includes(raw)
+    ? (raw as Align)
+    : "start";
+}
+
+function normalizeGap(raw: unknown): string | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return `${raw}px`;
+  }
+  if (typeof raw === "string" && raw.length > 0) return raw;
+  return undefined;
+}
+
+export const buttonsBlockV2 = defineBlock({
+  name: "core/buttons",
+  title: "Buttons",
+  icon: "MousePointerClick",
+  category: "interactive",
+  inputs: [
+    {
+      name: "align",
+      type: "select",
+      label: "Align",
+      options: ALIGNS.map((a) => ({ label: a, value: a })),
+    },
+    { name: "gap", type: "text", label: "Gap" },
+    { name: "items", type: "slot", label: "Buttons" },
+  ],
+  defaults: { align: "start" },
+  render: ({ attrs }): ReactNode => {
+    const align = pickAlign(attrs.align);
+    const gap = normalizeGap(attrs.gap);
+    const Items = attrs.items as (() => ReactNode) | undefined;
+    return (
+      <div data-align={align} data-gap={gap}>
+        {Items ? <Items /> : null}
+      </div>
+    );
+  },
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -103,6 +103,7 @@ export {
   listItemBlockV2,
   listOrderedBlockV2,
 } from "./list/v2.js";
+export { buttonsBlockV2 } from "./buttons/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";
 export { PlumixIslandBootstrap } from "./island-bootstrap.js";


### PR DESCRIPTION
Migrate the \`core/buttons\` wrapper block to v2 via the established coexistence pattern. Closes the buttons-wrapper portion of slice #17c interactive blocks.

\`buttonsBlockV2\` — wraps button children with:
- \`align\` select (start / center / end / between), defaults to \`start\` (v1 parity)
- \`gap\` text input accepting CSS lengths (\`\"16px\"\`, \`\"1rem\"\`, \`\"calc(…)\"\`) or positive numbers (coerced to \`Npx\`)
- \`items\` slot for the button children

Six tests cover default align, valid align+gap, numeric-gap coercion, invalid-fallback-to-start, non-px string passthrough, and slot-rendered children.

**Senpai pass applied before commit**:
- \`align\` defaults to \`start\` (was rendering no attribute — broke v1 parity for inspector + any CSS targeting \`[data-align=\"start\"]\`); \`pickAlign\` returns a definite \`Align\` now so invalid inputs fall back to \`start\` rather than dropping the attribute
- Non-px gap string coverage added (\`1rem\` / \`calc(…)\`); v1 had this case, v2 was missing it
- **Dropped \`columnBlockV2\` from this slice**: \`columnsBlockV2\` (on the feature branch) renders fixed \`left\`/\`right\` slots, so a standalone \`core/column\` has no v2 parent. Legacy content with \`core/column\` continues to render via the legacy walker until cutover #405; no v2 surface earns its keep.

**Simplifier pass**: tightened the default-state test from three substring assertions to one byte-exact \`toBe\` (matches the list / column / description-list precision pattern).

Refs #17c