### PR TITLE
feat(core): `entry.activity.list` rpc for co-author awareness

### DIFF
--- a/packages/core/src/revisions/activity-rpc.test.ts
+++ b/packages/core/src/revisions/activity-rpc.test.ts
@@ -1,0 +1,139 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+import { entries } from "../db/schema/entries.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { createRpcHarness } from "../test/rpc.js";
+
+function registryWithAutosave(): ReturnType<typeof createPluginRegistry> {
+  const plugins = createPluginRegistry();
+  plugins.entryTypes.set("post", {
+    name: "post",
+    label: "Posts",
+    supports: ["revisions", "autosave"],
+    versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
+    registeredBy: "test",
+  });
+  return plugins;
+}
+
+describe("entry.activity.list", () => {
+  test("returns empty list when no autosave rows exist for the entry", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithAutosave(),
+    });
+    const created = await h.client.entry.create({
+      title: "L",
+      slug: "l",
+      status: "published",
+    });
+    const result = await h.client.entry.activity.list({ entryId: created.id });
+    expect(result.users).toEqual([]);
+  });
+
+  test("excludes the calling user's own autosave row from the list", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithAutosave(),
+    });
+    const created = await h.client.entry.create({
+      title: "L",
+      slug: "l",
+      status: "published",
+    });
+    // Caller writes their own autosave — should NOT appear in their
+    // own activity list.
+    await h.client.entry.update({
+      id: created.id,
+      title: "My pending",
+      saveAs: "draft",
+    });
+    const result = await h.client.entry.activity.list({ entryId: created.id });
+    expect(result.users).toEqual([]);
+  });
+
+  test("returns a co-author who has an autosave row touched within the 5-minute window", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithAutosave(),
+    });
+    const created = await h.client.entry.create({
+      title: "L",
+      slug: "l",
+      status: "published",
+    });
+    // Second editor writes an autosave.
+    const second = await h.actingAs("editor");
+    await second.client.entry.update({
+      id: created.id,
+      title: "Their pending",
+      saveAs: "draft",
+    });
+
+    const result = await h.client.entry.activity.list({ entryId: created.id });
+    expect(result.users).toHaveLength(1);
+    expect(result.users[0]?.id).toBe(second.user.id);
+    expect(result.users[0]?.email).toBe(second.user.email);
+  });
+
+  test("filters out autosave rows older than 5 minutes", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithAutosave(),
+    });
+    const created = await h.client.entry.create({
+      title: "L",
+      slug: "l",
+      status: "published",
+    });
+    const second = await h.actingAs("editor");
+    await second.client.entry.update({
+      id: created.id,
+      title: "Their pending",
+      saveAs: "draft",
+    });
+    // Backdate the second user's autosave to 10 minutes ago.
+    const SIX_MINUTES_MS = 6 * 60 * 1000;
+    const longAgo = new Date(Date.now() - SIX_MINUTES_MS);
+    await h.db
+      .update(entries)
+      .set({ updatedAt: longAgo })
+      .where(eq(entries.authorId, second.user.id));
+
+    const result = await h.client.entry.activity.list({ entryId: created.id });
+    expect(result.users).toEqual([]);
+  });
+
+  test("subscriber gets FORBIDDEN — same gate as entry.revisions.list", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithAutosave(),
+    });
+    const created = await h.client.entry.create({
+      title: "L",
+      slug: "l",
+      status: "published",
+    });
+    const subscriber = await h.actingAs("subscriber");
+    await expect(
+      subscriber.client.entry.activity.list({ entryId: created.id }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "entry:post:read_revisions" },
+    });
+  });
+
+  test("NOT_FOUND on an unknown entry id (existence not observable through the activity endpoint)", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithAutosave(),
+    });
+    await expect(
+      h.client.entry.activity.list({ entryId: 999_999 }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      data: { kind: "entry" },
+    });
+  });
+});

--- a/packages/core/src/revisions/repository.ts
+++ b/packages/core/src/revisions/repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, like, lt } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, like, lt, ne } from "drizzle-orm";
 
 import type { Db } from "../context/app.js";
 import type { Entry, EntryContent } from "../db/schema/entries.js";
