### PR TITLE
feat(admin): persist v2 editor drafts to localstorage per entry

### DIFF
--- a/packages/admin/src/editor/v2/local-draft.test.ts
+++ b/packages/admin/src/editor/v2/local-draft.test.ts
@@ -1,0 +1,54 @@
+import type { Data } from "@puckeditor/core";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { readDraft, writeDraft } from "./local-draft.js";
+
+const KEY = "plumix.v2.draft.test.test-key";
+
+const sample: Data = {
+  content: [
+    {
+      type: "core/heading",
+      props: { id: "h1", text: "Hello", level: 2 },
+    },
+  ] as Data["content"],
+  root: { props: {} },
+};
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("local-draft round-trip", () => {
+  test("writeDraft persists data so the next readDraft returns it", () => {
+    writeDraft(KEY, sample);
+    expect(readDraft(KEY)).toEqual(sample);
+  });
+
+  test("readDraft returns undefined when the key is missing", () => {
+    expect(readDraft(KEY)).toBeUndefined();
+  });
+
+  test("readDraft returns undefined when the stored value is malformed JSON", () => {
+    localStorage.setItem(KEY, "{not-json");
+    expect(readDraft(KEY)).toBeUndefined();
+  });
+
+  test("readDraft returns undefined when the parsed value is not Puck-shaped", () => {
+    localStorage.setItem(KEY, JSON.stringify({ content: "nope", root: null }));
+    expect(readDraft(KEY)).toBeUndefined();
+  });
+
+  test("writeDraft swallows storage errors instead of crashing", () => {
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("setItem failed");
+      });
+    try {
+      expect(() => writeDraft(KEY, sample)).not.toThrow();
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+});

--- a/packages/admin/src/editor/v2/local-draft.ts
+++ b/packages/admin/src/editor/v2/local-draft.ts
@@ -1,0 +1,30 @@
+import type { Data } from "@puckeditor/core";
+
+export function readDraft(key: string): Data | undefined {
+  const raw = localStorage.getItem(key);
+  if (raw === null) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isPuckData(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeDraft(key: string, data: Data): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(data));
+  } catch (error) {
+    console.error("[plumix:local-draft] Failed to persist draft:", error);
+  }
+}
+
+function isPuckData(value: unknown): value is Data {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { content?: unknown; root?: unknown };
+  return (
+    Array.isArray(candidate.content) &&
+    typeof candidate.root === "object" &&
+    candidate.root !== null
+  );
+}

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -8,6 +8,7 @@ import { useCallback, useState } from "react";
 
 import { blockSpecsToPuckComponents } from "@/editor/v2/block-adapter.js";
 import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
+import { readDraft, writeDraft } from "@/editor/v2/local-draft.js";
 
 import "@puckeditor/core/puck.css";
 
@@ -44,7 +45,24 @@ export const Route = createFileRoute("/_editor/v2/entries/$slug/$id/edit")({
 });
 
 function PuckSpikeRoute(): ReactNode {
-  const [data, setData] = useState<Data>(initialData);
+  const { slug, id } = Route.useParams();
+  const draftKey = `plumix.v2.draft.${slug}.${id}`;
+  return <PuckSpikeRouteInner key={draftKey} draftKey={draftKey} />;
+}
+
+interface PuckSpikeRouteInnerProps {
+  readonly draftKey: string;
+}
+
+function PuckSpikeRouteInner({ draftKey }: PuckSpikeRouteInnerProps): ReactNode {
+  const [data, setData] = useState<Data>(() => readDraft(draftKey) ?? initialData);
+  const handleChange = useCallback(
+    (next: Data): void => {
+      setData(next);
+      writeDraft(draftKey, next);
+    },
+    [draftKey],
+  );
   const Layout = useCallback(
     (): ReactElement => (
       <PlumixEditorLayout registry={registry} tokens={sampleTokens} />
@@ -56,8 +74,8 @@ function PuckSpikeRoute(): ReactNode {
     <Puck
       config={config}
       data={data}
-      onPublish={setData}
-      onChange={setData}
+      onPublish={handleChange}
+      onChange={handleChange}
       iframe={{ enabled: false }}
       overrides={{ puck: Layout }}
     />


### PR DESCRIPTION
Authoring sessions in the v2 spike route now survive page refresh. A new `readDraft` / `writeDraft` pair serialises Puck `Data` under `plumix.v2.draft.<slug>.<id>` so each entry has its own slot, and the spike route reads back the draft on mount.

**Storage helpers**

Read parses inside a try/catch and runs a light structural check (`content: array`, `root: object`); any miss returns `undefined` so the editor falls back to empty state without crashing. Write catches storage errors (quota / SecurityError) and `console.error`s, matching the clipboard convention from #435.

**Per-entry isolation via remount**

The spike route splits into an outer wrapper that derives `draftKey` from the URL and renders `<PuckSpikeRouteInner key={draftKey} draftKey={draftKey} />`. TanStack Router preserves component instances across matching-route param changes, so the `key` prop forces a remount on entry navigation and the inner component's lazy `useState` re-reads the draft for the new entry — no cross-entry leak.

This is the smallest viable sub-step toward #391's RPC-backed autosave. Stays purely client-side so it has no dependency on the v2 entry-content substrate. Debouncing, the in-flight indicator, and `entry.update` wiring all stay deferred to #391 proper.

Refs #391

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>