### PR TITLE
feat(admin): add duplicate, delete and copy-json block actions

### DIFF
--- a/packages/admin/src/editor/v2/BlockActionsPanel.test.tsx
+++ b/packages/admin/src/editor/v2/BlockActionsPanel.test.tsx
@@ -78,7 +78,7 @@ describe("BlockActionsPanel", () => {
     expect(onTransform.mock.calls[0]?.[0].targetName).toBe("core/heading");
   });
 
-  test("hides the panel content when the spec has no available transforms", () => {
+  test("hides the panel content when the spec has no available transforms and no other actions", () => {
     const noTransforms = createBlockRegistry([
       spec({ name: "core/spacer", title: "Spacer" }),
     ]);
@@ -92,5 +92,89 @@ describe("BlockActionsPanel", () => {
     );
 
     expect(screen.queryByTestId("block-actions-list")).toBeNull();
+  });
+
+  test("renders a Duplicate button that fires onDuplicate when clicked", async () => {
+    const onDuplicate = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BlockActionsPanel
+        specName="core/paragraph"
+        registry={paragraphWithTransforms}
+        onTransform={vi.fn()}
+        onDuplicate={onDuplicate}
+      />,
+    );
+
+    await user.click(screen.getByTestId("block-action-duplicate"));
+
+    expect(onDuplicate).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders a Delete button that fires onDelete when clicked", async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BlockActionsPanel
+        specName="core/paragraph"
+        registry={paragraphWithTransforms}
+        onTransform={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    await user.click(screen.getByTestId("block-action-delete"));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders a Copy JSON button that fires onCopyJson when clicked", async () => {
+    const onCopyJson = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BlockActionsPanel
+        specName="core/paragraph"
+        registry={paragraphWithTransforms}
+        onTransform={vi.fn()}
+        onCopyJson={onCopyJson}
+      />,
+    );
+
+    await user.click(screen.getByTestId("block-action-copy-json"));
+
+    expect(onCopyJson).toHaveBeenCalledTimes(1);
+  });
+
+  test("omits a button entirely when its callback is undefined", () => {
+    render(
+      <BlockActionsPanel
+        specName="core/paragraph"
+        registry={paragraphWithTransforms}
+        onTransform={vi.fn()}
+        onDuplicate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("block-action-duplicate")).toBeDefined();
+    expect(screen.queryByTestId("block-action-delete")).toBeNull();
+    expect(screen.queryByTestId("block-action-copy-json")).toBeNull();
+  });
+
+  test("still renders the actions area when the spec has no transforms but other callbacks are present", () => {
+    const noTransforms = createBlockRegistry([
+      spec({ name: "core/spacer", title: "Spacer" }),
+    ]);
+
+    render(
+      <BlockActionsPanel
+        specName="core/spacer"
+        registry={noTransforms}
+        onTransform={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("block-actions-list")).toBeNull();
+    expect(screen.getByTestId("block-action-delete")).toBeDefined();
   });
 });

--- a/packages/admin/src/editor/v2/BlockActionsPanel.tsx
+++ b/packages/admin/src/editor/v2/BlockActionsPanel.tsx
@@ -10,12 +10,18 @@ interface BlockActionsPanelProps {
   readonly specName: string | undefined;
   readonly registry: BlockRegistryV2;
   readonly onTransform: (option: TransformOption) => void;
+  readonly onDuplicate?: () => void;
+  readonly onDelete?: () => void;
+  readonly onCopyJson?: () => void;
 }
 
 export function BlockActionsPanel({
   specName,
   registry,
   onTransform,
+  onDuplicate,
+  onDelete,
+  onCopyJson,
 }: BlockActionsPanelProps): ReactElement | null {
   const options = useMemo(
     () => (specName ? availableTransforms(specName, registry) : []),
@@ -33,28 +39,67 @@ export function BlockActionsPanel({
     );
   }
 
-  if (options.length === 0) return null;
+  const hasExtras = Boolean(onDuplicate ?? onDelete ?? onCopyJson);
+  if (options.length === 0 && !hasExtras) return null;
 
   return (
-    <div className="space-y-1 border-b p-3" data-testid="block-actions-panel">
-      <div className="text-xs text-muted-foreground">Transform to</div>
-      <ul
-        className="flex flex-wrap gap-1"
-        data-testid="block-actions-list"
-      >
-        {options.map((option) => (
-          <li key={option.targetName}>
+    <div className="space-y-2 border-b p-3" data-testid="block-actions-panel">
+      {options.length > 0 ? (
+        <div className="space-y-1">
+          <div className="text-xs text-muted-foreground">Transform to</div>
+          <ul
+            className="flex flex-wrap gap-1"
+            data-testid="block-actions-list"
+          >
+            {options.map((option) => (
+              <li key={option.targetName}>
+                <button
+                  type="button"
+                  onClick={() => onTransform(option)}
+                  className="rounded border px-2 py-1 text-xs"
+                  data-testid={`block-action-transform-${option.targetName}`}
+                >
+                  {option.targetTitle}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {hasExtras ? (
+        <div className="flex flex-wrap gap-1">
+          {onDuplicate ? (
             <button
               type="button"
-              onClick={() => onTransform(option)}
+              onClick={onDuplicate}
               className="rounded border px-2 py-1 text-xs"
-              data-testid={`block-action-transform-${option.targetName}`}
+              data-testid="block-action-duplicate"
             >
-              {option.targetTitle}
+              Duplicate
             </button>
-          </li>
-        ))}
-      </ul>
+          ) : null}
+          {onDelete ? (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="rounded border px-2 py-1 text-xs"
+              data-testid="block-action-delete"
+            >
+              Delete
+            </button>
+          ) : null}
+          {onCopyJson ? (
+            <button
+              type="button"
+              onClick={onCopyJson}
+              className="rounded border px-2 py-1 text-xs"
+              data-testid="block-action-copy-json"
+            >
+              Copy JSON
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -307,11 +307,46 @@ function PlumixBlockActions({ registry }: PlumixBlockActionsProps): ReactElement
     [puck, selectedItem, registry],
   );
 
+  const handleDuplicate = useCallback((): void => {
+    const { itemSelector } = puck.appState.ui;
+    if (!itemSelector) return;
+    puck.dispatch({
+      type: "duplicate",
+      sourceIndex: itemSelector.index,
+      sourceZone: itemSelector.zone ?? PUCK_ROOT_ZONE,
+    });
+  }, [puck]);
+
+  const handleDelete = useCallback((): void => {
+    const { itemSelector } = puck.appState.ui;
+    if (!itemSelector) return;
+    puck.dispatch({
+      type: "remove",
+      index: itemSelector.index,
+      zone: itemSelector.zone ?? PUCK_ROOT_ZONE,
+    });
+  }, [puck]);
+
+  const handleCopyJson = useCallback((): void => {
+    if (!selectedItem) return;
+    navigator.clipboard
+      .writeText(JSON.stringify(selectedItem, null, 2))
+      .catch((error: unknown) => {
+        console.error(
+          "[plumix:block-actions] Copy to clipboard failed:",
+          error,
+        );
+      });
+  }, [selectedItem]);
+
   return (
     <BlockActionsPanel
       specName={selectedItem?.type}
       registry={registry}
       onTransform={handleTransform}
+      onDuplicate={handleDuplicate}
+      onDelete={handleDelete}
+      onCopyJson={handleCopyJson}
     />
   );
 }


### PR DESCRIPTION
The BlockActionsPanel shipped in #434 only carried transforms. Layer the three remaining ActionBar items onto the same panel so every selected block exposes its full action vocabulary in the right sidebar.

**Panel contract**

`BlockActionsPanelProps` grows three optional callbacks (`onDuplicate?`, `onDelete?`, `onCopyJson?`). Each button only renders when its callback is provided, and the panel's null-gate is now "no transforms AND no extras" — so blocks without transforms still surface the universal Duplicate / Delete / Copy JSON.

**Dispatch wiring**

Duplicate dispatches Puck's `duplicate` action, which intentionally regenerates descendant ids (correct clone semantics, opposite direction from the in-place style-edit footgun fix in #433). Delete dispatches `remove`; after the action lands, Puck's `selectedItem` resolves through the stale selector to `null` via `getItem`, and the panel collapses to its empty-state on next render with no extra plumbing.

**Copy JSON shape and error handling**

Serialises the Puck-shaped item — `props.id`, nested slot arrays, the lot — rather than normalising through `puckDataToBlockTree`. That keeps the output round-trippable on paste once a paste flow exists; BlockNode shape would be human-readable but lossy. The clipboard write `.catch`es and `console.error`s on permission / insecure-origin failures, matching the `PlumixDragHandle.tsx` prior art so a silent rejection doesn't look like a no-op.

Refs #387

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>