### PR TITLE
feat(core): per-template document fragment with boot-time merge

### DIFF
--- a/packages/core/src/document-merge.test.ts
+++ b/packages/core/src/document-merge.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+
+import { mergeDocumentManifest } from "./document-merge.js";
+
+describe("mergeDocumentManifest", () => {
+  test("concats theme link[] then template link[]", () => {
+    const merged = mergeDocumentManifest(
+      { link: [{ rel: "icon", href: "/favicon.svg" }] },
+      { link: [{ rel: "stylesheet", href: "/single.css" }] },
+    );
+    expect(merged.link).toEqual([
+      { rel: "icon", href: "/favicon.svg" },
+      { rel: "stylesheet", href: "/single.css" },
+    ]);
+  });
+
+  test("concats meta[] in theme-then-template order", () => {
+    const merged = mergeDocumentManifest(
+      { meta: [{ name: "theme-color", content: "#fff" }] },
+      { meta: [{ name: "robots", content: "noindex" }] },
+    );
+    expect(merged.meta).toEqual([
+      { name: "theme-color", content: "#fff" },
+      { name: "robots", content: "noindex" },
+    ]);
+  });
+
+  test("concats script[] in theme-then-template order", () => {
+    const merged = mergeDocumentManifest(
+      { script: [{ src: "https://theme.example/a.js" }] },
+      { script: [{ src: "https://single.example/b.js", position: "headEnd" }] },
+    );
+    expect(merged.script).toEqual([
+      { src: "https://theme.example/a.js" },
+      { src: "https://single.example/b.js", position: "headEnd" },
+    ]);
+  });
+
+  test("theme-only merge (no template fragment) preserves theme arrays", () => {
+    const theme = {
+      link: [{ rel: "icon", href: "/x.svg" }],
+      meta: [{ name: "theme-color", content: "#000" }],
+    };
+    const merged = mergeDocumentManifest(theme, undefined);
+    expect(merged.link).toEqual(theme.link);
+    expect(merged.meta).toEqual(theme.meta);
+  });
+
+  test("html.className concatenates theme + template with a space separator", () => {
+    const merged = mergeDocumentManifest(
+      { html: { lang: "en", className: "theme" } },
+      { html: { className: "single-variant" } },
+    );
+    expect(merged.html).toEqual({
+      lang: "en",
+      className: "theme single-variant",
+    });
+  });
+
+  test("body.className also concatenates", () => {
+    const merged = mergeDocumentManifest(
+      { body: { className: "font-sans" } },
+      { body: { className: "post-page" } },
+    );
+    expect(merged.body).toEqual({ className: "font-sans post-page" });
+  });
+
+  test("template scalar html/body fields override theme (last-wins)", () => {
+    const merged = mergeDocumentManifest(
+      { html: { lang: "en", dir: "ltr" } },
+      { html: { lang: "fr" } },
+    );
+    expect(merged.html).toEqual({ lang: "fr", dir: "ltr" });
+  });
+
+  test("empty theme + template fragment surfaces the template's entries", () => {
+    const merged = mergeDocumentManifest(
+      {},
+      { link: [{ rel: "preconnect", href: "https://cdn.example" }] },
+    );
+    expect(merged.link).toEqual([
+      { rel: "preconnect", href: "https://cdn.example" },
+    ]);
+  });
+});

