### PR TITLE
feat(blocks,admin): add inserter:false escape hatch on v2 blockspec

### DIFF
--- a/packages/admin/src/editor/v2/slash-menu-items.test.ts
+++ b/packages/admin/src/editor/v2/slash-menu-items.test.ts
@@ -9,16 +9,7 @@ import {
 } from "./slash-menu-items.js";
 
 function spec(partial: Partial<BlockSpecV2> & { name: string }): BlockSpecV2 {
-  return {
-    name: partial.name,
-    title: partial.title,
-    description: partial.description,
-    keywords: partial.keywords,
-    icon: partial.icon,
-    category: partial.category,
-    capability: partial.capability,
-    render: () => null,
-  };
+  return { render: () => null, ...partial };
 }
 
 describe("resolveSlashMenuItems", () => {
@@ -139,6 +130,43 @@ describe("resolveSlashMenuItems", () => {
       "core/spacer",
     );
     expect(items.find((i) => i.name === "core/heading")?.title).toBe("Heading");
+  });
+
+  test("omits specs declared with `inserter: false` so structural-children stay out of the menu", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/table", title: "Table" }),
+      spec({
+        name: "core/table-row",
+        title: "Table row",
+        inserter: false,
+      }),
+      spec({
+        name: "core/table-cell",
+        title: "Table cell",
+        inserter: false,
+      }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "",
+    });
+
+    expect(items.map((i) => i.name)).toEqual(["core/table"]);
+  });
+
+  test("keeps specs that omit `inserter` (default shown) and specs that opt in with `inserter: true`", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "a/default", title: "Default" }),
+      spec({ name: "a/opt-in", title: "Opt-in", inserter: true }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "",
+    });
+
+    expect(items.map((i) => i.name).sort()).toEqual(["a/default", "a/opt-in"]);
   });
 
   test("treats whitespace-only queries as empty (no filtering)", () => {

--- a/packages/admin/src/editor/v2/slash-menu-items.ts
+++ b/packages/admin/src/editor/v2/slash-menu-items.ts
@@ -25,6 +25,7 @@ export function resolveSlashMenuItems(
   const scored: { item: SlashMenuItem; score: number }[] = [];
 
   for (const spec of registry) {
+    if (spec.inserter === false) continue;
     if (!isInsertableForCapabilities(spec, capabilities)) continue;
     const item = toItem(spec);
     if (needle === "") {

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -28,6 +28,7 @@ export interface BlockSpec<
   readonly keywords?: readonly string[];
   readonly icon?: string;
   readonly category?: string;
+  readonly inserter?: boolean;
   readonly inputs?: readonly BlockInput[];
   readonly render: BlockNodeComponent<Attrs>;
   readonly inline?: boolean;

--- a/packages/blocks/src/core-blocks-v2.test.ts
+++ b/packages/blocks/src/core-blocks-v2.test.ts
@@ -33,4 +33,29 @@ describe("coreBlocksV2", () => {
     const names = new Set(coreBlocksV2.map((b) => b.name));
     expect(names.has("core/html")).toBe(false);
   });
+
+  test("declares `inserter: false` on every spec that only makes sense inside a parent", () => {
+    const contentOnlyNames = new Set([
+      "core/table-header-row",
+      "core/table-body-row",
+      "core/table-header-cell",
+      "core/table-cell",
+      "core/list-item",
+      "core/description-term",
+      "core/description-detail",
+    ]);
+
+    for (const spec of coreBlocksV2) {
+      if (contentOnlyNames.has(spec.name)) {
+        expect(spec.inserter).toBe(false);
+      } else {
+        expect(spec.inserter).not.toBe(false);
+      }
+    }
+
+    const hidden = new Set(
+      coreBlocksV2.filter((s) => s.inserter === false).map((s) => s.name),
+    );
+    expect(hidden).toEqual(contentOnlyNames);
+  });
 });

--- a/packages/blocks/src/description-list/v2.tsx
+++ b/packages/blocks/src/description-list/v2.tsx
@@ -21,6 +21,7 @@ export const descriptionTermBlockV2 = defineBlock({
   icon: "Type",
   category: "text",
   inline: true,
+  inserter: false,
   inputs: [{ name: "text", type: "text", label: "Term" }],
   defaults: { text: "" },
   render: ({ attrs }): ReactNode => {
@@ -35,6 +36,7 @@ export const descriptionDetailBlockV2 = defineBlock({
   icon: "AlignLeft",
   category: "text",
   inline: true,
+  inserter: false,
   inputs: [{ name: "text", type: "textarea", label: "Detail" }],
   defaults: { text: "" },
   render: ({ attrs }): ReactNode => {

--- a/packages/blocks/src/list/v2.tsx
+++ b/packages/blocks/src/list/v2.tsx
@@ -44,6 +44,7 @@ export const listItemBlockV2 = defineBlock({
   title: "List item",
   category: "text",
   inline: true,
+  inserter: false,
   inputs: [{ name: "text", type: "text", label: "Item" }],
   defaults: { text: "" },
   render: ({ attrs }): ReactNode => {

--- a/packages/blocks/src/table/v2.tsx
+++ b/packages/blocks/src/table/v2.tsx
@@ -40,6 +40,7 @@ export const tableHeaderRowBlockV2 = defineBlock({
   icon: "Rows",
   category: "text",
   inline: true,
+  inserter: false,
   inputs: [{ name: "cells", type: "slot", label: "Cells" }],
   defaults: {},
   render: ({ attrs }): ReactNode => {
@@ -54,6 +55,7 @@ export const tableBodyRowBlockV2 = defineBlock({
   icon: "Rows",
   category: "text",
   inline: true,
+  inserter: false,
   inputs: [{ name: "cells", type: "slot", label: "Cells" }],
   defaults: {},
   render: ({ attrs }): ReactNode => {
@@ -68,6 +70,7 @@ export const tableHeaderCellBlockV2 = defineBlock({
   icon: "AlignLeft",
   category: "text",
   inline: true,
+  inserter: false,
   inputs: [
     { name: "text", type: "text", label: "Text" },
     {
@@ -95,6 +98,7 @@ export const tableCellBlockV2 = defineBlock({
   icon: "AlignLeft",
   category: "text",
   inline: true,
+  inserter: false,
   inputs: [
     { name: "text", type: "text", label: "Text" },
     {


### PR DESCRIPTION
Add an `inserter?: boolean` escape hatch to V2 `BlockSpec` so structural-children stay out of the slash menu. Closes the senpai-flagged follow-up from #429 — the prior slice wired `coreBlocksV2` into the slash menu and surfaced table rows/cells, list items, and dt/dd as standalone insertions that would have produced orphan markup at the root.

**Filter contract**

`resolveSlashMenuItems` now skips specs with `spec.inserter === false` before capability gating. Strict `=== false` keeps `undefined` and `true` default-shown — same form V1 uses in `items-from-registry.ts`.

**Catalog wiring**

Seven content-only V2 specs are marked: `core/table-header-row`, `core/table-body-row`, `core/table-header-cell`, `core/table-cell`, `core/list-item`, `core/description-term`, `core/description-detail`. They still render normally when nested inside their parents; only the standalone insertion path is hidden.

**Catalog test guards future additions**

The `coreBlocksV2` catalog test asserts every content-only spec carries the flag *and* cross-checks that the set of `inserter:false` specs equals the documented content-only list. A future content-only spec that forgets the flag (or a non-content spec that mistakenly opts out) fails the assertion.

Refs #429

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>