### PR TITLE
feat(plumix): islands prod chunk URLs + conditional bootstrap + e2e

### DIFF
--- a/examples/minimal/e2e/hmr.spec.ts
+++ b/examples/minimal/e2e/hmr.spec.ts
@@ -1,0 +1,47 @@
+// Verifies that editing a `"use client"` component file in dev mode
+// propagates on the next request. Vite's HMR machinery rebuilds the
+// served module; a full page reload re-fetches the SSR'd HTML + the
+// updated chunk. Live in-place HMR for hydrated islands is out of scope
+// (Astro / Next have the same constraint without RSC plumbing) — this
+// test just verifies "edits propagate on reload."
+
+import { readFile, writeFile } from "node:fs/promises";
+
+import { expect, test } from "@playwright/test";
+
+const COUNTER_PATH = "src/counter.tsx";
+
+test("editing the island source propagates to the next page load", async ({
+  page,
+}) => {
+  const original = await readFile(COUNTER_PATH, "utf8");
+  try {
+    // Baseline render.
+    await page.goto("/");
+    await expect(page.getByTestId("counter-header")).toHaveText("header: 0");
+
+    // Patch the source — change the label format.
+    await writeFile(
+      COUNTER_PATH,
+      original.replace(
+        "${props.label}: ${String(count)}",
+        "${props.label} count is ${String(count)}",
+      ),
+    );
+
+    // Give Vite a beat to invalidate, then reload.
+    await page.waitForTimeout(300);
+    await page.reload();
+    await expect(page.getByTestId("counter-header")).toHaveText(
+      "header count is 0",
+    );
+
+    // Hydration still works after the edit.
+    await page.getByTestId("counter-header").click();
+    await expect(page.getByTestId("counter-header")).toHaveText(
+      "header count is 1",
+    );
+  } finally {
+    await writeFile(COUNTER_PATH, original);
+  }
+});

--- a/examples/minimal/e2e/island-hydration.spec.ts
+++ b/examples/minimal/e2e/island-hydration.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+test("counter island hydrates from the dev server and click increments", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  await page.goto("http://localhost:5173/");
+  const btn = page.getByTestId("counter-header");
+  await expect(btn).toHaveText("header: 0");
+  await btn.click();
+  await expect(btn).toHaveText("header: 1");
+  await btn.click();
+  await expect(btn).toHaveText("header: 2");
+  expect(consoleErrors).toEqual([]);
+});
+
+test("page contains the islands runtime bootstrap script", async ({
+  request,
+}) => {
+  const html = await (await request.get("http://localhost:5173/")).text();
+  expect(html).toMatch(/<script type="module" src="[^"]*islands-entry\.ts"/);
+  expect(html).toContain("<plumix-island");
+});

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -13,12 +13,17 @@
   },
   "dependencies": {
     "@plumix/runtime-cloudflare": "workspace:*",
-    "plumix": "workspace:*"
+    "plumix": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
+    "@playwright/test": "^1.59.1",
     "@plumix/typescript-config": "workspace:*",
     "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
     "typescript": "catalog:",
     "wrangler": "catalog:"
   }

--- a/examples/minimal/playwright.config.ts
+++ b/examples/minimal/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:5173/",
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 60_000,
+  },
+  use: { baseURL: "http://localhost:5173/" },
+});

--- a/examples/minimal/plumix.config.ts
+++ b/examples/minimal/plumix.config.ts
@@ -5,6 +5,8 @@ import {
   d1,
 } from "@plumix/runtime-cloudflare";
 
+import { IndexTemplate } from "./src/template";
+
 // Derives `rpId` + `origin` from the Workers Builds env (`WORKERS_CI`,
 // `WORKERS_CI_BRANCH`): production deploys → `<worker>.<account>.workers.dev`,
 // preview deploys → `<branch>-<worker>.<account>.workers.dev`,
@@ -27,7 +29,5 @@ export default plumix({
       origin,
     },
   }),
-  // Noop placeholder — every Plumix app needs a theme. Replace with a
-  // real theme once you start rendering public routes.
-  theme: defineTheme({ templates: { index: () => null } }),
+  theme: defineTheme({ templates: { index: IndexTemplate } }),
 });

