### PR TITLE
feat(admin): wire the v2 spike editor's publish button to entry.update

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -313,4 +313,63 @@ test.describe("V2 spike editor renders end-to-end", () => {
     expect(lastInput.id).toBe(1);
     expect(lastInput.content.blocks.length).toBeGreaterThan(0);
   });
+
+  test("clicking the Publish button POSTs entry.update with status: published", async ({
+    page,
+  }) => {
+    const captures = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/update",
+      captureResponse: {
+        ...emptyEntry(1),
+        status: "published",
+        publishedAt: T0,
+        updatedAt: T0,
+      },
+      handlers: {
+        "/auth/session": AUTHED_ADMIN,
+        "/entry/get": emptyEntry(1),
+      },
+    });
+    await page.goto("v2/entries/posts/1/edit");
+
+    const button = page.getByTestId("plumix-editor-publish-button");
+    await expect(button).toBeEnabled();
+    await button.click();
+
+    await expect
+      .poll(
+        () =>
+          (captures.at(-1) as { status?: string } | undefined)?.status ?? null,
+      )
+      .toBe("published");
+    const lastInput = captures.at(-1) as {
+      readonly id: number;
+      readonly status: string;
+      readonly content?: unknown;
+    };
+    expect(lastInput.id).toBe(1);
+    expect(lastInput.content).toBeUndefined();
+  });
+
+  test("Publish button is disabled when the entry is already published", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: { ...emptyEntry(1), status: "published", publishedAt: T0 },
+            meta: [],
+          }),
+        });
+      }
+      return route.fallback();
+    });
+    await page.goto("v2/entries/posts/1/edit");
+
+    await expect(page.getByTestId("plumix-editor-publish-button")).toBeDisabled();
+  });
 });

--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -35,6 +35,9 @@ interface PlumixEditorLayoutProps {
   readonly capabilities?: ReadonlySet<string>;
   readonly tokens?: ThemeTokens;
   readonly children?: ReactNode;
+  readonly onPublish: () => void;
+  readonly isPublishing?: boolean;
+  readonly isPublished?: boolean;
 }
 
 const EMPTY_REGISTRY: BlockRegistryV2 = createBlockRegistry([]);
@@ -59,6 +62,9 @@ export function PlumixEditorLayout({
   registry = EMPTY_REGISTRY,
   capabilities = EMPTY_CAPS,
   tokens = EMPTY_TOKENS,
+  onPublish,
+  isPublishing = false,
+  isPublished = false,
 }: PlumixEditorLayoutProps): ReactElement {
   return (
     <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
@@ -76,8 +82,10 @@ export function PlumixEditorLayout({
         <AutosaveStatusPill />
         <button
           type="button"
-          className="rounded border px-3 py-1 text-sm"
+          className="rounded border px-3 py-1 text-sm disabled:opacity-50"
           data-testid="plumix-editor-publish-button"
+          onClick={onPublish}
+          disabled={isPublishing || isPublished}
         >
           Publish
         </button>

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -3,7 +3,7 @@ import type { Config, Data } from "@puckeditor/core";
 import type { ReactElement, ReactNode } from "react";
 import { coreBlocksV2, createBlockRegistry } from "@plumix/blocks";
 import { Puck } from "@puckeditor/core";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import * as v from "valibot";
@@ -145,11 +145,27 @@ function PuckSpikeRouteInner({
     },
     [debouncer],
   );
+  // Publish is a one-way state-machine transition server-side, not an
+  // idempotent re-stamp — the button is disabled once status === "published".
+  // expectedLiveUpdatedAt is not pinned yet; the concurrency-token gap
+  // (race between a concurrent publish and an in-flight content autosave)
+  // is owned by the error-UX slice on the #391 line.
+  const publish = useMutation({
+    mutationFn: () => orpc.entry.update.call({ id, status: "published" }),
+  });
+  const isPublished = entry.status === "published";
+  const handlePublish = useCallback(() => publish.mutate(), [publish]);
   const Layout = useCallback(
     (): ReactElement => (
-      <PlumixEditorLayout registry={registry} tokens={sampleTokens} />
+      <PlumixEditorLayout
+        registry={registry}
+        tokens={sampleTokens}
+        onPublish={handlePublish}
+        isPublishing={publish.isPending}
+        isPublished={isPublished}
+      />
     ),
-    [],
+    [handlePublish, publish.isPending, isPublished],
   );
 
   return (


### PR DESCRIPTION
Promote a v2 draft to published from the canvas without bouncing through the
v1 form route. The Publish button now calls `orpc.entry.update` with
`status: "published"` via TanStack Query's `useMutation`, and the button is
gated by the live entry state.

**State-machine-aware disabled gate**

Server-side publish is a one-way state-machine transition, not an idempotent
re-stamp: `assertCanPublishTransition` only fires when `existing.status !==
"published"`, and `publishedAt` is only stamped on the transition. A "Publish"
button on an already-published entry would silently no-op. The button is now
disabled when `entry.status === "published"` so the label can't mislead.

**Stateless layout, route-owned mutation**

`PlumixEditorLayout` drops to a stateless surface (required `onPublish`,
optional `isPublishing` / `isPublished` flags). The route owns the
`useMutation` and feeds derived state down. No local `useState`, no
`try/finally`, no Puck-override-identity churn driven by in-flight state.

Deferred for downstream slices (see #391 / #290): publish-side error UX,
`entry.get` / `entry.list` cache invalidation after publish, optimistic
concurrency via `expectedLiveUpdatedAt`, and the eventual label flip between
Publish / Update / Republish under the drafts-of-published model.

Refs #391
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>