### PR TITLE
feat(admin,core): wire capability gating end-to-end across editor surfaces

### DIFF
--- a/packages/admin/e2e/capability-gating.spec.ts
+++ b/packages/admin/e2e/capability-gating.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_CAPABILITY_GATES,
+  mockManifest,
+  rpcOkBody,
+  withCapabilities,
+} from "./support/rpc-mock.js";
+
+const T0 = new Date("2026-05-20T00:00:00Z");
+
+const AUTHED_LOW_CAP = withCapabilities(
+  AUTHED_ADMIN,
+  "entry:author:edit_any",
+  "entry:author:edit_own",
+  "entry:author:read",
+);
+
+const AUTHED_HIGH_CAP = withCapabilities(
+  AUTHED_LOW_CAP,
+  "entry:author:manage_internal_notes",
+  "entry:author:view_secret_notes",
+);
+
+function authorEntry(id: number): Record<string, unknown> {
+  return {
+    id,
+    type: "author",
+    parentId: null,
+    title: "Jane Doe",
+    slug: `author-${String(id)}`,
+    content: null,
+    excerpt: null,
+    status: "draft",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: null,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: { headline: "Staff writer" },
+  };
+}
+
+test.describe("capability gating in plain-form route", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_CAPABILITY_GATES);
+  });
+
+  test("low-cap viewer: gated metabox + gated field both absent", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_LOW_CAP),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: authorEntry(1), meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/authors/1/edit");
+
+    await expect(page.getByTestId("plain-form-meta-box-public-bio")).toBeVisible();
+    await expect(
+      page.getByTestId("meta-box-field-headline-input"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("meta-box-field-secret_note-input"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByTestId("plain-form-meta-box-internal-notes"),
+    ).toHaveCount(0);
+  });
+
+  test("high-cap viewer: gated metabox and gated field both visible", async ({
+    page,
+  }) => {
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_HIGH_CAP),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: authorEntry(1), meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/authors/1/edit");
+
+    await expect(
+      page.getByTestId("plain-form-meta-box-public-bio"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("meta-box-field-headline-input"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("meta-box-field-secret_note-input"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("plain-form-meta-box-internal-notes"),
+    ).toBeVisible();
+  });
+});

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -22,6 +22,60 @@ export {
   withCapabilities,
 } from "@plumix/core/test/playwright";
 
+// Manifest fixture exercising capability gating across both metabox and
+// field levels. Two levels of gating in one fixture.
+export const MANIFEST_WITH_CAPABILITY_GATES: PlumixManifest = {
+  ...emptyManifest(),
+  entryTypes: [
+    {
+      name: "author",
+      adminSlug: "authors",
+      label: "Authors",
+      labels: { singular: "Author", plural: "Authors" },
+      supports: ["title", "slug"],
+    },
+  ],
+  entryMetaBoxes: [
+    {
+      id: "public-bio",
+      label: "Public bio",
+      entryTypes: ["author"],
+      fields: [
+        {
+          key: "headline",
+          label: "Headline",
+          type: "string",
+          inputType: "text",
+          maxLength: 120,
+        },
+        {
+          key: "secret_note",
+          label: "Secret note",
+          type: "string",
+          inputType: "text",
+          maxLength: 240,
+          capability: "entry:author:view_secret_notes",
+        },
+      ],
+    },
+    {
+      id: "internal-notes",
+      label: "Internal notes",
+      entryTypes: ["author"],
+      capability: "entry:author:manage_internal_notes",
+      fields: [
+        {
+          key: "internal_notes",
+          label: "Notes",
+          type: "string",
+          inputType: "textarea",
+          maxLength: 1000,
+        },
+      ],
+    },
+  ],
+};
+
 // Non-editor entry-type fixture — supports lacks "editor", so the admin
 // route renders the plain-form (stacked Cards) layout instead of the
 // editor surface. Carries one entry metabox with two fields so the e2e

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -280,6 +280,41 @@ describe("entryMetaBoxesForType", () => {
     const source: PlumixManifest = {};
     expect(entryMetaBoxesForType("post", [], source)).toEqual([]);
   });
