### PR TITLE
feat(blocks,admin): wire the v2 corpus into the puck spike route

### DIFF
--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -1,45 +1,15 @@
 import type { ThemeTokens } from "@plumix/blocks";
 import type { Config, Data } from "@puckeditor/core";
 import type { ReactElement, ReactNode } from "react";
+import { coreBlocksV2, createBlockRegistry } from "@plumix/blocks";
 import { Puck } from "@puckeditor/core";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useState } from "react";
 
+import { blockSpecsToPuckComponents } from "@/editor/v2/block-adapter.js";
 import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
 
 import "@puckeditor/core/puck.css";
-
-interface HeadingProps {
-  readonly text: string;
-  readonly level: 1 | 2 | 3 | 4 | 5 | 6;
-}
-
-const config: Config<{ Heading: HeadingProps }> = {
-  components: {
-    Heading: {
-      label: "Heading",
-      fields: {
-        text: { type: "text" },
-        level: {
-          type: "select",
-          options: [
-            { label: "H1", value: 1 },
-            { label: "H2", value: 2 },
-            { label: "H3", value: 3 },
-            { label: "H4", value: 4 },
-            { label: "H5", value: 5 },
-            { label: "H6", value: 6 },
-          ],
-        },
-      },
-      defaultProps: { text: "Hello, Puck", level: 2 },
-      render: ({ text, level }) => {
-        const Tag = `h${level}` as const;
-        return <Tag>{text}</Tag>;
-      },
-    },
-  },
-};
 
 const initialData: Data = { content: [], root: {} };
 
@@ -64,6 +34,11 @@ const sampleTokens: ThemeTokens = {
   },
 };
 
+const registry = createBlockRegistry(coreBlocksV2);
+const config: Config = {
+  components: blockSpecsToPuckComponents(coreBlocksV2),
+};
+
 export const Route = createFileRoute("/_editor/v2/entries/$slug/$id/edit")({
   component: PuckSpikeRoute,
 });
