### PR TITLE
fix(core): close public-route leaks + harden themed error rendering

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -850,13 +850,14 @@ describe("resolvePublicRoute — taxonomy through theme", () => {
         publishedAt: null,
       })
       .returning();
+    if (!nullDated) throw new Error("insert returned no row");
     await h.factory.entryTerm.create({
       entryId: kept.id,
       termId: term.id,
       sortOrder: 0,
     });
     await h.factory.entryTerm.create({
-      entryId: nullDated!.id,
+      entryId: nullDated.id,
       termId: term.id,
       sortOrder: 1,
     });
@@ -1247,17 +1248,15 @@ describe("resolvePublicRoute — front-page through theme", () => {
     });
     // Side-step the factory's publishedAt coercion: insert directly so
     // `status: "published"` survives alongside an explicit null timestamp.
-    await h.db
-      .insert(entriesTable)
-      .values({
-        type: "post",
-        slug: "no-date",
-        title: "No Date",
-        content: null,
-        status: "published",
-        authorId: author.id,
-        publishedAt: null,
-      });
+    await h.db.insert(entriesTable).values({
+      type: "post",
+      slug: "no-date",
+      title: "No Date",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: null,
+    });
 
     const response = await h.dispatch(new Request("https://cms.example/"));
     const body = await response.text();

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -12,6 +12,7 @@ import type { EntryContent } from "@plumix/blocks";
 import { BlockRenderer } from "@plumix/blocks/renderer";
 
 import type { ResolvedEntry } from "./resolved-entry.js";
+import { entries as entriesTable } from "../../db/schema/entries.js";
 import { definePlugin } from "../../plugin/define.js";
 import { createDispatcherHarness } from "../../test/dispatcher.js";
 import { defineTheme } from "../../theme.js";
@@ -298,7 +299,7 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain("custom-doc");
   });
 
