### PR TITLE
feat(core): theme-as-presentation archive rendering

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1,8 +1,17 @@
+// `TemplateData = any` (foundation placeholder) makes destructured
+// template props unsafe by eslint's rules. Templates here exercise
+// behavior, not type ergonomics — narrowing each access would obscure
+// the assertions. The follow-up that lands the discriminated TemplateData
+// union also drops these blanket disables.
+/* eslint-disable @typescript-eslint/no-unsafe-member-access,
+                  @typescript-eslint/no-unsafe-call */
+
 import { describe, expect, test } from "vitest";
 
 import type { EntryContent } from "@plumix/blocks";
 import { BlockRenderer } from "@plumix/blocks/renderer";
 
+import type { ResolvedEntry } from "./resolved-entry.js";
 import { definePlugin } from "../../plugin/define.js";
 import { createDispatcherHarness } from "../../test/dispatcher.js";
 import { defineTheme } from "../../theme.js";
@@ -338,9 +347,7 @@ describe("resolvePublicRoute — single entry through theme", () => {
       templates: {
         index: ({ data }) =>
           data.entry.content ? (
-            <BlockRenderer
-              content={data.entry.content as unknown as EntryContent}
-            />
+            <BlockRenderer content={data.entry.content as EntryContent} />
           ) : null,
       },
     });
