### PR TITLE
feat(admin): editor preview mode via `?revision=<id>`

### DIFF
--- a/packages/admin/e2e/revisions-preview-mode.spec.ts
+++ b/packages/admin/e2e/revisions-preview-mode.spec.ts
@@ -1,0 +1,147 @@
+// E2E + visual verification for slice 2 of #289 — editor preview mode
+// via `?revision=<id>`. Covers the acceptance criterion: navigating
+// to the preview URL renders the banner read-only, Back-to-live
+// clears the param, and the canvas write affordances are gone.
+
+import { expect, test } from "@playwright/test";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+import { emptyManifest } from "@plumix/core/manifest";
+
+import { AUTHED_ADMIN, mockManifest, rpcOkBody } from "./support/rpc-mock.js";
+
+const T0 = new Date("2026-05-22T00:00:00Z");
+const T_REV = new Date("2026-05-22T10:00:00Z");
+
+const MANIFEST_WITH_REVISIONS: PlumixManifest = {
+  ...emptyManifest(),
+  entryTypes: [
+    {
+      name: "post",
+      adminSlug: "posts",
+      label: "Posts",
+      labels: { singular: "Post", plural: "Posts" },
+      supports: ["title", "editor", "revisions"],
+    },
+  ],
+};
+
+function liveEntry(): Record<string, unknown> {
+  return {
+    id: 1,
+    type: "post",
+    parentId: null,
+    title: "Live title",
+    slug: "entry-1",
+    content: null,
+    excerpt: null,
+    status: "draft",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: null,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: {},
+  };
+}
+
+function revisionRow(): Record<string, unknown> {
+  return {
+    id: 42,
+    type: "_rev:post",
+    parentId: null,
+    title: "Snapshot title",
+    slug: "rev:1:42",
+    content: { version: "plumix.v2", blocks: [] },
+    excerpt: null,
+    status: "draft",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: null,
+    createdAt: T_REV,
+    updatedAt: T_REV,
+    meta: {},
+    authorName: "Ada Lovelace",
+    authorEmail: "ada@example.test",
+  };
+}
+
+async function installMocks(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await mockManifest(page, MANIFEST_WITH_REVISIONS);
+  await page.route("**/_plumix/rpc/**", (route) => {
+    const url = route.request().url();
+    if (url.endsWith("/auth/session")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(AUTHED_ADMIN),
+      });
+    }
+    if (url.endsWith("/entry/get")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          json: liveEntry(),
+          meta: [
+            [1, "createdAt"],
+            [1, "updatedAt"],
+          ],
+        }),
+      });
+    }
+    if (url.endsWith("/entry/revisions/get")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          json: revisionRow(),
+          meta: [
+            [1, "createdAt"],
+            [1, "updatedAt"],
+          ],
+        }),
+      });
+    }
+    return route.fulfill({ status: 404, body: "not-mocked" });
+  });
+}
+
+test.describe("editor preview mode (#289 slice 2)", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("?revision=N renders the preview banner and hides the publish button", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("entries/posts/1/edit?revision=42");
+    const banner = page.getByTestId("revision-preview-banner");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("Ada Lovelace");
+    await expect(page.getByTestId("plumix-editor-publish-button")).toHaveCount(
+      0,
+    );
+    await expect(
+      page.getByTestId("plumix-editor-preview-shield"),
+    ).toBeVisible();
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: "tmp/preview-mode.png",
+      fullPage: false,
+    });
+  });
+
+  test("Back to live clears the search param", async ({ page }) => {
+    await installMocks(page);
+    await page.goto("entries/posts/1/edit?revision=42");
+    await expect(page.getByTestId("revision-preview-banner")).toBeVisible();
+    await page.getByTestId("revision-preview-back-to-live").click();
+    await expect.poll(() => page.url()).not.toContain("revision=");
+    await expect(page.getByTestId("revision-preview-banner")).toHaveCount(0);
+    await expect(
+      page.getByTestId("plumix-editor-publish-button"),
+    ).toBeVisible();
+  });
+});

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -69,6 +69,10 @@ interface PlumixEditorLayoutProps {
   // Route layer owns RPC wiring and feeds a fully-wired <RevisionsSheet />
   // here; the layout only allocates space and doesn't know the contract.
   readonly revisionsTrigger?: ReactNode;
+  // Optional preview-mode banner rendered above the header. When set,
+  // the route is in `?revision=<id>` preview mode — the title input
+  // and publish button are hidden because edits don't autosave.
+  readonly previewBanner?: ReactNode;
 }
 
 const EMPTY_REGISTRY: BlockRegistry = createBlockRegistry([]);
