### PR TITLE
feat(blocks): serialize island props on wrapper attribute

### DIFF
--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -7,6 +7,7 @@ import {
   registerIslandElement,
   setDynamicImport,
 } from "./island-element.js";
+import { serializeProps } from "./serialize.js";
 
 function makeIsland(attrs: Record<string, string>): PlumixIslandElement {
   registerIslandElement();
@@ -309,9 +310,57 @@ describe("PlumixIslandElement lifecycle", () => {
     vi.useRealTimers();
   });
 
-  // The sibling-script prop pipeline is covered end-to-end by the
-  // Playwright e2e in `packages/e2e/tests/islands-mvp.spec.ts` (Phase G).
-  // Verifying it here would mean flushing a React 19 concurrent commit
-  // out of jsdom, which is more harness wiring than value at the unit
-  // layer. The deserializer round-trip is in `serialize.test.ts`.
+  test("re-renders the component when the `props` attribute changes after mount", async () => {
+    const seen: Readonly<Record<string, unknown>>[] = [];
+    const Component = (props: Readonly<Record<string, unknown>>) => {
+      seen.push(props);
+      return null;
+    };
+    restoreImport = setDynamicImport(() =>
+      Promise.resolve({ default: Component } as unknown),
+    );
+    stubStrategies();
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "default",
+      opts: "{}",
+      props: serializeProps({ title: "first" }),
+    });
+    document.body.appendChild(el);
+    // React 19 concurrent commits don't land in a single setTimeout(0)
+    // tick — poll until the first render lands.
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0]).toEqual({ title: "first" });
+
+    el.setAttribute("props", serializeProps({ title: "second" }));
+    await vi.waitFor(() => expect(seen).toHaveLength(2));
+    expect(seen[1]).toEqual({ title: "second" });
+  });
+
+  test("declares `props` in observedAttributes", () => {
+    expect(PlumixIslandElement.observedAttributes).toContain("props");
+  });
+
+  test("reads props from the `props` attribute and forwards them to the component", async () => {
+    const seen: Readonly<Record<string, unknown>>[] = [];
+    const Component = (props: Readonly<Record<string, unknown>>) => {
+      seen.push(props);
+      return null;
+    };
+    restoreImport = setDynamicImport(() =>
+      Promise.resolve({ default: Component } as unknown),
+    );
+    stubStrategies();
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "default",
+      opts: "{}",
+      props: serializeProps({ title: "hello", n: 42 }),
+    });
+    document.body.appendChild(el);
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0]).toEqual({ title: "hello", n: 42 });
+  });
 });

--- a/packages/blocks/src/island-element.ts
+++ b/packages/blocks/src/island-element.ts
@@ -1,11 +1,9 @@
 // Port of Astro's `astro-island.ts` (Apache-2.0). The custom element
 // reads its hydration target from attributes the SSR walker emitted:
 // the chunk URL, the named export to mount, the strategy name, the
-// strategy-specific opts JSON, and an optional `await-children` flag
-// that gates hydration on `MutationObserver` until streamed children
-// settle. Props live in a sibling `<script type="application/json">`
-// rather than an attribute because attribute size limits in real
-// browsers (~64 KB on some engines) would clip a large prop graph.
+// strategy-specific opts JSON, the serialized `props` payload, and an
+// optional `await-children` flag that gates hydration on
+// `MutationObserver` until streamed children settle.
 //
 // On a failed chunk import, hydrate() retries once with a cache-bust
 // hash (`#plumix-retry=<ts>`) — covers the deploy-during-page-load
@@ -49,11 +47,36 @@ const FORBIDDEN_EXPORT_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 export class PlumixIslandElement extends HTMLElement {
+  static readonly observedAttributes: readonly string[] = ["props"];
+
   private root: Root | null = null;
   private retried = false;
   private hydrated = false;
+  private component: ComponentType<Readonly<Record<string, unknown>>> | null =
+    null;
   private childObserver: MutationObserver | null = null;
   private parentObserver: MutationObserver | null = null;
+
+  attributeChangedCallback(
+    _name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    // Spec fires this for every observed attribute already on the element
+    // at upgrade time (oldValue=null). The first render is owned by
+    // `start()` → `hydrate()`; skip until that completes. The root/
+    // component nullability checks satisfy TS — they're true together
+    // with `hydrated` by construction.
+    if (
+      !this.hydrated ||
+      !this.root ||
+      !this.component ||
+      oldValue === newValue
+    ) {
+      return;
+    }
+    this.root.render(createElement(this.component, readProps(this)));
+  }
 
   connectedCallback(): void {
     // If await-children is set, defer until the streaming SSR finishes
@@ -103,6 +126,7 @@ export class PlumixIslandElement extends HTMLElement {
       );
       this.root?.unmount();
       this.root = null;
+      this.component = null;
     }
   }
 
