### PR TITLE
feat(blocks): islands children + slot bridge via StaticHtml

### DIFF
--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -119,3 +119,6 @@ export type { MarkSpec } from "./marks/types.js";
 
 // ─── Islands authoring ──────────────────────────────────────────────────────
 export type { IslandProps, PlumixStrategy } from "./island-props.js";
+// Re-exported for the SSR shim the Vite plugin emits for `"use client"`
+// modules; not intended for direct theme/block-author consumption.
+export { serializeProps } from "./serialize.js";

--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -373,9 +373,7 @@ describe("PlumixIslandElement lifecycle", () => {
     expect(seen[0]?.label).toBe("x");
     // The slot value should now be a React element (the StaticHtml bridge)
     // — the simplest observable is `$$typeof === Symbol`.
-    const childrenProp = seen[0]?.children as
-      | { $$typeof?: symbol }
-      | undefined;
+    const childrenProp = seen[0]?.children as { $$typeof?: symbol } | undefined;
     expect(typeof childrenProp?.$$typeof).toBe("symbol");
   });
 

--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -342,6 +342,78 @@ describe("PlumixIslandElement lifecycle", () => {
     expect(PlumixIslandElement.observedAttributes).toContain("props");
   });
 
+  test("extracts SSR'd slot HTML and forwards it as a React-element prop on hydrate", async () => {
+    // When the SSR shim wraps a React-element prop in <plumix-static-slot>,
+    // the wrapper carries a `slots="<name>,<name>"` attribute listing
+    // those props. On hydrate the custom element finds each matching
+    // descendant and feeds its innerHTML back as a StaticHtml element
+    // bridged into the same prop slot.
+    const seen: Readonly<Record<string, unknown>>[] = [];
+    const Component = (props: Readonly<Record<string, unknown>>) => {
+      seen.push(props);
+      return null;
+    };
+    restoreImport = setDynamicImport(() =>
+      Promise.resolve({ default: Component } as unknown),
+    );
+    stubStrategies();
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "default",
+      opts: "{}",
+      props: serializeProps({ label: "x" }),
+      slots: "children",
+    });
+    // Drop a SSR'd slot inside the wrapper, as the server would emit.
+    el.innerHTML =
+      '<plumix-static-slot data-plumix-slot="children"><strong>child-text</strong></plumix-static-slot>';
+    document.body.appendChild(el);
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0]?.label).toBe("x");
+    // The slot value should now be a React element (the StaticHtml bridge)
+    // — the simplest observable is `$$typeof === Symbol`.
+    const childrenProp = seen[0]?.children as
+      | { $$typeof?: symbol }
+      | undefined;
+    expect(typeof childrenProp?.$$typeof).toBe("symbol");
+  });
+
+  test("nested-island slot is NOT claimed by the parent island", async () => {
+    // A nested <plumix-island> has its own <plumix-static-slot> child.
+    // The parent island's slot collector must filter via
+    // `closest('plumix-island') === this` so the inner slot doesn't get
+    // stolen and the nested island's children stay intact.
+    const seen: Readonly<Record<string, unknown>>[] = [];
+    const Component = (props: Readonly<Record<string, unknown>>) => {
+      seen.push(props);
+      return null;
+    };
+    restoreImport = setDynamicImport(() =>
+      Promise.resolve({ default: Component } as unknown),
+    );
+    stubStrategies();
+    const parent = makeIsland({
+      client: "load",
+      "chunk-url": "/p.js",
+      "component-export": "default",
+      opts: "{}",
+      props: serializeProps({}),
+      slots: "children",
+    });
+    parent.innerHTML = `
+      <plumix-island ssr="" client="load" chunk-url="/c.js" component-export="default" props="{}" slots="children">
+        <plumix-static-slot data-plumix-slot="children">child-slot</plumix-static-slot>
+      </plumix-island>
+    `;
+    document.body.appendChild(parent);
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    // Parent's children slot has no direct descendant <plumix-static-slot>
+    // it can claim (the only one belongs to the nested child), so its
+    // `children` prop is absent.
+    expect(seen[0]?.children).toBeUndefined();
+  });
+
   test("reads props from the `props` attribute and forwards them to the component", async () => {
     const seen: Readonly<Record<string, unknown>>[] = [];
     const Component = (props: Readonly<Record<string, unknown>>) => {

--- a/packages/blocks/src/island-element.ts
+++ b/packages/blocks/src/island-element.ts
@@ -19,6 +19,7 @@ import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
 import { deserializeProps } from "./serialize.js";
+import { StaticHtml } from "./static-html.js";
 
 export type IslandStrategy = (
   loadFn: () => Promise<void>,
@@ -193,7 +194,7 @@ export class PlumixIslandElement extends HTMLElement {
     }
     const Component = await this.loadComponent(chunkUrl, exportName);
     if (!Component) return;
-    const props = readProps(this);
+    const props = { ...readProps(this), ...readSlotProps(this) };
     this.hydrated = true;
     this.component = Component;
     this.root = createRoot(this);
@@ -283,6 +284,32 @@ function readProps(el: HTMLElement): Readonly<Record<string, unknown>> {
   const raw = el.getAttribute("props");
   if (!raw) return {};
   return deserializeProps(raw);
+}
+
+// React-element props (children + named slots) were wrapped in
+// <plumix-static-slot> at SSR and listed by name on `slots=`. On
+// hydrate, find each matching descendant and bridge its SSR'd HTML
+// back into the prop slot via <StaticHtml>. The closest('plumix-
+// island') === el guard filters nested-island slots so a parent
+// doesn't claim a child's.
+function readSlotProps(el: PlumixIslandElement): Record<string, unknown> {
+  const raw = el.getAttribute("slots");
+  if (!raw) return {};
+  const out: Record<string, unknown> = {};
+  for (const name of raw.split(",")) {
+    if (!name) continue;
+    const slot = Array.from(
+      el.querySelectorAll<HTMLElement>(
+        `plumix-static-slot[data-plumix-slot="${name}"]`,
+      ),
+    ).find((node) => node.closest(ISLAND_TAG) === el);
+    if (!slot) continue;
+    out[name] = createElement(StaticHtml, {
+      html: slot.innerHTML,
+      slotName: name,
+    });
+  }
+  return out;
 }
 
 export const ISLAND_TAG = "plumix-island";

--- a/packages/blocks/src/static-html.test.tsx
+++ b/packages/blocks/src/static-html.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { StaticHtml } from "./static-html.js";
+
+describe("StaticHtml", () => {
+  test("renders <plumix-static-slot> with the given inner HTML and slot name", () => {
+    const html = renderToStaticMarkup(
+      <StaticHtml html="<strong>x</strong>" slotName="children" />,
+    );
+    expect(html).toContain('<plumix-static-slot data-plumix-slot="children"');
+    expect(html).toContain("<strong>x</strong>");
+  });
+
+  test("defaults slotName to 'children' when omitted", () => {
+    const html = renderToStaticMarkup(<StaticHtml html="<em>y</em>" />);
+    expect(html).toContain('data-plumix-slot="children"');
+  });
+
+  test("memo() comparator always returns true — never re-renders on parent state change", () => {
+    // `React.memo(C, () => true)` short-circuits re-renders. We can't
+    // observe React's commit directly from SSR, but the memo comparator
+    // IS a public surface: invoking it must return true regardless of
+    // prop deltas. That's the contract the runtime depends on so the
+    // SSR'd HTML survives parent re-renders.
+    const Memoized = StaticHtml as unknown as {
+      compare?: (prev: unknown, next: unknown) => boolean;
+    };
+    // React stores the comparator on the component's `compare` slot for
+    // `memo(Component, compare)`. We invoke it with arbitrarily-different
+    // props to prove it always returns true.
+    expect(Memoized.compare).toBeDefined();
+    if (!Memoized.compare) return;
+    expect(
+      Memoized.compare(
+        { html: "<strong>a</strong>", slotName: "children" },
+        { html: "<em>b</em>", slotName: "caption" },
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/blocks/src/static-html.tsx
+++ b/packages/blocks/src/static-html.tsx
@@ -1,0 +1,24 @@
+// Bridges SSR'd HTML across the islands hydration boundary. Without an
+// RSC payload there's no way to pass live JSX as a prop into a client
+// island — this is the documented React 19 substitute, lifted from
+// Astro's `StaticHtml` (`packages/integrations/react/src/static-html.ts`,
+// Apache-2.0). The `memo(() => true)` comparator guarantees a parent
+// re-render never re-renders the static subtree.
+
+import { createElement, memo } from "react";
+
+interface StaticHtmlProps {
+  readonly html: string;
+  readonly slotName?: string;
+}
+
+export const StaticHtml = memo(
+  function StaticHtml({ html, slotName = "children" }: StaticHtmlProps) {
+    return createElement("plumix-static-slot", {
+      "data-plumix-slot": slotName,
+      dangerouslySetInnerHTML: { __html: html },
+      suppressHydrationWarning: true,
+    });
+  },
+  () => true,
+);

--- a/packages/plumix/src/vite/island-transform.test.ts
+++ b/packages/plumix/src/vite/island-transform.test.ts
@@ -308,10 +308,13 @@ describe("transformUseClientModule", () => {
     const result = transformUseClientModule(source, "/Action.tsx", {
       chunkUrl: "/Action.tsx",
     });
-    expect(result?.code).toContain("JSON.stringify(forward)");
-    // The shim must destructure `client` out before forwarding so the
+    // Props travel through `serializeProps` (plumix's tuple format)
+    // — the custom element's `deserializeProps` expects this shape
+    // so Date/Map/Set/etc. survive the round-trip.
+    expect(result?.code).toContain("__ser(rest)");
+    // The shim destructures `client` out before forwarding so the
     // strategy slot doesn't leak into the props attribute either.
-    expect(result?.code).toContain("const { client, ...forward }");
+    expect(result?.code).toContain("const { client, ...rest }");
   });
 
   test("returns null for files without the directive (no-op transform)", () => {
@@ -323,6 +326,27 @@ describe("transformUseClientModule", () => {
       chunkUrl: "/x.tsx",
     });
     expect(result).toBeNull();
+  });
+
+  test("shim wraps React-element props in <plumix-static-slot> and lists them on `slots`", () => {
+    const source = `
+      "use client";
+      export function Wrapper() { return null; }
+    `;
+    const result = transformUseClientModule(source, "/Wrapper.tsx", {
+      chunkUrl: "/Wrapper.tsx",
+    });
+    // The shim detects React elements via $$typeof === Symbol and wraps
+    // each in a <plumix-static-slot>. Slot names go on a `slots=`
+    // attribute so the custom element knows which descendants to extract
+    // at hydrate time.
+    expect(result?.code).toContain("$$typeof");
+    expect(result?.code).toContain('"plumix-static-slot"');
+    expect(result?.code).toContain('"slots"');
+    // Wrapped element props must NOT appear in the serialized `props=`
+    // attribute (they'd serialize to a meaningless object). Props go
+    // through `serializeProps` (plumix's tuple format).
+    expect(result?.code).toContain("__ser(rest)");
   });
 });
 

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -167,7 +167,32 @@ export function transformUseClientModule(
   const chunkUrl = JSON.stringify(options.chunkUrl);
   const lines: string[] = [
     `import { createElement as __c } from "react";`,
+    // Route props through `serializeProps` so Date/Map/Set/etc. survive
+    // the round-trip the custom element's `deserializeProps` expects.
+    // Plain JSON.stringify would silently coerce them.
+    `import { serializeProps as __ser } from "@plumix/blocks";`,
     `import * as __orig from ${origUrl};`,
+    // `wrapped` is the full prop set fed to the SSR'd Component (with
+    // React-element props replaced by <plumix-static-slot> wrappers).
+    // `rest` is the JSON-safe subset for the serialized `props=`
+    // attribute — element props are excluded and bridged via
+    // StaticHtml on hydrate.
+    `function __split(props) {`,
+    `  const { client, ...rest } = props ?? {};`,
+    `  const slots = [];`,
+    `  const wrapped = {};`,
+    `  for (const k of Object.keys(rest)) {`,
+    `    const v = rest[k];`,
+    `    if (v != null && typeof v === "object" && typeof v.$$typeof === "symbol") {`,
+    `      slots.push(k);`,
+    `      wrapped[k] = __c("plumix-static-slot", { "data-plumix-slot": k }, v);`,
+    `      delete rest[k];`,
+    `    } else {`,
+    `      wrapped[k] = v;`,
+    `    }`,
+    `  }`,
+    `  return { client, rest, wrapped, slots };`,
+    `}`,
   ];
   for (const finding of findings) {
     const name = finding.exportName;
@@ -176,20 +201,17 @@ export function transformUseClientModule(
     const exportPrefix = isDefault
       ? "export default function PlumixIsland(props)"
       : `export function ${name}(props)`;
-    // `client` is the framework-reserved strategy slot. `IslandProps<T>`
-    // guarantees the type at compile; if a consumer ignores the helper
-    // and passes garbage, the custom element dispatches
-    // `plumix:hydration-error` at runtime. No second guard here.
     lines.push(
       `${exportPrefix} {`,
-      `  const { client, ...forward } = props ?? {};`,
+      `  const { client, rest, wrapped, slots } = __split(props);`,
       `  return __c("plumix-island", {`,
       `    "chunk-url": ${chunkUrl},`,
       `    "component-export": ${targetLiteral},`,
       `    "client": typeof client === "string" ? client : "load",`,
-      `    "props": JSON.stringify(forward),`,
+      `    "props": __ser(rest),`,
+      `    "slots": slots.length ? slots.join(",") : null,`,
       `    "ssr": "",`,
-      `  }, __c(__orig[${targetLiteral}], forward));`,
+      `  }, __c(__orig[${targetLiteral}], wrapped));`,
       `}`,
     );
   }


### PR DESCRIPTION
Second slice of the islands authoring primitive (parent PRD #545). A `"use client"` component can now accept React-element props (`children` + named slots) and have them survive hydration without React 19 errors. A nested island inside the children hydrates with its own React root in correct top-down order — the existing parent-await guard from PR #543 already handles ordering; this slice adds the slot-bridge the parent's re-render needs so the DOM around the child stays intact.

**`StaticHtml` bridge**

Ported verbatim from Astro's `StaticHtml` (`packages/integrations/react/src/static-html.ts`, Apache-2.0). Three load-bearing pieces: `dangerouslySetInnerHTML` re-renders the exact SSR string, `suppressHydrationWarning` silences React 19's attribute check, and `memo(() => true)` ensures a parent re-render never re-renders the static subtree. Without an RSC bundler emitting a serialized payload this is the only documented React 19 mechanism for live JSX across a hydration boundary.

**Shim slot wrapping**

The Vite plugin's SSR shim now detects React-element props via `$$typeof === Symbol` and wraps each in `<plumix-static-slot data-plumix-slot="<propName>">`. The wrapped prop names are listed on a `slots="<comma-separated>"` attribute on the `<plumix-island>` wrapper. Wrapped props are excluded from the serialized `props=` attribute (they'd round-trip to a meaningless object otherwise).

**Custom element slot extraction**

`hydrate()` reads `slots=`, locates each matching `<plumix-static-slot>` descendant filtered by `closest('plumix-island') === this` (so nested-island slots aren't stolen by the parent), captures `innerHTML`, builds `<StaticHtml html={…} slotName={…} />`, and merges it into the props before `createRoot(this).render(<Component {...props} />)`.

**Serialization parity with the existing islands path**

Routes the shim's `props=` serialization through `serializeProps` (plumix's tuple format) instead of naked `JSON.stringify`. The custom element's `deserializeProps` expects the tuple shape, so Date / Map / Set / RegExp / URL / BigInt / typed-array props survive the round-trip — matches the existing `defineBlock({ client })` path. Re-exports `serializeProps` from `@plumix/blocks` for the SSR shim's generated import.

**Scope deferred**

Playwright e2e exercising the full SSR → browser hydration path for an island with nested children (acceptance criterion ~6). Unit-level coverage lands here; the cross-boundary e2e is the natural complement and matches the deferral pattern from slice #546.

Refs #547
Refs #545

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>