### PR TITLE
test(admin): cover v2 slash-menu insert and autosave pill cycle

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -87,4 +87,38 @@ test.describe("V2 spike editor renders end-to-end", () => {
 
     await expect(page.getByTestId("slash-menu-dialog")).toBeVisible();
   });
+
+  test("slash menu insert: selecting a paragraph adds it to the canvas", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("v2/entries/posts/1/edit");
+
+    const canvas = page.getByTestId("plumix-editor-canvas");
+    await canvas.focus();
+    await page.keyboard.press("/");
+
+    await expect(page.getByTestId("slash-menu-dialog")).toBeVisible();
+    await page.getByTestId("slash-menu-item-core/paragraph").click();
+
+    await expect(page.getByTestId("slash-menu-dialog")).toBeHidden();
+    await expect(canvas.locator("p")).toHaveCount(1);
+  });
+
+  test("autosave pill cycles saved → saving → saved when a block is inserted", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("v2/entries/posts/1/edit");
+
+    const pill = page.getByTestId("plumix-autosave-pill");
+    await expect(pill).toHaveAttribute("data-status", "saved");
+
+    await page.getByTestId("plumix-editor-canvas").focus();
+    await page.keyboard.press("/");
+    await page.getByTestId("slash-menu-item-core/paragraph").click();
+
+    await expect(pill).toHaveAttribute("data-status", "saving");
+    await expect(pill).toHaveAttribute("data-status", "saved");
+  });
 });

--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -8,6 +8,8 @@ import {
 } from "./support/rpc-mock.js";
 
 test.describe("V2 spike editor renders end-to-end", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
   test.beforeEach(async ({ page }) => {
     await mockManifest(page, MANIFEST_WITH_POST);
     await page.route("**/_plumix/rpc/**", async (route) => {
@@ -26,7 +28,6 @@ test.describe("V2 spike editor renders end-to-end", () => {
   test("desktop chrome renders: header, left sidebar tabs, canvas, right sidebar tabs", async ({
     page,
   }) => {
-    await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("v2/entries/posts/1/edit");
 
     await expect(page.getByTestId("plumix-editor-layout")).toBeVisible();
@@ -78,7 +79,6 @@ test.describe("V2 spike editor renders end-to-end", () => {
   test("slash menu opens on the canvas when '/' is pressed", async ({
     page,
   }) => {
-    await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("v2/entries/posts/1/edit");
 
     const canvas = page.getByTestId("plumix-editor-canvas");
@@ -91,7 +91,6 @@ test.describe("V2 spike editor renders end-to-end", () => {
   test("slash menu insert: selecting a paragraph adds it to the canvas", async ({
     page,
   }) => {
-    await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("v2/entries/posts/1/edit");
 
     const canvas = page.getByTestId("plumix-editor-canvas");
@@ -108,7 +107,6 @@ test.describe("V2 spike editor renders end-to-end", () => {
   test("autosave pill cycles saved → saving → saved when a block is inserted", async ({
     page,
   }) => {
-    await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("v2/entries/posts/1/edit");
 
     const pill = page.getByTestId("plumix-autosave-pill");


### PR DESCRIPTION
Continues the verification thread from #441 (static rendering) with two interaction cases that lock in the behaviours user-facing slices #386 (slash menu insert) and #437/#438/#439 (autosave pill state machine via localStorage debounce) ship. Both run against the production `vite preview` build.

**Slash-menu insert**

Focus the canvas, press `/`, click `slash-menu-item-core/paragraph`, assert the dialog closes and exactly one `<p>` element appears in the canvas. Verifies the full keystroke → Puck dispatch → canvas render path.

**Autosave pill cycles**

The same insert action triggers Puck's `onChange`, so the pill's `data-status` attribute must transition `saved → saving → saved` through the 300ms debounce. Playwright's auto-retrying `toHaveAttribute` catches the transient `saving` state without explicit waits — the test fails if the debounce stops running or the state machine breaks.

All five v2 spec cases pass (three from #441 + these two).

Refs #386, #391

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>