### PR TITLE
feat(admin): co-author indicator with 30s polling

### DIFF
--- a/packages/admin/e2e/coauthor-indicator.spec.ts
+++ b/packages/admin/e2e/coauthor-indicator.spec.ts
@@ -1,0 +1,146 @@
+// E2E + visual verification for #293 slice B — co-author indicator
+// in the editor header. Polls `entry.activity.list` every 30 s; when
+// the response contains other users editing the same entry, the
+// indicator shows up next to the autosave pill.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+import { emptyManifest } from "@plumix/core/manifest";
+
+import { AUTHED_ADMIN, mockManifest, rpcOkBody } from "./support/rpc-mock.js";
+
+const T_LIVE = new Date("2026-05-22T12:00:00Z");
+const T_30S_AGO = new Date("2026-05-22T11:59:30Z");
+
+const MANIFEST_WITH_AUTOSAVE: PlumixManifest = {
+  ...emptyManifest(),
+  entryTypes: [
+    {
+      name: "post",
+      adminSlug: "posts",
+      label: "Posts",
+      labels: { singular: "Post", plural: "Posts" },
+      supports: ["title", "editor", "revisions", "autosave"],
+    },
+  ],
+};
+
+function publishedEntry(): Record<string, unknown> {
+  return {
+    id: 1,
+    type: "post",
+    parentId: null,
+    title: "Live title",
+    slug: "entry-1",
+    content: null,
+    excerpt: null,
+    status: "published",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: T_LIVE,
+    createdAt: T_LIVE,
+    updatedAt: T_LIVE,
+    meta: {},
+    _preview: {
+      source: "live",
+      autosaveUpdatedAt: null,
+      liveUpdatedAt: T_LIVE,
+    },
+    terms: {},
+  };
+}
+
+async function installMocks(
+  page: Page,
+  opts: {
+    coAuthors: readonly {
+      id: number;
+      name: string | null;
+      email: string;
+      lastSeenAt: Date;
+    }[];
+  },
+): Promise<void> {
+  await mockManifest(page, MANIFEST_WITH_AUTOSAVE);
+  await page.route("**/_plumix/rpc/**", (route) => {
+    const url = route.request().url();
+    if (url.endsWith("/auth/session")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(AUTHED_ADMIN),
+      });
+    }
+    if (url.endsWith("/entry/get")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          json: publishedEntry(),
+          meta: [
+            [1, "createdAt"],
+            [1, "updatedAt"],
+            [1, "publishedAt"],
+            [1, "_preview", "liveUpdatedAt"],
+          ],
+        }),
+      });
+    }
+    if (url.endsWith("/entry/activity/list")) {
+      const lastSeenMetaPaths = opts.coAuthors.map((_, i) => [
+        1,
+        "users",
+        i,
+        "lastSeenAt",
+      ]);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          json: { users: opts.coAuthors },
+          meta: lastSeenMetaPaths,
+        }),
+      });
+    }
+    return route.fulfill({ status: 404, body: "not-mocked" });
+  });
+}
+
+test.describe("co-author indicator (#293 slice B)", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("renders the indicator when activity.list returns co-authors", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      coAuthors: [
+        {
+          id: 7,
+          name: "Ada Lovelace",
+          email: "ada@example.test",
+          lastSeenAt: T_30S_AGO,
+        },
+      ],
+    });
+    await page.goto("entries/posts/1/edit");
+    const indicator = page.getByTestId("coauthor-indicator");
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText("Ada Lovelace");
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: "tmp/coauthor-active.png",
+      fullPage: false,
+    });
+  });
+
+  test("no indicator when activity.list returns an empty user list", async ({
+    page,
+  }) => {
+    await installMocks(page, { coAuthors: [] });
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("plumix-editor-layout")).toBeVisible();
+    await expect(page.getByTestId("coauthor-indicator")).toHaveCount(0);
+  });
+});