@@ -248,6 +248,45 @@ export async function deleteAutosave(
     )
     .returning({ id: entries.id });
   return result.length > 0;
+}
+
+interface ListActiveAutosavesInput {
+  readonly entryId: number;
+  // Drop autosave rows whose `updatedAt` is older than this. Five
+  // minutes matches #293's "actively editing" threshold; the
+  // repository takes it as a parameter so tests can pin it to a
+  // fixture time.
+  readonly notOlderThan: Date;
+  // Exclude the calling user — every viewer should see their
+  // co-authors, not themselves.
+  readonly excludeAuthorId: number;
+}
+
+// Slug shape is `autosave:<entryId>:<authorId>`; the leading-anchor
+// `LIKE` scopes the query to one entry without a JOIN. Same pattern
+// as `listRevisions`.
+function entryAutosavePrefix(entryId: number): string {
+  return `autosave:${String(entryId)}:%`;
+}
+
+// Returns the autosave rows currently active on `entryId` — i.e.
+// touched within `notOlderThan` and not authored by the caller. The
+// RPC layer joins users on top for the wire surface; this returns
+// the raw rows so the join policy can change without touching the
+// repository.
+export async function listActiveAutosaves(
+  db: Db,
+  input: ListActiveAutosavesInput,
+): Promise<readonly Entry[]> {
+  return db.query.entries.findMany({
+    where: and(
+      eq(entries.type, AUTOSAVE_TYPE),
+      like(entries.slug, entryAutosavePrefix(input.entryId)),
+      gte(entries.updatedAt, input.notOlderThan),
+      ne(entries.authorId, input.excludeAuthorId),
+    ),
+    orderBy: [desc(entries.updatedAt)],
+  });
 }
 
 interface SetRevisionMessageInput {

--- a/packages/core/src/rpc/procedures/entry/activity.ts
+++ b/packages/core/src/rpc/procedures/entry/activity.ts
@@ -19,7 +19,6 @@ const listInput = v.object({ entryId: idParam });
 // SSE upgrade since the wire shape is just the user list.
 const ACTIVE_WINDOW_MS = 5 * 60 * 1000;
 
-
 // Returns the users currently editing `entryId` — autosave rows
 // touched within the last five minutes — excluding the caller. Empty
 // list when no co-authors are active. Polled by the editor header to

--- a/packages/core/src/rpc/procedures/entry/activity.ts
+++ b/packages/core/src/rpc/procedures/entry/activity.ts
@@ -19,12 +19,6 @@ const listInput = v.object({ entryId: idParam });
 // SSE upgrade since the wire shape is just the user list.
 const ACTIVE_WINDOW_MS = 5 * 60 * 1000;
 
-export interface ActivityUser {
-  readonly id: number;
-  readonly name: string | null;
-  readonly email: string;
-  readonly lastSeenAt: Date;
-}
 
 // Returns the users currently editing `entryId` — autosave rows
 // touched within the last five minutes — excluding the caller. Empty
@@ -60,15 +54,23 @@ export const list = base
       notOlderThan,
       excludeAuthorId: context.user.id,
     });
-    if (activeRows.length === 0)
-      return { users: [] as readonly ActivityUser[] };
+    // Inline element shape — naming the interface here would force
+    // an `export` (so the router-output type can name it), and knip
+    // flags unused exports. The anonymous literal lets TS infer the
+    // shape into the router type without a top-level export.
+    const items: {
+      id: number;
+      name: string | null;
+      email: string;
+      lastSeenAt: Date;
+    }[] = [];
+    if (activeRows.length === 0) return { users: items };
 
     const authorIds = Array.from(new Set(activeRows.map((r) => r.authorId)));
     const authorRows = await context.db.query.users.findMany({
       where: inArray(users.id, authorIds),
     });
     const userById = new Map(authorRows.map((u) => [u.id, u]));
