### PR TITLE
refactor(core): turn TemplateData into a discriminated union

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,16 @@ export type { MemoryStorageConfig } from "./runtime/memory-storage.js";
 export { runScheduledTasks } from "./runtime/scheduled.js";
 export type * from "./runtime/slots.js";
 export { slugify } from "./slugify.js";
+export type {
+  ArchiveData,
+  ErrorData,
+  FrontPageData,
+  Pagination,
+  ResolvedAuthor,
+  ResolvedEntry,
+  SingleData,
+  TaxonomyData,
+} from "./route/render/resolved-entry.js";
 export { defineTheme } from "./theme.js";
 export type {
   TemplateComponent,

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -58,9 +58,10 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("falls through to `index` template when no `single` is registered", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => (
-          <article data-testid="index">{data.entry.title}</article>
-        ),
+        index: ({ data }) =>
+          "entry" in data ? (
+            <article data-testid="index">{data.entry.title}</article>
+          ) : null,
       },
     });
 
@@ -116,7 +117,8 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("runs resolve:single:data filters before the template renders", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => <h1>{data.entry.title}</h1>,
+        index: () => null,
+        single: ({ data }) => <h1>{data.entry.title}</h1>,
       },
     });
 
@@ -152,7 +154,8 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("template receives ResolvedAuthor with public-safe fields", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => (
+        index: () => null,
+        single: ({ data }) => (
           <p data-testid="author">{data.entry.author.name}</p>
         ),
       },
@@ -185,7 +188,8 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("template receives eager-loaded terms in batched order", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => (
+        index: () => null,
+        single: ({ data }) => (
           <span data-testid="terms">{`terms:${String(data.entry.terms.length)}`}</span>
         ),
       },
@@ -233,7 +237,8 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("default document shell supplies doctype + html/head/body with charset, viewport, and title", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => <article>{data.entry.title}</article>,
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
       },
     });
 
