### PR TITLE
feat(core): autosave slug codec + reserved-type guards

### DIFF
--- a/packages/core/src/auth/rbac.test.ts
+++ b/packages/core/src/auth/rbac.test.ts
@@ -167,6 +167,7 @@ describe("deriveEntryTypeCapabilities", () => {
         edit_any: "admin",
         delete: "admin",
         read_revisions: "admin",
+        restore_revision: "admin",
       },
     });
     for (const cap of caps) {

--- a/packages/core/src/auth/rbac.ts
+++ b/packages/core/src/auth/rbac.ts
@@ -78,6 +78,11 @@ export const POST_TYPE_CAPABILITY_ACTIONS = {
   // ordinarily look at past versions of their own drafts. Matches the
   // PRD's "editors can see who saved what and when" framing.
   read_revisions: "editor",
+  // Restoring a prior revision overwrites the live row. Pairs with
+  // `read_revisions` for symmetry with the existing list/get gates;
+  // capability lands here so the full surface is consistent before
+  // the restore-into-autosave action wires up in a later slice.
+  restore_revision: "editor",
 } as const satisfies Record<string, UserRole>;
 
 export const TERM_TAXONOMY_CAPABILITY_ACTIONS = {

--- a/packages/core/src/revisions/slug-codec.test.ts
+++ b/packages/core/src/revisions/slug-codec.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  AUTOSAVE_TYPE,
+  buildAutosaveSlug,
   buildRevisionSlug,
+  decodeAutosaveSlug,
   decodeRevisionSlug,
+  isAutosaveType,
+  isReservedType,
   isRevisionType,
   REVISION_TYPE,
 } from "./slug-codec.js";
@@ -32,5 +37,63 @@ describe("revision slug codec", () => {
     expect(isRevisionType("post")).toBe(false);
     expect(isRevisionType("Revision")).toBe(false);
     expect(isRevisionType(undefined)).toBe(false);
+  });
+});
+
+describe("autosave slug codec", () => {
+  test("buildAutosaveSlug composes `autosave:<entryId>:<authorId>` from inputs", () => {
+    expect(buildAutosaveSlug({ entryId: 42, authorId: 7 })).toBe(
+      "autosave:42:7",
+    );
+  });
+
+  test("autosave slugs are deterministic per (entry, author) pair", () => {
+    // The deterministic shape is load-bearing — UNIQUE (type, slug)
+    // enforces one autosave per (entry, user) without a separate
+    // dedup query at write time.
+    expect(buildAutosaveSlug({ entryId: 42, authorId: 7 })).toBe(
+      buildAutosaveSlug({ entryId: 42, authorId: 7 }),
+    );
+    expect(buildAutosaveSlug({ entryId: 42, authorId: 7 })).not.toBe(
+      buildAutosaveSlug({ entryId: 42, authorId: 8 }),
+    );
+  });
+
+  test("decodeAutosaveSlug recovers entryId + authorId from a built slug", () => {
+    const slug = buildAutosaveSlug({ entryId: 100, authorId: 5 });
+    expect(decodeAutosaveSlug(slug)).toEqual({ entryId: 100, authorId: 5 });
+  });
+
+  test("decodeAutosaveSlug returns undefined for non-autosave or malformed slugs", () => {
+    expect(decodeAutosaveSlug("hello-world")).toBeUndefined();
+    expect(decodeAutosaveSlug("revision:42:abc")).toBeUndefined();
+    expect(decodeAutosaveSlug("autosave:")).toBeUndefined();
+    expect(decodeAutosaveSlug("autosave:abc:42")).toBeUndefined();
+    expect(decodeAutosaveSlug("autosave:42")).toBeUndefined();
+    expect(decodeAutosaveSlug("autosave:42:")).toBeUndefined();
+    expect(decodeAutosaveSlug("autosave:42:abc")).toBeUndefined();
+    expect(decodeAutosaveSlug("autosave:0:7")).toBeUndefined();
+    expect(decodeAutosaveSlug("autosave:42:0")).toBeUndefined();
+  });
+
+  test("isAutosaveType discriminates reserved type from public ones", () => {
+    expect(isAutosaveType(AUTOSAVE_TYPE)).toBe(true);
+    expect(isAutosaveType("post")).toBe(false);
+    expect(isAutosaveType("revision")).toBe(false);
+    expect(isAutosaveType(undefined)).toBe(false);
+  });
+});
+
+describe("isReservedType", () => {
+  test("returns true for both reserved types", () => {
+    expect(isReservedType(REVISION_TYPE)).toBe(true);
+    expect(isReservedType(AUTOSAVE_TYPE)).toBe(true);
+  });
+
+  test("returns false for public types", () => {
+    expect(isReservedType("post")).toBe(false);
+    expect(isReservedType("page")).toBe(false);
+    expect(isReservedType("")).toBe(false);
+    expect(isReservedType(undefined)).toBe(false);
   });
 });

