### PR TITLE
feat(admin): collapse the v2 right sidebar to a sheet on mobile

### DIFF
--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -4,6 +4,8 @@ import { useCallback, useMemo, useState } from "react";
 import { createBlockRegistry } from "@plumix/blocks";
 import { Puck, usePuck } from "@puckeditor/core";
 
+import { useIsMobile } from "@/hooks/use-mobile.js";
+
 import {
   Dialog,
   DialogContent,
@@ -19,6 +21,7 @@ import type { SlashMenuItem } from "./slash-menu-items.js";
 import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
+import { MobileInspectorSheet } from "./MobileInspectorSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
 import { PUCK_ROOT_ZONE } from "./puck-zones.js";
@@ -80,7 +83,7 @@ export function PlumixEditorLayout({
         </button>
       </header>
       <div
-        className="grid flex-1 grid-cols-[260px_1fr_320px] overflow-hidden"
+        className="grid flex-1 grid-cols-[260px_1fr] overflow-hidden md:grid-cols-[260px_1fr_320px]"
         data-testid="plumix-editor-cols"
       >
         <aside
@@ -114,30 +117,50 @@ export function PlumixEditorLayout({
           registry={registry}
           capabilities={capabilities}
         />
-        <aside
-          className="overflow-y-auto border-l"
-          data-testid="plumix-editor-right"
-        >
-          <PlumixBlockActions registry={registry} />
-          <Tabs defaultValue="block" className="h-full">
-            <TabsList className="w-full">
-              <TabsTrigger value="block" data-testid="plumix-editor-tab-block">
-                Block
-              </TabsTrigger>
-              <TabsTrigger value="style" data-testid="plumix-editor-tab-style">
-                Style
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="block">
-              <Puck.Fields />
-            </TabsContent>
-            <TabsContent value="style">
-              <PlumixStyleTab tokens={tokens} />
-            </TabsContent>
-          </Tabs>
-        </aside>
+        <InspectorBody registry={registry} tokens={tokens} />
       </div>
     </div>
+  );
+}
+
+interface InspectorBodyProps {
+  readonly registry: BlockRegistryV2;
+  readonly tokens: ThemeTokens;
+}
+
+function InspectorBody({ registry, tokens }: InspectorBodyProps): ReactElement {
+  const isMobile = useIsMobile();
+  const content = (
+    <>
+      <PlumixBlockActions registry={registry} />
+      <Tabs defaultValue="block" className="h-full">
+        <TabsList className="w-full">
+          <TabsTrigger value="block" data-testid="plumix-editor-tab-block">
+            Block
+          </TabsTrigger>
+          <TabsTrigger value="style" data-testid="plumix-editor-tab-style">
+            Style
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="block">
+          <Puck.Fields />
+        </TabsContent>
+        <TabsContent value="style">
+          <PlumixStyleTab tokens={tokens} />
+        </TabsContent>
+      </Tabs>
+    </>
+  );
+  if (isMobile) {
+    return <MobileInspectorSheet>{content}</MobileInspectorSheet>;
+  }
+  return (
+    <aside
+      className="overflow-y-auto border-l"
+      data-testid="plumix-editor-right"
+    >
+      {content}
+    </aside>
   );
 }
 

--- a/packages/admin/src/editor/v2/MobileInspectorSheet.test.tsx
+++ b/packages/admin/src/editor/v2/MobileInspectorSheet.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { MobileInspectorSheet } from "./MobileInspectorSheet.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MobileInspectorSheet", () => {
+  test("renders the inspector trigger button (always in the DOM)", () => {
+    render(
+      <MobileInspectorSheet>
+        <div data-testid="inspector-body">body</div>
+      </MobileInspectorSheet>,
+    );
+
+    expect(
+      screen.getByTestId("plumix-editor-mobile-inspector-trigger"),
+    ).toBeDefined();
+  });
+
+  test("reveals the children inside the sheet content after the trigger is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <MobileInspectorSheet>
+        <div data-testid="inspector-body">body</div>
+      </MobileInspectorSheet>,
+    );
+
+    expect(screen.queryByTestId("inspector-body")).toBeNull();
+
+    await user.click(
+      screen.getByTestId("plumix-editor-mobile-inspector-trigger"),
+    );
+
+    expect(screen.getByTestId("inspector-body")).toBeDefined();
+  });
+});

--- a/packages/admin/src/editor/v2/MobileInspectorSheet.tsx
+++ b/packages/admin/src/editor/v2/MobileInspectorSheet.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement, ReactNode } from "react";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet.js";
+
+interface MobileInspectorSheetProps {
+  readonly children: ReactNode;
+}
+
+export function MobileInspectorSheet({
+  children,
+}: MobileInspectorSheetProps): ReactElement {
+  return (
+    <Sheet>
+      <SheetTrigger
+        className="fixed right-4 bottom-4 z-40 rounded-full border bg-background px-3 py-2 text-xs shadow-md"
+        data-testid="plumix-editor-mobile-inspector-trigger"
+      >
+        Inspector
+      </SheetTrigger>
+      <SheetContent side="bottom" className="h-[80dvh] overflow-y-auto">
+        <SheetHeader className="sr-only">
+          <SheetTitle>Inspector</SheetTitle>
+          <SheetDescription>
+            Block actions, fields, and style controls for the selected block.
+          </SheetDescription>
+        </SheetHeader>
+        {children}
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
Narrow viewports were squeezed by the always-visible 320px right sidebar. Collapse it to a shadcn Sheet on mobile so the canvas keeps its width. Closes the "Mobile breakpoint collapses the right sidebar to a bottom sheet" acceptance criterion of #387; the left-sidebar mobile collapse is a separate slice.

A new `MobileInspectorSheet` wraps a fixed-position trigger button (bottom right) and a bottom-anchored Sheet hosting the BlockActions + Block / Style Tabs content. `EditorLayout` extracts the inspector body into a local `InspectorBody` component that calls `useIsMobile()` and conditionally renders either the desktop `<aside>` or the mobile sheet. The grid template adjusts to `grid-cols-[260px_1fr] md:grid-cols-[260px_1fr_320px]` so the 320px track collapses when the aside isn't rendered.

**JS-gating is load-bearing, not preemptive defense**

A Tailwind-only `hidden md:block` approach would leave both inspector trees mounted in the DOM (CSS visibility doesn't unmount React). That double-mounts `<Puck.Fields>`, which calls `useRegisterFieldsSlice` once per mount and races on `resolveFields` resolvers when two instances share a provider. No v2 block declares `resolveFields` today, but the failure mode is real for any future consumer. The `useIsMobile()` gate mounts exactly one instance per viewport.

Refs #387

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>