### PR TITLE
feat(core): autosave rpc procedures (update.saveAs, get.preview, publish, discardDraft)

### DIFF
--- a/packages/core/src/revisions/autosave-rpc.test.ts
+++ b/packages/core/src/revisions/autosave-rpc.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "vitest";
+
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { createRpcHarness } from "../test/rpc.js";
+
+function registryWithAutosave() {
+  const plugins = createPluginRegistry();
+  plugins.entryTypes.set("post", {
+    name: "post",
+    label: "Posts",
+    supports: ["revisions", "autosave"],
+    versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
+    registeredBy: "test",
+  });
+  return plugins;
+}
+
+function registryWithoutAutosave() {
+  const plugins = createPluginRegistry();
+  plugins.entryTypes.set("post", {
+    name: "post",
+    label: "Posts",
+    supports: ["revisions"],
+    versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
+    registeredBy: "test",
+  });
+  return plugins;
+}
+
+async function publishedPostFixture(): Promise<
+  Awaited<ReturnType<typeof createRpcHarness>> & { entryId: number }
+> {
+  const h = await createRpcHarness({
+    authAs: "editor",
+    plugins: registryWithAutosave(),
+  });
+  const created = await h.client.entry.create({
+    title: "Live",
+    slug: "live",
+    status: "published",
+  });
+  return Object.assign(h, { entryId: created.id });
+}
+
+describe("entry.update saveAs", () => {
+  test("default routing on a published+autosave-supporting type writes to autosave, not live", async () => {
+    const h = await publishedPostFixture();
+    const result = await h.client.entry.update({
+      id: h.entryId,
+      title: "Draft title",
+    });
+    // The returned row is the autosave (different id from live; type
+    // `autosave`). Client can't see this directly because the type
+    // declaration is `Entry` and `type` is a string — but the test
+    // can read the persisted shape.
+    expect(result.type).toBe("autosave");
+    expect(result.title).toBe("Draft title");
+    // Live is unchanged.
+    const live = await h.client.entry.get({ id: h.entryId });
+    expect(live.title).toBe("Live");
+  });
+
+  test("explicit saveAs: 'live' bypasses the default and writes to live even when supports has 'autosave'", async () => {
+    const h = await publishedPostFixture();
+    const result = await h.client.entry.update({
+      id: h.entryId,
+      title: "Edited live",
+      saveAs: "live",
+    });
+    expect(result.type).toBe("post");
+    expect(result.title).toBe("Edited live");
+  });
+
+  test("saveAs: 'draft' on a type without 'autosave' supports → BAD_REQUEST", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithoutAutosave(),
+    });
+    const created = await h.client.entry.create({
+      title: "L",
+      slug: "l",
+      status: "published",
+    });
+    await expect(
+      h.client.entry.update({
+        id: created.id,
+        title: "Draft",
+        saveAs: "draft",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      data: { reason: "autosave_unsupported" },
+    });
+  });
+
+  test("saveAs: 'draft' on a non-published entry → BAD_REQUEST", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithAutosave(),
+    });
+    const created = await h.client.entry.create({
+      title: "D",
+      slug: "d",
+      // default status is draft — not published, so a draft autosave
+      // makes no sense (the row IS the draft).
+    });
+    await expect(
+      h.client.entry.update({
+        id: created.id,
+        title: "Pending",
+        saveAs: "draft",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      data: { reason: "autosave_requires_published" },
+    });
+  });
+
+  test("autosave write fires entry:<type>:autosave_saved but NOT entry:updated", async () => {
+    const h = await publishedPostFixture();
+    const autosaveFires: number[] = [];
+    const updatedFires: number[] = [];
+    h.hooks.addAction("entry:post:autosave_saved", (autosave) => {
+      autosaveFires.push(autosave.id);
+    });
+    h.hooks.addAction("entry:post:updated", (entry) => {
+      updatedFires.push(entry.id);
+    });
+    await h.client.entry.update({
+      id: h.entryId,
+      title: "Pending",
+    });
+    expect(autosaveFires).toHaveLength(1);
+    expect(updatedFires).toHaveLength(0);
+  });
+});
+
+describe("entry.get preview", () => {
+  test("preview=true with an existing autosave overlays the pending fields and tags _preview source=autosave", async () => {
+    const h = await publishedPostFixture();
+    await h.client.entry.update({ id: h.entryId, title: "Pending title" });
+    const previewed = await h.client.entry.get({
+      id: h.entryId,
+      preview: true,
+    });
+    expect(previewed.title).toBe("Pending title");
+    expect(previewed._preview?.source).toBe("autosave");
+    expect(previewed._preview?.autosaveUpdatedAt).not.toBeNull();
+  });
+
+  test("preview=true with no autosave returns the live row tagged _preview source=live", async () => {
+    const h = await publishedPostFixture();
+    const previewed = await h.client.entry.get({
+      id: h.entryId,
+      preview: true,
+    });
+    expect(previewed.title).toBe("Live");
+    expect(previewed._preview?.source).toBe("live");
+    expect(previewed._preview?.autosaveUpdatedAt).toBeNull();
+  });
+
+  test("preview=false (default) returns the live row WITHOUT _preview metadata even when an autosave exists", async () => {
+    const h = await publishedPostFixture();
+    await h.client.entry.update({ id: h.entryId, title: "Pending" });
+    const live = await h.client.entry.get({ id: h.entryId });
+    expect(live.title).toBe("Live");
+    expect(live._preview).toBeUndefined();
+  });
+
+  test("preview=true without edit caps is rejected with FORBIDDEN", async () => {
+    // Subscribers can read published entries but not preview them —
+    // preview is an editorial concern gated by edit_own / edit_any.
+    const h = await publishedPostFixture();
+    const subscriber = await h.actingAs("subscriber");
+    await expect(
+      subscriber.client.entry.get({ id: h.entryId, preview: true }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("entry.publish", () => {
+  test("promotes the autosave fields onto live, deletes the autosave, creates a revision", async () => {
+    const h = await publishedPostFixture();
+    const beforePublish = await h.client.entry.get({ id: h.entryId });
+    await h.client.entry.update({
+      id: h.entryId,
+      title: "Promoted title",
+    });
+    const promoted = await h.client.entry.publish({
+      id: h.entryId,
+      expectedLiveUpdatedAt: beforePublish.updatedAt,
+    });
+    expect(promoted.title).toBe("Promoted title");
+    expect(promoted.type).toBe("post");
+    // Autosave is gone — preview now returns live with source=live.
+    const previewed = await h.client.entry.get({
+      id: h.entryId,
+      preview: true,
+    });
+    expect(previewed._preview?.source).toBe("live");
+    // Revision captured because the type supports it.
+    const revisions = await h.client.entry.revisions.list({
+      entryId: h.entryId,
+    });
+    expect(revisions.revisions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("returns CONFLICT when expectedLiveUpdatedAt is stale", async () => {
+    const h = await publishedPostFixture();
+    await h.client.entry.update({ id: h.entryId, title: "Pending" });
+    await expect(
+      h.client.entry.publish({
+        id: h.entryId,
+        expectedLiveUpdatedAt: new Date("2020-01-01"),
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "stale_expected_updated_at" },
+    });
+  });
+
+  test("returns BAD_REQUEST { reason: no_pending_draft } when the caller has no autosave", async () => {
+    const h = await publishedPostFixture();
+    const live = await h.client.entry.get({ id: h.entryId });
+    await expect(
+      h.client.entry.publish({
+        id: h.entryId,
+        expectedLiveUpdatedAt: live.updatedAt,
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      data: { reason: "no_pending_draft" },
+    });
+  });
+});
+
+describe("entry.discardDraft", () => {
+  test("deletes the caller's autosave and returns discarded=true", async () => {
+    const h = await publishedPostFixture();
+    await h.client.entry.update({ id: h.entryId, title: "Pending" });
+    const result = await h.client.entry.discardDraft({ id: h.entryId });
+    expect(result.discarded).toBe(true);
+    const previewed = await h.client.entry.get({
+      id: h.entryId,
+      preview: true,
+    });
+    expect(previewed._preview?.source).toBe("live");
+  });
+
+  test("returns discarded=false (no error) when there's nothing to clean up", async () => {
+    const h = await publishedPostFixture();
+    const result = await h.client.entry.discardDraft({ id: h.entryId });
+    expect(result.discarded).toBe(false);
+  });
+
+  test("fires entry:<type>:autosave_discarded when a row was actually deleted", async () => {
+    const h = await publishedPostFixture();
+    const discards: number[] = [];
+    h.hooks.addAction("entry:post:autosave_discarded", (live, authorId) => {
+      discards.push(authorId);
+    });
+    await h.client.entry.update({ id: h.entryId, title: "Pending" });
+    await h.client.entry.discardDraft({ id: h.entryId });
+    expect(discards).toHaveLength(1);
+    // Second call — nothing to discard, no hook fire.
+    await h.client.entry.discardDraft({ id: h.entryId });
+    expect(discards).toHaveLength(1);
+  });
+});

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -29,8 +29,15 @@ import type {
 
 // `entry.get` enriches the row with the assigned term ids per
 // taxonomy. Plugins editing the output filter receive this shape.
+// In preview mode the row also carries `_preview` so editor clients
+// can distinguish autosave-overlaid responses from straight live reads.
 type EntryWithTerms = Entry & {
   readonly terms: Record<string, readonly number[]>;
+  readonly _preview?: {
+    readonly source: "live" | "autosave";
+    readonly autosaveUpdatedAt: Date | null;
+    readonly liveUpdatedAt: Date;
+  };
 };
 
 // `user.list` decorates each row with `lastSignInAt` (max session
@@ -45,7 +52,10 @@ declare module "../hooks/types.js" {
     "rpc:entry.list:input": (input: EntryListInput) => EntryListInput;
     "rpc:entry.list:output": (output: readonly Entry[]) => readonly Entry[];
 
-    "rpc:entry.get:input": (input: { id: number }) => typeof input;
+    "rpc:entry.get:input": (input: {
+      id: number;
+      preview?: boolean;
+    }) => typeof input;
     "rpc:entry.get:output": (output: EntryWithTerms) => EntryWithTerms;
 
     "rpc:entry.create:input": (input: EntryCreateInput) => EntryCreateInput;
@@ -178,6 +188,31 @@ declare module "../hooks/types.js" {
     [K: `entry:${string}:revision_pruned`]: (
       live: Entry,
       prunedCount: number,
+    ) => void | Promise<void>;
+
+    /**
+     * Autosave lifecycle. Fires after `entry.update({ saveAs: 'draft' })`
+     * writes to the caller's autosave row (NOT the live row) and after
+     * `entry.discardDraft` removes it. Subscribers can sync editor
+     * sessions, drive co-author awareness, or log activity. The generic
+     * `entry:updated` hook deliberately does NOT fire on autosave writes
+     * — cache invalidators / RSS / sitemap should ignore pending drafts.
+     */
+    "entry:autosave_saved": (
+      autosave: Entry,
+      live: Entry,
+    ) => void | Promise<void>;
+    "entry:autosave_discarded": (
+      live: Entry,
+      authorId: number,
+    ) => void | Promise<void>;
+    [K: `entry:${string}:autosave_saved`]: (
+      autosave: Entry,
+      live: Entry,
+    ) => void | Promise<void>;
+    [K: `entry:${string}:autosave_discarded`]: (
+      live: Entry,
+      authorId: number,
     ) => void | Promise<void>;
 
     /**

--- a/packages/core/src/rpc/procedures/entry/discard-draft.ts
+++ b/packages/core/src/rpc/procedures/entry/discard-draft.ts
@@ -1,0 +1,46 @@
+import * as v from "valibot";
+
+import { eq } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { deleteAutosave } from "../../../revisions/repository.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { idParam } from "../../validation.js";
+import { entryCapability, fireEntryAutosaveDiscarded } from "./lifecycle.js";
+
+const discardDraftInput = v.object({ id: idParam });
+
+// Removes the caller's own pending autosave for an entry. Gated by
+// edit_own (for the entry's author) OR edit_any (for editors+).
+// Returns `{ discarded }` so the client can distinguish "we cleaned
+// up your row" from "there was nothing to clean up" — both happy
+// paths, neither an error.
+export const discardDraft = base
+  .use(authenticated)
+  .input(discardDraftInput)
+  .handler(async ({ input, context, errors }) => {
+    const live = await context.db.query.entries.findFirst({
+      where: eq(entries.id, input.id),
+    });
+    if (!live || isReservedType(live.type)) {
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: input.id } });
+    }
+    const isAuthor = live.authorId === context.user.id;
+    const editOwnCapability = entryCapability(live.type, "edit_own");
+    const editAnyCapability = entryCapability(live.type, "edit_any");
+    const canEdit =
+      (isAuthor && context.auth.can(editOwnCapability)) ||
+      context.auth.can(editAnyCapability);
+    if (!canEdit) {
+      throw errors.FORBIDDEN({ data: { capability: editAnyCapability } });
+    }
+    const discarded = await deleteAutosave(context.db, {
+      entryId: live.id,
+      authorId: context.user.id,
+    });
+    if (discarded) {
+      await fireEntryAutosaveDiscarded(context, live, context.user.id);
+    }
+    return { discarded };
+  });

--- a/packages/core/src/rpc/procedures/entry/get.ts
+++ b/packages/core/src/rpc/procedures/entry/get.ts
@@ -1,5 +1,6 @@
 import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
+import { getAutosave } from "../../../revisions/repository.js";
 import { isReservedType } from "../../../revisions/slug-codec.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
@@ -42,6 +43,49 @@ export const get = base
       if (!canSeeAny && !ownsAndCanEdit) {
         throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
       }
+    }
+
+    // Preview mode: overlay the caller's autosave (if any) onto the
+    // live row's read fields, leaving `id` / `slug` / `parentId` /
+    // `authorId` / `updatedAt` / `createdAt` etc. anchored to live.
+    // Gated by edit_own / edit_any because previewing a pending draft
+    // is an editor concern.
+    if (filtered.preview) {
+      const canSeeAny = context.auth.can(entryCapability(row.type, "edit_any"));
+      const ownsAndCanEdit =
+        row.authorId === context.user.id &&
+        context.auth.can(entryCapability(row.type, "edit_own"));
+      if (!canSeeAny && !ownsAndCanEdit) {
+        throw errors.FORBIDDEN({
+          data: { capability: entryCapability(row.type, "edit_own") },
+        });
+      }
+      const autosave = await getAutosave(context.db, {
+        entryId: row.id,
+        authorId: context.user.id,
+      });
+      const source: "autosave" | "live" = autosave ? "autosave" : "live";
+      const overlaid = autosave
+        ? {
+            ...row,
+            title: autosave.title,
+            content: autosave.content,
+            excerpt: autosave.excerpt,
+            meta: autosave.meta,
+          }
+        : row;
+      const meta = decodeMetaBag(context.plugins, overlaid, overlaid.meta);
+      const terms = await loadEntryTerms(context, row.id);
+      return context.hooks.applyFilter("rpc:entry.get:output", {
+        ...overlaid,
+        meta,
+        terms,
+        _preview: {
+          source,
+          autosaveUpdatedAt: autosave?.updatedAt ?? null,
+          liveUpdatedAt: row.updatedAt,
+        },
+      });
     }
 
     const meta = decodeMetaBag(context.plugins, row, row.meta);

--- a/packages/core/src/rpc/procedures/entry/index.ts
+++ b/packages/core/src/rpc/procedures/entry/index.ts
@@ -1,6 +1,8 @@
 import { create } from "./create.js";
+import { discardDraft } from "./discard-draft.js";
 import { get } from "./get.js";
 import { list } from "./list.js";
+import { publish } from "./publish.js";
 import { revisionsRouter } from "./revisions.js";
 import { trash } from "./trash.js";
 import { update } from "./update.js";
@@ -11,6 +13,8 @@ export const entryRouter = {
   create,
   update,
   trash,
+  publish,
+  discardDraft,
   revisions: revisionsRouter,
 } as const;
 

--- a/packages/core/src/rpc/procedures/entry/lifecycle.ts
+++ b/packages/core/src/rpc/procedures/entry/lifecycle.ts
@@ -67,6 +67,32 @@ export async function fireEntryTrashed(
   await ctx.hooks.doAction("entry:trashed", entry);
 }
 
+// Type-specific event keys on the live entry's type — the autosave row
+// itself carries `type='autosave'`, but subscribers care about the
+// type of the entry being edited (e.g. `entry:post:autosave_saved`),
+// not the framework storage type.
+export async function fireEntryAutosaveSaved(
+  ctx: AppContext,
+  autosave: Entry,
+  live: Entry,
+): Promise<void> {
+  await ctx.hooks.doAction(`entry:${live.type}:autosave_saved`, autosave, live);
+  await ctx.hooks.doAction("entry:autosave_saved", autosave, live);
+}
+
+export async function fireEntryAutosaveDiscarded(
+  ctx: AppContext,
+  live: Entry,
+  authorId: number,
+): Promise<void> {
+  await ctx.hooks.doAction(
+    `entry:${live.type}:autosave_discarded`,
+    live,
+    authorId,
+  );
+  await ctx.hooks.doAction("entry:autosave_discarded", live, authorId);
+}
+
 export function entryCapability(type: string, action: string): string {
   return `entry:${type}:${action}`;
 }

--- a/packages/core/src/rpc/procedures/entry/publish.ts
+++ b/packages/core/src/rpc/procedures/entry/publish.ts
@@ -1,0 +1,126 @@
+import * as v from "valibot";
+
+import { eq } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { deleteAutosave, getAutosave } from "../../../revisions/repository.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { idParam } from "../../validation.js";
+import { assertExpectedLiveUpdatedAt } from "./concurrency.js";
+import {
+  applyEntryBeforeSave,
+  captureRevisionIfSupported,
+  entryCapability,
+  fireEntryTransition,
+  fireEntryUpdated,
+} from "./lifecycle.js";
+
+const publishInput = v.object({
+  id: idParam,
+  // Required for the publish path — promoting a pending draft over a
+  // live row is the canonical concurrency battleground. Callers must
+  // round-trip the live `updatedAt` they observed when loading the
+  // editor; mismatched tokens fail loudly rather than silently
+  // clobbering a parallel write.
+  expectedLiveUpdatedAt: v.date(),
+});
+
+// Promotes the caller's autosave row onto the live entry. Mirrors the
+// transactional shape of `entry.update` minus the pre-save filter
+// (the autosave was already filtered when it was written): copy the
+// pending fields onto live, capture a revision via the existing
+// revisions-on-live-write semantics, delete the autosave.
+//
+// Errors:
+//   CONFLICT { reason: "stale_expected_updated_at" }
+//   NOT_FOUND  - no live entry / reserved-type row
+//   FORBIDDEN  - missing publish capability
+//   NO_PENDING_DRAFT - caller has no autosave for this entry
+export const publish = base
+  .use(authenticated)
+  .input(publishInput)
+  .handler(async ({ input, context, errors }) => {
+    const live = await context.db.query.entries.findFirst({
+      where: eq(entries.id, input.id),
+    });
+    if (!live || isReservedType(live.type)) {
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: input.id } });
+    }
+    const publishCapability = entryCapability(live.type, "publish");
+    if (!context.auth.can(publishCapability)) {
+      throw errors.FORBIDDEN({ data: { capability: publishCapability } });
+    }
+    assertExpectedLiveUpdatedAt(input.expectedLiveUpdatedAt, live.updatedAt, {
+      stale: () => {
+        throw errors.CONFLICT({
+          data: { reason: "stale_expected_updated_at" },
+        });
+      },
+    });
+    const autosave = await getAutosave(context.db, {
+      entryId: live.id,
+      authorId: context.user.id,
+    });
+    if (!autosave) {
+      throw errors.BAD_REQUEST({ data: { reason: "no_pending_draft" } });
+    }
+
+    // Copy the autosave fields onto the live row. Slug + parentId
+    // stay anchored to live (the autosave envelope carries them
+    // only for restore-from-revision flows, not for publish, which
+    // promotes content onto an already-existing slug).
+    const patch = {
+      title: autosave.title,
+      content: autosave.content,
+      excerpt: autosave.excerpt,
+      // Autosave's meta carries the snapshot envelope — strip it
+      // before writing back so the live row doesn't accrue a stale
+      // envelope reference.
+      meta: stripSnapshotEnvelope(autosave.meta),
+    };
+    const prepared = await applyEntryBeforeSave(context, live.type, {
+      ...live,
+      ...patch,
+    });
+    const toWrite = {
+      title: prepared.title,
+      content: prepared.content,
+      excerpt: prepared.excerpt,
+      meta: prepared.meta,
+    };
+    const [updatedRow] = await context.db
+      .update(entries)
+      .set(toWrite)
+      .where(eq(entries.id, live.id))
+      .returning();
+    if (!updatedRow) {
+      throw errors.CONFLICT({ data: { reason: "update_failed" } });
+    }
+
+    // Drop the autosave before firing hooks so a subscriber that
+    // re-reads the row state observes a clean "no pending draft"
+    // post-publish.
+    await deleteAutosave(context.db, {
+      entryId: live.id,
+      authorId: context.user.id,
+    });
+
+    await fireEntryUpdated(context, updatedRow, live);
+    await fireEntryTransition(context, updatedRow, live.status);
+    await captureRevisionIfSupported(context, updatedRow);
+    return updatedRow;
+  });
+
+// Snapshot envelope key — duplicated rather than imported to keep this
+// file's dependency surface tight. Worth folding into a shared helper
+// if a third consumer appears.
+const SNAPSHOT_META_KEY = "__plumix_snapshot";
+
+function stripSnapshotEnvelope(
+  meta: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const next = { ...meta };
+  delete next[SNAPSHOT_META_KEY];
+  return next;
+}

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -101,6 +101,14 @@ export const entryUpdateInputSchema = v.object({
    * write landed in between. Absent ⇒ legacy last-write-wins.
    */
   expectedLiveUpdatedAt: v.optional(v.date()),
+  /**
+   * Routes the write between the live row and the caller's autosave
+   * row. `'draft'` is only valid when the entry is currently published
+   * AND the type opts into `supports: ['autosave']`; otherwise the
+   * handler rejects with `BAD_REQUEST { reason: "autosave_unsupported" }`.
+   * Omitted ⇒ legacy `'live'` semantics for backwards compatibility.
+   */
+  saveAs: v.optional(v.picklist(["draft", "live"] as const)),
 });
 
 // Upper bound on the term-slug list per termTaxonomy clause. Mirrors the
@@ -199,7 +207,16 @@ export const entryListInputSchema = v.object({
   offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
 });
 
-export const entryGetInputSchema = v.object({ id: idParam });
+export const entryGetInputSchema = v.object({
+  id: idParam,
+  /**
+   * When `true`, the handler overlays the caller's autosave (if any)
+   * onto the live row and decorates the result with `_preview`
+   * metadata. Gated by `edit_own` / `edit_any` since previewing a
+   * pending draft is an editor concern.
+   */
+  preview: v.optional(v.boolean()),
+});
 export const entryTrashInputSchema = v.object({ id: idParam });
 
 export type EntryListInput = v.InferOutput<typeof entryListInputSchema>;

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -2,6 +2,7 @@ import type { AuthenticatedAppContext } from "../../../context/app.js";
 import type { Entry, NewEntry } from "../../../db/schema/entries.js";
 import { and, eq, isUniqueConstraintError, ne } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
+import { upsertAutosave } from "../../../revisions/repository.js";
 import { isReservedType } from "../../../revisions/slug-codec.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
@@ -16,6 +17,7 @@ import {
   applyEntryBeforeSave,
   captureRevisionIfSupported,
   entryCapability,
+  fireEntryAutosaveSaved,
   fireEntryPublished,
   fireEntryTransition,
   fireEntryUpdated,
@@ -183,6 +185,59 @@ export const update = base
       },
     );
 
+    // Resolve `saveAs` against the entry's state + type capabilities.
+    // The default keeps legacy callers writing to live unless the type
+    // explicitly opts into autosave AND the row is currently published;
+    // then a pending edit lands on a per-user autosave row instead.
+    const typeSupportsAutosave =
+      context.plugins.entryTypes
+        .get(existing.type)
+        ?.supports?.includes("autosave") ?? false;
+    const effectiveSaveAs: "draft" | "live" =
+      filtered.saveAs ??
+      (typeSupportsAutosave && existing.status === "published"
+        ? "draft"
+        : "live");
+    if (effectiveSaveAs === "draft") {
+      if (!typeSupportsAutosave) {
+        throw errors.BAD_REQUEST({
+          data: { reason: "autosave_unsupported" },
+        });
+      }
+      if (existing.status !== "published") {
+        // Drafts only make sense on a published row — the unpublished
+        // row IS the draft. Caller should write to live directly.
+        throw errors.BAD_REQUEST({
+          data: { reason: "autosave_requires_published" },
+        });
+      }
+      const autosave = await upsertAutosave(context.db, {
+        entry: existing,
+        authorId: context.user.id,
+        patch: {
+          title: filtered.title ?? existing.title,
+          content:
+            filtered.content !== undefined
+              ? filtered.content
+              : existing.content,
+          excerpt:
+            filtered.excerpt !== undefined
+              ? filtered.excerpt
+              : existing.excerpt,
+          // Autosave's meta bag tracks the in-progress edits; merge
+          // the caller's patch over the live row's current meta so
+          // unchanged keys persist across draft saves.
+          meta: { ...existing.meta, ...(filtered.meta ?? {}) },
+        },
+      });
+      await fireEntryAutosaveSaved(context, autosave, existing);
+      const decoded = decodeMetaBag(context.plugins, autosave, autosave.meta);
+      return context.hooks.applyFilter("rpc:entry.update:output", {
+        ...autosave,
+        meta: decoded,
+      });
+    }
+
     const isPublishTransition =
       filtered.status === "published" && existing.status !== "published";
     if (isPublishTransition) {
@@ -213,6 +268,7 @@ export const update = base
       terms: termsPatch,
       meta: metaInput,
       expectedLiveUpdatedAt: _expectedLiveUpdatedAt,
+      saveAs: _saveAs,
       ...changes
     } = filtered;
     const metaPatch = sanitizeMetaForRpc(


### PR DESCRIPTION
Third slice of #290. Wires the slice-B repository helpers into four
user-facing endpoints. Admin UI + plugin opt-in (`blog`, `pages`) land in
slice D.

**`entry.update` with `saveAs: 'draft' | 'live'`**

Server defaults to `'draft'` when the type opts into `supports: ['autosave']`
AND the row is currently published; otherwise `'live'` (legacy semantics).
The `'draft'` path bypasses the live-write pipeline entirely — it calls
`upsertAutosave` and fires only `entry:<type>:autosave_saved`. The generic
`entry:updated` hook does NOT fire on autosave writes, so cache invalidators
/ RSS / sitemap stay quiet on pending drafts.

Typed validation errors: `autosave_unsupported` and `autosave_requires_published`.

**`entry.get` with `preview: boolean`**

Overlays the caller's autosave (if any) onto the live row's read fields,
leaving `id` / `slug` / timestamps anchored to live. Returns a `_preview`
decoration with `source` (`'live'` | `'autosave'`) so editor clients can
key form state on the source. Gated by `edit_own` / `edit_any`.

**`entry.publish({ id, expectedLiveUpdatedAt })`**

Promotes the autosave fields onto live (stripping the snapshot envelope),
captures a revision via existing semantics, deletes the autosave, and
fires updated / transition / revision hooks. Error paths covered:
`stale_expected_updated_at` (CONFLICT), `no_pending_draft` (BAD_REQUEST),
missing publish cap (FORBIDDEN).

**`entry.discardDraft({ id })`**

Removes the caller's own autosave. Returns `{ discarded }` so no-op clears
aren't errors. Fires `entry:<type>:autosave_discarded` only when a row was
actually deleted.

15 new RPC tests cover all four happy paths + four documented error paths
+ hook-fire semantics.

Refs #290