### PR TITLE
feat(admin): add plain-form route for non-editor entry types

### DIFF
--- a/packages/admin/e2e/plain-form-route.spec.ts
+++ b/packages/admin/e2e/plain-form-route.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_PLAIN_FORM_TYPE,
+  mockManifest,
+  mockRpcWithCapture,
+  rpcOkBody,
+  withCapabilities,
+} from "./support/rpc-mock.js";
+
+const T0 = new Date("2026-05-20T00:00:00Z");
+
+const AUTHED_AUTHOR_EDITOR = withCapabilities(
+  AUTHED_ADMIN,
+  "entry:author:create",
+  "entry:author:edit_any",
+  "entry:author:edit_own",
+  "entry:author:publish",
+  "entry:author:read",
+  "entry:author:delete",
+);
+
+function authorEntry(id: number): Record<string, unknown> {
+  return {
+    id,
+    type: "author",
+    parentId: null,
+    title: "Jane Doe",
+    slug: `author-${String(id)}`,
+    content: null,
+    excerpt: null,
+    status: "draft",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: null,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: { headline: "Staff writer", twitter: "@jane" },
+  };
+}
+
+test.describe("plain-form route for non-editor entry types", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_PLAIN_FORM_TYPE);
+  });
+
+  test("renders the Card-based plain form when the entry type lacks editor support", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_AUTHOR_EDITOR),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: authorEntry(1), meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/authors/1/edit");
+
+    await expect(page.getByTestId("plain-form-layout")).toBeVisible();
+    await expect(page.getByTestId("plain-form-header")).toBeVisible();
+    await expect(page.getByTestId("plain-form-title-input")).toHaveValue(
+      "Jane Doe",
+    );
+    await expect(page.getByTestId("plain-form-status-pill")).toHaveText(
+      "Saved",
+    );
+    await expect(page.getByTestId("plain-form-save-button")).toBeVisible();
+    await expect(page.getByTestId("plain-form-publish-button")).toBeVisible();
+
+    const card = page.getByTestId("plain-form-meta-box-bio");
+    await expect(card).toBeVisible();
+    await expect(card).toHaveAttribute(
+      "aria-labelledby",
+      "plain-form-meta-box-heading-bio",
+    );
+    await expect(
+      page.getByTestId("plain-form-meta-box-heading-bio"),
+    ).toHaveText("Biography");
+    await expect(card.getByTestId("meta-box-field-headline-input")).toBeVisible();
+    await expect(card.getByTestId("meta-box-field-twitter-input")).toBeVisible();
+  });
+
+  test("Publish button submits an entry.update with status: published", async ({
+    page,
+  }) => {
+    const captures = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/update",
+      captureResponse: {
+        ...authorEntry(1),
+        status: "published",
+        publishedAt: T0,
+      },
+      handlers: {
+        "/auth/session": AUTHED_AUTHOR_EDITOR,
+        "/entry/get": authorEntry(1),
+      },
+    });
+
+    await page.goto("entries/authors/1/edit");
+    await page.getByTestId("plain-form-publish-button").click();
+
+    await expect
+      .poll(
+        () =>
+          (captures.at(-1) as { status?: string } | undefined)?.status ?? null,
+      )
+      .toBe("published");
+  });
+
+  test("Save button submits an entry.update preserving the current status", async ({
+    page,
+  }) => {
+    const captures = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/update",
+      captureResponse: { ...authorEntry(1), updatedAt: T0 },
+      handlers: {
+        "/auth/session": AUTHED_AUTHOR_EDITOR,
+        "/entry/get": authorEntry(1),
+      },
+    });
+
+    await page.goto("entries/authors/1/edit");
+    await page.getByTestId("plain-form-save-button").click();
+
+    await expect.poll(() => captures.length).toBeGreaterThan(0);
+    const lastInput = captures.at(-1) as {
+      readonly id: number;
+      readonly status: string;
+    };
+    expect(lastInput.id).toBe(1);
+    expect(lastInput.status).toBe("draft");
+  });
+});

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -22,6 +22,47 @@ export {
   withCapabilities,
 } from "@plumix/core/test/playwright";
 
+// Non-editor entry-type fixture — supports lacks "editor", so the admin
+// route renders the plain-form (stacked Cards) layout instead of the
+// editor surface. Carries one entry metabox with two fields so the e2e
+// can exercise the Card/section + MetaBoxField pipeline.
+export const MANIFEST_WITH_PLAIN_FORM_TYPE: PlumixManifest = {
+  ...emptyManifest(),
+  entryTypes: [
+    {
+      name: "author",
+      adminSlug: "authors",
+      label: "Authors",
+      labels: { singular: "Author", plural: "Authors" },
+      supports: ["title", "slug"],
+    },
+  ],
+  entryMetaBoxes: [
+    {
+      id: "bio",
+      label: "Biography",
+      description: "Public-facing author profile copy.",
+      entryTypes: ["author"],
+      fields: [
+        {
+          key: "headline",
+          label: "Headline",
+          type: "string",
+          inputType: "text",
+          maxLength: 120,
+        },
+        {
+          key: "twitter",
+          label: "Twitter handle",
+          type: "string",
+          inputType: "text",
+          maxLength: 40,
+        },
+      ],
+    },
+  ],
+};
+
 // Default post-type manifest fixture — one entry, slug `entries`, shared
 // by specs that just need "something to list" without caring about the
 // specifics.

