### PR TITLE
test(admin): lock the puck-to-css cascade seam end-to-end

### DIFF
--- a/packages/admin/src/editor/v2/style-cascade.test.tsx
+++ b/packages/admin/src/editor/v2/style-cascade.test.tsx
@@ -1,0 +1,53 @@
+import type { ThemeTokens } from "@plumix/blocks";
+import type { Data } from "@puckeditor/core";
+import {
+  createBlockRegistry,
+  headingBlock,
+  renderBlockTree,
+} from "@plumix/blocks";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { puckDataToBlockTree } from "./puck-to-block-tree.js";
+
+const tokens: ThemeTokens = {
+  spacing: {
+    sm: { value: "0.5rem", label: "Small" },
+    lg: { value: "2rem", label: "Large" },
+  },
+};
+
+const registry = createBlockRegistry([headingBlock]);
+
+describe("style cascade (Puck data → walker → public CSS)", () => {
+  test("emits the desktop rule followed by the mobile @media rule for a multi-bucket style edit", () => {
+    const puckData: Data = {
+      content: [
+        {
+          type: "core/heading",
+          props: {
+            id: "h1",
+            text: "Hello",
+            level: 2,
+            style: {
+              large: { padding: "lg" },
+              small: { padding: "sm" },
+            },
+          },
+        },
+      ] as Data["content"],
+      root: { props: {} },
+    };
+
+    const html = renderToStaticMarkup(
+      renderBlockTree(puckDataToBlockTree(puckData), registry, { tokens }),
+    );
+
+    const desktopRule =
+      ".plumix-block-h1 { padding: var(--plumix-spacing-lg, 2rem); }";
+    const mobileRule =
+      "@media (max-width: 640px) { .plumix-block-h1 { padding: var(--plumix-spacing-sm, 0.5rem); } }";
+
+    expect(html).toContain(`${desktopRule} ${mobileRule}`);
+  });
+});


### PR DESCRIPTION
Add an integration test that exercises the editor-to-SSR seam in one assertion: Puck `Data` carrying `style.large.padding=lg` plus `style.small.padding=sm` flows through `puckDataToBlockTree`, the V2 walker, and the style emitter, and the rendered HTML carries the desktop rule immediately followed by the `@media (max-width: 640px)` mobile rule with token ids resolved to the right CSS variables. The single concatenated `.toContain` catches both presence and ordering in one expectation — exactly the regression class the PRD acceptance criterion names.

Coverage is intentionally overlapping with three existing unit suites (`style-emitter.test.ts`, `puck-to-block-tree.test.ts`, `render-block-tree.test.ts`); the net-new is the seam composition — adapter + walker + emitter composed in one assertion plus HTML-string ordering.

Closes the "Public-side CSS shows correct desktop-first @media (max-width: ...) cascade reflecting both edits" acceptance criterion of #387.

Refs #387

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>