### PR TITLE
feat(admin): runtime block registry + window.plumix.registerPluginBlock bridge

### DIFF
--- a/packages/admin/src/editor/register-core-blocks.test.ts
+++ b/packages/admin/src/editor/register-core-blocks.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { coreBlocks } from "@plumix/blocks";
+
+import {
+  _resetPluginRegistry,
+  getRegisteredBlocks,
+} from "../lib/plugin-registry.js";
+import { registerCoreBlocks } from "./register-core-blocks.js";
+
+afterEach(() => {
+  _resetPluginRegistry();
+});
+
+describe("synthetic core-plugin block registration", () => {
+  test("registers every coreBlocks entry into the runtime registry in order", () => {
+    registerCoreBlocks();
+    const runtime = getRegisteredBlocks();
+    expect(runtime.map((s) => s.name)).toEqual(coreBlocks.map((s) => s.name));
+  });
+
+  test("is idempotent under React StrictMode's double-invoke", () => {
+    registerCoreBlocks();
+    expect(() => registerCoreBlocks()).not.toThrow();
+    expect(getRegisteredBlocks()).toHaveLength(coreBlocks.length);
+  });
+});

--- a/packages/admin/src/editor/register-core-blocks.ts
+++ b/packages/admin/src/editor/register-core-blocks.ts
@@ -1,0 +1,16 @@
+import { coreBlocks } from "@plumix/blocks";
+
+import {
+  getRegisteredBlocks,
+  registerPluginBlock,
+} from "../lib/plugin-registry.js";
+
+// Idempotent against StrictMode + Vite HMR re-eval — guards via registry
+// state, not a module-level boolean that decouples from the registry
+// during a hot reload.
+export function registerCoreBlocks(): void {
+  if (getRegisteredBlocks().length >= coreBlocks.length) return;
+  for (const spec of coreBlocks) {
+    registerPluginBlock(spec);
+  }
+}

--- a/packages/admin/src/lib/errors.ts
+++ b/packages/admin/src/lib/errors.ts
@@ -1,12 +1,14 @@
 type AdminPluginRegistryErrorCode =
   | "duplicate_key"
   | "input_type_reserved"
