### PR TITLE
feat(admin): invalidate entry.get and entry.list after v2 publish

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -372,4 +372,55 @@ test.describe("V2 spike editor renders end-to-end", () => {
 
     await expect(page.getByTestId("plumix-editor-publish-button")).toBeDisabled();
   });
+
+  test("publishing refetches entry.get so the button reflects the new status", async ({
+    page,
+  }) => {
+    let entryGetCalls = 0;
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        entryGetCalls += 1;
+        const status = entryGetCalls === 1 ? "draft" : "published";
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: {
+              ...emptyEntry(1),
+              status,
+              publishedAt: status === "published" ? T0 : null,
+            },
+            meta: [],
+          }),
+        });
+      }
+      if (url.endsWith("/entry/update")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: { ...emptyEntry(1), status: "published", publishedAt: T0 },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("v2/entries/posts/1/edit");
+
+    const button = page.getByTestId("plumix-editor-publish-button");
+    await expect(button).toBeEnabled();
+    await button.click();
+    await expect.poll(() => entryGetCalls).toBeGreaterThan(1);
+    await expect(button).toBeDisabled();
+  });
 });

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -3,7 +3,7 @@ import type { Config, Data } from "@puckeditor/core";
 import type { ReactElement, ReactNode } from "react";
 import { coreBlocksV2, createBlockRegistry } from "@plumix/blocks";
 import { Puck } from "@puckeditor/core";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import * as v from "valibot";
@@ -17,6 +17,7 @@ import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
 import { readDraft, writeDraft } from "@/editor/v2/local-draft.js";
 import { puckDataToBlockTree } from "@/editor/v2/puck-to-block-tree.js";
 import { seedPuckData } from "@/editor/v2/v2-entry-content.js";
+import { findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { idPathParam } from "@plumix/core/validation";
 
@@ -95,17 +96,27 @@ function ErrorScreen(): ReactNode {
 function PuckSpikeRoute(): ReactNode {
   const { slug, id } = Route.useParams();
   const draftKey = `plumix.v2.draft.${slug}.${id}`;
-  return <PuckSpikeRouteInner key={draftKey} draftKey={draftKey} id={id} />;
+  const entryTypeName = findEntryTypeBySlug(slug)?.name;
+  return (
+    <PuckSpikeRouteInner
+      key={draftKey}
+      draftKey={draftKey}
+      id={id}
+      entryTypeName={entryTypeName}
+    />
+  );
 }
 
 interface PuckSpikeRouteInnerProps {
   readonly draftKey: string;
   readonly id: number;
+  readonly entryTypeName: string | undefined;
 }
 
 function PuckSpikeRouteInner({
   draftKey,
   id,
+  entryTypeName,
 }: PuckSpikeRouteInnerProps): ReactNode {
   const { data: entry } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id } }),
@@ -145,6 +156,7 @@ function PuckSpikeRouteInner({
     },
     [debouncer],
   );
+  const queryClient = useQueryClient();
   // Publish is a one-way state-machine transition server-side, not an
   // idempotent re-stamp — the button is disabled once status === "published".
   // expectedLiveUpdatedAt is not pinned yet; the concurrency-token gap
@@ -152,6 +164,21 @@ function PuckSpikeRouteInner({
   // is owned by the error-UX slice on the #391 line.
   const publish = useMutation({
     mutationFn: () => orpc.entry.update.call({ id, status: "published" }),
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({ input: { id } }).queryKey,
+        }),
+        ...(entryTypeName
+          ? [
+              queryClient.invalidateQueries({
+                queryKey: orpc.entry.list.key({
+                  input: { type: entryTypeName },
+                }),
+              }),
+            ]
+          : []),
+      ]),
   });
   const isPublished = entry.status === "published";
   const handlePublish = useCallback(() => publish.mutate(), [publish]);


### PR DESCRIPTION
Close a UX hole left after PR #448 wired the v2 Publish button. Without
invalidation, the React Query cache stayed stale after publish: the button
disabled itself during the in-flight mutation, then re-enabled because the
cached `entry.status` still read "draft". Users would have to hard-refresh
to see the published state.

The publish `useMutation`'s `onSuccess` now invalidates both `entry.get` (by
id) and `entry.list` (scoped by entry type name) in parallel. The entry-type
name is resolved synchronously from the URL slug via `findEntryTypeBySlug`,
matching the v1 editor's invalidation surface.

**Button stays disabled across the refetch window**

`onSuccess` returns the invalidation promise, so `publish.isPending` stays
true until the refetch resolves. That's why the button transitions cleanly
from "in-flight → refetched → published" without flickering back to enabled
between the mutation settling and the refetched entry landing.

Autosave deliberately does NOT invalidate — invalidating on every
300ms-debounced keystroke would thrash the cache and re-render the editor
mid-typing. Local Puck state is the source of truth during edits.

Refs #391
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>