### PR TITLE
feat(admin,core): wire publishing, autosave, and revisions into v2 editor + plain-form route

### DIFF
--- a/packages/admin/src/components/editor/plain-form-layout.test.tsx
+++ b/packages/admin/src/components/editor/plain-form-layout.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createQueryClient } from "@/providers/query-client.js";
+
+import type { PostEditorValues } from "./entry-editor-form.js";
+
+import { PlainFormLayout } from "./plain-form-layout.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const initialValues: PostEditorValues = {
+  title: "Hello",
+  slug: "hello",
+  content: null,
+  excerpt: "",
+  status: "draft",
+  meta: {},
+  terms: {},
+  parentId: null,
+};
+
+function wrap(children: React.ReactNode) {
+  return (
+    <QueryClientProvider client={createQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+
+describe("PlainFormLayout", () => {
+  test("renders revisionsTrigger in the header when provided", () => {
+    render(
+      wrap(
+        <PlainFormLayout
+          initialValues={initialValues}
+          metaBoxes={[]}
+          headline="Edit author"
+          isSubmitting={false}
+          serverError={null}
+          onSubmit={() => undefined}
+          revisionsTrigger={
+            <button type="button" data-testid="custom-revisions-trigger">
+              Revisions
+            </button>
+          }
+        />,
+      ),
+    );
+    expect(
+      screen.getByTestId("custom-revisions-trigger"),
+    ).toBeInTheDocument();
+  });
+
+  test("autosave debounces field edits and fires onSubmit", async () => {
+    const onSubmit = vi.fn();
+    render(
+      wrap(
+        <PlainFormLayout
+          initialValues={initialValues}
+          metaBoxes={[]}
+          headline="Edit author"
+          isSubmitting={false}
+          serverError={null}
+          onSubmit={onSubmit}
+          autosaveMs={20}
+        />,
+      ),
+    );
+    const input = screen.getByTestId("plain-form-title-input");
+    fireEvent.change(input, { target: { value: "Hello world" } });
+    await waitFor(
+      () => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 1000 },
+    );
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      title: "Hello world",
+    });
+  });
+});

--- a/packages/admin/src/components/editor/plain-form-layout.tsx
+++ b/packages/admin/src/components/editor/plain-form-layout.tsx
@@ -1,5 +1,6 @@
 import type { EntryMetaBoxManifestEntry } from "@plumix/core/manifest";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
+import { useEffect, useRef } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { valibotResolver } from "@hookform/resolvers/valibot";
 