+
+  test("hides capability-gated fields from low-cap viewers", () => {
+    const source: PlumixManifest = {
+      entryMetaBoxes: [
+        box("bio", {
+          fields: [
+            {
+              key: "headline",
+              label: "Headline",
+              type: "string",
+              inputType: "text",
+            },
+            {
+              key: "secret",
+              label: "Secret",
+              type: "string",
+              inputType: "text",
+              capability: "entry:post:view_secret",
+            },
+          ],
+        }),
+      ],
+    };
+    const lowCap = entryMetaBoxesForType("post", [], source);
+    expect(lowCap[0]?.fields.map((f) => f.key)).toEqual(["headline"]);
+    const highCap = entryMetaBoxesForType(
+      "post",
+      ["entry:post:view_secret"],
+      source,
+    );
+    expect(highCap[0]?.fields.map((f) => f.key)).toEqual([
+      "headline",
+      "secret",
+    ]);
+  });
 });
 
 describe("visibleUserMetaBoxes", () => {

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -118,6 +118,7 @@ function filterMetaBoxes<
     readonly id: string;
     readonly capability?: string;
     readonly priority?: number;
+    readonly fields: readonly { readonly capability?: string }[];
   },
 >(
   boxes: readonly T[] | undefined,
@@ -131,6 +132,13 @@ function filterMetaBoxes<
         return false;
       return true;
     })
+    .map((box) => ({
+      ...box,
+      fields: box.fields.filter(
+        (field) =>
+          field.capability === undefined || caps.has(field.capability),
+      ),
+    }))
     .sort(byPriorityThen((b) => b.id));
 }
 
@@ -158,10 +166,7 @@ export function visibleUserMetaBoxes(
   capabilities: readonly string[],
   source: PlumixManifest = manifest,
 ): readonly UserMetaBoxManifestEntry[] {
-  const caps = new Set(capabilities);
-  return (source.userMetaBoxes ?? [])
-    .filter((box) => box.capability === undefined || caps.has(box.capability))
-    .sort(byPriorityThen((b) => b.id));
+  return filterMetaBoxes(source.userMetaBoxes, new Set(capabilities), () => true);
 }
 
 export function findSettingsPageByName(

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -104,6 +104,7 @@ function ErrorScreen(): ReactNode {
 
 function PuckSpikeRoute(): ReactNode {
   const { slug, id } = Route.useParams();
+  const { user } = Route.useRouteContext();
   const draftKey = `plumix.v2.draft.${slug}.${id}`;
   const entryTypeName = findEntryTypeBySlug(slug)?.name;
   return (
@@ -112,6 +113,7 @@ function PuckSpikeRoute(): ReactNode {
       draftKey={draftKey}
       id={id}
       entryTypeName={entryTypeName}
+      capabilities={user.capabilities}
     />
   );
 }
@@ -120,12 +122,14 @@ interface PuckSpikeRouteInnerProps {
   readonly draftKey: string;
   readonly id: number;
   readonly entryTypeName: string | undefined;
+  readonly capabilities: readonly string[];
 }
 
 function PuckSpikeRouteInner({
   draftKey,
   id,
   entryTypeName,
+  capabilities,
 }: PuckSpikeRouteInnerProps): ReactNode {
   const { data: entry } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id } }),
@@ -212,17 +216,22 @@ function PuckSpikeRouteInner({
   });
   const isPublished = entry.status === "published";
   const handlePublish = useCallback(() => publish.mutate(), [publish]);
+  const capabilitySet = useMemo(
+    () => new Set(capabilities),
+    [capabilities],
+  );
   const Layout = useCallback(
     (): ReactElement => (
       <PlumixEditorLayout
         registry={registry}
+        capabilities={capabilitySet}
         tokens={sampleTokens}
         onPublish={handlePublish}
         isPublishing={publish.isPending}
         isPublished={isPublished}
       />
     ),
-    [handlePublish, publish.isPending, isPublished],
+    [handlePublish, publish.isPending, isPublished, capabilitySet],
   );
 
   return (

--- a/packages/core/src/plugin/fields/checkbox.ts
+++ b/packages/core/src/plugin/fields/checkbox.ts
@@ -7,6 +7,7 @@ export interface CheckboxFieldOptions {
   readonly description?: string;
   readonly default?: boolean;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -25,6 +26,7 @@ export function checkbox(options: CheckboxFieldOptions): CheckboxMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/color.ts
+++ b/packages/core/src/plugin/fields/color.ts
@@ -8,6 +8,7 @@ export interface ColorFieldOptions {
   /** Hex string `#xxxxxx` (or `#xxx` shorthand). Must match `HEX_COLOR`. */
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   /**
    * Optional override. The builder ships a default sanitizer that
    * rejects non-hex values; passing a custom one replaces it
@@ -36,6 +37,7 @@ export function color(options: ColorFieldOptions): ColorMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize ?? defaultColorSanitize,
   };
 }

--- a/packages/core/src/plugin/fields/date.ts
+++ b/packages/core/src/plugin/fields/date.ts
@@ -11,6 +11,7 @@ export interface DateFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -32,6 +33,7 @@ export function date(options: DateFieldOptions): DateMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/datetime.ts
+++ b/packages/core/src/plugin/fields/datetime.ts
@@ -11,6 +11,7 @@ export interface DateTimeFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -34,6 +35,7 @@ export function datetime(options: DateTimeFieldOptions): DateTimeMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/email.ts
+++ b/packages/core/src/plugin/fields/email.ts
@@ -9,6 +9,7 @@ export interface EmailFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -25,6 +26,7 @@ export function email(options: EmailFieldOptions): EmailMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/entry-list.ts
+++ b/packages/core/src/plugin/fields/entry-list.ts
@@ -8,6 +8,7 @@ export interface EntryListFieldOptions {
   readonly description?: string;
   readonly default?: readonly string[];
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly entryTypes: readonly string[];
   readonly includeTrashed?: boolean;
   /** Max items allowed in the array. Omitted = unbounded. */
@@ -43,5 +44,6 @@ export function entryList(
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
   };
 }

--- a/packages/core/src/plugin/fields/entry.ts
+++ b/packages/core/src/plugin/fields/entry.ts
@@ -30,6 +30,7 @@ export interface EntryFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly entryTypes: readonly string[];
   readonly includeTrashed?: boolean;
 }
@@ -55,5 +56,6 @@ export function entry(options: EntryFieldOptions): EntryReferenceMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
   };
 }

