### PR TITLE
fix(admin): wire title, back button, viewport switcher, autosave dedup

### DIFF
--- a/packages/admin/e2e/editor-typing.spec.ts
+++ b/packages/admin/e2e/editor-typing.spec.ts
@@ -159,18 +159,15 @@ test.describe("v2 editor: typing into a richtext block", () => {
     await expect(tablet).toHaveAttribute("data-active", "true");
     await expect(desktop).toHaveAttribute("data-active", "false");
 
-    // The canvas opens at fit-to-screen, which depends on the test
-    // viewport — could be anywhere between 50 % and ~100 %. Don't pin
-    // a specific initial value; just step up until the max preset and
-    // verify the display reaches 200 %, then step down to verify the
-    // direction reverses. Two clicks of zoom-in should land us at the
-    // next preset above the fit; zoom-out reverses.
+    // The canvas opens at fit-to-screen, which varies with the canvas
+    // column width — pinning a specific initial percentage is brittle.
+    // Walk up to the max preset (button disables itself at 200 %),
+    // then step back down to 150 % to verify the direction reverses.
     const percent = page.getByTestId("plumix-editor-zoom-percent");
-    await page.getByTestId("plumix-editor-zoom-in").click();
-    await page.getByTestId("plumix-editor-zoom-in").click();
-    await page.getByTestId("plumix-editor-zoom-in").click();
-    await page.getByTestId("plumix-editor-zoom-in").click();
-    await page.getByTestId("plumix-editor-zoom-in").click();
+    const zoomIn = page.getByTestId("plumix-editor-zoom-in");
+    for (let i = 0; i < 6 && (await zoomIn.isEnabled()); i++) {
+      await zoomIn.click();
+    }
     await expect(percent).toHaveText("200%");
     await page.getByTestId("plumix-editor-zoom-out").click();
     await expect(percent).toHaveText("150%");

--- a/packages/admin/e2e/editor-typing.spec.ts
+++ b/packages/admin/e2e/editor-typing.spec.ts
@@ -125,7 +125,7 @@ test.describe("v2 editor: typing into a richtext block", () => {
     expect(last?.title).toBe("My new title");
   });
 
-  test("viewport switcher selects the tablet preset", async ({ page }) => {
+  test("canvas toolbar zooms and switches viewport", async ({ page }) => {
     await page.route("**/_plumix/rpc/**", (route) => {
       const url = route.request().url();
       if (url.endsWith("/auth/session")) {
@@ -147,7 +147,7 @@ test.describe("v2 editor: typing into a richtext block", () => {
 
     await page.goto("entries/posts/1/edit");
 
-    // The switcher ships Mobile (360) / Tablet (768) / Desktop (1280)
+    // The toolbar ships Mobile (360) / Tablet (768) / Desktop (1280)
     // presets. The editor mounts on Desktop via a one-shot effect; the
     // active button exposes data-active="true" — this is the chokepoint
     // where the dispatch shape would silently break.
@@ -158,6 +158,17 @@ test.describe("v2 editor: typing into a richtext block", () => {
     await tablet.click();
     await expect(tablet).toHaveAttribute("data-active", "true");
     await expect(desktop).toHaveAttribute("data-active", "false");
+
+    // Zoom percentage starts at 100% and steps through ZOOM_STEPS in
+    // 25% increments. The display is the chokepoint that surfaces a
+    // miswired stepZoom (e.g. off-by-one on the array indexing path).
+    const percent = page.getByTestId("plumix-editor-zoom-percent");
+    await expect(percent).toHaveText("100%");
+    await page.getByTestId("plumix-editor-zoom-out").click();
+    await expect(percent).toHaveText("75%");
+    await page.getByTestId("plumix-editor-zoom-in").click();
+    await page.getByTestId("plumix-editor-zoom-in").click();
+    await expect(percent).toHaveText("125%");
   });
 
   test("back button navigates to the entries list", async ({ page }) => {

--- a/packages/admin/e2e/editor-typing.spec.ts
+++ b/packages/admin/e2e/editor-typing.spec.ts
@@ -159,19 +159,21 @@ test.describe("v2 editor: typing into a richtext block", () => {
     await expect(tablet).toHaveAttribute("data-active", "true");
     await expect(desktop).toHaveAttribute("data-active", "false");
 
-    // The canvas opens at fit-to-screen, not 100%, so the percentage
-    // text depends on the test viewport. Lock the displayed value by
-    // tapping zoom-out once: the closest preset to the fit value (75%
-    // at 1280-viewport / 860-canvas) is 75%, and the next step down is
-    // 50%. Then zoom-in three times reaches 125% regardless of where
-    // we started.
+    // The canvas opens at fit-to-screen, which depends on the test
+    // viewport — could be anywhere between 50 % and ~100 %. Don't pin
+    // a specific initial value; just step up until the max preset and
+    // verify the display reaches 200 %, then step down to verify the
+    // direction reverses. Two clicks of zoom-in should land us at the
+    // next preset above the fit; zoom-out reverses.
     const percent = page.getByTestId("plumix-editor-zoom-percent");
+    await page.getByTestId("plumix-editor-zoom-in").click();
+    await page.getByTestId("plumix-editor-zoom-in").click();
+    await page.getByTestId("plumix-editor-zoom-in").click();
+    await page.getByTestId("plumix-editor-zoom-in").click();
+    await page.getByTestId("plumix-editor-zoom-in").click();
+    await expect(percent).toHaveText("200%");
     await page.getByTestId("plumix-editor-zoom-out").click();
-    await expect(percent).toHaveText("50%");
-    await page.getByTestId("plumix-editor-zoom-in").click();
-    await page.getByTestId("plumix-editor-zoom-in").click();
-    await page.getByTestId("plumix-editor-zoom-in").click();
-    await expect(percent).toHaveText("125%");
+    await expect(percent).toHaveText("150%");
   });
 
   test("back button navigates to the entries list", async ({ page }) => {

--- a/packages/admin/e2e/editor-typing.spec.ts
+++ b/packages/admin/e2e/editor-typing.spec.ts
@@ -125,6 +125,40 @@ test.describe("v2 editor: typing into a richtext block", () => {
     expect(last?.title).toBe("My new title");
   });
 
+  test("viewport switcher selects the tablet preset", async ({ page }) => {
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: emptyEntry(1), meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/1/edit");
+
+    // Puck's default viewports ship 360 / 768 / 1280 / 100%. The active
+    // state is exposed via data-active on the per-width button — this
+    // is the chokepoint where the dispatch shape would silently break.
+    const tablet = page.getByTestId("plumix-editor-viewport-768");
+    await expect(tablet).toBeVisible();
+    await tablet.click();
+    await expect(tablet).toHaveAttribute("data-active", "true");
+
+    const desktop = page.getByTestId("plumix-editor-viewport-1280");
+    await expect(desktop).toHaveAttribute("data-active", "false");
+  });
+
   test("back button navigates to the entries list", async ({ page }) => {
     await page.route("**/_plumix/rpc/**", (route) => {
       const url = route.request().url();

--- a/packages/admin/e2e/editor-typing.spec.ts
+++ b/packages/admin/e2e/editor-typing.spec.ts
@@ -159,13 +159,16 @@ test.describe("v2 editor: typing into a richtext block", () => {
     await expect(tablet).toHaveAttribute("data-active", "true");
     await expect(desktop).toHaveAttribute("data-active", "false");
 
-    // Zoom percentage starts at 100% and steps through ZOOM_STEPS in
-    // 25% increments. The display is the chokepoint that surfaces a
-    // miswired stepZoom (e.g. off-by-one on the array indexing path).
+    // The canvas opens at fit-to-screen, not 100%, so the percentage
+    // text depends on the test viewport. Lock the displayed value by
+    // tapping zoom-out once: the closest preset to the fit value (75%
+    // at 1280-viewport / 860-canvas) is 75%, and the next step down is
+    // 50%. Then zoom-in three times reaches 125% regardless of where
+    // we started.
     const percent = page.getByTestId("plumix-editor-zoom-percent");
-    await expect(percent).toHaveText("100%");
     await page.getByTestId("plumix-editor-zoom-out").click();
-    await expect(percent).toHaveText("75%");
+    await expect(percent).toHaveText("50%");
+    await page.getByTestId("plumix-editor-zoom-in").click();
     await page.getByTestId("plumix-editor-zoom-in").click();
     await page.getByTestId("plumix-editor-zoom-in").click();
     await expect(percent).toHaveText("125%");

--- a/packages/admin/e2e/editor-typing.spec.ts
+++ b/packages/admin/e2e/editor-typing.spec.ts
@@ -147,15 +147,16 @@ test.describe("v2 editor: typing into a richtext block", () => {
 
     await page.goto("entries/posts/1/edit");
 
-    // Puck's default viewports ship 360 / 768 / 1280 / 100%. The active
-    // state is exposed via data-active on the per-width button — this
-    // is the chokepoint where the dispatch shape would silently break.
+    // The switcher ships Mobile (360) / Tablet (768) / Desktop (1280)
+    // presets. The editor mounts on Desktop via a one-shot effect; the
+    // active button exposes data-active="true" — this is the chokepoint
+    // where the dispatch shape would silently break.
+    const desktop = page.getByTestId("plumix-editor-viewport-1280");
+    await expect(desktop).toHaveAttribute("data-active", "true");
+
     const tablet = page.getByTestId("plumix-editor-viewport-768");
-    await expect(tablet).toBeVisible();
     await tablet.click();
     await expect(tablet).toHaveAttribute("data-active", "true");
-
-    const desktop = page.getByTestId("plumix-editor-viewport-1280");
     await expect(desktop).toHaveAttribute("data-active", "false");
   });
 

--- a/packages/admin/e2e/editor-typing.spec.ts
+++ b/packages/admin/e2e/editor-typing.spec.ts
@@ -1,0 +1,154 @@
+// The CI-green cutover landed an editor whose canvas had no real typing
+// coverage — slash-menu insert + sidebar styling passed, but no test
+// actually typed into a richtext field on the canvas. This spec closes
+// that hole: insert a paragraph, type into it, assert the autosave
+// envelope reaches entry.update with the typed text and the server
+// answers OK (no 500, no INVALID_BLOCK_CONTENT).
+
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  mockRpcWithCapture,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+const T0 = new Date("2026-05-21T00:00:00Z");
+
+function emptyEntry(id: number): Record<string, unknown> {
+  return {
+    id,
+    type: "post",
+    parentId: null,
+    title: "Untitled",
+    slug: `entry-${String(id)}`,
+    content: null,
+    excerpt: null,
+    status: "draft",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: null,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: {},
+  };
+}
+
+test.describe("v2 editor: typing into a richtext block", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  test("typing into a paragraph block updates attrs.body and autosaves a valid envelope", async ({
+    page,
+  }) => {
+    const updateInputs = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/update",
+      captureResponse: { ...emptyEntry(1), updatedAt: T0 },
+      handlers: {
+        "/auth/session": AUTHED_ADMIN,
+        "/entry/get": emptyEntry(1),
+      },
+    });
+
+    await page.goto("entries/posts/1/edit");
+
+    const canvas = page.getByTestId("plumix-editor-canvas");
+    await canvas.focus();
+    await page.keyboard.press("/");
+    await page.keyboard.type("paragraph");
+    await expect(
+      page.getByTestId("slash-menu-item-core/paragraph"),
+    ).toBeVisible();
+    await page.keyboard.press("Enter");
+
+    // The paragraph was inserted; wait for autosave to dispatch the
+    // envelope. The very act of insertion should fire entry.update —
+    // this is the chokepoint where a 500 would surface.
+    await expect(canvas.locator("p")).toHaveCount(1);
+
+    // Wait for the debounced autosave to fire. The envelope is the
+    // single chokepoint where the cutover regressions surface: an
+    // unsanitised richtext doc, a missing block name, or a malformed
+    // attrs map all land here.
+    await expect
+      .poll(() => updateInputs.length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+
+    const last = updateInputs.at(-1) as
+      | {
+          id?: number;
+          title?: string;
+          content?: {
+            version?: string;
+            blocks?: readonly { name?: string; attrs?: unknown }[];
+          };
+        }
+      | undefined;
+    expect(last?.content?.version).toBe("plumix.v2");
+    const blocks = last?.content?.blocks ?? [];
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks[0]?.name).toBe("core/paragraph");
+
+    // The autosave pill flips back to "saved" once the server returns
+    // OK. If the server 500s, the pill stays on "error".
+    await expect(page.getByTestId("plumix-autosave-pill")).toHaveText("Saved");
+  });
+
+  test("editing the title fires entry.update with the new title", async ({
+    page,
+  }) => {
+    const updateInputs = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/update",
+      captureResponse: { ...emptyEntry(1), updatedAt: T0 },
+      handlers: {
+        "/auth/session": AUTHED_ADMIN,
+        "/entry/get": emptyEntry(1),
+      },
+    });
+
+    await page.goto("entries/posts/1/edit");
+
+    const titleInput = page.getByTestId("plumix-editor-title-input");
+    await expect(titleInput).toBeVisible();
+    await titleInput.fill("My new title");
+
+    await expect
+      .poll(() => updateInputs.length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+
+    const last = updateInputs.at(-1) as { title?: string } | undefined;
+    expect(last?.title).toBe("My new title");
+  });
+
+  test("back button navigates to the entries list", async ({ page }) => {
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/auth/session")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: rpcOkBody(AUTHED_ADMIN),
+        });
+      }
+      if (url.endsWith("/entry/get")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: emptyEntry(1), meta: [] }),
+        });
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/1/edit");
+
+    const back = page.getByTestId("plumix-editor-back-button");
+    await expect(back).toBeVisible();
+    await expect(back).toHaveAttribute("href", "/entries/posts");
+  });
+});

--- a/packages/admin/src/editor/BlockActionsPanel.tsx
+++ b/packages/admin/src/editor/BlockActionsPanel.tsx
@@ -31,7 +31,7 @@ export function BlockActionsPanel({
   if (!specName) {
     return (
       <div
-        className="text-muted-foreground p-3 text-xs"
+        className="text-muted-foreground p-4 text-xs"
         data-testid="block-actions-empty"
       >
         Select a block to see actions.
@@ -43,7 +43,7 @@ export function BlockActionsPanel({
   if (options.length === 0 && !hasExtras) return null;
 
   return (
-    <div className="space-y-2 border-b p-3" data-testid="block-actions-panel">
+    <div className="space-y-2 border-b p-4" data-testid="block-actions-panel">
       {options.length > 0 ? (
         <div className="space-y-1">
           <div className="text-muted-foreground text-xs">Transform to</div>

--- a/packages/admin/src/editor/BlockIcon.tsx
+++ b/packages/admin/src/editor/BlockIcon.tsx
@@ -1,0 +1,59 @@
+import type { ComponentType, SVGProps } from "react";
+import {
+  AlignLeft,
+  ChevronDown,
+  Code,
+  Columns,
+  Group,
+  Heading,
+  List,
+  ListOrdered,
+  Megaphone,
+  Minus,
+  MousePointerClick,
+  Pilcrow,
+  Quote,
+  Rows,
+  Square,
+  Table,
+  Type,
+} from "lucide-react";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+// Maps the `icon` string from `defineBlock` to a lucide React component.
+// `"Paragraph"` is aliased to `Pilcrow` because lucide ships a paragraph
+// mark glyph under that name; unknown names fall through to a neutral
+// `Square` so the layout stays consistent.
+const ICON_MAP: Record<string, IconComponent> = {
+  AlignLeft,
+  ChevronDown,
+  Code,
+  Columns,
+  Group,
+  Heading,
+  List,
+  ListOrdered,
+  Megaphone,
+  Minus,
+  MousePointerClick,
+  Paragraph: Pilcrow,
+  Quote,
+  Rows,
+  Table,
+  Type,
+};
+
+interface BlockIconProps {
+  readonly name: string | undefined;
+  readonly className?: string;
+}
+
+export function BlockIcon({
+  name,
+  className = "h-4 w-4 shrink-0",
+}: BlockIconProps): React.ReactElement {
+  const Component: IconComponent =
+    (name ? ICON_MAP[name] : undefined) ?? Square;
+  return <Component className={className} aria-hidden />;
+}

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -3,7 +3,7 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   ReactNode,
 } from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -72,35 +72,77 @@ const VIEWPORT_BTN_INACTIVE =
   "text-muted-foreground hover:bg-accent hover:text-foreground";
 const VIEWPORT_BTN_ACTIVE = "bg-accent text-foreground";
 
-function viewportGlyph(icon: unknown): ReactElement {
-  const cls = "h-4 w-4";
-  if (icon === "Smartphone") return <Smartphone className={cls} aria-hidden />;
-  if (icon === "Tablet") return <Tablet className={cls} aria-hidden />;
-  return <Monitor className={cls} aria-hidden />;
+interface ViewportPreset {
+  readonly width: number;
+  readonly height: "auto";
+  readonly label: string;
+  readonly icon: ReactElement;
 }
 
-function ViewportSwitcher(): ReactElement | null {
+// Puck stores the `viewports` prop on the store but leaves
+// `appState.ui.viewports.options` empty until something dispatches into
+// it, so the switcher owns its own preset list and only mutates the
+// single live `current` field via setUi.
+const VIEWPORT_PRESETS: readonly ViewportPreset[] = [
+  {
+    width: 360,
+    height: "auto",
+    label: "Mobile",
+    icon: <Smartphone className="h-4 w-4" aria-hidden />,
+  },
+  {
+    width: 768,
+    height: "auto",
+    label: "Tablet",
+    icon: <Tablet className="h-4 w-4" aria-hidden />,
+  },
+  {
+    width: 1280,
+    height: "auto",
+    label: "Desktop",
+    icon: <Monitor className="h-4 w-4" aria-hidden />,
+  },
+];
+
+// Index into VIEWPORT_PRESETS that the editor should open on. Puck
+// hardcodes initial `viewports.current` to its bundled Smartphone
+// (360px) preset, which lands authors in mobile preview — pick Desktop
+// instead so a fresh edit starts at the wide layout.
+const DEFAULT_VIEWPORT_INDEX = 2;
+
+function ViewportSwitcher(): ReactElement {
   const puck = usePuck();
   const { viewports } = puck.appState.ui;
-  const options = viewports.options;
-  if (options.length === 0) return null;
   const currentWidth = viewports.current.width;
-  const currentIndex = options.findIndex((v) => v.width === currentWidth);
-  const setViewport = (width: number | "100%", height: number | "auto"): void =>
+  const dispatch = puck.dispatch;
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current) return;
+    seededRef.current = true;
+    const target = VIEWPORT_PRESETS[DEFAULT_VIEWPORT_INDEX];
+    if (!target) return;
+    const { width, height } = target;
+    dispatch({
+      type: "setUi",
+      ui: (prev) => ({
+        viewports: { ...prev.viewports, current: { width, height } },
+      }),
+    });
+  }, [dispatch]);
+  const currentIndex = VIEWPORT_PRESETS.findIndex(
+    (v) => v.width === currentWidth,
+  );
+  const setViewport = (width: number, height: "auto"): void =>
     puck.dispatch({
       type: "setUi",
       ui: (prev) => ({
-        viewports: {
-          ...prev.viewports,
-          current: { width, height },
-        },
+        viewports: { ...prev.viewports, current: { width, height } },
       }),
     });
   const step = (delta: number): void => {
-    if (currentIndex < 0) return;
-    const next = options[currentIndex + delta];
+    const next = VIEWPORT_PRESETS[currentIndex + delta];
     if (!next) return;
-    setViewport(next.width, next.height ?? "auto");
+    setViewport(next.width, next.height);
   };
   return (
     <div
@@ -117,20 +159,20 @@ function ViewportSwitcher(): ReactElement | null {
       >
         <Minus className="h-4 w-4" aria-hidden />
       </button>
-      {options.map((v) => {
+      {VIEWPORT_PRESETS.map((v) => {
         const isActive = v.width === currentWidth;
         return (
           <button
-            key={`${v.width}`}
+            key={v.width}
             type="button"
             className={`${VIEWPORT_BTN} ${isActive ? VIEWPORT_BTN_ACTIVE : VIEWPORT_BTN_INACTIVE}`}
             data-testid={`plumix-editor-viewport-${v.width}`}
             data-active={isActive ? "true" : "false"}
-            aria-label={v.label ?? `Viewport ${v.width}`}
+            aria-label={v.label}
             aria-pressed={isActive}
-            onClick={() => setViewport(v.width, v.height ?? "auto")}
+            onClick={() => setViewport(v.width, v.height)}
           >
-            {viewportGlyph(v.icon)}
+            {v.icon}
           </button>
         );
       })}
@@ -140,7 +182,9 @@ function ViewportSwitcher(): ReactElement | null {
         data-testid="plumix-editor-viewport-wider"
         aria-label="Wider viewport"
         onClick={() => step(1)}
-        disabled={currentIndex < 0 || currentIndex >= options.length - 1}
+        disabled={
+          currentIndex < 0 || currentIndex >= VIEWPORT_PRESETS.length - 1
+        }
       >
         <Plus className="h-4 w-4" aria-hidden />
       </button>

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -3,7 +3,14 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   ReactNode,
 } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Dialog,
   DialogContent,
@@ -140,14 +147,15 @@ function CanvasToolbar({
     });
     onZoomChange(null);
   };
-  // When the current zoom is between presets (e.g. fit-to-screen lands
-  // at 62%), step to the next preset above or below — never get stuck
-  // at the off-preset value because +/- can't find an exact-index match.
+  // Step to the next preset strictly above/below the current zoom. The
+  // 1 % tolerance keeps a step away from an effectively-equal preset
+  // (e.g. fit-to-screen at 0.497 should still snap UP to 0.75, not
+  // shuffle to 0.5 and display the same percentage).
   const stepZoom = (delta: number): void => {
     const next =
       delta > 0
-        ? ZOOM_STEPS.find((s) => s > zoom + 0.001)
-        : [...ZOOM_STEPS].reverse().find((s) => s < zoom - 0.001);
+        ? ZOOM_STEPS.find((s) => s > zoom + 0.01)
+        : [...ZOOM_STEPS].reverse().find((s) => s < zoom - 0.01);
     if (next !== undefined) onZoomChange(next);
   };
   const firstStep = ZOOM_STEPS[0] ?? 0;
@@ -547,7 +555,11 @@ function PlumixCanvasWithSlashMenu({
   const [manualZoom, setManualZoom] = useState<number | null>(null);
   const mainRef = useRef<HTMLElement>(null);
   const [mainInnerWidth, setMainInnerWidth] = useState(0);
-  useEffect(() => {
+  // useLayoutEffect so the synchronous initial measure runs before
+  // paint — without it the canvas flashes 100% for one frame before
+  // dropping to the fit value, which races CI tests that click the
+  // zoom buttons immediately after navigation.
+  useLayoutEffect(() => {
     const el = mainRef.current;
     if (!el) return;
     const measure = (): void => {

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -35,6 +35,7 @@ import type { TransformOption } from "./available-transforms.js";
 import type { SlashMenuItem } from "./slash-menu-items.js";
 import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
+import { BlockIcon } from "./BlockIcon.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { mergePropsAtSelector } from "./merge-variation-attrs.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
@@ -289,17 +290,19 @@ function BlocksBody({ registry, capabilities }: BlocksBodyProps): ReactElement {
   const isMobile = useIsMobile();
   const content = (
     <Tabs defaultValue="blocks" className="h-full">
-      <TabsList className="w-full">
-        <TabsTrigger value="blocks" data-testid="plumix-editor-tab-blocks">
-          Blocks
-        </TabsTrigger>
-        <TabsTrigger value="outline" data-testid="plumix-editor-tab-outline">
-          Outline
-        </TabsTrigger>
-        <TabsTrigger value="audit" data-testid="plumix-editor-tab-audit">
-          Audit
-        </TabsTrigger>
-      </TabsList>
+      <div className="px-2 pt-2">
+        <TabsList className="w-full">
+          <TabsTrigger value="blocks" data-testid="plumix-editor-tab-blocks">
+            Blocks
+          </TabsTrigger>
+          <TabsTrigger value="outline" data-testid="plumix-editor-tab-outline">
+            Outline
+          </TabsTrigger>
+          <TabsTrigger value="audit" data-testid="plumix-editor-tab-audit">
+            Audit
+          </TabsTrigger>
+        </TabsList>
+      </div>
       <TabsContent value="blocks">
         <PlumixBlocksTab registry={registry} capabilities={capabilities} />
       </TabsContent>
@@ -385,11 +388,12 @@ function PlumixBlocksTab({
         <li key={entry.slug}>
           <button
             type="button"
-            className="hover:bg-muted w-full rounded border px-3 py-2 text-left text-sm"
+            className="hover:bg-muted flex w-full items-center gap-2 rounded border px-3 py-2 text-left text-sm"
             data-testid={`plumix-blocks-tab-item-${entry.slug}`}
             onClick={() => handleInsert(entry)}
           >
-            {entry.title}
+            <BlockIcon name={entry.icon} />
+            <span className="truncate">{entry.title}</span>
           </button>
         </li>
       ))}
@@ -408,14 +412,16 @@ function InspectorBody({ registry, tokens }: InspectorBodyProps): ReactElement {
     <>
       <PlumixBlockActions registry={registry} />
       <Tabs defaultValue="block" className="h-full">
-        <TabsList className="w-full">
-          <TabsTrigger value="block" data-testid="plumix-editor-tab-block">
-            Block
-          </TabsTrigger>
-          <TabsTrigger value="style" data-testid="plumix-editor-tab-style">
-            Style
-          </TabsTrigger>
-        </TabsList>
+        <div className="px-2 pt-2">
+          <TabsList className="w-full">
+            <TabsTrigger value="block" data-testid="plumix-editor-tab-block">
+              Block
+            </TabsTrigger>
+            <TabsTrigger value="style" data-testid="plumix-editor-tab-style">
+              Style
+            </TabsTrigger>
+          </TabsList>
+        </div>
         <TabsContent value="block">
           <Puck.Fields />
         </TabsContent>

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -49,6 +49,9 @@ interface PlumixEditorLayoutProps {
   readonly capabilities?: ReadonlySet<string>;
   readonly tokens?: ThemeTokens;
   readonly children?: ReactNode;
+  readonly title: string;
+  readonly onTitleChange: (next: string) => void;
+  readonly backHref: string;
   readonly onPublish: () => void;
   readonly isPublishing?: boolean;
   readonly isPublished?: boolean;
@@ -80,6 +83,9 @@ export function PlumixEditorLayout({
   registry = EMPTY_REGISTRY,
   capabilities = EMPTY_CAPS,
   tokens = EMPTY_TOKENS,
+  title,
+  onTitleChange,
+  backHref,
   onPublish,
   isPublishing = false,
   isPublished = false,
@@ -91,12 +97,22 @@ export function PlumixEditorLayout({
         className="flex items-center gap-3 border-b px-4 py-2"
         data-testid="plumix-editor-header"
       >
+        <a
+          href={backHref}
+          aria-label="Back to list"
+          className="text-muted-foreground hover:text-foreground rounded border px-2 py-1 text-sm"
+          data-testid="plumix-editor-back-button"
+        >
+          ←
+        </a>
         <input
           type="text"
           placeholder="Untitled"
           aria-label="Entry title"
           className="flex-1 bg-transparent outline-none"
           data-testid="plumix-editor-title-input"
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
         />
         <AutosaveStatusPill />
         {revisionsTrigger}

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -3,7 +3,7 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   ReactNode,
 } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -18,6 +18,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs.js";
 import { useIsMobile } from "@/hooks/use-mobile.js";
+import { cn } from "@/lib/utils.js";
 import { Puck, usePuck } from "@puckeditor/core";
 import { Minus, Monitor, Plus, Smartphone, Tablet } from "lucide-react";
 
@@ -66,11 +67,9 @@ const EMPTY_REGISTRY: BlockRegistry = createBlockRegistry([]);
 const EMPTY_CAPS: ReadonlySet<string> = new Set();
 const EMPTY_TOKENS: ThemeTokens = {};
 
-const VIEWPORT_BTN =
-  "inline-flex h-8 w-8 items-center justify-center rounded-md disabled:opacity-40";
-const VIEWPORT_BTN_INACTIVE =
-  "text-muted-foreground hover:bg-accent hover:text-foreground";
-const VIEWPORT_BTN_ACTIVE = "bg-accent text-foreground";
+const TOOLBAR_BTN =
+  "inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-40";
+const ZOOM_STEPS: readonly number[] = [0.5, 0.75, 1, 1.25, 1.5, 2];
 
 interface ViewportPreset {
   readonly width: number;
@@ -79,10 +78,6 @@ interface ViewportPreset {
   readonly icon: ReactElement;
 }
 
-// Puck stores the `viewports` prop on the store but leaves
-// `appState.ui.viewports.options` empty until something dispatches into
-// it, so the switcher owns its own preset list and only mutates the
-// single live `current` field via setUi.
 const VIEWPORT_PRESETS: readonly ViewportPreset[] = [
   {
     width: 360,
@@ -104,21 +99,25 @@ const VIEWPORT_PRESETS: readonly ViewportPreset[] = [
   },
 ];
 
-// Index into VIEWPORT_PRESETS that the editor should open on. Puck
-// hardcodes initial `viewports.current` to its bundled Smartphone
-// (360px) preset, which lands authors in mobile preview — pick Desktop
-// instead so a fresh edit starts at the wide layout.
+// Puck hardcodes initial `viewports.current` to its bundled Smartphone
+// (360px) preset, which lands authors in mobile preview — open on
+// Desktop instead so the editor starts at the wide layout.
 const DEFAULT_VIEWPORT_INDEX = 2;
 
-function ViewportSwitcher(): ReactElement {
+interface CanvasToolbarProps {
+  readonly zoom: number;
+  readonly onZoomChange: (next: number) => void;
+}
+
+function CanvasToolbar({
+  zoom,
+  onZoomChange,
+}: CanvasToolbarProps): ReactElement {
   const puck = usePuck();
   const { viewports } = puck.appState.ui;
   const currentWidth = viewports.current.width;
   const dispatch = puck.dispatch;
-  const seededRef = useRef(false);
   useEffect(() => {
-    if (seededRef.current) return;
-    seededRef.current = true;
     const target = VIEWPORT_PRESETS[DEFAULT_VIEWPORT_INDEX];
     if (!target) return;
     const { width, height } = target;
@@ -129,65 +128,78 @@ function ViewportSwitcher(): ReactElement {
       }),
     });
   }, [dispatch]);
-  const currentIndex = VIEWPORT_PRESETS.findIndex(
-    (v) => v.width === currentWidth,
-  );
   const setViewport = (width: number, height: "auto"): void =>
-    puck.dispatch({
+    dispatch({
       type: "setUi",
       ui: (prev) => ({
         viewports: { ...prev.viewports, current: { width, height } },
       }),
     });
-  const step = (delta: number): void => {
-    const next = VIEWPORT_PRESETS[currentIndex + delta];
-    if (!next) return;
-    setViewport(next.width, next.height);
+  const zoomIndex = ZOOM_STEPS.indexOf(zoom);
+  const stepZoom = (delta: number): void => {
+    const next = ZOOM_STEPS[zoomIndex + delta];
+    if (next !== undefined) onZoomChange(next);
   };
   return (
     <div
-      className="flex items-center gap-1"
-      data-testid="plumix-editor-viewports"
+      className="bg-background flex h-10 shrink-0 items-center justify-center gap-2 border-b"
+      data-testid="plumix-editor-canvas-toolbar"
     >
-      <button
-        type="button"
-        className={`${VIEWPORT_BTN} ${VIEWPORT_BTN_INACTIVE}`}
-        data-testid="plumix-editor-viewport-narrower"
-        aria-label="Narrower viewport"
-        onClick={() => step(-1)}
-        disabled={currentIndex <= 0}
+      <div
+        className="flex items-center gap-1"
+        data-testid="plumix-editor-viewports"
       >
-        <Minus className="h-4 w-4" aria-hidden />
-      </button>
-      {VIEWPORT_PRESETS.map((v) => {
-        const isActive = v.width === currentWidth;
-        return (
-          <button
-            key={v.width}
-            type="button"
-            className={`${VIEWPORT_BTN} ${isActive ? VIEWPORT_BTN_ACTIVE : VIEWPORT_BTN_INACTIVE}`}
-            data-testid={`plumix-editor-viewport-${v.width}`}
-            data-active={isActive ? "true" : "false"}
-            aria-label={v.label}
-            aria-pressed={isActive}
-            onClick={() => setViewport(v.width, v.height)}
-          >
-            {v.icon}
-          </button>
-        );
-      })}
-      <button
-        type="button"
-        className={`${VIEWPORT_BTN} ${VIEWPORT_BTN_INACTIVE}`}
-        data-testid="plumix-editor-viewport-wider"
-        aria-label="Wider viewport"
-        onClick={() => step(1)}
-        disabled={
-          currentIndex < 0 || currentIndex >= VIEWPORT_PRESETS.length - 1
-        }
+        {VIEWPORT_PRESETS.map((v) => {
+          const isActive = v.width === currentWidth;
+          return (
+            <button
+              key={v.width}
+              type="button"
+              className={cn(
+                TOOLBAR_BTN,
+                isActive && "bg-accent text-foreground",
+              )}
+              data-testid={`plumix-editor-viewport-${v.width}`}
+              data-active={isActive ? "true" : "false"}
+              aria-label={v.label}
+              aria-pressed={isActive}
+              onClick={() => setViewport(v.width, v.height)}
+            >
+              {v.icon}
+            </button>
+          );
+        })}
+      </div>
+      <div className="bg-border h-5 w-px" aria-hidden />
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className={TOOLBAR_BTN}
+          data-testid="plumix-editor-zoom-out"
+          aria-label="Zoom out"
+          onClick={() => stepZoom(-1)}
+          disabled={zoomIndex <= 0}
+        >
+          <Minus className="h-4 w-4" aria-hidden />
+        </button>
+        <button
+          type="button"
+          className={TOOLBAR_BTN}
+          data-testid="plumix-editor-zoom-in"
+          aria-label="Zoom in"
+          onClick={() => stepZoom(1)}
+          disabled={zoomIndex >= ZOOM_STEPS.length - 1}
+        >
+          <Plus className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+      <div className="bg-border h-5 w-px" aria-hidden />
+      <span
+        className="text-muted-foreground w-12 text-center text-xs tabular-nums"
+        data-testid="plumix-editor-zoom-percent"
       >
-        <Plus className="h-4 w-4" aria-hidden />
-      </button>
+        {Math.round(zoom * 100)}%
+      </span>
     </div>
   );
 }
@@ -241,7 +253,6 @@ export function PlumixEditorLayout({
           value={title}
           onChange={(e) => onTitleChange(e.target.value)}
         />
-        <ViewportSwitcher />
         <AutosaveStatusPill />
         {revisionsTrigger}
         <button
@@ -255,7 +266,7 @@ export function PlumixEditorLayout({
         </button>
       </header>
       <div
-        className="grid flex-1 grid-cols-[1fr] overflow-hidden md:grid-cols-[260px_1fr_320px]"
+        className="grid flex-1 grid-cols-[minmax(0,1fr)] overflow-hidden md:grid-cols-[260px_minmax(0,1fr)_320px]"
         data-testid="plumix-editor-cols"
       >
         <BlocksBody registry={registry} capabilities={capabilities} />
@@ -508,20 +519,27 @@ function PlumixCanvasWithSlashMenu({
   );
 
   const currentViewportWidth = puck.appState.ui.viewports.current.width;
-  const canvasFrameWidth =
-    currentViewportWidth === "100%" ? "100%" : `${currentViewportWidth}px`;
+  const viewportPx =
+    typeof currentViewportWidth === "number"
+      ? currentViewportWidth
+      : VIEWPORT_PRESETS[DEFAULT_VIEWPORT_INDEX]?.width ?? 1280;
+  const [zoom, setZoom] = useState(1);
 
   return (
-    <>
+    <div
+      className="flex min-h-0 flex-col"
+      data-testid="plumix-editor-canvas-column"
+    >
+      <CanvasToolbar zoom={zoom} onZoomChange={setZoom} />
       <main
-        className="bg-muted/30 overflow-auto px-8 py-6"
+        className="bg-muted/30 flex-1 overflow-auto px-8 py-6"
         data-testid="plumix-editor-canvas"
         tabIndex={0}
         onKeyDown={handleCanvasKeyDown}
       >
         <div
-          className="bg-background mx-auto min-h-full rounded-md border p-8 shadow-sm transition-[width]"
-          style={{ width: canvasFrameWidth, maxWidth: "100%" }}
+          className="bg-background mx-auto rounded-md border p-8 shadow-sm transition-[width]"
+          style={{ width: viewportPx, zoom }}
           data-testid="plumix-editor-canvas-frame"
         >
           <Puck.Preview />
@@ -548,7 +566,7 @@ function PlumixCanvasWithSlashMenu({
           />
         </DialogContent>
       </Dialog>
-    </>
+    </div>
   );
 }
 

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -541,7 +541,7 @@ function PlumixCanvasWithSlashMenu({
   const viewportPx =
     typeof currentViewportWidth === "number"
       ? currentViewportWidth
-      : VIEWPORT_PRESETS[DEFAULT_VIEWPORT_INDEX]?.width ?? 1280;
+      : (VIEWPORT_PRESETS[DEFAULT_VIEWPORT_INDEX]?.width ?? 1280);
   // `null` keeps the canvas at fit-to-screen; an explicit number is
   // the manual override the zoom +/- buttons emit.
   const [manualZoom, setManualZoom] = useState<number | null>(null);

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/tabs.js";
 import { useIsMobile } from "@/hooks/use-mobile.js";
 import { Puck, usePuck } from "@puckeditor/core";
+import { Minus, Monitor, Plus, Smartphone, Tablet } from "lucide-react";
 
 import type {
   BlockRegistry,
@@ -65,6 +66,88 @@ const EMPTY_REGISTRY: BlockRegistry = createBlockRegistry([]);
 const EMPTY_CAPS: ReadonlySet<string> = new Set();
 const EMPTY_TOKENS: ThemeTokens = {};
 
+const VIEWPORT_BTN =
+  "inline-flex h-8 w-8 items-center justify-center rounded-md disabled:opacity-40";
+const VIEWPORT_BTN_INACTIVE =
+  "text-muted-foreground hover:bg-accent hover:text-foreground";
+const VIEWPORT_BTN_ACTIVE = "bg-accent text-foreground";
+
+function viewportGlyph(icon: unknown): ReactElement {
+  const cls = "h-4 w-4";
+  if (icon === "Smartphone") return <Smartphone className={cls} aria-hidden />;
+  if (icon === "Tablet") return <Tablet className={cls} aria-hidden />;
+  return <Monitor className={cls} aria-hidden />;
+}
+
+function ViewportSwitcher(): ReactElement | null {
+  const puck = usePuck();
+  const { viewports } = puck.appState.ui;
+  const options = viewports.options;
+  if (options.length === 0) return null;
+  const currentWidth = viewports.current.width;
+  const currentIndex = options.findIndex((v) => v.width === currentWidth);
+  const setViewport = (width: number | "100%", height: number | "auto"): void =>
+    puck.dispatch({
+      type: "setUi",
+      ui: (prev) => ({
+        viewports: {
+          ...prev.viewports,
+          current: { width, height },
+        },
+      }),
+    });
+  const step = (delta: number): void => {
+    if (currentIndex < 0) return;
+    const next = options[currentIndex + delta];
+    if (!next) return;
+    setViewport(next.width, next.height ?? "auto");
+  };
+  return (
+    <div
+      className="flex items-center gap-1"
+      data-testid="plumix-editor-viewports"
+    >
+      <button
+        type="button"
+        className={`${VIEWPORT_BTN} ${VIEWPORT_BTN_INACTIVE}`}
+        data-testid="plumix-editor-viewport-narrower"
+        aria-label="Narrower viewport"
+        onClick={() => step(-1)}
+        disabled={currentIndex <= 0}
+      >
+        <Minus className="h-4 w-4" aria-hidden />
+      </button>
+      {options.map((v) => {
+        const isActive = v.width === currentWidth;
+        return (
+          <button
+            key={`${v.width}`}
+            type="button"
+            className={`${VIEWPORT_BTN} ${isActive ? VIEWPORT_BTN_ACTIVE : VIEWPORT_BTN_INACTIVE}`}
+            data-testid={`plumix-editor-viewport-${v.width}`}
+            data-active={isActive ? "true" : "false"}
+            aria-label={v.label ?? `Viewport ${v.width}`}
+            aria-pressed={isActive}
+            onClick={() => setViewport(v.width, v.height ?? "auto")}
+          >
+            {viewportGlyph(v.icon)}
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        className={`${VIEWPORT_BTN} ${VIEWPORT_BTN_INACTIVE}`}
+        data-testid="plumix-editor-viewport-wider"
+        aria-label="Wider viewport"
+        onClick={() => step(1)}
+        disabled={currentIndex < 0 || currentIndex >= options.length - 1}
+      >
+        <Plus className="h-4 w-4" aria-hidden />
+      </button>
+    </div>
+  );
+}
+
 function PlumixAuditTab(): ReactElement {
   const puck = usePuck();
   const tree = useMemo(
@@ -94,13 +177,13 @@ export function PlumixEditorLayout({
   return (
     <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
       <header
-        className="flex items-center gap-3 border-b px-4 py-2"
+        className="bg-background flex h-12 shrink-0 items-center gap-3 border-b px-4"
         data-testid="plumix-editor-header"
       >
         <a
           href={backHref}
           aria-label="Back to list"
-          className="text-muted-foreground hover:text-foreground rounded border px-2 py-1 text-sm"
+          className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border text-sm"
           data-testid="plumix-editor-back-button"
         >
           ←
@@ -109,16 +192,17 @@ export function PlumixEditorLayout({
           type="text"
           placeholder="Untitled"
           aria-label="Entry title"
-          className="flex-1 bg-transparent outline-none"
+          className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent px-2 text-base font-medium outline-none"
           data-testid="plumix-editor-title-input"
           value={title}
           onChange={(e) => onTitleChange(e.target.value)}
         />
+        <ViewportSwitcher />
         <AutosaveStatusPill />
         {revisionsTrigger}
         <button
           type="button"
-          className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+          className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-8 items-center rounded-md px-3 text-sm font-medium disabled:opacity-50"
           data-testid="plumix-editor-publish-button"
           onClick={onPublish}
           disabled={isPublishing || isPublished}
@@ -379,15 +463,25 @@ function PlumixCanvasWithSlashMenu({
     [puck],
   );
 
+  const currentViewportWidth = puck.appState.ui.viewports.current.width;
+  const canvasFrameWidth =
+    currentViewportWidth === "100%" ? "100%" : `${currentViewportWidth}px`;
+
   return (
     <>
       <main
-        className="overflow-auto"
+        className="bg-muted/30 overflow-auto px-8 py-6"
         data-testid="plumix-editor-canvas"
         tabIndex={0}
         onKeyDown={handleCanvasKeyDown}
       >
-        <Puck.Preview />
+        <div
+          className="bg-background mx-auto min-h-full rounded-md border p-8 shadow-sm transition-[width]"
+          style={{ width: canvasFrameWidth, maxWidth: "100%" }}
+          data-testid="plumix-editor-canvas-frame"
+        >
+          <Puck.Preview />
+        </div>
       </main>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -290,7 +290,7 @@ function BlocksBody({ registry, capabilities }: BlocksBodyProps): ReactElement {
   const isMobile = useIsMobile();
   const content = (
     <Tabs defaultValue="blocks" className="h-full">
-      <div className="px-2 pt-2">
+      <div className="px-4 pt-4">
         <TabsList className="w-full">
           <TabsTrigger value="blocks" data-testid="plumix-editor-tab-blocks">
             Blocks
@@ -412,7 +412,7 @@ function InspectorBody({ registry, tokens }: InspectorBodyProps): ReactElement {
     <>
       <PlumixBlockActions registry={registry} />
       <Tabs defaultValue="block" className="h-full">
-        <div className="px-2 pt-2">
+        <div className="px-4 pt-4">
           <TabsList className="w-full">
             <TabsTrigger value="block" data-testid="plumix-editor-tab-block">
               Block

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -3,7 +3,7 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   ReactNode,
 } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -107,7 +107,9 @@ const DEFAULT_VIEWPORT_INDEX = 2;
 
 interface CanvasToolbarProps {
   readonly zoom: number;
-  readonly onZoomChange: (next: number) => void;
+  // null clears the manual override so the canvas tracks fit-to-screen
+  // again. Numeric values pin the zoom level until cleared.
+  readonly onZoomChange: (next: number | null) => void;
 }
 
 function CanvasToolbar({
@@ -129,18 +131,29 @@ function CanvasToolbar({
       }),
     });
   }, [dispatch]);
-  const setViewport = (width: number, height: "auto"): void =>
+  const setViewport = (width: number, height: "auto"): void => {
     dispatch({
       type: "setUi",
       ui: (prev) => ({
         viewports: { ...prev.viewports, current: { width, height } },
       }),
     });
-  const zoomIndex = ZOOM_STEPS.indexOf(zoom);
+    onZoomChange(null);
+  };
+  // When the current zoom is between presets (e.g. fit-to-screen lands
+  // at 62%), step to the next preset above or below — never get stuck
+  // at the off-preset value because +/- can't find an exact-index match.
   const stepZoom = (delta: number): void => {
-    const next = ZOOM_STEPS[zoomIndex + delta];
+    const next =
+      delta > 0
+        ? ZOOM_STEPS.find((s) => s > zoom + 0.001)
+        : [...ZOOM_STEPS].reverse().find((s) => s < zoom - 0.001);
     if (next !== undefined) onZoomChange(next);
   };
+  const firstStep = ZOOM_STEPS[0] ?? 0;
+  const lastStep = ZOOM_STEPS[ZOOM_STEPS.length - 1] ?? 1;
+  const atMin = zoom <= firstStep;
+  const atMax = zoom >= lastStep;
   return (
     <div
       className="bg-background flex h-10 shrink-0 items-center justify-center gap-2 border-b"
@@ -179,7 +192,7 @@ function CanvasToolbar({
           data-testid="plumix-editor-zoom-out"
           aria-label="Zoom out"
           onClick={() => stepZoom(-1)}
-          disabled={zoomIndex <= 0}
+          disabled={atMin}
         >
           <Minus className="h-4 w-4" aria-hidden />
         </button>
@@ -189,7 +202,7 @@ function CanvasToolbar({
           data-testid="plumix-editor-zoom-in"
           aria-label="Zoom in"
           onClick={() => stepZoom(1)}
-          disabled={zoomIndex >= ZOOM_STEPS.length - 1}
+          disabled={atMax}
         >
           <Plus className="h-4 w-4" aria-hidden />
         </button>
@@ -529,15 +542,37 @@ function PlumixCanvasWithSlashMenu({
     typeof currentViewportWidth === "number"
       ? currentViewportWidth
       : VIEWPORT_PRESETS[DEFAULT_VIEWPORT_INDEX]?.width ?? 1280;
-  const [zoom, setZoom] = useState(1);
+  // `null` keeps the canvas at fit-to-screen; an explicit number is
+  // the manual override the zoom +/- buttons emit.
+  const [manualZoom, setManualZoom] = useState<number | null>(null);
+  const mainRef = useRef<HTMLElement>(null);
+  const [mainInnerWidth, setMainInnerWidth] = useState(0);
+  useEffect(() => {
+    const el = mainRef.current;
+    if (!el) return;
+    const measure = (): void => {
+      const styles = window.getComputedStyle(el);
+      const padX =
+        parseFloat(styles.paddingLeft) + parseFloat(styles.paddingRight);
+      setMainInnerWidth(el.clientWidth - padX);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+  const fitZoom =
+    mainInnerWidth > 0 ? Math.min(1, mainInnerWidth / viewportPx) : 1;
+  const zoom = manualZoom ?? fitZoom;
 
   return (
     <div
       className="flex min-h-0 flex-col"
       data-testid="plumix-editor-canvas-column"
     >
-      <CanvasToolbar zoom={zoom} onZoomChange={setZoom} />
+      <CanvasToolbar zoom={zoom} onZoomChange={setManualZoom} />
       <main
+        ref={mainRef}
         className="bg-muted/30 flex-1 overflow-auto px-8 py-6"
         data-testid="plumix-editor-canvas"
         tabIndex={0}

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -396,7 +396,7 @@ function PlumixBlocksTab({
   );
 
   return (
-    <ul className="flex flex-col gap-1 p-2" data-testid="plumix-blocks-tab">
+    <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
       {entries.map((entry) => (
         <li key={entry.slug}>
           <button

--- a/packages/admin/src/editor/HeadingAuditPanel.tsx
+++ b/packages/admin/src/editor/HeadingAuditPanel.tsx
@@ -26,7 +26,7 @@ export function HeadingAuditPanel({
   }
 
   return (
-    <ul role="list" className="space-y-2 p-2" data-testid="heading-audit-list">
+    <ul role="list" className="space-y-2 p-4" data-testid="heading-audit-list">
       {violations.map((violation, index) => {
         const nodeIds = nodeIdsFor(violation);
         const primaryId = nodeIds[0];

--- a/packages/admin/src/editor/field-type-translator.ts
+++ b/packages/admin/src/editor/field-type-translator.ts
@@ -36,6 +36,10 @@ export function translateField(
       return {
         type: "richtext",
         label: input.label,
+        // contentEditable: true lets authors type directly on the canvas
+        // (Puck's inline-edit mode); without it the field is sidebar-only,
+        // which is the wrong UX for a paragraph body.
+        contentEditable: true,
         ...(options.richtextExtensions
           ? { tiptap: { extensions: options.richtextExtensions } }
           : {}),

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -36,9 +36,11 @@ import "@puckeditor/core/puck.css";
 
 const EMPTY_DATA: Data = { content: [], root: {} };
 
-// 5 s batches typing bursts so quiet pauses do not pile up identical
-// revisions. WordPress defaults to 60 s.
-const AUTOSAVE_DEBOUNCE_MS = 5000;
+// 1 s batches typing bursts; the dedup snapshot in the autosave closure
+// is what actually prevents identical revisions. WordPress's 60 s
+// equivalent is overkill here because we round-trip a workers DB on
+// every save and revisions are cheap.
+const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 // Keep in sync with the identical helper in _editor/entries/$slug/$id/edit.tsx.
 function isStaleConflictError(err: unknown): boolean {

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -34,7 +34,7 @@ import { idPathParam } from "@plumix/core/validation";
 
 import "@puckeditor/core/puck.css";
 
-const initialData: Data = { content: [], root: {} };
+const EMPTY_DATA: Data = { content: [], root: {} };
 
 // 5 s batches typing bursts so quiet pauses do not pile up identical
 // revisions. WordPress defaults to 60 s.
@@ -178,23 +178,22 @@ function PuckSpikeRouteInner({
   const { data: entry } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id } }),
   );
-  const [data, setData] = useState<Data>(() =>
-    seedPuckData(entry.content, readDraft(draftKey) ?? initialData),
+  // Initial-only: Puck owns the live editor state via its internal store.
+  // Re-seeding `<Puck data>` mid-keystroke unmounts Tiptap and steals
+  // focus — useState's init function runs once per component instance
+  // and is immune to entry refetches.
+  const [initialData] = useState<Data>(() =>
+    seedPuckData(entry.content, readDraft(draftKey) ?? EMPTY_DATA),
   );
   const [title, setTitle] = useState<string>(entry.title);
   const [status, setStatus] = useState<AutosaveStatus>("saved");
   // Optimistic-concurrency token; trailing-response wins on overlap.
   const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
   const queryClient = useQueryClient();
-  // Latest title + data refs so the debounced save closure always reads
-  // the most recent values (it's created once + called on every change).
-  // Effect-assign avoids the `react-hooks/refs` rule (no writes during
-  // render).
   const titleRef = useRef(title);
-  const dataRef = useRef(data);
+  const dataRef = useRef<Data>(initialData);
   useEffect(() => {
     titleRef.current = title;
-    dataRef.current = data;
   });
   // Seed dedup snapshots from the *server* entry, never from the local
   // `data` — `data` may have been hydrated from a stale localStorage
@@ -204,7 +203,7 @@ function PuckSpikeRouteInner({
   const lastSavedContentRef = useRef<string>(
     JSON.stringify(
       puckDataToBlockTree({
-        content: seedPuckData(entry.content, initialData).content,
+        content: seedPuckData(entry.content, EMPTY_DATA).content,
       }),
     ),
   );
@@ -268,7 +267,7 @@ function PuckSpikeRouteInner({
   useEffect(() => () => debouncer.flush(), [debouncer]);
   const handleChange = useCallback(
     (next: Data): void => {
-      setData(next);
+      dataRef.current = next;
       setStatus("saving");
       debouncer.call();
     },
@@ -349,7 +348,7 @@ function PuckSpikeRouteInner({
     <AutosaveStatusContext.Provider value={status}>
       <Puck
         config={config}
-        data={data}
+        data={initialData}
         onChange={handleChange}
         iframe={{ enabled: false }}
         overrides={{ puck: Layout }}

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -36,6 +36,10 @@ import "@puckeditor/core/puck.css";
 
 const initialData: Data = { content: [], root: {} };
 
+// 5 s batches typing bursts so quiet pauses do not pile up identical
+// revisions. WordPress defaults to 60 s.
+const AUTOSAVE_DEBOUNCE_MS = 5000;
+
 // Keep in sync with the identical helper in _editor/entries/$slug/$id/edit.tsx.
 function isStaleConflictError(err: unknown): boolean {
   if (!(err instanceof ORPCError)) return false;
@@ -192,27 +196,54 @@ function PuckSpikeRouteInner({
     titleRef.current = title;
     dataRef.current = data;
   });
+  // Seed dedup snapshots from the *server* entry, never from the local
+  // `data` — `data` may have been hydrated from a stale localStorage
+  // draft, and matching against that would skip the first autosave and
+  // silently strand the draft on the client.
+  const lastSavedTitleRef = useRef<string>(entry.title);
+  const lastSavedContentRef = useRef<string>(
+    JSON.stringify(
+      puckDataToBlockTree({
+        content: seedPuckData(entry.content, initialData).content,
+      }),
+    ),
+  );
   /* eslint-disable react-hooks/refs -- callback fires post-keystroke, not during render */
   const debouncer = useMemo(
     () =>
       createDebouncer(async () => {
         writeDraft(draftKey, dataRef.current);
+        // entry.update's `title` schema is `trimmedText(300)` with a
+        // minLength of 1 — an empty title rejects with INVALID_INPUT.
+        // Omit the title from the payload when blank so a user mid-
+        // typing an empty input doesn't break their autosave loop.
+        const trimmedTitle = titleRef.current.trim();
+        const blocks = puckDataToBlockTree({
+          content: dataRef.current.content,
+        });
+        const serializedBlocks = JSON.stringify(blocks);
+        const titleChanged =
+          trimmedTitle.length > 0 && trimmedTitle !== lastSavedTitleRef.current;
+        const contentChanged = serializedBlocks !== lastSavedContentRef.current;
+        if (!titleChanged && !contentChanged) {
+          // Nothing actually changed since the last successful save.
+          // Skip the round-trip so we don't burn revision slots or
+          // generate identical rows. The pill stays on "saved".
+          setStatus("saved");
+          return;
+        }
         try {
-          // entry.update's `title` schema is `trimmedText(300)` with a
-          // minLength of 1 — an empty title rejects with INVALID_INPUT.
-          // Omit the title from the payload when blank so a user mid-
-          // typing an empty input doesn't break their autosave loop.
-          const trimmedTitle = titleRef.current.trim();
           const updated = await orpc.entry.update.call({
             id,
-            ...(trimmedTitle.length > 0 ? { title: trimmedTitle } : {}),
-            content: {
-              version: "plumix.v2",
-              blocks: puckDataToBlockTree({ content: dataRef.current.content }),
-            },
+            ...(titleChanged ? { title: trimmedTitle } : {}),
+            ...(contentChanged
+              ? { content: { version: "plumix.v2", blocks } }
+              : {}),
             expectedLiveUpdatedAt: liveUpdatedAtRef.current,
           });
           liveUpdatedAtRef.current = updated.updatedAt;
+          if (titleChanged) lastSavedTitleRef.current = trimmedTitle;
+          if (contentChanged) lastSavedContentRef.current = serializedBlocks;
           setStatus("saved");
         } catch (err) {
           setStatus("error");
@@ -230,7 +261,7 @@ function PuckSpikeRouteInner({
             }
           }
         }
-      }, 300),
+      }, AUTOSAVE_DEBOUNCE_MS),
     [draftKey, id, queryClient],
   );
   /* eslint-enable react-hooks/refs */

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -129,6 +129,7 @@ function PuckSpikeRoute(): ReactNode {
   const supportsEditor = entryType?.supports
     ? entryType.supports.includes("editor")
     : true;
+  const backHref = `/entries/${slug}`;
   if (!supportsEditor && entryType) {
     return (
       <PlainFormRouteInner
@@ -148,6 +149,7 @@ function PuckSpikeRoute(): ReactNode {
       entryTypeName={entryType?.name}
       supportsRevisions={supportsRevisions}
       capabilities={user.capabilities}
+      backHref={backHref}
     />
   );
 }
@@ -158,6 +160,7 @@ interface PuckSpikeRouteInnerProps {
   readonly entryTypeName: string | undefined;
   readonly supportsRevisions: boolean;
   readonly capabilities: readonly string[];
+  readonly backHref: string;
 }
 
 function PuckSpikeRouteInner({
@@ -166,6 +169,7 @@ function PuckSpikeRouteInner({
   entryTypeName,
   supportsRevisions,
   capabilities,
+  backHref,
 }: PuckSpikeRouteInnerProps): ReactNode {
   const { data: entry } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id } }),
@@ -173,21 +177,38 @@ function PuckSpikeRouteInner({
   const [data, setData] = useState<Data>(() =>
     seedPuckData(entry.content, readDraft(draftKey) ?? initialData),
   );
+  const [title, setTitle] = useState<string>(entry.title);
   const [status, setStatus] = useState<AutosaveStatus>("saved");
   // Optimistic-concurrency token; trailing-response wins on overlap.
   const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
   const queryClient = useQueryClient();
+  // Latest title + data refs so the debounced save closure always reads
+  // the most recent values (it's created once + called on every change).
+  // Effect-assign avoids the `react-hooks/refs` rule (no writes during
+  // render).
+  const titleRef = useRef(title);
+  const dataRef = useRef(data);
+  useEffect(() => {
+    titleRef.current = title;
+    dataRef.current = data;
+  });
   /* eslint-disable react-hooks/refs -- callback fires post-keystroke, not during render */
   const debouncer = useMemo(
     () =>
-      createDebouncer(async (next: Data) => {
-        writeDraft(draftKey, next);
+      createDebouncer(async () => {
+        writeDraft(draftKey, dataRef.current);
         try {
+          // entry.update's `title` schema is `trimmedText(300)` with a
+          // minLength of 1 — an empty title rejects with INVALID_INPUT.
+          // Omit the title from the payload when blank so a user mid-
+          // typing an empty input doesn't break their autosave loop.
+          const trimmedTitle = titleRef.current.trim();
           const updated = await orpc.entry.update.call({
             id,
+            ...(trimmedTitle.length > 0 ? { title: trimmedTitle } : {}),
             content: {
               version: "plumix.v2",
-              blocks: puckDataToBlockTree({ content: next.content }),
+              blocks: puckDataToBlockTree({ content: dataRef.current.content }),
             },
             expectedLiveUpdatedAt: liveUpdatedAtRef.current,
           });
@@ -218,7 +239,15 @@ function PuckSpikeRouteInner({
     (next: Data): void => {
       setData(next);
       setStatus("saving");
-      debouncer.call(next);
+      debouncer.call();
+    },
+    [debouncer],
+  );
+  const handleTitleChange = useCallback(
+    (next: string): void => {
+      setTitle(next);
+      setStatus("saving");
+      debouncer.call();
     },
     [debouncer],
   );
@@ -264,6 +293,9 @@ function PuckSpikeRouteInner({
         registry={registry}
         capabilities={capabilitySet}
         tokens={sampleTokens}
+        title={title}
+        onTitleChange={handleTitleChange}
+        backHref={backHref}
         onPublish={handlePublish}
         isPublishing={publish.isPending}
         isPublished={isPublished}
@@ -271,6 +303,9 @@ function PuckSpikeRouteInner({
       />
     ),
     [
+      title,
+      handleTitleChange,
+      backHref,
       handlePublish,
       publish.isPending,
       isPublished,

--- a/packages/blocks/src/paragraph/index.test.tsx
+++ b/packages/blocks/src/paragraph/index.test.tsx
@@ -7,60 +7,37 @@ import { renderBlockTree } from "../render-block-tree.js";
 import { paragraphBlock } from "./index.js";
 
 describe("core/paragraph end-to-end through new defineBlock + walker + style emitter", () => {
-  test("walks the Tiptap doc body and renders inline marks", () => {
+  test("renders inline marks from the HTML body string", () => {
     const registry = createBlockRegistry([paragraphBlock]);
     const tree: readonly BlockNode[] = [
       {
         id: "p1",
         name: "core/paragraph",
-        attrs: {
-          body: {
-            type: "doc",
-            content: [
-              {
-                type: "paragraph",
-                content: [
-                  { type: "text", text: "Hello " },
-                  { type: "text", text: "world", marks: [{ type: "bold" }] },
-                ],
-              },
-            ],
-          },
-        },
+        attrs: { body: "<p>Hello <strong>world</strong></p>" },
       },
     ];
 
     const html = renderToStaticMarkup(renderBlockTree(tree, registry));
 
     expect(html).toBe(
-      '<div data-plumix-block="core/paragraph"><p>Hello <strong>world</strong></p></div>',
+      '<div data-plumix-block="core/paragraph"><div><p>Hello <strong>world</strong></p></div></div>',
     );
   });
 
-  test("renders a <p> wrapped in data-plumix-block", () => {
+  test("renders the HTML body wrapped in data-plumix-block", () => {
     const registry = createBlockRegistry([paragraphBlock]);
     const tree: readonly BlockNode[] = [
       {
         id: "p1",
         name: "core/paragraph",
-        attrs: {
-          body: {
-            type: "doc",
-            content: [
-              {
-                type: "paragraph",
-                content: [{ type: "text", text: "Hello, world" }],
-              },
-            ],
-          },
-        },
+        attrs: { body: "<p>Hello, world</p>" },
       },
     ];
 
     const html = renderToStaticMarkup(renderBlockTree(tree, registry));
 
     expect(html).toBe(
-      '<div data-plumix-block="core/paragraph"><p>Hello, world</p></div>',
+      '<div data-plumix-block="core/paragraph"><div><p>Hello, world</p></div></div>',
     );
   });
 
@@ -70,17 +47,7 @@ describe("core/paragraph end-to-end through new defineBlock + walker + style emi
       {
         id: "p1",
         name: "core/paragraph",
-        attrs: {
-          body: {
-            type: "doc",
-            content: [
-              {
-                type: "paragraph",
-                content: [{ type: "text", text: "Cascading" }],
-              },
-            ],
-          },
-        },
+        attrs: { body: "<p>Cascading</p>" },
         style: {
           large: { padding: "lg" },
           small: { padding: "sm" },

--- a/packages/blocks/src/paragraph/index.tsx
+++ b/packages/blocks/src/paragraph/index.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
+import { isValidElement } from "react";
 
 import { defineBlock } from "../block-registry.js";
-import { renderInline } from "../marks/render-inline.js";
 
 export const paragraphBlock = defineBlock({
   name: "core/paragraph",
@@ -9,9 +9,7 @@ export const paragraphBlock = defineBlock({
   icon: "Paragraph",
   category: "text",
   inputs: [{ name: "body", type: "richtext", label: "Body" }],
-  // ProseMirror's `doc` requires at least one block child; an empty
-  // paragraph keeps the editor mountable on first focus.
-  defaults: { body: { type: "doc", content: [{ type: "paragraph" }] } },
+  defaults: { body: "<p></p>" },
   transforms: {
     priority: 50,
     to: [
@@ -22,17 +20,16 @@ export const paragraphBlock = defineBlock({
       },
     ],
   },
-  // Always emit a `<p>`. The first-paragraph inline run lives inside;
-  // multi-paragraph docs surface a single block but only the first run
-  // renders (Enter splits into a new paragraph block at the editor
-  // level, not a paragraph node inside one block).
+  // Puck's richtext field stores HTML strings (see apps/demo/config/
+  // blocks/RichText). The admin canvas hands `attrs.body` wrapped as a
+  // <RichTextRender> React element; SSR / walker callers see the raw
+  // string. TODO(#XXX): sanitize the HTML at the entry.update ingest —
+  // the trust boundary is the stored bytes, not the editor.
   render: ({ attrs }): ReactNode => {
-    if (typeof attrs.body === "object" && attrs.body !== null) {
-      return <p>{renderInline(attrs.body)}</p>;
+    if (isValidElement(attrs.body)) return attrs.body;
+    if (typeof attrs.body === "string") {
+      return <div dangerouslySetInnerHTML={{ __html: attrs.body }} />;
     }
-    // Legacy plain-string content (pre-richtext entries, nested-slot
-    // test fixtures). Drops once existing entries + fixtures move to
-    // the doc shape.
     if (typeof attrs.text === "string") return <p>{attrs.text}</p>;
     return <p />;
   },

--- a/packages/plugins/blog/e2e/blog.spec.ts
+++ b/packages/plugins/blog/e2e/blog.spec.ts
@@ -25,26 +25,27 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
     }
   });
 
-  test.skip("create a draft post → row appears in the list", async ({
-    page,
-  }) => {
+  test("create a draft post → row appears in the list", async ({ page }) => {
+    // v2 flow: click New takes the user through /entries/posts/create
+    // (the redirect-on-mount route that calls entry.create + navigates
+    // to the edit URL), then we land in the Puck editor. Title is
+    // bound to the title input; autosave fires on change.
     await page.goto("entries/posts");
-    await page.getByTestId("content-list-new-button").click();
-
-    await expect(page.getByTestId("post-editor-form")).toBeVisible();
-    await page.getByTestId("post-editor-title-input").fill("Hello world");
-    // Arm the navigation waiter BEFORE the click so we never miss a
-    // fast post-create redirect — playwright's `waitForURL` only matches
-    // navigations that start after it's armed, and the create RPC can
-    // resolve in <10ms against a warm worker.
     const navigated = page.waitForURL(/\/entries\/posts\/\d+\/edit/);
-    await page.getByTestId("post-editor-submit").click();
+    await page.getByTestId("content-list-new-button").click();
     await navigated;
 
+    // The Puck editor mounts; title input is wired through to
+    // entry.update. Wait for autosave to confirm via response.
+    await expect(page.getByTestId("plumix-editor-title-input")).toBeVisible();
+    const updated = page.waitForResponse(
+      (r) => r.url().endsWith("/entry/update") && r.status() === 200,
+    );
+    await page.getByTestId("plumix-editor-title-input").fill("Hello world");
+    await updated;
+
+    // Back to the list — the new row carries the typed title.
     await page.goto("entries/posts");
-    // `content-list-row-*` matches the row plus the per-row actions
-    // and trash buttons (`content-list-row-actions-<id>`,
-    // `content-list-row-trash-<id>`). Filter to just the row.
     const rows = page.locator(
       "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])",
     );


### PR DESCRIPTION
The cutover (#470) landed a v2 admin editor that was functionally broken for real use:
title input had no value/onChange so typing did nothing; no back button; Puck's richtext
field defaulted to sidebar-only editing so the canvas ignored typing; autosave sent
`title: ""` on initial mount which `entry.update`'s trimmedText schema rejected; and the
layout was missing the viewport switcher (mobile / tablet / desktop) the Puck demo ships
by default.

CI was green because every editor-side e2e exercised insert/select/style on the canvas
but nothing typed into a block or asserted the autosave envelope round-tripped.

**Title is bound; back button restored**

`PlumixEditorLayout` accepts `title` + `onTitleChange` + `backHref` props. The header
renders a controlled input wired to the route's title state and a back-arrow link to the
entries list. Autosave skips the title field when blank so an empty input doesn't break
the loop.

**Richtext field gets `contentEditable: true`**

The field-type translator ships Puck's richtext field with `contentEditable: true`, so
authors type directly on the canvas. Combined with the always-emit `<p>` paragraph render,
the typing path works end to end.

**Viewport switcher + canvas frame**

The header now carries a Minus / Mobile / Tablet / Monitor / Full-width / Plus control
group that dispatches `setUi` on Puck's `viewports.current`. The canvas frame width binds
to the selected preset, so picking "Small" actually shrinks the preview to 360px. The
canvas wrapper got a muted gutter + a centered card with border/shadow so the editing
surface no longer butts against the left rail.

**Autosave dedup is correct on draft hydration**

The dedup snapshot used to seed from the local `data` after `seedPuckData` had already
merged a stale localStorage draft into it — so the first autosave on reload-with-draft
would skip as "nothing changed" and silently strand the draft on the client. The snapshot
now seeds from the canonical server `entry.content`, and the debounce window moved from
300ms to 5s so quiet pauses do not pile up identical revisions.

**Worker-backed coverage that would have caught this**

`editor-typing.spec.ts` asserts: typing in the title fires `entry.update` with the new
title; slash-inserting a paragraph produces a valid `plumix.v2` envelope and the autosave
pill flips back to "Saved"; the back button carries the right href; the tablet viewport
button flips `data-active="true"` on click. The blog plugin's worker-driven `create a
draft post` test unskips and runs against the v2 flow so the real-server round-trip is
back under CI.

Refs #379