@@ -251,9 +255,12 @@ export function PlumixEditorLayout({
   isPublishing = false,
   isPublished = false,
   revisionsTrigger,
+  previewBanner,
 }: PlumixEditorLayoutProps): ReactElement {
+  const isPreview = previewBanner !== undefined;
   return (
     <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
+      {previewBanner}
       <header
         className="bg-background flex h-12 shrink-0 items-center gap-3 border-b px-4"
         data-testid="plumix-editor-header"
@@ -270,32 +277,55 @@ export function PlumixEditorLayout({
           type="text"
           placeholder="Untitled"
           aria-label="Entry title"
-          className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent px-2 text-base font-medium outline-none"
+          className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent px-2 text-base font-medium outline-none disabled:cursor-not-allowed disabled:opacity-60"
           data-testid="plumix-editor-title-input"
           value={title}
           onChange={(e) => onTitleChange(e.target.value)}
+          disabled={isPreview}
         />
-        <AutosaveStatusPill />
+        {isPreview ? null : <AutosaveStatusPill />}
         {revisionsTrigger}
-        <button
-          type="button"
-          className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-8 items-center rounded-md px-3 text-sm font-medium disabled:opacity-50"
-          data-testid="plumix-editor-publish-button"
-          onClick={onPublish}
-          disabled={isPublishing || isPublished}
-        >
-          Publish
-        </button>
+        {isPreview ? null : (
+          <button
+            type="button"
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-8 items-center rounded-md px-3 text-sm font-medium disabled:opacity-50"
+            data-testid="plumix-editor-publish-button"
+            onClick={onPublish}
+            disabled={isPublishing || isPublished}
+          >
+            Publish
+          </button>
+        )}
       </header>
       <div
         className="grid flex-1 grid-cols-[minmax(0,1fr)] overflow-hidden md:grid-cols-[260px_minmax(0,1fr)_320px]"
         data-testid="plumix-editor-cols"
       >
         <BlocksBody registry={registry} capabilities={capabilities} />
-        <PlumixCanvasWithSlashMenu
-          registry={registry}
-          capabilities={capabilities}
-        />
+        {isPreview ? (
+          // Puck's `permissions` strips drag / insert / delete / dup /
+          // edit, but Tiptap inside rich-text fields keeps its own
+          // `editable: true`. Cover the canvas with a transparent
+          // overlay so the user can't type into rich-text without
+          // realising preview mode skips autosave.
+          <div className="relative" data-testid="plumix-editor-preview-shield">
+            <div
+              aria-hidden
+              className="bg-background/0 pointer-events-auto absolute inset-0 z-10"
+            />
+            <div className="pointer-events-none h-full">
+              <PlumixCanvasWithSlashMenu
+                registry={registry}
+                capabilities={capabilities}
+              />
+            </div>
+          </div>
+        ) : (
+          <PlumixCanvasWithSlashMenu
+            registry={registry}
+            capabilities={capabilities}
+          />
+        )}
         <InspectorBody registry={registry} tokens={tokens} />
       </div>
     </div>

--- a/packages/admin/src/editor/revisions/PreviewBanner.test.tsx
+++ b/packages/admin/src/editor/revisions/PreviewBanner.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { PreviewBanner } from "./PreviewBanner.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const T0 = new Date("2026-05-22T12:00:00Z");
+
+describe("PreviewBanner", () => {
+  test("renders the revision metadata so the user knows what they're previewing", () => {
+    render(
+      <PreviewBanner
+        revisionUpdatedAt={T0}
+        revisionAuthor="Ada Lovelace"
+        relativeTime={() => "2 hours ago"}
+        onBackToLive={vi.fn()}
+        onRestore={vi.fn()}
+        isRestoring={false}
+      />,
+    );
+    const banner = screen.getByTestId("revision-preview-banner");
+    expect(banner.textContent).toContain("Ada Lovelace");
+    expect(banner.textContent).toContain("2 hours ago");
+  });
+
+  test("clicking Back to live fires onBackToLive", () => {
+    const onBackToLive = vi.fn();
+    render(
+      <PreviewBanner
+        revisionUpdatedAt={T0}
+        revisionAuthor="Ada"
+        relativeTime={() => "now"}
+        onBackToLive={onBackToLive}
+        onRestore={vi.fn()}
+        isRestoring={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("revision-preview-back-to-live"));
+    expect(onBackToLive).toHaveBeenCalled();
+  });
+
+  test("clicking Restore fires onRestore", () => {
+    const onRestore = vi.fn();
+    render(
+      <PreviewBanner
+        revisionUpdatedAt={T0}
+        revisionAuthor="Ada"
+        relativeTime={() => "now"}
+        onBackToLive={vi.fn()}
+        onRestore={onRestore}
+        isRestoring={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("revision-preview-restore"));
+    expect(onRestore).toHaveBeenCalled();
+  });
+
+  test("Restore button disables while a restore is in flight", () => {
+    render(
+      <PreviewBanner
+        revisionUpdatedAt={T0}
+        revisionAuthor="Ada"
+        relativeTime={() => "now"}
+        onBackToLive={vi.fn()}
+        onRestore={vi.fn()}
+        isRestoring={true}
+      />,
+    );
+    const restore = screen.getByTestId("revision-preview-restore");
+    expect(restore).toBeDisabled();
+  });
+
+  test("surfaces restoreError inline so a stale-token CONFLICT doesn't look like a silent no-op", () => {
+    render(
+      <PreviewBanner
+        revisionUpdatedAt={T0}
+        revisionAuthor="Ada"
+        relativeTime={() => "now"}
+        onBackToLive={vi.fn()}
+        onRestore={vi.fn()}
+        isRestoring={false}
+        restoreError="Another editor changed this entry. Reload and try again."
+      />,
+    );
+    const err = screen.getByTestId("revision-preview-restore-error");
+    expect(err.textContent).toContain("Another editor changed this entry");
+  });
+});

--- a/packages/admin/src/editor/revisions/PreviewBanner.tsx
+++ b/packages/admin/src/editor/revisions/PreviewBanner.tsx
@@ -1,0 +1,67 @@
+import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button.js";
+
+interface PreviewBannerProps {
+  readonly revisionUpdatedAt: Date;
+  readonly revisionAuthor: string;
+  readonly relativeTime: (date: Date) => string;
+  readonly onBackToLive: () => void;
+  readonly onRestore: () => void;
+  readonly isRestoring: boolean;
+  // Surface restore failures inline. CONFLICT (stale token) is the
+  // most likely cause — another tab edited the live entry after the
+  // preview loaded — but any server rejection lands here so the user
+  // doesn't watch a silent no-op.
+  readonly restoreError?: string | null;
+}
+
+export function PreviewBanner({
+  revisionUpdatedAt,
+  revisionAuthor,
+  relativeTime,
+  onBackToLive,
+  onRestore,
+  isRestoring,
+  restoreError = null,
+}: PreviewBannerProps): ReactElement {
+  return (
+    <div
+      data-testid="revision-preview-banner"
+      role="status"
+      className="flex shrink-0 flex-wrap items-center gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:bg-amber-950/40 dark:text-amber-100"
+    >
+      <span className="font-medium">Previewing revision</span>
+      <span>
+        from {relativeTime(revisionUpdatedAt)} by {revisionAuthor}
+      </span>
+      <div className="ml-auto flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          data-testid="revision-preview-back-to-live"
+          onClick={onBackToLive}
+        >
+          ← Back to live
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          data-testid="revision-preview-restore"
+          onClick={onRestore}
+          disabled={isRestoring}
+        >
+          {isRestoring ? "Restoring…" : "Restore this revision"}
+        </Button>
+      </div>
+      {restoreError !== null ? (
+        <div
+          data-testid="revision-preview-restore-error"
+          role="alert"
+          className="text-destructive basis-full text-xs"
+        >
+          {restoreError}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
@@ -41,6 +41,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           relativeTime={() => "now"}
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -75,6 +76,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           relativeTime={() => "now"}
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -122,6 +124,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           relativeTime={() => "now"}
           fetchRevision={fetchRevision}
           fetchCurrent={fetchCurrent}
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -172,6 +175,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
               meta: {},
             })
           }
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -214,6 +218,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           relativeTime={() => "now"}
           fetchRevision={() => Promise.reject(new Error("boom"))}
           fetchCurrent={() => Promise.reject(new Error("boom"))}
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -264,6 +269,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           relativeTime={() => "now"}
           fetchRevision={() => Promise.resolve(revision)}
           fetchCurrent={() => Promise.resolve(current)}
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -295,6 +301,7 @@ describe("RevisionsSheet", () => {
           relativeTime={(d) => d.toISOString()}
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -337,6 +344,7 @@ describe("RevisionsSheet", () => {
           relativeTime={() => "just now"}
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -394,6 +402,7 @@ describe("RevisionsSheet", () => {
           relativeTime={() => "now"}
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
         />,
       ),
     );
@@ -410,12 +419,12 @@ describe("RevisionsSheet", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("restore button calls onRestore and closes the sheet", async () => {
+  test("clicking the row body calls onPreview with the revision id and closes the sheet", async () => {
     const fetchPage = vi.fn(() =>
       Promise.resolve({
         revisions: [
           {
-            id: 8,
+            id: 21,
             title: "Snapshot",
             updatedAt: new Date("2026-05-17T12:00:00Z"),
             authorId: 1,
@@ -426,56 +435,36 @@ describe("RevisionsSheet", () => {
         nextCursor: null,
       }),
     );
-    const onRestore = vi.fn(() => Promise.resolve());
+    const onPreview = vi.fn();
     render(
       wrap(
         <RevisionsSheet
           entryId={42}
           fetchPage={fetchPage}
           relativeTime={() => "now"}
-          fetchRevision={() =>
-            Promise.resolve({
-              title: "S",
-              slug: "s",
-              excerpt: null,
-              content: { type: "doc", content: [] },
-              meta: {},
-            })
-          }
-          fetchCurrent={() =>
-            Promise.resolve({
-              title: "S v2",
-              slug: "s",
-              excerpt: null,
-              content: { type: "doc", content: [] },
-              meta: {},
-            })
-          }
-          onRestore={onRestore}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+          onPreview={onPreview}
         />,
       ),
     );
     fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
-    await waitFor(() => screen.getByTestId("revisions-sheet-item-8-select"));
-    fireEvent.click(screen.getByTestId("revisions-sheet-item-8-select"));
-    await waitFor(() => screen.getByTestId("revisions-sheet-diff"));
-    fireEvent.click(screen.getByTestId("revisions-sheet-restore"));
-    await waitFor(() => {
-      expect(onRestore).toHaveBeenCalledWith(8);
-    });
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-21"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-21-select"));
+    expect(onPreview).toHaveBeenCalledWith(21);
     await waitFor(() => {
       expect(
-        screen.queryByTestId("revisions-sheet-diff"),
+        screen.queryByTestId("revisions-sheet-list"),
       ).not.toBeInTheDocument();
     });
   });
 
-  test("selecting a revision opens the diff panel and fetches both snapshots", async () => {
+  test("no inline diff panel renders after a row click — preview lives on the route", async () => {
     const fetchPage = vi.fn(() =>
       Promise.resolve({
         revisions: [
           {
-            id: 8,
+            id: 22,
             title: "Snapshot",
             updatedAt: new Date("2026-05-17T12:00:00Z"),
             authorId: 1,
@@ -486,45 +475,26 @@ describe("RevisionsSheet", () => {
         nextCursor: null,
       }),
     );
-    const fetchRevision = vi.fn(() =>
-      Promise.resolve({
-        title: "Snapshot",
-        slug: "post",
-        excerpt: null,
-        content: { type: "doc", content: [] },
-        meta: {},
-      }),
-    );
-    const fetchCurrent = vi.fn(() =>
-      Promise.resolve({
-        title: "Snapshot v2",
-        slug: "post",
-        excerpt: null,
-        content: { type: "doc", content: [] },
-        meta: {},
-      }),
-    );
     render(
       wrap(
         <RevisionsSheet
           entryId={42}
           fetchPage={fetchPage}
           relativeTime={() => "now"}
-          fetchRevision={fetchRevision}
-          fetchCurrent={fetchCurrent}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
         />,
       ),
     );
     fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
-    await waitFor(() => screen.getByTestId("revisions-sheet-item-8-select"));
-    fireEvent.click(screen.getByTestId("revisions-sheet-item-8-select"));
-    await waitFor(() => screen.getByTestId("revisions-sheet-diff"));
-    expect(fetchRevision).toHaveBeenCalledWith(8);
-    expect(fetchCurrent).toHaveBeenCalledWith(42);
-    // The diff renders the title field diff (Snapshot vs Snapshot v2).
-    expect(screen.getByTestId("revision-diff-field-title")).toBeInTheDocument();
-    // Back button returns to the list.
-    fireEvent.click(screen.getByTestId("revisions-sheet-back"));
-    await waitFor(() => screen.getByTestId("revisions-sheet-list"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-22-select"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-22-select"));
+    expect(
+      screen.queryByTestId("revisions-sheet-diff"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("revisions-sheet-restore"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/admin/src/editor/revisions/RevisionsSheet.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.tsx
@@ -16,10 +16,9 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs.js";
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { RevisionDiffDialog } from "./RevisionDiffDialog.js";
-import { RevisionDiffPanel } from "./RevisionDiffPanel.js";
 
 interface RevisionListItem {
   readonly id: number;
@@ -52,13 +51,15 @@ interface RevisionsSheetProps {
   // Injected so the admin can plug in its own intl helper and tests
   // can stub it deterministically (must return a stable string).
   readonly relativeTime: (date: Date) => string;
-  // Both fetchers are injected (consistent with `fetchPage`) so the
-  // route layer owns RPC wiring and tests can stub deterministically.
+  // Modal-only fetchers — the dev-mode JSON diff dialog reads from
+  // these. The inline diff panel was removed in slice 2; previews
+  // now live on the editor route via `?revision=<id>`.
   readonly fetchRevision: (revisionId: number) => Promise<DiffSnapshot>;
   readonly fetchCurrent: (entryId: number) => Promise<DiffSnapshot>;
-  // When omitted the restore action is hidden — keeps the sheet usable
-  // as a read-only diff viewer for roles without `edit_*` capabilities.
-  readonly onRestore?: (revisionId: number) => Promise<void>;
+  // Fires when the user clicks a row body — caller is expected to
+  // navigate to the preview URL. The sheet closes itself afterwards
+  // so the editor surface is unobstructed.
+  readonly onPreview: (revisionId: number) => void;
 }
 
 export function RevisionsSheet({
@@ -67,12 +68,9 @@ export function RevisionsSheet({
   relativeTime,
   fetchRevision,
   fetchCurrent,
-  onRestore,
+  onPreview,
 }: RevisionsSheetProps): ReactElement {
   const [open, setOpen] = useState(false);
-  const [selectedRevisionId, setSelectedRevisionId] = useState<number | null>(
-    null,
-  );
   const query = useInfiniteQuery({
     queryKey: ["entry.revisions", entryId],
     enabled: open,
@@ -80,38 +78,16 @@ export function RevisionsSheet({
     queryFn: ({ pageParam }) => fetchPage({ entryId, cursor: pageParam }),
     getNextPageParam: (page) => page.nextCursor,
   });
-  const revisionQuery = useQuery({
-    queryKey: ["entry.revision.diff", selectedRevisionId],
-    enabled: selectedRevisionId !== null,
-    // `enabled` already guards null; `?? 0` is the narrowest dodge
-    // around TanStack's exhaustive typing without an `as` cast.
-    queryFn: () => fetchRevision(selectedRevisionId ?? 0),
-  });
-  const currentQuery = useQuery({
-    queryKey: ["entry.current.diff", entryId],
-    enabled: selectedRevisionId !== null,
-    queryFn: () => fetchCurrent(entryId),
-  });
 
-  const [restorePending, setRestorePending] = useState(false);
   const [diffModalRevisionId, setDiffModalRevisionId] = useState<number | null>(
     null,
   );
   const allRevisions = query.data?.pages.flatMap((p) => p.revisions) ?? [];
   const hasMore = Boolean(query.data?.pages.at(-1)?.nextCursor);
-  const showDiff = selectedRevisionId !== null;
-  const canRestore = onRestore !== undefined && selectedRevisionId !== null;
 
-  async function handleRestore(): Promise<void> {
-    if (!onRestore || selectedRevisionId === null) return;
-    setRestorePending(true);
-    try {
-      await onRestore(selectedRevisionId);
-      setSelectedRevisionId(null);
-      setOpen(false);
-    } finally {
-      setRestorePending(false);
-    }
+  function handlePreview(revisionId: number): void {
+    onPreview(revisionId);
+    setOpen(false);
   }
 
   return (
@@ -137,97 +113,60 @@ export function RevisionsSheet({
         className="overflow-y-auto"
       >
         <SheetHeader>
-          <SheetTitle>{showDiff ? "Revision diff" : "Revisions"}</SheetTitle>
+          <SheetTitle>Revisions</SheetTitle>
           <SheetDescription>
-            {showDiff
-              ? "Changes between this revision and the current entry."
-              : "Every save creates a new revision. Newest first."}
+            Every save creates a new revision. Newest first.
           </SheetDescription>
-          {showDiff ? (
-            <div className="mt-2 flex w-fit gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                data-testid="revisions-sheet-back"
-                onClick={() => setSelectedRevisionId(null)}
-              >
-                ← Back to list
-              </Button>
-              {canRestore ? (
-                <Button
-                  variant="default"
-                  size="sm"
-                  data-testid="revisions-sheet-restore"
-                  disabled={restorePending}
-                  onClick={() => void handleRestore()}
-                >
-                  {restorePending ? "Restoring…" : "Restore this revision"}
-                </Button>
-              ) : null}
-            </div>
-          ) : null}
         </SheetHeader>
-        {showDiff ? (
-          <DiffSection
-            revisionLoading={revisionQuery.isLoading}
-            currentLoading={currentQuery.isLoading}
-            error={revisionQuery.isError || currentQuery.isError}
-            revision={revisionQuery.data}
-            current={currentQuery.data}
-          />
-        ) : (
-          (() => {
-            // Both All and Publishes render the identical list today —
-            // every revision is a publish. Once a revision-kind field
-            // exists (slice 2 of #289), Publishes will filter and the
-            // two panels diverge. Sharing the element keeps the JSX
-            // honest about the current shape.
-            const listPanel = (
-              <ListSection
-                isLoading={query.isLoading}
-                isError={query.isError}
-                allRevisions={allRevisions}
-                relativeTime={relativeTime}
-                onSelect={setSelectedRevisionId}
-                onOpenDiff={setDiffModalRevisionId}
-                hasMore={hasMore}
-                isFetchingNextPage={query.isFetchingNextPage}
-                fetchNextPage={() => void query.fetchNextPage()}
-              />
-            );
-            return (
-              <Tabs defaultValue="all" className="mt-2">
-                <TabsList className="w-full">
-                  <TabsTrigger value="all" data-testid="revisions-tab-all">
-                    All
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="publishes"
-                    data-testid="revisions-tab-publishes"
-                  >
-                    Publishes
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="autosaves"
-                    data-testid="revisions-tab-autosaves"
-                  >
-                    Autosaves
-                  </TabsTrigger>
-                </TabsList>
-                <TabsContent value="all">{listPanel}</TabsContent>
-                <TabsContent value="publishes">{listPanel}</TabsContent>
-                <TabsContent value="autosaves">
-                  <div
-                    data-testid="revisions-autosaves-empty"
-                    className="text-muted-foreground px-4 py-6 text-sm"
-                  >
-                    Autosaves will appear here once drafts-of-published lands.
-                  </div>
-                </TabsContent>
-              </Tabs>
-            );
-          })()
-        )}
+        {(() => {
+          // Both All and Publishes render the identical list today —
+          // every revision is a publish. Once a revision-kind field
+          // lands, Publishes will filter and the two panels diverge.
+          const listPanel = (
+            <ListSection
+              isLoading={query.isLoading}
+              isError={query.isError}
+              allRevisions={allRevisions}
+              relativeTime={relativeTime}
+              onPreview={handlePreview}
+              onOpenDiff={setDiffModalRevisionId}
+              hasMore={hasMore}
+              isFetchingNextPage={query.isFetchingNextPage}
+              fetchNextPage={() => void query.fetchNextPage()}
+            />
+          );
+          return (
+            <Tabs defaultValue="all" className="mt-2">
+              <TabsList className="w-full">
+                <TabsTrigger value="all" data-testid="revisions-tab-all">
+                  All
+                </TabsTrigger>
+                <TabsTrigger
+                  value="publishes"
+                  data-testid="revisions-tab-publishes"
+                >
+                  Publishes
+                </TabsTrigger>
+                <TabsTrigger
+                  value="autosaves"
+                  data-testid="revisions-tab-autosaves"
+                >
+                  Autosaves
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="all">{listPanel}</TabsContent>
+              <TabsContent value="publishes">{listPanel}</TabsContent>
+              <TabsContent value="autosaves">
+                <div
+                  data-testid="revisions-autosaves-empty"
+                  className="text-muted-foreground px-4 py-6 text-sm"
+                >
+                  Autosaves will appear here once drafts-of-published lands.
+                </div>
+              </TabsContent>
+            </Tabs>
+          );
+        })()}
       </SheetContent>
       <RevisionDiffDialog
         entryId={entryId}
@@ -247,7 +186,7 @@ interface ListSectionProps {
   readonly isError: boolean;
   readonly allRevisions: readonly RevisionListItem[];
   readonly relativeTime: (date: Date) => string;
-  readonly onSelect: (id: number) => void;
+  readonly onPreview: (id: number) => void;
   readonly onOpenDiff: (id: number) => void;
   readonly hasMore: boolean;
   readonly isFetchingNextPage: boolean;
@@ -259,7 +198,7 @@ function ListSection({
   isError,
   allRevisions,
   relativeTime,
-  onSelect,
+  onPreview,
   onOpenDiff,
   hasMore,
   isFetchingNextPage,
@@ -309,7 +248,7 @@ function ListSection({
               <button
                 type="button"
                 data-testid={`revisions-sheet-item-${rev.id}-select`}
-                onClick={() => onSelect(rev.id)}
+                onClick={() => onPreview(rev.id)}
                 className="hover:bg-accent min-w-0 flex-1 rounded-md p-2 text-left"
               >
                 <div className="truncate text-sm font-medium">{rev.title}</div>
@@ -346,54 +285,5 @@ function ListSection({
         </div>
       ) : null}
     </>
-  );
-}
-
-interface DiffSectionProps {
-  readonly revisionLoading: boolean;
-  readonly currentLoading: boolean;
-  readonly error: boolean;
-  readonly revision: DiffSnapshot | undefined;
-  readonly current: DiffSnapshot | undefined;
-}
-
-function DiffSection({
-  revisionLoading,
-  currentLoading,
-  error,
-  revision,
-  current,
-}: DiffSectionProps): ReactElement {
-  if (error) {
-    return (
-      <div
-        data-testid="revisions-sheet-diff-error"
-        className="text-destructive px-4 py-6"
-      >
-        Failed to load the diff.
-      </div>
-    );
-  }
-  if (revisionLoading || currentLoading || !revision || !current) {
-    return (
-      <div
-        data-testid="revisions-sheet-diff-loading"
-        aria-label="Loading diff"
-        aria-busy="true"
-        className="space-y-3 px-4 py-6"
-      >
-        {Array.from({ length: 5 }, (_, i) => (
-          <div key={i} className="space-y-1.5">
-            <Skeleton className="h-3 w-24" />
-            <Skeleton className="h-4 w-full" />
-          </div>
-        ))}
-      </div>
-    );
-  }
-  return (
-    <div data-testid="revisions-sheet-diff" className="px-3">
-      <RevisionDiffPanel revision={revision} current={current} />
-    </div>
   );
 }

--- a/packages/admin/src/editor/revisions/use-revisions-trigger.tsx
+++ b/packages/admin/src/editor/revisions/use-revisions-trigger.tsx
@@ -1,18 +1,17 @@
-import type { ReactNode, RefObject } from "react";
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { RevisionsSheet } from "@/editor/revisions/RevisionsSheet.js";
 import { orpc } from "@/lib/orpc.js";
 import { formatRelativeTime } from "@/lib/relative-time.js";
-import { useQueryClient } from "@tanstack/react-query";
 
 interface UseRevisionsTriggerInput {
   readonly entryId: number;
   readonly enabled: boolean;
-  // Optimistic-concurrency token source. Both routes mutate the same
-  // server-confirmed `updatedAt` they pass through `entry.update`, so
-  // the trigger reads from the same ref to send a fresh token on
-  // restore.
-  readonly liveUpdatedAtRef: RefObject<Date>;
+  // Fires when a row body is clicked — caller navigates the editor to
+  // preview the chosen revision (`?revision=<id>`). Restore now lives
+  // on the preview banner, not the sheet, so the sheet no longer
+  // owns the optimistic-concurrency token.
+  readonly onPreview: (revisionId: number) => void;
 }
 
 // Single chokepoint for the `<RevisionsSheet />` adapter both v1 and
@@ -21,9 +20,8 @@ interface UseRevisionsTriggerInput {
 export function useRevisionsTrigger({
   entryId,
   enabled,
-  liveUpdatedAtRef,
+  onPreview,
 }: UseRevisionsTriggerInput): ReactNode {
-  const queryClient = useQueryClient();
   return useMemo<ReactNode>(() => {
     if (!enabled) return null;
     return (
@@ -53,18 +51,8 @@ export function useRevisionsTrigger({
             meta: current.meta,
           };
         }}
-        onRestore={async (revisionId) => {
-          const restored = await orpc.entry.revisions.restore.call({
-            revisionId,
-            expectedLiveUpdatedAt: liveUpdatedAtRef.current,
-          });
-          liveUpdatedAtRef.current = restored.updatedAt;
-          await queryClient.invalidateQueries({
-            queryKey: orpc.entry.get.queryOptions({ input: { id: entryId } })
-              .queryKey,
-          });
-        }}
+        onPreview={onPreview}
       />
     );
-  }, [entryId, enabled, liveUpdatedAtRef, queryClient]);
+  }, [entryId, enabled, onPreview]);
 }

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -11,10 +11,12 @@ import { seedPuckData } from "@/editor/entry-content.js";
 import { readDraft, writeDraft } from "@/editor/local-draft.js";
 import { puckDataToBlockTree } from "@/editor/puck-to-block-tree.js";
 import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
+import { PreviewBanner } from "@/editor/revisions/PreviewBanner.js";
 import { useRevisionsTrigger } from "@/editor/revisions/use-revisions-trigger.js";
 import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
+import { formatRelativeTime } from "@/lib/relative-time.js";
 import { ORPCError } from "@orpc/client";
 import { Puck } from "@puckeditor/core";
 import {
@@ -81,6 +83,15 @@ const config: Config = {
   }),
 };
 
+// `?revision=<id>` switches the route into preview mode: the editor
+// loads the chosen revision's content read-only and replaces the
+// header with a `<PreviewBanner>` that offers "Back to live" + restore.
+// Schema is loose so any other admin search params (e.g. future tab
+// state) pass through untouched.
+const editSearchSchema = v.looseObject({
+  revision: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+});
+
 export const Route = createFileRoute("/_editor/entries/$slug/$id/edit")({
   params: {
     parse: (raw) => {
@@ -92,6 +103,7 @@ export const Route = createFileRoute("/_editor/entries/$slug/$id/edit")({
       return { slug: raw.slug, id: result.output };
     },
   },
+  validateSearch: (search) => v.parse(editSearchSchema, search),
   loader: ({ context, params }) =>
     context.queryClient.ensureQueryData(
       orpc.entry.get.queryOptions({ input: { id: params.id } }),
@@ -126,6 +138,7 @@ function ErrorScreen(): ReactNode {
 function PuckSpikeRoute(): ReactNode {
   const { slug, id } = Route.useParams();
   const { user } = Route.useRouteContext();
+  const { revision: previewRevisionId } = Route.useSearch();
   const draftKey = `plumix.v2.draft.${slug}.${id}`;
   const entryType = findEntryTypeBySlug(slug);
   const supportsRevisions = entryType?.supports?.includes("revisions") ?? false;
@@ -144,6 +157,20 @@ function PuckSpikeRoute(): ReactNode {
         id={id}
         supportsRevisions={supportsRevisions}
         capabilities={user.capabilities}
+      />
+    );
+  }
+  // `key` flips on the preview revision so the editor remounts cleanly
+  // when entering / leaving preview — the `useState` initialisers that
+  // seed Puck data run again instead of stale-rendering live content.
+  if (previewRevisionId !== undefined) {
+    return (
+      <PuckPreviewRouteInner
+        key={`preview-${String(previewRevisionId)}`}
+        id={id}
+        revisionId={previewRevisionId}
+        capabilities={user.capabilities}
+        backHref={backHref}
       />
     );
   }
@@ -314,10 +341,17 @@ function PuckSpikeRouteInner({
   const isPublished = entry.status === "published";
   const handlePublish = useCallback(() => publish.mutate(), [publish]);
   const capabilitySet = useMemo(() => new Set(capabilities), [capabilities]);
+  const navigate = Route.useNavigate();
+  const handlePreview = useCallback(
+    (revisionId: number): void => {
+      void navigate({ search: (prev) => ({ ...prev, revision: revisionId }) });
+    },
+    [navigate],
+  );
   const revisionsTrigger = useRevisionsTrigger({
     entryId: id,
     enabled: supportsRevisions,
-    liveUpdatedAtRef,
+    onPreview: handlePreview,
   });
   const Layout = useCallback(
     (): ReactElement => (
@@ -356,6 +390,131 @@ function PuckSpikeRouteInner({
         overrides={{ puck: Layout }}
       />
     </AutosaveStatusContext.Provider>
+  );
+}
+
+// All five Puck Permissions flags off — drops drag handles, the +
+// insert affordance, inline-edit, the duplicate menu item, and the
+// delete action. Combined with the disabled title input + hidden
+// publish button in PlumixEditorLayout this leaves no write path
+// for the user while previewing a revision.
+const READ_ONLY_PERMISSIONS = {
+  drag: false,
+  duplicate: false,
+  delete: false,
+  edit: false,
+  insert: false,
+} as const;
+
+interface PuckPreviewRouteInnerProps {
+  readonly id: number;
+  readonly revisionId: number;
+  readonly capabilities: readonly string[];
+  readonly backHref: string;
+}
+
+function PuckPreviewRouteInner({
+  id,
+  revisionId,
+  capabilities,
+  backHref,
+}: PuckPreviewRouteInnerProps): ReactNode {
+  const { data: liveEntry } = useSuspenseQuery(
+    orpc.entry.get.queryOptions({ input: { id } }),
+  );
+  const { data: revision } = useSuspenseQuery(
+    orpc.entry.revisions.get.queryOptions({ input: { revisionId } }),
+  );
+  const queryClient = useQueryClient();
+  const navigate = Route.useNavigate();
+  const liveUpdatedAtRef = useRef<Date>(liveEntry.updatedAt);
+  // Read-once seed: Puck owns state internally after mount, and the
+  // outer `key` change on the search-param transition is what triggers
+  // a fresh init when entering / leaving preview.
+  const [initialData] = useState<Data>(() =>
+    seedPuckData(revision.content, EMPTY_DATA),
+  );
+  const capabilitySet = useMemo(() => new Set(capabilities), [capabilities]);
+
+  const handleBackToLive = useCallback((): void => {
+    void navigate({ search: (prev) => ({ ...prev, revision: undefined }) });
+  }, [navigate]);
+
+  const restore = useMutation({
+    mutationFn: async () => {
+      const restored = await orpc.entry.revisions.restore.call({
+        revisionId,
+        expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+      });
+      liveUpdatedAtRef.current = restored.updatedAt;
+      return restored;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: orpc.entry.get.queryOptions({ input: { id } }).queryKey,
+      });
+      handleBackToLive();
+    },
+  });
+
+  const handleRestore = useCallback(() => restore.mutate(), [restore]);
+  // Surface the most useful detail for the user. CONFLICT (stale
+  // `expectedLiveUpdatedAt`) is the common case when another tab
+  // edited the live entry after this preview loaded.
+  const restoreError =
+    restore.error instanceof ORPCError && restore.error.code === "CONFLICT"
+      ? "Another editor changed this entry. Reload and try again."
+      : restore.error instanceof Error
+        ? restore.error.message
+        : null;
+  const revisionAuthor =
+    revision.authorName ?? revision.authorEmail ?? `#${String(revisionId)}`;
+  const Layout = useCallback(
+    (): ReactElement => (
+      <PlumixEditorLayout
+        registry={registry}
+        capabilities={capabilitySet}
+        tokens={sampleTokens}
+        title={revision.title}
+        onTitleChange={() => undefined}
+        backHref={backHref}
+        onPublish={() => undefined}
+        isPublishing={false}
+        isPublished={false}
+        previewBanner={
+          <PreviewBanner
+            revisionUpdatedAt={revision.updatedAt}
+            revisionAuthor={revisionAuthor}
+            relativeTime={formatRelativeTime}
+            onBackToLive={handleBackToLive}
+            onRestore={handleRestore}
+            isRestoring={restore.isPending}
+            restoreError={restoreError}
+          />
+        }
+      />
+    ),
+    [
+      revision.title,
+      revision.updatedAt,
+      revisionAuthor,
+      backHref,
+      capabilitySet,
+      handleBackToLive,
+      handleRestore,
+      restore.isPending,
+      restoreError,
+    ],
+  );
+
+  return (
+    <Puck
+      config={config}
+      data={initialData}
+      iframe={{ enabled: false }}
+      permissions={READ_ONLY_PERMISSIONS}
+      overrides={{ puck: Layout }}
+    />
   );
 }
 
@@ -406,10 +565,17 @@ function PlainFormRouteInner({
     },
   });
 
+  const navigate = Route.useNavigate();
+  const handlePreview = useCallback(
+    (revisionId: number): void => {
+      void navigate({ search: (prev) => ({ ...prev, revision: revisionId }) });
+    },
+    [navigate],
+  );
   const revisionsTrigger = useRevisionsTrigger({
     entryId: id,
     enabled: supportsRevisions,
-    liveUpdatedAtRef,
+    onPreview: handlePreview,
   });
 
   const initialValues = {

--- a/packages/core/src/revisions/rpc.test.ts
+++ b/packages/core/src/revisions/rpc.test.ts
@@ -104,6 +104,10 @@ describe("entry.revisions.get", () => {
     });
     expect(fetched.id).toBe(first.id);
     expect(fetched.title).toBe("G2");
+    // Author join: the editor preview banner needs name/email so it
+    // can render "by <author>" without a second user roundtrip.
+    expect(fetched.authorName).toBe(first.authorName);
+    expect(fetched.authorEmail).toBe(first.authorEmail);
   });
 
   test("contributor gets FORBIDDEN on entry.revisions.get", async () => {

--- a/packages/core/src/rpc/procedures/entry/revisions.ts
+++ b/packages/core/src/rpc/procedures/entry/revisions.ts
@@ -125,7 +125,17 @@ export const get = base
     if (!context.auth.can(capability)) {
       throw errors.FORBIDDEN({ data: { capability } });
     }
-    return revision;
+    // Join the author so the editor preview banner can show "by
+    // <name>" without a second roundtrip. Matches the shape `list`
+    // returns per row.
+    const author = await context.db.query.users.findFirst({
+      where: eq(users.id, revision.authorId),
+    });
+    return {
+      ...revision,
+      authorName: author?.name ?? null,
+      authorEmail: author?.email ?? null,
+    };
   });
 
 export const restore = base


### PR DESCRIPTION
Second slice of the Builder-aligned revisions UI. Clicking a revision row in
the sheet now loads that revision into the editor as a read-only preview
instead of opening the old inline diff panel.

**Preview mode route fork**

`?revision=N` is validated as a positive integer and forks the route at mount.
The preview path mounts a new `PuckPreviewRouteInner` keyed by `preview-N` so
re-entering preview reseeds Puck cleanly. The live edit path is unchanged. The
preview inner sets `permissions` to the all-false read-only set; the editor
layout hides autosave + publish, disables the title input, and renders a
`<PreviewBanner>` above the header.

**Tiptap shield**

Puck's `permissions` strips drag / insert / delete / dup / edit affordances,
but Tiptap inside rich-text fields keeps its own `editable: true` surface
that Puck doesn't reach. A transparent overlay + `pointer-events-none` on the
canvas region stops the user typing into rich-text fields and assuming
autosave fired.

**Sheet contract change**

`RevisionsSheet` gains a required `onPreview(revisionId)` prop and drops the
inline diff section, restore button, and `selectedRevisionId` state. Restore
now lives on the preview banner. `fetchRevision` / `fetchCurrent` stay on
the sheet because the dev-mode `</>` JSON-diff modal still uses them.

**Server: author join**

`entry.revisions.get` now joins the author row so the banner can render
"by <name>" without a second user roundtrip. Matches the shape `list`
already returns per row.

Refs #289