### PR TITLE
feat(admin): surface autosave failures in the v2 status pill

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -6,6 +6,7 @@ import {
   MANIFEST_WITH_POST,
   mockManifest,
   mockRpcWithCapture,
+  rpcErrorBody,
   rpcOkBody,
 } from "./support/rpc-mock.js";
 
@@ -422,5 +423,34 @@ test.describe("V2 spike editor renders end-to-end", () => {
     await button.click();
     await expect.poll(() => entryGetCalls).toBeGreaterThan(1);
     await expect(button).toBeDisabled();
+  });
+
+  test("autosave pill flips to error when entry.update rejects", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/entry/update")) {
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: rpcErrorBody({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "boom",
+          }),
+        });
+      }
+      return route.fallback();
+    });
+    await page.goto("v2/entries/posts/1/edit");
+
+    const pill = page.getByTestId("plumix-autosave-pill");
+    await expect(pill).toHaveAttribute("data-status", "saved");
+
+    await page.getByTestId("plumix-editor-canvas").focus();
+    await page.keyboard.press("/");
+    await page.getByTestId("slash-menu-item-core/paragraph").click();
+
+    await expect(pill).toHaveAttribute("data-status", "error");
   });
 });

--- a/packages/admin/src/editor/v2/AutosaveStatus.test.tsx
+++ b/packages/admin/src/editor/v2/AutosaveStatus.test.tsx
@@ -27,4 +27,16 @@ describe("AutosaveStatusPill", () => {
     expect(pill.textContent).toBe("Saving...");
     expect(pill.getAttribute("data-status")).toBe("saving");
   });
+
+  test("renders 'Failed to save' when the Provider supplies the 'error' status", () => {
+    render(
+      <AutosaveStatusContext.Provider value="error">
+        <AutosaveStatusPill />
+      </AutosaveStatusContext.Provider>,
+    );
+
+    const pill = screen.getByTestId("plumix-autosave-pill");
+    expect(pill.textContent).toBe("Failed to save");
+    expect(pill.getAttribute("data-status")).toBe("error");
+  });
 });

--- a/packages/admin/src/editor/v2/AutosaveStatus.tsx
+++ b/packages/admin/src/editor/v2/AutosaveStatus.tsx
@@ -1,20 +1,28 @@
 import type { ReactElement } from "react";
 import { createContext, useContext } from "react";
 
-export type AutosaveStatus = "saved" | "saving";
+import { cn } from "@/lib/utils.js";
+
+export type AutosaveStatus = "saved" | "saving" | "error";
 
 export const AutosaveStatusContext = createContext<AutosaveStatus>("saved");
 
 const LABEL: Readonly<Record<AutosaveStatus, string>> = {
   saved: "Saved",
   saving: "Saving...",
+  error: "Failed to save",
 };
 
 export function AutosaveStatusPill(): ReactElement {
   const status = useContext(AutosaveStatusContext);
   return (
     <span
-      className="rounded bg-muted px-2 py-1 text-xs"
+      className={cn(
+        "rounded px-2 py-1 text-xs",
+        status === "error"
+          ? "bg-destructive/10 text-destructive"
+          : "bg-muted",
+      )}
       data-testid="plumix-autosave-pill"
       data-status={status}
     >

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -127,9 +127,6 @@ function PuckSpikeRouteInner({
   const [status, setStatus] = useState<AutosaveStatus>("saved");
   const debouncer = useMemo(
     () =>
-      // Rejections are swallowed deliberately: error-state UX (retry, stuck
-      // pill, conflict surface) is its own slice. Without the catch the
-      // promise would surface as an unhandled rejection in CI smoke.
       createDebouncer(async (next: Data) => {
         writeDraft(draftKey, next);
         try {
@@ -142,7 +139,7 @@ function PuckSpikeRouteInner({
           });
           setStatus("saved");
         } catch {
-          // intentionally empty — see comment above
+          setStatus("error");
         }
       }, 300),
     [draftKey, id],
@@ -161,7 +158,7 @@ function PuckSpikeRouteInner({
   // idempotent re-stamp — the button is disabled once status === "published".
   // expectedLiveUpdatedAt is not pinned yet; the concurrency-token gap
   // (race between a concurrent publish and an in-flight content autosave)
-  // is owned by the error-UX slice on the #391 line.
+  // is owned by a follow-up slice on the #391 line.
   const publish = useMutation({
     mutationFn: () => orpc.entry.update.call({ id, status: "published" }),
     onSuccess: () =>


### PR DESCRIPTION
Close the autosave error UX gap PR #447 explicitly deferred. Before this
slice, a failed autosave silently swallowed the rejection and the pill
stayed on "Saving..." indefinitely — users had no signal that their edits
weren't reaching the server. The route's catch now flips a new "error"
status that the pill renders as a destructive-tinted "Failed to save" chip.

**The pill is now a true autosave oracle**

The `AutosaveStatus` union widens to `"saved" | "saving" | "error"`. On the
next successful autosave the regular `saving → saved` cycle clears the
error state organically — no retry button or click-to-retry is wired yet.
The pill's destructive styling matches the existing `plugin-error-boundary`
chip pattern (`bg-destructive/10 text-destructive`) so it reads as the same
visual family across the admin.

Still deferred (own slices): click-to-retry / retry button, `aria-live`
announcement of the new state (covered by the a11y full-pass on #400),
code-discriminated copy (CONFLICT vs FORBIDDEN vs 5xx), and the
`expectedLiveUpdatedAt` concurrency token.

Refs #391
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>