### PR TITLE
feat(plugin-media): register media blocks via window.plumix.registerPluginBlock

### DIFF
--- a/packages/plugins/media/src/admin/index.test.ts
+++ b/packages/plugins/media/src/admin/index.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  delete (globalThis as { window?: unknown }).window;
+});
+
+describe("media admin entry side effects", () => {
+  test("registers every mediaBlocks spec via window.plumix.registerPluginBlock on load", async () => {
+    const registerPluginBlock = vi.fn();
+    const registerPluginFieldType = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      plumix: { registerPluginBlock, registerPluginFieldType },
+    };
+
+    vi.resetModules();
+    // Import after resetModules so admin entry + mediaBlocks share the
+    // same fresh module instance (object identity matters for the
+    // toHaveBeenNthCalledWith spec assertions).
+    await import("./index.js");
+    const { mediaBlocks } = await import("../index.js");
+
+    expect(registerPluginBlock).toHaveBeenCalledTimes(mediaBlocks.length);
+    mediaBlocks.forEach((spec, i) => {
+      expect(registerPluginBlock).toHaveBeenNthCalledWith(i + 1, spec);
+    });
+  });
+
+  test("warns and does not throw when window.plumix is missing", async () => {
+    (globalThis as { window?: unknown }).window = {};
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    vi.resetModules();
+    await expect(import("./index.js")).resolves.toBeDefined();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/window\.plumix not initialized/);
+  });
+});

