### PR TITLE
feat(plumix): add workspace-root public/ directory convention

### DIFF
--- a/examples/blog/public/favicon.svg
+++ b/examples/blog/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="#0ea5e9"/><text x="16" y="22" font-family="ui-sans-serif,system-ui" font-size="18" font-weight="700" text-anchor="middle" fill="#fff">P</text></svg>

--- a/examples/blog/public/robots.txt
+++ b/examples/blog/public/robots.txt
@@ -1,0 +1,3 @@
+# Demo app — do not index in any search engine.
+User-agent: *
+Disallow: /

--- a/examples/minimal/public/favicon.svg
+++ b/examples/minimal/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="#0ea5e9"/><text x="16" y="22" font-family="ui-sans-serif,system-ui" font-size="18" font-weight="700" text-anchor="middle" fill="#fff">P</text></svg>

--- a/examples/minimal/public/robots.txt
+++ b/examples/minimal/public/robots.txt
@@ -1,0 +1,3 @@
+# Demo app — do not index in any search engine.
+User-agent: *
+Disallow: /

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -32,6 +32,7 @@ import {
   assemblePluginAdminBundle,
 } from "./admin-plugin-bundle.js";
 import { VitePluginError } from "./errors.js";
+import { stageUserPublic } from "./public-staging.js";
 
 // `import.meta.url` for this module lives at plumix/dist/vite/index.js in
 // consumer installs, so the pre-compiled admin artifact is a sibling at
@@ -81,6 +82,11 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
       const emitted = await regenerate(root, options.configFile);
       configPath = emitted.configPath;
       warnOnPluginAdminMismatch(emitted.plugins, this.warn.bind(this));
+      // User `public/` is staged BEFORE admin so the admin SPA's
+      // freshness check still works against its own source mtime —
+      // and the `_plumix/` filter in `stageUserPublic` keeps users
+      // from corrupting admin's subtree on collision.
+      await stageUserPublic({ workspaceRoot: root, publicDir });
       await stageAdminAssets(
         publicDir,
         emitted.manifest,
@@ -89,11 +95,15 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
         root,
       );
     },