--- a/packages/core/src/plugin/fields/json.ts
+++ b/packages/core/src/plugin/fields/json.ts
@@ -7,6 +7,7 @@ export interface JsonFieldOptions {
   readonly description?: string;
   readonly default?: unknown;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -25,6 +26,7 @@ export function json(options: JsonFieldOptions): JsonMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/multiselect.ts
+++ b/packages/core/src/plugin/fields/multiselect.ts
@@ -12,6 +12,7 @@ export interface MultiselectFieldOptions {
   readonly description?: string;
   readonly default?: readonly string[];
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -34,6 +35,7 @@ export function multiselect(
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize ?? buildOptionSanitizer(options.options),
   };
 }

--- a/packages/core/src/plugin/fields/number.ts
+++ b/packages/core/src/plugin/fields/number.ts
@@ -11,6 +11,7 @@ export interface NumberFieldOptions {
   readonly description?: string;
   readonly default?: number;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -33,6 +34,7 @@ export function number(options: NumberFieldOptions): NumberMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/password.ts
+++ b/packages/core/src/plugin/fields/password.ts
@@ -9,6 +9,7 @@ export interface PasswordFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -32,6 +33,7 @@ export function password(options: PasswordFieldOptions): PasswordMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/radio.ts
+++ b/packages/core/src/plugin/fields/radio.ts
@@ -12,6 +12,7 @@ export interface RadioFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -27,6 +28,7 @@ export function radio(options: RadioFieldOptions): RadioMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/range.ts
+++ b/packages/core/src/plugin/fields/range.ts
@@ -11,6 +11,7 @@ export interface RangeFieldOptions {
   readonly description?: string;
   readonly default?: number;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   /**
    * Optional override. The builder ships a default sanitizer that
    * enforces the declared `min`/`max` bounds on write; passing a
@@ -46,6 +47,7 @@ export function range(options: RangeFieldOptions): RangeMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize ?? buildBoundsSanitizer(min, max),
   };
 }

--- a/packages/core/src/plugin/fields/repeater.ts
+++ b/packages/core/src/plugin/fields/repeater.ts
@@ -13,6 +13,7 @@ export interface RepeaterFieldOptions {
   readonly description?: string;
   readonly default?: unknown;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly subFields: readonly MetaBoxField[];
   readonly min?: number;
   readonly max?: number;
@@ -78,6 +79,7 @@ export function repeater(options: RepeaterFieldOptions): RepeaterMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: walkRepeaterRows(options.subFields, {
       min: options.min,
       max: options.max,

--- a/packages/core/src/plugin/fields/richtext.ts
+++ b/packages/core/src/plugin/fields/richtext.ts
@@ -9,6 +9,7 @@ export interface RichtextFieldOptions {
   readonly description?: string;
   readonly default?: unknown;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly marks?: readonly string[];
   readonly nodes?: readonly string[];
   readonly blocks?: readonly string[];
@@ -35,6 +36,7 @@ export function richtext(options: RichtextFieldOptions): RichtextMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: walkRichtextDoc({
       marks: options.marks,
       nodes: options.nodes,

--- a/packages/core/src/plugin/fields/select.ts
+++ b/packages/core/src/plugin/fields/select.ts
@@ -12,6 +12,7 @@ export interface SelectFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -31,6 +32,7 @@ export function select(options: SelectFieldOptions): SelectMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/term-list.ts
+++ b/packages/core/src/plugin/fields/term-list.ts
@@ -8,6 +8,7 @@ export interface TermListFieldOptions {
   readonly description?: string;
   readonly default?: readonly string[];
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly termTaxonomies: readonly string[];
   /** Max items allowed in the array. Omitted = unbounded. */
   readonly max?: number;
@@ -39,5 +40,6 @@ export function termList(options: TermListFieldOptions): TermListMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
   };
 }

--- a/packages/core/src/plugin/fields/term.ts
+++ b/packages/core/src/plugin/fields/term.ts
@@ -25,6 +25,7 @@ export interface TermFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly termTaxonomies: readonly string[];
 }
 
