### PR TITLE
feat(admin): slash menu inserts blocks via puck dispatch

### DIFF
--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -1,15 +1,36 @@
-import type { ReactElement, ReactNode } from "react";
-import { useMemo } from "react";
+import type { BlockRegistryV2 } from "@plumix/blocks";
+import type { KeyboardEvent as ReactKeyboardEvent, ReactElement, ReactNode } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { createBlockRegistry } from "@plumix/blocks";
 import { Puck, usePuck } from "@puckeditor/core";
 
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.js";
+
+import type { SlashMenuItem } from "./slash-menu-items.js";
 
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
+import {
+  nextInsertPoint,
+  resolveSlashMenuItems,
+} from "./slash-menu-items.js";
+import { SlashMenuPanel } from "./SlashMenuPanel.js";
 
 interface PlumixEditorLayoutProps {
+  readonly registry?: BlockRegistryV2;
+  readonly capabilities?: ReadonlySet<string>;
   readonly children?: ReactNode;
 }
+
+const EMPTY_REGISTRY: BlockRegistryV2 = createBlockRegistry([]);
+const EMPTY_CAPS: ReadonlySet<string> = new Set();
 
 function PlumixAuditTab(): ReactElement {
   const puck = usePuck();
@@ -25,9 +46,10 @@ function PlumixAuditTab(): ReactElement {
   return <HeadingAuditPanel tree={tree} onSelect={handleSelect} />;
 }
 
-export function PlumixEditorLayout(
-  _props: PlumixEditorLayoutProps,
-): ReactElement {
+export function PlumixEditorLayout({
+  registry = EMPTY_REGISTRY,
+  capabilities = EMPTY_CAPS,
+}: PlumixEditorLayoutProps): ReactElement {
   return (
     <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
       <header
@@ -86,12 +108,10 @@ export function PlumixEditorLayout(
             </TabsContent>
           </Tabs>
         </aside>
-        <main
-          className="overflow-auto"
-          data-testid="plumix-editor-canvas"
-        >
-          <Puck.Preview />
-        </main>
+        <PlumixCanvasWithSlashMenu
+          registry={registry}
+          capabilities={capabilities}
+        />
         <aside
           className="overflow-y-auto border-l"
           data-testid="plumix-editor-right"
@@ -100,5 +120,102 @@ export function PlumixEditorLayout(
         </aside>
       </div>
     </div>
+  );
+}
+
+interface PlumixCanvasWithSlashMenuProps {
+  readonly registry: BlockRegistryV2;
+  readonly capabilities: ReadonlySet<string>;
+}
+
+function PlumixCanvasWithSlashMenu({
+  registry,
+  capabilities,
+}: PlumixCanvasWithSlashMenuProps): ReactElement {
+  const puck = usePuck();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const items = useMemo(
+    () => resolveSlashMenuItems(registry, { capabilities, query }),
+    [registry, capabilities, query],
+  );
+
+  const handleCanvasKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLElement>): void => {
+      if (
+        event.key !== "/" ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        event.nativeEvent.isComposing
+      ) {
+        return;
+      }
+      const target = event.target as HTMLElement;
+      if (
+        target.matches(
+          'input, textarea, [contenteditable=""], [contenteditable="true"]',
+        )
+      ) {
+        return;
+      }
+      event.preventDefault();
+      setQuery("");
+      setOpen(true);
+    },
+    [],
+  );
+
+  const handleSelect = useCallback(
+    (item: SlashMenuItem): void => {
+      const { itemSelector } = puck.appState.ui;
+      const { zone, index } = nextInsertPoint(
+        itemSelector,
+        puck.appState.data.content.length,
+      );
+      puck.dispatch({
+        type: "insert",
+        componentType: item.name,
+        destinationZone: zone,
+        destinationIndex: index,
+      });
+      setOpen(false);
+    },
+    [puck],
+  );
+
+  return (
+    <>
+      <main
+        className="overflow-auto"
+        data-testid="plumix-editor-canvas"
+        tabIndex={0}
+        onKeyDown={handleCanvasKeyDown}
+      >
+        <Puck.Preview />
+      </main>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="max-w-md p-0"
+          data-testid="slash-menu-dialog"
+          showCloseButton={false}
+        >
+          <DialogHeader className="sr-only">
+            <DialogTitle>Insert block</DialogTitle>
+            <DialogDescription>
+              Search blocks by title or keyword and press Enter to insert.
+            </DialogDescription>
+          </DialogHeader>
+          <SlashMenuPanel
+            items={items}
+            query={query}
+            onQueryChange={setQuery}
+            onSelect={handleSelect}
+            onDismiss={() => setOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/packages/admin/src/editor/v2/SlashMenuPanel.test.tsx
+++ b/packages/admin/src/editor/v2/SlashMenuPanel.test.tsx
@@ -1,0 +1,135 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { SlashMenuItem } from "./slash-menu-items.js";
+
+import { SlashMenuPanel } from "./SlashMenuPanel.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const heading: SlashMenuItem = {
+  name: "core/heading",
+  title: "Heading",
+  description: "Section title",
+  category: "typography",
+};
+
+const quote: SlashMenuItem = {
+  name: "core/quote",
+  title: "Quote",
+  description: "Pull quote",
+  category: "typography",
+};
+
+const noop = vi.fn();
+
+describe("SlashMenuPanel", () => {
+  test("renders one item per resolved entry with stable testids and category headings", () => {
+    render(
+      <SlashMenuPanel
+        items={[heading, quote]}
+        query=""
+        onQueryChange={noop}
+        onSelect={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    expect(screen.getByTestId("slash-menu-item-core/heading")).toBeDefined();
+    expect(screen.getByTestId("slash-menu-item-core/quote")).toBeDefined();
+    expect(screen.getByTestId("slash-menu-group-typography")).toBeDefined();
+  });
+
+  test("renders an empty-state when no items resolve", () => {
+    render(
+      <SlashMenuPanel
+        items={[]}
+        query="xyz"
+        onQueryChange={noop}
+        onSelect={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    expect(screen.getByTestId("slash-menu-empty")).toBeDefined();
+  });
+
+  test("calls onSelect with the clicked item", async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SlashMenuPanel
+        items={[heading, quote]}
+        query=""
+        onQueryChange={noop}
+        onSelect={onSelect}
+        onDismiss={noop}
+      />,
+    );
+
+    await user.click(screen.getByTestId("slash-menu-item-core/quote"));
+
+    expect(onSelect).toHaveBeenCalledWith(quote);
+  });
+
+  test("calls onQueryChange when the input value changes", async () => {
+    const onQueryChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SlashMenuPanel
+        items={[heading]}
+        query=""
+        onQueryChange={onQueryChange}
+        onSelect={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    const input = screen.getByTestId("slash-menu-input");
+    await user.click(input);
+    await user.keyboard("h");
+
+    expect(onQueryChange).toHaveBeenCalledWith("h");
+  });
+
+  test("calls onDismiss when Escape is pressed inside the panel", async () => {
+    const onDismiss = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SlashMenuPanel
+        items={[heading]}
+        query=""
+        onQueryChange={noop}
+        onSelect={noop}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    await user.click(screen.getByTestId("slash-menu-input"));
+    await user.keyboard("{Escape}");
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("selects the highlighted item when Enter is pressed", async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SlashMenuPanel
+        items={[heading, quote]}
+        query=""
+        onQueryChange={noop}
+        onSelect={onSelect}
+        onDismiss={noop}
+      />,
+    );
+
+    await user.click(screen.getByTestId("slash-menu-input"));
+    await user.keyboard("{Enter}");
+
+    expect(onSelect).toHaveBeenCalledWith(heading);
+  });
+});

--- a/packages/admin/src/editor/v2/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/v2/SlashMenuPanel.tsx
@@ -1,0 +1,96 @@
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+import { Command as CommandPrimitive } from "cmdk";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command.js";
+
+import type { SlashMenuItem } from "./slash-menu-items.js";
+
+interface SlashMenuPanelProps {
+  readonly items: readonly SlashMenuItem[];
+  readonly query: string;
+  readonly onQueryChange: (query: string) => void;
+  readonly onSelect: (item: SlashMenuItem) => void;
+  readonly onDismiss: () => void;
+}
+
+const UNCATEGORIZED = "other";
+
+export function SlashMenuPanel({
+  items,
+  query,
+  onQueryChange,
+  onSelect,
+  onDismiss,
+}: SlashMenuPanelProps): ReactElement {
+  const buckets = useMemo(() => {
+    const map = new Map<string, SlashMenuItem[]>();
+    for (const item of items) {
+      const key = item.category ?? UNCATEGORIZED;
+      const bucket = map.get(key) ?? [];
+      bucket.push(item);
+      map.set(key, bucket);
+    }
+    return Array.from(map);
+  }, [items]);
+
+  return (
+    <Command
+      shouldFilter={false}
+      data-plumix-slash-menu=""
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          onDismiss();
+        }
+      }}
+      className="w-72 max-w-full border shadow-md"
+    >
+      <CommandPrimitive.Input
+        value={query}
+        onValueChange={onQueryChange}
+        data-testid="slash-menu-input"
+        autoFocus
+        className="sr-only"
+        aria-label="Search blocks"
+      />
+      <CommandList>
+        <CommandEmpty data-testid="slash-menu-empty">
+          No blocks found
+        </CommandEmpty>
+        {buckets.map(([category, members]) => (
+          <CommandGroup
+            key={category}
+            heading={category}
+            data-testid={`slash-menu-group-${category}`}
+          >
+            {members.map((item) => (
+              <CommandItem
+                key={item.name}
+                value={item.name}
+                data-testid={`slash-menu-item-${item.name}`}
+                onSelect={() => onSelect(item)}
+                className="flex items-start gap-2"
+              >
+                <span className="flex min-w-0 flex-col">
+                  <span className="text-sm font-medium">{item.title}</span>
+                  {item.description ? (
+                    <span className="text-muted-foreground text-xs">
+                      {item.description}
+                    </span>
+                  ) : null}
+                </span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
+      </CommandList>
+    </Command>
+  );
+}

--- a/packages/admin/src/editor/v2/slash-menu-items.test.ts
+++ b/packages/admin/src/editor/v2/slash-menu-items.test.ts
@@ -1,0 +1,189 @@
+import type { BlockSpecV2 } from "@plumix/blocks";
+import { createBlockRegistry } from "@plumix/blocks";
+import { describe, expect, test } from "vitest";
+
+import {
+  nextInsertPoint,
+  PUCK_ROOT_ZONE,
+  resolveSlashMenuItems,
+} from "./slash-menu-items.js";
+
+function spec(partial: Partial<BlockSpecV2> & { name: string }): BlockSpecV2 {
+  return {
+    name: partial.name,
+    title: partial.title,
+    description: partial.description,
+    keywords: partial.keywords,
+    icon: partial.icon,
+    category: partial.category,
+    capability: partial.capability,
+    render: () => null,
+  };
+}
+
+describe("resolveSlashMenuItems", () => {
+  test("projects every block in the registry into a SlashMenuItem", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", title: "Heading", category: "typography" }),
+      spec({ name: "core/columns", title: "Columns", category: "layout" }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "",
+    });
+
+    expect(items.map((i) => i.name).sort()).toEqual([
+      "core/columns",
+      "core/heading",
+    ]);
+    expect(items.find((i) => i.name === "core/columns")?.category).toBe(
+      "layout",
+    );
+  });
+
+  test("matches blocks by title (substring) and name (substring), case-insensitive", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", title: "Heading" }),
+      spec({ name: "core/paragraph", title: "Paragraph" }),
+    ]);
+
+    const byTitle = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "HEAD",
+    });
+    expect(byTitle.map((i) => i.name)).toEqual(["core/heading"]);
+
+    const byName = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "paragraph",
+    });
+    expect(byName.map((i) => i.name)).toEqual(["core/paragraph"]);
+  });
+
+  test("matches keywords by prefix (alias semantics), not substring", () => {
+    const registry = createBlockRegistry([
+      spec({
+        name: "x/pull",
+        title: "Pull",
+        keywords: ["blockquote"],
+      }),
+    ]);
+
+    const prefixMatch = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "block",
+    });
+    expect(prefixMatch.map((i) => i.name)).toEqual(["x/pull"]);
+
+    const substringNonMatch = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "quote",
+    });
+    expect(substringNonMatch.map((i) => i.name)).toEqual([]);
+  });
+
+  test("omits blocks whose `capability` is not present in the viewer's capability set", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", title: "Heading" }),
+      spec({ name: "core/html", title: "HTML", capability: "edit_html" }),
+    ]);
+
+    const restricted = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "",
+    });
+    expect(restricted.map((i) => i.name)).toEqual(["core/heading"]);
+
+    const elevated = resolveSlashMenuItems(registry, {
+      capabilities: new Set(["edit_html"]),
+      query: "",
+    });
+    expect(elevated.map((i) => i.name).sort()).toEqual([
+      "core/heading",
+      "core/html",
+    ]);
+  });
+
+  test("ranks title matches above keyword matches above name-only matches", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "z/title", title: "Quote Title" }),
+      spec({ name: "z/keyword", title: "Pull", keywords: ["quote"] }),
+      spec({ name: "core/quote", title: "Pull" }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "quote",
+    });
+
+    expect(items.map((i) => i.name)).toEqual([
+      "z/title",
+      "z/keyword",
+      "core/quote",
+    ]);
+  });
+
+  test("returns the title verbatim and falls back to the block name when title is undefined", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/spacer" }),
+      spec({ name: "core/heading", title: "Heading" }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "",
+    });
+
+    expect(items.find((i) => i.name === "core/spacer")?.title).toBe(
+      "core/spacer",
+    );
+    expect(items.find((i) => i.name === "core/heading")?.title).toBe("Heading");
+  });
+
+  test("treats whitespace-only queries as empty (no filtering)", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", title: "Heading" }),
+      spec({ name: "core/quote", title: "Quote" }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "   ",
+    });
+
+    expect(items).toHaveLength(2);
+  });
+});
+
+describe("nextInsertPoint", () => {
+  test("returns root zone + end-of-content when no item is selected", () => {
+    expect(nextInsertPoint(null, 4)).toEqual({
+      zone: PUCK_ROOT_ZONE,
+      index: 4,
+    });
+    expect(nextInsertPoint(undefined, 0)).toEqual({
+      zone: PUCK_ROOT_ZONE,
+      index: 0,
+    });
+  });
+
+  test("inserts immediately after a selected top-level block in the root zone", () => {
+    expect(
+      nextInsertPoint({ zone: PUCK_ROOT_ZONE, index: 2 }, 5),
+    ).toEqual({ zone: PUCK_ROOT_ZONE, index: 3 });
+  });
+
+  test("inserts immediately after a selected block inside a nested zone", () => {
+    expect(
+      nextInsertPoint({ zone: "section-abc:left", index: 0 }, 5),
+    ).toEqual({ zone: "section-abc:left", index: 1 });
+  });
+
+  test("falls back to root zone when a selector lacks zone metadata", () => {
+    expect(nextInsertPoint({ index: 1 }, 5)).toEqual({
+      zone: PUCK_ROOT_ZONE,
+      index: 2,
+    });
+  });
+});

