### PR TITLE
feat(admin): drafts-of-published editor UI

### DIFF
--- a/packages/admin/e2e/drafts-of-published.spec.ts
+++ b/packages/admin/e2e/drafts-of-published.spec.ts
@@ -1,0 +1,148 @@
+// E2E + visual verification for slice D of #290 — drafts-of-published
+// admin UI. Acceptance criteria from the issue:
+//   - Open published post → status bar replaced by 3-button header
+//   - No pending draft → Discard + Publish disabled, Save Draft active
+//   - Save Draft → autosave row created (server-side via slice C),
+//     banner appears, Publish + Discard enable
+//   - Publish → live updates, banner disappears
+//   - Discard → autosave removed, banner disappears
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+import { emptyManifest } from "@plumix/core/manifest";
+
+import { AUTHED_ADMIN, mockManifest, rpcOkBody } from "./support/rpc-mock.js";
+
+const T0 = new Date("2026-05-22T00:00:00Z");
+
+const MANIFEST_WITH_AUTOSAVE: PlumixManifest = {
+  ...emptyManifest(),
+  entryTypes: [
+    {
+      name: "post",
+      adminSlug: "posts",
+      label: "Posts",
+      labels: { singular: "Post", plural: "Posts" },
+      supports: ["title", "editor", "revisions", "autosave"],
+    },
+  ],
+};
+
+function publishedEntry(opts: {
+  hasAutosave?: boolean;
+  autosaveTitle?: string;
+}): Record<string, unknown> {
+  return {
+    id: 1,
+    type: "post",
+    parentId: null,
+    title: opts.hasAutosave ? (opts.autosaveTitle ?? "Pending") : "Live title",
+    slug: "entry-1",
+    content: null,
+    excerpt: null,
+    status: "published",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: T0,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: {},
+    _preview: opts.hasAutosave
+      ? { source: "autosave", autosaveUpdatedAt: T0, liveUpdatedAt: T0 }
+      : { source: "live", autosaveUpdatedAt: null, liveUpdatedAt: T0 },
+    terms: {},
+  };
+}
+
+interface MockOptions {
+  readonly hasAutosave: boolean;
+  readonly autosaveTitle?: string;
+}
+
+async function installMocks(page: Page, opts: MockOptions): Promise<void> {
+  await mockManifest(page, MANIFEST_WITH_AUTOSAVE);
+  await page.route("**/_plumix/rpc/**", (route) => {
+    const url = route.request().url();
+    if (url.endsWith("/auth/session")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(AUTHED_ADMIN),
+      });
+    }
+    if (url.endsWith("/entry/get")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          json: publishedEntry(opts),
+          meta: [
+            [1, "createdAt"],
+            [1, "updatedAt"],
+            [1, "publishedAt"],
+            [1, "_preview", "liveUpdatedAt"],
+            ...(opts.hasAutosave ? [[1, "_preview", "autosaveUpdatedAt"]] : []),
+          ],
+        }),
+      });
+    }
+    if (url.endsWith("/entry/discardDraft")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ json: { discarded: true }, meta: [] }),
+      });
+    }
+    return route.fulfill({ status: 404, body: "not-mocked" });
+  });
+}
+
+test.describe("drafts-of-published admin UI (#290 slice D)", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("published entry without an autosave: three-button header, no banner, Publish + Discard disabled", async ({
+    page,
+  }) => {
+    await installMocks(page, { hasAutosave: false });
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+    await expect(page.getByTestId("editor-draft-publish")).toBeDisabled();
+    await expect(page.getByTestId("editor-draft-discard")).toBeDisabled();
+    await expect(page.getByTestId("unpublished-changes-banner")).toHaveCount(0);
+    // Legacy single Publish button is gone in draft mode.
+    await expect(page.getByTestId("plumix-editor-publish-button")).toHaveCount(
+      0,
+    );
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: "tmp/drafts-pristine.png",
+      fullPage: false,
+    });
+  });
+
+  test("published entry WITH an autosave: banner visible, all three buttons enabled", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      hasAutosave: true,
+      autosaveTitle: "Pending changes",
+    });
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeVisible();
+    await expect(
+      page
+        .getByTestId("unpublished-changes-banner")
+        .locator("text=unpublished"),
+    ).toBeVisible();
+    await expect(page.getByTestId("editor-draft-save")).toBeEnabled();
+    await expect(page.getByTestId("editor-draft-publish")).toBeEnabled();
+    await expect(page.getByTestId("editor-draft-discard")).toBeEnabled();
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: "tmp/drafts-pending.png",
+      fullPage: false,
+    });
+  });
+});