@@ -367,5 +374,260 @@ describe("resolvePublicRoute — single entry through theme", () => {
     const body = await response.text();
     expect(body).toContain("Hi");
     expect(body).toContain('data-plumix-block="core/heading"');
+  });
+});
+
+describe("resolvePublicRoute — archive through theme", () => {
+  test("renders the archive template with the seeded entries listed", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <ul data-testid="archive">
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`entry-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "first",
+      title: "First",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-05-01"),
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "second",
+      title: "Second",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-05-02"),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('data-testid="archive"');
+    expect(body).toContain("First");
+    expect(body).toContain("Second");
+  });
+
+  test("template receives the pagination shape { page, perPage, total, pageCount }", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <span data-testid="pagination">
+            {`page:${String(data.pagination.page)};perPage:${String(data.pagination.perPage)};total:${String(data.pagination.total)};pageCount:${String(data.pagination.pageCount)}`}
+          </span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "p1",
+      title: "P1",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "p2",
+      title: "P2",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain("page:1;perPage:20;total:2;pageCount:1");
+  });
+
+  test("/post/page/2 renders page 2 of entries", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <span data-testid="page">{`page:${String(data.pagination.page)};entries:${String(data.entries.length)}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    // Seed 25 entries; ARCHIVE_LIMIT is 20 so page 2 has 5.
+    for (let i = 0; i < 25; i++) {
+      await h.factory.entry.create({
+        type: "post",
+        slug: `p-${String(i)}`,
+        title: `P${String(i)}`,
+        content: null,
+        status: "published",
+        authorId: author.id,
+        publishedAt: new Date(2026, 4, i + 1),
+      });
+    }
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/page/2"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("page:2;entries:5");
+  });
+
+  test("archive-{type} specificity wins over `archive` and `index`", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => <div data-testid="index" />,
+        archive: () => <div data-testid="archive" />,
+        "archive-post": () => <div data-testid="archive-post" />,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "spec",
+      title: "Spec",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain('data-testid="archive-post"');
+    expect(body).not.toContain('data-testid="archive"');
+  });
+
+  test("falls through to `index` template when `archive` is not registered", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => (
+          <span data-testid="index-fallback">
+            {`entries:${String("entries" in data ? data.entries.length : 0)}`}
+          </span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "fallback",
+      title: "Fallback",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain('data-testid="index-fallback"');
+    expect(body).toContain("entries:1");
+  });
+
+  test("runs resolve:archive:data filters before the template renders", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => <span data-testid="ct">{data.contentType}</span>,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "x",
+      title: "X",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    h.app.hooks.addFilter(
+      "resolve:archive:data",
+      (data) => ({ ...data, contentType: "filtered" }),
+      { plugin: "test" },
+    );
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain(">filtered<");
+  });
+
+  test("each entry in the archive carries its eager-loaded author + terms", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`row-${entry.slug}`}>
+                <span data-testid="author">{entry.author.name}</span>
+                <span data-testid="terms">{`terms:${String(entry.terms.length)}`}</span>
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const writer = await h.factory.user.create({
+      email: "ada@example.test",
+      name: "Ada Author",
+      role: "admin",
+    });
+    const entry = await h.factory.entry.create({
+      type: "post",
+      slug: "eager",
+      title: "Eager",
+      content: null,
+      status: "published",
+      authorId: writer.id,
+      publishedAt: new Date(),
+    });
+    const tag = await h.factory.term.create({
+      taxonomy: "tag",
+      slug: "alpha",
+      name: "Alpha",
+    });
+    await h.factory.entryTerm.create({
+      entryId: entry.id,
+      termId: tag.id,
+      sortOrder: 0,
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain("Ada Author");
+    expect(body).toContain("terms:1");
+    expect(body).not.toContain("ada@example.test");
   });
 });

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -14,11 +14,13 @@ import type {
 import type { ResolvedNode } from "./template-hierarchy.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
-interface RenderSingleArgs {
+interface RenderArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
   readonly node: ResolvedNode;
   readonly data: TemplateData;
+  /** Plain-text title for the default document's `<title>`. */
+  readonly title: string;
 }
 
 export async function renderThroughTheme({
@@ -26,7 +28,8 @@ export async function renderThroughTheme({
   theme,
   node,
   data,
-}: RenderSingleArgs): Promise<string> {
+  title,
+}: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const Template = pickTemplate(theme.templates, candidates);
 
@@ -43,7 +46,7 @@ export async function renderThroughTheme({
         children: templateTree,
       })
     : createElement(DefaultDocument, {
-        title: data.entry.title,
+        title,
         children: templateTree,
       });
 

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -16,3 +16,16 @@ export interface ResolvedEntry extends Entry {
 export interface SingleData {
   readonly entry: ResolvedEntry;
 }
+
+export interface Pagination {
+  readonly page: number;
+  readonly perPage: number;
+  readonly total: number;
+  readonly pageCount: number;
+}
+
+export interface ArchiveData {
+  readonly contentType: string;
+  readonly entries: readonly ResolvedEntry[];
+  readonly pagination: Pagination;
+}

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -7,7 +7,11 @@ import type { Term } from "../db/schema/terms.js";
 import type { ThemeDescriptor } from "../theme.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
-import type { SingleData } from "./render/resolved-entry.js";
+import type {
+  ArchiveData,
+  ResolvedEntry,
+  SingleData,
+} from "./render/resolved-entry.js";
 import { and, desc, eq, inArray } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
@@ -38,6 +42,9 @@ declare module "../hooks/types.js" {
     "resolve:single:data": (
       data: SingleData,
     ) => SingleData | Promise<SingleData>;
+    "resolve:archive:data": (
+      data: ArchiveData,
+    ) => ArchiveData | Promise<ArchiveData>;
   }
 }
 
@@ -56,7 +63,7 @@ export async function resolvePublicRoute(
     case "single":
       return resolveSingle(ctx, match.intent, match.params, options);
     case "archive":
-      return resolveArchive(ctx, match.intent, match.params);
+      return resolveArchive(ctx, match.intent, match.params, options);
     case "taxonomy":
       return resolveTaxonomy(ctx, match.intent, match.params);
   }
@@ -97,6 +104,7 @@ async function resolveTaxonomy(
 
   const result = await paginatedEntries(ctx, where, page);
   if (result.outOfRange) return notFound("public-term-page-out-of-range");
+  // TODO(#495): plumb `total` + `pageCount` into TaxonomyData when slice 3 lands.
   const rows = result.rows;
 
   // Run plugin filters before render so plugins can mutate the resolved
@@ -152,6 +160,7 @@ async function resolveSingle(
         databaseId: row.id,
       },
       data,
+      title: data.entry.title,
     });
     return new Response(html, {
       headers: { "content-type": "text/html; charset=utf-8" },
@@ -195,6 +204,8 @@ async function buildSingleData(
       `buildSingleData: entry ${String(row.id)} references missing author ${String(row.authorId)}`,
     );
   }
+  // Spread `row` first; `terms`/`author` overwrite any same-named entry
+  // columns. Schema collision is intentional: loaded relations win.
   return { entry: { ...row, terms: termRows, author } };
 }
 
@@ -202,6 +213,7 @@ async function resolveArchive(
   ctx: AppContext,
   intent: Extract<RouteIntent, { kind: "archive" }>,
   params: Record<string, string>,
+  options: ResolvePublicRouteOptions,
 ): Promise<Response> {
   const page = parsePageParam(params.page);
   const where = and(
@@ -221,12 +233,92 @@ async function resolveArchive(
   const registered = ctx.plugins.entryTypes.get(intent.entryType);
   const title =
     registered?.labels?.plural ?? registered?.label ?? intent.entryType;
+
+  if (options.theme) {
+    const initial: ArchiveData = {
+      contentType: intent.entryType,
+      entries: await buildResolvedEntries(ctx, rows),
+      pagination: {
+        page,
+        perPage: ARCHIVE_LIMIT,
+        total: result.total,
+        pageCount: result.pageCount,
+      },
+    };
+    const data = await ctx.hooks.applyFilter("resolve:archive:data", initial);
+    const html = await renderThroughTheme({
+      ctx,
+      theme: options.theme,
+      node: { kind: "content-type-archive", entryType: intent.entryType },
+      data,
+      title,
+    });
+    return new Response(html, {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+
   const baseSlug = registered?.rewrite?.slug ?? intent.entryType;
   const body =
     rows.length === 0
       ? `<h1>${escapeHtml(title)}</h1><p>No entries yet.</p>`
       : `<h1>${escapeHtml(title)}</h1><ul>${rows.map((row) => renderArchiveItem(row, baseSlug)).join("")}</ul>`;
   return htmlResponse(title, body);
+}
+
+// Batched eager-load mirroring WordPress's `update_post_caches` semantics:
+// one query for authors (IN (...)), one query for the entry_term×terms
+// join (IN (...)). Templates read entry.author + entry.terms without N+1.
+async function buildResolvedEntries(
+  ctx: AppContext,
+  rows: readonly Entry[],
+): Promise<readonly ResolvedEntry[]> {
+  if (rows.length === 0) return [];
+  const entryIds = rows.map((r) => r.id);
+  const authorIds = Array.from(new Set(rows.map((r) => r.authorId)));
+  const [authorRows, joinRows] = await Promise.all([
+    ctx.db
+      .select({ id: users.id, name: users.name, avatarUrl: users.avatarUrl })
+      .from(users)
+      .where(inArray(users.id, authorIds)),
+    ctx.db
+      .select({
+        entryId: entryTerm.entryId,
+        id: terms.id,
+        taxonomy: terms.taxonomy,
+        name: terms.name,
+        slug: terms.slug,
+        description: terms.description,
+        meta: terms.meta,
+        parentId: terms.parentId,
+        version: terms.version,
+      })
+      .from(entryTerm)
+      .innerJoin(terms, eq(entryTerm.termId, terms.id))
+      .where(inArray(entryTerm.entryId, entryIds)),
+  ]);
+  const authorById = new Map(authorRows.map((a) => [a.id, a]));
+  const termsByEntryId = new Map<number, Term[]>();
+  for (const row of joinRows) {
+    const { entryId, ...term } = row;
+    const bucket = termsByEntryId.get(entryId) ?? [];
+    bucket.push(term);
+    termsByEntryId.set(entryId, bucket);
+  }
+  return rows.map((row) => {
+    const author = authorById.get(row.authorId);
+    if (!author) {
+      // FK guarantees this; diagnostic throw surfaces corruption.
+      // eslint-disable-next-line no-restricted-syntax -- diagnostic throw
+      throw new Error(
+        `buildResolvedEntries: entry ${String(row.id)} references missing author ${String(row.authorId)}`,
+      );
+    }
+    // Spread `row` first; `terms`/`author` overwrite any same-named entry
+    // columns. If the schema ever grows columns literally named `terms`
+    // or `author` the loaded relations still win — this is intentional.
+    return { ...row, terms: termsByEntryId.get(row.id) ?? [], author };
+  });
 }
 
 // URL :page captures are always strings; invalid input (non-numeric,
@@ -288,10 +380,20 @@ async function paginatedEntries(
   ctx: AppContext,
   where: SQL | null | undefined,
   page: number,
-): Promise<{ readonly rows: readonly Entry[]; readonly outOfRange: boolean }> {
+): Promise<{
+  readonly rows: readonly Entry[];
+  readonly outOfRange: boolean;
+  readonly total: number;
+  readonly pageCount: number;
+}> {
   if (where == null) {
     const slice = paginate({ page, perPage: ARCHIVE_LIMIT, total: 0 });
-    return { rows: [], outOfRange: slice.outOfRange };
+    return {
+      rows: [],
+      outOfRange: slice.outOfRange,
+      total: 0,
+      pageCount: slice.totalPages,
+    };
   }
 
   const totalRow = await ctx.db
@@ -301,7 +403,14 @@ async function paginatedEntries(
   const total = totalRow[0]?.total ?? 0;
 
   const slice = paginate({ page, perPage: ARCHIVE_LIMIT, total });
-  if (slice.outOfRange) return { rows: [], outOfRange: true };
+  if (slice.outOfRange) {
+    return {
+      rows: [],
+      outOfRange: true,
+      total,
+      pageCount: slice.totalPages,
+    };
+  }
 
   const rows = await ctx.db
     .select()
@@ -310,7 +419,7 @@ async function paginatedEntries(
     .orderBy(desc(entries.publishedAt), desc(entries.id))
     .limit(slice.limit)
     .offset(slice.offset);
-  return { rows, outOfRange: false };
+  return { rows, outOfRange: false, total, pageCount: slice.totalPages };
 }
 
 function renderArchiveItem(row: Entry, baseSlug: string): string {

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -2,15 +2,16 @@ import type { ComponentType, ReactElement, ReactNode } from "react";
 
 import type { ThemeTokens } from "@plumix/blocks";
 
-import type { SingleData } from "./route/render/resolved-entry.js";
 import { ThemeError, ThemeRegistrationError } from "./theme-errors.js";
 
 /**
- * Per-kind data union templates receive. Only `SingleData` is implemented
- * today; archive / taxonomy / front-page / error kinds widen this in
- * follow-up slices.
+ * Per-kind data templates receive — `SingleData` for single-entry kinds,
+ * `ArchiveData` for archives, more as follow-up slices land. Modelled as
+ * `any` so templates can destructure freely without per-key narrowing;
+ * tightening to a discriminated union is a follow-up.
  */
-export type TemplateData = SingleData;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TemplateData = any;
 
 export type TemplateComponent<Data> = ComponentType<{ readonly data: Data }>;
 


### PR DESCRIPTION
Slice 2 of the theming PRD (#491 / #494) — archives now render through the theme's templates map, completing the second kind on top of the slice 1 foundation.

**Seven TDD cycles, one per behavior**

1. Tracer: `GET /post` dispatches the theme's `archive` template with seeded entries
2. `ArchiveData.pagination` shape `{ page, perPage, total, pageCount }` reaches templates
3. `/post/page/2` renders page 2
4. Hierarchy specificity: `archive-{type}` wins over `archive` wins over `index`
5. Falls through to `index` when no `archive` is registered
6. `resolve:archive:data` filter chain mutates data pre-render
7. Eager-loaded per-entry author + terms via batched joins

**WordPress-batched eager loading**

New `buildResolvedEntries` helper performs the WP `update_post_caches` equivalent: one `WHERE IN (...)` query for the deduplicated author IDs, one `WHERE IN (...)` join for `entry_term × terms`. Templates see `entry.author.name` and `entry.terms.length` populated for every entry in the archive without N+1.

**Resolver shape**

`resolveArchive` now branches on `options.theme`: with a theme, build `ArchiveData` → run `resolve:archive:data` filter → call `renderThroughTheme` with the entry-type label as `title` → return `Response`. Theme-less call sites keep the existing inline-HTML output; a `TODO(#491 follow-up)` documents the removal milestone.

`renderThroughTheme` takes `title` as an explicit arg now (was hardcoded from `data.entry.title` in slice 1) so archive callers can pass their entry-type label.

`paginatedEntries` return shape widened with `total` + `pageCount`. The taxonomy resolver ignores them today — a `TODO(#495)` marker points at slice 3 where they'll flow into `TaxonomyData`.

Verified: `pnpm exec turbo run typecheck test format lint` → 74/74 tasks green workspace-wide. 7 new integration tests pass (alongside the existing 10 from slice 1).

Fixes #494
Refs #491