### PR TITLE
feat(admin): style tab grows color and font-size axes

### DIFF
--- a/packages/admin/src/editor/v2/StyleTab.test.tsx
+++ b/packages/admin/src/editor/v2/StyleTab.test.tsx
@@ -147,4 +147,89 @@ describe("StyleTab", () => {
 
     expect(onStyleChange).toHaveBeenCalledWith(undefined);
   });
+
+  test("omits sections whose token category isn't declared on the theme", () => {
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={makeItem()}
+        bucket="large"
+        onStyleChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("style-tab-section-background")).toBeNull();
+    expect(screen.queryByTestId("style-tab-section-color")).toBeNull();
+    expect(screen.queryByTestId("style-tab-section-fontSize")).toBeNull();
+    expect(screen.queryByTestId("style-tab-section-spacing")).toBeDefined();
+  });
+
+  test("clicking a background swatch writes the token id to style.<bucket>.background", async () => {
+    const fullTokens: ThemeTokens = {
+      colors: { brand: { value: "#0070f3", label: "Brand" } },
+    };
+    const onStyleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StyleTab
+        tokens={fullTokens}
+        selectedItem={makeItem()}
+        bucket="medium"
+        onStyleChange={onStyleChange}
+      />,
+    );
+
+    await user.click(screen.getByTestId("style-tab-background-token-brand"));
+
+    expect(onStyleChange).toHaveBeenCalledWith({
+      medium: { background: "brand" },
+    });
+  });
+
+  test("clicking a text-color swatch writes the token id to style.<bucket>.color", async () => {
+    const fullTokens: ThemeTokens = {
+      colors: { ink: { value: "#111", label: "Ink" } },
+    };
+    const onStyleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StyleTab
+        tokens={fullTokens}
+        selectedItem={makeItem()}
+        bucket="large"
+        onStyleChange={onStyleChange}
+      />,
+    );
+
+    await user.click(screen.getByTestId("style-tab-color-token-ink"));
+
+    expect(onStyleChange).toHaveBeenCalledWith({
+      large: { color: "ink" },
+    });
+  });
+
+  test("selecting a font-size option writes the token id to style.<bucket>.fontSize", async () => {
+    const fullTokens: ThemeTokens = {
+      typography: { xl: { value: "1.5rem", label: "Extra large" } },
+    };
+    const onStyleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StyleTab
+        tokens={fullTokens}
+        selectedItem={makeItem()}
+        bucket="large"
+        onStyleChange={onStyleChange}
+      />,
+    );
+
+    await user.selectOptions(
+      screen.getByTestId("style-tab-fontSize-select"),
+      "xl",
+    );
+
+    expect(onStyleChange).toHaveBeenCalledWith({
+      large: { fontSize: "xl" },
+    });
+  });
 });

--- a/packages/admin/src/editor/v2/StyleTab.tsx
+++ b/packages/admin/src/editor/v2/StyleTab.tsx
@@ -1,9 +1,16 @@
-import type { ResponsiveStyleSlot, ThemeTokens } from "@plumix/blocks";
-import type { ChangeEvent, ReactElement } from "react";
+import type {
+  ResponsiveStyleSlot,
+  ThemeTokenGroup,
+  ThemeTokens,
+} from "@plumix/blocks";
+import type { ReactElement } from "react";
 import type { ComponentData } from "@puckeditor/core";
 
 import { setStyleProperty } from "./style-edit.js";
+import { TokenSwatchList } from "./TokenSwatchList.js";
 import type { StyleBucket } from "./viewport-bucket.js";
