### PR TITLE
feat(admin,core): per-row revision comments via `message` envelope

### DIFF
--- a/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.test.tsx
@@ -22,6 +22,7 @@ interface RevisionFixture {
   readonly authorId: number;
   readonly authorName: string | null;
   readonly authorEmail: string | null;
+  readonly message: string | null;
 }
 
 function wrap(child: React.ReactNode) {
@@ -42,6 +43,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -68,6 +70,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
                   authorId: 1,
                   authorName: "Ada",
                   authorEmail: "ada@x",
+                  message: null,
                 },
               ] satisfies RevisionFixture[],
               nextCursor: null,
@@ -77,6 +80,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -116,6 +120,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
                   authorId: 1,
                   authorName: "Ada",
                   authorEmail: "ada@x",
+                  message: null,
                 },
               ] satisfies RevisionFixture[],
               nextCursor: null,
@@ -125,6 +130,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           fetchRevision={fetchRevision}
           fetchCurrent={fetchCurrent}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -151,6 +157,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
                   authorId: 1,
                   authorName: "Ada",
                   authorEmail: "ada@x",
+                  message: null,
                 },
               ] satisfies RevisionFixture[],
               nextCursor: null,
@@ -176,6 +183,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
             })
           }
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -210,6 +218,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
                   authorId: 1,
                   authorName: "Ada",
                   authorEmail: "ada@x",
+                  message: null,
                 },
               ] satisfies RevisionFixture[],
               nextCursor: null,
@@ -219,6 +228,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           fetchRevision={() => Promise.reject(new Error("boom"))}
           fetchCurrent={() => Promise.reject(new Error("boom"))}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -261,6 +271,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
                   authorId: 1,
                   authorName: "Ada",
                   authorEmail: "ada@x",
+                  message: null,
                 },
               ] satisfies RevisionFixture[],
               nextCursor: null,
