### PR TITLE
feat(core,blocks): theme-as-presentation rendering for single entries

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -11,6 +11,10 @@
     "./test": {
       "types": "./dist/test/index.d.ts",
       "default": "./dist/test/index.js"
+    },
+    "./renderer": {
+      "types": "./dist/renderer/index.d.ts",
+      "default": "./dist/renderer/index.js"
     }
   },
   "scripts": {

--- a/packages/blocks/src/renderer/errors.ts
+++ b/packages/blocks/src/renderer/errors.ts
@@ -1,0 +1,26 @@
+export class RendererError extends Error {
+  static {
+    RendererError.prototype.name = "RendererError";
+  }
+
+  readonly code: "missing_provider";
+  readonly consumer: string;
+
+  private constructor(
+    code: "missing_provider",
+    message: string,
+    consumer: string,
+  ) {
+    super(message);
+    this.code = code;
+    this.consumer = consumer;
+  }
+
+  static missingProvider(ctx: { consumer: string }): RendererError {
+    return new RendererError(
+      "missing_provider",
+      `${ctx.consumer} must be used inside a <PlumixProvider/>.`,
+      ctx.consumer,
+    );
+  }
+}

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -1,9 +1,11 @@
-import { createContext, type ReactNode, useContext } from "react";
+import type { ReactNode } from "react";
+import { createContext, useContext } from "react";
 
 import type { BlockRegistry } from "../block-registry.js";
 import type { EntryContent } from "../entry-content.js";
-import { renderBlockTree } from "../render-block-tree.js";
 import type { ThemeTokens } from "../styles/types.js";
+import { renderBlockTree } from "../render-block-tree.js";
+import { RendererError } from "./errors.js";
 
 export interface PlumixContextValue {
   readonly registry: BlockRegistry;
@@ -15,7 +17,7 @@ const PlumixContext = createContext<PlumixContextValue | null>(null);
 function usePlumixContext(consumer: string): PlumixContextValue {
   const ctx = useContext(PlumixContext);
   if (!ctx) {
-    throw new Error(`${consumer} must be used inside a <PlumixProvider/>.`);
+    throw RendererError.missingProvider({ consumer });
   }
   return ctx;
 }

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -1,0 +1,46 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+import type { BlockRegistry } from "../block-registry.js";
+import type { EntryContent } from "../entry-content.js";
+import { renderBlockTree } from "../render-block-tree.js";
+import type { ThemeTokens } from "../styles/types.js";
+
+export interface PlumixContextValue {
+  readonly registry: BlockRegistry;
+  readonly tokens?: ThemeTokens;
+}
+
+const PlumixContext = createContext<PlumixContextValue | null>(null);
+
+function usePlumixContext(consumer: string): PlumixContextValue {
+  const ctx = useContext(PlumixContext);
+  if (!ctx) {
+    throw new Error(`${consumer} must be used inside a <PlumixProvider/>.`);
+  }
+  return ctx;
+}
+
+export function PlumixProvider({
+  value,
+  children,
+}: {
+  readonly value: PlumixContextValue;
+  readonly children: ReactNode;
+}): ReactNode {
+  return (
+    <PlumixContext.Provider value={value}>{children}</PlumixContext.Provider>
+  );
+}
+
+export function BlockRenderer({
+  content,
+}: {
+  readonly content: EntryContent;
+}): ReactNode {
+  const ctx = usePlumixContext("BlockRenderer");
+  return renderBlockTree(content.blocks, ctx.registry, { tokens: ctx.tokens });
+}
+
+export function useTokens(): ThemeTokens | undefined {
+  return usePlumixContext("useTokens").tokens;
+}

--- a/packages/blocks/src/renderer/renderer.test.tsx
+++ b/packages/blocks/src/renderer/renderer.test.tsx
@@ -1,0 +1,66 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry } from "../block-registry.js";
+import { BlockRenderer, PlumixProvider, useTokens } from "./index.js";
+
+const headingRegistry = createBlockRegistry([
+  {
+    name: "core/heading",
+    render: ({ attrs }) => {
+      const { text } = attrs as { readonly text: string };
+      return <h1>{text}</h1>;
+    },
+  },
+]);
+
+describe("BlockRenderer", () => {
+  test("renders block tree using the registry from PlumixProvider", () => {
+    const content = {
+      version: "plumix.v2" as const,
+      blocks: [{ id: "h", name: "core/heading", attrs: { text: "Hello" } }],
+    };
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: headingRegistry }}>
+        <BlockRenderer content={content} />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("Hello");
+  });
+
+  test("throws when used outside a PlumixProvider", () => {
+    const content = { version: "plumix.v2" as const, blocks: [] };
+    expect(() =>
+      renderToStaticMarkup(<BlockRenderer content={content} />),
+    ).toThrow(/PlumixProvider/);
+  });
+});
+
+describe("useTokens", () => {
+  test("returns the tokens from the active provider", () => {
+    const tokens = { colors: { primary: { value: "#0066cc" } } };
+
+    function Probe() {
+      const result = useTokens();
+      return <span data-testid="probe">{JSON.stringify(result)}</span>;
+    }
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: headingRegistry, tokens }}>
+        <Probe />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("#0066cc");
+  });
+
+  test("throws when used outside a PlumixProvider", () => {
+    function Probe() {
+      useTokens();
+      return null;
+    }
+    expect(() => renderToStaticMarkup(<Probe />)).toThrow(/PlumixProvider/);
+  });
+});

--- a/packages/core/src/cli/schema-codegen.test.ts
+++ b/packages/core/src/cli/schema-codegen.test.ts
@@ -11,7 +11,6 @@ const baseConfig: PlumixConfig = {
   auth: auth({
     passkey: { rpName: "t", rpId: "t", origin: "https://t" },
   }),
-  themes: [],
   plugins: [],
 };
 

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -23,10 +23,10 @@ const authConfig = auth({
   },
 });
 
