### PR TITLE
feat(admin): wire heading-audit click-to-jump to puck selection

### DIFF
--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -17,7 +17,12 @@ function PlumixAuditTab(): ReactElement {
     () => puckDataToBlockTree(puck.appState.data),
     [puck.appState.data],
   );
-  return <HeadingAuditPanel tree={tree} />;
+  const handleSelect = (nodeId: string): void => {
+    const itemSelector = puck.getSelectorForId(nodeId);
+    if (!itemSelector) return;
+    puck.dispatch({ type: "setUi", ui: { itemSelector } });
+  };
+  return <HeadingAuditPanel tree={tree} onSelect={handleSelect} />;
 }
 
 export function PlumixEditorLayout(

--- a/packages/admin/src/editor/v2/HeadingAuditPanel.test.tsx
+++ b/packages/admin/src/editor/v2/HeadingAuditPanel.test.tsx
@@ -1,5 +1,6 @@
 import type { BlockNode } from "@plumix/blocks";
 import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { afterEach, describe, expect, test } from "vitest";
 
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
@@ -59,6 +60,39 @@ describe("HeadingAuditPanel", () => {
     expect(item.textContent).toContain(
       "Multiple <h1> on the page (2 found).",
     );
+  });
+
+  test("invokes onSelect with the violation's primary node id when the click-to-jump button is pressed", async () => {
+    const calls: string[] = [];
+    const user = userEvent.setup();
+    const tree: readonly BlockNode[] = [
+      { id: "first", name: "core/heading", attrs: { level: 1, text: "A" } },
+      { id: "skip", name: "core/heading", attrs: { level: 4, text: "B" } },
+    ];
+
+    render(
+      <HeadingAuditPanel
+        tree={tree}
+        onSelect={(nodeId) => calls.push(nodeId)}
+      />,
+    );
+
+    await user.click(screen.getByTestId("heading-audit-jump-skipped-level"));
+
+    expect(calls).toEqual(["skip"]);
+  });
+
+  test("renders a plain warning (no button) when onSelect is not provided", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "h", name: "core/heading", attrs: { level: 1, text: "" } },
+    ];
+
+    render(<HeadingAuditPanel tree={tree} />);
+
+    expect(screen.queryByTestId("heading-audit-jump-empty-heading")).toBeNull();
+    expect(
+      screen.getByTestId("heading-audit-violation-empty-heading").textContent,
+    ).toContain("Empty heading.");
   });
 
   test("emits data-node-ids on each list item so the action-bar follow-up can click-to-jump", () => {

--- a/packages/admin/src/editor/v2/HeadingAuditPanel.tsx
+++ b/packages/admin/src/editor/v2/HeadingAuditPanel.tsx
@@ -5,9 +5,13 @@ import { analyzeHeadingStructure } from "@plumix/blocks";
 
 interface HeadingAuditPanelProps {
   readonly tree: readonly BlockNode[];
+  readonly onSelect?: (nodeId: string) => void;
 }
 
-export function HeadingAuditPanel({ tree }: HeadingAuditPanelProps): ReactNode {
+export function HeadingAuditPanel({
+  tree,
+  onSelect,
+}: HeadingAuditPanelProps): ReactNode {
   const violations = analyzeHeadingStructure(tree);
 
   if (violations.length === 0) {
@@ -24,17 +28,37 @@ export function HeadingAuditPanel({ tree }: HeadingAuditPanelProps): ReactNode {
       className="space-y-2 p-2"
       data-testid="heading-audit-list"
     >
-      {violations.map((violation, index) => (
-        <li
-          key={`${violation.kind}-${index}`}
-          role="listitem"
-          className="rounded border border-amber-200 bg-amber-50 p-2 text-sm"
-          data-testid={`heading-audit-violation-${violation.kind}`}
-          data-node-ids={nodeIdsFor(violation).join(",")}
-        >
-          <strong>Warning:</strong> {describe(violation)}
-        </li>
-      ))}
+      {violations.map((violation, index) => {
+        const nodeIds = nodeIdsFor(violation);
+        const primaryId = nodeIds[0];
+        const message = (
+          <>
+            <strong>Warning:</strong> {describe(violation)}
+          </>
+        );
+        return (
+          <li
+            key={`${violation.kind}-${index}`}
+            role="listitem"
+            className="rounded border border-amber-200 bg-amber-50 p-2 text-sm"
+            data-testid={`heading-audit-violation-${violation.kind}`}
+            data-node-ids={nodeIds.join(",")}
+          >
+            {onSelect && primaryId !== undefined ? (
+              <button
+                type="button"
+                onClick={() => onSelect(primaryId)}
+                className="w-full text-left"
+                data-testid={`heading-audit-jump-${violation.kind}`}
+              >
+                {message}
+              </button>
+            ) : (
+              message
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
 }


### PR DESCRIPTION
Make heading-audit violations clickable in the Puck editor's Audit tab so authors can jump straight to the offending block, including blocks nested inside slot zones.

**Click-to-jump wire-up**

`HeadingAuditPanel` now accepts an optional `onSelect(nodeId)` prop. When set, each violation renders inside a `<button>` (kept inside the existing `<li role="listitem">` so the data-node-ids contract is unchanged); when unset, the panel renders the same plain warning as before.

**Nested-zone support via Puck's own selector resolver**

`PlumixAuditTab` uses `puck.getSelectorForId(nodeId)` rather than a flat `findIndex` on `appState.data.content`. Puck walks the full tree natively and returns `{ index, zone }`, so click-to-jump now works for blocks inside columns/group/details/etc., not only top-level content.

**Test coverage**

Adds two tests: `onSelect` is invoked with the violation's primary node id when its button is clicked (`userEvent.click`), and no jump button is rendered when `onSelect` is omitted. Existing data-node-ids and violation-rendering tests stay green.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>