### PR TITLE
feat(admin,blocks): add block variations and consolidate core/list

### DIFF
--- a/packages/admin/e2e/v2-editor-render.spec.ts
+++ b/packages/admin/e2e/v2-editor-render.spec.ts
@@ -135,6 +135,42 @@ test.describe("V2 spike editor renders end-to-end", () => {
     await expect(canvas.locator("p")).toHaveCount(1);
   });
 
+  test("slash menu insert: bullet variation inserts a <ul>, parent core/list slug is absent", async ({
+    page,
+  }) => {
+    await page.goto("v2/entries/posts/1/edit");
+    const canvas = page.getByTestId("plumix-editor-canvas");
+    await canvas.focus();
+    await page.keyboard.press("/");
+    await expect(page.getByTestId("slash-menu-item-core/list")).toHaveCount(0);
+    await page.getByTestId("slash-menu-item-bullet").click();
+    await expect(canvas.locator("ul")).toHaveCount(1);
+    await expect(canvas.locator("ol")).toHaveCount(0);
+  });
+
+  test("slash menu insert: numbered variation inserts an <ol>", async ({
+    page,
+  }) => {
+    await page.goto("v2/entries/posts/1/edit");
+    const canvas = page.getByTestId("plumix-editor-canvas");
+    await canvas.focus();
+    await page.keyboard.press("/");
+    await page.getByTestId("slash-menu-item-numbered").click();
+    await expect(canvas.locator("ol")).toHaveCount(1);
+    await expect(canvas.locator("ul")).toHaveCount(0);
+  });
+
+  test("blocks tab numbered button inserts an <ol> in the canvas", async ({
+    page,
+  }) => {
+    await page.goto("v2/entries/posts/1/edit");
+    const canvas = page.getByTestId("plumix-editor-canvas");
+    await page.getByTestId("plumix-blocks-tab-item-numbered").click();
+    await expect(canvas.locator("ol")).toHaveCount(1);
+    await expect(canvas.locator("ul")).toHaveCount(0);
+  });
+
+
   test("server-loaded plumix.v2 content renders in the canvas on initial mount", async ({
     page,
   }) => {

--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -1,7 +1,13 @@
-import type { BlockRegistryV2, ResponsiveStyleSlot, ThemeTokens } from "@plumix/blocks";
+import type {
+  BlockRegistryV2,
+  BlockSpecV2,
+  InsertableBlockEntry,
+  ResponsiveStyleSlot,
+  ThemeTokens,
+} from "@plumix/blocks";
 import type { KeyboardEvent as ReactKeyboardEvent, ReactElement, ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
-import { createBlockRegistry } from "@plumix/blocks";
+import { createBlockRegistry, expandBlockVariations } from "@plumix/blocks";
 import { Puck, usePuck } from "@puckeditor/core";
 
 import { useIsMobile } from "@/hooks/use-mobile.js";
@@ -21,6 +27,7 @@ import type { SlashMenuItem } from "./slash-menu-items.js";
 import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
+import { mergePropsAtSelector } from "./merge-variation-attrs.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
@@ -94,7 +101,7 @@ export function PlumixEditorLayout({
         className="grid flex-1 grid-cols-[1fr] overflow-hidden md:grid-cols-[260px_1fr_320px]"
         data-testid="plumix-editor-cols"
       >
-        <BlocksBody />
+        <BlocksBody registry={registry} capabilities={capabilities} />
         <PlumixCanvasWithSlashMenu
           registry={registry}
           capabilities={capabilities}
@@ -105,7 +112,12 @@ export function PlumixEditorLayout({
   );
 }
 
-function BlocksBody(): ReactElement {
+interface BlocksBodyProps {
+  readonly registry: BlockRegistryV2;
+  readonly capabilities: ReadonlySet<string>;
+}
+
+function BlocksBody({ registry, capabilities }: BlocksBodyProps): ReactElement {
   const isMobile = useIsMobile();
   const content = (
     <Tabs defaultValue="blocks" className="h-full">
@@ -121,7 +133,7 @@ function BlocksBody(): ReactElement {
         </TabsTrigger>
       </TabsList>
       <TabsContent value="blocks">
-        <Puck.Components />
+        <PlumixBlocksTab registry={registry} capabilities={capabilities} />
       </TabsContent>
       <TabsContent value="outline">
         <Puck.Outline />
@@ -151,6 +163,69 @@ function BlocksBody(): ReactElement {
     >
       {content}
     </aside>
+  );
+}
+
+interface PlumixBlocksTabProps {
+  readonly registry: BlockRegistryV2;
+  readonly capabilities: ReadonlySet<string>;
+}
+
+function PlumixBlocksTab({
+  registry,
+  capabilities,
+}: PlumixBlocksTabProps): ReactElement {
+  const puck = usePuck();
+  const entries = useMemo(() => {
+    const eligible: BlockSpecV2[] = [];
+    for (const spec of registry) {
+      if (spec.inserter === false) continue;
+      if (spec.capability && !capabilities.has(spec.capability)) continue;
+      eligible.push(spec);
+    }
+    return expandBlockVariations(eligible);
+  }, [registry, capabilities]);
+
+  const handleInsert = useCallback(
+    (entry: InsertableBlockEntry): void => {
+      const index = puck.appState.data.content.length;
+      puck.dispatch({
+        type: "insert",
+        componentType: entry.name,
+        destinationZone: PUCK_ROOT_ZONE,
+        destinationIndex: index,
+      });
+      const variationAttrs = entry.attrs;
+      if (variationAttrs !== undefined) {
+        puck.dispatch({
+          type: "setData",
+          data: (previous) =>
+            mergePropsAtSelector(
+              previous,
+              { zone: PUCK_ROOT_ZONE, index },
+              variationAttrs,
+            ),
+        });
+      }
+    },
+    [puck],
+  );
+
+  return (
+    <ul className="flex flex-col gap-1 p-2" data-testid="plumix-blocks-tab">
+      {entries.map((entry) => (
+        <li key={entry.slug}>
+          <button
+            type="button"
+            className="w-full rounded border px-3 py-2 text-left text-sm hover:bg-muted"
+            data-testid={`plumix-blocks-tab-item-${entry.slug}`}
+            onClick={() => handleInsert(entry)}
+          >
+            {entry.title}
+          </button>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -262,6 +337,14 @@ function PlumixCanvasWithSlashMenu({
         destinationZone: zone,
         destinationIndex: index,
       });
+      const variationAttrs = item.attrs;
+      if (variationAttrs !== undefined) {
+        puck.dispatch({
+          type: "setData",
+          data: (previous) =>
+            mergePropsAtSelector(previous, { zone, index }, variationAttrs),
+        });
+      }
       setOpen(false);
     },
     [puck],

--- a/packages/admin/src/editor/v2/SlashMenuPanel.test.tsx
+++ b/packages/admin/src/editor/v2/SlashMenuPanel.test.tsx
@@ -12,6 +12,7 @@ afterEach(() => {
 
 const heading: SlashMenuItem = {
   name: "core/heading",
+  slug: "core/heading",
   title: "Heading",
   description: "Section title",
   category: "typography",
@@ -19,6 +20,7 @@ const heading: SlashMenuItem = {
 
 const quote: SlashMenuItem = {
   name: "core/quote",
+  slug: "core/quote",
   title: "Quote",
   description: "Pull quote",
   category: "typography",

--- a/packages/admin/src/editor/v2/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/v2/SlashMenuPanel.tsx
@@ -72,9 +72,9 @@ export function SlashMenuPanel({
           >
             {members.map((item) => (
               <CommandItem
-                key={item.name}
-                value={item.name}
-                data-testid={`slash-menu-item-${item.name}`}
+                key={item.slug}
+                value={item.slug}
+                data-testid={`slash-menu-item-${item.slug}`}
                 onSelect={() => onSelect(item)}
                 className="flex items-start gap-2"
               >

--- a/packages/admin/src/editor/v2/merge-variation-attrs.test.ts
+++ b/packages/admin/src/editor/v2/merge-variation-attrs.test.ts
@@ -1,0 +1,78 @@
+import type { Data } from "@puckeditor/core";
+import { describe, expect, test } from "vitest";
+
+import { mergePropsAtSelector } from "./merge-variation-attrs.js";
+import { PUCK_ROOT_ZONE } from "./puck-zones.js";
+
+function data(content: Data["content"]): Data {
+  return { content, root: {} };
+}
+
+describe("mergePropsAtSelector", () => {
+  test("merges attrs into the props of the root block at the given index", () => {
+    const previous = data([
+      { type: "core/list", props: { id: "l1" } },
+    ]);
+    const next = mergePropsAtSelector(
+      previous,
+      { zone: PUCK_ROOT_ZONE, index: 0 },
+      { variant: "numbered" },
+    );
+    expect(next.content[0]).toEqual({
+      type: "core/list",
+      props: { id: "l1", variant: "numbered" },
+    });
+  });
+
+  test("merges into a block inside a single-slot wrapper via <parentId>:<slotName> zones", () => {
+    const previous = data([
+      {
+        type: "core/group",
+        props: {
+          id: "g1",
+          content: [{ type: "core/list", props: { id: "l1" } }],
+        },
+      },
+    ]);
+    const next = mergePropsAtSelector(
+      previous,
+      { zone: "g1:content", index: 0 },
+      { variant: "numbered" },
+    );
+    const slot = (next.content[0]?.props as { content?: { props: unknown }[] })
+      .content;
+    expect(slot?.[0]?.props).toEqual({ id: "l1", variant: "numbered" });
+  });
+
+  test("recurses arbitrarily deep through nested wrappers", () => {
+    const previous = data([
+      {
+        type: "core/group",
+        props: {
+          id: "outer",
+          content: [
+            {
+              type: "core/group",
+              props: {
+                id: "inner",
+                content: [{ type: "core/list", props: { id: "l1" } }],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    const next = mergePropsAtSelector(
+      previous,
+      { zone: "inner:content", index: 0 },
+      { variant: "numbered" },
+    );
+    const outerSlot = (next.content[0]?.props as {
+      content?: { props: { content?: { props: unknown }[] } }[];
+    }).content;
+    expect(outerSlot?.[0]?.props.content?.[0]?.props).toEqual({
+      id: "l1",
+      variant: "numbered",
+    });
+  });
+});

--- a/packages/admin/src/editor/v2/merge-variation-attrs.ts
+++ b/packages/admin/src/editor/v2/merge-variation-attrs.ts
@@ -1,0 +1,85 @@
+import type { ComponentData, Data } from "@puckeditor/core";
+
+import { PUCK_ROOT_ZONE } from "./puck-zones.js";
+
+export interface MergeSelector {
+  readonly zone: string;
+  readonly index: number;
+}
+
+export function mergePropsAtSelector(
+  data: Data,
+  selector: MergeSelector,
+  attrs: Readonly<Record<string, unknown>>,
+): Data {
+  if (selector.zone === PUCK_ROOT_ZONE) {
+    return { ...data, content: mergeAtIndex(data.content, selector.index, attrs) };
+  }
+  const [parentId, slotName] = selector.zone.split(":", 2) as [string, string];
+  return {
+    ...data,
+    content: data.content.map((item) =>
+      mergeInSlot(item, parentId, slotName, selector.index, attrs),
+    ),
+  };
+}
+
+function mergeInSlot(
+  item: ComponentData,
+  parentId: string,
+  slotName: string,
+  index: number,
+  attrs: Readonly<Record<string, unknown>>,
+): ComponentData {
+  const props = item.props as Record<string, unknown>;
+  if (props.id === parentId) {
+    const slot = props[slotName];
+    if (!isComponentDataArray(slot)) return item;
+    return {
+      ...item,
+      props: {
+        ...props,
+        [slotName]: mergeAtIndex(slot, index, attrs),
+      } as ComponentData["props"],
+    };
+  }
+  let nextProps: Record<string, unknown> | undefined;
+  for (const [key, value] of Object.entries(props)) {
+    if (!isComponentDataArray(value)) continue;
+    const recursed = value.map((child) =>
+      mergeInSlot(child, parentId, slotName, index, attrs),
+    );
+    if (recursed.some((child, i) => child !== value[i])) {
+      nextProps ??= { ...props };
+      nextProps[key] = recursed;
+    }
+  }
+  return nextProps
+    ? { ...item, props: nextProps as ComponentData["props"] }
+    : item;
+}
+
+function isComponentDataArray(value: unknown): value is readonly ComponentData[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as { type?: unknown }).type === "string" &&
+        typeof (item as { props?: unknown }).props === "object",
+    )
+  );
+}
+
+function mergeAtIndex(
+  list: readonly ComponentData[],
+  index: number,
+  attrs: Readonly<Record<string, unknown>>,
+): ComponentData[] {
+  return list.map((item, i) =>
+    i === index
+      ? { ...item, props: { ...item.props, ...attrs } }
+      : item,
+  );
+}

--- a/packages/admin/src/editor/v2/slash-menu-items.test.ts
+++ b/packages/admin/src/editor/v2/slash-menu-items.test.ts
@@ -169,6 +169,38 @@ describe("resolveSlashMenuItems", () => {
     expect(items.map((i) => i.name).sort()).toEqual(["a/default", "a/opt-in"]);
   });
 
+  test("emits one item per variation when a block declares variations, slugs distinguish them", () => {
+    const registry = createBlockRegistry([
+      spec({
+        name: "core/list",
+        title: "List",
+        category: "text",
+        variations: [
+          { slug: "bullet", title: "Bulleted list", attrs: { variant: "bullet" } },
+          {
+            slug: "numbered",
+            title: "Numbered list",
+            attrs: { variant: "numbered" },
+          },
+        ],
+      }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "",
+    });
+
+    expect(items.map((i) => i.slug)).toEqual(["bullet", "numbered"]);
+    expect(items.map((i) => i.title)).toEqual([
+      "Bulleted list",
+      "Numbered list",
+    ]);
+    expect(items.every((i) => i.name === "core/list")).toBe(true);
+    expect(items[0]?.attrs).toEqual({ variant: "bullet" });
+    expect(items[1]?.attrs).toEqual({ variant: "numbered" });
+  });
+
   test("treats whitespace-only queries as empty (no filtering)", () => {
     const registry = createBlockRegistry([
       spec({ name: "core/heading", title: "Heading" }),

--- a/packages/admin/src/editor/v2/slash-menu-items.ts
+++ b/packages/admin/src/editor/v2/slash-menu-items.ts
@@ -1,16 +1,15 @@
-import type { BlockRegistryV2, BlockSpecV2 } from "@plumix/blocks";
+import type {
+  BlockRegistryV2,
+  BlockSpecV2,
+  InsertableBlockEntry,
+} from "@plumix/blocks";
+import { expandBlockVariations } from "@plumix/blocks";
 
 import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 
 export { PUCK_ROOT_ZONE };
 
-export interface SlashMenuItem {
-  readonly name: string;
-  readonly title: string;
-  readonly description?: string;
-  readonly category?: string;
-  readonly icon?: string;
-}
+export type SlashMenuItem = InsertableBlockEntry;
 
 export interface ResolveSlashMenuItemsOptions {
   readonly capabilities: ReadonlySet<string>;
@@ -28,15 +27,19 @@ export function resolveSlashMenuItems(
   const needle = query.trim().toLowerCase();
   const scored: { item: SlashMenuItem; score: number }[] = [];
 
+  const eligibleSpecs: BlockSpecV2[] = [];
   for (const spec of registry) {
     if (spec.inserter === false) continue;
     if (!isInsertableForCapabilities(spec, capabilities)) continue;
-    const item = toItem(spec);
+    eligibleSpecs.push(spec);
+  }
+
+  for (const item of expandBlockVariations(eligibleSpecs)) {
     if (needle === "") {
       scored.push({ item, score: 0 });
       continue;
     }
-    const score = matchScore(spec, item, needle);
+    const score = matchScore(item, needle);
     if (score > 0) scored.push({ item, score });
   }
 
@@ -54,26 +57,12 @@ function isInsertableForCapabilities(
   return capabilities.has(spec.capability);
 }
 
-function toItem(spec: BlockSpecV2): SlashMenuItem {
-  return {
-    name: spec.name,
-    title: spec.title ?? spec.name,
-    description: spec.description,
-    category: spec.category,
-    icon: spec.icon,
-  };
-}
-
-function matchScore(
-  spec: BlockSpecV2,
-  item: SlashMenuItem,
-  needle: string,
-): number {
+function matchScore(item: SlashMenuItem, needle: string): number {
   if (item.title.toLowerCase().includes(needle)) return TITLE_MATCH;
-  if (spec.keywords?.some((k) => k.toLowerCase().startsWith(needle))) {
+  if (item.keywords?.some((k) => k.toLowerCase().startsWith(needle))) {
     return KEYWORD_MATCH;
   }
-  if (spec.name.toLowerCase().includes(needle)) return NAME_MATCH;
+  if (item.name.toLowerCase().includes(needle)) return NAME_MATCH;
   return 0;
 }
 

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -17,6 +17,15 @@ export interface ClientIslandDescriptor {
   readonly script: string;
 }
 
+export interface BlockVariation {
+  readonly slug: string;
+  readonly title: string;
+  readonly icon?: string;
+  readonly description?: string;
+  readonly keywords?: readonly string[];
+  readonly attrs?: Readonly<Record<string, unknown>>;
+}
+
 export interface BlockSpec<
   Attrs extends Readonly<Record<string, unknown>> = Readonly<
     Record<string, unknown>
@@ -37,6 +46,7 @@ export interface BlockSpec<
   readonly capability?: string;
   readonly client?: ClientIslandDescriptor;
   readonly transforms?: BlockTransforms;
+  readonly variations?: readonly BlockVariation[];
 }
 
 export interface BlockRegistry {

--- a/packages/blocks/src/core-blocks-v2.ts
+++ b/packages/blocks/src/core-blocks-v2.ts
@@ -12,11 +12,7 @@ import {
 import { detailsBlockV2 } from "./details/v2.js";
 import { groupBlockV2 } from "./group/v2.js";
 import { headingBlock } from "./heading/index.js";
-import {
-  listBlockV2,
-  listItemBlockV2,
-  listOrderedBlockV2,
-} from "./list/v2.js";
+import { listBlockV2, listItemBlockV2 } from "./list/v2.js";
 import { paragraphBlockV2 } from "./paragraph/v2.js";
 import { quoteBlockV2 } from "./quote/v2.js";
 import { separatorBlockV2 } from "./separator/v2.js";
@@ -37,7 +33,6 @@ export const coreBlocksV2: readonly BlockSpec[] = Object.freeze([
   spacerBlockV2,
   codeBlockV2,
   listBlockV2,
-  listOrderedBlockV2,
   listItemBlockV2,
   descriptionListBlockV2,
   descriptionTermBlockV2,

--- a/packages/blocks/src/expand-block-variations.test.ts
+++ b/packages/blocks/src/expand-block-variations.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockSpec } from "./block-registry.js";
+import { expandBlockVariations } from "./expand-block-variations.js";
+
+function block(spec: Partial<BlockSpec> & { name: string }): BlockSpec {
+  return { render: () => null, ...spec };
+}
+
+describe("expandBlockVariations", () => {
+  test("emits one entry per variation when a block declares variations, dropping the parent entry", () => {
+    const entries = expandBlockVariations([
+      block({
+        name: "core/list",
+        title: "List",
+        icon: "List",
+        category: "text",
+        variations: [
+          {
+            slug: "bullet",
+            title: "Bulleted list",
+            icon: "List",
+            attrs: { variant: "bullet" },
+          },
+          {
+            slug: "numbered",
+            title: "Numbered list",
+            icon: "ListOrdered",
+            attrs: { variant: "numbered" },
+          },
+        ],
+      }),
+    ]);
+    expect(entries.map((e) => e.slug)).toEqual(["bullet", "numbered"]);
+    expect(entries.every((e) => e.name === "core/list")).toBe(true);
+    expect(entries[0]?.attrs).toEqual({ variant: "bullet" });
+    expect(entries[1]?.attrs).toEqual({ variant: "numbered" });
+    expect(entries[0]?.icon).toBe("List");
+    expect(entries[1]?.icon).toBe("ListOrdered");
+    expect(entries.every((e) => e.category === "text")).toBe(true);
+  });
+
+  test("emits one entry per registered block when no variations declared", () => {
+    const entries = expandBlockVariations([
+      block({ name: "core/paragraph", title: "Paragraph" }),
+      block({ name: "core/heading", title: "Heading" }),
+    ]);
+    expect(entries.map((e) => e.name)).toEqual([
+      "core/paragraph",
+      "core/heading",
+    ]);
+    expect(entries.map((e) => e.slug)).toEqual([
+      "core/paragraph",
+      "core/heading",
+    ]);
+  });
+});

--- a/packages/blocks/src/expand-block-variations.ts
+++ b/packages/blocks/src/expand-block-variations.ts
@@ -1,0 +1,45 @@
+import type { BlockSpec } from "./block-registry.js";
+
+export interface InsertableBlockEntry {
+  readonly name: string;
+  readonly slug: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly category?: string;
+  readonly icon?: string;
+  readonly keywords?: readonly string[];
+  readonly attrs?: Readonly<Record<string, unknown>>;
+}
+
+export function expandBlockVariations(
+  specs: Iterable<BlockSpec>,
+): readonly InsertableBlockEntry[] {
+  const out: InsertableBlockEntry[] = [];
+  for (const spec of specs) {
+    if (spec.variations && spec.variations.length > 0) {
+      for (const v of spec.variations) {
+        out.push({
+          name: spec.name,
+          slug: v.slug,
+          title: v.title,
+          description: v.description,
+          category: spec.category,
+          icon: v.icon,
+          keywords: v.keywords,
+          attrs: v.attrs,
+        });
+      }
+      continue;
+    }
+    out.push({
+      name: spec.name,
+      slug: spec.name,
+      title: spec.title ?? spec.name,
+      description: spec.description,
+      category: spec.category,
+      icon: spec.icon,
+      keywords: spec.keywords,
+    });
+  }
+  return out;
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -66,11 +66,14 @@ export type {
   RenderBlockTreeOptions,
 } from "./render-block-tree.js";
 export { createBlockRegistry, defineBlock as defineBlockSpec } from "./block-registry.js";
+export { expandBlockVariations } from "./expand-block-variations.js";
+export type { InsertableBlockEntry } from "./expand-block-variations.js";
 export type {
   BlockInput,
   BlockInputOption,
   BlockRegistry as BlockRegistryV2,
   BlockSpec as BlockSpecV2,
+  BlockVariation as BlockVariationV2,
   ClientIslandDescriptor,
 } from "./block-registry.js";
 export {
@@ -106,11 +109,7 @@ export {
   tableHeaderCellBlockV2,
   tableHeaderRowBlockV2,
 } from "./table/v2.js";
-export {
-  listBlockV2,
-  listItemBlockV2,
-  listOrderedBlockV2,
-} from "./list/v2.js";
+export { listBlockV2, listItemBlockV2 } from "./list/v2.js";
 export { buttonsBlockV2 } from "./buttons/v2.js";
 export { collectActiveIslands } from "./islands.js";
 export type { ActiveIsland } from "./islands.js";

--- a/packages/blocks/src/list/v2.test.tsx
+++ b/packages/blocks/src/list/v2.test.tsx
@@ -2,54 +2,58 @@ import type { BlockNode } from "../render-block-tree.js";
 import { describe, expect, test } from "vitest";
 
 import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "../test/index.js";
-import {
-  listBlockV2,
-  listItemBlockV2,
-  listOrderedBlockV2,
-} from "./v2.js";
+import { listBlockV2, listItemBlockV2 } from "./v2.js";
 
-describe("core/list family v2", () => {
-  test("renders an empty <ul> for the bulleted list", () => {
+describe("core/list v2", () => {
+  test("renders an empty <ul> for the bullet variant (default)", () => {
     const html = renderBlockSpecToHtml(listBlockV2, {});
-
-    expect(html).toBe(
-      '<div data-plumix-block="core/list"><ul></ul></div>',
-    );
+    expect(html).toBe('<div data-plumix-block="core/list"><ul></ul></div>');
   });
 
-  test("renders an empty <ol> with no start attribute when no attrs are supplied", () => {
-    const html = renderBlockSpecToHtml(listOrderedBlockV2, {});
-
-    expect(html).toBe(
-      '<div data-plumix-block="core/list-ordered"><ol></ol></div>',
-    );
+  test("renders an empty <ol> when the numbered variant is selected", () => {
+    const html = renderBlockSpecToHtml(listBlockV2, { variant: "numbered" });
+    expect(html).toBe('<div data-plumix-block="core/list"><ol></ol></div>');
   });
 
-  test("renders the start attribute on <ol> when greater than the implicit default of 1", () => {
-    const html = renderBlockSpecToHtml(listOrderedBlockV2, { start: 5 });
-
+  test("renders the start attribute on the numbered variant when greater than 1", () => {
+    const html = renderBlockSpecToHtml(listBlockV2, {
+      variant: "numbered",
+      start: 5,
+    });
     expect(html).toContain('<ol start="5">');
   });
 
-  test("drops the start attribute when it equals the canonical default of 1 (legacy parity)", () => {
-    const html = renderBlockSpecToHtml(listOrderedBlockV2, { start: 1 });
-
+  test("drops the start attribute when it equals the canonical default of 1", () => {
+    const html = renderBlockSpecToHtml(listBlockV2, {
+      variant: "numbered",
+      start: 1,
+    });
     expect(html).not.toContain("start=");
   });
 
   test("ignores invalid start values (zero, negative, fractional, NaN, Infinity, non-number)", () => {
     for (const start of [0, -3, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
-      const html = renderBlockSpecToHtml(listOrderedBlockV2, { start });
+      const html = renderBlockSpecToHtml(listBlockV2, {
+        variant: "numbered",
+        start,
+      });
       expect(html).not.toContain("start=");
     }
     expect(
-      renderBlockSpecToHtml(listOrderedBlockV2, { start: "5" }),
+      renderBlockSpecToHtml(listBlockV2, {
+        variant: "numbered",
+        start: "5",
+      }),
     ).not.toContain("start=");
+  });
+
+  test("ignores the start attribute on the bullet variant", () => {
+    const html = renderBlockSpecToHtml(listBlockV2, { start: 5 });
+    expect(html).toBe('<div data-plumix-block="core/list"><ul></ul></div>');
   });
 
   test("renders a list-item as inline <li> (no universal wrapper)", () => {
     const html = renderBlockSpecToHtml(listItemBlockV2, { text: "Bullet" });
-
     expect(html).toBe("<li>Bullet</li>");
   });
 
@@ -66,32 +70,36 @@ describe("core/list family v2", () => {
         },
       },
     ];
-
     const html = renderBlockTreeToHtml(
       [listBlockV2, listItemBlockV2],
       tree,
     );
-
     expect(html).toContain("<ul><li>A</li><li>B</li></ul>");
   });
 
-  test("li nests as a direct child of <ol> with start attribute preserved", () => {
+  test("li nests as a direct child of <ol> with the start attribute preserved", () => {
     const tree: readonly BlockNode[] = [
       {
         id: "o1",
-        name: "core/list-ordered",
+        name: "core/list",
         attrs: {
+          variant: "numbered",
           start: 3,
           items: [{ id: "i1", name: "core/list-item", attrs: { text: "x" } }],
         },
       },
     ];
-
     const html = renderBlockTreeToHtml(
-      [listOrderedBlockV2, listItemBlockV2],
+      [listBlockV2, listItemBlockV2],
       tree,
     );
-
     expect(html).toContain('<ol start="3"><li>x</li></ol>');
+  });
+
+  test("declares Bullet and Numbered variations", () => {
+    expect(listBlockV2.variations?.map((v) => v.slug)).toEqual([
+      "bullet",
+      "numbered",
+    ]);
   });
 });

--- a/packages/blocks/src/list/v2.tsx
+++ b/packages/blocks/src/list/v2.tsx
@@ -4,38 +4,51 @@ import { defineBlock } from "../block-registry.js";
 
 export const listBlockV2 = defineBlock({
   name: "core/list",
-  title: "Bulleted list",
+  title: "List",
   icon: "List",
   category: "text",
-  inputs: [{ name: "items", type: "slot", label: "Items" }],
-  defaults: {},
-  render: ({ attrs }): ReactNode => {
-    const Items = attrs.items as (() => ReactNode) | undefined;
-    return <ul>{Items ? <Items /> : null}</ul>;
-  },
-});
-
-export const listOrderedBlockV2 = defineBlock({
-  name: "core/list-ordered",
-  title: "Numbered list",
-  icon: "ListOrdered",
-  category: "text",
   inputs: [
+    {
+      name: "variant",
+      type: "select",
+      label: "Style",
+      options: [
+        { label: "Bulleted", value: "bullet" },
+        { label: "Numbered", value: "numbered" },
+      ],
+    },
     { name: "start", type: "number", label: "Start" },
     { name: "items", type: "slot", label: "Items" },
   ],
-  defaults: {},
+  defaults: { variant: "bullet" },
+  variations: [
+    {
+      slug: "bullet",
+      title: "Bulleted list",
+      icon: "List",
+      attrs: { variant: "bullet" },
+    },
+    {
+      slug: "numbered",
+      title: "Numbered list",
+      icon: "ListOrdered",
+      attrs: { variant: "numbered" },
+    },
+  ],
   render: ({ attrs }): ReactNode => {
-    const startRaw = attrs.start as number | undefined;
-    // Drop start when it equals the canonical default of 1 — matches the
-    // legacy walker, which omits the attribute so the rendered HTML stays
-    // identical to the implicit <ol>.
-    const start =
-      typeof startRaw === "number" && Number.isInteger(startRaw) && startRaw > 1
-        ? startRaw
-        : undefined;
     const Items = attrs.items as (() => ReactNode) | undefined;
-    return <ol start={start}>{Items ? <Items /> : null}</ol>;
+    if (attrs.variant === "numbered") {
+      const startRaw = attrs.start;
+      // Drop start when it equals the canonical default of 1 — matches the
+      // legacy walker, which omits the attribute so the rendered HTML stays
+      // identical to the implicit <ol>.
+      const start =
+        typeof startRaw === "number" && Number.isInteger(startRaw) && startRaw > 1
+          ? startRaw
+          : undefined;
+      return <ol start={start}>{Items ? <Items /> : null}</ol>;
+    }
+    return <ul>{Items ? <Items /> : null}</ul>;
   },
 });
 


### PR DESCRIPTION
Adds the `variations` field to v2 `BlockSpec` and ships the inserter wiring
that surfaces each variation as a distinct insertable. `core/list`
consolidates the old `listBlockV2` + `listOrderedBlockV2` into a single
block with Bullet and Numbered variations that share render logic; the
render dispatches on `attrs.variant` for `<ul>` vs `<ol>`. Both the slash
menu and the new `PlumixBlocksTab` (replacing `<Puck.Components />`)
delegate to a pure `expandBlockVariations` module — same expander, two
inserter surfaces.

**Slot-zone-aware variation insert**

The first version of the post-insert attrs merge was root-only. Reviewing
caught a silent data-loss path: a slash-menu insertion into a wrapper-block
slot (user has a child of `core/group` selected) would land the new block
in the slot but apply the variation attrs to the wrong root block — or
drop them entirely. `mergePropsAtSelector` is now zone-aware; it walks the
wrapper-block slot props for nested zones (mirrors `patch-style.ts`).

**Two dispatches, one undo entry**

The insertion path is `puck.dispatch(insert)` followed by
`puck.dispatch(setData)` to merge the variation's attrs onto the
just-inserted block. Puck's reducer excludes `setData` from history by
default, so the user's undo stack records one entry per variation insert —
same UX as inserting a plain block.

`SlashMenuItem` collapses to an alias of the expander's
`InsertableBlockEntry`; testids switch from `name` to `slug` so two
variations of the same parent have distinct selectors. Screenshot tests
(acceptance #6) ship as DOM-shape assertions in Playwright; pixel-level
screenshots need a Docker-based Playwright runner, which is its own
deferred infra slice.

Follow-ups (own slices): variation surface at the public `plumix/blocks`
package; BlockInput visibility predicates; keyword inheritance semantics;
drag affordance return in `PlumixBlocksTab`; pixel-level screenshots once
the Docker runner lands.

Refs #395
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>