### PR TITLE
feat(core): autosave repository helpers (upsert/get/delete)

### DIFF
--- a/packages/core/src/revisions/repository.test.ts
+++ b/packages/core/src/revisions/repository.test.ts
@@ -5,12 +5,15 @@ import { entries } from "../db/schema/entries.js";
 import { userFactory } from "../test/factories.js";
 import { createTestDb } from "../test/harness.js";
 import {
+  deleteAutosave,
+  getAutosave,
   getRevision,
   listRevisions,
   pruneOldRevisions,
   snapshotAsRevision,
+  upsertAutosave,
 } from "./repository.js";
-import { REVISION_TYPE } from "./slug-codec.js";
+import { AUTOSAVE_TYPE, REVISION_TYPE } from "./slug-codec.js";
 import { decodeSnapshotEnvelope } from "./snapshot-envelope.js";
 
 async function seedLiveEntry(db: Awaited<ReturnType<typeof createTestDb>>) {
@@ -211,5 +214,136 @@ describe("pruneOldRevisions", () => {
     expect(
       await pruneOldRevisions(db, { entryId: entry.id, maxRevisions: 5 }),
     ).toBe(0);
+  });
+});
+
+describe("upsertAutosave", () => {
+  test("inserts a new row mirroring the user's pending edit and snapshotting the live slug + parentId", async () => {
+    const db = await createTestDb();
+    const { author, entry } = await seedLiveEntry(db);
+    const autosave = await upsertAutosave(db, {
+      entry,
+      authorId: author.id,
+      patch: {
+        title: "Draft title",
+        content: { type: "doc", content: [{ type: "paragraph" }] },
+        excerpt: null,
+        meta: { foo: "bar" },
+      },
+    });
+    expect(autosave.type).toBe(AUTOSAVE_TYPE);
+    expect(autosave.title).toBe("Draft title");
+    expect(autosave.authorId).toBe(author.id);
+    expect(autosave.slug).toBe(`autosave:${String(entry.id)}:${String(author.id)}`);
+    // The snapshot envelope carries the live's slug + parentId so
+    // publish can recover them without an extra query.
+    const envelope = decodeSnapshotEnvelope(autosave.meta);
+    expect(envelope?.slug).toBe(entry.slug);
+    expect(envelope?.parentId).toBe(entry.parentId);
+  });
+
+  test("upserts on a second call from the same author — no UNIQUE collision, content gets the new values", async () => {
+    const db = await createTestDb();
+    const { author, entry } = await seedLiveEntry(db);
+    const first = await upsertAutosave(db, {
+      entry,
+      authorId: author.id,
+      patch: {
+        title: "First",
+        content: null,
+        excerpt: null,
+        meta: {},
+      },
+    });
+    const second = await upsertAutosave(db, {
+      entry,
+      authorId: author.id,
+      patch: {
+        title: "Second",
+        content: { type: "doc", content: [{ type: "paragraph" }] },
+        excerpt: "summary",
+        meta: { foo: "bar" },
+      },
+    });
+    expect(second.id).toBe(first.id);
+    expect(second.title).toBe("Second");
+    expect(second.excerpt).toBe("summary");
+  });
+
+  test("two different authors editing the same entry get distinct rows (per-user isolation)", async () => {
+    const db = await createTestDb();
+    const ada = await userFactory.transient({ db }).create({ role: "author" });
+    const bea = await userFactory.transient({ db }).create({ role: "author" });
+    const { entry } = await seedLiveEntry(db);
+    const adaSave = await upsertAutosave(db, {
+      entry,
+      authorId: ada.id,
+      patch: { title: "Ada's draft", content: null, excerpt: null, meta: {} },
+    });
+    const beaSave = await upsertAutosave(db, {
+      entry,
+      authorId: bea.id,
+      patch: { title: "Bea's draft", content: null, excerpt: null, meta: {} },
+    });
+    expect(adaSave.id).not.toBe(beaSave.id);
+    expect(adaSave.title).toBe("Ada's draft");
+    expect(beaSave.title).toBe("Bea's draft");
+  });
+});
+
+describe("getAutosave + deleteAutosave", () => {
+  test("getAutosave returns the row for (entry, author) or undefined when none", async () => {
+    const db = await createTestDb();
+    const { author, entry } = await seedLiveEntry(db);
+    expect(
+      await getAutosave(db, { entryId: entry.id, authorId: author.id }),
+    ).toBeUndefined();
+    await upsertAutosave(db, {
+      entry,
+      authorId: author.id,
+      patch: { title: "Hi", content: null, excerpt: null, meta: {} },
+    });
+    const fetched = await getAutosave(db, {
+      entryId: entry.id,
+      authorId: author.id,
+    });
+    expect(fetched?.title).toBe("Hi");
+  });
+
+  test("deleteAutosave removes the row for the caller only — other authors' autosaves survive", async () => {
+    const db = await createTestDb();
+    const ada = await userFactory.transient({ db }).create({ role: "author" });
+    const bea = await userFactory.transient({ db }).create({ role: "author" });
+    const { entry } = await seedLiveEntry(db);
+    await upsertAutosave(db, {
+      entry,
+      authorId: ada.id,
+      patch: { title: "A", content: null, excerpt: null, meta: {} },
+    });
+    await upsertAutosave(db, {
+      entry,
+      authorId: bea.id,
+      patch: { title: "B", content: null, excerpt: null, meta: {} },
+    });
+    expect(
+      await deleteAutosave(db, { entryId: entry.id, authorId: ada.id }),
+    ).toBe(true);
+    expect(
+      await getAutosave(db, { entryId: entry.id, authorId: ada.id }),
+    ).toBeUndefined();
+    // Bea's autosave is untouched.
+    const beaSave = await getAutosave(db, {
+      entryId: entry.id,
+      authorId: bea.id,
+    });
+    expect(beaSave?.title).toBe("B");
+  });
+
+  test("deleteAutosave returns false when no row exists for (entry, author)", async () => {
+    const db = await createTestDb();
+    const { author, entry } = await seedLiveEntry(db);
+    expect(
+      await deleteAutosave(db, { entryId: entry.id, authorId: author.id }),
+    ).toBe(false);
   });
 });

