### PR TITLE
refactor(plugin-menu): expose menus via registerTemplateDep

### DIFF
--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -77,7 +77,7 @@ export type DeferFn = (promise: Promise<unknown>) => void;
  * route, hook listeners) read them via `ctx.<key>`.
  *
  * Empty by default — plugins augment via TypeScript module merging,
- * mirroring `PluginContextExtensions` / `ThemeContextExtensions`.
+ * mirroring `PluginContextExtensions`.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface AppContextExtensions {}

--- a/packages/core/src/plugin/errors.test.ts
+++ b/packages/core/src/plugin/errors.test.ts
@@ -37,12 +37,12 @@ describe("PluginContextError — extend-context factories", () => {
   test("extendContextReservedKey", () => {
     const err = PluginContextError.extendContextReservedKey({
       pluginId: "blog",
-      kind: "Theme",
+      kind: "App",
       key: "__proto__",
     });
     expect(err.code).toBe("extend_context_reserved_key");
     expect(err.key).toBe("__proto__");
-    expect(err.message).toContain("extendThemeContext with the reserved name");
+    expect(err.message).toContain("extendAppContext with the reserved name");
     expect(err.message).toContain('"__proto__"');
   });
 

--- a/packages/core/src/plugin/errors.ts
+++ b/packages/core/src/plugin/errors.ts
@@ -122,7 +122,7 @@ export class PluginContextError extends Error {
 
   static extendContextInvalidKey(ctx: {
     pluginId: string;
-    kind: "Plugin" | "Theme" | "App";
+    kind: "Plugin" | "App";
   }): PluginContextError {
     return new PluginContextError(
       "extend_context_invalid_key",
@@ -134,7 +134,7 @@ export class PluginContextError extends Error {
 
   static extendContextReservedKey(ctx: {
     pluginId: string;
-    kind: "Plugin" | "Theme" | "App";
+    kind: "Plugin" | "App";
     key: string;
   }): PluginContextError {
     return new PluginContextError(
@@ -163,7 +163,7 @@ export class PluginContextError extends Error {
 
   static extendContextDuplicate(ctx: {
     pluginId: string;
-    kind: "Plugin" | "Theme" | "App";
+    kind: "Plugin" | "App";
     key: string;
     existingOwner: string;
   }): PluginContextError {

--- a/packages/core/src/template-deps.test.tsx
+++ b/packages/core/src/template-deps.test.tsx
@@ -137,16 +137,19 @@ function makeRegistry(
 
 describe("loadTemplateDeps", () => {
   test("invokes every declared kind in parallel via Promise.all", async () => {
-    // Two loaders each sleep 30ms — serial would take 60ms, parallel
-    // ~30ms. Window with 5ms slack for CI noise.
+    // Two loaders each sleep 50ms — serial would take 100ms, parallel
+    // ~50ms. The threshold sits below the serial floor so a regression
+    // to sequential `await`s fails the test, but stays far enough
+    // above the parallel floor to absorb CI scheduler jitter (saw 61ms
+    // for 30ms+5ms-slack tuning).
     const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
     const registry = makeRegistry({
       "test-thing": async () => {
-        await sleep(30);
+        await sleep(50);
         return { a: { value: "thing-a" } };
       },
       "test-other": async () => {
-        await sleep(30);
+        await sleep(50);
         return { b: 7 };
       },
     });
@@ -159,7 +162,7 @@ describe("loadTemplateDeps", () => {
     const elapsed = Date.now() - start;
     expect(deps["test-thing"]).toEqual({ a: { value: "thing-a" } });
     expect(deps["test-other"]).toEqual({ b: 7 });
-    expect(elapsed).toBeLessThan(55);
+    expect(elapsed).toBeLessThan(90);
   });
 
   test("a slug missing from the loader result fills with null", async () => {

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -1,7 +1,17 @@
 import { definePlugin } from "plumix/plugin";
 
-import type { ResolvedMenuItem } from "./server/types.js";
+import type { ResolvedMenu, ResolvedMenuItem } from "./server/types.js";
 import { createMenuRouter } from "./rpc.js";
+import { getMenuByName } from "./server/getMenuByName.js";
+
+// Register the `menus` template-dep kind so themes can declare
+// `defineTemplate({ menus: ["primary", "footer"], render })` and the
+// framework batches loads per request via the registered loader below.
+declare module "plumix/plugin" {
+  interface TemplateDepRegistry {
+    menus: { slug: string; result: ResolvedMenu };
+  }
+}
 
 // `@plumix/plugin-menu` augments the core option shapes with
 // menu-eligibility flags and the hook registries with three menu
@@ -9,10 +19,6 @@ import { createMenuRouter } from "./rpc.js";
 // in the project's `node_modules`. The eligibility flags are read at
 // admin time by the eligibility resolver (`getEligibleMenuKinds`);
 // the hooks are fired by `getMenuByName` and `menu.save`.
-//
-// `registerMenuLocation` is deferred — `theme.setup` was removed in
-// the theming foundation slice; a new registration path lands with
-// the menu-locations follow-up.
 declare module "plumix/plugin" {
   interface EntryTypeOptions {
     /**
@@ -101,6 +107,18 @@ export const menu = definePlugin("menu", {
       isHierarchical: false,
       entryTypes: ["menu_item"],
       isPublic: false,
+    });
+
+    ctx.registerTemplateDep("menus", {
+      load: async (slugs, appCtx) => {
+        const result: Record<string, ResolvedMenu | null> = {};
+        await Promise.all(
+          slugs.map(async (slug) => {
+            result[slug] = await getMenuByName(appCtx, slug);
+          }),
+        );
+        return result;
+      },
     });
 
     ctx.registerRpcRouter(createMenuRouter());

--- a/packages/plugins/menu/src/server/locations.ts
+++ b/packages/plugins/menu/src/server/locations.ts
@@ -2,16 +2,12 @@ import type { MenuLocationOptions, RegisteredMenuLocation } from "./types.js";
 import { MenuPluginError } from "../errors.js";
 
 /**
- * Module-scoped registry of menu locations. Themes call
- * `registerMenuLocation` from their `setup` callback (the implementation
- * is wired into `ThemeContextExtensions` from the plugin's `provides`),
- * which delegates to `recordLocation` here.
- *
- * Lifetime: populated once during `buildApp`, read for the rest of the
- * process / Worker isolate. The CF Worker model reuses isolates across
- * requests, so this is effectively boot-time-immutable in production.
- *
- * Tests reset between cases via `clearRegisteredLocations`.
+ * Module-scoped registry of menu locations populated at boot. The
+ * menu RPC's `locations.list` + `locations.assign` procedures read it
+ * to validate which location slots a theme has declared. Tests reset
+ * state between cases via `clearRegisteredLocations`. A re-registration
+ * path for themes (lost when `theme.setup` went away) is a separate
+ * follow-up.
  */
 const locations = new Map<string, RegisteredMenuLocation>();
 

--- a/packages/plugins/menu/src/template-deps.test.tsx
+++ b/packages/plugins/menu/src/template-deps.test.tsx
@@ -1,0 +1,210 @@
+import type { AppContext, PluginRegistry } from "plumix/plugin";
+import {
+  createPluginRegistry,
+  definePlugin,
+  HookRegistry,
+  installPlugins,
+  registerCoreLookupAdapters,
+} from "plumix/plugin";
+import {
+  adminUser,
+  createDispatcherHarness,
+  createTestDb,
+  entryFactory,
+  entryTermFactory,
+  factoriesFor,
+} from "plumix/test";
+import { defineTemplate, defineTheme } from "plumix/theme";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import type { MenuItemMeta, ResolvedMenu } from "./server/types.js";
+import { menu } from "./index.js";
+
+type MenuLoader = NonNullable<
+  ReturnType<PluginRegistry["templateDeps"]["get"]>
+>["load"];
+
+interface TestBundle {
+  readonly db: Awaited<ReturnType<typeof createTestDb>>;
+  readonly factories: ReturnType<typeof factoriesFor>;
+  readonly ctx: AppContext;
+  readonly load: MenuLoader;
+  readonly authorId: number;
+}
+
+async function bundle(): Promise<TestBundle> {
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  registerCoreLookupAdapters(registry);
+  await installPlugins({
+    hooks,
+    plugins: [
+      definePlugin("menu-host", (ctx) => {
+        ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      }),
+      menu,
+    ],
+    registry,
+  });
+  const db = await createTestDb();
+  const factories = factoriesFor(db);
+  const author = await adminUser
+    .transient({ db })
+    .create({ email: "menu-loader@example.test" });
+  const ctx = {
+    db,
+    plugins: registry,
+    hooks,
+    request: new Request("https://test.example/"),
+    resolvedEntity: null,
+  } as unknown as AppContext;
+  const dep = registry.templateDeps.get("menus");
+  if (!dep) throw new Error("menus template dep not registered");
+  return { db, factories, ctx, load: dep.load, authorId: author.id };
+}
+
+async function seedMenuItem(
+  b: TestBundle,
+  termId: number,
+  title: string,
+  meta: MenuItemMeta,
+  index = 0,
+): Promise<number> {
+  const entry = await entryFactory.transient({ db: b.db }).create({
+    type: "menu_item",
+    title,
+    slug: `menu-item-${termId}-${index}-${Date.now()}-${Math.random()}`,
+    status: "published",
+    authorId: b.authorId,
+    parentId: null,
+    sortOrder: index,
+    meta: meta as unknown as Record<string, unknown>,
+  });
+  await entryTermFactory
+    .transient({ db: b.db })
+    .create({ entryId: entry.id, termId, sortOrder: index });
+  return entry.id;
+}
+
+describe("@plumix/plugin-menu — menus template dep loader", () => {
+  let b: TestBundle;
+  beforeEach(async () => {
+    b = await bundle();
+  });
+
+  test("resolves a single declared slug via getMenuByName", async () => {
+    const term = await b.factories.term.create({
+      taxonomy: "menu",
+      slug: "primary",
+      name: "Primary nav",
+    });
+    await seedMenuItem(b, term.id, "Home", { kind: "custom", url: "/" });
+
+    const result = await b.load(["primary"], b.ctx);
+    const primary = result.primary as ResolvedMenu | null;
+    expect(primary?.name).toBe("Primary nav");
+    expect(primary?.items.map((i) => i.label)).toEqual(["Home"]);
+  });
+
+  test("batches multiple declared slugs in one loader call", async () => {
+    const primary = await b.factories.term.create({
+      taxonomy: "menu",
+      slug: "primary",
+      name: "Primary",
+    });
+    const footer = await b.factories.term.create({
+      taxonomy: "menu",
+      slug: "footer",
+      name: "Footer",
+    });
+    await seedMenuItem(b, primary.id, "Home", { kind: "custom", url: "/" }, 0);
+    await seedMenuItem(
+      b,
+      footer.id,
+      "Privacy",
+      { kind: "custom", url: "/privacy" },
+      0,
+    );
+
+    const result = await b.load(["primary", "footer"], b.ctx);
+    expect((result.primary as ResolvedMenu | null)?.name).toBe("Primary");
+    expect((result.footer as ResolvedMenu | null)?.name).toBe("Footer");
+  });
+
+  test("returns null for a slug with no matching menu term", async () => {
+    const result = await b.load(["nope"], b.ctx);
+    expect(result.nope).toBeNull();
+  });
+});
+
+describe("@plumix/plugin-menu — end-to-end SSR", () => {
+  test("a template declaring `menus` renders the loaded menu", async () => {
+    const blogPlugin = definePlugin("blog", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+      });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          menus: ["primary"],
+          render: (args) => {
+            const primary = args.menus?.primary;
+            return (
+              <nav>
+                {primary?.items.map((item) => (
+                  <a key={item.id} href={item.href} data-testid="menu-link">
+                    {item.label}
+                  </a>
+                )) ?? null}
+              </nav>
+            );
+          },
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, menu],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "menu-flow",
+      title: "Menu Flow",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    const term = await h.factory.term.create({
+      taxonomy: "menu",
+      slug: "primary",
+      name: "Primary nav",
+    });
+    const menuItem = await h.factory.entry.create({
+      type: "menu_item",
+      slug: "menu-item-home",
+      title: "Home",
+      status: "published",
+      authorId: author.id,
+      meta: { kind: "custom", url: "/" } as unknown as Record<string, unknown>,
+    });
+    await h.factory.entryTerm.create({
+      entryId: menuItem.id,
+      termId: term.id,
+      sortOrder: 0,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/menu-flow"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('href="/"');
+    expect(body).toContain("Home");
+  });
+});


### PR DESCRIPTION
Themes can now declare `defineTemplate({ menus: ["primary", "footer"], render })` and the
framework hands them a typed `Record<slug, ResolvedMenu | null>` in render args. The menu
plugin registers a `menus` template-dep loader via `ctx.registerTemplateDep` (PR #534), so
the framework's per-request dispatch fires one batched load per template no matter how
many slugs the theme declares.

**Loader shape**

The loader fans out across declared slugs with `Promise.all` over `getMenuByName(ctx, slug)`:

```ts
ctx.registerTemplateDep("menus", {
  load: async (slugs, appCtx) => {
    const result: Record<string, ResolvedMenu | null> = {};
    await Promise.all(
      slugs.map(async (slug) => {
        result[slug] = await getMenuByName(appCtx, slug);
      }),
    );
    return result;
  },
});
```

Slugs with no matching menu term resolve to `null` — themes use `args.menus?.primary?.items`.

**Dead-code cleanup**

Stale references from the deferred `registerMenuLocation` / `ThemeContextExtensions` plumbing
(removed in prior slices, comments left behind) are gone from `menu/index.ts`,
`menu/server/locations.ts`, and `core/context/app.ts`. The vestigial `"Theme"` variant on
`PluginContextError`'s `kind` union is dropped — nothing in production passes it anymore.

The menu RPC + admin location-binding UI are untouched. `getRegisteredLocations` /
`recordLocation` stay because the location-binding RPCs depend on them; a re-registration
path for themes (lost when `theme.setup` went away) is a separate follow-up.

Closes #519
Refs #515