@@ -171,6 +195,7 @@ export class PlumixIslandElement extends HTMLElement {
     if (!Component) return;
     const props = readProps(this);
     this.hydrated = true;
+    this.component = Component;
     this.root = createRoot(this);
     this.root.render(createElement(Component, props));
     // Clearing the `ssr` attribute signals any nested island awaiting
@@ -255,22 +280,9 @@ function parseJsonAttr(raw: string | null): Readonly<Record<string, unknown>> {
 }
 
 function readProps(el: HTMLElement): Readonly<Record<string, unknown>> {
-  // SSR emits `<script type="application/json" data-plumix-island-props>`
-  // as a sibling of the island element. Known limitation: any DOM
-  // rewriter that inserts a non-script element between the two (third-
-  // party scripts, translate extensions, theme post-processors) breaks
-  // the lookup and the React component mounts with `{}` props. A more
-  // robust lookup keyed by an explicit `props-id` attribute is filed
-  // for a follow-up — for the islands MVP, the positional sibling
-  // pattern matches the contract the walker emits.
-  const script = el.nextElementSibling;
-  if (
-    !(script instanceof HTMLScriptElement) ||
-    script.getAttribute("data-plumix-island-props") === null
-  ) {
-    return {};
-  }
-  return deserializeProps(script.textContent || "{}");
+  const raw = el.getAttribute("props");
+  if (!raw) return {};
+  return deserializeProps(raw);
 }
 
 export const ISLAND_TAG = "plumix-island";

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -361,9 +361,9 @@ describe("renderBlockTree", () => {
       // nested children can defer their own hydration until the parent
       // clears it. Removed by the custom element after hydrate() runs.
       expect(html).toContain('ssr=""');
-      expect(html).toContain(
-        '<script type="application/json" data-plumix-island-props="">',
-      );
+      // Props ride on the wrapper attribute — no sibling script.
+      expect(html).toMatch(/<plumix-island [^>]*props="/);
+      expect(html).not.toContain('<script type="application/json"');
     });
 
     test("falls back to plain div when client is declared but no manifest entry resolves", () => {
@@ -386,7 +386,9 @@ describe("renderBlockTree", () => {
       expect(html).toContain("ssr-fallback");
     });
 
-    test("escapes </script> sequences in serialized props", () => {
+    test("HTML-escapes props attribute so embedded quotes survive parsing", () => {
+      // React's JSX renderer is responsible for the attribute escape;
+      // round-tripping through a real DOM parse is what proves it.
       const Widget = () => null;
       const registry = createBlockRegistry([
         {
@@ -398,23 +400,23 @@ describe("renderBlockTree", () => {
       const manifest = new Map([
         [Widget, { chunkUrl: "/w.js", exportName: "Widget" }],
       ]);
+      const tricky = `alert("hi") & </script>`;
       const tree: readonly BlockNode[] = [
-        {
-          id: "w1",
-          name: "acme/widget",
-          attrs: { code: "alert('hi'); </script>" },
-        },
+        { id: "w1", name: "acme/widget", attrs: { code: tricky } },
       ];
 
       const html = renderToStaticMarkup(
         renderBlockTree(tree, registry, { islandManifest: manifest }),
       );
 
-      // The legitimate closing `</script>` for the prop tag exists once;
-      // the escape must prevent a second one from appearing inside the JSON.
-      const closingMatches = html.match(/<\/script>/g);
-      expect(closingMatches).toHaveLength(1);
-      expect(html).toContain("<\\/script");
+      document.body.innerHTML = html;
+      const island = document.querySelector("plumix-island");
+      const propsAttr = island?.getAttribute("props") ?? "";
+      const parsed = JSON.parse(propsAttr) as Record<
+        string,
+        readonly [number, string]
+      >;
+      expect(parsed.code?.[1]).toBe(tricky);
     });
   });
 

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -235,9 +235,7 @@ function renderNode(
   // a manifest entry exists for this block's `client.component`; a
   // build without the islands Vite plugin (or a block whose component
   // wasn't bundled) gracefully degrades to the SSR'd output without a
-  // wrapper. Props from `node.attrs` are serialized to a sibling
-  // `<script type="application/json">` rather than an attribute so
-  // large prop graphs don't run into HTML attribute size limits.
+  // wrapper.
   if (spec.client && islandManifest) {
     const entry = islandManifest.get(spec.client.component);
     if (entry) {
@@ -278,41 +276,32 @@ interface RenderIslandArgs {
 }
 
 function renderIsland(args: RenderIslandArgs): ReactNode {
+  // Practical size limit: HTML attribute values are unbounded by spec,
+  // but browser engines truncate around 64 KB. Blocks whose prop graphs
+  // exceed that should fetch their data on the client instead.
   const propsPayload = serializeProps(args.attrs, {
     displayName: args.displayName,
   });
-  // Escape the JSON string against premature `</script>` termination —
-  // a string prop containing `</script>` would otherwise close the
-  // element here and let the rest of the JSON leak into the DOM as
-  // markup. Forward-slash escape is safe inside JSON.
-  const safePayload = propsPayload.replace(/<\/script/gi, "<\\/script");
   return createElement(
-    Fragment,
-    { key: args.node.id },
-    createElement(
-      "plumix-island",
-      {
-        "chunk-url": args.entry.chunkUrl,
-        "component-export": args.entry.exportName,
-        client: args.hydrateWhen,
-        "data-plumix-block": args.node.name,
-        // `ssr` marks the wrapper as SSR'd-but-not-yet-hydrated. The
-        // custom element removes it after `hydrate()` runs. Nested
-        // islands check this attribute on their closest ancestor and
-        // defer their own start() until the parent clears it — keeps
-        // the top-down hydration order React expects when a parent
-        // island can re-render and swap out a child.
-        ssr: "",
-        className: args.className,
-      },
-      args.styleTag,
-      args.rendered,
-    ),
-    createElement("script", {
-      type: "application/json",
-      "data-plumix-island-props": "",
-      dangerouslySetInnerHTML: { __html: safePayload },
-    }),
+    "plumix-island",
+    {
+      key: args.node.id,
+      "chunk-url": args.entry.chunkUrl,
+      "component-export": args.entry.exportName,
+      client: args.hydrateWhen,
+      "data-plumix-block": args.node.name,
+      // `ssr` marks the wrapper as SSR'd-but-not-yet-hydrated. The
+      // custom element removes it after `hydrate()` runs. Nested
+      // islands check this attribute on their closest ancestor and
+      // defer their own start() until the parent clears it — keeps
+      // the top-down hydration order React expects when a parent
+      // island can re-render and swap out a child.
+      ssr: "",
+      props: propsPayload,
+      className: args.className,
+    },
+    args.styleTag,
+    args.rendered,
   );
 }
 


### PR DESCRIPTION
Switches `<plumix-island>` from a sibling `<script type="application/json" data-plumix-island-props>` to a `props=` attribute on the wrapper itself. Adds `observedAttributes = ["props"]` + `attributeChangedCallback` so a post-mount attribute write re-renders into the existing React root.

**Why the wrapper attribute**

The sibling-script lookup walked the rendered DOM via `nextElementSibling`. Any node that splices markup between the wrapper and the script (theme post-processors, Cloudflare Rocket Loader, AMP transforms, browser extensions) silently broke the lookup and the React component mounted with `{}` props with no error surface. Putting props on the wrapper itself collapses the lookup to one attribute read and lines the runtime up with Astro's `astro-island.ts:229-231` contract.

**`observedAttributes` re-render**

Storing the loaded component reference on the element lets `attributeChangedCallback` re-render via the existing React root — no chunk re-import, no `createRoot` leak. This is the gate any future view-transition / persisted-island work needs.

**Escape pass**

React's JSX renderer applies the HTML-attribute escape, so the prior `</script>` regex pass is gone. The walker test now round-trips a payload containing `"`, `&`, and `</script>` through a real DOM parse to prove the escape lands.

**Size budget**

HTML attribute values are unbounded by spec but browser engines truncate around 64 KB. Blocks whose prop graphs exceed that should fetch their data on the client. Documented in `renderIsland`.

Fixes #541
Refs #520