### PR TITLE
feat(admin): surface block transforms in the right sidebar

### DIFF
--- a/packages/admin/src/editor/v2/BlockActionsPanel.test.tsx
+++ b/packages/admin/src/editor/v2/BlockActionsPanel.test.tsx
@@ -1,0 +1,96 @@
+import type { BlockSpecV2 } from "@plumix/blocks";
+import { createBlockRegistry } from "@plumix/blocks";
+
+import type { TransformOption } from "./available-transforms.js";
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { BlockActionsPanel } from "./BlockActionsPanel.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function spec(partial: Partial<BlockSpecV2> & { name: string }): BlockSpecV2 {
+  return { render: () => null, ...partial };
+}
+
+const paragraphWithTransforms = createBlockRegistry([
+  spec({
+    name: "core/paragraph",
+    title: "Paragraph",
+    transforms: {
+      priority: 50,
+      to: [{ target: "core/heading" }, { target: "core/quote" }],
+    },
+  }),
+  spec({ name: "core/heading", title: "Heading" }),
+  spec({ name: "core/quote", title: "Quote" }),
+]);
+
+describe("BlockActionsPanel", () => {
+  test("renders the empty-state when no spec name is provided", () => {
+    render(
+      <BlockActionsPanel
+        specName={undefined}
+        registry={paragraphWithTransforms}
+        onTransform={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("block-actions-empty")).toBeDefined();
+  });
+
+  test("renders one button per available transform target with the target title", () => {
+    render(
+      <BlockActionsPanel
+        specName="core/paragraph"
+        registry={paragraphWithTransforms}
+        onTransform={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("block-action-transform-core/heading").textContent,
+    ).toContain("Heading");
+    expect(
+      screen.getByTestId("block-action-transform-core/quote"),
+    ).toBeDefined();
+  });
+
+  test("invokes onTransform with the option when its button is clicked", async () => {
+    const onTransform = vi.fn<(option: TransformOption) => void>();
+    const user = userEvent.setup();
+    render(
+      <BlockActionsPanel
+        specName="core/paragraph"
+        registry={paragraphWithTransforms}
+        onTransform={onTransform}
+      />,
+    );
+
+    await user.click(
+      screen.getByTestId("block-action-transform-core/heading"),
+    );
+
+    expect(onTransform).toHaveBeenCalledTimes(1);
+    expect(onTransform.mock.calls[0]?.[0].targetName).toBe("core/heading");
+  });
+
+  test("hides the panel content when the spec has no available transforms", () => {
+    const noTransforms = createBlockRegistry([
+      spec({ name: "core/spacer", title: "Spacer" }),
+    ]);
+
+    render(
+      <BlockActionsPanel
+        specName="core/spacer"
+        registry={noTransforms}
+        onTransform={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("block-actions-list")).toBeNull();
+  });
+});

--- a/packages/admin/src/editor/v2/BlockActionsPanel.tsx
+++ b/packages/admin/src/editor/v2/BlockActionsPanel.tsx
@@ -1,0 +1,60 @@
+import type { BlockRegistryV2 } from "@plumix/blocks";
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+
+import type { TransformOption } from "./available-transforms.js";
+
+import { availableTransforms } from "./available-transforms.js";
+
+interface BlockActionsPanelProps {
+  readonly specName: string | undefined;
+  readonly registry: BlockRegistryV2;
+  readonly onTransform: (option: TransformOption) => void;
+}
+
+export function BlockActionsPanel({
+  specName,
+  registry,
+  onTransform,
+}: BlockActionsPanelProps): ReactElement | null {
+  const options = useMemo(
+    () => (specName ? availableTransforms(specName, registry) : []),
+    [specName, registry],
+  );
+
+  if (!specName) {
+    return (
+      <div
+        className="p-3 text-xs text-muted-foreground"
+        data-testid="block-actions-empty"
+      >
+        Select a block to see actions.
+      </div>
+    );
+  }
+
+  if (options.length === 0) return null;
+
+  return (
+    <div className="space-y-1 border-b p-3" data-testid="block-actions-panel">
+      <div className="text-xs text-muted-foreground">Transform to</div>
+      <ul
+        className="flex flex-wrap gap-1"
+        data-testid="block-actions-list"
+      >
+        {options.map((option) => (
+          <li key={option.targetName}>
+            <button
+              type="button"
+              onClick={() => onTransform(option)}
+              className="rounded border px-2 py-1 text-xs"
+              data-testid={`block-action-transform-${option.targetName}`}
+            >
+              {option.targetTitle}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -13,11 +13,14 @@ import {
 } from "@/components/ui/dialog.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.js";
 
+import type { TransformOption } from "./available-transforms.js";
 import type { SlashMenuItem } from "./slash-menu-items.js";
 
+import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
+import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 import { nextInsertPoint, resolveSlashMenuItems } from "./slash-menu-items.js";
 import { SlashMenuPanel } from "./SlashMenuPanel.js";
 import { StyleTab } from "./StyleTab.js";
@@ -119,6 +122,7 @@ export function PlumixEditorLayout({
           className="overflow-y-auto border-l"
           data-testid="plumix-editor-right"
         >
+          <PlumixBlockActions registry={registry} />
           <Tabs defaultValue="block" className="h-full">
             <TabsList className="w-full">
               <TabsTrigger value="block" data-testid="plumix-editor-tab-block">
@@ -267,6 +271,47 @@ function PlumixStyleTab({ tokens }: PlumixStyleTabProps): ReactElement {
       selectedItem={selectedItem}
       bucket={bucket}
       onStyleChange={handleStyleChange}
+    />
+  );
+}
+
+interface PlumixBlockActionsProps {
+  readonly registry: BlockRegistryV2;
+}
+
+function PlumixBlockActions({ registry }: PlumixBlockActionsProps): ReactElement {
+  const puck = usePuck();
+  const { selectedItem } = puck;
+
+  const handleTransform = useCallback(
+    (option: TransformOption): void => {
+      const { itemSelector } = puck.appState.ui;
+      if (!itemSelector || !selectedItem) return;
+      const currentAttrs = selectedItem.props as Record<string, unknown>;
+      const targetDefaults = registry.get(option.targetName)?.defaults ?? {};
+      const mappedAttrs = option.mapAttrs?.(currentAttrs) ?? {};
+      puck.dispatch({
+        type: "replace",
+        destinationZone: itemSelector.zone ?? PUCK_ROOT_ZONE,
+        destinationIndex: itemSelector.index,
+        data: {
+          type: option.targetName,
+          props: {
+            ...targetDefaults,
+            ...mappedAttrs,
+            id: currentAttrs.id as string,
+          },
+        },
+      });
+    },
+    [puck, selectedItem, registry],
+  );
+
+  return (
+    <BlockActionsPanel
+      specName={selectedItem?.type}
+      registry={registry}
+      onTransform={handleTransform}
     />
   );
 }

--- a/packages/admin/src/editor/v2/available-transforms.test.ts
+++ b/packages/admin/src/editor/v2/available-transforms.test.ts
@@ -1,0 +1,69 @@
+import type { BlockSpecV2 } from "@plumix/blocks";
+import { createBlockRegistry } from "@plumix/blocks";
+import { describe, expect, test } from "vitest";
+
+import { availableTransforms } from "./available-transforms.js";
+
+function spec(partial: Partial<BlockSpecV2> & { name: string }): BlockSpecV2 {
+  return { render: () => null, ...partial };
+}
+
+describe("availableTransforms", () => {
+  test("returns an empty array when the source spec declares no transforms", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/spacer", title: "Spacer" }),
+      spec({ name: "core/heading", title: "Heading" }),
+    ]);
+
+    expect(availableTransforms("core/spacer", registry)).toEqual([]);
+  });
+
+  test("omits targets whose specs aren't present in the registry", () => {
+    const registry = createBlockRegistry([
+      spec({
+        name: "core/paragraph",
+        title: "Paragraph",
+        transforms: {
+          priority: 50,
+          to: [
+            { target: "core/heading" },
+            { target: "core/ghost-missing" },
+          ],
+        },
+      }),
+      spec({ name: "core/heading", title: "Heading" }),
+    ]);
+
+    const options = availableTransforms("core/paragraph", registry);
+
+    expect(options.map((o) => o.targetName)).toEqual(["core/heading"]);
+  });
+
+  test("returns the resolved transforms with titles pulled from registry specs", () => {
+    const registry = createBlockRegistry([
+      spec({
+        name: "core/paragraph",
+        title: "Paragraph",
+        transforms: {
+          priority: 50,
+          to: [
+            { target: "core/heading", mapAttrs: (a) => ({ level: 2, text: a.text }) },
+            { target: "core/quote", mapAttrs: (a) => ({ text: a.text, citation: "" }) },
+          ],
+        },
+      }),
+      spec({ name: "core/heading", title: "Heading" }),
+      spec({ name: "core/quote", title: "Quote" }),
+    ]);
+
+    const options = availableTransforms("core/paragraph", registry);
+
+    expect(options.map((o) => o.targetName).sort()).toEqual([
+      "core/heading",
+      "core/quote",
+    ]);
+    expect(
+      options.find((o) => o.targetName === "core/heading")?.targetTitle,
+    ).toBe("Heading");
+  });
+});

--- a/packages/admin/src/editor/v2/available-transforms.ts
+++ b/packages/admin/src/editor/v2/available-transforms.ts
@@ -1,0 +1,24 @@
+import type { BlockRegistryV2, BlockShortcutMode } from "@plumix/blocks";
+import { resolveBlockTransformsV2 } from "@plumix/blocks";
+
+export interface TransformOption {
+  readonly targetName: string;
+  readonly targetTitle: string;
+  readonly mapAttrs?: (
+    attrs: Readonly<Record<string, unknown>>,
+  ) => Readonly<Record<string, unknown>>;
+  readonly mode?: BlockShortcutMode;
+}
+
+export function availableTransforms(
+  sourceName: string,
+  registry: BlockRegistryV2,
+): readonly TransformOption[] {
+  const resolved = resolveBlockTransformsV2(sourceName, Array.from(registry));
+  return resolved.map((entry) => ({
+    targetName: entry.target,
+    targetTitle: registry.get(entry.target)?.title ?? entry.target,
+    mapAttrs: entry.mapAttrs,
+    mode: entry.mode,
+  }));
+}


### PR DESCRIPTION
V2 block specs declare `transforms.to` (e.g., paragraph → heading) and `resolveBlockTransformsV2` has been in place since the spec migration, but the editor had no UI to invoke them. Surface the available targets as buttons above the right-sidebar Block / Style tabs whenever the selected block has any.

**Transform dispatch**

Clicking a target dispatches Puck's `replace` action with the target's component type and a merged props bag: `{...targetSpec.defaults, ...mapAttrs?(currentAttrs), id: currentAttrs.id}`. Defaults-first means a future transform declared without `mapAttrs` still lands on a complete target prop set; the original block id is preserved across the swap so descendant selectors and history references stay stable.

**Wrapper transforms stay deferred (not regressed)**

V2 transforms today are all leaf-to-leaf (paragraph / heading / quote), so `replace` is safe — there are no slot children to regenerate ids on. If a wrapper transform appears later, the senpai-flagged slot-id-regeneration footgun (PR #427/#433) returns, but `TransformOption.mode` threads through every option so the connector can branch into a slot-preserving dispatch path without retrofitting the contract.

Refs #387

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>