@@ -266,7 +271,8 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("theme `document` override replaces the default shell", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => <article>{data.entry.title}</article>,
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
       },
       document: ({ children }) => (
         <html lang="fr">
@@ -302,7 +308,8 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("`document` override renders children between header and footer", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => (
+        index: () => null,
+        single: ({ data }) => (
           <div data-testid="template-payload">{data.entry.title}</div>
         ),
       },
@@ -344,7 +351,8 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("react 19 metadata hoisting: template-rendered <title> lands in <head>", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) => (
+        index: () => null,
+        single: ({ data }) => (
           <>
             <title>From-Template</title>
             <article>{data.entry.title}</article>
@@ -388,9 +396,12 @@ describe("resolvePublicRoute — single entry through theme", () => {
   test("template can render <BlockRenderer/> against the entry's content tree", async () => {
     const theme = defineTheme({
       templates: {
-        index: ({ data }) =>
+        index: () => null,
+        single: ({ data }) =>
           data.entry.content ? (
-            <BlockRenderer content={data.entry.content as EntryContent} />
+            <BlockRenderer
+              content={data.entry.content as unknown as EntryContent}
+            />
           ) : null,
       },
     });

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -32,7 +32,6 @@ export async function renderThroughTheme({
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const Template = pickTemplate(theme.templates, candidates);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TemplateData placeholder
   return renderTree({ ctx, theme, data, title, Template });
 }
 
@@ -59,7 +58,8 @@ export function renderErrorThroughTheme({
   data,
 }: RenderErrorArgs): string {
   const variant = ERROR_VARIANTS[kind];
-  const Template = theme.templates[variant.key] ?? variant.fallback;
+  const Template = (theme.templates[variant.key] ??
+    variant.fallback) as TemplateComponent<TemplateData>;
   return renderTree({ ctx, theme, data, title: variant.title, Template });
 }
 
@@ -102,9 +102,12 @@ function pickTemplate(
   templates: TemplateRegistry,
   candidates: readonly string[],
 ): TemplateComponent<TemplateData> {
+  // The candidate list is derived from the route's kind, so the picked
+  // template's narrowed data shape always matches the runtime `data`.
+  // TS can't see that — widen with a cast at the boundary.
   for (const name of candidates) {
     const candidate = templates[name];
-    if (candidate) return candidate;
+    if (candidate) return candidate as TemplateComponent<TemplateData>;
   }
   return templates.index;
 }

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -2,18 +2,40 @@ import type { ComponentType, ReactElement, ReactNode } from "react";
 
 import type { ThemeTokens } from "@plumix/blocks";
 
+import type {
+  ArchiveData,
+  ErrorData,
+  FrontPageData,
+  SingleData,
+  TaxonomyData,
+} from "./route/render/resolved-entry.js";
 import { ThemeError, ThemeRegistrationError } from "./theme-errors.js";
 
 /**
- * Per-kind data templates receive — `SingleData` for single-entry kinds,
- * `ArchiveData` for archives, more as follow-up slices land. Modelled as
- * `any` so templates can destructure freely without per-key narrowing;
- * tightening to a discriminated union is a follow-up.
+ * Discriminated union of every data shape a template can receive. Per-kind
+ * templates (`single`, `archive`, …) narrow via the registry; `index`
+ * receives the union and discriminates at runtime (e.g. `"entry" in data`).
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type TemplateData = any;
+export type TemplateData =
+  | SingleData
+  | ArchiveData
+  | TaxonomyData
+  | FrontPageData
+  | ErrorData;
 
 export type TemplateComponent<Data> = ComponentType<{ readonly data: Data }>;
+
+// Catch-all for the registry's index signature. The narrow per-key
+// slots can't share a single typed slot due to contravariance, so the
+// signature accepts any concrete-shape component (`single-{type}`,
+// `archive-{type}`, …) or one written against the full union.
+type DynamicTemplateComponent =
+  | TemplateComponent<SingleData>
+  | TemplateComponent<ArchiveData>
+  | TemplateComponent<TaxonomyData>
+  | TemplateComponent<FrontPageData>
+  | TemplateComponent<ErrorData>
+  | TemplateComponent<TemplateData>;
 
 export type ThemeDocument = (props: {
   readonly data: TemplateData;
@@ -23,7 +45,18 @@ export type ThemeDocument = (props: {
 
 export interface TemplateRegistry {
   readonly index: TemplateComponent<TemplateData>;
-  readonly [key: string]: TemplateComponent<TemplateData>;
+  readonly single?: TemplateComponent<SingleData>;
+  readonly singular?: TemplateComponent<SingleData>;
+  readonly page?: TemplateComponent<SingleData>;
+  readonly archive?: TemplateComponent<ArchiveData>;
+  readonly taxonomy?: TemplateComponent<TaxonomyData>;
+  readonly category?: TemplateComponent<TaxonomyData>;
+  readonly tag?: TemplateComponent<TaxonomyData>;
+  readonly "front-page"?: TemplateComponent<FrontPageData>;
+  readonly home?: TemplateComponent<FrontPageData>;
+  readonly "404"?: TemplateComponent<ErrorData>;
+  readonly "500"?: TemplateComponent<ErrorData>;
+  readonly [key: string]: DynamicTemplateComponent | undefined;
 }
 
 export interface ThemeDescriptor {


### PR DESCRIPTION
`TemplateData` was an `any` placeholder so themes could destructure freely.
Theme authors paid for it with no autocomplete and no shape-mismatch safety.
Tighten it to a union of the existing data shapes
(`SingleData | ArchiveData | TaxonomyData | FrontPageData | ErrorData`)
and narrow `TemplateRegistry`'s per-key slots so each known
WordPress-hierarchy key receives the right data type.

**Per-key slots match the hierarchy walker**

`single` / `singular` / `page` → `SingleData`; `archive` → `ArchiveData`;
`taxonomy` / `category` / `tag` → `TaxonomyData`;
`front-page` / `home` → `FrontPageData`; `404` / `500` → `ErrorData`.
`index` keeps the full union since it's the catch-all fallback for every
route. Dynamic keys (`single-{type}`, `archive-{type}`, `taxonomy-{name}`,
`page-{slug}`, …) flow through a private union in the index signature.

**Two internal casts widen at the dispatch boundary**

`pickTemplate` and the error-variant lookup in `render-template.tsx` cast
the narrow per-key slot back to `TemplateComponent<TemplateData>` at the
call site. The candidate list is built from the route kind, so the picked
template's narrow data always matches the runtime data — TS can't see that
invariant. The comment in `pickTemplate` captures the contract.

**Data types are now re-exported from `plumix`**

Themes can `import type { SingleData, ArchiveData, ResolvedEntry, … }`
from the top-level package instead of runtime-discriminating on shape.
Additive — no breaking removals.

Refs #491