--- a/packages/admin/src/editor/v2/slash-menu-items.ts
+++ b/packages/admin/src/editor/v2/slash-menu-items.ts
@@ -1,0 +1,91 @@
+import type { BlockRegistryV2, BlockSpecV2 } from "@plumix/blocks";
+
+export interface SlashMenuItem {
+  readonly name: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly category?: string;
+  readonly icon?: string;
+}
+
+export interface ResolveSlashMenuItemsOptions {
+  readonly capabilities: ReadonlySet<string>;
+  readonly query: string;
+}
+
+const TITLE_MATCH = 3;
+const KEYWORD_MATCH = 2;
+const NAME_MATCH = 1;
+
+export function resolveSlashMenuItems(
+  registry: BlockRegistryV2,
+  { capabilities, query }: ResolveSlashMenuItemsOptions,
+): readonly SlashMenuItem[] {
+  const needle = query.trim().toLowerCase();
+  const scored: { item: SlashMenuItem; score: number }[] = [];
+
+  for (const spec of registry) {
+    if (!isInsertableForCapabilities(spec, capabilities)) continue;
+    const item = toItem(spec);
+    if (needle === "") {
+      scored.push({ item, score: 0 });
+      continue;
+    }
+    const score = matchScore(spec, item, needle);
+    if (score > 0) scored.push({ item, score });
+  }
+
+  if (needle !== "") {
+    scored.sort((a, b) => b.score - a.score);
+  }
+  return scored.map(({ item }) => item);
+}
+
+function isInsertableForCapabilities(
+  spec: BlockSpecV2,
+  capabilities: ReadonlySet<string>,
+): boolean {
+  if (!spec.capability) return true;
+  return capabilities.has(spec.capability);
+}
+
+function toItem(spec: BlockSpecV2): SlashMenuItem {
+  return {
+    name: spec.name,
+    title: spec.title ?? spec.name,
+    description: spec.description,
+    category: spec.category,
+    icon: spec.icon,
+  };
+}
+
+function matchScore(
+  spec: BlockSpecV2,
+  item: SlashMenuItem,
+  needle: string,
+): number {
+  if (item.title.toLowerCase().includes(needle)) return TITLE_MATCH;
+  if (spec.keywords?.some((k) => k.toLowerCase().startsWith(needle))) {
+    return KEYWORD_MATCH;
+  }
+  if (spec.name.toLowerCase().includes(needle)) return NAME_MATCH;
+  return 0;
+}
+
+export const PUCK_ROOT_ZONE = "root:default-zone";
+
+export interface InsertPointSelector {
+  readonly zone?: string;
+  readonly index: number;
+}
+
+export function nextInsertPoint(
+  selector: InsertPointSelector | null | undefined,
+  rootContentLength: number,
+): { zone: string; index: number } {
+  if (!selector) return { zone: PUCK_ROOT_ZONE, index: rootContentLength };
+  return {
+    zone: selector.zone ?? PUCK_ROOT_ZONE,
+    index: selector.index + 1,
+  };
+}

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -55,6 +55,7 @@ function PuckSpikeRoute(): ReactNode {
       data={data}
       onPublish={setData}
       onChange={setData}
+      iframe={{ enabled: false }}
       overrides={{ puck: PlumixEditorLayout }}
     />
   );

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -24,6 +24,8 @@ export interface BlockSpec<
 > {
   readonly name: string;
   readonly title?: string;
+  readonly description?: string;
+  readonly keywords?: readonly string[];
   readonly icon?: string;
   readonly category?: string;
   readonly inputs?: readonly BlockInput[];


### PR DESCRIPTION
Closes #386. Pressing `/` inside the v2 editor canvas now opens a block picker; selecting an entry dispatches Puck's `insert` action and the new block becomes the current selection.

**Picker behavior**

A new deep module `resolveSlashMenuItems(registry, {capabilities, query})` projects the V2 registry into ranked `SlashMenuItem`s. Match weighting is title (substring) > keyword (prefix alias) > name (substring). Blocks whose `capability` field is set are absent from the menu unless the viewer carries that capability.

`nextInsertPoint(selector, contentLength)` is the second deep module. It returns `{ zone, index }` from Puck's `ItemSelector`: after the selected block in its zone (nested or root), or end-of-content in `root:default-zone` when nothing is selected.

**V2 BlockSpec extension**

`BlockSpec` gains optional `keywords` and `description` (additive). No existing v2 block declares them yet; consumers can opt in as authors layer them on.

**Spike-route iframe opt-out**

Puck's default iframe-isolated canvas would swallow the `/` keystroke. The spike route now passes `iframe={{ enabled: false }}` so keydowns reach the host document. The keystroke guard skips `/` when focus is in `input`, `textarea`, or `[contenteditable=""|"true"]`, and ignores IME compositions (`isComposing`) and modifier-key chords.

**Out of scope (called out for the follow-up slices)**

- `variations` field on V2 `BlockSpec` — no V2 block declares variations today, and shipping a half-supported field is worse than waiting until a real consumer needs it.
- Wiring the real V2 core-block registry into the spike route — the route still renders against an empty registry, so the menu opens to the empty state. Block-adapter ↔ slash-menu integration is its own slice.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>