### PR TITLE
refactor(blocks,admin): share VIEWPORT_MAX_PX between ssr and admin

### DIFF
--- a/packages/admin/src/editor/v2/viewport-bucket.ts
+++ b/packages/admin/src/editor/v2/viewport-bucket.ts
@@ -1,11 +1,10 @@
-export type StyleBucket = "small" | "medium" | "large";
+import { VIEWPORT_MAX_PX } from "@plumix/blocks";
 
-const SMALL_MAX_PX = 640;
-const MEDIUM_MAX_PX = 991;
+export type StyleBucket = "small" | "medium" | "large";
 
 export function viewportWidthToBucket(width: number | "100%"): StyleBucket {
   if (width === "100%") return "large";
-  if (width <= SMALL_MAX_PX) return "small";
-  if (width <= MEDIUM_MAX_PX) return "medium";
+  if (width <= VIEWPORT_MAX_PX.small) return "small";
+  if (width <= VIEWPORT_MAX_PX.medium) return "medium";
   return "large";
 }

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -69,6 +69,7 @@ export type {
 export {
   emitBlockStyleCss,
   tokenIdToCssVar,
+  VIEWPORT_MAX_PX,
 } from "./styles/style-emitter.js";
 export type {
   ResponsiveStyleBucket,

--- a/packages/blocks/src/styles/style-emitter.ts
+++ b/packages/blocks/src/styles/style-emitter.ts
@@ -22,7 +22,7 @@ const PROPERTY_TO_CATEGORY: Readonly<Record<string, TokenCategory>> = {
 
 const SAFE_CSS_TOKEN_RE = /^[A-Za-z0-9_-]+$/;
 
-const VIEWPORT_MAX_PX: Readonly<Record<"medium" | "small", number>> = {
+export const VIEWPORT_MAX_PX: Readonly<Record<"medium" | "small", number>> = {
   medium: 991,
   small: 640,
 };

--- a/packages/blocks/src/styles/viewport-breakpoints.test.ts
+++ b/packages/blocks/src/styles/viewport-breakpoints.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+
+import { VIEWPORT_MAX_PX } from "../index.js";
+
+describe("VIEWPORT_MAX_PX", () => {
+  test("exposes the canonical responsive breakpoints", () => {
+    expect(VIEWPORT_MAX_PX).toEqual({ medium: 991, small: 640 });
+  });
+});


### PR DESCRIPTION
The responsive breakpoints (`640`, `991`) lived in two places: SSR's `style-emitter.ts` (private const) and the admin's `viewport-bucket.ts` mapper (separate `SMALL_MAX_PX` / `MEDIUM_MAX_PX` locals). If the two drifted, an editor edit on a given viewport could land in one bucket while SSR emitted the matching `@media (max-width: ...)` at a different boundary.

Promote `VIEWPORT_MAX_PX` to a public export from `@plumix/blocks` and have both consumers read from it. A one-line pin test in `viewport-breakpoints.test.ts` makes any future drift a deliberate edit rather than an accidental skew. No behaviour change — the existing boundary tests in `viewport-bucket.test.ts` stay green and now exercise the shared constant indirectly.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>