### PR TITLE
feat(plumix): islands "use client" directive discovery + SSR shim

### DIFF
--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -116,3 +116,6 @@ export {
 // ─── Inline marks ───────────────────────────────────────────────────────────
 export { coreMarks, coreMarkExtensions } from "./marks/core/index.js";
 export type { MarkSpec } from "./marks/types.js";
+
+// ─── Islands authoring ──────────────────────────────────────────────────────
+export type { IslandProps, PlumixStrategy } from "./island-props.js";

--- a/packages/blocks/src/island-props.test.ts
+++ b/packages/blocks/src/island-props.test.ts
@@ -1,0 +1,53 @@
+// Type-level test for `IslandProps<T>`. The helper has no runtime —
+// these assertions exist to catch regressions in the mapped-type logic.
+
+import { describe, expectTypeOf, test } from "vitest";
+
+import type { IslandProps, PlumixStrategy } from "./island-props.js";
+
+interface Primitives {
+  label: string;
+  count: number;
+  cfg: { open: boolean };
+}
+
+interface WithCallbacks {
+  label: string;
+  onClick: () => void;
+  onSubmit?: (value: string) => Promise<void>;
+}
+
+interface WithClientProp {
+  label: string;
+  client: string;
+}
+
+interface NoClientProp {
+  label: string;
+}
+
+describe("IslandProps<T>", () => {
+  test("preserves primitive and object props", () => {
+    type Out = IslandProps<Primitives>;
+    expectTypeOf<Out["label"]>().toEqualTypeOf<string>();
+    expectTypeOf<Out["count"]>().toEqualTypeOf<number>();
+    expectTypeOf<Out["cfg"]>().toEqualTypeOf<{ open: boolean }>();
+  });
+
+  test("strips function-typed properties", () => {
+    type Out = IslandProps<WithCallbacks>;
+    expectTypeOf<Out>().toHaveProperty("label");
+    expectTypeOf<Out>().not.toHaveProperty("onClick");
+    expectTypeOf<Out>().not.toHaveProperty("onSubmit");
+  });
+
+  test("reserves `client` as an optional strategy prop, overriding any consumer-defined `client`", () => {
+    type Out = IslandProps<WithClientProp>;
+    expectTypeOf<Out["client"]>().toEqualTypeOf<PlumixStrategy | undefined>();
+  });
+
+  test("adds `client?: PlumixStrategy` even when the input has no `client` prop", () => {
+    type Out = IslandProps<NoClientProp>;
+    expectTypeOf<Out["client"]>().toEqualTypeOf<PlumixStrategy | undefined>();
+  });
+});

--- a/packages/blocks/src/island-props.ts
+++ b/packages/blocks/src/island-props.ts
@@ -1,0 +1,39 @@
+/**
+ * Hydration strategies the islands runtime recognizes. New strategies
+ * land alongside their runtime implementation; v0 ships `load`
+ * (eager) and `visible` (IntersectionObserver-gated).
+ */
+export type PlumixStrategy = "load" | "visible";
+
+/**
+ * Props helper for components marked with `"use client";`. Two safety
+ * properties:
+ *
+ * 1. **Function-typed properties are excluded.** Functions don't survive
+ *    the SSR → hydration JSON round-trip — the SSR'd render gets the
+ *    real callback, but the client receives `undefined` after the wrapper
+ *    re-parses the `props=` attribute. Forcing authors to omit them at
+ *    the type layer catches the silent drop at compile time.
+ *
+ * 2. **The `client` prop is reserved for hydration strategy.** The
+ *    server-side shim strips this prop and uses its string value to
+ *    select the strategy (`"load"`, `"visible"`). A consumer who used
+ *    the same name for their own data would silently lose it. Reserving
+ *    the slot via the type makes the conflict visible at compile time.
+ *
+ * Authors declare component props as:
+ *
+ * ```ts
+ * "use client";
+ * function MyWidget(props: IslandProps<{ label: string; size?: number }>) { ... }
+ * ```
+ */
+export type IslandProps<T> = OmitFunctions<Omit<T, "client">> & {
+  readonly client?: PlumixStrategy;
+};
+
+type OmitFunctions<T> = {
+  [K in keyof T as T[K] extends ((...args: never[]) => unknown) | undefined
+    ? never
+    : K]: T[K];
+};

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -34,7 +34,11 @@ import {
 } from "./admin-plugin-bundle.js";
 import { generateClientEntrySource } from "./client-entry-codegen.js";
 import { VitePluginError } from "./errors.js";
-import { scanUserSources } from "./island-transform.js";
+import {
+  ORIG_QUERY,
+  scanUserSources,
+  transformUseClientModule,
+} from "./island-transform.js";
 import { plumixPathAliases } from "./path-aliases.js";
 import { stageUserPublic } from "./public-staging.js";
 
@@ -138,12 +142,25 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
       root = config.root;
       publicDir = config.publicDir;
     },