+
+type StyleProperty = "background" | "color" | "fontSize" | "padding";
 
 interface StyleTabProps {
   readonly tokens: ThemeTokens;
@@ -36,41 +43,116 @@ export function StyleTab({
   }
 
   const style = selectedItem.props.style as ResponsiveStyleSlot | undefined;
-  const padding = style?.[bucket]?.padding ?? "";
-  const spacingTokens = Object.entries(tokens.spacing ?? {});
-
-  const handlePaddingChange = (event: ChangeEvent<HTMLSelectElement>): void => {
-    const next = event.target.value === "" ? undefined : event.target.value;
-    onStyleChange(setStyleProperty(style, bucket, "padding", next));
+  const writeProperty = (
+    property: StyleProperty,
+    tokenId: string | undefined,
+  ): void => {
+    onStyleChange(setStyleProperty(style, bucket, property, tokenId));
   };
 
   return (
-    <div className="p-3" data-testid="style-tab">
+    <div className="space-y-4 p-3" data-testid="style-tab">
       <div
-        className="mb-3 rounded bg-muted px-2 py-1 text-xs"
+        className="rounded bg-muted px-2 py-1 text-xs"
         data-testid="style-tab-active-bucket"
       >
         Editing for: {BUCKET_LABEL[bucket]}
       </div>
-      <section className="space-y-2" data-testid="style-tab-section-spacing">
-        <h3 className="text-sm font-medium">Spacing</h3>
-        <label className="flex flex-col gap-1 text-xs">
-          <span>Padding</span>
-          <select
-            value={padding}
-            onChange={handlePaddingChange}
-            className="rounded border px-2 py-1 text-sm"
-            data-testid="style-tab-padding-select"
-          >
-            <option value="">None</option>
-            {spacingTokens.map(([id, entry]) => (
-              <option key={id} value={id}>
-                {entry.label ?? id}
-              </option>
-            ))}
-          </select>
-        </label>
-      </section>
+      <SwatchSection
+        heading="Background"
+        testId="style-tab-section-background"
+        property="background"
+        tokens={tokens.colors}
+        value={style?.[bucket]?.background ?? ""}
+        onWrite={writeProperty}
+      />
+      <SwatchSection
+        heading="Text color"
+        testId="style-tab-section-color"
+        property="color"
+        tokens={tokens.colors}
+        value={style?.[bucket]?.color ?? ""}
+        onWrite={writeProperty}
+      />
+      <SelectSection
+        heading="Font size"
+        testId="style-tab-section-fontSize"
+        property="fontSize"
+        tokens={tokens.typography}
+        value={style?.[bucket]?.fontSize ?? ""}
+        onWrite={writeProperty}
+      />
+      <SelectSection
+        heading="Padding"
+        testId="style-tab-section-spacing"
+        property="padding"
+        tokens={tokens.spacing}
+        value={style?.[bucket]?.padding ?? ""}
+        onWrite={writeProperty}
+      />
     </div>
+  );
+}
+
+interface SectionProps {
+  readonly heading: string;
+  readonly testId: string;
+  readonly property: StyleProperty;
+  readonly tokens: ThemeTokenGroup | undefined;
+  readonly value: string;
+  readonly onWrite: (property: StyleProperty, tokenId: string | undefined) => void;
+}
+
+function SwatchSection({
+  heading,
+  testId,
+  property,
+  tokens,
+  value,
+  onWrite,
+}: SectionProps): ReactElement | null {
+  if (!tokens) return null;
+  return (
+    <section className="space-y-2" data-testid={testId}>
+      <h3 className="text-sm font-medium">{heading}</h3>
+      <TokenSwatchList
+        tokens={tokens}
+        value={value}
+        onChange={(next) => onWrite(property, next)}
+        testIdPrefix={`style-tab-${property}`}
+        ariaLabel={heading}
+      />
+    </section>
+  );
+}
+
+function SelectSection({
+  heading,
+  testId,
+  property,
+  tokens,
+  value,
+  onWrite,
+}: SectionProps): ReactElement | null {
+  if (!tokens) return null;
+  return (
+    <section className="space-y-2" data-testid={testId}>
+      <h3 className="text-sm font-medium">{heading}</h3>
+      <select
+        value={value}
+        onChange={(event) =>
+          onWrite(property, event.target.value === "" ? undefined : event.target.value)
+        }
+        className="w-full rounded border px-2 py-1 text-sm"
+        data-testid={`style-tab-${property}-select`}
+      >
+        <option value="">None</option>
+        {Object.entries(tokens).map(([id, entry]) => (
+          <option key={id} value={id}>
+            {entry.label ?? id}
+          </option>
+        ))}
+      </select>
+    </section>
   );
 }

--- a/packages/admin/src/editor/v2/TokenSwatchList.test.tsx
+++ b/packages/admin/src/editor/v2/TokenSwatchList.test.tsx
@@ -1,0 +1,106 @@
+import type { ThemeTokenGroup } from "@plumix/blocks";
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { TokenSwatchList } from "./TokenSwatchList.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const colorTokens: ThemeTokenGroup = {
+  primary: { value: "#0070f3", label: "Primary" },
+  danger: { value: "#e00", label: "Danger" },
+};
+
+describe("TokenSwatchList", () => {
+  test("renders one radio per token plus a 'None' clear, inside a labelled radiogroup", () => {
+    render(
+      <TokenSwatchList
+        tokens={colorTokens}
+        value=""
+        onChange={vi.fn()}
+        testIdPrefix="bg"
+        ariaLabel="Background color"
+      />,
+    );
+
+    const group = screen.getByTestId("bg-list");
+    expect(group.getAttribute("role")).toBe("radiogroup");
+    expect(group.getAttribute("aria-label")).toBe("Background color");
+    expect(screen.getByTestId("bg-clear")).toBeDefined();
+    expect(screen.getByTestId("bg-token-primary")).toBeDefined();
+    expect(screen.getByTestId("bg-token-danger")).toBeDefined();
+  });
+
+  test("emits the token's resolved CSS value as the swatch background-color", () => {
+    render(
+      <TokenSwatchList
+        tokens={colorTokens}
+        value=""
+        onChange={vi.fn()}
+        testIdPrefix="bg"
+        ariaLabel="Background color"
+      />,
+    );
+
+    const swatch = screen.getByTestId("bg-swatch-primary");
+    expect(swatch.style.backgroundColor).toBe("rgb(0, 112, 243)");
+  });
+
+  test("marks the active token as the checked radio", () => {
+    render(
+      <TokenSwatchList
+        tokens={colorTokens}
+        value="primary"
+        onChange={vi.fn()}
+        testIdPrefix="bg"
+        ariaLabel="Background color"
+      />,
+    );
+
+    expect(
+      screen.getByTestId<HTMLInputElement>("bg-token-primary").checked,
+    ).toBe(true);
+    expect(
+      screen.getByTestId<HTMLInputElement>("bg-token-danger").checked,
+    ).toBe(false);
+  });
+
+  test("invokes onChange with the token id when its swatch is clicked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <TokenSwatchList
+        tokens={colorTokens}
+        value=""
+        onChange={onChange}
+        testIdPrefix="bg"
+        ariaLabel="Background color"
+      />,
+    );
+
+    await user.click(screen.getByTestId("bg-token-danger"));
+
+    expect(onChange).toHaveBeenCalledWith("danger");
+  });
+
+  test("invokes onChange with undefined when the 'None' radio is clicked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <TokenSwatchList
+        tokens={colorTokens}
+        value="primary"
+        onChange={onChange}
+        testIdPrefix="bg"
+        ariaLabel="Background color"
+      />,
+    );
+
+    await user.click(screen.getByTestId("bg-clear"));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/admin/src/editor/v2/TokenSwatchList.tsx
+++ b/packages/admin/src/editor/v2/TokenSwatchList.tsx
@@ -1,0 +1,64 @@
+import type { ThemeTokenGroup } from "@plumix/blocks";
+import type { ReactElement } from "react";
+import { useId } from "react";
+
+interface TokenSwatchListProps {
+  readonly tokens: ThemeTokenGroup;
+  readonly value: string;
+  readonly onChange: (next: string | undefined) => void;
+  readonly testIdPrefix: string;
+  readonly ariaLabel: string;
+}
+
+export function TokenSwatchList({
+  tokens,
+  value,
+  onChange,
+  testIdPrefix,
+  ariaLabel,
+}: TokenSwatchListProps): ReactElement {
+  const name = useId();
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="flex flex-wrap gap-1"
+      data-testid={`${testIdPrefix}-list`}
+    >
+      <label className="inline-flex items-center rounded border px-2 py-1 text-xs">
+        <input
+          type="radio"
+          name={name}
+          value=""
+          checked={value === ""}
+          onChange={() => onChange(undefined)}
+          className="sr-only"
+          data-testid={`${testIdPrefix}-clear`}
+        />
+        None
+      </label>
+      {Object.entries(tokens).map(([id, entry]) => (
+        <label
+          key={id}
+          className="inline-flex items-center gap-1 rounded border px-2 py-1 text-xs"
+        >
+          <input
+            type="radio"
+            name={name}
+            value={id}
+            checked={value === id}
+            onChange={() => onChange(id)}
+            className="sr-only"
+            data-testid={`${testIdPrefix}-token-${id}`}
+          />
+          <span
+            className="size-3 rounded border"
+            style={{ backgroundColor: entry.value }}
+            data-testid={`${testIdPrefix}-swatch-${id}`}
+          />
+          {entry.label ?? id}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -1,8 +1,9 @@
+import type { ThemeTokens } from "@plumix/blocks";
 import type { Config, Data } from "@puckeditor/core";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { Puck } from "@puckeditor/core";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
 
@@ -42,12 +43,37 @@ const config: Config<{ Heading: HeadingProps }> = {
 
 const initialData: Data = { content: [], root: {} };
 
+const sampleTokens: ThemeTokens = {
+  colors: {
+    background: { value: "#ffffff", label: "Background" },
+    surface: { value: "#f4f4f5", label: "Surface" },
+    brand: { value: "#0070f3", label: "Brand" },
+    ink: { value: "#111111", label: "Ink" },
+  },
+  spacing: {
+    none: { value: "0", label: "None" },
+    sm: { value: "0.5rem", label: "Small" },
+    md: { value: "1rem", label: "Medium" },
+    lg: { value: "2rem", label: "Large" },
+  },
+  typography: {
+    sm: { value: "0.875rem", label: "Small" },
+    md: { value: "1rem", label: "Medium" },
+    lg: { value: "1.25rem", label: "Large" },
+    xl: { value: "1.5rem", label: "Extra large" },
+  },
+};
+
 export const Route = createFileRoute("/_editor/v2/entries/$slug/$id/edit")({
   component: PuckSpikeRoute,
 });
 
 function PuckSpikeRoute(): ReactNode {
   const [data, setData] = useState<Data>(initialData);
+  const Layout = useCallback(
+    (): ReactElement => <PlumixEditorLayout tokens={sampleTokens} />,
+    [],
+  );
 
   return (
     <Puck
@@ -56,7 +82,7 @@ function PuckSpikeRoute(): ReactNode {
       onPublish={setData}
       onChange={setData}
       iframe={{ enabled: false }}
-      overrides={{ puck: PlumixEditorLayout }}
+      overrides={{ puck: Layout }}
     />
   );
 }


### PR DESCRIPTION
Second sub-slice of #387: the Style tab now covers four axes (Background, Text color, Font size, Padding), color tokens render as visual swatches inside a labelled radiogroup, and the spike route ships a sample theme so the demo actually shows tokens.

**TokenSwatchList primitive**

A new `<TokenSwatchList>` component renders a `role="radiogroup"` with one native `<input type="radio">` per token (`sr-only`, visually replaced by a labelled colored tile). The "None" entry is the empty-value radio. Native radio semantics give arrow-key roving and screen-reader cardinality announcements for free, which is the right ARIA pattern for a single-select swatch picker (`role="radio"`, not `aria-pressed` toggles).

**StyleTab sections**

`StyleTab` now composes `SwatchSection` (Background, Text color) and `SelectSection` (Font size, Padding) helpers. Each section hides itself when its token category isn't declared, so a theme that only registers `spacing` only sees the Padding control. The `property` arg is narrowed to a closed union (`"background" | "color" | "fontSize" | "padding"`) so a future section can't silently write an unknown CSS axis through `setStyleProperty`.

**Spike-route theme**

The route declares a sample `ThemeTokens` (4 colors, 4 spacing scales, 4 type sizes) and passes it via a stable `useCallback` Puck-override closure. The demo now shows real tokens in every section.

**Out of scope (next sub-slices of #387)**

- Collapsible sections (currently always-expanded)
- Margin / line-height / font-weight / border axes
- Real theme-registry sourcing (the route's tokens stay literal until the registry slice)
- Playwright screenshot coverage
- Slot-bearing wrappers (Puck's `replace` still regenerates child ids — leaf-block-only)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>