### PR TITLE
feat(admin): wire HeadingAuditPanel into EditorLayout Audit tab + recursive Puck→BlockNode converter

### DIFF
--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -1,10 +1,23 @@
 import type { ReactElement, ReactNode } from "react";
-import { Puck } from "@puckeditor/core";
+import { useMemo } from "react";
+import { Puck, usePuck } from "@puckeditor/core";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.js";
 
+import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
+import { puckDataToBlockTree } from "./puck-to-block-tree.js";
+
 interface PlumixEditorLayoutProps {
   readonly children?: ReactNode;
+}
+
+function PlumixAuditTab(): ReactElement {
+  const puck = usePuck();
+  const tree = useMemo(
+    () => puckDataToBlockTree(puck.appState.data),
+    [puck.appState.data],
+  );
+  return <HeadingAuditPanel tree={tree} />;
 }
 
 export function PlumixEditorLayout(
@@ -53,12 +66,18 @@ export function PlumixEditorLayout(
               <TabsTrigger value="outline" data-testid="plumix-editor-tab-outline">
                 Outline
               </TabsTrigger>
+              <TabsTrigger value="audit" data-testid="plumix-editor-tab-audit">
+                Audit
+              </TabsTrigger>
             </TabsList>
             <TabsContent value="blocks">
               <Puck.Components />
             </TabsContent>
             <TabsContent value="outline">
               <Puck.Outline />
+            </TabsContent>
+            <TabsContent value="audit">
+              <PlumixAuditTab />
             </TabsContent>
           </Tabs>
         </aside>

--- a/packages/admin/src/editor/v2/puck-to-block-tree.test.ts
+++ b/packages/admin/src/editor/v2/puck-to-block-tree.test.ts
@@ -1,0 +1,163 @@
+import type { Data } from "@puckeditor/core";
+import { describe, expect, test } from "vitest";
+
+import { puckDataToBlockTree } from "./puck-to-block-tree.js";
+
+function data(content: readonly { type: string; props: Record<string, unknown> }[]): Data {
+  return {
+    content: content as Data["content"],
+    root: { props: {} },
+  };
+}
+
+describe("puckDataToBlockTree", () => {
+  test("converts a flat Puck content array to BlockNode[]", () => {
+    const result = puckDataToBlockTree(
+      data([
+        { type: "core/heading", props: { id: "h1", text: "Title", level: 2 } },
+        { type: "core/paragraph", props: { id: "p1", text: "Body" } },
+      ]),
+    );
+
+    expect(result).toEqual([
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: { id: "h1", text: "Title", level: 2 },
+      },
+      {
+        id: "p1",
+        name: "core/paragraph",
+        attrs: { id: "p1", text: "Body" },
+      },
+    ]);
+  });
+
+  test("uses a fallback id when props.id is missing or empty", () => {
+    const result = puckDataToBlockTree(
+      data([
+        { type: "core/heading", props: { text: "x" } },
+        { type: "core/heading", props: { id: "", text: "y" } },
+      ]),
+    );
+
+    expect(result[0]?.id).toBe("puck-0");
+    expect(result[1]?.id).toBe("puck-1");
+  });
+
+  test("recurses into slot-typed nested {type, props} arrays inside props", () => {
+    const result = puckDataToBlockTree(
+      data([
+        {
+          type: "core/section",
+          props: {
+            id: "section",
+            content: [
+              {
+                type: "core/heading",
+                props: { id: "inner", text: "Inside", level: 1 },
+              },
+            ],
+          },
+        },
+      ]),
+    );
+
+    expect(result).toEqual([
+      {
+        id: "section",
+        name: "core/section",
+        attrs: {
+          id: "section",
+          content: [
+            {
+              id: "inner",
+              name: "core/heading",
+              attrs: { id: "inner", text: "Inside", level: 1 },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("recurses through multi-slot parents (e.g. columns with left + right)", () => {
+    const result = puckDataToBlockTree(
+      data([
+        {
+          type: "core/columns",
+          props: {
+            id: "cols",
+            left: [
+              { type: "core/heading", props: { id: "lh", text: "L", level: 2 } },
+            ],
+            right: [
+              { type: "core/heading", props: { id: "rh", text: "R", level: 2 } },
+            ],
+          },
+        },
+      ]),
+    );
+
+    expect(Array.isArray(result[0]?.attrs?.left)).toBe(true);
+    expect(Array.isArray(result[0]?.attrs?.right)).toBe(true);
+    const left = result[0]?.attrs?.left as readonly { id: string }[];
+    expect(left[0]?.id).toBe("lh");
+  });
+
+  test("walks slots arbitrarily deep without crashing", () => {
+    const result = puckDataToBlockTree(
+      data([
+        {
+          type: "a/outer",
+          props: {
+            id: "outer",
+            content: [
+              {
+                type: "a/middle",
+                props: {
+                  id: "middle",
+                  content: [
+                    {
+                      type: "a/inner",
+                      props: { id: "inner", text: "deep" },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ]),
+    );
+
+    // Walk three levels deep and confirm the innermost block is properly shaped.
+    const outerContent = result[0]?.attrs?.content as readonly { attrs: Record<string, unknown> }[];
+    const middle = outerContent[0];
+    expect(middle).toBeDefined();
+    const inner = (middle?.attrs.content as readonly { id: string }[])[0];
+    expect(inner?.id).toBe("inner");
+  });
+
+  test("leaves non-slot arrays in attrs alone (does not false-positive on plain data lists)", () => {
+    const result = puckDataToBlockTree(
+      data([
+        {
+          type: "core/picker",
+          props: {
+            id: "p",
+            tags: [
+              { value: "foo" },
+              { value: "bar" },
+            ],
+          },
+        },
+      ]),
+    );
+
+    expect(result[0]?.attrs?.tags).toEqual([
+      { value: "foo" },
+      { value: "bar" },
+    ]);
+  });
+});

--- a/packages/admin/src/editor/v2/puck-to-block-tree.ts
+++ b/packages/admin/src/editor/v2/puck-to-block-tree.ts
@@ -1,0 +1,50 @@
+import type { BlockNode } from "@plumix/blocks";
+import type { Data } from "@puckeditor/core";
+
+interface PuckComponentDataLike {
+  readonly type: string;
+  readonly props: Readonly<Record<string, unknown>>;
+}
+
+function isPuckComponentDataArray(
+  value: unknown,
+): value is readonly PuckComponentDataLike[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as { readonly type?: unknown }).type === "string" &&
+        typeof (item as { readonly props?: unknown }).props === "object",
+    )
+  );
+}
+
+function toBlockNode(
+  item: PuckComponentDataLike,
+  fallbackId: string,
+): BlockNode {
+  const rawId = item.props.id;
+  const id =
+    typeof rawId === "string" && rawId.length > 0 ? rawId : fallbackId;
+  const attrs: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(item.props)) {
+    if (isPuckComponentDataArray(value)) {
+      attrs[key] = value.map((child, idx) =>
+        toBlockNode(child, `${id}-${key}-${idx}`),
+      );
+    } else {
+      attrs[key] = value;
+    }
+  }
+  return { id, name: item.type, attrs };
+}
+
+export function puckDataToBlockTree(
+  data: Pick<Data, "content">,
+): readonly BlockNode[] {
+  return data.content.map((item, idx) =>
+    toBlockNode(item as PuckComponentDataLike, `puck-${idx}`),
+  );
+}


### PR DESCRIPTION
Closes the Audit-tab wiring portion of slice #389.

**Editor chrome** — adds a third left-sidebar tab \"Audit\" alongside Blocks + Outline. \`PlumixAuditTab\` reads the current Puck data via \`usePuck()\`, converts it through the new \`puckDataToBlockTree\` helper, and feeds the result to \`HeadingAuditPanel\`.

**Recursive converter** — \`packages/admin/src/editor/v2/puck-to-block-tree.ts\`. Walks every Puck slot recursively so headings inside columns / section / details / etc. count toward the audit. Plain data arrays in props (term pickers and similar) pass through untouched via structural shape detection (\`{ type: string, props: object }\` ⇒ slot child).

**Why the extraction matters** — senpai caught that the original inline converter only flattened \`data.content\` one level, so any heading inside a slot would silently miss the audit once columns / section blocks land in the editor. Extracted to its own pure module with six unit tests covering flat data, fallback id generation, single + multi-slot recursion, arbitrary nesting depth, and the non-slot-array passthrough boundary.

**Memo** — \`useMemo\` keyed on \`puck.appState.data\` so the converter + analyzer only re-run on actual content changes, not on every selection / hover state tick that \`usePuck()\` re-renders for.

Senpai + simplifier ran before commit per workflow.

Refs #389