### PR TITLE
test(core): pin children-position guarantee on theme document override

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -298,6 +298,52 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain("custom-doc");
   });
 
+  test("`document` override positions children inside the supplied body wrapper", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: ({ data }) => (
+          <div data-testid="template-payload">{data.entry.title}</div>
+        ),
+      },
+      document: ({ children }) => (
+        <html lang="en">
+          <head>
+            <title>doc</title>
+          </head>
+          <body>
+            <header data-testid="doc-chrome-before">chrome-before</header>
+            {children}
+            <footer data-testid="doc-chrome-after">chrome-after</footer>
+          </body>
+        </html>
+      ),
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "positioned",
+      title: "Positioned",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/positioned"),
+    );
+    const body = await response.text();
+    // Order: chrome-before → template payload → chrome-after.
+    const beforeIdx = body.indexOf("chrome-before");
+    const payloadIdx = body.indexOf("Positioned");
+    const afterIdx = body.indexOf("chrome-after");
+    expect(beforeIdx).toBeGreaterThan(-1);
+    expect(payloadIdx).toBeGreaterThan(beforeIdx);
+    expect(afterIdx).toBeGreaterThan(payloadIdx);
+  });
+
   test("react 19 metadata hoisting: template-rendered <title> lands in <head>", async () => {
     const theme = defineTheme({
       templates: {


### PR DESCRIPTION
Closes slice 6 of the theming PRD (#491 / #498). Most of the surface — `ThemeDocument` type, `defineTheme.document?`, the `DefaultDocument` fallback, React 19 metadata hoisting — landed in slice 1's foundation commit. This PR pins the one acceptance criterion that wasn't yet asserted explicitly.

**One focused integration test**

The new test wraps the rendered template tree with a `<header>` + `<footer>` inside the theme's document override, then asserts the rendered HTML positions them in order: `chrome-before → template payload → chrome-after`. A future regression that emits children at the wrong position (or wraps them in extra markup that disrupts the order) fails here.

**Already covered by slice 1's tests**

- `ThemeDocument` type definition + export
- `defineTheme` accepts optional `document` field
- Default document shell (doctype + html/head/body with charset/viewport/title)
- Override replaces the shell (`<html lang="fr">` + body class)
- React 19 metadata hoisting (`<title>` rendered in the body tree lands in `<head>`)

So this PR is just the one missing pin. The implementation surface is unchanged.

Verified: `pnpm exec turbo run typecheck test format lint` → 74/74 tasks green workspace-wide. 29 integration tests now cover single + archive + taxonomy + front-page + errors + document-children-position.

Fixes #498
Refs #491