### PR TITLE
feat(admin): tabs + per-row json diff modal in revisions sheet

### DIFF
--- a/packages/admin/src/editor/revisions/RevisionDiffDialog.tsx
+++ b/packages/admin/src/editor/revisions/RevisionDiffDialog.tsx
@@ -1,0 +1,100 @@
+import type { ReactElement } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
+import { useQuery } from "@tanstack/react-query";
+
+interface DiffSnapshot {
+  readonly title: string;
+  readonly slug: string;
+  readonly excerpt: string | null;
+  readonly content: unknown;
+  readonly meta: Readonly<Record<string, unknown>>;
+}
+
+interface RevisionDiffDialogProps {
+  readonly entryId: number;
+  readonly revisionId: number | null;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly fetchRevision: (revisionId: number) => Promise<DiffSnapshot>;
+  readonly fetchCurrent: (entryId: number) => Promise<DiffSnapshot>;
+}
+
+export function RevisionDiffDialog({
+  entryId,
+  revisionId,
+  onOpenChange,
+  fetchRevision,
+  fetchCurrent,
+}: RevisionDiffDialogProps): ReactElement {
+  const revisionQuery = useQuery({
+    queryKey: ["revision-diff-dialog.revision", revisionId],
+    enabled: revisionId !== null,
+    queryFn: () => fetchRevision(revisionId ?? 0),
+  });
+  const currentQuery = useQuery({
+    queryKey: ["revision-diff-dialog.current", entryId],
+    enabled: revisionId !== null,
+    queryFn: () => fetchCurrent(entryId),
+  });
+  return (
+    <Dialog open={revisionId !== null} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-4xl"
+        data-testid="revision-diff-modal"
+        showCloseButton
+      >
+        <DialogHeader>
+          <DialogTitle>Revision JSON diff</DialogTitle>
+          <DialogDescription>
+            Side-by-side: this revision (left) vs. the current entry (right).
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <DiffPane
+            label="This revision"
+            snapshot={revisionQuery.data}
+            isError={revisionQuery.isError}
+          />
+          <DiffPane
+            label="Current"
+            snapshot={currentQuery.data}
+            isError={currentQuery.isError}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DiffPane({
+  label,
+  snapshot,
+  isError,
+}: {
+  readonly label: string;
+  readonly snapshot: DiffSnapshot | undefined;
+  readonly isError: boolean;
+}): ReactElement {
+  return (
+    <section>
+      <div className="text-muted-foreground mb-1 text-xs font-medium">
+        {label}
+      </div>
+      <pre
+        className="bg-muted max-h-96 overflow-auto rounded-md p-2 text-xs"
+        data-testid={isError ? "revision-diff-modal-error" : undefined}
+      >
+        {isError
+          ? "Failed to load snapshot."
+          : snapshot
+            ? JSON.stringify(snapshot, null, 2)
+            : "Loading…"}
+      </pre>
+    </section>
+  );
+}

--- a/packages/admin/src/editor/revisions/RevisionDiffDialog.tsx
+++ b/packages/admin/src/editor/revisions/RevisionDiffDialog.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { useId, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -31,14 +32,28 @@ export function RevisionDiffDialog({
   fetchRevision,
   fetchCurrent,
 }: RevisionDiffDialogProps): ReactElement {
+  // Sticky id keeps query results visible during Radix's close
+  // animation: once `revisionId` flips to null the queries would
+  // disable and the panes would flash to "Loading…" while the
+  // dialog fades out. Use the setState-during-render memoization
+  // pattern (refs would trip react-hooks/cannot-access-during-render).
+  const [stickyRevisionId, setStickyRevisionId] = useState<number | null>(
+    revisionId,
+  );
+  if (revisionId !== null && revisionId !== stickyRevisionId) {
+    setStickyRevisionId(revisionId);
+  }
+  // Same query keys as the inline diff section in RevisionsSheet — both
+  // surfaces read from a single TanStack cache entry, so opening the
+  // modal after the inline view doesn't re-fetch.
   const revisionQuery = useQuery({
-    queryKey: ["revision-diff-dialog.revision", revisionId],
-    enabled: revisionId !== null,
-    queryFn: () => fetchRevision(revisionId ?? 0),
+    queryKey: ["entry.revision.diff", stickyRevisionId],
+    enabled: stickyRevisionId !== null,
+    queryFn: () => fetchRevision(stickyRevisionId ?? 0),
   });
   const currentQuery = useQuery({
-    queryKey: ["revision-diff-dialog.current", entryId],
-    enabled: revisionId !== null,
+    queryKey: ["entry.current.diff", entryId],
+    enabled: stickyRevisionId !== null,
     queryFn: () => fetchCurrent(entryId),
   });
   return (
@@ -80,9 +95,13 @@ function DiffPane({
   readonly snapshot: DiffSnapshot | undefined;
   readonly isError: boolean;
 }): ReactElement {
+  const labelId = useId();
   return (
-    <section>
-      <div className="text-muted-foreground mb-1 text-xs font-medium">
+    <section aria-labelledby={labelId}>
+      <div
+        id={labelId}
+        className="text-muted-foreground mb-1 text-xs font-medium"
+      >
         {label}
       </div>
       <pre

--- a/packages/admin/src/editor/revisions/RevisionDiffDialog.tsx
+++ b/packages/admin/src/editor/revisions/RevisionDiffDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
 import { useQuery } from "@tanstack/react-query";
 
 interface DiffSnapshot {
@@ -96,6 +97,44 @@ function DiffPane({
   readonly isError: boolean;
 }): ReactElement {
   const labelId = useId();
+  if (isError) {
+    return (
+      <section aria-labelledby={labelId}>
+        <div
+          id={labelId}
+          className="text-muted-foreground mb-1 text-xs font-medium"
+        >
+          {label}
+        </div>
+        <pre
+          className="bg-muted max-h-96 overflow-auto rounded-md p-2 text-xs"
+          data-testid="revision-diff-modal-error"
+        >
+          Failed to load snapshot.
+        </pre>
+      </section>
+    );
+  }
+  if (!snapshot) {
+    return (
+      <section aria-labelledby={labelId} aria-busy="true">
+        <div
+          id={labelId}
+          className="text-muted-foreground mb-1 text-xs font-medium"
+        >
+          {label}
+        </div>
+        <div
+          data-testid="revision-diff-modal-loading"
+          className="max-h-96 space-y-2 rounded-md border p-3"
+        >
+          {Array.from({ length: 8 }, (_, i) => (
+            <Skeleton key={i} className={i % 3 === 0 ? "h-3 w-2/3" : "h-3"} />
+          ))}
+        </div>
+      </section>
+    );
+  }
   return (
     <section aria-labelledby={labelId}>
       <div
@@ -104,15 +143,8 @@ function DiffPane({
       >
         {label}
       </div>
-      <pre
-        className="bg-muted max-h-96 overflow-auto rounded-md p-2 text-xs"
-        data-testid={isError ? "revision-diff-modal-error" : undefined}
-      >
-        {isError
-          ? "Failed to load snapshot."
-          : snapshot
-            ? JSON.stringify(snapshot, null, 2)
-            : "Loading…"}
+      <pre className="bg-muted max-h-96 overflow-auto rounded-md p-2 text-xs">
+        {JSON.stringify(snapshot, null, 2)}
       </pre>
     </section>
   );

--- a/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
@@ -30,6 +30,225 @@ function wrap(child: React.ReactNode) {
   return <QueryClientProvider client={qc}>{child}</QueryClientProvider>;
 }
 
+describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
+  test("renders three tabs (All / Publishes / Autosaves) when open", async () => {
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={1}
+          fetchPage={() => Promise.resolve({ revisions: [], nextCursor: null })}
+          relativeTime={() => "now"}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => {
+      expect(screen.getByTestId("revisions-tab-all")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("revisions-tab-publishes")).toBeInTheDocument();
+    expect(screen.getByTestId("revisions-tab-autosaves")).toBeInTheDocument();
+  });
+
+  test("switching to the Autosaves tab shows the empty-state stub, not the row list", async () => {
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={1}
+          fetchPage={() =>
+            Promise.resolve({
+              revisions: [
+                {
+                  id: 9,
+                  title: "Snap",
+                  updatedAt: new Date("2026-05-22T00:00:00Z"),
+                  authorId: 1,
+                  authorName: "Ada",
+                  authorEmail: "ada@x",
+                },
+              ] satisfies RevisionFixture[],
+              nextCursor: null,
+            })
+          }
+          relativeTime={() => "now"}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => {
+      expect(screen.getByTestId("revisions-tab-autosaves")).toBeInTheDocument();
+    });
+    // Wait for the row to render under the default All tab so we know
+    // data loaded before we switch tabs.
+    await waitFor(() => {
+      expect(screen.getByTestId("revisions-sheet-item-9")).toBeInTheDocument();
+    });
+    const autosavesTab = screen.getByTestId("revisions-tab-autosaves");
+    fireEvent.pointerDown(autosavesTab);
+    fireEvent.mouseDown(autosavesTab);
+    fireEvent.click(autosavesTab);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("revisions-autosaves-empty"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("closing the sheet also closes an open diff modal", async () => {
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={1}
+          fetchPage={() =>
+            Promise.resolve({
+              revisions: [
+                {
+                  id: 11,
+                  title: "Snap",
+                  updatedAt: new Date("2026-05-22T00:00:00Z"),
+                  authorId: 1,
+                  authorName: "Ada",
+                  authorEmail: "ada@x",
+                },
+              ] satisfies RevisionFixture[],
+              nextCursor: null,
+            })
+          }
+          relativeTime={() => "now"}
+          fetchRevision={() =>
+            Promise.resolve({
+              title: "T",
+              slug: "t",
+              excerpt: null,
+              content: {},
+              meta: {},
+            })
+          }
+          fetchCurrent={() =>
+            Promise.resolve({
+              title: "T",
+              slug: "t",
+              excerpt: null,
+              content: {},
+              meta: {},
+            })
+          }
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-11-diff"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-11-diff"));
+    await waitFor(() =>
+      expect(screen.getByTestId("revision-diff-modal")).toBeInTheDocument(),
+    );
+    // Esc closes the sheet — both the sheet panel and the diff modal
+    // must unmount, otherwise an orphan modal sits on a hidden sheet.
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("revision-diff-modal"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("modal surfaces an error state when snapshot fetch fails", async () => {
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={1}
+          fetchPage={() =>
+            Promise.resolve({
+              revisions: [
+                {
+                  id: 13,
+                  title: "Snap",
+                  updatedAt: new Date("2026-05-22T00:00:00Z"),
+                  authorId: 1,
+                  authorName: "Ada",
+                  authorEmail: "ada@x",
+                },
+              ] satisfies RevisionFixture[],
+              nextCursor: null,
+            })
+          }
+          relativeTime={() => "now"}
+          fetchRevision={() => Promise.reject(new Error("boom"))}
+          fetchCurrent={() => Promise.reject(new Error("boom"))}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-13-diff"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-13-diff"));
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId("revision-diff-modal-error").length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  test("per-row code-diff icon opens a modal with both JSON snapshots", async () => {
+    const revision = {
+      title: "Was",
+      slug: "was",
+      excerpt: null,
+      content: { blocks: [{ id: "a", name: "core/heading", attrs: {} }] },
+      meta: {},
+    };
+    const current = {
+      title: "Now",
+      slug: "now",
+      excerpt: null,
+      content: { blocks: [{ id: "a", name: "core/rich-text", attrs: {} }] },
+      meta: {},
+    };
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={1}
+          fetchPage={() =>
+            Promise.resolve({
+              revisions: [
+                {
+                  id: 42,
+                  title: "Snap",
+                  updatedAt: new Date("2026-05-22T00:00:00Z"),
+                  authorId: 1,
+                  authorName: "Ada",
+                  authorEmail: "ada@x",
+                },
+              ] satisfies RevisionFixture[],
+              nextCursor: null,
+            })
+          }
+          relativeTime={() => "now"}
+          fetchRevision={() => Promise.resolve(revision)}
+          fetchCurrent={() => Promise.resolve(current)}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("revisions-sheet-item-42-diff"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-42-diff"));
+    await waitFor(() => {
+      expect(screen.getByTestId("revision-diff-modal").textContent).toContain(
+        "core/heading",
+      );
+    });
+    expect(screen.getByTestId("revision-diff-modal").textContent).toContain(
+      "core/rich-text",
+    );
+  });
+});
+
 describe("RevisionsSheet", () => {
   test("renders nothing in the DOM tree before the trigger opens it", () => {
     render(

--- a/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { RevisionsSheet } from "./RevisionsSheet.js";
@@ -86,15 +87,50 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("revisions-sheet-item-9")).toBeInTheDocument();
     });
-    const autosavesTab = screen.getByTestId("revisions-tab-autosaves");
-    fireEvent.pointerDown(autosavesTab);
-    fireEvent.mouseDown(autosavesTab);
-    fireEvent.click(autosavesTab);
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("revisions-tab-autosaves"));
     await waitFor(() => {
       expect(
         screen.getByTestId("revisions-autosaves-empty"),
       ).toBeInTheDocument();
     });
+  });
+
+  test("dialog does not fetch before the user clicks the diff icon", async () => {
+    const fetchRevision = vi.fn();
+    const fetchCurrent = vi.fn();
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={1}
+          fetchPage={() =>
+            Promise.resolve({
+              revisions: [
+                {
+                  id: 17,
+                  title: "Snap",
+                  updatedAt: new Date("2026-05-22T00:00:00Z"),
+                  authorId: 1,
+                  authorName: "Ada",
+                  authorEmail: "ada@x",
+                },
+              ] satisfies RevisionFixture[],
+              nextCursor: null,
+            })
+          }
+          relativeTime={() => "now"}
+          fetchRevision={fetchRevision}
+          fetchCurrent={fetchCurrent}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-17-diff"));
+    // The sheet is open and rows are rendered, but no row has been
+    // clicked — neither snapshot fetcher should have fired.
+    expect(fetchRevision).not.toHaveBeenCalled();
+    expect(fetchCurrent).not.toHaveBeenCalled();
   });
 
   test("closing the sheet also closes an open diff modal", async () => {

--- a/packages/admin/src/editor/revisions/RevisionsSheet.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.tsx
@@ -9,8 +9,15 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet.js";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs.js";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 
+import { RevisionDiffDialog } from "./RevisionDiffDialog.js";
 import { RevisionDiffPanel } from "./RevisionDiffPanel.js";
 
 interface RevisionListItem {
@@ -75,9 +82,8 @@ export function RevisionsSheet({
   const revisionQuery = useQuery({
     queryKey: ["entry.revision.diff", selectedRevisionId],
     enabled: selectedRevisionId !== null,
-    // `enabled` guards null; the non-null assertion is the
-    // narrowest fix that satisfies TanStack's exhaustive typing
-    // without dragging an error factory into a UI component.
+    // `enabled` already guards null; `?? 0` is the narrowest dodge
+    // around TanStack's exhaustive typing without an `as` cast.
     queryFn: () => fetchRevision(selectedRevisionId ?? 0),
   });
   const currentQuery = useQuery({
@@ -87,6 +93,9 @@ export function RevisionsSheet({
   });
 
   const [restorePending, setRestorePending] = useState(false);
+  const [diffModalRevisionId, setDiffModalRevisionId] = useState<number | null>(
+    null,
+  );
   const allRevisions = query.data?.pages.flatMap((p) => p.revisions) ?? [];
   const hasMore = Boolean(query.data?.pages.at(-1)?.nextCursor);
   const showDiff = selectedRevisionId !== null;
@@ -105,7 +114,13 @@ export function RevisionsSheet({
   }
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
+    <Sheet
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) setDiffModalRevisionId(null);
+      }}
+    >
       <SheetTrigger asChild>
         <Button
           variant="outline"
@@ -160,18 +175,70 @@ export function RevisionsSheet({
             current={currentQuery.data}
           />
         ) : (
-          <ListSection
-            isLoading={query.isLoading}
-            isError={query.isError}
-            allRevisions={allRevisions}
-            relativeTime={relativeTime}
-            onSelect={setSelectedRevisionId}
-            hasMore={hasMore}
-            isFetchingNextPage={query.isFetchingNextPage}
-            fetchNextPage={() => void query.fetchNextPage()}
-          />
+          <Tabs defaultValue="all" className="mt-2">
+            <TabsList className="w-full">
+              <TabsTrigger value="all" data-testid="revisions-tab-all">
+                All
+              </TabsTrigger>
+              <TabsTrigger
+                value="publishes"
+                data-testid="revisions-tab-publishes"
+              >
+                Publishes
+              </TabsTrigger>
+              <TabsTrigger
+                value="autosaves"
+                data-testid="revisions-tab-autosaves"
+              >
+                Autosaves
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="all">
+              <ListSection
+                isLoading={query.isLoading}
+                isError={query.isError}
+                allRevisions={allRevisions}
+                relativeTime={relativeTime}
+                onSelect={setSelectedRevisionId}
+                onOpenDiff={setDiffModalRevisionId}
+                hasMore={hasMore}
+                isFetchingNextPage={query.isFetchingNextPage}
+                fetchNextPage={() => void query.fetchNextPage()}
+              />
+            </TabsContent>
+            <TabsContent value="publishes">
+              <ListSection
+                isLoading={query.isLoading}
+                isError={query.isError}
+                allRevisions={allRevisions}
+                relativeTime={relativeTime}
+                onSelect={setSelectedRevisionId}
+                onOpenDiff={setDiffModalRevisionId}
+                hasMore={hasMore}
+                isFetchingNextPage={query.isFetchingNextPage}
+                fetchNextPage={() => void query.fetchNextPage()}
+              />
+            </TabsContent>
+            <TabsContent value="autosaves">
+              <div
+                data-testid="revisions-autosaves-empty"
+                className="text-muted-foreground px-4 py-6 text-sm"
+              >
+                Autosaves will appear here once drafts-of-published lands.
+              </div>
+            </TabsContent>
+          </Tabs>
         )}
       </SheetContent>
+      <RevisionDiffDialog
+        entryId={entryId}
+        revisionId={diffModalRevisionId}
+        onOpenChange={(o) => {
+          if (!o) setDiffModalRevisionId(null);
+        }}
+        fetchRevision={fetchRevision}
+        fetchCurrent={fetchCurrent}
+      />
     </Sheet>
   );
 }
@@ -182,6 +249,7 @@ interface ListSectionProps {
   readonly allRevisions: readonly RevisionListItem[];
   readonly relativeTime: (date: Date) => string;
   readonly onSelect: (id: number) => void;
+  readonly onOpenDiff: (id: number) => void;
   readonly hasMore: boolean;
   readonly isFetchingNextPage: boolean;
   readonly fetchNextPage: () => void;
@@ -193,6 +261,7 @@ function ListSection({
   allRevisions,
   relativeTime,
   onSelect,
+  onOpenDiff,
   hasMore,
   isFetchingNextPage,
   fetchNextPage,
@@ -223,20 +292,29 @@ function ListSection({
             <li
               key={rev.id}
               data-testid={`revisions-sheet-item-${rev.id}`}
-              className="py-2"
+              className="flex items-center gap-1 py-2"
             >
               <button
                 type="button"
                 data-testid={`revisions-sheet-item-${rev.id}-select`}
                 onClick={() => onSelect(rev.id)}
-                className="hover:bg-accent w-full rounded-md p-2 text-left"
+                className="hover:bg-accent min-w-0 flex-1 rounded-md p-2 text-left"
               >
-                <div className="text-sm font-medium">{rev.title}</div>
+                <div className="truncate text-sm font-medium">{rev.title}</div>
                 <div className="text-muted-foreground text-xs">
                   <span>{rev.authorName ?? rev.authorEmail ?? "Unknown"}</span>
                   {" · "}
                   <span>{relativeTime(rev.updatedAt)}</span>
                 </div>
+              </button>
+              <button
+                type="button"
+                data-testid={`revisions-sheet-item-${rev.id}-diff`}
+                aria-label="View JSON diff"
+                onClick={() => onOpenDiff(rev.id)}
+                className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md font-mono text-xs"
+              >
+                &lt;/&gt;
               </button>
             </li>
           ))}

--- a/packages/admin/src/editor/revisions/RevisionsSheet.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.tsx
@@ -9,6 +9,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
 import {
   Tabs,
   TabsContent,
@@ -267,9 +268,22 @@ function ListSection({
   return (
     <>
       {isLoading ? (
-        <div data-testid="revisions-sheet-loading" className="px-4 py-6">
-          Loading revisions…
-        </div>
+        <ul
+          data-testid="revisions-sheet-loading"
+          aria-label="Loading revisions"
+          aria-busy="true"
+          className="divide-y px-4 py-2"
+        >
+          {Array.from({ length: 4 }, (_, i) => (
+            <li key={i} className="flex items-center gap-1 py-2">
+              <div className="min-w-0 flex-1 p-2">
+                <Skeleton className="mb-2 h-4 w-2/3" />
+                <Skeleton className="h-3 w-1/3" />
+              </div>
+              <Skeleton className="h-7 w-7 shrink-0 rounded-md" />
+            </li>
+          ))}
+        </ul>
       ) : null}
       {isError ? (
         <div
@@ -362,8 +376,18 @@ function DiffSection({
   }
   if (revisionLoading || currentLoading || !revision || !current) {
     return (
-      <div data-testid="revisions-sheet-diff-loading" className="px-4 py-6">
-        Loading diff…
+      <div
+        data-testid="revisions-sheet-diff-loading"
+        aria-label="Loading diff"
+        aria-busy="true"
+        className="space-y-3 px-4 py-6"
+      >
+        {Array.from({ length: 5 }, (_, i) => (
+          <div key={i} className="space-y-1.5">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-4 w-full" />
+          </div>
+        ))}
       </div>
     );
   }

--- a/packages/admin/src/editor/revisions/RevisionsSheet.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.tsx
@@ -175,25 +175,13 @@ export function RevisionsSheet({
             current={currentQuery.data}
           />
         ) : (
-          <Tabs defaultValue="all" className="mt-2">
-            <TabsList className="w-full">
-              <TabsTrigger value="all" data-testid="revisions-tab-all">
-                All
-              </TabsTrigger>
-              <TabsTrigger
-                value="publishes"
-                data-testid="revisions-tab-publishes"
-              >
-                Publishes
-              </TabsTrigger>
-              <TabsTrigger
-                value="autosaves"
-                data-testid="revisions-tab-autosaves"
-              >
-                Autosaves
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="all">
+          (() => {
+            // Both All and Publishes render the identical list today —
+            // every revision is a publish. Once a revision-kind field
+            // exists (slice 2 of #289), Publishes will filter and the
+            // two panels diverge. Sharing the element keeps the JSX
+            // honest about the current shape.
+            const listPanel = (
               <ListSection
                 isLoading={query.isLoading}
                 isError={query.isError}
@@ -205,29 +193,39 @@ export function RevisionsSheet({
                 isFetchingNextPage={query.isFetchingNextPage}
                 fetchNextPage={() => void query.fetchNextPage()}
               />
-            </TabsContent>
-            <TabsContent value="publishes">
-              <ListSection
-                isLoading={query.isLoading}
-                isError={query.isError}
-                allRevisions={allRevisions}
-                relativeTime={relativeTime}
-                onSelect={setSelectedRevisionId}
-                onOpenDiff={setDiffModalRevisionId}
-                hasMore={hasMore}
-                isFetchingNextPage={query.isFetchingNextPage}
-                fetchNextPage={() => void query.fetchNextPage()}
-              />
-            </TabsContent>
-            <TabsContent value="autosaves">
-              <div
-                data-testid="revisions-autosaves-empty"
-                className="text-muted-foreground px-4 py-6 text-sm"
-              >
-                Autosaves will appear here once drafts-of-published lands.
-              </div>
-            </TabsContent>
-          </Tabs>
+            );
+            return (
+              <Tabs defaultValue="all" className="mt-2">
+                <TabsList className="w-full">
+                  <TabsTrigger value="all" data-testid="revisions-tab-all">
+                    All
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="publishes"
+                    data-testid="revisions-tab-publishes"
+                  >
+                    Publishes
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="autosaves"
+                    data-testid="revisions-tab-autosaves"
+                  >
+                    Autosaves
+                  </TabsTrigger>
+                </TabsList>
+                <TabsContent value="all">{listPanel}</TabsContent>
+                <TabsContent value="publishes">{listPanel}</TabsContent>
+                <TabsContent value="autosaves">
+                  <div
+                    data-testid="revisions-autosaves-empty"
+                    className="text-muted-foreground px-4 py-6 text-sm"
+                  >
+                    Autosaves will appear here once drafts-of-published lands.
+                  </div>
+                </TabsContent>
+              </Tabs>
+            );
+          })()
         )}
       </SheetContent>
       <RevisionDiffDialog


### PR DESCRIPTION
First slice of the Builder-aligned revisions UI. Adds tabs (All / Publishes /
Autosaves) wrapping the existing list and a per-row `</>` icon that opens a
dev-mode side-by-side JSON diff modal.

Autosaves shows an empty-state stub until drafts-of-published lands (#290). All
and Publishes render the same data today; once a revision-kind discriminator
exists the Publishes tab will filter on it. The two `<TabsContent>` panels
share a single `<ListSection>` element so the JSX stays honest about that.

**Dev-mode JSON diff modal**

A new `RevisionDiffDialog` renders the selected revision and the current entry
as side-by-side `<pre>JSON.stringify(...)</pre>` blocks. This is explicitly the
*raw-JSON view for devs* — not a replacement for the existing field-by-field
inline diff opened by clicking a row. The dialog mounts at sheet root (not
inside `SheetContent`) to dodge Radix's nested-portal z-index ordering; closing
the sheet now also clears the modal so an open dialog can't orphan over a
hidden sheet. A sticky revisionId keeps the panes populated during Radix's
200ms close animation instead of flashing to `Loading…`.

**Shared query cache**

The dialog reuses the same TanStack query keys as the inline diff section so
both surfaces read from a single cache entry — opening the modal after the
inline view does not re-fetch.

**Failure surface + responsive grid**

Diff panes render a `Failed to load snapshot.` state on fetch error instead of
stalling on `Loading…`. The grid collapses to a single column under `md` so
the modal stays readable on mobile. Each pane carries `aria-labelledby` so
screen readers announce the pane label before the JSON blob.

Refs #289