@@ -26,6 +27,15 @@ interface PlainFormLayoutProps {
   readonly isSubmitting: boolean;
   readonly serverError: string | null;
   readonly onSubmit: (values: PostEditorValues) => void;
+  // Optional Revisions trigger slot — route layer wires the
+  // `<RevisionsSheet />` with RPC fetchers + onRestore and passes it
+  // here when the entry type declares `supports: ['revisions']`.
+  readonly revisionsTrigger?: ReactNode;
+  // Debounce window for autosave. When > 0, value edits trigger
+  // `onSubmit` after the window elapses with no new edits. 0 (default)
+  // disables autosave entirely so the layout keeps its explicit-save
+  // behaviour for callers that don't want it.
+  readonly autosaveMs?: number;
 }
 
 const LABEL: Readonly<Record<SaveStatus, string>> = {
@@ -50,6 +60,8 @@ export function PlainFormLayout({
   isSubmitting,
   serverError,
   onSubmit,
+  revisionsTrigger,
+  autosaveMs = 0,
 }: PlainFormLayoutProps): ReactElement {
   const form = useForm({
     resolver: valibotResolver(postEditorSchema),
@@ -59,6 +71,24 @@ export function PlainFormLayout({
   // whole tree (every Card + MetaBoxField) to re-render on every keystroke.
   const status = useWatch({ control: form.control, name: "status" });
   const saveStatus = resolveStatus(isSubmitting, serverError);
+  const watched = useWatch({ control: form.control });
+  const isDirty = form.formState.isDirty;
+  const onSubmitRef = useRef(onSubmit);
+  useEffect(() => {
+    onSubmitRef.current = onSubmit;
+  });
+  useEffect(() => {
+    if (autosaveMs <= 0) return;
+    if (!isDirty) return;
+    // Skip while a save is already in flight — the timer's keystroke
+    // dep makes it re-arm as soon as `isSubmitting` flips back to
+    // false, so a single coalesced save runs per quiet window.
+    if (isSubmitting) return;
+    const timer = setTimeout(() => {
+      void form.handleSubmit((values) => onSubmitRef.current(values))();
+    }, autosaveMs);
+    return () => clearTimeout(timer);
+  }, [watched, autosaveMs, isDirty, isSubmitting, form]);
   return (
     <Form {...form}>
       <form
@@ -97,6 +127,7 @@ export function PlainFormLayout({
           >
             {LABEL[saveStatus]}
           </span>
+          {revisionsTrigger}
           <Button
             type="submit"
             variant="outline"

--- a/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
@@ -155,6 +155,64 @@ describe("RevisionsSheet", () => {
     ).not.toBeInTheDocument();
   });
 
+  test("restore button calls onRestore and closes the sheet", async () => {
+    const fetchPage = vi.fn(() =>
+      Promise.resolve({
+        revisions: [
+          {
+            id: 8,
+            title: "Snapshot",
+            updatedAt: new Date("2026-05-17T12:00:00Z"),
+            authorId: 1,
+            authorName: "Ada",
+            authorEmail: "ada@x",
+          },
+        ] satisfies RevisionFixture[],
+        nextCursor: null,
+      }),
+    );
+    const onRestore = vi.fn(() => Promise.resolve());
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={42}
+          fetchPage={fetchPage}
+          relativeTime={() => "now"}
+          fetchRevision={() =>
+            Promise.resolve({
+              title: "S",
+              slug: "s",
+              excerpt: null,
+              content: { type: "doc", content: [] },
+              meta: {},
+            })
+          }
+          fetchCurrent={() =>
+            Promise.resolve({
+              title: "S v2",
+              slug: "s",
+              excerpt: null,
+              content: { type: "doc", content: [] },
+              meta: {},
+            })
+          }
+          onRestore={onRestore}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-8-select"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-8-select"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-diff"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-restore"));
+    await waitFor(() => {
+      expect(onRestore).toHaveBeenCalledWith(8);
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("revisions-sheet-diff")).not.toBeInTheDocument();
+    });
+  });
+
   test("selecting a revision opens the diff panel and fetches both snapshots", async () => {
     const fetchPage = vi.fn(() =>
       Promise.resolve({

--- a/packages/admin/src/editor/revisions/RevisionsSheet.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.tsx
@@ -48,6 +48,9 @@ interface RevisionsSheetProps {
   // route layer owns RPC wiring and tests can stub deterministically.
   readonly fetchRevision: (revisionId: number) => Promise<DiffSnapshot>;
   readonly fetchCurrent: (entryId: number) => Promise<DiffSnapshot>;
+  // When omitted the restore action is hidden — keeps the sheet usable
+  // as a read-only diff viewer for roles without `edit_*` capabilities.
+  readonly onRestore?: (revisionId: number) => Promise<void>;
 }
 
 export function RevisionsSheet({
@@ -56,6 +59,7 @@ export function RevisionsSheet({
   relativeTime,
   fetchRevision,
   fetchCurrent,
+  onRestore,
 }: RevisionsSheetProps): ReactElement {
   const [open, setOpen] = useState(false);
   const [selectedRevisionId, setSelectedRevisionId] = useState<number | null>(
@@ -82,9 +86,23 @@ export function RevisionsSheet({
     queryFn: () => fetchCurrent(entryId),
   });
 
+  const [restorePending, setRestorePending] = useState(false);
   const allRevisions = query.data?.pages.flatMap((p) => p.revisions) ?? [];
   const hasMore = Boolean(query.data?.pages.at(-1)?.nextCursor);
   const showDiff = selectedRevisionId !== null;
+  const canRestore = onRestore !== undefined && selectedRevisionId !== null;
+
+  async function handleRestore(): Promise<void> {
+    if (!onRestore || selectedRevisionId === null) return;
+    setRestorePending(true);
+    try {
+      await onRestore(selectedRevisionId);
+      setSelectedRevisionId(null);
+      setOpen(false);
+    } finally {
+      setRestorePending(false);
+    }
+  }
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -110,15 +128,27 @@ export function RevisionsSheet({
               : "Every save creates a new revision. Newest first."}
           </SheetDescription>
           {showDiff ? (
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="revisions-sheet-back"
-              onClick={() => setSelectedRevisionId(null)}
-              className="mt-2 w-fit"
-            >
-              ← Back to list
-            </Button>
+            <div className="mt-2 flex w-fit gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="revisions-sheet-back"
+                onClick={() => setSelectedRevisionId(null)}
+              >
+                ← Back to list
+              </Button>
+              {canRestore ? (
+                <Button
+                  variant="default"
+                  size="sm"
+                  data-testid="revisions-sheet-restore"
+                  disabled={restorePending}
+                  onClick={() => void handleRestore()}
+                >
+                  {restorePending ? "Restoring…" : "Restore this revision"}
+                </Button>
+              ) : null}
+            </div>
           ) : null}
         </SheetHeader>
         {showDiff ? (

--- a/packages/admin/src/editor/revisions/use-revisions-trigger.tsx
+++ b/packages/admin/src/editor/revisions/use-revisions-trigger.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode, RefObject } from "react";
+import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { RevisionsSheet } from "@/editor/revisions/RevisionsSheet.js";
+import { orpc } from "@/lib/orpc.js";
+import { formatRelativeTime } from "@/lib/relative-time.js";
+
+interface UseRevisionsTriggerInput {
+  readonly entryId: number;
+  readonly enabled: boolean;
+  // Optimistic-concurrency token source. Both routes mutate the same
+  // server-confirmed `updatedAt` they pass through `entry.update`, so
+  // the trigger reads from the same ref to send a fresh token on
+  // restore.
+  readonly liveUpdatedAtRef: RefObject<Date>;
+}
+
+// Single chokepoint for the `<RevisionsSheet />` adapter both v1 and
+// v2 edit routes mount. Returns null when `enabled` is false so
+// callers can drop the trigger straight into the layout's slot.
+export function useRevisionsTrigger({
+  entryId,
+  enabled,
+  liveUpdatedAtRef,
+}: UseRevisionsTriggerInput): ReactNode {
+  const queryClient = useQueryClient();
+  return useMemo<ReactNode>(() => {
+    if (!enabled) return null;
+    return (
+      <RevisionsSheet
+        entryId={entryId}
+        relativeTime={formatRelativeTime}
+        fetchPage={({ entryId, cursor }) =>
+          orpc.entry.revisions.list.call({ entryId, cursor })
+        }
+        fetchRevision={async (revisionId) => {
+          const rev = await orpc.entry.revisions.get.call({ revisionId });
+          return {
+            title: rev.title,
+            slug: rev.slug,
+            excerpt: rev.excerpt,
+            content: rev.content,
+            meta: rev.meta,
+          };
+        }}
+        fetchCurrent={async (entryId) => {
+          const current = await orpc.entry.get.call({ id: entryId });
+          return {
+            title: current.title,
+            slug: current.slug,
+            excerpt: current.excerpt,
+            content: current.content,
+            meta: current.meta,
+          };
+        }}
+        onRestore={async (revisionId) => {
+          const restored = await orpc.entry.revisions.restore.call({
+            revisionId,
+            expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+          });
+          liveUpdatedAtRef.current = restored.updatedAt;
+          await queryClient.invalidateQueries({
+            queryKey: orpc.entry.get.queryOptions({ input: { id: entryId } })
+              .queryKey,
+          });
+        }}
+      />
+    );
+  }, [entryId, enabled, liveUpdatedAtRef, queryClient]);
+}

--- a/packages/admin/src/editor/v2/EditorLayout.tsx
+++ b/packages/admin/src/editor/v2/EditorLayout.tsx
@@ -45,6 +45,10 @@ interface PlumixEditorLayoutProps {
   readonly onPublish: () => void;
   readonly isPublishing?: boolean;
   readonly isPublished?: boolean;
+  // Optional Revisions trigger rendered in the top-right header slot.
+  // Route layer owns RPC wiring and feeds a fully-wired <RevisionsSheet />
+  // here; the layout only allocates space and doesn't know the contract.
+  readonly revisionsTrigger?: ReactNode;
 }
 
 const EMPTY_REGISTRY: BlockRegistryV2 = createBlockRegistry([]);
@@ -72,6 +76,7 @@ export function PlumixEditorLayout({
   onPublish,
   isPublishing = false,
   isPublished = false,
+  revisionsTrigger,
 }: PlumixEditorLayoutProps): ReactElement {
   return (
     <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
@@ -87,6 +92,7 @@ export function PlumixEditorLayout({
           data-testid="plumix-editor-title-input"
         />
         <AutosaveStatusPill />
+        {revisionsTrigger}
         <button
           type="button"
           className="rounded border px-3 py-1 text-sm disabled:opacity-50"

--- a/packages/admin/src/lib/relative-time.test.ts
+++ b/packages/admin/src/lib/relative-time.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+
+import { formatRelativeTime } from "./relative-time.js";
+
+const NOW = new Date("2026-05-20T12:00:00Z");
+
+describe("formatRelativeTime", () => {
+  test("returns 'now' for the present moment", () => {
+    expect(formatRelativeTime(NOW, NOW)).toContain("now");
+  });
+
+  test("renders minutes-ago", () => {
+    const earlier = new Date(NOW.getTime() - 5 * 60_000);
+    expect(formatRelativeTime(earlier, NOW)).toMatch(/5.*minute/);
+  });
+
+  test("renders hours-ago", () => {
+    const earlier = new Date(NOW.getTime() - 3 * 3_600_000);
+    expect(formatRelativeTime(earlier, NOW)).toMatch(/3.*hour/);
+  });
+});

--- a/packages/admin/src/lib/relative-time.ts
+++ b/packages/admin/src/lib/relative-time.ts
@@ -1,0 +1,20 @@
+const MINUTE = 60;
+const HOUR = MINUTE * 60;
+const DAY = HOUR * 24;
+const WEEK = DAY * 7;
+const MONTH = DAY * 30;
+const YEAR = DAY * 365;
+
+const RTF = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+export function formatRelativeTime(date: Date, now: Date = new Date()): string {
+  const seconds = Math.round((date.getTime() - now.getTime()) / 1000);
+  const abs = Math.abs(seconds);
+  if (abs < MINUTE) return RTF.format(seconds, "second");
+  if (abs < HOUR) return RTF.format(Math.round(seconds / MINUTE), "minute");
+  if (abs < DAY) return RTF.format(Math.round(seconds / HOUR), "hour");
+  if (abs < WEEK) return RTF.format(Math.round(seconds / DAY), "day");
+  if (abs < MONTH) return RTF.format(Math.round(seconds / WEEK), "week");
+  if (abs < YEAR) return RTF.format(Math.round(seconds / MONTH), "month");
+  return RTF.format(Math.round(seconds / YEAR), "year");
+}

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -1,6 +1,6 @@
 import type { PostEditorValues } from "@/components/editor/entry-editor-form.js";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { EntryConflictDialog } from "@/components/editor/entry-conflict-dialog.js";
 import {
   POST_EDITOR_STATUSES,
@@ -9,6 +9,7 @@ import {
 import { PlainFormLayout } from "@/components/editor/plain-form-layout.js";
 import { useEntryFormScope } from "@/components/editor/use-entry-form-scope.js";
 import { useParentOptions } from "@/components/editor/use-parent-options.js";
+import { useRevisionsTrigger } from "@/editor/revisions/use-revisions-trigger.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import { hasCap } from "@/lib/caps.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
@@ -110,6 +111,11 @@ function EditPostRoute(): ReactNode {
   );
 
   const isHierarchical = entryType.isHierarchical === true;
+  // Optimistic-concurrency token — server-confirmed `updatedAt` after
+  // each successful write. Keeping it in a ref lets the autosave path
+  // through `PlainFormLayout` send the up-to-date value without
+  // remounting the form mid-typing.
+  const liveUpdatedAtRef = useRef<Date>(post.updatedAt);
 
   const updatePost = useMutation({
     mutationFn: ({
@@ -134,8 +140,9 @@ function EditPostRoute(): ReactNode {
     onMutate: () => {
       setServerError(null);
     },
-    onSuccess: async () => {
+    onSuccess: async (updated) => {
       setConflict(null);
+      liveUpdatedAtRef.current = updated.updatedAt;
       // List variants are scoped by `type` so sibling post types
       // don't needlessly refetch.
       await Promise.all([
@@ -203,6 +210,13 @@ function EditPostRoute(): ReactNode {
     excludeSelfId: entryId,
   });
 
+  const supportsRevisions = Boolean(entryType.supports?.includes("revisions"));
+  const plainFormRevisionsTrigger = useRevisionsTrigger({
+    entryId,
+    enabled: supportsRevisions,
+    liveUpdatedAtRef,
+  });
+
   const capNamespace = `entry:${entryType.capabilityType ?? entryType.name}`;
   const canEditAny = hasCap(user.capabilities, `${capNamespace}:edit_any`);
   const canEditOwn =
@@ -225,23 +239,21 @@ function EditPostRoute(): ReactNode {
     return (
       <>
         <PlainFormLayout
-          // Remount on a successful update so the form's defaultValues
-          // resync to the refetched entry (parallels the editor route's
-          // same trick at the PostEditorForm call site).
-          key={
-            post.updatedAt instanceof Date
-              ? post.updatedAt.toISOString()
-              : String(post.updatedAt)
-          }
+          // Key on the entry id only: each id is its own form instance,
+          // but successful autosaves no longer remount the form (which
+          // would steal focus + drop in-flight keystrokes).
+          key={entryId}
           initialValues={initialValues}
           metaBoxes={metaBoxes}
           headline={`Edit ${singularLower}`}
           isSubmitting={updatePost.isPending}
           serverError={updatePost.isPending ? null : serverError}
+          autosaveMs={500}
+          revisionsTrigger={plainFormRevisionsTrigger}
           onSubmit={(values) => {
             updatePost.mutate({
               values,
-              expectedLiveUpdatedAt: post.updatedAt,
+              expectedLiveUpdatedAt: liveUpdatedAtRef.current,
             });
           }}
         />

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -18,6 +18,7 @@ import { PlumixEditorLayout } from "@/editor/v2/EditorLayout.js";
 import { readDraft, writeDraft } from "@/editor/v2/local-draft.js";
 import { puckDataToBlockTree } from "@/editor/v2/puck-to-block-tree.js";
 import { seedPuckData } from "@/editor/v2/v2-entry-content.js";
+import { useRevisionsTrigger } from "@/editor/revisions/use-revisions-trigger.js";
 import { findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { idPathParam } from "@plumix/core/validation";
@@ -106,13 +107,15 @@ function PuckSpikeRoute(): ReactNode {
   const { slug, id } = Route.useParams();
   const { user } = Route.useRouteContext();
   const draftKey = `plumix.v2.draft.${slug}.${id}`;
-  const entryTypeName = findEntryTypeBySlug(slug)?.name;
+  const entryType = findEntryTypeBySlug(slug);
+  const supportsRevisions = entryType?.supports?.includes("revisions") ?? false;
   return (
     <PuckSpikeRouteInner
       key={draftKey}
       draftKey={draftKey}
       id={id}
-      entryTypeName={entryTypeName}
+      entryTypeName={entryType?.name}
+      supportsRevisions={supportsRevisions}
       capabilities={user.capabilities}
     />
   );
@@ -122,6 +125,7 @@ interface PuckSpikeRouteInnerProps {
   readonly draftKey: string;
   readonly id: number;
   readonly entryTypeName: string | undefined;
+  readonly supportsRevisions: boolean;
   readonly capabilities: readonly string[];
 }
 
@@ -129,6 +133,7 @@ function PuckSpikeRouteInner({
   draftKey,
   id,
   entryTypeName,
+  supportsRevisions,
   capabilities,
 }: PuckSpikeRouteInnerProps): ReactNode {
   const { data: entry } = useSuspenseQuery(
@@ -220,6 +225,11 @@ function PuckSpikeRouteInner({
     () => new Set(capabilities),
     [capabilities],
   );
+  const revisionsTrigger = useRevisionsTrigger({
+    entryId: id,
+    enabled: supportsRevisions,
+    liveUpdatedAtRef,
+  });
   const Layout = useCallback(
     (): ReactElement => (
       <PlumixEditorLayout
@@ -229,9 +239,16 @@ function PuckSpikeRouteInner({
         onPublish={handlePublish}
         isPublishing={publish.isPending}
         isPublished={isPublished}
+        revisionsTrigger={revisionsTrigger}
       />
     ),
-    [handlePublish, publish.isPending, isPublished, capabilitySet],
+    [
+      handlePublish,
+      publish.isPending,
+      isPublished,
+      capabilitySet,
+      revisionsTrigger,
+    ],
   );
 
   return (

--- a/packages/core/src/revisions/restore.test.ts
+++ b/packages/core/src/revisions/restore.test.ts
@@ -1,0 +1,145 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+import { entries } from "../db/schema/entries.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { createRpcHarness } from "../test/rpc.js";
+import { REVISION_TYPE } from "./slug-codec.js";
+
+function registryWithRevisions() {
+  const plugins = createPluginRegistry();
+  plugins.entryTypes.set("post", {
+    name: "post",
+    label: "Posts",
+    supports: ["revisions"],
+    versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
+    registeredBy: "test",
+  });
+  return plugins;
+}
+
+async function seedEntryWithRevision(): Promise<{
+  readonly h: Awaited<ReturnType<typeof createRpcHarness>>;
+  readonly entryId: number;
+  readonly revisionId: number;
+}> {
+  const h = await createRpcHarness({
+    authAs: "editor",
+    plugins: registryWithRevisions(),
+  });
+  const created = await h.client.entry.create({
+    title: "First",
+    slug: "first",
+  });
+  await h.client.entry.update({ id: created.id, title: "Second" });
+  const [revision] = await h.db.query.entries.findMany({
+    where: eq(entries.type, REVISION_TYPE),
+  });
+  if (!revision) throw new Error("expected one captured revision");
+  return { h, entryId: created.id, revisionId: revision.id };
+}
+
+describe("entry.revisions.restore", () => {
+  test("writes the revision's content/title into the live entry", async () => {
+    const { h, entryId, revisionId } = await seedEntryWithRevision();
+    await h.client.entry.update({ id: entryId, title: "Third" });
+
+    const restored = await h.client.entry.revisions.restore({ revisionId });
+
+    expect(restored.id).toBe(entryId);
+    expect(restored.title).toBe("Second");
+    const live = await h.db.query.entries.findFirst({
+      where: eq(entries.id, entryId),
+    });
+    expect(live?.title).toBe("Second");
+  });
+
+  test("does NOT snapshot the post-restore state — restore is invisible to history", async () => {
+    const { h, entryId, revisionId } = await seedEntryWithRevision();
+    await h.client.entry.update({ id: entryId, title: "Third" });
+
+    const before = await h.db.query.entries.findMany({
+      where: eq(entries.type, REVISION_TYPE),
+    });
+    await h.client.entry.revisions.restore({ revisionId });
+    const after = await h.db.query.entries.findMany({
+      where: eq(entries.type, REVISION_TYPE),
+    });
+    expect(after.length).toBe(before.length);
+  });
+
+  test("stale expectedLiveUpdatedAt rejects with CONFLICT", async () => {
+    const { h, entryId, revisionId } = await seedEntryWithRevision();
+    const stale = new Date(Date.now() - 60_000);
+    await h.client.entry.update({ id: entryId, title: "Third" });
+    await expect(
+      h.client.entry.revisions.restore({
+        revisionId,
+        expectedLiveUpdatedAt: stale,
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "stale_expected_updated_at" },
+    });
+  });
+
+  test("restores the snapshotted slug from the envelope", async () => {
+    const { h, entryId, revisionId } = await seedEntryWithRevision();
+    await h.client.entry.update({ id: entryId, slug: "third-slug" });
+
+    const restored = await h.client.entry.revisions.restore({ revisionId });
+
+    expect(restored.slug).toBe("first");
+  });
+
+  test("fires entry:published when the revision restores a draft to published", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithRevisions(),
+    });
+    const created = await h.client.entry.create({
+      title: "P",
+      slug: "p",
+      status: "draft",
+    });
+    await h.client.entry.update({
+      id: created.id,
+      status: "published",
+    });
+    await h.client.entry.update({ id: created.id, status: "draft" });
+    const allRevisions = await h.db.query.entries.findMany({
+      where: eq(entries.type, REVISION_TYPE),
+    });
+    const publishedRevision = allRevisions.find((r) => r.status === "published");
+    if (!publishedRevision) throw new Error("expected a published revision");
+    const onPublished = h.spyAction("entry:published");
+    await h.client.entry.revisions.restore({
+      revisionId: publishedRevision.id,
+    });
+    onPublished.assertCalledOnce();
+  });
+
+  test("rejects with FORBIDDEN when the viewer lacks read_revisions", async () => {
+    const { h, revisionId } = await seedEntryWithRevision();
+    const subscriber = await h.actingAs("subscriber");
+    await expect(
+      subscriber.client.entry.revisions.restore({ revisionId }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "entry:post:read_revisions" },
+    });
+  });
+
+  test("rejects with NOT_FOUND for an unknown revisionId", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithRevisions(),
+    });
+    await expect(
+      h.client.entry.revisions.restore({ revisionId: 999_999 }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      data: { kind: "revision" },
+    });
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/revisions.ts
+++ b/packages/core/src/rpc/procedures/entry/revisions.ts
@@ -1,6 +1,7 @@
 import { inArray } from "drizzle-orm";
 import * as v from "valibot";
 
+import type { Entry, NewEntry } from "../../../db/schema/entries.js";
 import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
 import { users } from "../../../db/schema/users.js";
@@ -12,10 +13,25 @@ import {
   decodeRevisionSlug,
   isRevisionType,
 } from "../../../revisions/slug-codec.js";
+import {
+  decodeSnapshotEnvelope,
+  SNAPSHOT_META_KEY,
+} from "../../../revisions/snapshot-envelope.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { idParam } from "../../validation.js";
-import { entryCapability } from "./lifecycle.js";
+import { assertExpectedLiveUpdatedAt } from "./concurrency.js";
+import {
+  assertContentValidAgainstRegistries,
+  assertContentWithinByteCap,
+} from "./content.js";
+import {
+  applyEntryBeforeSave,
+  entryCapability,
+  fireEntryPublished,
+  fireEntryTransition,
+  fireEntryUpdated,
+} from "./lifecycle.js";
 
 const listInput = v.object({
   entryId: idParam,
@@ -28,6 +44,11 @@ const listInput = v.object({
 });
 
 const getInput = v.object({ revisionId: idParam });
+
+const restoreInput = v.object({
+  revisionId: idParam,
+  expectedLiveUpdatedAt: v.optional(v.date()),
+});
 
 export const list = base
   .use(authenticated)
@@ -107,4 +128,118 @@ export const get = base
     return revision;
   });
 
-export const revisionsRouter = { list, get } as const;
+export const restore = base
+  .use(authenticated)
+  .input(restoreInput)
+  .handler(async ({ input, context, errors }) => {
+    const notFound = () =>
+      errors.NOT_FOUND({ data: { kind: "revision", id: input.revisionId } });
+
+    const revision = await repoGetRevision(context.db, {
+      revisionId: input.revisionId,
+    });
+    if (!revision) throw notFound();
+
+    const decoded = decodeRevisionSlug(revision.slug);
+    if (!decoded) throw notFound();
+    const live = await context.db.query.entries.findFirst({
+      where: eq(entries.id, decoded.entryId),
+    });
+    if (!live || isRevisionType(live.type)) throw notFound();
+
+    const readCapability = entryCapability(live.type, "read_revisions");
+    if (!context.auth.can(readCapability)) {
+      throw errors.FORBIDDEN({ data: { capability: readCapability } });
+    }
+    const isAuthor = live.authorId === context.user.id;
+    const editOwnCapability = entryCapability(live.type, "edit_own");
+    const editAnyCapability = entryCapability(live.type, "edit_any");
+    const canEdit =
+      (isAuthor && context.auth.can(editOwnCapability)) ||
+      context.auth.can(editAnyCapability);
+    if (!canEdit) {
+      throw errors.FORBIDDEN({ data: { capability: editAnyCapability } });
+    }
+
+    assertExpectedLiveUpdatedAt(input.expectedLiveUpdatedAt, live.updatedAt, {
+      stale: () => {
+        throw errors.CONFLICT({
+          data: { reason: "stale_expected_updated_at" },
+        });
+      },
+    });
+
+    // Snapshot's `meta` carries the framework `__plumix_snapshot`
+    // envelope plus whatever the live entry's meta bag held at capture
+    // time. The envelope is internal — strip before writing back.
+    const snapshotMeta: Record<string, unknown> = { ...revision.meta };
+    const decodedEnvelope = decodeSnapshotEnvelope(snapshotMeta);
+    delete snapshotMeta[SNAPSHOT_META_KEY];
+
+    // Snapshots survive block deregistration — a block removed since
+    // capture would render but never validate via `entry.update`. Run
+    // the same gate so a stale revision can't land invalid content on
+    // the live row.
+    assertContentWithinByteCap(revision.content, errors);
+    assertContentValidAgainstRegistries(
+      revision.content,
+      { blocks: context.blocks, marks: context.marks },
+      errors,
+    );
+
+    const isPublishTransition =
+      revision.status === "published" && live.status !== "published";
+    if (isPublishTransition) {
+      const publishCapability = entryCapability(live.type, "publish");
+      if (!context.auth.can(publishCapability)) {
+        throw errors.FORBIDDEN({ data: { capability: publishCapability } });
+      }
+    }
+
+    const patch: Partial<NewEntry> = {
+      title: revision.title,
+      slug: decodedEnvelope?.slug ?? live.slug,
+      content: revision.content,
+      excerpt: revision.excerpt,
+      status: revision.status,
+      parentId: decodedEnvelope?.parentId ?? live.parentId,
+      meta: snapshotMeta,
+    };
+    if (isPublishTransition && !live.publishedAt) {
+      patch.publishedAt = new Date();
+    }
+
+    const prepared = await applyEntryBeforeSave(context, live.type, {
+      ...live,
+      ...patch,
+    });
+    const toWrite: Partial<NewEntry> = {};
+    for (const key of Object.keys(patch) as (keyof NewEntry)[]) {
+      (toWrite as Record<string, unknown>)[key] = prepared[key];
+    }
+
+    const [updatedRow] = await context.db
+      .update(entries)
+      .set(toWrite)
+      .where(eq(entries.id, live.id))
+      .returning();
+    if (!updatedRow) {
+      throw errors.CONFLICT({ data: { reason: "update_failed" } });
+    }
+    const updated: Entry = updatedRow;
+
+    await fireEntryUpdated(context, updated, live);
+    await fireEntryTransition(context, updated, live.status);
+    if (isPublishTransition) {
+      await fireEntryPublished(context, updated);
+    }
+    // WordPress's `wp_restore_post_revision` does not snapshot the
+    // post-restore state: the restored revision row already records
+    // the new live content, so writing another duplicate row would
+    // burn one slot of `versioning.maxRevisions` per restore for no
+    // history value. Audit attribution belongs in the audit-log
+    // plugin via a dedicated hook in a later slice.
+    return updated;
+  });
+
+export const revisionsRouter = { list, get, restore } as const;


### PR DESCRIPTION
Close out PRD #379's publishing + autosave + revisions integration end to end. Both editor surfaces (Puck v2 canvas and v1 plain-form route) now share the same data lifecycle against the entry RPC: initial load via `entry.get`, debounced autosave through `entry.update`, explicit `Publish`, and a per-entry revisions sheet with one-click restore for entry types declaring `supports: ['revisions']`.

**restore RPC re-runs block-content validation**

A revision captured before a block was deregistered cannot land malformed content on the live row — `entry.revisions.restore` runs `assertContentWithinByteCap` + `assertContentValidAgainstRegistries` against the merged block / mark registries before any write, matching the gate on `entry.update`. The `__plumix_snapshot` envelope is stripped from the restored meta bag and its captured slug + parentId are honoured. Capability gates are layered: `read_revisions`, then `edit_own` / `edit_any` against the live entry's type, plus `publish` when the snapshot drives a draft → published transition. Optional `expectedLiveUpdatedAt` rejects with `CONFLICT { reason: stale_expected_updated_at }` when a Restore races another edit.

**restore does not re-snapshot the post-restore state**

WordPress parity: `wp_restore_post_revision` writes the live row but does not create a new revision for the restore itself. The restored revision row is already the history record. Re-snapshotting would burn one slot of `versioning.maxRevisions` per restore on a duplicate. Audit attribution belongs in a dedicated `entry:revision_restored` hook in a follow-up slice.

**plain-form autosave keeps focus + coalesces concurrent saves**

The v1 plain-form route opts into `autosaveMs={500}`. Two correctness fixes wrap the new path:

```diff
-          key={post.updatedAt.toISOString()}
+          key={entryId}
```

The `updatedAt` key remount made sense in the explicit-Save world (clears `isDirty` on save). Once autosave fires mid-typing, that remount eats focus + later keystrokes. The plain-form branch now keys on `entryId` and tracks the server-confirmed timestamp through a `liveUpdatedAtRef`, mirroring the v2 editor.

The autosave effect also skips while a save is in flight (`isSubmitting`) so two debounced timers cannot both send the same stale concurrency token and produce a gratuitous CONFLICT.

Admin-side, both editor routes mount the revisions sheet through a new `useRevisionsTrigger` hook — the orpc fetchers + concurrency-token plumbing live in one place rather than being duplicated near-verbatim across v1 and v2.

Tests:
- core: 7 cases in `restore.test.ts` covering happy path, NOT_FOUND on unknown revisionId, FORBIDDEN for viewers lacking `read_revisions`, stale `expectedLiveUpdatedAt` → CONFLICT, snapshotted-slug round-trip, re-snapshot suppression, and `entry:published` firing on a draft-from-published-revision transition.
- admin: RevisionsSheet test covers the restore button calling `onRestore` and closing the sheet; PlainFormLayout tests cover the `revisionsTrigger` slot rendering and the debounced autosave path; new `formatRelativeTime` unit-tested for minute/hour boundaries.

Known gaps tracked for follow-ups (out of scope for this slice):
- `snapshotAsRevision` does not capture term assignments, so restoring an entry whose only meaningful change between revisions was a term reassignment is a silent no-op. Worth an explicit snapshot-envelope extension.
- The legacy `PostEditorForm` (v1 main editor) does not yet expose a `revisionsTrigger` slot. That editor is slated for deletion at cutover (#405); the v2 Puck editor + plain-form route both ship the trigger now, which is the only surface the rearchitecture commits to.

Refs #391
Refs #379