### PR TITLE
feat(core): walk asset-manifest import graph + ship _headers cache rules

### DIFF
--- a/examples/blog/public/_headers
+++ b/examples/blog/public/_headers
@@ -1,0 +1,11 @@
+# Cache hashed assets aggressively. Vite emits content-hashed filenames
+# for client bundles under `/assets/` (the default `assetsDir`) — bytes
+# at a given URL are stable for the lifetime of the URL, so immutable
+# is safe. The `/_plumix/assets/*` rule covers any future build that
+# overrides `assetsDir` to namespace plumix output (e.g. when admin
+# chunks and theme chunks need separation); today the path is empty.
+/_plumix/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/examples/minimal/public/_headers
+++ b/examples/minimal/public/_headers
@@ -1,0 +1,11 @@
+# Cache hashed assets aggressively. Vite emits content-hashed filenames
+# for client bundles under `/assets/` (the default `assetsDir`) — bytes
+# at a given URL are stable for the lifetime of the URL, so immutable
+# is safe. The `/_plumix/assets/*` rule covers any future build that
+# overrides `assetsDir` to namespace plumix output (e.g. when admin
+# chunks and theme chunks need separation); today the path is empty.
+/_plumix/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/packages/core/src/route/render/asset-manifest.test.ts
+++ b/packages/core/src/route/render/asset-manifest.test.ts
@@ -46,6 +46,83 @@ describe("bundledCssTags", () => {
     };
     const html = bundledCssTags(manifest);
     expect(html).toBe('<link rel="stylesheet" href="/shared-abc.css" />');
+    // Exact-match above already pins this; the count check guards
+    // against a future refactor accidentally emitting duplicate tags.
+    expect(html.split("<link").length - 1).toBe(1);
+  });
+
+  test("walks `imports[]` to surface code-split chunks' CSS", () => {
+    // Vite splits a heavy theme dependency into its own chunk. The
+    // entry references it via `imports[]`; the dependency owns the
+    // CSS bytes. Browsers won't load that CSS unless the renderer
+    // walks the import graph and emits a <link> for every reachable
+    // chunk.
+    const manifest: AssetManifest = {
+      "src/theme/index.ts": {
+        file: "assets/theme-abc.js",
+        isEntry: true,
+        imports: ["_chunks/vendor-xyz.js"],
+        css: ["assets/theme-abc.css"],
+      },
+      "_chunks/vendor-xyz.js": {
+        file: "_chunks/vendor-xyz.js",
+        css: ["_chunks/vendor-xyz.css"],
+      },
+    };
+    const html = bundledCssTags(manifest);
+    expect(html).toContain(
+      '<link rel="stylesheet" href="/assets/theme-abc.css" />',
+    );
+    expect(html).toContain(
+      '<link rel="stylesheet" href="/_chunks/vendor-xyz.css" />',
+    );
+  });
+
+  test("walks `dynamicImports[]` to surface lazy chunks' CSS", () => {
+    const manifest: AssetManifest = {
+      "src/theme/index.ts": {
+        file: "assets/theme.js",
+        isEntry: true,
+        dynamicImports: ["_chunks/lazy.js"],
+      },
+      "_chunks/lazy.js": {
+        file: "_chunks/lazy.js",
+        css: ["_chunks/lazy.css"],
+      },
+    };
+    expect(bundledCssTags(manifest)).toBe(
+      '<link rel="stylesheet" href="/_chunks/lazy.css" />',
+    );
+  });
+
+  test("import-graph traversal is cycle-safe", () => {
+    // Vite occasionally produces manifests where two non-entry
+    // chunks reference each other (circular `imports[]`). The
+    // walker must not loop forever.
+    const manifest: AssetManifest = {
+      "src/theme/index.ts": {
+        file: "theme.js",
+        isEntry: true,
+        imports: ["_chunks/a.js"],
+      },
+      "_chunks/a.js": {
+        file: "_chunks/a.js",
+        imports: ["_chunks/b.js"],
+        css: ["_chunks/a.css"],
+      },
+      "_chunks/b.js": {
+        file: "_chunks/b.js",
+        imports: ["_chunks/a.js"],
+        css: ["_chunks/b.css"],
+      },
+    };
+    const html = bundledCssTags(manifest);
+    expect(html).toContain(
+      '<link rel="stylesheet" href="/_chunks/a.css" />',
+    );
+    expect(html).toContain(
+      '<link rel="stylesheet" href="/_chunks/b.css" />',
+    );
   });
 
   test("ignores entries that are not marked isEntry", () => {

--- a/packages/core/src/route/render/asset-manifest.test.ts
+++ b/packages/core/src/route/render/asset-manifest.test.ts
@@ -117,12 +117,8 @@ describe("bundledCssTags", () => {
       },
     };
     const html = bundledCssTags(manifest);
-    expect(html).toContain(
-      '<link rel="stylesheet" href="/_chunks/a.css" />',
-    );
-    expect(html).toContain(
-      '<link rel="stylesheet" href="/_chunks/b.css" />',
-    );
+    expect(html).toContain('<link rel="stylesheet" href="/_chunks/a.css" />');
+    expect(html).toContain('<link rel="stylesheet" href="/_chunks/b.css" />');
   });
 
   test("ignores entries that are not marked isEntry", () => {

--- a/packages/core/src/route/render/asset-manifest.ts
+++ b/packages/core/src/route/render/asset-manifest.ts
@@ -17,17 +17,43 @@ export interface AssetManifestEntry {
 
 export type AssetManifest = Readonly<Record<string, AssetManifestEntry>>;
 
-// Dedupes across entries that share a CSS bundle. Walks `isEntry: true`
-// chunks only; CSS attached to code-split chunks (via `imports[]` /
-// `dynamicImports[]`) won't surface until that walk lands as a follow-up.
+// Walks the import graph starting from every `isEntry: true` chunk and
+// collects CSS from every reachable chunk (including code-split nodes
+// under `imports[]` / `dynamicImports[]`). Dedupes across entries that
+// share a bundle. Cycle-safe via the visited set.
+//
+// Output order is DFS-from-entries — deterministic for a given manifest
+// (V8 preserves Object.entries insertion order) but not author-
+// controllable. Themes that need a specific cascade should declare
+// CSS via `document.link[]` (emits before bundled CSS) and rely on
+// CSS specificity for the rest.
 export function bundledCssTags(manifest: AssetManifest): string {
-  const seen = new Set<string>();
-  for (const entry of Object.values(manifest)) {
-    if (!entry.isEntry || !entry.css) continue;
-    for (const href of entry.css) seen.add(href);
+  const css = new Set<string>();
+  const visited = new Set<string>();
+  for (const [key, entry] of Object.entries(manifest)) {
+    if (entry.isEntry) collectReachableCss(key, manifest, css, visited);
   }
-  if (seen.size === 0) return "";
-  return Array.from(seen)
+  if (css.size === 0) return "";
+  return Array.from(css)
     .map((href) => `<link rel="stylesheet" href="/${href}" />`)
     .join("");
+}
+
+function collectReachableCss(
+  key: string,
+  manifest: AssetManifest,
+  css: Set<string>,
+  visited: Set<string>,
+): void {
+  if (visited.has(key)) return;
+  visited.add(key);
+  const entry = manifest[key];
+  if (!entry) return;
+  for (const href of entry.css ?? []) css.add(href);
+  for (const dep of entry.imports ?? []) {
+    collectReachableCss(dep, manifest, css, visited);
+  }
+  for (const dep of entry.dynamicImports ?? []) {
+    collectReachableCss(dep, manifest, css, visited);
+  }
 }


### PR DESCRIPTION
Wrap-up slice for PRD #510. `bundledCssTags` now walks the asset-manifest
import graph from every entry chunk and emits `<link rel=\"stylesheet\">`
tags for every reachable chunk's CSS — not just top-level entries. Both
example apps gain a Cloudflare Workers Assets `_headers` file applying
`Cache-Control: public, max-age=31536000, immutable` to hashed asset paths.

**Import-graph traversal with cycle safety**

The renderer recurses through `imports[]` + `dynamicImports[]` from every
`isEntry` chunk and collects CSS via a `visited` set. A code-split theme
that puts its CSS on a shared dependency chunk now has that `<link>`
surface in SSR'd `<head>`. Three new tests pin the behavior (imports[],
dynamicImports[], cycle-safety). Output order is DFS-from-entries —
deterministic per manifest but not author-controllable; themes that need
explicit cascade control should declare CSS via `document.link[]`, which
emits before bundled CSS in the head.

**Workers Assets `_headers` files**

Both `examples/blog/public/_headers` and `examples/minimal/public/_headers`
declare `Cache-Control: public, max-age=31536000, immutable` for `/assets/*`
(Vite's default `assetsDir`) and `/_plumix/assets/*` (future-proofing for
an `assetsDir` override). The files flow through the workspace `public/`
staging convention into `dist/client/_headers` — standard Pages/Workers
mechanism, no wrangler.jsonc change needed.

This closes out PRD #510's asset-pipeline track. The Tailwind dogfood
example was verified live earlier (CSS bundled, link tag emitted, computed
styles applied in browser); the cold-build ordering edge case where the
worker env bakes an empty manifest on a fresh project is documented in
the `virtual:plumix/asset-manifest` `load` hook's JSDoc.

Refs #510
Closes #514
Closes #528