--- a/packages/core/src/revisions/slug-codec.ts
+++ b/packages/core/src/revisions/slug-codec.ts
@@ -30,3 +30,48 @@ export function decodeRevisionSlug(
 export function isRevisionType(type: unknown): type is typeof REVISION_TYPE {
   return type === REVISION_TYPE;
 }
+
+// Per-user pending edit on a published entry. Same table as the live
+// row + revision row, distinguished by `type='autosave'` and a slug of
+// `autosave:<entryId>:<authorId>`. The deterministic shape lets the
+// existing `UNIQUE (type, slug)` index enforce one autosave per
+// (entry, user) — no separate dedup query at write time.
+export const AUTOSAVE_TYPE = "autosave";
+
+const AUTOSAVE_SLUG_PATTERN = /^autosave:(\d+):(\d+)$/;
+
+interface DecodedAutosaveSlug {
+  readonly entryId: number;
+  readonly authorId: number;
+}
+
+export function buildAutosaveSlug(parts: DecodedAutosaveSlug): string {
+  return `autosave:${String(parts.entryId)}:${String(parts.authorId)}`;
+}
+
+export function decodeAutosaveSlug(
+  slug: string,
+): DecodedAutosaveSlug | undefined {
+  const match = AUTOSAVE_SLUG_PATTERN.exec(slug);
+  if (!match) return undefined;
+  const [, entryIdRaw, authorIdRaw] = match;
+  if (!entryIdRaw || !authorIdRaw) return undefined;
+  const entryId = Number.parseInt(entryIdRaw, 10);
+  const authorId = Number.parseInt(authorIdRaw, 10);
+  if (!Number.isInteger(entryId) || entryId <= 0) return undefined;
+  if (!Number.isInteger(authorId) || authorId <= 0) return undefined;
+  return { entryId, authorId };
+}
+
+export function isAutosaveType(type: unknown): type is typeof AUTOSAVE_TYPE {
+  return type === AUTOSAVE_TYPE;
+}
+
+// Reserved-type guard for entry CRUD: both revision and autosave rows
+// live in the same table as public entries but are off-limits to
+// callers — they're written by framework code only. Use this at every
+// write surface (`entry.create`, `entry.update`) to reject the type
+// before it can land in the database.
+export function isReservedType(type: unknown): boolean {
+  return isRevisionType(type) || isAutosaveType(type);
+}

--- a/packages/core/src/rpc/procedures/entry/create.ts
+++ b/packages/core/src/rpc/procedures/entry/create.ts
@@ -1,6 +1,6 @@
 import type { NewEntry } from "../../../db/schema/entries.js";
 import { entries } from "../../../db/schema/entries.js";
-import { isRevisionType } from "../../../revisions/slug-codec.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import {
@@ -38,10 +38,10 @@ export const create = base
       input,
     );
 
