### PR TITLE
feat(admin,docs): pin v2 editor a11y contract and ship keyboard shortcut map

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,70 @@
+# Editor keyboard shortcuts
+
+This is the keyboard map for the v2 admin editor and its surrounding
+chrome. All shortcuts work in both the editor route (Puck canvas) and
+the plain-form route unless noted.
+
+## Canvas
+
+| Shortcut | Action |
+| --- | --- |
+| `/` | Open the slash menu at the cursor. |
+| `Esc` | Close the slash menu (no insertion). |
+| `Ctrl/Cmd + Z` | Undo the most recent edit. |
+| `Ctrl/Cmd + Shift + Z` | Redo. |
+
+## Slash menu
+
+The slash menu is a listbox; arrow keys move the focus ring, Enter
+inserts the focused item.
+
+| Shortcut | Action |
+| --- | --- |
+| `↑` / `↓` | Move focus between items. |
+| `Enter` | Insert the focused block. |
+| `Esc` | Dismiss the menu without inserting. |
+| Type any letters | Filter items by title or keyword. |
+
+## Sidebar tabs
+
+Both left (Blocks / Outline / Audit) and right (Block / Style) tab
+strips behave as a single tab group: Tab focus lands on the active
+tab, arrow keys cycle siblings.
+
+| Shortcut | Action |
+| --- | --- |
+| `Tab` | Move focus into the tab strip. |
+| `←` / `→` | Cycle between tabs in the strip. |
+| `Home` / `End` | Jump to the first / last tab. |
+| `Enter` / `Space` | Activate the focused tab. |
+
+## Action bar (Block actions)
+
+Visible in the right rail when a block is selected. All controls are
+real `<button>` elements; Tab cycles into them in document order.
+
+| Shortcut | Action |
+| --- | --- |
+| `Tab` | Move focus into the action bar. |
+| `Enter` / `Space` | Invoke the focused button (Transform / Duplicate / Delete / Copy JSON). |
+
+## Inline rich text (per-block `richtext` fields)
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl/Cmd + B` | Bold. |
+| `Ctrl/Cmd + I` | Italic. |
+| `Ctrl/Cmd + K` | Insert link. |
+| `Ctrl/Cmd + Shift + S` | Strike. |
+| `Ctrl/Cmd + .` | Subscript. |
+| `Ctrl/Cmd + ,` | Superscript. |
+| `Ctrl/Cmd + Shift + H` | Highlight. |
+
+## Mobile sidebar sheet
+
+The mobile bottom sheet is a focus-trapping dialog.
+
+| Shortcut | Action |
+| --- | --- |
+| `Esc` | Close the sheet (focus returns to the trigger button). |
+| `Tab` | Cycle focus within the open sheet (trapped). |

--- a/packages/admin/e2e/editor-aria.spec.ts
+++ b/packages/admin/e2e/editor-aria.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+const T0 = new Date("2026-05-20T00:00:00Z");
+
+function emptyEntry(id: number): Record<string, unknown> {
+  return {
+    id,
+    type: "post",
+    parentId: null,
+    title: "Untitled",
+    slug: `entry-${String(id)}`,
+    content: null,
+    excerpt: null,
+    status: "draft",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: null,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: {},
+  };
+}
+
+// Plumix-specific ARIA contract assertions. Role/parent-child checks are
+// covered by axe in v2-editor-render.spec.ts; this spec pins only the
+// attributes plumix itself sets (testid-anchored elements + their
+// aria-selected / aria-label values).
+test.describe("v2 editor ARIA semantics", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: emptyEntry(1), meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+  });
+
+  test("left sidebar tab triggers carry role=tab + aria-selected reflecting active tab", async ({
+    page,
+  }) => {
+    await page.goto("v2/entries/posts/1/edit");
+    const blocksTab = page.getByTestId("plumix-editor-tab-blocks");
+    const outlineTab = page.getByTestId("plumix-editor-tab-outline");
+    const auditTab = page.getByTestId("plumix-editor-tab-audit");
+    await expect(blocksTab).toHaveAttribute("role", "tab");
+    await expect(blocksTab).toHaveAttribute("aria-selected", "true");
+    await expect(outlineTab).toHaveAttribute("aria-selected", "false");
+    await expect(auditTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("slash menu input carries the aria-label that screen readers announce", async ({
+    page,
+  }) => {
+    await page.goto("v2/entries/posts/1/edit");
+    await page.getByTestId("plumix-editor-canvas").focus();
+    await page.keyboard.press("/");
+    await expect(page.getByTestId("slash-menu-input")).toHaveAttribute(
+      "aria-label",
+      "Search blocks",
+    );
+  });
+});

--- a/packages/admin/e2e/editor-v2-keyboard-walkthrough.spec.ts
+++ b/packages/admin/e2e/editor-v2-keyboard-walkthrough.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+const T0 = new Date("2026-05-20T00:00:00Z");
+
+function emptyEntry(id: number): Record<string, unknown> {
+  return {
+    id,
+    type: "post",
+    parentId: null,
+    title: "Untitled",
+    slug: `entry-${String(id)}`,
+    content: null,
+    excerpt: null,
+    status: "draft",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: null,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: {},
+  };
+}
+
+test.describe("v2 editor: keyboard-only walkthrough", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: emptyEntry(1), meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+  });
+
+  test("/, type, Enter inserts a block via keyboard alone", async ({
+    page,
+  }) => {
+    await page.goto("v2/entries/posts/1/edit");
+
+    const canvas = page.getByTestId("plumix-editor-canvas");
+    await canvas.focus();
+    await page.keyboard.press("/");
+    await page.keyboard.type("paragraph");
+    // Confirm the filter narrowed to the expected item before Enter —
+    // a future block adding "paragraph" to its keywords could otherwise
+    // silently change which spec gets inserted while this still passes.
+    await expect(
+      page.getByTestId("slash-menu-item-core/paragraph"),
+    ).toBeVisible();
+    await page.keyboard.press("Enter");
+
+    await expect(canvas.locator("p")).toHaveCount(1);
+  });
+
+  test("Escape closes the slash menu without inserting", async ({ page }) => {
+    await page.goto("v2/entries/posts/1/edit");
+
+    await page.getByTestId("plumix-editor-canvas").focus();
+    await page.keyboard.press("/");
+    await expect(page.getByTestId("slash-menu-dialog")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("slash-menu-dialog")).toBeHidden();
+  });
+});

--- a/packages/admin/e2e/plain-form-route.spec.ts
+++ b/packages/admin/e2e/plain-form-route.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { expectNoAxeViolations } from "./support/axe.js";
 import {
   AUTHED_ADMIN,
   MANIFEST_WITH_PLAIN_FORM_TYPE,
@@ -91,6 +92,8 @@ test.describe("plain-form route for non-editor entry types", () => {
     ).toHaveText("Biography");
     await expect(card.getByTestId("meta-box-field-headline-input")).toBeVisible();
     await expect(card.getByTestId("meta-box-field-twitter-input")).toBeVisible();
+
+    await expectNoAxeViolations(page);
   });
 
   test("Publish button submits an entry.update with status: published", async ({


### PR DESCRIPTION
Pin the ARIA contract + keyboard surface of the v2 admin editor and the plain-form
route, and ship a user-facing keyboard shortcut map. The pre-slice audit confirmed
shadcn + radix + cmdk primitives already provide the bulk of the contract; this PR
adds the verification harness that holds those guarantees + the keyboard docs that
were missing.

**Verification harness over an already-compliant baseline**

Tests pin only the plumix-specific attribute values — tab triggers carry `role=tab`
and the correct `aria-selected` for the active tab, the slash-menu input carries
`aria-label="Search blocks"` for screen readers. Role/parent-child checks
(role=tablist on the wrapper, role=listbox on cmdk, role=option per item) are
deliberately not re-asserted: `expectNoAxeViolations` in v2-editor-render.spec.ts
already catches missing roles or misnested children at the integration boundary,
and re-asserting framework semantics is the kind of test that fails on internal
library bumps without flagging any plumix regression.

**Slash-menu item visibility asserted before Enter**

The keyboard-insert case (`/ → type → Enter`) checks the filtered item is visible
before pressing Enter. Without that step a future block adding "paragraph" to its
keywords could silently change which spec gets inserted while the assertion stays
green — the suite would lie about the keyboard path still working.

The plain-form route was the only editor surface without axe coverage; a single
`expectNoAxeViolations(page)` call after the existing render assertions closes the
gap.

Deferred (out of scope for this slice):

- BlockActionsPanel `aria-disabled`: the panel uses conditional rendering when a
  callback is absent, which screen readers handle correctly. No regression risk.
- Mobile-sheet focus-trap test: radix Dialog already provides focus trap + return;
  mobile-inspector-sheet.spec.ts covers the visibility surface.
- Triplicated `emptyEntry(id)` + route-mock fixtures across the three v2 editor
  specs — worth consolidating to `support/rpc-mock.ts` later but outside this slice.

Refs #400
Refs #379