--- a/packages/admin/src/components/editor/entry-editor-form.tsx
+++ b/packages/admin/src/components/editor/entry-editor-form.tsx
@@ -81,7 +81,7 @@ const EMPTY_NUMBER_IDS: readonly number[] = [];
 // surfaces the same error inline without a round-trip.
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-const postEditorSchema = v.object({
+export const postEditorSchema = v.object({
   title: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(300)),
   slug: v.pipe(
     v.string(),

--- a/packages/admin/src/components/editor/plain-form-layout.tsx
+++ b/packages/admin/src/components/editor/plain-form-layout.tsx
@@ -1,0 +1,155 @@
+import type { EntryMetaBoxManifestEntry } from "@plumix/core/manifest";
+import type { ReactElement } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { valibotResolver } from "@hookform/resolvers/valibot";
+
+import type { PostEditorValues } from "./entry-editor-form.js";
+import { postEditorSchema } from "./entry-editor-form.js";
+
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from "@/components/ui/card.js";
+import { Form, FormControl, FormField, FormItem } from "@/components/ui/form.js";
+import { Input } from "@/components/ui/input.js";
+import { MetaBoxField } from "@/components/meta-box/meta-box-field.js";
+
+type SaveStatus = "saved" | "saving" | "error";
+
+interface PlainFormLayoutProps {
+  readonly initialValues: PostEditorValues;
+  readonly metaBoxes: readonly EntryMetaBoxManifestEntry[];
+  readonly headline: string;
+  readonly isSubmitting: boolean;
+  readonly serverError: string | null;
+  readonly onSubmit: (values: PostEditorValues) => void;
+}
+
+const LABEL: Readonly<Record<SaveStatus, string>> = {
+  saved: "Saved",
+  saving: "Saving...",
+  error: "Failed to save",
+};
+
+function resolveStatus(
+  isSubmitting: boolean,
+  serverError: string | null,
+): SaveStatus {
+  if (isSubmitting) return "saving";
+  if (serverError) return "error";
+  return "saved";
+}
+
+export function PlainFormLayout({
+  initialValues,
+  metaBoxes,
+  headline,
+  isSubmitting,
+  serverError,
+  onSubmit,
+}: PlainFormLayoutProps): ReactElement {
+  const form = useForm({
+    resolver: valibotResolver(postEditorSchema),
+    defaultValues: initialValues,
+  });
+  // useWatch keeps the Publish button's disabled state from forcing the
+  // whole tree (every Card + MetaBoxField) to re-render on every keystroke.
+  const status = useWatch({ control: form.control, name: "status" });
+  const saveStatus = resolveStatus(isSubmitting, serverError);
+  return (
+    <Form {...form}>
+      <form
+        className="mx-auto flex max-w-2xl flex-col gap-4 p-6"
+        data-testid="plain-form-layout"
+        onSubmit={(event) => {
+          void form.handleSubmit(onSubmit)(event);
+        }}
+      >
+        <h1 className="sr-only">{headline}</h1>
+        <header
+          className="flex items-center gap-3 border-b pb-3"
+          data-testid="plain-form-header"
+        >
+          <FormField
+            control={form.control}
+            name="title"
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                <FormControl>
+                  <Input
+                    {...field}
+                    type="text"
+                    placeholder="Untitled"
+                    aria-label="Entry title"
+                    data-testid="plain-form-title-input"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <span
+            className="rounded bg-muted px-2 py-1 text-xs"
+            data-testid="plain-form-status-pill"
+            data-status={saveStatus}
+          >
+            {LABEL[saveStatus]}
+          </span>
+          <Button
+            type="submit"
+            variant="outline"
+            data-testid="plain-form-save-button"
+            disabled={isSubmitting}
+          >
+            Save
+          </Button>
+          <Button
+            type="button"
+            data-testid="plain-form-publish-button"
+            disabled={isSubmitting || status === "published"}
+            onClick={() => {
+              form.setValue("status", "published");
+              void form.handleSubmit(onSubmit)();
+            }}
+          >
+            Publish
+          </Button>
+        </header>
+        {metaBoxes.map((box) => (
+          <section
+            key={box.id}
+            aria-labelledby={`plain-form-meta-box-heading-${box.id}`}
+            data-testid={`plain-form-meta-box-${box.id}`}
+          >
+            <Card className="@container">
+              <CardHeader>
+                <h2
+                  id={`plain-form-meta-box-heading-${box.id}`}
+                  className="text-lg leading-none font-semibold"
+                  data-testid={`plain-form-meta-box-heading-${box.id}`}
+                >
+                  {box.label}
+                </h2>
+                {box.description ? (
+                  <CardDescription>{box.description}</CardDescription>
+                ) : null}
+              </CardHeader>
+              <CardContent className="flex flex-col gap-4">
+                {box.fields.map((field) => (
+                  <MetaBoxField
+                    key={field.key}
+                    field={field}
+                    name={`meta.${field.key}`}
+                    disabled={isSubmitting}
+                  />
+                ))}
+              </CardContent>
+            </Card>
+          </section>
+        ))}
+      </form>
+    </Form>
+  );
+}

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -6,6 +6,7 @@ import {
   POST_EDITOR_STATUSES,
   PostEditorForm,
 } from "@/components/editor/entry-editor-form.js";
+import { PlainFormLayout } from "@/components/editor/plain-form-layout.js";
 import { useEntryFormScope } from "@/components/editor/use-entry-form-scope.js";
 import { useParentOptions } from "@/components/editor/use-parent-options.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
@@ -216,6 +217,50 @@ function EditPostRoute(): ReactNode {
   }
 
   const initialValues: PostEditorValues = toEditorValues(post, entryType);
+
+  const supportsEditor = (entryType.supports ?? ["title", "editor", "slug"])
+    .includes("editor");
+
+  if (!supportsEditor) {
+    return (
+      <>
+        <PlainFormLayout
+          // Remount on a successful update so the form's defaultValues
+          // resync to the refetched entry (parallels the editor route's
+          // same trick at the PostEditorForm call site).
+          key={
+            post.updatedAt instanceof Date
+              ? post.updatedAt.toISOString()
+              : String(post.updatedAt)
+          }
+          initialValues={initialValues}
+          metaBoxes={metaBoxes}
+          headline={`Edit ${singularLower}`}
+          isSubmitting={updatePost.isPending}
+          serverError={updatePost.isPending ? null : serverError}
+          onSubmit={(values) => {
+            updatePost.mutate({
+              values,
+              expectedLiveUpdatedAt: post.updatedAt,
+            });
+          }}
+        />
+        <EntryConflictDialog
+          open={conflict !== null}
+          singularLabel={singularLower}
+          mine={conflict?.mine ?? null}
+          theirs={conflict?.theirs ?? null}
+          onKeepMine={handleKeepMine}
+          onTakeTheirs={() => {
+            void handleTakeTheirs();
+          }}
+          onOpenChange={(open) => {
+            if (!open) setConflict(null);
+          }}
+        />
+      </>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
Entry types declared without `editor` in their `supports` list now render a
centered single-column stack of shadcn Cards — one per registered metabox
— instead of the editor surface. Closes issue #390.

The existing `_editor/entries/$slug/$id/edit` route branches on
`entryType.supports` inside its component: editor-supports renders the
existing PostEditorForm; absent it returns the new PlainFormLayout. Both
paths reuse the same `updatePost` mutation, `MetaBoxField` dispatcher,
cap-check, and `EntryConflictDialog` (the dialog now mounts on the
plain-form path too, not just the editor path — without that fix a stale-
token CONFLICT was silent on this surface).

**Validation parity with the editor**

PlainFormLayout uses `useForm` with the existing `postEditorSchema`
valibot resolver. Save and Publish refuse to submit invalid input client-
side — empty title or 300+ char slug rejects before the wire. The
schema was exported from `entry-editor-form.tsx` for reuse.

**Perf: Publish-button disable via useWatch**

The Publish button is disabled when the entry is already `"published"`.
That subscription used `form.watch` initially, which fanned out a re-
render across every Card + MetaBoxField on every keystroke. Switched to
`useWatch({ control, name: "status" })` so only the header re-renders on
status changes.

Semantic HTML: each Card is wrapped in `<section aria-labelledby>` with
a true `<h2>` (no nested CardTitle div around a heading). Page-level
`<h1 className="sr-only">` gives the document outline a route-level
anchor for screen readers. `@puckeditor/core` is not pulled into the
plain-form bundle (the v1 editor route doesn't import Puck; the branch
adds nothing to the import graph).

Pixel-level screenshot tests defer to the Docker-based Playwright runner
(per project_ci_affected_deferred memory) — this PR ships DOM-shape
Playwright assertions for the form chrome, the Card structure, the
aria-labelledby relationship, and the Save / Publish click outcomes.

Refs #390
Refs #379

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>