### PR TITLE
feat(admin): stale-draft resolver dialog at editor mount

### DIFF
--- a/packages/admin/e2e/stale-draft-dialog.spec.ts
+++ b/packages/admin/e2e/stale-draft-dialog.spec.ts
@@ -1,0 +1,168 @@
+// E2E + visual verification for #291 slice 2 — stale-draft resolver
+// dialog. Fires at editor mount when the autosave was anchored
+// against an older live row than what's on the server now.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+import { emptyManifest } from "@plumix/core/manifest";
+
+import { AUTHED_ADMIN, mockManifest, rpcOkBody } from "./support/rpc-mock.js";
+
+const T_LIVE = new Date("2026-05-22T12:00:00Z");
+const T_AUTOSAVE_OLD = new Date("2026-05-22T10:00:00Z"); // before live
+const T_AUTOSAVE_FRESH = new Date("2026-05-22T13:00:00Z"); // after live
+
+const MANIFEST_WITH_AUTOSAVE: PlumixManifest = {
+  ...emptyManifest(),
+  entryTypes: [
+    {
+      name: "post",
+      adminSlug: "posts",
+      label: "Posts",
+      labels: { singular: "Post", plural: "Posts" },
+      supports: ["title", "editor", "revisions", "autosave"],
+    },
+  ],
+};
+
+function publishedEntry(opts: {
+  hasAutosave: boolean;
+  autosaveUpdatedAt: Date | null;
+}): Record<string, unknown> {
+  return {
+    id: 1,
+    type: "post",
+    parentId: null,
+    title: opts.hasAutosave ? "Pending edit" : "Live title",
+    slug: "entry-1",
+    content: null,
+    excerpt: null,
+    status: "published",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: T_LIVE,
+    createdAt: T_LIVE,
+    updatedAt: T_LIVE,
+    meta: {},
+    _preview: opts.hasAutosave
+      ? {
+          source: "autosave",
+          autosaveUpdatedAt: opts.autosaveUpdatedAt,
+          liveUpdatedAt: T_LIVE,
+        }
+      : { source: "live", autosaveUpdatedAt: null, liveUpdatedAt: T_LIVE },
+    terms: {},
+  };
+}
+
+async function installMocks(
+  page: Page,
+  opts: { hasAutosave: boolean; autosaveUpdatedAt: Date | null },
+): Promise<void> {
+  await mockManifest(page, MANIFEST_WITH_AUTOSAVE);
+  await page.route("**/_plumix/rpc/**", (route) => {
+    const url = route.request().url();
+    if (url.endsWith("/auth/session")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(AUTHED_ADMIN),
+      });
+    }
+    if (url.endsWith("/entry/get")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          json: publishedEntry(opts),
+          meta: [
+            [1, "createdAt"],
+            [1, "updatedAt"],
+            [1, "publishedAt"],
+            [1, "_preview", "liveUpdatedAt"],
+            ...(opts.hasAutosave && opts.autosaveUpdatedAt
+              ? [[1, "_preview", "autosaveUpdatedAt"]]
+              : []),
+          ],
+        }),
+      });
+    }
+    return route.fulfill({ status: 404, body: "not-mocked" });
+  });
+}
+
+test.describe("stale-draft dialog (#291 slice 2)", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("stale autosave: dialog fires at mount with the three actions", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      hasAutosave: true,
+      autosaveUpdatedAt: T_AUTOSAVE_OLD,
+    });
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("stale-draft-dialog")).toBeVisible();
+    await expect(page.getByTestId("stale-draft-use-mine")).toBeEnabled();
+    await expect(page.getByTestId("stale-draft-use-theirs")).toBeEnabled();
+    await expect(page.getByTestId("stale-draft-compare")).toBeEnabled();
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: "tmp/stale-draft-dialog.png",
+      fullPage: false,
+    });
+  });
+
+  test("fresh autosave (newer than live): no dialog", async ({ page }) => {
+    await installMocks(page, {
+      hasAutosave: true,
+      autosaveUpdatedAt: T_AUTOSAVE_FRESH,
+    });
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("plumix-editor-layout")).toBeVisible();
+    await expect(page.getByTestId("stale-draft-dialog")).toHaveCount(0);
+  });
+
+  test("no autosave: no dialog", async ({ page }) => {
+    await installMocks(page, { hasAutosave: false, autosaveUpdatedAt: null });
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("plumix-editor-layout")).toBeVisible();
+    await expect(page.getByTestId("stale-draft-dialog")).toHaveCount(0);
+  });
+
+  test("Use mine dismisses the dialog and lets the editor proceed with the autosave content", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      hasAutosave: true,
+      autosaveUpdatedAt: T_AUTOSAVE_OLD,
+    });
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("stale-draft-dialog")).toBeVisible();
+    await page.getByTestId("stale-draft-use-mine").click();
+    await expect(page.getByTestId("stale-draft-dialog")).toHaveCount(0);
+    // Title input still shows the autosave value the route was seeded
+    // with — user explicitly chose to keep their draft.
+    await expect(page.getByTestId("plumix-editor-title-input")).toHaveValue(
+      "Pending edit",
+    );
+  });
+
+  test("Compare expands an inline side-by-side JSON diff", async ({ page }) => {
+    await installMocks(page, {
+      hasAutosave: true,
+      autosaveUpdatedAt: T_AUTOSAVE_OLD,
+    });
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("stale-draft-dialog")).toBeVisible();
+    await page.getByTestId("stale-draft-compare").click();
+    await expect(page.getByTestId("stale-draft-compare-panes")).toBeVisible();
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: "tmp/stale-draft-compare.png",
+      fullPage: false,
+    });
+  });
+});

