### PR TITLE
feat(core): registerTemplateDep + per-request dispatch + core settings

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export type {
   TemplateRender,
   TemplateRenderArgs,
 } from "./template.js";
+export type { TemplateDepLoader } from "./template-deps.js";
 export { defineTheme } from "./theme.js";
 export type {
   DocumentLink,

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -7,6 +7,7 @@ import type {
 import type { AppContext } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { RouteIntent } from "../route/intent.js";
+import type { RegisteredTemplateDep } from "../template-deps.js";
 import type { RegisteredLookupAdapter } from "./lookup.js";
 import { DuplicateAdminSlugError, PluginDefinitionError } from "./errors.js";
 
@@ -1066,6 +1067,7 @@ export interface PluginRegistry {
   readonly markSpecs: ReadonlyMap<string, RegisteredMark>;
   readonly lookupAdapters: ReadonlyMap<string, RegisteredLookupAdapter>;
   readonly scheduledTasks: readonly RegisteredScheduledTask[];
+  readonly templateDeps: ReadonlyMap<string, RegisteredTemplateDep>;
 }
 
 export interface MutablePluginRegistry extends PluginRegistry {
@@ -1087,6 +1089,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly markSpecs: Map<string, RegisteredMark>;
   readonly lookupAdapters: Map<string, RegisteredLookupAdapter>;
   readonly scheduledTasks: RegisteredScheduledTask[];
+  readonly templateDeps: Map<string, RegisteredTemplateDep>;
 }
 
 export function createPluginRegistry(): MutablePluginRegistry {
@@ -1109,6 +1112,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     markSpecs: new Map(),
     lookupAdapters: new Map(),
     scheduledTasks: [],
+    templateDeps: new Map(),
   };
 }
 

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -15,11 +15,11 @@ import type {
   HookOptions,
 } from "../hooks/types.js";
 import type { RouteIntent } from "../route/intent.js";
-import type { TemplateDepRegistry } from "../template.js";
 import type {
   RegisteredTemplateDep,
   TemplateDepLoader,
 } from "../template-deps.js";
+import type { TemplateDepRegistry } from "../template.js";
 import type { LookupAdapterOptions } from "./lookup.js";
 import type {
   AdminPageOptions,
@@ -590,9 +590,10 @@ export function createPluginSetupContext({
       }
       // Erase the per-kind generic at storage time — the typed view is
       // recovered when `defineTemplate` looks the loader up by kind.
+      const erased = load as unknown as RegisteredTemplateDep["load"];
       registry.templateDeps.set(kind, {
         kind,
-        load: load as RegisteredTemplateDep["load"],
+        load: erased,
         registeredBy: pluginId,
       });
     },

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -15,6 +15,11 @@ import type {
   HookOptions,
 } from "../hooks/types.js";
 import type { RouteIntent } from "../route/intent.js";
+import type { TemplateDepRegistry } from "../template.js";
+import type {
+  RegisteredTemplateDep,
+  TemplateDepLoader,
+} from "../template-deps.js";
 import type { LookupAdapterOptions } from "./lookup.js";
 import type {
   AdminPageOptions,
@@ -222,6 +227,19 @@ export interface PluginSetupContextBase {
    * `cron`; per-task cron filtering is a follow-up.
    */
   registerScheduledTask(task: ScheduledTask): void;
+  /**
+   * Register a template-dep loader. Themes declare what they need
+   * (`defineTemplate({ [kind]: ["slug-a", "slug-b"], render })`); the
+   * framework fires every declared dep's loader in parallel per
+   * request and passes the results to the template's render
+   * function. The `kind` must match a key in the augmentable
+   * `TemplateDepRegistry` interface; two plugins registering the
+   * same `kind` is a boot-time error.
+   */
+  registerTemplateDep<TKind extends keyof TemplateDepRegistry>(
+    kind: TKind,
+    options: { readonly load: TemplateDepLoader<TKind> },
+  ): void;
 }
 
 export type PluginSetupContext = PluginSetupContextBase &
@@ -558,6 +576,23 @@ export function createPluginSetupContext({
       }
       registry.scheduledTasks.push({
         ...task,
+        registeredBy: pluginId,
+      });
+    },
+
+    registerTemplateDep: (kind, { load }) => {
+      const existing = registry.templateDeps.get(kind);
+      if (existing) {
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "template dep",
+          identifier: kind,
+        });
+      }
+      // Erase the per-kind generic at storage time — the typed view is
+      // recovered when `defineTemplate` looks the loader up by kind.
+      registry.templateDeps.set(kind, {
+        kind,
+        load: load as RegisteredTemplateDep["load"],
         registeredBy: pluginId,
       });
     },

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -5,8 +5,8 @@ import { renderToString } from "react-dom/server";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { AppContext } from "../../context/app.js";
-import type { Template } from "../../template.js";
 import type { RegisteredTemplateDep } from "../../template-deps.js";
+import type { Template } from "../../template.js";
 import type {
   DocumentLink,
   DocumentManifest,
@@ -19,8 +19,8 @@ import type {
 import type { AssetManifest } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
-import { normalizeTemplate } from "../../template.js";
 import { loadTemplateDeps } from "../../template-deps.js";
+import { normalizeTemplate } from "../../template.js";
 import { bundledCssTags } from "./asset-manifest.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -157,9 +157,7 @@ function renderTree({
   // misregistered dep kind literally named `"data"` or `"ctx"` can't
   // silently clobber the canonical args.
   const TemplateAdapter = (): ReactNode =>
-    template.render({ ...deps, data, ctx } as Parameters<
-      typeof template.render
-    >[0]);
+    template.render({ ...deps, data, ctx });
   const templateTree: ReactNode = createElement(PlumixProvider, {
     value: { registry: ctx.blocks },
     children: createElement(TemplateAdapter),

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -6,6 +6,7 @@ import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { AppContext } from "../../context/app.js";
 import type { Template } from "../../template.js";
+import type { RegisteredTemplateDep } from "../../template-deps.js";
 import type {
   DocumentLink,
   DocumentManifest,
@@ -19,6 +20,7 @@ import type { AssetManifest } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
 import { normalizeTemplate } from "../../template.js";
+import { loadTemplateDeps } from "../../template-deps.js";
 import { bundledCssTags } from "./asset-manifest.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -27,6 +29,7 @@ interface RenderArgs {
   readonly theme: ThemeDescriptor;
   readonly document: DocumentManifest;
   readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
+  readonly templateDeps: ReadonlyMap<string, RegisteredTemplateDep>;
   readonly assetManifest: AssetManifest;
   readonly node: ResolvedNode;
   readonly data: TemplateData;
@@ -38,6 +41,7 @@ export async function renderThroughTheme({
   theme,
   document,
   templateDocuments,
+  templateDeps,
   assetManifest,
   node,
   data,
@@ -48,6 +52,14 @@ export async function renderThroughTheme({
   // Per-template fragment is precomputed at boot; fall back to the
   // theme-wide document when the template didn't declare its own.
   const renderDocument = templateDocuments.get(slot) ?? document;
+  // Load every dep the template declared in parallel before render.
+  // Loader failures don't 500 the page — `loadTemplateDeps` swallows
+  // them, logs via `ctx.logger.error`, and seeds an empty map.
+  const deps = await loadTemplateDeps(
+    template as unknown as Record<string, unknown>,
+    templateDeps,
+    ctx,
+  );
   return renderTree({
     ctx,
     document: renderDocument,
@@ -55,6 +67,7 @@ export async function renderThroughTheme({
     data,
     title,
     template,
+    deps,
   });
 }
 
@@ -63,6 +76,7 @@ interface RenderErrorArgs {
   readonly theme: ThemeDescriptor;
   readonly document: DocumentManifest;
   readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
+  readonly templateDeps: ReadonlyMap<string, RegisteredTemplateDep>;
   readonly assetManifest: AssetManifest;
   readonly kind: "not-found" | "server-error";
   readonly data: ErrorData;
@@ -77,19 +91,27 @@ const ERROR_VARIANTS = {
   },
 } as const;
 
-export function renderErrorThroughTheme({
+export async function renderErrorThroughTheme({
   ctx,
   theme,
   document,
   templateDocuments,
+  templateDeps,
   assetManifest,
   kind,
   data,
-}: RenderErrorArgs): string {
+}: RenderErrorArgs): Promise<string> {
   const variant = ERROR_VARIANTS[kind];
   const raw = theme.templates[variant.key] ?? variant.fallback;
   const template = normalizeTemplate(raw, variant.key);
   const renderDocument = templateDocuments.get(variant.key) ?? document;
+  // Error templates can declare deps too — loader failures still log
+  // + empty-map fallback so a 404/500 render never escalates.
+  const deps = await loadTemplateDeps(
+    template as unknown as Record<string, unknown>,
+    templateDeps,
+    ctx,
+  );
   return renderTree({
     ctx,
     document: renderDocument,
@@ -97,6 +119,7 @@ export function renderErrorThroughTheme({
     data,
     title: variant.title,
     template,
+    deps,
   });
 }
 
@@ -107,6 +130,7 @@ interface RenderTreeArgs {
   readonly data: TemplateData;
   readonly title: string;
   readonly template: Template<TemplateData>;
+  readonly deps: Record<string, Record<string, unknown>>;
 }
 
 // React 19 reorders every child of `<head>` (metadata first, scripts /
@@ -122,14 +146,20 @@ function renderTree({
   data,
   title,
   template,
+  deps,
 }: RenderTreeArgs): string {
-  // Adapter FC wraps `template.render({ data, ctx })` so it executes
-  // inside React's render pass — hooks (useState, useId, useMemo,
-  // useSyncExternalStore) inside a factory template are legal. A
-  // direct `template.render({data, ctx})` here would throw "Invalid
-  // hook call" because React's dispatcher isn't set yet at this
-  // construction point.
-  const TemplateAdapter = (): ReactNode => template.render({ data, ctx });
+  // Adapter FC wraps `template.render({ data, ctx, ...deps })` so it
+  // executes inside React's render pass — hooks (useState, useId,
+  // useMemo, useSyncExternalStore) inside a factory template are
+  // legal. A direct call here would throw "Invalid hook call" because
+  // React's dispatcher isn't set yet at this construction point.
+  // `data` + `ctx` are framework-owned; spread `deps` first so a
+  // misregistered dep kind literally named `"data"` or `"ctx"` can't
+  // silently clobber the canonical args.
+  const TemplateAdapter = (): ReactNode =>
+    template.render({ ...deps, data, ctx } as Parameters<
+      typeof template.render
+    >[0]);
   const templateTree: ReactNode = createElement(PlumixProvider, {
     value: { registry: ctx.blocks },
     children: createElement(TemplateAdapter),

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -4,10 +4,10 @@ import { count } from "drizzle-orm";
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
+import type { RegisteredTemplateDep } from "../template-deps.js";
 import type { DocumentManifest, ThemeDescriptor } from "../theme.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
-import type { RegisteredTemplateDep } from "../template-deps.js";
 import type { AssetManifest } from "./render/asset-manifest.js";
 import type {
   ArchiveData,

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -7,6 +7,7 @@ import type { Term } from "../db/schema/terms.js";
 import type { DocumentManifest, ThemeDescriptor } from "../theme.js";
 import type { RouteIntent } from "./intent.js";
 import type { RouteMatch } from "./match.js";
+import type { RegisteredTemplateDep } from "../template-deps.js";
 import type { AssetManifest } from "./render/asset-manifest.js";
 import type {
   ArchiveData,
@@ -50,6 +51,7 @@ export async function resolvePublicRoute(
   theme: ThemeDescriptor,
   document: DocumentManifest,
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
+  templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   switch (match.intent.kind) {
@@ -61,6 +63,7 @@ export async function resolvePublicRoute(
         theme,
         document,
         templateDocuments,
+        templateDeps,
         assetManifest,
       );
     case "archive":
@@ -71,6 +74,7 @@ export async function resolvePublicRoute(
         theme,
         document,
         templateDocuments,
+        templateDeps,
         assetManifest,
       );
     case "taxonomy":
@@ -81,6 +85,7 @@ export async function resolvePublicRoute(
         theme,
         document,
         templateDocuments,
+        templateDeps,
         assetManifest,
       );
     case "front-page":
@@ -89,6 +94,7 @@ export async function resolvePublicRoute(
         theme,
         document,
         templateDocuments,
+        templateDeps,
         assetManifest,
       );
   }
@@ -99,6 +105,7 @@ async function resolveFrontPage(
   theme: ThemeDescriptor,
   document: DocumentManifest,
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
+  templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const page = 1;
@@ -130,6 +137,7 @@ async function resolveFrontPage(
     theme,
     document,
     templateDocuments,
+    templateDeps,
     assetManifest,
     node: { kind: "front-page" },
     data,
@@ -147,6 +155,7 @@ async function resolveTaxonomy(
   theme: ThemeDescriptor,
   document: DocumentManifest,
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
+  templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const term = await findTermForTaxonomy(ctx, intent.taxonomy, params);
@@ -196,6 +205,7 @@ async function resolveTaxonomy(
     theme,
     document,
     templateDocuments,
+    templateDeps,
     assetManifest,
     node: {
       kind: "term",
@@ -218,6 +228,7 @@ async function resolveSingle(
   theme: ThemeDescriptor,
   document: DocumentManifest,
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
+  templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const row = await findEntryForSingle(ctx, intent.entryType, params);
@@ -237,6 +248,7 @@ async function resolveSingle(
     theme,
     document,
     templateDocuments,
+    templateDeps,
     assetManifest,
     node: {
       kind: "content",
@@ -259,6 +271,7 @@ async function resolveArchive(
   theme: ThemeDescriptor,
   document: DocumentManifest,
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
+  templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const page = parsePageParam(params.page);
@@ -296,6 +309,7 @@ async function resolveArchive(
     theme,
     document,
     templateDocuments,
+    templateDeps,
     assetManifest,
     node: { kind: "content-type-archive", entryType: intent.entryType },
     data,

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -38,6 +38,7 @@ import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { appRouter } from "../rpc/router.js";
+import { registerCoreTemplateDeps } from "../template-deps-core.js";
 import { isTemplate } from "../template.js";
 import { ThemeRegistrationError } from "../theme-errors.js";
 import { validateDocumentManifest } from "../theme.js";
@@ -167,6 +168,7 @@ export async function buildApp(
   const hooks = new HookRegistry();
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
+  registerCoreTemplateDeps(seededRegistry);
   const { registry, appContextExtensions } = await installPlugins({
     hooks,
     plugins: config.plugins,

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -183,15 +183,17 @@ async function dispatchPublicRoute(
   const theme = app.config.theme;
   const document = app.document;
   const templateDocuments = app.templateDocuments;
+  const templateDeps = app.plugins.templateDeps;
   const assetManifest = app.assetManifest;
   try {
     const response = await resolvePublicRouteOrFallback(app, ctx, url);
     if (response.status === 404) {
-      const html = renderErrorThroughTheme({
+      const html = await renderErrorThroughTheme({
         ctx,
         theme,
         document,
         templateDocuments,
+        templateDeps,
         assetManifest,
         kind: "not-found",
         data: {
@@ -210,11 +212,12 @@ async function dispatchPublicRoute(
       err: err instanceof Error ? err.message : String(err),
     });
     try {
-      const html = renderErrorThroughTheme({
+      const html = await renderErrorThroughTheme({
         ctx,
         theme,
         document,
         templateDocuments,
+        templateDeps,
         assetManifest,
         kind: "server-error",
         data: { request: ctx.request },
@@ -247,6 +250,7 @@ async function resolvePublicRouteOrFallback(
   const theme = app.config.theme;
   const document = app.document;
   const templateDocuments = app.templateDocuments;
+  const templateDeps = app.plugins.templateDeps;
   const assetManifest = app.assetManifest;
   const match = matchRoute(url, app.routeMap);
   if (match !== null) {
@@ -256,6 +260,7 @@ async function resolvePublicRouteOrFallback(
       theme,
       document,
       templateDocuments,
+      templateDeps,
       assetManifest,
     );
   }
@@ -266,6 +271,7 @@ async function resolvePublicRouteOrFallback(
       theme,
       document,
       templateDocuments,
+      templateDeps,
       assetManifest,
     );
   }

--- a/packages/core/src/template-deps-core.ts
+++ b/packages/core/src/template-deps-core.ts
@@ -1,8 +1,8 @@
 import { inArray } from "drizzle-orm";
 
 import type { AppContext } from "./context/app.js";
-import { settings } from "./db/schema/settings.js";
 import type { MutablePluginRegistry } from "./plugin/manifest.js";
+import { settings } from "./db/schema/settings.js";
 
 // Augment the registry with the core `settings` dep — themes declare
 // `defineTemplate({ settings: ["site-info", ...], render })` and the

--- a/packages/core/src/template-deps-core.ts
+++ b/packages/core/src/template-deps-core.ts
@@ -1,0 +1,52 @@
+import { inArray } from "drizzle-orm";
+
+import type { AppContext } from "./context/app.js";
+import { settings } from "./db/schema/settings.js";
+import type { MutablePluginRegistry } from "./plugin/manifest.js";
+
+// Augment the registry with the core `settings` dep — themes declare
+// `defineTemplate({ settings: ["site-info", ...], render })` and the
+// loader returns each requested group as a `Record<key, value>`.
+declare module "./template.js" {
+  interface TemplateDepRegistry {
+    settings: { slug: string; result: Record<string, unknown> };
+  }
+}
+
+/**
+ * Seed the plugin registry with built-in template deps before plugin
+ * `setup()` runs. Mirrors `registerCoreLookupAdapters` — core's slot
+ * lands first so a plugin `ctx.registerTemplateDep("settings", ...)`
+ * trips the boot-time collision guard.
+ */
+export function registerCoreTemplateDeps(
+  registry: MutablePluginRegistry,
+): void {
+  registry.templateDeps.set("settings", {
+    kind: "settings",
+    registeredBy: null,
+    load: settingsLoader,
+  });
+}
+
+async function settingsLoader(
+  groups: readonly string[],
+  ctx: AppContext,
+): Promise<Record<string, Record<string, unknown>>> {
+  if (groups.length === 0) return {};
+  const rows = await ctx.db
+    .select({ group: settings.group, key: settings.key, value: settings.value })
+    .from(settings)
+    .where(inArray(settings.group, [...groups]));
+  // Build a `Record<group, Record<key, value>>` so each declared
+  // group maps to its full key/value bag. Groups that have no rows
+  // surface as undefined in the per-group record but the caller's
+  // `loadTemplateDeps` fills missing slugs with `null`.
+  const grouped: Record<string, Record<string, unknown>> = {};
+  for (const row of rows) {
+    const bag = grouped[row.group] ?? {};
+    bag[row.key] = row.value;
+    grouped[row.group] = bag;
+  }
+  return grouped;
+}

--- a/packages/core/src/template-deps.test.tsx
+++ b/packages/core/src/template-deps.test.tsx
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "vitest";
 
+import type { RegisteredTemplateDep } from "./template-deps.js";
 import { auth } from "./auth/config.js";
 import { plumix } from "./config.js";
 import { definePlugin } from "./plugin/define.js";
 import { DuplicateRegistrationError } from "./plugin/errors.js";
 import { buildApp } from "./runtime/app.js";
-import { defineTemplate, normalizeTemplate } from "./template.js";
 import { loadTemplateDeps } from "./template-deps.js";
-import type { RegisteredTemplateDep } from "./template-deps.js";
+import { defineTemplate, normalizeTemplate } from "./template.js";
 import { createDispatcherHarness } from "./test/dispatcher.js";
 import { defineTheme } from "./theme.js";
 
@@ -34,8 +34,10 @@ describe("ctx.registerTemplateDep", () => {
   test("a plugin's registration lands in app.plugins.templateDeps", async () => {
     const probe = definePlugin("probe", (ctx) => {
       ctx.registerTemplateDep("test-thing", {
-        load: async (slugs) =>
-          Object.fromEntries(slugs.map((s) => [s, { value: s }])),
+        load: (slugs) =>
+          Promise.resolve(
+            Object.fromEntries(slugs.map((s) => [s, { value: s }])),
+          ),
       });
     });
     const app = await buildApp(
@@ -54,10 +56,14 @@ describe("ctx.registerTemplateDep", () => {
 
   test("two plugins registering the same kind throw at boot", async () => {
     const first = definePlugin("first", (ctx) => {
-      ctx.registerTemplateDep("test-thing", { load: async () => ({}) });
+      ctx.registerTemplateDep("test-thing", {
+        load: () => Promise.resolve({}),
+      });
     });
     const second = definePlugin("second", (ctx) => {
-      ctx.registerTemplateDep("test-thing", { load: async () => ({}) });
+      ctx.registerTemplateDep("test-thing", {
+        load: () => Promise.resolve({}),
+      });
     });
     await expect(
       buildApp(
@@ -75,11 +81,13 @@ describe("ctx.registerTemplateDep", () => {
   test("different kinds from different plugins coexist", async () => {
     const a = definePlugin("a", (ctx) => {
       ctx.registerTemplateDep("test-thing", {
-        load: async () => ({ x: { value: "from-a" } }),
+        load: () => Promise.resolve({ x: { value: "from-a" } }),
       });
     });
     const b = definePlugin("b", (ctx) => {
-      ctx.registerTemplateDep("test-other", { load: async () => ({ y: 42 }) });
+      ctx.registerTemplateDep("test-other", {
+        load: () => Promise.resolve({ y: 42 }),
+      });
     });
     const app = await buildApp(
       plumix({
@@ -96,7 +104,7 @@ describe("ctx.registerTemplateDep", () => {
 });
 
 const captureLogger = () => {
-  const errors: Array<{ msg: string; ctx?: Record<string, unknown> }> = [];
+  const errors: { msg: string; ctx?: Record<string, unknown> }[] = [];
   return {
     errors,
     logger: {
@@ -121,7 +129,7 @@ function makeRegistry(
     out.set(kind, {
       kind,
       registeredBy: "test",
-      load: async (slugs, _ctx) => load(slugs),
+      load: (slugs, _ctx) => load(slugs),
     });
   }
   return out;
@@ -145,11 +153,9 @@ describe("loadTemplateDeps", () => {
     const template = { "test-thing": ["a"], "test-other": ["b"] };
     const ctx = captureLogger();
     const start = Date.now();
-    const deps = await loadTemplateDeps(
-      template,
-      registry,
-      { logger: ctx.logger } as unknown as Parameters<typeof loadTemplateDeps>[2],
-    );
+    const deps = await loadTemplateDeps(template, registry, {
+      logger: ctx.logger,
+    } as unknown as Parameters<typeof loadTemplateDeps>[2]);
     const elapsed = Date.now() - start;
     expect(deps["test-thing"]).toEqual({ a: { value: "thing-a" } });
     expect(deps["test-other"]).toEqual({ b: 7 });
@@ -158,15 +164,13 @@ describe("loadTemplateDeps", () => {
 
   test("a slug missing from the loader result fills with null", async () => {
     const registry = makeRegistry({
-      "test-thing": async () => ({ present: { value: "yes" } }),
+      "test-thing": () => Promise.resolve({ present: { value: "yes" } }),
     });
     const template = { "test-thing": ["present", "absent"] };
     const ctx = captureLogger();
-    const deps = await loadTemplateDeps(
-      template,
-      registry,
-      { logger: ctx.logger } as unknown as Parameters<typeof loadTemplateDeps>[2],
-    );
+    const deps = await loadTemplateDeps(template, registry, {
+      logger: ctx.logger,
+    } as unknown as Parameters<typeof loadTemplateDeps>[2]);
     expect(deps["test-thing"]).toEqual({
       present: { value: "yes" },
       absent: null,
@@ -175,17 +179,13 @@ describe("loadTemplateDeps", () => {
 
   test("a thrown loader logs `template_dep_load_failed` and seeds an empty map", async () => {
     const registry = makeRegistry({
-      "test-thing": async () => {
-        throw new Error("db down");
-      },
+      "test-thing": () => Promise.reject(new Error("db down")),
     });
     const template = { "test-thing": ["x"] };
     const ctx = captureLogger();
-    const deps = await loadTemplateDeps(
-      template,
-      registry,
-      { logger: ctx.logger } as unknown as Parameters<typeof loadTemplateDeps>[2],
-    );
+    const deps = await loadTemplateDeps(template, registry, {
+      logger: ctx.logger,
+    } as unknown as Parameters<typeof loadTemplateDeps>[2]);
     expect(deps["test-thing"]).toEqual({});
     expect(ctx.errors[0]?.msg).toBe("template_dep_load_failed");
     expect(ctx.errors[0]?.ctx).toMatchObject({
@@ -205,8 +205,12 @@ describe("renderThroughTheme — template deps lifecycle", () => {
         hasArchive: true,
       });
       ctx.registerTemplateDep("test-thing", {
-        load: async (slugs) =>
-          Object.fromEntries(slugs.map((s) => [s, { value: `loaded-${s}` }])),
+        load: (slugs) =>
+          Promise.resolve(
+            Object.fromEntries(
+              slugs.map((s) => [s, { value: `loaded-${s}` }]),
+            ),
+          ),
       });
     });
     const theme = defineTheme({
@@ -215,10 +219,17 @@ describe("renderThroughTheme — template deps lifecycle", () => {
         single: defineTemplate({
           "test-thing": ["alpha", "beta"],
           render: (args) => {
-            const deps = (args as unknown as Record<string, Record<string, { value: string } | null>>)["test-thing"];
+            const deps = (
+              args as unknown as Record<
+                string,
+                Record<string, { value: string } | null>
+              >
+            )["test-thing"];
             return (
               <article>
-                <span data-testid="alpha">{deps?.alpha?.value ?? "missing"}</span>
+                <span data-testid="alpha">
+                  {deps?.alpha?.value ?? "missing"}
+                </span>
                 <span data-testid="beta">{deps?.beta?.value ?? "missing"}</span>
               </article>
             );
@@ -254,9 +265,7 @@ describe("renderThroughTheme — template deps lifecycle", () => {
         hasArchive: true,
       });
       ctx.registerTemplateDep("test-thing", {
-        load: async () => {
-          throw new Error("loader exploded");
-        },
+        load: () => Promise.reject(new Error("loader exploded")),
       });
     });
     const theme = defineTheme({
@@ -303,16 +312,10 @@ describe("core settings dep", () => {
         single: defineTemplate({
           settings: ["site-info"],
           render: (args) => {
-            const all = (
-              args as unknown as Record<
-                string,
-                Record<string, Record<string, unknown> | null> | undefined
-              >
-            ).settings;
-            const siteInfo = all?.["site-info"];
+            const siteInfo = args.settings?.["site-info"];
             const title =
               siteInfo && typeof siteInfo === "object"
-                ? (siteInfo as Record<string, unknown>).title
+                ? siteInfo.title
                 : undefined;
             return (
               <h1 data-testid="site-title">
@@ -359,13 +362,15 @@ describe("loadTemplateDeps — legacy templates", () => {
   test("a normalized legacy function template has no declarations; returns {}", async () => {
     const legacy = normalizeTemplate(() => null, "single");
     const registry = makeRegistry({
-      "test-thing": async () => ({ x: { value: "should-not-load" } }),
+      "test-thing": () => Promise.resolve({ x: { value: "should-not-load" } }),
     });
     const ctx = captureLogger();
     const deps = await loadTemplateDeps(
       legacy as unknown as Record<string, unknown>,
       registry,
-      { logger: ctx.logger } as unknown as Parameters<typeof loadTemplateDeps>[2],
+      { logger: ctx.logger } as unknown as Parameters<
+        typeof loadTemplateDeps
+      >[2],
     );
     expect(deps).toEqual({});
     expect(ctx.errors).toEqual([]);

--- a/packages/core/src/template-deps.test.tsx
+++ b/packages/core/src/template-deps.test.tsx
@@ -207,9 +207,7 @@ describe("renderThroughTheme — template deps lifecycle", () => {
       ctx.registerTemplateDep("test-thing", {
         load: (slugs) =>
           Promise.resolve(
-            Object.fromEntries(
-              slugs.map((s) => [s, { value: `loaded-${s}` }]),
-            ),
+            Object.fromEntries(slugs.map((s) => [s, { value: `loaded-${s}` }])),
           ),
       });
     });

--- a/packages/core/src/template-deps.test.tsx
+++ b/packages/core/src/template-deps.test.tsx
@@ -1,0 +1,373 @@
+import { describe, expect, test } from "vitest";
+
+import { auth } from "./auth/config.js";
+import { plumix } from "./config.js";
+import { definePlugin } from "./plugin/define.js";
+import { DuplicateRegistrationError } from "./plugin/errors.js";
+import { buildApp } from "./runtime/app.js";
+import { defineTemplate, normalizeTemplate } from "./template.js";
+import { loadTemplateDeps } from "./template-deps.js";
+import type { RegisteredTemplateDep } from "./template-deps.js";
+import { createDispatcherHarness } from "./test/dispatcher.js";
+import { defineTheme } from "./theme.js";
+
+const stubAdapter = {
+  name: "test",
+  buildFetchHandler: () => () => new Response("stub"),
+};
+const stubDatabase = { kind: "test", connect: () => ({ db: {} }) };
+const stubAuth = auth({
+  passkey: { rpName: "t", rpId: "t", origin: "https://t" },
+});
+const stubTheme = defineTheme({ templates: { index: () => null } });
+
+// Augment the registry with a test-only kind so the typed
+// `registerTemplateDep("test-thing", ...)` calls below compile.
+declare module "./template.js" {
+  interface TemplateDepRegistry {
+    "test-thing": { slug: string; result: { value: string } };
+    "test-other": { slug: string; result: number };
+  }
+}
+
+describe("ctx.registerTemplateDep", () => {
+  test("a plugin's registration lands in app.plugins.templateDeps", async () => {
+    const probe = definePlugin("probe", (ctx) => {
+      ctx.registerTemplateDep("test-thing", {
+        load: async (slugs) =>
+          Object.fromEntries(slugs.map((s) => [s, { value: s }])),
+      });
+    });
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme: stubTheme,
+        plugins: [probe],
+      }),
+    );
+    const dep = app.plugins.templateDeps.get("test-thing");
+    expect(dep?.registeredBy).toBe("probe");
+    expect(typeof dep?.load).toBe("function");
+  });
+
+  test("two plugins registering the same kind throw at boot", async () => {
+    const first = definePlugin("first", (ctx) => {
+      ctx.registerTemplateDep("test-thing", { load: async () => ({}) });
+    });
+    const second = definePlugin("second", (ctx) => {
+      ctx.registerTemplateDep("test-thing", { load: async () => ({}) });
+    });
+    await expect(
+      buildApp(
+        plumix({
+          runtime: stubAdapter,
+          database: stubDatabase,
+          auth: stubAuth,
+          theme: stubTheme,
+          plugins: [first, second],
+        }),
+      ),
+    ).rejects.toThrow(DuplicateRegistrationError);
+  });
+
+  test("different kinds from different plugins coexist", async () => {
+    const a = definePlugin("a", (ctx) => {
+      ctx.registerTemplateDep("test-thing", {
+        load: async () => ({ x: { value: "from-a" } }),
+      });
+    });
+    const b = definePlugin("b", (ctx) => {
+      ctx.registerTemplateDep("test-other", { load: async () => ({ y: 42 }) });
+    });
+    const app = await buildApp(
+      plumix({
+        runtime: stubAdapter,
+        database: stubDatabase,
+        auth: stubAuth,
+        theme: stubTheme,
+        plugins: [a, b],
+      }),
+    );
+    expect(app.plugins.templateDeps.get("test-thing")?.registeredBy).toBe("a");
+    expect(app.plugins.templateDeps.get("test-other")?.registeredBy).toBe("b");
+  });
+});
+
+const captureLogger = () => {
+  const errors: Array<{ msg: string; ctx?: Record<string, unknown> }> = [];
+  return {
+    errors,
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: (msg: string, ctx?: Record<string, unknown>) => {
+        errors.push({ msg, ctx });
+      },
+    },
+  };
+};
+
+function makeRegistry(
+  entries: Record<
+    string,
+    (slugs: readonly string[]) => Promise<Record<string, unknown>>
+  >,
+): ReadonlyMap<string, RegisteredTemplateDep> {
+  const out = new Map<string, RegisteredTemplateDep>();
+  for (const [kind, load] of Object.entries(entries)) {
+    out.set(kind, {
+      kind,
+      registeredBy: "test",
+      load: async (slugs, _ctx) => load(slugs),
+    });
+  }
+  return out;
+}
+
+describe("loadTemplateDeps", () => {
+  test("invokes every declared kind in parallel via Promise.all", async () => {
+    // Two loaders each sleep 30ms — serial would take 60ms, parallel
+    // ~30ms. Window with 5ms slack for CI noise.
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const registry = makeRegistry({
+      "test-thing": async () => {
+        await sleep(30);
+        return { a: { value: "thing-a" } };
+      },
+      "test-other": async () => {
+        await sleep(30);
+        return { b: 7 };
+      },
+    });
+    const template = { "test-thing": ["a"], "test-other": ["b"] };
+    const ctx = captureLogger();
+    const start = Date.now();
+    const deps = await loadTemplateDeps(
+      template,
+      registry,
+      { logger: ctx.logger } as unknown as Parameters<typeof loadTemplateDeps>[2],
+    );
+    const elapsed = Date.now() - start;
+    expect(deps["test-thing"]).toEqual({ a: { value: "thing-a" } });
+    expect(deps["test-other"]).toEqual({ b: 7 });
+    expect(elapsed).toBeLessThan(55);
+  });
+
+  test("a slug missing from the loader result fills with null", async () => {
+    const registry = makeRegistry({
+      "test-thing": async () => ({ present: { value: "yes" } }),
+    });
+    const template = { "test-thing": ["present", "absent"] };
+    const ctx = captureLogger();
+    const deps = await loadTemplateDeps(
+      template,
+      registry,
+      { logger: ctx.logger } as unknown as Parameters<typeof loadTemplateDeps>[2],
+    );
+    expect(deps["test-thing"]).toEqual({
+      present: { value: "yes" },
+      absent: null,
+    });
+  });
+
+  test("a thrown loader logs `template_dep_load_failed` and seeds an empty map", async () => {
+    const registry = makeRegistry({
+      "test-thing": async () => {
+        throw new Error("db down");
+      },
+    });
+    const template = { "test-thing": ["x"] };
+    const ctx = captureLogger();
+    const deps = await loadTemplateDeps(
+      template,
+      registry,
+      { logger: ctx.logger } as unknown as Parameters<typeof loadTemplateDeps>[2],
+    );
+    expect(deps["test-thing"]).toEqual({});
+    expect(ctx.errors[0]?.msg).toBe("template_dep_load_failed");
+    expect(ctx.errors[0]?.ctx).toMatchObject({
+      kind: "test-thing",
+      slugs: ["x"],
+      err: "db down",
+    });
+  });
+});
+
+describe("renderThroughTheme — template deps lifecycle", () => {
+  test("a template declaring deps receives the loader's results in render", async () => {
+    const seoPlugin = definePlugin("seo", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+      });
+      ctx.registerTemplateDep("test-thing", {
+        load: async (slugs) =>
+          Object.fromEntries(slugs.map((s) => [s, { value: `loaded-${s}` }])),
+      });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          "test-thing": ["alpha", "beta"],
+          render: (args) => {
+            const deps = (args as unknown as Record<string, Record<string, { value: string } | null>>)["test-thing"];
+            return (
+              <article>
+                <span data-testid="alpha">{deps?.alpha?.value ?? "missing"}</span>
+                <span data-testid="beta">{deps?.beta?.value ?? "missing"}</span>
+              </article>
+            );
+          },
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [seoPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "deps-flow",
+      title: "Deps Flow",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/deps-flow"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("loaded-alpha");
+    expect(body).toContain("loaded-beta");
+  });
+
+  test("a loader throw does not 500 the response", async () => {
+    const broken = definePlugin("broken", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+      });
+      ctx.registerTemplateDep("test-thing", {
+        load: async () => {
+          throw new Error("loader exploded");
+        },
+      });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          "test-thing": ["anything"],
+          render: () => <p data-testid="rendered">ok</p>,
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [broken], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "broken-dep",
+      title: "Broken Dep",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/broken-dep"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('data-testid="rendered"');
+  });
+});
+
+describe("core settings dep", () => {
+  test("settings table rows flow into a template declaring `settings: [...groups]`", async () => {
+    const blogPlugin = definePlugin("blog", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+      });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          settings: ["site-info"],
+          render: (args) => {
+            const all = (
+              args as unknown as Record<
+                string,
+                Record<string, Record<string, unknown> | null> | undefined
+              >
+            ).settings;
+            const siteInfo = all?.["site-info"];
+            const title =
+              siteInfo && typeof siteInfo === "object"
+                ? (siteInfo as Record<string, unknown>).title
+                : undefined;
+            return (
+              <h1 data-testid="site-title">
+                {typeof title === "string" ? title : "Untitled"}
+              </h1>
+            );
+          },
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "settings-flow",
+      title: "Settings Flow",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    // Without a settings row, the template renders the fallback.
+    const before = await h.dispatch(
+      new Request("https://cms.example/post/settings-flow"),
+    );
+    expect(await before.text()).toContain("Untitled");
+
+    const { settings } = await import("./db/schema/settings.js");
+    await h.db.insert(settings).values({
+      group: "site-info",
+      key: "title",
+      value: "Plumix Demo",
+    });
+
+    const after = await h.dispatch(
+      new Request("https://cms.example/post/settings-flow"),
+    );
+    expect(await after.text()).toContain("Plumix Demo");
+  });
+});
+
+describe("loadTemplateDeps — legacy templates", () => {
+  test("a normalized legacy function template has no declarations; returns {}", async () => {
+    const legacy = normalizeTemplate(() => null, "single");
+    const registry = makeRegistry({
+      "test-thing": async () => ({ x: { value: "should-not-load" } }),
+    });
+    const ctx = captureLogger();
+    const deps = await loadTemplateDeps(
+      legacy as unknown as Record<string, unknown>,
+      registry,
+      { logger: ctx.logger } as unknown as Parameters<typeof loadTemplateDeps>[2],
+    );
+    expect(deps).toEqual({});
+    expect(ctx.errors).toEqual([]);
+  });
+});

--- a/packages/core/src/template-deps.ts
+++ b/packages/core/src/template-deps.ts
@@ -45,7 +45,7 @@ export interface RegisteredTemplateDep {
  * the deps map — themes use optional chaining (`settings?.["site"]`).
  */
 export async function loadTemplateDeps(
-  template: { readonly [key: string]: unknown },
+  template: Readonly<Record<string, unknown>>,
   registry: ReadonlyMap<string, RegisteredTemplateDep>,
   ctx: AppContext,
 ): Promise<Record<string, Record<string, unknown>>> {
@@ -70,9 +70,7 @@ async function loadOne(
     const raw = await loader.load(slugs, ctx);
     // Fill any slug the loader omitted with null — themes get a
     // stable shape per declared slug.
-    const filled = Object.fromEntries(
-      slugs.map((s) => [s, raw[s] ?? null]),
-    );
+    const filled = Object.fromEntries(slugs.map((s) => [s, raw[s] ?? null]));
     return [kind, filled];
   } catch (err) {
     ctx.logger.error("template_dep_load_failed", {

--- a/packages/core/src/template-deps.ts
+++ b/packages/core/src/template-deps.ts
@@ -1,0 +1,85 @@
+import type { AppContext } from "./context/app.js";
+import type { TemplateDepRegistry } from "./template.js";
+
+/**
+ * Loader signature for a template dep. Receives the slugs declared by
+ * every template using this kind on the current request (deduped +
+ * batched) and the per-request `AppContext`. Returns a record keyed by
+ * slug. Slugs not present in the returned record render as `null` in
+ * the deps passed to the template's render function.
+ */
+export type TemplateDepLoader<TKind extends keyof TemplateDepRegistry> = (
+  slugs: readonly TemplateDepRegistry[TKind]["slug"][],
+  ctx: AppContext,
+) => Promise<Record<string, TemplateDepRegistry[TKind]["result"] | null>>;
+
+// Untyped flavor used inside the framework's registry storage — the
+// per-kind generic narrows are recovered when the loader is invoked
+// against a declared kind in `defineTemplate`. Keeping the registry
+// loose lets us store loaders for kinds the typed registry hasn't
+// been augmented with yet (e.g. early plugin boot before module
+// augmentation merges).
+type UntypedTemplateDepLoader = (
+  slugs: readonly string[],
+  ctx: AppContext,
+) => Promise<Record<string, unknown>>;
+
+export interface RegisteredTemplateDep {
+  readonly kind: string;
+  readonly load: UntypedTemplateDepLoader;
+  /** Plugin id, or `null` for core-registered deps (e.g. `settings`). */
+  readonly registeredBy: string | null;
+}
+
+/**
+ * Per-request dep loader. Reads the picked template's declared dep
+ * slugs, fires every registered loader in parallel via `Promise.all`,
+ * and assembles the results object passed into the render function.
+ *
+ * Loader failures don't break the render: the dep's result becomes
+ * `{}` (empty per-slug map), the failure is logged via
+ * `ctx.logger.error("template_dep_load_failed", { kind, slugs, err })`,
+ * and the response stays 200.
+ *
+ * Slugs not present in a loader's returned record render as `null` in
+ * the deps map — themes use optional chaining (`settings?.["site"]`).
+ */
+export async function loadTemplateDeps(
+  template: { readonly [key: string]: unknown },
+  registry: ReadonlyMap<string, RegisteredTemplateDep>,
+  ctx: AppContext,
+): Promise<Record<string, Record<string, unknown>>> {
+  const pending: Promise<readonly [string, Record<string, unknown>]>[] = [];
+  for (const [kind, loader] of registry) {
+    const declared = template[kind];
+    if (!Array.isArray(declared) || declared.length === 0) continue;
+    const slugs = declared as readonly string[];
+    pending.push(loadOne(kind, slugs, loader, ctx));
+  }
+  if (pending.length === 0) return {};
+  return Object.fromEntries(await Promise.all(pending));
+}
+
+async function loadOne(
+  kind: string,
+  slugs: readonly string[],
+  loader: RegisteredTemplateDep,
+  ctx: AppContext,
+): Promise<readonly [string, Record<string, unknown>]> {
+  try {
+    const raw = await loader.load(slugs, ctx);
+    // Fill any slug the loader omitted with null — themes get a
+    // stable shape per declared slug.
+    const filled = Object.fromEntries(
+      slugs.map((s) => [s, raw[s] ?? null]),
+    );
+    return [kind, filled];
+  } catch (err) {
+    ctx.logger.error("template_dep_load_failed", {
+      kind,
+      slugs,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return [kind, {}];
+  }
+}

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -13,14 +13,41 @@ import { ThemeRegistrationError } from "./theme-errors.js";
 const PLUMIX_TEMPLATE_BRAND: unique symbol = Symbol("plumix.template");
 
 /**
- * Augmentable registry of template-level dep slots. Slice #518 wires
- * `registerTemplateDep` against this interface; today it stays empty
- * so subsequent module augmentations don't require an ABI bump.
+ * Augmentable registry of template-level dep slots. Plugins register
+ * loaders via `ctx.registerTemplateDep(kind, { load })` and themes
+ * declare what they need via `defineTemplate({ [kind]: slugs[], ... })`.
+ * The framework loads each declared dep in parallel per request and
+ * passes results into render.
+ *
+ * Each entry shape: `{ slug: string; result: ResultType }`. Augment via
+ * declaration merging — see `core` registering `settings` for the
+ * canonical example.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- intentional augmentation seam
 export interface TemplateDepRegistry {}
 
-export interface TemplateRenderArgs<TData extends TemplateData> {
+/**
+ * Per-kind declarations on a template — array of slugs the template
+ * needs the framework to load before render. Optional per kind so a
+ * template can opt into just the deps it uses.
+ */
+export type TemplateDepDeclarations = {
+  readonly [K in keyof TemplateDepRegistry]?: readonly TemplateDepRegistry[K]["slug"][];
+};
+
+/**
+ * Per-kind results threaded into the render function. Keyed by slug,
+ * `null` when the loader didn't return a value for that slug (or
+ * threw — see `template_dep_load_failed` log).
+ */
+export type TemplateDepResults = {
+  readonly [K in keyof TemplateDepRegistry]?: Readonly<
+    Record<string, TemplateDepRegistry[K]["result"] | null>
+  >;
+};
+
+export interface TemplateRenderArgs<TData extends TemplateData>
+  extends TemplateDepResults {
   readonly data: TData;
   readonly ctx: AppContext;
 }
@@ -38,14 +65,20 @@ export type TemplateRender<TData extends TemplateData> = (
  * theme's site-wide document at boot. Per-request renders look up the
  * already-merged result keyed by the matched template slot — zero
  * runtime merge cost.
+ *
+ * Dep declarations (`[K in keyof TemplateDepRegistry]?`) live directly
+ * on the template object so the framework's per-request dispatch can
+ * read them via `template[kind]` and fire the registered loaders.
  */
-export interface Template<TData extends TemplateData = TemplateData> {
+export interface Template<TData extends TemplateData = TemplateData>
+  extends TemplateDepDeclarations {
   readonly render: TemplateRender<TData>;
   readonly document?: DocumentManifest;
   readonly [PLUMIX_TEMPLATE_BRAND]: true;
 }
 
-interface DefineTemplateConfig<TData extends TemplateData> {
+interface DefineTemplateConfig<TData extends TemplateData>
+  extends TemplateDepDeclarations {
   readonly render: TemplateRender<TData>;
   readonly document?: DocumentManifest;
 }
@@ -53,13 +86,12 @@ interface DefineTemplateConfig<TData extends TemplateData> {
 export function defineTemplate<TData extends TemplateData = TemplateData>(
   config: DefineTemplateConfig<TData>,
 ): Template<TData> {
-  const template: {
-    render: TemplateRender<TData>;
-    document?: DocumentManifest;
-  } = {
-    render: config.render,
-  };
-  if (config.document !== undefined) template.document = config.document;
+  // Copy every config key onto the template object. That preserves
+  // any declared dep kinds (`settings`, `menus`, ...) which live as
+  // top-level slug arrays — the framework's per-request dispatch
+  // reads `template[kind]` to know which loaders to fire. `render` +
+  // `document` come along the same way.
+  const template: Record<string | symbol, unknown> = { ...config };
   // `enumerable: false` keeps the brand out of `Object.keys` / JSON;
   // writable/configurable defaults are fine — the symbol itself is
   // module-local so no caller can forge or rewrite it.
@@ -67,7 +99,7 @@ export function defineTemplate<TData extends TemplateData = TemplateData>(
     value: true,
     enumerable: false,
   });
-  return template as Template<TData>;
+  return template as unknown as Template<TData>;
 }
 
 export function isTemplate(value: unknown): value is Template<TemplateData> {

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -46,8 +46,9 @@ export type TemplateDepResults = {
   >;
 };
 
-export interface TemplateRenderArgs<TData extends TemplateData>
-  extends TemplateDepResults {
+export interface TemplateRenderArgs<
+  TData extends TemplateData,
+> extends TemplateDepResults {
   readonly data: TData;
   readonly ctx: AppContext;
 }
@@ -70,15 +71,17 @@ export type TemplateRender<TData extends TemplateData> = (
  * on the template object so the framework's per-request dispatch can
  * read them via `template[kind]` and fire the registered loaders.
  */
-export interface Template<TData extends TemplateData = TemplateData>
-  extends TemplateDepDeclarations {
+export interface Template<
+  TData extends TemplateData = TemplateData,
+> extends TemplateDepDeclarations {
   readonly render: TemplateRender<TData>;
   readonly document?: DocumentManifest;
   readonly [PLUMIX_TEMPLATE_BRAND]: true;
 }
 
-interface DefineTemplateConfig<TData extends TemplateData>
-  extends TemplateDepDeclarations {
+interface DefineTemplateConfig<
+  TData extends TemplateData,
+> extends TemplateDepDeclarations {
   readonly render: TemplateRender<TData>;
   readonly document?: DocumentManifest;
 }

--- a/packages/plumix/src/theme/index.ts
+++ b/packages/plumix/src/theme/index.ts
@@ -12,6 +12,7 @@ export {
   type EntryArchiveProps,
   type TaxonomyArchiveProps,
   type Template,
+  type TemplateDepLoader,
   type TemplateDepRegistry,
   type TemplateRender,
   type TemplateRenderArgs,


### PR DESCRIPTION
Plugins now register template-dep loaders via
`ctx.registerTemplateDep(kind, { load })`; themes declare per-template needs
via `defineTemplate({ [kind]: slugs[], render })`. The framework fires every
declared dep's loader in parallel via `Promise.all` per request and passes the
results into the template's render function. Core ships a built-in `settings`
dep against the existing settings table so every plumix app gets site-wide
settings consumption out of the box.

**Per-request dispatch with graceful degradation**

The renderer reads each picked template's declared kinds (from the
`TemplateDepRegistry` augmentation seam), fires every registered loader with
the deduped slugs via `Promise.all`, fills missing slugs with `null`, and
spreads results into the render function. Loader throws log
`template_dep_load_failed` via `ctx.logger.error` and seed an empty map —
never escalate to a 500. The `TemplateAdapter` spread order puts `data`/`ctx`
last so a misregistered dep kind named `\"data\"` or `\"ctx\"` can't clobber
the canonical args.

**Built-in `settings` dep, registered before plugins**

`registerCoreTemplateDeps(seededRegistry)` runs in `buildApp` BEFORE
`installPlugins`, mirroring `registerCoreLookupAdapters`. The `settings` slot
lands first; a plugin trying to re-register the same kind trips
`DuplicateRegistrationError` at boot. The loader does
`inArray(settings.group, slugs)` and groups rows into
`Record<group, Record<key, value>>`. Groups with zero rows are absent from the
loader's return, and the per-slug fill converts that to `null`.

**Test coverage**

10 colocated tests cover: registration via plugin ctx, collision throws,
multi-plugin coexistence, parallel load (timing < serial-sum), missing-slug
→ null, loader-throw → log + empty map, end-to-end SSR surfaces deps in
render, broken loader returns 200, end-to-end settings dep with a real row,
and legacy normalized templates with no declarations → `{}`.

Slice #519 (menu plugin refactor to use `registerTemplateDep`) lands next and
closes out PRD #515.

Refs #515
Closes #518