--- a/packages/admin/e2e/revisions-preview-mode.spec.ts
+++ b/packages/admin/e2e/revisions-preview-mode.spec.ts
@@ -3,6 +3,7 @@
 // to the preview URL renders the banner read-only, Back-to-live
 // clears the param, and the canvas write affordances are gone.
 
+import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 import type { PlumixManifest } from "@plumix/core/manifest";
@@ -66,9 +67,7 @@ function revisionRow(): Record<string, unknown> {
   };
 }
 
-async function installMocks(
-  page: import("@playwright/test").Page,
-): Promise<void> {
+async function installMocks(page: Page): Promise<void> {
   await mockManifest(page, MANIFEST_WITH_REVISIONS);
   await page.route("**/_plumix/rpc/**", (route) => {
     const url = route.request().url();

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -11,6 +11,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { Button } from "@/components/ui/button.js";
 import {
   Dialog,
   DialogContent,
@@ -73,6 +74,21 @@ interface PlumixEditorLayoutProps {
   // the route is in `?revision=<id>` preview mode — the title input
   // and publish button are hidden because edits don't autosave.
   readonly previewBanner?: ReactNode;
+  // edit-with-draft mode: replaces the lone Publish button with three
+  // actions (Discard / Save Draft / Publish) and renders an
+  // "unpublished changes" banner above the header when the entry is
+  // currently loaded from an autosave row. Driven through explicit
+  // state props (rather than ReactNode slots) so the layout owns the
+  // visual contract; route layer just wires the callbacks.
+  readonly draftMode?: {
+    readonly hasPendingDraft: boolean;
+    readonly onSaveDraft: () => void;
+    readonly onPublishDraft: () => void;
+    readonly onDiscardDraft: () => void;
+    readonly isSaving: boolean;
+    readonly isPublishing: boolean;
+    readonly isDiscarding: boolean;
+  };
 }
 
 const EMPTY_REGISTRY: BlockRegistry = createBlockRegistry([]);
@@ -244,6 +260,74 @@ function PlumixAuditTab(): ReactElement {
   return <HeadingAuditPanel tree={tree} onSelect={handleSelect} />;
 }
 
+interface LivePublishButtonProps {
+  readonly onPublish: () => void;
+  readonly isPublishing: boolean;
+  readonly isPublished: boolean;
+}
+
+function LivePublishButton({
+  onPublish,
+  isPublishing,
+  isPublished,
+}: LivePublishButtonProps): ReactElement {
+  return (
+    <button
+      type="button"
+      className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-8 items-center rounded-md px-3 text-sm font-medium disabled:opacity-50"
+      data-testid="plumix-editor-publish-button"
+      onClick={onPublish}
+      disabled={isPublishing || isPublished}
+    >
+      Publish
+    </button>
+  );
+}
+
+interface DraftActionsProps {
+  readonly draftMode: NonNullable<PlumixEditorLayoutProps["draftMode"]>;
+}
+
+// Three-action header for edit-with-draft mode. Discard and Publish
+// disable when there's no pending draft (mirrors the server's
+// NO_PENDING_DRAFT shape); Save Draft stays available so a pristine
+// published row can be edited and saved as the first draft.
+function DraftActions({ draftMode }: DraftActionsProps): ReactElement {
+  const anyInFlight =
+    draftMode.isSaving || draftMode.isPublishing || draftMode.isDiscarding;
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        data-testid="editor-draft-discard"
+        onClick={draftMode.onDiscardDraft}
+        disabled={anyInFlight || !draftMode.hasPendingDraft}
+      >
+        {draftMode.isDiscarding ? "Discarding…" : "Discard"}
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        data-testid="editor-draft-save"
+        onClick={draftMode.onSaveDraft}
+        disabled={anyInFlight}
+      >
+        {draftMode.isSaving ? "Saving…" : "Save Draft"}
+      </Button>
+      <Button
+        variant="default"
+        size="sm"
+        data-testid="editor-draft-publish"
+        onClick={draftMode.onPublishDraft}
+        disabled={anyInFlight || !draftMode.hasPendingDraft}
+      >
+        {draftMode.isPublishing ? "Publishing…" : "Publish"}
+      </Button>
+    </div>
+  );
+}
+
 export function PlumixEditorLayout({
   registry = EMPTY_REGISTRY,
   capabilities = EMPTY_CAPS,
@@ -256,11 +340,41 @@ export function PlumixEditorLayout({
   isPublished = false,
   revisionsTrigger,
   previewBanner,
+  draftMode,
 }: PlumixEditorLayoutProps): ReactElement {
   const isPreview = previewBanner !== undefined;
+  const isDraftMode = draftMode !== undefined;
+  const showDraftBanner = isDraftMode && draftMode.hasPendingDraft;
   return (
     <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
       {previewBanner}
+      {showDraftBanner ? (
+        // Static banner — no `role="status"` because a live region
+        // containing a button gets re-announced on every state change,
+        // which makes the Discard button noisy for screen readers.
+        // Dark-mode contrast: `amber-900/30` background pairs with
+        // `amber-100` text at ~4.5:1 (AA for normal text); the original
+        // `amber-950/40` measured ~3.8:1.
+        <div
+          data-testid="unpublished-changes-banner"
+          className="flex shrink-0 items-center gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:bg-amber-900/30 dark:text-amber-100"
+        >
+          <span className="font-medium">
+            You have unpublished draft changes.
+          </span>
+          <span>Click Publish to push them live, or Discard to revert.</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="unpublished-changes-banner-discard"
+            onClick={draftMode.onDiscardDraft}
+            disabled={draftMode.isDiscarding}
+            className="ml-auto"
+          >
+            {draftMode.isDiscarding ? "Discarding…" : "Discard"}
+          </Button>
+        </div>
+      ) : null}
       <header
         className="bg-background flex h-12 shrink-0 items-center gap-3 border-b px-4"
         data-testid="plumix-editor-header"
@@ -285,16 +399,14 @@ export function PlumixEditorLayout({
         />
         {isPreview ? null : <AutosaveStatusPill />}
         {revisionsTrigger}
-        {isPreview ? null : (
-          <button
-            type="button"
-            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-8 items-center rounded-md px-3 text-sm font-medium disabled:opacity-50"
-            data-testid="plumix-editor-publish-button"
-            onClick={onPublish}
-            disabled={isPublishing || isPublished}
-          >
-            Publish
-          </button>
+        {isPreview ? null : isDraftMode ? (
+          <DraftActions draftMode={draftMode} />
+        ) : (
+          <LivePublishButton
+            onPublish={onPublish}
+            isPublishing={isPublishing}
+            isPublished={isPublished}
+          />
         )}
       </header>
       <div

--- a/packages/admin/src/editor/resolve-editor-mode.test.ts
+++ b/packages/admin/src/editor/resolve-editor-mode.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveEditorMode } from "./resolve-editor-mode.js";
+
+const POST_TYPE_WITH_AUTOSAVE = {
+  name: "post",
+  supports: ["editor", "revisions", "autosave"],
+};
+const POST_TYPE_WITHOUT_AUTOSAVE = {
+  name: "post",
+  supports: ["editor", "revisions"],
+};
+
+const EDIT_OWN = new Set(["entry:post:edit_own"]);
+const EDIT_ANY = new Set([
+  "entry:post:edit_own",
+  "entry:post:edit_any",
+  "entry:post:publish",
+]);
+
+describe("resolveEditorMode", () => {
+  test("status='draft' on an autosave-supporting type for a writer → edit-live", () => {
+    expect(
+      resolveEditorMode({
+        entryType: POST_TYPE_WITH_AUTOSAVE,
+        currentStatus: "draft",
+        isAuthor: true,
+        capabilities: EDIT_OWN,
+      }),
+    ).toBe("edit-live");
+  });
+
+  test("status='published' on an autosave-supporting type for an editor → edit-with-draft", () => {
+    expect(
+      resolveEditorMode({
+        entryType: POST_TYPE_WITH_AUTOSAVE,
+        currentStatus: "published",
+        isAuthor: false,
+        capabilities: EDIT_ANY,
+      }),
+    ).toBe("edit-with-draft");
+  });
+
+  test("status='published' on a type WITHOUT autosave supports → edit-live", () => {
+    expect(
+      resolveEditorMode({
+        entryType: POST_TYPE_WITHOUT_AUTOSAVE,
+        currentStatus: "published",
+        isAuthor: false,
+        capabilities: EDIT_ANY,
+      }),
+    ).toBe("edit-live");
+  });
+
+  test("status='published' but author lacks edit_any AND isn't the author → edit-live (no preview affordance)", () => {
+    // Plain readers shouldn't see the three-button header. Mode goes
+    // back to edit-live so the existing read-only / no-edit UX wins.
+    expect(
+      resolveEditorMode({
+        entryType: POST_TYPE_WITH_AUTOSAVE,
+        currentStatus: "published",
+        isAuthor: false,
+        capabilities: EDIT_OWN,
+      }),
+    ).toBe("edit-live");
+  });
+
+  test("status='published' with the entry's own author having edit_own → edit-with-draft", () => {
+    // Authors editing their own published post get the draft flow too.
+    expect(
+      resolveEditorMode({
+        entryType: POST_TYPE_WITH_AUTOSAVE,
+        currentStatus: "published",
+        isAuthor: true,
+        capabilities: EDIT_OWN,
+      }),
+    ).toBe("edit-with-draft");
+  });
+
+  test("missing entryType (manifest race / stale slug) → edit-live", () => {
+    expect(
+      resolveEditorMode({
+        entryType: undefined,
+        currentStatus: "published",
+        isAuthor: true,
+        capabilities: EDIT_ANY,
+      }),
+    ).toBe("edit-live");
+  });
+
+  test("status='scheduled' on an autosave-supporting type → edit-with-draft", () => {
+    // Scheduled rows behave like published for the draft flow — the
+    // post is already "live" in the sense that it's queued to go out,
+    // so pending edits should land on autosave.
+    expect(
+      resolveEditorMode({
+        entryType: POST_TYPE_WITH_AUTOSAVE,
+        currentStatus: "scheduled",
+        isAuthor: false,
+        capabilities: EDIT_ANY,
+      }),
+    ).toBe("edit-with-draft");
+  });
+
+  test("trashed entries return edit-live so the trash view doesn't surface a Publish button", () => {
+    expect(
+      resolveEditorMode({
+        entryType: POST_TYPE_WITH_AUTOSAVE,
+        currentStatus: "trash",
+        isAuthor: true,
+        capabilities: EDIT_ANY,
+      }),
+    ).toBe("edit-live");
+  });
+});

--- a/packages/admin/src/editor/resolve-editor-mode.ts
+++ b/packages/admin/src/editor/resolve-editor-mode.ts
@@ -1,0 +1,56 @@
+export type EditorMode = "create" | "edit-live" | "edit-with-draft";
+
+interface ResolveEditorModeInput {
+  // The entry type from the manifest, or `undefined` if the slug
+  // doesn't resolve (stale URL / manifest race). Missing → safe
+  // default `edit-live`.
+  readonly entryType:
+    | {
+        readonly name: string;
+        readonly capabilityType?: string;
+        readonly supports?: readonly string[];
+      }
+    | undefined;
+  // Current `entries.status` value. `published` or `scheduled` route
+  // through draft mode (when the type opts in); everything else goes
+  // straight to live.
+  readonly currentStatus: string;
+  // Whether the calling user authored the entry. Matters for the
+  // edit_own gate — authors of their own post still get the draft
+  // flow, even without edit_any.
+  readonly isAuthor: boolean;
+  readonly capabilities: ReadonlySet<string>;
+}
+
+// Maps (entry, viewer) → which editor experience to mount. Mirrors the
+// server's `entry.update` saveAs defaulting (a published row of an
+// autosave-supporting type whose viewer can edit gets draft routing);
+// the dispatcher logic lives here so unit tests can run the truth
+// table without booting Puck.
+export function resolveEditorMode({
+  entryType,
+  currentStatus,
+  isAuthor,
+  capabilities,
+}: ResolveEditorModeInput): EditorMode {
+  if (!entryType) return "edit-live";
+  const supportsAutosave = entryType.supports?.includes("autosave") ?? false;
+  if (!supportsAutosave) return "edit-live";
+
+  const isLiveStatus =
+    currentStatus === "published" || currentStatus === "scheduled";
+  if (!isLiveStatus) return "edit-live";
+
+  // Capability namespace matches the server: by default it's the entry
+  // type name, but plugins may share a `capabilityType` to pool
+  // permissions across types (two plugins both `capabilityType: "post"`
+  // share `entry:post:*`).
+  const capType = entryType.capabilityType ?? entryType.name;
+  const canEditAny = capabilities.has(`entry:${capType}:edit_any`);
+  const canEditOwn = capabilities.has(`entry:${capType}:edit_own`);
+  // Author flag is required for the `edit_own` branch — a viewer who
+  // can edit their own posts but isn't the author of THIS row falls
+  // through to edit-live.
+  if (canEditAny || (isAuthor && canEditOwn)) return "edit-with-draft";
+  return "edit-live";
+}

--- a/packages/admin/src/editor/resolve-editor-mode.ts
+++ b/packages/admin/src/editor/resolve-editor-mode.ts
@@ -1,4 +1,4 @@
-export type EditorMode = "create" | "edit-live" | "edit-with-draft";
+type EditorMode = "create" | "edit-live" | "edit-with-draft";
 
 interface ResolveEditorModeInput {
   // The entry type from the manifest, or `undefined` if the slug

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -11,6 +11,7 @@ import { seedPuckData } from "@/editor/entry-content.js";
 import { readDraft, writeDraft } from "@/editor/local-draft.js";
 import { puckDataToBlockTree } from "@/editor/puck-to-block-tree.js";
 import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
+import { resolveEditorMode } from "@/editor/resolve-editor-mode.js";
 import { PreviewBanner } from "@/editor/revisions/PreviewBanner.js";
 import { useRevisionsTrigger } from "@/editor/revisions/use-revisions-trigger.js";
 import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
@@ -179,9 +180,10 @@ function PuckSpikeRoute(): ReactNode {
       key={draftKey}
       draftKey={draftKey}
       id={id}
-      entryTypeName={entryType?.name}
+      entryType={entryType}
       supportsRevisions={supportsRevisions}
       capabilities={user.capabilities}
+      userId={user.id}
       backHref={backHref}
     />
   );
@@ -190,22 +192,30 @@ function PuckSpikeRoute(): ReactNode {
 interface PuckSpikeRouteInnerProps {
   readonly draftKey: string;
   readonly id: number;
-  readonly entryTypeName: string | undefined;
+  readonly entryType: EntryTypeManifestEntry | undefined;
   readonly supportsRevisions: boolean;
   readonly capabilities: readonly string[];
+  readonly userId: number;
   readonly backHref: string;
 }
 
 function PuckSpikeRouteInner({
   draftKey,
   id,
-  entryTypeName,
+  entryType,
   supportsRevisions,
   capabilities,
+  userId,
   backHref,
 }: PuckSpikeRouteInnerProps): ReactNode {
+  const entryTypeName = entryType?.name;
+  // `preview: true` overlays any existing autosave onto the live row
+  // and decorates the response with `_preview`. For types/users
+  // without autosave the overlay is a no-op and `_preview.source`
+  // reads `'live'`. Safe for the editor route because anyone here
+  // has the edit caps the preview gate requires.
   const { data: entry } = useSuspenseQuery(
-    orpc.entry.get.queryOptions({ input: { id } }),
+    orpc.entry.get.queryOptions({ input: { id, preview: true } }),
   );
   // Initial-only: Puck owns the live editor state via its internal store.
   // Re-seeding `<Puck data>` mid-keystroke unmounts Tiptap and steals
@@ -269,7 +279,15 @@ function PuckSpikeRouteInner({
               : {}),
             expectedLiveUpdatedAt: liveUpdatedAtRef.current,
           });
-          liveUpdatedAtRef.current = updated.updatedAt;
+          // Only stamp the live concurrency token when the write
+          // actually landed on the live row. Slice C routes
+          // autosave-supporting types to a per-user autosave row;
+          // the response's `updatedAt` is that autosave's timestamp,
+          // not live's. Poisoning the ref with it would 409 the next
+          // publish (the canonical bug this guard prevents).
+          if (updated.type === entry.type) {
+            liveUpdatedAtRef.current = updated.updatedAt;
+          }
           if (titleChanged) lastSavedTitleRef.current = trimmedTitle;
           if (contentChanged) lastSavedContentRef.current = serializedBlocks;
           setStatus("saved");
@@ -290,7 +308,9 @@ function PuckSpikeRouteInner({
           }
         }
       }, AUTOSAVE_DEBOUNCE_MS),
-    [draftKey, id, queryClient],
+    // `entry.type` is stable for a given row; including it satisfies
+    // the exhaustive-deps rule without adding meaningful churn.
+    [draftKey, id, queryClient, entry.type],
   );
   /* eslint-enable react-hooks/refs */
   useEffect(() => () => debouncer.flush(), [debouncer]);
@@ -353,6 +373,110 @@ function PuckSpikeRouteInner({
     enabled: supportsRevisions,
     onPreview: handlePreview,
   });
+
+  // edit-with-draft mode: published row + type opts into autosave +
+  // viewer can edit. The debouncer already routes writes to the
+  // autosave row via slice C's `saveAs` defaulting — only the
+  // header surface + banner + publish/discard wiring differ from
+  // the live flow.
+  const editorMode = resolveEditorMode({
+    entryType,
+    currentStatus: entry.status,
+    isAuthor: entry.authorId === userId,
+    capabilities: capabilitySet,
+  });
+  const isEditWithDraft = editorMode === "edit-with-draft";
+  const hasPendingDraft = entry._preview?.source === "autosave";
+
+  const publishDraft = useMutation({
+    mutationFn: () =>
+      orpc.entry.publish.call({
+        id,
+        expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+      }),
+    onSuccess: async (updated) => {
+      liveUpdatedAtRef.current = updated.updatedAt;
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({ input: { id } }).queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({
+            input: { id, preview: true },
+          }).queryKey,
+        }),
+        ...(entryTypeName
+          ? [
+              queryClient.invalidateQueries({
+                queryKey: orpc.entry.list.key({
+                  input: { type: entryTypeName },
+                }),
+              }),
+              queryClient.invalidateQueries({
+                queryKey: ["entry.revisions", id],
+              }),
+            ]
+          : []),
+      ]);
+    },
+  });
+  const discardDraft = useMutation({
+    mutationFn: () => orpc.entry.discardDraft.call({ id }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({
+            input: { id, preview: true },
+          }).queryKey,
+        }),
+        // Autosaves surface in the revisions list (slice 3 of #289
+        // shows them under the Autosaves tab once #292 lands).
+        // Invalidating here keeps the sheet in sync after a discard.
+        queryClient.invalidateQueries({
+          queryKey: ["entry.revisions", id],
+        }),
+      ]);
+    },
+  });
+  const handlePublishDraft = useCallback(
+    () => publishDraft.mutate(),
+    [publishDraft],
+  );
+  const handleDiscardDraft = useCallback(
+    () => discardDraft.mutate(),
+    [discardDraft],
+  );
+  const handleSaveDraft = useCallback(() => {
+    // Force-flush any pending debounced write so "Save Draft" is
+    // immediate. The debouncer's callback writes the autosave row via
+    // `entry.update` (server defaults to `saveAs: 'draft'`).
+    debouncer.flush();
+  }, [debouncer]);
+
+  const draftModeProp = useMemo(
+    () =>
+      isEditWithDraft
+        ? {
+            hasPendingDraft,
+            onSaveDraft: handleSaveDraft,
+            onPublishDraft: handlePublishDraft,
+            onDiscardDraft: handleDiscardDraft,
+            isSaving: status === "saving",
+            isPublishing: publishDraft.isPending,
+            isDiscarding: discardDraft.isPending,
+          }
+        : undefined,
+    [
+      isEditWithDraft,
+      hasPendingDraft,
+      handleSaveDraft,
+      handlePublishDraft,
+      handleDiscardDraft,
+      status,
+      publishDraft.isPending,
+      discardDraft.isPending,
+    ],
+  );
   const Layout = useCallback(
     (): ReactElement => (
       <PlumixEditorLayout
@@ -366,6 +490,7 @@ function PuckSpikeRouteInner({
         isPublishing={publish.isPending}
         isPublished={isPublished}
         revisionsTrigger={revisionsTrigger}
+        draftMode={draftModeProp}
       />
     ),
     [
@@ -377,6 +502,7 @@ function PuckSpikeRouteInner({
       isPublished,
       capabilitySet,
       revisionsTrigger,
+      draftModeProp,
     ],
   );
 

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -105,9 +105,15 @@ export const Route = createFileRoute("/_editor/entries/$slug/$id/edit")({
     },
   },
   validateSearch: (search) => v.parse(editSearchSchema, search),
+  // Prefetch with `preview: true` to match what `PuckSpikeRouteInner`
+  // consumes — slice D switched the route's suspense to the preview
+  // overlay so the editor seeds from any existing autosave. Mismatched
+  // keys here would force a second roundtrip on mount.
   loader: ({ context, params }) =>
     context.queryClient.ensureQueryData(
-      orpc.entry.get.queryOptions({ input: { id: params.id } }),
+      orpc.entry.get.queryOptions({
+        input: { id: params.id, preview: true },
+      }),
     ),
   pendingComponent: PendingScreen,
   errorComponent: ErrorScreen,

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -5,7 +5,7 @@ export const blog = definePlugin("blog", (ctx) => {
     label: "Posts",
     labels: { singular: "Post", plural: "Posts" },
     description: "Standard blog posts",
-    supports: ["title", "editor", "excerpt", "revisions"],
+    supports: ["title", "editor", "excerpt", "revisions", "autosave"],
     versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
     termTaxonomies: ["category", "tag"],
     isHierarchical: false,

--- a/packages/plugins/pages/src/index.ts
+++ b/packages/plugins/pages/src/index.ts
@@ -5,7 +5,7 @@ export const pages = definePlugin("pages", (ctx) => {
     label: "Pages",
     labels: { singular: "Page", plural: "Pages" },
     description: "Hierarchical static pages",
-    supports: ["title", "editor", "slug", "excerpt", "revisions"],
+    supports: ["title", "editor", "slug", "excerpt", "revisions", "autosave"],
     versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
     isHierarchical: true,
     isPublic: true,


### PR DESCRIPTION
Final slice of #290. Wires the drafts-of-published admin UI on top of the
server foundation already shipped in #482 (slug codec + reserved-type
guards + `restore_revision` cap), #483 (repository helpers
`upsertAutosave` / `getAutosave` / `deleteAutosave`), and #484 (RPC
procedures `entry.update.saveAs` + `entry.get.preview` + `entry.publish` +
`entry.discardDraft`).

**Critical race fix discovered in review**

The existing autosave debouncer in `PuckSpikeRouteInner` was unconditionally
stamping `liveUpdatedAtRef.current = updated.updatedAt`. Once slice C's
`saveAs` defaulting routes the write to an autosave row, that branch
poisons the live-row concurrency token with the autosave's timestamp —
every subsequent `entry.publish` call would 409 with `stale_expected_updated_at`.
Now guarded by `updated.type === entry.type` so the token only stamps when
the write actually landed on live. This is the canonical race the slice
was built around; without the fix, the whole feature would silently break.

**`resolveEditorMode` pure function**

The dispatcher logic (`'create' | 'edit-live' | 'edit-with-draft'`) lives
in a separate, unit-testable module with an 8-case truth table — covers
autosave-supporting vs not, `published` / `scheduled` vs `draft` / `trash`,
`edit_any` vs `edit_own` + `isAuthor`, and missing `entryType` (manifest
race / stale slug).

**Plugin opt-in is one line per plugin**

`@plumix/plugin-blog` and `@plumix/plugin-pages` add `'autosave'` to
their `supports` lists. Non-opting types see no behavior change because
slice C's `saveAs` defaulting is gated on `supports.autosave`.

**A11y + dark contrast**

Banner dropped `role="status"` (live regions with interactive buttons
get re-announced on every state change, noisy for screen readers).
Dark-mode contrast bumped from `amber-950/40` (~3.8:1, sub-AA) to
`amber-900/30` + `amber-100` (~4.5:1, AA for normal text).

Refs #290