--- a/packages/core/src/document-merge.ts
+++ b/packages/core/src/document-merge.ts
@@ -1,0 +1,59 @@
+import type { DocumentManifest } from "./theme.js";
+
+/**
+ * Merge a template's per-template document fragment onto the theme's
+ * site-wide merged document. Theme bytes always come first so the
+ * cascade lands template overrides last (which is what authors expect:
+ * "this template adds X / overrides Y").
+ *
+ * Rules:
+ *  - `link[]` / `meta[]` / `script[]` arrays: theme entries first,
+ *    template entries appended. v1 does no identity-based dedupe —
+ *    `<link rel="canonical">` declared in both theme and template
+ *    surfaces twice (per the PRD).
+ *  - `html` / `body` attribute objects: scalar fields last-wins
+ *    (template overrides theme), `className` space-concatenated +
+ *    whitespace-normalized.
+ *
+ * Returns a new object — callers freeze the result if they want to
+ * lock it down (e.g. boot-time precomputation on `PlumixApp`).
+ */
+export function mergeDocumentManifest(
+  theme: DocumentManifest,
+  fragment: DocumentManifest | undefined,
+): DocumentManifest {
+  return {
+    html: mergeAttrs(theme.html, fragment?.html),
+    body: mergeAttrs(theme.body, fragment?.body),
+    link: concatArrays(theme.link, fragment?.link),
+    meta: concatArrays(theme.meta, fragment?.meta),
+    script: concatArrays(theme.script, fragment?.script),
+  };
+}
+
+function concatArrays<T>(
+  a: readonly T[] | undefined,
+  b: readonly T[] | undefined,
+): readonly T[] | undefined {
+  if (!a && !b) return undefined;
+  return [...(a ?? []), ...(b ?? [])];
+}
+
+function mergeAttrs(
+  theme: Readonly<Record<string, unknown>> | undefined,
+  fragment: Readonly<Record<string, unknown>> | undefined,
+): Readonly<Record<string, unknown>> | undefined {
+  if (!theme && !fragment) return undefined;
+  const merged: Record<string, unknown> = { ...theme, ...fragment };
+  const themeClass = theme?.className;
+  const fragmentClass = fragment?.className;
+  if (typeof themeClass === "string" && typeof fragmentClass === "string") {
+    // Trim each side + normalize internal whitespace so a leading /
+    // trailing space on either input (or doubled separators) doesn't
+    // produce ugly `<html class=\"site  trim-me \">` output.
+    merged.className = `${themeClass} ${fragmentClass}`
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+  return merged;
+}

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -365,6 +365,137 @@ describe("resolvePublicRoute — single entry through theme", () => {
     );
   });
 