--- a/examples/minimal/src/counter.tsx
+++ b/examples/minimal/src/counter.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { createElement, useState } from "react";
+
+interface CounterProps {
+  readonly label: string;
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = useState(0);
+  return createElement(
+    "button",
+    {
+      "data-testid": `counter-${props.label}`,
+      onClick: () => {
+        setCount((n) => n + 1);
+      },
+      style: { padding: "0.5rem 1rem" },
+    },
+    `${props.label}: ${String(count)}`,
+  );
+}

--- a/examples/minimal/src/template.tsx
+++ b/examples/minimal/src/template.tsx
@@ -1,0 +1,37 @@
+// Uses `createElement` instead of JSX so the plumix config loader
+// (jiti) can parse this file when it pulls in the theme template.
+// JSX in `.tsx` files loaded via `import` from `plumix.config.ts`
+// trips jiti's TypeScript transformer; the Vite worker bundler does
+// support JSX, but the config-load pass runs through jiti.
+
+import { createElement } from "react";
+import type { ReactNode } from "react";
+
+import { Counter } from "./counter";
+
+export function IndexTemplate(): ReactNode {
+  return createElement(
+    "html",
+    { lang: "en" },
+    createElement(
+      "head",
+      null,
+      createElement("title", null, "Plumix minimal"),
+    ),
+    createElement(
+      "body",
+      null,
+      createElement(
+        "header",
+        { "data-testid": "theme-header" },
+        createElement("h1", null, "Plumix minimal"),
+        createElement(Counter, { label: "header" }),
+      ),
+      createElement(
+        "main",
+        null,
+        createElement("p", null, "Static content (no JS)."),
+      ),
+    ),
+  );
+}

--- a/examples/minimal/tsconfig.json
+++ b/examples/minimal/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@plumix/typescript-config/base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "types": ["node", "@cloudflare/workers-types"]
   },