--- a/packages/plugins/media/src/admin/index.test.ts
+++ b/packages/plugins/media/src/admin/index.test.ts
@@ -19,7 +19,7 @@ describe("media admin entry side effects", () => {
     // same fresh module instance (object identity matters for the
     // toHaveBeenNthCalledWith spec assertions).
     await import("./index.js");
-    const { mediaBlocks } = await import("../index.js");
+    const { mediaBlocks } = await import("../media-blocks.js");
 
     expect(registerPluginBlock).toHaveBeenCalledTimes(mediaBlocks.length);
     mediaBlocks.forEach((spec, i) => {

--- a/packages/plugins/media/src/admin/index.tsx
+++ b/packages/plugins/media/src/admin/index.tsx
@@ -11,11 +11,10 @@
 // `registerPluginFieldType`'s registry. The host's meta-box-field
 // dispatcher consults that registry on every render.
 
+import type { BlockSpec } from "plumix/blocks";
 import type { ComponentType } from "react";
 
-import type { BlockSpec } from "plumix/blocks";
-
-import { mediaBlocks } from "../index.js";
+import { mediaBlocks } from "../media-blocks.js";
 import { MediaListPickerField } from "./MediaListPickerField.js";
 import { MediaPickerField } from "./MediaPickerField.js";
 

--- a/packages/plugins/media/src/admin/index.tsx
+++ b/packages/plugins/media/src/admin/index.tsx
@@ -13,17 +13,21 @@
 
 import type { ComponentType } from "react";
 
+import type { BlockSpec } from "plumix/blocks";
+
+import { mediaBlocks } from "../index.js";
 import { MediaListPickerField } from "./MediaListPickerField.js";
 import { MediaPickerField } from "./MediaPickerField.js";
 
 // Minimal structural shape of the host admin's `window.plumix` —
-// we only need the field-type registration entry. The host's full
-// declaration lives in `packages/admin/src/lib/plumix-globals.ts`.
+// we only need the registration entries. The host's full declaration
+// lives in `packages/admin/src/lib/plumix-globals.ts`.
 interface PlumixWindowGlobal {
   readonly registerPluginFieldType: (
     type: string,
     component: ComponentType<never>,
   ) => void;
+  readonly registerPluginBlock: (spec: BlockSpec) => void;
 }
 
 declare const window:
@@ -42,6 +46,9 @@ if (typeof window !== "undefined") {
       "mediaList",
       MediaListPickerField as ComponentType<never>,
     );
+    for (const spec of mediaBlocks) {
+      window.plumix.registerPluginBlock(spec);
+    }
   } else {
     // Silent no-op would leave the `media`/`mediaList` field renderers
     // unregistered for the whole session — every media field would fall
@@ -50,8 +57,8 @@ if (typeof window !== "undefined") {
     // load-order is diagnosable instead of silently degraded.
     console.warn(
       "[plumix-plugin-media] window.plumix not initialized — media " +
-        "field renderers not registered. Verify the host admin has booted " +
-        "plumix-globals before the plugin chunk loads.",
+        "field renderers and blocks not registered. Verify the host admin " +
+        "has booted plumix-globals before the plugin chunk loads.",
     );
   }
 }

--- a/packages/plugins/media/src/index.ts
+++ b/packages/plugins/media/src/index.ts
@@ -1,4 +1,3 @@
-import type { BlockSpec } from "plumix/blocks";
 import type { PluginDescriptor } from "plumix/plugin";
 import { definePlugin } from "plumix/plugin";
 
@@ -20,14 +19,8 @@ export { DEFAULT_ACCEPTED_TYPES };
 /** Default max upload size — 25 MiB. */
 export const DEFAULT_MAX_UPLOAD_SIZE = 25 * 1024 * 1024;
 
-// Out-of-band v2 spec export; collapses into `ctx.registerBlockSpec` later.
-export const mediaBlocks: readonly BlockSpec[] = Object.freeze([
-  imageBlock,
-  galleryBlock,
-  videoBlock,
-  audioBlock,
-  fileBlock,
-]);
+// Re-export the canonical list from `media-blocks.ts` (server-clean).
+export { mediaBlocks } from "./media-blocks.js";
 
 interface MediaPluginOptions {
   /**

--- a/packages/plugins/media/src/media-blocks.ts
+++ b/packages/plugins/media/src/media-blocks.ts
@@ -1,0 +1,18 @@
+import type { BlockSpec } from "plumix/blocks";
+
+import { audioBlock } from "./blocks/audio/index.js";
+import { fileBlock } from "./blocks/file/index.js";
+import { galleryBlock } from "./blocks/gallery/index.js";
+import { imageBlock } from "./blocks/image/index.js";
+import { videoBlock } from "./blocks/video/index.js";
+
+// Browser-clean canonical list — no server-side imports — so the
+// admin chunk can pull it without transitively dragging in the
+// plugin's RPC routes, upload handler, or `definePlugin`.
+export const mediaBlocks: readonly BlockSpec[] = Object.freeze([
+  imageBlock,
+  galleryBlock,
+  videoBlock,
+  audioBlock,
+  fileBlock,
+]);


### PR DESCRIPTION
Wire the media plugin's 5 blocks (image, gallery, video, audio, file) into the host admin's runtime block registry via `window.plumix.registerPluginBlock(spec)`. The media admin chunk already side-effect-registers its field renderers on load; this extends the same hook to surface its blocks. The host route stays oblivious — `getRegisteredBlocks()` returns core + media uniformly.

Slice 2 of #472. Slice 1 (#476) added the host bridge; slice 3 will land a cross-plugin e2e that asserts `slash-menu-item-media/image` is reachable in the inserter end-to-end.

**Single source of truth**

The admin entry imports `mediaBlocks` directly from `src/index.ts` — the same frozen array `ctx.registerBlock` walks server-side. The earlier draft duplicated the list in the admin chunk, which would have drifted on every block addition; structurally killing the drift was a senpai callout.

**Tests skip the top-level admin-entry import**

Because the admin entry registers on module load, a top-level test import would fire the warn branch against jsdom's bare `window` before any spy could attach — silently polluting output and weakening the "warns exactly once" assertion. Both tests use `vi.resetModules()` + dynamic import so the side effect re-fires against a freshly stubbed `window` per test.

Refs #472