### PR TITLE
feat(admin): make style tab sections collapsible via shadcn accordion

### DIFF
--- a/packages/admin/src/editor/v2/StyleTab.test.tsx
+++ b/packages/admin/src/editor/v2/StyleTab.test.tsx
@@ -161,7 +161,7 @@ describe("StyleTab", () => {
     expect(screen.queryByTestId("style-tab-section-background")).toBeNull();
     expect(screen.queryByTestId("style-tab-section-color")).toBeNull();
     expect(screen.queryByTestId("style-tab-section-fontSize")).toBeNull();
-    expect(screen.queryByTestId("style-tab-section-spacing")).toBeDefined();
+    expect(screen.queryByTestId("style-tab-section-padding")).toBeDefined();
   });
 
   test("clicking a background swatch writes the token id to style.<bucket>.background", async () => {
@@ -206,6 +206,25 @@ describe("StyleTab", () => {
     expect(onStyleChange).toHaveBeenCalledWith({
       large: { color: "ink" },
     });
+  });
+
+  test("clicking a section's trigger collapses its inner control", async () => {
+    const onStyleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StyleTab
+        tokens={tokens}
+        selectedItem={makeItem()}
+        bucket="large"
+        onStyleChange={onStyleChange}
+      />,
+    );
+
+    expect(screen.getByTestId("style-tab-padding-select")).toBeDefined();
+
+    await user.click(screen.getByTestId("style-tab-section-padding-trigger"));
+
+    expect(screen.queryByTestId("style-tab-padding-select")).toBeNull();
   });
 
   test("selecting a font-size option writes the token id to style.<bucket>.fontSize", async () => {

--- a/packages/admin/src/editor/v2/StyleTab.tsx
+++ b/packages/admin/src/editor/v2/StyleTab.tsx
@@ -3,8 +3,15 @@ import type {
   ThemeTokenGroup,
   ThemeTokens,
 } from "@plumix/blocks";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import type { ComponentData } from "@puckeditor/core";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion.js";
 
 import { setStyleProperty } from "./style-edit.js";
 import { TokenSwatchList } from "./TokenSwatchList.js";
@@ -24,6 +31,8 @@ const BUCKET_LABEL: Readonly<Record<StyleBucket, string>> = {
   medium: "Tablet",
   large: "Desktop",
 };
+
+const SECTION_VALUES = ["background", "color", "fontSize", "padding"] as const;
 
 export function StyleTab({
   tokens,
@@ -58,88 +67,107 @@ export function StyleTab({
       >
         Editing for: {BUCKET_LABEL[bucket]}
       </div>
-      <SwatchSection
-        heading="Background"
-        testId="style-tab-section-background"
-        property="background"
-        tokens={tokens.colors}
-        value={style?.[bucket]?.background ?? ""}
-        onWrite={writeProperty}
-      />
-      <SwatchSection
-        heading="Text color"
-        testId="style-tab-section-color"
-        property="color"
-        tokens={tokens.colors}
-        value={style?.[bucket]?.color ?? ""}
-        onWrite={writeProperty}
-      />
-      <SelectSection
-        heading="Font size"
-        testId="style-tab-section-fontSize"
-        property="fontSize"
-        tokens={tokens.typography}
-        value={style?.[bucket]?.fontSize ?? ""}
-        onWrite={writeProperty}
-      />
-      <SelectSection
-        heading="Padding"
-        testId="style-tab-section-spacing"
-        property="padding"
-        tokens={tokens.spacing}
-        value={style?.[bucket]?.padding ?? ""}
-        onWrite={writeProperty}
-      />
+      <Accordion type="multiple" defaultValue={[...SECTION_VALUES]}>
+        <SwatchSection
+          heading="Background"
+          property="background"
+          tokens={tokens.colors}
+          activeToken={style?.[bucket]?.background ?? ""}
+          onWrite={writeProperty}
+        />
+        <SwatchSection
+          heading="Text color"
+          property="color"
+          tokens={tokens.colors}
+          activeToken={style?.[bucket]?.color ?? ""}
+          onWrite={writeProperty}
+        />
+        <SelectSection
+          heading="Font size"
+          property="fontSize"
+          tokens={tokens.typography}
+          activeToken={style?.[bucket]?.fontSize ?? ""}
+          onWrite={writeProperty}
+        />
+        <SelectSection
+          heading="Padding"
+          property="padding"
+          tokens={tokens.spacing}
+          activeToken={style?.[bucket]?.padding ?? ""}
+          onWrite={writeProperty}
+        />
+      </Accordion>
     </div>
   );
 }
 
 interface SectionProps {
   readonly heading: string;
-  readonly testId: string;
   readonly property: StyleProperty;
   readonly tokens: ThemeTokenGroup | undefined;
-  readonly value: string;
+  readonly activeToken: string;
   readonly onWrite: (property: StyleProperty, tokenId: string | undefined) => void;
+}
+
+interface CollapsibleSectionProps {
+  readonly property: StyleProperty;
+  readonly heading: string;
+  readonly children: ReactNode;
+}
+
+function CollapsibleSection({
+  property,
+  heading,
+  children,
+}: CollapsibleSectionProps): ReactElement {
+  return (
+    <AccordionItem
+      value={property}
+      data-testid={`style-tab-section-${property}`}
+    >
+      <AccordionTrigger
+        data-testid={`style-tab-section-${property}-trigger`}
+      >
+        {heading}
+      </AccordionTrigger>
+      <AccordionContent>{children}</AccordionContent>
+    </AccordionItem>
+  );
 }
 
 function SwatchSection({
   heading,
-  testId,
   property,
   tokens,
-  value,
+  activeToken,
   onWrite,
 }: SectionProps): ReactElement | null {
   if (!tokens) return null;
   return (
-    <section className="space-y-2" data-testid={testId}>
-      <h3 className="text-sm font-medium">{heading}</h3>
+    <CollapsibleSection property={property} heading={heading}>
       <TokenSwatchList
         tokens={tokens}
-        value={value}
+        value={activeToken}
         onChange={(next) => onWrite(property, next)}
         testIdPrefix={`style-tab-${property}`}
         ariaLabel={heading}
       />
-    </section>
+    </CollapsibleSection>
   );
 }
 
 function SelectSection({
   heading,
-  testId,
   property,
   tokens,
-  value,
+  activeToken,
   onWrite,
 }: SectionProps): ReactElement | null {
   if (!tokens) return null;
   return (
-    <section className="space-y-2" data-testid={testId}>
-      <h3 className="text-sm font-medium">{heading}</h3>
+    <CollapsibleSection property={property} heading={heading}>
       <select
-        value={value}
+        value={activeToken}
         onChange={(event) =>
           onWrite(property, event.target.value === "" ? undefined : event.target.value)
         }
@@ -153,6 +181,6 @@ function SelectSection({
           </option>
         ))}
       </select>
-    </section>
+    </CollapsibleSection>
   );
 }


### PR DESCRIPTION
Wrap the four StyleTab sections (Background, Text color, Font size, Padding) in a multi-select shadcn `Accordion` that defaults to all-expanded. Authors can fold sections they're not editing without losing their place. Closes the "collapsible Background / Typography / Spacing sections" acceptance criterion of #387.

**Accordion shell**

A new `CollapsibleSection({property, heading, children})` helper emits the `AccordionItem` + `AccordionTrigger` + `AccordionContent` triplet, so both `SwatchSection` and `SelectSection` stay one call apiece. Existing controls (`TokenSwatchList`, native `<select>`) and their `data-testid` selectors are untouched, so all eleven prior StyleTab tests stay green and now implicitly assert default-expanded behaviour. Radix unmounts `AccordionContent` when closed, which the new test exercises via `queryByTestId` returning null after `user.click` on the trigger.

**Padding section id rename**

The Padding section's accordion id moves from `spacing` to `padding`. The `spacing` value was a leftover from when the section's `data-testid` was hand-rolled; the section id is now 1:1 with the `StyleProperty` union, and the `value` + `property` props on the section helpers collapse into a single `property` prop. Two existing tests (the "omits sections" assertion and the new collapse test) update to `style-tab-section-padding`.

Refs #387

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>