### PR TITLE
feat(admin): style tab writes padding to the active viewport bucket

### DIFF
--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -1,4 +1,5 @@
-import type { BlockRegistryV2 } from "@plumix/blocks";
+import type { BlockRegistryV2, ResponsiveStyleSlot, ThemeTokens } from "@plumix/blocks";
+import type { ComponentData } from "@puckeditor/core";
 import type { KeyboardEvent as ReactKeyboardEvent, ReactElement, ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { createBlockRegistry } from "@plumix/blocks";
@@ -19,18 +20,23 @@ import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
 import {
   nextInsertPoint,
+  PUCK_ROOT_ZONE,
   resolveSlashMenuItems,
 } from "./slash-menu-items.js";
 import { SlashMenuPanel } from "./SlashMenuPanel.js";
+import { StyleTab } from "./StyleTab.js";
+import { viewportWidthToBucket } from "./viewport-bucket.js";
 
 interface PlumixEditorLayoutProps {
   readonly registry?: BlockRegistryV2;
   readonly capabilities?: ReadonlySet<string>;
+  readonly tokens?: ThemeTokens;
   readonly children?: ReactNode;
 }
 
 const EMPTY_REGISTRY: BlockRegistryV2 = createBlockRegistry([]);
 const EMPTY_CAPS: ReadonlySet<string> = new Set();
+const EMPTY_TOKENS: ThemeTokens = {};
 
 function PlumixAuditTab(): ReactElement {
   const puck = usePuck();
@@ -49,6 +55,7 @@ function PlumixAuditTab(): ReactElement {
 export function PlumixEditorLayout({
   registry = EMPTY_REGISTRY,
   capabilities = EMPTY_CAPS,
+  tokens = EMPTY_TOKENS,
 }: PlumixEditorLayoutProps): ReactElement {
   return (
     <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
@@ -116,7 +123,22 @@ export function PlumixEditorLayout({
           className="overflow-y-auto border-l"
           data-testid="plumix-editor-right"
         >
-          <Puck.Fields />
+          <Tabs defaultValue="block" className="h-full">
+            <TabsList className="w-full">
+              <TabsTrigger value="block" data-testid="plumix-editor-tab-block">
+                Block
+              </TabsTrigger>
+              <TabsTrigger value="style" data-testid="plumix-editor-tab-style">
+                Style
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="block">
+              <Puck.Fields />
+            </TabsContent>
+            <TabsContent value="style">
+              <PlumixStyleTab tokens={tokens} />
+            </TabsContent>
+          </Tabs>
         </aside>
       </div>
     </div>
@@ -219,3 +241,47 @@ function PlumixCanvasWithSlashMenu({
     </>
   );
 }
+
+interface PlumixStyleTabProps {
+  readonly tokens: ThemeTokens;
+}
+
+function PlumixStyleTab({ tokens }: PlumixStyleTabProps): ReactElement {
+  const puck = usePuck();
+  const { selectedItem } = puck;
+  const bucket = viewportWidthToBucket(
+    puck.appState.ui.viewports.current.width,
+  );
+
+  const handleStyleChange = useCallback(
+    (nextStyle: ResponsiveStyleSlot | undefined): void => {
+      const { itemSelector } = puck.appState.ui;
+      if (!itemSelector || !selectedItem) return;
+      const baseProps = selectedItem.props as { id: string } & Record<
+        string,
+        unknown
+      >;
+      const data: ComponentData = {
+        type: selectedItem.type,
+        props: { ...baseProps, style: nextStyle },
+      };
+      puck.dispatch({
+        type: "replace",
+        destinationZone: itemSelector.zone ?? PUCK_ROOT_ZONE,
+        destinationIndex: itemSelector.index,
+        data,
+      });
+    },
+    [puck, selectedItem],
+  );
+
+  return (
+    <StyleTab
+      tokens={tokens}
+      selectedItem={selectedItem}
+      bucket={bucket}
+      onStyleChange={handleStyleChange}
+    />
+  );
+}
+

--- a/packages/admin/src/editor/v2/StyleTab.test.tsx
+++ b/packages/admin/src/editor/v2/StyleTab.test.tsx
@@ -1,0 +1,150 @@
+import type { ThemeTokens } from "@plumix/blocks";
+import type { ComponentData } from "@puckeditor/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { StyleTab } from "./StyleTab.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const tokens: ThemeTokens = {
+  spacing: {
+    sm: { value: "0.5rem", label: "Small" },
+    md: { value: "1rem", label: "Medium" },
+    lg: { value: "2rem", label: "Large" },
+  },
+};
+
+function makeItem(props: Record<string, unknown> = {}): ComponentData {
+  return {
+    type: "core/heading",
+    props: { id: "h1", ...props },
+  };
+}
+
+describe("StyleTab", () => {
+  test("renders the empty-state when no block is selected", () => {
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={null}
+        bucket="large"
+        onStyleChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("style-tab-empty")).toBeDefined();
+  });
+
+  test("lists every spacing token as a dropdown option (plus a 'None' clear)", () => {
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={makeItem()}
+        bucket="large"
+        onStyleChange={vi.fn()}
+      />,
+    );
+
+    const select = screen.getByTestId("style-tab-padding-select");
+    const optionValues = new Set(
+      Array.from(select.querySelectorAll("option")).map((o) => o.value),
+    );
+    expect(optionValues).toEqual(new Set(["", "sm", "md", "lg"]));
+  });
+
+  test("renders the active bucket label so authors know which viewport they're editing", () => {
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={makeItem()}
+        bucket="small"
+        onStyleChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("style-tab-active-bucket").textContent,
+    ).toContain("Mobile");
+  });
+
+  test("seeds the dropdown from the active bucket's stored token id", () => {
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={makeItem({ style: { large: { padding: "md" } } })}
+        bucket="large"
+        onStyleChange={vi.fn()}
+      />,
+    );
+
+    const select = screen.getByTestId("style-tab-padding-select");
+    expect((select as HTMLSelectElement).value).toBe("md");
+  });
+
+  test("editing on Desktop writes the new token id to style.large.padding", async () => {
+    const onStyleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={makeItem()}
+        bucket="large"
+        onStyleChange={onStyleChange}
+      />,
+    );
+
+    await user.selectOptions(
+      screen.getByTestId("style-tab-padding-select"),
+      "lg",
+    );
+
+    expect(onStyleChange).toHaveBeenCalledWith({ large: { padding: "lg" } });
+  });
+
+  test("editing on Mobile writes the new token id to style.small.padding and preserves desktop", async () => {
+    const onStyleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={makeItem({ style: { large: { padding: "lg" } } })}
+        bucket="small"
+        onStyleChange={onStyleChange}
+      />,
+    );
+
+    await user.selectOptions(
+      screen.getByTestId("style-tab-padding-select"),
+      "sm",
+    );
+
+    expect(onStyleChange).toHaveBeenCalledWith({
+      large: { padding: "lg" },
+      small: { padding: "sm" },
+    });
+  });
+
+  test("selecting 'None' clears the property from the active bucket", async () => {
+    const onStyleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={makeItem({ style: { large: { padding: "md" } } })}
+        bucket="large"
+        onStyleChange={onStyleChange}
+      />,
+    );
+
+    await user.selectOptions(
+      screen.getByTestId("style-tab-padding-select"),
+      "",
+    );
+
+    expect(onStyleChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/admin/src/editor/v2/StyleTab.tsx
+++ b/packages/admin/src/editor/v2/StyleTab.tsx
@@ -1,0 +1,76 @@
+import type { ResponsiveStyleSlot, ThemeTokens } from "@plumix/blocks";
+import type { ChangeEvent, ReactElement } from "react";
+import type { ComponentData } from "@puckeditor/core";
+
+import { setStyleProperty } from "./style-edit.js";
+import type { StyleBucket } from "./viewport-bucket.js";
+
+interface StyleTabProps {
+  readonly tokens: ThemeTokens;
+  readonly selectedItem: ComponentData | null;
+  readonly bucket: StyleBucket;
+  readonly onStyleChange: (nextStyle: ResponsiveStyleSlot | undefined) => void;
+}
+
+const BUCKET_LABEL: Readonly<Record<StyleBucket, string>> = {
+  small: "Mobile",
+  medium: "Tablet",
+  large: "Desktop",
+};
+
+export function StyleTab({
+  tokens,
+  selectedItem,
+  bucket,
+  onStyleChange,
+}: StyleTabProps): ReactElement {
+  if (!selectedItem) {
+    return (
+      <div
+        className="p-4 text-sm text-muted-foreground"
+        data-testid="style-tab-empty"
+      >
+        Select a block to style.
+      </div>
+    );
+  }
+
+  const style = selectedItem.props.style as ResponsiveStyleSlot | undefined;
+  const padding = style?.[bucket]?.padding ?? "";
+  const spacingTokens = Object.entries(tokens.spacing ?? {});
+
+  const handlePaddingChange = (event: ChangeEvent<HTMLSelectElement>): void => {
+    const next = event.target.value === "" ? undefined : event.target.value;
+    onStyleChange(setStyleProperty(style, bucket, "padding", next));
+  };
+
+  return (
+    <div className="p-3" data-testid="style-tab">
+      <div
+        className="mb-3 rounded bg-muted px-2 py-1 text-xs"
+        data-testid="style-tab-active-bucket"
+      >
+        Editing for: {BUCKET_LABEL[bucket]}
+      </div>
+      <section className="space-y-2" data-testid="style-tab-section-spacing">
+        <h3 className="text-sm font-medium">Spacing</h3>
+        <label className="flex flex-col gap-1 text-xs">
+          <span>Padding</span>
+          <select
+            value={padding}
+            onChange={handlePaddingChange}
+            className="rounded border px-2 py-1 text-sm"
+            data-testid="style-tab-padding-select"
+          >
+            <option value="">None</option>
+            {spacingTokens.map(([id, entry]) => (
+              <option key={id} value={id}>
+                {entry.label ?? id}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+    </div>
+  );
+}

--- a/packages/admin/src/editor/v2/puck-to-block-tree.test.ts
+++ b/packages/admin/src/editor/v2/puck-to-block-tree.test.ts
@@ -131,12 +131,50 @@ describe("puckDataToBlockTree", () => {
       ]),
     );
 
-    // Walk three levels deep and confirm the innermost block is properly shaped.
     const outerContent = result[0]?.attrs?.content as readonly { attrs: Record<string, unknown> }[];
     const middle = outerContent[0];
     expect(middle).toBeDefined();
     const inner = (middle?.attrs.content as readonly { id: string }[])[0];
     expect(inner?.id).toBe("inner");
+  });
+
+  test("elevates props.style to node.style (separate from attrs)", () => {
+    const result = puckDataToBlockTree(
+      data([
+        {
+          type: "core/heading",
+          props: {
+            id: "h1",
+            text: "Title",
+            style: { large: { padding: "md" } },
+          },
+        },
+      ]),
+    );
+
+    expect(result[0]?.style).toEqual({ large: { padding: "md" } });
+    expect((result[0]?.attrs as Record<string, unknown>).style).toBeUndefined();
+  });
+
+  test("omits node.style when props.style is absent", () => {
+    const result = puckDataToBlockTree(
+      data([{ type: "core/heading", props: { id: "h1", text: "Title" } }]),
+    );
+    expect(result[0]?.style).toBeUndefined();
+  });
+
+  test("drops malformed props.style (null, primitive, array) without polluting attrs", () => {
+    const result = puckDataToBlockTree(
+      data([
+        { type: "core/heading", props: { id: "h1", style: null } },
+        { type: "core/heading", props: { id: "h2", style: "foo" } },
+        { type: "core/heading", props: { id: "h3", style: [] } },
+      ]),
+    );
+    for (const node of result) {
+      expect(node.style).toBeUndefined();
+      expect((node.attrs as Record<string, unknown>).style).toBeUndefined();
+    }
   });
 
   test("leaves non-slot arrays in attrs alone (does not false-positive on plain data lists)", () => {

--- a/packages/admin/src/editor/v2/puck-to-block-tree.ts
+++ b/packages/admin/src/editor/v2/puck-to-block-tree.ts
@@ -1,4 +1,4 @@
-import type { BlockNode } from "@plumix/blocks";
+import type { BlockNode, ResponsiveStyleSlot } from "@plumix/blocks";
 import type { Data } from "@puckeditor/core";
 
 interface PuckComponentDataLike {
@@ -29,7 +29,14 @@ function toBlockNode(
   const id =
     typeof rawId === "string" && rawId.length > 0 ? rawId : fallbackId;
   const attrs: Record<string, unknown> = {};
+  let style: ResponsiveStyleSlot | undefined;
   for (const [key, value] of Object.entries(item.props)) {
+    if (key === "style") {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        style = value;
+      }
+      continue;
+    }
     if (isPuckComponentDataArray(value)) {
       attrs[key] = value.map((child, idx) =>
         toBlockNode(child, `${id}-${key}-${idx}`),
@@ -38,7 +45,7 @@ function toBlockNode(
       attrs[key] = value;
     }
   }
-  return { id, name: item.type, attrs };
+  return style ? { id, name: item.type, attrs, style } : { id, name: item.type, attrs };
 }
 
 export function puckDataToBlockTree(

--- a/packages/admin/src/editor/v2/style-edit.test.ts
+++ b/packages/admin/src/editor/v2/style-edit.test.ts
@@ -1,0 +1,60 @@
+import type { ResponsiveStyleSlot } from "@plumix/blocks";
+import { describe, expect, test } from "vitest";
+
+import { setStyleProperty } from "./style-edit.js";
+
+describe("setStyleProperty", () => {
+  test("creates a new bucket when one doesn't yet exist", () => {
+    const result = setStyleProperty(undefined, "large", "padding", "md");
+    expect(result).toEqual({ large: { padding: "md" } });
+  });
+
+  test("merges with an existing bucket, overwriting only the targeted property", () => {
+    const before: ResponsiveStyleSlot = {
+      large: { padding: "sm", margin: "lg" },
+    };
+    const result = setStyleProperty(before, "large", "padding", "md");
+    expect(result).toEqual({ large: { padding: "md", margin: "lg" } });
+  });
+
+  test("preserves other buckets when writing to a different bucket", () => {
+    const before: ResponsiveStyleSlot = { large: { padding: "lg" } };
+    const result = setStyleProperty(before, "small", "padding", "sm");
+    expect(result).toEqual({
+      large: { padding: "lg" },
+      small: { padding: "sm" },
+    });
+  });
+
+  test("removes a property when tokenId is undefined", () => {
+    const before: ResponsiveStyleSlot = {
+      large: { padding: "md", margin: "lg" },
+    };
+    const result = setStyleProperty(before, "large", "padding", undefined);
+    expect(result).toEqual({ large: { margin: "lg" } });
+  });
+
+  test("drops an empty bucket after the final property in it is removed", () => {
+    const before: ResponsiveStyleSlot = { large: { padding: "md" } };
+    const result = setStyleProperty(before, "large", "padding", undefined);
+    expect(result).toBeUndefined();
+  });
+
+  test("preserves siblings when clearing a property from one bucket", () => {
+    const before: ResponsiveStyleSlot = {
+      large: { padding: "md" },
+      small: { padding: "sm" },
+    };
+    const result = setStyleProperty(before, "large", "padding", undefined);
+    expect(result).toEqual({ small: { padding: "sm" } });
+  });
+
+  test("does not mutate the input style object", () => {
+    const before: ResponsiveStyleSlot = { large: { padding: "md" } };
+    const frozen = Object.freeze({
+      large: Object.freeze({ ...before.large }),
+    }) as ResponsiveStyleSlot;
+    expect(() => setStyleProperty(frozen, "large", "padding", "lg")).not.toThrow();
+    expect(frozen.large?.padding).toBe("md");
+  });
+});

--- a/packages/admin/src/editor/v2/style-edit.ts
+++ b/packages/admin/src/editor/v2/style-edit.ts
@@ -1,0 +1,21 @@
+import type { ResponsiveStyleSlot } from "@plumix/blocks";
+
+import type { StyleBucket } from "./viewport-bucket.js";
+
+export function setStyleProperty(
+  style: ResponsiveStyleSlot | undefined,
+  bucket: StyleBucket,
+  property: string,
+  tokenId: string | undefined,
+): ResponsiveStyleSlot | undefined {
+  const nextBucket: Record<string, string> = { ...(style?.[bucket] ?? {}) };
+  if (tokenId === undefined) {
+    delete nextBucket[property];
+  } else {
+    nextBucket[property] = tokenId;
+  }
+  const { [bucket]: _omit, ...rest } = style ?? {};
+  const merged: ResponsiveStyleSlot =
+    Object.keys(nextBucket).length === 0 ? rest : { ...rest, [bucket]: nextBucket };
+  return Object.keys(merged).length === 0 ? undefined : merged;
+}

--- a/packages/admin/src/editor/v2/viewport-bucket.test.ts
+++ b/packages/admin/src/editor/v2/viewport-bucket.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import { viewportWidthToBucket } from "./viewport-bucket.js";
+
+describe("viewportWidthToBucket", () => {
+  test("maps 100% (responsive default) to the large bucket", () => {
+    expect(viewportWidthToBucket("100%")).toBe("large");
+  });
+
+  test("maps widths up to and including 640 to the small bucket", () => {
+    expect(viewportWidthToBucket(320)).toBe("small");
+    expect(viewportWidthToBucket(640)).toBe("small");
+  });
+
+  test("maps widths between 641 and 991 inclusive to the medium bucket", () => {
+    expect(viewportWidthToBucket(641)).toBe("medium");
+    expect(viewportWidthToBucket(768)).toBe("medium");
+    expect(viewportWidthToBucket(991)).toBe("medium");
+  });
+
+  test("maps widths above 991 to the large bucket", () => {
+    expect(viewportWidthToBucket(992)).toBe("large");
+    expect(viewportWidthToBucket(1440)).toBe("large");
+  });
+});

--- a/packages/admin/src/editor/v2/viewport-bucket.ts
+++ b/packages/admin/src/editor/v2/viewport-bucket.ts
@@ -1,0 +1,11 @@
+export type StyleBucket = "small" | "medium" | "large";
+
+const SMALL_MAX_PX = 640;
+const MEDIUM_MAX_PX = 991;
+
+export function viewportWidthToBucket(width: number | "100%"): StyleBucket {
+  if (width === "100%") return "large";
+  if (width <= SMALL_MAX_PX) return "small";
+  if (width <= MEDIUM_MAX_PX) return "medium";
+  return "large";
+}


### PR DESCRIPTION
First sub-slice of #387: prove the Style tab ↔ viewport-bucket binding end-to-end with one axis (`spacing.padding`) before layering on the rest.

**Style tab**

Right sidebar now has `Block` (the existing `Puck.Fields`) and `Style` tabs. Style renders an "Editing for: \<viewport\>" badge plus a Spacing section with a `padding` token dropdown sourced from `tokens.spacing`. A "None" option clears the token from the active bucket.

**Viewport-bucket binding**

`viewportWidthToBucket(puck.appState.ui.viewports.current.width)` derives the active bucket using the same `<=640` / `<=991` breakpoints the SSR style-emitter uses, so an edit on Desktop lands in `style.large.padding`, an edit on Mobile lands in `style.small.padding`, and the public-side `@media (max-width: ...)` cascade comes out right.

**SSR bridge fix**

`puck-to-block-tree` now elevates `props.style` to `node.style` rather than letting it land in `node.attrs.style`, so the walker sees and emits it. Malformed `props.style` (null, primitive, array) is dropped instead of polluting `attrs`.

**Two pure deep modules**

- `viewportWidthToBucket(width)` — 4 tests on the breakpoint boundaries.
- `setStyleProperty(style, bucket, property, tokenId?)` — 7 tests on bucket creation, sibling preservation, clear-and-drop-empty, frozen-input non-mutation.

**Explicitly out of scope (follow-up sub-slices of #387)**

- Color/typography/background axes and color-token swatches
- Collapsible Background / Typography / Spacing sections
- Theme-registry → route wiring (the spike route still passes an empty `tokens` prop, so the dropdown only shows "None" in the live demo today)
- Playwright screenshot coverage
- Slot-bearing wrappers — Puck's `replace` action regenerates child ids on every dispatch, so this slice's style edits stay leaf-block-only. A `setData` patch path is the next move when a follow-up styles wrappers.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>