@@ -48,5 +49,6 @@ export function term(options: TermFieldOptions): TermReferenceMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
   };
 }

--- a/packages/core/src/plugin/fields/text.ts
+++ b/packages/core/src/plugin/fields/text.ts
@@ -16,6 +16,7 @@ export interface TextFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -45,6 +46,7 @@ export function text(options: TextFieldOptions): TextMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/textarea.ts
+++ b/packages/core/src/plugin/fields/textarea.ts
@@ -9,6 +9,7 @@ export interface TextareaFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -28,6 +29,7 @@ export function textarea(options: TextareaFieldOptions): TextareaMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/time.ts
+++ b/packages/core/src/plugin/fields/time.ts
@@ -11,6 +11,7 @@ export interface TimeFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -32,6 +33,7 @@ export function time(options: TimeFieldOptions): TimeMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/url.ts
+++ b/packages/core/src/plugin/fields/url.ts
@@ -9,6 +9,7 @@ export interface UrlFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly sanitize?: (value: unknown) => unknown;
 }
 
@@ -25,6 +26,7 @@ export function url(options: UrlFieldOptions): UrlMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
     sanitize: options.sanitize,
   };
 }

--- a/packages/core/src/plugin/fields/user-list.ts
+++ b/packages/core/src/plugin/fields/user-list.ts
@@ -9,6 +9,7 @@ export interface UserListFieldOptions {
   readonly description?: string;
   readonly default?: readonly string[];
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly roles?: readonly UserRole[];
   readonly includeDisabled?: boolean;
   /** Max items allowed in the array. Omitted = unbounded. */
@@ -42,5 +43,6 @@ export function userList(options: UserListFieldOptions): UserListMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
   };
 }

--- a/packages/core/src/plugin/fields/user.ts
+++ b/packages/core/src/plugin/fields/user.ts
@@ -25,6 +25,7 @@ export interface UserFieldOptions {
   readonly description?: string;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
+  readonly capability?: string;
   readonly roles?: readonly UserRole[];
   readonly includeDisabled?: boolean;
 }
@@ -55,5 +56,6 @@ export function user(options: UserFieldOptions): UserMetaBoxField {
     description: options.description,
     default: options.default,
     span: options.span,
+    capability: options.capability,
   };
 }

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -191,6 +191,16 @@ export interface MetaBoxFieldBase {
    * width. See `MetaBoxFieldSpan` for the responsive object form.
    */
   readonly span?: MetaBoxFieldSpan;
+  /**
+   * Capability gate for the individual field. When set, the admin hides
+   * the field from viewers whose capability set lacks it. The server
+   * rejects entry/term/user writes that include the field's key — both
+   * upserts and deletes count, so a viewer can't blank a value they
+   * can't see. Gating applies at the top-level field only; capabilities
+   * on repeater subfields are ignored (a row's gate is the parent
+   * repeater field's gate). Defaults to no gating.
+   */
+  readonly capability?: string;
 }
 
 /**
@@ -1263,6 +1273,10 @@ export interface MetaBoxFieldManifestEntry {
    * through this list when rendering each row.
    */
   readonly subFields?: readonly EntryMetaBoxFieldManifestEntry[];