@@ -71,7 +46,9 @@ export const Route = createFileRoute("/_editor/v2/entries/$slug/$id/edit")({
 function PuckSpikeRoute(): ReactNode {
   const [data, setData] = useState<Data>(initialData);
   const Layout = useCallback(
-    (): ReactElement => <PlumixEditorLayout tokens={sampleTokens} />,
+    (): ReactElement => (
+      <PlumixEditorLayout registry={registry} tokens={sampleTokens} />
+    ),
     [],
   );
 

--- a/packages/blocks/src/core-blocks-v2.test.ts
+++ b/packages/blocks/src/core-blocks-v2.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry } from "./block-registry.js";
+import { coreBlocksV2 } from "./core-blocks-v2.js";
+
+describe("coreBlocksV2", () => {
+  test("includes the canonical typography and layout blocks the V2 corpus has migrated", () => {
+    const names = new Set(coreBlocksV2.map((b) => b.name));
+    expect(names.has("core/heading")).toBe(true);
+    expect(names.has("core/paragraph")).toBe(true);
+    expect(names.has("core/quote")).toBe(true);
+    expect(names.has("core/code")).toBe(true);
+    expect(names.has("core/group")).toBe(true);
+    expect(names.has("core/columns")).toBe(true);
+    expect(names.has("core/table")).toBe(true);
+    expect(names.has("core/list")).toBe(true);
+  });
+
+  test("declares unique block names with no duplicates", () => {
+    const names = coreBlocksV2.map((b) => b.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("seeds a BlockRegistry losslessly (size matches input length)", () => {
+    const registry = createBlockRegistry(coreBlocksV2);
+    expect(registry.size).toBe(coreBlocksV2.length);
+    for (const spec of coreBlocksV2) {
+      expect(registry.get(spec.name)).toBe(spec);
+    }
+  });
+
+  test("does not include the html block (operators opt in explicitly)", () => {
+    const names = new Set(coreBlocksV2.map((b) => b.name));
+    expect(names.has("core/html")).toBe(false);
+  });
+});

--- a/packages/blocks/src/core-blocks-v2.ts
+++ b/packages/blocks/src/core-blocks-v2.ts
@@ -1,0 +1,56 @@
+import type { BlockSpec } from "./block-registry.js";
+import { buttonBlockV2 } from "./button/v2.js";
+import { buttonsBlockV2 } from "./buttons/v2.js";
+import { calloutBlockV2 } from "./callout/v2.js";
+import { codeBlockV2 } from "./code/v2.js";
+import { columnsBlockV2 } from "./columns/v2.js";
+import {
+  descriptionDetailBlockV2,
+  descriptionListBlockV2,
+  descriptionTermBlockV2,
+} from "./description-list/v2.js";
+import { detailsBlockV2 } from "./details/v2.js";
+import { groupBlockV2 } from "./group/v2.js";
+import { headingBlock } from "./heading/index.js";
+import {
+  listBlockV2,
+  listItemBlockV2,
+  listOrderedBlockV2,
+} from "./list/v2.js";
+import { paragraphBlockV2 } from "./paragraph/v2.js";
+import { quoteBlockV2 } from "./quote/v2.js";
+import { separatorBlockV2 } from "./separator/v2.js";
+import { spacerBlockV2 } from "./spacer/v2.js";
+import {
+  tableBlockV2,
+  tableBodyRowBlockV2,
+  tableCellBlockV2,
+  tableHeaderCellBlockV2,
+  tableHeaderRowBlockV2,
+} from "./table/v2.js";
+
+export const coreBlocksV2: readonly BlockSpec[] = Object.freeze([
+  headingBlock,
+  paragraphBlockV2,
+  quoteBlockV2,
+  separatorBlockV2,
+  spacerBlockV2,
+  codeBlockV2,
+  listBlockV2,
+  listOrderedBlockV2,
+  listItemBlockV2,
+  descriptionListBlockV2,
+  descriptionTermBlockV2,
+  descriptionDetailBlockV2,
+  groupBlockV2,
+  columnsBlockV2,
+  buttonsBlockV2,
+  buttonBlockV2,
+  detailsBlockV2,
+  calloutBlockV2,
+  tableBlockV2,
+  tableHeaderRowBlockV2,
+  tableBodyRowBlockV2,
+  tableHeaderCellBlockV2,
+  tableCellBlockV2,
+]);

--- a/packages/blocks/src/heading/index.tsx
+++ b/packages/blocks/src/heading/index.tsx
@@ -8,6 +8,22 @@ export const headingBlock = defineBlock({
   title: "Heading",
   icon: "Heading",
   category: "text",
+  inputs: [
+    { name: "text", type: "text", label: "Text" },
+    {
+      name: "level",
+      type: "select",
+      label: "Level",
+      options: [
+        { label: "H1", value: 1 },
+        { label: "H2", value: 2 },
+        { label: "H3", value: 3 },
+        { label: "H4", value: 4 },
+        { label: "H5", value: 5 },
+        { label: "H6", value: 6 },
+      ],
+    },
+  ],
   defaults: { level: 2, text: "" },
   transforms: {
     priority: 50,

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -145,6 +145,7 @@ export type {
 export { coreMarks } from "./marks/core/index.js";
 
 export { coreBlocks } from "./core-blocks.js";
+export { coreBlocksV2 } from "./core-blocks-v2.js";
 export { buttonBlock } from "./button/index.js";
 export { buttonsBlock } from "./buttons/index.js";
 export { calloutBlock } from "./callout/index.js";


### PR DESCRIPTION
Replace the v2 spike route's hand-rolled "Heading" stub with the real V2 corpus so the canvas, Blocks tab, and slash menu surface all 23 migrated specs.

**`coreBlocksV2` catalog**

A new frozen, ordered array in `@plumix/blocks` collects `headingBlock` + 22 `*BlockV2` exports. Order mirrors v1's typography → layout → interactive → structured convention so the picker UX stays familiar. `htmlBlockV2` is deliberately omitted to match v1's explicit-opt-in policy.

**Spike-route wiring**

The route now builds `config.components` via `blockSpecsToPuckComponents(coreBlocksV2)` and passes `createBlockRegistry(coreBlocksV2)` to `PlumixEditorLayout`, so the slash menu, Style tab, and Blocks tab all operate against the real registry.

**Heading inputs restored**

`headingBlock` migrated to V2 in slice #381 but never gained `inputs` — its editor controls only lived in the spike route's stub. Dropping the stub would have been a strict regression for heading editability, so `headingBlock` now declares `text` and `level` (H1–H6) inputs.

V2 `BlockSpec` still lacks an `inserter: false` (or `parent: string`) escape hatch, so the slash menu now surfaces content-only specs (table rows/cells, list items, dt/dd) as standalone insertions. The spike route starts with an empty document so this isn't user-visible today; a follow-up sub-slice will add the flag and mark the seven content-only specs.

Refs #386, #381

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>