### PR TITLE
feat(admin): debounce the v2 draft write so drag doesn't thrash storage

### DIFF
--- a/packages/admin/src/editor/v2/debounce.test.ts
+++ b/packages/admin/src/editor/v2/debounce.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createDebouncer } from "./debounce.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createDebouncer", () => {
+  test("invokes fn once after the delay elapses from the last call", () => {
+    const fn = vi.fn();
+    const d = createDebouncer(fn, 300);
+
+    d.call("a");
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(300);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("a");
+  });
+
+  test("coalesces rapid calls into one trailing-edge invocation with the latest args", () => {
+    const fn = vi.fn();
+    const d = createDebouncer(fn, 300);
+
+    d.call("a");
+    vi.advanceTimersByTime(100);
+    d.call("b");
+    vi.advanceTimersByTime(100);
+    d.call("c");
+    vi.advanceTimersByTime(299);
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("c");
+  });
+
+  test("flush invokes fn immediately with the pending args and cancels the timer", () => {
+    const fn = vi.fn();
+    const d = createDebouncer(fn, 300);
+
+    d.call("a");
+    d.flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("a");
+
+    vi.advanceTimersByTime(300);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("flush is a no-op when no call is pending", () => {
+    const fn = vi.fn();
+    const d = createDebouncer(fn, 300);
+
+    d.flush();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test("cancel prevents fn from firing", () => {
+    const fn = vi.fn();
+    const d = createDebouncer(fn, 300);
+
+    d.call("a");
+    d.cancel();
+    vi.advanceTimersByTime(300);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/editor/v2/debounce.ts
+++ b/packages/admin/src/editor/v2/debounce.ts
@@ -1,0 +1,38 @@
+export interface Debouncer<Args extends readonly unknown[]> {
+  readonly call: (...args: Args) => void;
+  readonly flush: () => void;
+  readonly cancel: () => void;
+}
+
+export function createDebouncer<Args extends readonly unknown[]>(
+  fn: (...args: Args) => void,
+  delayMs: number,
+): Debouncer<Args> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let pending: Args | undefined;
+
+  const fire = (): void => {
+    if (pending === undefined) return;
+    const args = pending;
+    pending = undefined;
+    timer = undefined;
+    fn(...args);
+  };
+
+  return {
+    call(...args) {
+      pending = args;
+      clearTimeout(timer);
+      timer = setTimeout(fire, delayMs);
+    },
+    flush() {
+      clearTimeout(timer);
+      fire();
+    },
+    cancel() {
+      clearTimeout(timer);
+      timer = undefined;
+      pending = undefined;
+    },
+  };
+}

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -4,9 +4,10 @@ import type { ReactElement, ReactNode } from "react";
 import { coreBlocksV2, createBlockRegistry } from "@plumix/blocks";
 import { Puck } from "@puckeditor/core";
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { blockSpecsToPuckComponents } from "@/editor/v2/block-adapter.js";
+import { createDebouncer } from "@/editor/v2/debounce.js";
 import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
 import { readDraft, writeDraft } from "@/editor/v2/local-draft.js";
 
@@ -56,12 +57,17 @@ interface PuckSpikeRouteInnerProps {
 
 function PuckSpikeRouteInner({ draftKey }: PuckSpikeRouteInnerProps): ReactNode {
   const [data, setData] = useState<Data>(() => readDraft(draftKey) ?? initialData);
+  const debouncer = useMemo(
+    () => createDebouncer((next: Data) => writeDraft(draftKey, next), 300),
+    [draftKey],
+  );
+  useEffect(() => () => debouncer.flush(), [debouncer]);
   const handleChange = useCallback(
     (next: Data): void => {
       setData(next);
-      writeDraft(draftKey, next);
+      debouncer.call(next);
     },
-    [draftKey],
+    [debouncer],
   );
   const Layout = useCallback(
     (): ReactElement => (


### PR DESCRIPTION
The local-draft persistence shipped in #437 wrote on every Puck `onChange`. A real-browser drag fires those dispatches at ~10 Hz, so the synchronous `localStorage.setItem` was running 10+ times a second on the drag path. Add a small trailing-edge `createDebouncer(fn, delayMs)` primitive and wrap the draft write at 300 ms; storage write drops from "every dispatch" to ~3 max per author-pause.

**Loss-free across entry navigation**

The outer `key={draftKey}` remount from #437 means navigation triggers an unmount; the new `useEffect(() => () => debouncer.flush(), [debouncer])` runs the cleanup, flushing the pending write before the new entry's instance mounts. The autosave indicator and `entry.update` wiring stay deferred to #391 proper.

Refs #391

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>