### PR TITLE
feat(core): theme-as-presentation 404 + 500 error rendering

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -978,3 +978,116 @@ describe("resolvePublicRoute — front-page through theme", () => {
     expect(body).toContain("Latest");
   });
 });
+
+describe("resolvePublicRoute — error pages through theme", () => {
+  test("registered `404` template renders for an unmatched URL", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "404": ({ data }) => (
+          <main data-testid="four-oh-four">
+            <h1>Page missing</h1>
+            <code data-testid="hint">{data.hint ?? ""}</code>
+          </main>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/never-existed"),
+    );
+    expect(response.status).toBe(404);
+    const body = await response.text();
+    expect(body).toContain('data-testid="four-oh-four"');
+    expect(body).toContain("Page missing");
+  });
+
+  test("built-in 404 default renders when the theme has no `404` template", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/never-existed"),
+    );
+    expect(response.status).toBe(404);
+    const body = await response.text();
+    // Sanity: it's the built-in shell, not an empty 404.
+    expect(body).toContain("<!doctype html>");
+    expect(body).toContain("Not Found");
+  });
+
+  test("theme template that throws renders the `500` template + 500 status", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: () => {
+          throw new Error("kaboom-secret-payload");
+        },
+        "500": ({ data }) => (
+          <main data-testid="five-oh-oh">
+            <h1>Server error</h1>
+            <p data-testid="hint">{data.hint ?? ""}</p>
+          </main>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "boom",
+      title: "Boom",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/boom"),
+    );
+    expect(response.status).toBe(500);
+    const body = await response.text();
+    expect(body).toContain('data-testid="five-oh-oh"');
+    // Internal error text must never leak to clients.
+    expect(body).not.toContain("kaboom-secret-payload");
+  });
+
+  test("built-in 500 default renders when the theme has no `500` template", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: () => {
+          throw new Error("kaboom-different-payload");
+        },
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "boom2",
+      title: "Boom2",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/boom2"),
+    );
+    expect(response.status).toBe(500);
+    const body = await response.text();
+    expect(body).toContain("<!doctype html>");
+    expect(body).toContain("Internal Server Error");
+    expect(body).not.toContain("kaboom-different-payload");
+  });
+});

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -11,6 +11,7 @@ import type {
   TemplateRegistry,
   ThemeDescriptor,
 } from "../../theme.js";
