### PR TITLE
test(admin): pin v2 editor a11y baseline with axe-core smoke

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { expectNoAxeViolations } from "./support/axe.js";
 import {
   AUTHED_ADMIN,
   MANIFEST_WITH_POST,
@@ -224,6 +225,28 @@ test.describe("V2 spike editor renders end-to-end", () => {
 
     const canvas = page.getByTestId("plumix-editor-canvas");
     await expect(canvas.locator("h3")).toHaveText("Inside group");
+  });
+
+  test("v2 editor chrome has no WCAG 2.1 AA violations from axe-core", async ({
+    page,
+  }) => {
+    await page.goto("v2/entries/posts/1/edit");
+    await expect(page.getByTestId("plumix-editor-layout")).toBeVisible();
+    await expectNoAxeViolations(page);
+  });
+
+  test("mobile inspector sheet has no WCAG 2.1 AA violations when open", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 480, height: 800 });
+    await page.goto("v2/entries/posts/1/edit");
+
+    await page
+      .getByTestId("plumix-editor-mobile-inspector-trigger")
+      .click();
+    await expect(page.getByTestId("plumix-editor-tab-block")).toBeVisible();
+
+    await expectNoAxeViolations(page);
   });
 
   test("autosave pill cycles saved → saving → saved when a block is inserted", async ({


### PR DESCRIPTION
Two new Playwright cases scan the v2 editor against the shared `expectNoAxeViolations` helper (WCAG 2.1 AA tags) — desktop chrome and the open mobile inspector sheet. Both pass on first run with no production-code change. The shadcn / Radix / cmdk vendor primitives carry good a11y defaults; the bespoke surface (title input `aria-label`, autosave pill `data-status`, sr-only sheet headers) covers the rest.

**Mobile sheet coverage is load-bearing**

The desktop scan covers the static chrome only. Radix Dialog overlays are where vendor a11y defaults most often slip (focus traps, `aria-modal`, off-screen content scanning), so the second case re-uses the mobile fixture, clicks the Inspector trigger to open the sheet, waits for the sheet's Block tab to settle, then scans. Both DOM subtrees now have a baseline.

Bare expectation — no allowlist, no rule narrowing — so any future regression fails the suite cleanly and forces a fix at PR time, rather than rotting silently in a defer list.

Refs #400

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>