### PR TITLE
feat(admin): stale-autosave detector module

### DIFF
--- a/packages/admin/src/editor/detect-stale-autosave.test.ts
+++ b/packages/admin/src/editor/detect-stale-autosave.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { detectStaleAutosave } from "./detect-stale-autosave.js";
+
+const LIVE = new Date("2026-05-22T12:00:00Z");
+const BEFORE = new Date("2026-05-22T11:00:00Z");
+const AFTER = new Date("2026-05-22T13:00:00Z");
+const EQUAL = new Date("2026-05-22T12:00:00Z");
+
+describe("detectStaleAutosave", () => {
+  test("returns 'none' when there is no autosave at all", () => {
+    expect(detectStaleAutosave(null, LIVE)).toBe("none");
+  });
+
+  test("returns 'stale' when the autosave is older than the live row (someone else published in between)", () => {
+    expect(detectStaleAutosave(BEFORE, LIVE)).toBe("stale");
+  });
+
+  test("returns 'fresh' when the autosave is newer than the live row (typical pending edit)", () => {
+    expect(detectStaleAutosave(AFTER, LIVE)).toBe("fresh");
+  });
+
+  test("returns 'fresh' when the autosave timestamp equals live's (no third-party publish race)", () => {
+    // Tie goes to the autosave — the user's pending work isn't
+    // 'stale' relative to a live row written at the same instant
+    // (in practice, the autosave is always written after live, so
+    // an exact match means the autosave row was created right after
+    // the load that anchored its timestamp).
+    expect(detectStaleAutosave(EQUAL, LIVE)).toBe("fresh");
+  });
+
+  test("strict `<` boundary: one millisecond older counts as stale, one millisecond newer counts as fresh", () => {
+    // Pins the comparison operator — flipping to `<=` would change
+    // the equal-timestamps tie-break, and an off-by-one in either
+    // direction would mis-classify the most common race window.
+    const liveMs = LIVE.getTime();
+    expect(detectStaleAutosave(new Date(liveMs - 1), LIVE)).toBe("stale");
+    expect(detectStaleAutosave(new Date(liveMs + 1), LIVE)).toBe("fresh");
+  });
+});

--- a/packages/admin/src/editor/detect-stale-autosave.ts
+++ b/packages/admin/src/editor/detect-stale-autosave.ts
@@ -1,0 +1,20 @@
+// "stale" means the user's pending autosave was anchored against an
+// older version of the live row than what's on the server now —
+// somebody else published or edited live in between. The editor
+// surfaces a three-action dialog (Use mine / Use theirs / Compare)
+// at mount when this returns `'stale'` so the author resolves the
+// fork before their next save lands on top of a newer live row.
+//
+// `'none'` short-circuits the dialog flow when the user has nothing
+// pending in the first place.
+type StaleAutosaveState = "fresh" | "stale" | "none";
+
+export function detectStaleAutosave(
+  autosaveUpdatedAt: Date | null,
+  liveUpdatedAt: Date,
+): StaleAutosaveState {
+  if (autosaveUpdatedAt === null) return "none";
+  return autosaveUpdatedAt.getTime() < liveUpdatedAt.getTime()
+    ? "stale"
+    : "fresh";
+}


### PR DESCRIPTION
First slice of #291. Pure-function seam for the stale-draft dialog wiring
that lands in slice 2.

`detectStaleAutosave(autosaveUpdatedAt, liveUpdatedAt)` returns
`'fresh' | 'stale' | 'none'`. `'stale'` fires when the autosave was
anchored against an older live row (somebody else published in between)
so the editor route can surface the three-action resolver dialog at
mount; `'none'` short-circuits when there's no pending autosave.

**Strict `<` boundary**

Ties at equal timestamps go to `'fresh'` — in normal flow the autosave
row is written after live, so an exact match means the autosave was
created right after the load that anchored its timestamp. A 1ms-older
/ 1ms-newer pair pins the comparison operator, so flipping to `<=`
would break the suite.

Refs #291