+import type { NotFoundData, ServerErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -32,7 +33,51 @@ export async function renderThroughTheme({
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const Template = pickTemplate(theme.templates, candidates);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TemplateData placeholder
+  return renderTree({ ctx, theme, data, title, Template });
+}
 
+interface RenderErrorArgs {
+  readonly ctx: AppContext;
+  readonly theme: ThemeDescriptor;
+  readonly kind: "not-found" | "server-error";
+  readonly data: NotFoundData | ServerErrorData;
+}
+
+export function renderErrorThroughTheme({
+  ctx,
+  theme,
+  kind,
+  data,
+}: RenderErrorArgs): string {
+  const key = kind === "not-found" ? "404" : "500";
+  const fallbackTitle =
+    kind === "not-found" ? "Not Found" : "Internal Server Error";
+  const Template = theme.templates[key] ?? defaultErrorTemplateFor(kind);
+  return renderTree({
+    ctx,
+    theme,
+    data,
+    title: fallbackTitle,
+    Template,
+  });
+}
+
+interface RenderTreeArgs {
+  readonly ctx: AppContext;
+  readonly theme: ThemeDescriptor;
+  readonly data: TemplateData;
+  readonly title: string;
+  readonly Template: TemplateComponent<TemplateData>;
+}
+
+function renderTree({
+  ctx,
+  theme,
+  data,
+  title,
+  Template,
+}: RenderTreeArgs): string {
   const templateTree: ReactNode = createElement(PlumixProvider, {
     value: { registry: ctx.blocks },
     children: createElement(Template, { data }),
@@ -80,5 +125,30 @@ function DefaultDocument({
       </head>
       <body>{children}</body>
     </html>
+  );
+}
+
+function defaultErrorTemplateFor(
+  kind: "not-found" | "server-error",
+): TemplateComponent<TemplateData> {
+  if (kind === "not-found") return DefaultNotFound;
+  return DefaultServerError;
+}
+
+function DefaultNotFound() {
+  return (
+    <main>
+      <h1>Not Found</h1>
+      <p>The page you're looking for doesn't exist.</p>
+    </main>
+  );
+}
+
+function DefaultServerError() {
+  return (
+    <main>
+      <h1>Internal Server Error</h1>
+      <p>Something went wrong while rendering this page.</p>
+    </main>
   );
 }

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -41,3 +41,15 @@ export interface FrontPageData {
   readonly entries: readonly ResolvedEntry[];
   readonly pagination: Pagination;
 }
+
+/** Sanitised — never includes the raw Error or stack trace. */
+export interface NotFoundData {
+  readonly request: Request;
+  readonly hint?: string;
+}
+
+/** Sanitised — never includes the raw Error or stack trace. */
+export interface ServerErrorData {
+  readonly request: Request;
+  readonly hint?: string;
+}

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -27,6 +27,7 @@ import {
 } from "../auth/passkey/routes.js";
 import { withUser } from "../context/app.js";
 import { matchRoute } from "../route/match.js";
+import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
 import { forbidden, jsonResponse, methodNotAllowed, notFound } from "./http.js";
 
@@ -171,6 +172,62 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
     return methodNotAllowed(["GET", "HEAD"]);
   }
 
+  return dispatchPublicRoute(app, ctx, url);
+}
+
+async function dispatchPublicRoute(
+  app: PlumixApp,
+  ctx: AppContext,
+  url: URL,
+): Promise<Response> {
+  const theme = app.config.theme;
+  try {
+    const response = await resolvePublicRouteOrFallback(app, ctx, url);
+    if (response.status === 404 && theme) {
+      const html = renderErrorThroughTheme({
+        ctx,
+        theme,
+        kind: "not-found",
+        data: {
+          request: ctx.request,
+          hint: response.headers.get("x-plumix-hint") ?? undefined,
+        },
+      });
+      return new Response(html, {
+        status: 404,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+    return response;
+  } catch (err) {
+    ctx.logger.error("dispatch_failed", {
+      url: url.href,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    if (!theme) {
+      return new Response("Internal Server Error", {
+        status: 500,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+    const html = renderErrorThroughTheme({
+      ctx,
+      theme,
+      kind: "server-error",
+      data: { request: ctx.request },
+    });
+    return new Response(html, {
+      status: 500,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+}
+
+async function resolvePublicRouteOrFallback(
+  app: PlumixApp,
+  ctx: AppContext,
+  url: URL,
+): Promise<Response> {
   const match = matchRoute(url, app.routeMap);
   if (match !== null) {
     return resolvePublicRoute(ctx, match, { theme: app.config.theme });


### PR DESCRIPTION
Slice 5 of the theming PRD (#491 / #497) — error responses now flow through the theme's templates when available, with framework defaults as the fallback.

**TDD cycles**

1. Theme-registered `404` template renders for an unmatched URL
2. Built-in 404 default kicks in when the theme has no `404`
3. A throwing template returns 500 with the theme's `500`
4. Built-in 500 default kicks in when the theme has no `500`

**Dispatcher wraps the public-route path**

The public-route portion of `dispatcher.route()` now lives inside a `try` with a 404-status interception. On 404 with a theme configured, the dispatcher re-renders through `renderErrorThroughTheme`, threading the `x-plumix-hint` header (set by `notFound(hint)`) into `NotFoundData.hint` so theme authors can branch on the reason. On an uncaught exception the dispatcher logs server-side and renders the 500 path.

Without a theme the old plaintext fallbacks survive — same shape the CF adapter tests depend on (`/` 404s, exceptions return 500 text). The change is additive for theme-less deployments.

**No raw error in responses**

`ServerErrorData = { request, hint? }` — no Error object, no stack trace, no internal message. The cycle-3 test seeds a template that throws `Error("kaboom-secret-payload")` and asserts the literal string is absent from the response body. Same for the built-in default in cycle 4.

**Built-in defaults**

`DefaultNotFound` and `DefaultServerError` are React components inside `render-template.tsx`. They render through the same `renderTree` helper used for regular kinds — so PlumixProvider context, theme's `document` override, and React 19 metadata hoisting all behave consistently.

Verified: `pnpm exec turbo run typecheck test format lint` → 74/74 tasks green workspace-wide. 4 new integration tests pass (alongside the 24 from slices 1-4).

Fixes #497
Refs #491