+    // No watcher on workspace `public/` here — Vite serves `publicDir`
+    // contents directly from disk in dev, so file edits / additions are
+    // picked up on next request without a re-stage.
     configureServer(server) {
       server.watcher.on("change", (path) => {
         if (!configPath || resolve(path) !== configPath) return;
         void regenerate(root, options.configFile)
           .then(async (emitted) => {
+            await stageUserPublic({ workspaceRoot: root, publicDir });
             await stageAdminAssets(
               publicDir,
               emitted.manifest,

--- a/packages/plumix/src/vite/public-staging.test.ts
+++ b/packages/plumix/src/vite/public-staging.test.ts
@@ -2,7 +2,6 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { stageUserPublic } from "./public-staging.js";

--- a/packages/plumix/src/vite/public-staging.test.ts
+++ b/packages/plumix/src/vite/public-staging.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { stageUserPublic } from "./public-staging.js";
+
+describe("stageUserPublic", () => {
+  let workspace: string;
+  let publicDir: string;
+
+  beforeEach(async () => {
+    workspace = mkdtempSync(join(tmpdir(), "plumix-public-staging-"));
+    publicDir = join(workspace, ".plumix/public");
+    await mkdir(publicDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test("copies workspace public/<file> into <publicDir>/<file>", async () => {
+    await mkdir(join(workspace, "public"), { recursive: true });
+    writeFileSync(
+      join(workspace, "public/robots.txt"),
+      "User-agent: *\nDisallow:\n",
+      "utf8",
+    );
+
+    await stageUserPublic({ workspaceRoot: workspace, publicDir });
+
+    const staged = readFileSync(join(publicDir, "robots.txt"), "utf8");
+    expect(staged).toBe("User-agent: *\nDisallow:\n");
+  });
+
+  test("no-op when workspace public/ does not exist", async () => {
+    await expect(
+      stageUserPublic({ workspaceRoot: workspace, publicDir }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("preserves nested directory structure", async () => {
+    await mkdir(join(workspace, "public/assets/icons"), { recursive: true });
+    writeFileSync(
+      join(workspace, "public/assets/icons/logo.svg"),
+      "<svg/>",
+      "utf8",
+    );
+
+    await stageUserPublic({ workspaceRoot: workspace, publicDir });
+
+    const staged = readFileSync(
+      join(publicDir, "assets/icons/logo.svg"),
+      "utf8",
+    );
+    expect(staged).toBe("<svg/>");
+  });
+
+  test("does not copy user files under the reserved _plumix/ namespace", async () => {
+    await mkdir(join(workspace, "public/_plumix/admin"), { recursive: true });
+    writeFileSync(
+      join(workspace, "public/_plumix/admin/index.html"),
+      "<!-- user attempt to shadow admin -->",
+      "utf8",
+    );
+    writeFileSync(join(workspace, "public/robots.txt"), "ok\n", "utf8");
+
+    await stageUserPublic({ workspaceRoot: workspace, publicDir });
+
+    expect(() =>
+      readFileSync(join(publicDir, "_plumix/admin/index.html"), "utf8"),
+    ).toThrow(/ENOENT/);
+    expect(readFileSync(join(publicDir, "robots.txt"), "utf8")).toBe("ok\n");
+  });
+});

--- a/packages/plumix/src/vite/public-staging.ts
+++ b/packages/plumix/src/vite/public-staging.ts
@@ -1,0 +1,37 @@
+import { cp, stat } from "node:fs/promises";
+import { relative, resolve, sep } from "node:path";
+
+/**
+ * Copy the workspace's user-facing `public/` directory contents into
+ * Vite's resolved `publicDir`. Files in `public/robots.txt` end up at
+ * `<publicDir>/robots.txt` so that:
+ *   - the dev server (Vite) serves them at `/robots.txt`
+ *   - `vite build` copies them into the static-asset output directory
+ *
+ * No-op when the workspace has no `public/` directory. Files under the
+ * reserved `_plumix/` namespace are skipped — admin staging owns that
+ * subtree and a user copy would corrupt the freshness check that gates
+ * `stageAdminAssets`.
+ */
+export async function stageUserPublic(args: {
+  readonly workspaceRoot: string;
+  readonly publicDir: string;
+}): Promise<void> {
+  const source = resolve(args.workspaceRoot, "public");
+  let stats: Awaited<ReturnType<typeof stat>>;
+  try {
+    stats = await stat(source);
+  } catch {
+    return;
+  }
+  if (!stats.isDirectory()) return;
+  await cp(source, args.publicDir, {
+    recursive: true,
+    filter: (src) => !isReservedPath(source, src),
+  });
+}
+
+function isReservedPath(sourceRoot: string, src: string): boolean {
+  const head = relative(sourceRoot, src).split(sep, 1)[0];
+  return head === "_plumix";
+}


### PR DESCRIPTION
Files in `<root>/public/robots.txt` now serve at `/robots.txt` in both `plumix
dev` (Vite dev server) and after `plumix build` (deposited into the static-asset
output Workers Assets serves in prod). The example apps gain baseline
`robots.txt` and `favicon.svg`.

**stageUserPublic + buildStart wiring**

A new helper in `packages/plumix/src/vite/public-staging.ts` copies
`<workspaceRoot>/public/` into Vite's resolved `publicDir`, skipping the
reserved `_plumix/` namespace. Wired into the plugin's `buildStart` BEFORE
`stageAdminAssets` so admin's mtime-based freshness check still works against
its own source. Four colocated unit tests cover the copy, no-op, reserved
filter, and nested-subdir paths.

**`_plumix/` is reserved**

Admin SPA owns the `_plumix/` subtree of `publicDir`. The stager filters out
user files under that prefix via `cp`'s `filter` callback. If a user file
slipped through, the next `stageAdminAssets` would see a fresh mtime in dest
and skip the admin copy, shipping a stale or wrong admin. The filter prevents
that footgun.

**Convention note**

Astro and TanStack Start point `publicDir` at the user's `public/` directly
and ship framework-private assets via `emitFile` + dev middleware. We diverge
today because the admin SPA already lives in `.plumix/public/`; inverting is a
larger refactor tracked separately.

Refs #510
Closes #512