### PR TITLE
feat(core): theme-as-presentation front-page rendering at /

### DIFF
--- a/packages/core/src/route/intent.ts
+++ b/packages/core/src/route/intent.ts
@@ -10,7 +10,8 @@
 export type RouteIntent =
   | { readonly kind: "single"; readonly entryType: string }
   | { readonly kind: "archive"; readonly entryType: string }
-  | { readonly kind: "taxonomy"; readonly taxonomy: string };
+  | { readonly kind: "taxonomy"; readonly taxonomy: string }
+  | { readonly kind: "front-page" };
 
 /**
  * Compiled rule. `priority` preserves arch-doc ordering semantics — lower

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -939,3 +939,42 @@ describe("resolvePublicRoute — taxonomy through theme", () => {
     expect(body).toContain("Feature");
   });
 });
+
+describe("resolvePublicRoute — front-page through theme", () => {
+  test("renders the front-page template with the latest entries at /", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": ({ data }) => (
+          <section data-testid="front-page">
+            <ul>
+              {data.entries.map((entry: ResolvedEntry) => (
+                <li key={entry.id} data-testid={`row-${entry.slug}`}>
+                  {entry.title}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "latest",
+      title: "Latest",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('data-testid="front-page"');
+    expect(body).toContain("Latest");
+  });
+});

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -36,3 +36,8 @@ export interface TaxonomyData {
   readonly entries: readonly ResolvedEntry[];
   readonly pagination: Pagination;
 }
+
+export interface FrontPageData {
+  readonly entries: readonly ResolvedEntry[];
+  readonly pagination: Pagination;
+}

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -9,6 +9,7 @@ import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
 import type {
   ArchiveData,
+  FrontPageData,
   ResolvedEntry,
   SingleData,
   TaxonomyData,
@@ -55,6 +56,9 @@ declare module "../hooks/types.js" {
     "resolve:term:data": (
       data: TaxonomyData,
     ) => TaxonomyData | Promise<TaxonomyData>;
+    "resolve:front-page:data": (
+      data: FrontPageData,
+    ) => FrontPageData | Promise<FrontPageData>;
   }
 }
 
@@ -76,7 +80,44 @@ export async function resolvePublicRoute(
       return resolveArchive(ctx, match.intent, match.params, options);
     case "taxonomy":
       return resolveTaxonomy(ctx, match.intent, match.params, options);
+    case "front-page":
+      return resolveFrontPage(ctx, options);
   }
+}
+
+async function resolveFrontPage(
+  ctx: AppContext,
+  options: ResolvePublicRouteOptions,
+): Promise<Response> {
+  // The dispatcher only synthesizes the front-page intent when a theme
+  // is configured. The `if (options.theme)` guard is defensive — a
+  // direct caller bypassing the dispatcher would 500 instead of crashing.
+  if (!options.theme) return notFound("public-route-not-found");
+
+  const page = 1;
+  const where = eq(entries.status, "published");
+  const result = await paginatedEntries(ctx, where, page);
+
+  const initial: FrontPageData = {
+    entries: await buildResolvedEntries(ctx, result.rows),
+    pagination: {
+      page,
+      perPage: ARCHIVE_LIMIT,
+      total: result.total,
+      pageCount: result.pageCount,
+    },
+  };
+  const data = await ctx.hooks.applyFilter("resolve:front-page:data", initial);
+  const html = await renderThroughTheme({
+    ctx,
+    theme: options.theme,
+    node: { kind: "front-page" },
+    data,
+    title: "Home",
+  });
+  return new Response(html, {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
 }
 
 async function resolveTaxonomy(

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -6,7 +6,10 @@ import { createDispatcherHarness, plumixRequest } from "../test/dispatcher.js";
 import { matchPluginRawRoute } from "./dispatcher.js";
 
 describe("dispatcher — routing", () => {
-  test("public / 404s when no plugin claims it", async () => {
+  test("public / 404s when no theme is configured", async () => {
+    // `/` only synthesizes a front-page match when a theme is configured;
+    // otherwise the resolver has no template to render through, so the
+    // dispatcher falls back to the standard "no rule claimed it" 404.
     const h = await createDispatcherHarness();
     const response = await h.dispatch(new Request("https://cms.example/"));
     expect(response.status).toBe(404);

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -172,8 +172,22 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   }
 
   const match = matchRoute(url, app.routeMap);
-  if (match === null) return notFound("public-route-not-found");
-  return resolvePublicRoute(ctx, match, { theme: app.config.theme });
+  if (match !== null) {
+    return resolvePublicRoute(ctx, match, { theme: app.config.theme });
+  }
+  // `/` doesn't compile into the rule map; plugins can register
+  // `registerRewriteRule({ pattern: "/", ... })` which would have matched
+  // above. With a theme configured we synthesize the front-page intent
+  // so the default homepage flows through the resolver. Without a theme
+  // there's nothing to render — fall through to the 404.
+  if (url.pathname === "/" && app.config.theme) {
+    return resolvePublicRoute(
+      ctx,
+      { intent: { kind: "front-page" }, params: {} },
+      { theme: app.config.theme },
+    );
+  }
+  return notFound("public-route-not-found");
 }
 
 interface PluginRawRouteMatch {


### PR DESCRIPTION
Slice 4 of the theming PRD (#491 / #496) — the default homepage now flows through the resolver and into the theme's templates map.

**TDD cycle (single tracer + filter coverage from earlier slices)**

`GET /` with a theme registering a `front-page` template dispatches the resolver, which builds `FrontPageData = { entries, pagination }` from the latest published entries (across all entry types), runs the new `resolve:front-page:data` filter chain, and renders through the theme. Eager-loaded author + terms come from the same `buildResolvedEntries` helper archives and taxonomies use.

**Dispatcher synthesis, not a compiled rule**

The route map intentionally has no rule for `/`. The dispatcher synthesizes the front-page intent when `matchRoute` returns null AND a theme is configured — this keeps the existing "no plugin claimed `/` → 404" behavior intact for theme-less deployments (the CF adapter tests rely on it) without forcing all consumers to register a rule.

A plugin can still override with `registerRewriteRule({ pattern: "/", ... })` — that compiles into the regular path with regular priority and takes precedence over the synthesized front-page.

**Out of scope (deferred)**

Designated-entry-as-homepage (the "show a specific page at `/`" case) requires the settings follow-up to ship — operators need somewhere to pick the designated entry. The default behavior in this slice is latest-entries, matching what the master PRD specs.

Verified: `pnpm exec turbo run typecheck test format lint` → 74/74 tasks green workspace-wide. 24 integration tests now cover single + archive + taxonomy + front-page.

Fixes #496
Refs #491