### PR TITLE
feat(blocks): per-block SSR loaders with TanStack-style type inference

### DIFF
--- a/docs/block-authoring.md
+++ b/docs/block-authoring.md
@@ -58,7 +58,9 @@ the slash menu, and the SSR `<EntryContent>` walker.
 | `inline` | no | Skip the wrapper `<div data-plumix-block>` and emit the rendered element bare. |
 | `transforms` | no | Convert-to / convert-from descriptors surfaced in the action bar. |
 | `variations` | no | Pre-set attr configurations surfaced as their own inserter entries. |
-| `render` | yes | React function that receives `{ attrs, context }` and returns the block UI. |
+| `render` | yes | React function that receives `{ attrs, context, loaders }` and returns the block UI. |
+| `loaders` | no | Per-block SSR data fetchers — see [Server-side data](#server-side-data). |
+| `errorFallback` | no | Renders in place of `render` when a loader rejects. |
 
 ## Inputs
 
@@ -146,6 +148,142 @@ transforms: {
 The reverse direction is derived automatically — if `B` declares a
 `transforms.to[].target === "A"`, then `A`'s action bar surfaces a
 "Transform to B" row computed from B's mapper inverse.
+
+## Server-side data
+
+A block that needs to fetch data at SSR — "latest 3 posts", "featured
+author", "trending tags in this category" — declares one or more
+`loaders`. Each loader is a function that receives the request's
+`AppContext` plus the block's `attrs` and returns a Promise. The
+walker pre-resolves every loader across the page in parallel before
+the React render pass; the resolved data flows into `render` as a
+typed `loaders` record.
+
+```tsx
+import { and, desc, eq } from "drizzle-orm";
+import { defineBlock, entries } from "plumix";
+
+export const latestPosts = defineBlock({
+  name: "acme/latest-posts",
+  inputs: [
+    { name: "count", type: "number", default: 3, label: "How many?" },
+  ],
+  loaders: {
+    posts: ({ ctx, attrs }) =>
+      ctx.db.query.entries.findMany({
+        where: eq(entries.kind, "post"),
+        orderBy: desc(entries.publishedAt),
+        limit: (attrs.count as number) ?? 3,
+      }),
+  },
+  render: ({ loaders }) => (
+    // `loaders.posts` is `Awaited<ReturnType<typeof posts>>` — full
+    // autocomplete on `p.title`, `p.slug`, etc.
+    <section>
+      <h2>Latest</h2>
+      <ul>
+        {loaders.posts.map((p) => (
+          <li key={p.id}><a href={p.slug}>{p.title}</a></li>
+        ))}
+      </ul>
+    </section>
+  ),
+});
+```
+
+Loader return types flow into `render`'s `loaders` prop automatically
+via `ResolvedLoaders<L>`. No `useLoaderData()` cast, no manual type
+imports — declare a loader returning `Promise<Post[]>`, get
+`loaders.posts: Post[]` in render.
+
+### Request data inside a loader
+
+`ctx.request` is a standard `Request` — pull query strings, headers,
+or cookies straight off it:
+
+```tsx
+loaders: {
+  results: ({ ctx, attrs }) => {
+    const url = new URL(ctx.request.url);
+    const q = url.searchParams.get("q") ?? "";
+    return ctx.db.query.entries.findMany({
+      where: like(entries.title, `%${q}%`),
+      limit: attrs.limit as number,
+    });
+  },
+},
+```
+
+The matched entity for a public route is on `ctx.resolvedEntity`. The
+authenticated user (if any) is on `ctx.user`; capability checks go
+through `ctx.auth.can(...)` as anywhere else.
+
+### Error handling
+
+A loader can throw — bad query, dropped connection, missing record.
+The walker catches per-block (one block's failure never 500s the
+page) and renders an optional `errorFallback` for that node only:
+
+```tsx
+defineBlock({
+  loaders: { posts: ... },
+  errorFallback: ({ attrs, error }) => (
+    <div role="status">Couldn't load posts: {(error as Error).message}</div>
+  ),
+  render: ({ loaders }) => ...,
+});
+```
+
+Without an `errorFallback`, the block emits nothing in production.
+Observability plugins subscribe to the `blocks:loader:error` hook to
+log/report rejections regardless of whether a fallback was provided.
+
+### Loaders + client islands
+
+A loader-using block can hand the SSR-resolved data straight to a
+`"use client"` component as initial state — the same prop-serialization
+machinery the islands shim uses elsewhere:
+
+```tsx
+render: ({ loaders }) => (
+  <SearchWidgetClient
+    initialPosts={loaders.initialPosts}
+    client="visible"
+  />
+),
+```
+
+The client component owns later refetches (filters, infinite scroll,
+etc.) via fetch / RPC / whatever fits — SSR loaders are one-shot per
+request.
+
+### Treat `attrs` as untrusted input
+
+The `attrs` record fed to a loader comes straight from the entry's
+stored block tree. Validate it before using it in a query — drizzle
+parameterizes values so SQLi is unlikely, but a hostile
+`attrs.limit = 10_000_000` is wide open. The recommended pattern is
+to parse with zod at the top of the loader and let the schema set the
+upper bound on numeric inputs.
+
+### No built-in timeout / concurrency cap
+
+v1 fires every loader on the page in parallel and waits on all of
+them. A slow query blocks the request indefinitely. If a real consumer
+hits this, pass an `AbortSignal` derived from `ctx.request.signal`
+manually inside the loader body and race against `setTimeout`.
+
+### What loaders are not
+
+- **Not request-scoped caching.** Two loaders that hit the same query
+  fire twice. Add a `ctx.cache` LRU yourself if a real consumer needs
+  dedup.
+- **Not React 19 `use(promise)`.** The walker pre-resolves; `render`
+  stays synchronous. No Suspense boundaries needed.
+- **Not for archive/taxonomy listings.** v1 only pre-resolves block
+  loaders on the single-entry path (`data.entry.content`). A theme
+  that renders `<BlockRenderer content={data.entries[i].content}/>`
+  in an archive sees empty `loaders` records for those blocks.
 
 ## Client islands
 

--- a/packages/admin/src/editor/block-adapter.ts
+++ b/packages/admin/src/editor/block-adapter.ts
@@ -28,6 +28,9 @@ export function blockSpecsToPuckComponents(
           spec.render({
             attrs: props,
             context: DEFAULT_BLOCK_CONTEXT,
+            // Admin preview has no SSR pass; loader data only flows
+            // through `renderBlockTree({ loaderData })` at the server.
+            loaders: {},
           }),
         ),
     };

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -1,3 +1,6 @@
+import type { ReactNode } from "react";
+
+import type { BlockLoaderRecord } from "./loaders.js";
 import type { BlockNodeComponent } from "./render-block-tree.js";
 
 export interface BlockInputOption {
@@ -54,6 +57,7 @@ export interface BlockSpec<
   Attrs extends Readonly<Record<string, unknown>> = Readonly<
     Record<string, unknown>
   >,
+  Loaders extends BlockLoaderRecord = BlockLoaderRecord,
 > {
   readonly name: string;
   readonly title?: string;
@@ -63,9 +67,20 @@ export interface BlockSpec<
   readonly category?: string;
   readonly inserter?: boolean;
   readonly inputs?: readonly BlockInput[];
-  readonly render: BlockNodeComponent<Attrs>;
+  readonly render: BlockNodeComponent<Attrs, Loaders>;
+  readonly loaders?: Loaders;
+  // Renders in place of `render` when a loader rejects. Without one,
+  // the walker emits nothing (same shape as the unknown-block path).
+  readonly errorFallback?: (args: {
+    readonly attrs: Attrs;
+    readonly error: unknown;
+  }) => ReactNode;
   readonly inline?: boolean;
-  readonly defaults?: Readonly<Partial<Attrs>>;
+  // `NoInfer` keeps `defaults` from driving `Attrs` inference at
+  // `defineBlock` — without it, `{ defaults: { text: "" } }` would
+  // narrow `Attrs` to `{ text: string }` even when `render` reads other
+  // keys. `defaults` checks against the inferred `Attrs`, doesn't bias it.
+  readonly defaults?: Readonly<Partial<NoInfer<Attrs>>>;
   readonly placeholder?: string;
   readonly capability?: string;
   readonly transforms?: BlockTransforms;
@@ -96,6 +111,19 @@ export function createBlockRegistry(
   });
 }
 
-export function defineBlock(spec: BlockSpec): BlockSpec {
-  return Object.freeze(spec);
+// Strong typing flows through the inline spec literal (so `render`
+// sees `loaders` typed from the `loaders` record, and `defaults` is
+// checked against `Attrs`). The return type widens to plain `BlockSpec`
+// because `BlockRegistry` stores a homogenized row and `BlockSpec` is
+// invariant in both generics. Same shape TanStack uses for
+// `match.loaderData`. `Attrs` defaults wide so call sites that read
+// extra keys from `attrs` aren't accidentally narrowed by `defaults`.
+export function defineBlock<
+  Attrs extends Readonly<Record<string, unknown>> = Readonly<
+    Record<string, unknown>
+  >,
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  Loaders extends BlockLoaderRecord = {},
+>(spec: BlockSpec<Attrs, Loaders>): BlockSpec {
+  return Object.freeze(spec) as unknown as BlockSpec;
 }

--- a/packages/blocks/src/define-block.test.ts
+++ b/packages/blocks/src/define-block.test.ts
@@ -1,0 +1,54 @@
+import { describe, expectTypeOf, test } from "vitest";
+
+import { defineBlock } from "./block-registry.js";
+
+describe("defineBlock type inference", () => {
+  test("loader return types flow into the render function's loaders param", () => {
+    // The inference target is `render`'s `loaders` arg at the spec-
+    // literal callsite. The returned `BlockSpec` is intentionally
+    // widened (`BlockSpec` is invariant in its generics, so a narrow
+    // return type wouldn't fit `BlockRegistry`'s homogenized row).
+    // Strong typing lives inside the spec literal, exactly where the
+    // block author needs it.
+    defineBlock({
+      name: "acme/typed",
+      render: ({ loaders }) => {
+        expectTypeOf(loaders.posts).toEqualTypeOf<readonly string[]>();
+        expectTypeOf(loaders.featured).toEqualTypeOf<number | null>();
+        return null;
+      },
+      loaders: {
+        posts: () => Promise.resolve(["a", "b"] as readonly string[]),
+        featured: (): Promise<number | null> => Promise.resolve(null),
+      },
+    });
+  });
+
+  test("loaders param is a known empty record when no loaders are declared", () => {
+    defineBlock({
+      name: "acme/no-loaders",
+      render: ({ loaders }) => {
+        expectTypeOf<keyof typeof loaders>().toEqualTypeOf<never>();
+        // `loaders` used in the type assertion above; runtime ref so
+        // lint sees the value used, not just the type.
+        void loaders;
+        return null;
+      },
+    });
+  });
+
+  test("`defaults` checks against the inferred `Attrs` but does not drive its inference", () => {
+    // The `NoInfer` wrapper on `defaults` means it can't narrow `Attrs`.
+    // `render` reads `attrs.somethingElse` — if `defaults` drove inference,
+    // `Attrs` would narrow to `{ text: string }` and this would be a type
+    // error. It isn't.
+    defineBlock({
+      name: "acme/defaults-no-narrow",
+      defaults: { text: "" },
+      render: ({ attrs }) => {
+        void (attrs.somethingElse as string | undefined);
+        return null;
+      },
+    });
+  });
+});

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -39,6 +39,20 @@ export type {
 export { isEntryContent } from "./entry-content.js";
 export type { EntryContent } from "./entry-content.js";
 
+// ─── Per-block SSR loaders ──────────────────────────────────────────────────
+export { collectLoaderEntries, resolveBlockLoaders } from "./loaders.js";
+export type {
+  BlockLoaderArgs,
+  BlockLoaderFn,
+  BlockLoaderRecord,
+  LoaderEntry,
+  LoaderErrorEvent,
+  ResolveBlockLoadersOptions,
+  ResolvedBlockLoaderData,
+  ResolvedBlockLoaders,
+  ResolvedLoaders,
+} from "./loaders.js";
+
 // ─── Transforms + insertable expansion ─────────────────────────────────────
 export { resolveBlockTransforms } from "./transforms.js";
 export type { ResolvedTransformTarget } from "./transforms.js";

--- a/packages/blocks/src/loaders.test.ts
+++ b/packages/blocks/src/loaders.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "vitest";
 
-import type { BlockNode } from "./render-block-tree.js";
 import type { BlockLoaderArgs } from "./loaders.js";
-import { collectLoaderEntries, resolveBlockLoaders } from "./loaders.js";
+import type { BlockNode } from "./render-block-tree.js";
 import { createBlockRegistry } from "./block-registry.js";
+import { collectLoaderEntries, resolveBlockLoaders } from "./loaders.js";
 
 describe("collectLoaderEntries", () => {
   test("returns empty list when no block in the tree declares loaders", () => {
@@ -189,14 +189,19 @@ describe("resolveBlockLoaders", () => {
       { id: "n1", name: "acme/two-loaders", attrs: {} },
     ];
 
-    await resolveBlockLoaders(tree, registry, {}, {
-      onLoaderError: ({ spec, key, error }) =>
-        events.push({
-          name: spec.name,
-          key,
-          message: (error as Error).message,
-        }),
-    });
+    await resolveBlockLoaders(
+      tree,
+      registry,
+      {},
+      {
+        onLoaderError: ({ spec, key, error }) =>
+          events.push({
+            name: spec.name,
+            key,
+            message: (error as Error).message,
+          }),
+      },
+    );
 
     expect(events).toEqual([
       { name: "acme/two-loaders", key: "bad", message: "kaboom" },

--- a/packages/blocks/src/loaders.test.ts
+++ b/packages/blocks/src/loaders.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "./render-block-tree.js";
+import type { BlockLoaderArgs } from "./loaders.js";
+import { collectLoaderEntries, resolveBlockLoaders } from "./loaders.js";
+import { createBlockRegistry } from "./block-registry.js";
+
+describe("collectLoaderEntries", () => {
+  test("returns empty list when no block in the tree declares loaders", () => {
+    const registry = createBlockRegistry([
+      { name: "core/heading", render: () => null },
+    ]);
+    const tree: readonly BlockNode[] = [
+      { id: "h1", name: "core/heading", attrs: {} },
+    ];
+
+    expect(collectLoaderEntries(tree, registry)).toEqual([]);
+  });
+
+  test("recurses into slot-children to find nested loader-bearing blocks", () => {
+    const registry = createBlockRegistry([
+      { name: "core/group", render: () => null },
+      {
+        name: "acme/posts",
+        render: () => null,
+        loaders: { posts: () => Promise.resolve([]) },
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      {
+        id: "g1",
+        name: "core/group",
+        attrs: {
+          children: [
+            { id: "nested", name: "acme/posts", attrs: {} },
+          ] as readonly BlockNode[],
+        },
+      },
+    ];
+
+    const entries = collectLoaderEntries(tree, registry);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.nodeId).toBe("nested");
+  });
+
+  test("emits one entry per block whose spec declares loaders", () => {
+    const fetchPosts = () => Promise.resolve([{ id: 1 }]);
+    const registry = createBlockRegistry([
+      { name: "core/heading", render: () => null },
+      {
+        name: "acme/posts",
+        render: () => null,
+        loaders: { posts: fetchPosts },
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      { id: "h1", name: "core/heading", attrs: {} },
+      { id: "p1", name: "acme/posts", attrs: {} },
+    ];
+
+    const entries = collectLoaderEntries(tree, registry);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.nodeId).toBe("p1");
+    expect(entries[0]?.spec.name).toBe("acme/posts");
+  });
+});
+
+describe("resolveBlockLoaders", () => {
+  test("returns the resolved data keyed by node id", async () => {
+    const registry = createBlockRegistry([
+      {
+        name: "acme/posts",
+        render: () => null,
+        loaders: { posts: () => Promise.resolve(["a", "b"]) },
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      { id: "p1", name: "acme/posts", attrs: {} },
+    ];
+
+    const resolved = await resolveBlockLoaders(tree, registry, {});
+
+    expect(resolved.get("p1")).toEqual({
+      loaders: { posts: ["a", "b"] },
+      error: null,
+    });
+  });
+
+  test("fires every loader on the tree in parallel, not serially", async () => {
+    const sleep = (ms: number) =>
+      new Promise<number>((r) => setTimeout(() => r(ms), ms));
+    const registry = createBlockRegistry([
+      {
+        name: "acme/slow-a",
+        render: () => null,
+        loaders: { v: () => sleep(40) },
+      },
+      {
+        name: "acme/slow-b",
+        render: () => null,
+        loaders: { v: () => sleep(40) },
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      { id: "a", name: "acme/slow-a", attrs: {} },
+      { id: "b", name: "acme/slow-b", attrs: {} },
+    ];
+
+    const startedAt = Date.now();
+    await resolveBlockLoaders(tree, registry, {});
+    const elapsed = Date.now() - startedAt;
+
+    expect(elapsed).toBeLessThan(80);
+  });
+
+  test("isolates a synchronously-thrown loader from sibling blocks", async () => {
+    const registry = createBlockRegistry([
+      {
+        name: "acme/sync-throw",
+        render: () => null,
+        // Throws before returning a Promise — easy to do by accident
+        // when the loader body forgets `await` and dereferences an
+        // unexpected null.
+        loaders: {
+          v: () => {
+            throw new Error("sync-fail");
+          },
+        },
+      },
+      {
+        name: "acme/fine",
+        render: () => null,
+        loaders: { v: () => Promise.resolve("ok") },
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      { id: "x", name: "acme/sync-throw", attrs: {} },
+      { id: "y", name: "acme/fine", attrs: {} },
+    ];
+
+    const resolved = await resolveBlockLoaders(tree, registry, {});
+
+    expect((resolved.get("x")?.error as Error).message).toBe("sync-fail");
+    expect(resolved.get("y")?.error).toBeNull();
+    expect(resolved.get("y")?.loaders).toEqual({ v: "ok" });
+  });
+
+  test("isolates per-block loader rejections from sibling blocks", async () => {
+    const registry = createBlockRegistry([
+      {
+        name: "acme/breaks",
+        render: () => null,
+        loaders: { v: () => Promise.reject(new Error("nope")) },
+      },
+      {
+        name: "acme/fine",
+        render: () => null,
+        loaders: { v: () => Promise.resolve("ok") },
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      { id: "x", name: "acme/breaks", attrs: {} },
+      { id: "y", name: "acme/fine", attrs: {} },
+    ];
+
+    const resolved = await resolveBlockLoaders(tree, registry, {});
+
+    expect(resolved.get("x")?.error).toBeInstanceOf(Error);
+    expect(resolved.get("x")?.loaders).toEqual({});
+    expect(resolved.get("y")?.error).toBeNull();
+    expect(resolved.get("y")?.loaders).toEqual({ v: "ok" });
+  });
+
+  test("invokes onLoaderError for each rejected loader with block context", async () => {
+    const events: { name: string; key: string; message: string }[] = [];
+    const registry = createBlockRegistry([
+      {
+        name: "acme/two-loaders",
+        render: () => null,
+        loaders: {
+          ok: () => Promise.resolve("fine"),
+          bad: () => Promise.reject(new Error("kaboom")),
+        },
+      },
+    ]);
+    const tree: readonly BlockNode[] = [
+      { id: "n1", name: "acme/two-loaders", attrs: {} },
+    ];
+
+    await resolveBlockLoaders(tree, registry, {}, {
+      onLoaderError: ({ spec, key, error }) =>
+        events.push({
+          name: spec.name,
+          key,
+          message: (error as Error).message,
+        }),
+    });
+
+    expect(events).toEqual([
+      { name: "acme/two-loaders", key: "bad", message: "kaboom" },
+    ]);
+  });
+
+  test("passes ctx and node attrs into each loader", async () => {
+    let seenCtx: unknown;
+    let seenAttrs: unknown;
+    const registry = createBlockRegistry([
+      {
+        name: "acme/echo",
+        render: () => null,
+        loaders: {
+          v: ({ ctx, attrs }: BlockLoaderArgs) => {
+            seenCtx = ctx;
+            seenAttrs = attrs;
+            return Promise.resolve("ok");
+          },
+        },
+      },
+    ]);
+    const ctx = { request: new Request("https://example.test/?q=foo") };
+    const tree: readonly BlockNode[] = [
+      { id: "e", name: "acme/echo", attrs: { foo: 1 } },
+    ];
+
+    await resolveBlockLoaders(tree, registry, ctx);
+
+    expect(seenCtx).toBe(ctx);
+    expect(seenAttrs).toEqual({ foo: 1 });
+  });
+});

--- a/packages/blocks/src/loaders.ts
+++ b/packages/blocks/src/loaders.ts
@@ -1,0 +1,144 @@
+import type { BlockRegistry, BlockSpec } from "./block-registry.js";
+import type { BlockNode } from "./render-block-tree.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+
+// `ctx` is `unknown` here because `@plumix/blocks` can't depend on
+// `@plumix/core` (where `AppContext` lives) — core depends on blocks.
+// Block authors typically widen it themselves or pull from a typed
+// re-export at the consumer boundary.
+export interface BlockLoaderArgs {
+  readonly ctx: unknown;
+  readonly attrs: Readonly<Record<string, unknown>>;
+}
+
+export type BlockLoaderFn = (args: BlockLoaderArgs) => Promise<unknown>;
+export type BlockLoaderRecord = Readonly<Record<string, BlockLoaderFn>>;
+
+// Maps a loader record to the shape `render` sees after SSR resolution
+// (one loader fn → its awaited return type, keyed the same way). Same
+// pattern as TanStack Router's `ResolveLoaderData`.
+export type ResolvedLoaders<L extends BlockLoaderRecord> = {
+  readonly [K in keyof L]: Awaited<ReturnType<L[K]>>;
+};
+
+export interface LoaderEntry {
+  readonly nodeId: string;
+  readonly node: BlockNode;
+  readonly spec: BlockSpec;
+}
+
+// Resolved data for one block. On success: `loaders` carries the
+// resolved record, `error` is `null`. On any rejection: `loaders` is
+// `{}`, `error` carries the first rejection (per-block isolation —
+// siblings are unaffected).
+export interface ResolvedBlockLoaderData {
+  readonly loaders: Readonly<Record<string, unknown>>;
+  readonly error: unknown;
+}
+
+export type ResolvedBlockLoaders = ReadonlyMap<string, ResolvedBlockLoaderData>;
+
+export function collectLoaderEntries(
+  nodes: readonly BlockNode[],
+  registry: BlockRegistry,
+): readonly LoaderEntry[] {
+  const out: LoaderEntry[] = [];
+  collectInto(nodes, registry, out);
+  return out;
+}
+
+function collectInto(
+  nodes: readonly BlockNode[],
+  registry: BlockRegistry,
+  out: LoaderEntry[],
+): void {
+  for (const node of nodes) {
+    const spec = registry.get(node.name);
+    if (spec?.loaders) out.push({ nodeId: node.id, node, spec });
+    if (!node.attrs) continue;
+    for (const value of Object.values(node.attrs)) {
+      if (isBlockNodeArray(value)) collectInto(value, registry, out);
+    }
+  }
+}
+
+export interface LoaderErrorEvent {
+  readonly spec: BlockSpec;
+  readonly node: BlockNode;
+  readonly key: string;
+  readonly error: unknown;
+}
+
+export interface ResolveBlockLoadersOptions {
+  // Fires once per rejected loader (not once per block). Used by the
+  // core dispatcher to bridge into the `blocks:loader:error` filter —
+  // blocks can't depend on core's hook system, so the wire-up lives at
+  // the dispatcher layer.
+  readonly onLoaderError?: (event: LoaderErrorEvent) => void;
+}
+
+// Walks the block tree, fires every declared loader in parallel, and
+// returns a map keyed by node id. Per-block isolation: one rejected
+// loader doesn't fail siblings — its block ends up with `loaders: {}`
+// and `error: <first-rejection-in-declaration-order>`.
+export async function resolveBlockLoaders(
+  nodes: readonly BlockNode[],
+  registry: BlockRegistry,
+  ctx: unknown,
+  options: ResolveBlockLoadersOptions = {},
+): Promise<ResolvedBlockLoaders> {
+  const entries = collectLoaderEntries(nodes, registry);
+  if (entries.length === 0) return new Map();
+  const resolved = await Promise.all(
+    entries.map(async (entry) => {
+      const data = await resolveEntry(entry, ctx, options.onLoaderError);
+      return [entry.nodeId, data] as const;
+    }),
+  );
+  return new Map(resolved);
+}
+
+async function resolveEntry(
+  entry: LoaderEntry,
+  ctx: unknown,
+  onLoaderError: ((event: LoaderErrorEvent) => void) | undefined,
+): Promise<ResolvedBlockLoaderData> {
+  // `Promise.resolve().then(...)` traps a synchronous throw from `fn`
+  // and re-routes it through `.then`'s rejection branch. Without this,
+  // a sync throw escapes the `Promise.all` below and rejects the entire
+  // `resolveBlockLoaders` call — breaking the per-block isolation
+  // contract. Order-preserving: `firstError` is the first rejection in
+  // declaration order, not first-by-time.
+  const settled = await Promise.all(
+    Object.entries(entry.spec.loaders ?? {}).map(([key, fn]) =>
+      Promise.resolve()
+        .then(() => fn({ ctx, attrs: entry.node.attrs ?? {} }))
+        .then(
+          (value): SettledLoader => ({ key, ok: true, value }),
+          (reason: unknown): SettledLoader => ({ key, ok: false, reason }),
+        ),
+    ),
+  );
+  const loaders: Record<string, unknown> = {};
+  let firstError: unknown = null;
+  for (const item of settled) {
+    if (item.ok) {
+      loaders[item.key] = item.value;
+      continue;
+    }
+    if (firstError === null) firstError = item.reason;
+    onLoaderError?.({
+      spec: entry.spec,
+      node: entry.node,
+      key: item.key,
+      error: item.reason,
+    });
+  }
+  return firstError === null
+    ? { loaders, error: null }
+    : { loaders: {}, error: firstError };
+}
+
+type SettledLoader =
+  | { readonly key: string; readonly ok: true; readonly value: unknown }
+  | { readonly key: string; readonly ok: false; readonly reason: unknown };

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -2,8 +2,8 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import type { BlockContext, BlockNode } from "./render-block-tree.js";
 import type { ResolvedBlockLoaders } from "./loaders.js";
+import type { BlockContext, BlockNode } from "./render-block-tree.js";
 import { createBlockRegistry } from "./block-registry.js";
 import { renderBlockTree } from "./render-block-tree.js";
 
@@ -598,9 +598,7 @@ describe("renderBlockTree", () => {
       ]);
 
       const html = withProductionEnv(() =>
-        renderToStaticMarkup(
-          renderBlockTree(tree, registry, { loaderData }),
-        ),
+        renderToStaticMarkup(renderBlockTree(tree, registry, { loaderData })),
       );
 
       expect(html).toBe("");

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import type { BlockContext, BlockNode } from "./render-block-tree.js";
+import type { ResolvedBlockLoaders } from "./loaders.js";
 import { createBlockRegistry } from "./block-registry.js";
 import { renderBlockTree } from "./render-block-tree.js";
 
@@ -506,6 +507,104 @@ describe("renderBlockTree", () => {
       expect(html).toContain('data-plumix-unknown-block="acme/missing"');
       expect(html).toContain('data-plumix-unknown-block="acme/other"');
       expect(warn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("loader data", () => {
+    test("passes resolved loader data into the block's render fn", () => {
+      let seen: unknown;
+      const registry = createBlockRegistry([
+        {
+          name: "acme/needs-data",
+          render: ({ loaders }) => {
+            seen = loaders;
+            return null;
+          },
+          loaders: { posts: () => Promise.resolve([]) },
+        },
+      ]);
+      const tree: readonly BlockNode[] = [
+        { id: "n1", name: "acme/needs-data", attrs: {} },
+      ];
+      const loaderData: ResolvedBlockLoaders = new Map([
+        ["n1", { loaders: { posts: ["a", "b"] }, error: null }],
+      ]);
+
+      renderToStaticMarkup(renderBlockTree(tree, registry, { loaderData }));
+
+      expect(seen).toEqual({ posts: ["a", "b"] });
+    });
+
+    test("passes an empty record when the resolver has no entry for the node", () => {
+      let seen: unknown;
+      const registry = createBlockRegistry([
+        {
+          name: "acme/loaderless",
+          render: ({ loaders }) => {
+            seen = loaders;
+            return null;
+          },
+        },
+      ]);
+      const tree: readonly BlockNode[] = [
+        { id: "l1", name: "acme/loaderless", attrs: {} },
+      ];
+
+      renderToStaticMarkup(renderBlockTree(tree, registry));
+
+      expect(seen).toEqual({});
+    });
+
+    test("invokes errorFallback when the node's loader rejected", () => {
+      const registry = createBlockRegistry([
+        {
+          name: "acme/risky",
+          render: () => "should-not-render",
+          errorFallback: ({ error }) => `oops: ${(error as Error).message}`,
+          loaders: { v: () => Promise.resolve(null) },
+        },
+      ]);
+      const tree: readonly BlockNode[] = [
+        { id: "r1", name: "acme/risky", attrs: {} },
+      ];
+      const loaderData: ResolvedBlockLoaders = new Map([
+        ["r1", { loaders: {}, error: new Error("boom") }],
+      ]);
+
+      const html = renderToStaticMarkup(
+        renderBlockTree(tree, registry, { loaderData }),
+      );
+
+      expect(html).toContain("oops: boom");
+      expect(html).not.toContain("should-not-render");
+    });
+
+    test("renders nothing in production when a loader rejected and no errorFallback is declared", () => {
+      const warn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      const registry = createBlockRegistry([
+        {
+          name: "acme/risky-silent",
+          render: () => "should-not-render",
+          loaders: { v: () => Promise.resolve(null) },
+        },
+      ]);
+      const tree: readonly BlockNode[] = [
+        { id: "r2", name: "acme/risky-silent", attrs: {} },
+      ];
+      const loaderData: ResolvedBlockLoaders = new Map([
+        ["r2", { loaders: {}, error: new Error("boom") }],
+      ]);
+
+      const html = withProductionEnv(() =>
+        renderToStaticMarkup(
+          renderBlockTree(tree, registry, { loaderData }),
+        ),
+      );
+
+      expect(html).toBe("");
+      expect(warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -2,6 +2,11 @@ import type { ReactNode } from "react";
 import { createElement, Fragment } from "react";
 
 import type { BlockRegistry } from "./block-registry.js";
+import type {
+  BlockLoaderRecord,
+  ResolvedBlockLoaders,
+  ResolvedLoaders,
+} from "./loaders.js";
 import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
 import type { ThemeTokens } from "./styles/types.js";
 import { emitBlockStyleCss } from "./styles/style-emitter.js";
@@ -46,18 +51,22 @@ export interface BlockRenderHooks {
 export interface RenderBlockTreeOptions {
   readonly tokens?: ThemeTokens;
   readonly hooks?: BlockRenderHooks;
+  readonly loaderData?: ResolvedBlockLoaders;
 }
 
 export interface BlockNodeRenderProps<
   Attrs = Readonly<Record<string, unknown>>,
+  Loaders extends BlockLoaderRecord = BlockLoaderRecord,
 > {
   readonly attrs: Attrs;
   readonly context: BlockContext;
+  readonly loaders: ResolvedLoaders<Loaders>;
 }
 
-export type BlockNodeComponent<Attrs = Readonly<Record<string, unknown>>> = (
-  props: BlockNodeRenderProps<Attrs>,
-) => ReactNode;
+export type BlockNodeComponent<
+  Attrs = Readonly<Record<string, unknown>>,
+  Loaders extends BlockLoaderRecord = BlockLoaderRecord,
+> = (props: BlockNodeRenderProps<Attrs, Loaders>) => ReactNode;
 
 export const DEFAULT_BLOCK_CONTEXT: BlockContext = Object.freeze({
   entry: null,
@@ -113,55 +122,48 @@ export function isBlockNodeArray(
 
 function materializeSlots(
   attrs: Readonly<Record<string, unknown>>,
-  registry: BlockRegistry,
-  devState: DevWarnState,
+  env: WalkerEnv,
   childContext: BlockContext,
-  tokens: ThemeTokens | undefined,
-  hooks: BlockRenderHooks | undefined,
 ): Readonly<Record<string, unknown>> {
   let materialized: Record<string, unknown> | undefined;
   for (const [key, value] of Object.entries(attrs)) {
     if (isBlockNodeArray(value)) {
       materialized ??= { ...attrs };
       materialized[key] = function SlotComponent() {
-        return renderNodes(
-          value,
-          registry,
-          devState,
-          childContext,
-          tokens,
-          hooks,
-        );
+        return renderNodes(value, env, childContext);
       };
     }
   }
   return materialized ?? attrs;
 }
 
+interface WalkerEnv {
+  readonly registry: BlockRegistry;
+  readonly devState: DevWarnState;
+  readonly tokens: ThemeTokens | undefined;
+  readonly hooks: BlockRenderHooks | undefined;
+  readonly loaderData: ResolvedBlockLoaders | undefined;
+}
+
 function renderNodes(
   nodes: readonly BlockNode[],
-  registry: BlockRegistry,
-  devState: DevWarnState,
+  env: WalkerEnv,
   context: BlockContext,
-  tokens: ThemeTokens | undefined,
-  hooks: BlockRenderHooks | undefined,
 ): ReactNode {
   return nodes.map((node) => {
-    hooks?.beforeRender?.(node, context);
-    const result = renderNode(node, registry, devState, context, tokens, hooks);
-    hooks?.afterRender?.(node, context);
+    env.hooks?.beforeRender?.(node, context);
+    const result = renderNode(node, env, context);
+    env.hooks?.afterRender?.(node, context);
     return result;
   });
 }
 
 function renderNode(
   node: BlockNode,
-  registry: BlockRegistry,
-  devState: DevWarnState,
+  env: WalkerEnv,
   context: BlockContext,
-  tokens: ThemeTokens | undefined,
-  hooks: BlockRenderHooks | undefined,
 ): ReactNode {
+  const { registry, devState, tokens, loaderData } = env;
   const spec = registry.get(node.name);
   if (!spec) {
     return createElement(
@@ -175,15 +177,19 @@ function renderNode(
     parent: node.name,
     depth: context.depth + 1,
   };
-  const attrs = materializeSlots(
-    node.attrs ?? {},
-    registry,
-    devState,
-    childContext,
-    tokens,
-    hooks,
-  );
-  const rendered = createElement(spec.render, { attrs, context });
+  const attrs = materializeSlots(node.attrs ?? {}, env, childContext);
+  const data = loaderData?.get(node.id);
+  let rendered: ReactNode;
+  if (data && data.error !== null) {
+    // Same shape as the unknown-block path: emit nothing when the block
+    // didn't declare a fallback. Observability flows through the
+    // `blocks:loader:error` hook, not a console warn here.
+    if (!spec.errorFallback) return createElement(Fragment, { key: node.id });
+    rendered = spec.errorFallback({ attrs, error: data.error });
+  } else {
+    const loaders = data?.loaders ?? EMPTY_LOADERS;
+    rendered = createElement(spec.render, { attrs, context, loaders });
+  }
   if (spec.inline) {
     return createElement(Fragment, { key: node.id }, rendered);
   }
@@ -209,17 +215,19 @@ function renderNode(
   );
 }
 
+const EMPTY_LOADERS: Readonly<Record<string, unknown>> = Object.freeze({});
+
 export function renderBlockTree(
   nodes: readonly BlockNode[],
   registry: BlockRegistry,
   options?: RenderBlockTreeOptions,
 ): ReactNode {
-  return renderNodes(
-    nodes,
+  const env: WalkerEnv = {
     registry,
-    devWarnState(registry),
-    DEFAULT_BLOCK_CONTEXT,
-    options?.tokens,
-    options?.hooks,
-  );
+    devState: devWarnState(registry),
+    tokens: options?.tokens,
+    hooks: options?.hooks,
+    loaderData: options?.loaderData,
+  };
+  return renderNodes(nodes, env, DEFAULT_BLOCK_CONTEXT);
 }

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from "react";
 
 import type { BlockRegistry } from "../block-registry.js";
 import type { EntryContent } from "../entry-content.js";
+import type { ResolvedBlockLoaders } from "../loaders.js";
 import type { ThemeTokens } from "../styles/types.js";
 import { renderBlockTree } from "../render-block-tree.js";
 import { RendererError } from "./errors.js";
@@ -10,6 +11,7 @@ import { RendererError } from "./errors.js";
 export interface PlumixContextValue {
   readonly registry: BlockRegistry;
   readonly tokens?: ThemeTokens;
+  readonly loaderData?: ResolvedBlockLoaders;
 }
 
 const PlumixContext = createContext<PlumixContextValue | null>(null);
@@ -42,6 +44,7 @@ export function BlockRenderer({
   const ctx = usePlumixContext("BlockRenderer");
   return renderBlockTree(content.blocks, ctx.registry, {
     tokens: ctx.tokens,
+    loaderData: ctx.loaderData,
   });
 }
 

--- a/packages/core/src/hooks/block-render.ts
+++ b/packages/core/src/hooks/block-render.ts
@@ -11,11 +11,22 @@
 
 import type { ReactNode } from "react";
 
-import type { BlockContext, BlockNode } from "@plumix/blocks";
+import type { BlockContext, BlockNode, BlockSpec } from "@plumix/blocks";
 
 export interface BlockRenderHookContext {
   readonly node: BlockNode;
   readonly context: BlockContext;
+}
+
+// Fired by the SSR dispatcher once per rejected loader. The hook is
+// observational only (filters return `void`); plugins typically log to
+// external observability and leave user-visible fallback to
+// `BlockSpec.errorFallback`.
+export interface BlockLoaderErrorContext {
+  readonly spec: BlockSpec;
+  readonly node: BlockNode;
+  readonly key: string;
+  readonly error: unknown;
 }
 
 declare module "./types.js" {
@@ -28,5 +39,9 @@ declare module "./types.js" {
       element: ReactNode,
       ctx: BlockRenderHookContext,
     ) => ReactNode;
+    "blocks:loader:error": (
+      result: void,
+      ctx: BlockLoaderErrorContext,
+    ) => void;
   }
 }

--- a/packages/core/src/hooks/block-render.ts
+++ b/packages/core/src/hooks/block-render.ts
@@ -39,9 +39,6 @@ declare module "./types.js" {
       element: ReactNode,
       ctx: BlockRenderHookContext,
     ) => ReactNode;
-    "blocks:loader:error": (
-      result: void,
-      ctx: BlockLoaderErrorContext,
-    ) => void;
+    "blocks:loader:error": (result: void, ctx: BlockLoaderErrorContext) => void;
   }
 }

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -2,4 +2,7 @@ import "./block-render.js";
 
 export * from "./registry.js";
 export * from "./types.js";
-export type { BlockRenderHookContext } from "./block-render.js";
+export type {
+  BlockLoaderErrorContext,
+  BlockRenderHookContext,
+} from "./block-render.js";

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1073,9 +1073,7 @@ describe("resolvePublicRoute — single entry through theme", () => {
           loaders: {
             marker: () => Promise.resolve("loaded-on-server"),
           },
-          render: ({ loaders }) => (
-            <div data-loaded>{loaders.marker}</div>
-          ),
+          render: ({ loaders }) => <div data-loaded>{loaders.marker}</div>,
         }),
       );
     });

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -2,6 +2,7 @@ import { useId } from "react";
 import { describe, expect, test } from "vitest";
 
 import type { EntryContent } from "@plumix/blocks";
+import { defineBlock } from "@plumix/blocks";
 import { BlockRenderer } from "@plumix/blocks/renderer";
 
 import type { ResolvedEntry } from "./resolved-entry.js";
@@ -1062,6 +1063,58 @@ describe("resolvePublicRoute — single entry through theme", () => {
     const body = await response.text();
     expect(body).toContain("Hi");
     expect(body).toContain('data-plumix-block="core/heading"');
+  });
+
+  test("dispatcher pre-resolves block loaders before render — render() sees the resolved data", async () => {
+    const probePlugin = definePlugin("acme-probe", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/probe",
+          loaders: {
+            marker: () => Promise.resolve("loaded-on-server"),
+          },
+          render: ({ loaders }) => (
+            <div data-loaded>{loaders.marker}</div>
+          ),
+        }),
+      );
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) =>
+          data.entry.content ? (
+            <BlockRenderer
+              content={data.entry.content as unknown as EntryContent}
+            />
+          ) : null,
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, probePlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "with-loader",
+      title: "Loader Block",
+      content: {
+        version: "plumix.v2",
+        blocks: [{ id: "n", name: "acme/probe", attrs: {} }],
+      },
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/with-loader"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("loaded-on-server");
   });
 });
 

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -2,6 +2,12 @@ import type { ReactNode } from "react";
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
 
+import type {
+  EntryContent,
+  LoaderErrorEvent,
+  ResolvedBlockLoaders,
+} from "@plumix/blocks";
+import { isEntryContent, resolveBlockLoaders } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { AppContext } from "../../context/app.js";
@@ -61,6 +67,7 @@ export async function renderThroughTheme({
     templateDeps,
     ctx,
   );
+  const loaderData = await prefetchEntryLoaders(ctx, data);
   return renderTree({
     ctx,
     document: renderDocument,
@@ -69,6 +76,7 @@ export async function renderThroughTheme({
     title,
     template,
     deps,
+    loaderData,
   });
 }
 
@@ -121,7 +129,45 @@ export async function renderErrorThroughTheme({
     title: variant.title,
     template,
     deps,
+    loaderData: undefined,
   });
+}
+
+// v1 only pre-resolves loaders on the single-entry path. Listing
+// shapes (archive / taxonomy / front-page) carry entry arrays but
+// their templates render summaries, not block trees — a future slice
+// can broaden coverage once a real consumer needs it.
+async function prefetchEntryLoaders(
+  ctx: AppContext,
+  data: TemplateData,
+): Promise<ResolvedBlockLoaders | undefined> {
+  const content = singleEntryContent(data);
+  if (!content) return undefined;
+  return resolveBlockLoaders(content.blocks, ctx.blocks, ctx, {
+    // Fire-and-forget bridge into the framework filter so plugins can
+    // subscribe via `addFilter("blocks:loader:error", ...)`. `applyFilter`
+    // is async; we don't await (the loader resolver shouldn't back-pressure
+    // on observability), but we DO catch — a throwing subscriber would
+    // otherwise surface as an unhandledRejection and on workers that
+    // kills the request. `LoaderErrorEvent` shape matches `BlockLoaderErrorContext`.
+    onLoaderError: (event: LoaderErrorEvent) => {
+      ctx.hooks
+        .applyFilter("blocks:loader:error", undefined, event)
+        .catch((hookError: unknown) => {
+          ctx.logger.error("[plumix] blocks:loader:error hook threw", {
+            hookError,
+            blockName: event.spec.name,
+            nodeId: event.node.id,
+          });
+        });
+    },
+  });
+}
+
+function singleEntryContent(data: TemplateData): EntryContent | null {
+  const candidate =
+    (data as { entry?: { content?: unknown } }).entry?.content ?? null;
+  return isEntryContent(candidate) ? candidate : null;
 }
 
 interface RenderTreeArgs {
@@ -132,6 +178,7 @@ interface RenderTreeArgs {
   readonly title: string;
   readonly template: Template<TemplateData>;
   readonly deps: Record<string, Record<string, unknown>>;
+  readonly loaderData: ResolvedBlockLoaders | undefined;
 }
 
 // React 19 reorders every child of `<head>` (metadata first, scripts /
@@ -148,6 +195,7 @@ function renderTree({
   title,
   template,
   deps,
+  loaderData,
 }: RenderTreeArgs): string {
   // Adapter FC wraps `template.render({ data, ctx, ...deps })` so it
   // executes inside React's render pass — hooks (useState, useId,
@@ -160,7 +208,7 @@ function renderTree({
   const TemplateAdapter = (): ReactNode =>
     template.render({ ...deps, data, ctx });
   const templateTree: ReactNode = createElement(PlumixProvider, {
-    value: { registry: ctx.blocks },
+    value: { registry: ctx.blocks, loaderData },
     children: createElement(TemplateAdapter),
   });
   const rendered = renderToString(templateTree);


### PR DESCRIPTION
Adds a `loaders` record to `defineBlock` so blocks can fetch data at SSR. The dispatcher pre-resolves every loader on the page in one parallel pass before the React render, then threads the resolved data into `render({ attrs, context, loaders })` with full type inference. Closes #557.

**Block-author surface**

```tsx
defineBlock({
  name: "acme/latest-posts",
  loaders: {
    posts: ({ ctx, attrs }) =>
      ctx.db.query.entries.findMany({ limit: attrs.count as number }),
  },
  render: ({ loaders }) => (
    // `loaders.posts` is `Awaited<ReturnType<typeof loaders.posts>>` —
    // full autocomplete on `p.title`, `p.slug`, etc.
    <ul>{loaders.posts.map((p) => <li key={p.id}>{p.title}</li>)}</ul>
  ),
  errorFallback: ({ error }) => <div>Couldn't load: {String(error)}</div>,
});
```

`ctx.request`, `ctx.user`, `ctx.resolvedEntity` are all available inside loaders — query strings / headers / matched entity all reachable without a new primitive.

**Type-inference shape (TanStack-style)**

`ResolvedLoaders<L> = { [K in keyof L]: Awaited<ReturnType<L[K]>> }` ports directly from TanStack Router's `ResolveLoaderData` (`router-core/src/route.ts:307-344`). The strong typing lives inside the spec literal at `defineBlock`; the returned `BlockSpec` widens because `BlockSpec` is invariant in its generics and a narrow return wouldn't fit the homogenized `BlockRegistry` row — same trick TanStack uses for `match.loaderData`. `defaults` uses `NoInfer` so declaring `defaults: { text: "" }` doesn't accidentally narrow `Attrs` and reject `render`'s other reads.

**Per-block error isolation**

A loader's rejection never 500s the page. The block's optional `errorFallback({ attrs, error })` renders in its place, or nothing in production when omitted. The dispatcher routes each rejection through the new `blocks:loader:error` filter hook for observability plugins. Sync throws inside a loader body are trapped via `Promise.resolve().then(() => fn(...))` before reaching `Promise.all`, preserving the isolation contract. The hook's `applyFilter` rejections are caught + logged so a throwing subscriber can't crash the worker via `unhandledRejection`.

**Walker integration**

`renderBlockTree` stays synchronous. The dispatcher pre-resolves loaders before `renderToString`, threads the resolved map through `PlumixProvider`, and `renderNode` reads it via `loaderData?.get(node.id)`. No streaming SSR, no `use(promise)`, no new React 19 surface. v1 only pre-resolves `data.entry.content` (single-entry path) — archive / taxonomy / front-page templates render summaries, not block trees; broader coverage can land when a consumer needs it.

**Out of scope (documented)**

No built-in loader timeout, no concurrency cap, no request-scoped query caching. `attrs` is untrusted input — docs recommend zod validation before use in queries. All three are explicit non-goals in the issue body; this PR doesn't introduce new mitigations.

Fixes #557