### PR TITLE
feat(core): add defineTemplate factory with ctx in render

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,13 @@ export type {
   SingleData,
   TaxonomyData,
 } from "./route/render/resolved-entry.js";
+export { defineTemplate } from "./template.js";
+export type {
+  Template,
+  TemplateDepRegistry,
+  TemplateRender,
+  TemplateRenderArgs,
+} from "./template.js";
 export { defineTheme } from "./theme.js";
 export type {
   DocumentLink,
@@ -54,6 +61,7 @@ export type {
   DocumentScript,
   TemplateComponent,
   TemplateData,
+  TemplateEntry,
   TemplateRegistry,
   ThemeDescriptor,
 } from "./theme.js";

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -7,6 +7,9 @@ import type { ResolvedEntry } from "./resolved-entry.js";
 import { entries as entriesTable } from "../../db/schema/entries.js";
 import { definePlugin } from "../../plugin/define.js";
 import { createDispatcherHarness } from "../../test/dispatcher.js";
+import { useId } from "react";
+
+import { defineTemplate } from "../../template.js";
 import { defineTheme } from "../../theme.js";
 
 const blogPlugin = definePlugin("blog", (ctx) => {
@@ -361,6 +364,85 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(headSection).toMatch(
       /<link\s+rel="icon"[\s\S]*<link\s+rel="stylesheet"\s+href="\/_plumix\/assets\/theme-def456\.css"/,
     );
+  });
+
+  test("React hooks (useId) inside a factory template render correctly", async () => {
+    // Regression for the gotcha: if the renderer calls `template.render`
+    // outside React's render pass, useId / useState etc. throw with
+    // "Invalid hook call". The TemplateAdapter wraps the call so hooks
+    // are legal — this test enforces that contract.
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          render: ({ data }) => {
+            const id = useId();
+            return (
+              <article id={id} data-testid="hook-host">
+                {data.entry.title}
+              </article>
+            );
+          },
+        }),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hooks-ok",
+      title: "Hooks Ok",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/hooks-ok"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('data-testid="hook-host"');
+    // React 19's useId returns deterministic SSR ids beginning with «r;
+    // assert just the presence of an id attribute, not its value.
+    expect(body).toMatch(/<article\s+id="[^"]+"/);
+  });
+
+  test("factory-built template's render receives ctx with request + resolvedEntity", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          render: ({ data, ctx }) => (
+            <article data-testid="entry">
+              <h1>{data.entry.title}</h1>
+              <p data-testid="ctx-host">{new URL(ctx.request.url).host}</p>
+            </article>
+          ),
+        }),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "ctx-aware",
+      title: "Ctx Aware",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/ctx-aware"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="ctx-host"');
+    expect(body).toContain("cms.example");
+    expect(body).toContain("Ctx Aware");
   });
 
   test("`theme:document` filter contributions surface in SSR'd <head>", async () => {

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { describe, expect, test } from "vitest";
 
 import type { EntryContent } from "@plumix/blocks";
@@ -6,10 +7,8 @@ import { BlockRenderer } from "@plumix/blocks/renderer";
 import type { ResolvedEntry } from "./resolved-entry.js";
 import { entries as entriesTable } from "../../db/schema/entries.js";
 import { definePlugin } from "../../plugin/define.js";
-import { createDispatcherHarness } from "../../test/dispatcher.js";
-import { useId } from "react";
-
 import { defineTemplate } from "../../template.js";
+import { createDispatcherHarness } from "../../test/dispatcher.js";
 import { defineTheme } from "../../theme.js";
 
 const blogPlugin = definePlugin("blog", (ctx) => {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -5,12 +5,12 @@ import { renderToString } from "react-dom/server";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { AppContext } from "../../context/app.js";
+import type { Template } from "../../template.js";
 import type {
   DocumentLink,
   DocumentManifest,
   DocumentMeta,
   DocumentScript,
-  TemplateComponent,
   TemplateData,
   TemplateRegistry,
   ThemeDescriptor,
@@ -18,6 +18,7 @@ import type {
 import type { AssetManifest } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
+import { normalizeTemplate } from "../../template.js";
 import { bundledCssTags } from "./asset-manifest.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -41,8 +42,8 @@ export async function renderThroughTheme({
   title,
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
-  const Template = pickTemplate(theme.templates, candidates);
-  return renderTree({ ctx, document, assetManifest, data, title, Template });
+  const template = pickTemplate(theme.templates, candidates);
+  return renderTree({ ctx, document, assetManifest, data, title, template });
 }
 
 interface RenderErrorArgs {
@@ -72,15 +73,15 @@ export function renderErrorThroughTheme({
   data,
 }: RenderErrorArgs): string {
   const variant = ERROR_VARIANTS[kind];
-  const Template = (theme.templates[variant.key] ??
-    variant.fallback) as TemplateComponent<TemplateData>;
+  const raw = theme.templates[variant.key] ?? variant.fallback;
+  const template = normalizeTemplate(raw, variant.key);
   return renderTree({
     ctx,
     document,
     assetManifest,
     data,
     title: variant.title,
-    Template,
+    template,
   });
 }
 
@@ -90,7 +91,7 @@ interface RenderTreeArgs {
   readonly assetManifest: AssetManifest;
   readonly data: TemplateData;
   readonly title: string;
-  readonly Template: TemplateComponent<TemplateData>;
+  readonly template: Template<TemplateData>;
 }
 
 // React 19 reorders every child of `<head>` (metadata first, scripts /
@@ -105,11 +106,18 @@ function renderTree({
   assetManifest,
   data,
   title,
-  Template,
+  template,
 }: RenderTreeArgs): string {
+  // Adapter FC wraps `template.render({ data, ctx })` so it executes
+  // inside React's render pass — hooks (useState, useId, useMemo,
+  // useSyncExternalStore) inside a factory template are legal. A
+  // direct `template.render({data, ctx})` here would throw "Invalid
+  // hook call" because React's dispatcher isn't set yet at this
+  // construction point.
+  const TemplateAdapter = (): ReactNode => template.render({ data, ctx });
   const templateTree: ReactNode = createElement(PlumixProvider, {
     value: { registry: ctx.blocks },
-    children: createElement(Template, { data }),
+    children: createElement(TemplateAdapter),
   });
   const rendered = renderToString(templateTree);
   const { hoisted, body } = splitHoistedMetadata(rendered);
@@ -271,15 +279,16 @@ function escapeAttr(value: string): string {
 function pickTemplate(
   templates: TemplateRegistry,
   candidates: readonly string[],
-): TemplateComponent<TemplateData> {
+): Template<TemplateData> {
   // The candidate list is derived from the route's kind, so the picked
   // template's narrowed data shape always matches the runtime `data`.
-  // TS can't see that — widen with a cast at the boundary.
+  // Normalize at the boundary — accepts both plain function templates
+  // (legacy) and factory-built `Template<T>` objects.
   for (const name of candidates) {
     const candidate = templates[name];
-    if (candidate) return candidate as TemplateComponent<TemplateData>;
+    if (candidate) return normalizeTemplate(candidate, name);
   }
-  return templates.index;
+  return normalizeTemplate(templates.index, "index");
 }
 
 function DefaultNotFound() {

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -13,8 +13,12 @@ export interface ResolvedEntry extends Entry {
   readonly author: ResolvedAuthor;
 }
 
-export interface SingleData {
-  readonly entry: ResolvedEntry;
+// Per-kind data shapes are generic over the entry projection so theme
+// authors can narrow `data.entry` to plugin-populated types (e.g.
+// `defineTemplate<SingleData<BlogPost>>`). Default to `ResolvedEntry`
+// — the framework's internal renderer always sees the default.
+export interface SingleData<TEntry extends ResolvedEntry = ResolvedEntry> {
+  readonly entry: TEntry;
 }
 
 export interface Pagination {
@@ -24,21 +28,21 @@ export interface Pagination {
   readonly pageCount: number;
 }
 
-export interface ArchiveData {
+export interface ArchiveData<TEntry extends ResolvedEntry = ResolvedEntry> {
   readonly contentType: string;
-  readonly entries: readonly ResolvedEntry[];
+  readonly entries: readonly TEntry[];
   readonly pagination: Pagination;
 }
 
-export interface TaxonomyData {
+export interface TaxonomyData<TEntry extends ResolvedEntry = ResolvedEntry> {
   readonly taxonomy: string;
   readonly term: Term;
-  readonly entries: readonly ResolvedEntry[];
+  readonly entries: readonly TEntry[];
   readonly pagination: Pagination;
 }
 
-export interface FrontPageData {
-  readonly entries: readonly ResolvedEntry[];
+export interface FrontPageData<TEntry extends ResolvedEntry = ResolvedEntry> {
+  readonly entries: readonly TEntry[];
   readonly pagination: Pagination;
 }
 

--- a/packages/core/src/template.test.ts
+++ b/packages/core/src/template.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+
+import { defineTemplate, isTemplate, normalizeTemplate } from "./template.js";
+import { ThemeRegistrationError } from "./theme-errors.js";
+
+describe("defineTemplate", () => {
+  test("returns a Template that `isTemplate` recognizes", () => {
+    const tmpl = defineTemplate({ render: () => null });
+    expect(isTemplate(tmpl)).toBe(true);
+  });
+
+  test("preserves the render function unchanged on the branded object", () => {
+    const render = () => null;
+    const tmpl = defineTemplate({ render });
+    expect(tmpl.render).toBe(render);
+  });
+
+  test("a hand-written `{ render }` literal is NOT recognized as a Template", () => {
+    // Locks the brand invariant — only `defineTemplate`'s output passes
+    // `isTemplate`. A future deps / document-fragment field added to
+    // the factory contract would otherwise be silently absent on a
+    // plain literal.
+    expect(isTemplate({ render: () => null })).toBe(false);
+  });
+});
+
+describe("normalizeTemplate", () => {
+  test("wraps a plain function into a branded Template (factory shape)", () => {
+    // The wrapper invokes the legacy fn via `createElement` so React's
+    // render pass handles hooks. Asserting that the returned ReactNode
+    // is a React element whose `type` points at the original fn proves
+    // the wiring without spinning up `renderToString`.
+    const fn = () => null;
+    const normalized = normalizeTemplate(fn, "index");
+    expect(isTemplate(normalized)).toBe(true);
+    const element = normalized.render({
+      data: {} as unknown as Parameters<typeof normalized.render>[0]["data"],
+      ctx: {} as unknown as Parameters<typeof normalized.render>[0]["ctx"],
+    }) as unknown as { type: unknown; props: unknown };
+    expect(element.type).toBe(fn);
+  });
+
+  test("passes a factory-built template through unchanged", () => {
+    const tmpl = defineTemplate({ render: () => null });
+    const normalized = normalizeTemplate(tmpl, "single");
+    expect(normalized).toBe(tmpl);
+  });
+
+  test("rejects an unbranded `{ render: fn }` object with a typed error", () => {
+    const unbranded = { render: () => null };
+    expect(() => normalizeTemplate(unbranded, "archive")).toThrow(
+      ThemeRegistrationError,
+    );
+  });
+});

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -39,7 +39,7 @@ export interface Template<TData extends TemplateData = TemplateData> {
   readonly [PLUMIX_TEMPLATE_BRAND]: true;
 }
 
-export interface DefineTemplateConfig<TData extends TemplateData> {
+interface DefineTemplateConfig<TData extends TemplateData> {
   readonly render: TemplateRender<TData>;
 }
 

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -1,0 +1,97 @@
+import type { ComponentType, ReactNode } from "react";
+import { createElement } from "react";
+
+import type { AppContext } from "./context/app.js";
+import type { TemplateData } from "./theme.js";
+import { ThemeRegistrationError } from "./theme-errors.js";
+
+// Module-local brand — not `Symbol.for(...)`. The global registry
+// would let any caller forge a fake template via
+// `Symbol.for("plumix.template")`, defeating the whole point of the
+// brand. A module-local symbol is only obtainable through this
+// file's exports (`defineTemplate`, `isTemplate`).
+const PLUMIX_TEMPLATE_BRAND: unique symbol = Symbol("plumix.template");
+
+/**
+ * Augmentable registry of template-level dep slots. Slice #518 wires
+ * `registerTemplateDep` against this interface; today it stays empty
+ * so subsequent module augmentations don't require an ABI bump.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- intentional augmentation seam
+export interface TemplateDepRegistry {}
+
+export interface TemplateRenderArgs<TData extends TemplateData> {
+  readonly data: TData;
+  readonly ctx: AppContext;
+}
+
+export type TemplateRender<TData extends TemplateData> = (
+  args: TemplateRenderArgs<TData>,
+) => ReactNode;
+
+/**
+ * Output of `defineTemplate`. The brand symbol is non-enumerable so
+ * it doesn't pollute `Object.keys` / JSON serialization but stays
+ * load-bearing for runtime identification via `isTemplate`.
+ */
+export interface Template<TData extends TemplateData = TemplateData> {
+  readonly render: TemplateRender<TData>;
+  readonly [PLUMIX_TEMPLATE_BRAND]: true;
+}
+
+export interface DefineTemplateConfig<TData extends TemplateData> {
+  readonly render: TemplateRender<TData>;
+}
+
+export function defineTemplate<TData extends TemplateData = TemplateData>(
+  config: DefineTemplateConfig<TData>,
+): Template<TData> {
+  const template: { render: TemplateRender<TData> } = {
+    render: config.render,
+  };
+  // `enumerable: false` keeps the brand out of `Object.keys` / JSON;
+  // writable/configurable defaults are fine — the symbol itself is
+  // module-local so no caller can forge or rewrite it.
+  Object.defineProperty(template, PLUMIX_TEMPLATE_BRAND, {
+    value: true,
+    enumerable: false,
+  });
+  return template as Template<TData>;
+}
+
+export function isTemplate(value: unknown): value is Template<TemplateData> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<symbol, unknown>)[PLUMIX_TEMPLATE_BRAND] === true
+  );
+}
+
+/**
+ * Boot-time normalizer. Plain function templates (the existing
+ * `TemplateComponent` form) get wrapped into a branded `Template`;
+ * factory-built templates pass through verbatim. Hand-written
+ * `{ render: fn }` literals — close to but not from the factory —
+ * fail loud so a future deps / document-fragment field doesn't get
+ * silently ignored on a malformed registration.
+ */
+export function normalizeTemplate(
+  value: unknown,
+  slot: string,
+): Template<TemplateData> {
+  if (isTemplate(value)) return value;
+  if (typeof value === "function") {
+    // Invoke the legacy template via `createElement` so it runs inside
+    // React's render pass — preserves hooks (useState, useId, etc.)
+    // and supports both function and class components. Calling the
+    // function directly would throw "Invalid hook call" the moment a
+    // theme author reaches for a hook.
+    const ComponentLike = value as ComponentType<{
+      readonly data: TemplateData;
+    }>;
+    return defineTemplate({
+      render: ({ data }) => createElement(ComponentLike, { data }),
+    });
+  }
+  throw ThemeRegistrationError.invalidTemplate({ slot });
+}

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -2,7 +2,8 @@ type ThemeRegistrationCode =
   | "missing_theme"
   | "missing_index_template"
   | "document_invalid_link"
-  | "document_invalid_script";
+  | "document_invalid_script"
+  | "invalid_template";
 
 export class ThemeRegistrationError extends Error {
   static {
@@ -42,6 +43,17 @@ export class ThemeRegistrationError extends Error {
         `entry without a \`rel\` attribute. Every \`<link>\` in the document ` +
         `manifest must declare a \`rel\` — browsers ignore unkeyed link tags ` +
         `and the renderer would emit invalid HTML.`,
+    );
+  }
+
+  static invalidTemplate(ctx: { slot: string }): ThemeRegistrationError {
+    return new ThemeRegistrationError(
+      "invalid_template",
+      `Theme registration: templates.${ctx.slot} must be either a plain ` +
+        `function (legacy form) or a Template built via \`defineTemplate({ ` +
+        `render: ... })\`. A hand-written \`{ render }\` literal that ` +
+        `didn't go through the factory is rejected so future deps / ` +
+        `document-fragment fields don't get silently ignored.`,
     );
   }
 

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -9,6 +9,7 @@ import type {
   SingleData,
   TaxonomyData,
 } from "./route/render/resolved-entry.js";
+import type { Template } from "./template.js";
 import { ThemeError, ThemeRegistrationError } from "./theme-errors.js";
 
 // `theme:document` is a boot-time filter chain. `buildApp` fires it once,
@@ -38,17 +39,25 @@ export type TemplateData =
 
 export type TemplateComponent<Data> = ComponentType<{ readonly data: Data }>;
 
+// Per-slot entry type: either the legacy plain-function form
+// (`TemplateComponent<T>`) or a `Template<T>` built via `defineTemplate`.
+// The `normalizeTemplate` boot-time helper accepts both and rejects
+// hand-written `{ render }` literals that didn't go through the factory.
+export type TemplateEntry<Data extends TemplateData> =
+  | TemplateComponent<Data>
+  | Template<Data>;
+
 // Catch-all for the registry's index signature. The narrow per-key
 // slots can't share a single typed slot due to contravariance, so the
-// signature accepts any concrete-shape component (`single-{type}`,
+// signature accepts any concrete-shape entry (`single-{type}`,
 // `archive-{type}`, …) or one written against the full union.
-type DynamicTemplateComponent =
-  | TemplateComponent<SingleData>
-  | TemplateComponent<ArchiveData>
-  | TemplateComponent<TaxonomyData>
-  | TemplateComponent<FrontPageData>
-  | TemplateComponent<ErrorData>
-  | TemplateComponent<TemplateData>;
+type DynamicTemplateEntry =
+  | TemplateEntry<SingleData>
+  | TemplateEntry<ArchiveData>
+  | TemplateEntry<TaxonomyData>
+  | TemplateEntry<FrontPageData>
+  | TemplateEntry<ErrorData>
+  | TemplateEntry<TemplateData>;
 
 /**
  * Strip React-isms that don't belong in HTML attribute descriptors:
@@ -99,19 +108,19 @@ export interface DocumentManifest {
 }
 
 export interface TemplateRegistry {
-  readonly index: TemplateComponent<TemplateData>;
-  readonly single?: TemplateComponent<SingleData>;
-  readonly singular?: TemplateComponent<SingleData>;
-  readonly page?: TemplateComponent<SingleData>;
-  readonly archive?: TemplateComponent<ArchiveData>;
-  readonly taxonomy?: TemplateComponent<TaxonomyData>;
-  readonly category?: TemplateComponent<TaxonomyData>;
-  readonly tag?: TemplateComponent<TaxonomyData>;
-  readonly "front-page"?: TemplateComponent<FrontPageData>;
-  readonly home?: TemplateComponent<FrontPageData>;
-  readonly "404"?: TemplateComponent<ErrorData>;
-  readonly "500"?: TemplateComponent<ErrorData>;
-  readonly [key: string]: DynamicTemplateComponent | undefined;
+  readonly index: TemplateEntry<TemplateData>;
+  readonly single?: TemplateEntry<SingleData>;
+  readonly singular?: TemplateEntry<SingleData>;
+  readonly page?: TemplateEntry<SingleData>;
+  readonly archive?: TemplateEntry<ArchiveData>;
+  readonly taxonomy?: TemplateEntry<TaxonomyData>;
+  readonly category?: TemplateEntry<TaxonomyData>;
+  readonly tag?: TemplateEntry<TaxonomyData>;
+  readonly "front-page"?: TemplateEntry<FrontPageData>;
+  readonly home?: TemplateEntry<FrontPageData>;
+  readonly "404"?: TemplateEntry<ErrorData>;
+  readonly "500"?: TemplateEntry<ErrorData>;
+  readonly [key: string]: DynamicTemplateEntry | undefined;
 }
 
 export interface ThemeDescriptor {

--- a/packages/plumix/src/theme/index.ts
+++ b/packages/plumix/src/theme/index.ts
@@ -1,4 +1,5 @@
 export {
+  defineTemplate,
   defineTheme,
   isEntryArchive,
   isTaxonomy,
@@ -10,5 +11,9 @@ export {
   type DocumentScript,
   type EntryArchiveProps,
   type TaxonomyArchiveProps,
+  type Template,
+  type TemplateDepRegistry,
+  type TemplateRender,
+  type TemplateRenderArgs,
   type ThemeDescriptor,
 } from "@plumix/core";


### PR DESCRIPTION
Themes can now author templates via `defineTemplate({ render: ({ data, ctx }) => ... })` and
receive the full `AppContext` (request, db, hooks, plugins, resolvedEntity) in render. Plain
function templates keep working — they normalize to the factory shape at boot. Data
interfaces (`SingleData`, `ArchiveData`, `TaxonomyData`, `FrontPageData`) become generic over
the entry type so theme authors can narrow `data.entry` to plugin-populated shapes.

**Brand via module-local symbol, not the global registry**

The factory stamps a non-enumerable `Symbol(\"plumix.template\")` — NOT `Symbol.for(...)`.
The global registry would let any caller forge a fake template, defeating the whole point
of the brand: `defineTemplate`'s contract is the one place we can attach future deps /
document-fragment validation. A hand-written `{ render }` literal that didn't go through
the factory throws a `ThemeRegistrationError` at boot, naming the offending slot.

**Render-pass invariants for hooks**

Legacy function templates invoke via `createElement(fn, { data })` so they run inside
React's render phase — preserves hooks and supports both function and class components.
Factory templates render through a tiny `TemplateAdapter` FC that calls
`template.render({ data, ctx })` from within the render phase. A direct call from outside
would throw \"Invalid hook call\" the moment a theme reaches for `useId`, `useState`,
`useMemo`, or `useSyncExternalStore`. Regression test pins this.

**Parametric data types are the public extension point**

`SingleData<TEntry extends ResolvedEntry = ResolvedEntry>` (and the archive / taxonomy /
front-page siblings) default to `ResolvedEntry` so the framework's internal renderer
sees the existing shape. Theme authors narrow via `defineTemplate<SingleData<MyEntry>>(...)`
and pair the narrowing with a plugin's `resolve:single:data` filter to populate the
extra fields — the variance gotcha is the explicit point of the API.

This slice adds the factory + ctx + parametric types. Per-template document fragment
(#517) and deps support (#518) follow. `TemplateDepRegistry` ships now as an augmentable
empty interface so #518 doesn't trigger an ABI bump.

Refs #515
Closes #516