### PR TITLE
feat(admin): persist v2 autosave to the server via entry.update

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -5,6 +5,7 @@ import {
   AUTHED_ADMIN,
   MANIFEST_WITH_POST,
   mockManifest,
+  mockRpcWithCapture,
   rpcOkBody,
 } from "./support/rpc-mock.js";
 
@@ -252,6 +253,19 @@ test.describe("V2 spike editor renders end-to-end", () => {
   test("autosave pill cycles saved → saving → saved when a block is inserted", async ({
     page,
   }) => {
+    await page.route("**/_plumix/rpc/**", (route) => {
+      if (route.request().url().endsWith("/entry/update")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: { ...emptyEntry(1), updatedAt: T0 },
+            meta: [],
+          }),
+        });
+      }
+      return route.fallback();
+    });
     await page.goto("v2/entries/posts/1/edit");
 
     const pill = page.getByTestId("plumix-autosave-pill");
@@ -263,5 +277,40 @@ test.describe("V2 spike editor renders end-to-end", () => {
 
     await expect(pill).toHaveAttribute("data-status", "saving");
     await expect(pill).toHaveAttribute("data-status", "saved");
+  });
+
+  test("autosave POSTs a plumix.v2 envelope to entry.update after a block is inserted", async ({
+    page,
+  }) => {
+    const captures = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/update",
+      captureResponse: { ...emptyEntry(1), updatedAt: T0 },
+      handlers: {
+        "/auth/session": AUTHED_ADMIN,
+        "/entry/get": emptyEntry(1),
+      },
+    });
+    await page.goto("v2/entries/posts/1/edit");
+
+    await page.getByTestId("plumix-editor-canvas").focus();
+    await page.keyboard.press("/");
+    await page.getByTestId("slash-menu-item-core/paragraph").click();
+
+    await expect
+      .poll(
+        () =>
+          (
+            captures.at(-1) as
+              | { content?: { version?: string } }
+              | undefined
+          )?.content?.version ?? null,
+      )
+      .toBe("plumix.v2");
+    const lastInput = captures.at(-1) as {
+      readonly id: number;
+      readonly content: { readonly blocks: unknown[] };
+    };
+    expect(lastInput.id).toBe(1);
+    expect(lastInput.content.blocks.length).toBeGreaterThan(0);
   });
 });

--- a/packages/admin/src/editor/v2/debounce.ts
+++ b/packages/admin/src/editor/v2/debounce.ts
@@ -5,7 +5,7 @@ export interface Debouncer<Args extends readonly unknown[]> {
 }
 
 export function createDebouncer<Args extends readonly unknown[]>(
-  fn: (...args: Args) => void,
+  fn: (...args: Args) => void | Promise<void>,
   delayMs: number,
 ): Debouncer<Args> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -16,7 +16,7 @@ export function createDebouncer<Args extends readonly unknown[]>(
     const args = pending;
     pending = undefined;
     timer = undefined;
-    fn(...args);
+    void fn(...args);
   };
 
   return {

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -15,6 +15,7 @@ import { blockSpecsToPuckComponents } from "@/editor/v2/block-adapter.js";
 import { createDebouncer } from "@/editor/v2/debounce.js";
 import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
 import { readDraft, writeDraft } from "@/editor/v2/local-draft.js";
+import { puckDataToBlockTree } from "@/editor/v2/puck-to-block-tree.js";
 import { seedPuckData } from "@/editor/v2/v2-entry-content.js";
 import { orpc } from "@/lib/orpc.js";
 import { idPathParam } from "@plumix/core/validation";
@@ -115,11 +116,25 @@ function PuckSpikeRouteInner({
   const [status, setStatus] = useState<AutosaveStatus>("saved");
   const debouncer = useMemo(
     () =>
-      createDebouncer((next: Data) => {
+      // Rejections are swallowed deliberately: error-state UX (retry, stuck
+      // pill, conflict surface) is its own slice. Without the catch the
+      // promise would surface as an unhandled rejection in CI smoke.
+      createDebouncer(async (next: Data) => {
         writeDraft(draftKey, next);
-        setStatus("saved");
+        try {
+          await orpc.entry.update.call({
+            id,
+            content: {
+              version: "plumix.v2",
+              blocks: puckDataToBlockTree({ content: next.content }),
+            },
+          });
+          setStatus("saved");
+        } catch {
+          // intentionally empty — see comment above
+        }
       }, 300),
-    [draftKey],
+    [draftKey, id],
   );
   useEffect(() => () => debouncer.flush(), [debouncer]);
   const handleChange = useCallback(


### PR DESCRIPTION
Close the v2 autosave write loop end-to-end. The spike route's 300ms debouncer now
calls `entry.update` with a plumix.v2 envelope (built from the existing
`puckDataToBlockTree` inverse converter) and flips the pill to "saved" only after
the server resolves. Until this lands, the admin spike could only read v2 entries —
PR #446 made the server accept v2 envelopes, this lands the admin half.

**Autosave write loop**

The debouncer becomes async; rejections are deliberately caught and swallowed so
error-state UX (stuck pill, conflict surface, retry) stays its own slice. Without
the catch, a failed autosave would surface as an unhandled rejection in CI smoke.
`createDebouncer`'s fn signature widens to accept `Promise<void>` so the body reads
as a plain async function. The Playwright case captures the request via
`mockRpcWithCapture` and asserts the v2 envelope shape on the wire.

**Deferred for downstream slices**

Three known limitations remain on the autosave path, intentionally not addressed
here: overlapping debounced writes can race (the trailing response wins, not
necessarily the latest request) — mitigation needs a request-id or `useMutation`,
which fits the error-UX slice; `entry.get` / `entry.list` aren't invalidated after
a successful update (v1 invalidates both), so list views won't refresh
mid-typing — own slice; `expectedLiveUpdatedAt` optimistic-concurrency isn't pinned
yet, which the global e2e stub masks (the stub never advances `updatedAt`).

Refs #391
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>