### PR TITLE
feat(admin): recover v2 autosave from stale-token CONFLICT

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -429,6 +429,90 @@ test.describe("V2 spike editor renders end-to-end", () => {
     await expect(button).toBeDisabled();
   });
 
+  test("autosave CONFLICT recovers: the next save sends the refreshed token", async ({
+    page,
+  }) => {
+    let entryGetCalls = 0;
+    let entryUpdateCalls = 0;
+    const T1 = new Date("2026-06-01T00:00:00Z");
+    const updateInputs: unknown[] = [];
+    // Hand-rolled error envelope: rpcErrorBody omits `defined`/`status`
+    // which oRPC's isORPCErrorJson requires to decode the rejection.
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        entryGetCalls += 1;
+        const updatedAt = entryGetCalls === 1 ? T0 : T1;
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: { ...emptyEntry(1), updatedAt },
+            meta: [],
+          }),
+        });
+      }
+      if (url.endsWith("/entry/update")) {
+        entryUpdateCalls += 1;
+        const body = route.request().postDataJSON() as { json?: unknown };
+        updateInputs.push(body.json);
+        if (entryUpdateCalls === 1) {
+          return route.fulfill({
+            status: 409,
+            contentType: "application/json",
+            body: JSON.stringify({
+              json: {
+                defined: true,
+                code: "CONFLICT",
+                status: 409,
+                message: "Resource conflict",
+                data: { reason: "stale_expected_updated_at" },
+              },
+              meta: [],
+            }),
+          });
+        }
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            json: { ...emptyEntry(1), updatedAt: T1 },
+            meta: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+    await page.goto("v2/entries/posts/1/edit");
+
+    const pill = page.getByTestId("plumix-autosave-pill");
+    const canvas = page.getByTestId("plumix-editor-canvas");
+
+    await canvas.focus();
+    await page.keyboard.press("/");
+    await page.getByTestId("slash-menu-item-core/paragraph").click();
+
+    await expect(pill).toHaveAttribute("data-status", "error");
+    await expect.poll(() => entryGetCalls).toBe(2);
+
+    await canvas.focus();
+    await page.keyboard.press("/");
+    await page.getByTestId("slash-menu-item-core/paragraph").click();
+
+    await expect(pill).toHaveAttribute("data-status", "saved");
+    expect(
+      (updateInputs.at(-1) as { expectedLiveUpdatedAt: string })
+        .expectedLiveUpdatedAt,
+    ).toBe(T1.toISOString());
+  });
+
   test("autosave pill flips to error when entry.update rejects", async ({
     page,
   }) => {

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -2,6 +2,7 @@ import type { ThemeTokens } from "@plumix/blocks";
 import type { Config, Data } from "@puckeditor/core";
 import type { ReactElement, ReactNode } from "react";
 import { coreBlocksV2, createBlockRegistry } from "@plumix/blocks";
+import { ORPCError } from "@orpc/client";
 import { Puck } from "@puckeditor/core";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
@@ -24,6 +25,14 @@ import { idPathParam } from "@plumix/core/validation";
 import "@puckeditor/core/puck.css";
 
 const initialData: Data = { content: [], root: {} };
+
+// Keep in sync with the identical helper in _editor/entries/$slug/$id/edit.tsx.
+function isStaleConflictError(err: unknown): boolean {
+  if (!(err instanceof ORPCError)) return false;
+  if (err.code !== "CONFLICT") return false;
+  const data = err.data as { reason?: unknown };
+  return data.reason === "stale_expected_updated_at";
+}
 
 const sampleTokens: ThemeTokens = {
   colors: {
@@ -125,10 +134,9 @@ function PuckSpikeRouteInner({
     seedPuckData(entry.content, readDraft(draftKey) ?? initialData),
   );
   const [status, setStatus] = useState<AutosaveStatus>("saved");
-  // Optimistic-concurrency token; trailing-response wins on overlap, so a
-  // persistent CONFLICT leaves the ref stuck stale until reload (conflict
-  // resolution UI is the next slice on the #391 line).
+  // Optimistic-concurrency token; trailing-response wins on overlap.
   const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
+  const queryClient = useQueryClient();
   /* eslint-disable react-hooks/refs -- callback fires post-keystroke, not during render */
   const debouncer = useMemo(
     () =>
@@ -145,11 +153,24 @@ function PuckSpikeRouteInner({
           });
           liveUpdatedAtRef.current = updated.updatedAt;
           setStatus("saved");
-        } catch {
+        } catch (err) {
           setStatus("error");
+          if (isStaleConflictError(err)) {
+            // Puck state is seeded once and ignores this refetch — in-progress
+            // edits aren't overwritten.
+            try {
+              const fresh = await queryClient.fetchQuery({
+                ...orpc.entry.get.queryOptions({ input: { id } }),
+                staleTime: 0,
+              });
+              liveUpdatedAtRef.current = fresh.updatedAt;
+            } catch {
+              // Best-effort: pill already says "error"; next keystroke retries.
+            }
+          }
         }
       }, 300),
-    [draftKey, id],
+    [draftKey, id, queryClient],
   );
   /* eslint-enable react-hooks/refs */
   useEffect(() => () => debouncer.flush(), [debouncer]);
@@ -161,7 +182,6 @@ function PuckSpikeRouteInner({
     },
     [debouncer],
   );
-  const queryClient = useQueryClient();
   // Publish is a one-way state-machine transition server-side, not an
   // idempotent re-stamp — the button is disabled once status === "published".
   const publish = useMutation({


### PR DESCRIPTION
Make the v2 editor self-heal from stale-token CONFLICTs. PR #451 pinned the
optimistic-concurrency token but never refreshed it — a single stale-tab
CONFLICT permanently broke the editor because every subsequent save would
reject against the same stale token until reload. The autosave catch now
refetches `entry.get`, lands the fresh `updatedAt` on the ref, and the next
save succeeds. The Puck canvas state is seeded once via `useState`
initializer and ignores the refetch, so in-progress edits aren't overwritten.

**The next save uses the refreshed token**

The slice's user-visible contract — "editor self-heals from stale-token
CONFLICT" — is locked in by an e2e that asserts the pill flashes to "error"
on the failing save, `entry.get` refetches, the *next* `entry.update`
payload carries the fresh token, and the pill returns to "saved". A
regression that fires the refetch but forgets to update the ref fails the
test.

**`fetchQuery({ ...options, staleTime: 0 })` instead of invalidate-then-fetch**

The app-level `QueryClient` sets `staleTime: 60_000`, which `fetchQuery`
would otherwise inherit and return cached data. Passing `staleTime: 0` in
call options forces the network round trip in a single call (the
invalidate-then-fetch alternative is two calls for the same effect).

Recovery awaits live inside a narrow inner try/catch — failures are
best-effort because the outer catch already flipped the pill to "error",
and the user's next keystroke retries naturally.

Refs #391
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>