-    // Reserved internal types are written only by the framework's
-    // snapshot path — reject here so a hostile input.type can't
-    // smuggle revision rows into the table.
-    if (isRevisionType(filtered.type)) {
+    // Reserved internal types (revision, autosave) are written only by
+    // the framework's snapshot / draft paths — reject here so a hostile
+    // input.type can't smuggle reserved rows into the table.
+    if (isReservedType(filtered.type)) {
       throw errors.BAD_REQUEST({ data: { reason: "reserved_type" } });
     }
 

--- a/packages/core/src/rpc/procedures/entry/get.ts
+++ b/packages/core/src/rpc/procedures/entry/get.ts
@@ -1,6 +1,6 @@
 import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
-import { isRevisionType } from "../../../revisions/slug-codec.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { entryCapability } from "./lifecycle.js";
@@ -23,9 +23,10 @@ export const get = base
     if (!row) {
       throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
     }
-    // Revision rows surface through entry.revisions.get only — their
-    // existence here shouldn't be observable, so 404 (not BAD_REQUEST).
-    if (isRevisionType(row.type)) {
+    // Reserved-type rows (revisions, autosaves) surface through their
+    // dedicated endpoints only — their existence here shouldn't be
+    // observable, so 404 (not BAD_REQUEST).
+    if (isReservedType(row.type)) {
       throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
     }
 

--- a/packages/core/src/rpc/procedures/entry/list.ts
+++ b/packages/core/src/rpc/procedures/entry/list.ts
@@ -17,7 +17,7 @@ import {
 import { entries } from "../../../db/schema/entries.js";
 import { entryTerm } from "../../../db/schema/entry_term.js";
 import { terms } from "../../../db/schema/terms.js";
-import { isRevisionType } from "../../../revisions/slug-codec.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { entryCapability } from "./lifecycle.js";
@@ -36,7 +36,7 @@ export const list = base
     );
 
     const type = filtered.type ?? "post";
-    if (isRevisionType(type)) {
+    if (isReservedType(type)) {
       throw errors.BAD_REQUEST({ data: { reason: "reserved_type" } });
     }
     const readCapability = entryCapability(type, "read");

--- a/packages/core/src/rpc/procedures/entry/revisions.ts
+++ b/packages/core/src/rpc/procedures/entry/revisions.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../revisions/repository.js";
 import {
   decodeRevisionSlug,
-  isRevisionType,
+  isReservedType,
 } from "../../../revisions/slug-codec.js";
 import {
   decodeRevisionMessage,
@@ -67,7 +67,7 @@ export const list = base
         data: { kind: "entry", id: input.entryId },
       });
     }
-    if (isRevisionType(live.type)) {
+    if (isReservedType(live.type)) {
       throw errors.BAD_REQUEST({ data: { reason: "reserved_type" } });
     }
     const capability = entryCapability(live.type, "read_revisions");
@@ -123,7 +123,7 @@ export const get = base
     const live = await context.db.query.entries.findFirst({
       where: eq(entries.id, decoded.entryId),
     });
-    if (!live || isRevisionType(live.type)) throw notFound();
+    if (!live || isReservedType(live.type)) throw notFound();
 
     const capability = entryCapability(live.type, "read_revisions");
     if (!context.auth.can(capability)) {
@@ -160,7 +160,7 @@ export const restore = base
     const live = await context.db.query.entries.findFirst({
       where: eq(entries.id, decoded.entryId),
     });
-    if (!live || isRevisionType(live.type)) throw notFound();
+    if (!live || isReservedType(live.type)) throw notFound();
 
     const readCapability = entryCapability(live.type, "read_revisions");
     if (!context.auth.can(readCapability)) {
@@ -293,7 +293,7 @@ export const setMessage = base
     const live = await context.db.query.entries.findFirst({
       where: eq(entries.id, decoded.entryId),
     });
-    if (!live || isRevisionType(live.type)) throw notFound();
+    if (!live || isReservedType(live.type)) throw notFound();
 
     const readCapability = entryCapability(live.type, "read_revisions");
     if (!context.auth.can(readCapability)) {

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -2,6 +2,7 @@ import type { AuthenticatedAppContext } from "../../../context/app.js";
 import type { Entry, NewEntry } from "../../../db/schema/entries.js";
 import { and, eq, isUniqueConstraintError, ne } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { isEmptyMetaPatch } from "../../meta/core.js";
@@ -153,7 +154,11 @@ export const update = base
     const existing = await context.db.query.entries.findFirst({
       where: eq(entries.id, filtered.id),
     });
-    if (!existing) {
+    // Reserved-type rows (revisions, autosaves) are written by the
+    // framework's snapshot / draft paths, not `entry.update`. Surface
+    // the same 404 a public row would emit so reserved-row existence
+    // isn't observable.
+    if (!existing || isReservedType(existing.type)) {
       throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
     }
 


### PR DESCRIPTION
First slice of #290 (drafts-of-published). Server foundation only — no RPC
surface, no UI; the next slice wires `entry.update`, `entry.get`, `entry.publish`,
`entry.discardDraft`.

**Slug shape: `autosave:<entryId>:<authorId>`**

Deterministic per (entry, user) pair so the existing `UNIQUE (type, slug)`
index enforces "one autosave per editor" without a dedup query at write
time. Mirrors `revision:<entryId>:<nanoid>` for shape consistency; codec
helpers (`buildAutosaveSlug`, `decodeAutosaveSlug`, `isAutosaveType`,
`AUTOSAVE_TYPE`) sit next to the revision pair.

**`isReservedType` chokepoint**

Every CRUD surface that previously rejected `'revision'` rows now uses a
combined `isReservedType` that covers both reserved kinds. `entry.create`
and `entry.list` keep returning `BAD_REQUEST { reason: "reserved_type" }`;
`entry.get`, `entry.update`, and the `entry.revisions.*` family return 404
so reserved-row existence isn't observable through public endpoints.

**`restore_revision` capability**

New action on the post-type capability map at minRole `editor`. Lands the
full capability surface now so subsequent restore-into-autosave work
(slice 2 of #292) can gate against an already-registered cap.

Refs #290