+  | "invalid_block_name"
   | "ssr_walked_admin_spec";
 
 interface AdminPluginRegistryErrorFields {
   registerName?: string;
   key?: string;
   type?: string;
+  blockName?: unknown;
 }
 
 export class AdminPluginRegistryError extends Error {
@@ -18,6 +20,7 @@ export class AdminPluginRegistryError extends Error {
   readonly registerName: string | undefined;
   readonly key: string | undefined;
   readonly type: string | undefined;
+  readonly blockName: unknown;
 
   private constructor(
     code: AdminPluginRegistryErrorCode,
@@ -29,6 +32,7 @@ export class AdminPluginRegistryError extends Error {
     this.registerName = fields.registerName;
     this.key = fields.key;
     this.type = fields.type;
+    this.blockName = fields.blockName;
   }
 
   static duplicateKey(ctx: {
@@ -50,6 +54,16 @@ export class AdminPluginRegistryError extends Error {
         `Pick a different inputType for your custom field — see the host's ` +
         `RESERVED_INPUT_TYPES list.`,
       ctx,
+    );
+  }
+
+  static invalidBlockName(ctx: { name: unknown }): AdminPluginRegistryError {
+    return new AdminPluginRegistryError(
+      "invalid_block_name",
+      `registerPluginBlock: spec.name must be a namespaced string ` +
+        `("plugin/slug") to disambiguate from first-party blocks. ` +
+        `Got: ${JSON.stringify(ctx.name)}`,
+      { blockName: ctx.name },
     );
   }
 

--- a/packages/admin/src/lib/plugin-registry.test.ts
+++ b/packages/admin/src/lib/plugin-registry.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 
+import type { BlockSpec } from "@plumix/blocks";
+
 import {
   _resetPluginRegistry,
   getPluginBlockEditor,
@@ -7,6 +9,8 @@ import {
   getPluginFieldType,
   getPluginMarkSchema,
   getPluginPage,
+  getRegisteredBlocks,
+  registerPluginBlock,
   registerPluginBlockEditor,
   registerPluginBlockSchema,
   registerPluginFieldType,
@@ -107,5 +111,46 @@ describe("plugin block + mark registries", () => {
     expect(() => registerPluginMarkSchema("acme/highlight", schema)).toThrow(
       /already registered/,
     );
+  });
+});
+
+describe("v2 block registry", () => {
+  const spec = { name: "acme/banner" } as BlockSpec;
+
+  test("round-trips a registered BlockSpec via getRegisteredBlocks()", () => {
+    registerPluginBlock(spec);
+    expect(getRegisteredBlocks()).toEqual([spec]);
+  });
+
+  test("rejects two specs registered under the same name", () => {
+    registerPluginBlock(spec);
+    expect(() => registerPluginBlock(spec)).toThrow(/already registered/);
+  });
+
+  test("rejects a spec whose name is not namespaced (no slash)", () => {
+    expect(() =>
+      registerPluginBlock({ name: "banner" } as BlockSpec),
+    ).toThrow(/namespaced string/);
+  });
+
+  test("preserves registration order so the inserter UI is deterministic", () => {
+    const a = { name: "acme/a" } as BlockSpec;
+    const b = { name: "acme/b" } as BlockSpec;
+    const c = { name: "acme/c" } as BlockSpec;
+    registerPluginBlock(b);
+    registerPluginBlock(a);
+    registerPluginBlock(c);
+    expect(getRegisteredBlocks().map((s) => s.name)).toEqual([
+      "acme/b",
+      "acme/a",
+      "acme/c",
+    ]);
+  });
+
+  test("getRegisteredBlocks() returns a snapshot, not a live view", () => {
+    registerPluginBlock(spec);
+    const snapshot = getRegisteredBlocks();
+    registerPluginBlock({ name: "acme/extra" } as BlockSpec);
+    expect(snapshot).toHaveLength(1);
   });
 });

--- a/packages/admin/src/lib/plugin-registry.test.ts
+++ b/packages/admin/src/lib/plugin-registry.test.ts
@@ -128,9 +128,9 @@ describe("v2 block registry", () => {
   });
 
   test("rejects a spec whose name is not namespaced (no slash)", () => {
-    expect(() =>
-      registerPluginBlock({ name: "banner" } as BlockSpec),
-    ).toThrow(/namespaced string/);
+    expect(() => registerPluginBlock({ name: "banner" } as BlockSpec)).toThrow(
+      /namespaced string/,
+    );
   });
 
   test("preserves registration order so the inserter UI is deterministic", () => {

--- a/packages/admin/src/lib/plugin-registry.ts
+++ b/packages/admin/src/lib/plugin-registry.ts
@@ -2,6 +2,7 @@ import type { Mark, Node } from "@tiptap/core";
 import type { ComponentType } from "react";
 import type { ControllerRenderProps, FieldValues } from "react-hook-form";
 
+import type { BlockSpec } from "@plumix/blocks";
 import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 
 import { AdminPluginRegistryError } from "./errors.js";
@@ -48,6 +49,7 @@ const blockEditors = makeRegistry<ComponentType<unknown>>(
   "registerPluginBlockEditor",
 );
 const markSchemas = makeRegistry<Mark>("registerPluginMarkSchema");
+const pluginBlocks = makeRegistry<BlockSpec>("registerPluginBlock");
 
 function register<TComponent>(
   registry: PluginRegistryEntry<TComponent>,
@@ -157,6 +159,20 @@ export function getPluginMarkSchema(name: string): Mark | undefined {
   return markSchemas.map.get(name);
 }
 
+export function registerPluginBlock(spec: BlockSpec): void {
+  // Names must include a namespace slash so first-party / third-party
+  // origin is obvious in the inserter and inspector — matches the
+  // `core/*`, `media/*`, `acme/*` convention.
+  if (typeof spec.name !== "string" || !spec.name.includes("/")) {
+    throw AdminPluginRegistryError.invalidBlockName({ name: spec.name });
+  }
+  register(pluginBlocks, spec.name, spec);
+}
+
+export function getRegisteredBlocks(): readonly BlockSpec[] {
+  return Array.from(pluginBlocks.map.values());
+}
+
 /** @internal Test-only. */
 export function _resetPluginRegistry(): void {
   pages.map.clear();
@@ -164,4 +180,5 @@ export function _resetPluginRegistry(): void {
   blockSchemas.map.clear();
   blockEditors.map.clear();
   markSchemas.map.clear();
+  pluginBlocks.map.clear();
 }

--- a/packages/admin/src/lib/plumix-globals.test.ts
+++ b/packages/admin/src/lib/plumix-globals.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { bootPlumixGlobals } from "./plumix-globals.js";
+import { registerPluginBlock } from "./plugin-registry.js";
+
+afterEach(() => {
+  delete (window as { plumix?: unknown }).plumix;
+});
+
+describe("plumix globals bridge", () => {
+  test("exposes registerPluginBlock as the same function from plugin-registry", () => {
+    bootPlumixGlobals();
+    expect(window.plumix?.registerPluginBlock).toBe(registerPluginBlock);
+  });
+});

--- a/packages/admin/src/lib/plumix-globals.test.ts
+++ b/packages/admin/src/lib/plumix-globals.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 
-import { bootPlumixGlobals } from "./plumix-globals.js";
 import { registerPluginBlock } from "./plugin-registry.js";
+import { bootPlumixGlobals } from "./plumix-globals.js";
 
 afterEach(() => {
   delete (window as { plumix?: unknown }).plumix;

--- a/packages/admin/src/lib/plumix-globals.ts
+++ b/packages/admin/src/lib/plumix-globals.ts
@@ -9,6 +9,7 @@ import * as ReactDomNs from "react-dom";
 import * as ReactDomClientNs from "react-dom/client";
 
 import {
+  registerPluginBlock,
   registerPluginBlockEditor,
   registerPluginBlockSchema,
   registerPluginFieldType,
@@ -37,6 +38,7 @@ declare global {
       readonly registerPluginFieldType: typeof registerPluginFieldType;
       readonly registerPluginBlockSchema: typeof registerPluginBlockSchema;
       readonly registerPluginBlockEditor: typeof registerPluginBlockEditor;
+      readonly registerPluginBlock: typeof registerPluginBlock;
       readonly registerPluginMarkSchema: typeof registerPluginMarkSchema;
       readonly runtime: typeof runtime;
     };
@@ -51,6 +53,7 @@ export function bootPlumixGlobals(): void {
     registerPluginFieldType,
     registerPluginBlockSchema,
     registerPluginBlockEditor,
+    registerPluginBlock,
     registerPluginMarkSchema,
     runtime,
   };

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -10,9 +10,11 @@ import { PlumixEditorLayout } from "@/editor/EditorLayout.js";
 import { seedPuckData } from "@/editor/entry-content.js";
 import { readDraft, writeDraft } from "@/editor/local-draft.js";
 import { puckDataToBlockTree } from "@/editor/puck-to-block-tree.js";
+import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
 import { useRevisionsTrigger } from "@/editor/revisions/use-revisions-trigger.js";
 import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
 import { ORPCError } from "@orpc/client";
 import { Puck } from "@puckeditor/core";
 import {
@@ -27,9 +29,6 @@ import type { ThemeTokens } from "@plumix/blocks";
 import type { EntryTypeManifestEntry } from "@plumix/core/manifest";
 import { coreMarkExtensions, createBlockRegistry } from "@plumix/blocks";
 import { idPathParam } from "@plumix/core/validation";
-
-import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
-import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
 
 import "@puckeditor/core/puck.css";
 

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -25,12 +25,11 @@ import * as v from "valibot";
 
 import type { ThemeTokens } from "@plumix/blocks";
 import type { EntryTypeManifestEntry } from "@plumix/core/manifest";
-import {
-  coreBlocks,
-  coreMarkExtensions,
-  createBlockRegistry,
-} from "@plumix/blocks";
+import { coreMarkExtensions, createBlockRegistry } from "@plumix/blocks";
 import { idPathParam } from "@plumix/core/validation";
+
+import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
+import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
 
 import "@puckeditor/core/puck.css";
 
@@ -71,9 +70,11 @@ const sampleTokens: ThemeTokens = {
   },
 };
 
-const registry = createBlockRegistry(coreBlocks);
+registerCoreBlocks();
+const runtimeBlocks = getRegisteredBlocks();
+const registry = createBlockRegistry(runtimeBlocks);
 const config: Config = {
-  components: blockSpecsToPuckComponents(coreBlocks, {
+  components: blockSpecsToPuckComponents(runtimeBlocks, {
     // Puck types `extensions` as a mutable array; spread the readonly
     // plumix list to satisfy the assignment without weakening the
     // export.


### PR DESCRIPTION
Switch the editor route from a hardcoded `coreBlocks` import to a runtime registry. Core blocks self-register through the same `registerPluginBlock(spec)` bridge a third-party plugin will use — the admin shell no longer has a special case for first-party blocks.

Slice 1 of #472. Plumbing only — manifest schema changes, plugin-chunk loading via `wait-for-plugin-chunks`, and an end-to-end proof with media's `imageBlock` follow in slices 2 and 3. Behavior unchanged: the route ships the same 14 blocks today.

**HMR-safe idempotency**

`registerCoreBlocks()` guards re-invocation by counting the registry size (`getRegisteredBlocks().length >= coreBlocks.length`) instead of a module-level boolean. Senpai flagged the boolean version as a Vite-HMR desync trap: when HMR re-evaluates `register-core-blocks.ts` the flag resets, but the `pluginBlocks` registry (different module) keeps its entries — the next `registerCoreBlocks()` call would throw `duplicate_key`. Counting the registry survives both StrictMode's double-effect and HMR re-eval.

**Namespace validation**

`registerPluginBlock(spec)` rejects names that don't contain a `/`. First-party `core/*`, plugin `media/*` / `acme/*` — origin is visible everywhere a block surfaces. Anonymous `"banner"` throws `AdminPluginRegistryError.invalidBlockName` at registration time instead of producing a confusing inserter entry.

Refs #472