+  /**
+   * Capability gate for the individual field. See `MetaBoxFieldBase.capability`.
+   */
+  readonly capability?: string;
 }
 
 /**
@@ -2283,6 +2297,7 @@ function toEntryMetaBoxFieldEntry(
     marks: view.marks,
     nodes: view.nodes,
     blocks: view.blocks,
+    capability: field.capability,
     // Repeater subfields recurse through the same projection — the
     // wire shape is uniform end to end, span dropped (rows are
     // full-width), sanitize callbacks stripped (server-only).

--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -446,4 +446,34 @@ describe("entry.create", () => {
       code: "BAD_REQUEST",
     });
   });
+
+  test("rejects creating an entry with a capability-gated meta field", async () => {
+    const plugins = createPluginRegistry();
+    plugins.entryMetaBoxes.set("test-gated", {
+      id: "test-gated",
+      label: "Gated",
+      entryTypes: ["post"],
+      fields: [
+        {
+          key: "private_note",
+          label: "Private note",
+          type: "string",
+          inputType: "text",
+          capability: "entry:post:view_private_notes",
+        },
+      ],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "author", plugins });
+    await expect(
+      h.client.entry.create({
+        title: "gated",
+        slug: "gated",
+        meta: { private_note: "leaked" },
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "entry:post:view_private_notes" },
+    });
+  });
 });

--- a/packages/core/src/rpc/procedures/entry/create.ts
+++ b/packages/core/src/rpc/procedures/entry/create.ts
@@ -15,6 +15,7 @@ import {
   loadReadableParent,
 } from "./lifecycle.js";
 import {
+  assertEntryMetaCapabilities,
   decodeMetaBag,
   loadEntryMeta,
   sanitizeMetaForRpc,
@@ -87,6 +88,13 @@ export const create = base
       errors,
     );
     if (metaPatch) {
+      assertEntryMetaCapabilities(
+        context.plugins,
+        filtered.type,
+        metaPatch,
+        context.auth,
+        errors,
+      );
       await validateEntryMetaReferences(
         context,
         filtered.type,

--- a/packages/core/src/rpc/procedures/entry/meta.ts
+++ b/packages/core/src/rpc/procedures/entry/meta.ts
@@ -30,6 +30,57 @@ export function sanitizeMetaForRpc(
 }
 
 /**
+ * Reject a meta patch that writes to a capability-gated field the viewer
+ * can't access. Treats the field's `capability` as a server-side gate so
+ * the API stays honest regardless of admin-side filtering. Deletes count
+ * as writes — you can't blank a value you can't see. Repeater subfields
+ * are NOT recursed: capability gates apply at the top-level field only;
+ * a row's capability is whichever the parent repeater field declares.
+ */
+export function assertEntryMetaCapabilities(
+  registry: PluginRegistry,
+  entryType: string,
+  patch: MetaPatch,
+  auth: { can(capability: string): boolean },
+  errors: {
+    FORBIDDEN: (args: { data: { capability: string } }) => Error;
+  },
+): void {
+  assertMetaCapabilities(
+    patch,
+    (key) => findEntryMetaField(registry, entryType, key),
+    auth,
+    errors,
+  );
+}
+
+/**
+ * Generic shape — `term.{create,update}` and `user.update` reuse this by
+ * passing their own `findField` lookup so all three surfaces honour the
+ * field-level capability gate uniformly.
+ */
+export function assertMetaCapabilities(
+  patch: MetaPatch,
+  findField: (key: string) => { readonly capability?: string } | undefined,
+  auth: { can(capability: string): boolean },
+  errors: {
+    FORBIDDEN: (args: { data: { capability: string } }) => Error;
+  },
+): void {
+  const touched = new Set<string>([
+    ...patch.upserts.keys(),
+    ...patch.deletes,
+  ]);
+  for (const key of touched) {
+    const field = findField(key);
+    if (!field?.capability) continue;
+    if (!auth.can(field.capability)) {
+      throw errors.FORBIDDEN({ data: { capability: field.capability } });
+    }
+  }
+}
+
+/**
  * Async second pass on a sanitised entry-meta patch: validates each
  * reference field's upserted ID against its registered
  * `LookupAdapter`. RPC procedures call this between

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -547,4 +547,37 @@ describe("entry.update", () => {
     });
     expect(updated.content).toEqual(v2Content);
   });
+
+  test("rejects writing a capability-gated meta field with FORBIDDEN", async () => {
+    const plugins = createPluginRegistry();
+    plugins.entryMetaBoxes.set("test-gated", {
+      id: "test-gated",
+      label: "Gated",
+      entryTypes: ["post"],
+      fields: [
+        {
+          key: "private_note",
+          label: "Private note",
+          type: "string",
+          inputType: "text",
+          capability: "view_private_notes",
+        },
+      ],
+      registeredBy: "test",
+    });
+    const h = await createRpcHarness({ authAs: "author", plugins });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "gated-field",
+    });
+    await expect(
+      h.client.entry.update({
+        id: own.id,
+        meta: { private_note: "leaked" },
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "view_private_notes" },
+    });
+  });
 });

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -22,6 +22,7 @@ import {
   wouldCreateParentCycle,
 } from "./lifecycle.js";
 import {
+  assertEntryMetaCapabilities,
   decodeMetaBag,
   loadEntryMeta,
   sanitizeMetaForRpc,
@@ -216,6 +217,13 @@ export const update = base
       errors,
     );
     if (metaPatch) {
+      assertEntryMetaCapabilities(
+        context.plugins,
+        existing.type,
+        metaPatch,
+        context.auth,
+        errors,
+      );
       await validateEntryMetaReferences(
         context,
         existing.type,

--- a/packages/core/src/rpc/procedures/term/create.ts
+++ b/packages/core/src/rpc/procedures/term/create.ts
@@ -4,6 +4,7 @@ import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { taxonomyCapability } from "./helpers.js";
 import {
+  assertTermMetaCapabilities,
   decodeMetaBag,
   loadTermMeta,
   sanitizeMetaForRpc,
@@ -53,6 +54,13 @@ export const create = base
       errors,
     );
     if (metaPatch) {
+      assertTermMetaCapabilities(
+        context.plugins,
+        filtered.taxonomy,
+        metaPatch,
+        context.auth,
+        errors,
+      );
       await validateTermMetaReferences(
         context,
         filtered.taxonomy,

--- a/packages/core/src/rpc/procedures/term/meta.ts
+++ b/packages/core/src/rpc/procedures/term/meta.ts
@@ -12,6 +12,7 @@ import {
   sanitizeMetaForRpc as sanitizeMetaForRpcCore,
   validateMetaReferencesForRpc,
 } from "../../meta/core.js";
+import { assertMetaCapabilities } from "../entry/meta.js";
 
 export type { MetaChanges as TermMetaChanges } from "../../meta/core.js";
 
@@ -39,6 +40,24 @@ export async function validateTermMetaReferences(
     ctx,
     (key) => findTermMetaField(ctx.plugins, taxonomy, key),
     patch,
+    errors,
+  );
+}
+
+/** Mirror of `assertEntryMetaCapabilities` for the term meta surface. */
+export function assertTermMetaCapabilities(
+  registry: PluginRegistry,
+  taxonomy: string,
+  patch: MetaPatch,
+  auth: { can(capability: string): boolean },
+  errors: {
+    FORBIDDEN: (args: { data: { capability: string } }) => Error;
+  },
+): void {
+  assertMetaCapabilities(
+    patch,
+    (key) => findTermMetaField(registry, taxonomy, key),
+    auth,
     errors,
   );
 }

