### PR TITLE
feat(admin): walk slot children when seeding puck data from server v2 content

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -175,6 +175,57 @@ test.describe("V2 spike editor renders end-to-end", () => {
     await expect(canvas.locator("h2")).toHaveText("Hello from server");
   });
 
+  test("server-loaded wrapper block renders its nested children in the canvas", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              ...emptyEntry(1),
+              content: {
+                version: "plumix.v2",
+                blocks: [
+                  {
+                    id: "g1",
+                    name: "core/group",
+                    attrs: {
+                      content: [
+                        {
+                          id: "child-h",
+                          name: "core/heading",
+                          attrs: { level: 3, text: "Inside group" },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("v2/entries/posts/1/edit");
+
+    const canvas = page.getByTestId("plumix-editor-canvas");
+    await expect(canvas.locator("h3")).toHaveText("Inside group");
+  });
+
   test("autosave pill cycles saved → saving → saved when a block is inserted", async ({
     page,
   }) => {

--- a/packages/admin/src/editor/v2/v2-entry-content.test.ts
+++ b/packages/admin/src/editor/v2/v2-entry-content.test.ts
@@ -61,6 +61,130 @@ describe("blockNodesToPuckContent", () => {
       false,
     );
   });
+
+  test("recursively converts a single-slot wrapper's nested children", () => {
+    const nodes: readonly BlockNode[] = [
+      {
+        id: "g1",
+        name: "core/group",
+        attrs: {
+          content: [
+            { id: "h1", name: "core/heading", attrs: { level: 2, text: "X" } },
+          ],
+        },
+      },
+    ];
+
+    expect(blockNodesToPuckContent(nodes)).toEqual([
+      {
+        type: "core/group",
+        props: {
+          id: "g1",
+          content: [
+            { type: "core/heading", props: { id: "h1", level: 2, text: "X" } },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("converts independent slot arrays on a multi-slot parent", () => {
+    const nodes: readonly BlockNode[] = [
+      {
+        id: "c1",
+        name: "core/columns",
+        attrs: {
+          left: [
+            { id: "lh", name: "core/heading", attrs: { level: 2, text: "L" } },
+          ],
+          right: [
+            { id: "rh", name: "core/heading", attrs: { level: 2, text: "R" } },
+          ],
+        },
+      },
+    ];
+
+    expect(blockNodesToPuckContent(nodes)).toEqual([
+      {
+        type: "core/columns",
+        props: {
+          id: "c1",
+          left: [
+            { type: "core/heading", props: { id: "lh", level: 2, text: "L" } },
+          ],
+          right: [
+            { type: "core/heading", props: { id: "rh", level: 2, text: "R" } },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("walks slots arbitrarily deep", () => {
+    const nodes: readonly BlockNode[] = [
+      {
+        id: "outer",
+        name: "core/group",
+        attrs: {
+          content: [
+            {
+              id: "middle",
+              name: "core/group",
+              attrs: {
+                content: [
+                  {
+                    id: "inner",
+                    name: "core/heading",
+                    attrs: { level: 3, text: "Deep" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    expect(blockNodesToPuckContent(nodes)).toEqual([
+      {
+        type: "core/group",
+        props: {
+          id: "outer",
+          content: [
+            {
+              type: "core/group",
+              props: {
+                id: "middle",
+                content: [
+                  {
+                    type: "core/heading",
+                    props: { id: "inner", level: 3, text: "Deep" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("leaves non-slot arrays in attrs untouched", () => {
+    const nodes: readonly BlockNode[] = [
+      {
+        id: "picker",
+        name: "core/picker",
+        attrs: { tags: [{ value: "foo" }, { value: "bar" }] },
+      },
+    ];
+
+    expect(blockNodesToPuckContent(nodes)).toEqual([
+      {
+        type: "core/picker",
+        props: { id: "picker", tags: [{ value: "foo" }, { value: "bar" }] },
+      },
+    ]);
+  });
 });
 
 describe("isV2EntryContent", () => {

--- a/packages/admin/src/editor/v2/v2-entry-content.ts
+++ b/packages/admin/src/editor/v2/v2-entry-content.ts
@@ -1,5 +1,5 @@
 import type { BlockNode } from "@plumix/blocks";
-import type { Data } from "@puckeditor/core";
+import type { ComponentData, Data } from "@puckeditor/core";
 import { isBlockNodeArray } from "@plumix/blocks";
 
 export interface V2EntryContent {
@@ -16,14 +16,18 @@ export function isV2EntryContent(value: unknown): value is V2EntryContent {
 export function blockNodesToPuckContent(
   nodes: readonly BlockNode[],
 ): Data["content"] {
-  return nodes.map((node) => ({
-    type: node.name,
-    props: {
-      id: node.id,
-      ...node.attrs,
-      ...(node.style ? { style: node.style } : {}),
-    },
-  }));
+  return nodes.map(nodeToComponentData);
+}
+
+function nodeToComponentData(node: BlockNode): ComponentData {
+  const props: Record<string, unknown> = { id: node.id };
+  for (const [key, value] of Object.entries(node.attrs ?? {})) {
+    props[key] = isBlockNodeArray(value)
+      ? value.map(nodeToComponentData)
+      : value;
+  }
+  if (node.style) props.style = node.style;
+  return { type: node.name, props: props as ComponentData["props"] };
 }
 
 export function seedPuckData(content: unknown, fallback: Data): Data {


### PR DESCRIPTION
PR #443 introduced `blockNodesToPuckContent` as leaf-only — wrapper blocks (core/group, core/columns, core/details) loaded their attrs but their nested children silently dropped. This slice teaches the walker the same recursion the inverse `puck-to-block-tree.ts:toBlockNode` already does, so load and save paths are symmetric across slot-bearing wrappers.

The converter now delegates to a private `nodeToComponentData(node)` walker that iterates `node.attrs`, recursively converts any value matching the shared `isBlockNodeArray` guard to `ComponentData[]`, copies non-slot values verbatim, and appends `props.style` from the leaf style slot (unchanged from #443).

Unit suite grows to 16 (4 new): single-slot recursion, multi-slot independent conversion, deeply nested 3-level walk, non-slot arrays passthrough. Playwright gains a 7th case mocking `entry.get` with a `core/group` containing a nested `core/heading` and asserting the heading text renders in the canvas. All 7 e2e cases pass against the production build.

Refs #391

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>