--- a/packages/core/src/revisions/repository.test.ts
+++ b/packages/core/src/revisions/repository.test.ts
@@ -234,7 +234,9 @@ describe("upsertAutosave", () => {
     expect(autosave.type).toBe(AUTOSAVE_TYPE);
     expect(autosave.title).toBe("Draft title");
     expect(autosave.authorId).toBe(author.id);
-    expect(autosave.slug).toBe(`autosave:${String(entry.id)}:${String(author.id)}`);
+    expect(autosave.slug).toBe(
+      `autosave:${String(entry.id)}:${String(author.id)}`,
+    );
     // The snapshot envelope carries the live's slug + parentId so
     // publish can recover them without an extra query.
     const envelope = decodeSnapshotEnvelope(autosave.meta);

--- a/packages/core/src/revisions/repository.ts
+++ b/packages/core/src/revisions/repository.ts
@@ -1,11 +1,16 @@
 import { and, desc, eq, inArray, like, lt } from "drizzle-orm";
 
 import type { Db } from "../context/app.js";
-import type { Entry } from "../db/schema/entries.js";
+import type { Entry, EntryContent } from "../db/schema/entries.js";
 import { isUniqueConstraintError } from "../db/errors.js";
 import { entries } from "../db/schema/entries.js";
 import { RevisionRepositoryError } from "./errors.js";
-import { buildRevisionSlug, REVISION_TYPE } from "./slug-codec.js";
+import {
+  AUTOSAVE_TYPE,
+  buildAutosaveSlug,
+  buildRevisionSlug,
+  REVISION_TYPE,
+} from "./slug-codec.js";
 import {
   encodeSnapshotEnvelope,
   REVISION_MESSAGE_META_KEY,
@@ -142,6 +147,107 @@ export async function getRevision(
     ),
   });
   return row;
+}
+
+interface UpsertAutosaveInput {
+  // The live entry whose identity (id, slug, parentId) the autosave
+  // tracks. The slug + parentId get snapshotted into the autosave's
+  // meta envelope so `entry.publish` can restore them onto live
+  // without a separate roundtrip.
+  readonly entry: Entry;
+  // The user editing. Combined with `entry.id` to produce the
+  // deterministic slug — UNIQUE (type, slug) enforces "one autosave
+  // per (entry, user)" without an extra dedup query.
+  readonly authorId: number;
+  readonly patch: {
+    readonly title: string;
+    readonly content: EntryContent | null;
+    readonly excerpt: string | null;
+    readonly meta: Readonly<Record<string, unknown>>;
+  };
+}
+
+// Writes the per-user pending edit, inserting on first call and
+// upserting on subsequent ones. Returns the post-write row so callers
+// can read back `updatedAt` (used as the optimistic-concurrency token
+// for the next save). `meta.__plumix_snapshot` stays load-bearing —
+// the publish path reads it to recover the live slug + parentId.
+export async function upsertAutosave(
+  db: Db,
+  input: UpsertAutosaveInput,
+): Promise<Entry> {
+  const { entry, authorId, patch } = input;
+  const meta = {
+    ...patch.meta,
+    ...encodeSnapshotEnvelope({ slug: entry.slug, parentId: entry.parentId }),
+  };
+  const slug = buildAutosaveSlug({ entryId: entry.id, authorId });
+  const [row] = await db
+    .insert(entries)
+    .values({
+      type: AUTOSAVE_TYPE,
+      parentId: null,
+      title: patch.title,
+      slug,
+      content: patch.content,
+      excerpt: patch.excerpt,
+      status: entry.status,
+      authorId,
+      sortOrder: 0,
+      meta,
+      publishedAt: entry.publishedAt,
+    })
+    .onConflictDoUpdate({
+      target: [entries.type, entries.slug],
+      // The autosave row's identity (type / slug / authorId) is
+      // fixed by the deterministic-slug contract; only the editable
+      // fields + the snapshot envelope can change. `excluded.*`
+      // references the conflicting insert's values per SQLite's
+      // upsert dialect.
+      set: {
+        title: patch.title,
+        content: patch.content,
+        excerpt: patch.excerpt,
+        meta,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+  if (!row) throw RevisionRepositoryError.insertReturnedNoRow();
+  return row;
+}
+
+interface AutosavePairInput {
+  readonly entryId: number;
+  readonly authorId: number;
+}
+
+export async function getAutosave(
+  db: Db,
+  input: AutosavePairInput,
+): Promise<Entry | undefined> {
+  return db.query.entries.findFirst({
+    where: and(
+      eq(entries.type, AUTOSAVE_TYPE),
+      eq(entries.slug, buildAutosaveSlug(input)),
+    ),
+  });
+}
+
+export async function deleteAutosave(
+  db: Db,
+  input: AutosavePairInput,
+): Promise<boolean> {
+  const result = await db
+    .delete(entries)
+    .where(
+      and(
+        eq(entries.type, AUTOSAVE_TYPE),
+        eq(entries.slug, buildAutosaveSlug(input)),
+      ),
+    )
+    .returning({ id: entries.id });
+  return result.length > 0;
 }
 
 interface SetRevisionMessageInput {


### PR DESCRIPTION
Second slice of #290 (drafts-of-published). Pure data-layer foundation for
per-user pending edits — RPC surface lands in slice C, admin UI in slice D.

**Three repository helpers**

- `upsertAutosave(db, { entry, authorId, patch })` writes the row. Inserts on
  first call, upserts on subsequent calls from the same author via the
  deterministic `autosave:<entryId>:<authorId>` slug + the existing
  `UNIQUE (type, slug)` index. The live entry's slug + parentId get
  snapshotted into `meta.__plumix_snapshot` so the publish path can
  recover them without an extra roundtrip.
- `getAutosave(db, { entryId, authorId })` returns the row for the (entry,
  author) pair or `undefined`.
- `deleteAutosave(db, { entryId, authorId })` removes the caller's own
  row only — sibling autosaves from other authors stay intact. Returns
  whether anything was deleted.

**Per-user isolation**

Two authors editing the same published entry get distinct autosave rows
(covered by an explicit test). This is the data-layer guarantee that
the upcoming co-author awareness slice (#293) relies on for "X is also
editing this" — separate rows, distinct timestamps.

Refs #290