-test("plumix() defaults missing plugins and themes to empty arrays", () => {
+test("plumix() defaults missing plugins to an empty array and theme to undefined", () => {
   const config = plumix({ runtime, database, auth: authConfig });
   expect(config.plugins).toEqual([]);
-  expect(config.themes).toEqual([]);
+  expect(config.theme).toBeUndefined();
 });
 
 test("plumix() exposes defineConfig as an alias", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -43,7 +43,7 @@ export interface PlumixConfigInput {
    * is the dev default.
    */
   readonly mailer?: Mailer;
-  readonly themes?: readonly ThemeDescriptor[];
+  readonly theme?: ThemeDescriptor;
   readonly plugins?: readonly AnyPluginDescriptor[];
   /**
    * Block-system configuration. Today only exposes the operator-
@@ -63,7 +63,7 @@ export interface PlumixConfig {
   readonly imageDelivery?: ImageDelivery;
   readonly kv?: KV;
   readonly mailer?: Mailer;
-  readonly themes: readonly ThemeDescriptor[];
+  readonly theme?: ThemeDescriptor;
   readonly plugins: readonly AnyPluginDescriptor[];
   readonly blocks?: {
     readonly htmlAllowlist?: HtmlAllowlistOverride;
@@ -89,7 +89,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
     imageDelivery: config.imageDelivery,
     kv: config.kv,
     mailer: config.mailer,
-    themes: config.themes ?? [],
+    theme: config.theme,
     plugins: config.plugins ?? [],
     blocks: config.blocks,
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,10 @@ export type * from "./runtime/slots.js";
 export { slugify } from "./slugify.js";
 export { defineTheme } from "./theme.js";
 export type {
+  TemplateComponent,
+  TemplateData,
+  TemplateRegistry,
   ThemeDescriptor,
-  ThemeSetupContext,
-  ThemeSetupContextBase,
+  ThemeDocument,
 } from "./theme.js";
+export { ThemeError, ThemeRegistrationError } from "./theme-errors.js";

--- a/packages/core/src/plugin/provides-context.ts
+++ b/packages/core/src/plugin/provides-context.ts
@@ -9,18 +9,11 @@ export interface ContextExtensionEntry {
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface PluginContextExtensions {}
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ThemeContextExtensions {}
-
 export interface PluginProvidesContext {
   readonly id: string;
   extendPluginContext<TKey extends keyof PluginContextExtensions>(
     key: TKey,
     value: PluginContextExtensions[TKey],
-  ): void;
-  extendThemeContext<TKey extends keyof ThemeContextExtensions>(
-    key: TKey,
-    value: ThemeContextExtensions[TKey],
   ): void;
   /**
    * Register a runtime helper on every per-request `AppContext`. Reads
@@ -37,7 +30,6 @@ export interface PluginProvidesContext {
 interface CreateProvidesContextArgs {
   readonly pluginId: string;
   readonly pluginExtensions: Map<string, ContextExtensionEntry>;
-  readonly themeExtensions: Map<string, ContextExtensionEntry>;
   readonly appExtensions: Map<string, ContextExtensionEntry>;
 }
 
@@ -81,12 +73,11 @@ const APP_CONTEXT_BASE_KEYS: ReadonlySet<string> = new Set([
 export function createPluginProvidesContext({
   pluginId,
   pluginExtensions,
-  themeExtensions,
   appExtensions,
 }: CreateProvidesContextArgs): PluginProvidesContext {
   const stash = (
     target: Map<string, ContextExtensionEntry>,
-    kind: "Plugin" | "Theme" | "App",
+    kind: "Plugin" | "App",
     key: string,
     value: unknown,
   ): void => {
@@ -121,9 +112,6 @@ export function createPluginProvidesContext({
     id: pluginId,
     extendPluginContext: (key, value) => {
       stash(pluginExtensions, "Plugin", key, value);
-    },
-    extendThemeContext: (key, value) => {
-      stash(themeExtensions, "Theme", key, value);
     },
     extendAppContext: (key, value) => {
       stash(appExtensions, "App", key, value);

--- a/packages/core/src/plugin/provides.test.ts
+++ b/packages/core/src/plugin/provides.test.ts
@@ -14,9 +14,6 @@ declare module "./provides-context.js" {
       url(key: string): string;
     };
   }
-  interface ThemeContextExtensions {
-    registerMenuLocation(id: string, opts: { readonly label: string }): void;
-  }
 }
 
 declare module "../context/app.js" {
@@ -136,48 +133,6 @@ describe("provides phase", () => {
       installPlugins({ hooks: new HookRegistry(), plugins: [evil] }),
     ).rejects.toThrow(
       /"addFilter" collides with a built-in PluginSetupContext/,
-    );
-  });
-
-  test("theme extensions are collected and surfaced on the install result", async () => {
-    const menus = definePlugin("menus", {
-      provides: (ctx) => {
-        ctx.extendThemeContext("registerMenuLocation", (id, opts) => ({
-          id,
-          opts,
-        }));
-      },
-      setup: () => undefined,
-    });
-
-    const result = await installPlugins({
-      hooks: new HookRegistry(),
-      plugins: [menus],
-    });
-
-    const entry = result.themeExtensions.get("registerMenuLocation");
-    expect(entry?.pluginId).toBe("menus");
-    expect(typeof entry?.value).toBe("function");
-  });
-
-  test("two plugins extending the same theme-context key throw with both ids", async () => {
-    const a = definePlugin("a", {
-      provides: (ctx) => {
-        ctx.extendThemeContext("registerMenuLocation", () => undefined);
-      },
-      setup: () => undefined,
-    });
-    const b = definePlugin("b", {
-      provides: (ctx) => {
-        ctx.extendThemeContext("registerMenuLocation", () => undefined);
-      },
-      setup: () => undefined,
-    });
-
-    await expect(
-      installPlugins({ hooks: new HookRegistry(), plugins: [a, b] }),
-    ).rejects.toThrow(
-      /Plugin "b" extended.*"registerMenuLocation".*"a" already registered/s,
     );
   });
 

--- a/packages/core/src/plugin/register.ts
+++ b/packages/core/src/plugin/register.ts
@@ -11,7 +11,6 @@ import { createPluginSetupContext } from "./setup-context.js";
 export interface PluginInstallResult {
   readonly hooks: HookRegistry;
   readonly registry: PluginRegistry;
-  readonly themeExtensions: ReadonlyMap<string, ContextExtensionEntry>;
   /**
    * Plugin-contributed AppContext helpers from
    * `provides(ctx).extendAppContext(...)`. Runtime adapters merge these
@@ -46,14 +45,12 @@ export async function installPlugins({
   }
 
   const pluginExtensions = new Map<string, ContextExtensionEntry>();
-  const themeExtensions = new Map<string, ContextExtensionEntry>();
   const appContextExtensions = new Map<string, ContextExtensionEntry>();
   for (const descriptor of plugins) {
     if (!descriptor.provides) continue;
     const providesCtx = createPluginProvidesContext({
       pluginId: descriptor.id,
       pluginExtensions,
-      themeExtensions,
       appExtensions: appContextExtensions,
     });
     await descriptor.provides(providesCtx);
@@ -74,5 +71,5 @@ export async function installPlugins({
     await descriptor.setup(ctx, undefined);
   }
 
-  return { hooks, registry, themeExtensions, appContextExtensions };
+  return { hooks, registry, appContextExtensions };
 }

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1,5 +1,7 @@
-import { BlockRenderer } from "@plumix/blocks/renderer";
 import { describe, expect, test } from "vitest";
+
+import type { EntryContent } from "@plumix/blocks";
+import { BlockRenderer } from "@plumix/blocks/renderer";
 
 import { definePlugin } from "../../plugin/define.js";
 import { createDispatcherHarness } from "../../test/dispatcher.js";
@@ -18,9 +20,7 @@ describe("resolvePublicRoute — single entry through theme", () => {
     const theme = defineTheme({
       templates: {
         index: () => null,
-        single: ({ data }) => (
-          <h1 data-testid="title">{data.entry.title}</h1>
-        ),
+        single: ({ data }) => <h1 data-testid="title">{data.entry.title}</h1>,
       },
     });
 
@@ -336,7 +336,12 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("template can render <BlockRenderer/> against the entry's content tree", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => <BlockRenderer content={data.entry.content} />,
+        index: ({ data }) =>
+          data.entry.content ? (
+            <BlockRenderer
+              content={data.entry.content as unknown as EntryContent}
+            />
+          ) : null,
       },
     });
 

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1,0 +1,366 @@
+import { BlockRenderer } from "@plumix/blocks/renderer";
+import { describe, expect, test } from "vitest";
+
+import { definePlugin } from "../../plugin/define.js";
+import { createDispatcherHarness } from "../../test/dispatcher.js";
+import { defineTheme } from "../../theme.js";
+
+const blogPlugin = definePlugin("blog", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+});
+
+describe("resolvePublicRoute — single entry through theme", () => {
+  test("renders the entry title via the matched `single` template", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => (
+          <h1 data-testid="title">{data.entry.title}</h1>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hello",
+      title: "Hello",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/hello"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('data-testid="title"');
+    expect(body).toContain("Hello");
+  });
+
+  test("falls through to `index` template when no `single` is registered", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => (
+          <article data-testid="index">{data.entry.title}</article>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "fallback",
+      title: "Fallback",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/fallback"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="index"');
+    expect(body).toContain("Fallback");
+  });
+
+  test("more-specific keys win: single-{type} > single > index", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => <div data-testid="index" />,
+        single: () => <div data-testid="single" />,
+        "single-post": () => <div data-testid="single-post" />,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "specific",
+      title: "Specific",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/specific"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="single-post"');
+    expect(body).not.toContain('data-testid="single"');
+  });
+
+  test("runs resolve:single:data filters before the template renders", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => <h1>{data.entry.title}</h1>,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "filtered",
+      title: "Original",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    h.app.hooks.addFilter(
+      "resolve:single:data",
+      (data) => ({
+        ...data,
+        entry: { ...data.entry, title: "Filtered" },
+      }),
+      { plugin: "test" },
+    );
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/filtered"),
+    );
+    const body = await response.text();
+    expect(body).toContain("Filtered");
+    expect(body).not.toContain("Original");
+  });
+
+  test("template receives ResolvedAuthor with public-safe fields", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => (
+          <p data-testid="author">{data.entry.author.name}</p>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.factory.user.create({
+      email: "byline-author@example.test",
+      name: "Eve Author",
+      role: "admin",
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "with-byline",
+      title: "Byline",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/with-byline"),
+    );
+    const body = await response.text();
+    expect(body).toContain("Eve Author");
+    expect(body).not.toContain("byline-author@example.test");
+  });
+
+  test("template receives eager-loaded terms in batched order", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => (
+          <span data-testid="terms">{`terms:${String(data.entry.terms.length)}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    const entry = await h.factory.entry.create({
+      type: "post",
+      slug: "tagged",
+      title: "Tagged",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const a = await h.factory.term.create({
+      taxonomy: "category",
+      slug: "alpha",
+      name: "Alpha",
+    });
+    const b = await h.factory.term.create({
+      taxonomy: "category",
+      slug: "beta",
+      name: "Beta",
+    });
+    await h.factory.entryTerm.create({
+      entryId: entry.id,
+      termId: a.id,
+      sortOrder: 0,
+    });
+    await h.factory.entryTerm.create({
+      entryId: entry.id,
+      termId: b.id,
+      sortOrder: 1,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/tagged"),
+    );
+    const body = await response.text();
+    expect(body).toContain("terms:2");
+  });
+
+  test("default document shell supplies doctype + html/head/body with charset, viewport, and title", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "doc",
+      title: "DocTitle",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/doc"),
+    );
+    const body = await response.text();
+    expect(body).toContain("<!doctype html>");
+    expect(body).toContain('<html lang="en">');
+    expect(body).toContain('<meta charSet="utf-8"/>');
+    expect(body).toContain(
+      '<meta name="viewport" content="width=device-width, initial-scale=1"/>',
+    );
+    expect(body).toContain("<title>DocTitle</title>");
+    expect(body).toContain("<body>");
+  });
+
+  test("theme `document` override replaces the default shell", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => <article>{data.entry.title}</article>,
+      },
+      document: ({ children }) => (
+        <html lang="fr">
+          <head>
+            <title>custom-doc</title>
+          </head>
+          <body className="branded">{children}</body>
+        </html>
+      ),
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "doc-override",
+      title: "Doc",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/doc-override"),
+    );
+    const body = await response.text();
+    expect(body).toContain('<html lang="fr">');
+    expect(body).toContain('class="branded"');
+    expect(body).toContain("custom-doc");
+  });
+
+  test("react 19 metadata hoisting: template-rendered <title> lands in <head>", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => (
+          <>
+            <title>From-Template</title>
+            <article>{data.entry.title}</article>
+          </>
+        ),
+      },
+      document: ({ children }) => (
+        <html lang="en">
+          <head>
+            <meta charSet="utf-8" />
+          </head>
+          <body>{children}</body>
+        </html>
+      ),
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hoisting",
+      title: "Body",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/hoisting"),
+    );
+    const body = await response.text();
+    // React 19 hoists <title> rendered in the body tree into <head>.
+    const headSection = body.slice(
+      body.indexOf("<head>"),
+      body.indexOf("</head>"),
+    );
+    expect(headSection).toContain("<title>From-Template</title>");
+  });
+
+  test("template can render <BlockRenderer/> against the entry's content tree", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => <BlockRenderer content={data.entry.content} />,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "with-blocks",
+      title: "Blocks",
+      content: {
+        version: "plumix.v2",
+        blocks: [{ id: "h", name: "core/heading", attrs: { text: "Hi" } }],
+      },
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/with-blocks"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Hi");
+    expect(body).toContain('data-plumix-block="core/heading"');
+  });
+});

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -1,0 +1,66 @@
+import { PlumixProvider } from "@plumix/blocks/renderer";
+import { createElement, type ReactNode } from "react";
+import { renderToString } from "react-dom/server";
+
+import type { AppContext } from "../../context/app.js";
+import type { ThemeDescriptor } from "../../theme.js";
+import type { ResolvedNode } from "./template-hierarchy.js";
+import { resolveTemplateCandidates } from "./template-hierarchy.js";
+
+interface RenderSingleArgs {
+  readonly ctx: AppContext;
+  readonly theme: ThemeDescriptor;
+  readonly node: ResolvedNode;
+  readonly data: { readonly entry: { readonly title: string } };
+}
+
+export async function renderThroughTheme({
+  ctx,
+  theme,
+  node,
+  data,
+}: RenderSingleArgs): Promise<string> {
+  const candidates = await resolveTemplateCandidates(node, ctx.hooks);
+  const matched = candidates.find((name) => theme.templates[name]);
+  const Template = matched
+    ? theme.templates[matched]!
+    : theme.templates.index;
+
+  const templateTree: ReactNode = createElement(PlumixProvider, {
+    value: { registry: ctx.blocks },
+    children: createElement(Template, { data }),
+  });
+
+  const Document = theme.document;
+  const documentTree = Document
+    ? createElement(Document, {
+        data,
+        request: ctx.request,
+        children: templateTree,
+      })
+    : createElement(DefaultDocument, {
+        title: data.entry.title,
+        children: templateTree,
+      });
+
+  return "<!doctype html>" + renderToString(documentTree);
+}
+
+function DefaultDocument({
+  title,
+  children,
+}: {
+  readonly title: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{title}</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -1,9 +1,16 @@
-import { PlumixProvider } from "@plumix/blocks/renderer";
-import { createElement, type ReactNode } from "react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
 import { renderToString } from "react-dom/server";
 
+import { PlumixProvider } from "@plumix/blocks/renderer";
+
 import type { AppContext } from "../../context/app.js";
-import type { ThemeDescriptor } from "../../theme.js";
+import type {
+  TemplateComponent,
+  TemplateData,
+  TemplateRegistry,
+  ThemeDescriptor,
+} from "../../theme.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -11,7 +18,7 @@ interface RenderSingleArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
   readonly node: ResolvedNode;
-  readonly data: { readonly entry: { readonly title: string } };
+  readonly data: TemplateData;
 }
 
 export async function renderThroughTheme({
@@ -21,10 +28,7 @@ export async function renderThroughTheme({
   data,
 }: RenderSingleArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
-  const matched = candidates.find((name) => theme.templates[name]);
-  const Template = matched
-    ? theme.templates[matched]!
-    : theme.templates.index;
+  const Template = pickTemplate(theme.templates, candidates);
 
   const templateTree: ReactNode = createElement(PlumixProvider, {
     value: { registry: ctx.blocks },
@@ -44,6 +48,17 @@ export async function renderThroughTheme({
       });
 
   return "<!doctype html>" + renderToString(documentTree);
+}
+
+function pickTemplate(
+  templates: TemplateRegistry,
+  candidates: readonly string[],
+): TemplateComponent<TemplateData> {
+  for (const name of candidates) {
+    const candidate = templates[name];
+    if (candidate) return candidate;
+  }
+  return templates.index;
 }
 
 function DefaultDocument({

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -1,0 +1,18 @@
+import type { Entry } from "../../db/schema/entries.js";
+import type { Term } from "../../db/schema/terms.js";
+
+/** Public-safe author projection — query select narrows away email + auth columns. */
+export interface ResolvedAuthor {
+  readonly id: number;
+  readonly name: string | null;
+  readonly avatarUrl: string | null;
+}
+
+export interface ResolvedEntry extends Entry {
+  readonly terms: readonly Term[];
+  readonly author: ResolvedAuthor;
+}
+
+export interface SingleData {
+  readonly entry: ResolvedEntry;
+}

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -7,6 +7,7 @@ import type { Term } from "../db/schema/terms.js";
 import type { ThemeDescriptor } from "../theme.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
+import type { SingleData } from "./render/resolved-entry.js";
 import { and, desc, eq, inArray } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
@@ -29,35 +30,20 @@ interface ResolvedTaxonomyData {
   readonly entries: readonly Entry[];
 }
 
-interface ResolvedAuthor {
-  readonly id: number;
-  readonly name: string | null;
-  readonly avatarUrl: string | null;
-}
-
-interface ResolvedEntry extends Entry {
-  readonly terms: readonly Term[];
-  readonly author: ResolvedAuthor;
-}
-
-interface ResolvedSingleData {
-  readonly entry: ResolvedEntry;
-}
-
 declare module "../hooks/types.js" {
   interface FilterRegistry {
     "resolve:taxonomy:data": (
       data: ResolvedTaxonomyData,
     ) => ResolvedTaxonomyData | Promise<ResolvedTaxonomyData>;
     "resolve:single:data": (
-      data: ResolvedSingleData,
-    ) => ResolvedSingleData | Promise<ResolvedSingleData>;
+      data: SingleData,
+    ) => SingleData | Promise<SingleData>;
   }
 }
 
 const ARCHIVE_LIMIT = 20;
 
-export interface ResolvePublicRouteOptions {
+interface ResolvePublicRouteOptions {
   readonly theme?: ThemeDescriptor;
 }
 
@@ -180,7 +166,7 @@ async function resolveSingle(
 async function buildSingleData(
   ctx: AppContext,
   row: Entry,
-): Promise<ResolvedSingleData> {
+): Promise<SingleData> {
   const [authorRows, termRows] = await Promise.all([
     ctx.db
       .select({ id: users.id, name: users.name, avatarUrl: users.avatarUrl })

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -4,12 +4,14 @@ import { count } from "drizzle-orm";
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
+import type { ThemeDescriptor } from "../theme.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
 import { and, desc, eq, inArray } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
 import { terms } from "../db/schema/terms.js";
+import { users } from "../db/schema/users.js";
 import { notFound } from "../runtime/http.js";
 import { paginate } from "./paginate.js";
 import { findEntryByPath, findTermByPath } from "./path-chain.js";
@@ -18,6 +20,7 @@ import {
   escapeHtml,
   renderDefaultDocument,
 } from "./render/document.js";
+import { renderThroughTheme } from "./render/render-template.js";
 import { renderTiptapContent } from "./render/tiptap.js";
 
 interface ResolvedTaxonomyData {
@@ -26,23 +29,46 @@ interface ResolvedTaxonomyData {
   readonly entries: readonly Entry[];
 }
 
+interface ResolvedAuthor {
+  readonly id: number;
+  readonly name: string | null;
+  readonly avatarUrl: string | null;
+}
+
+interface ResolvedEntry extends Entry {
+  readonly terms: readonly Term[];
+  readonly author: ResolvedAuthor;
+}
+
+interface ResolvedSingleData {
+  readonly entry: ResolvedEntry;
+}
+
 declare module "../hooks/types.js" {
   interface FilterRegistry {
     "resolve:taxonomy:data": (
       data: ResolvedTaxonomyData,
     ) => ResolvedTaxonomyData | Promise<ResolvedTaxonomyData>;
+    "resolve:single:data": (
+      data: ResolvedSingleData,
+    ) => ResolvedSingleData | Promise<ResolvedSingleData>;
   }
 }
 
 const ARCHIVE_LIMIT = 20;
 
+export interface ResolvePublicRouteOptions {
+  readonly theme?: ThemeDescriptor;
+}
+
 export async function resolvePublicRoute(
   ctx: AppContext,
   match: RouteMatch,
+  options: ResolvePublicRouteOptions = {},
 ): Promise<Response> {
   switch (match.intent.kind) {
     case "single":
-      return resolveSingle(ctx, match.intent, match.params);
+      return resolveSingle(ctx, match.intent, match.params, options);
     case "archive":
       return resolveArchive(ctx, match.intent, match.params);
     case "taxonomy":
@@ -116,6 +142,7 @@ async function resolveSingle(
   ctx: AppContext,
   intent: Extract<RouteIntent, { kind: "single" }>,
   params: Record<string, string>,
+  options: ResolvePublicRouteOptions,
 ): Promise<Response> {
   // `:path+` rules surface their capture as `params.path` (multi-segment);
   // flat `:slug` rules surface a single segment as `params.slug`. The
@@ -124,13 +151,65 @@ async function resolveSingle(
   const row = await findEntryForSingle(ctx, intent.entryType, params);
   if (!row) return notFound("public-post-not-found");
 
-  // Stash the matched entity so render-side helpers (menu plugin's
-  // `isCurrent`, breadcrumbs, canonical tags) can identify the
-  // current page without re-running URL matching.
   ctx.resolvedEntity = { kind: "entry", id: row.id };
 
+  if (options.theme) {
+    const initial = await buildSingleData(ctx, row);
+    const data = await ctx.hooks.applyFilter("resolve:single:data", initial);
+    const html = await renderThroughTheme({
+      ctx,
+      theme: options.theme,
+      node: {
+        kind: "content",
+        entryType: row.type,
+        slug: row.slug,
+        databaseId: row.id,
+      },
+      data,
+    });
+    return new Response(html, {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // TODO(#491 follow-up): drop this fallback once all consumers ship a theme.
   const body = `<article><h1>${escapeHtml(row.title)}</h1>${renderTiptapContent(row.content)}</article>`;
   return htmlResponse(row.title, body);
+}
+
+async function buildSingleData(
+  ctx: AppContext,
+  row: Entry,
+): Promise<ResolvedSingleData> {
+  const [authorRows, termRows] = await Promise.all([
+    ctx.db
+      .select({ id: users.id, name: users.name, avatarUrl: users.avatarUrl })
+      .from(users)
+      .where(eq(users.id, row.authorId)),
+    ctx.db
+      .select({
+        id: terms.id,
+        taxonomy: terms.taxonomy,
+        name: terms.name,
+        slug: terms.slug,
+        description: terms.description,
+        meta: terms.meta,
+        parentId: terms.parentId,
+        version: terms.version,
+      })
+      .from(entryTerm)
+      .innerJoin(terms, eq(entryTerm.termId, terms.id))
+      .where(eq(entryTerm.entryId, row.id)),
+  ]);
+  const author = authorRows[0];
+  if (!author) {
+    // FK constraint guarantees this; defensive throw surfaces corruption fast.
+    // eslint-disable-next-line no-restricted-syntax -- diagnostic throw
+    throw new Error(
+      `buildSingleData: entry ${String(row.id)} references missing author ${String(row.authorId)}`,
+    );
+  }
+  return { entry: { ...row, terms: termRows, author } };
 }
 
 async function resolveArchive(

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -146,8 +146,13 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     registry: seededRegistry,
   });
 
-  if (config.theme && !config.theme.templates.index) {
-    throw ThemeRegistrationError.missingIndexTemplate();
+  if (config.theme) {
+    const templates = config.theme.templates as Readonly<
+      Record<string, unknown>
+    >;
+    if (!templates.index) {
+      throw ThemeRegistrationError.missingIndexTemplate();
+    }
   }
 
   const schema: Record<string, unknown> = { ...coreSchema };
@@ -238,4 +243,3 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     themeTokens,
   };
 }
-

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -26,11 +26,6 @@ import type {
 } from "../plugin/manifest.js";
 import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RouteRule } from "../route/intent.js";
-import type {
-  ThemeDescriptor,
-  ThemeSetupContext,
-  ThemeSetupContextBase,
-} from "../theme.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
@@ -45,6 +40,7 @@ import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { appRouter } from "../rpc/router.js";
+import { ThemeRegistrationError } from "../theme-errors.js";
 import { AppBootError } from "./errors.js";
 
 export interface OAuthProviderSummary {
@@ -144,26 +140,14 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   const hooks = new HookRegistry();
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
-  const { registry, themeExtensions, appContextExtensions } =
-    await installPlugins({
-      hooks,
-      plugins: config.plugins,
-      registry: seededRegistry,
-    });
+  const { registry, appContextExtensions } = await installPlugins({
+    hooks,
+    plugins: config.plugins,
+    registry: seededRegistry,
+  });
 
-  // Themes run after plugins so plugins' `provides` callbacks have already
-  // populated `themeExtensions`. Each theme's setup runs in declared
-  // order; ids are unique across `config.themes`.
-  const themeIds = new Set<string>();
-  for (const theme of config.themes) {
-    if (themeIds.has(theme.id)) {
-      throw AppBootError.duplicateThemeId({ themeId: theme.id });
-    }
-    themeIds.add(theme.id);
-    if (theme.setup) {
-      const ctx = buildThemeSetupContext(theme.id, themeExtensions);
-      await theme.setup(ctx);
-    }
+  if (config.theme && !config.theme.templates.index) {
+    throw ThemeRegistrationError.missingIndexTemplate();
   }
 
   const schema: Record<string, unknown> = { ...coreSchema };
@@ -229,11 +213,7 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     config.blocks?.htmlAllowlist,
   );
 
-  // Per-group merge across themes: a theme that declares only `colors`
-  // doesn't wipe `spacing` / `typography` from an earlier base theme.
-  // Within a group, later themes win per-slug — same precedence as the
-  // block/mark override flatten above.
-  const themeTokens = mergeThemeTokens(config.themes);
+  const themeTokens = config.theme?.tokens;
 
   return {
     config,
@@ -259,53 +239,3 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
   };
 }
 
-/**
- * Flatten per-name component overrides from every theme in declaration
- * order. Later themes win when names collide, mirroring CSS cascade
- * intuition (the most-recently-applied theme has the final say). The
- * reported `themeId` is the last theme that contributed any override —
- * used by `mergeMarkRegistry` / `mergeBlockRegistry` only to attribute
- * `themeOverrideUnknownName` errors.
- */
-function mergeThemeTokens(
-  themes: readonly ThemeDescriptor[],
-): ThemeTokens | undefined {
-  let merged: ThemeTokens | undefined;
-  for (const theme of themes) {
-    if (!theme.tokens) continue;
-    merged = {
-      ...(merged ?? {}),
-      ...(theme.tokens.colors !== undefined && {
-        colors: { ...(merged?.colors ?? {}), ...theme.tokens.colors },
-      }),
-      ...(theme.tokens.spacing !== undefined && {
-        spacing: { ...(merged?.spacing ?? {}), ...theme.tokens.spacing },
-      }),
-      ...(theme.tokens.typography !== undefined && {
-        typography: {
-          ...(merged?.typography ?? {}),
-          ...theme.tokens.typography,
-        },
-      }),
-      ...(theme.tokens.border !== undefined && {
-        border: { ...(merged?.border ?? {}), ...theme.tokens.border },
-      }),
-    };
-  }
-  return merged;
-}
-
-function buildThemeSetupContext(
-  id: string,
-  themeExtensions: ReadonlyMap<string, ContextExtensionEntry>,
-): ThemeSetupContext {
-  // `satisfies` so adding a field to `ThemeSetupContextBase` later forces
-  // this builder to update — a plain `Record<string, unknown>` cast would
-  // silently produce a context missing the new field.
-  const base = { id } satisfies ThemeSetupContextBase;
-  const ctx: Record<string, unknown> = { ...base };
-  for (const [key, entry] of themeExtensions) {
-    ctx[key] = entry.value;
-  }
-  return ctx as unknown as ThemeSetupContext;
-}

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -173,7 +173,7 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
 
   const match = matchRoute(url, app.routeMap);
   if (match === null) return notFound("public-route-not-found");
-  return resolvePublicRoute(ctx, match);
+  return resolvePublicRoute(ctx, match, { theme: app.config.theme });
 }
 
 interface PluginRawRouteMatch {

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -22,6 +22,7 @@ import type {
 import type { Factories } from "./factories.js";
 import type { FetchOptions } from "./request.js";
 import type { ActionSpy, FilterSpy } from "./spies.js";
+import type { ThemeDescriptor } from "../theme.js";
 import { auth } from "../auth/config.js";
 import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
 import { createSession } from "../auth/sessions.js";
@@ -104,6 +105,7 @@ export interface CreateDispatcherHarnessOptions {
    * default passkey-only rail).
    */
   readonly bootstrapVia?: BootstrapVia;
+  readonly theme?: ThemeDescriptor;
 }
 
 export interface DispatcherHarness {
@@ -210,6 +212,7 @@ export async function createDispatcherHarness(
     plugins: options.plugins,
     imageDelivery: options.imageDelivery,
     mailer: options.mailer,
+    theme: options.theme,
   });
   const app = await buildApp(config);
   const dispatcher = createPlumixDispatcher(app);

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -19,10 +19,10 @@ import type {
   ConnectedObjectStorage,
   ImageDelivery,
 } from "../runtime/slots.js";
+import type { ThemeDescriptor } from "../theme.js";
 import type { Factories } from "./factories.js";
 import type { FetchOptions } from "./request.js";
 import type { ActionSpy, FilterSpy } from "./spies.js";
-import type { ThemeDescriptor } from "../theme.js";
 import { auth } from "../auth/config.js";
 import { SESSION_COOKIE_NAME } from "../auth/cookies.js";
 import { createSession } from "../auth/sessions.js";

--- a/packages/core/src/theme-errors.test.ts
+++ b/packages/core/src/theme-errors.test.ts
@@ -2,52 +2,9 @@ import { describe, expect, test } from "vitest";
 
 import { ThemeError } from "./theme-errors.js";
 
-describe("ThemeError.invalidThemeId", () => {
-  test("class identity, code, and exposed themeId", () => {
-    const err = ThemeError.invalidThemeId({
-      themeId: "Bad Id!",
-      pattern: "^[a-z][a-z0-9-]*$",
-      maxLength: 64,
-    });
-    expect(err).toBeInstanceOf(ThemeError);
-    expect(err).toBeInstanceOf(Error);
-    expect(err.name).toBe("ThemeError");
-    expect(err.code).toBe("invalid_theme_id");
-    expect(err.themeId).toBe("Bad Id!");
-  });
-
-  test("message interpolates the bad id, the regex, and the length cap from context", () => {
-    const err = ThemeError.invalidThemeId({
-      themeId: "Bad Id!",
-      pattern: "^[a-z][a-z0-9-]*$",
-      maxLength: 64,
-    });
-    expect(err.message).toContain('defineTheme: id "Bad Id!" is invalid');
-    expect(err.message).toContain("^[a-z][a-z0-9-]*$");
-    expect(err.message).toContain("64");
-  });
-});
-
-describe("ThemeError.setupNotAFunction", () => {
-  test("class identity, code, and exposed themeId", () => {
-    const err = ThemeError.setupNotAFunction({ themeId: "blog" });
-    expect(err).toBeInstanceOf(ThemeError);
-    expect(err.name).toBe("ThemeError");
-    expect(err.code).toBe("setup_not_a_function");
-    expect(err.themeId).toBe("blog");
-  });
-
-  test("message names defineTheme and the offending theme id", () => {
-    const err = ThemeError.setupNotAFunction({ themeId: "blog" });
-    expect(err.message).toContain('defineTheme("blog")');
-    expect(err.message).toContain("`setup` must be a function");
-  });
-});
-
 describe("ThemeError.invalidTokenSlug", () => {
   test("class identity, code, group, slug", () => {
     const err = ThemeError.invalidTokenSlug({
-      themeId: "blog",
       group: "colors",
       slug: "x } body",
     });
@@ -62,7 +19,6 @@ describe("ThemeError.invalidTokenSlug", () => {
 describe("ThemeError.invalidTokenValue", () => {
   test("class identity, code, group, slug", () => {
     const err = ThemeError.invalidTokenValue({
-      themeId: "blog",
       group: "colors",
       slug: "primary",
       value: "#fff; } body { display:none",

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -39,10 +39,7 @@ export class ThemeError extends Error {
     this.slug = slug;
   }
 
-  static invalidTokenSlug(ctx: {
-    group: string;
-    slug: string;
-  }): ThemeError {
+  static invalidTokenSlug(ctx: { group: string; slug: string }): ThemeError {
     return new ThemeError(
       "invalid_token_slug",
       `defineTheme: tokens.${ctx.group} slug ${JSON.stringify(ctx.slug)} is invalid. ` +

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -1,91 +1,73 @@
+export class ThemeRegistrationError extends Error {
+  static {
+    ThemeRegistrationError.prototype.name = "ThemeRegistrationError";
+  }
+
+  readonly code = "missing_index_template" as const;
+
+  constructor(message: string) {
+    super(message);
+  }
+
+  static missingIndexTemplate(): ThemeRegistrationError {
+    return new ThemeRegistrationError(
+      `Theme registration: \`templates.index\` is required. Every theme ` +
+        `must declare an \`index\` template — it is the final fallback the ` +
+        `template hierarchy walks to when no more-specific template matches.`,
+    );
+  }
+}
+
 export class ThemeError extends Error {
   static {
     ThemeError.prototype.name = "ThemeError";
   }
 
-  readonly code:
-    | "invalid_theme_id"
-    | "setup_not_a_function"
-    | "invalid_token_slug"
-    | "invalid_token_value";
-  readonly themeId: string;
-  readonly group: string | undefined;
-  readonly slug: string | undefined;
+  readonly code: "invalid_token_slug" | "invalid_token_value";
+  readonly group: string;
+  readonly slug: string;
 
   private constructor(
-    code:
-      | "invalid_theme_id"
-      | "setup_not_a_function"
-      | "invalid_token_slug"
-      | "invalid_token_value",
+    code: "invalid_token_slug" | "invalid_token_value",
     message: string,
-    themeId: string,
-    extra?: { group?: string; slug?: string },
+    group: string,
+    slug: string,
   ) {
     super(message);
     this.code = code;
-    this.themeId = themeId;
-    this.group = extra?.group;
-    this.slug = extra?.slug;
-  }
-
-  static invalidThemeId(ctx: {
-    themeId: string;
-    pattern: string;
-    maxLength: number;
-  }): ThemeError {
-    return new ThemeError(
-      "invalid_theme_id",
-      `defineTheme: id "${ctx.themeId}" is invalid. Theme ids must ` +
-        `match /${ctx.pattern}/ and be 1–${String(ctx.maxLength)} chars.`,
-      ctx.themeId,
-    );
-  }
-
-  static setupNotAFunction(ctx: { themeId: string }): ThemeError {
-    return new ThemeError(
-      "setup_not_a_function",
-      `defineTheme("${ctx.themeId}"): \`setup\` must be a function when provided.`,
-      ctx.themeId,
-    );
+    this.group = group;
+    this.slug = slug;
   }
 
   static invalidTokenSlug(ctx: {
-    themeId: string;
     group: string;
     slug: string;
   }): ThemeError {
     return new ThemeError(
       "invalid_token_slug",
-      `defineTheme("${ctx.themeId}"): tokens.${ctx.group} slug ${JSON.stringify(
-        ctx.slug,
-      )} is invalid. Token slugs must match /^[a-z][a-z0-9-]*$/ — they ` +
-        `are concatenated into CSS class names (e.g. "has-<slug>-padding") ` +
-        `and CSS custom-property names (e.g. "--plumix-color-<slug>"), so ` +
-        `whitespace, braces, or other CSS-delimiter characters break the ` +
-        `stylesheet at build time.`,
-      ctx.themeId,
-      { group: ctx.group, slug: ctx.slug },
+      `defineTheme: tokens.${ctx.group} slug ${JSON.stringify(ctx.slug)} is invalid. ` +
+        `Token slugs must match /^[a-z][a-z0-9-]*$/ — they are concatenated into CSS ` +
+        `custom-property names, so whitespace or CSS-delimiter characters would break ` +
+        `themes that bind them.`,
+      ctx.group,
+      ctx.slug,
     );
   }
 
   static invalidTokenValue(ctx: {
-    themeId: string;
     group: string;
     slug: string;
     value: string;
   }): ThemeError {
     return new ThemeError(
       "invalid_token_value",
-      `defineTheme("${ctx.themeId}"): tokens.${ctx.group}.${ctx.slug} value ` +
-        `${JSON.stringify(ctx.value)} contains characters that would break ` +
-        `out of a CSS declaration value (semicolons, braces, comment ` +
-        `delimiters, or newlines). The Vite plugin emits this value ` +
-        `verbatim into ` +
-        `\`virtual:plumix/blocks/tokens.css\`, so any of those bytes lets ` +
-        `the token rewrite arbitrary rules in the bundle.`,
-      ctx.themeId,
-      { group: ctx.group, slug: ctx.slug },
+      `defineTheme: tokens.${ctx.group}.${ctx.slug} value ${JSON.stringify(ctx.value)} ` +
+        `contains characters that would break out of a CSS declaration value ` +
+        `(semicolons, braces, comment delimiters, or newlines). Themes embed token ` +
+        `values via CSS \`var(...)\` references, so any of those bytes lets the token ` +
+        `rewrite arbitrary rules.`,
+      ctx.group,
+      ctx.slug,
     );
   }
 }

--- a/packages/core/src/theme-tokens.test.ts
+++ b/packages/core/src/theme-tokens.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, test } from "vitest";
 import { ThemeError } from "./theme-errors.js";
 import { defineTheme } from "./theme.js";
 
+const Stub = () => null;
+
 describe("defineTheme tokens validation", () => {
   test("accepts valid tokens", () => {
     expect(() =>
       defineTheme({
-        id: "blog",
+        templates: { index: Stub },
         tokens: {
           colors: { primary: { value: "#0066cc", label: "Primary" } },
           spacing: { md: { value: "1rem" } },
@@ -19,12 +21,8 @@ describe("defineTheme tokens validation", () => {
   test("rejects a slug with CSS-breaking characters", () => {
     expect(() =>
       defineTheme({
-        id: "blog",
-        tokens: {
-          colors: {
-            "x } body": { value: "#fff" },
-          },
-        },
+        templates: { index: Stub },
+        tokens: { colors: { "x } body": { value: "#fff" } } },
       }),
     ).toThrow(ThemeError);
   });
@@ -32,7 +30,7 @@ describe("defineTheme tokens validation", () => {
   test("rejects a slug starting with a digit", () => {
     expect(() =>
       defineTheme({
-        id: "blog",
+        templates: { index: Stub },
         tokens: { colors: { "1bad": { value: "#fff" } } },
       }),
     ).toThrow(ThemeError);
@@ -41,11 +39,9 @@ describe("defineTheme tokens validation", () => {
   test("rejects a value with `;` (declaration breakout)", () => {
     expect(() =>
       defineTheme({
-        id: "blog",
+        templates: { index: Stub },
         tokens: {
-          colors: {
-            primary: { value: "#fff; } body { display:none" },
-          },
+          colors: { primary: { value: "#fff; } body { display:none" } },
         },
       }),
     ).toThrow(ThemeError);
@@ -54,7 +50,7 @@ describe("defineTheme tokens validation", () => {
   test("rejects a value with `*/` (comment breakout)", () => {
     expect(() =>
       defineTheme({
-        id: "blog",
+        templates: { index: Stub },
         tokens: {
           colors: { primary: { value: "#fff */ body { x: 1 } /*" } },
         },
@@ -65,7 +61,7 @@ describe("defineTheme tokens validation", () => {
   test("rejects a value with embedded newline", () => {
     expect(() =>
       defineTheme({
-        id: "blog",
+        templates: { index: Stub },
         tokens: { colors: { primary: { value: "#fff\nbody { x: 1 }" } } },
       }),
     ).toThrow(ThemeError);

--- a/packages/core/src/theme.test.ts
+++ b/packages/core/src/theme.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+
+import { plumix } from "./config.js";
+import { auth } from "./auth/config.js";
+import { buildApp } from "./runtime/app.js";
+import { defineTheme } from "./theme.js";
+import { ThemeRegistrationError } from "./theme-errors.js";
+
+const stubAdapter = {
+  name: "test",
+  buildFetchHandler: () => () => new Response("stub"),
+};
+const stubDatabase = { kind: "test", connect: () => ({ db: {} }) };
+const stubAuth = auth({
+  passkey: { rpName: "t", rpId: "t", origin: "https://t" },
+});
+
+describe("defineTheme", () => {
+  test("throws ThemeRegistrationError when templates.index is missing", () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      defineTheme({ templates: {} as any }),
+    ).toThrow(ThemeRegistrationError);
+  });
+});
+
+describe("buildApp", () => {
+  test("throws ThemeRegistrationError when config.theme omits templates.index", async () => {
+    // Bypass defineTheme's compile-time guard with `as any` to simulate
+    // a hand-rolled descriptor that skipped the factory.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const badTheme = { templates: {} } as any;
+    await expect(
+      buildApp(
+        plumix({
+          runtime: stubAdapter,
+          database: stubDatabase,
+          auth: stubAuth,
+          theme: badTheme,
+        }),
+      ),
+    ).rejects.toThrow(ThemeRegistrationError);
+  });
+});

--- a/packages/core/src/theme.test.ts
+++ b/packages/core/src/theme.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { plumix } from "./config.js";
+import type { ThemeDescriptor } from "./theme.js";
 import { auth } from "./auth/config.js";
+import { plumix } from "./config.js";
 import { buildApp } from "./runtime/app.js";
-import { defineTheme } from "./theme.js";
 import { ThemeRegistrationError } from "./theme-errors.js";
+import { defineTheme } from "./theme.js";
 
 const stubAdapter = {
   name: "test",
@@ -15,21 +16,18 @@ const stubAuth = auth({
   passkey: { rpName: "t", rpId: "t", origin: "https://t" },
 });
 
+// Bypass the compile-time `templates.index` requirement to simulate a
+// hand-rolled descriptor that skipped the `defineTheme` factory.
+const badTheme = { templates: {} } as unknown as ThemeDescriptor;
+
 describe("defineTheme", () => {
   test("throws ThemeRegistrationError when templates.index is missing", () => {
-    expect(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      defineTheme({ templates: {} as any }),
-    ).toThrow(ThemeRegistrationError);
+    expect(() => defineTheme(badTheme)).toThrow(ThemeRegistrationError);
   });
 });
 
 describe("buildApp", () => {
   test("throws ThemeRegistrationError when config.theme omits templates.index", async () => {
-    // Bypass defineTheme's compile-time guard with `as any` to simulate
-    // a hand-rolled descriptor that skipped the factory.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const badTheme = { templates: {} } as any;
     await expect(
       buildApp(
         plumix({

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,89 +1,60 @@
 import type { ThemeTokens } from "@plumix/blocks";
+import type { ComponentType, ReactElement, ReactNode } from "react";
 
-import type { ThemeContextExtensions } from "./plugin/provides-context.js";
-import { ThemeError } from "./theme-errors.js";
+import { ThemeError, ThemeRegistrationError } from "./theme-errors.js";
 
-export interface ThemeSetupContextBase {
-  readonly id: string;
+// Placeholder until the per-kind data union lands in a follow-up cycle.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TemplateData = any;
+
+export type TemplateComponent<Data> = ComponentType<{ readonly data: Data }>;
+
+export type ThemeDocument = (props: {
+  readonly data: TemplateData;
+  readonly request: Request;
+  readonly children: ReactNode;
+}) => ReactElement;
+
+export interface TemplateRegistry {
+  readonly index: TemplateComponent<TemplateData>;
+  readonly [key: string]: TemplateComponent<TemplateData>;
 }
 
-/**
- * Composed type a theme's `setup` callback receives. Plugins augment
- * `ThemeContextExtensions` via TypeScript declaration merging from their
- * own modules — installing `@plumix/plugin-menu`, for instance, adds
- * `registerMenuLocation` to the surface.
- */
-export type ThemeSetupContext = ThemeSetupContextBase & ThemeContextExtensions;
-
 export interface ThemeDescriptor {
-  readonly id: string;
-  /**
-   * Registration callback invoked once during `buildApp`, after plugins'
-   * `provides` callbacks have populated the theme context. Use it to
-   * register menu locations, theme settings, and any other concerns the
-   * theme contributes through plugins' theme-context extensions.
-   */
-  readonly setup?: (ctx: ThemeSetupContext) => void | Promise<void>;
-  /**
-   * Design-token vocabulary the theme exposes to block style picks.
-   * Authored values like `attrs.style.color.background = "primary"`
-   * resolve at render time through the universal Style slot in
-   * `renderBlockTree`. The Vite plugin also reads this at build time to
-   * populate `virtual:plumix/blocks/tokens.css` with CSS variables.
-   */
+  readonly templates: TemplateRegistry;
+  readonly document?: ThemeDocument;
   readonly tokens?: ThemeTokens;
 }
 
-const THEME_ID_RE = /^[a-z][a-z0-9-]*$/;
-const MAX_THEME_ID_LENGTH = 64;
 const TOKEN_SLUG_RE = /^[a-z][a-z0-9-]*$/;
-// Bytes that close out of a CSS declaration value or comment context.
-// `;` ends the declaration; `{` `}` close out of the surrounding rule;
-// `/* */` is comment delimiter; newlines + `\` break the CSS lexer's
-// string state. Operator-controlled tokens still flow into the bundle
-// verbatim, so any of these would let a hostile/careless theme rewrite
-// arbitrary rules.
 const TOKEN_VALUE_FORBIDDEN_CHARS = /[;{}\\\n\r]|\/\*|\*\//;
 
 export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
-  if (
-    typeof descriptor.id !== "string" ||
-    descriptor.id.length === 0 ||
-    descriptor.id.length > MAX_THEME_ID_LENGTH ||
-    !THEME_ID_RE.test(descriptor.id)
-  ) {
-    throw ThemeError.invalidThemeId({
-      themeId: String(descriptor.id),
-      pattern: THEME_ID_RE.source,
-      maxLength: MAX_THEME_ID_LENGTH,
-    });
-  }
-  if (
-    descriptor.setup !== undefined &&
-    typeof descriptor.setup !== "function"
-  ) {
-    throw ThemeError.setupNotAFunction({ themeId: descriptor.id });
+  // Defense-in-depth: the type system already requires `templates.index`,
+  // but JS callers can drop it. The hierarchy walker terminates at
+  // `index`, so an absent fallback would render blank pages.
+  if (!descriptor.templates.index) {
+    throw ThemeRegistrationError.missingIndexTemplate();
   }
   if (descriptor.tokens) {
-    validateTokens(descriptor.id, descriptor.tokens);
+    validateTokens(descriptor.tokens);
   }
   return descriptor;
 }
 
-function validateTokens(themeId: string, tokens: ThemeTokens): void {
+function validateTokens(tokens: ThemeTokens): void {
   for (const group of ["colors", "spacing", "typography", "border"] as const) {
     const entries = tokens[group];
     if (!entries) continue;
     for (const [slug, entry] of Object.entries(entries)) {
       if (!TOKEN_SLUG_RE.test(slug)) {
-        throw ThemeError.invalidTokenSlug({ themeId, group, slug });
+        throw ThemeError.invalidTokenSlug({ group, slug });
       }
       if (
         typeof entry.value !== "string" ||
         TOKEN_VALUE_FORBIDDEN_CHARS.test(entry.value)
       ) {
         throw ThemeError.invalidTokenValue({
-          themeId,
           group,
           slug,
           value: String(entry.value),

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,11 +1,16 @@
-import type { ThemeTokens } from "@plumix/blocks";
 import type { ComponentType, ReactElement, ReactNode } from "react";
 
+import type { ThemeTokens } from "@plumix/blocks";
+
+import type { SingleData } from "./route/render/resolved-entry.js";
 import { ThemeError, ThemeRegistrationError } from "./theme-errors.js";
 
-// Placeholder until the per-kind data union lands in a follow-up cycle.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type TemplateData = any;
+/**
+ * Per-kind data union templates receive. Only `SingleData` is implemented
+ * today; archive / taxonomy / front-page / error kinds widen this in
+ * follow-up slices.
+ */
+export type TemplateData = SingleData;
 
 export type TemplateComponent<Data> = ComponentType<{ readonly data: Data }>;
 
@@ -33,7 +38,8 @@ export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
   // Defense-in-depth: the type system already requires `templates.index`,
   // but JS callers can drop it. The hierarchy walker terminates at
   // `index`, so an absent fallback would render blank pages.
-  if (!descriptor.templates.index) {
+  const templates = descriptor.templates as Readonly<Record<string, unknown>>;
+  if (!templates.index) {
     throw ThemeRegistrationError.missingIndexTemplate();
   }
   if (descriptor.tokens) {

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "stripInternal": true
   },
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@plumix/typescript-config/library.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "types": ["node"]
   },
   "include": ["src"]

--- a/packages/plugins/menu/e2e/menu.spec.ts
+++ b/packages/plugins/menu/e2e/menu.spec.ts
@@ -97,7 +97,12 @@ test.describe.serial("@plumix/plugin-menu — worker-driven happy path", () => {
     await expect(reloadedRows.last()).toContainText("Home");
   });
 
-  test("locations tab — assign the menu to Primary Nav, reload, assignment persists", async ({
+  // Skipped pending a new menu-location registration path. theme.setup was
+  // removed in the theming-foundation slice (#493 / PR #500), which means
+  // the playground no longer registers a "primary" location. A follow-up
+  // will reintroduce registration via plugin config or admin-defined
+  // locations; this test is the canary that unskips when that lands.
+  test.skip("locations tab — assign the menu to Primary Nav, reload, assignment persists", async ({
     page,
   }) => {
     await page.goto("pages/menus");

--- a/packages/plugins/menu/playground/plumix.config.ts
+++ b/packages/plugins/menu/playground/plumix.config.ts
@@ -1,5 +1,4 @@
 import { auth, plumix } from "plumix";
-import { defineTheme } from "plumix/theme";
 
 import { menu } from "@plumix/plugin-menu";
 import {
@@ -7,18 +6,6 @@ import {
   cloudflareDeployOrigin,
   d1,
 } from "@plumix/runtime-cloudflare";
-
-// Minimal theme that registers menu locations. Without a theme the
-// menu plugin's locations list is empty, so the worker-driven e2e
-// can't exercise the location-assignment flow. Themes are the
-// canonical surface that ships menu locations to admin authors.
-const playgroundTheme = defineTheme({
-  id: "menu-playground-theme",
-  setup: (themeCtx) => {
-    themeCtx.registerMenuLocation("primary", { label: "Primary Nav" });
-    themeCtx.registerMenuLocation("footer", { label: "Footer" });
-  },
-});
 
 // Plumix consumer wiring only the menu plugin — the smallest config
 // you can run to dogfood `@plumix/plugin-menu` without bringing the
@@ -47,6 +34,5 @@ export default plumix({
       origin,
     },
   }),
-  themes: [playgroundTheme],
   plugins: [menu],
 });

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -1,22 +1,19 @@
 import { definePlugin } from "plumix/plugin";
 
-import type { MenuLocationOptions, ResolvedMenuItem } from "./server/types.js";
+import type { ResolvedMenuItem } from "./server/types.js";
 import { createMenuRouter } from "./rpc.js";
-import { recordLocation } from "./server/locations.js";
 
-// `@plumix/plugin-menu` augments the theme setup context with
-// `registerMenuLocation`, plus three core option shapes with
-// menu-eligibility flags, plus the hook registries with three menu
+// `@plumix/plugin-menu` augments the core option shapes with
+// menu-eligibility flags and the hook registries with three menu
 // hooks. TypeScript surfaces all of these only when this plugin is
-// in the project's `node_modules`. The runtime implementation of
-// `registerMenuLocation` is wired via `extendThemeContext` below;
-// the eligibility flags are read at admin time by the eligibility
-// resolver (`getEligibleMenuKinds`); the hooks are fired by
-// `getMenuByName` and `menu.save`.
+// in the project's `node_modules`. The eligibility flags are read at
+// admin time by the eligibility resolver (`getEligibleMenuKinds`);
+// the hooks are fired by `getMenuByName` and `menu.save`.
+//
+// `registerMenuLocation` is deferred — `theme.setup` was removed in
+// the theming foundation slice; a new registration path lands with
+// the menu-locations follow-up.
 declare module "plumix/plugin" {
-  interface ThemeContextExtensions {
-    registerMenuLocation: (id: string, options: MenuLocationOptions) => void;
-  }
   interface EntryTypeOptions {
     /**
      * Whether this entry type appears in the menu plugin's item picker.
@@ -86,11 +83,6 @@ const ADMIN_ENTRY_PATH = "node_modules/@plumix/plugin-menu/dist/admin/index.js";
  */
 export const menu = definePlugin("menu", {
   adminEntry: ADMIN_ENTRY_PATH,
-  provides: (ctx) => {
-    ctx.extendThemeContext("registerMenuLocation", (id, options) => {
-      recordLocation(id, options);
-    });
-  },
   setup: (ctx) => {
     ctx.registerEntryType("menu_item", {
       label: "Menu items",

--- a/packages/plugins/menu/src/server/getMenuForLocation.test.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.test.ts
@@ -156,4 +156,3 @@ describe("getMenuForLocation", () => {
     expect(a?.slug).toBe(b?.slug);
   });
 });
-

--- a/packages/plugins/menu/src/server/getMenuForLocation.test.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.test.ts
@@ -1,13 +1,6 @@
-import type {
-  AppContext,
-  PluginRegistry,
-  ThemeDescriptor,
-} from "plumix/plugin";
+import type { AppContext, PluginRegistry } from "plumix/plugin";
 import {
-  auth,
-  buildApp,
   createPluginRegistry,
-  defineTheme,
   HookRegistry,
   installPlugins,
   registerCoreLookupAdapters,
@@ -25,16 +18,6 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { menu } from "../index.js";
 import { getMenuForLocation } from "./getMenuForLocation.js";
 import { clearRegisteredLocations } from "./locations.js";
-
-function testAuth() {
-  return auth({
-    passkey: {
-      rpName: "Test",
-      rpId: "localhost",
-      origin: "http://localhost",
-    },
-  });
-}
 
 interface TestRegistryBundle {
   readonly registry: PluginRegistry;
@@ -174,104 +157,3 @@ describe("getMenuForLocation", () => {
   });
 });
 
-describe("defineTheme + registerMenuLocation integration via buildApp", () => {
-  afterEach(() => {
-    clearRegisteredLocations();
-  });
-
-  test("theme setup runs after plugin install and registers locations", async () => {
-    const blogTheme: ThemeDescriptor = defineTheme({
-      id: "blog",
-      setup: (themeCtx) => {
-        themeCtx.registerMenuLocation("primary", {
-          label: "Primary navigation",
-        });
-        themeCtx.registerMenuLocation("footer", { label: "Footer" });
-      },
-    });
-
-    const stubAdapter = {
-      name: "test",
-      buildFetchHandler: () => () => new Response("stub"),
-    };
-    const stubDatabase = {
-      kind: "test",
-      connect: () => ({ db: {} }),
-    };
-
-    await buildApp({
-      runtime: stubAdapter,
-      database: stubDatabase,
-      auth: testAuth(),
-      plugins: [menu],
-      themes: [blogTheme],
-    });
-
-    const { getRegisteredLocations } = await import("./locations.js");
-    const registered = getRegisteredLocations();
-    expect(registered.size).toBe(2);
-    expect(registered.get("primary")?.label).toBe("Primary navigation");
-    expect(registered.get("footer")?.label).toBe("Footer");
-  });
-
-  test("multiple themes' setup callbacks invoke in declared order", async () => {
-    const order: string[] = [];
-    const stubAdapter = {
-      name: "test",
-      buildFetchHandler: () => () => new Response("stub"),
-    };
-    const stubDatabase = {
-      kind: "test",
-      connect: () => ({ db: {} }),
-    };
-
-    await buildApp({
-      runtime: stubAdapter,
-      database: stubDatabase,
-      auth: testAuth(),
-      plugins: [menu],
-      themes: [
-        defineTheme({
-          id: "first",
-          setup: (themeCtx) => {
-            order.push("first");
-            themeCtx.registerMenuLocation("a", { label: "A" });
-          },
-        }),
-        defineTheme({
-          id: "second",
-          setup: (themeCtx) => {
-            order.push("second");
-            themeCtx.registerMenuLocation("b", { label: "B" });
-          },
-        }),
-      ],
-    });
-
-    expect(order).toEqual(["first", "second"]);
-  });
-
-  test("rejects duplicate theme ids in config.themes", async () => {
-    const stubAdapter = {
-      name: "test",
-      buildFetchHandler: () => () => new Response("stub"),
-    };
-    const stubDatabase = {
-      kind: "test",
-      connect: () => ({ db: {} }),
-    };
-
-    await expect(
-      buildApp({
-        runtime: stubAdapter,
-        database: stubDatabase,
-        auth: testAuth(),
-        plugins: [menu],
-        themes: [
-          defineTheme({ id: "blog", setup: () => undefined }),
-          defineTheme({ id: "blog", setup: () => undefined }),
-        ],
-      }),
-    ).rejects.toThrow(/Theme id "blog" appears more than once/);
-  });
-});

--- a/packages/plumix/src/cli/commands/migrate.test.ts
+++ b/packages/plumix/src/cli/commands/migrate.test.ts
@@ -20,7 +20,6 @@ function fakeApp(): PlumixApp {
         kind: "plumix",
         passkey: { rpName: "x", rpId: "localhost", origin: "http://x" },
       },
-      themes: [],
       plugins: [],
     },
   } as unknown as PlumixApp;

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -168,32 +168,7 @@ async function regenerate(
     config.plugins,
   );
 
-  // Per-group merge across themes — a theme adding only `colors`
-  // doesn't wipe `spacing` / `typography` from a base theme. Mirrors
-  // `mergeThemeTokens` in `buildApp` so the virtual module's CSS
-  // matches the runtime resolver's tokens.
-  let themeTokens: ThemeTokens | undefined;
-  for (const theme of config.themes) {
-    if (!theme.tokens) continue;
-    themeTokens = {
-      ...(themeTokens ?? {}),
-      ...(theme.tokens.colors !== undefined && {
-        colors: { ...(themeTokens?.colors ?? {}), ...theme.tokens.colors },
-      }),
-      ...(theme.tokens.spacing !== undefined && {
-        spacing: { ...(themeTokens?.spacing ?? {}), ...theme.tokens.spacing },
-      }),
-      ...(theme.tokens.typography !== undefined && {
-        typography: {
-          ...(themeTokens?.typography ?? {}),
-          ...theme.tokens.typography,
-        },
-      }),
-      ...(theme.tokens.border !== undefined && {
-        border: { ...(themeTokens?.border ?? {}), ...theme.tokens.border },
-      }),
-    };
-  }
+  const themeTokens: ThemeTokens | undefined = config.theme?.tokens;
 
   return {
     configPath,

--- a/packages/plumix/test/cli.test.ts
+++ b/packages/plumix/test/cli.test.ts
@@ -32,7 +32,6 @@ export default {
       origin: "http://localhost:8787",
     },
   },
-  themes: [],
   plugins: [],
 };
 `;


### PR DESCRIPTION
Closes slice 1 of the theming PRD (#491 / #493). Driven via strict TDD — one failing behavior test, minimum impl, repeat. Seventeen cycles built up the renderer package, the `defineTheme` reshape, the resolver wiring, and the integration tests proving each load-bearing behavior.

**TDD cycles in order**

1. Tracer: `GET /post/{slug}` renders via the theme's `single` template
2. Hierarchy fallback through `index` when no `single` is registered
3. Hierarchy specificity: `single-{type}` > `single` > `index`
4. `resolve:single:data` filter chain mutates data pre-render
5. `ResolvedAuthor.name` reaches templates
6. `ResolvedAuthor` is narrowed — email never reaches templates
7. Eager-loaded terms via batched join (WordPress `update_post_caches` shape)
8. Default document shell supplies doctype, lang, charset, viewport, title
9. Theme `document` override fully replaces the shell
10. React 19 metadata hoisting: template `<title>` lands in `<head>`
11. `defineTheme` throws `ThemeRegistrationError` on missing `index`
12. `buildApp` throws `ThemeRegistrationError` on missing `index`
13. `<BlockRenderer/>` renders block tree from `<PlumixProvider/>` context
14. `<BlockRenderer/>` throws outside provider
15. `useTokens()` returns provider tokens
16. `useTokens()` throws outside provider
17. (caught in sentry-review) integration test wiring `<BlockRenderer/>` through the resolver — production crash if PlumixProvider isn't wrapped around the template tree

**Breaking `defineTheme` reshape (pre-1.0)**

Before:

```ts
config.themes: ThemeDescriptor[]
ThemeDescriptor = { id, setup?, tokens? }
```

After:

```ts
config.theme?: ThemeDescriptor
ThemeDescriptor = { templates: TemplateRegistry, document?, tokens? }
TemplateRegistry = { index: TemplateComponent<TemplateData>; [key: string]: TemplateComponent<TemplateData> }
```

`id` and `setup` are gone. `templates.index` is required at the type level and at runtime; both `defineTheme` and `buildApp` throw `ThemeRegistrationError` when missing.

**Resolver pipeline (single kind)**

When a theme is configured, `resolveSingle` now:

1. Builds `{ entry: ResolvedEntry }` via two parallel Drizzle queries — one batched join for terms, one column-narrowed select for the author. No N+1; matches WordPress's `update_post_caches` shape.
2. Runs the `resolve:single:data` filter chain in registration order.
3. Walks the existing template-hierarchy candidate list against `theme.templates`, picks the first registered match (falls through to `index`).
4. Wraps the matched template in `<PlumixProvider value={{ registry }}/>` so `<BlockRenderer/>` can read its registry from context.
5. Wraps in the theme's `document` component (when supplied) or the default shell.
6. `renderToString` → prepend `<!doctype html>` → returns `Response` with `text/html; charset=utf-8`.

Theme-less call sites keep the inline-HTML output for migration; a TODO documents the removal milestone.

**Sentry review caught real issues in the same diff**

- **Production crash from missing provider wrap.** Templates using `<BlockRenderer content={data.entry.content}/>` would have thrown at render time because `resolveSingle` didn't wrap the template tree in `<PlumixProvider/>`. Added a cycle-18 integration test that reproduces it, then fixed.
- **Dead `themeExtensions` plumbing swept out.** The menu plugin's `ctx.extendThemeContext("registerMenuLocation", recordLocation)` stashed a callback that nothing invoked once `theme.setup` was gone — a silent regression for any menu consumer. Dropped `extendThemeContext` from `PluginProvidesContext`, the `themeExtensions` map from `installPlugins`, the `ThemeContextExtensions` interface, the menu plugin's augmentation + callsite, and the related tests.
- **Bug in token validation error messages.** `var(--plumix-${group.replace(/^./, "")}-...)` was stripping the first character of group names (`olors`, `pacing`, `ypography`, `order`). Fixed by removing the buggy var fragment.

**Known regression**

Menu locations registered via `theme.setup` no longer work. The menu plugin's `ThemeContextExtensions` augmentation + `extendThemeContext` callsite are removed in this commit (visible-dead is better than silent-dead). A new registration path (likely plugin-level config or admin-defined locations) lands with a follow-up against the menu plugin.

Verified: `pnpm exec turbo run typecheck test` → 49/49 tasks green workspace-wide. 1558 core tests pass, plus 4 renderer-package tests, 2 theme runtime tests, and 10 resolver integration tests.

Fixes #493
Refs #491