### PR TITLE
feat(blocks): add core/rich-text block alongside existing prose blocks

### DIFF
--- a/packages/blocks/src/core-blocks.test.ts
+++ b/packages/blocks/src/core-blocks.test.ts
@@ -16,6 +16,11 @@ describe("coreBlocks", () => {
     expect(names.has("core/list")).toBe(true);
   });
 
+  test("places core/rich-text immediately after core/paragraph so the inserter groups prose blocks together", () => {
+    const names = coreBlocks.map((b) => b.name);
+    expect(names[names.indexOf("core/paragraph") + 1]).toBe("core/rich-text");
+  });
+
   test("declares unique block names with no duplicates", () => {
     const names = coreBlocks.map((b) => b.name);
     expect(new Set(names).size).toBe(names.length);

--- a/packages/blocks/src/core-blocks.ts
+++ b/packages/blocks/src/core-blocks.ts
@@ -15,6 +15,7 @@ import { headingBlock } from "./heading/index.js";
 import { listBlock, listItemBlock } from "./list/index.js";
 import { paragraphBlock } from "./paragraph/index.js";
 import { quoteBlock } from "./quote/index.js";
+import { richTextBlock } from "./rich-text/index.js";
 import { separatorBlock } from "./separator/index.js";
 import { spacerBlock } from "./spacer/index.js";
 import {
@@ -28,6 +29,7 @@ import {
 export const coreBlocks: readonly BlockSpec[] = Object.freeze([
   headingBlock,
   paragraphBlock,
+  richTextBlock,
   quoteBlock,
   separatorBlock,
   spacerBlock,

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -106,6 +106,7 @@ export { htmlBlock } from "./html/index.js";
 export { listBlock, listItemBlock } from "./list/index.js";
 export { paragraphBlock } from "./paragraph/index.js";
 export { quoteBlock } from "./quote/index.js";
+export { richTextBlock } from "./rich-text/index.js";
 export { separatorBlock } from "./separator/index.js";
 export { spacerBlock } from "./spacer/index.js";
 export {

--- a/packages/blocks/src/rich-text/index.test.tsx
+++ b/packages/blocks/src/rich-text/index.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "../render-block-tree.js";
+import { createBlockRegistry } from "../block-registry.js";
+import { renderBlockTree } from "../render-block-tree.js";
+import { richTextBlock } from "./index.js";
+
+describe("core/rich-text walker render", () => {
+  test("renders the default empty body as a single wrapped paragraph", () => {
+    const registry = createBlockRegistry([richTextBlock]);
+    const tree: readonly BlockNode[] = [
+      { id: "r1", name: "core/rich-text", attrs: { body: "<p></p>" } },
+    ];
+
+    const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/rich-text"><div><p></p></div></div>',
+    );
+  });
+
+  test("returns the admin's React-element body verbatim so Tiptap mounts inline", () => {
+    // The admin Puck preview wraps `attrs.body` as a <RichTextRender>
+    // element before calling the block render. Wrapping that element in
+    // another <div dangerouslySetInnerHTML> would mount the editor on a
+    // stale snapshot and lose focus after the first keystroke (the bug
+    // #471 fixed for the paragraph block). The block must surface the
+    // element directly.
+    const registry = createBlockRegistry([richTextBlock]);
+    const adminElement = (
+      <div data-puck-overlay-portal="true">
+        <span>inline editor mock</span>
+      </div>
+    );
+    const tree: readonly BlockNode[] = [
+      { id: "r1", name: "core/rich-text", attrs: { body: adminElement } },
+    ];
+
+    const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+    expect(html).toBe(
+      '<div data-plumix-block="core/rich-text"><div data-puck-overlay-portal="true"><span>inline editor mock</span></div></div>',
+    );
+  });
+
+  test("hydrates a multi-element HTML body verbatim (lists, headings, marks)", () => {
+    const registry = createBlockRegistry([richTextBlock]);
+    const body =
+      "<h2>Intro</h2><ul><li>First</li><li><strong>Second</strong></li></ul>";
+    const tree: readonly BlockNode[] = [
+      { id: "r1", name: "core/rich-text", attrs: { body } },
+    ];
+
+    const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+    expect(html).toBe(
+      `<div data-plumix-block="core/rich-text"><div>${body}</div></div>`,
+    );
+  });
+});

--- a/packages/blocks/src/rich-text/index.tsx
+++ b/packages/blocks/src/rich-text/index.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { isValidElement } from "react";
+
+import { defineBlock } from "../block-registry.js";
+
+export const richTextBlock = defineBlock({
+  name: "core/rich-text",
+  title: "Rich text",
+  icon: "Type",
+  category: "text",
+  inputs: [{ name: "body", type: "richtext", label: "Body" }],
+  defaults: { body: "<p></p>" },
+  // Mirrors `paragraph/index.tsx` — admin Puck preview hands `attrs.body`
+  // wrapped as a <RichTextRender> React element, SSR / walker callers see
+  // the raw HTML string. TODO(#XXX): sanitize the HTML at the
+  // entry.update ingest — the trust boundary is the stored bytes, not
+  // the editor.
+  render: ({ attrs }): ReactNode => {
+    if (isValidElement(attrs.body)) return attrs.body;
+    if (typeof attrs.body === "string") {
+      return <div dangerouslySetInnerHTML={{ __html: attrs.body }} />;
+    }
+    return <div />;
+  },
+});


### PR DESCRIPTION
Add `core/rich-text` as a Puck-aligned prose block backed by a single HTML-string body field. Existing `core/paragraph` and the list-block trio stay in place; the migration that collapses them into `core/rich-text` lands in a follow-up slice.

**Non-breaking by design**

Slice 1 of #473 — ships the new block without touching the legacy prose blocks. The follow-up slice deletes them and runs a one-shot data migration; isolating the migration risk in its own PR keeps this change cleanly revertable.

**Toolbar comes for free**

Puck's bundled richtext field already enables UL / OL / blockquote / code-block extensions by default (per `PuckRichTextOptions` in `@puckeditor/core`), so `field-type-translator.ts` needs no change — the new block's toolbar covers everything the four blocks it replaces today do.

**XSS surface unchanged**

The render mirrors `paragraph/index.tsx`: admin Puck preview gets the `<RichTextRender>` element back verbatim so Tiptap mounts inline, SSR walker hydrates the HTML string via `dangerouslySetInnerHTML`. The TODO about ingest-time sanitization is carried over so the trust-boundary note survives when paragraph is deleted later.

Refs #473