### PR TITLE
feat(admin,blocks): load v2 entries from the server via entry.get

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -7,6 +7,27 @@ import {
   rpcOkBody,
 } from "./support/rpc-mock.js";
 
+const T0 = new Date("2026-05-20T00:00:00Z");
+
+function emptyEntry(id: number): Record<string, unknown> {
+  return {
+    id,
+    type: "post",
+    parentId: null,
+    title: "Untitled",
+    slug: `entry-${String(id)}`,
+    content: null,
+    excerpt: null,
+    status: "draft",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: null,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: {},
+  };
+}
+
 test.describe("V2 spike editor renders end-to-end", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
@@ -19,6 +40,13 @@ test.describe("V2 spike editor renders end-to-end", () => {
           status: 200,
           contentType: "application/json",
           body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: emptyEntry(1), meta: [] }),
         });
       }
       return route.fulfill({ status: 404, body: "not-mocked" });
@@ -102,6 +130,49 @@ test.describe("V2 spike editor renders end-to-end", () => {
 
     await expect(page.getByTestId("slash-menu-dialog")).toBeHidden();
     await expect(canvas.locator("p")).toHaveCount(1);
+  });
+
+  test("server-loaded plumix.v2 content renders in the canvas on initial mount", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              ...emptyEntry(1),
+              content: {
+                version: "plumix.v2",
+                blocks: [
+                  {
+                    id: "h1",
+                    name: "core/heading",
+                    attrs: { level: 2, text: "Hello from server" },
+                  },
+                ],
+              },
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("v2/entries/posts/1/edit");
+
+    const canvas = page.getByTestId("plumix-editor-canvas");
+    await expect(canvas.locator("h2")).toHaveText("Hello from server");
   });
 
   test("autosave pill cycles saved → saving → saved when a block is inserted", async ({

--- a/packages/admin/src/editor/v2/v2-entry-content.test.ts
+++ b/packages/admin/src/editor/v2/v2-entry-content.test.ts
@@ -1,0 +1,140 @@
+import type { BlockNode } from "@plumix/blocks";
+import type { Data } from "@puckeditor/core";
+import { describe, expect, test } from "vitest";
+
+import {
+  blockNodesToPuckContent,
+  isV2EntryContent,
+  seedPuckData,
+} from "./v2-entry-content.js";
+
+describe("blockNodesToPuckContent", () => {
+  test("converts a leaf BlockNode to a ComponentData with type + id-attrs in props", () => {
+    const nodes: readonly BlockNode[] = [
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: { level: 2, text: "Hello" },
+      },
+    ];
+
+    const content = blockNodesToPuckContent(nodes);
+
+    expect(content).toEqual([
+      {
+        type: "core/heading",
+        props: { id: "h1", level: 2, text: "Hello" },
+      },
+    ]);
+  });
+
+  test("passes node.style through into props.style", () => {
+    const nodes: readonly BlockNode[] = [
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: { level: 2, text: "Hello" },
+        style: { large: { padding: "md" } },
+      },
+    ];
+
+    const content = blockNodesToPuckContent(nodes);
+
+    expect(content[0]?.props).toEqual({
+      id: "h1",
+      level: 2,
+      text: "Hello",
+      style: { large: { padding: "md" } },
+    });
+  });
+
+  test("omits props.style when the node has no style slot", () => {
+    const nodes: readonly BlockNode[] = [
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: { level: 2 },
+      },
+    ];
+
+    expect("style" in (blockNodesToPuckContent(nodes)[0]?.props ?? {})).toBe(
+      false,
+    );
+  });
+});
+
+describe("isV2EntryContent", () => {
+  test("accepts the canonical plumix.v2 envelope", () => {
+    expect(
+      isV2EntryContent({
+        version: "plumix.v2",
+        blocks: [{ id: "h1", name: "core/heading", attrs: { level: 2 } }],
+      }),
+    ).toBe(true);
+  });
+
+  test("accepts an empty blocks array", () => {
+    expect(isV2EntryContent({ version: "plumix.v2", blocks: [] })).toBe(true);
+  });
+
+  test("rejects Tiptap-shaped content", () => {
+    expect(
+      isV2EntryContent({
+        type: "doc",
+        content: [{ type: "core/heading", attrs: { level: 2 } }],
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects null, undefined, primitives, and arrays", () => {
+    expect(isV2EntryContent(null)).toBe(false);
+    expect(isV2EntryContent(undefined)).toBe(false);
+    expect(isV2EntryContent("plumix.v2")).toBe(false);
+    expect(isV2EntryContent([])).toBe(false);
+  });
+
+  test("rejects missing or wrong version", () => {
+    expect(isV2EntryContent({ blocks: [] })).toBe(false);
+    expect(isV2EntryContent({ version: "plumix.v1", blocks: [] })).toBe(false);
+  });
+
+  test("rejects malformed blocks (entries missing id or name)", () => {
+    expect(
+      isV2EntryContent({ version: "plumix.v2", blocks: [{ name: "x" }] }),
+    ).toBe(false);
+    expect(
+      isV2EntryContent({ version: "plumix.v2", blocks: [{ id: "x" }] }),
+    ).toBe(false);
+  });
+});
+
+describe("seedPuckData", () => {
+  const fallback: Data = { content: [], root: {} };
+
+  test("uses server content when it has the v2 envelope", () => {
+    const seeded = seedPuckData(
+      {
+        version: "plumix.v2",
+        blocks: [
+          { id: "h1", name: "core/heading", attrs: { level: 2, text: "Server" } },
+        ],
+      },
+      fallback,
+    );
+    expect(seeded.content).toEqual([
+      { type: "core/heading", props: { id: "h1", level: 2, text: "Server" } },
+    ]);
+  });
+
+  test("returns the fallback when the content is not v2-shaped", () => {
+    const seeded = seedPuckData(
+      { type: "doc", content: [{ type: "core/heading" }] },
+      fallback,
+    );
+    expect(seeded).toBe(fallback);
+  });
+
+  test("returns the fallback when content is null", () => {
+    expect(seedPuckData(null, fallback)).toBe(fallback);
+  });
+});

--- a/packages/admin/src/editor/v2/v2-entry-content.ts
+++ b/packages/admin/src/editor/v2/v2-entry-content.ts
@@ -1,0 +1,32 @@
+import type { BlockNode } from "@plumix/blocks";
+import type { Data } from "@puckeditor/core";
+import { isBlockNodeArray } from "@plumix/blocks";
+
+export interface V2EntryContent {
+  readonly version: "plumix.v2";
+  readonly blocks: readonly BlockNode[];
+}
+
+export function isV2EntryContent(value: unknown): value is V2EntryContent {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { version?: unknown; blocks?: unknown };
+  return candidate.version === "plumix.v2" && isBlockNodeArray(candidate.blocks);
+}
+
+export function blockNodesToPuckContent(
+  nodes: readonly BlockNode[],
+): Data["content"] {
+  return nodes.map((node) => ({
+    type: node.name,
+    props: {
+      id: node.id,
+      ...node.attrs,
+      ...(node.style ? { style: node.style } : {}),
+    },
+  }));
+}
+
+export function seedPuckData(content: unknown, fallback: Data): Data {
+  if (!isV2EntryContent(content)) return fallback;
+  return { content: blockNodesToPuckContent(content.blocks), root: {} };
+}

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -3,8 +3,10 @@ import type { Config, Data } from "@puckeditor/core";
 import type { ReactElement, ReactNode } from "react";
 import { coreBlocksV2, createBlockRegistry } from "@plumix/blocks";
 import { Puck } from "@puckeditor/core";
-import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, notFound } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import * as v from "valibot";
 
 import type { AutosaveStatus } from "@/editor/v2/AutosaveStatus.js";
 
@@ -13,6 +15,9 @@ import { blockSpecsToPuckComponents } from "@/editor/v2/block-adapter.js";
 import { createDebouncer } from "@/editor/v2/debounce.js";
 import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
 import { readDraft, writeDraft } from "@/editor/v2/local-draft.js";
+import { seedPuckData } from "@/editor/v2/v2-entry-content.js";
+import { orpc } from "@/lib/orpc.js";
+import { idPathParam } from "@plumix/core/validation";
 
 import "@puckeditor/core/puck.css";
 
@@ -45,21 +50,68 @@ const config: Config = {
 };
 
 export const Route = createFileRoute("/_editor/v2/entries/$slug/$id/edit")({
+  params: {
+    parse: (raw) => {
+      const result = v.safeParse(idPathParam, raw.id);
+      if (!result.success) {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router control-flow
+        throw notFound();
+      }
+      return { slug: raw.slug, id: result.output };
+    },
+  },
+  loader: ({ context, params }) =>
+    context.queryClient.ensureQueryData(
+      orpc.entry.get.queryOptions({ input: { id: params.id } }),
+    ),
+  pendingComponent: PendingScreen,
+  errorComponent: ErrorScreen,
   component: PuckSpikeRoute,
 });
+
+function PendingScreen(): ReactNode {
+  return (
+    <div
+      className="p-6 text-sm text-muted-foreground"
+      data-testid="plumix-editor-pending"
+    >
+      Loading entry…
+    </div>
+  );
+}
+
+function ErrorScreen(): ReactNode {
+  return (
+    <div
+      className="p-6 text-sm text-muted-foreground"
+      data-testid="plumix-editor-error"
+    >
+      Couldn't load this entry.
+    </div>
+  );
+}
 
 function PuckSpikeRoute(): ReactNode {
   const { slug, id } = Route.useParams();
   const draftKey = `plumix.v2.draft.${slug}.${id}`;
-  return <PuckSpikeRouteInner key={draftKey} draftKey={draftKey} />;
+  return <PuckSpikeRouteInner key={draftKey} draftKey={draftKey} id={id} />;
 }
 
 interface PuckSpikeRouteInnerProps {
   readonly draftKey: string;
+  readonly id: number;
 }
 
-function PuckSpikeRouteInner({ draftKey }: PuckSpikeRouteInnerProps): ReactNode {
-  const [data, setData] = useState<Data>(() => readDraft(draftKey) ?? initialData);
+function PuckSpikeRouteInner({
+  draftKey,
+  id,
+}: PuckSpikeRouteInnerProps): ReactNode {
+  const { data: entry } = useSuspenseQuery(
+    orpc.entry.get.queryOptions({ input: { id } }),
+  );
+  const [data, setData] = useState<Data>(() =>
+    seedPuckData(entry.content, readDraft(draftKey) ?? initialData),
+  );
   const [status, setStatus] = useState<AutosaveStatus>("saved");
   const debouncer = useMemo(
     () =>
@@ -97,3 +149,4 @@ function PuckSpikeRouteInner({ draftKey }: PuckSpikeRouteInnerProps): ReactNode 
     </AutosaveStatusContext.Provider>
   );
 }
+

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -46,7 +46,11 @@ export type {
   EntryContentProps,
   SyncFilterExecutor,
 } from "./walker.js";
-export { DEFAULT_BLOCK_CONTEXT, renderBlockTree } from "./render-block-tree.js";
+export {
+  DEFAULT_BLOCK_CONTEXT,
+  isBlockNodeArray,
+  renderBlockTree,
+} from "./render-block-tree.js";
 export { analyzeHeadingStructure } from "./heading/audit.js";
 export type { HeadingAuditViolation } from "./heading/audit.js";
 export { resolveBlockTransformsV2 } from "./transforms-v2.js";

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -84,7 +84,7 @@ function isDevMode(): boolean {
   return process.env.NODE_ENV !== "production";
 }
 
-function isBlockNodeArray(value: unknown): value is readonly BlockNode[] {
+export function isBlockNodeArray(value: unknown): value is readonly BlockNode[] {
   if (!Array.isArray(value)) return false;
   return value.every(
     (item) =>


### PR DESCRIPTION
The v2 spike route only read from localStorage. Wire `entry.get` so canonical content arrives from the server on initial mount, with the local-draft path demoted to its proper role as the debounce buffer for the offline-edit loop. Continues the #391 progression after the local-draft cache (#437), debounce (#438), and status pill (#439).

**V2 entry content envelope**

A new `packages/admin/src/editor/v2/v2-entry-content.ts` declares `interface V2EntryContent { version: "plumix.v2"; blocks: readonly BlockNode[] }` plus `isV2EntryContent`, `blockNodesToPuckContent`, and `seedPuckData(content, fallback)`. The structural guard reuses a newly-public `isBlockNodeArray` from `@plumix/blocks` (promoted from a private helper) so admin and the SSR walker share one canonical check.

**Route loader + pending/error chrome**

`PuckSpikeRoute` gains a valibot `params.parse` for id validation, a `loader` that prefetches `entry.get` via `ensureQueryData`, and `pendingComponent` / `errorComponent` screens (mirrors the v1 route's pattern). `PuckSpikeRouteInner` now reads the entry via `useSuspenseQuery` and seeds Puck Data through `seedPuckData(entry.content, readDraft(draftKey) ?? initialData)` — server content wins; the localStorage path stays as the offline buffer.

**Known limitations (deferred to #391 proper)**

Server content overwrites a localStorage draft on initial mount (mitigated by the 300ms debounce window — real autosave-merge belongs to #391 itself). Conversion is also leaf-only; slot-bearing wrappers (group / columns / details) load their attrs but their nested children won't materialise until the slot walker lands.

Playwright keeps the existing 5 cases green by adding a default `entry.get` mock in `beforeEach` (route now requires the RPC) and adds a 6th case that mocks v2-shaped content and asserts the heading text appears in the canvas. All 6 cases pass against the production build.

Refs #391

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>