### PR TITLE
docs: rewrite authoring + reference guides against the new substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A headless CMS for the edge, built on Cloudflare Workers.
 
 🚧 Under active development. Not yet published to npm.
 
+## Documentation
+
+See [`docs/`](./docs/README.md) for authoring guides, the field-type
+catalog, editor-surface walkthroughs, and the keyboard shortcut map.
+
 ## License
 
 [MIT](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# Plumix documentation
+
+A headless CMS for the edge, built on Cloudflare Workers.
+
+## Authoring
+
+- [Block authoring](./block-authoring.md) — the `defineBlock` surface,
+  inputs, slots, variations, transforms, client islands.
+- [Theme authoring](./theme-authoring.md) — tokens, breakpoints, block
+  overrides.
+- [Plugin author guide](./plugin-author.md) — registering metaboxes,
+  blocks, field types, RPC routers from a plugin.
+
+## Reference
+
+- [Field-type catalog](./field-types.md) — the 26+ field types and how
+  they map to Puck primitives.
+- [Core blocks migration notes](./core-blocks-migration.md) — the v2
+  block roster shipped in `coreBlocksV2`.
+
+## Surfaces
+
+- [Editor surface](./editor-surface.md) — sidebars, action bar, slash
+  menu, viewport switching, publishing, revisions.
+- [Keyboard shortcuts](./keyboard-shortcuts.md) — canvas, slash menu,
+  sidebars, action bar, rich text.
+- [Responsive guide](./responsive.md) — desktop-first cascade,
+  per-viewport overrides, fluid tokens.
+
+## Internal
+
+The `agents/` directory carries prompts + glossaries used by coding
+agents that work on the codebase. End-user authors can ignore it.

--- a/docs/block-authoring.md
+++ b/docs/block-authoring.md
@@ -1,0 +1,199 @@
+# Block-authoring guide
+
+A block is a themeable rendering primitive: a name, an icon, a flat list of
+`inputs`, default attribute values, and a React `render` function. The editor
+canvas and the SSR walker both consume the same `BlockSpec`. There is no
+schema/component split, no Tiptap node, no per-block mark registration.
+
+## Minimum-viable block
+
+```tsx
+import { defineBlock } from "plumix/blocks";
+
+export const calloutBlock = defineBlock({
+  name: "acme/callout",
+  title: "Callout",
+  icon: "Megaphone",
+  category: "text",
+  inputs: [
+    { name: "text", type: "text", label: "Body" },
+    {
+      name: "variant",
+      type: "select",
+      label: "Variant",
+      options: [
+        { label: "Info", value: "info" },
+        { label: "Warning", value: "warn" },
+      ],
+    },
+  ],
+  defaults: { text: "", variant: "info" },
+  render: ({ attrs }) => (
+    <aside role="note" data-variant={attrs.variant}>
+      {attrs.text}
+    </aside>
+  ),
+});
+```
+
+That is the entire surface — register it via the plugin context's
+`ctx.registerBlock(calloutBlock)` and the editor shows it in the Blocks tab,
+the slash menu, and the SSR `<EntryContent>` walker.
+
+## `BlockSpec` fields
+
+| Field | Required | What it does |
+| --- | --- | --- |
+| `name` | yes | Globally unique block name (`namespace/slug`, lowercase). |
+| `title` | recommended | Display label in the Blocks tab and slash menu. |
+| `description` | no | Sub-label in inserter rows. |
+| `icon` | no | Lucide icon name shown in the inserter. |
+| `category` | no | Inserter section grouping. |
+| `keywords` | no | Extra search tokens for the slash-menu filter. |
+| `inserter` | no | Set `false` to register a block that other blocks emit but the inserter hides. |
+| `inputs` | no | Flat array of field declarations. |
+| `defaults` | no | Initial attribute values for newly-inserted blocks. |
+| `placeholder` | no | Empty-state copy shown when the block has no content. |
+| `capability` | no | Gate insertion + visibility on a named capability. |
+| `inline` | no | Skip the wrapper `<div data-plumix-block>` and emit the rendered element bare. |
+| `transforms` | no | Convert-to / convert-from descriptors surfaced in the action bar. |
+| `variations` | no | Pre-set attr configurations surfaced as their own inserter entries. |
+| `client` | no | Hydration descriptor for browser-side interactive blocks. |
+| `render` | yes | React function that receives `{ attrs, context }` and returns the block UI. |
+
+## Inputs
+
+The `inputs` array drives the right-rail Inspector. Each input becomes a
+single field in the editor; the value travels to the block's `render` via
+`attrs[name]`. Type-flow from `inputs` into `render` is preserved by
+TypeScript, so the render function's `attrs` is typed against the inputs.
+
+### Supported `type` values
+
+- `text`, `textarea`, `number` — Puck-native primitives.
+- `select`, `radio` — discriminated by `options: [{label, value}]`.
+- `checkbox` — translator surfaces a Yes/No radio so the field returns booleans rather than the string `"true"`.
+- `slot` — accepts child blocks.
+- `richtext` — Tiptap-backed inline rich text with all marks available.
+
+### Reference and media field types
+
+- `image`, `image[]` — registered by `@plumix/plugin-media`. Plug the picker in via the media plugin.
+- `entry`, `entry[]`, `term`, `term[]`, `user`, `user[]` — reference pickers.
+- `date`, `datetime`, `time`, `email`, `url`, `password`, `range`, `color`,
+  `multiselect`, `json`, `repeater` — see the field-type catalog reference
+  for the full inventory.
+
+Custom field types register through `ctx.registerFieldType(...)` from a
+plugin's `setup` function.
+
+## Slot fields
+
+A `slot` input accepts child blocks. The render receives the slot as a
+React component the block spreads where children belong:
+
+```tsx
+inputs: [
+  { name: "layout", type: "select", options: [...] },
+  { name: "content", type: "slot", label: "Items" },
+],
+render: ({ attrs }) => {
+  const Content = attrs.content as (() => ReactNode) | undefined;
+  return (
+    <div data-layout={attrs.layout}>
+      {Content ? <Content /> : null}
+    </div>
+  );
+},
+```
+
+The Component is provided by the walker (or Puck in the editor). Children
+serialize as `BlockNode[]` inside `attrs.content`. Multi-slot blocks
+(Columns, Tabs) declare each slot with its own `name`.
+
+## Variations
+
+Variations are pre-set attribute configurations that surface as their own
+inserter entries. `core/list` ships Bullet and Numbered as variations of a
+single block:
+
+```tsx
+variations: [
+  { slug: "bullet", title: "Bullet list", icon: "List" },
+  { slug: "numbered", title: "Numbered list", icon: "ListOrdered",
+    attrs: { variant: "numbered" } },
+],
+```
+
+Each variation's `attrs` merges over `defaults`. Selecting a variation in
+the slash menu or Blocks tab inserts the parent block with the merged
+attrs applied.
+
+## Transforms
+
+Transforms surface in the action bar as "Transform to" rows. Each entry
+in `transforms.to` names a target block + an attribute mapper:
+
+```tsx
+transforms: {
+  priority: 50,
+  to: [
+    { target: "core/heading", mapAttrs: (a) => ({ level: 2, body: a.body }) },
+    { target: "core/quote", mapAttrs: (a) => ({ body: a.body, citation: "" }) },
+  ],
+},
+```
+
+The reverse direction is derived automatically — if `B` declares a
+`transforms.to[].target === "A"`, then `A`'s action bar surfaces a
+"Transform to B" row computed from B's mapper inverse.
+
+## Client islands
+
+Blocks with browser-side interactivity declare a `client` descriptor:
+
+```tsx
+client: { script: "/_plumix/admin/assets/media-embed.client.js" },
+```
+
+The SSR walker emits a placeholder `<div data-block>` plus a `<script
+type="module">` adjacent. The script hydrates the React component on the
+client. Use this for carousels, accordions, anything that needs JS.
+
+## Inline blocks
+
+`inline: true` opts out of the universal wrapper `<div data-plumix-block>`.
+The render function then receives `style`/`className` it must apply to its
+own root element. Use this for layout-sensitive blocks (Spacer,
+Description Term, anything that must be a specific HTML element at the
+root).
+
+## Capability gating
+
+A `capability: string` on a block hides the block from the Blocks tab and
+slash menu for viewers whose role doesn't grant the capability. Server-
+side validation rejects inserts that bypass the client filter.
+
+## Testing
+
+`plumix/blocks/test` ships SSR helpers:
+
+```ts
+import { renderBlockSpecToHtml, renderBlockTreeToHtml } from "plumix/blocks/test";
+
+test("renders the variant data attribute", () => {
+  const html = renderBlockSpecToHtml(calloutBlock, { variant: "warn" });
+  expect(html).toContain('data-variant="warn"');
+});
+```
+
+Use `renderBlockSpecToHtml(spec, attrs)` for single-block assertions and
+`renderBlockTreeToHtml(specs, tree)` for slot composition.
+
+## See also
+
+- [Theme authoring](./theme-authoring.md) for overriding blocks at theme load.
+- [Plugin author guide](./plugin-author.md) for registering blocks from a plugin.
+- [Field-type catalog](./field-types.md) for the full input type list.
+- [Responsive guide](./responsive.md) for per-viewport styling.
+- [Keyboard shortcuts](./keyboard-shortcuts.md) for editor accelerators.

--- a/docs/core-blocks-migration.md
+++ b/docs/core-blocks-migration.md
@@ -1,0 +1,133 @@
+# Core block migration notes
+
+Internal record of which blocks moved to the v2 `defineBlock` surface and
+what each migration changed. Reader audience is the maintainer crew; once
+the v1 stubs delete at cutover (#405) this file documents the final
+shape of `coreBlocksV2`.
+
+## What changed at the type level
+
+- **`BlockSpec`** — flat shape: `name`, `title`, `icon`, `category`,
+  `inputs`, `render`, `defaults`, optional `transforms` / `variations` /
+  `client` / `inline` / `capability` / `placeholder` / `inserter`.
+- **Dropped**: `schema` (Tiptap node), `attributes` schema config,
+  `supports` (per-block design-token declarations), `legacyAliases`,
+  `parsePaste`, `keyboardShortcuts`, `markdownShortcuts`, `adminSchema`,
+  `adminEditor`. The universal Style slot at the framework layer
+  replaces per-block `supports`; design tokens fold into one place.
+- **`inputs`** — flat array of `{ name, type, label, options?, … }`.
+  Replaces the v1 `attributes` schema + the v1 `adminEditor` Inspector
+  rendering.
+- **`render`** — single function. No more `schema` + `Component` +
+  `adminSchema` split.
+
+## Per-block roster (v2 names in `coreBlocksV2`)
+
+### Text blocks
+
+- **`core/paragraph`** — `body: richtext` input storing a Tiptap doc.
+  Render via `renderInlineAll(attrs.body)`. Legacy `attrs.text` plain
+  string still rendered as a transitional shim; drops at cutover.
+- **`core/heading`** — `level: select (1–6)` + `body: text` (richtext
+  upgrade lands with the next paragraph follow-up). Render emits the
+  `h<level>` element.
+- **`core/quote`** — `text: text` + `citation: text`. Renders
+  `<blockquote cite="…">{text}</blockquote>`.
+- **`core/code`** — code block.
+- **`core/separator`** — `<hr>`.
+
+### Inline / structural
+
+- **`core/spacer`** — `inline: true`, emits a sized `<div>` with no
+  wrapper.
+- **`core/details`** + **`core/details-summary`** — collapsible disclosure.
+- **`core/callout`** — variant select + slotted content.
+
+### List family
+
+- **`core/list`** — Bullet + Numbered shipped as `variations`. Single
+  block with `variant: bullet | numbered` attr; render switches `<ul>` /
+  `<ol>`. `start` attr surfaces on the numbered variation.
+- **`core/list-item`** — `inline: true`, emits `<li>` directly.
+
+### Description list
+
+- **`core/description-list`** + **`core/description-term`** +
+  **`core/description-detail`** — three blocks composing `<dl><dt><dd>`
+  semantics.
+
+### Layout
+
+- **`core/group`** — `layout: flow | flex-row | flex-column | grid` +
+  `content: slot`.
+- **`core/columns`** — multi-slot block (`left`, `right`, etc.).
+- **`core/buttons`** + **`core/button`** — button group + button.
+
+### Tables
+
+- **`core/table`** + **`core/table-header-row`** +
+  **`core/table-body-row`** + **`core/table-header-cell`** +
+  **`core/table-cell`** — five blocks composing `<table><thead><tbody>`
+  semantics.
+
+## Media plugin (`@plumix/plugin-media`)
+
+Five v2 blocks shipped via `mediaBlocksV2`:
+
+- `media/image` — figure + img with focal-point cropping (object-position).
+- `media/gallery` — grid container with `content: slot` for `media/image`
+  children.
+- `media/video` — `<video>` with poster + controls.
+- `media/audio` — `<audio>` with controls.
+- `media/file` — download anchor with size + MIME label.
+- `media/embed` — oEmbed-style client island.
+
+Each block ships alongside its v1 sibling. v1 stubs delete at cutover.
+
+## Marks
+
+All 13 inline marks ride Puck's `richtext` field via `coreMarkExtensions`:
+
+- **Puck-bundled (Tiptap defaults)**: bold, italic, strike, code, link,
+  underline. Each carries its standard `Cmd+B` / `Cmd+I` / etc. shortcut.
+- **Plumix-specific (custom Tiptap extensions)**: subscript, superscript,
+  highlight, kbd, abbr, cite, small. Available via Inspector menu in the
+  richtext field; keyboard shortcuts declared per-mark in `defineMark`.
+
+`linkSchema` sanitises href at `parseHTML` + `renderHTML` so unsafe
+schemes never enter the editor doc.
+
+## Walker
+
+`packages/blocks/src/marks/render-inline.tsx` is the shared walker that
+turns a Tiptap doc into React nodes. Two entry points:
+
+- `renderInline(doc)` — first paragraph's inline run.
+- `renderInlineAll(doc)` — one `<p>` per paragraph child.
+
+Both apply marks via the shared `SIMPLE_MARK_TAGS` map + dedicated
+`link` / `abbr` handlers. The walker re-sanitises link hrefs as defense
+in depth.
+
+## Tests + utilities
+
+`plumix/blocks/test` exports two SSR helpers used by every v2 block's
+colocated tests:
+
+- `renderBlockSpecToHtml(spec, attrs)` — single-block render.
+- `renderBlockTreeToHtml(specs, tree)` — slot composition + multi-block
+  trees.
+
+Both return HTML strings produced by `react-dom/server.renderToStaticMarkup`.
+The walker emits `data-plumix-block="<name>"` on a wrapper `<div>` for
+every non-inline block, so test assertions can anchor on either the
+wrapper or the block-specific markup inside.
+
+## Out of scope at this PR
+
+- v1 stub deletion (lives at cutover #405).
+- Admin runtime wiring for plugin-contributed v2 blocks via
+  `ctx.registerBlockSpec` (separate plumbing slice).
+- Full richtext upgrade for heading / quote / callout summary / details
+  summary — paragraph is the only block whose `inputs` use `richtext`
+  today.

--- a/docs/editor-surface.md
+++ b/docs/editor-surface.md
@@ -1,0 +1,143 @@
+# Editor surface guide
+
+The v2 admin editor has two routes:
+
+- **Editor route** (`/entries/<slug>/<id>/edit` on v2-supports types) —
+  Puck-driven canvas with sidebars, action bar, and viewport switching.
+- **Plain-form route** — used when an entry type's `supports` list omits
+  `editor`. Stacked Cards, autosave, no canvas, no Puck bundle.
+
+Both routes share the same publish + autosave + revisions header.
+
+## Header
+
+- **Title input** — entry title, autosaved with the body.
+- **Autosave pill** — Saved / Saving… / Failed to save. Reflects the live
+  `entry.update` mutation state.
+- **Revisions trigger** — appears when the entry type declares
+  `supports: ["revisions"]`. Opens a Sheet listing prior revisions with
+  per-revision diff + Restore.
+- **Publish button** — promotes the draft to published via `entry.update`
+  with `status: "published"`. Disabled once already published.
+
+## Left sidebar
+
+Tabs: **Blocks**, **Outline**, **Audit**.
+
+- **Blocks** — searchable, capability-filtered list of insertable blocks
+  and variations. Click to insert at the canvas cursor; or drag
+  (returning when the drag-handle slice completes).
+- **Outline** — the page's block tree. Click a node to select it on the
+  canvas.
+- **Audit** — Heading-structure accessibility audit. Lists outline issues
+  (skipped levels, missing h1, etc.); click an issue to jump to the
+  offending block.
+
+## Canvas
+
+`<Puck.Preview />` renders the block tree as a live editable surface.
+Typing `/` at the cursor opens the slash menu; selecting a block reveals
+the action bar and switches the right rail to the Block tab.
+
+## Right sidebar
+
+Two states:
+
+### When a block is selected
+
+Tabs: **Block**, **Style**.
+
+- **Block** — the selected block's `inputs`. Each input renders via the
+  field-type translator (`text`, `select`, `richtext`, `slot`, etc.).
+- **Style** — the universal Style slot. Edits land in the active
+  viewport bucket (`large` by default; switches to `medium` / `small`
+  when the viewport switcher is engaged). Tokens drive the choices: the
+  color picker offers the theme's `colors` tokens, spacing offers the
+  theme's `spacing` tokens, etc.
+
+### When nothing is selected
+
+Stacked Accordion of registered metaboxes. Permalink, Status, Excerpt,
+plugin-contributed metaboxes — each one its own collapsible section.
+
+## Action bar
+
+Renders below the right-rail header when a block is selected. Native
+`<button>` elements; reachable via Tab from the canvas:
+
+- **Transform to** — per-target buttons derived from the block's
+  `transforms.to` + the symmetric inverse of other blocks' `transforms.from`.
+- **Duplicate** — clones the selected block in place.
+- **Delete** — removes the selected block.
+- **Copy JSON** — copies the block's serialized JSON to the clipboard.
+
+The full keyboard map lives in [keyboard-shortcuts.md](./keyboard-shortcuts.md).
+
+## Slash menu
+
+Cursor-position inserter:
+
+- `/` opens the menu.
+- Type to filter by title or keyword.
+- Arrow keys move focus; Enter inserts.
+- Escape dismisses.
+
+The menu surface is a listbox (`role="listbox"` via cmdk); the search
+input carries `aria-label="Search blocks"`.
+
+Capability-gated blocks are hidden from viewers whose role doesn't grant
+the capability.
+
+## Viewport switching
+
+Toolbar control (Mobile / Tablet / Desktop / Wide). Editing the Style
+tab while a non-default viewport is active lands the override in that
+viewport's bucket; the canvas re-renders at the selected width so the
+override is visible immediately.
+
+The active viewport reflects through `data-plumix-viewport-bucket` on
+the Style tab so screen readers announce "Editing for: tablet" etc.
+
+## Publish workflow
+
+- **Draft** → **Published**: one-way via the Publish button. Promotes via
+  `entry.update({ status: "published" })`; fires `entry:published` plugin
+  hooks.
+- **Autosave**: 300 ms debounce on every canvas / metabox / Style edit.
+  Optimistic-concurrency token (`expectedLiveUpdatedAt`) is sent on every
+  save so a stale tab can't clobber a concurrent edit; the server returns
+  `CONFLICT` and the editor surfaces a Conflict dialog with Compare /
+  Keep mine / Take theirs actions.
+
+## Revisions
+
+For entry types declaring `supports: ["revisions"]`:
+
+- Each successful `entry.update` snapshots the post-write state into a
+  revision row.
+- The header's **Revisions** trigger opens a Sheet listing prior
+  revisions with author + relative time.
+- Selecting a revision opens the diff view side-by-side with the live
+  entry.
+- **Restore this revision** writes the snapshot's content back into the
+  live entry via `entry.revisions.restore`, fires the same lifecycle
+  hooks as a manual save, and re-runs block-content validation so a
+  block deregistered since capture can't surface invalid content.
+- Restore does *not* snapshot the post-restore state — restoring a
+  revision is invisible to history (matches WordPress's behaviour;
+  prevents a duplicate row burning a `maxRevisions` slot).
+
+## Plain-form route
+
+Stacked Cards layout for non-editor entry types. The header carries the
+same title input + autosave pill + Revisions trigger + Publish button as
+the editor route. Each metabox renders as its own `<section>` with an
+`<h2>` heading and `aria-labelledby` wiring. Same `MetaBoxField` renderer
+as the editor route — registering a custom field type from a plugin
+surfaces it identically in both surfaces.
+
+## See also
+
+- [Keyboard shortcuts](./keyboard-shortcuts.md)
+- [Block authoring](./block-authoring.md)
+- [Responsive guide](./responsive.md)

--- a/docs/field-types.md
+++ b/docs/field-types.md
@@ -1,0 +1,120 @@
+# Field-type catalog
+
+Every field type lives in one of two surfaces:
+
+- **Block inputs** — declared on a `BlockSpec.inputs[i].type`; renders
+  inside Puck's right-rail Inspector.
+- **Metabox / entry-type fields** — declared on
+  `EntryMetaBoxManifestEntry.fields[i].inputType`; renders inside
+  `MetaBoxField`.
+
+The block-input translator (`field-type-translator.ts`) and
+`MetaBoxField` cover the same field-type names. A custom field type
+registered via `ctx.registerFieldType(...)` renders identically in both
+surfaces.
+
+## Built-in field types
+
+### Text-shaped
+
+| Name | Block-input maps to | Metabox renders | Returns |
+| --- | --- | --- | --- |
+| `text` | Puck `text` | `<Input type="text">` | string |
+| `textarea` | Puck `textarea` | `<Textarea>` | string |
+| `number` | Puck `number` | `<Input type="number">` | number |
+| `range` | custom slider | `<Input type="range">` | number |
+| `email` | Puck `text` | `<Input type="email">` | string |
+| `url` | Puck `text` | `<Input type="url">` | string |
+| `password` | Puck `text` | `<Input type="password">` | string |
+| `color` | Puck `custom` | `react-colorful` picker | `#RRGGBB` string |
+| `richtext` | Puck `richtext` | n/a | Tiptap doc |
+
+### Choice-shaped
+
+| Name | Block-input | Metabox | Returns |
+| --- | --- | --- | --- |
+| `select` | Puck `select` (options) | `<Select>` | scalar |
+| `multiselect` | Puck `array` of selects | combobox | scalar[] |
+| `radio` | Puck `radio` (options) | `<RadioGroup>` | scalar |
+| `checkbox` | Puck Yes/No `radio` (forces boolean) | `<Checkbox>` | boolean |
+
+### Date/time-shaped
+
+| Name | Block-input | Metabox |
+| --- | --- | --- |
+| `date` | Puck `custom` | calendar popover, returns `YYYY-MM-DD` |
+| `datetime` | Puck `custom` | calendar + time, returns ISO 8601 |
+| `time` | Puck `custom` | `<Input type="time">`, returns `HH:MM` |
+
+### Structural
+
+| Name | Block-input | Metabox | Returns |
+| --- | --- | --- | --- |
+| `json` | Puck `textarea` (JSON-parsed) | JSON textarea + validator | object |
+| `repeater` | Puck `array` | sortable list of sub-fields | array of sub-field shapes |
+| `slot` | Puck `slot` | (block-only) | `BlockNode[]` |
+
+### Reference-shaped
+
+The reference field types resolve a foreign-key id into a labelled
+option. The picker UI varies by kind; the underlying storage is always
+`number` (single) or `number[]` (list).
+
+| Name | Picks |
+| --- | --- |
+| `entry` | a single entry id; filterable by entry type |
+| `entry[]` (alias `entry-list`) | many entry ids |
+| `term` | a single term id; filterable by taxonomy |
+| `term[]` (alias `term-list`) | many term ids |
+| `user` | a single user id |
+| `user[]` (alias `user-list`) | many user ids |
+| `image` (from `@plumix/plugin-media`) | a single media id, returns the file's resolved URL too |
+| `image[]` (from `@plumix/plugin-media`) | many media ids |
+
+Reference fields require a registered lookup adapter (see
+[Plugin author guide](./plugin-author.md#reference-fields)).
+
+## Registering a custom field type
+
+```ts
+ctx.registerFieldType({
+  name: "address",
+  render: AddressPickerField, // imported from the plugin's admin bundle
+});
+```
+
+The `render` component receives RHF-style props (`field`, `disabled`,
+`fieldDef`). It must handle both block-input usage (under `attrs[name]`)
+and metabox usage (under `meta[key]`) — the props shape is the same.
+
+For Puck integration, the translator maps custom field types to Puck
+`custom` fields by default. If a custom type needs different Puck
+semantics (e.g. an `external` field for a media picker), declare the
+mapping inside the plugin's admin bundle and re-register via
+`ctx.registerFieldType`.
+
+## Defaulting rules
+
+- `inputs[i].defaults`: applied at the inserter when a block is freshly
+  inserted. Not applied at render time — the render function must handle
+  missing attrs.
+- Reference fields: empty (no id selected) is the natural default; the
+  picker shows a "Pick…" placeholder.
+- Boolean (`checkbox`): defaults to `false` unless the spec sets `true`.
+
+## Validation rules
+
+- `text` / `textarea` / `string` accept any string.
+- `number` accepts finite numbers; the server-side validator clamps to
+  the spec's `min` / `max` if provided.
+- `email` / `url` go through valibot validators server-side.
+- `json` validates that the stored value is a valid JSON object at
+  parse time; malformed bodies reject as `INVALID_BLOCK_CONTENT` at
+  `entry.update`.
+
+## See also
+
+- [Block authoring](./block-authoring.md#inputs) — declaring inputs on a
+  block spec.
+- [Plugin author guide](./plugin-author.md#custom-field-types) — wiring
+  a custom field-type renderer.

--- a/docs/plugin-author.md
+++ b/docs/plugin-author.md
@@ -1,0 +1,187 @@
+# Plugin-author guide
+
+A plugin is a function. It receives a context object and contributes to
+the merged registry: entry types, term taxonomies, blocks, marks, field
+types, metaboxes, settings groups, lookup adapters, scheduled tasks, RPC
+routers, capabilities, login links, admin pages, rewrite rules.
+
+## Minimum-viable plugin
+
+```ts
+import { definePlugin } from "plumix/plugin";
+
+export function newsletterSignup() {
+  return definePlugin("newsletter", (ctx) => {
+    ctx.registerEntryMetaBox({
+      id: "newsletter-fields",
+      label: "Newsletter",
+      entryTypes: ["post"],
+      fields: [
+        { key: "newsletter_subject", label: "Subject line", type: "string", inputType: "text" },
+        { key: "newsletter_send_after", label: "Send after", type: "string", inputType: "datetime" },
+      ],
+    });
+  });
+}
+```
+
+Pass it into the Plumix config under `plugins: [newsletterSignup()]`.
+
+## Setup context surface
+
+The `ctx` passed to the plugin's setup function exposes these registration
+methods. Each is idempotent within one merge; cross-plugin collisions
+(same id, same name) reject at startup.
+
+### Content + taxonomy
+
+- `ctx.registerEntryType(name, options)` — declares a custom entry type
+  with `labels`, `supports`, `versioning`, `termTaxonomies`.
+- `ctx.registerTermTaxonomy(name, options)` — declares a taxonomy
+  attached to one or more entry types.
+
+### UI extension
+
+- `ctx.registerEntryMetaBox(options)` — Card / Accordion section in the
+  editor sidebar (and editor route). Per-entry-type filterable; per-field
+  capability-gateable.
+- `ctx.registerTermMetaBox(options)` / `ctx.registerUserMetaBox(options)`
+  — same for term-edit and user-profile routes.
+- `ctx.registerSettingsGroup(...)` / `ctx.registerSettingsPage(...)` —
+  contributes settings groups composed into pages on the Settings route.
+- `ctx.registerAdminPage(...)` — full-page admin route under
+  `/<plugin>/<path>`.
+
+### Block + mark + field-type
+
+- `ctx.registerBlock(blockSpec)` — register a `BlockSpec` produced by
+  `defineBlock`. Specs in the `core/` namespace are rejected (reserved
+  for `@plumix/blocks`).
+- `ctx.registerMark(markSpec)` — register a custom inline mark.
+- `ctx.registerFieldType(options)` — register a custom field type
+  available in block inputs and metabox fields. The same renderer covers
+  both surfaces.
+
+### RPC + lookup
+
+- `ctx.registerRpcRouter(name, router)` — contribute an oRPC router under
+  `/_plumix/rpc/<name>/*`.
+- `ctx.registerLookupAdapter(options)` — register a reference target
+  kind. `entry` / `term` / `user` ship with core; plugins add `media`
+  (`@plumix/plugin-media`) etc.
+
+### Lifecycle + auth
+
+- `ctx.hooks.addAction(name, handler)` / `ctx.hooks.addFilter(name, fn)`
+  — subscribe to lifecycle events (entry:published, entry:updated, etc.)
+  or filter pipeline values.
+- `ctx.registerCapability(name, options)` — declare a capability the
+  plugin checks at RPC handlers.
+- `ctx.registerLoginLink(options)` — surface a login button on the
+  standard login screen pointing at the plugin's sign-in flow.
+
+### Scheduling + rewrite
+
+- `ctx.registerScheduledTask(options)` — cron-style background work.
+- `ctx.registerRewriteRule(options)` — request-path rewrite.
+
+## Custom blocks
+
+Use the full `defineBlock` surface from `plumix/blocks`. The plugin's
+contribution merges into the per-app block registry at `buildApp` time
+with precedence `theme > plugin > core` — a theme can override a plugin
+block by re-declaring inside `defineTheme.setup`.
+
+```ts
+import { defineBlock } from "plumix/blocks";
+import { definePlugin } from "plumix/plugin";
+
+const heroBlock = defineBlock({
+  name: "acme/hero",
+  title: "Hero",
+  category: "marketing",
+  inputs: [
+    { name: "headline", type: "richtext", label: "Headline" },
+    { name: "ctaText", type: "text", label: "CTA text" },
+    { name: "ctaHref", type: "url", label: "CTA URL" },
+  ],
+  defaults: { /* … */ },
+  render: ({ attrs }) => { /* … */ },
+});
+
+export function acme() {
+  return definePlugin("acme", (ctx) => {
+    ctx.registerBlock(heroBlock);
+  });
+}
+```
+
+## Custom field types
+
+Wrapping a third-party UI as a field type — point picker, address autocomplete,
+audio uploader, anything Plumix doesn't ship. The same renderer must work in
+both block inputs (Puck) and entry metaboxes (the admin's MetaBoxField).
+
+```ts
+ctx.registerFieldType({
+  name: "address",
+  render: AddressPickerField,
+});
+```
+
+See [field-type catalog](./field-types.md) for the full inventory and the
+admin-bundle wiring details.
+
+## Reference fields
+
+The `entry`, `term`, `user` reference field types are pre-registered.
+Adding a new reference kind (e.g. `media` in the media plugin) requires
+two pieces:
+
+1. `ctx.registerLookupAdapter({ kind: "media", … })` — the server-side
+   resolver that turns a reference id into a `LookupResult`.
+2. `ctx.registerFieldType({ name: "media", … })` — the admin-side picker
+   UI.
+
+The reference-field RPC dispatches by `kind` to the adapter's lookup
+function; the admin-side picker shows the right UI for the kind.
+
+## Lifecycle hooks
+
+Plugin authors subscribe via `ctx.hooks`. Two flavours:
+
+- **Actions** (`hooks.addAction`) — side-effect subscribers. Return value
+  ignored. Used for audit logging, cache invalidation, sending email.
+- **Filters** (`hooks.addFilter`) — pipeline transformers. Receive the
+  value, return a (possibly modified) value. Used for content rewrites,
+  attribute defaulting.
+
+Every action / filter has a generic form (`entry:updated`) and a
+type-scoped form (`entry:post:updated`). Subscribe to whichever
+granularity you need.
+
+Documented hook names live in the `HookRegistry` type; the in-repo
+`audit-log` plugin is a working example.
+
+## Testing plugins
+
+`@plumix/core/test` ships `createRpcHarness` for integration tests:
+
+```ts
+import { createRpcHarness } from "@plumix/core/test/rpc";
+
+test("newsletter metabox is registered for post entries", async () => {
+  const h = await createRpcHarness({ authAs: "editor", plugins: [newsletterSignup()] });
+  const manifest = await h.client.manifest.get();
+  expect(manifest.entryMetaBoxes.some(b => b.id === "newsletter-fields")).toBe(true);
+});
+```
+
+For block-only tests use `plumix/blocks/test` (see
+[block-authoring guide's testing section](./block-authoring.md#testing)).
+
+## See also
+
+- [Block authoring](./block-authoring.md) — the full `defineBlock` surface.
+- [Theme authoring](./theme-authoring.md) — overriding plugin blocks.
+- [Field-type catalog](./field-types.md) — the 26+ field types.

--- a/docs/responsive.md
+++ b/docs/responsive.md
@@ -1,0 +1,132 @@
+# Responsive styling guide
+
+Plumix's responsive model is **desktop-first cascade with per-viewport
+overrides at the block instance level**. Every block has a universal
+Style slot the framework owns; per-block design-token declarations
+(`supports.spacing.padding`, etc.) no longer exist.
+
+## Viewport buckets
+
+A block's Style slot stores values keyed by viewport bucket:
+
+```ts
+style: {
+  large?: { padding: "lg", color: "ink" },
+  medium?: { padding: "md" },
+  small?: { padding: "sm" },
+}
+```
+
+- `large` is the **base**. Always applies.
+- `medium` overrides `large` when the viewport is below the `large`
+  breakpoint.
+- `small` overrides `medium` when below the `medium` breakpoint.
+
+The walker emits CSS unconditionally with `@media (max-width: …)`
+wrappers; the browser's media-query engine handles cascading. No
+client-side JS reads viewport width.
+
+## When to use which layer
+
+- **Theme tokens** with fluid values (`clamp()`, `min()`, `max()`) — for
+  values that should scale linearly with viewport. One declaration,
+  works at every size.
+- **Per-viewport block overrides** — for values that *don't* scale
+  linearly. A heading that needs to be 64 px on desktop, 48 px on
+  tablet, 32 px on mobile (each a discrete step, not a fluid range).
+- **Block author's `inline: true` opt-out + custom CSS** — only when the
+  block needs control beyond what the universal Style slot supports.
+
+## Editor UX
+
+The viewport switcher in the editor toolbar selects which bucket Style
+edits land in:
+
+- **Desktop** active → edits land in `large`.
+- **Tablet** active → edits land in `medium`.
+- **Mobile** active → edits land in `small`.
+
+The canvas re-renders at the selected viewport width so the override
+applies immediately. The Style tab's `data-plumix-viewport-bucket`
+attribute reflects the active bucket so screen readers announce
+"Editing for: tablet" etc.
+
+## Storage shape
+
+The block-tree stores style buckets directly:
+
+```jsonc
+{
+  "id": "p1",
+  "name": "core/paragraph",
+  "attrs": { /* … */ },
+  "style": {
+    "large": { "padding": "lg" },
+    "small": { "padding": "sm" }
+  }
+}
+```
+
+Each value references a token id (`"lg"`, `"sm"`); the walker resolves
+the id to `var(--plumix-spacing-lg, 24px)` at render time so token
+swaps (theme change at runtime) re-style without re-render.
+
+## Cascade example
+
+A paragraph with `large: { padding: "lg" }` and `small: { padding: "sm" }`
+emits:
+
+```css
+.plumix-block-p1 { padding: var(--plumix-spacing-lg, 24px); }
+@media (max-width: 640px) {
+  .plumix-block-p1 { padding: var(--plumix-spacing-sm, 8px); }
+}
+```
+
+No `medium` declared → medium viewports inherit the `large` value.
+
+## Breakpoints
+
+Theme-controlled (see [theme-authoring guide](./theme-authoring.md#breakpoints)).
+Default breakpoints:
+
+- `small` — below 640 px.
+- `medium` — 640 to 1024 px.
+- `large` — 1024 px and above.
+
+A theme overrides via `defineTheme({ breakpoints: { small: 600, medium: 960, large: 1280 } })`.
+
+## When the Style slot doesn't fit
+
+Some blocks need wrapper-free output (`<a>` for a button, `<li>` for a
+list item, `<hr>` for a separator). These blocks declare `inline: true`
+and receive `style`/`className` props the render must apply to its own
+root element. Inline blocks lose the per-viewport cascade unless the
+render function handles the bucketing itself.
+
+## Testing per-viewport overrides
+
+The colocated SSR tests in `@plumix/blocks` already cover the cascade:
+
+```ts
+const html = renderToStaticMarkup(
+  renderBlockTree(tree, registry, {
+    tokens: {
+      spacing: { lg: { value: "24px" }, sm: { value: "8px" } },
+    },
+  }),
+);
+expect(html).toContain(".plumix-block-p1 { padding: var(--plumix-spacing-lg, 24px); }");
+expect(html).toContain(
+  "@media (max-width: 640px) { .plumix-block-p1 { padding: var(--plumix-spacing-sm, 8px); } }",
+);
+```
+
+Pass `tokens` to `renderBlockTree` (or via the walker options) so the
+test reflects the active theme's token values.
+
+## See also
+
+- [Theme authoring](./theme-authoring.md) — token declarations + breakpoint customization.
+- [Block authoring](./block-authoring.md) — `inline: true` opt-out and block-specific styling.
+- [Editor surface](./editor-surface.md#viewport-switching) — the editor's viewport switcher.

--- a/docs/theme-authoring.md
+++ b/docs/theme-authoring.md
@@ -1,0 +1,151 @@
+# Theme-authoring guide
+
+A theme is a function. Pass it tokens, optional breakpoints, and a `setup`
+callback that runs at theme activation. The theme is registered through the
+Plumix config; switching themes re-runs every theme's setup so overrides
+roll back cleanly.
+
+## Minimum-viable theme
+
+```ts
+import { defineTheme } from "plumix/theme";
+
+export default defineTheme({
+  name: "acme",
+  tokens: {
+    colors: {
+      brand: { value: "#0070f3", label: "Brand" },
+      ink:   { value: "#111111", label: "Ink" },
+    },
+    spacing: {
+      sm: { value: "0.5rem", label: "Small" },
+      md: { value: "1rem",   label: "Medium" },
+      lg: { value: "2rem",   label: "Large" },
+    },
+    typography: {
+      base: { value: "1rem", label: "Body" },
+      lg:   { value: "1.25rem", label: "Large" },
+    },
+  },
+});
+```
+
+Tokens render as CSS variables (`var(--plumix-colors-brand, #0070f3)`),
+so theme switching at runtime is a `:root` style rewrite rather than a
+re-render.
+
+## Token buckets
+
+The framework knows about these buckets out of the box:
+
+- `colors`
+- `spacing`
+- `typography` (size)
+- `fontFamily`
+- `fontWeight`
+- `letterSpacing`
+- `border` (width / radius)
+- `boxShadow`
+- `textShadow`
+
+Each token is a `{ value, label }` pair. `value` is a CSS value (any
+string CSS accepts including `clamp()`, `min()`, `max()`, raw colors,
+named colors, gradients). `label` is what content editors see in the
+Inspector's Style tab.
+
+## Responsive token values
+
+Tokens can encode fluid responsive behaviour without leaving the token
+layer:
+
+```ts
+typography: {
+  hero: { value: "clamp(2rem, 4vw + 1rem, 4rem)", label: "Hero" },
+}
+```
+
+Use this when the size scales linearly with viewport. Use per-viewport
+overrides at the block level only when an instance needs to deviate from
+the token's default scaling.
+
+## Breakpoints
+
+Default viewport breakpoints (in pixels) are:
+
+- `small` — below 640
+- `medium` — 640 to 1024
+- `large` — 1024 and above
+
+Override at theme-level:
+
+```ts
+defineTheme({
+  name: "acme",
+  breakpoints: { small: 600, medium: 960, large: 1280 },
+  tokens: { /* … */ },
+});
+```
+
+The walker emits responsive overrides as `@media (max-width: …)` rules
+matching the configured pixel widths.
+
+## Block overrides
+
+A theme can replace any registered block's render by re-declaring the
+block with the same name inside `setup`:
+
+```ts
+defineTheme({
+  name: "acme",
+  setup: (themeCtx) => {
+    themeCtx.defineBlock({
+      name: "core/quote",
+      // Re-declare the full BlockSpec — the theme's spec wholly replaces
+      // the core block.
+      inputs: [
+        { name: "body", type: "richtext", label: "Body" },
+        { name: "citation", type: "text", label: "Citation" },
+      ],
+      defaults: { body: { type: "doc", content: [{ type: "paragraph" }] } },
+      render: ({ attrs }) => (
+        <figure className="acme-quote">
+          <blockquote>{/* … */}</blockquote>
+          <figcaption>{attrs.citation}</figcaption>
+        </figure>
+      ),
+    });
+  },
+});
+```
+
+Theme block overrides apply at theme activation. Switching themes
+restores the previous registry — there is no permanent registry
+mutation.
+
+## Override precedence
+
+`theme > plugin > core`. A theme block override beats a plugin's block
+which beats `coreBlocks`. The `mergeBlockRegistry` call in `buildApp`
+applies precedence at startup; subsequent theme switches re-merge.
+
+## Override etiquette
+
+- Match the existing `inputs` shape if possible. Changing input names is a
+  schema change for stored entries; the override should accept the same
+  attrs the previous block did.
+- Document the override in the theme README so site operators know which
+  blocks are themed.
+- For minor adjustments (CSS-variable rebinding, colour tweaks), prefer
+  token overrides over full block re-declarations.
+
+## Testing
+
+Themes can be tested via the same `plumix/blocks/test` helpers — render
+the overridden block through the test registry and assert markup. See the
+[block-authoring guide's testing section](./block-authoring.md#testing).
+
+## See also
+
+- [Block authoring](./block-authoring.md) — full `defineBlock` surface.
+- [Responsive guide](./responsive.md) — per-viewport overrides at the
+  block instance level.


### PR DESCRIPTION
Land the canonical author-facing documentation for the page-builder rearchitecture.
Seven guides + an index cover blocks, themes, plugins, field types, the editor
surface, responsive behaviour, and the core-block migration record. Pure prose;
no code paths touched.

**Describes shipped surfaces, not aspirational ones**

Every guide reflects the v2 substrate as it stands on the integration branch
today — the spike route, the paragraph richtext migration, capability gating,
autosave + revisions, the field-type catalog. Where a piece is gated behind a
follow-up (richtext upgrade for heading / quote / callout summary / details
summary, plugin v2 runtime plumbing, hosted docs site), the relevant guide
calls it out as "out of scope" rather than describing future behaviour.

`docs/core-blocks-migration.md` is positioned as an in-repo maintainer record
rather than user prose. It captures what dropped at the `BlockSpec` type level
(`schema`, `Component`, `adminEditor`, `supports`, `legacyAliases`,
`parsePaste`, `keyboardShortcuts`, `markdownShortcuts`, `adminSchema`) and
why the universal Style slot replaces per-block `supports`, so the next
maintainer working on the rearchitecture inherits the rationale alongside
the types.

Out of scope (tracked):

- Hosted docs site. The repo has no hosted docs surface today. Building one
  (Docusaurus / Astro Starlight / equivalent) is its own slice if and when
  product wants it.
- Tutorial-shaped getting-started content. The guides are reference-shaped;
  a "build your first plugin" walkthrough belongs in a tutorials section
  once the API surface stabilises post-cutover.

Refs #404
Refs #379