### PR TITLE
fix(admin): preserve nested ids when editing styles on wrapper blocks

### DIFF
--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -1,5 +1,4 @@
 import type { BlockRegistryV2, ResponsiveStyleSlot, ThemeTokens } from "@plumix/blocks";
-import type { ComponentData } from "@puckeditor/core";
 import type { KeyboardEvent as ReactKeyboardEvent, ReactElement, ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { createBlockRegistry } from "@plumix/blocks";
@@ -17,12 +16,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.j
 import type { SlashMenuItem } from "./slash-menu-items.js";
 
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
+import { patchStyleAtSelector } from "./patch-style.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
-import {
-  nextInsertPoint,
-  PUCK_ROOT_ZONE,
-  resolveSlashMenuItems,
-} from "./slash-menu-items.js";
+import { nextInsertPoint, resolveSlashMenuItems } from "./slash-menu-items.js";
 import { SlashMenuPanel } from "./SlashMenuPanel.js";
 import { StyleTab } from "./StyleTab.js";
 import { viewportWidthToBucket } from "./viewport-bucket.js";
@@ -256,23 +252,13 @@ function PlumixStyleTab({ tokens }: PlumixStyleTabProps): ReactElement {
   const handleStyleChange = useCallback(
     (nextStyle: ResponsiveStyleSlot | undefined): void => {
       const { itemSelector } = puck.appState.ui;
-      if (!itemSelector || !selectedItem) return;
-      const baseProps = selectedItem.props as { id: string } & Record<
-        string,
-        unknown
-      >;
-      const data: ComponentData = {
-        type: selectedItem.type,
-        props: { ...baseProps, style: nextStyle },
-      };
+      if (!itemSelector) return;
       puck.dispatch({
-        type: "replace",
-        destinationZone: itemSelector.zone ?? PUCK_ROOT_ZONE,
-        destinationIndex: itemSelector.index,
-        data,
+        type: "setData",
+        data: (previous) => patchStyleAtSelector(previous, itemSelector, nextStyle),
       });
     },
-    [puck, selectedItem],
+    [puck],
   );
 
   return (

--- a/packages/admin/src/editor/v2/patch-style.test.ts
+++ b/packages/admin/src/editor/v2/patch-style.test.ts
@@ -1,0 +1,98 @@
+import type { Data } from "@puckeditor/core";
+import { describe, expect, test } from "vitest";
+
+import { patchStyleAtSelector } from "./patch-style.js";
+
+function data(content: readonly { type: string; props: Record<string, unknown> }[]): Data {
+  return {
+    content: content as Data["content"],
+    root: { props: {} },
+  };
+}
+
+describe("patchStyleAtSelector", () => {
+  test("patches the style prop of a top-level item at the selector's index", () => {
+    const before = data([
+      { type: "core/heading", props: { id: "h1", text: "A" } },
+      { type: "core/heading", props: { id: "h2", text: "B" } },
+    ]);
+
+    const after = patchStyleAtSelector(
+      before,
+      { index: 1, zone: "root:default-zone" },
+      { large: { padding: "md" } },
+    );
+
+    expect(after.content[1]?.props).toEqual({
+      id: "h2",
+      text: "B",
+      style: { large: { padding: "md" } },
+    });
+    expect(after.content[0]).toBe(before.content[0]);
+  });
+
+  test("patches a nested item inside a parent's slot, preserving sibling ids", () => {
+    const before = data([
+      {
+        type: "core/group",
+        props: {
+          id: "g1",
+          content: [
+            { type: "core/heading", props: { id: "child-a", text: "A" } },
+            { type: "core/heading", props: { id: "child-b", text: "B" } },
+          ],
+        },
+      },
+    ]);
+
+    const after = patchStyleAtSelector(
+      before,
+      { index: 1, zone: "g1:content" },
+      { large: { padding: "lg" } },
+    );
+
+    const parent = after.content[0]?.props as { content: { props: { id: string; style?: unknown } }[] };
+    expect(parent.content[0]?.props.id).toBe("child-a");
+    expect(parent.content[1]?.props.id).toBe("child-b");
+    expect(parent.content[1]?.props.style).toEqual({ large: { padding: "lg" } });
+  });
+
+  test("treats a selector without a zone as root-level (matches Puck's default)", () => {
+    const before = data([
+      { type: "core/heading", props: { id: "h1", text: "A" } },
+    ]);
+
+    const after = patchStyleAtSelector(
+      before,
+      { index: 0 },
+      { large: { padding: "sm" } },
+    );
+
+    expect(after.content[0]?.props).toEqual({
+      id: "h1",
+      text: "A",
+      style: { large: { padding: "sm" } },
+    });
+  });
+
+  test("clears the style key when nextStyle is undefined", () => {
+    const before = data([
+      {
+        type: "core/heading",
+        props: {
+          id: "h1",
+          text: "A",
+          style: { large: { padding: "md" } },
+        },
+      },
+    ]);
+
+    const after = patchStyleAtSelector(
+      before,
+      { index: 0, zone: "root:default-zone" },
+      undefined,
+    );
+
+    expect(after.content[0]?.props).toEqual({ id: "h1", text: "A" });
+  });
+});

--- a/packages/admin/src/editor/v2/patch-style.ts
+++ b/packages/admin/src/editor/v2/patch-style.ts
@@ -1,0 +1,92 @@
+import type { ResponsiveStyleSlot } from "@plumix/blocks";
+import type { ComponentData, Data } from "@puckeditor/core";
+
+import { PUCK_ROOT_ZONE } from "./puck-zones.js";
+
+interface PatchSelector {
+  readonly index: number;
+  readonly zone?: string;
+}
+
+export function patchStyleAtSelector(
+  data: Data,
+  selector: PatchSelector,
+  nextStyle: ResponsiveStyleSlot | undefined,
+): Data {
+  const zone = selector.zone ?? PUCK_ROOT_ZONE;
+  if (zone === PUCK_ROOT_ZONE) {
+    return { ...data, content: patchItemAtIndex(data.content, selector.index, nextStyle) };
+  }
+  const [parentId, slotName] = zone.split(":", 2) as [string, string];
+  return {
+    ...data,
+    content: data.content.map((item) =>
+      patchInSlot(item, parentId, slotName, selector.index, nextStyle),
+    ),
+  };
+}
+
+function patchInSlot(
+  item: ComponentData,
+  parentId: string,
+  slotName: string,
+  index: number,
+  nextStyle: ResponsiveStyleSlot | undefined,
+): ComponentData {
+  const props = item.props as Record<string, unknown>;
+  if (props.id === parentId) {
+    const slot = props[slotName];
+    if (!isComponentDataArray(slot)) return item;
+    return {
+      ...item,
+      props: {
+        ...props,
+        [slotName]: patchItemAtIndex(slot, index, nextStyle),
+      } as ComponentData["props"],
+    };
+  }
+  let nextProps: Record<string, unknown> | undefined;
+  for (const [key, value] of Object.entries(props)) {
+    if (!isComponentDataArray(value)) continue;
+    const patched = value.map((child) =>
+      patchInSlot(child, parentId, slotName, index, nextStyle),
+    );
+    if (patched.some((child, i) => child !== value[i])) {
+      nextProps ??= { ...props };
+      nextProps[key] = patched;
+    }
+  }
+  return nextProps
+    ? { ...item, props: nextProps as ComponentData["props"] }
+    : item;
+}
+
+function isComponentDataArray(value: unknown): value is readonly ComponentData[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as { type?: unknown }).type === "string" &&
+        typeof (item as { props?: unknown }).props === "object",
+    )
+  );
+}
+
+function patchItemAtIndex(
+  list: readonly ComponentData[],
+  index: number,
+  nextStyle: ResponsiveStyleSlot | undefined,
+): ComponentData[] {
+  return list.map((item, i) => {
+    if (i !== index) return item;
+    const nextProps: Record<string, unknown> = { ...item.props };
+    if (nextStyle === undefined) {
+      delete nextProps.style;
+    } else {
+      nextProps.style = nextStyle;
+    }
+    return { ...item, props: nextProps as ComponentData["props"] };
+  });
+}

