### PR TITLE
fix(blocks): close 3 islands correctness gaps from astro comparison

### DIFF
--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -122,7 +122,12 @@ describe("PlumixIslandElement lifecycle", () => {
     // A nested child blocked on the parent's `ssr` attribute that gets
     // detached before its parent ever hydrates. No mount happened, so
     // no unmount event should fire — listeners pair the two.
-    stubStrategies();
+    //
+    // Strategy captures loadFn without invoking it so neither parent
+    // nor child ever progresses past `start()` — keeps the test focused
+    // on the unmount-event contract without leaking an in-flight
+    // `dynamicImport` into the next test.
+    stubStrategies(() => undefined);
     const listener = vi.fn();
     window.addEventListener("plumix:unmount", listener);
     const parent = makeIsland({

--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -88,6 +88,142 @@ describe("PlumixIslandElement lifecycle", () => {
     expect(strategy).toHaveBeenCalledTimes(1);
   });
 
+  test("disconnectedCallback dispatches `plumix:unmount` on window with element in detail", async () => {
+    // Forward-compat with future view-transitions / client-side
+    // navigation: when an island is removed from the DOM (e.g. a route
+    // swap unmounts the page), themes can listen for `plumix:unmount`
+    // to clean up subscriptions before React's `root.unmount()` runs.
+    // Dispatched on window because the element is already detached
+    // when disconnectedCallback fires.
+    stubStrategies();
+    restoreImport = setDynamicImport(() =>
+      Promise.resolve({ default: () => null } as unknown),
+    );
+    const listener = vi.fn();
+    window.addEventListener("plumix:unmount", listener);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "default",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    el.remove();
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0]?.[0] as CustomEvent<{
+      element: PlumixIslandElement;
+    }>;
+    expect(event.detail.element).toBe(el);
+    window.removeEventListener("plumix:unmount", listener);
+  });
+
+  test("a never-hydrated (deferred) island that disconnects does NOT emit `plumix:unmount`", async () => {
+    // A nested child blocked on the parent's `ssr` attribute that gets
+    // detached before its parent ever hydrates. No mount happened, so
+    // no unmount event should fire — listeners pair the two.
+    stubStrategies();
+    const listener = vi.fn();
+    window.addEventListener("plumix:unmount", listener);
+    const parent = makeIsland({
+      client: "load",
+      "chunk-url": "/parent.js",
+      opts: "{}",
+      ssr: "",
+    });
+    const child = makeIsland({
+      client: "load",
+      "chunk-url": "/child.js",
+      opts: "{}",
+      ssr: "",
+    });
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    await Promise.resolve();
+    // Detach the child WHILE it's still deferred. The parentObserver
+    // teardown should also run (no leaked MutationObserver) but the
+    // observable surface here is the absence of plumix:unmount.
+    child.remove();
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener("plumix:unmount", listener);
+  });
+
+  test("a nested island defers its strategy until the parent island clears its `ssr` attribute", async () => {
+    // SSR'd structure: <plumix-island ssr><...inner content with another
+    // <plumix-island ssr>...></plumix-island>. The child must NOT
+    // hydrate while the parent is still marked SSR — Astro's top-down
+    // contract. Walker emits both with `ssr=""`; each clears its own
+    // attribute after its `hydrate()` runs.
+    const strategy = vi.fn<IslandStrategy>((loadFn) => loadFn());
+    stubStrategies(strategy);
+    const importer = vi.fn(() =>
+      Promise.resolve({ default: () => null } as unknown),
+    );
+    restoreImport = setDynamicImport(importer);
+    const parent = makeIsland({
+      client: "load",
+      "chunk-url": "/parent.js",
+      "component-export": "default",
+      opts: "{}",
+      ssr: "",
+    });
+    const child = makeIsland({
+      client: "load",
+      "chunk-url": "/child.js",
+      "component-export": "default",
+      opts: "{}",
+      ssr: "",
+    });
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    // Yield one microtask; child should defer, only the parent should
+    // have invoked its strategy.
+    await Promise.resolve();
+    await Promise.resolve();
+    const childStrategyCalls = strategy.mock.calls.filter(
+      (call) => call[2] === child,
+    );
+    expect(childStrategyCalls).toHaveLength(0);
+
+    // Parent clears its ssr attribute → child should hydrate next tick.
+    parent.removeAttribute("ssr");
+    await Promise.resolve();
+    await Promise.resolve();
+    const childStrategyCallsAfter = strategy.mock.calls.filter(
+      (call) => call[2] === child,
+    );
+    expect(childStrategyCallsAfter).toHaveLength(1);
+  });
+
+  test("start() bails when the element is no longer connected by the time the strategy fires", async () => {
+    // Real-world: connectedCallback fires, strategy schedules an async
+    // import, the parent React render unmounts the island wrapper before
+    // the import resolves. createRoot on a detached node would throw.
+    let deferredLoad: (() => Promise<void>) | undefined;
+    stubStrategies((loadFn) => {
+      // Capture loadFn without invoking it — defers hydration.
+      deferredLoad = loadFn;
+    });
+    const importer = vi.fn(() =>
+      Promise.resolve({ default: () => null } as unknown),
+    );
+    restoreImport = setDynamicImport(importer);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "default",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    // Detach BEFORE the strategy's loadFn runs.
+    el.remove();
+    expect(el.isConnected).toBe(false);
+    await deferredLoad?.();
+    // hydrate's component lookup should never have fired.
+    expect(importer).not.toHaveBeenCalled();
+  });
+
   test("rejects a __proto__ component-export with plumix:hydration-error (proto pollution guard)", async () => {
     stubStrategies();
     const listener = vi.fn();

--- a/packages/blocks/src/island-element.ts
+++ b/packages/blocks/src/island-element.ts
@@ -118,9 +118,7 @@ export class PlumixIslandElement extends HTMLElement {
     // Searching from `parentElement`, not `this` — the walker stamps
     // `ssr=""` on every island including this one, so a self-rooted
     // `closest` would match `this` and self-block forever.
-    const blockingAncestor = this.parentElement?.closest(
-      `${ISLAND_TAG}[ssr]`,
-    );
+    const blockingAncestor = this.parentElement?.closest(`${ISLAND_TAG}[ssr]`);
     if (blockingAncestor) {
       const observer = new MutationObserver(() => {
         if (!blockingAncestor.hasAttribute("ssr")) {

--- a/packages/blocks/src/island-element.ts
+++ b/packages/blocks/src/island-element.ts
@@ -53,6 +53,7 @@ export class PlumixIslandElement extends HTMLElement {
   private retried = false;
   private hydrated = false;
   private childObserver: MutationObserver | null = null;
+  private parentObserver: MutationObserver | null = null;
 
   connectedCallback(): void {
     // If await-children is set, defer until the streaming SSR finishes
@@ -82,12 +83,59 @@ export class PlumixIslandElement extends HTMLElement {
   disconnectedCallback(): void {
     this.childObserver?.disconnect();
     this.childObserver = null;
-    this.root?.unmount();
-    this.root = null;
+    this.parentObserver?.disconnect();
+    this.parentObserver = null;
+    // Only signal unmount when there's something to unmount. A deferred
+    // island that never hydrated (parent never cleared `ssr`, or
+    // `await-children` never settled) shouldn't emit `plumix:unmount`
+    // — listeners pair these with the hydration lifecycle.
+    if (this.hydrated) {
+      // Dispatch on `window` (not `this`) because the element is
+      // already detached by the time `disconnectedCallback` fires — a
+      // bubbling event has no parent chain to traverse. Matches the
+      // `plumix:hydration-error` event surface. Fires BEFORE
+      // `root.unmount()` so listeners can read React state via refs
+      // before teardown.
+      window.dispatchEvent(
+        new CustomEvent<{ element: PlumixIslandElement }>("plumix:unmount", {
+          detail: { element: this },
+        }),
+      );
+      this.root?.unmount();
+      this.root = null;
+    }
   }
 
   private async start(): Promise<void> {
     if (this.hydrated) return;
+    // Top-down hydration: a nested island must NOT hydrate until its
+    // closest `<plumix-island>` ancestor has cleared its `ssr` marker.
+    // Without this, a parent React render that swaps the child's
+    // subtree mid-hydration leaves a dangling `createRoot` on a
+    // detached node. Mirrors Astro's `closest('astro-island[ssr]')`
+    // contract.
+    //
+    // Searching from `parentElement`, not `this` — the walker stamps
+    // `ssr=""` on every island including this one, so a self-rooted
+    // `closest` would match `this` and self-block forever.
+    const blockingAncestor = this.parentElement?.closest(
+      `${ISLAND_TAG}[ssr]`,
+    );
+    if (blockingAncestor) {
+      const observer = new MutationObserver(() => {
+        if (!blockingAncestor.hasAttribute("ssr")) {
+          observer.disconnect();
+          this.parentObserver = null;
+          void this.start();
+        }
+      });
+      this.parentObserver = observer;
+      observer.observe(blockingAncestor, {
+        attributes: true,
+        attributeFilter: ["ssr"],
+      });
+      return;
+    }
     const strategy = this.getAttribute("client") ?? "load";
     const opts = parseJsonAttr(this.getAttribute("opts"));
     const strategies = window.Plumix;
@@ -103,6 +151,12 @@ export class PlumixIslandElement extends HTMLElement {
 
   private async hydrate(): Promise<void> {
     if (this.hydrated) return;
+    // Bail when the parent React render has unmounted us between the
+    // strategy firing and the loadFn callback executing — `createRoot`
+    // on a detached node throws, and hydrating something not in the
+    // document is moot anyway. Mirrors Astro's `if (!isConnected)`
+    // guard in `astro-island.ts`.
+    if (!this.isConnected) return;
     const chunkUrl = this.getAttribute("chunk-url");
     const exportName = this.getAttribute("component-export") ?? "default";
     if (!chunkUrl) {
@@ -121,6 +175,10 @@ export class PlumixIslandElement extends HTMLElement {
     this.hydrated = true;
     this.root = createRoot(this);
     this.root.render(createElement(Component, props));
+    // Clearing the `ssr` attribute signals any nested island awaiting
+    // this parent that it's safe to hydrate now. See the MutationObserver
+    // in `start()` that watches the closest ancestor's `ssr` attribute.
+    this.removeAttribute("ssr");
   }
 
   private async loadComponent(

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -357,6 +357,10 @@ describe("renderBlockTree", () => {
       expect(html).toContain('client="load"');
       expect(html).toContain('data-plumix-block="acme/search"');
       expect(html).toContain("ssr-fallback");
+      // `ssr` attribute marks an SSR'd-but-not-yet-hydrated island so
+      // nested children can defer their own hydration until the parent
+      // clears it. Removed by the custom element after hydrate() runs.
+      expect(html).toContain('ssr=""');
       expect(html).toContain(
         '<script type="application/json" data-plumix-island-props="">',
       );

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -296,6 +296,13 @@ function renderIsland(args: RenderIslandArgs): ReactNode {
         "component-export": args.entry.exportName,
         client: args.hydrateWhen,
         "data-plumix-block": args.node.name,
+        // `ssr` marks the wrapper as SSR'd-but-not-yet-hydrated. The
+        // custom element removes it after `hydrate()` runs. Nested
+        // islands check this attribute on their closest ancestor and
+        // defer their own start() until the parent clears it — keeps
+        // the top-down hydration order React expects when a parent
+        // island can re-render and swap out a child.
+        ssr: "",
         className: args.className,
       },
       args.styleTag,


### PR DESCRIPTION
Closes three gaps the recent Astro comparison surfaced in the islands
custom element. None of these mechanisms are exercised by a consumer
today — landing them now so future slices (deferred strategies #522,
eventually client-side navigation) drop into correct primitives rather
than retro-fixing the custom element.

**`isConnected` guard.** `hydrate()` short-circuits when the element is
already detached from the DOM. A parent React render that unmounts the
island mid-strategy would previously call `createRoot(disconnectedNode).render(...)`
and throw.

**Top-down hydration via `ssr` attribute.** Walker emits `ssr=""` on
every `<plumix-island>` wrapper. The custom element removes its own
`ssr` after `hydrate()` runs. A nested island finds the closest
ancestor `<plumix-island>[ssr]` and defers via a MutationObserver
until the ancestor clears `ssr`. Mirrors Astro's `closest('astro-island[ssr]')`
contract.

```ts
// New: nested-island parent-await
const blockingAncestor = this.parentElement?.closest(`${ISLAND_TAG}[ssr]`);
if (blockingAncestor) {
  this.parentObserver = new MutationObserver(() => {
    if (!blockingAncestor.hasAttribute("ssr")) {
      this.parentObserver?.disconnect();
      void this.start();
    }
  });
  this.parentObserver.observe(blockingAncestor, {
    attributes: true,
    attributeFilter: ["ssr"],
  });
  return;
}
```

**`disconnectedCallback` unmount + `plumix:unmount` event.** Disconnect
tears down both MutationObservers, unmounts the React root, and
dispatches `plumix:unmount` on `window` (the element is already detached
so bubbling has no parent chain). Dispatch is gated on `this.hydrated`
so a deferred-but-never-mounted island doesn't emit an orphan event —
keeps the mount/unmount lifecycle symmetric for future listeners.

**Sentry findings folded in:** inline comment explaining the
`parentElement?.closest` (not `this.closest`) choice; gated unmount on
`hydrated`; added regression test for the deferred-then-disconnected
case; tightened `plumix:unmount` detail type to `PlumixIslandElement`.

Closes #542
Refs #520