### PR TITLE
feat(admin): pin expectedLiveUpdatedAt on v2 autosave and publish

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -310,9 +310,11 @@ test.describe("V2 spike editor renders end-to-end", () => {
     const lastInput = captures.at(-1) as {
       readonly id: number;
       readonly content: { readonly blocks: unknown[] };
+      readonly expectedLiveUpdatedAt: string;
     };
     expect(lastInput.id).toBe(1);
     expect(lastInput.content.blocks.length).toBeGreaterThan(0);
+    expect(lastInput.expectedLiveUpdatedAt).toBe(T0.toISOString());
   });
 
   test("clicking the Publish button POSTs entry.update with status: published", async ({
@@ -347,9 +349,11 @@ test.describe("V2 spike editor renders end-to-end", () => {
       readonly id: number;
       readonly status: string;
       readonly content?: unknown;
+      readonly expectedLiveUpdatedAt: string;
     };
     expect(lastInput.id).toBe(1);
     expect(lastInput.content).toBeUndefined();
+    expect(lastInput.expectedLiveUpdatedAt).toBe(T0.toISOString());
   });
 
   test("Publish button is disabled when the entry is already published", async ({

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -5,7 +5,7 @@ import { coreBlocksV2, createBlockRegistry } from "@plumix/blocks";
 import { Puck } from "@puckeditor/core";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as v from "valibot";
 
 import type { AutosaveStatus } from "@/editor/v2/AutosaveStatus.js";
@@ -125,18 +125,25 @@ function PuckSpikeRouteInner({
     seedPuckData(entry.content, readDraft(draftKey) ?? initialData),
   );
   const [status, setStatus] = useState<AutosaveStatus>("saved");
+  // Optimistic-concurrency token; trailing-response wins on overlap, so a
+  // persistent CONFLICT leaves the ref stuck stale until reload (conflict
+  // resolution UI is the next slice on the #391 line).
+  const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
+  /* eslint-disable react-hooks/refs -- callback fires post-keystroke, not during render */
   const debouncer = useMemo(
     () =>
       createDebouncer(async (next: Data) => {
         writeDraft(draftKey, next);
         try {
-          await orpc.entry.update.call({
+          const updated = await orpc.entry.update.call({
             id,
             content: {
               version: "plumix.v2",
               blocks: puckDataToBlockTree({ content: next.content }),
             },
+            expectedLiveUpdatedAt: liveUpdatedAtRef.current,
           });
+          liveUpdatedAtRef.current = updated.updatedAt;
           setStatus("saved");
         } catch {
           setStatus("error");
@@ -144,6 +151,7 @@ function PuckSpikeRouteInner({
       }, 300),
     [draftKey, id],
   );
+  /* eslint-enable react-hooks/refs */
   useEffect(() => () => debouncer.flush(), [debouncer]);
   const handleChange = useCallback(
     (next: Data): void => {
@@ -156,11 +164,16 @@ function PuckSpikeRouteInner({
   const queryClient = useQueryClient();
   // Publish is a one-way state-machine transition server-side, not an
   // idempotent re-stamp — the button is disabled once status === "published".
-  // expectedLiveUpdatedAt is not pinned yet; the concurrency-token gap
-  // (race between a concurrent publish and an in-flight content autosave)
-  // is owned by a follow-up slice on the #391 line.
   const publish = useMutation({
-    mutationFn: () => orpc.entry.update.call({ id, status: "published" }),
+    mutationFn: async () => {
+      const updated = await orpc.entry.update.call({
+        id,
+        status: "published",
+        expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+      });
+      liveUpdatedAtRef.current = updated.updatedAt;
+      return updated;
+    },
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({


### PR DESCRIPTION
Send the optimistic-concurrency token (`expectedLiveUpdatedAt`) on every v2
autosave and publish call so the server's stale-token check actually runs.
The four prior slices on the #391 line deliberately deferred this; without
it, a stale-tab scenario or a concurrent edit silently overwrites without
surfacing CONFLICT. Now stale tokens reject server-side, and the existing
error pill renders the CONFLICT as "Failed to save".

The token lives in a `useRef<Date>` seeded from the initial entry.get and
refreshed from each successful update response. Both the autosave debouncer
and the publish mutation feed it through.

**Trailing response wins the ref**

Overlapping in-flight writes can still race; the trailing successful
response refreshes the ref last. The 300ms debounce makes overlap rare, so
this is best-effort by design. A persistent CONFLICT leaves the ref stuck
stale until reload — refetching `entry.get` on CONFLICT to refresh the ref
is the next slice on the #391 line.

Refs #391
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>