### PR TITLE
feat(core,plumix): auto-inject bundled css via vite asset manifest

### DIFF
--- a/packages/core/src/cli/worker-codegen.test.ts
+++ b/packages/core/src/cli/worker-codegen.test.ts
@@ -42,6 +42,14 @@ describe("generateWorkerSource", () => {
     expect(source).toContain("scheduledHandler ??=");
   });
 
+  test("imports the asset manifest virtual module and threads it into buildApp", () => {
+    const source = generateWorkerSource({ configModule: "./config.ts" });
+    expect(source).toContain(
+      'import assetManifest from "virtual:plumix/asset-manifest";',
+    );
+    expect(source).toContain("buildApp(config, { assetManifest })");
+  });
+
   test("no-ops cleanly when the runtime omits buildScheduledHandler", () => {
     const source = generateWorkerSource({ configModule: "./config.ts" });
     // The generated code guards the call so a runtime that returns

--- a/packages/core/src/cli/worker-codegen.ts
+++ b/packages/core/src/cli/worker-codegen.ts
@@ -10,9 +10,14 @@ export function generateWorkerSource({
     "// Regenerated from plumix.config.ts on each build.",
     "",
     'import { buildApp } from "plumix";',
+    // The plumix Vite plugin resolves this virtual module — in dev it's
+    // `{}`; in build it's the parsed `.vite/manifest.json` Vite emitted
+    // for the client environment. The SSR renderer reads it to inject
+    // hashed `<link rel="stylesheet">` tags after the theme's `link[]`.
+    'import assetManifest from "virtual:plumix/asset-manifest";',
     `import config from ${JSON.stringify(configModule)};`,
     "",
-    "const appPromise = buildApp(config);",
+    "const appPromise = buildApp(config, { assetManifest });",
     "let fetchHandler;",
     "let scheduledHandler;",
     "",

--- a/packages/core/src/route/render/asset-manifest.test.ts
+++ b/packages/core/src/route/render/asset-manifest.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+
+import type { AssetManifest } from "./asset-manifest.js";
+import { bundledCssTags } from "./asset-manifest.js";
+
+describe("bundledCssTags", () => {
+  test("emits a stylesheet <link> for every CSS file linked from an entry chunk", () => {
+    const manifest: AssetManifest = {
+      "src/theme/index.ts": {
+        file: "_plumix/assets/theme-abc123.js",
+        isEntry: true,
+        css: ["_plumix/assets/theme-def456.css"],
+      },
+    };
+    expect(bundledCssTags(manifest)).toBe(
+      '<link rel="stylesheet" href="/_plumix/assets/theme-def456.css" />',
+    );
+  });
+
+  test("emits nothing when no entry chunk references CSS", () => {
+    const manifest: AssetManifest = {
+      "src/theme/index.ts": {
+        file: "_plumix/assets/theme-abc123.js",
+        isEntry: true,
+      },
+    };
+    expect(bundledCssTags(manifest)).toBe("");
+  });
+
+  test("emits nothing for an empty manifest", () => {
+    expect(bundledCssTags({})).toBe("");
+  });
+
+  test("deduplicates css files when multiple entries share the same bundle", () => {
+    const manifest: AssetManifest = {
+      "src/a.ts": {
+        file: "a.js",
+        isEntry: true,
+        css: ["shared-abc.css"],
+      },
+      "src/b.ts": {
+        file: "b.js",
+        isEntry: true,
+        css: ["shared-abc.css"],
+      },
+    };
+    const html = bundledCssTags(manifest);
+    expect(html).toBe('<link rel="stylesheet" href="/shared-abc.css" />');
+  });
+
+  test("ignores entries that are not marked isEntry", () => {
+    const manifest: AssetManifest = {
+      "src/theme/index.ts": {
+        file: "_plumix/assets/theme.js",
+        isEntry: true,
+        css: ["_plumix/assets/theme.css"],
+      },
+      "src/internal.ts": {
+        file: "_plumix/assets/internal.js",
+        css: ["_plumix/assets/internal.css"],
+      },
+    };
+    expect(bundledCssTags(manifest)).toBe(
+      '<link rel="stylesheet" href="/_plumix/assets/theme.css" />',
+    );
+  });
+});

--- a/packages/core/src/route/render/asset-manifest.ts
+++ b/packages/core/src/route/render/asset-manifest.ts
@@ -1,0 +1,33 @@
+/**
+ * The Vite-emitted manifest shape (subset). Vite writes this to
+ * `<outDir>/.vite/manifest.json` when `build.manifest: true`; plumix's
+ * Vite plugin reads it and exposes the parsed object via the
+ * `virtual:plumix/asset-manifest` module that the generated worker
+ * imports.
+ */
+export interface AssetManifestEntry {
+  readonly file: string;
+  readonly isEntry?: boolean;
+  readonly isDynamicEntry?: boolean;
+  readonly css?: readonly string[];
+  readonly assets?: readonly string[];
+  readonly imports?: readonly string[];
+  readonly dynamicImports?: readonly string[];
+}
+
+export type AssetManifest = Readonly<Record<string, AssetManifestEntry>>;
+
+// Dedupes across entries that share a CSS bundle. Walks `isEntry: true`
+// chunks only; CSS attached to code-split chunks (via `imports[]` /
+// `dynamicImports[]`) won't surface until that walk lands as a follow-up.
+export function bundledCssTags(manifest: AssetManifest): string {
+  const seen = new Set<string>();
+  for (const entry of Object.values(manifest)) {
+    if (!entry.isEntry || !entry.css) continue;
+    for (const href of entry.css) seen.add(href);
+  }
+  if (seen.size === 0) return "";
+  return Array.from(seen)
+    .map((href) => `<link rel="stylesheet" href="/${href}" />`)
+    .join("");
+}

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -316,6 +316,53 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain('<body class="font-sans theme-light">');
   });
 
+  test("bundled CSS from the asset manifest auto-injects after theme link[]", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+      document: {
+        link: [{ rel: "icon", href: "/favicon.svg" }],
+      },
+    });
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin],
+      theme,
+      assetManifest: {
+        "src/theme/index.ts": {
+          file: "_plumix/assets/theme-abc123.js",
+          isEntry: true,
+          css: ["_plumix/assets/theme-def456.css"],
+        },
+      },
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "css-bundle",
+      title: "CSS Bundle",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/css-bundle"),
+    );
+    const body = await response.text();
+    const headSection = body.slice(
+      body.indexOf("<head>"),
+      body.indexOf("</head>"),
+    );
+    // The bundled CSS link must follow the theme's own `link[]` so it
+    // wins the cascade.
+    expect(headSection).toMatch(
+      /<link\s+rel="icon"[\s\S]*<link\s+rel="stylesheet"\s+href="\/_plumix\/assets\/theme-def456\.css"/,
+    );
+  });
+
   test("`theme:document` filter contributions surface in SSR'd <head>", async () => {
     const seoPlugin = definePlugin("seo", (ctx) => {
       ctx.registerEntryType("post", {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -17,12 +17,15 @@ import type {
 } from "../../theme.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
+import type { AssetManifest } from "./asset-manifest.js";
+import { bundledCssTags } from "./asset-manifest.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
 interface RenderArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
   readonly document: DocumentManifest;
+  readonly assetManifest: AssetManifest;
   readonly node: ResolvedNode;
   readonly data: TemplateData;
   readonly title: string;
@@ -32,19 +35,21 @@ export async function renderThroughTheme({
   ctx,
   theme,
   document,
+  assetManifest,
   node,
   data,
   title,
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const Template = pickTemplate(theme.templates, candidates);
-  return renderTree({ ctx, document, data, title, Template });
+  return renderTree({ ctx, document, assetManifest, data, title, Template });
 }
 
 interface RenderErrorArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
   readonly document: DocumentManifest;
+  readonly assetManifest: AssetManifest;
   readonly kind: "not-found" | "server-error";
   readonly data: ErrorData;
 }
@@ -62,18 +67,27 @@ export function renderErrorThroughTheme({
   ctx,
   theme,
   document,
+  assetManifest,
   kind,
   data,
 }: RenderErrorArgs): string {
   const variant = ERROR_VARIANTS[kind];
   const Template = (theme.templates[variant.key] ??
     variant.fallback) as TemplateComponent<TemplateData>;
-  return renderTree({ ctx, document, data, title: variant.title, Template });
+  return renderTree({
+    ctx,
+    document,
+    assetManifest,
+    data,
+    title: variant.title,
+    Template,
+  });
 }
 
 interface RenderTreeArgs {
   readonly ctx: AppContext;
   readonly document: DocumentManifest;
+  readonly assetManifest: AssetManifest;
   readonly data: TemplateData;
   readonly title: string;
   readonly Template: TemplateComponent<TemplateData>;
@@ -88,6 +102,7 @@ interface RenderTreeArgs {
 function renderTree({
   ctx,
   document,
+  assetManifest,
   data,
   title,
   Template,
@@ -111,6 +126,8 @@ function renderTree({
     ? ""
     : `<title>${escapeHtml(title)}</title>`;
 
+  // Bundled CSS lands AFTER theme `link[]` so theme-local stylesheets
+  // override CDN imports declared in `link[]` (last-wins cascade).
   const headContent =
     scripts.headStart.map(scriptToHtml).join("") +
     '<meta charSet="utf-8"/>' +
@@ -118,6 +135,7 @@ function renderTree({
     hoisted +
     titleFallback +
     voidTagsToHtml("link", document.link) +
+    bundledCssTags(assetManifest) +
     voidTagsToHtml("meta", document.meta) +
     scripts.headEnd.map(scriptToHtml).join("");
 

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -15,9 +15,9 @@ import type {
   TemplateRegistry,
   ThemeDescriptor,
 } from "../../theme.js";
+import type { AssetManifest } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
-import type { AssetManifest } from "./asset-manifest.js";
 import { bundledCssTags } from "./asset-manifest.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -4,6 +4,7 @@ import { count } from "drizzle-orm";
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
+import type { AssetManifest } from "./render/asset-manifest.js";
 import type { DocumentManifest, ThemeDescriptor } from "../theme.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
@@ -48,16 +49,38 @@ export async function resolvePublicRoute(
   match: RouteMatch,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  assetManifest: AssetManifest,
 ): Promise<Response> {
   switch (match.intent.kind) {
     case "single":
-      return resolveSingle(ctx, match.intent, match.params, theme, document);
+      return resolveSingle(
+        ctx,
+        match.intent,
+        match.params,
+        theme,
+        document,
+        assetManifest,
+      );
     case "archive":
-      return resolveArchive(ctx, match.intent, match.params, theme, document);
+      return resolveArchive(
+        ctx,
+        match.intent,
+        match.params,
+        theme,
+        document,
+        assetManifest,
+      );
     case "taxonomy":
-      return resolveTaxonomy(ctx, match.intent, match.params, theme, document);
+      return resolveTaxonomy(
+        ctx,
+        match.intent,
+        match.params,
+        theme,
+        document,
+        assetManifest,
+      );
     case "front-page":
-      return resolveFrontPage(ctx, theme, document);
+      return resolveFrontPage(ctx, theme, document, assetManifest);
   }
 }
 
@@ -65,6 +88,7 @@ async function resolveFrontPage(
   ctx: AppContext,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  assetManifest: AssetManifest,
 ): Promise<Response> {
   const page = 1;
   const publicTypes = Array.from(ctx.plugins.entryTypes.entries())
@@ -94,6 +118,7 @@ async function resolveFrontPage(
     ctx,
     theme,
     document,
+    assetManifest,
     node: { kind: "front-page" },
     data,
     title: "Home",
@@ -109,6 +134,7 @@ async function resolveTaxonomy(
   params: Record<string, string>,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  assetManifest: AssetManifest,
 ): Promise<Response> {
   const term = await findTermForTaxonomy(ctx, intent.taxonomy, params);
   if (!term) return notFound("public-term-not-found");
@@ -156,6 +182,7 @@ async function resolveTaxonomy(
     ctx,
     theme,
     document,
+    assetManifest,
     node: {
       kind: "term",
       taxonomy: intent.taxonomy,
@@ -176,6 +203,7 @@ async function resolveSingle(
   params: Record<string, string>,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  assetManifest: AssetManifest,
 ): Promise<Response> {
   const row = await findEntryForSingle(ctx, intent.entryType, params);
   if (!row) return notFound("public-post-not-found");
@@ -193,6 +221,7 @@ async function resolveSingle(
     ctx,
     theme,
     document,
+    assetManifest,
     node: {
       kind: "content",
       entryType: row.type,
@@ -213,6 +242,7 @@ async function resolveArchive(
   params: Record<string, string>,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  assetManifest: AssetManifest,
 ): Promise<Response> {
   const page = parsePageParam(params.page);
   const where = and(
@@ -248,6 +278,7 @@ async function resolveArchive(
     ctx,
     theme,
     document,
+    assetManifest,
     node: { kind: "content-type-archive", entryType: intent.entryType },
     data,
     title,

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -4,10 +4,10 @@ import { count } from "drizzle-orm";
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
-import type { AssetManifest } from "./render/asset-manifest.js";
 import type { DocumentManifest, ThemeDescriptor } from "../theme.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
+import type { AssetManifest } from "./render/asset-manifest.js";
 import type {
   ArchiveData,
   FrontPageData,

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -21,6 +21,7 @@ import type {
 } from "../plugin/manifest.js";
 import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RouteRule } from "../route/intent.js";
+import type { AssetManifest } from "../route/render/asset-manifest.js";
 import type { DocumentManifest } from "../theme.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
@@ -131,9 +132,30 @@ export interface PlumixApp {
    * cost. Frozen post-resolution to keep the contract immutable.
    */
   readonly document: DocumentManifest;
+  /**
+   * Vite-emitted asset manifest baked into the worker bundle via
+   * `virtual:plumix/asset-manifest`. The renderer reads this to inject
+   * `<link rel="stylesheet">` tags for bundled theme CSS. Empty `{}`
+   * in dev (Vite serves source directly) and when no client entries
+   * exist (e.g. tests that don't run a full Vite build).
+   */
+  readonly assetManifest: AssetManifest;
 }
 
-export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
+/**
+ * Runtime-only state the worker template injects at boot — values
+ * resolved by the Vite plugin from virtual modules (asset manifest)
+ * or the worker runtime (TBD). Optional in tests + cases that don't
+ * spin up the full build pipeline.
+ */
+export interface RuntimeContext {
+  readonly assetManifest?: AssetManifest;
+}
+
+export async function buildApp(
+  config: PlumixConfig,
+  runtime: RuntimeContext = {},
+): Promise<PlumixApp> {
   const hooks = new HookRegistry();
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
@@ -238,6 +260,7 @@ export async function buildApp(config: PlumixConfig): Promise<PlumixApp> {
     marks,
     htmlAllowlist,
     document,
+    assetManifest: runtime.assetManifest ?? {},
   };
 }
 

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -142,13 +142,11 @@ export interface PlumixApp {
   readonly assetManifest: AssetManifest;
 }
 
-/**
- * Runtime-only state the worker template injects at boot — values
- * resolved by the Vite plugin from virtual modules (asset manifest)
- * or the worker runtime (TBD). Optional in tests + cases that don't
- * spin up the full build pipeline.
- */
-export interface RuntimeContext {
+// Runtime-only state the worker template injects at boot — values
+// resolved by the Vite plugin from virtual modules (asset manifest).
+// Kept internal: consumers (tests + the generated worker) pass an
+// inline object literal that structurally satisfies the type.
+interface RuntimeContext {
   readonly assetManifest?: AssetManifest;
 }
 

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -182,6 +182,7 @@ async function dispatchPublicRoute(
 ): Promise<Response> {
   const theme = app.config.theme;
   const document = app.document;
+  const assetManifest = app.assetManifest;
   try {
     const response = await resolvePublicRouteOrFallback(app, ctx, url);
     if (response.status === 404) {
@@ -189,6 +190,7 @@ async function dispatchPublicRoute(
         ctx,
         theme,
         document,
+        assetManifest,
         kind: "not-found",
         data: {
           request: ctx.request,
@@ -210,6 +212,7 @@ async function dispatchPublicRoute(
         ctx,
         theme,
         document,
+        assetManifest,
         kind: "server-error",
         data: { request: ctx.request },
       });
@@ -240,14 +243,18 @@ async function resolvePublicRouteOrFallback(
 ): Promise<Response> {
   const theme = app.config.theme;
   const document = app.document;
+  const assetManifest = app.assetManifest;
   const match = matchRoute(url, app.routeMap);
-  if (match !== null) return resolvePublicRoute(ctx, match, theme, document);
+  if (match !== null) {
+    return resolvePublicRoute(ctx, match, theme, document, assetManifest);
+  }
   if (url.pathname === "/") {
     return resolvePublicRoute(
       ctx,
       { intent: { kind: "front-page" }, params: {} },
       theme,
       document,
+      assetManifest,
     );
   }
   return notFound("public-route-not-found");

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -12,9 +12,9 @@ import type {
   FilterName,
   FilterRest,
 } from "../hooks/types.js";
+import type { AssetManifest } from "../route/render/asset-manifest.js";
 import type { PlumixApp } from "../runtime/app.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
-import type { AssetManifest } from "../route/render/asset-manifest.js";
 import type {
   AssetsBinding,
   ConnectedObjectStorage,

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -14,6 +14,7 @@ import type {
 } from "../hooks/types.js";
 import type { PlumixApp } from "../runtime/app.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
+import type { AssetManifest } from "../route/render/asset-manifest.js";
 import type {
   AssetsBinding,
   ConnectedObjectStorage,
@@ -107,6 +108,13 @@ export interface CreateDispatcherHarnessOptions {
    */
   readonly bootstrapVia?: BootstrapVia;
   readonly theme?: ThemeDescriptor;
+  /**
+   * Vite-emitted asset manifest. Tests that exercise the renderer's
+   * `<link rel="stylesheet">` auto-injection pass a stub manifest here;
+   * the default empty object mirrors the runtime's "no client entries"
+   * fallback.
+   */
+  readonly assetManifest?: AssetManifest;
 }
 
 export interface DispatcherHarness {
@@ -215,7 +223,9 @@ export async function createDispatcherHarness(
     mailer: options.mailer,
     theme: options.theme ?? defaultTestTheme,
   });
-  const app = await buildApp(config);
+  const app = await buildApp(config, {
+    assetManifest: options.assetManifest,
+  });
   const dispatcher = createPlumixDispatcher(app);
   const { assets, storage } = options;
 

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -46,6 +46,9 @@ export interface PlumixVitePluginOptions {
   readonly configFile?: string;
 }
 
+const ASSET_MANIFEST_VIRTUAL_ID = "virtual:plumix/asset-manifest";
+const ASSET_MANIFEST_RESOLVED_ID = "\0" + ASSET_MANIFEST_VIRTUAL_ID;
+
 export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
   let root = process.cwd();
   let publicDir = "";
@@ -71,12 +74,30 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
           process.env.WORKERS_CI_BRANCH ?? "",
         ),
       };
-      if (userConfig.publicDir !== undefined) return { define };
-      return { publicDir: ".plumix/public", define };
+      // `build.manifest: true` makes Vite emit `<outDir>/.vite/manifest.json`,
+      // which the worker imports through `virtual:plumix/asset-manifest` so
+      // the SSR renderer knows which hashed `<link rel="stylesheet">` tags
+      // to inject after the theme's own `link[]`.
+      const build = { manifest: true };
+      if (userConfig.publicDir !== undefined) return { define, build };
+      return { publicDir: ".plumix/public", define, build };
     },
     configResolved(config) {
       root = config.root;
       publicDir = config.publicDir;
+    },
+    resolveId(id) {
+      if (id === ASSET_MANIFEST_VIRTUAL_ID) return ASSET_MANIFEST_RESOLVED_ID;
+      return null;
+    },
+    load(id) {
+      if (id !== ASSET_MANIFEST_RESOLVED_ID) return null;
+      // Build mode reads the manifest Vite emitted to
+      // `<outDir>/.vite/manifest.json` from a previous environment in
+      // the same build pass (sequential build order from
+      // @cloudflare/vite-plugin). Dev mode never produces a manifest;
+      // `loadAssetManifest` returns `{}` when the file isn't present.
+      return `export default ${JSON.stringify(loadAssetManifest(root))};`;
     },
     async buildStart() {
       const emitted = await regenerate(root, options.configFile);
@@ -382,6 +403,27 @@ async function destIsFresh(dest: string, src: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+// Vite emits `.vite/manifest.json` under the client environment's
+// outDir. Cross-environment builds (e.g. @cloudflare/vite-plugin) run
+// the client env first, then the worker — so the worker's `load` hook
+// for the asset-manifest virtual module can read the file synchronously
+// off disk. Returns `{}` when the file isn't present yet (dev, or first
+// build pass before the client env finishes).
+function loadAssetManifest(rootDir: string): unknown {
+  const candidates = [
+    resolve(rootDir, "dist/client/.vite/manifest.json"),
+    resolve(rootDir, "dist/.vite/manifest.json"),
+  ];
+  for (const path of candidates) {
+    try {
+      return JSON.parse(readFileSync(path, "utf8")) as unknown;
+    } catch {
+      continue;
+    }
+  }
+  return {};
 }
 
 function writeIfChanged(path: string, content: string): void {


### PR DESCRIPTION
Theme entries' bundled CSS now auto-injects as `<link rel=\"stylesheet\">` tags
in SSR'd output. The plumix Vite plugin enables Vite's `build.manifest: true`
and exposes a `virtual:plumix/asset-manifest` module that resolves to the
parsed manifest Vite emits to `<outDir>/.vite/manifest.json`. The generated
worker imports the virtual module and threads it into `buildApp`; the
renderer reads it and emits the bundled CSS link tags right after the
theme's own `link[]`, so theme-local CSS wins the cascade against CDN
imports declared in `link[]`.

**Virtual asset-manifest module**

The Vite plugin's `resolveId` / `load` hooks handle the virtual id. `load`
reads `dist/client/.vite/manifest.json` (with `dist/.vite/manifest.json` as
a fallback for single-environment builds); returns `{}` when missing — dev
mode, or the worker env loading before the client env finishes. The
cross-environment build order is enforced by `@cloudflare/vite-plugin`.

**Cascade-correct CSS injection**

`bundledCssTags(manifest)` extracts CSS from `isEntry: true` chunks, dedupes
shared bundles, and emits `<link rel=\"stylesheet\">` tags. They land
between the theme's own `link[]` and `meta[]` so theme-local CSS overrides
CDN imports while still loading before content. Walks top-level entries
only — code-split chunks via `imports[]` / `dynamicImports[]` is a
documented gap tracked separately.

**Worker template + buildApp seam**

Generated `.plumix/worker.ts` now imports the virtual module and calls
`buildApp(config, { assetManifest })`. A new optional `RuntimeContext` arg
on `buildApp` keeps the boot contract typed without forcing every test
fixture to construct a manifest — defaults to `{}`. Matches the
runtime-injection pattern from the `document` work in the previous slice.

This PR lands the pipeline plumbing only. The Tailwind example in
`examples/blog`, the `wrangler.jsonc` cache-header rule for
`/_plumix/assets/*`, and the integration test that runs `plumix build`
against a fixture are deferred to follow-up #528 — the SSR-CSS plumbing
through `@cloudflare/vite-plugin` is a distinct design decision worth its
own slice.

Refs #510
Refs #514
Refs #528