+  test("per-template document fragment merges with theme document; theme entries first", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          document: {
+            meta: [{ name: "robots", content: "noindex" }],
+            html: { className: "single-variant" },
+          },
+          render: ({ data }) => <article>{data.entry.title}</article>,
+        }),
+      },
+      document: {
+        meta: [{ name: "theme-color", content: "#0ea5e9" }],
+        html: { lang: "en", className: "site" },
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "merged-doc",
+      title: "Merged",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/merged-doc"),
+    );
+    const body = await response.text();
+    // html.className concatenated, theme first then template
+    expect(body).toContain('<html lang="en" class="site single-variant">');
+    // Meta from both theme and template appear, theme before template
+    const headSection = body.slice(
+      body.indexOf("<head>"),
+      body.indexOf("</head>"),
+    );
+    expect(headSection).toMatch(
+      /<meta\s+name="theme-color"[\s\S]*<meta\s+name="robots"\s+content="noindex"/,
+    );
+  });
+
+  test("per-template script[] with headEnd position lands in head after theme scripts", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          document: {
+            script: [
+              {
+                src: "https://template.example/single.js",
+                position: "headEnd",
+                defer: true,
+              },
+            ],
+          },
+          render: ({ data }) => <article>{data.entry.title}</article>,
+        }),
+      },
+      document: {
+        script: [
+          {
+            src: "https://theme.example/site.js",
+            position: "headEnd",
+          },
+        ],
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "script-position",
+      title: "Script Position",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/script-position"),
+    );
+    const body = await response.text();
+    const headSection = body.slice(
+      body.indexOf("<head>"),
+      body.indexOf("</head>"),
+    );
+    // Both scripts in head; theme's first, template's after
+    expect(headSection).toMatch(
+      /<script\s+src="https:\/\/theme\.example\/site\.js"[^>]*><\/script>[\s\S]*<script\s+src="https:\/\/template\.example\/single\.js"/,
+    );
+  });
+
+  test("templates without a document fragment fall back to the theme-wide document", async () => {
+    // Locks the contract: a template that doesn't declare its own
+    // fragment shouldn't pay any per-template cost — and shouldn't
+    // accidentally render a wrong document either.
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        // Plain function form — no `document` at all.
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+      document: {
+        meta: [{ name: "theme-color", content: "#0ea5e9" }],
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "no-fragment",
+      title: "No Fragment",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/no-fragment"),
+    );
+    const body = await response.text();
+    expect(body).toContain('<meta name="theme-color" content="#0ea5e9"');
+  });
+
   test("React hooks (useId) inside a factory template render correctly", async () => {
     // Regression for the gotcha: if the renderer calls `template.render`
     // outside React's render pass, useId / useState etc. throw with

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -303,9 +303,13 @@ function pickTemplate(
   // `templateDocuments` map.
   for (const name of candidates) {
     const candidate = templates[name];
-    if (candidate) return { template: normalizeTemplate(candidate, name), slot: name };
+    if (candidate)
+      return { template: normalizeTemplate(candidate, name), slot: name };
   }
-  return { template: normalizeTemplate(templates.index, "index"), slot: "index" };
+  return {
+    template: normalizeTemplate(templates.index, "index"),
+    slot: "index",
+  };
 }
 
 function DefaultNotFound() {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -26,6 +26,7 @@ interface RenderArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
   readonly document: DocumentManifest;
+  readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
   readonly assetManifest: AssetManifest;
   readonly node: ResolvedNode;
   readonly data: TemplateData;
@@ -36,20 +37,32 @@ export async function renderThroughTheme({
   ctx,
   theme,
   document,
+  templateDocuments,
   assetManifest,
   node,
   data,
   title,
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
-  const template = pickTemplate(theme.templates, candidates);
-  return renderTree({ ctx, document, assetManifest, data, title, template });
+  const { template, slot } = pickTemplate(theme.templates, candidates);
+  // Per-template fragment is precomputed at boot; fall back to the
+  // theme-wide document when the template didn't declare its own.
+  const renderDocument = templateDocuments.get(slot) ?? document;
+  return renderTree({
+    ctx,
+    document: renderDocument,
+    assetManifest,
+    data,
+    title,
+    template,
+  });
 }
 
 interface RenderErrorArgs {
   readonly ctx: AppContext;
   readonly theme: ThemeDescriptor;
   readonly document: DocumentManifest;
+  readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
   readonly assetManifest: AssetManifest;
   readonly kind: "not-found" | "server-error";
   readonly data: ErrorData;
@@ -68,6 +81,7 @@ export function renderErrorThroughTheme({
   ctx,
   theme,
   document,
+  templateDocuments,
   assetManifest,
   kind,
   data,
@@ -75,9 +89,10 @@ export function renderErrorThroughTheme({
   const variant = ERROR_VARIANTS[kind];
   const raw = theme.templates[variant.key] ?? variant.fallback;
   const template = normalizeTemplate(raw, variant.key);
+  const renderDocument = templateDocuments.get(variant.key) ?? document;
   return renderTree({
     ctx,
-    document,
+    document: renderDocument,
     assetManifest,
     data,
     title: variant.title,
@@ -279,16 +294,18 @@ function escapeAttr(value: string): string {
 function pickTemplate(
   templates: TemplateRegistry,
   candidates: readonly string[],
-): Template<TemplateData> {
+): { template: Template<TemplateData>; slot: string } {
   // The candidate list is derived from the route's kind, so the picked
   // template's narrowed data shape always matches the runtime `data`.
   // Normalize at the boundary — accepts both plain function templates
-  // (legacy) and factory-built `Template<T>` objects.
+  // (legacy) and factory-built `Template<T>` objects. The returned
+  // `slot` keys per-template document lookups on the app's precomputed
+  // `templateDocuments` map.
   for (const name of candidates) {
     const candidate = templates[name];
-    if (candidate) return normalizeTemplate(candidate, name);
+    if (candidate) return { template: normalizeTemplate(candidate, name), slot: name };
   }
-  return normalizeTemplate(templates.index, "index");
+  return { template: normalizeTemplate(templates.index, "index"), slot: "index" };
 }
 
 function DefaultNotFound() {

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -84,7 +84,13 @@ export async function resolvePublicRoute(
         assetManifest,
       );
     case "front-page":
-      return resolveFrontPage(ctx, theme, document, templateDocuments, assetManifest);
+      return resolveFrontPage(
+        ctx,
+        theme,
+        document,
+        templateDocuments,
+        assetManifest,
+      );
   }
 }
 

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -49,6 +49,7 @@ export async function resolvePublicRoute(
   match: RouteMatch,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  templateDocuments: ReadonlyMap<string, DocumentManifest>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   switch (match.intent.kind) {
@@ -59,6 +60,7 @@ export async function resolvePublicRoute(
         match.params,
         theme,
         document,
+        templateDocuments,
         assetManifest,
       );
     case "archive":
@@ -68,6 +70,7 @@ export async function resolvePublicRoute(
         match.params,
         theme,
         document,
+        templateDocuments,
         assetManifest,
       );
     case "taxonomy":
@@ -77,10 +80,11 @@ export async function resolvePublicRoute(
         match.params,
         theme,
         document,
+        templateDocuments,
         assetManifest,
       );
     case "front-page":
-      return resolveFrontPage(ctx, theme, document, assetManifest);
+      return resolveFrontPage(ctx, theme, document, templateDocuments, assetManifest);
   }
 }
 
@@ -88,6 +92,7 @@ async function resolveFrontPage(
   ctx: AppContext,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  templateDocuments: ReadonlyMap<string, DocumentManifest>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const page = 1;
@@ -118,6 +123,7 @@ async function resolveFrontPage(
     ctx,
     theme,
     document,
+    templateDocuments,
     assetManifest,
     node: { kind: "front-page" },
     data,
@@ -134,6 +140,7 @@ async function resolveTaxonomy(
   params: Record<string, string>,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  templateDocuments: ReadonlyMap<string, DocumentManifest>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const term = await findTermForTaxonomy(ctx, intent.taxonomy, params);
@@ -182,6 +189,7 @@ async function resolveTaxonomy(
     ctx,
     theme,
     document,
+    templateDocuments,
     assetManifest,
     node: {
       kind: "term",
@@ -203,6 +211,7 @@ async function resolveSingle(
   params: Record<string, string>,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  templateDocuments: ReadonlyMap<string, DocumentManifest>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const row = await findEntryForSingle(ctx, intent.entryType, params);
@@ -221,6 +230,7 @@ async function resolveSingle(
     ctx,
     theme,
     document,
+    templateDocuments,
     assetManifest,
     node: {
       kind: "content",
@@ -242,6 +252,7 @@ async function resolveArchive(
   params: Record<string, string>,
   theme: ThemeDescriptor,
   document: DocumentManifest,
+  templateDocuments: ReadonlyMap<string, DocumentManifest>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const page = parsePageParam(params.page);
@@ -278,6 +289,7 @@ async function resolveArchive(
     ctx,
     theme,
     document,
+    templateDocuments,
     assetManifest,
     node: { kind: "content-type-archive", entryType: intent.entryType },
     data,

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -23,6 +23,8 @@ import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RouteRule } from "../route/intent.js";
 import type { AssetManifest } from "../route/render/asset-manifest.js";
 import type { DocumentManifest } from "../theme.js";
+import { mergeDocumentManifest } from "../document-merge.js";
+import { isTemplate } from "../template.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
@@ -140,6 +142,14 @@ export interface PlumixApp {
    * exist (e.g. tests that don't run a full Vite build).
    */
   readonly assetManifest: AssetManifest;
+  /**
+   * Per-template merged document manifest. Each entry is the result
+   * of `mergeDocumentManifest(app.document, template.document)`,
+   * resolved once at boot and frozen. The renderer looks up by the
+   * matched template slot (`single`, `archive`, `index`, etc.) so
+   * per-request renders pay zero merge cost.
+   */
+  readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
 }
 
 // Runtime-only state the worker template injects at boot — values
@@ -236,6 +246,7 @@ export async function buildApp(
   );
 
   const document = await resolveDocumentManifest(hooks, config.theme.document);
+  const templateDocuments = buildTemplateDocuments(config.theme.templates, document);
 
   return {
     config,
@@ -259,7 +270,38 @@ export async function buildApp(
     htmlAllowlist,
     document,
     assetManifest: runtime.assetManifest ?? {},
+    templateDocuments,
   };
+}
+
+// Precompute the per-template merged document — theme-wide manifest
+// (already through the `theme:document` filter chain) merged with each
+// template's optional fragment. Each result is deep-frozen; the map
+// itself is frozen too. The renderer looks up by matched template slot
+// at request time and pays zero merge cost.
+function buildTemplateDocuments(
+  templates: Record<string, unknown>,
+  themeDocument: DocumentManifest,
+): ReadonlyMap<string, DocumentManifest> {
+  const result = new Map<string, DocumentManifest>();
+  for (const [slot, value] of Object.entries(templates)) {
+    if (!isTemplate(value)) {
+      // Legacy function form has no `document` field — render still
+      // uses `app.document` via the fallback lookup, so we don't need
+      // a per-slot entry.
+      continue;
+    }
+    if (value.document === undefined) {
+      // No fragment means the template wants the site-wide document
+      // verbatim; skip the entry so the renderer falls back to
+      // `app.document` (already deep-frozen).
+      continue;
+    }
+    const merged = mergeDocumentManifest(themeDocument, value.document);
+    validateDocumentManifest(merged, slot);
+    result.set(slot, deepFreezeManifest(merged));
+  }
+  return Object.freeze(result);
 }
 
 // Run the `theme:document` filter chain once at boot. Plugins spread + add

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -23,13 +23,12 @@ import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RouteRule } from "../route/intent.js";
 import type { AssetManifest } from "../route/render/asset-manifest.js";
 import type { DocumentManifest } from "../theme.js";
-import { mergeDocumentManifest } from "../document-merge.js";
-import { isTemplate } from "../template.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
 import * as coreSchema from "../db/schema/index.js";
+import { mergeDocumentManifest } from "../document-merge.js";
 import { HookRegistry } from "../hooks/registry.js";
 import {
   CORE_RPC_NAMESPACES,
@@ -39,6 +38,7 @@ import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { appRouter } from "../rpc/router.js";
+import { isTemplate } from "../template.js";
 import { ThemeRegistrationError } from "../theme-errors.js";
 import { validateDocumentManifest } from "../theme.js";
 import { AppBootError } from "./errors.js";
@@ -246,7 +246,10 @@ export async function buildApp(
   );
 
   const document = await resolveDocumentManifest(hooks, config.theme.document);
-  const templateDocuments = buildTemplateDocuments(config.theme.templates, document);
+  const templateDocuments = buildTemplateDocuments(
+    config.theme.templates,
+    document,
+  );
 
   return {
     config,

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -182,6 +182,7 @@ async function dispatchPublicRoute(
 ): Promise<Response> {
   const theme = app.config.theme;
   const document = app.document;
+  const templateDocuments = app.templateDocuments;
   const assetManifest = app.assetManifest;
   try {
     const response = await resolvePublicRouteOrFallback(app, ctx, url);
@@ -190,6 +191,7 @@ async function dispatchPublicRoute(
         ctx,
         theme,
         document,
+        templateDocuments,
         assetManifest,
         kind: "not-found",
         data: {
@@ -212,6 +214,7 @@ async function dispatchPublicRoute(
         ctx,
         theme,
         document,
+        templateDocuments,
         assetManifest,
         kind: "server-error",
         data: { request: ctx.request },
@@ -243,10 +246,18 @@ async function resolvePublicRouteOrFallback(
 ): Promise<Response> {
   const theme = app.config.theme;
   const document = app.document;
+  const templateDocuments = app.templateDocuments;
   const assetManifest = app.assetManifest;
   const match = matchRoute(url, app.routeMap);
   if (match !== null) {
-    return resolvePublicRoute(ctx, match, theme, document, assetManifest);
+    return resolvePublicRoute(
+      ctx,
+      match,
+      theme,
+      document,
+      templateDocuments,
+      assetManifest,
+    );
   }
   if (url.pathname === "/") {
     return resolvePublicRoute(
@@ -254,6 +265,7 @@ async function resolvePublicRouteOrFallback(
       { intent: { kind: "front-page" }, params: {} },
       theme,
       document,
+      templateDocuments,
       assetManifest,
     );
   }

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -2,7 +2,7 @@ import type { ComponentType, ReactNode } from "react";
 import { createElement } from "react";
 
 import type { AppContext } from "./context/app.js";
-import type { TemplateData } from "./theme.js";
+import type { DocumentManifest, TemplateData } from "./theme.js";
 import { ThemeRegistrationError } from "./theme-errors.js";
 
 // Module-local brand — not `Symbol.for(...)`. The global registry
@@ -33,22 +33,33 @@ export type TemplateRender<TData extends TemplateData> = (
  * Output of `defineTemplate`. The brand symbol is non-enumerable so
  * it doesn't pollute `Object.keys` / JSON serialization but stays
  * load-bearing for runtime identification via `isTemplate`.
+ *
+ * `document` is the optional per-template fragment merged with the
+ * theme's site-wide document at boot. Per-request renders look up the
+ * already-merged result keyed by the matched template slot — zero
+ * runtime merge cost.
  */
 export interface Template<TData extends TemplateData = TemplateData> {
   readonly render: TemplateRender<TData>;
+  readonly document?: DocumentManifest;
   readonly [PLUMIX_TEMPLATE_BRAND]: true;
 }
 
 interface DefineTemplateConfig<TData extends TemplateData> {
   readonly render: TemplateRender<TData>;
+  readonly document?: DocumentManifest;
 }
 
 export function defineTemplate<TData extends TemplateData = TemplateData>(
   config: DefineTemplateConfig<TData>,
 ): Template<TData> {
-  const template: { render: TemplateRender<TData> } = {
+  const template: {
+    render: TemplateRender<TData>;
+    document?: DocumentManifest;
+  } = {
     render: config.render,
   };
+  if (config.document !== undefined) template.document = config.document;
   // `enumerable: false` keeps the brand out of `Object.keys` / JSON;
   // writable/configurable defaults are fine — the symbol itself is
   // module-local so no caller can forge or rewrite it.

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -36,13 +36,19 @@ export class ThemeRegistrationError extends Error {
     );
   }
 
-  static documentInvalidLink(ctx: { index: number }): ThemeRegistrationError {
+  static documentInvalidLink(ctx: {
+    index: number;
+    slot?: string;
+  }): ThemeRegistrationError {
+    const source = ctx.slot
+      ? `template \`${ctx.slot}\` document fragment`
+      : "`theme:document` filter chain";
     return new ThemeRegistrationError(
       "document_invalid_link",
-      `\`theme:document\` filter chain produced a \`link[${ctx.index}]\` ` +
-        `entry without a \`rel\` attribute. Every \`<link>\` in the document ` +
-        `manifest must declare a \`rel\` — browsers ignore unkeyed link tags ` +
-        `and the renderer would emit invalid HTML.`,
+      `${source} produced a \`link[${ctx.index}]\` entry without a \`rel\` ` +
+        `attribute. Every \`<link>\` in the document manifest must declare ` +
+        `a \`rel\` — browsers ignore unkeyed link tags and the renderer ` +
+        `would emit invalid HTML.`,
     );
   }
 
@@ -57,11 +63,17 @@ export class ThemeRegistrationError extends Error {
     );
   }
 
-  static documentInvalidScript(ctx: { index: number }): ThemeRegistrationError {
+  static documentInvalidScript(ctx: {
+    index: number;
+    slot?: string;
+  }): ThemeRegistrationError {
+    const source = ctx.slot
+      ? `template \`${ctx.slot}\` document fragment`
+      : "`theme:document` filter chain";
     return new ThemeRegistrationError(
       "document_invalid_script",
-      `\`theme:document\` filter chain produced a \`script[${ctx.index}]\` ` +
-        `entry with neither \`src\` nor inline content (\`children\` / ` +
+      `${source} produced a \`script[${ctx.index}]\` entry with neither ` +
+        `\`src\` nor inline content (\`children\` / ` +
         `\`dangerouslySetInnerHTML\`). Scripts must reference a source URL ` +
         `or carry an inline body — an empty \`<script>\` tag is dead weight.`,
     );

--- a/packages/core/src/theme.test.ts
+++ b/packages/core/src/theme.test.ts
@@ -217,6 +217,78 @@ describe("buildApp — theme:document filter", () => {
   });
 });
 
+describe("buildApp — per-template document fragments", () => {
+  test("PlumixApp.templateDocuments holds the per-template merged manifest", async () => {
+    const { defineTemplate } = await import("./template.js");
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          render: () => null,
+          document: { meta: [{ name: "robots", content: "noindex" }] },
+        }),
+      },
+      document: {
+        meta: [{ name: "theme-color", content: "#0ea5e9" }],
+      },
+    });
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme,
+      }),
+    );
+    const singleDoc = app.templateDocuments.get("single");
+    expect(singleDoc?.meta).toEqual([
+      { name: "theme-color", content: "#0ea5e9" },
+      { name: "robots", content: "noindex" },
+    ]);
+  });
+
+  test("templates without a document fragment do NOT populate the map", async () => {
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme: defineTheme({
+          templates: { index: () => null, single: () => null },
+          document: { meta: [{ name: "x", content: "y" }] },
+        }),
+      }),
+    );
+    expect(app.templateDocuments.has("single")).toBe(false);
+    expect(app.templateDocuments.has("index")).toBe(false);
+  });
+
+  test("templateDocuments entries are deep-frozen", async () => {
+    const { defineTemplate } = await import("./template.js");
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme: defineTheme({
+          templates: {
+            index: () => null,
+            single: defineTemplate({
+              render: () => null,
+              document: { link: [{ rel: "icon", href: "/x.svg" }] },
+            }),
+          },
+        }),
+      }),
+    );
+    const doc = app.templateDocuments.get("single");
+    expect(Object.isFrozen(doc)).toBe(true);
+    expect(() => {
+      (doc as { link?: unknown }).link = "mutated";
+    }).toThrow(TypeError);
+  });
+});
+
 describe("buildApp", () => {
   test("throws ThemeRegistrationError when config.theme omits templates.index", async () => {
     await expect(

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -159,10 +159,13 @@ export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
 // can't recover from gracefully — link entries without `rel` (browsers
 // ignore them, invalid HTML) and scripts with no src + no inline body
 // (dead weight, signals a plugin bug worth surfacing loud).
-export function validateDocumentManifest(manifest: DocumentManifest): void {
+export function validateDocumentManifest(
+  manifest: DocumentManifest,
+  slot?: string,
+): void {
   manifest.link?.forEach((entry, index) => {
     if (typeof entry.rel !== "string" || entry.rel.length === 0) {
-      throw ThemeRegistrationError.documentInvalidLink({ index });
+      throw ThemeRegistrationError.documentInvalidLink({ index, slot });
     }
   });
   manifest.script?.forEach((entry, index) => {
@@ -173,7 +176,7 @@ export function validateDocumentManifest(manifest: DocumentManifest): void {
       typeof entry.dangerouslySetInnerHTML?.__html === "string" &&
       entry.dangerouslySetInnerHTML.__html.length > 0;
     if (!hasSrc && !hasChildren && !hasInnerHtml) {
-      throw ThemeRegistrationError.documentInvalidScript({ index });
+      throw ThemeRegistrationError.documentInvalidScript({ index, slot });
     }
   });
 }


### PR DESCRIPTION
`defineTemplate` config now accepts an optional `document?: DocumentManifest`
field. Framework merges each template's fragment with the theme-wide document
at `buildApp` and stores the result on `PlumixApp.templateDocuments` as a frozen
`Map<slot, DocumentManifest>`. The renderer reads
`templateDocuments.get(slot) ?? document` so per-request renders pay zero
merge cost.

**Theme-first / template-after merge**

`link[]` / `meta[]` / `script[]` concat in that order, `html` / `body` scalars
last-wins, `className` space-concatenated + whitespace-normalized. Authors get
the natural \"template overrides theme\" cascade. v1 does no identity-based
dedupe — a `<link rel=\"canonical\">` declared in both surfaces twice. The PRD
deferred dedupe to v2; the merge function's JSDoc says so.

**Sparseness is the contract**

`buildTemplateDocuments` skips legacy plain-function templates (no surface to
declare a fragment) AND factory templates without a fragment. The renderer's
`??` fallback to `app.document` covers both. A denser map would force cloning
the theme-wide document N times for identical input — no win.

**Validation surfaces the offending template**

`documentInvalidLink` / `documentInvalidScript` factories take an optional
`slot?: string`. Error messages name the source (`template \`single\` document
fragment` vs `theme:document filter chain`) so a malformed contribution
surfaces at the right offending template at boot, not a generic filter-chain
pointer.

Builds on slice #516 (`defineTemplate` factory) and slice #513 (`theme:document`
filter). Together they form the full per-template document story. Slice #518
(`registerTemplateDep`) lands next.

Refs #515
Closes #517