### PR TITLE
feat(admin): show autosave status in the v2 editor header pill

### DIFF
--- a/packages/admin/src/editor/v2/AutosaveStatus.test.tsx
+++ b/packages/admin/src/editor/v2/AutosaveStatus.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { AutosaveStatusContext, AutosaveStatusPill } from "./AutosaveStatus.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AutosaveStatusPill", () => {
+  test("renders 'Saved' by default (no Provider above)", () => {
+    render(<AutosaveStatusPill />);
+
+    const pill = screen.getByTestId("plumix-autosave-pill");
+    expect(pill.textContent).toBe("Saved");
+    expect(pill.getAttribute("data-status")).toBe("saved");
+  });
+
+  test("renders 'Saving...' when the Provider supplies the 'saving' status", () => {
+    render(
+      <AutosaveStatusContext.Provider value="saving">
+        <AutosaveStatusPill />
+      </AutosaveStatusContext.Provider>,
+    );
+
+    const pill = screen.getByTestId("plumix-autosave-pill");
+    expect(pill.textContent).toBe("Saving...");
+    expect(pill.getAttribute("data-status")).toBe("saving");
+  });
+});

--- a/packages/admin/src/editor/v2/AutosaveStatus.tsx
+++ b/packages/admin/src/editor/v2/AutosaveStatus.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from "react";
+import { createContext, useContext } from "react";
+
+export type AutosaveStatus = "saved" | "saving";
+
+export const AutosaveStatusContext = createContext<AutosaveStatus>("saved");
+
+const LABEL: Readonly<Record<AutosaveStatus, string>> = {
+  saved: "Saved",
+  saving: "Saving...",
+};
+
+export function AutosaveStatusPill(): ReactElement {
+  const status = useContext(AutosaveStatusContext);
+  return (
+    <span
+      className="rounded bg-muted px-2 py-1 text-xs"
+      data-testid="plumix-autosave-pill"
+      data-status={status}
+    >
+      {LABEL[status]}
+    </span>
+  );
+}

--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -16,6 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.j
 import type { TransformOption } from "./available-transforms.js";
 import type { SlashMenuItem } from "./slash-menu-items.js";
 
+import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { patchStyleAtSelector } from "./patch-style.js";
@@ -69,12 +70,7 @@ export function PlumixEditorLayout({
           className="flex-1 bg-transparent outline-none"
           data-testid="plumix-editor-title-input"
         />
-        <span
-          className="rounded bg-muted px-2 py-1 text-xs"
-          data-testid="plumix-editor-status-pill"
-        >
-          Draft
-        </span>
+        <AutosaveStatusPill />
         <button
           type="button"
           className="rounded border px-3 py-1 text-sm"

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -6,6 +6,9 @@ import { Puck } from "@puckeditor/core";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import type { AutosaveStatus } from "@/editor/v2/AutosaveStatus.js";
+
+import { AutosaveStatusContext } from "@/editor/v2/AutosaveStatus.js";
 import { blockSpecsToPuckComponents } from "@/editor/v2/block-adapter.js";
 import { createDebouncer } from "@/editor/v2/debounce.js";
 import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
@@ -57,14 +60,20 @@ interface PuckSpikeRouteInnerProps {
 
 function PuckSpikeRouteInner({ draftKey }: PuckSpikeRouteInnerProps): ReactNode {
   const [data, setData] = useState<Data>(() => readDraft(draftKey) ?? initialData);
+  const [status, setStatus] = useState<AutosaveStatus>("saved");
   const debouncer = useMemo(
-    () => createDebouncer((next: Data) => writeDraft(draftKey, next), 300),
+    () =>
+      createDebouncer((next: Data) => {
+        writeDraft(draftKey, next);
+        setStatus("saved");
+      }, 300),
     [draftKey],
   );
   useEffect(() => () => debouncer.flush(), [debouncer]);
   const handleChange = useCallback(
     (next: Data): void => {
       setData(next);
+      setStatus("saving");
       debouncer.call(next);
     },
     [debouncer],
@@ -77,13 +86,14 @@ function PuckSpikeRouteInner({ draftKey }: PuckSpikeRouteInnerProps): ReactNode 
   );
 
   return (
-    <Puck
-      config={config}
-      data={data}
-      onPublish={handleChange}
-      onChange={handleChange}
-      iframe={{ enabled: false }}
-      overrides={{ puck: Layout }}
-    />
+    <AutosaveStatusContext.Provider value={status}>
+      <Puck
+        config={config}
+        data={data}
+        onChange={handleChange}
+        iframe={{ enabled: false }}
+        overrides={{ puck: Layout }}
+      />
+    </AutosaveStatusContext.Provider>
   );
 }


### PR DESCRIPTION
The localStorage draft persistence from #437 and the debounce from #438 had no visible signal — authors couldn't tell whether their edits were being persisted. Replace the static "Draft" span in the editor header with an `AutosaveStatusPill` that flips between "Saved" and "Saving..." as the user types.

**Context-routed status with a stable layout identity**

`AutosaveStatusPill` reads its status via a small `AutosaveStatusContext`. The route owns the state, flips to "saving" in `handleChange`, and flips back to "saved" inside the debouncer's wrapped fn after the localStorage write fires. `<Puck>` is wrapped in the Provider so the pill re-renders on every transition without remounting the layout — the override's `useCallback([])` identity stays stable.

**Drop the misleading `onPublish` wire**

`onPublish` had been aliased to `handleChange`, which meant clicking Publish briefly flipped the pill to "Saving..." then wrote a draft instead of publishing. Unwired it. Publish stays inert until #391 proper lands the real publish path.

Refs #391

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>