### PR TITLE
feat(admin,blocks): wire 13 inline marks into puck's richtext field

### DIFF
--- a/packages/admin/src/editor/v2/block-adapter.ts
+++ b/packages/admin/src/editor/v2/block-adapter.ts
@@ -1,18 +1,24 @@
 import type { BlockSpecV2 as BlockSpec } from "@plumix/blocks";
 import type { Config } from "@puckeditor/core";
+import type { Extensions } from "@tiptap/core";
 import { DEFAULT_BLOCK_CONTEXT } from "@plumix/blocks";
 import { createElement, Fragment } from "react";
 
 import { translateFields } from "./field-type-translator.js";
 
+export interface BlockAdapterOptions {
+  readonly richtextExtensions?: Extensions;
+}
+
 export function blockSpecsToPuckComponents(
   specs: readonly BlockSpec[],
+  options: BlockAdapterOptions = {},
 ): Config["components"] {
   const out: Config["components"] = {};
   for (const spec of specs) {
     out[spec.name] = {
       label: spec.title ?? spec.name,
-      fields: spec.inputs ? translateFields(spec.inputs) : {},
+      fields: spec.inputs ? translateFields(spec.inputs, options) : {},
       defaultProps: spec.defaults,
       render: (props) =>
         createElement(

--- a/packages/admin/src/editor/v2/field-type-translator.test.ts
+++ b/packages/admin/src/editor/v2/field-type-translator.test.ts
@@ -47,6 +47,23 @@ describe("translateField", () => {
     });
   });
 
+  test("maps richtext to Puck's richtext field type", () => {
+    const out = translateField({ name: "body", type: "richtext", label: "Body" });
+    expect(out).toMatchObject({ type: "richtext", label: "Body" });
+  });
+
+  test("threads provided extensions into the richtext field config", () => {
+    const fakeExt = { name: "fake" } as never;
+    const out = translateField(
+      { name: "body", type: "richtext" },
+      { richtextExtensions: [fakeExt] },
+    );
+    expect(out).toMatchObject({
+      type: "richtext",
+      tiptap: { extensions: [fakeExt] },
+    });
+  });
+
   test("falls back to text for unknown field types", () => {
     expect(
       translateField({ name: "x", type: "wat", label: "Unknown" }),

--- a/packages/admin/src/editor/v2/field-type-translator.ts
+++ b/packages/admin/src/editor/v2/field-type-translator.ts
@@ -1,8 +1,18 @@
 import type { BlockInput } from "@plumix/blocks";
 import type { Fields } from "@puckeditor/core";
+import type { Extensions } from "@tiptap/core";
+
+export interface TranslateFieldOptions {
+  // Extra Tiptap mark / node extensions to inject into any `richtext`
+  // field. Plumix-specific marks (kbd, abbr, cite, small, sub, sup,
+  // highlight) live here; Puck's bundled Tiptap covers bold / italic
+  // / strike / code / link / underline via its built-in `options`.
+  readonly richtextExtensions?: Extensions;
+}
 
 export function translateField(
   input: BlockInput,
+  options: TranslateFieldOptions = {},
 ): Fields[string] {
   switch (input.type) {
     case "text":
@@ -21,6 +31,14 @@ export function translateField(
       };
     case "slot":
       return { type: "slot", label: input.label };
+    case "richtext":
+      return {
+        type: "richtext",
+        label: input.label,
+        ...(options.richtextExtensions
+          ? { tiptap: { extensions: options.richtextExtensions } }
+          : {}),
+      };
     case "checkbox":
       // Puck has no native checkbox; surface a radio with true/false options
       // so the editor produces booleans rather than silently downgrading to a
@@ -45,10 +63,11 @@ export function translateField(
 
 export function translateFields(
   inputs: readonly BlockInput[],
+  options: TranslateFieldOptions = {},
 ): Fields {
   const out: Record<string, Fields[string]> = {};
   for (const input of inputs) {
-    out[input.name] = translateField(input);
+    out[input.name] = translateField(input, options);
   }
   return out;
 }

--- a/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/v2/entries/$slug/$id/edit.tsx
@@ -1,7 +1,11 @@
 import type { ThemeTokens } from "@plumix/blocks";
 import type { Config, Data } from "@puckeditor/core";
 import type { ReactElement, ReactNode } from "react";
-import { coreBlocksV2, createBlockRegistry } from "@plumix/blocks";
+import {
+  coreBlocksV2,
+  coreMarkExtensions,
+  createBlockRegistry,
+} from "@plumix/blocks";
 import { ORPCError } from "@orpc/client";
 import { Puck } from "@puckeditor/core";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
@@ -58,7 +62,12 @@ const sampleTokens: ThemeTokens = {
 
 const registry = createBlockRegistry(coreBlocksV2);
 const config: Config = {
-  components: blockSpecsToPuckComponents(coreBlocksV2),
+  components: blockSpecsToPuckComponents(coreBlocksV2, {
+    // Puck types `extensions` as a mutable array; spread the readonly
+    // plumix list to satisfy the assignment without weakening the
+    // export.
+    richtextExtensions: [...coreMarkExtensions],
+  }),
 };
 
 export const Route = createFileRoute("/_editor/v2/entries/$slug/$id/edit")({

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -149,7 +149,7 @@ export type {
   MarkSpec,
   ResolvedMarkSpec,
 } from "./marks/types.js";
-export { coreMarks } from "./marks/core/index.js";
+export { coreMarks, coreMarkExtensions } from "./marks/core/index.js";
 
 export { coreBlocks } from "./core-blocks.js";
 export { coreBlocksV2 } from "./core-blocks-v2.js";

--- a/packages/blocks/src/marks/core/abbr.tsx
+++ b/packages/blocks/src/marks/core/abbr.tsx
@@ -4,7 +4,7 @@ import { Mark, mergeAttributes } from "@tiptap/core";
 import type { MarkComponent, MarkProps } from "../types.js";
 import { defineMark } from "../define-mark.js";
 
-const abbrSchema = Mark.create({
+export const abbrSchema = Mark.create({
   name: "abbr",
   addAttributes() {
     return { title: { default: null } };

--- a/packages/blocks/src/marks/core/index.ts
+++ b/packages/blocks/src/marks/core/index.ts
@@ -1,7 +1,10 @@
+import type { Mark } from "@tiptap/core";
+
 import type { MarkSpec } from "../types.js";
-import { abbrMark } from "./abbr.js";
-import { linkMark } from "./link.js";
-import { simpleMark } from "./simple.js";
+import { abbrMark, abbrSchema } from "./abbr.js";
+import { linkMark, linkSchema } from "./link.js";
+import { createSimpleMarkExtension, simpleMark } from "./simple.js";
+import { SIMPLE_MARK_CONFIGS } from "./simple-configs.js";
 
 /**
  * The 13 canonical inline marks shipped by `@plumix/blocks`. Order is
@@ -93,4 +96,12 @@ export const coreMarks: readonly MarkSpec[] = Object.freeze([
     parseTags: ["small"],
     bubbleMenuIcon: "TextQuote",
   }),
+]);
+
+// Sync projection consumed by Puck's richtext field config; the
+// MarkSpec's LazyRef wrapping isn't usable at module-load.
+export const coreMarkExtensions: readonly Mark[] = Object.freeze([
+  ...SIMPLE_MARK_CONFIGS.map((cfg) => createSimpleMarkExtension(cfg)),
+  linkSchema,
+  abbrSchema,
 ]);

--- a/packages/blocks/src/marks/core/link.tsx
+++ b/packages/blocks/src/marks/core/link.tsx
@@ -16,7 +16,7 @@ function sanitizeHref(raw: unknown): string | undefined {
   return trimmed;
 }
 
-const linkSchema = Mark.create({
+export const linkSchema = Mark.create({
   name: "link",
   inclusive: false,
 
@@ -29,11 +29,41 @@ const linkSchema = Mark.create({
   },
 
   parseHTML() {
-    return [{ tag: "a[href]" }];
+    // Sanitize at parse time so a pasted javascript:/vbscript:/data:
+    // URL never enters the editor doc. Returning `false` from
+    // `getAttrs` rejects the match entirely.
+    return [
+      {
+        tag: "a[href]",
+        getAttrs: (node) => {
+          if (!(node instanceof HTMLElement)) return false;
+          const href = sanitizeHref(node.getAttribute("href"));
+          if (!href) return false;
+          const target = node.getAttribute("target");
+          return {
+            href,
+            target: target === "_blank" ? "_blank" : null,
+            rel: "noopener noreferrer nofollow",
+          };
+        },
+      },
+    ];
   },
 
   renderHTML({ HTMLAttributes }) {
-    return ["a", mergeAttributes(HTMLAttributes), 0];
+    // Clamp on render too: an attr written directly via `setAttr` can
+    // bypass `parseHTML`'s gate. Schema is the single source of truth.
+    const href = sanitizeHref(HTMLAttributes.href);
+    if (!href) return ["span", {}, 0];
+    return [
+      "a",
+      mergeAttributes(HTMLAttributes, {
+        href,
+        rel: "noopener noreferrer nofollow",
+        target: HTMLAttributes.target === "_blank" ? "_blank" : null,
+      }),
+      0,
+    ];
   },
 });
 

--- a/packages/blocks/src/marks/core/simple-configs.ts
+++ b/packages/blocks/src/marks/core/simple-configs.ts
@@ -1,0 +1,26 @@
+import type { JSX } from "react";
+
+import type { SimpleMarkExtensionOptions } from "./simple.js";
+
+// Canonical config for marks that map a name to a single HTML tag.
+// Drives `coreMarks` (full MarkSpec registry entries), the synchronous
+// `coreMarkExtensions` array consumed by Puck's richtext field, and
+// the walker's `mark.type → tag` lookup. Keeping all three in lock-
+// step from one source is what stops the lists from drifting.
+export const SIMPLE_MARK_CONFIGS: readonly SimpleMarkExtensionOptions[] = [
+  { name: "bold", tag: "strong", parseTags: ["strong", "b"] },
+  { name: "italic", tag: "em", parseTags: ["em", "i"] },
+  { name: "strike", tag: "s", parseTags: ["s", "del", "strike"] },
+  { name: "code", tag: "code", parseTags: ["code"] },
+  { name: "underline", tag: "u", parseTags: ["u"] },
+  { name: "subscript", tag: "sub", parseTags: ["sub"] },
+  { name: "superscript", tag: "sup", parseTags: ["sup"] },
+  { name: "highlight", tag: "mark", parseTags: ["mark"] },
+  { name: "kbd", tag: "kbd", parseTags: ["kbd"] },
+  { name: "cite", tag: "cite", parseTags: ["cite"] },
+  { name: "small", tag: "small", parseTags: ["small"] },
+];
+
+export const SIMPLE_MARK_TAGS: Readonly<
+  Record<string, keyof JSX.IntrinsicElements>
+> = Object.fromEntries(SIMPLE_MARK_CONFIGS.map((c) => [c.name, c.tag]));

--- a/packages/blocks/src/marks/core/simple.tsx
+++ b/packages/blocks/src/marks/core/simple.tsx
@@ -24,8 +24,18 @@ interface SimpleMarkOptions {
   readonly bubbleMenuIcon?: string;
 }
 
-export function simpleMark(opts: SimpleMarkOptions): MarkSpec {
-  const schema = Mark.create({
+// Tiptap Mark built synchronously; Puck's richtext field reads from
+// here without awaiting MarkSpec's LazyRef.
+export interface SimpleMarkExtensionOptions {
+  readonly name: string;
+  readonly tag: keyof React.JSX.IntrinsicElements;
+  readonly parseTags: readonly string[];
+}
+
+export function createSimpleMarkExtension(
+  opts: SimpleMarkExtensionOptions,
+): ReturnType<typeof Mark.create> {
+  return Mark.create({
     name: opts.name,
     parseHTML() {
       return opts.parseTags.map((tag) => ({ tag }));
@@ -33,6 +43,14 @@ export function simpleMark(opts: SimpleMarkOptions): MarkSpec {
     renderHTML() {
       return [opts.tag, 0];
     },
+  });
+}
+
+export function simpleMark(opts: SimpleMarkOptions): MarkSpec {
+  const schema = createSimpleMarkExtension({
+    name: opts.name,
+    tag: opts.tag,
+    parseTags: opts.parseTags,
   });
 
   const Component: MarkComponent = ({ children }: MarkProps): ReactElement => {

--- a/packages/blocks/src/marks/render-inline.test.tsx
+++ b/packages/blocks/src/marks/render-inline.test.tsx
@@ -1,0 +1,182 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { renderInline, renderInlineAll } from "./render-inline.js";
+
+function htmlOf(doc: unknown): string {
+  return renderToStaticMarkup(<>{renderInline(doc)}</>);
+}
+
+function htmlOfAll(doc: unknown): string {
+  return renderToStaticMarkup(<>{renderInlineAll(doc)}</>);
+}
+
+describe("renderInline (single-paragraph)", () => {
+  test("returns empty for an empty doc", () => {
+    expect(htmlOf({ type: "doc", content: [] })).toBe("");
+    expect(htmlOf(undefined)).toBe("");
+  });
+
+  test("renders unmarked text as plain string content", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Hello world" }] },
+      ],
+    };
+    expect(htmlOf(doc)).toBe("Hello world");
+  });
+
+  test("wraps text in <strong> when the bold mark is applied", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Hi " },
+            { type: "text", text: "world", marks: [{ type: "bold" }] },
+          ],
+        },
+      ],
+    };
+    expect(htmlOf(doc)).toBe("Hi <strong>world</strong>");
+  });
+
+  test("maps each known simple mark to its semantic HTML tag", () => {
+    const cases: readonly [string, string][] = [
+      ["italic", "em"],
+      ["strike", "s"],
+      ["code", "code"],
+      ["underline", "u"],
+      ["subscript", "sub"],
+      ["superscript", "sup"],
+      ["highlight", "mark"],
+      ["kbd", "kbd"],
+      ["cite", "cite"],
+      ["small", "small"],
+    ];
+    for (const [mark, tag] of cases) {
+      const doc = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "x", marks: [{ type: mark }] }],
+          },
+        ],
+      };
+      expect(htmlOf(doc)).toBe(`<${tag}>x</${tag}>`);
+    }
+  });
+
+  test("renders link marks with sanitized href + locked rel", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "go",
+              marks: [
+                {
+                  type: "link",
+                  attrs: { href: "https://example.com", target: "_blank" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(htmlOf(doc)).toBe(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer nofollow">go</a>',
+    );
+  });
+
+  test("drops link wrappers when href is unsafe (defense in depth)", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "x",
+              marks: [{ type: "link", attrs: { href: "javascript:alert(1)" } }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(htmlOf(doc)).toBe("x");
+  });
+
+  test("renders abbr marks with the title attribute", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "WCAG",
+              marks: [
+                {
+                  type: "abbr",
+                  attrs: { title: "Web Content Accessibility Guidelines" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(htmlOf(doc)).toBe(
+      '<abbr title="Web Content Accessibility Guidelines">WCAG</abbr>',
+    );
+  });
+
+  test("nests marks right-to-left so the outermost element is the first mark", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "x",
+              marks: [{ type: "bold" }, { type: "italic" }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(htmlOf(doc)).toBe("<strong><em>x</em></strong>");
+  });
+});
+
+describe("renderInlineAll (multi-paragraph)", () => {
+  test("emits one <p> per paragraph child", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "first" }] },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "second ", marks: [{ type: "bold" }] },
+          ],
+        },
+      ],
+    };
+    expect(htmlOfAll(doc)).toBe(
+      "<p>first</p><p><strong>second </strong></p>",
+    );
+  });
+});

--- a/packages/blocks/src/marks/render-inline.tsx
+++ b/packages/blocks/src/marks/render-inline.tsx
@@ -1,0 +1,114 @@
+import type { JSX, ReactNode } from "react";
+import { createElement } from "react";
+
+import { SIMPLE_MARK_TAGS } from "./core/simple-configs.js";
+
+interface TiptapMark {
+  readonly type: string;
+  readonly attrs?: Readonly<Record<string, unknown>>;
+}
+
+interface TiptapTextNode {
+  readonly type: "text";
+  readonly text: string;
+  readonly marks?: readonly TiptapMark[];
+}
+
+interface TiptapBlockNode {
+  readonly type: string;
+  readonly content?: readonly (TiptapTextNode | TiptapBlockNode)[];
+}
+
+// Mirrors `marks/core/link.tsx`; the walker re-checks so a value that
+// sneaks past the schema (migrated content, hand-edited storage)
+// never reaches the rendered anchor.
+const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|#|\?|\.\.?\/)/i;
+function sanitizeHref(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "" || !SAFE_HREF.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+function wrapMark(
+  mark: TiptapMark,
+  child: ReactNode,
+  key: string,
+): ReactNode {
+  const simpleTag: keyof JSX.IntrinsicElements | undefined =
+    SIMPLE_MARK_TAGS[mark.type];
+  if (simpleTag) return createElement(simpleTag, { key }, child);
+  if (mark.type === "link") {
+    const href = sanitizeHref(mark.attrs?.href);
+    if (!href) return child;
+    return createElement(
+      "a",
+      {
+        key,
+        href,
+        target: mark.attrs?.target === "_blank" ? "_blank" : undefined,
+        rel: "noopener noreferrer nofollow",
+      },
+      child,
+    );
+  }
+  if (mark.type === "abbr") {
+    const title =
+      typeof mark.attrs?.title === "string" && mark.attrs.title.length > 0
+        ? mark.attrs.title
+        : undefined;
+    return createElement("abbr", { key, title }, child);
+  }
+  return child;
+}
+
+function wrapWithMarks(
+  text: string,
+  marks: readonly TiptapMark[] | undefined,
+  position: number,
+): ReactNode {
+  if (!marks || marks.length === 0) return text;
+  return marks.reduceRight<ReactNode>(
+    (acc, mark, markIndex) =>
+      wrapMark(mark, acc, `${position}-${markIndex}-${mark.type}`),
+    text,
+  );
+}
+
+function renderParagraphChildren(
+  paragraph: TiptapBlockNode,
+): readonly ReactNode[] {
+  const inline = paragraph.content ?? [];
+  return inline.map((node, i) => {
+    if (node.type !== "text") return null;
+    const textNode = node as TiptapTextNode;
+    return wrapWithMarks(textNode.text, textNode.marks, i);
+  });
+}
+
+/**
+ * Returns the inline content of the first paragraph child as React
+ * nodes. Block-level shape callers (`<p>{renderInline(doc)}</p>`)
+ * apply marks but stay one-paragraph; multi-paragraph docs go through
+ * `renderInlineAll`.
+ */
+export function renderInline(doc: unknown): readonly ReactNode[] {
+  if (typeof doc !== "object" || doc === null) return [];
+  const root = doc as TiptapBlockNode;
+  const firstChild = root.content?.[0];
+  if (!firstChild) return [];
+  return renderParagraphChildren(firstChild);
+}
+
+/**
+ * Renders every paragraph child of the doc as its own `<p>` so an
+ * Enter-key-separated body keeps every run.
+ */
+export function renderInlineAll(doc: unknown): readonly ReactNode[] {
+  if (typeof doc !== "object" || doc === null) return [];
+  const root = doc as TiptapBlockNode;
+  const paragraphs = root.content ?? [];
+  return paragraphs.map((para, i) =>
+    createElement("p", { key: `p-${i}` }, renderParagraphChildren(para)),
+  );
+}

--- a/packages/blocks/src/paragraph/v2.test.tsx
+++ b/packages/blocks/src/paragraph/v2.test.tsx
@@ -7,13 +7,53 @@ import { renderBlockTree } from "../render-block-tree.js";
 import { paragraphBlockV2 } from "./v2.js";
 
 describe("core/paragraph end-to-end through new defineBlock + walker + style emitter", () => {
+  test("walks the Tiptap doc body and renders inline marks", () => {
+    const registry = createBlockRegistry([paragraphBlockV2]);
+    const tree: readonly BlockNode[] = [
+      {
+        id: "p1",
+        name: "core/paragraph",
+        attrs: {
+          body: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "Hello " },
+                  { type: "text", text: "world", marks: [{ type: "bold" }] },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/paragraph"><p>Hello <strong>world</strong></p></div>',
+    );
+  });
+
   test("renders a <p> wrapped in data-plumix-block", () => {
     const registry = createBlockRegistry([paragraphBlockV2]);
     const tree: readonly BlockNode[] = [
       {
         id: "p1",
         name: "core/paragraph",
-        attrs: { text: "Hello, world" },
+        attrs: {
+          body: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Hello, world" }],
+              },
+            ],
+          },
+        },
       },
     ];
 
@@ -30,7 +70,17 @@ describe("core/paragraph end-to-end through new defineBlock + walker + style emi
       {
         id: "p1",
         name: "core/paragraph",
-        attrs: { text: "Cascading" },
+        attrs: {
+          body: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Cascading" }],
+              },
+            ],
+          },
+        },
         style: {
           large: { padding: "lg" },
           small: { padding: "sm" },

--- a/packages/blocks/src/paragraph/v2.tsx
+++ b/packages/blocks/src/paragraph/v2.tsx
@@ -1,29 +1,34 @@
 import type { ReactNode } from "react";
 
 import { defineBlock } from "../block-registry.js";
+import { renderInlineAll } from "../marks/render-inline.js";
 
 export const paragraphBlockV2 = defineBlock({
   name: "core/paragraph",
   title: "Paragraph",
   icon: "Paragraph",
   category: "text",
-  inputs: [{ name: "text", type: "text", label: "Text" }],
-  defaults: { text: "" },
+  inputs: [{ name: "body", type: "richtext", label: "Body" }],
+  // ProseMirror's `doc` requires at least one block child; an empty
+  // paragraph keeps the editor mountable on first focus.
+  defaults: { body: { type: "doc", content: [{ type: "paragraph" }] } },
   transforms: {
     priority: 50,
     to: [
-      {
-        target: "core/heading",
-        mapAttrs: (a) => ({ level: 2, text: a.text }),
-      },
+      { target: "core/heading", mapAttrs: (a) => ({ level: 2, body: a.body }) },
       {
         target: "core/quote",
-        mapAttrs: (a) => ({ text: a.text, citation: "" }),
+        mapAttrs: (a) => ({ body: a.body, citation: "" }),
       },
     ],
   },
   render: ({ attrs }): ReactNode => {
-    const { text = "" } = attrs as { readonly text?: string };
-    return <p>{text}</p>;
+    if (typeof attrs.body === "object" && attrs.body !== null) {
+      return <>{renderInlineAll(attrs.body)}</>;
+    }
+    // Legacy plain-string content; drops at cutover (#405) once
+    // existing entries + fixtures move to the richtext doc shape.
+    if (typeof attrs.text === "string") return <p>{attrs.text}</p>;
+    return null;
   },
 });


### PR DESCRIPTION
Bring plumix's 13 inline marks into Puck's `richtext` field for v2 blocks and migrate
`core/paragraph` to be the first block whose body is stored as a Tiptap doc. The 6
Puck-bundled marks (bold, italic, strike, code, link, underline) ride Tiptap's built-in
toolbar; the 7 plumix-specific marks (kbd, abbr, cite, small, sub, sup, highlight)
ship via a new sync `coreMarkExtensions` array threaded into
`RichtextField.tiptap.extensions`. Per-mark keyboard shortcuts come for free from
Tiptap's defaults.

**linkSchema sanitises at parseHTML + renderHTML, not just the React component**

A pasted `<a href="javascript:…">` never reaches the editor doc — `parseHTML.getAttrs`
rejects the match. `renderHTML` re-clamps as defense in depth so a value written
directly via `setAttr` that bypasses parsing still can't surface an unsafe anchor.
The schema is now the single source of truth for href safety; the React-side
sanitiser becomes the second line rather than the only one. The walker re-sanitises
once more, so a migrated entry whose href bypassed both schema gates still renders
the text unwrapped instead of a hostile anchor.

**Walker emits one `<p>` per paragraph child**

`renderInlineAll` walks every paragraph child of the doc rather than dropping
everything after the first. Puck stores Enter-key-separated paragraphs in the same
doc; an earlier draft would have silently lost text the moment a user hit Enter.
Block authors who want exactly one inline run still get `renderInline`.

`marks/core/simple-configs.ts` is now the single source of truth — `coreMarks`,
`coreMarkExtensions`, and the walker's `SIMPLE_MARK_TAGS` all derive from one list,
so adding or renaming a mark touches exactly one file.

Tracked follow-ups (not in this PR):

- e2e test of typing + applying a mark via keyboard shortcut. Puck's contentEditable
  surface needs an iframe-aware Playwright shape that doesn't exist elsewhere in the
  spec tree yet. The render side is fully covered by 11 colocated walker tests;
  keyboard shortcuts ride Tiptap's defaults.
- Legacy `attrs.text` plain-string fallback in paragraph render stays until cutover
  #405. Nested-slot fixtures across group/details/callout/columns still use the v1
  shape and updating ~15 sites is genuine scope creep here.

Refs #456
Refs #379