### PR TITLE
feat(blocks): islands MVP framework primitives

### DIFF
--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -1,3 +1,5 @@
+import type { ComponentType } from "react";
+
 import type { BlockNodeComponent } from "./render-block-tree.js";
 
 export interface BlockInputOption {
@@ -12,8 +14,26 @@ export interface BlockInput {
   readonly options?: readonly BlockInputOption[];
 }
 
+/**
+ * Hydration strategy declared by a block's `client` descriptor. Only
+ * `load` is wired in the islands MVP; the remaining values are exported
+ * up front so block-author code targeting the full strategy set
+ * compiles today even though `idle`/`visible`/`interaction`/`only` land
+ * in a follow-up slice.
+ */
+export type HydrateWhen = "load" | "idle" | "visible" | "interaction" | "only";
+
+/**
+ * Prefetch strategy for the island's JS chunk. Like `HydrateWhen`,
+ * declared as a full union for compile-time stability; only `load`
+ * acts today.
+ */
+export type PrefetchWhen = "load" | "idle" | "visible";
+
 export interface ClientIslandDescriptor {
-  readonly script: string;
+  readonly component: ComponentType<Readonly<Record<string, unknown>>>;
+  readonly hydrateWhen?: HydrateWhen;
+  readonly prefetchWhen?: PrefetchWhen;
 }
 
 export interface BlockVariation {

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -19,6 +19,8 @@ export type {
   BlockTransforms,
   BlockVariation,
   ClientIslandDescriptor,
+  HydrateWhen,
+  PrefetchWhen,
 } from "./block-registry.js";
 
 // ─── Walker + render contract ───────────────────────────────────────────────
@@ -32,6 +34,8 @@ export type {
   BlockNode,
   BlockNodeComponent,
   BlockNodeRenderProps,
+  IslandManifest,
+  IslandManifestEntry,
   BlockRenderHooks,
   RenderBlockTreeOptions,
 } from "./render-block-tree.js";

--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { IslandStrategy } from "./island-element.js";
+import {
+  ISLAND_TAG,
+  PlumixIslandElement,
+  registerIslandElement,
+  setDynamicImport,
+} from "./island-element.js";
+
+function makeIsland(attrs: Record<string, string>): PlumixIslandElement {
+  registerIslandElement();
+  const el = document.createElement(ISLAND_TAG) as PlumixIslandElement;
+  for (const [key, value] of Object.entries(attrs)) {
+    el.setAttribute(key, value);
+  }
+  return el;
+}
+
+const stubStrategies = (
+  load: IslandStrategy = (loadFn) => loadFn(),
+): IslandStrategy => {
+  window.Plumix = { load };
+  return load;
+};
+
+describe("registerIslandElement", () => {
+  beforeEach(() => {
+    // Clear the document between cases — registered tag persists since
+    // customElements.define cannot be undone in a window's lifetime.
+    document.body.innerHTML = "";
+  });
+
+  test("registers the <plumix-island> custom element exactly once", () => {
+    registerIslandElement();
+    const first = customElements.get(ISLAND_TAG);
+    registerIslandElement();
+    const second = customElements.get(ISLAND_TAG);
+    expect(first).toBe(second);
+    expect(first).toBe(PlumixIslandElement);
+  });
+});
+
+describe("PlumixIslandElement lifecycle", () => {
+  let restoreImport: () => void = () => undefined;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete (window as { Plumix?: unknown }).Plumix;
+    restoreImport = () => undefined;
+  });
+
+  afterEach(() => {
+    restoreImport();
+  });
+
+  test("connectedCallback invokes the registered `load` strategy", async () => {
+    const strategy = vi.fn<IslandStrategy>();
+    stubStrategies(strategy);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "Search",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(strategy).toHaveBeenCalledTimes(1);
+    expect(strategy.mock.calls[0]?.[2]).toBe(el);
+  });
+
+  test("`await-children` delays start until ssr-complete is set", async () => {
+    const strategy = vi.fn<IslandStrategy>();
+    stubStrategies(strategy);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "await-children": "",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(strategy).not.toHaveBeenCalled();
+    el.setAttribute("ssr-complete", "");
+    // Wait two microtasks for MutationObserver + the start() promise.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(strategy).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispatches plumix:hydration-error when no strategy is registered", async () => {
+    const listener = vi.fn();
+    window.addEventListener("plumix:hydration-error", listener);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.cancelable).toBe(true);
+    window.removeEventListener("plumix:hydration-error", listener);
+  });
+
+  test("retries the chunk import with #plumix-retry hash after one failure", async () => {
+    vi.useFakeTimers();
+    const calls: string[] = [];
+    restoreImport = setDynamicImport((url) => {
+      calls.push(url);
+      if (calls.length === 1) return Promise.reject(new Error("network blip"));
+      return Promise.resolve({ Search: () => null });
+    });
+    stubStrategies();
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "Search",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    // First import fails immediately; the retry sleeps 1000ms before
+    // firing.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toBe("/chunk.js");
+    expect(calls[1]).toMatch(/^\/chunk\.js#plumix-retry=\d+$/);
+    vi.useRealTimers();
+  });
+
+  test("dispatches plumix:hydration-error after the second import failure", async () => {
+    vi.useFakeTimers();
+    restoreImport = setDynamicImport(() => Promise.reject(new Error("404")));
+    stubStrategies();
+    const listener = vi.fn();
+    window.addEventListener("plumix:hydration-error", listener);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "Search",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.cancelable).toBe(true);
+    window.removeEventListener("plumix:hydration-error", listener);
+    vi.useRealTimers();
+  });
+
+  // The sibling-script prop pipeline is covered end-to-end by the
+  // Playwright e2e in `packages/e2e/tests/islands-mvp.spec.ts` (Phase G).
+  // Verifying it here would mean flushing a React 19 concurrent commit
+  // out of jsdom, which is more harness wiring than value at the unit
+  // layer. The deserializer round-trip is in `serialize.test.ts`.
+});