@@ -270,6 +281,7 @@ describe("RevisionsSheet — Builder-style tabs (#289 slice 1)", () => {
           fetchRevision={() => Promise.resolve(revision)}
           fetchCurrent={() => Promise.resolve(current)}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -302,6 +314,7 @@ describe("RevisionsSheet", () => {
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -323,6 +336,7 @@ describe("RevisionsSheet", () => {
             authorId: 1,
             authorName: "Ada",
             authorEmail: "ada@example.test",
+            message: null,
           },
           {
             id: 6,
@@ -331,6 +345,7 @@ describe("RevisionsSheet", () => {
             authorId: 1,
             authorName: "Ada",
             authorEmail: "ada@example.test",
+            message: null,
           },
         ] satisfies RevisionFixture[],
         nextCursor: null,
@@ -345,6 +360,7 @@ describe("RevisionsSheet", () => {
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -377,6 +393,7 @@ describe("RevisionsSheet", () => {
             authorId: 1,
             authorName: "Ada",
             authorEmail: "ada@x",
+            message: null,
           },
         ],
         nextCursor: "cur-1",
@@ -390,6 +407,7 @@ describe("RevisionsSheet", () => {
             authorId: 1,
             authorName: "Ada",
             authorEmail: "ada@x",
+            message: null,
           },
         ],
         nextCursor: null,
@@ -403,6 +421,7 @@ describe("RevisionsSheet", () => {
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -430,6 +449,7 @@ describe("RevisionsSheet", () => {
             authorId: 1,
             authorName: "Ada",
             authorEmail: "ada@x",
+            message: null,
           },
         ] satisfies RevisionFixture[],
         nextCursor: null,
@@ -445,6 +465,7 @@ describe("RevisionsSheet", () => {
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
           onPreview={onPreview}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -470,6 +491,7 @@ describe("RevisionsSheet", () => {
             authorId: 1,
             authorName: "Ada",
             authorEmail: "ada@x",
+            message: null,
           },
         ] satisfies RevisionFixture[],
         nextCursor: null,
@@ -484,6 +506,7 @@ describe("RevisionsSheet", () => {
           fetchRevision={vi.fn()}
           fetchCurrent={vi.fn()}
           onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
         />,
       ),
     );
@@ -496,5 +519,262 @@ describe("RevisionsSheet", () => {
     expect(
       screen.queryByTestId("revisions-sheet-restore"),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("RevisionsSheet — comment editing (#289 slice 3)", () => {
+  test("row without a message shows the comment-add icon and no inline display", async () => {
+    const fetchPage = vi.fn(() =>
+      Promise.resolve({
+        revisions: [
+          {
+            id: 31,
+            title: "Snapshot",
+            updatedAt: new Date("2026-05-22T12:00:00Z"),
+            authorId: 1,
+            authorName: "Ada",
+            authorEmail: "ada@x",
+            message: null,
+          },
+        ] satisfies RevisionFixture[],
+        nextCursor: null,
+      }),
+    );
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={42}
+          fetchPage={fetchPage}
+          relativeTime={() => "now"}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-31-comment"));
+    expect(
+      screen.queryByTestId("revisions-sheet-item-31-comment-display"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("row with a message renders the comment text inline so the list is scannable", async () => {
+    const fetchPage = vi.fn(() =>
+      Promise.resolve({
+        revisions: [
+          {
+            id: 32,
+            title: "Snapshot",
+            updatedAt: new Date("2026-05-22T12:00:00Z"),
+            authorId: 1,
+            authorName: "Ada",
+            authorEmail: "ada@x",
+            message: "before the redesign",
+          },
+        ] satisfies RevisionFixture[],
+        nextCursor: null,
+      }),
+    );
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={42}
+          fetchPage={fetchPage}
+          relativeTime={() => "now"}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
+          onSaveMessage={vi.fn()}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() =>
+      screen.getByTestId("revisions-sheet-item-32-comment-display"),
+    );
+    expect(
+      screen.getByTestId("revisions-sheet-item-32-comment-display").textContent,
+    ).toContain("before the redesign");
+  });
+
+  test("clicking the comment icon opens an inline editor; Save calls onSaveMessage with the typed text", async () => {
+    const fetchPage = vi.fn(() =>
+      Promise.resolve({
+        revisions: [
+          {
+            id: 33,
+            title: "Snapshot",
+            updatedAt: new Date("2026-05-22T12:00:00Z"),
+            authorId: 1,
+            authorName: "Ada",
+            authorEmail: "ada@x",
+            message: null,
+          },
+        ] satisfies RevisionFixture[],
+        nextCursor: null,
+      }),
+    );
+    const onSaveMessage = vi.fn(() => Promise.resolve());
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={42}
+          fetchPage={fetchPage}
+          relativeTime={() => "now"}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
+          onSaveMessage={onSaveMessage}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-33-comment"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-33-comment"));
+    const input = screen.getByTestId("revisions-sheet-item-33-comment-input");
+    fireEvent.change(input, { target: { value: "first publish" } });
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-33-comment-save"));
+    await waitFor(() => {
+      expect(onSaveMessage).toHaveBeenCalledWith({
+        revisionId: 33,
+        message: "first publish",
+      });
+    });
+  });
+
+  test("Save with an empty input calls onSaveMessage with message=null (clears the comment)", async () => {
+    const fetchPage = vi.fn(() =>
+      Promise.resolve({
+        revisions: [
+          {
+            id: 34,
+            title: "Snapshot",
+            updatedAt: new Date("2026-05-22T12:00:00Z"),
+            authorId: 1,
+            authorName: "Ada",
+            authorEmail: "ada@x",
+            message: "old text",
+          },
+        ] satisfies RevisionFixture[],
+        nextCursor: null,
+      }),
+    );
+    const onSaveMessage = vi.fn(() => Promise.resolve());
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={42}
+          fetchPage={fetchPage}
+          relativeTime={() => "now"}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
+          onSaveMessage={onSaveMessage}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-34-comment"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-34-comment"));
+    const input = screen.getByTestId("revisions-sheet-item-34-comment-input");
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-34-comment-save"));
+    await waitFor(() => {
+      expect(onSaveMessage).toHaveBeenCalledWith({
+        revisionId: 34,
+        message: null,
+      });
+    });
+  });
+
+  test("re-clicking the comment icon closes the editor — second open re-seeds from the latest message", async () => {
+    const fetchPage = vi.fn(() =>
+      Promise.resolve({
+        revisions: [
+          {
+            id: 36,
+            title: "Snapshot",
+            updatedAt: new Date("2026-05-22T12:00:00Z"),
+            authorId: 1,
+            authorName: "Ada",
+            authorEmail: "ada@x",
+            message: "saved",
+          },
+        ] satisfies RevisionFixture[],
+        nextCursor: null,
+      }),
+    );
+    const onSaveMessage = vi.fn();
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={42}
+          fetchPage={fetchPage}
+          relativeTime={() => "now"}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
+          onSaveMessage={onSaveMessage}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-36-comment"));
+    // First click opens the editor seeded with the saved message.
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-36-comment"));
+    expect(
+      screen.getByTestId("revisions-sheet-item-36-comment-editor"),
+    ).toBeInTheDocument();
+    // Second click on the same icon closes the editor (toggle).
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-36-comment"));
+    expect(
+      screen.queryByTestId("revisions-sheet-item-36-comment-editor"),
+    ).not.toBeInTheDocument();
+    expect(onSaveMessage).not.toHaveBeenCalled();
+  });
+
+  test("Cancel button closes the editor without calling onSaveMessage", async () => {
+    const fetchPage = vi.fn(() =>
+      Promise.resolve({
+        revisions: [
+          {
+            id: 35,
+            title: "Snapshot",
+            updatedAt: new Date("2026-05-22T12:00:00Z"),
+            authorId: 1,
+            authorName: "Ada",
+            authorEmail: "ada@x",
+            message: null,
+          },
+        ] satisfies RevisionFixture[],
+        nextCursor: null,
+      }),
+    );
+    const onSaveMessage = vi.fn();
+    render(
+      wrap(
+        <RevisionsSheet
+          entryId={42}
+          fetchPage={fetchPage}
+          relativeTime={() => "now"}
+          fetchRevision={vi.fn()}
+          fetchCurrent={vi.fn()}
+          onPreview={vi.fn()}
+          onSaveMessage={onSaveMessage}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("revisions-sheet-trigger"));
+    await waitFor(() => screen.getByTestId("revisions-sheet-item-35-comment"));
+    fireEvent.click(screen.getByTestId("revisions-sheet-item-35-comment"));
+    fireEvent.click(
+      screen.getByTestId("revisions-sheet-item-35-comment-cancel"),
+    );
+    expect(
+      screen.queryByTestId("revisions-sheet-item-35-comment-editor"),
+    ).not.toBeInTheDocument();
+    expect(onSaveMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/admin/src/editor/revisions/RevisionsSheet.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button.js";
+import { Input } from "@/components/ui/input.js";
 import {
   Sheet,
   SheetContent,
@@ -17,6 +18,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs.js";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { MessageCircle, MessageCircleMore } from "lucide-react";
 
 import { RevisionDiffDialog } from "./RevisionDiffDialog.js";
 
@@ -27,6 +29,10 @@ interface RevisionListItem {
   readonly authorId: number;
   readonly authorName: string | null;
   readonly authorEmail: string | null;
+  // Author-supplied label for the revision. `null` when unset; the
+  // row UI renders an em dash placeholder so existing rows pre-#289
+  // slice 3 stay legible.
+  readonly message: string | null;
 }
 
 interface RevisionPage {
@@ -60,6 +66,13 @@ interface RevisionsSheetProps {
   // navigate to the preview URL. The sheet closes itself afterwards
   // so the editor surface is unobstructed.
   readonly onPreview: (revisionId: number) => void;
+  // PATCHes `revision.message`. `null` clears the comment. The sheet
+  // owns the optimistic-update path so callers don't have to wire
+  // cache invalidation per render.
+  readonly onSaveMessage: (input: {
+    readonly revisionId: number;
+    readonly message: string | null;
+  }) => Promise<void>;
 }
 
 export function RevisionsSheet({
@@ -69,6 +82,7 @@ export function RevisionsSheet({
   fetchRevision,
   fetchCurrent,
   onPreview,
+  onSaveMessage,
 }: RevisionsSheetProps): ReactElement {
   const [open, setOpen] = useState(false);
   const query = useInfiniteQuery({
@@ -130,6 +144,7 @@ export function RevisionsSheet({
               relativeTime={relativeTime}
               onPreview={handlePreview}
               onOpenDiff={setDiffModalRevisionId}
+              onSaveMessage={onSaveMessage}
               hasMore={hasMore}
               isFetchingNextPage={query.isFetchingNextPage}
               fetchNextPage={() => void query.fetchNextPage()}
@@ -188,6 +203,10 @@ interface ListSectionProps {
   readonly relativeTime: (date: Date) => string;
   readonly onPreview: (id: number) => void;
   readonly onOpenDiff: (id: number) => void;
+  readonly onSaveMessage: (input: {
+    readonly revisionId: number;
+    readonly message: string | null;
+  }) => Promise<void>;
   readonly hasMore: boolean;
   readonly isFetchingNextPage: boolean;
   readonly fetchNextPage: () => void;
@@ -200,6 +219,7 @@ function ListSection({
   relativeTime,
   onPreview,
   onOpenDiff,
+  onSaveMessage,
   hasMore,
   isFetchingNextPage,
   fetchNextPage,
@@ -240,34 +260,14 @@ function ListSection({
       {allRevisions.length > 0 ? (
         <ul data-testid="revisions-sheet-list" className="divide-y px-4 py-2">
           {allRevisions.map((rev) => (
-            <li
+            <RevisionRow
               key={rev.id}
-              data-testid={`revisions-sheet-item-${rev.id}`}
-              className="flex items-center gap-1 py-2"
-            >
-              <button
-                type="button"
-                data-testid={`revisions-sheet-item-${rev.id}-select`}
-                onClick={() => onPreview(rev.id)}
-                className="hover:bg-accent min-w-0 flex-1 rounded-md p-2 text-left"
-              >
-                <div className="truncate text-sm font-medium">{rev.title}</div>
-                <div className="text-muted-foreground text-xs">
-                  <span>{rev.authorName ?? rev.authorEmail ?? "Unknown"}</span>
-                  {" · "}
-                  <span>{relativeTime(rev.updatedAt)}</span>
-                </div>
-              </button>
-              <button
-                type="button"
-                data-testid={`revisions-sheet-item-${rev.id}-diff`}
-                aria-label="View JSON diff"
-                onClick={() => onOpenDiff(rev.id)}
-                className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md font-mono text-xs"
-              >
-                &lt;/&gt;
-              </button>
-            </li>
+              revision={rev}
+              relativeTime={relativeTime}
+              onPreview={onPreview}
+              onOpenDiff={onOpenDiff}
+              onSaveMessage={onSaveMessage}
+            />
           ))}
         </ul>
       ) : null}
@@ -285,5 +285,158 @@ function ListSection({
         </div>
       ) : null}
     </>
+  );
+}
+
+interface RevisionRowProps {
+  readonly revision: RevisionListItem;
+  readonly relativeTime: (date: Date) => string;
+  readonly onPreview: (id: number) => void;
+  readonly onOpenDiff: (id: number) => void;
+  readonly onSaveMessage: (input: {
+    readonly revisionId: number;
+    readonly message: string | null;
+  }) => Promise<void>;
+}
+
+function RevisionRow({
+  revision,
+  relativeTime,
+  onPreview,
+  onOpenDiff,
+  onSaveMessage,
+}: RevisionRowProps): ReactElement {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(revision.message ?? "");
+  const [saving, setSaving] = useState(false);
+
+  // Toggle: re-clicking the icon while the editor is open closes it
+  // (without destroying the draft for the *next* open — `openEditor`
+  // re-seeds from the current message on each open). Without this,
+  // a second click would silently reset the in-progress text.
+  function toggleEditor(): void {
+    if (editing) {
+      setEditing(false);
+      return;
+    }
+    setDraft(revision.message ?? "");
+    setEditing(true);
+  }
+  async function save(): Promise<void> {
+    const next = draft.trim();
+    setSaving(true);
+    try {
+      await onSaveMessage({
+        revisionId: revision.id,
+        message: next.length === 0 ? null : next,
+      });
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <li
+      data-testid={`revisions-sheet-item-${revision.id}`}
+      className="flex flex-col gap-1 py-2"
+    >
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          data-testid={`revisions-sheet-item-${revision.id}-select`}
+          onClick={() => onPreview(revision.id)}
+          className="hover:bg-accent min-w-0 flex-1 rounded-md p-2 text-left"
+        >
+          <div className="truncate text-sm font-medium">{revision.title}</div>
+          <div className="text-muted-foreground text-xs">
+            <span>
+              {revision.authorName ?? revision.authorEmail ?? "Unknown"}
+            </span>
+            {" · "}
+            <span>{relativeTime(revision.updatedAt)}</span>
+          </div>
+        </button>
+        <button
+          type="button"
+          data-testid={`revisions-sheet-item-${revision.id}-comment`}
+          aria-label={
+            revision.message === null ? "Add comment" : "Edit comment"
+          }
+          aria-pressed={editing}
+          onClick={toggleEditor}
+          className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+        >
+          {revision.message === null ? (
+            <MessageCircle className="h-4 w-4" aria-hidden />
+          ) : (
+            <MessageCircleMore
+              className="text-foreground h-4 w-4"
+              aria-hidden
+            />
+          )}
+        </button>
+        <button
+          type="button"
+          data-testid={`revisions-sheet-item-${revision.id}-diff`}
+          aria-label="View JSON diff"
+          onClick={() => onOpenDiff(revision.id)}
+          className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md font-mono text-xs"
+        >
+          &lt;/&gt;
+        </button>
+      </div>
+      {editing ? (
+        <div
+          data-testid={`revisions-sheet-item-${revision.id}-comment-editor`}
+          className="flex items-start gap-2 px-2"
+        >
+          <Input
+            type="text"
+            data-testid={`revisions-sheet-item-${revision.id}-comment-input`}
+            value={draft}
+            maxLength={280}
+            placeholder="Describe this revision…"
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setEditing(false);
+              // Skip Enter while an IME composition is active (CJK
+              // input methods commit on Enter to accept the candidate;
+              // saving here would fire prematurely).
+              if (e.key === "Enter" && !saving && !e.nativeEvent.isComposing) {
+                void save();
+              }
+            }}
+            className="h-8 text-xs"
+          />
+
+          <Button
+            variant="default"
+            size="sm"
+            data-testid={`revisions-sheet-item-${revision.id}-comment-save`}
+            onClick={() => void save()}
+            disabled={saving}
+          >
+            {saving ? "…" : "Save"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid={`revisions-sheet-item-${revision.id}-comment-cancel`}
+            onClick={() => setEditing(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : revision.message !== null ? (
+        <div
+          data-testid={`revisions-sheet-item-${revision.id}-comment-display`}
+          className="text-muted-foreground truncate px-2 text-xs italic"
+        >
+          {revision.message}
+        </div>
+      ) : null}
+    </li>
   );
 }

--- a/packages/admin/src/editor/revisions/use-revisions-trigger.tsx
+++ b/packages/admin/src/editor/revisions/use-revisions-trigger.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { RevisionsSheet } from "@/editor/revisions/RevisionsSheet.js";
 import { orpc } from "@/lib/orpc.js";
 import { formatRelativeTime } from "@/lib/relative-time.js";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface UseRevisionsTriggerInput {
   readonly entryId: number;
@@ -22,6 +23,7 @@ export function useRevisionsTrigger({
   enabled,
   onPreview,
 }: UseRevisionsTriggerInput): ReactNode {
+  const queryClient = useQueryClient();
   return useMemo<ReactNode>(() => {
     if (!enabled) return null;
     return (
@@ -52,7 +54,17 @@ export function useRevisionsTrigger({
           };
         }}
         onPreview={onPreview}
+        onSaveMessage={async ({ revisionId, message }) => {
+          await orpc.entry.revisions.setMessage.call({ revisionId, message });
+          // Invalidate the infinite-list query so the row re-renders
+          // with the new message. Cheap to refetch — at most 25 rows
+          // and the user just clicked Save so they're focused on the
+          // sheet.
+          await queryClient.invalidateQueries({
+            queryKey: ["entry.revisions", entryId],
+          });
+        }}
       />
     );
-  }, [entryId, enabled, onPreview]);
+  }, [entryId, enabled, onPreview, queryClient]);
 }

--- a/packages/core/src/revisions/repository.ts
+++ b/packages/core/src/revisions/repository.ts
@@ -6,7 +6,10 @@ import { isUniqueConstraintError } from "../db/errors.js";
 import { entries } from "../db/schema/entries.js";
 import { RevisionRepositoryError } from "./errors.js";
 import { buildRevisionSlug, REVISION_TYPE } from "./slug-codec.js";
-import { encodeSnapshotEnvelope } from "./snapshot-envelope.js";
+import {
+  encodeSnapshotEnvelope,
+  REVISION_MESSAGE_META_KEY,
+} from "./snapshot-envelope.js";
 
 // 21 chars × 64-char alphabet = 126 bits of entropy — collision-
 // resistant under the `(type, slug)` unique index. URL-safe.
@@ -138,6 +141,36 @@ export async function getRevision(
       eq(entries.type, REVISION_TYPE),
     ),
   });
+  return row;
+}
+
+interface SetRevisionMessageInput {
+  readonly revisionId: number;
+  // `null` clears the message (deletes the meta key). The RPC layer
+  // is responsible for normalizing empty strings to null before it
+  // gets here — the repository writes what it's told.
+  readonly message: string | null;
+}
+
+// Patches the revision row's `meta.__plumix_revision_message`. Returns
+// the updated row, or `undefined` if `revisionId` doesn't exist.
+export async function setRevisionMessage(
+  db: Db,
+  input: SetRevisionMessageInput,
+): Promise<Entry | undefined> {
+  const current = await getRevision(db, { revisionId: input.revisionId });
+  if (!current) return undefined;
+  const nextMeta = { ...current.meta };
+  if (input.message === null) {
+    delete nextMeta[REVISION_MESSAGE_META_KEY];
+  } else {
+    nextMeta[REVISION_MESSAGE_META_KEY] = input.message;
+  }
+  const [row] = await db
+    .update(entries)
+    .set({ meta: nextMeta })
+    .where(eq(entries.id, input.revisionId))
+    .returning();
   return row;
 }
 

--- a/packages/core/src/revisions/rpc.test.ts
+++ b/packages/core/src/revisions/rpc.test.ts
@@ -110,6 +110,126 @@ describe("entry.revisions.get", () => {
     expect(fetched.authorEmail).toBe(first.authorEmail);
   });
 
+  test("list + get include message=null for revisions with no comment", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithRevisions(),
+    });
+    const created = await h.client.entry.create({ title: "M", slug: "m" });
+    await h.client.entry.update({ id: created.id, title: "M2" });
+    const listed = await h.client.entry.revisions.list({
+      entryId: created.id,
+    });
+    const [row] = listed.revisions;
+    if (!row) throw new Error("expected a revision");
+    expect(row.message).toBeNull();
+    const fetched = await h.client.entry.revisions.get({
+      revisionId: row.id,
+    });
+    expect(fetched.message).toBeNull();
+  });
+
+  test("setMessage persists a comment and surfaces it on list + get", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithRevisions(),
+    });
+    const created = await h.client.entry.create({ title: "M", slug: "m" });
+    await h.client.entry.update({ id: created.id, title: "M2" });
+    const listed = await h.client.entry.revisions.list({
+      entryId: created.id,
+    });
+    const [row] = listed.revisions;
+    if (!row) throw new Error("expected a revision");
+    const result = await h.client.entry.revisions.setMessage({
+      revisionId: row.id,
+      message: "before the redesign",
+    });
+    expect(result.message).toBe("before the redesign");
+    const refetched = await h.client.entry.revisions.list({
+      entryId: created.id,
+    });
+    expect(refetched.revisions[0]?.message).toBe("before the redesign");
+    const fetched = await h.client.entry.revisions.get({
+      revisionId: row.id,
+    });
+    expect(fetched.message).toBe("before the redesign");
+  });
+
+  test("setMessage with null clears a previously-set comment", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithRevisions(),
+    });
+    const created = await h.client.entry.create({ title: "M", slug: "m" });
+    await h.client.entry.update({ id: created.id, title: "M2" });
+    const listed = await h.client.entry.revisions.list({
+      entryId: created.id,
+    });
+    const [row] = listed.revisions;
+    if (!row) throw new Error("expected a revision");
+    await h.client.entry.revisions.setMessage({
+      revisionId: row.id,
+      message: "scratch",
+    });
+    const cleared = await h.client.entry.revisions.setMessage({
+      revisionId: row.id,
+      message: null,
+    });
+    expect(cleared.message).toBeNull();
+  });
+
+  test("setMessage rejects messages longer than 280 characters", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithRevisions(),
+    });
+    const created = await h.client.entry.create({ title: "M", slug: "m" });
+    await h.client.entry.update({ id: created.id, title: "M2" });
+    const listed = await h.client.entry.revisions.list({
+      entryId: created.id,
+    });
+    const [row] = listed.revisions;
+    if (!row) throw new Error("expected a revision");
+    await expect(
+      h.client.entry.revisions.setMessage({
+        revisionId: row.id,
+        message: "a".repeat(281),
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  test("contributor without edit caps gets FORBIDDEN on setMessage", async () => {
+    const editor = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithRevisions(),
+    });
+    const created = await editor.client.entry.create({
+      title: "M",
+      slug: "m",
+    });
+    await editor.client.entry.update({ id: created.id, title: "M2" });
+    const listed = await editor.client.entry.revisions.list({
+      entryId: created.id,
+    });
+    const [row] = listed.revisions;
+    if (!row) throw new Error("expected a revision");
+
+    const contributor = await createRpcHarness({
+      authAs: "contributor",
+      plugins: registryWithRevisions(),
+    });
+    // Contributor lacks `read_revisions` on a foreign-authored entry —
+    // the read gate fires before the edit gate, so the rejection is
+    // the same NOT_FOUND that `get` raises (avoids leaking existence).
+    await expect(
+      contributor.client.entry.revisions.setMessage({
+        revisionId: row.id,
+        message: "from contributor",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
   test("contributor gets FORBIDDEN on entry.revisions.get", async () => {
     const h = await createRpcHarness({
       authAs: "editor",

--- a/packages/core/src/revisions/snapshot-envelope.test.ts
+++ b/packages/core/src/revisions/snapshot-envelope.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  decodeRevisionMessage,
   decodeSnapshotEnvelope,
   encodeSnapshotEnvelope,
+  REVISION_MESSAGE_META_KEY,
 } from "./snapshot-envelope.js";
 
 describe("snapshot envelope codec", () => {
@@ -15,5 +17,31 @@ describe("snapshot envelope codec", () => {
       slug: "hello-world",
       parentId: 42,
     });
+  });
+});
+
+describe("revision message decoder", () => {
+  test("returns null when the meta has no message key", () => {
+    expect(decodeRevisionMessage({})).toBeNull();
+  });
+
+  test("returns null when the message is an empty string", () => {
+    expect(
+      decodeRevisionMessage({ [REVISION_MESSAGE_META_KEY]: "" }),
+    ).toBeNull();
+  });
+
+  test("returns null when the meta key is not a string", () => {
+    expect(
+      decodeRevisionMessage({ [REVISION_MESSAGE_META_KEY]: 42 }),
+    ).toBeNull();
+  });
+
+  test("returns the string when set", () => {
+    expect(
+      decodeRevisionMessage({
+        [REVISION_MESSAGE_META_KEY]: "before the redesign",
+      }),
+    ).toBe("before the redesign");
   });
 });

--- a/packages/core/src/revisions/snapshot-envelope.ts
+++ b/packages/core/src/revisions/snapshot-envelope.ts
@@ -3,6 +3,15 @@
 // fields cannot use this prefix.
 export const SNAPSHOT_META_KEY = "__plumix_snapshot";
 
+// Author-supplied label for a revision (Builder.io's "Comment" icon).
+// Lives under a separate envelope key so it can be patched in isolation
+// — no need to round-trip the whole snapshot envelope on every edit.
+export const REVISION_MESSAGE_META_KEY = "__plumix_revision_message";
+
+// Soft cap on author-typed labels. Long enough for one sentence, short
+// enough to render inline without truncating the row UI.
+export const REVISION_MESSAGE_MAX_LENGTH = 280;
+
 interface SnapshotEnvelope {
   readonly slug: string;
   readonly parentId: number | null;
@@ -23,4 +32,15 @@ export function decodeSnapshotEnvelope(
   if (typeof slug !== "string" || slug.length === 0) return undefined;
   if (parentId !== null && typeof parentId !== "number") return undefined;
   return { slug, parentId };
+}
+
+export function decodeRevisionMessage(
+  meta: Readonly<Record<string, unknown>>,
+): string | null {
+  const raw = meta[REVISION_MESSAGE_META_KEY];
+  // Treat both missing and empty string as "no message" so callers
+  // get a stable `null | string` discriminator without an empty-string
+  // edge case downstream.
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  return raw;
 }

--- a/packages/core/src/rpc/procedures/entry/revisions.ts
+++ b/packages/core/src/rpc/procedures/entry/revisions.ts
@@ -8,13 +8,16 @@ import { users } from "../../../db/schema/users.js";
 import {
   getRevision as repoGetRevision,
   listRevisions as repoListRevisions,
+  setRevisionMessage as repoSetRevisionMessage,
 } from "../../../revisions/repository.js";
 import {
   decodeRevisionSlug,
   isRevisionType,
 } from "../../../revisions/slug-codec.js";
 import {
+  decodeRevisionMessage,
   decodeSnapshotEnvelope,
+  REVISION_MESSAGE_MAX_LENGTH,
   SNAPSHOT_META_KEY,
 } from "../../../revisions/snapshot-envelope.js";
 import { authenticated } from "../../authenticated.js";
@@ -95,6 +98,7 @@ export const list = base
         authorId: r.authorId,
         authorName: author?.name ?? null,
         authorEmail: author?.email ?? null,
+        message: decodeRevisionMessage(r.meta),
       };
     });
     return { revisions: items, nextCursor: page.nextCursor };
@@ -135,6 +139,7 @@ export const get = base
       ...revision,
       authorName: author?.name ?? null,
       authorEmail: author?.email ?? null,
+      message: decodeRevisionMessage(revision.meta),
     };
   });
 
@@ -252,4 +257,71 @@ export const restore = base
     return updated;
   });
 
-export const revisionsRouter = { list, get, restore } as const;
+const setMessageInput = v.object({
+  revisionId: idParam,
+  // `null` clears the comment. Empty strings are coerced to null at
+  // the repository layer; the API surface accepts both so the UI can
+  // send whatever the input contains without a client-side trim
+  // pass.
+  message: v.union([
+    v.null(),
+    v.pipe(v.string(), v.maxLength(REVISION_MESSAGE_MAX_LENGTH)),
+  ]),
+});
+
+// Patches `revision.message`. Capability gate deliberately matches
+// `restore` (read_revisions + edit_own/edit_any) for symmetry — a
+// user who can revert a revision can also re-caption it; future
+// loosening (e.g. comment-only role) should change both gates in
+// lockstep. No `expectedLiveUpdatedAt` token: comment edits don't
+// touch the live entry, so concurrent label edits are
+// last-write-wins on the same revision row.
+export const setMessage = base
+  .use(authenticated)
+  .input(setMessageInput)
+  .handler(async ({ input, context, errors }) => {
+    const notFound = () =>
+      errors.NOT_FOUND({ data: { kind: "revision", id: input.revisionId } });
+
+    const revision = await repoGetRevision(context.db, {
+      revisionId: input.revisionId,
+    });
+    if (!revision) throw notFound();
+
+    const decoded = decodeRevisionSlug(revision.slug);
+    if (!decoded) throw notFound();
+    const live = await context.db.query.entries.findFirst({
+      where: eq(entries.id, decoded.entryId),
+    });
+    if (!live || isRevisionType(live.type)) throw notFound();
+
+    const readCapability = entryCapability(live.type, "read_revisions");
+    if (!context.auth.can(readCapability)) {
+      throw errors.FORBIDDEN({ data: { capability: readCapability } });
+    }
+    const isAuthor = live.authorId === context.user.id;
+    const editOwnCapability = entryCapability(live.type, "edit_own");
+    const editAnyCapability = entryCapability(live.type, "edit_any");
+    const canEdit =
+      (isAuthor && context.auth.can(editOwnCapability)) ||
+      context.auth.can(editAnyCapability);
+    if (!canEdit) {
+      throw errors.FORBIDDEN({ data: { capability: editAnyCapability } });
+    }
+
+    // Normalize empty string to null at the input boundary so the
+    // repository writes a canonical shape (delete-key vs set-key)
+    // and the on-disk meta stays clean across re-edits.
+    const normalized =
+      input.message === null || input.message.length === 0
+        ? null
+        : input.message;
+    const updated = await repoSetRevisionMessage(context.db, {
+      revisionId: input.revisionId,
+      message: normalized,
+    });
+    if (!updated) throw notFound();
+    return { id: updated.id, message: decodeRevisionMessage(updated.meta) };
+  });
+
+export const revisionsRouter = { list, get, restore, setMessage } as const;


### PR DESCRIPTION
Final slice of the Builder-aligned revisions UI (#289). Each revision row
now carries an optional author-supplied label — the third icon Builder.io's
History UI offers. Click to open an inline editor; saved messages display
under the row title in italic muted text.

**Storage in `meta`, no schema migration**

Revisions are already `entries` rows of type `_rev:<parentType>` with a JSON
`meta` bag, so the message lives under `__plumix_revision_message` in the
same envelope namespace as the existing snapshot pointer. `decodeRevisionMessage`
normalizes missing / empty / non-string to `null` so the wire surface is a
stable `string | null`.

**New RPC: `entry.revisions.setMessage`**

Capability gate matches `restore` (`read_revisions + edit_own/edit_any`) for
symmetry — a user who can revert a revision can also re-caption it. Future
loosening (e.g. a comment-only role) should change both gates in lockstep.
No `expectedLiveUpdatedAt` token because comment edits don't touch the live
entry; concurrent edits on the same revision are last-write-wins.

**Editor UX**

`<RevisionsSheet>` gains a required `onSaveMessage` prop. Per-row icon flips
between `MessageCircle` (no comment) and `MessageCircleMore` (has comment).
Click toggles a shadcn `<Input>` editor; Enter saves, Escape cancels, and
re-clicking the icon also closes (skips `Enter` while `isComposing` so CJK
IME authors aren't cut off mid-candidate). Empty input on save sends
`message: null`, which clears the comment.

Refs #289