-    resolveId(id) {
+    resolveId(id, importer) {
       if (id === ASSET_MANIFEST_VIRTUAL_ID) return ASSET_MANIFEST_RESOLVED_ID;
       if (id === ISLAND_MANIFEST_VIRTUAL_ID) return ISLAND_MANIFEST_RESOLVED_ID;
+      // `<file>?plumix-orig` — the SSR shim imports the original module
+      // from this virtual ID; `transform` short-circuits on it so the
+      // shim isn't recursively wrapped. The shim emits an absolute path,
+      // so passing `id` straight through resolves correctly.
+      if (id.endsWith(ORIG_QUERY)) {
+        if (!importer) return id;
+        const cleanId = id.slice(0, -ORIG_QUERY.length);
+        return resolve(dirname(importer), cleanId) + ORIG_QUERY;
+      }
       return null;
     },
     load(id) {
+      if (id.endsWith(ORIG_QUERY)) {
+        const filePath = id.slice(0, -ORIG_QUERY.length);
+        return readFileSync(filePath, "utf8");
+      }
       if (id === ASSET_MANIFEST_RESOLVED_ID) {
         // Read the manifest Vite emits to `<outDir>/.vite/manifest.json`.
         // Returns `{}` when missing — which happens in dev (no manifest
@@ -158,6 +175,17 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
         return generateIslandManifestSource(root, islands);
       }
       return null;
+    },
+    transform(code, id, options) {
+      if (!options?.ssr) return null;
+      if (id.endsWith(ORIG_QUERY)) return null;
+      if (!id.endsWith(".tsx") && !id.endsWith(".ts")) return null;
+      if (!code.includes("use client")) return null;
+      // Dev chunk URL. Production needs the hashed path from Vite's
+      // `.vite/manifest.json` — follow-up to this slice.
+      const chunkUrl = "/@fs" + id;
+      const result = transformUseClientModule(code, id, { chunkUrl });
+      return result ? { code: result.code, map: null } : null;
     },
     async buildStart() {
       const emitted = await regenerate(root, options.configFile);

--- a/packages/plumix/src/vite/island-transform.test.ts
+++ b/packages/plumix/src/vite/island-transform.test.ts
@@ -246,9 +246,7 @@ describe("findUseClientIslands", () => {
       "use client";
       export function Counter() { return null; }
     `;
-    expect(findUseClientIslands(source)).toEqual([
-      { exportName: "Counter" },
-    ]);
+    expect(findUseClientIslands(source)).toEqual([{ exportName: "Counter" }]);
   });
 });
 
@@ -270,9 +268,7 @@ describe("transformUseClientModule", () => {
     const out = result.code;
     // Re-imports the original file via the ?plumix-orig query so the
     // shim doesn't recursively re-trigger this transform.
-    expect(out).toContain(
-      `from "/abs/path/Counter.tsx?plumix-orig"`,
-    );
+    expect(out).toContain(`from "/abs/path/Counter.tsx?plumix-orig"`);
     // Re-exports every name the original exports, but as a shim.
     expect(out).toMatch(/export\s+function\s+Counter\s*\(/);
     // Shim wraps in `<plumix-island>` with chunk-url + component-export

--- a/packages/plumix/src/vite/island-transform.test.ts
+++ b/packages/plumix/src/vite/island-transform.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "vitest";
 
 import type { ScannerFs } from "./island-transform.js";
-import { findIslands, scanUserSources } from "./island-transform.js";
+import {
+  findIslands,
+  findUseClientIslands,
+  scanUserSources,
+  transformUseClientModule,
+} from "./island-transform.js";
 
 function fixtureFs(
   files: Record<string, string>,
@@ -167,6 +172,164 @@ describe("findIslands", () => {
   });
 });
 
+describe("findUseClientIslands", () => {
+  test("extracts a single named export from a `use client` module", () => {
+    const source = `
+      "use client";
+      import { useState } from "react";
+      export function Counter() {
+        const [n, setN] = useState(0);
+        return <button onClick={() => setN(n + 1)}>{n}</button>;
+      }
+    `;
+    const islands = findUseClientIslands(source);
+    expect(islands).toEqual([{ exportName: "Counter" }]);
+  });
+
+  test("returns [] when the directive isn't the first statement", () => {
+    // Match React 19 / RSC semantics — the directive must lead.
+    const source = `
+      const sentinel = 42;
+      "use client";
+      export function Counter() { return null; }
+    `;
+    expect(findUseClientIslands(source)).toEqual([]);
+  });
+
+  test("returns [] when the file lacks the directive entirely", () => {
+    const source = `
+      import { useState } from "react";
+      export function NotAnIsland() { return null; }
+    `;
+    expect(findUseClientIslands(source)).toEqual([]);
+  });
+
+  test("returns one finding per named function/const/class export", () => {
+    const source = `
+      "use client";
+      export function A() { return null; }
+      export const B = () => null;
+      export class C {}
+    `;
+    const islands = findUseClientIslands(source);
+    expect(islands.map((i) => i.exportName)).toEqual(["A", "B", "C"]);
+  });
+
+  test("includes the default export, encoded as exportName='default'", () => {
+    const source = `
+      "use client";
+      export default function MyComponent() { return null; }
+    `;
+    const islands = findUseClientIslands(source);
+    expect(islands).toEqual([{ exportName: "default" }]);
+  });
+
+  test("drops exports whose name is a prototype-pollution key", () => {
+    // `mod["__proto__"]` would resolve to Object.prototype on the client
+    // side and `createRoot(...).render(<Component />)` would crash.
+    // Match the existing `FORBIDDEN_EXPORT_KEYS` guard from defineBlock
+    // discovery.
+    const source = `
+      "use client";
+      export const __proto__ = () => null;
+      export const constructor = () => null;
+      export const Counter = () => null;
+    `;
+    const islands = findUseClientIslands(source);
+    expect(islands.map((i) => i.exportName)).toEqual(["Counter"]);
+  });
+
+  test("ignores comments and leading whitespace before the directive", () => {
+    const source = `
+      // Copyright header
+      /* multiline note */
+      "use client";
+      export function Counter() { return null; }
+    `;
+    expect(findUseClientIslands(source)).toEqual([
+      { exportName: "Counter" },
+    ]);
+  });
+});
+
+describe("transformUseClientModule", () => {
+  test("rewrites a `use client` module to re-export shim components", () => {
+    const source = `
+      "use client";
+      import { useState } from "react";
+      export function Counter() {
+        const [n, setN] = useState(0);
+        return <button onClick={() => setN(n + 1)}>{n}</button>;
+      }
+    `;
+    const result = transformUseClientModule(source, "/abs/path/Counter.tsx", {
+      chunkUrl: "/src/Counter.tsx",
+    });
+    expect(result).not.toBeNull();
+    if (!result) return;
+    const out = result.code;
+    // Re-imports the original file via the ?plumix-orig query so the
+    // shim doesn't recursively re-trigger this transform.
+    expect(out).toContain(
+      `from "/abs/path/Counter.tsx?plumix-orig"`,
+    );
+    // Re-exports every name the original exports, but as a shim.
+    expect(out).toMatch(/export\s+function\s+Counter\s*\(/);
+    // Shim wraps in `<plumix-island>` with chunk-url + component-export
+    // + ssr="" baked in. We just check the literals are present — the
+    // exact JSX/createElement shape is an internal detail.
+    expect(out).toContain('"chunk-url": "/src/Counter.tsx"');
+    expect(out).toContain('"component-export": "Counter"');
+    expect(out).toContain('"ssr": ""');
+  });
+
+  test("shim forwards strategy from the `client` JSX prop, defaulting to load", () => {
+    // `IslandProps<T>` enforces the type at compile time; the custom
+    // element dispatches `plumix:hydration-error` for unknown strategies
+    // at runtime. The shim itself just passes the value through.
+    const source = `
+      "use client";
+      export function Counter() { return null; }
+    `;
+    const result = transformUseClientModule(source, "/Counter.tsx", {
+      chunkUrl: "/Counter.tsx",
+    });
+    expect(result?.code).toContain(
+      `typeof client === "string" ? client : "load"`,
+    );
+  });
+
+  test("shim serializes props via JSON.stringify (functions drop automatically)", () => {
+    // The shim's `props=` attribute is built by `JSON.stringify(forward)`.
+    // JSON.stringify omits function-typed values at every depth — a
+    // standard JS behavior we rely on rather than re-implement. Assert
+    // the generated source uses JSON.stringify on the forwarded props
+    // (the strip happens for free).
+    const source = `
+      "use client";
+      export function Action() { return null; }
+    `;
+    const result = transformUseClientModule(source, "/Action.tsx", {
+      chunkUrl: "/Action.tsx",
+    });
+    expect(result?.code).toContain("JSON.stringify(forward)");
+    // The shim must destructure `client` out before forwarding so the
+    // strategy slot doesn't leak into the props attribute either.
+    expect(result?.code).toContain("const { client, ...forward }");
+  });
+
+  test("returns null for files without the directive (no-op transform)", () => {
+    const source = `
+      import { useState } from "react";
+      export function NotAnIsland() { return null; }
+    `;
+    const result = transformUseClientModule(source, "/x.tsx", {
+      chunkUrl: "/x.tsx",
+    });
+    expect(result).toBeNull();
+  });
+});
+
 describe("scanUserSources", () => {
   test("finds a single island and resolves its importPath against the block file dir", () => {
     const fs = fixtureFs({
@@ -202,6 +365,37 @@ describe("scanUserSources", () => {
     });
     const islands = scanUserSources("/app", fs);
     expect(islands.map((i) => i.exportName)).toEqual(["A"]);
+  });
+
+  test("surfaces `use client` modules alongside defineBlock findings", () => {
+    const fs = fixtureFs({
+      "/app/src/blocks.ts": `
+        import { Search } from "./Search.tsx";
+        import { defineBlock } from "@plumix/blocks";
+        export const block = defineBlock({
+          name: "acme/search",
+          render: () => null,
+          client: { component: Search },
+        });
+      `,
+      "/app/src/Search.tsx": "export const Search = () => null;",
+      // A separate `use client` module — not referenced by any defineBlock,
+      // but a theme template imports `Header` and `Footer` and uses them.
+      "/app/src/header.tsx": `
+        "use client";
+        export function Header() { return null; }
+        export function Footer() { return null; }
+      `,
+    });
+    const islands = scanUserSources("/app", fs);
+    const summarized = islands
+      .map((i) => `${i.sourcePath}#${i.exportName}`)
+      .sort();
+    expect(summarized).toEqual([
+      "/app/src/Search.tsx#Search",
+      "/app/src/header.tsx#Footer",
+      "/app/src/header.tsx#Header",
+    ]);
   });
 
   test("aggregates findings across multiple files in subdirectories", () => {

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -51,6 +51,124 @@ const FORBIDDEN_EXPORT_KEYS: ReadonlySet<string> = new Set([
   "prototype",
 ]);
 
+export interface UseClientFinding {
+  readonly exportName: string;
+}
+
+export function findUseClientIslands(
+  source: string,
+): readonly UseClientFinding[] {
+  if (!hasUseClientDirective(source)) return [];
+  const seen = new Set<string>();
+  const out: UseClientFinding[] = [];
+  const push = (name: string | undefined): void => {
+    if (!name || FORBIDDEN_EXPORT_KEYS.has(name) || seen.has(name)) return;
+    seen.add(name);
+    out.push({ exportName: name });
+  };
+  // `export function|const|let|var|class X`.
+  const named =
+    /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = named.exec(source)) !== null) push(m[1]);
+  // `export { Foo, Bar as Baz }` — common when authors split definition
+  // from export. Bare re-exports without `from` only; `export { Foo }
+  // from "./other"` is intentionally out of scope (the source file is
+  // the originating island module).
+  const reexport = /export\s*\{([^}]+)\}(?!\s*from)/g;
+  while ((m = reexport.exec(source)) !== null) {
+    const list = m[1] ?? "";
+    for (const part of list.split(",")) {
+      const aliased = part.trim().split(/\s+as\s+/);
+      push(aliased[aliased.length - 1]);
+    }
+  }
+  if (/export\s+default\b/.test(source)) push("default");
+  return out;
+}
+
+// RSC convention: `"use client"` must lead the module. Earlier
+// statements disqualify the file.
+function hasUseClientDirective(source: string): boolean {
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === " " || ch === "\n" || ch === "\r" || ch === "\t") {
+      i++;
+      continue;
+    }
+    if (source.startsWith("//", i)) {
+      const nl = source.indexOf("\n", i);
+      i = nl === -1 ? source.length : nl + 1;
+      continue;
+    }
+    if (source.startsWith("/*", i)) {
+      const end = source.indexOf("*/", i);
+      i = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    break;
+  }
+  const head = source.slice(i, i + 14);
+  return head.startsWith('"use client"') || head.startsWith("'use client'");
+}
+
+// Vite virtual-module suffix the SSR shim uses to read the original
+// `"use client"` source — the plugin's `resolveId`/`load` serve the
+// unmodified file at this query and `transform` short-circuits, so the
+// shim's `import * as __orig from "<file>?plumix-orig"` doesn't
+// recursively re-trigger this transform.
+export const ORIG_QUERY = "?plumix-orig";
+
+export interface TransformUseClientOptions {
+  readonly chunkUrl: string;
+}
+
+export interface TransformUseClientResult {
+  readonly code: string;
+}
+
+export function transformUseClientModule(
+  source: string,
+  filePath: string,
+  options: TransformUseClientOptions,
+): TransformUseClientResult | null {
+  const findings = findUseClientIslands(source);
+  if (findings.length === 0) return null;
+
+  const origUrl = JSON.stringify(filePath + ORIG_QUERY);
+  const chunkUrl = JSON.stringify(options.chunkUrl);
+  const lines: string[] = [
+    `import { createElement as __c } from "react";`,
+    `import * as __orig from ${origUrl};`,
+  ];
+  for (const finding of findings) {
+    const name = finding.exportName;
+    const isDefault = name === "default";
+    const targetLiteral = JSON.stringify(name);
+    const exportPrefix = isDefault
+      ? "export default function PlumixIsland(props)"
+      : `export function ${name}(props)`;
+    // `client` is the framework-reserved strategy slot. `IslandProps<T>`
+    // guarantees the type at compile; if a consumer ignores the helper
+    // and passes garbage, the custom element dispatches
+    // `plumix:hydration-error` at runtime. No second guard here.
+    lines.push(
+      `${exportPrefix} {`,
+      `  const { client, ...forward } = props ?? {};`,
+      `  return __c("plumix-island", {`,
+      `    "chunk-url": ${chunkUrl},`,
+      `    "component-export": ${targetLiteral},`,
+      `    "client": typeof client === "string" ? client : "load",`,
+      `    "props": JSON.stringify(forward),`,
+      `    "ssr": "",`,
+      `  }, __c(__orig[${targetLiteral}], forward));`,
+      `}`,
+    );
+  }
+  return { code: lines.join("\n") };
+}
+
 export function findIslands(
   source: string,
   filePath: string,
@@ -143,10 +261,20 @@ export function scanUserSources(
 ): readonly DiscoveredIsland[] {
   const islands: DiscoveredIsland[] = [];
   walk(cwd, fs, (filePath, source) => {
-    const findings = findIslands(source, filePath);
-    for (const finding of findings) {
+    for (const finding of findIslands(source, filePath)) {
       islands.push({
         sourcePath: resolveImportPath(filePath, finding.importPath),
+        exportName: finding.exportName,
+        blockFile: toPosix(filePath),
+      });
+    }
+    // `"use client"` modules ARE their own source — sourcePath and
+    // blockFile collapse to the file itself; the manifest reads the
+    // chunk from this entry the same way it does for defineBlock-
+    // discovered components.
+    for (const finding of findUseClientIslands(source)) {
+      islands.push({
+        sourcePath: toPosix(filePath),
         exportName: finding.exportName,
         blockFile: toPosix(filePath),
       });
@@ -176,10 +304,12 @@ function walk(
     if (!SCANNABLE_EXTS.has(extname(entry.name))) continue;
     try {
       const source = fs.readFile(full);
-      // Cheap pre-filter: skip any file that can't possibly contain a
-      // defineBlock call. Saves the AST parse on the vast majority of
-      // user-source files (auth, RPC, db helpers, etc.).
-      if (!source.includes("defineBlock")) continue;
+      // Cheap pre-filter: skip files that can't possibly contain either
+      // a `defineBlock(...)` call or a `"use client"` directive. Saves
+      // the AST parse on the vast majority of user-source files (auth,
+      // RPC, db helpers, etc.).
+      if (!source.includes("defineBlock") && !source.includes("use client"))
+        continue;
       visit(full, source);
     } catch {
       // Unreadable file (permissions, deleted mid-scan) — skip

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -51,66 +51,93 @@ const FORBIDDEN_EXPORT_KEYS: ReadonlySet<string> = new Set([
   "prototype",
 ]);
 
-export interface UseClientFinding {
+interface UseClientFinding {
   readonly exportName: string;
 }
 
 export function findUseClientIslands(
   source: string,
 ): readonly UseClientFinding[] {
-  if (!hasUseClientDirective(source)) return [];
+  // Cheap reject before paying the parse cost.
+  if (!source.includes("use client")) return [];
+  const sourceFile = ts.createSourceFile(
+    "use-client-scan.tsx",
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TSX,
+  );
+  // RSC convention: `"use client"` must be the first non-comment
+  // statement. TypeScript exposes it as an `ExpressionStatement` whose
+  // expression is a string literal — matches both `"use client";` and
+  // `'use client';`. Anything else as the first statement disqualifies.
+  const first = sourceFile.statements[0];
+  if (!first || !ts.isExpressionStatement(first)) return [];
+  const expr = first.expression;
+  if (!ts.isStringLiteral(expr) || expr.text !== "use client") return [];
+
   const seen = new Set<string>();
   const out: UseClientFinding[] = [];
-  const push = (name: string | undefined): void => {
-    if (!name || FORBIDDEN_EXPORT_KEYS.has(name) || seen.has(name)) return;
+  const push = (name: string): void => {
+    if (FORBIDDEN_EXPORT_KEYS.has(name) || seen.has(name)) return;
     seen.add(name);
     out.push({ exportName: name });
   };
-  // `export function|const|let|var|class X`.
-  const named =
-    /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = named.exec(source)) !== null) push(m[1]);
-  // `export { Foo, Bar as Baz }` — common when authors split definition
-  // from export. Bare re-exports without `from` only; `export { Foo }
-  // from "./other"` is intentionally out of scope (the source file is
-  // the originating island module).
-  const reexport = /export\s*\{([^}]+)\}(?!\s*from)/g;
-  while ((m = reexport.exec(source)) !== null) {
-    const list = m[1] ?? "";
-    for (const part of list.split(",")) {
-      const aliased = part.trim().split(/\s+as\s+/);
-      push(aliased[aliased.length - 1]);
+
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isFunctionDeclaration(statement) ||
+      ts.isClassDeclaration(statement)
+    ) {
+      if (!hasExportModifier(statement)) continue;
+      if (hasDefaultModifier(statement)) push("default");
+      else if (statement.name) push(statement.name.text);
+      continue;
+    }
+    if (ts.isVariableStatement(statement)) {
+      if (!hasExportModifier(statement)) continue;
+      for (const decl of statement.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name)) push(decl.name.text);
+      }
+      continue;
+    }
+    if (ts.isExportAssignment(statement)) {
+      // `export default <expr>`.
+      if (!statement.isExportEquals) push("default");
+      continue;
+    }
+    if (ts.isExportDeclaration(statement)) {
+      // `export { Foo, Bar as Baz } [from "..."]`.
+      // Re-exports from another module (`... from "..."`) name the
+      // current file as the chunk source, so they're skipped — the
+      // re-exporter isn't the island module.
+      if (statement.moduleSpecifier) continue;
+      if (!statement.exportClause || !ts.isNamedExports(statement.exportClause))
+        continue;
+      for (const element of statement.exportClause.elements) {
+        // `name` is the outward-facing name (after `as`); we feed the
+        // chunk's `mod[exportName]` lookup, so use the outward name.
+        push(element.name.text);
+      }
     }
   }
-  if (/export\s+default\b/.test(source)) push("default");
   return out;
 }
 
-// RSC convention: `"use client"` must lead the module. Earlier
-// statements disqualify the file.
-function hasUseClientDirective(source: string): boolean {
-  let i = 0;
-  while (i < source.length) {
-    const ch = source[i];
-    if (ch === " " || ch === "\n" || ch === "\r" || ch === "\t") {
-      i++;
-      continue;
-    }
-    if (source.startsWith("//", i)) {
-      const nl = source.indexOf("\n", i);
-      i = nl === -1 ? source.length : nl + 1;
-      continue;
-    }
-    if (source.startsWith("/*", i)) {
-      const end = source.indexOf("*/", i);
-      i = end === -1 ? source.length : end + 2;
-      continue;
-    }
-    break;
-  }
-  const head = source.slice(i, i + 14);
-  return head.startsWith('"use client"') || head.startsWith("'use client'");
+function hasExportModifier(node: ts.HasModifiers): boolean {
+  return (
+    ts
+      .getModifiers(node)
+      ?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
+  );
+}
+
+function hasDefaultModifier(node: ts.HasModifiers): boolean {
+  return (
+    ts
+      .getModifiers(node)
+      ?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword) ?? false
+  );
 }
 
 // Vite virtual-module suffix the SSR shim uses to read the original
@@ -120,11 +147,11 @@ function hasUseClientDirective(source: string): boolean {
 // recursively re-trigger this transform.
 export const ORIG_QUERY = "?plumix-orig";
 
-export interface TransformUseClientOptions {
+interface TransformUseClientOptions {
   readonly chunkUrl: string;
 }
 
-export interface TransformUseClientResult {
+interface TransformUseClientResult {
   readonly code: string;
 }
 


### PR DESCRIPTION
First slice of the new islands authoring primitive (parent PRD #545). The Vite plugin gains `"use client"` discovery: any `.tsx`/`.ts` module that opens with the directive becomes an island and its server-side import resolves to a shim that wraps the SSR'd output in `<plumix-island chunk-url=… component-export=… client=<strategy> props=<json> ssr="">`. The existing `defineBlock({ client })` discovery path is untouched — both coexist; the old path's removal lands in #548.

**Discovery scope**

Covers `export function|const|let|var|class X`, `export { Foo, Bar as Baz }`, and `export default`. Forbidden export names (`__proto__`, `constructor`, `prototype`) are dropped — same guard the existing `defineBlock` path enforces. The directive must lead the module per RSC semantics; stray statements before it disqualify the file.

**`?plumix-orig` virtual**

The shim imports the original code via `<file>?plumix-orig` so the inner SSR render runs unmodified user code. The plugin's `resolveId` and `load` serve the raw file at that virtual ID; `transform` short-circuits on it so the shim isn't recursively wrapped.

**Strategy + props handling**

- `client` JSX prop is destructured by the shim and forwarded as the wrapper's strategy attribute (`typeof client === "string" ? client : "load"`). The new `IslandProps<T>` helper types `client` as `PlumixStrategy | undefined` so authors get a compile error on unknown values, and the custom element dispatches `plumix:hydration-error` for unrecognized strategies at runtime — the shim itself doesn't re-validate.
- Everything else is `JSON.stringify`d into the `props=` attribute. Functions drop automatically as part of JSON serialization (documented limitation).

**`IslandProps<T>` TypeScript helper**

Exported from `@plumix/blocks`. Omits function-typed properties from `T` (catches the silent hydration drop at compile time) and reserves the `client` prop as `PlumixStrategy | undefined` (overrides any consumer-defined `client` slot). Four type-level tests via vitest's `expectTypeOf`.

**Scope deferred to follow-ups**

- Production chunk URL via Vite's `.vite/manifest.json` — dev path uses `/@fs<path>`.
- Conditional bootstrap script injection (today's islands MVP doesn't yet inject; the criterion remains open on the parent issue).
- Playwright e2e in `packages/admin/e2e/`.
- Slot/children bridge — separate slice #547.

The deferred items are individually scoped and won't block reviewing the discovery + shim mechanics this PR ships.

Refs #546
Refs #545

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>