--- a/packages/blocks/src/island-element.ts
+++ b/packages/blocks/src/island-element.ts
@@ -1,0 +1,215 @@
+// Port of Astro's `astro-island.ts` (Apache-2.0). The custom element
+// reads its hydration target from attributes the SSR walker emitted:
+// the chunk URL, the named export to mount, the strategy name, the
+// strategy-specific opts JSON, and an optional `await-children` flag
+// that gates hydration on `MutationObserver` until streamed children
+// settle. Props live in a sibling `<script type="application/json">`
+// rather than an attribute because attribute size limits in real
+// browsers (~64 KB on some engines) would clip a large prop graph.
+//
+// On a failed chunk import, hydrate() retries once with a cache-bust
+// hash (`#plumix-retry=<ts>`) — covers the deploy-during-page-load
+// case where the SSR'd HTML references a chunk URL that no longer
+// resolves. After the second failure the element dispatches a
+// cancelable `plumix:hydration-error` CustomEvent on `window`: a
+// theme can `preventDefault()` to swallow it or surface a user-
+// visible error UI, but the framework never crashes the page.
+
+import type { ComponentType } from "react";
+import type { Root } from "react-dom/client";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import { deserializeProps } from "./serialize.js";
+
+export type IslandStrategy = (
+  loadFn: () => Promise<void>,
+  opts: Readonly<Record<string, unknown>>,
+  el: PlumixIslandElement,
+) => void | Promise<void>;
+
+declare global {
+  interface Window {
+    Plumix?: Readonly<Record<string, IslandStrategy>>;
+  }
+}
+
+const RETRY_DELAY_MS = 1000;
+
+export class PlumixIslandElement extends HTMLElement {
+  private root: Root | null = null;
+  private retried = false;
+  private hydrated = false;
+  private childObserver: MutationObserver | null = null;
+
+  connectedCallback(): void {
+    // If await-children is set, defer until the streaming SSR finishes
+    // emitting children — Astro's same gate. Without it the element
+    // would hydrate against half-rendered markup and React would warn
+    // about a hydration mismatch.
+    if (
+      this.hasAttribute("await-children") &&
+      !this.hasAttribute("ssr-complete")
+    ) {
+      this.childObserver = new MutationObserver(() => {
+        if (this.hasAttribute("ssr-complete")) {
+          this.childObserver?.disconnect();
+          this.childObserver = null;
+          void this.start();
+        }
+      });
+      this.childObserver.observe(this, {
+        attributes: true,
+        attributeFilter: ["ssr-complete"],
+      });
+      return;
+    }
+    void this.start();
+  }
+
+  disconnectedCallback(): void {
+    this.childObserver?.disconnect();
+    this.childObserver = null;
+    this.root?.unmount();
+    this.root = null;
+  }
+
+  private async start(): Promise<void> {
+    if (this.hydrated) return;
+    const strategy = this.getAttribute("client") ?? "load";
+    const opts = parseJsonAttr(this.getAttribute("opts"));
+    const strategies = window.Plumix;
+    const fn = strategies?.[strategy];
+    if (!fn) {
+      // No registered strategy — the runtime entry script never loaded.
+      // Surface the same hydration-error event so the page can react.
+      this.dispatchHydrationError(new Error(`unknown strategy: ${strategy}`));
+      return;
+    }
+    await fn(() => this.hydrate(), opts, this);
+  }
+
+  private async hydrate(): Promise<void> {
+    if (this.hydrated) return;
+    const chunkUrl = this.getAttribute("chunk-url");
+    const exportName = this.getAttribute("component-export") ?? "default";
+    if (!chunkUrl) {
+      this.dispatchHydrationError(new Error("missing chunk-url attribute"));
+      return;
+    }
+    const Component = await this.loadComponent(chunkUrl, exportName);
+    if (!Component) return;
+    const props = readProps(this);
+    this.hydrated = true;
+    this.root = createRoot(this);
+    this.root.render(createElement(Component, props));
+  }
+
+  private async loadComponent(
+    chunkUrl: string,
+    exportName: string,
+  ): Promise<ComponentType<Readonly<Record<string, unknown>>> | null> {
+    try {
+      const mod = (await dynamicImport(chunkUrl)) as Record<string, unknown>;
+      return mod[exportName] as ComponentType<
+        Readonly<Record<string, unknown>>
+      >;
+    } catch (err) {
+      if (this.retried) {
+        this.dispatchHydrationError(err);
+        return null;
+      }
+      this.retried = true;
+      await sleep(RETRY_DELAY_MS);
+      try {
+        const retryUrl = appendCacheBust(chunkUrl);
+        const mod = (await dynamicImport(retryUrl)) as Record<string, unknown>;
+        return mod[exportName] as ComponentType<
+          Readonly<Record<string, unknown>>
+        >;
+      } catch (retryErr) {
+        this.dispatchHydrationError(retryErr);
+        return null;
+      }
+    }
+  }
+
+  private dispatchHydrationError(err: unknown): void {
+    window.dispatchEvent(
+      new CustomEvent("plumix:hydration-error", {
+        detail: { error: err, element: this },
+        cancelable: true,
+      }),
+    );
+  }
+}
+
+// Test-injectable dynamic import. jsdom can't resolve real module URLs
+// in unit tests; swapping this lets the retry-and-error paths be
+// exercised without spinning up a bundler.
+let dynamicImport: (url: string) => Promise<unknown> = (url) => import(url);
+
+export function setDynamicImport(
+  fn: (url: string) => Promise<unknown>,
+): () => void {
+  const prev = dynamicImport;
+  dynamicImport = fn;
+  return () => {
+    dynamicImport = prev;
+  };
+}
+
+function appendCacheBust(url: string): string {
+  return `${url}#plumix-retry=${Date.now()}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseJsonAttr(raw: string | null): Readonly<Record<string, unknown>> {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed !== null && typeof parsed === "object") {
+      return parsed as Readonly<Record<string, unknown>>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function readProps(el: HTMLElement): Readonly<Record<string, unknown>> {
+  // SSR emits `<script type="application/json" data-plumix-island-props>`
+  // as a sibling of the island element. Known limitation: any DOM
+  // rewriter that inserts a non-script element between the two (third-
+  // party scripts, translate extensions, theme post-processors) breaks
+  // the lookup and the React component mounts with `{}` props. A more
+  // robust lookup keyed by an explicit `props-id` attribute is filed
+  // for a follow-up — for the islands MVP, the positional sibling
+  // pattern matches the contract the walker emits.
+  const script = el.nextElementSibling;
+  if (
+    !(script instanceof HTMLScriptElement) ||
+    script.getAttribute("data-plumix-island-props") === null
+  ) {
+    return {};
+  }
+  return deserializeProps(script.textContent || "{}");
+}
+
+export const ISLAND_TAG = "plumix-island";
+
+/**
+ * Register the `<plumix-island>` custom element. Guarded so a second
+ * call (e.g. HMR reload during dev) doesn't throw — `customElements`
+ * rejects redefinition. The framework's runtime entry script calls
+ * this once on first execution; theme code generally never imports it
+ * directly.
+ */
+export function registerIslandElement(): void {
+  if (!customElements.get(ISLAND_TAG)) {
+    customElements.define(ISLAND_TAG, PlumixIslandElement);
+  }
+}

--- a/packages/blocks/src/island-runtime.test.ts
+++ b/packages/blocks/src/island-runtime.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { ISLAND_TAG } from "./island-element.js";
+
+describe("bootstrapIslandRuntime", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete (window as { Plumix?: unknown }).Plumix;
+  });
+
+  afterEach(() => {
+    delete (window as { Plumix?: unknown }).Plumix;
+  });
+
+  test("registers the custom element + the load strategy at import time", async () => {
+    await import("./island-runtime.js");
+    expect(customElements.get(ISLAND_TAG)).toBeDefined();
+    expect(
+      typeof (window as { Plumix?: Record<string, unknown> }).Plumix?.load,
+    ).toBe("function");
+  });
+
+  test("re-running bootstrap is idempotent", async () => {
+    const { bootstrapIslandRuntime } = await import("./island-runtime.js");
+    bootstrapIslandRuntime();
+    bootstrapIslandRuntime();
+    expect(customElements.get(ISLAND_TAG)).toBeDefined();
+  });
+});

--- a/packages/blocks/src/island-runtime.ts
+++ b/packages/blocks/src/island-runtime.ts
@@ -1,0 +1,17 @@
+// Client-side runtime entry for the islands MVP. The Vite islands
+// plugin (`plugin-islands.ts`) registers this as a script tag in the
+// document head; on first execution it registers the custom element
+// and every supported strategy. Subsequent executions (e.g. HMR) are
+// idempotent — both registration functions guard against
+// double-registration. Theme code never imports this; the framework
+// emits the script tag from SSR.
+
+import { registerIslandElement } from "./island-element.js";
+import { registerLoadStrategy } from "./island-strategies/load.js";
+
+export function bootstrapIslandRuntime(): void {
+  registerLoadStrategy();
+  registerIslandElement();
+}
+
+bootstrapIslandRuntime();

--- a/packages/blocks/src/island-strategies/load.ts
+++ b/packages/blocks/src/island-strategies/load.ts
@@ -1,0 +1,20 @@
+// `load` strategy — the simplest hydration trigger. Fires the chunk
+// import as soon as the strategy runs, which happens immediately on
+// `connectedCallback` for islands that don't declare `await-children`.
+// Registers via `self.Plumix.load` so the custom element finds it on
+// the global namespace. Exported as an IIFE-like initializer the
+// runtime entry script wires up; theme code doesn't import this
+// directly.
+
+import type { IslandStrategy } from "../island-element.js";
+
+export const loadStrategy: IslandStrategy = (loadFn) => {
+  void loadFn();
+};
+
+export function registerLoadStrategy(): void {
+  const target = self as unknown as {
+    Plumix?: Record<string, IslandStrategy>;
+  };
+  target.Plumix = { ...(target.Plumix ?? {}), load: loadStrategy };
+}

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -311,51 +311,6 @@ describe("renderBlockTree", () => {
   });
 
   describe("client islands", () => {
-    test("emits a <script type='module'> next to the wrapper when spec.client is declared", () => {
-      const registry = createBlockRegistry([
-        {
-          name: "acme/carousel",
-          render: () => <div className="carousel" />,
-          client: { script: "/assets/carousel.js" },
-        },
-      ]);
-      const tree: readonly BlockNode[] = [
-        { id: "c1", name: "acme/carousel", attrs: {} },
-      ];
-
-      const html = renderToStaticMarkup(renderBlockTree(tree, registry));
-
-      expect(html).toContain('data-plumix-block="acme/carousel"');
-      expect(html).toContain(
-        '<script type="module" src="/assets/carousel.js"></script>',
-      );
-    });
-
-    test("dedupes the hydration script when multiple instances share a client.script URL", () => {
-      const registry = createBlockRegistry([
-        {
-          name: "acme/carousel",
-          render: () => <div />,
-          client: { script: "/assets/carousel.js" },
-        },
-      ]);
-      const tree: readonly BlockNode[] = [
-        { id: "c1", name: "acme/carousel", attrs: {} },
-        { id: "c2", name: "acme/carousel", attrs: {} },
-      ];
-
-      const html = renderToStaticMarkup(renderBlockTree(tree, registry));
-
-      const scriptMatches = html.match(
-        /<script[^>]*src="\/assets\/carousel.js"/g,
-      );
-      expect(scriptMatches).toHaveLength(1);
-      // Each instance still carries the island marker so the bootstrap can
-      // find every DOM anchor by name.
-      const islandMatches = html.match(/data-plumix-island="acme\/carousel"/g);
-      expect(islandMatches).toHaveLength(2);
-    });
-
     test("does not emit a script for blocks without spec.client", () => {
       const heading: BlockNode = {
         id: "h1",
@@ -368,6 +323,94 @@ describe("renderBlockTree", () => {
       );
 
       expect(html).not.toContain("<script");
+    });
+
+    test("wraps the block in <plumix-island> when client + manifest entry present", () => {
+      const Search = () => <input data-testid="search" />;
+      const registry = createBlockRegistry([
+        {
+          name: "acme/search",
+          render: () => <input className="ssr-fallback" />,
+          client: { component: Search, hydrateWhen: "load" },
+        },
+      ]);
+      const manifest = new Map([
+        [
+          Search,
+          {
+            chunkUrl: "/_plumix/assets/search.abc123.js",
+            exportName: "Search",
+          },
+        ],
+      ]);
+      const tree: readonly BlockNode[] = [
+        { id: "s1", name: "acme/search", attrs: { placeholder: "Type…" } },
+      ];
+
+      const html = renderToStaticMarkup(
+        renderBlockTree(tree, registry, { islandManifest: manifest }),
+      );
+
+      expect(html).toContain("<plumix-island");
+      expect(html).toContain('chunk-url="/_plumix/assets/search.abc123.js"');
+      expect(html).toContain('component-export="Search"');
+      expect(html).toContain('client="load"');
+      expect(html).toContain('data-plumix-block="acme/search"');
+      expect(html).toContain("ssr-fallback");
+      expect(html).toContain(
+        '<script type="application/json" data-plumix-island-props="">',
+      );
+    });
+
+    test("falls back to plain div when client is declared but no manifest entry resolves", () => {
+      const Search = () => null;
+      const registry = createBlockRegistry([
+        {
+          name: "acme/search",
+          render: () => <input className="ssr-fallback" />,
+          client: { component: Search, hydrateWhen: "load" },
+        },
+      ]);
+      const tree: readonly BlockNode[] = [
+        { id: "s1", name: "acme/search", attrs: {} },
+      ];
+
+      // No manifest passed → graceful degradation.
+      const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+      expect(html).not.toContain("<plumix-island");
+      expect(html).toContain("ssr-fallback");
+    });
+
+    test("escapes </script> sequences in serialized props", () => {
+      const Widget = () => null;
+      const registry = createBlockRegistry([
+        {
+          name: "acme/widget",
+          render: () => <span />,
+          client: { component: Widget, hydrateWhen: "load" },
+        },
+      ]);
+      const manifest = new Map([
+        [Widget, { chunkUrl: "/w.js", exportName: "Widget" }],
+      ]);
+      const tree: readonly BlockNode[] = [
+        {
+          id: "w1",
+          name: "acme/widget",
+          attrs: { code: "alert('hi'); </script>" },
+        },
+      ];
+
+      const html = renderToStaticMarkup(
+        renderBlockTree(tree, registry, { islandManifest: manifest }),
+      );
+
+      // The legitimate closing `</script>` for the prop tag exists once;
+      // the escape must prevent a second one from appearing inside the JSON.
+      const closingMatches = html.match(/<\/script>/g);
+      expect(closingMatches).toHaveLength(1);
+      expect(html).toContain("<\\/script");
     });
   });
 

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -1,10 +1,28 @@
-import type { ReactNode } from "react";
+import type { ComponentType, ReactNode } from "react";
 import { createElement, Fragment } from "react";
 
 import type { BlockRegistry } from "./block-registry.js";
 import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
 import type { ThemeTokens } from "./styles/types.js";
+import { serializeProps } from "./serialize.js";
 import { emitBlockStyleCss } from "./styles/style-emitter.js";
+
+/**
+ * Per-component manifest entry the Vite islands plugin produces at
+ * build time. Keyed by the component reference (`spec.client.component`)
+ * so the walker can resolve `chunkUrl` + `exportName` for any island
+ * the registry contains. Phase F (`plugin-islands.ts`) populates this;
+ * the walker reads it but never builds it.
+ */
+export interface IslandManifestEntry {
+  readonly chunkUrl: string;
+  readonly exportName: string;
+}
+
+export type IslandManifest = ReadonlyMap<
+  ComponentType<Readonly<Record<string, unknown>>>,
+  IslandManifestEntry
+>;
 
 /**
  * Threaded through `renderBlockTree` recursion. Block components introspect
@@ -46,6 +64,7 @@ export interface BlockRenderHooks {
 export interface RenderBlockTreeOptions {
   readonly tokens?: ThemeTokens;
   readonly hooks?: BlockRenderHooks;
+  readonly islandManifest?: IslandManifest;
 }
 
 export interface BlockNodeRenderProps<
@@ -118,6 +137,7 @@ function materializeSlots(
   childContext: BlockContext,
   tokens: ThemeTokens | undefined,
   hooks: BlockRenderHooks | undefined,
+  islandManifest: IslandManifest | undefined,
 ): Readonly<Record<string, unknown>> {
   let materialized: Record<string, unknown> | undefined;
   for (const [key, value] of Object.entries(attrs)) {
@@ -131,6 +151,7 @@ function materializeSlots(
           childContext,
           tokens,
           hooks,
+          islandManifest,
         );
       };
     }
@@ -145,8 +166,8 @@ function renderNodes(
   context: BlockContext,
   tokens: ThemeTokens | undefined,
   hooks: BlockRenderHooks | undefined,
+  islandManifest: IslandManifest | undefined,
 ): ReactNode {
-  const seenScripts = new Set<string>();
   return nodes.map((node) => {
     hooks?.beforeRender?.(node, context);
     const result = renderNode(
@@ -156,7 +177,7 @@ function renderNodes(
       context,
       tokens,
       hooks,
-      seenScripts,
+      islandManifest,
     );
     hooks?.afterRender?.(node, context);
     return result;
@@ -170,7 +191,7 @@ function renderNode(
   context: BlockContext,
   tokens: ThemeTokens | undefined,
   hooks: BlockRenderHooks | undefined,
-  seenScripts: Set<string>,
+  islandManifest: IslandManifest | undefined,
 ): ReactNode {
   const spec = registry.get(node.name);
   if (!spec) {
@@ -192,6 +213,7 @@ function renderNode(
     childContext,
     tokens,
     hooks,
+    islandManifest,
   );
   const rendered = createElement(spec.render, { attrs, context });
   if (spec.inline) {
@@ -206,29 +228,85 @@ function renderNode(
   const styleTag = styleCss
     ? createElement("style", { key: "style" }, styleCss)
     : null;
-  const wrappedEl = createElement(
+
+  // Client island? Wrap in `<plumix-island>` so the custom element
+  // (`packages/blocks/src/island-element.ts`) can hydrate the React
+  // component on the client. The walker only emits the wrapper when
+  // a manifest entry exists for this block's `client.component`; a
+  // build without the islands Vite plugin (or a block whose component
+  // wasn't bundled) gracefully degrades to the SSR'd output without a
+  // wrapper. Props from `node.attrs` are serialized to a sibling
+  // `<script type="application/json">` rather than an attribute so
+  // large prop graphs don't run into HTML attribute size limits.
+  if (spec.client && islandManifest) {
+    const entry = islandManifest.get(spec.client.component);
+    if (entry) {
+      return renderIsland({
+        node,
+        entry,
+        hydrateWhen: spec.client.hydrateWhen ?? "load",
+        className,
+        styleTag,
+        rendered,
+        attrs,
+        displayName: spec.client.component.displayName ?? spec.name,
+      });
+    }
+  }
+
+  return createElement(
     "div",
     {
       key: node.id,
       "data-plumix-block": node.name,
-      "data-plumix-island": spec.client ? node.name : undefined,
       className,
     },
     styleTag,
     rendered,
   );
-  if (!spec.client) return wrappedEl;
-  // Dedupe per-renderNodes-call so N instances of the same client block ship
-  // one <script type="module">, not N. The module loader already dedupes
-  // execution by URL; this avoids shipping the tag at all for siblings.
-  if (seenScripts.has(spec.client.script)) return wrappedEl;
-  seenScripts.add(spec.client.script);
-  const hydrationScript = createElement("script", {
-    key: "client-island",
-    type: "module",
-    src: spec.client.script,
+}
+
+interface RenderIslandArgs {
+  readonly node: BlockNode;
+  readonly entry: IslandManifestEntry;
+  readonly hydrateWhen: string;
+  readonly className: string | undefined;
+  readonly styleTag: ReactNode;
+  readonly rendered: ReactNode;
+  readonly attrs: Readonly<Record<string, unknown>>;
+  readonly displayName: string;
+}
+
+function renderIsland(args: RenderIslandArgs): ReactNode {
+  const propsPayload = serializeProps(args.attrs, {
+    displayName: args.displayName,
   });
-  return createElement(Fragment, { key: node.id }, wrappedEl, hydrationScript);
+  // Escape the JSON string against premature `</script>` termination —
+  // a string prop containing `</script>` would otherwise close the
+  // element here and let the rest of the JSON leak into the DOM as
+  // markup. Forward-slash escape is safe inside JSON.
+  const safePayload = propsPayload.replace(/<\/script/gi, "<\\/script");
+  return createElement(
+    Fragment,
+    { key: args.node.id },
+    createElement(
+      "plumix-island",
+      {
+        "chunk-url": args.entry.chunkUrl,
+        "component-export": args.entry.exportName,
+        client: args.hydrateWhen,
+        "data-plumix-block": args.node.name,
+        className: args.className,
+      },
+      args.styleTag,
+      args.rendered,
+    ),
+    createElement("script", {
+      type: "application/json",
+      "data-plumix-island-props": "",
+      dangerouslySetInnerHTML: { __html: safePayload },
+    }),
+  );
 }
 
 export function renderBlockTree(
@@ -243,5 +321,6 @@ export function renderBlockTree(
     DEFAULT_BLOCK_CONTEXT,
     options?.tokens,
     options?.hooks,
+    options?.islandManifest,
   );
 }

--- a/packages/blocks/src/serialize.test.ts
+++ b/packages/blocks/src/serialize.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "vitest";
+
+import { deserializeProps, PROP_TYPE, serializeProps } from "./serialize.js";
+
+describe("serializeProps / deserializeProps", () => {
+  test("round-trips a plain string under PROP_TYPE.Value", () => {
+    const serialized = serializeProps({ title: "hello" });
+    const parsed = JSON.parse(serialized) as Record<
+      string,
+      readonly [number, unknown]
+    >;
+    expect(parsed.title?.[0]).toBe(PROP_TYPE.Value);
+    expect(parsed.title?.[1]).toBe("hello");
+    expect(deserializeProps(serialized)).toEqual({ title: "hello" });
+  });
+
+  test("round-trips a nested plain object", () => {
+    const props = { user: { name: "Ada", age: 36 } };
+    expect(deserializeProps(serializeProps(props))).toEqual(props);
+  });
+
+  test("round-trips an array of primitives via PROP_TYPE.JSON", () => {
+    const props = { tags: ["alpha", "beta", "gamma"] };
+    const serialized = serializeProps(props);
+    const parsed = JSON.parse(serialized) as Record<
+      string,
+      readonly [number, unknown]
+    >;
+    expect(parsed.tags?.[0]).toBe(PROP_TYPE.JSON);
+    expect(deserializeProps(serialized)).toEqual(props);
+  });
+
+  test("round-trips Date", () => {
+    const d = new Date("2026-01-01T12:00:00.000Z");
+    const out = deserializeProps(serializeProps({ when: d })) as {
+      when: Date;
+    };
+    expect(out.when).toBeInstanceOf(Date);
+    expect(out.when.toISOString()).toBe(d.toISOString());
+  });
+
+  test("round-trips RegExp", () => {
+    const re = /^hello\b/gi;
+    const out = deserializeProps(serializeProps({ pattern: re })) as {
+      pattern: RegExp;
+    };
+    expect(out.pattern).toBeInstanceOf(RegExp);
+    expect(out.pattern.source).toBe(re.source);
+    expect(out.pattern.flags).toBe(re.flags);
+  });
+
+  test("round-trips Map and Set", () => {
+    const m = new Map<string, number>([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    const s = new Set<string>(["x", "y"]);
+    const out = deserializeProps(serializeProps({ m, s })) as {
+      m: Map<string, number>;
+      s: Set<string>;
+    };
+    expect(out.m).toBeInstanceOf(Map);
+    expect([...out.m.entries()]).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(out.s).toBeInstanceOf(Set);
+    expect([...out.s.values()]).toEqual(["x", "y"]);
+  });
+
+  test("round-trips BigInt and URL", () => {
+    const big = 9007199254740993n;
+    const u = new URL("https://plumix.dev/path?q=1");
+    const out = deserializeProps(serializeProps({ big, u })) as {
+      big: bigint;
+      u: URL;
+    };
+    expect(out.big).toBe(big);
+    expect(out.u).toBeInstanceOf(URL);
+    expect(out.u.toString()).toBe(u.toString());
+  });
+
+  test("round-trips typed arrays (Uint8/16/32)", () => {
+    const u8 = new Uint8Array([1, 2, 3]);
+    const u16 = new Uint16Array([1000, 2000]);
+    const u32 = new Uint32Array([100000, 200000]);
+    const out = deserializeProps(serializeProps({ u8, u16, u32 })) as {
+      u8: Uint8Array;
+      u16: Uint16Array;
+      u32: Uint32Array;
+    };
+    expect(Array.from(out.u8)).toEqual([1, 2, 3]);
+    expect(Array.from(out.u16)).toEqual([1000, 2000]);
+    expect(Array.from(out.u32)).toEqual([100000, 200000]);
+  });
+
+  test("round-trips +Infinity and -Infinity", () => {
+    const out = deserializeProps(
+      serializeProps({ pos: Infinity, neg: -Infinity }),
+    ) as { pos: number; neg: number };
+    expect(out.pos).toBe(Infinity);
+    expect(out.neg).toBe(-Infinity);
+  });
+
+  test("throws on cyclic refs with the component displayName in the message", () => {
+    const a: Record<string, unknown> = {};
+    a.self = a;
+    expect(() =>
+      serializeProps({ value: a }, { displayName: "SearchBlock" }),
+    ).toThrow(/SearchBlock/);
+  });
+
+  test("a shared (non-cyclic) reference threaded through two slots is fine", () => {
+    const shared = { color: "blue", weight: 700 };
+    const props = { header: { theme: shared }, footer: { theme: shared } };
+    expect(() => serializeProps(props)).not.toThrow();
+    expect(deserializeProps(serializeProps(props))).toEqual(props);
+  });
+
+  test("PROP_TYPE enum values are byte-identical to Astro", () => {
+    expect(PROP_TYPE.Value).toBe(0);
+    expect(PROP_TYPE.JSON).toBe(1);
+    expect(PROP_TYPE.RegExp).toBe(2);
+    expect(PROP_TYPE.Date).toBe(3);
+    expect(PROP_TYPE.Map).toBe(4);
+    expect(PROP_TYPE.Set).toBe(5);
+    expect(PROP_TYPE.BigInt).toBe(6);
+    expect(PROP_TYPE.URL).toBe(7);
+    expect(PROP_TYPE.Uint8Array).toBe(8);
+    expect(PROP_TYPE.Uint16Array).toBe(9);
+    expect(PROP_TYPE.Uint32Array).toBe(10);
+    expect(PROP_TYPE.Infinity).toBe(11);
+  });
+});

--- a/packages/blocks/src/serialize.ts
+++ b/packages/blocks/src/serialize.ts
@@ -1,0 +1,226 @@
+// Port of Astro's prop serializer (Apache-2.0). PROP_TYPE integer
+// codes match Astro 1:1 so the wire format reads as a familiar tag.
+// The payload shape diverges in one place: nested Map/Set/Array/typed-
+// array values are stored as JSON-stringified strings (Astro stores
+// them as nested arrays). That's a conscious simplification — it keeps
+// the encoder/decoder symmetric and matches what `JSON.parse` returns
+// in one step on the client; if a future slice wants to share fixtures
+// or runtime with Astro it'll need a wire-format pass to align.
+//
+// Cycle detection runs at the SSR boundary and throws with the
+// component displayName so a broken prop graph fails loud rather than
+// producing nested-tuple soup the client can't decode. `seen.delete`
+// after the recursive walk so a *shared* reference (same object in
+// two slots) is fine — only true cycles raise.
+
+export class IslandPropSerializationError extends Error {
+  static {
+    IslandPropSerializationError.prototype.name =
+      "IslandPropSerializationError";
+  }
+
+  readonly code: "cyclic_reference";
+  readonly displayName: string | undefined;
+
+  private constructor(
+    code: "cyclic_reference",
+    message: string,
+    displayName: string | undefined,
+  ) {
+    super(message);
+    this.code = code;
+    this.displayName = displayName;
+  }
+
+  static cyclicReference(ctx: {
+    displayName: string | undefined;
+  }): IslandPropSerializationError {
+    const where = ctx.displayName ? ` in <${ctx.displayName}>` : "";
+    return new IslandPropSerializationError(
+      "cyclic_reference",
+      `Cyclic reference detected while serializing island props${where}.`,
+      ctx.displayName,
+    );
+  }
+}
+
+export enum PROP_TYPE {
+  Value = 0,
+  JSON = 1,
+  RegExp = 2,
+  Date = 3,
+  Map = 4,
+  Set = 5,
+  BigInt = 6,
+  URL = 7,
+  Uint8Array = 8,
+  Uint16Array = 9,
+  Uint32Array = 10,
+  Infinity = 11,
+}
+
+export interface SerializePropsOptions {
+  readonly displayName?: string;
+}
+
+type Encoded = readonly [PROP_TYPE, unknown];
+
+export function serializeProps(
+  props: Readonly<Record<string, unknown>>,
+  options: SerializePropsOptions = {},
+): string {
+  const seen = new WeakSet<object>();
+  const out: Record<string, Encoded> = {};
+  for (const [key, value] of Object.entries(props)) {
+    out[key] = encode(value, seen, options.displayName);
+  }
+  return JSON.stringify(out);
+}
+
+export function deserializeProps(payload: string): Record<string, unknown> {
+  const parsed = JSON.parse(payload) as Record<string, Encoded>;
+  const out: Record<string, unknown> = {};
+  for (const [key, encoded] of Object.entries(parsed)) {
+    out[key] = decode(encoded);
+  }
+  return out;
+}
+
+function encode(
+  value: unknown,
+  seen: WeakSet<object>,
+  displayName: string | undefined,
+): Encoded {
+  if (value === Infinity) return [PROP_TYPE.Infinity, 1];
+  if (value === -Infinity) return [PROP_TYPE.Infinity, -1];
+  if (typeof value === "bigint") return [PROP_TYPE.BigInt, value.toString()];
+  if (value === null || typeof value !== "object")
+    return [PROP_TYPE.Value, value];
+
+  // From here on, value is a non-null object — guard cycles before
+  // any recursion can re-enter the same node.
+  if (seen.has(value)) {
+    throw IslandPropSerializationError.cyclicReference({ displayName });
+  }
+  seen.add(value);
+  try {
+    return encodeInner(value, seen, displayName);
+  } finally {
+    // Remove the value AFTER the recursive walk completes so a sibling
+    // slot can reuse the same reference without tripping the cycle
+    // guard. Cycles still raise because the inner walk hits `seen.has`
+    // before this `finally` runs on the outer call.
+    seen.delete(value);
+  }
+}
+
+function encodeInner(
+  value: object,
+  seen: WeakSet<object>,
+  displayName: string | undefined,
+): Encoded {
+  const tag = Object.prototype.toString.call(value);
+  switch (tag) {
+    case "[object Date]":
+      return [PROP_TYPE.Date, (value as Date).toISOString()];
+    case "[object RegExp]": {
+      const re = value as RegExp;
+      return [PROP_TYPE.RegExp, { source: re.source, flags: re.flags }];
+    }
+    case "[object URL]":
+      return [PROP_TYPE.URL, (value as URL).toString()];
+    case "[object Map]":
+      return [
+        PROP_TYPE.Map,
+        JSON.stringify(
+          [...(value as Map<unknown, unknown>).entries()].map((entry) => [
+            encode(entry[0], seen, displayName),
+            encode(entry[1], seen, displayName),
+          ]),
+        ),
+      ];
+    case "[object Set]":
+      return [
+        PROP_TYPE.Set,
+        JSON.stringify(
+          [...(value as Set<unknown>).values()].map((v) =>
+            encode(v, seen, displayName),
+          ),
+        ),
+      ];
+    case "[object Uint8Array]":
+      return [PROP_TYPE.Uint8Array, JSON.stringify([...(value as Uint8Array)])];
+    case "[object Uint16Array]":
+      return [
+        PROP_TYPE.Uint16Array,
+        JSON.stringify([...(value as Uint16Array)]),
+      ];
+    case "[object Uint32Array]":
+      return [
+        PROP_TYPE.Uint32Array,
+        JSON.stringify([...(value as Uint32Array)]),
+      ];
+    case "[object Array]":
+      return [
+        PROP_TYPE.JSON,
+        JSON.stringify(
+          (value as readonly unknown[]).map((v) =>
+            encode(v, seen, displayName),
+          ),
+        ),
+      ];
+    default: {
+      const obj: Record<string, Encoded> = {};
+      const rec = value as Record<string, unknown>;
+      for (const key of Object.keys(rec)) {
+        obj[key] = encode(rec[key], seen, displayName);
+      }
+      return [PROP_TYPE.Value, obj];
+    }
+  }
+}
+
+function decode(encoded: Encoded): unknown {
+  const [type, raw] = encoded;
+  switch (type) {
+    case PROP_TYPE.Value:
+      return decodeValue(raw);
+    case PROP_TYPE.JSON:
+      return (JSON.parse(raw as string) as Encoded[]).map(decode);
+    case PROP_TYPE.RegExp: {
+      const { source, flags } = raw as { source: string; flags: string };
+      return new RegExp(source, flags);
+    }
+    case PROP_TYPE.Date:
+      return new Date(raw as string);
+    case PROP_TYPE.Map: {
+      const entries = JSON.parse(raw as string) as [Encoded, Encoded][];
+      return new Map(entries.map(([k, v]) => [decode(k), decode(v)]));
+    }
+    case PROP_TYPE.Set: {
+      const values = JSON.parse(raw as string) as Encoded[];
+      return new Set(values.map(decode));
+    }
+    case PROP_TYPE.BigInt:
+      return BigInt(raw as string);
+    case PROP_TYPE.URL:
+      return new URL(raw as string);
+    case PROP_TYPE.Uint8Array:
+      return new Uint8Array(JSON.parse(raw as string) as number[]);
+    case PROP_TYPE.Uint16Array:
+      return new Uint16Array(JSON.parse(raw as string) as number[]);
+    case PROP_TYPE.Uint32Array:
+      return new Uint32Array(JSON.parse(raw as string) as number[]);
+    case PROP_TYPE.Infinity:
+      return (raw as number) > 0 ? Infinity : -Infinity;
+  }
+}
+
+function decodeValue(raw: unknown): unknown {
+  if (raw === null || typeof raw !== "object") return raw;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    out[k] = decode(v as Encoded);
+  }
+  return out;
+}

--- a/packages/blocks/src/serialize.ts
+++ b/packages/blocks/src/serialize.ts
@@ -59,7 +59,7 @@ export enum PROP_TYPE {
   Infinity = 11,
 }
 
-export interface SerializePropsOptions {
+interface SerializePropsOptions {
   readonly displayName?: string;
 }
 


### PR DESCRIPTION
Lands the islands MVP framework primitives — prop serializer, `<plumix-island>` custom element,
`load` strategy, runtime entry, walker integration, and the new `BlockSpec.client` shape. End-to-end
demoability is intentionally split into two follow-ups: #536 for the Vite plugin that populates the
manifest and #537 for the examples/blog interactive search block + Playwright e2e.

The split was a conscious scope call mid-implementation: spec-faithful `ComponentType → source-path`
resolution needs either a Babel/SWC transform or AST scanning of plugin source files, neither of which
fits one drive. This PR's walker already handles a missing manifest by falling back to a plain `<div>`,
so it lands safely on `main` without breaking any block. No production block uses `client` today; the
v0 `{ script: string }` shape is removed in the same commit.

**Prop serializer port from Astro**

`PROP_TYPE` enum codes 0–11 match Astro's wire format for tag identity (Value, JSON, RegExp, Date,
Map, Set, BigInt, URL, Uint8Array, Uint16Array, Uint32Array, Infinity). Payload shape diverges in one
place — nested Map/Set/Array/typed-array values are JSON-stringified strings rather than nested
arrays, which keeps encode/decode symmetric. Cycle detection uses `WeakSet` with `seen.delete` after
each recursive walk so shared (non-cyclic) refs threaded through two slots are fine; only true cycles
throw `IslandPropSerializationError.cyclicReference(...)` with the component displayName.

**`<plumix-island>` custom element**

Port of `astro-island.ts`. Attributes the walker emits (`chunk-url`, `component-export`, `client`,
`opts`, `await-children`, `ssr-complete`) drive a lifecycle that runs the registered strategy via
`window.Plumix[strategy]`, dynamic-imports the chunk, and mounts the React component into the element
via `createRoot`. Failed imports retry once after 1s with a `#plumix-retry=<ts>` cache-bust hash; a
second failure dispatches a cancelable `plumix:hydration-error` CustomEvent on `window` so themes can
surface a user-visible error UI without crashing the page. `setDynamicImport()` test seam covers both
retry paths in unit tests without spinning up a bundler.

**Walker emission with graceful degradation**

```jsx
// Before — v0 `client: { script: string }`
<div data-plumix-block="acme/carousel" data-plumix-island="acme/carousel">…</div>
<script type="module" src="/assets/carousel.js"></script>
```

```jsx
// After — `client: { component, hydrateWhen }`
<plumix-island chunk-url="/_plumix/assets/search.abc.js" component-export="Search" client="load" data-plumix-block="acme/search">
  …SSR'd block markup…
</plumix-island>
<script type="application/json" data-plumix-island-props="">{"placeholder":[0,"Search…"]}</script>
```

Blocks without `client`, or builds without an `islandManifest` populated (no Vite plugin yet),
render unchanged with no wrapper. `</script>` sequences inside the serialized props payload are
escaped so a string prop containing `</script>` can't close the prop tag prematurely.

Refs #520
Closes #521