### PR TITLE
feat(blocks,core): accept the plumix.v2 content envelope in entry RPC writes

### DIFF
--- a/packages/admin/src/editor/v2/v2-entry-content.ts
+++ b/packages/admin/src/editor/v2/v2-entry-content.ts
@@ -1,17 +1,9 @@
 import type { BlockNode } from "@plumix/blocks";
 import type { ComponentData, Data } from "@puckeditor/core";
-import { isBlockNodeArray } from "@plumix/blocks";
+import { isBlockNodeArray, isV2EntryContent } from "@plumix/blocks";
 
-export interface V2EntryContent {
-  readonly version: "plumix.v2";
-  readonly blocks: readonly BlockNode[];
-}
-
-export function isV2EntryContent(value: unknown): value is V2EntryContent {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as { version?: unknown; blocks?: unknown };
-  return candidate.version === "plumix.v2" && isBlockNodeArray(candidate.blocks);
-}
+export type { V2EntryContent } from "@plumix/blocks";
+export { isV2EntryContent } from "@plumix/blocks";
 
 export function blockNodesToPuckContent(
   nodes: readonly BlockNode[],

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -51,6 +51,9 @@ export {
   isBlockNodeArray,
   renderBlockTree,
 } from "./render-block-tree.js";
+export { isV2EntryContent } from "./v2-entry-content.js";
+export type { V2EntryContent } from "./v2-entry-content.js";
+export { validateV2EntryContent } from "./validate-v2-content.js";
 export { analyzeHeadingStructure } from "./heading/audit.js";
 export type { HeadingAuditViolation } from "./heading/audit.js";
 export { resolveBlockTransformsV2 } from "./transforms-v2.js";

--- a/packages/blocks/src/v2-entry-content.ts
+++ b/packages/blocks/src/v2-entry-content.ts
@@ -1,0 +1,13 @@
+import type { BlockNode } from "./render-block-tree.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+
+export interface V2EntryContent {
+  readonly version: "plumix.v2";
+  readonly blocks: readonly BlockNode[];
+}
+
+export function isV2EntryContent(value: unknown): value is V2EntryContent {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { version?: unknown; blocks?: unknown };
+  return candidate.version === "plumix.v2" && isBlockNodeArray(candidate.blocks);
+}

--- a/packages/blocks/src/validate-v2-content.test.ts
+++ b/packages/blocks/src/validate-v2-content.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "vitest";
+
+import { validateV2EntryContent } from "./validate-v2-content.js";
+
+const registry = {
+  has(name: string): boolean {
+    return name === "core/heading" || name === "core/group";
+  },
+};
+
+describe("validateV2EntryContent", () => {
+  test("accepts a valid leaf-block envelope", () => {
+    const result = validateV2EntryContent(
+      {
+        version: "plumix.v2",
+        blocks: [
+          { id: "h1", name: "core/heading", attrs: { level: 2, text: "Hi" } },
+        ],
+      },
+      registry,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("rejects an envelope with an unregistered top-level block name", () => {
+    const result = validateV2EntryContent(
+      {
+        version: "plumix.v2",
+        blocks: [
+          { id: "x1", name: "acme/widget", attrs: {} },
+        ],
+      },
+      registry,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toEqual([
+      {
+        code: "unknown_block_type",
+        message: 'Unknown block type "acme/widget" at blocks[0].',
+        path: "blocks[0]",
+        nodeName: "acme/widget",
+      },
+    ]);
+  });
+
+  test("rejects an unregistered block name nested inside a slot child", () => {
+    const result = validateV2EntryContent(
+      {
+        version: "plumix.v2",
+        blocks: [
+          {
+            id: "g1",
+            name: "core/group",
+            attrs: {
+              content: [
+                { id: "x1", name: "acme/widget", attrs: {} },
+              ],
+            },
+          },
+        ],
+      },
+      registry,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toEqual([
+      {
+        code: "unknown_block_type",
+        message: 'Unknown block type "acme/widget" at blocks[0].content[0].',
+        path: "blocks[0].content[0]",
+        nodeName: "acme/widget",
+      },
+    ]);
+  });
+
+  test("accepts an empty blocks array", () => {
+    const result = validateV2EntryContent(
+      { version: "plumix.v2", blocks: [] },
+      registry,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("accepts a nested wrapper subtree where every name is registered", () => {
+    const result = validateV2EntryContent(
+      {
+        version: "plumix.v2",
+        blocks: [
+          {
+            id: "g1",
+            name: "core/group",
+            attrs: {
+              content: [
+                {
+                  id: "h1",
+                  name: "core/heading",
+                  attrs: { level: 3, text: "Inside group" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      registry,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/packages/blocks/src/validate-v2-content.ts
+++ b/packages/blocks/src/validate-v2-content.ts
@@ -1,0 +1,44 @@
+import type { BlockNode } from "./render-block-tree.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+import type { BlockContentValidationResult } from "./validate-content.js";
+import type { V2EntryContent } from "./v2-entry-content.js";
+import type { BlockContentValidationIssue } from "./validation-errors.js";
+
+// Issues emit a v2-specific path grammar: `blocks[i]` at the root and
+// `blocks[i].<slotKey>[j]` for nested slot children. Admin clients can
+// dispatch validator origin off the path prefix (v1 always starts with
+// `content[`, v2 always starts with `blocks[`).
+export function validateV2EntryContent(
+  content: V2EntryContent,
+  registry: { has(name: string): boolean },
+): BlockContentValidationResult {
+  const errors: BlockContentValidationIssue[] = [];
+  walk(content.blocks, "blocks", errors, registry);
+  if (errors.length === 0) return { ok: true };
+  return { ok: false, errors };
+}
+
+function walk(
+  nodes: readonly BlockNode[],
+  basePath: string,
+  out: BlockContentValidationIssue[],
+  registry: { has(name: string): boolean },
+): void {
+  nodes.forEach((node, i) => {
+    const path = `${basePath}[${i}]`;
+    if (!registry.has(node.name)) {
+      out.push({
+        code: "unknown_block_type",
+        message: `Unknown block type "${node.name}" at ${path}.`,
+        path,
+        nodeName: node.name,
+      });
+      return;
+    }
+    for (const [key, value] of Object.entries(node.attrs ?? {})) {
+      if (isBlockNodeArray(value)) {
+        walk(value, `${path}.${key}`, out, registry);
+      }
+    }
+  });
+}

--- a/packages/core/src/rpc/procedures/entry/content.ts
+++ b/packages/core/src/rpc/procedures/entry/content.ts
@@ -3,7 +3,11 @@ import type {
   BlockRegistry,
   MarkRegistry,
 } from "@plumix/blocks";
-import { validateBlockContent } from "@plumix/blocks";
+import {
+  isV2EntryContent,
+  validateBlockContent,
+  validateV2EntryContent,
+} from "@plumix/blocks";
 
 import type { EntryContent } from "../../../db/schema/entries.js";
 import { MAX_CONTENT_BYTES } from "./schemas.js";
@@ -33,7 +37,9 @@ export function assertContentValidAgainstRegistries(
   errors: Pick<ContentErrors, "INVALID_BLOCK_CONTENT">,
 ): void {
   if (content == null) return;
-  const result = validateBlockContent(content, registries);
+  const result = isV2EntryContent(content)
+    ? validateV2EntryContent(content, registries.blocks)
+    : validateBlockContent(content, registries);
   if (!result.ok) {
     throw errors.INVALID_BLOCK_CONTENT({
       data: { issues: [...result.errors] },

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -524,4 +524,27 @@ describe("entry.update", () => {
       });
     });
   });
+
+  // Round-trip implies the v2 branch was taken: the v1 validator would
+  // reject this envelope at the root (`Content root must be a Tiptap doc
+  // node`), so a successful update + content match proves the dispatch in
+  // `assertContentValidAgainstRegistries`.
+  test("persists a plumix.v2 content envelope through entry.update", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "v2-write",
+    });
+    const v2Content = {
+      version: "plumix.v2",
+      blocks: [
+        { id: "p1", name: "core/paragraph", attrs: { text: "Hello" } },
+      ],
+    };
+    const updated = await h.client.entry.update({
+      id: own.id,
+      content: v2Content,
+    });
+    expect(updated.content).toEqual(v2Content);
+  });
 });


### PR DESCRIPTION
Teach the server-side content validator to accept the plumix.v2 envelope so entry RPC
writes round-trip. Before this slice, anything other than a Tiptap doc threw
INVALID_BLOCK_CONTENT, which blocked the admin spike's autosave write loop end-to-end.

**Dispatch and validator scope**

`assertContentValidAgainstRegistries` now branches on `isV2EntryContent`: v2 envelopes
route to a new `validateV2EntryContent` that walks each top-level `BlockNode` plus
nested slot children (recursing via `isBlockNodeArray` over arbitrary attr keys) and
rejects unregistered block names. The v1 Tiptap-doc path is unchanged. The new
validator stops at registry-membership — attribute-level validation against block
specs' `inputs` is deferred to its own slice.

**Shared error envelope**

The v2 path reuses `BlockContentValidationResult` and `BlockContentValidationIssue`,
so the `INVALID_BLOCK_CONTENT` shape stays consistent across v1/v2. The v2 path
grammar (`blocks[i].<slotKey>[j]`) is distinct from v1's `content[i].content[j]`, so
admin clients can dispatch validator origin off the path prefix when they need to.

`V2EntryContent` + `isV2EntryContent` move from `packages/admin` into `@plumix/blocks`
so the server and admin consume the same guard; admin keeps a thin re-export and its
Puck-data converters.

Refs #391
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>