-  "include": ["plumix.config.ts", ".plumix"]
+  "include": ["plumix.config.ts", "src", "e2e", ".plumix"]
 }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -65,6 +65,11 @@ const config: KnipConfig = {
         "src/admin/theme.css",
         "src/blocks/index.ts",
         "src/blocks/test.ts",
+        // The islands runtime entry is loaded by the consumer's
+        // generated `.plumix/islands-entry.ts` via `import
+        // "plumix/blocks/island-runtime"` — runtime import knip
+        // can't see.
+        "src/blocks/island-runtime.ts",
         "src/cli/index.ts",
         "src/fields/index.ts",
         "src/i18n/index.ts",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -15,6 +15,10 @@
     "./renderer": {
       "types": "./dist/renderer/index.d.ts",
       "default": "./dist/renderer/index.js"
+    },
+    "./island-runtime": {
+      "types": "./dist/island-runtime.d.ts",
+      "default": "./dist/island-runtime.js"
     }
   },
   "scripts": {

--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -51,8 +51,17 @@ describe("PlumixIslandElement lifecycle", () => {
     restoreImport = () => undefined;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     restoreImport();
+    // Detach any islands the test mounted so the React scheduler
+    // unmounts their roots before the next test (or vitest's jsdom
+    // teardown). React 19's scheduler queues work via setImmediate /
+    // MessageChannel; without a clean unmount + microtask drain, the
+    // deferred callback fires after jsdom is torn down and throws
+    // `ReferenceError: window is not defined`, which vitest reports as
+    // an unhandled error and fails the run.
+    document.body.innerHTML = "";
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
   test("connectedCallback invokes the registered `load` strategy", async () => {

--- a/packages/core/src/route/render/inject-islands-bootstrap.test.ts
+++ b/packages/core/src/route/render/inject-islands-bootstrap.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { injectIslandsBootstrap } from "./inject-islands-bootstrap.js";
+
+describe("injectIslandsBootstrap", () => {
+  test("returns the body unchanged when no <plumix-island> is present", () => {
+    const body = "<header><h1>Static</h1></header>";
+    expect(injectIslandsBootstrap(body, {}, "serve")).toBe(body);
+    expect(injectIslandsBootstrap(body, {}, "build")).toBe(body);
+  });
+
+  test("dev mode uses the source entry — manifest is ignored even when present", () => {
+    // A stale `dist/.vite/manifest.json` from a previous build must not
+    // leak hashed prod paths into dev responses.
+    const body = '<plumix-island chunk-url="/x"></plumix-island>';
+    const staleManifest = {
+      ".plumix/islands-entry.ts": {
+        file: "assets/plumix-islands-runtime.abc.js",
+        isEntry: true,
+      },
+    };
+    expect(injectIslandsBootstrap(body, staleManifest, "serve")).toContain(
+      '<script type="module" src="/.plumix/islands-entry.ts"></script>',
+    );
+  });
+
+  test("build mode uses the hashed manifest URL when present", () => {
+    const body = '<plumix-island chunk-url="/x"></plumix-island>';
+    const manifest = {
+      ".plumix/islands-entry.ts": {
+        file: "assets/plumix-islands-runtime-abc123.js",
+        isEntry: true,
+      },
+    };
+    expect(injectIslandsBootstrap(body, manifest, "build")).toContain(
+      '<script type="module" src="/assets/plumix-islands-runtime-abc123.js"></script>',
+    );
+  });
+
+  test("build mode falls back to the dev path when manifest entry is missing", () => {
+    // First-build edge: manifest exists but doesn't have the runtime
+    // entry yet (the cold-build ordering @cloudflare/vite-plugin
+    // produces). Don't break the page — emit the dev path so the page
+    // still hydrates locally even in this transient state.
+    const body = '<plumix-island chunk-url="/x"></plumix-island>';
+    expect(injectIslandsBootstrap(body, {}, "build")).toContain(
+      '<script type="module" src="/.plumix/islands-entry.ts"></script>',
+    );
+  });
+});

--- a/packages/core/src/route/render/inject-islands-bootstrap.ts
+++ b/packages/core/src/route/render/inject-islands-bootstrap.ts
@@ -1,0 +1,34 @@
+// Conditionally injects the islands runtime `<script>` tag into the
+// SSR'd body — only when the page contains at least one
+// `<plumix-island>`. Pages without islands ship zero JS.
+//
+// In dev (`serve`) the script src points at `/.plumix/islands-entry.ts`
+// — Vite serves the source directly via its dev-server middleware so
+// HMR works on full page reload. The asset manifest is intentionally
+// not consulted in dev mode because a stale `dist/.vite/manifest.json`
+// from a previous build would otherwise leak hashed prod paths into
+// dev responses.
+//
+// In build (`build`) the script src is the hashed asset path Vite
+// emitted for the `plumix-islands-runtime` Rollup input (registered as
+// `.plumix/islands-entry.ts` in the Vite plugin's
+// `rollupOptions.input`). Read from Vite's `.vite/manifest.json`.
+
+import type { AssetManifest } from "./asset-manifest.js";
+
+const DEV_ENTRY_PATH = "/.plumix/islands-entry.ts";
+const RUNTIME_MANIFEST_KEY = ".plumix/islands-entry.ts";
+
+export function injectIslandsBootstrap(
+  body: string,
+  manifest: AssetManifest,
+  command: "serve" | "build",
+): string {
+  if (!body.includes("<plumix-island")) return body;
+  let src = DEV_ENTRY_PATH;
+  if (command === "build") {
+    const entry = manifest[RUNTIME_MANIFEST_KEY];
+    if (entry?.file) src = "/" + entry.file;
+  }
+  return body + `<script type="module" src="${src}"></script>`;
+}

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -22,6 +22,7 @@ import type { ResolvedNode } from "./template-hierarchy.js";
 import { loadTemplateDeps } from "../../template-deps.js";
 import { normalizeTemplate } from "../../template.js";
 import { bundledCssTags } from "./asset-manifest.js";
+import { injectIslandsBootstrap } from "./inject-islands-bootstrap.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
 interface RenderArgs {
@@ -192,7 +193,14 @@ function renderTree({
 
   const bodyContent =
     scripts.bodyStart.map(scriptToHtml).join("") +
-    body +
+    injectIslandsBootstrap(
+      body,
+      assetManifest,
+      // `process.env.PLUMIX_DEV` is Vite-substituted at SSR-bundle time
+      // — non-empty in `plumix dev`, empty in `plumix build`. The
+      // plumix Vite plugin's `define` populates the literal.
+      process.env.PLUMIX_DEV ? "serve" : "build",
+    ) +
     scripts.bodyEnd.map(scriptToHtml).join("") +
     HYDRATION_SLOT;
 

--- a/packages/create-plumix-app/src/scaffold.ts
+++ b/packages/create-plumix-app/src/scaffold.ts
@@ -72,6 +72,10 @@ const PLUMIX_PACKAGE_VERSION = "^0.1.0";
 const CATALOG_RESOLUTIONS: Record<string, string> = {
   "@cloudflare/workers-types": "^4.20260421.1",
   "@types/node": "^24.12.2",
+  "@types/react": "^19.2.14",
+  "@types/react-dom": "^19.2.3",
+  react: "^19.2.6",
+  "react-dom": "^19.2.6",
   typescript: "^6.0.3",
   wrangler: "^4.86.0",
 };

--- a/packages/plumix/package.json
+++ b/packages/plumix/package.json
@@ -21,7 +21,7 @@
     "typescript",
     "headless-cms"
   ],
-  "sideEffects": false,
+  "sideEffects": ["./dist/blocks/island-runtime.js"],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -90,6 +90,10 @@
     "./blocks/test": {
       "types": "./dist/blocks/test.d.ts",
       "default": "./dist/blocks/test.js"
+    },
+    "./blocks/island-runtime": {
+      "types": "./dist/blocks/island-runtime.d.ts",
+      "default": "./dist/blocks/island-runtime.js"
     },
     "./schema": {
       "types": "./dist/schema/index.d.ts",

--- a/packages/plumix/package.json
+++ b/packages/plumix/package.json
@@ -21,7 +21,9 @@
     "typescript",
     "headless-cms"
   ],
-  "sideEffects": ["./dist/blocks/island-runtime.js"],
+  "sideEffects": [
+    "./dist/blocks/island-runtime.js"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/plumix/src/blocks/index.ts
+++ b/packages/plumix/src/blocks/index.ts
@@ -20,7 +20,11 @@ export {
   resolveBlockTransforms,
   expandBlockVariations,
   validateEntryContent,
+  // Re-exported for the SSR shim the Vite plugin generates for
+  // `"use client"` modules. Not intended for direct consumption.
+  serializeProps,
 } from "@plumix/blocks";
+export type { IslandProps, PlumixStrategy } from "@plumix/blocks";
 export type {
   BlockContext,
   BlockInput,

--- a/packages/plumix/src/blocks/island-runtime.ts
+++ b/packages/plumix/src/blocks/island-runtime.ts
@@ -1,0 +1,13 @@
+// Bridges the islands client runtime into the `plumix` package's
+// public exports so consumer apps don't need a direct dep on the
+// workspace-internal `@plumix/blocks`.
+//
+// `island-runtime.ts` runs `bootstrapIslandRuntime()` at module load
+// (registers the custom element + strategies). A bare `export *`
+// re-export here would strip the side effect through Rolldown's
+// tree-shake; the side-effect `import` below preserves it AND the
+// named exports.
+
+import "@plumix/blocks/island-runtime";
+
+export * from "@plumix/blocks/island-runtime";

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -61,11 +61,9 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
   let root = process.cwd();
   let publicDir = "";
   let configPath: string | undefined;
+  let command: "serve" | "build" = "serve";
   // Discovered at config() time so rollupOptions.input can be extended
-  // before Vite resolves entries. The list is also what the
-  // `virtual:plumix/island-manifest` virtual module's `load` hook reads
-  // to emit the Map<ComponentType, { chunkUrl, exportName }> the SSR
-  // walker uses for `<plumix-island>` wrapper emission.
+  // before Vite resolves entries.
   let islands: readonly DiscoveredIsland[] = [];
 
   return {
@@ -81,11 +79,18 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     // doesn't depend on `process.env` being populated — CF Workers'
     // process.env is empty by default and the helper would otherwise
     // fall back to localhost on every deployed request.
-    config(userConfig) {
+    config(userConfig, env) {
       const define = {
         "process.env.WORKERS_CI": JSON.stringify(process.env.WORKERS_CI ?? ""),
         "process.env.WORKERS_CI_BRANCH": JSON.stringify(
           process.env.WORKERS_CI_BRANCH ?? "",
+        ),
+        // Used by `injectIslandsBootstrap` to pick between the dev
+        // source-entry path and the hashed build manifest URL. Vite
+        // substitutes this literal at bundle time so the SSR worker
+        // gets a static boolean (no `process` lookup at runtime).
+        "process.env.PLUMIX_DEV": JSON.stringify(
+          env.command === "build" ? "" : "1",
         ),
       };
       // `build.manifest: true` makes Vite emit `<outDir>/.vite/manifest.json`,
@@ -100,17 +105,18 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
       // none is set (see packages/vite-plugin-cloudflare/src/build.ts).
       // Vite merges this with the CF plugin's config; the merged
       // result has both `manifest: true` and our entry input.
-      // Scan user source for block-side islands BEFORE Vite resolves
-      // entries. Each discovered island becomes its own rollupOptions
-      // input so Vite emits a content-hashed chunk per island
-      // (matches the asset pipeline from PRD #510 slice #514). The
-      // SSR worker imports `virtual:plumix/island-manifest` which
-      // resolves the chunk URL per component out of Vite's
-      // `manifest.json` post-build.
+      // Scan user source for islands BEFORE Vite resolves entries. Each
+      // `"use client"` module becomes its own `rollupOptions.input` so
+      // Vite emits one content-hashed chunk per island. The SSR shim
+      // resolves chunk URLs from Vite's `.vite/manifest.json` at build
+      // time (see `resolveIslandChunkUrl`).
       const scanRoot = userConfig.root ?? process.cwd();
       islands = scanUserSources(scanRoot);
       const islandInputs: Record<string, string> = {};
+      const seenSourcePaths = new Set<string>();
       for (const island of islands) {
+        if (seenSourcePaths.has(island.sourcePath)) continue;
+        seenSourcePaths.add(island.sourcePath);
         islandInputs[islandEntryName(island)] = island.sourcePath;
       }
       const environments = {
@@ -120,6 +126,11 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
             rollupOptions: {
               input: {
                 "plumix-client": ".plumix/client-entry.ts",
+                // Per-page islands runtime — bootstraps the custom element
+                // + strategies. Bundled as its own chunk so the SSR layer
+                // can inject `<script src="<hashed-url>">` only when the
+                // page contains at least one `<plumix-island>`.
+                "plumix-islands-runtime": ".plumix/islands-entry.ts",
                 ...islandInputs,
               },
             },
@@ -139,6 +150,7 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     configResolved(config) {
       root = config.root;
       publicDir = config.publicDir;
+      command = config.command;
     },
     resolveId(id, importer) {
       if (id === ASSET_MANIFEST_VIRTUAL_ID) return ASSET_MANIFEST_RESOLVED_ID;
@@ -175,9 +187,7 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
       if (id.endsWith(ORIG_QUERY)) return null;
       if (!id.endsWith(".tsx") && !id.endsWith(".ts")) return null;
       if (!code.includes("use client")) return null;
-      // Dev chunk URL. Production needs the hashed path from Vite's
-      // `.vite/manifest.json` — follow-up to this slice.
-      const chunkUrl = "/@fs" + id;
+      const chunkUrl = resolveIslandChunkUrl(id, command, root);
       const result = transformUseClientModule(code, id, { chunkUrl });
       return result ? { code: result.code, map: null } : null;
     },
@@ -271,6 +281,17 @@ async function regenerate(
   // hitting the config loader.
   const clientEntrySource = generateClientEntrySource(config.theme.css ?? []);
   writeIfChanged(resolve(cwd, ".plumix/client-entry.ts"), clientEntrySource);
+
+  // Always-emit islands runtime entry. The file is bundled as its own
+  // client chunk (`plumix-islands-runtime` in rollupOptions.input) so
+  // the SSR layer can inject `<script src="<hashed-url>">` only on
+  // pages that contain at least one `<plumix-island>`. Importing the
+  // runtime is a side-effect — it registers the custom element +
+  // strategies on `self.Plumix` + `customElements`.
+  writeIfChanged(
+    resolve(cwd, ".plumix/islands-entry.ts"),
+    `// Generated by plumix — do not edit.\nimport "plumix/blocks/island-runtime";\n`,
+  );
 
   const { manifest, registry } = await computeManifestAndRegistry(
     config.plugins,
@@ -508,6 +529,39 @@ function simpleHash(input: string): number {
     h = (h * 0x01000193) >>> 0;
   }
   return h >>> 0;
+}
+
+// Resolve a `"use client"` module's chunk URL for the shim's
+// `<plumix-island chunk-url="…">` attribute.
+//
+// Dev (`serve`): `/@fs<absolute-id>` — Vite serves the original
+// module via its dev-server middleware. The custom element's dynamic
+// `import()` loads it through Vite's module graph so HMR plumbing
+// works (full-page reload on edit; live patch isn't supported across
+// the island boundary).
+//
+// Build: look up the per-island Rollup input by its
+// `islandEntryName` and emit the hashed `file:` from Vite's
+// `.vite/manifest.json`. Falls back to `/@fs<id>` if the manifest
+// entry is missing (cold-build edge case the asset-manifest virtual
+// module already documents).
+export function resolveIslandChunkUrl(
+  id: string,
+  command: "serve" | "build",
+  rootDir: string,
+): string {
+  if (command === "serve") return "/@fs" + id;
+  const manifest = loadAssetManifest(rootDir) as Record<
+    string,
+    { file?: string } | undefined
+  >;
+  // Vite's manifest keys source paths relative to the project root,
+  // not by the `rollupOptions.input` name. Compute the relative POSIX
+  // path so the lookup matches.
+  const relativeId = relative(rootDir, id).replace(/\\/g, "/");
+  const entry = manifest[relativeId];
+  if (entry?.file) return "/" + entry.file;
+  return "/@fs" + id;
 }
 
 function loadAssetManifest(rootDir: string): unknown {

--- a/packages/plumix/src/vite/island-chunk-url.test.ts
+++ b/packages/plumix/src/vite/island-chunk-url.test.ts
@@ -1,0 +1,70 @@
+// Pure-function tests for `resolveIslandChunkUrl`. The helper is the
+// only thing the SSR shim relies on to bridge dev (`/@fs<id>` direct
+// module URL) and build (hashed chunk path from Vite's manifest).
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { resolveIslandChunkUrl } from "./index.js";
+
+describe("resolveIslandChunkUrl", () => {
+  test("dev mode returns /@fs<absolute-id>", () => {
+    const url = resolveIslandChunkUrl(
+      "/abs/path/to/counter.tsx",
+      "serve",
+      "/anything",
+    );
+    expect(url).toBe("/@fs/abs/path/to/counter.tsx");
+  });
+
+  describe("build mode", () => {
+    let root: string;
+
+    beforeEach(() => {
+      root = mkdtempSync(join(tmpdir(), "plumix-island-chunk-"));
+    });
+
+    afterEach(() => {
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    test("looks up the hashed chunk URL from Vite's manifest by source path relative to root", () => {
+      // Vite stores manifest entries keyed by source path relative to
+      // the project root — the rollupOptions.input name we registered
+      // (`island-<slug>-<hash>`) is only used as the chunk's `.name`,
+      // not as the manifest lookup key.
+      const id = join(root, "src", "counter.tsx");
+      const manifestDir = join(root, "dist", "client", ".vite");
+      mkdirSync(manifestDir, { recursive: true });
+      writeFileSync(
+        join(manifestDir, "manifest.json"),
+        JSON.stringify({
+          "src/counter.tsx": { file: "assets/counter.abc123.js" },
+        }),
+      );
+
+      expect(resolveIslandChunkUrl(id, "build", root)).toBe(
+        "/assets/counter.abc123.js",
+      );
+    });
+
+    test("falls back to /@fs<id> when the manifest entry is missing", () => {
+      // Empty manifest — happens on the first build before the client
+      // env has finished and the worker env's transform fires.
+      const id = join(root, "src", "counter.tsx");
+      const manifestDir = join(root, "dist", "client", ".vite");
+      mkdirSync(manifestDir, { recursive: true });
+      writeFileSync(join(manifestDir, "manifest.json"), JSON.stringify({}));
+
+      expect(resolveIslandChunkUrl(id, "build", root)).toBe("/@fs" + id);
+    });
+
+    test("falls back when no manifest file exists at all", () => {
+      // No `dist/.vite/manifest.json` — earliest cold-build state.
+      const id = join(root, "src", "counter.tsx");
+      expect(resolveIslandChunkUrl(id, "build", root)).toBe("/@fs" + id);
+    });
+  });
+});

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -134,7 +134,7 @@ export function transformUseClientModule(
     // Route props through `serializeProps` so Date/Map/Set/etc. survive
     // the round-trip the custom element's `deserializeProps` expects.
     // Plain JSON.stringify would silently coerce them.
-    `import { serializeProps as __ser } from "@plumix/blocks";`,
+    `import { serializeProps as __ser } from "plumix/blocks";`,
     `import * as __orig from ${origUrl};`,
     // `wrapped` is the full prop set fed to the SSR'd Component (with
     // React-element props replaced by <plumix-static-slot> wrappers).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,16 +141,31 @@ importers:
       plumix:
         specifier: workspace:*
         version: link:../../packages/plumix
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 4.20260520.1
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@plumix/typescript-config':
         specifier: workspace:*
         version: link:../../tooling/typescript
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".cache/tsbuildinfo.json", "dist/**"],
-      "env": ["WORKERS_CI", "WORKERS_CI_BRANCH"]
+      "env": ["WORKERS_CI", "WORKERS_CI_BRANCH", "PLUMIX_DEV"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Closes the three open follow-ups from the islands authoring slices (#546/#547/#548): production chunk URL resolution from Vite's manifest, conditional bootstrap script injection, and a real Playwright e2e running against the dev server.

**Production chunk URL resolution**

New `resolveIslandChunkUrl(id, command, root)` helper. Dev → `/@fs<id>` (Vite serves through its middleware). Build → reads `<root>/dist/client/.vite/manifest.json`, looks up by source path relative to root, returns the hashed asset path. Cold-build edge falls back to `/@fs<id>`. 4 unit tests cover all 4 branches.

**Islands runtime entry + Rollup input**

Plumix generates `.plumix/islands-entry.ts` (side-effect import that bootstraps the custom element + strategies). The Vite plugin registers it as `plumix-islands-runtime` in `rollupOptions.input` so Rolldown emits a content-hashed chunk (~187 KB / gz 59 KB — React is the bulk). The entry imports through a new `plumix/blocks/island-runtime` subpath export so consumers don't need `@plumix/blocks` as a direct dep. `sideEffects: false` on the plumix package is narrowed to `["./dist/blocks/island-runtime.js"]` so the bootstrap call survives tree-shake.

**Conditional bootstrap injection**

`injectIslandsBootstrap(body, manifest, command)` in `@plumix/core` runs inside `renderTree`. No `<plumix-island>` → no-op, page ships zero JS. Islands present + dev → `<script src="/.plumix/islands-entry.ts">`. Islands present + build → hashed manifest URL. 4 unit tests cover no-islands, dev (ignores stale build manifest), build with manifest, build with missing entry.

**Dev/build discriminator**

The plumix Vite plugin's `config()` hook derives `process.env.PLUMIX_DEV` from `env.command` and adds it to `define`. `renderTree` reads the Vite-substituted value to pick the dev or build path. Listed in `turbo.json` under `build.env`.

**Stale-manifest defense**

A prior `pnpm build` leaves `dist/client/.vite/manifest.json` on disk. Dev SSR would otherwise pick up those hashed paths and 404 the user on the next `pnpm dev`. Both the bootstrap injector and the per-island chunk URL resolver explicitly skip the manifest in `serve` mode.

**Public-route e2e (`examples/minimal`)**

The minimal example gains a `"use client"` Counter, a real index template that uses it, and a Playwright config. 3 scenarios verified:

| Scenario | Test |
|---|---|
| Counter hydrates from SSR, increments on click, zero console errors | `e2e/island-hydration.spec.ts` |
| Bootstrap `<script>` is present in the response when islands are on the page | same |
| Editing `src/counter.tsx` propagates on next page load + island re-hydrates | `e2e/hmr.spec.ts` |

Refs #545

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>