### PR TITLE
feat(plumix): vite plugin for islands MVP — build-time discovery + manifest

### DIFF
--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -88,6 +88,23 @@ describe("PlumixIslandElement lifecycle", () => {
     expect(strategy).toHaveBeenCalledTimes(1);
   });
 
+  test("rejects a __proto__ component-export with plumix:hydration-error (proto pollution guard)", async () => {
+    stubStrategies();
+    const listener = vi.fn();
+    window.addEventListener("plumix:hydration-error", listener);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "__proto__",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener("plumix:hydration-error", listener);
+  });
+
   test("dispatches plumix:hydration-error when no strategy is registered", async () => {
     const listener = vi.fn();
     window.addEventListener("plumix:hydration-error", listener);

--- a/packages/blocks/src/island-element.ts
+++ b/packages/blocks/src/island-element.ts
@@ -36,6 +36,18 @@ declare global {
 
 const RETRY_DELAY_MS = 1000;
 
+// Prototype-pollution defense: the element does `mod[exportName]` to
+// resolve the component, and `mod["__proto__"]` would return
+// `Object.prototype` which `createRoot(...).render(<Component />)`
+// would happily then try to mount. Mirror's Astro's
+// `FORBIDDEN_COMPONENT_EXPORT_KEYS` and the matching server-side
+// guard in `packages/plumix/src/vite/island-transform.ts`.
+const FORBIDDEN_EXPORT_KEYS: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
 export class PlumixIslandElement extends HTMLElement {
   private root: Root | null = null;
   private retried = false;
@@ -95,6 +107,12 @@ export class PlumixIslandElement extends HTMLElement {
     const exportName = this.getAttribute("component-export") ?? "default";
     if (!chunkUrl) {
       this.dispatchHydrationError(new Error("missing chunk-url attribute"));
+      return;
+    }
+    if (FORBIDDEN_EXPORT_KEYS.has(exportName)) {
+      this.dispatchHydrationError(
+        new Error(`forbidden component-export key: ${exportName}`),
+      );
       return;
     }
     const Component = await this.loadComponent(chunkUrl, exportName);

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from "react";
 
 import type { BlockRegistry } from "../block-registry.js";
 import type { EntryContent } from "../entry-content.js";
+import type { IslandManifest } from "../render-block-tree.js";
 import type { ThemeTokens } from "../styles/types.js";
 import { renderBlockTree } from "../render-block-tree.js";
 import { RendererError } from "./errors.js";
@@ -10,6 +11,15 @@ import { RendererError } from "./errors.js";
 export interface PlumixContextValue {
   readonly registry: BlockRegistry;
   readonly tokens?: ThemeTokens;
+  /**
+   * Map from each block-island `ComponentType` reference to its
+   * `{ chunkUrl, exportName }` entry. Populated by the SSR worker from
+   * `virtual:plumix/island-manifest`; the walker uses it to emit a
+   * `<plumix-island>` wrapper around blocks declaring `client`.
+   * Optional so consumers that never use islands (or pre-islands
+   * builds) compile cleanly.
+   */
+  readonly islandManifest?: IslandManifest;
 }
 
 const PlumixContext = createContext<PlumixContextValue | null>(null);
@@ -40,7 +50,10 @@ export function BlockRenderer({
   readonly content: EntryContent;
 }): ReactNode {
   const ctx = usePlumixContext("BlockRenderer");
-  return renderBlockTree(content.blocks, ctx.registry, { tokens: ctx.tokens });
+  return renderBlockTree(content.blocks, ctx.registry, {
+    tokens: ctx.tokens,
+    islandManifest: ctx.islandManifest,
+  });
 }
 
 export function useTokens(): ThemeTokens | undefined {

--- a/packages/blocks/src/serialize.test.ts
+++ b/packages/blocks/src/serialize.test.ts
@@ -117,6 +117,28 @@ describe("serializeProps / deserializeProps", () => {
     expect(deserializeProps(serializeProps(props))).toEqual(props);
   });
 
+  test("preserves nested-value type fidelity inside Map/Set/Array (Astro parity)", () => {
+    // The previous wire format JSON.stringified nested collection values,
+    // which silently degraded inner Date/Map/Set to strings on round-trip.
+    // The nested-array form preserves type identity through the graph.
+    const epoch = new Date("2026-01-01T00:00:00.000Z");
+    const props = {
+      m: new Map<string, Date>([["k", epoch]]),
+      s: new Set<Date>([epoch]),
+      a: [epoch, new URL("https://plumix.dev/")],
+    };
+    const out = deserializeProps(serializeProps(props)) as {
+      m: Map<string, Date>;
+      s: Set<Date>;
+      a: [Date, URL];
+    };
+    expect(out.m.get("k")).toBeInstanceOf(Date);
+    expect(out.m.get("k")?.toISOString()).toBe(epoch.toISOString());
+    expect([...out.s][0]).toBeInstanceOf(Date);
+    expect(out.a[0]).toBeInstanceOf(Date);
+    expect(out.a[1]).toBeInstanceOf(URL);
+  });
+
   test("PROP_TYPE enum values are byte-identical to Astro", () => {
     expect(PROP_TYPE.Value).toBe(0);
     expect(PROP_TYPE.JSON).toBe(1);

--- a/packages/blocks/src/serialize.ts
+++ b/packages/blocks/src/serialize.ts
@@ -156,9 +156,7 @@ function encodeInner(
     case "[object Array]":
       return [
         PROP_TYPE.JSON,
-        (value as readonly unknown[]).map((v) =>
-          encode(v, seen, displayName),
-        ),
+        (value as readonly unknown[]).map((v) => encode(v, seen, displayName)),
       ];
     default: {
       const obj: Record<string, Encoded> = {};

--- a/packages/blocks/src/serialize.ts
+++ b/packages/blocks/src/serialize.ts
@@ -1,11 +1,14 @@
 // Port of Astro's prop serializer (Apache-2.0). PROP_TYPE integer
-// codes match Astro 1:1 so the wire format reads as a familiar tag.
-// The payload shape diverges in one place: nested Map/Set/Array/typed-
-// array values are stored as JSON-stringified strings (Astro stores
-// them as nested arrays). That's a conscious simplification — it keeps
-// the encoder/decoder symmetric and matches what `JSON.parse` returns
-// in one step on the client; if a future slice wants to share fixtures
-// or runtime with Astro it'll need a wire-format pass to align.
+// codes AND payload shape match Astro byte-for-byte: nested collection
+// types (Map/Set/Array/typed-arrays) are encoded as nested arrays of
+// `[type, value]` tuples, NOT JSON-stringified strings. The single
+// outer `JSON.stringify` in `serializeProps` walks the whole tree once.
+//
+// Why this matters: encoding `new Map([["k", new Date(0)]])` with the
+// old nested-stringify approach would lose the inner Date — it would
+// round-trip as `Map<string, string>` because the second-stage JSON
+// parse couldn't see the nested `[PROP_TYPE.Date, "..."]` tuple. The
+// nested-array form preserves type fidelity through the whole graph.
 //
 // Cycle detection runs at the SSR boundary and throws with the
 // component displayName so a broken prop graph fails loud rather than
@@ -132,41 +135,29 @@ function encodeInner(
     case "[object Map]":
       return [
         PROP_TYPE.Map,
-        JSON.stringify(
-          [...(value as Map<unknown, unknown>).entries()].map((entry) => [
-            encode(entry[0], seen, displayName),
-            encode(entry[1], seen, displayName),
-          ]),
-        ),
+        [...(value as Map<unknown, unknown>).entries()].map((entry) => [
+          encode(entry[0], seen, displayName),
+          encode(entry[1], seen, displayName),
+        ]),
       ];
     case "[object Set]":
       return [
         PROP_TYPE.Set,
-        JSON.stringify(
-          [...(value as Set<unknown>).values()].map((v) =>
-            encode(v, seen, displayName),
-          ),
+        [...(value as Set<unknown>).values()].map((v) =>
+          encode(v, seen, displayName),
         ),
       ];
     case "[object Uint8Array]":
-      return [PROP_TYPE.Uint8Array, JSON.stringify([...(value as Uint8Array)])];
+      return [PROP_TYPE.Uint8Array, [...(value as Uint8Array)]];
     case "[object Uint16Array]":
-      return [
-        PROP_TYPE.Uint16Array,
-        JSON.stringify([...(value as Uint16Array)]),
-      ];
+      return [PROP_TYPE.Uint16Array, [...(value as Uint16Array)]];
     case "[object Uint32Array]":
-      return [
-        PROP_TYPE.Uint32Array,
-        JSON.stringify([...(value as Uint32Array)]),
-      ];
+      return [PROP_TYPE.Uint32Array, [...(value as Uint32Array)]];
     case "[object Array]":
       return [
         PROP_TYPE.JSON,
-        JSON.stringify(
-          (value as readonly unknown[]).map((v) =>
-            encode(v, seen, displayName),
-          ),
+        (value as readonly unknown[]).map((v) =>
+          encode(v, seen, displayName),
         ),
       ];
     default: {
@@ -186,7 +177,7 @@ function decode(encoded: Encoded): unknown {
     case PROP_TYPE.Value:
       return decodeValue(raw);
     case PROP_TYPE.JSON:
-      return (JSON.parse(raw as string) as Encoded[]).map(decode);
+      return (raw as readonly Encoded[]).map(decode);
     case PROP_TYPE.RegExp: {
       const { source, flags } = raw as { source: string; flags: string };
       return new RegExp(source, flags);
@@ -194,11 +185,11 @@ function decode(encoded: Encoded): unknown {
     case PROP_TYPE.Date:
       return new Date(raw as string);
     case PROP_TYPE.Map: {
-      const entries = JSON.parse(raw as string) as [Encoded, Encoded][];
+      const entries = raw as readonly [Encoded, Encoded][];
       return new Map(entries.map(([k, v]) => [decode(k), decode(v)]));
     }
     case PROP_TYPE.Set: {
-      const values = JSON.parse(raw as string) as Encoded[];
+      const values = raw as readonly Encoded[];
       return new Set(values.map(decode));
     }
     case PROP_TYPE.BigInt:
@@ -206,11 +197,11 @@ function decode(encoded: Encoded): unknown {
     case PROP_TYPE.URL:
       return new URL(raw as string);
     case PROP_TYPE.Uint8Array:
-      return new Uint8Array(JSON.parse(raw as string) as number[]);
+      return new Uint8Array(raw as readonly number[]);
     case PROP_TYPE.Uint16Array:
-      return new Uint16Array(JSON.parse(raw as string) as number[]);
+      return new Uint16Array(raw as readonly number[]);
     case PROP_TYPE.Uint32Array:
-      return new Uint32Array(JSON.parse(raw as string) as number[]);
+      return new Uint32Array(raw as readonly number[]);
     case PROP_TYPE.Infinity:
       return (raw as number) > 0 ? Infinity : -Infinity;
   }

--- a/packages/core/src/cli/worker-codegen.test.ts
+++ b/packages/core/src/cli/worker-codegen.test.ts
@@ -42,12 +42,17 @@ describe("generateWorkerSource", () => {
     expect(source).toContain("scheduledHandler ??=");
   });
 
-  test("imports the asset manifest virtual module and threads it into buildApp", () => {
+  test("imports the asset + island manifest virtual modules and threads them into buildApp", () => {
     const source = generateWorkerSource({ configModule: "./config.ts" });
     expect(source).toContain(
       'import assetManifest from "virtual:plumix/asset-manifest";',
     );
-    expect(source).toContain("buildApp(config, { assetManifest })");
+    expect(source).toContain(
+      'import { islandManifest } from "virtual:plumix/island-manifest";',
+    );
+    expect(source).toContain(
+      "buildApp(config, { assetManifest, islandManifest })",
+    );
   });
 
   test("no-ops cleanly when the runtime omits buildScheduledHandler", () => {

--- a/packages/core/src/cli/worker-codegen.ts
+++ b/packages/core/src/cli/worker-codegen.ts
@@ -15,9 +15,10 @@ export function generateWorkerSource({
     // for the client environment. The SSR renderer reads it to inject
     // hashed `<link rel="stylesheet">` tags after the theme's `link[]`.
     'import assetManifest from "virtual:plumix/asset-manifest";',
+    'import { islandManifest } from "virtual:plumix/island-manifest";',
     `import config from ${JSON.stringify(configModule)};`,
     "",
-    "const appPromise = buildApp(config, { assetManifest });",
+    "const appPromise = buildApp(config, { assetManifest, islandManifest });",
     "let fetchHandler;",
     "let scheduledHandler;",
     "",

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
 
+import type { IslandManifest } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { AppContext } from "../../context/app.js";
@@ -31,6 +32,7 @@ interface RenderArgs {
   readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
   readonly templateDeps: ReadonlyMap<string, RegisteredTemplateDep>;
   readonly assetManifest: AssetManifest;
+  readonly islandManifest: IslandManifest;
   readonly node: ResolvedNode;
   readonly data: TemplateData;
   readonly title: string;
@@ -43,6 +45,7 @@ export async function renderThroughTheme({
   templateDocuments,
   templateDeps,
   assetManifest,
+  islandManifest,
   node,
   data,
   title,
@@ -64,6 +67,7 @@ export async function renderThroughTheme({
     ctx,
     document: renderDocument,
     assetManifest,
+    islandManifest,
     data,
     title,
     template,
@@ -78,6 +82,7 @@ interface RenderErrorArgs {
   readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
   readonly templateDeps: ReadonlyMap<string, RegisteredTemplateDep>;
   readonly assetManifest: AssetManifest;
+  readonly islandManifest: IslandManifest;
   readonly kind: "not-found" | "server-error";
   readonly data: ErrorData;
 }
@@ -98,6 +103,7 @@ export async function renderErrorThroughTheme({
   templateDocuments,
   templateDeps,
   assetManifest,
+  islandManifest,
   kind,
   data,
 }: RenderErrorArgs): Promise<string> {
@@ -116,6 +122,7 @@ export async function renderErrorThroughTheme({
     ctx,
     document: renderDocument,
     assetManifest,
+    islandManifest,
     data,
     title: variant.title,
     template,
@@ -127,6 +134,7 @@ interface RenderTreeArgs {
   readonly ctx: AppContext;
   readonly document: DocumentManifest;
   readonly assetManifest: AssetManifest;
+  readonly islandManifest: IslandManifest;
   readonly data: TemplateData;
   readonly title: string;
   readonly template: Template<TemplateData>;
@@ -143,6 +151,7 @@ function renderTree({
   ctx,
   document,
   assetManifest,
+  islandManifest,
   data,
   title,
   template,
@@ -159,7 +168,7 @@ function renderTree({
   const TemplateAdapter = (): ReactNode =>
     template.render({ ...deps, data, ctx });
   const templateTree: ReactNode = createElement(PlumixProvider, {
-    value: { registry: ctx.blocks },
+    value: { registry: ctx.blocks, islandManifest },
     children: createElement(TemplateAdapter),
   });
   const rendered = renderToString(templateTree);

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -1,6 +1,8 @@
 import type { SQL } from "drizzle-orm";
 import { count } from "drizzle-orm";
 
+import type { IslandManifest } from "@plumix/blocks";
+
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
@@ -53,6 +55,7 @@ export async function resolvePublicRoute(
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
   templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
+  islandManifest: IslandManifest,
 ): Promise<Response> {
   switch (match.intent.kind) {
     case "single":
@@ -65,6 +68,7 @@ export async function resolvePublicRoute(
         templateDocuments,
         templateDeps,
         assetManifest,
+        islandManifest,
       );
     case "archive":
       return resolveArchive(
@@ -76,6 +80,7 @@ export async function resolvePublicRoute(
         templateDocuments,
         templateDeps,
         assetManifest,
+        islandManifest,
       );
     case "taxonomy":
       return resolveTaxonomy(
@@ -87,6 +92,7 @@ export async function resolvePublicRoute(
         templateDocuments,
         templateDeps,
         assetManifest,
+        islandManifest,
       );
     case "front-page":
       return resolveFrontPage(
@@ -96,6 +102,7 @@ export async function resolvePublicRoute(
         templateDocuments,
         templateDeps,
         assetManifest,
+        islandManifest,
       );
   }
 }
@@ -107,6 +114,7 @@ async function resolveFrontPage(
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
   templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
+  islandManifest: IslandManifest,
 ): Promise<Response> {
   const page = 1;
   const publicTypes = Array.from(ctx.plugins.entryTypes.entries())
@@ -139,6 +147,7 @@ async function resolveFrontPage(
     templateDocuments,
     templateDeps,
     assetManifest,
+    islandManifest,
     node: { kind: "front-page" },
     data,
     title: "Home",
@@ -157,6 +166,7 @@ async function resolveTaxonomy(
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
   templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
+  islandManifest: IslandManifest,
 ): Promise<Response> {
   const term = await findTermForTaxonomy(ctx, intent.taxonomy, params);
   if (!term) return notFound("public-term-not-found");
@@ -207,6 +217,7 @@ async function resolveTaxonomy(
     templateDocuments,
     templateDeps,
     assetManifest,
+    islandManifest,
     node: {
       kind: "term",
       taxonomy: intent.taxonomy,
@@ -230,6 +241,7 @@ async function resolveSingle(
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
   templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
+  islandManifest: IslandManifest,
 ): Promise<Response> {
   const row = await findEntryForSingle(ctx, intent.entryType, params);
   if (!row) return notFound("public-post-not-found");
@@ -250,6 +262,7 @@ async function resolveSingle(
     templateDocuments,
     templateDeps,
     assetManifest,
+    islandManifest,
     node: {
       kind: "content",
       entryType: row.type,
@@ -273,6 +286,7 @@ async function resolveArchive(
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
   templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
+  islandManifest: IslandManifest,
 ): Promise<Response> {
   const page = parsePageParam(params.page);
   const where = and(
@@ -311,6 +325,7 @@ async function resolveArchive(
     templateDocuments,
     templateDeps,
     assetManifest,
+    islandManifest,
     node: { kind: "content-type-archive", entryType: intent.entryType },
     data,
     title,

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -1,6 +1,11 @@
 import { RPCHandler } from "@orpc/server/fetch";
 
-import type { BlockRegistry, HtmlAllowlist, MarkSpec } from "@plumix/blocks";
+import type {
+  BlockRegistry,
+  HtmlAllowlist,
+  IslandManifest,
+  MarkSpec,
+} from "@plumix/blocks";
 import {
   buildHtmlAllowlist,
   coreBlocks,
@@ -151,14 +156,25 @@ export interface PlumixApp {
    * per-request renders pay zero merge cost.
    */
   readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
+  /**
+   * Map from each block-island `ComponentType` reference to its
+   * `{ chunkUrl, exportName }`. Vite resolves this from
+   * `virtual:plumix/island-manifest` and the worker template passes it
+   * into `buildApp`; the SSR renderer threads it through `PlumixProvider`
+   * so `BlockRenderer` can emit `<plumix-island>` wrappers with the
+   * right chunk URL per component. Empty `Map` in dev / tests / builds
+   * that haven't been through the islands Vite pipeline.
+   */
+  readonly islandManifest: IslandManifest;
 }
 
 // Runtime-only state the worker template injects at boot — values
-// resolved by the Vite plugin from virtual modules (asset manifest).
-// Kept internal: consumers (tests + the generated worker) pass an
-// inline object literal that structurally satisfies the type.
+// resolved by the Vite plugin from virtual modules (asset + island
+// manifests). Kept internal: consumers (tests + the generated worker)
+// pass an inline object literal that structurally satisfies the type.
 interface RuntimeContext {
   readonly assetManifest?: AssetManifest;
+  readonly islandManifest?: IslandManifest;
 }
 
 export async function buildApp(
@@ -276,6 +292,7 @@ export async function buildApp(
     document,
     assetManifest: runtime.assetManifest ?? {},
     templateDocuments,
+    islandManifest: runtime.islandManifest ?? new Map(),
   };
 }
 

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -185,6 +185,7 @@ async function dispatchPublicRoute(
   const templateDocuments = app.templateDocuments;
   const templateDeps = app.plugins.templateDeps;
   const assetManifest = app.assetManifest;
+  const islandManifest = app.islandManifest;
   try {
     const response = await resolvePublicRouteOrFallback(app, ctx, url);
     if (response.status === 404) {
@@ -195,6 +196,7 @@ async function dispatchPublicRoute(
         templateDocuments,
         templateDeps,
         assetManifest,
+        islandManifest,
         kind: "not-found",
         data: {
           request: ctx.request,
@@ -219,6 +221,7 @@ async function dispatchPublicRoute(
         templateDocuments,
         templateDeps,
         assetManifest,
+        islandManifest,
         kind: "server-error",
         data: { request: ctx.request },
       });
@@ -252,6 +255,7 @@ async function resolvePublicRouteOrFallback(
   const templateDocuments = app.templateDocuments;
   const templateDeps = app.plugins.templateDeps;
   const assetManifest = app.assetManifest;
+  const islandManifest = app.islandManifest;
   const match = matchRoute(url, app.routeMap);
   if (match !== null) {
     return resolvePublicRoute(
@@ -262,6 +266,7 @@ async function resolvePublicRouteOrFallback(
       templateDocuments,
       templateDeps,
       assetManifest,
+      islandManifest,
     );
   }
   if (url.pathname === "/") {
@@ -273,6 +278,7 @@ async function resolvePublicRouteOrFallback(
       templateDocuments,
       templateDeps,
       assetManifest,
+      islandManifest,
     );
   }
   return notFound("public-route-not-found");

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -26,6 +26,7 @@ import {
   installPlugins,
 } from "@plumix/core";
 
+import type { DiscoveredIsland } from "./island-transform.js";
 import { loadConfig } from "../cli/load-config.js";
 import {
   ADMIN_URL_PREFIX,
@@ -33,6 +34,7 @@ import {
 } from "./admin-plugin-bundle.js";
 import { generateClientEntrySource } from "./client-entry-codegen.js";
 import { VitePluginError } from "./errors.js";
+import { scanUserSources } from "./island-transform.js";
 import { plumixPathAliases } from "./path-aliases.js";
 import { stageUserPublic } from "./public-staging.js";
 
@@ -50,11 +52,19 @@ export interface PlumixVitePluginOptions {
 
 const ASSET_MANIFEST_VIRTUAL_ID = "virtual:plumix/asset-manifest";
 const ASSET_MANIFEST_RESOLVED_ID = "\0" + ASSET_MANIFEST_VIRTUAL_ID;
+const ISLAND_MANIFEST_VIRTUAL_ID = "virtual:plumix/island-manifest";
+const ISLAND_MANIFEST_RESOLVED_ID = "\0" + ISLAND_MANIFEST_VIRTUAL_ID;
 
 export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
   let root = process.cwd();
   let publicDir = "";
   let configPath: string | undefined;
+  // Discovered at config() time so rollupOptions.input can be extended
+  // before Vite resolves entries. The list is also what the
+  // `virtual:plumix/island-manifest` virtual module's `load` hook reads
+  // to emit the Map<ComponentType, { chunkUrl, exportName }> the SSR
+  // walker uses for `<plumix-island>` wrapper emission.
+  let islands: readonly DiscoveredIsland[] = [];
 
   return {
     name: "plumix",
@@ -88,6 +98,19 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
       // none is set (see packages/vite-plugin-cloudflare/src/build.ts).
       // Vite merges this with the CF plugin's config; the merged
       // result has both `manifest: true` and our entry input.
+      // Scan user source for block-side islands BEFORE Vite resolves
+      // entries. Each discovered island becomes its own rollupOptions
+      // input so Vite emits a content-hashed chunk per island
+      // (matches the asset pipeline from PRD #510 slice #514). The
+      // SSR worker imports `virtual:plumix/island-manifest` which
+      // resolves the chunk URL per component out of Vite's
+      // `manifest.json` post-build.
+      const scanRoot = userConfig.root ?? process.cwd();
+      islands = scanUserSources(scanRoot);
+      const islandInputs: Record<string, string> = {};
+      for (const island of islands) {
+        islandInputs[islandEntryName(island)] = island.sourcePath;
+      }
       const environments = {
         client: {
           build: {
@@ -95,6 +118,7 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
             rollupOptions: {
               input: {
                 "plumix-client": ".plumix/client-entry.ts",
+                ...islandInputs,
               },
             },
           },
@@ -116,18 +140,24 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     },
     resolveId(id) {
       if (id === ASSET_MANIFEST_VIRTUAL_ID) return ASSET_MANIFEST_RESOLVED_ID;
+      if (id === ISLAND_MANIFEST_VIRTUAL_ID) return ISLAND_MANIFEST_RESOLVED_ID;
       return null;
     },
     load(id) {
-      if (id !== ASSET_MANIFEST_RESOLVED_ID) return null;
-      // Read the manifest Vite emits to `<outDir>/.vite/manifest.json`.
-      // Returns `{}` when missing — which happens in dev (no manifest
-      // is written) AND on the FIRST production build of a fresh
-      // project: @cloudflare/vite-plugin builds the worker env before
-      // the client env, so on a cold build the worker bakes an empty
-      // manifest and the second build picks up the real entries.
-      // Followup #528 tracks the fix.
-      return `export default ${JSON.stringify(loadAssetManifest(root))};`;
+      if (id === ASSET_MANIFEST_RESOLVED_ID) {
+        // Read the manifest Vite emits to `<outDir>/.vite/manifest.json`.
+        // Returns `{}` when missing — which happens in dev (no manifest
+        // is written) AND on the FIRST production build of a fresh
+        // project: @cloudflare/vite-plugin builds the worker env before
+        // the client env, so on a cold build the worker bakes an empty
+        // manifest and the second build picks up the real entries.
+        // Followup #528 tracks the fix.
+        return `export default ${JSON.stringify(loadAssetManifest(root))};`;
+      }
+      if (id === ISLAND_MANIFEST_RESOLVED_ID) {
+        return generateIslandManifestSource(root, islands);
+      }
+      return null;
     },
     async buildStart() {
       const emitted = await regenerate(root, options.configFile);
@@ -447,6 +477,83 @@ async function destIsFresh(dest: string, src: string): Promise<boolean> {
 // for the asset-manifest virtual module can read the file synchronously
 // off disk. Returns `{}` when the file isn't present yet (dev, or first
 // build pass before the client env finishes).
+/**
+ * Per-island synthesized entry name. Used as the `rollupOptions.input`
+ * key (the chunk's name in Vite's manifest.json) and as the lookup key
+ * in `generateIslandManifestSource`. A short content-derived suffix is
+ * appended so two sources whose paths differ only by case or by stripped
+ * punctuation (`/foo/Bar.tsx` vs `/foo-Bar.tsx`) don't collide on
+ * case-insensitive filesystems.
+ */
+function islandEntryName(island: DiscoveredIsland): string {
+  const slug = island.sourcePath.replace(/[^A-Za-z0-9]/g, "_");
+  const suffix = simpleHash(island.sourcePath).toString(16).slice(0, 8);
+  return `island-${slug}-${suffix}`;
+}
+
+// 32-bit FNV-1a — enough entropy to disambiguate path-slug collisions
+// without pulling in `node:crypto` for what's effectively a deterministic
+// label. Production correctness comes from `sourcePath` being unique
+// per resolved component, not from the hash.
+function simpleHash(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = (h * 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * Generate the source for the `virtual:plumix/island-manifest` virtual
+ * module. The shape is a `Map<ComponentType, { chunkUrl, exportName }>`
+ * keyed by the component reference — the SSR walker uses this key to
+ * resolve a block's `client.component` to its hashed client-bundle URL.
+ *
+ * Component identity is preserved across the manifest import + the
+ * worker's evaluated plumix.config.ts because both import the same
+ * source path — JavaScript module identity makes the keys equal-by-ref.
+ *
+ * Returns an empty Map when no islands were discovered, so consumers
+ * (BlockRenderer) can unconditionally read from context.
+ */
+function generateIslandManifestSource(
+  rootDir: string,
+  islands: readonly DiscoveredIsland[],
+): string {
+  if (islands.length === 0) {
+    return "export const islandManifest = new Map();\n";
+  }
+  const assetManifest = loadAssetManifest(rootDir) as Record<
+    string,
+    { file?: string } | undefined
+  >;
+  const imports: string[] = [];
+  const entries: string[] = [];
+  islands.forEach((island, idx) => {
+    const localName = `Component_${idx}`;
+    const importClause =
+      island.exportName === "default"
+        ? `import ${localName} from ${JSON.stringify(island.sourcePath)};`
+        : `import { ${island.exportName} as ${localName} } from ${JSON.stringify(island.sourcePath)};`;
+    imports.push(importClause);
+    // Match the manifest key Vite uses — the rollup input key (e.g.
+    // `island-_abs_path_to_Search_tsx`). If Vite hasn't emitted the
+    // chunk yet (dev mode + cold-build edge case the asset-manifest
+    // virtual module documents), fall back to a dev-server path so the
+    // browser still loads the source module via Vite's middleware.
+    const manifestKey = islandEntryName(island);
+    const chunkUrl =
+      assetManifest[manifestKey]?.file !== undefined
+        ? `/${assetManifest[manifestKey].file}`
+        : `/@fs${island.sourcePath}`;
+    entries.push(
+      `  [${localName}, { chunkUrl: ${JSON.stringify(chunkUrl)}, exportName: ${JSON.stringify(island.exportName)} }],`,
+    );
+  });
+  return `${imports.join("\n")}\nexport const islandManifest = new Map([\n${entries.join("\n")}\n]);\n`;
+}
+
 function loadAssetManifest(rootDir: string): unknown {
   const candidates = [
     resolve(rootDir, "dist/client/.vite/manifest.json"),

--- a/packages/plumix/src/vite/island-transform.test.ts
+++ b/packages/plumix/src/vite/island-transform.test.ts
@@ -137,6 +137,21 @@ describe("findIslands", () => {
     expect(findIslands(source, "/x.ts")).toEqual([]);
   });
 
+  test("drops a finding whose exportName is a prototype-pollution key", () => {
+    // `import { __proto__ as Foo } from "..."` — would resolve to
+    // Object.prototype on the client's `mod[exportName]` lookup.
+    const source = `
+      import { __proto__ as Foo } from "./Foo.tsx";
+      import { defineBlock } from "@plumix/blocks";
+      export const block = defineBlock({
+        name: "acme/x",
+        render: () => null,
+        client: { component: Foo },
+      });
+    `;
+    expect(findIslands(source, "/x.ts")).toEqual([]);
+  });
+
   test("parses .tsx sources without complaining about JSX in render", () => {
     const source = `
       import { Search } from "./Search.tsx";

--- a/packages/plumix/src/vite/island-transform.test.ts
+++ b/packages/plumix/src/vite/island-transform.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "vitest";
+
+import type { ScannerFs } from "./island-transform.js";
+import { findIslands, scanUserSources } from "./island-transform.js";
+
+function fixtureFs(
+  files: Record<string, string>,
+  dirs: readonly string[] = [],
+): ScannerFs {
+  const dirSet = new Set<string>(dirs);
+  for (const path of Object.keys(files)) {
+    let cur = "/";
+    for (const part of path.split("/").filter(Boolean).slice(0, -1)) {
+      cur = cur === "/" ? `/${part}` : `${cur}/${part}`;
+      dirSet.add(cur);
+    }
+  }
+  const childrenOf = (dirPath: string) => {
+    const out: { name: string; isDirectory: boolean }[] = [];
+    const prefix = dirPath === "/" ? "/" : `${dirPath}/`;
+    const seen = new Set<string>();
+    for (const path of Object.keys(files)) {
+      if (!path.startsWith(prefix)) continue;
+      const rest = path.slice(prefix.length);
+      const next = rest.split("/")[0];
+      if (!next || seen.has(next)) continue;
+      seen.add(next);
+      const fullChild = `${prefix}${next}`;
+      out.push({ name: next, isDirectory: dirSet.has(fullChild) });
+    }
+    return out;
+  };
+  return {
+    readDir: (path) => {
+      if (!dirSet.has(path) && path !== "/") {
+        throw new Error(`no such dir: ${path}`);
+      }
+      return childrenOf(path);
+    },
+    readFile: (path) => {
+      const content = files[path];
+      if (content === undefined) throw new Error(`no such file: ${path}`);
+      return content;
+    },
+  };
+}
+
+describe("findIslands", () => {
+  test("extracts a single named-import island from a defineBlock call", () => {
+    const source = `
+      import { Search } from "./Search.tsx";
+      import { defineBlock } from "@plumix/blocks";
+      export const searchBlock = defineBlock({
+        name: "acme/search",
+        render: () => null,
+        client: { component: Search, hydrateWhen: "load" },
+      });
+    `;
+    const islands = findIslands(source, "/abs/path/to/blocks.ts");
+    expect(islands).toHaveLength(1);
+    expect(islands[0]).toMatchObject({
+      localBindingName: "Search",
+      importPath: "./Search.tsx",
+      exportName: "Search",
+    });
+  });
+
+  test("resolves an aliased named import to its source export name", () => {
+    const source = `
+      import { Search as PageSearch } from "./Search.tsx";
+      import { defineBlock } from "@plumix/blocks";
+      export const block = defineBlock({
+        name: "acme/x",
+        render: () => null,
+        client: { component: PageSearch, hydrateWhen: "load" },
+      });
+    `;
+    const islands = findIslands(source, "/x.ts");
+    expect(islands[0]).toMatchObject({
+      localBindingName: "PageSearch",
+      importPath: "./Search.tsx",
+      exportName: "Search",
+    });
+  });
+
+  test("resolves a default import as exportName='default'", () => {
+    const source = `
+      import Counter from "./Counter.tsx";
+      import { defineBlock } from "@plumix/blocks";
+      export const block = defineBlock({
+        name: "acme/counter",
+        render: () => null,
+        client: { component: Counter, hydrateWhen: "load" },
+      });
+    `;
+    const islands = findIslands(source, "/x.ts");
+    expect(islands[0]).toMatchObject({
+      localBindingName: "Counter",
+      importPath: "./Counter.tsx",
+      exportName: "default",
+    });
+  });
+
+  test("returns multiple findings for multiple defineBlock calls in one file", () => {
+    const source = `
+      import { A } from "./A.tsx";
+      import { B } from "./B.tsx";
+      import { defineBlock } from "@plumix/blocks";
+      export const a = defineBlock({ name: "a", render: () => null, client: { component: A } });
+      export const b = defineBlock({ name: "b", render: () => null, client: { component: B } });
+    `;
+    const islands = findIslands(source, "/x.ts");
+    expect(islands).toHaveLength(2);
+    expect(islands.map((i) => i.localBindingName)).toEqual(["A", "B"]);
+  });
+
+  test("returns [] for a defineBlock with no client field", () => {
+    const source = `
+      import { defineBlock } from "@plumix/blocks";
+      export const block = defineBlock({ name: "acme/x", render: () => null });
+    `;
+    expect(findIslands(source, "/x.ts")).toEqual([]);
+  });
+
+  test("returns [] when the component identifier isn't imported (probably local fn)", () => {
+    const source = `
+      import { defineBlock } from "@plumix/blocks";
+      function Local() { return null; }
+      export const block = defineBlock({
+        name: "acme/x",
+        render: () => null,
+        client: { component: Local },
+      });
+    `;
+    // Local-scoped components fall off the discovery path — documented
+    // limitation in the IslandFinding doc-comment.
+    expect(findIslands(source, "/x.ts")).toEqual([]);
+  });
+
+  test("parses .tsx sources without complaining about JSX in render", () => {
+    const source = `
+      import { Search } from "./Search.tsx";
+      import { defineBlock } from "@plumix/blocks";
+      export const block = defineBlock({
+        name: "acme/search",
+        render: () => <span>fallback</span>,
+        client: { component: Search },
+      });
+    `;
+    const islands = findIslands(source, "/blocks.tsx");
+    expect(islands).toHaveLength(1);
+  });
+});
+
+describe("scanUserSources", () => {
+  test("finds a single island and resolves its importPath against the block file dir", () => {
+    const fs = fixtureFs({
+      "/app/src/blocks.ts": `
+        import { Search } from "./client/Search.tsx";
+        import { defineBlock } from "@plumix/blocks";
+        export const block = defineBlock({
+          name: "acme/search",
+          render: () => null,
+          client: { component: Search },
+        });
+      `,
+      "/app/src/client/Search.tsx": "export const Search = () => null;",
+    });
+    const islands = scanUserSources("/app", fs);
+    expect(islands).toEqual([
+      {
+        sourcePath: "/app/src/client/Search.tsx",
+        exportName: "Search",
+        blockFile: "/app/src/blocks.ts",
+      },
+    ]);
+  });
+
+  test("skips node_modules, .plumix, dist, .wrangler, .git, .turbo", () => {
+    const fs = fixtureFs({
+      "/app/src/blocks.ts": `import { A } from "./A.tsx"; import { defineBlock } from "@plumix/blocks"; export const a = defineBlock({ name: "a", render: () => null, client: { component: A } });`,
+      "/app/src/A.tsx": "export const A = () => null;",
+      "/app/node_modules/pkg/blocks.ts": `import { B } from "./B.tsx"; import { defineBlock } from "@plumix/blocks"; export const b = defineBlock({ name: "b", render: () => null, client: { component: B } });`,
+      "/app/node_modules/pkg/B.tsx": "export const B = () => null;",
+      "/app/.plumix/blocks.ts": `import { C } from "./C.tsx"; import { defineBlock } from "@plumix/blocks"; export const c = defineBlock({ name: "c", render: () => null, client: { component: C } });`,
+      "/app/dist/blocks.ts": `import { D } from "./D.tsx"; import { defineBlock } from "@plumix/blocks"; export const d = defineBlock({ name: "d", render: () => null, client: { component: D } });`,
+    });
+    const islands = scanUserSources("/app", fs);
+    expect(islands.map((i) => i.exportName)).toEqual(["A"]);
+  });
+
+  test("aggregates findings across multiple files in subdirectories", () => {
+    const fs = fixtureFs({
+      "/app/src/a/blocks.ts": `import { A } from "./A.tsx"; import { defineBlock } from "@plumix/blocks"; export const a = defineBlock({ name: "a", render: () => null, client: { component: A } });`,
+      "/app/src/a/A.tsx": "x",
+      "/app/src/b/blocks.ts": `import { B } from "./B.tsx"; import { defineBlock } from "@plumix/blocks"; export const b = defineBlock({ name: "b", render: () => null, client: { component: B } });`,
+      "/app/src/b/B.tsx": "x",
+    });
+    const islands = scanUserSources("/app", fs);
+    expect(islands).toHaveLength(2);
+    expect(new Set(islands.map((i) => i.sourcePath))).toEqual(
+      new Set(["/app/src/a/A.tsx", "/app/src/b/B.tsx"]),
+    );
+  });
+
+  test("ignores files that don't mention defineBlock (cheap pre-filter)", () => {
+    const reads: string[] = [];
+    const baseFs = fixtureFs({
+      "/app/src/blocks.ts": `import { A } from "./A.tsx"; import { defineBlock } from "@plumix/blocks"; export const a = defineBlock({ name: "a", render: () => null, client: { component: A } });`,
+      "/app/src/db.ts": "export const db = {};",
+      "/app/src/A.tsx": "x",
+    });
+    const wrappedFs: ScannerFs = {
+      ...baseFs,
+      readFile: (path) => {
+        reads.push(path);
+        return baseFs.readFile(path);
+      },
+    };
+    const islands = scanUserSources("/app", wrappedFs);
+    expect(islands).toHaveLength(1);
+    // db.ts gets a single read (the pre-filter is content-based, so we DO
+    // open it once) but AST parse is skipped — we don't strictly assert
+    // that here, just that the scan completes without confusing db.ts.
+    expect(reads).toContain("/app/src/blocks.ts");
+  });
+});

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -35,6 +35,22 @@ interface IslandFinding {
 // degrades to a plain `<div>` per the design.
 const IDENT_RE = /^[A-Za-z_$][\w$]*$/;
 
+// Prototype-pollution defense. The client-side runtime does
+// `mod[exportName]` to look up the component; a malicious or
+// accidentally-named `__proto__` / `constructor` / `prototype` export
+// would resolve to `Object.prototype` or the module's constructor and
+// `createRoot(...).render(<Component />)` would throw or worse —
+// emit DOM in a confused state. Both the codegen here AND the
+// client-side island element guard against these keys; defense in
+// depth, since export names are author-controlled but the regex alone
+// happily admits `__proto__`. Matches Astro's
+// `FORBIDDEN_COMPONENT_EXPORT_KEYS` set.
+const FORBIDDEN_EXPORT_KEYS: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
 export function findIslands(
   source: string,
   filePath: string,
@@ -54,7 +70,11 @@ export function findIslands(
       const componentRef = extractClientComponentIdentifier(node);
       if (componentRef !== null) {
         const match = imports.get(componentRef);
-        if (match && IDENT_RE.test(match.exportName)) {
+        if (
+          match &&
+          IDENT_RE.test(match.exportName) &&
+          !FORBIDDEN_EXPORT_KEYS.has(match.exportName)
+        ) {
           findings.push({
             localBindingName: componentRef,
             importPath: match.importPath,

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -1,0 +1,275 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
+import ts from "typescript";
+
+/**
+ * One block-side island discovered in a source file. The Vite plugin
+ * uses this to build the manifest virtual module: `localBindingName`
+ * is what the SSR-side `BlockSpec.client.component` reference points
+ * at, `importPath` is what the client-side chunk entry imports from,
+ * and `exportName` is the named export the chunk should re-export
+ * (or "default" for default imports — emitted as such by the manifest
+ * codegen).
+ *
+ * Limitations of the v1 scanner:
+ * - Only named and default imports are resolved. Namespace imports
+ *   (`import * as M from "..."`) and re-exports are out of scope; a
+ *   block author hitting those falls off the discovery path and the
+ *   walker degrades to a plain `<div>` (no island wrapper).
+ * - The `defineBlock` identifier must be the literal name — if the
+ *   block author aliases it (`defineBlock as db`), we don't detect.
+ *   Documented as a known limitation in the slice spec.
+ */
+export interface IslandFinding {
+  readonly localBindingName: string;
+  readonly importPath: string;
+  readonly exportName: string;
+}
+
+// JS identifier shape — letters / digits / _ / $, can't start with a digit.
+// The manifest codegen interpolates `exportName` directly as an
+// *identifier* in an `import { ... }` form, so an export that doesn't
+// match (e.g. a TS string-literal export like `"weird-name"`) would
+// produce uncompilable codegen. Findings with a non-identifier export
+// are dropped — the block falls off the discovery path and the walker
+// degrades to a plain `<div>` per the design.
+const IDENT_RE = /^[A-Za-z_$][\w$]*$/;
+
+export function findIslands(
+  source: string,
+  filePath: string,
+): readonly IslandFinding[] {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    inferScriptKind(filePath),
+  );
+  const imports = collectImports(sourceFile);
+  const findings: IslandFinding[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (isDefineBlockCall(node)) {
+      const componentRef = extractClientComponentIdentifier(node);
+      if (componentRef !== null) {
+        const match = imports.get(componentRef);
+        if (match && IDENT_RE.test(match.exportName)) {
+          findings.push({
+            localBindingName: componentRef,
+            importPath: match.importPath,
+            exportName: match.exportName,
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return findings;
+}
+
+/**
+ * Discovered island after `scanUserSources` resolves an `IslandFinding`'s
+ * relative `importPath` against the file it was found in. `sourcePath` is
+ * the absolute path to the component's source file; the Vite plugin uses
+ * it to (a) extend `rollupOptions.input` with a per-island client entry
+ * and (b) emit `import { Component } from "<sourcePath>"` in the
+ * `virtual:plumix/island-manifest` virtual module.
+ */
+export interface DiscoveredIsland {
+  readonly sourcePath: string;
+  readonly exportName: string;
+  /** The file where the `defineBlock` call lives. */
+  readonly blockFile: string;
+}
+
+/**
+ * Injectable fs surface so the scanner is unit-testable without a real
+ * directory tree. Production passes Node's `fs` synchronous primitives.
+ */
+export interface ScannerFs {
+  readDir(path: string): readonly { name: string; isDirectory: boolean }[];
+  readFile(path: string): string;
+}
+
+const SCANNABLE_EXTS: ReadonlySet<string> = new Set([".ts", ".tsx"]);
+const SKIP_DIRS: ReadonlySet<string> = new Set([
+  "node_modules",
+  ".plumix",
+  "dist",
+  ".wrangler",
+  ".turbo",
+  ".cache",
+  ".git",
+]);
+
+/**
+ * Walks `cwd` recursively, runs `findIslands` on every `.ts`/`.tsx`
+ * source it sees (skipping the noise dirs above), and resolves each
+ * finding's relative `importPath` to an absolute `sourcePath`. The
+ * importPath is resolved against the directory of the file the
+ * `defineBlock` call lives in — same semantics as the user's source
+ * imports.
+ *
+ * v1 only walks the user's `cwd`. Block-island declarations in
+ * published npm packages (under `node_modules`) are out of scope; a
+ * follow-up can opt in via an explicit package list once the use case
+ * surfaces. Documented in the `#536` follow-up plan.
+ */
+export function scanUserSources(
+  cwd: string,
+  fs: ScannerFs = nodeFs,
+): readonly DiscoveredIsland[] {
+  const islands: DiscoveredIsland[] = [];
+  walk(cwd, fs, (filePath, source) => {
+    const findings = findIslands(source, filePath);
+    for (const finding of findings) {
+      islands.push({
+        sourcePath: resolveImportPath(filePath, finding.importPath),
+        exportName: finding.exportName,
+        blockFile: toPosix(filePath),
+      });
+    }
+  });
+  return islands;
+}
+
+function walk(
+  dirPath: string,
+  fs: ScannerFs,
+  visit: (filePath: string, source: string) => void,
+): void {
+  let entries: readonly { name: string; isDirectory: boolean }[];
+  try {
+    entries = fs.readDir(dirPath);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dirPath, entry.name);
+    if (entry.isDirectory) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walk(full, fs, visit);
+      continue;
+    }
+    if (!SCANNABLE_EXTS.has(extname(entry.name))) continue;
+    try {
+      const source = fs.readFile(full);
+      // Cheap pre-filter: skip any file that can't possibly contain a
+      // defineBlock call. Saves the AST parse on the vast majority of
+      // user-source files (auth, RPC, db helpers, etc.).
+      if (!source.includes("defineBlock")) continue;
+      visit(full, source);
+    } catch {
+      // Unreadable file (permissions, deleted mid-scan) — skip
+      // rather than aborting the entire scan.
+    }
+  }
+}
+
+/**
+ * Resolve a finding's `importPath` to an absolute file path. Relative
+ * paths (`./X`, `../X`) resolve against the block file's directory.
+ * Bare specifiers (`@plumix/x`, `react`, etc.) are returned as-is —
+ * the manifest emit later passes them through to Vite which knows how
+ * to resolve npm packages.
+ *
+ * Path separators are normalized to POSIX. The downstream emit slots
+ * the result into Vite's `/@fs/<path>` dev URL and into the import
+ * specifier of the generated manifest module — both require forward
+ * slashes regardless of the host OS.
+ */
+function resolveImportPath(blockFile: string, importPath: string): string {
+  if (importPath.startsWith("./") || importPath.startsWith("../")) {
+    return toPosix(resolve(dirname(blockFile), importPath));
+  }
+  return importPath;
+}
+
+function toPosix(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+const nodeFs: ScannerFs = {
+  readDir: (path) =>
+    readdirSync(path, { withFileTypes: true }).map((entry) => ({
+      name: entry.name,
+      isDirectory: entry.isDirectory(),
+    })),
+  readFile: (path) => readFileSync(path, "utf8"),
+};
+
+interface ImportBinding {
+  readonly importPath: string;
+  readonly exportName: string;
+}
+
+function collectImports(
+  sourceFile: ts.SourceFile,
+): ReadonlyMap<string, ImportBinding> {
+  const map = new Map<string, ImportBinding>();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const importPath = statement.moduleSpecifier.text;
+    const clause = statement.importClause;
+    if (!clause) continue;
+    // Default import: `import Foo from "./Foo"`. The local binding is
+    // whatever name the author chose; the export name is "default".
+    if (clause.name) {
+      map.set(clause.name.text, { importPath, exportName: "default" });
+    }
+    // Named imports: `import { Foo, Bar as B } from "./x"`. Track the
+    // local binding (`B`) -> source export (`Bar`) mapping so an alias
+    // doesn't drop the discovery.
+    if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+      for (const element of clause.namedBindings.elements) {
+        const localName = element.name.text;
+        const exportName = element.propertyName?.text ?? localName;
+        map.set(localName, { importPath, exportName });
+      }
+    }
+  }
+  return map;
+}
+
+function isDefineBlockCall(node: ts.Node): node is ts.CallExpression {
+  if (!ts.isCallExpression(node)) return false;
+  const callee = node.expression;
+  return ts.isIdentifier(callee) && callee.text === "defineBlock";
+}
+
+function extractClientComponentIdentifier(
+  call: ts.CallExpression,
+): string | null {
+  const arg = call.arguments[0];
+  if (!arg || !ts.isObjectLiteralExpression(arg)) return null;
+  const clientProp = findObjectProperty(arg, "client");
+  if (!clientProp) return null;
+  if (!ts.isObjectLiteralExpression(clientProp)) return null;
+  const componentProp = findObjectProperty(clientProp, "component");
+  if (!componentProp || !ts.isIdentifier(componentProp)) return null;
+  return componentProp.text;
+}
+
+function findObjectProperty(
+  obj: ts.ObjectLiteralExpression,
+  name: string,
+): ts.Expression | null {
+  for (const property of obj.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const key = property.name;
+    if (ts.isIdentifier(key) && key.text === name) return property.initializer;
+    if (ts.isStringLiteral(key) && key.text === name)
+      return property.initializer;
+  }
+  return null;
+}
+
+function inferScriptKind(filePath: string): ts.ScriptKind {
+  if (filePath.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (filePath.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (filePath.endsWith(".js")) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -20,7 +20,7 @@ import ts from "typescript";
  *   block author aliases it (`defineBlock as db`), we don't detect.
  *   Documented as a known limitation in the slice spec.
  */
-export interface IslandFinding {
+interface IslandFinding {
   readonly localBindingName: string;
   readonly importPath: string;
   readonly exportName: string;


### PR DESCRIPTION
Pairs with the islands MVP framework primitives that landed in #538. Plumix's
Vite plugin now discovers block-side islands at build time, emits one
hashed client chunk per discovered component, and exposes a
`virtual:plumix/island-manifest` virtual module the SSR worker imports so
the walker can hand each `<plumix-island>` wrapper its `chunkUrl` and
`exportName`.

**Static AST scan, not runtime metadata-stamping**

The original plan was a jiti `transform` hook that stamps `__plumixIslandMeta`
on each component at config-eval time. Implementing that cleanly would have
required reimplementing TS→JS compilation inside the custom-transform hook
(jiti's hook replaces the whole pipeline). The static path is simpler, doesn't
need new framework deps, and reuses TypeScript's compiler API which is
already a workspace dev dep.

`findIslands(source, filePath)` walks the AST of one file, finds every
`defineBlock({ client: { component: X } })` call, resolves `X` back to its
named or default import, and returns `IslandFinding[]`. `scanUserSources(cwd)`
walks the user's source tree (skip node_modules / .plumix / dist / .wrangler /
.git / .turbo / .cache, only .ts/.tsx, cheap pre-filter by
`source.includes("defineBlock")`) and aggregates findings with
POSIX-normalized absolute paths.

**Wiring**

```ts
// Before — virtual:plumix/asset-manifest only
buildApp(config, { assetManifest });
```

```ts
// After
import { islandManifest } from "virtual:plumix/island-manifest";
buildApp(config, { assetManifest, islandManifest });
```

The Vite plugin extends `environments.client.build.rollupOptions.input` at
`config()` time with one entry per discovered island (key = path slug + FNV-1a
suffix for collision-safe disambiguation on case-insensitive filesystems). The
new `virtual:plumix/island-manifest` virtual module's `load` hook emits TS
source that imports each component from its absolute source path and builds a
`Map<ComponentType, { chunkUrl, exportName }>` by reading Vite's
`.vite/manifest.json`. Falls back to `/@fs/<path>` in dev when the chunk
isn't built yet.

Component identity at SSR time works because the manifest module and the
worker's evaluated `plumix.config.ts` import from the same source path — JS
module identity makes the Map key match by reference.

**v1 limitations**

- Named + default imports only (no namespace, no re-exports). Block files
  using `import * as M from "..."` fall off the discovery path; the walker
  degrades to a plain `<div>` per #538's design.
- `defineBlock` must be the literal identifier — `defineBlock as db` skips.
- Only the user's `cwd` is walked. Block-island declarations in published
  npm packages are out of scope for v1.
- `exportName` is validated against an identifier regex before codegen —
  TS string-literal exports (`import { "weird-name" as Foo }`) drop the
  finding rather than emit uncompilable TS.

Refs #520
Closes #536