-  test("`document` override positions children inside the supplied body wrapper", async () => {
+  test("`document` override renders children between header and footer", async () => {
     const theme = defineTheme({
       templates: {
         index: ({ data }) => (
@@ -311,9 +312,9 @@ describe("resolvePublicRoute — single entry through theme", () => {
             <title>doc</title>
           </head>
           <body>
-            <header data-testid="doc-chrome-before">chrome-before</header>
+            <header>chrome-before</header>
             {children}
-            <footer data-testid="doc-chrome-after">chrome-after</footer>
+            <footer>chrome-after</footer>
           </body>
         </html>
       ),
@@ -335,13 +336,9 @@ describe("resolvePublicRoute — single entry through theme", () => {
       new Request("https://cms.example/post/positioned"),
     );
     const body = await response.text();
-    // Order: chrome-before → template payload → chrome-after.
-    const beforeIdx = body.indexOf("chrome-before");
-    const payloadIdx = body.indexOf("Positioned");
-    const afterIdx = body.indexOf("chrome-after");
-    expect(beforeIdx).toBeGreaterThan(-1);
-    expect(payloadIdx).toBeGreaterThan(beforeIdx);
-    expect(afterIdx).toBeGreaterThan(payloadIdx);
+    expect(body).toMatch(
+      /chrome-before[\s\S]*data-testid="template-payload"[\s\S]*chrome-after/,
+    );
   });
 
   test("react 19 metadata hoisting: template-rendered <title> lands in <head>", async () => {
@@ -467,6 +464,49 @@ describe("resolvePublicRoute — archive through theme", () => {
     expect(body).toContain('data-testid="archive"');
     expect(body).toContain("First");
     expect(body).toContain("Second");
+  });
+
+  test("excludes published entries with NULL publishedAt from the archive", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`entry-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "kept",
+      title: "Kept",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.db.insert(entriesTable).values({
+      type: "post",
+      slug: "no-date",
+      title: "No Date",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: null,
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain('data-testid="entry-kept"');
+    expect(body).not.toContain('data-testid="entry-no-date"');
   });
 
   test("template receives the pagination shape { page, perPage, total, pageCount }", async () => {
@@ -766,6 +806,69 @@ describe("resolvePublicRoute — taxonomy through theme", () => {
     expect(body).toContain("Story A");
   });
 
+  test("excludes published entries with NULL publishedAt from the term archive", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        taxonomy: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`entry-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [topicPlugin], theme });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.term.create({
+      taxonomy: "topic",
+      slug: "news",
+      name: "News",
+    });
+    const kept = await h.factory.entry.create({
+      type: "post",
+      slug: "kept",
+      title: "Kept",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const [nullDated] = await h.db
+      .insert(entriesTable)
+      .values({
+        type: "post",
+        slug: "no-date",
+        title: "No Date",
+        content: null,
+        status: "published",
+        authorId: author.id,
+        publishedAt: null,
+      })
+      .returning();
+    await h.factory.entryTerm.create({
+      entryId: kept.id,
+      termId: term.id,
+      sortOrder: 0,
+    });
+    await h.factory.entryTerm.create({
+      entryId: nullDated!.id,
+      termId: term.id,
+      sortOrder: 1,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/topic/news"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="entry-kept"');
+    expect(body).not.toContain('data-testid="entry-no-date"');
+  });
+
   test("renders built-in `category` template via the category-* hierarchy", async () => {
     const theme = defineTheme({
       templates: {
@@ -1023,6 +1126,216 @@ describe("resolvePublicRoute — front-page through theme", () => {
     expect(body).toContain('data-testid="front-page"');
     expect(body).toContain("Latest");
   });
+
+  test("excludes entries whose type is not registered by any plugin", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`row-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "kept",
+      title: "Kept",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    // An entry whose type is not registered (e.g. plugin uninstalled).
+    await h.factory.entry.create({
+      type: "ghost",
+      slug: "leaked",
+      title: "Leaked",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    const body = await response.text();
+    expect(body).toContain('data-testid="row-kept"');
+    expect(body).not.toContain('data-testid="row-leaked"');
+  });
+
+  test("excludes entries from `isPublic: false` types", async () => {
+    const mixedPlugin = definePlugin("mixed", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerEntryType("internal", { label: "Internal", isPublic: false });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`row-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [mixedPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "public",
+      title: "Public",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entry.create({
+      type: "internal",
+      slug: "private",
+      title: "Private",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    const body = await response.text();
+    expect(body).toContain('data-testid="row-public"');
+    expect(body).not.toContain('data-testid="row-private"');
+  });
+
+  test("excludes published entries with NULL publishedAt", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`row-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "kept",
+      title: "Kept",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    // Side-step the factory's publishedAt coercion: insert directly so
+    // `status: "published"` survives alongside an explicit null timestamp.
+    await h.db
+      .insert(entriesTable)
+      .values({
+        type: "post",
+        slug: "no-date",
+        title: "No Date",
+        content: null,
+        status: "published",
+        authorId: author.id,
+        publishedAt: null,
+      });
+
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    const body = await response.text();
+    expect(body).toContain('data-testid="row-kept"');
+    expect(body).not.toContain('data-testid="row-no-date"');
+  });
+
+  test("plugin-registered `/` rewrite rule wins over front-page synthesis", async () => {
+    const homepagePlugin = definePlugin("homepage", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerRewriteRule("/", { kind: "archive", entryType: "post" });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": () => <section data-testid="front-page" />,
+        archive: () => <section data-testid="archive" />,
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [homepagePlugin],
+      theme,
+    });
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    const body = await response.text();
+    expect(body).toContain('data-testid="archive"');
+    expect(body).not.toContain('data-testid="front-page"');
+  });
+
+  test("runs resolve:front-page:data filters before the template renders", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`row-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    h.spyFilter("resolve:front-page:data").override((data) => ({
+      ...data,
+      entries: data.entries.filter(
+        (entry: ResolvedEntry) => entry.slug !== "filtered-out",
+      ),
+    }));
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "filtered-out",
+      title: "Filtered Out",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "kept-by-filter",
+      title: "Kept",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    const body = await response.text();
+    expect(body).toContain('data-testid="row-kept-by-filter"');
+    expect(body).not.toContain('data-testid="row-filtered-out"');
+  });
 });
 
 describe("resolvePublicRoute — error pages through theme", () => {
@@ -1047,6 +1360,33 @@ describe("resolvePublicRoute — error pages through theme", () => {
     const body = await response.text();
     expect(body).toContain('data-testid="four-oh-four"');
     expect(body).toContain("Page missing");
+  });
+
+  test("themed 404 preserves the `x-plumix-hint` diagnostic header", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "404": () => <main data-testid="four-oh-four" />,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/never-existed"),
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("public-post-not-found");
+  });
+
+  test("no-theme 404 surfaces the plaintext `notFound` response unchanged", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/never-existed"),
+    );
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(response.headers.get("x-plumix-hint")).toBe("public-post-not-found");
+    expect(await response.text()).toBe("Not Found");
   });
 
   test("built-in 404 default renders when the theme has no `404` template", async () => {
@@ -1135,5 +1475,75 @@ describe("resolvePublicRoute — error pages through theme", () => {
     expect(body).toContain("<!doctype html>");
     expect(body).toContain("Internal Server Error");
     expect(body).not.toContain("kaboom-different-payload");
+  });
+
+  test("a resolver-side throw renders the themed `500` template, not JSON", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <h1>{data.entry.title}</h1>,
+        "500": () => <main data-testid="five-oh-oh" />,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    h.spyFilter("resolve:single:data").override(() => {
+      throw new Error("kaboom-resolver-secret");
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "boom-resolver",
+      title: "Boom Resolver",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/boom-resolver"),
+    );
+    expect(response.status).toBe(500);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    const body = await response.text();
+    expect(body).toContain('data-testid="five-oh-oh"');
+    expect(body).not.toContain("kaboom-resolver-secret");
+  });
+
+  test("falls back to plaintext 500 when the theme's `500` template also throws", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: () => {
+          throw new Error("kaboom-inner-secret");
+        },
+        "500": () => {
+          throw new Error("kaboom-error-template-secret");
+        },
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "double-boom",
+      title: "Double Boom",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/double-boom"),
+    );
+    expect(response.status).toBe(500);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    const body = await response.text();
+    expect(body).toContain("Internal Server Error");
+    expect(body).not.toContain("kaboom-inner-secret");
+    expect(body).not.toContain("kaboom-error-template-secret");
   });
 });

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -11,7 +11,7 @@ import type {
   TemplateRegistry,
   ThemeDescriptor,
 } from "../../theme.js";
-import type { NotFoundData, ServerErrorData } from "./resolved-entry.js";
+import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -20,7 +20,6 @@ interface RenderArgs {
   readonly theme: ThemeDescriptor;
   readonly node: ResolvedNode;
   readonly data: TemplateData;
-  /** Plain-text title for the default document's `<title>`. */
   readonly title: string;
 }
 
@@ -33,7 +32,6 @@ export async function renderThroughTheme({
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const Template = pickTemplate(theme.templates, candidates);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TemplateData placeholder
   return renderTree({ ctx, theme, data, title, Template });
 }
 
@@ -41,8 +39,17 @@ interface RenderErrorArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
   readonly kind: "not-found" | "server-error";
-  readonly data: NotFoundData | ServerErrorData;
+  readonly data: ErrorData;
 }
+
+const ERROR_VARIANTS = {
+  "not-found": { key: "404", title: "Not Found", fallback: DefaultNotFound },
+  "server-error": {
+    key: "500",
+    title: "Internal Server Error",
+    fallback: DefaultServerError,
+  },
+} as const;
 
 export function renderErrorThroughTheme({
   ctx,
@@ -50,17 +57,9 @@ export function renderErrorThroughTheme({
   kind,
   data,
 }: RenderErrorArgs): string {
-  const key = kind === "not-found" ? "404" : "500";
-  const fallbackTitle =
-    kind === "not-found" ? "Not Found" : "Internal Server Error";
-  const Template = theme.templates[key] ?? defaultErrorTemplateFor(kind);
-  return renderTree({
-    ctx,
-    theme,
-    data,
-    title: fallbackTitle,
-    Template,
-  });
+  const variant = ERROR_VARIANTS[kind];
+  const Template = theme.templates[variant.key] ?? variant.fallback;
+  return renderTree({ ctx, theme, data, title: variant.title, Template });
 }
 
 interface RenderTreeArgs {
@@ -126,13 +125,6 @@ function DefaultDocument({
       <body>{children}</body>
     </html>
   );
-}
-
-function defaultErrorTemplateFor(
-  kind: "not-found" | "server-error",
-): TemplateComponent<TemplateData> {
-  if (kind === "not-found") return DefaultNotFound;
-  return DefaultServerError;
 }
 
 function DefaultNotFound() {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -32,6 +32,7 @@ export async function renderThroughTheme({
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const Template = pickTemplate(theme.templates, candidates);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TemplateData placeholder
   return renderTree({ ctx, theme, data, title, Template });
 }
 

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -42,14 +42,12 @@ export interface FrontPageData {
   readonly pagination: Pagination;
 }
 
-/** Sanitised — never includes the raw Error or stack trace. */
-export interface NotFoundData {
-  readonly request: Request;
-  readonly hint?: string;
-}
-
-/** Sanitised — never includes the raw Error or stack trace. */
-export interface ServerErrorData {
+/**
+ * Payload threaded to a theme's `404` / `500` template. Public-safe by
+ * shape — there is no Error field, so internal exception messages have
+ * no path to the rendered output.
+ */
+export interface ErrorData {
   readonly request: Request;
   readonly hint?: string;
 }

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -14,7 +14,7 @@ import type {
   SingleData,
   TaxonomyData,
 } from "./render/resolved-entry.js";
-import { and, desc, eq, inArray } from "../db/index.js";
+import { and, desc, eq, inArray, isNotNull } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
 import { terms } from "../db/schema/terms.js";
@@ -64,38 +64,41 @@ declare module "../hooks/types.js" {
 
 const ARCHIVE_LIMIT = 20;
 
-interface ResolvePublicRouteOptions {
-  readonly theme?: ThemeDescriptor;
-}
-
 export async function resolvePublicRoute(
   ctx: AppContext,
   match: RouteMatch,
-  options: ResolvePublicRouteOptions = {},
+  theme: ThemeDescriptor | undefined,
 ): Promise<Response> {
   switch (match.intent.kind) {
     case "single":
-      return resolveSingle(ctx, match.intent, match.params, options);
+      return resolveSingle(ctx, match.intent, match.params, theme);
     case "archive":
-      return resolveArchive(ctx, match.intent, match.params, options);
+      return resolveArchive(ctx, match.intent, match.params, theme);
     case "taxonomy":
-      return resolveTaxonomy(ctx, match.intent, match.params, options);
+      return resolveTaxonomy(ctx, match.intent, match.params, theme);
     case "front-page":
-      return resolveFrontPage(ctx, options);
+      return resolveFrontPage(ctx, theme);
   }
 }
 
 async function resolveFrontPage(
   ctx: AppContext,
-  options: ResolvePublicRouteOptions,
+  theme: ThemeDescriptor | undefined,
 ): Promise<Response> {
-  // The dispatcher only synthesizes the front-page intent when a theme
-  // is configured. The `if (options.theme)` guard is defensive — a
-  // direct caller bypassing the dispatcher would 500 instead of crashing.
-  if (!options.theme) return notFound("public-route-not-found");
+  if (!theme) return notFound("public-route-not-found");
 
   const page = 1;
-  const where = eq(entries.status, "published");
+  const publicTypes = Array.from(ctx.plugins.entryTypes.entries())
+    .filter(([, spec]) => spec.isPublic !== false)
+    .map(([key]) => key);
+  const where =
+    publicTypes.length === 0
+      ? null
+      : and(
+          eq(entries.status, "published"),
+          isNotNull(entries.publishedAt),
+          inArray(entries.type, publicTypes),
+        );
   const result = await paginatedEntries(ctx, where, page);
 
   const initial: FrontPageData = {
@@ -110,7 +113,7 @@ async function resolveFrontPage(
   const data = await ctx.hooks.applyFilter("resolve:front-page:data", initial);
   const html = await renderThroughTheme({
     ctx,
-    theme: options.theme,
+    theme,
     node: { kind: "front-page" },
     data,
     title: "Home",
@@ -124,7 +127,7 @@ async function resolveTaxonomy(
   ctx: AppContext,
   intent: Extract<RouteIntent, { kind: "taxonomy" }>,
   params: Record<string, string>,
-  options: ResolvePublicRouteOptions,
+  theme: ThemeDescriptor | undefined,
 ): Promise<Response> {
   // Same dispatch as resolveSingle: `:path+` rules surface params.path
   // (multi-segment), flat `:term` rules surface params.term.
@@ -144,6 +147,7 @@ async function resolveTaxonomy(
       ? null
       : and(
           eq(entries.status, "published"),
+          isNotNull(entries.publishedAt),
           inArray(entries.type, allowedTypes),
           inArray(
             entries.id,
@@ -158,7 +162,7 @@ async function resolveTaxonomy(
   if (result.outOfRange) return notFound("public-term-page-out-of-range");
   const rows = result.rows;
 
-  if (options.theme) {
+  if (theme) {
     const initial: TaxonomyData = {
       taxonomy: intent.taxonomy,
       term,
@@ -173,7 +177,7 @@ async function resolveTaxonomy(
     const data = await ctx.hooks.applyFilter("resolve:term:data", initial);
     const html = await renderThroughTheme({
       ctx,
-      theme: options.theme,
+      theme,
       node: {
         kind: "term",
         taxonomy: intent.taxonomy,
@@ -217,7 +221,7 @@ async function resolveSingle(
   ctx: AppContext,
   intent: Extract<RouteIntent, { kind: "single" }>,
   params: Record<string, string>,
-  options: ResolvePublicRouteOptions,
+  theme: ThemeDescriptor | undefined,
 ): Promise<Response> {
   // `:path+` rules surface their capture as `params.path` (multi-segment);
   // flat `:slug` rules surface a single segment as `params.slug`. The
@@ -228,12 +232,13 @@ async function resolveSingle(
 
   ctx.resolvedEntity = { kind: "entry", id: row.id };
 
-  if (options.theme) {
-    const initial = await buildSingleData(ctx, row);
+  if (theme) {
+    const [entry] = await buildResolvedEntries(ctx, [row]);
+    const initial: SingleData = { entry: entry! };
     const data = await ctx.hooks.applyFilter("resolve:single:data", initial);
     const html = await renderThroughTheme({
       ctx,
-      theme: options.theme,
+      theme,
       node: {
         kind: "content",
         entryType: row.type,
@@ -253,53 +258,17 @@ async function resolveSingle(
   return htmlResponse(row.title, body);
 }
 
-async function buildSingleData(
-  ctx: AppContext,
-  row: Entry,
-): Promise<SingleData> {
-  const [authorRows, termRows] = await Promise.all([
-    ctx.db
-      .select({ id: users.id, name: users.name, avatarUrl: users.avatarUrl })
-      .from(users)
-      .where(eq(users.id, row.authorId)),
-    ctx.db
-      .select({
-        id: terms.id,
-        taxonomy: terms.taxonomy,
-        name: terms.name,
-        slug: terms.slug,
-        description: terms.description,
-        meta: terms.meta,
-        parentId: terms.parentId,
-        version: terms.version,
-      })
-      .from(entryTerm)
-      .innerJoin(terms, eq(entryTerm.termId, terms.id))
-      .where(eq(entryTerm.entryId, row.id)),
-  ]);
-  const author = authorRows[0];
-  if (!author) {
-    // FK constraint guarantees this; defensive throw surfaces corruption fast.
-    // eslint-disable-next-line no-restricted-syntax -- diagnostic throw
-    throw new Error(
-      `buildSingleData: entry ${String(row.id)} references missing author ${String(row.authorId)}`,
-    );
-  }
-  // Spread `row` first; `terms`/`author` overwrite any same-named entry
-  // columns. Schema collision is intentional: loaded relations win.
-  return { entry: { ...row, terms: termRows, author } };
-}
-
 async function resolveArchive(
   ctx: AppContext,
   intent: Extract<RouteIntent, { kind: "archive" }>,
   params: Record<string, string>,
-  options: ResolvePublicRouteOptions,
+  theme: ThemeDescriptor | undefined,
 ): Promise<Response> {
   const page = parsePageParam(params.page);
   const where = and(
     eq(entries.type, intent.entryType),
     eq(entries.status, "published"),
+    isNotNull(entries.publishedAt),
   );
 
   const result = await paginatedEntries(ctx, where, page);
@@ -315,7 +284,7 @@ async function resolveArchive(
   const title =
     registered?.labels?.plural ?? registered?.label ?? intent.entryType;
 
-  if (options.theme) {
+  if (theme) {
     const initial: ArchiveData = {
       contentType: intent.entryType,
       entries: await buildResolvedEntries(ctx, rows),
@@ -329,7 +298,7 @@ async function resolveArchive(
     const data = await ctx.hooks.applyFilter("resolve:archive:data", initial);
     const html = await renderThroughTheme({
       ctx,
-      theme: options.theme,
+      theme,
       node: { kind: "content-type-archive", entryType: intent.entryType },
       data,
       title,
@@ -389,15 +358,11 @@ async function buildResolvedEntries(
   return rows.map((row) => {
     const author = authorById.get(row.authorId);
     if (!author) {
-      // FK guarantees this; diagnostic throw surfaces corruption.
       // eslint-disable-next-line no-restricted-syntax -- diagnostic throw
       throw new Error(
         `buildResolvedEntries: entry ${String(row.id)} references missing author ${String(row.authorId)}`,
       );
     }
-    // Spread `row` first; `terms`/`author` overwrite any same-named entry
-    // columns. If the schema ever grows columns literally named `terms`
-    // or `author` the loaded relations still win — this is intentional.
     return { ...row, terms: termsByEntryId.get(row.id) ?? [], author };
   });
 }

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -234,7 +234,11 @@ async function resolveSingle(
 
   if (theme) {
     const [entry] = await buildResolvedEntries(ctx, [row]);
-    const initial: SingleData = { entry: entry! };
+    if (!entry) {
+      // eslint-disable-next-line no-restricted-syntax -- diagnostic throw
+      throw new Error("buildResolvedEntries: empty result for one row");
+    }
+    const initial: SingleData = { entry };
     const data = await ctx.hooks.applyFilter("resolve:single:data", initial);
     const html = await renderThroughTheme({
       ctx,

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -193,10 +193,9 @@ async function dispatchPublicRoute(
           hint: response.headers.get("x-plumix-hint") ?? undefined,
         },
       });
-      return new Response(html, {
-        status: 404,
-        headers: { "content-type": "text/html; charset=utf-8" },
-      });
+      const headers = new Headers(response.headers);
+      headers.set("content-type", "text/html; charset=utf-8");
+      return new Response(html, { status: 404, headers });
     }
     return response;
   } catch (err) {
@@ -204,21 +203,31 @@ async function dispatchPublicRoute(
       url: url.href,
       err: err instanceof Error ? err.message : String(err),
     });
-    if (!theme) {
-      return new Response("Internal Server Error", {
-        status: 500,
-        headers: { "content-type": "text/plain; charset=utf-8" },
-      });
+    if (theme) {
+      try {
+        const html = renderErrorThroughTheme({
+          ctx,
+          theme,
+          kind: "server-error",
+          data: { request: ctx.request },
+        });
+        return new Response(html, {
+          status: 500,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        });
+      } catch (templateErr) {
+        ctx.logger.error("error_template_failed", {
+          url: url.href,
+          err:
+            templateErr instanceof Error
+              ? templateErr.message
+              : String(templateErr),
+        });
+      }
     }
-    const html = renderErrorThroughTheme({
-      ctx,
-      theme,
-      kind: "server-error",
-      data: { request: ctx.request },
-    });
-    return new Response(html, {
+    return new Response("Internal Server Error", {
       status: 500,
-      headers: { "content-type": "text/html; charset=utf-8" },
+      headers: { "content-type": "text/plain; charset=utf-8" },
     });
   }
 }
@@ -228,20 +237,14 @@ async function resolvePublicRouteOrFallback(
   ctx: AppContext,
   url: URL,
 ): Promise<Response> {
+  const theme = app.config.theme;
   const match = matchRoute(url, app.routeMap);
-  if (match !== null) {
-    return resolvePublicRoute(ctx, match, { theme: app.config.theme });
-  }
-  // `/` doesn't compile into the rule map; plugins can register
-  // `registerRewriteRule({ pattern: "/", ... })` which would have matched
-  // above. With a theme configured we synthesize the front-page intent
-  // so the default homepage flows through the resolver. Without a theme
-  // there's nothing to render — fall through to the 404.
-  if (url.pathname === "/" && app.config.theme) {
+  if (match !== null) return resolvePublicRoute(ctx, match, theme);
+  if (url.pathname === "/" && theme) {
     return resolvePublicRoute(
       ctx,
       { intent: { kind: "front-page" }, params: {} },
-      { theme: app.config.theme },
+      theme,
     );
   }
   return notFound("public-route-not-found");


### PR DESCRIPTION
Retroactive sentry review of merged theming-PRD slices (#491) surfaced four
public-route bugs and a handful of simplifications. Each bug was TDD'd —
RED test before fix — and the simplifications ride along behind the safety
net those + the existing core suite provide.

**Four public-route leaks closed**

- `/` now filters to publicly-listable registered entry types: rows whose
  type belongs to an uninstalled plugin or to an `isPublic: false` type no
  longer surface on the homepage.
- `/`, content-type archives, and term archives now require
  `isNotNull(publishedAt)`. A row with `status: \"published\"` and
  `publishedAt: NULL` (a data-migration or scheduled-publish race) used to
  appear in all three.
- Themed 404 preserves the response's headers — most notably
  `x-plumix-hint`, which middleware/log scrapers key on. The dispatcher
  now clones the upstream headers and only swaps `content-type`.

**Themed-500 fallback is new**

When the theme's `500` template itself throws, the dispatcher used to let
the error bubble to the outer JSON catch — content-type drifted from HTML
to JSON mid-error. The render now sits inside a try/catch that falls back
to plaintext `Internal Server Error` and emits a distinct
`error_template_failed` log event.

**Simplifications**

`NotFoundData` + `ServerErrorData` collapse into one `ErrorData`;
`renderErrorThroughTheme` reads its key/title/fallback from an
`ERROR_VARIANTS` lookup table; `defaultErrorTemplateFor` and
`buildSingleData` inline; the one-field `ResolvePublicRouteOptions`
wrapper is gone; resolvers take a bare `theme: ThemeDescriptor | undefined`.
A stale eslint-disable, a few narrating comments, and the doc-comment
drift on the old error types are dropped. The `document`-override test
collapses to a single regex assertion.

Refs #491