--- a/packages/core/src/rpc/procedures/term/update.ts
+++ b/packages/core/src/rpc/procedures/term/update.ts
@@ -7,6 +7,7 @@ import { isEmptyMetaPatch } from "../../meta/core.js";
 import { stripUndefined } from "../entry/helpers.js";
 import { parentWouldCreateCycle, taxonomyCapability } from "./helpers.js";
 import {
+  assertTermMetaCapabilities,
   decodeMetaBag,
   loadTermMeta,
   sanitizeMetaForRpc,
@@ -68,6 +69,13 @@ export const update = base
       errors,
     );
     if (metaPatch) {
+      assertTermMetaCapabilities(
+        context.plugins,
+        existing.taxonomy,
+        metaPatch,
+        context.auth,
+        errors,
+      );
       await validateTermMetaReferences(
         context,
         existing.taxonomy,

--- a/packages/core/src/rpc/procedures/user/meta.ts
+++ b/packages/core/src/rpc/procedures/user/meta.ts
@@ -3,6 +3,7 @@ import type { PluginRegistry } from "../../../plugin/manifest.js";
 import type { MetaPatch } from "../../meta/core.js";
 import { users } from "../../../db/schema/users.js";
 import { findUserMetaField } from "../../../plugin/manifest.js";
+import { assertMetaCapabilities } from "../entry/meta.js";
 import {
   applyMetaPatch,
   decodeMetaBag as decodeMetaBagCore,
@@ -38,6 +39,23 @@ export async function validateUserMetaReferences(
     ctx,
     (key) => findUserMetaField(ctx.plugins, key),
     patch,
+    errors,
+  );
+}
+
+/** Mirror of `assertEntryMetaCapabilities` for the user meta surface. */
+export function assertUserMetaCapabilities(
+  registry: PluginRegistry,
+  patch: MetaPatch,
+  auth: { can(capability: string): boolean },
+  errors: {
+    FORBIDDEN: (args: { data: { capability: string } }) => Error;
+  },
+): void {
+  assertMetaCapabilities(
+    patch,
+    (key) => findUserMetaField(registry, key),
+    auth,
     errors,
   );
 }

--- a/packages/core/src/rpc/procedures/user/update.ts
+++ b/packages/core/src/rpc/procedures/user/update.ts
@@ -9,6 +9,7 @@ import { isEmptyMetaPatch } from "../../meta/core.js";
 import { stripUndefined } from "../entry/helpers.js";
 import { otherActiveAdminExists } from "./helpers.js";
 import {
+  assertUserMetaCapabilities,
   decodeMetaBag,
   loadUserMeta,
   sanitizeMetaForRpc,
@@ -122,6 +123,12 @@ export const update = base
     const { id: _id, meta: metaInput, ...changes } = filtered;
     const metaPatch = sanitizeMetaForRpc(context.plugins, metaInput, errors);
     if (metaPatch) {
+      assertUserMetaCapabilities(
+        context.plugins,
+        metaPatch,
+        context.auth,
+        errors,
+      );
       await validateUserMetaReferences(context, metaPatch, errors);
     }
     const patch: Partial<NewUser> = stripUndefined(changes);


### PR DESCRIPTION
Honour block, metabox, and field capability declarations on every editor surface and every meta-touching write path. Low-cap viewers no longer see gated UI; gated writes are rejected on the server even if the client filter is bypassed.

**field-level gating is new**

Plugin authors can declare `capability?: string` on any meta-box field (text, number, repeater, the lot). The admin hides the field from viewers without the cap; the server rejects writes that include the field's key in either `upserts` or `deletes` — viewers can't blank a value they can't see. Gating applies at the top-level field only; capabilities on repeater subfields are intentionally ignored so a row's gate is single-source (parent repeater field).

**single chokepoint for both admin and server**

Admin: `filterMetaBoxes` projects each visible box with its fields pre-filtered by `field.capability`. The editor sidebar (via `useEntryFormScope`), plain-form route, term-edit, and user-edit all route through this one function, so metabox-level and field-level gates always agree across surfaces.

Server: generic `assertMetaCapabilities(patch, findField, auth, errors)` is shared by entry, term, and user meta paths via thin wrappers (`assertEntryMetaCapabilities`, `assertTermMetaCapabilities`, `assertUserMetaCapabilities`) wired into `entry.create`, `entry.update`, `term.create`, `term.update`, and `user.update`.

**block-insertion gates use viewer's real capability set**

The v2 spike route now reads `user.capabilities` from the route context and passes them down to `PlumixEditorLayout`. The existing slash menu and Blocks tab capability filters previously fired against an `EMPTY_CAPS` placeholder; both surfaces now hide blocks declaring a `capability` from low-cap viewers.

Tests:
- Server: `entry.update` + `entry.create` reject gated-field writes with `FORBIDDEN` + `data.capability` matching the field's declaration.
- Admin: `manifest.test.ts` asserts `entryMetaBoxesForType` filters fields by capability across low-cap vs high-cap viewers.
- e2e: `capability-gating.spec.ts` covers the plain-form route end to end — low-cap viewer sees neither the gated metabox nor the gated field; high-cap viewer sees both.

Refs #396
Refs #379