--- a/packages/admin/src/editor/v2/puck-zones.ts
+++ b/packages/admin/src/editor/v2/puck-zones.ts
@@ -1,0 +1,1 @@
+export const PUCK_ROOT_ZONE = "root:default-zone";

--- a/packages/admin/src/editor/v2/slash-menu-items.ts
+++ b/packages/admin/src/editor/v2/slash-menu-items.ts
@@ -1,5 +1,9 @@
 import type { BlockRegistryV2, BlockSpecV2 } from "@plumix/blocks";
 
+import { PUCK_ROOT_ZONE } from "./puck-zones.js";
+
+export { PUCK_ROOT_ZONE };
+
 export interface SlashMenuItem {
   readonly name: string;
   readonly title: string;
@@ -72,8 +76,6 @@ function matchScore(
   if (spec.name.toLowerCase().includes(needle)) return NAME_MATCH;
   return 0;
 }
-
-export const PUCK_ROOT_ZONE = "root:default-zone";
 
 export interface InsertPointSelector {
   readonly zone?: string;


### PR DESCRIPTION
Puck's `replace` action regenerates every nested slot child id when dispatched on a wrapper block. The Style tab's prior handler used `replace` to write back the selected item's props, which silently broke descendant selectors and history references whenever an author edited padding / colour / font-size on a group, columns, or details block.

**Surgical `setData` updater**

`PlumixStyleTab.handleStyleChange` now dispatches `setData` with a functional updater that calls a new pure deep module `patchStyleAtSelector(data, selector, nextStyle)`. For root-zone selectors it patches `data.content[index]` directly; for nested `parentId:slotName` zones it walks `data.content` recursively until it finds the parent by `props.id`, then patches `props[slotName][index]`. Descendants are preserved by reference — only the targeted block's `props.style` changes.

**Shared `puck-zones.ts` module**

The `PUCK_ROOT_ZONE` constant moves out of `slash-menu-items.ts` into a tiny `puck-zones.ts` so the patch helper doesn't reach cross-module for it. `slash-menu-items.ts` re-exports the constant so existing test imports stay untouched.

Refs #427, #387

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>