### PR TITLE
feat(core): wire boot-time theme:document filter for plugin contributions

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -316,6 +316,53 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain('<body class="font-sans theme-light">');
   });
 
+  test("`theme:document` filter contributions surface in SSR'd <head>", async () => {
+    const seoPlugin = definePlugin("seo", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+      });
+      ctx.addFilter("theme:document", (manifest) => ({
+        ...manifest,
+        meta: [
+          ...(manifest.meta ?? []),
+          { property: "og:site_name", content: "Demo" },
+        ],
+      }));
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [seoPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "filtered",
+      title: "Filtered",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/filtered"),
+    );
+    const body = await response.text();
+    const headSection = body.slice(
+      body.indexOf("<head>"),
+      body.indexOf("</head>"),
+    );
+    expect(headSection).toContain(
+      '<meta property="og:site_name" content="Demo"',
+    );
+  });
+
   test("manifest `link[]` entries land in <head> in declared order", async () => {
     const theme = defineTheme({
       templates: {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -7,6 +7,7 @@ import { PlumixProvider } from "@plumix/blocks/renderer";
 import type { AppContext } from "../../context/app.js";
 import type {
   DocumentLink,
+  DocumentManifest,
   DocumentMeta,
   DocumentScript,
   TemplateComponent,
@@ -21,6 +22,7 @@ import { resolveTemplateCandidates } from "./template-hierarchy.js";
 interface RenderArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
+  readonly document: DocumentManifest;
   readonly node: ResolvedNode;
   readonly data: TemplateData;
   readonly title: string;
@@ -29,18 +31,20 @@ interface RenderArgs {
 export async function renderThroughTheme({
   ctx,
   theme,
+  document,
   node,
   data,
   title,
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const Template = pickTemplate(theme.templates, candidates);
-  return renderTree({ ctx, theme, data, title, Template });
+  return renderTree({ ctx, document, data, title, Template });
 }
 
 interface RenderErrorArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
+  readonly document: DocumentManifest;
   readonly kind: "not-found" | "server-error";
   readonly data: ErrorData;
 }
@@ -57,18 +61,19 @@ const ERROR_VARIANTS = {
 export function renderErrorThroughTheme({
   ctx,
   theme,
+  document,
   kind,
   data,
 }: RenderErrorArgs): string {
   const variant = ERROR_VARIANTS[kind];
   const Template = (theme.templates[variant.key] ??
     variant.fallback) as TemplateComponent<TemplateData>;
-  return renderTree({ ctx, theme, data, title: variant.title, Template });
+  return renderTree({ ctx, document, data, title: variant.title, Template });
 }
 
 interface RenderTreeArgs {
   readonly ctx: AppContext;
-  readonly theme: ThemeDescriptor;
+  readonly document: DocumentManifest;
   readonly data: TemplateData;
   readonly title: string;
   readonly Template: TemplateComponent<TemplateData>;
@@ -82,7 +87,7 @@ interface RenderTreeArgs {
 // template — Astro's approach for the same reason.
 function renderTree({
   ctx,
-  theme,
+  document,
   data,
   title,
   Template,
@@ -94,11 +99,10 @@ function renderTree({
   const rendered = renderToString(templateTree);
   const { hoisted, body } = splitHoistedMetadata(rendered);
 
-  const manifest = theme.document;
-  const scripts = groupScriptsByPosition(manifest?.script);
+  const scripts = groupScriptsByPosition(document.script);
 
-  const htmlAttrs = renderAttrs({ lang: "en", ...manifest?.html });
-  const bodyAttrs = renderAttrs(manifest?.body);
+  const htmlAttrs = renderAttrs({ lang: "en", ...document.html });
+  const bodyAttrs = renderAttrs(document.body);
 
   // A template-rendered `<title>` is part of `hoisted`. Browsers honor the
   // first `<title>` in document order, so emitting the framework default
@@ -113,8 +117,8 @@ function renderTree({
     '<meta name="viewport" content="width=device-width, initial-scale=1"/>' +
     hoisted +
     titleFallback +
-    voidTagsToHtml("link", manifest?.link) +
-    voidTagsToHtml("meta", manifest?.meta) +
+    voidTagsToHtml("link", document.link) +
+    voidTagsToHtml("meta", document.meta) +
     scripts.headEnd.map(scriptToHtml).join("");
 
   const bodyContent =

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -4,7 +4,7 @@ import { count } from "drizzle-orm";
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
-import type { ThemeDescriptor } from "../theme.js";
+import type { DocumentManifest, ThemeDescriptor } from "../theme.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
 import type {
@@ -47,22 +47,24 @@ export async function resolvePublicRoute(
   ctx: AppContext,
   match: RouteMatch,
   theme: ThemeDescriptor,
+  document: DocumentManifest,
 ): Promise<Response> {
   switch (match.intent.kind) {
     case "single":
-      return resolveSingle(ctx, match.intent, match.params, theme);
+      return resolveSingle(ctx, match.intent, match.params, theme, document);
     case "archive":
-      return resolveArchive(ctx, match.intent, match.params, theme);
+      return resolveArchive(ctx, match.intent, match.params, theme, document);
     case "taxonomy":
-      return resolveTaxonomy(ctx, match.intent, match.params, theme);
+      return resolveTaxonomy(ctx, match.intent, match.params, theme, document);
     case "front-page":
-      return resolveFrontPage(ctx, theme);
+      return resolveFrontPage(ctx, theme, document);
   }
 }
 
 async function resolveFrontPage(
   ctx: AppContext,
   theme: ThemeDescriptor,
+  document: DocumentManifest,
 ): Promise<Response> {
   const page = 1;
   const publicTypes = Array.from(ctx.plugins.entryTypes.entries())
@@ -91,6 +93,7 @@ async function resolveFrontPage(
   const html = await renderThroughTheme({
     ctx,
     theme,
+    document,
     node: { kind: "front-page" },
     data,
     title: "Home",
@@ -105,6 +108,7 @@ async function resolveTaxonomy(
   intent: Extract<RouteIntent, { kind: "taxonomy" }>,
   params: Record<string, string>,
   theme: ThemeDescriptor,
+  document: DocumentManifest,
 ): Promise<Response> {
   const term = await findTermForTaxonomy(ctx, intent.taxonomy, params);
   if (!term) return notFound("public-term-not-found");
@@ -151,6 +155,7 @@ async function resolveTaxonomy(
   const html = await renderThroughTheme({
     ctx,
     theme,
+    document,
     node: {
       kind: "term",
       taxonomy: intent.taxonomy,
@@ -170,6 +175,7 @@ async function resolveSingle(
   intent: Extract<RouteIntent, { kind: "single" }>,
   params: Record<string, string>,
   theme: ThemeDescriptor,
+  document: DocumentManifest,
 ): Promise<Response> {
   const row = await findEntryForSingle(ctx, intent.entryType, params);
   if (!row) return notFound("public-post-not-found");
@@ -186,6 +192,7 @@ async function resolveSingle(
   const html = await renderThroughTheme({
     ctx,
     theme,
+    document,
     node: {
       kind: "content",
       entryType: row.type,
@@ -205,6 +212,7 @@ async function resolveArchive(
   intent: Extract<RouteIntent, { kind: "archive" }>,
   params: Record<string, string>,
   theme: ThemeDescriptor,
+  document: DocumentManifest,
 ): Promise<Response> {
   const page = parsePageParam(params.page);
   const where = and(
@@ -239,6 +247,7 @@ async function resolveArchive(
   const html = await renderThroughTheme({
     ctx,
     theme,
+    document,
     node: { kind: "content-type-archive", entryType: intent.entryType },
     data,
     title,

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -35,7 +35,9 @@ import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { appRouter } from "../rpc/router.js";
+import type { DocumentManifest } from "../theme.js";
 import { ThemeRegistrationError } from "../theme-errors.js";
+import { validateDocumentManifest } from "../theme.js";
 import { AppBootError } from "./errors.js";
 
 export interface OAuthProviderSummary {
@@ -122,6 +124,13 @@ export interface PlumixApp {
    * output rather than being silently swapped with the baseline.
    */
   readonly htmlAllowlist: HtmlAllowlist;
+  /**
+   * Document manifest after the `theme:document` filter chain runs.
+   * Resolved once at boot from `config.theme.document ?? {}` so plugin
+   * contributions surface in every SSR render without per-request merge
+   * cost. Frozen post-resolution to keep the contract immutable.
+   */
+  readonly document: DocumentManifest;
 }
 
 export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
@@ -206,6 +215,8 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     config.blocks?.htmlAllowlist,
   );
 
+  const document = await resolveDocumentManifest(hooks, config.theme.document);
+
   return {
     config,
     hooks,
@@ -226,5 +237,35 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     blocks,
     marks,
     htmlAllowlist,
+    document,
   };
+}
+
+// Run the `theme:document` filter chain once at boot. Plugins spread + add
+// onto a `{}` seed when the theme has no `document` of its own, so authors
+// never need null-checks. The post-filter result is validated for shape
+// (renderer can't recover from missing `link.rel` or empty `<script>`)
+// then deep-frozen so per-request renders treat it as the immutable contract
+// — a shallow freeze would still let a plugin mutate `app.document.meta`
+// after boot and corrupt state across requests.
+async function resolveDocumentManifest(
+  hooks: HookRegistry,
+  themeManifest: DocumentManifest | undefined,
+): Promise<DocumentManifest> {
+  const seed: DocumentManifest = themeManifest ?? {};
+  const merged = await hooks.applyFilter("theme:document", seed);
+  validateDocumentManifest(merged);
+  return deepFreezeManifest(merged);
+}
+
+function deepFreezeManifest(manifest: DocumentManifest): DocumentManifest {
+  manifest.link?.forEach((entry) => Object.freeze(entry));
+  manifest.meta?.forEach((entry) => Object.freeze(entry));
+  manifest.script?.forEach((entry) => Object.freeze(entry));
+  if (manifest.link) Object.freeze(manifest.link);
+  if (manifest.meta) Object.freeze(manifest.meta);
+  if (manifest.script) Object.freeze(manifest.script);
+  if (manifest.html) Object.freeze(manifest.html);
+  if (manifest.body) Object.freeze(manifest.body);
+  return Object.freeze(manifest);
 }

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -21,6 +21,7 @@ import type {
 } from "../plugin/manifest.js";
 import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RouteRule } from "../route/intent.js";
+import type { DocumentManifest } from "../theme.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
@@ -35,7 +36,6 @@ import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { appRouter } from "../rpc/router.js";
-import type { DocumentManifest } from "../theme.js";
 import { ThemeRegistrationError } from "../theme-errors.js";
 import { validateDocumentManifest } from "../theme.js";
 import { AppBootError } from "./errors.js";

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -181,12 +181,14 @@ async function dispatchPublicRoute(
   url: URL,
 ): Promise<Response> {
   const theme = app.config.theme;
+  const document = app.document;
   try {
     const response = await resolvePublicRouteOrFallback(app, ctx, url);
     if (response.status === 404) {
       const html = renderErrorThroughTheme({
         ctx,
         theme,
+        document,
         kind: "not-found",
         data: {
           request: ctx.request,
@@ -207,6 +209,7 @@ async function dispatchPublicRoute(
       const html = renderErrorThroughTheme({
         ctx,
         theme,
+        document,
         kind: "server-error",
         data: { request: ctx.request },
       });
@@ -236,13 +239,15 @@ async function resolvePublicRouteOrFallback(
   url: URL,
 ): Promise<Response> {
   const theme = app.config.theme;
+  const document = app.document;
   const match = matchRoute(url, app.routeMap);
-  if (match !== null) return resolvePublicRoute(ctx, match, theme);
+  if (match !== null) return resolvePublicRoute(ctx, match, theme, document);
   if (url.pathname === "/") {
     return resolvePublicRoute(
       ctx,
       { intent: { kind: "front-page" }, params: {} },
       theme,
+      document,
     );
   }
   return notFound("public-route-not-found");

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -35,9 +35,7 @@ export class ThemeRegistrationError extends Error {
     );
   }
 
-  static documentInvalidLink(ctx: {
-    index: number;
-  }): ThemeRegistrationError {
+  static documentInvalidLink(ctx: { index: number }): ThemeRegistrationError {
     return new ThemeRegistrationError(
       "document_invalid_link",
       `\`theme:document\` filter chain produced a \`link[${ctx.index}]\` ` +
@@ -47,9 +45,7 @@ export class ThemeRegistrationError extends Error {
     );
   }
 
-  static documentInvalidScript(ctx: {
-    index: number;
-  }): ThemeRegistrationError {
+  static documentInvalidScript(ctx: { index: number }): ThemeRegistrationError {
     return new ThemeRegistrationError(
       "document_invalid_script",
       `\`theme:document\` filter chain produced a \`script[${ctx.index}]\` ` +

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -1,4 +1,8 @@
-type ThemeRegistrationCode = "missing_theme" | "missing_index_template";
+type ThemeRegistrationCode =
+  | "missing_theme"
+  | "missing_index_template"
+  | "document_invalid_link"
+  | "document_invalid_script";
 
 export class ThemeRegistrationError extends Error {
   static {
@@ -28,6 +32,30 @@ export class ThemeRegistrationError extends Error {
       `Theme registration: \`templates.index\` is required. Every theme ` +
         `must declare an \`index\` template — it is the final fallback the ` +
         `template hierarchy walks to when no more-specific template matches.`,
+    );
+  }
+
+  static documentInvalidLink(ctx: {
+    index: number;
+  }): ThemeRegistrationError {
+    return new ThemeRegistrationError(
+      "document_invalid_link",
+      `\`theme:document\` filter chain produced a \`link[${ctx.index}]\` ` +
+        `entry without a \`rel\` attribute. Every \`<link>\` in the document ` +
+        `manifest must declare a \`rel\` — browsers ignore unkeyed link tags ` +
+        `and the renderer would emit invalid HTML.`,
+    );
+  }
+
+  static documentInvalidScript(ctx: {
+    index: number;
+  }): ThemeRegistrationError {
+    return new ThemeRegistrationError(
+      "document_invalid_script",
+      `\`theme:document\` filter chain produced a \`script[${ctx.index}]\` ` +
+        `entry with neither \`src\` nor inline content (\`children\` / ` +
+        `\`dangerouslySetInnerHTML\`). Scripts must reference a source URL ` +
+        `or carry an inline body — an empty \`<script>\` tag is dead weight.`,
     );
   }
 }

--- a/packages/core/src/theme.test.ts
+++ b/packages/core/src/theme.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import type { ThemeDescriptor } from "./theme.js";
 import { auth } from "./auth/config.js";
 import { plumix } from "./config.js";
+import { definePlugin } from "./plugin/define.js";
 import { buildApp } from "./runtime/app.js";
 import { ThemeRegistrationError } from "./theme-errors.js";
 import { defineTheme } from "./theme.js";
@@ -23,6 +24,196 @@ const badTheme = { templates: {} } as unknown as ThemeDescriptor;
 describe("defineTheme", () => {
   test("throws ThemeRegistrationError when templates.index is missing", () => {
     expect(() => defineTheme(badTheme)).toThrow(ThemeRegistrationError);
+  });
+});
+
+describe("buildApp — theme:document filter", () => {
+  test("app.document mirrors theme.document when no plugin filters are registered", async () => {
+    const theme = defineTheme({
+      templates: { index: () => null },
+      document: { link: [{ rel: "icon", href: "/favicon.svg" }] },
+    });
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme,
+      }),
+    );
+    expect(app.document).toEqual({
+      link: [{ rel: "icon", href: "/favicon.svg" }],
+    });
+  });
+
+  test("multiple plugin filters compose in registration order", async () => {
+    const firstPlugin = definePlugin("first", (ctx) => {
+      ctx.addFilter("theme:document", (manifest) => ({
+        ...manifest,
+        meta: [
+          ...(manifest.meta ?? []),
+          { name: "viewport", content: "first" },
+        ],
+      }));
+    });
+    const secondPlugin = definePlugin("second", (ctx) => {
+      ctx.addFilter("theme:document", (manifest) => ({
+        ...manifest,
+        meta: [
+          ...(manifest.meta ?? []),
+          { name: "viewport", content: "second" },
+        ],
+      }));
+    });
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme: defineTheme({ templates: { index: () => null } }),
+        plugins: [firstPlugin, secondPlugin],
+      }),
+    );
+    expect(app.document.meta).toEqual([
+      { name: "viewport", content: "first" },
+      { name: "viewport", content: "second" },
+    ]);
+  });
+
+  test("plugins receive {} when the theme has no `document`", async () => {
+    let observedInput: unknown;
+    const probePlugin = definePlugin("probe", (ctx) => {
+      ctx.addFilter("theme:document", (manifest) => {
+        observedInput = manifest;
+        return manifest;
+      });
+    });
+    await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme: defineTheme({ templates: { index: () => null } }),
+        plugins: [probePlugin],
+      }),
+    );
+    expect(observedInput).toEqual({});
+  });
+
+  test("app.document is frozen — mutation throws in strict mode", async () => {
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme: defineTheme({
+          templates: { index: () => null },
+          document: { meta: [{ name: "viewport", content: "x" }] },
+        }),
+      }),
+    );
+    expect(Object.isFrozen(app.document)).toBe(true);
+    expect(() => {
+      (app.document as { meta?: unknown }).meta = "mutated";
+    }).toThrow(TypeError);
+  });
+
+  test("validation throws when post-filter `link[]` entry is missing `rel`", async () => {
+    const broken = definePlugin("broken-link", (ctx) => {
+      ctx.addFilter("theme:document", (manifest) => ({
+        ...manifest,
+        link: [
+          ...(manifest.link ?? []),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exercise the post-filter validator with a JS-shaped contribution
+          { href: "/orphan.css" } as any,
+        ],
+      }));
+    });
+    await expect(
+      buildApp(
+        plumix({
+          runtime: stubAdapter,
+          database: stubDatabase,
+          auth: stubAuth,
+          theme: defineTheme({ templates: { index: () => null } }),
+          plugins: [broken],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      name: "ThemeRegistrationError",
+      code: "document_invalid_link",
+    });
+  });
+
+  test("validation throws when post-filter `script[]` has neither src nor inline content", async () => {
+    const broken = definePlugin("broken-script", (ctx) => {
+      ctx.addFilter("theme:document", (manifest) => ({
+        ...manifest,
+        script: [...(manifest.script ?? []), { type: "module" }],
+      }));
+    });
+    await expect(
+      buildApp(
+        plumix({
+          runtime: stubAdapter,
+          database: stubDatabase,
+          auth: stubAuth,
+          theme: defineTheme({ templates: { index: () => null } }),
+          plugins: [broken],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      name: "ThemeRegistrationError",
+      code: "document_invalid_script",
+    });
+  });
+
+  test("buildApp rejects when a theme:document filter throws", async () => {
+    const explode = definePlugin("explode", (ctx) => {
+      ctx.addFilter("theme:document", () => {
+        throw new Error("filter blew up");
+      });
+    });
+    await expect(
+      buildApp(
+        plumix({
+          runtime: stubAdapter,
+          database: stubDatabase,
+          auth: stubAuth,
+          theme: defineTheme({ templates: { index: () => null } }),
+          plugins: [explode],
+        }),
+      ),
+    ).rejects.toThrow(/filter blew up/);
+  });
+
+  test("a single plugin filter merges into app.document", async () => {
+    const seoPlugin = definePlugin("seo", (ctx) => {
+      ctx.addFilter("theme:document", (manifest) => ({
+        ...manifest,
+        meta: [
+          ...(manifest.meta ?? []),
+          { property: "og:site_name", content: "Demo" },
+        ],
+      }));
+    });
+    const theme = defineTheme({
+      templates: { index: () => null },
+      document: { link: [{ rel: "icon", href: "/favicon.svg" }] },
+    });
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme,
+        plugins: [seoPlugin],
+      }),
+    );
+    expect(app.document.link).toEqual([{ rel: "icon", href: "/favicon.svg" }]);
+    expect(app.document.meta).toEqual([
+      { property: "og:site_name", content: "Demo" },
+    ]);
   });
 });
 

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -11,6 +11,19 @@ import type {
 } from "./route/render/resolved-entry.js";
 import { ThemeError, ThemeRegistrationError } from "./theme-errors.js";
 
+// `theme:document` is a boot-time filter chain. `buildApp` fires it once,
+// after plugins install, threading the theme's own `document` manifest
+// (or `{}` if absent) through every registered filter. The merged result
+// is frozen on `PlumixApp.document` so per-request renders pay zero merge
+// cost.
+declare module "./hooks/types.js" {
+  interface FilterRegistry {
+    "theme:document": (
+      manifest: DocumentManifest,
+    ) => DocumentManifest | Promise<DocumentManifest>;
+  }
+}
+
 /**
  * Discriminated union of every data shape a template can receive. Per-kind
  * templates (`single`, `archive`, …) narrow via the registry; `index`
@@ -122,6 +135,30 @@ export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
     validateTokens(descriptor.tokens);
   }
   return descriptor;
+}
+
+// Post-filter validation: catches malformed contributions at boot
+// (before any request can render). Validates the two cases the renderer
+// can't recover from gracefully — link entries without `rel` (browsers
+// ignore them, invalid HTML) and scripts with no src + no inline body
+// (dead weight, signals a plugin bug worth surfacing loud).
+export function validateDocumentManifest(manifest: DocumentManifest): void {
+  manifest.link?.forEach((entry, index) => {
+    if (typeof entry.rel !== "string" || entry.rel.length === 0) {
+      throw ThemeRegistrationError.documentInvalidLink({ index });
+    }
+  });
+  manifest.script?.forEach((entry, index) => {
+    const hasSrc = typeof entry.src === "string" && entry.src.length > 0;
+    const hasChildren =
+      typeof entry.children === "string" && entry.children.length > 0;
+    const hasInnerHtml =
+      typeof entry.dangerouslySetInnerHTML?.__html === "string" &&
+      entry.dangerouslySetInnerHTML.__html.length > 0;
+    if (!hasSrc && !hasChildren && !hasInnerHtml) {
+      throw ThemeRegistrationError.documentInvalidScript({ index });
+    }
+  });
 }
 
 function validateTokens(tokens: ThemeTokens): void {


### PR DESCRIPTION
Plugins can now contribute to the theme's document manifest via the existing
`addFilter` primitive. A new `theme:document` filter runs once at `buildApp`
after plugins install, threading the theme's own `document` (or `{}` when
absent) through every registered handler. The merged result is validated,
deep-frozen, and stored on `PlumixApp.document`. The renderer reads from
there, so plugin contributions surface in SSR'd output with zero per-request
merge cost.

**Boot-time filter chain, frozen output**

`resolveDocumentManifest(hooks, themeManifest)` seeds with `themeManifest ?? {}`,
runs `hooks.applyFilter("theme:document", seed)`, validates the shape, then
deep-freezes the manifest object, every entry in `link`/`meta`/`script`, the
arrays themselves, and the `html`/`body` attribute objects. A plugin can't
mutate `app.document.meta.push(...)` post-boot.

**Validation at the boot seam**

Two cases the renderer can't recover from gracefully are caught at boot:
`link[]` entries without `rel` (browsers ignore them, invalid HTML) and
`script[]` entries with neither `src` nor inline content
(`children` / `dangerouslySetInnerHTML`). Both throw `ThemeRegistrationError`
with codes (`document_invalid_link` / `document_invalid_script`) that pin
down which array index failed.

**Renderer signature change**

`renderThroughTheme` / `renderErrorThroughTheme` / `renderTree` now take a
`document: DocumentManifest` arg instead of reading `theme.document`. Every
resolver (`resolveFrontPage`, `resolveTaxonomy`, `resolveSingle`,
`resolveArchive`) and the dispatcher thread `app.document` through. Verbose
plumbing is intentional — keeps a per-call seam for future renderer call
sites (drafts preview, error pages outside the dispatcher) instead of
coupling to \`app\`.

Refs #510
Closes #513