--- a/packages/admin/src/editor/StaleDraftDialog.test.tsx
+++ b/packages/admin/src/editor/StaleDraftDialog.test.tsx
@@ -1,0 +1,123 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { StaleDraftDialog } from "./StaleDraftDialog.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+interface Snapshot {
+  readonly title: string;
+  readonly content: unknown;
+}
+
+const AUTOSAVE: Snapshot = {
+  title: "My pending edit",
+  content: { blocks: [{ name: "core/heading", attrs: {} }] },
+};
+const LIVE: Snapshot = {
+  title: "Latest published",
+  content: { blocks: [{ name: "core/rich-text", attrs: {} }] },
+};
+
+describe("StaleDraftDialog", () => {
+  test("renders the three actions when open", () => {
+    render(
+      <StaleDraftDialog
+        open={true}
+        autosaveSnapshot={AUTOSAVE}
+        liveSnapshot={LIVE}
+        onUseMine={vi.fn()}
+        onUseTheirs={vi.fn()}
+        isResolving={false}
+      />,
+    );
+    expect(screen.getByTestId("stale-draft-use-mine")).toBeInTheDocument();
+    expect(screen.getByTestId("stale-draft-use-theirs")).toBeInTheDocument();
+    expect(screen.getByTestId("stale-draft-compare")).toBeInTheDocument();
+  });
+
+  test("does not render anything when open=false", () => {
+    render(
+      <StaleDraftDialog
+        open={false}
+        autosaveSnapshot={AUTOSAVE}
+        liveSnapshot={LIVE}
+        onUseMine={vi.fn()}
+        onUseTheirs={vi.fn()}
+        isResolving={false}
+      />,
+    );
+    expect(
+      screen.queryByTestId("stale-draft-use-mine"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("clicking Use mine fires onUseMine", () => {
+    const onUseMine = vi.fn();
+    render(
+      <StaleDraftDialog
+        open={true}
+        autosaveSnapshot={AUTOSAVE}
+        liveSnapshot={LIVE}
+        onUseMine={onUseMine}
+        onUseTheirs={vi.fn()}
+        isResolving={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("stale-draft-use-mine"));
+    expect(onUseMine).toHaveBeenCalledOnce();
+  });
+
+  test("clicking Use theirs fires onUseTheirs", () => {
+    const onUseTheirs = vi.fn();
+    render(
+      <StaleDraftDialog
+        open={true}
+        autosaveSnapshot={AUTOSAVE}
+        liveSnapshot={LIVE}
+        onUseMine={vi.fn()}
+        onUseTheirs={onUseTheirs}
+        isResolving={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("stale-draft-use-theirs"));
+    expect(onUseTheirs).toHaveBeenCalledOnce();
+  });
+
+  test("clicking Compare expands an inline side-by-side JSON diff", () => {
+    render(
+      <StaleDraftDialog
+        open={true}
+        autosaveSnapshot={AUTOSAVE}
+        liveSnapshot={LIVE}
+        onUseMine={vi.fn()}
+        onUseTheirs={vi.fn()}
+        isResolving={false}
+      />,
+    );
+    expect(
+      screen.queryByTestId("stale-draft-compare-panes"),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("stale-draft-compare"));
+    const panes = screen.getByTestId("stale-draft-compare-panes");
+    expect(panes.textContent).toContain("core/heading"); // autosave content
+    expect(panes.textContent).toContain("core/rich-text"); // live content
+  });
+
+  test("Use mine and Use theirs disable while a resolution is in flight", () => {
+    render(
+      <StaleDraftDialog
+        open={true}
+        autosaveSnapshot={AUTOSAVE}
+        liveSnapshot={LIVE}
+        onUseMine={vi.fn()}
+        onUseTheirs={vi.fn()}
+        isResolving={true}
+      />,
+    );
+    expect(screen.getByTestId("stale-draft-use-mine")).toBeDisabled();
+    expect(screen.getByTestId("stale-draft-use-theirs")).toBeDisabled();
+  });
+});

--- a/packages/admin/src/editor/StaleDraftDialog.tsx
+++ b/packages/admin/src/editor/StaleDraftDialog.tsx
@@ -1,0 +1,128 @@
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
+
+interface StaleDraftDialogProps {
+  readonly open: boolean;
+  // The user's pending autosave content + the current live row. Both
+  // already loaded by the route — passed in so the Compare toggle
+  // doesn't need to re-fetch.
+  readonly autosaveSnapshot: unknown;
+  readonly liveSnapshot: unknown;
+  // `Use mine` keeps the autosave seeded into the canvas. `Use theirs`
+  // discards the autosave row server-side; the route's success
+  // handler then refetches live and the editor re-seeds.
+  readonly onUseMine: () => void;
+  readonly onUseTheirs: () => void;
+  // True while the discard mutation is in flight after Use theirs.
+  readonly isResolving: boolean;
+}
+
+// Three-action resolver surfaced at editor mount when a pending
+// autosave was anchored against an older live row than what's on the
+// server now. Builder.io's history UI uses the same three options —
+// "yours" / "theirs" / "compare" — for parallel-edit conflicts.
+export function StaleDraftDialog({
+  open,
+  autosaveSnapshot,
+  liveSnapshot,
+  onUseMine,
+  onUseTheirs,
+  isResolving,
+}: StaleDraftDialogProps): ReactElement {
+  const [comparing, setComparing] = useState(false);
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        className="max-w-4xl"
+        showCloseButton={false}
+        data-testid="stale-draft-dialog"
+        // Radix Dialog closes on Escape / outside-click by default;
+        // prevent both so the resolver actually blocks until the user
+        // picks one of the three actions. Without these, the dialog
+        // dismisses but the canvas stays seeded with the stale
+        // autosave content — silent contract violation.
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Your draft is out of date</DialogTitle>
+          <DialogDescription>
+            Someone else published changes to this entry while you had pending
+            edits. Pick which version to keep before continuing.
+          </DialogDescription>
+        </DialogHeader>
+        {comparing ? (
+          <div
+            data-testid="stale-draft-compare-panes"
+            // `aria-live` so screen-reader users get a "compare opened"
+            // announcement when they click the toggle. Without this
+            // the JSON appears silently and the toggle reads as no-op.
+            aria-live="polite"
+            className="grid grid-cols-1 gap-3 md:grid-cols-2"
+          >
+            <ComparePane label="Your draft" snapshot={autosaveSnapshot} />
+            <ComparePane label="Live now" snapshot={liveSnapshot} />
+          </div>
+        ) : null}
+        <DialogFooter className="sm:justify-between">
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="stale-draft-compare"
+            onClick={() => setComparing((prev) => !prev)}
+          >
+            {comparing ? "Hide comparison" : "Compare"}
+          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="stale-draft-use-theirs"
+              onClick={onUseTheirs}
+              disabled={isResolving}
+            >
+              {isResolving ? "Discarding…" : "Use theirs"}
+            </Button>
+            <Button
+              variant="default"
+              size="sm"
+              data-testid="stale-draft-use-mine"
+              onClick={onUseMine}
+              disabled={isResolving}
+            >
+              Use mine
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ComparePane({
+  label,
+  snapshot,
+}: {
+  readonly label: string;
+  readonly snapshot: unknown;
+}): ReactElement {
+  return (
+    <section>
+      <div className="text-muted-foreground mb-1 text-xs font-medium">
+        {label}
+      </div>
+      <pre className="bg-muted max-h-72 overflow-auto rounded-md p-2 text-xs">
+        {JSON.stringify(snapshot, null, 2)}
+      </pre>
+    </section>
+  );
+}

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -6,6 +6,7 @@ import { PlainFormLayout } from "@/components/editor/plain-form-layout.js";
 import { AutosaveStatusContext } from "@/editor/AutosaveStatus.js";
 import { blockSpecsToPuckComponents } from "@/editor/block-adapter.js";
 import { createDebouncer } from "@/editor/debounce.js";
+import { detectStaleAutosave } from "@/editor/detect-stale-autosave.js";
 import { PlumixEditorLayout } from "@/editor/EditorLayout.js";
 import { seedPuckData } from "@/editor/entry-content.js";
 import { readDraft, writeDraft } from "@/editor/local-draft.js";
@@ -14,6 +15,7 @@ import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
 import { resolveEditorMode } from "@/editor/resolve-editor-mode.js";
 import { PreviewBanner } from "@/editor/revisions/PreviewBanner.js";
 import { useRevisionsTrigger } from "@/editor/revisions/use-revisions-trigger.js";
+import { StaleDraftDialog } from "@/editor/StaleDraftDialog.js";
 import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
@@ -22,6 +24,7 @@ import { ORPCError } from "@orpc/client";
 import { Puck } from "@puckeditor/core";
 import {
   useMutation,
+  useQuery,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
@@ -148,6 +151,16 @@ function PuckSpikeRoute(): ReactNode {
   const { revision: previewRevisionId } = Route.useSearch();
   const draftKey = `plumix.v2.draft.${slug}.${id}`;
   const entryType = findEntryTypeBySlug(slug);
+  // Same suspense query the inner consumes — React Query caches the
+  // result, so the read here is free. Used to compute the inner's
+  // remount key from `_preview.source`: when the user picks "Use
+  // theirs" in the stale-draft dialog the discard mutation flips the
+  // source to `live`, the inner remounts, and Puck's `useState` seed
+  // re-inits from the now-live entry content.
+  const { data: entryForKey } = useSuspenseQuery(
+    orpc.entry.get.queryOptions({ input: { id, preview: true } }),
+  );
+  const previewSource = entryForKey._preview?.source ?? "live";
   const supportsRevisions = entryType?.supports?.includes("revisions") ?? false;
   // Non-editor entry types (structured records like authors, products,
   // events) get the plain-form Cards layout instead of the Puck canvas.
@@ -183,7 +196,7 @@ function PuckSpikeRoute(): ReactNode {
   }
   return (
     <PuckSpikeRouteInner
-      key={draftKey}
+      key={`${draftKey}:${previewSource}`}
       draftKey={draftKey}
       id={id}
       entryType={entryType}
@@ -353,6 +366,14 @@ function PuckSpikeRouteInner({
         queryClient.invalidateQueries({
           queryKey: orpc.entry.get.queryOptions({ input: { id } }).queryKey,
         }),
+        // Preview-mode key is its own cache entry; without this the
+        // editor stays seeded against the pre-publish snapshot until
+        // a navigation refetches it.
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({
+            input: { id, preview: true },
+          }).queryKey,
+        }),
         ...(entryTypeName
           ? [
               queryClient.invalidateQueries({
@@ -393,6 +414,29 @@ function PuckSpikeRouteInner({
   });
   const isEditWithDraft = editorMode === "edit-with-draft";
   const hasPendingDraft = entry._preview?.source === "autosave";
+
+  // Stale-draft state: pending autosave was anchored against an older
+  // live row than what the server has now. Show the resolver dialog
+  // until the user picks Use mine / Use theirs (or the source flips
+  // to `live` via the cache refetch after Use theirs).
+  // `_preview` only exists when the route fetches with `preview: true`,
+  // which it always does — see the `useSuspenseQuery` at line ~210.
+  // Treat the absence as a programming error rather than masking it
+  // with a `entry.updatedAt` fallback (autosave timing isn't the
+  // same as live's `updatedAt` and a silent fallback would
+  // mis-classify the stale state).
+  const staleAutosaveState = entry._preview
+    ? detectStaleAutosave(
+        entry._preview.autosaveUpdatedAt,
+        entry._preview.liveUpdatedAt,
+      )
+    : "none";
+  const [staleResolved, setStaleResolved] = useState(false);
+  const showStaleDialog = staleAutosaveState === "stale" && !staleResolved;
+  // Use mine acknowledges the new live anchor — without this, the
+  // concurrency token still references the old `updatedAt` and every
+  // subsequent autosave write 409s on the server's stale-token guard.
+  const liveAnchorAfterResolve = entry._preview?.liveUpdatedAt;
 
   const publishDraft = useMutation({
     mutationFn: () =>
@@ -459,6 +503,32 @@ function PuckSpikeRouteInner({
     debouncer.flush();
   }, [debouncer]);
 
+  // Live snapshot for the stale-draft dialog's Compare pane. Enabled
+  // only when the resolver dialog is showing, so non-stale loads don't
+  // burn a roundtrip on read.
+  const liveSnapshotQuery = useQuery({
+    ...orpc.entry.get.queryOptions({ input: { id } }),
+    enabled: showStaleDialog,
+  });
+  const handleUseMine = useCallback((): void => {
+    if (liveAnchorAfterResolve) {
+      liveUpdatedAtRef.current = liveAnchorAfterResolve;
+    }
+    setStaleResolved(true);
+  }, [liveAnchorAfterResolve]);
+  const handleUseTheirs = useCallback((): void => {
+    discardDraft.mutate(undefined, {
+      onSuccess: () => {
+        // Discard succeeded → preview query invalidates → source flips
+        // to 'live' → the dispatcher's `key` changes → this inner
+        // remounts with a fresh seed. No need to manage local state
+        // beyond clearing the dialog visibility for the brief
+        // pre-remount window.
+        setStaleResolved(true);
+      },
+    });
+  }, [discardDraft]);
+
   const draftModeProp = useMemo(
     () =>
       isEditWithDraft
@@ -520,6 +590,31 @@ function PuckSpikeRouteInner({
         onChange={handleChange}
         iframe={{ enabled: false }}
         overrides={{ puck: Layout }}
+      />
+      {/*
+        Stale-draft resolver: blocks the canvas until the user picks
+        Use mine / Use theirs when their autosave was anchored against
+        an older live row than what's on the server now.
+       */}
+      <StaleDraftDialog
+        open={showStaleDialog}
+        autosaveSnapshot={{
+          title: entry.title,
+          content: entry.content,
+          excerpt: entry.excerpt,
+        }}
+        liveSnapshot={
+          liveSnapshotQuery.data
+            ? {
+                title: liveSnapshotQuery.data.title,
+                content: liveSnapshotQuery.data.content,
+                excerpt: liveSnapshotQuery.data.excerpt,
+              }
+            : { title: "Loading…", content: null, excerpt: null }
+        }
+        onUseMine={handleUseMine}
+        onUseTheirs={handleUseTheirs}
+        isResolving={discardDraft.isPending}
       />
     </AutosaveStatusContext.Provider>
   );


### PR DESCRIPTION
Closes #291. Wires the slice-1 detector (#486) into the editor route and
ships the three-action resolver dialog that fires when the user's pending
autosave was anchored against an older live row than what's on the server
now (someone else published in between).

**Critical bug found in review**

`publish.onSuccess` was missing the preview-query invalidation, leaving the
editor seeded against the pre-publish snapshot until a navigation refetched
it. Now mirrors `publishDraft.onSuccess`. Without this, the stale-draft
state could silently misfire after a live publish from the same editor
instance.

**Use mine bumps the concurrency token**

If the user picks "Use mine" the route updates `liveUpdatedAtRef` to the
new live anchor. Without this, every subsequent autosave write 409s on the
server's `stale_expected_updated_at` guard because the ref still points at
the pre-publish `updatedAt`.

**Dispatcher key flips on source change**

`PuckSpikeRoute` reads the same `useSuspenseQuery` the inner uses (cache
hit, zero extra network) to compute `${draftKey}:${previewSource}` as the
inner's `key`. When the discard mutation flips `_preview.source` from
`'autosave'` to `'live'`, the inner remounts and Puck's `useState`
initializer re-seeds from the now-live content. This delivers the
deferred #290 acceptance criterion ("Editor form keys on
`${preview.source}:${preview.sourceTimestamp}`").

**Non-dismissable resolver**

`StaleDraftDialog` prevents Escape / outside-click dismissal explicitly —
Radix Dialog would otherwise close the chrome but leave the seeded
autosave canvas underneath, a silent contract violation. `aria-live` on
the Compare pane so screen-reader users get an announcement when the
toggle opens.

Refs #291