--- a/packages/admin/src/editor/CoAuthorIndicator.test.tsx
+++ b/packages/admin/src/editor/CoAuthorIndicator.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { CoAuthorIndicator } from "./CoAuthorIndicator.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const T_NOW = new Date("2026-05-22T12:00:00Z");
+const T_30S_AGO = new Date("2026-05-22T11:59:30Z");
+const T_2M_AGO = new Date("2026-05-22T11:58:00Z");
+
+describe("CoAuthorIndicator", () => {
+  test("renders nothing when there are no co-authors (no visual noise)", () => {
+    const { container } = render(
+      <CoAuthorIndicator users={[]} relativeTime={() => "now"} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders an avatar + count for a single co-author", () => {
+    render(
+      <CoAuthorIndicator
+        users={[
+          {
+            id: 7,
+            name: "Ada Lovelace",
+            email: "ada@example.test",
+            lastSeenAt: T_30S_AGO,
+          },
+        ]}
+        relativeTime={() => "30 seconds ago"}
+      />,
+    );
+    const indicator = screen.getByTestId("coauthor-indicator");
+    expect(indicator.textContent).toContain("Ada Lovelace");
+    expect(indicator.textContent).toContain("30 seconds ago");
+  });
+
+  test("renders multiple co-authors with their individual last-seen labels", () => {
+    render(
+      <CoAuthorIndicator
+        users={[
+          {
+            id: 7,
+            name: "Ada",
+            email: "ada@example.test",
+            lastSeenAt: T_30S_AGO,
+          },
+          {
+            id: 8,
+            name: null,
+            email: "bea@example.test",
+            lastSeenAt: T_2M_AGO,
+          },
+        ]}
+        relativeTime={(d) =>
+          d.getTime() === T_30S_AGO.getTime() ? "30s" : "2m"
+        }
+      />,
+    );
+    const indicator = screen.getByTestId("coauthor-indicator");
+    expect(indicator.textContent).toContain("Ada");
+    // Author without a name falls back to email so the user can still
+    // tell who's editing.
+    expect(indicator.textContent).toContain("bea@example.test");
+    expect(indicator.textContent).toContain("30s");
+    expect(indicator.textContent).toContain("2m");
+  });
+
+  test("each avatar carries an aria-label with identity + last-seen so screen readers get per-item context", () => {
+    render(
+      <CoAuthorIndicator
+        users={[
+          {
+            id: 7,
+            name: "Ada Lovelace",
+            email: "ada@example.test",
+            lastSeenAt: T_30S_AGO,
+          },
+        ]}
+        relativeTime={() => "30 seconds ago"}
+      />,
+    );
+    const avatar = screen
+      .getByTestId("coauthor-avatar-fallback-7")
+      .closest("[data-slot=avatar]");
+    expect(avatar?.getAttribute("aria-label")).toContain("Ada Lovelace");
+    expect(avatar?.getAttribute("aria-label")).toContain("30 seconds ago");
+  });
+
+  test("avatar fallback uses the first letter of name or email (initials surface)", () => {
+    render(
+      <CoAuthorIndicator
+        users={[
+          {
+            id: 7,
+            name: "Ada Lovelace",
+            email: "ada@example.test",
+            lastSeenAt: T_NOW,
+          },
+          {
+            id: 8,
+            name: null,
+            email: "bea@example.test",
+            lastSeenAt: T_NOW,
+          },
+        ]}
+        relativeTime={() => "now"}
+      />,
+    );
+    const fallbacks = screen.getAllByTestId(/coauthor-avatar-fallback-/);
+    expect(fallbacks).toHaveLength(2);
+    expect(fallbacks[0]?.textContent).toBe("A"); // Ada
+    expect(fallbacks[1]?.textContent).toBe("B"); // bea@
+  });
+});

--- a/packages/admin/src/editor/CoAuthorIndicator.tsx
+++ b/packages/admin/src/editor/CoAuthorIndicator.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from "react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar.js";
+
+interface CoAuthor {
+  readonly id: number;
+  readonly name: string | null;
+  readonly email: string;
+  readonly lastSeenAt: Date;
+}
+
+interface CoAuthorIndicatorProps {
+  readonly users: readonly CoAuthor[];
+  readonly relativeTime: (date: Date) => string;
+}
+
+// Shown next to the autosave pill when one or more co-authors are
+// actively editing the same entry. Renders nothing when the list is
+// empty so the header stays uncluttered for solo editing — which is
+// the common case.
+export function CoAuthorIndicator({
+  users,
+  relativeTime,
+}: CoAuthorIndicatorProps): ReactElement | null {
+  if (users.length === 0) return null;
+  return (
+    <div
+      data-testid="coauthor-indicator"
+      className="flex items-center gap-2 text-xs"
+    >
+      {/*
+        Each avatar carries an `aria-label` so screen-reader users get
+        the identity per item, not just the container count. The
+        visible name+timestamp list below is `sr-only md:block` so
+        mobile users (where the visible list is hidden for space) still
+        get the SR text — `hidden` would also strip it from a11y.
+       */}
+      <ul className="flex -space-x-1.5" aria-label="Active co-authors">
+        {users.map((user) => {
+          const display = user.name ?? user.email;
+          const lastSeen = relativeTime(user.lastSeenAt);
+          return (
+            <li key={user.id}>
+              <Avatar
+                size="sm"
+                className="ring-background ring-2"
+                aria-label={`${display} · last seen ${lastSeen}`}
+              >
+                <AvatarFallback
+                  data-testid={`coauthor-avatar-fallback-${String(user.id)}`}
+                >
+                  {initialFor(user)}
+                </AvatarFallback>
+              </Avatar>
+            </li>
+          );
+        })}
+      </ul>
+      <ul className="text-muted-foreground sr-only md:not-sr-only md:block">
+        {users.map((user) => (
+          <li key={user.id} className="truncate">
+            <span className="text-foreground font-medium">
+              {user.name ?? user.email}
+            </span>
+            <span> · {relativeTime(user.lastSeenAt)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function initialFor(user: CoAuthor): string {
+  const source = user.name ?? user.email;
+  const first = source.trim().charAt(0);
+  return first.toUpperCase();
+}

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -70,6 +70,10 @@ interface PlumixEditorLayoutProps {
   // Route layer owns RPC wiring and feeds a fully-wired <RevisionsSheet />
   // here; the layout only allocates space and doesn't know the contract.
   readonly revisionsTrigger?: ReactNode;
+  // Optional co-author indicator (avatar group + last-seen labels)
+  // surfaced next to the autosave pill. Route layer owns the
+  // `entry.activity.list` polling; the layout just allocates space.
+  readonly coAuthorIndicator?: ReactNode;
   // Optional preview-mode banner rendered above the header. When set,
   // the route is in `?revision=<id>` preview mode — the title input
   // and publish button are hidden because edits don't autosave.
@@ -339,6 +343,7 @@ export function PlumixEditorLayout({
   isPublishing = false,
   isPublished = false,
   revisionsTrigger,
+  coAuthorIndicator,
   previewBanner,
   draftMode,
 }: PlumixEditorLayoutProps): ReactElement {
@@ -398,6 +403,7 @@ export function PlumixEditorLayout({
           disabled={isPreview}
         />
         {isPreview ? null : <AutosaveStatusPill />}
+        {isPreview ? null : coAuthorIndicator}
         {revisionsTrigger}
         {isPreview ? null : isDraftMode ? (
           <DraftActions draftMode={draftMode} />

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PlainFormLayout } from "@/components/editor/plain-form-layout.js";
 import { AutosaveStatusContext } from "@/editor/AutosaveStatus.js";
 import { blockSpecsToPuckComponents } from "@/editor/block-adapter.js";
+import { CoAuthorIndicator } from "@/editor/CoAuthorIndicator.js";
 import { createDebouncer } from "@/editor/debounce.js";
 import { detectStaleAutosave } from "@/editor/detect-stale-autosave.js";
 import { PlumixEditorLayout } from "@/editor/EditorLayout.js";
@@ -39,6 +40,16 @@ import { idPathParam } from "@plumix/core/validation";
 import "@puckeditor/core/puck.css";
 
 const EMPTY_DATA: Data = { content: [], root: {} };
+
+// Stable empty array for the co-author indicator's no-data state. A
+// fresh `[]` per render would invalidate the `Layout` `useCallback`
+// even though the list is logically unchanged.
+const EMPTY_COAUTHORS: readonly {
+  id: number;
+  name: string | null;
+  email: string;
+  lastSeenAt: Date;
+}[] = [];
 
 // 1 s batches typing bursts; the dedup snapshot in the autosave closure
 // is what actually prevents identical revisions. WordPress's 60 s
@@ -510,6 +521,17 @@ function PuckSpikeRouteInner({
     ...orpc.entry.get.queryOptions({ input: { id } }),
     enabled: showStaleDialog,
   });
+  // Co-author awareness polling (#293). 30 s interval matches the
+  // server's 5-minute "active" window — a co-author whose autosave
+  // ages out drops off the indicator within one interval. `staleTime`
+  // keeps other consumers from forcing churn refetches between polls.
+  const coAuthorQuery = useQuery({
+    ...orpc.entry.activity.list.queryOptions({ input: { entryId: id } }),
+    enabled: isEditWithDraft,
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  });
+  const coAuthors = coAuthorQuery.data?.users ?? EMPTY_COAUTHORS;
   const handleUseMine = useCallback((): void => {
     if (liveAnchorAfterResolve) {
       liveUpdatedAtRef.current = liveAnchorAfterResolve;
@@ -566,6 +588,14 @@ function PuckSpikeRouteInner({
         isPublishing={publish.isPending}
         isPublished={isPublished}
         revisionsTrigger={revisionsTrigger}
+        coAuthorIndicator={
+          coAuthors.length > 0 ? (
+            <CoAuthorIndicator
+              users={coAuthors}
+              relativeTime={formatRelativeTime}
+            />
+          ) : null
+        }
         draftMode={draftModeProp}
       />
     ),
@@ -578,6 +608,7 @@ function PuckSpikeRouteInner({
       isPublished,
       capabilitySet,
       revisionsTrigger,
+      coAuthors,
       draftModeProp,
     ],
   );


### PR DESCRIPTION
Closes #293. Surfaces other editors working on the same entry in the header
next to the autosave pill. Polls `entry.activity.list` every 30 s with
`staleTime: 10 s`, exactly as #293's spec calls for.

**A11y from the start**

Per-avatar `aria-label` ("name · last seen Ns ago") so screen-reader users
get identity per item, not just a container count. The name+timestamp list
is `sr-only md:not-sr-only` instead of `hidden md:block` so mobile users
keep the SR text where the visual list is hidden.

**Polling gate matches the autosave-supporting types**

Query is `enabled: isEditWithDraft` — tighter than the server's
`read_revisions` gate so non-autosave types (which have no autosave rows
to surface) never poll. `EMPTY_COAUTHORS` module-level frozen array
stabilizes the no-data state's reference so the `Layout` callback's deps
don't churn on every pre-poll render.

**Suppressed under preview**

The indicator is part of the live-edit header chrome (next to the autosave
pill). Preview mode hides both the pill and the indicator since neither
applies to a read-only past revision.

Refs #293