### PR TITLE
feat(core): theme-as-presentation taxonomy rendering + resolve:term:data hook

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -631,3 +631,311 @@ describe("resolvePublicRoute — archive through theme", () => {
     expect(body).not.toContain("ada@example.test");
   });
 });
+
+const topicPlugin = definePlugin("blog-topic", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+  ctx.registerTermTaxonomy("topic", {
+    label: "Topics",
+    labels: { singular: "Topic" },
+    entryTypes: ["post"],
+    isHierarchical: false,
+  });
+});
+
+const categoryPlugin = definePlugin("blog-category", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+  ctx.registerTermTaxonomy("category", {
+    label: "Categories",
+    labels: { singular: "Category" },
+    entryTypes: ["post"],
+    isHierarchical: false,
+  });
+  ctx.registerTermTaxonomy("tag", {
+    label: "Tags",
+    labels: { singular: "Tag" },
+    entryTypes: ["post"],
+    isHierarchical: false,
+  });
+});
+
+describe("resolvePublicRoute — taxonomy through theme", () => {
+  test("renders the taxonomy template with the term + its entries", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        taxonomy: ({ data }) => (
+          <section data-testid="taxonomy">
+            <h1 data-testid="term-name">{data.term.name}</h1>
+            <ul>
+              {data.entries.map((entry: ResolvedEntry) => (
+                <li key={entry.id}>{entry.title}</li>
+              ))}
+            </ul>
+          </section>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [topicPlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.term.create({
+      taxonomy: "topic",
+      slug: "news",
+      name: "News",
+    });
+    const a = await h.factory.entry.create({
+      type: "post",
+      slug: "story-a",
+      title: "Story A",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entryTerm.create({
+      entryId: a.id,
+      termId: term.id,
+      sortOrder: 0,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/topic/news"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('data-testid="taxonomy"');
+    expect(body).toContain('data-testid="term-name"');
+    expect(body).toContain("News");
+    expect(body).toContain("Story A");
+  });
+
+  test("renders built-in `category` template via the category-* hierarchy", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        category: ({ data }) => (
+          <div data-testid="category">{data.term.name}</div>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [categoryPlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    const cat = await h.factory.term.create({
+      taxonomy: "category",
+      slug: "biz",
+      name: "Biz",
+    });
+    const post = await h.factory.entry.create({
+      type: "post",
+      slug: "biz-1",
+      title: "Biz 1",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entryTerm.create({
+      entryId: post.id,
+      termId: cat.id,
+      sortOrder: 0,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/category/biz"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="category"');
+    expect(body).toContain("Biz");
+  });
+
+  test("/topic/{slug}/page/2 renders page 2 of entries", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        taxonomy: ({ data }) => (
+          <span data-testid="page">{`page:${String(data.pagination.page)};entries:${String(data.entries.length)}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [topicPlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.term.create({
+      taxonomy: "topic",
+      slug: "page-tax",
+      name: "PageTax",
+    });
+    for (let i = 0; i < 22; i++) {
+      const e = await h.factory.entry.create({
+        type: "post",
+        slug: `e-${String(i)}`,
+        title: `E${String(i)}`,
+        content: null,
+        status: "published",
+        authorId: author.id,
+        publishedAt: new Date(2026, 4, i + 1),
+      });
+      await h.factory.entryTerm.create({
+        entryId: e.id,
+        termId: term.id,
+        sortOrder: i,
+      });
+    }
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/topic/page-tax/page/2"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("page:2;entries:2");
+  });
+
+  test("runs resolve:term:data filters before the template renders", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        taxonomy: ({ data }) => (
+          <span data-testid="name">{data.term.name}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [topicPlugin],
+      theme,
+    });
+    await h.factory.term.create({
+      taxonomy: "topic",
+      slug: "filtered",
+      name: "Original",
+    });
+
+    h.app.hooks.addFilter(
+      "resolve:term:data",
+      (data) => ({
+        ...data,
+        term: { ...data.term, name: "Filtered" },
+      }),
+      { plugin: "test" },
+    );
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/topic/filtered"),
+    );
+    const body = await response.text();
+    expect(body).toContain("Filtered");
+    expect(body).not.toContain("Original");
+  });
+
+  test("each entry in the taxonomy carries eager-loaded author + terms", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        taxonomy: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id}>
+                <span data-testid="author">{entry.author.name}</span>
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [topicPlugin],
+      theme,
+    });
+    const writer = await h.factory.user.create({
+      email: "secret@example.test",
+      name: "Public Writer",
+      role: "admin",
+    });
+    const term = await h.factory.term.create({
+      taxonomy: "topic",
+      slug: "eager",
+      name: "Eager",
+    });
+    const post = await h.factory.entry.create({
+      type: "post",
+      slug: "p",
+      title: "P",
+      content: null,
+      status: "published",
+      authorId: writer.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entryTerm.create({
+      entryId: post.id,
+      termId: term.id,
+      sortOrder: 0,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/topic/eager"),
+    );
+    const body = await response.text();
+    expect(body).toContain("Public Writer");
+    expect(body).not.toContain("secret@example.test");
+  });
+
+  test("built-in `tag` template via the tag-* hierarchy mirrors `category`", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        tag: ({ data }) => <div data-testid="tag">{data.term.name}</div>,
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [categoryPlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    const t = await h.factory.term.create({
+      taxonomy: "tag",
+      slug: "feature",
+      name: "Feature",
+    });
+    const post = await h.factory.entry.create({
+      type: "post",
+      slug: "tagged",
+      title: "Tagged",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entryTerm.create({
+      entryId: post.id,
+      termId: t.id,
+      sortOrder: 0,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/tag/feature"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="tag"');
+    expect(body).toContain("Feature");
+  });
+});

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -29,3 +29,10 @@ export interface ArchiveData {
   readonly entries: readonly ResolvedEntry[];
   readonly pagination: Pagination;
 }
+
+export interface TaxonomyData {
+  readonly taxonomy: string;
+  readonly term: Term;
+  readonly entries: readonly ResolvedEntry[];
+  readonly pagination: Pagination;
+}

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -11,6 +11,7 @@ import type {
   ArchiveData,
   ResolvedEntry,
   SingleData,
+  TaxonomyData,
 } from "./render/resolved-entry.js";
 import { and, desc, eq, inArray } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
@@ -36,6 +37,12 @@ interface ResolvedTaxonomyData {
 
 declare module "../hooks/types.js" {
   interface FilterRegistry {
+    /**
+     * @deprecated since slice 3 of #491. Fires only on the theme-less
+     * fallback path and receives raw `Entry[]`, not eager-loaded
+     * `ResolvedEntry[]`. Migrate to `resolve:term:data` when the
+     * resolver is rendering through a theme.
+     */
     "resolve:taxonomy:data": (
       data: ResolvedTaxonomyData,
     ) => ResolvedTaxonomyData | Promise<ResolvedTaxonomyData>;
@@ -45,6 +52,9 @@ declare module "../hooks/types.js" {
     "resolve:archive:data": (
       data: ArchiveData,
     ) => ArchiveData | Promise<ArchiveData>;
+    "resolve:term:data": (
+      data: TaxonomyData,
+    ) => TaxonomyData | Promise<TaxonomyData>;
   }
 }
 
@@ -65,7 +75,7 @@ export async function resolvePublicRoute(
     case "archive":
       return resolveArchive(ctx, match.intent, match.params, options);
     case "taxonomy":
-      return resolveTaxonomy(ctx, match.intent, match.params);
+      return resolveTaxonomy(ctx, match.intent, match.params, options);
   }
 }
 
@@ -73,6 +83,7 @@ async function resolveTaxonomy(
   ctx: AppContext,
   intent: Extract<RouteIntent, { kind: "taxonomy" }>,
   params: Record<string, string>,
+  options: ResolvePublicRouteOptions,
 ): Promise<Response> {
   // Same dispatch as resolveSingle: `:path+` rules surface params.path
   // (multi-segment), flat `:term` rules surface params.term.
@@ -104,8 +115,37 @@ async function resolveTaxonomy(
 
   const result = await paginatedEntries(ctx, where, page);
   if (result.outOfRange) return notFound("public-term-page-out-of-range");
-  // TODO(#495): plumb `total` + `pageCount` into TaxonomyData when slice 3 lands.
   const rows = result.rows;
+
+  if (options.theme) {
+    const initial: TaxonomyData = {
+      taxonomy: intent.taxonomy,
+      term,
+      entries: await buildResolvedEntries(ctx, rows),
+      pagination: {
+        page,
+        perPage: ARCHIVE_LIMIT,
+        total: result.total,
+        pageCount: result.pageCount,
+      },
+    };
+    const data = await ctx.hooks.applyFilter("resolve:term:data", initial);
+    const html = await renderThroughTheme({
+      ctx,
+      theme: options.theme,
+      node: {
+        kind: "term",
+        taxonomy: intent.taxonomy,
+        slug: term.slug,
+        databaseId: term.id,
+      },
+      data,
+      title: taxonomy?.labels?.singular ?? taxonomy?.label ?? term.name,
+    });
+    return new Response(html, {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
 
   // Run plugin filters before render so plugins can mutate the resolved
   // shape (drop entries, append plugin-contributed fields, etc.) without


### PR DESCRIPTION
Slice 3 of the theming PRD (#491 / #495) — taxonomy archives now render through the theme's templates map, completing the third kind on top of slices 1 and 2.

**Six TDD cycles**

1. Tracer: `GET /topic/{slug}` dispatches the theme's `taxonomy` template with term + entries
2. Built-in `category-*` hierarchy: `category` template wins for `category` taxonomy
3. `/topic/{slug}/page/2` pagination
4. `resolve:term:data` filter chain mutates pre-render
5. Per-entry eager-loaded author + terms (reuses `buildResolvedEntries`)
6. `tag-*` hierarchy parity — second built-in alias chain works the same way

**Filter hook rename (sort of)**

`resolve:term:data` is the new symmetric counterpart to `resolve:single:data` / `resolve:archive:data`. It carries `TaxonomyData = { taxonomy, term, entries: ResolvedEntry[], pagination }`.

The original `resolve:taxonomy:data` is kept JSDoc-deprecated. It still fires on the theme-less fallback path with the legacy `{ taxonomy, term, entries: Entry[] }` shape (no eager-load, no pagination) — same path that's been there since before slice 1. Removing it is queued with the theme-less fallback retirement when all consumers ship a theme.

**Sentry-review fixes folded in**

- Collapsed four per-test plugin definitions to two module-level fixtures (`topicPlugin` + `categoryPlugin`).
- Sharpened the deprecation JSDoc to call out the shape divergence between the legacy and new hooks.
- Added a `tag` parity test alongside `category` so the WP-style alias contract is locked in for both.

Verified: `pnpm exec turbo run typecheck test format lint` → 74/74 tasks green workspace-wide. 6 new integration tests pass (alongside the 17 from slices 1+2).

Fixes #495
Refs #491