-    const items: ActivityUser[] = [];
     for (const row of activeRows) {
       const user = userById.get(row.authorId);
       if (!user) continue;

--- a/packages/core/src/rpc/procedures/entry/activity.ts
+++ b/packages/core/src/rpc/procedures/entry/activity.ts
@@ -1,0 +1,83 @@
+import { inArray } from "drizzle-orm";
+import * as v from "valibot";
+
+import { eq } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { users } from "../../../db/schema/users.js";
+import { listActiveAutosaves } from "../../../revisions/repository.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { idParam } from "../../validation.js";
+import { entryCapability } from "./lifecycle.js";
+
+const listInput = v.object({ entryId: idParam });
+
+// Five-minute "actively editing" window per #293. Pure HTTP polling,
+// not real-time presence — admin clients poll every ~30 s with a
+// short `staleTime`. The window is forward-compatible with a future
+// SSE upgrade since the wire shape is just the user list.
+const ACTIVE_WINDOW_MS = 5 * 60 * 1000;
+
+export interface ActivityUser {
+  readonly id: number;
+  readonly name: string | null;
+  readonly email: string;
+  readonly lastSeenAt: Date;
+}
+
+// Returns the users currently editing `entryId` — autosave rows
+// touched within the last five minutes — excluding the caller. Empty
+// list when no co-authors are active. Polled by the editor header to
+// surface a "X is also editing this" indicator before the user
+// hits Publish.
+export const list = base
+  .use(authenticated)
+  .input(listInput)
+  .handler(async ({ input, context, errors }) => {
+    const live = await context.db.query.entries.findFirst({
+      where: eq(entries.id, input.entryId),
+    });
+    if (!live) {
+      throw errors.NOT_FOUND({
+        data: { kind: "entry", id: input.entryId },
+      });
+    }
+    if (isReservedType(live.type)) {
+      throw errors.BAD_REQUEST({ data: { reason: "reserved_type" } });
+    }
+    // Same gate as `entry.revisions.list` — co-author awareness
+    // depends on reading other users' pending edits, which is the
+    // same trust level as reading their historical revisions.
+    const capability = entryCapability(live.type, "read_revisions");
+    if (!context.auth.can(capability)) {
+      throw errors.FORBIDDEN({ data: { capability } });
+    }
+
+    const notOlderThan = new Date(Date.now() - ACTIVE_WINDOW_MS);
+    const activeRows = await listActiveAutosaves(context.db, {
+      entryId: input.entryId,
+      notOlderThan,
+      excludeAuthorId: context.user.id,
+    });
+    if (activeRows.length === 0)
+      return { users: [] as readonly ActivityUser[] };
+
+    const authorIds = Array.from(new Set(activeRows.map((r) => r.authorId)));
+    const authorRows = await context.db.query.users.findMany({
+      where: inArray(users.id, authorIds),
+    });
+    const userById = new Map(authorRows.map((u) => [u.id, u]));
+    const items: ActivityUser[] = [];
+    for (const row of activeRows) {
+      const user = userById.get(row.authorId);
+      if (!user) continue;
+      items.push({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        lastSeenAt: row.updatedAt,
+      });
+    }
+    return { users: items };
+  });

--- a/packages/core/src/rpc/procedures/entry/index.ts
+++ b/packages/core/src/rpc/procedures/entry/index.ts
@@ -1,3 +1,4 @@
+import { list as activityList } from "./activity.js";
 import { create } from "./create.js";
 import { discardDraft } from "./discard-draft.js";
 import { get } from "./get.js";
@@ -16,6 +17,7 @@ export const entryRouter = {
   publish,
   discardDraft,
   revisions: revisionsRouter,
+  activity: { list: activityList },
 } as const;
 
 export type EntryRouter = typeof entryRouter;


### PR DESCRIPTION
First slice of #293 — server side of polling-based co-author awareness.
Admin header indicator + 30s poll wiring land in slice B.

**Single endpoint, contract-only**

`entry.activity.list({ entryId })` returns `{ users: { id, name, email,
lastSeenAt }[] }` — the users with an autosave row touched within the
last five minutes, excluding the caller. Empty list when no co-authors
are active so the admin renders nothing rather than an empty pill.

**Capability gate matches `entry.revisions.list`**

Reading other users' pending edits is the same trust level as reading
their historical revisions — same gate (`entry:<type>:read_revisions`),
same NOT_FOUND-on-existence behavior for unknown entry ids.

**Forward-compatible with SSE**

Pure HTTP polling for now. The wire shape is just the user list, so a
future SSE upgrade can stream the same payload over a hot connection
without an API change.

Refs #293