### PR TITLE
feat(blocks,plumix): add deferred island hydration strategies

### DIFF
--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -127,7 +127,11 @@ export { coreMarks, coreMarkExtensions } from "./marks/core/index.js";
 export type { MarkSpec } from "./marks/types.js";
 
 // ─── Islands authoring ──────────────────────────────────────────────────────
-export type { IslandProps, PlumixStrategy } from "./island-props.js";
+export type {
+  IslandProps,
+  PlumixPrefetch,
+  PlumixStrategy,
+} from "./island-props.js";
 // Re-exported for the SSR shim the Vite plugin emits for `"use client"`
 // modules; not intended for direct theme/block-author consumption.
 export { serializeProps } from "./serialize.js";

--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -490,3 +490,115 @@ describe("PlumixIslandElement lifecycle", () => {
     expect(seen[0]).toEqual({ title: "hello", n: 42 });
   });
 });
+
+describe("PlumixIslandElement prefetch/hydrate split", () => {
+  let restoreImport: () => void = () => undefined;
+  let restoreRenderer: () => void = () => undefined;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete (window as { Plumix?: unknown }).Plumix;
+    restoreImport = () => undefined;
+    restoreRenderer = setRendererImport(() => Promise.resolve(islandRenderer));
+  });
+
+  afterEach(async () => {
+    restoreImport();
+    restoreRenderer();
+    document.body.innerHTML = "";
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  test("wires prefetch separately from hydrate and warms the chunk without mounting", async () => {
+    const imports: string[] = [];
+    restoreImport = setDynamicImport((url) => {
+      imports.push(url);
+      return Promise.resolve({ default: () => null } as unknown);
+    });
+    let prefetchLoad: (() => Promise<void>) | undefined;
+    let hydrateLoad: (() => Promise<void>) | undefined;
+    window.Plumix = {
+      visible: (loadFn) => {
+        prefetchLoad = loadFn;
+      },
+      interaction: (loadFn) => {
+        hydrateLoad = loadFn;
+      },
+    };
+    const el = makeIsland({
+      client: "interaction",
+      prefetch: "visible",
+      "chunk-url": "/chunk.js",
+      "component-export": "default",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    // Both triggers are wired; nothing has been fetched yet.
+    expect(typeof prefetchLoad).toBe("function");
+    expect(typeof hydrateLoad).toBe("function");
+    expect(imports).toEqual([]);
+
+    // Firing the prefetch trigger warms the component chunk without mounting.
+    await prefetchLoad?.();
+    expect(imports).toContain("/chunk.js");
+  });
+
+  test("skips the prefetch strategy entirely when hydration is immediate (load)", async () => {
+    const calls: string[] = [];
+    window.Plumix = {
+      load: () => {
+        calls.push("load");
+      },
+      visible: () => {
+        calls.push("visible");
+      },
+    };
+    const el = makeIsland({
+      client: "load",
+      prefetch: "load",
+      "chunk-url": "/c.js",
+      "component-export": "default",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(calls).toEqual(["load"]);
+  });
+
+  test("does not double-wire when the prefetch trigger equals the hydrate trigger", async () => {
+    const calls: string[] = [];
+    window.Plumix = {
+      visible: () => {
+        calls.push("visible");
+      },
+    };
+    const el = makeIsland({
+      client: "visible",
+      prefetch: "visible",
+      "chunk-url": "/c.js",
+      "component-export": "default",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(calls).toEqual(["visible"]);
+  });
+
+  test("runs a strategy's teardown when the island disconnects", async () => {
+    const teardown = vi.fn();
+    window.Plumix = { visible: () => teardown };
+    const el = makeIsland({
+      client: "visible",
+      "chunk-url": "/c.js",
+      "component-export": "default",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(teardown).not.toHaveBeenCalled();
+    el.remove();
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/blocks/src/island-element.ts
+++ b/packages/blocks/src/island-element.ts
@@ -26,11 +26,15 @@ interface RendererModule {
   mount(element: HTMLElement): IslandRoot;
 }
 
+// A strategy decides *when* to run `loadFn` (hydrate or prefetch). It may
+// return a teardown the element calls on `disconnectedCallback` — so an
+// island removed before its trigger fires doesn't leak the strategy's
+// observer / listener (a leak both Astro and Nuxt carry).
 export type IslandStrategy = (
   loadFn: () => Promise<void>,
   opts: Readonly<Record<string, unknown>>,
   el: PlumixIslandElement,
-) => void | Promise<void>;
+) => void | (() => void) | Promise<void | (() => void)>;
 
 declare global {
   interface Window {
@@ -62,6 +66,11 @@ export class PlumixIslandElement extends HTMLElement {
     null;
   private childObserver: MutationObserver | null = null;
   private parentObserver: MutationObserver | null = null;
+  private prefetched = false;
+  // Teardowns returned by the hydrate + prefetch strategies, run on
+  // disconnect so a deferred island removed before its trigger doesn't leak
+  // an IntersectionObserver / event-listener registration.
+  private strategyCleanups: (() => void)[] = [];
 
   attributeChangedCallback(
     _name: string,
@@ -117,6 +126,8 @@ export class PlumixIslandElement extends HTMLElement {
     this.childObserver = null;
     this.parentObserver?.disconnect();
     this.parentObserver = null;
+    for (const cleanup of this.strategyCleanups) cleanup();
+    this.strategyCleanups = [];
     // Only signal unmount when there's something to unmount. A deferred
     // island that never hydrated (parent never cleared `ssr`, or
     // `await-children` never settled) shouldn't emit `plumix:unmount`
@@ -168,8 +179,27 @@ export class PlumixIslandElement extends HTMLElement {
       return;
     }
     const strategy = this.getAttribute("client") ?? "load";
+    const prefetch = this.getAttribute("prefetch");
     const opts = parseJsonAttr(this.getAttribute("opts"));
     const strategies = window.Plumix;
+
+    // Prefetch is wired first — it fires no later than hydration. Skip it
+    // when hydration is already immediate (`load`/`only`) or shares the
+    // trigger, since the hydrate path's own fetch covers that case. This
+    // split (warm the chunk on `visible`, hydrate on `interaction`) is the
+    // lever Astro and Nuxt lack — both couple fetch to the hydrate trigger.
+    if (prefetch && shouldPrefetch(strategy, prefetch)) {
+      const prefetchFn = strategies?.[prefetch];
+      if (prefetchFn) {
+        const cleanup = await prefetchFn(
+          () => Promise.resolve(this.prefetch()),
+          opts,
+          this,
+        );
+        if (typeof cleanup === "function") this.strategyCleanups.push(cleanup);
+      }
+    }
+
     const fn = strategies?.[strategy];
     if (!fn) {
       // No registered strategy — the runtime entry script never loaded.
@@ -177,7 +207,23 @@ export class PlumixIslandElement extends HTMLElement {
       this.dispatchHydrationError(new Error(`unknown strategy: ${strategy}`));
       return;
     }
-    await fn(() => this.hydrate(), opts, this);
+    const cleanup = await fn(() => this.hydrate(), opts, this);
+    if (typeof cleanup === "function") this.strategyCleanups.push(cleanup);
+  }
+
+  // Warm the browser's module cache for this island's component chunk and
+  // the shared renderer chunk, without mounting. `hydrate()` then resolves
+  // its `import()`s from cache, so the work left at trigger time is pure
+  // CPU (createRoot + render) — no network round-trip. Best-effort: a
+  // failed prefetch is swallowed; `hydrate()` owns the retry + error event.
+  private prefetch(): void {
+    if (this.hydrated || this.prefetched) return;
+    this.prefetched = true;
+    const chunkUrl = this.getAttribute("chunk-url");
+    const exportName = this.getAttribute("component-export") ?? "default";
+    if (!chunkUrl || FORBIDDEN_EXPORT_KEYS.has(exportName)) return;
+    void dynamicImport(chunkUrl).catch(() => undefined);
+    void loadRenderer().catch(() => undefined);
   }
 
   private async hydrate(): Promise<void> {
@@ -344,6 +390,15 @@ function appendCacheBust(url: string): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Prefetch only earns its keep when it fires strictly before hydration.
+// `load`/`only` hydrate immediately (nothing to pre-warm), and a prefetch
+// trigger equal to the hydrate trigger is covered by the hydrate fetch
+// itself — so both cases skip the extra strategy registration.
+function shouldPrefetch(hydrateWhen: string, prefetchWhen: string): boolean {
+  if (hydrateWhen === "load" || hydrateWhen === "only") return false;
+  return hydrateWhen !== prefetchWhen;
 }
 
 function parseJsonAttr(raw: string | null): Readonly<Record<string, unknown>> {

--- a/packages/blocks/src/island-props.test.ts
+++ b/packages/blocks/src/island-props.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, expectTypeOf, test } from "vitest";
 
-import type { IslandProps, PlumixStrategy } from "./island-props.js";
+import type {
+  IslandProps,
+  PlumixPrefetch,
+  PlumixStrategy,
+} from "./island-props.js";
 
 interface Primitives {
   label: string;
@@ -24,6 +28,11 @@ interface WithClientProp {
 
 interface NoClientProp {
   label: string;
+}
+
+interface WithPrefetchProp {
+  label: string;
+  prefetch: string;
 }
 
 describe("IslandProps<T>", () => {
@@ -49,5 +58,20 @@ describe("IslandProps<T>", () => {
   test("adds `client?: PlumixStrategy` even when the input has no `client` prop", () => {
     type Out = IslandProps<NoClientProp>;
     expectTypeOf<Out["client"]>().toEqualTypeOf<PlumixStrategy | undefined>();
+  });
+
+  test("`PlumixStrategy` covers all five hydration triggers", () => {
+    expectTypeOf<PlumixStrategy>().toEqualTypeOf<
+      "load" | "idle" | "visible" | "interaction" | "only"
+    >();
+  });
+
+  test("`PlumixPrefetch` is the subset valid as a prefetch trigger", () => {
+    expectTypeOf<PlumixPrefetch>().toEqualTypeOf<"load" | "idle" | "visible">();
+  });
+
+  test("reserves `prefetch` as an optional prefetch-trigger prop", () => {
+    type Out = IslandProps<WithPrefetchProp>;
+    expectTypeOf<Out["prefetch"]>().toEqualTypeOf<PlumixPrefetch | undefined>();
   });
 });

--- a/packages/blocks/src/island-props.ts
+++ b/packages/blocks/src/island-props.ts
@@ -1,12 +1,34 @@
 /**
- * Hydration strategies the islands runtime recognizes. New strategies
- * land alongside their runtime implementation; v0 ships `load`
- * (eager) and `visible` (IntersectionObserver-gated).
+ * Hydration strategies the islands runtime recognizes. Each lands
+ * alongside its runtime implementation in `island-strategies/`:
+ *
+ * - `load` — hydrate eagerly on connect.
+ * - `idle` — hydrate in a `requestIdleCallback` slot (capped fallback).
+ * - `visible` — hydrate when the island scrolls into view.
+ * - `interaction` — hydrate on first user intent, then replay the
+ *   triggering event so the first click/keypress isn't lost.
+ * - `only` — no SSR markup; render client-side on connect.
  */
-export type PlumixStrategy = "load" | "visible";
+export type PlumixStrategy =
+  | "load"
+  | "idle"
+  | "visible"
+  | "interaction"
+  | "only";
 
 /**
- * Props helper for components marked with `"use client";`. Two safety
+ * The subset of strategies valid as a *prefetch* trigger. Prefetch warms
+ * the chunk over the network ahead of hydration, so it only makes sense for
+ * triggers that fire on their own (no user intent) and never later than the
+ * hydration trigger: `load`, `idle`, `visible`. Prefetching "on
+ * interaction" is meaningless — the chunk would arrive after the click it
+ * was meant to make instant — so `interaction`/`only` are excluded at the
+ * type layer.
+ */
+export type PlumixPrefetch = "load" | "idle" | "visible";
+
+/**
+ * Props helper for components marked with `"use client";`. Three safety
  * properties:
  *
  * 1. **Function-typed properties are excluded.** Functions don't survive
@@ -15,11 +37,16 @@ export type PlumixStrategy = "load" | "visible";
  *    re-parses the `props=` attribute. Forcing authors to omit them at
  *    the type layer catches the silent drop at compile time.
  *
- * 2. **The `client` prop is reserved for hydration strategy.** The
- *    server-side shim strips this prop and uses its string value to
- *    select the strategy (`"load"`, `"visible"`). A consumer who used
- *    the same name for their own data would silently lose it. Reserving
- *    the slot via the type makes the conflict visible at compile time.
+ * 2. **The `client` prop is reserved for the hydration strategy.** The
+ *    server-side shim strips this prop and uses its value to select the
+ *    strategy. A consumer who used the same name for their own data would
+ *    silently lose it; reserving the slot makes the conflict a compile
+ *    error.
+ *
+ * 3. **The `prefetch` prop is reserved for the prefetch trigger.** Splits
+ *    *when the chunk downloads* from *when the island hydrates* — the
+ *    plumix-specific lever Astro/Nuxt lack. Defaults are derived from
+ *    `client` (see the SSR shim), so authors only set this to override.
  *
  * Authors declare component props as:
  *
@@ -28,8 +55,9 @@ export type PlumixStrategy = "load" | "visible";
  * function MyWidget(props: IslandProps<{ label: string; size?: number }>) { ... }
  * ```
  */
-export type IslandProps<T> = OmitFunctions<Omit<T, "client">> & {
+export type IslandProps<T> = OmitFunctions<Omit<T, "client" | "prefetch">> & {
   readonly client?: PlumixStrategy;
+  readonly prefetch?: PlumixPrefetch;
 };
 
 type OmitFunctions<T> = {

--- a/packages/blocks/src/island-runtime-ordering.test.ts
+++ b/packages/blocks/src/island-runtime-ordering.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+// Isolated from `island-runtime.test.ts` on purpose: this file must be the
+// first thing to define `<plumix-island>` in its jsdom instance, so the
+// element upgrade happens *during* bootstrap — exactly as it does in the
+// browser when the runtime script runs against SSR'd markup already in the
+// document. `island-runtime.test.ts` appends islands AFTER bootstrap, so it
+// never exercises this ordering.
+
+afterEach(() => {
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+test("an SSR'd eager island already in the DOM hydrates with the renderer URL set", async () => {
+  // Arrange the page as SSR delivers it: the island markup + the bootstrap
+  // script carrying the renderer URL are in the document BEFORE the runtime
+  // module executes.
+  const script = document.createElement("script");
+  script.setAttribute("data-plumix-renderer-url", "/assets/renderer.js");
+  document.head.appendChild(script);
+
+  const el = document.createElement("plumix-island");
+  el.setAttribute("client", "load");
+  el.setAttribute("chunk-url", "/chunk.js");
+  el.setAttribute("component-export", "default");
+  el.setAttribute("ssr", "");
+  document.body.appendChild(el);
+
+  // Stub the chunk importer before the element is defined (defining it
+  // upgrades the island and `load` hydrates synchronously in
+  // connectedCallback). island-element doesn't auto-bootstrap, so importing
+  // it here is side-effect free.
+  const { setDynamicImport } = await import("./island-element.js");
+  const imported: string[] = [];
+  setDynamicImport((url) => {
+    imported.push(url);
+    return Promise.resolve({
+      default: () => null,
+      mount: () => ({ render: () => undefined, unmount: () => undefined }),
+    });
+  });
+
+  const errors: string[] = [];
+  window.addEventListener("plumix:hydration-error", (e) => {
+    const detail = (e as CustomEvent<{ error?: unknown }>).detail;
+    errors.push(String(detail.error));
+  });
+
+  // Importing the runtime runs `bootstrapIslandRuntime()` once: it must set
+  // the renderer URL BEFORE defining the element, or the eager island
+  // hydrates against a null renderer URL.
+  await import("./island-runtime.js");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(errors.join("\n")).not.toContain("island renderer URL not set");
+  expect(imported).toContain("/assets/renderer.js");
+});

--- a/packages/blocks/src/island-runtime.test.ts
+++ b/packages/blocks/src/island-runtime.test.ts
@@ -22,6 +22,18 @@ describe("bootstrapIslandRuntime", () => {
     ).toBe("function");
   });
 
+  test("registers all five hydration strategies on window.Plumix", async () => {
+    // Call the exported bootstrap directly: the module-body invocation runs
+    // once (module cache), but beforeEach clears window.Plumix, so we
+    // re-bootstrap to populate it deterministically.
+    const { bootstrapIslandRuntime } = await import("./island-runtime.js");
+    bootstrapIslandRuntime();
+    const plumix = (window as { Plumix?: Record<string, unknown> }).Plumix;
+    for (const name of ["load", "idle", "visible", "interaction", "only"]) {
+      expect(typeof plumix?.[name]).toBe("function");
+    }
+  });
+
   test("re-running bootstrap is idempotent", async () => {
     const { bootstrapIslandRuntime } = await import("./island-runtime.js");
     bootstrapIslandRuntime();

--- a/packages/blocks/src/island-runtime.ts
+++ b/packages/blocks/src/island-runtime.ts
@@ -7,16 +7,28 @@
 // emits the script tag from SSR.
 
 import { registerIslandElement, setRendererUrl } from "./island-element.js";
+import { registerIdleStrategy } from "./island-strategies/idle.js";
+import { registerInteractionStrategy } from "./island-strategies/interaction.js";
 import { registerLoadStrategy } from "./island-strategies/load.js";
+import { registerOnlyStrategy } from "./island-strategies/only.js";
+import { registerVisibleStrategy } from "./island-strategies/visible.js";
 
 export function bootstrapIslandRuntime(): void {
   registerLoadStrategy();
-  registerIslandElement();
-  // The SSR-injected bootstrap `<script>` carries the renderer chunk's
-  // URL (resolved from Vite's manifest). Thread it into the element so
-  // `hydrate()` can lazily import the React renderer on first hydration.
+  registerIdleStrategy();
+  registerVisibleStrategy();
+  registerInteractionStrategy();
+  registerOnlyStrategy();
+  // Thread the renderer chunk URL (carried on the SSR-injected bootstrap
+  // `<script>`, resolved from Vite's manifest) in BEFORE defining the
+  // custom element. `customElements.define` synchronously upgrades any
+  // `<plumix-island>` already in the SSR'd DOM, and an eager strategy
+  // (`load`) hydrates right there in `connectedCallback` — `loadRenderer()`
+  // would otherwise run before the URL is set and reject with "island
+  // renderer URL not set".
   const url = readRendererUrl();
   if (url) setRendererUrl(url);
+  registerIslandElement();
 }
 
 function readRendererUrl(): string | null {

--- a/packages/blocks/src/island-strategies/idle.test.ts
+++ b/packages/blocks/src/island-strategies/idle.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { PlumixIslandElement } from "../island-element.js";
+import { idleStrategy } from "./idle.js";
+
+// The strategy only touches `loadFn` and `opts`; the element arg is unused.
+const EL = {} as PlumixIslandElement;
+
+describe("idleStrategy", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test("hydrates inside a requestIdleCallback slot, capped at 2000ms by default", () => {
+    const ric = vi.fn();
+    vi.stubGlobal("requestIdleCallback", ric);
+    const loadFn = vi.fn(() => Promise.resolve());
+
+    void idleStrategy(loadFn, {}, EL);
+
+    expect(ric).toHaveBeenCalledTimes(1);
+    expect(ric.mock.calls[0]?.[1]).toEqual({ timeout: 2000 });
+    // The slot callback, not loadFn, is scheduled — loadFn fires when it runs.
+    expect(loadFn).not.toHaveBeenCalled();
+    (ric.mock.calls[0]?.[0] as () => void)();
+    expect(loadFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("honors an explicit `opts.timeout` cap", () => {
+    const ric = vi.fn();
+    vi.stubGlobal("requestIdleCallback", ric);
+
+    void idleStrategy(() => Promise.resolve(), { timeout: 500 }, EL);
+
+    expect(ric.mock.calls[0]?.[1]).toEqual({ timeout: 500 });
+  });
+
+  test("falls back to setTimeout(200) when requestIdleCallback is absent", () => {
+    vi.stubGlobal("requestIdleCallback", undefined);
+    vi.useFakeTimers();
+    const loadFn = vi.fn(() => Promise.resolve());
+
+    void idleStrategy(loadFn, {}, EL);
+    expect(loadFn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(199);
+    expect(loadFn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(loadFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/blocks/src/island-strategies/idle.ts
+++ b/packages/blocks/src/island-strategies/idle.ts
@@ -1,0 +1,42 @@
+// `idle` strategy — hydrate in a `requestIdleCallback` slot so the work
+// lands after the browser finishes more urgent main-thread tasks.
+//
+// Two deviations from the implementations we studied, both deliberate:
+//   - Astro passes no `timeout`, so under sustained main-thread load the
+//     callback can starve and the island never hydrates. Nuxt caps at
+//     10s, an eternity for something below the fold the user is about to
+//     reach. We cap at 2000ms by default (override via `opts.timeout`) —
+//     idle fires sooner when the thread is free, but is guaranteed within
+//     the cap.
+//   - The Safari/no-`requestIdleCallback` fallback is `setTimeout(200)`
+//     (Astro's value), not Nuxt's `setTimeout(1)` — 200ms keeps eager
+//     hydration off the critical first-paint window without a perceptible
+//     delay.
+
+import type { IslandStrategy } from "../island-element.js";
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const FALLBACK_DELAY_MS = 200;
+
+interface IdleWindow {
+  requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+}
+
+export const idleStrategy: IslandStrategy = (loadFn, opts) => {
+  const timeout =
+    typeof opts.timeout === "number" ? opts.timeout : DEFAULT_TIMEOUT_MS;
+  const run = (): void => void loadFn();
+  const w = self as unknown as IdleWindow;
+  if (typeof w.requestIdleCallback === "function") {
+    w.requestIdleCallback(run, { timeout });
+    return;
+  }
+  setTimeout(run, FALLBACK_DELAY_MS);
+};
+
+export function registerIdleStrategy(): void {
+  const target = self as unknown as {
+    Plumix?: Record<string, IslandStrategy>;
+  };
+  target.Plumix = { ...(target.Plumix ?? {}), idle: idleStrategy };
+}

--- a/packages/blocks/src/island-strategies/interaction.test.ts
+++ b/packages/blocks/src/island-strategies/interaction.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { PlumixIslandElement } from "../island-element.js";
+import { interactionStrategy } from "./interaction.js";
+
+// A single document-level capture listener is registered once at module
+// load and persists across tests; each test registers its own island and
+// tears it down, so the registry never leaks between cases. rAF is stubbed
+// to run synchronously so replay is observable without a real frame.
+const cleanups: (() => void)[] = [];
+
+function register(
+  el: PlumixIslandElement,
+  opts: Readonly<Record<string, unknown>> = {},
+): { loadFn: ReturnType<typeof vi.fn>; resolve: () => void } {
+  // `loadFn` is invoked lazily (on the trigger), so capture its resolver
+  // through a holder and return a stable `resolve` that calls the latest.
+  let resolver: (() => void) | undefined;
+  const loadFn = vi.fn(
+    () =>
+      new Promise<void>((r) => {
+        resolver = r;
+      }),
+  );
+  const cleanup = interactionStrategy(loadFn, opts, el);
+  if (typeof cleanup === "function") cleanups.push(cleanup);
+  return { loadFn, resolve: () => resolver?.() };
+}
+
+function makeIsland(): {
+  island: PlumixIslandElement;
+  button: HTMLButtonElement;
+} {
+  const island = document.createElement("plumix-island") as PlumixIslandElement;
+  const button = document.createElement("button");
+  island.appendChild(button);
+  document.body.appendChild(island);
+  return { island, button };
+}
+
+// Let the `loadFn().then(replay)` microtask + the (sync-stubbed) rAF run.
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("interactionStrategy", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    for (const cleanup of cleanups.splice(0)) cleanup();
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  test("defers hydration until a click, suppresses the dead-DOM event, then replays it", async () => {
+    const { island, button } = makeIsland();
+    const seen: string[] = [];
+    button.addEventListener("click", () => seen.push("click"));
+    const { loadFn, resolve } = register(island);
+
+    const notCancelled = button.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    // The triggering click is fully suppressed on the un-hydrated DOM.
+    expect(notCancelled).toBe(false);
+    expect(seen).toEqual([]);
+    expect(loadFn).toHaveBeenCalledTimes(1);
+
+    resolve();
+    await flush();
+
+    // After hydration the captured click is replayed onto the button.
+    expect(seen).toEqual(["click"]);
+  });
+
+  test("queues events arriving between trigger and hydration (hover→click is not lost)", async () => {
+    const { island, button } = makeIsland();
+    const seen: string[] = [];
+    button.addEventListener("click", () => seen.push("click"));
+    const { loadFn, resolve } = register(island);
+
+    // pointerenter triggers hydration but doesn't bubble → not replayed.
+    button.dispatchEvent(new Event("pointerenter", { bubbles: false }));
+    expect(loadFn).toHaveBeenCalledTimes(1);
+
+    // The real click lands while the chunk is still loading. Nuxt loses it;
+    // we queue it.
+    button.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    expect(loadFn).toHaveBeenCalledTimes(1); // second event doesn't re-trigger
+    expect(seen).toEqual([]);
+
+    resolve();
+    await flush();
+    expect(seen).toEqual(["click"]);
+  });
+
+  test("reconstructs the replayed event via its own constructor (keyboard data survives)", async () => {
+    const { island, button } = makeIsland();
+    const replayed: KeyboardEvent[] = [];
+    button.addEventListener("keydown", (e) => replayed.push(e));
+    const { resolve } = register(island, { events: ["keydown"] });
+
+    button.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        code: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    resolve();
+    await flush();
+
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0]).toBeInstanceOf(KeyboardEvent);
+    expect(replayed[0]?.key).toBe("Enter");
+    expect(replayed[0]?.code).toBe("Enter");
+  });
+
+  test("re-applies .focus() after replaying a focus event (suppressed native side-effect)", async () => {
+    const { island, button } = makeIsland();
+    const focusSpy = vi.spyOn(button, "focus");
+    const { resolve } = register(island, { events: ["focusin"] });
+
+    button.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    resolve();
+    await flush();
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores events outside any registered island", () => {
+    makeIsland(); // an island exists, but we click elsewhere
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    const { loadFn } = register(
+      document.createElement("plumix-island") as PlumixIslandElement,
+    );
+
+    const notCancelled = outside.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(notCancelled).toBe(true);
+    expect(loadFn).not.toHaveBeenCalled();
+  });
+
+  test("teardown unregisters the island so later events are ignored", () => {
+    const { island, button } = makeIsland();
+    const loadFn = vi.fn(() => Promise.resolve());
+    const cleanup = interactionStrategy(loadFn, {}, island);
+
+    (cleanup as () => void)();
+    button.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(loadFn).not.toHaveBeenCalled();
+  });
+
+  test("hydrates the nearest island and replays onto a nested target", async () => {
+    const { island, button } = makeIsland();
+    const span = document.createElement("span");
+    button.appendChild(span);
+    const seen: (EventTarget | null)[] = [];
+    span.addEventListener("click", (e) => seen.push(e.target));
+    const { resolve } = register(island);
+
+    span.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    resolve();
+    await flush();
+
+    expect(seen).toEqual([span]);
+  });
+});

--- a/packages/blocks/src/island-strategies/interaction.ts
+++ b/packages/blocks/src/island-strategies/interaction.ts
@@ -1,0 +1,224 @@
+// `interaction` strategy — the headline trigger. Hydration is deferred
+// until the user actually engages with the island, then the triggering
+// event is *replayed* onto the hydrated component so the first
+// click/keypress isn't lost. Paired with `prefetch: "visible"` (the
+// default), the chunk is already warm when the user clicks, so hydrate →
+// replay feels instant.
+//
+// This is where Astro and Nuxt fall short and we improve:
+//   - Astro replays nothing — the first interaction during the SSR-only
+//     window is silently dropped (inherent to its hydrate-from-scratch
+//     model).
+//   - Nuxt replays, but only the *first* event and via a synthetic
+//     re-dispatch; a click that arrives while the chunk is still loading
+//     (e.g. after a `pointerenter` trigger) is lost (vuejs/core), and its
+//     reconstruction loses keyboard state.
+//
+// The mechanism mirrors TanStack Start's `interaction.ts`: a single
+// document-level *capture-phase* listener (registered once), walk to the
+// nearest island marker, `preventDefault` + stop propagation so the dead
+// DOM does nothing, encode a positional path to the real target, and after
+// hydration `requestAnimationFrame` → re-dispatch. We diverge from TanStack
+// on three correctness points it gets wrong:
+//   1. Reconstruct with `event.constructor`, not a hardcoded
+//      MouseEvent/FocusEvent ladder — so `KeyboardEvent` (key/code/
+//      modifiers) survives the replay. TanStack drops it.
+//   2. After replaying a focus event, call `.focus()` on the target —
+//      re-dispatching a `FocusEvent` does not move `document.activeElement`,
+//      so the native side-effect `preventDefault` suppressed is restored.
+//   3. Queue *every* matching event between the trigger and hydration, not
+//      just the first, and replay them in order — so the hover→click race
+//      that loses Nuxt's click is handled.
+
+import type { IslandStrategy, PlumixIslandElement } from "../island-element.js";
+
+// The superset the single document listener subscribes to. An island's
+// `opts.events` (if any) must be a subset; `pointerenter` is a trigger only
+// — it doesn't bubble, so it's never replayed (only its bubbling cousins
+// are), matching browser event semantics.
+const SUPPORTED_EVENTS = [
+  "pointerenter",
+  "focusin",
+  "pointerdown",
+  "click",
+  "keydown",
+] as const;
+
+interface QueuedEvent {
+  readonly type: string;
+  readonly path: readonly number[];
+  readonly event: Event;
+}
+
+interface Registration {
+  readonly loadFn: () => Promise<void>;
+  readonly events: ReadonlySet<string>;
+  triggered: boolean;
+  readonly queue: QueuedEvent[];
+}
+
+const registry = new Map<PlumixIslandElement, Registration>();
+let listening = false;
+
+export const interactionStrategy: IslandStrategy = (loadFn, opts, el) => {
+  registry.set(el, {
+    loadFn,
+    events: readEvents(opts),
+    triggered: false,
+    queue: [],
+  });
+  ensureListeners();
+  return () => registry.delete(el);
+};
+
+function readEvents(
+  opts: Readonly<Record<string, unknown>>,
+): ReadonlySet<string> {
+  const raw = opts.events;
+  const list = Array.isArray(raw)
+    ? raw.filter((e): e is string => typeof e === "string")
+    : null;
+  return new Set(list && list.length > 0 ? list : SUPPORTED_EVENTS);
+}
+
+function ensureListeners(): void {
+  if (listening || typeof document === "undefined") return;
+  listening = true;
+  for (const type of SUPPORTED_EVENTS) {
+    document.addEventListener(type, onIntent, true);
+  }
+}
+
+function onIntent(event: Event): void {
+  if (registry.size === 0) return;
+  const target = eventTarget(event);
+  if (!target) return;
+  const marker = nearestMarker(target, event.type);
+  if (!marker) return;
+  const reg = registry.get(marker);
+  if (!reg) return;
+
+  // Kill the event on the dead DOM — nothing is wired up yet. Capture phase
+  // + stopImmediatePropagation means no other listener sees it either, so
+  // we have full control over the replay.
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+
+  // Only bubbling events can be faithfully replayed; `pointerenter` /
+  // `focus` don't bubble, so they trigger hydration but aren't queued.
+  if (event.bubbles) {
+    reg.queue.push({
+      type: event.type,
+      path: encodePath(marker, target),
+      // Reconstruct now, synchronously: the live event is recycled by the
+      // browser once this handler returns, but its init values are still
+      // readable here.
+      event: reconstruct(event),
+    });
+  }
+
+  if (reg.triggered) return;
+  reg.triggered = true;
+  void reg.loadFn().then(() => replay(marker, reg));
+}
+
+// Nearest registered, not-yet-hydrated island that is `target` or an
+// ancestor of it and listens for this event type.
+function nearestMarker(
+  target: Element,
+  type: string,
+): PlumixIslandElement | null {
+  let el: Element | null = target.closest(ISLAND_SELECTOR);
+  while (el) {
+    const reg = registry.get(el as PlumixIslandElement);
+    if (reg?.events.has(type)) return el as PlumixIslandElement;
+    el = el.parentElement?.closest(ISLAND_SELECTOR) ?? null;
+  }
+  return null;
+}
+
+function replay(marker: PlumixIslandElement, reg: Registration): void {
+  // React is mounted and listening now; stop intercepting so further events
+  // reach it natively, then re-dispatch what we captured.
+  registry.delete(marker);
+  if (reg.queue.length === 0) return;
+  requestAnimationFrame(() => {
+    for (const queued of reg.queue) {
+      const node = resolvePath(marker, queued.path);
+      // A focus event can't be faithfully replayed by dispatch: re-
+      // dispatching a `FocusEvent` doesn't move `document.activeElement`,
+      // and doing both `.focus()` AND `dispatchEvent` would fire the
+      // component's focus handler twice. `.focus()` alone produces the
+      // genuine native focus → focusin sequence the component expects.
+      if (
+        (queued.type === "focusin" || queued.type === "focus") &&
+        node instanceof HTMLElement
+      ) {
+        node.focus();
+      } else {
+        node.dispatchEvent(queued.event);
+      }
+    }
+  });
+}
+
+// Positional path from the marker down to the target: child-index at each
+// level, top-down.
+function encodePath(marker: Element, target: Element): readonly number[] {
+  const path: number[] = [];
+  let node: Element = target;
+  while (node !== marker) {
+    const parent = node.parentElement;
+    if (!parent) return [];
+    path.push(Array.prototype.indexOf.call(parent.children, node));
+    node = parent;
+  }
+  path.reverse();
+  return path;
+}
+
+function resolvePath(marker: Element, path: readonly number[]): Element {
+  let node: Element = marker;
+  for (const index of path) {
+    const next = node.children[index];
+    if (!next) return node;
+    node = next;
+  }
+  return node;
+}
+
+// Re-construct via the original event's own constructor so subtype data
+// (MouseEvent coordinates, KeyboardEvent key/code/modifiers, PointerEvent
+// pressure) is preserved — the event itself is a valid init dict for its
+// own constructor. Falls back to a plain bubbling Event if the subtype
+// isn't constructible in this environment.
+type EventConstructor = new (type: string, init: Event) => Event;
+
+function reconstruct(event: Event): Event {
+  const Ctor = event.constructor as EventConstructor;
+  try {
+    return new Ctor(event.type, event);
+  } catch {
+    return new Event(event.type, { bubbles: true, cancelable: true });
+  }
+}
+
+function eventTarget(event: Event): Element | null {
+  const target = event.target;
+  if (target instanceof Element) return target;
+  if (target instanceof Node) return target.parentElement;
+  return null;
+}
+
+const ISLAND_SELECTOR = "plumix-island";
+
+export function registerInteractionStrategy(): void {
+  const target = self as unknown as {
+    Plumix?: Record<string, IslandStrategy>;
+  };
+  target.Plumix = {
+    ...(target.Plumix ?? {}),
+    interaction: interactionStrategy,
+  };
+}

--- a/packages/blocks/src/island-strategies/only.test.ts
+++ b/packages/blocks/src/island-strategies/only.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { PlumixIslandElement } from "../island-element.js";
+import { onlyStrategy } from "./only.js";
+
+const EL = {} as PlumixIslandElement;
+
+describe("onlyStrategy", () => {
+  test("hydrates immediately on connect (the empty shell renders client-side)", () => {
+    const loadFn = vi.fn(() => Promise.resolve());
+    void onlyStrategy(loadFn, {}, EL);
+    expect(loadFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/blocks/src/island-strategies/only.ts
+++ b/packages/blocks/src/island-strategies/only.ts
@@ -1,0 +1,20 @@
+// `only` strategy — the component is never server-rendered; the SSR shim
+// emits an empty `<plumix-island when="only">` shell and the client renders
+// into it on connect. At runtime that's the same trigger as `load` (fire
+// immediately), so this delegates the timing; the behavioural difference
+// lives entirely in the SSR shim (no markup, no `ssr` gate attribute).
+// Registered under its own name so the element's dispatcher resolves
+// `client="only"`.
+
+import type { IslandStrategy } from "../island-element.js";
+
+export const onlyStrategy: IslandStrategy = (loadFn) => {
+  void loadFn();
+};
+
+export function registerOnlyStrategy(): void {
+  const target = self as unknown as {
+    Plumix?: Record<string, IslandStrategy>;
+  };
+  target.Plumix = { ...(target.Plumix ?? {}), only: onlyStrategy };
+}

--- a/packages/blocks/src/island-strategies/visible.test.ts
+++ b/packages/blocks/src/island-strategies/visible.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { PlumixIslandElement } from "../island-element.js";
+import { visibleStrategy } from "./visible.js";
+
+// Minimal IntersectionObserver double: records construction options and
+// observed targets, and lets a test fire a synthetic intersection.
+class FakeIO {
+  static instances: FakeIO[] = [];
+  readonly observed: Element[] = [];
+  disconnected = false;
+  constructor(
+    readonly callback: IntersectionObserverCallback,
+    readonly options?: IntersectionObserverInit,
+  ) {
+    FakeIO.instances.push(this);
+  }
+  observe(el: Element): void {
+    this.observed.push(el);
+  }
+  disconnect(): void {
+    this.disconnected = true;
+  }
+  fire(isIntersecting: boolean): void {
+    this.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+// jsdom's getBoundingClientRect returns all-zeros, so `isInViewport` is
+// false by default and the observer path is taken. The already-visible test
+// stubs the rect + viewport explicitly.
+function makeEl(): PlumixIslandElement {
+  return document.createElement("plumix-island") as PlumixIslandElement;
+}
+
+describe("visibleStrategy", () => {
+  beforeEach(() => {
+    FakeIO.instances = [];
+    vi.stubGlobal("IntersectionObserver", FakeIO);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  test("observes the element and hydrates on first intersection", () => {
+    const loadFn = vi.fn(() => Promise.resolve());
+    const el = makeEl();
+
+    void visibleStrategy(loadFn, {}, el);
+
+    expect(FakeIO.instances).toHaveLength(1);
+    const io = FakeIO.instances[0];
+    expect(io?.observed).toEqual([el]);
+    expect(loadFn).not.toHaveBeenCalled();
+
+    // A non-intersecting entry must not trigger.
+    io?.fire(false);
+    expect(loadFn).not.toHaveBeenCalled();
+
+    io?.fire(true);
+    expect(loadFn).toHaveBeenCalledTimes(1);
+    // Single-shot: disconnect on first hit so a re-entry can't double-fire.
+    expect(io?.disconnected).toBe(true);
+  });
+
+  test("defaults rootMargin to 200px so the chunk warms before entering view", () => {
+    void visibleStrategy(() => Promise.resolve(), {}, makeEl());
+    expect(FakeIO.instances[0]?.options).toEqual({ rootMargin: "200px" });
+  });
+
+  test("honors an explicit `opts.rootMargin`", () => {
+    void visibleStrategy(
+      () => Promise.resolve(),
+      { rootMargin: "0px" },
+      makeEl(),
+    );
+    expect(FakeIO.instances[0]?.options).toEqual({ rootMargin: "0px" });
+  });
+
+  test("returns a teardown that disconnects the observer (no leak on early removal)", () => {
+    const cleanup = visibleStrategy(() => Promise.resolve(), {}, makeEl());
+    expect(typeof cleanup).toBe("function");
+    (cleanup as () => void)();
+    expect(FakeIO.instances[0]?.disconnected).toBe(true);
+  });
+
+  test("hydrates immediately and skips the observer when already in viewport", () => {
+    const loadFn = vi.fn(() => Promise.resolve());
+    const el = makeEl();
+    vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+      top: 10,
+      left: 10,
+      bottom: 110,
+      right: 110,
+      width: 100,
+      height: 100,
+    } as DOMRect);
+    vi.stubGlobal("innerWidth", 1024);
+    vi.stubGlobal("innerHeight", 768);
+
+    void visibleStrategy(loadFn, {}, el);
+
+    expect(loadFn).toHaveBeenCalledTimes(1);
+    expect(FakeIO.instances).toHaveLength(0);
+  });
+});

--- a/packages/blocks/src/island-strategies/visible.ts
+++ b/packages/blocks/src/island-strategies/visible.ts
@@ -1,0 +1,68 @@
+// `visible` strategy — hydrate (or prefetch) when the island scrolls near
+// the viewport. Adapted from Astro's `client:visible` and Nuxt's
+// `hydrateOnVisible`, with three deliberate improvements:
+//
+//   - Astro observes `el.children`, not the element, because
+//     `<astro-island>` is `display: contents` (zero box → the observer
+//     never fires). A pass-through component that renders only its children
+//     then has nothing observable and stays forever un-hydrated
+//     (withastro/astro#4103, #5309). `<plumix-island>` has a normal box, so
+//     we observe the element directly and dodge that blind spot.
+//   - Both Astro and Nuxt default `rootMargin` to the browser's `"0px"`, so
+//     the chunk fetch only starts once the island is literally on-screen —
+//     a flash on slow connections. We default to `"200px"` so it warms just
+//     before entering view; override via `opts.rootMargin`.
+//   - We return a teardown that disconnects the observer. Astro and Nuxt
+//     leak the observer if the island is removed before it ever intersects;
+//     the element calls this on `disconnectedCallback`.
+//
+// The synchronous already-in-viewport pre-check (Nuxt's) fires `loadFn`
+// without ever constructing an observer for an above-the-fold island.
+
+import type { IslandStrategy } from "../island-element.js";
+
+const DEFAULT_ROOT_MARGIN = "200px";
+
+export const visibleStrategy: IslandStrategy = (loadFn, opts, el) => {
+  if (isInViewport(el)) {
+    void loadFn();
+    return;
+  }
+  const rootMargin =
+    typeof opts.rootMargin === "string" ? opts.rootMargin : DEFAULT_ROOT_MARGIN;
+  const io = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        io.disconnect();
+        void loadFn();
+        return;
+      }
+    },
+    { rootMargin },
+  );
+  io.observe(el);
+  return () => io.disconnect();
+};
+
+function isInViewport(el: Element): boolean {
+  const rect = el.getBoundingClientRect();
+  const viewportWidth = self.innerWidth || document.documentElement.clientWidth;
+  const viewportHeight =
+    self.innerHeight || document.documentElement.clientHeight;
+  return (
+    rect.width > 0 &&
+    rect.height > 0 &&
+    rect.bottom > 0 &&
+    rect.right > 0 &&
+    rect.top < viewportHeight &&
+    rect.left < viewportWidth
+  );
+}
+
+export function registerVisibleStrategy(): void {
+  const target = self as unknown as {
+    Plumix?: Record<string, IslandStrategy>;
+  };
+  target.Plumix = { ...(target.Plumix ?? {}), visible: visibleStrategy };
+}

--- a/packages/plumix/src/vite/island-transform.test.ts
+++ b/packages/plumix/src/vite/island-transform.test.ts
@@ -153,13 +153,16 @@ describe("transformUseClientModule", () => {
     // exact JSX/createElement shape is an internal detail.
     expect(out).toContain('"chunk-url": "/src/Counter.tsx"');
     expect(out).toContain('"component-export": "Counter"');
-    expect(out).toContain('"ssr": ""');
+    // `ssr=""` gates nested hydration for SSR'd islands; `only` islands get
+    // `null` (no markup, no gate).
+    expect(out).toContain('"ssr": __only ? null : ""');
   });
 
-  test("shim forwards strategy from the `client` JSX prop, defaulting to load", () => {
+  test("shim defaults the hydration trigger to `interaction`", () => {
     // `IslandProps<T>` enforces the type at compile time; the custom
-    // element dispatches `plumix:hydration-error` for unknown strategies
-    // at runtime. The shim itself just passes the value through.
+    // element dispatches `plumix:hydration-error` for unknown strategies at
+    // runtime. The shim passes an explicit `client` prop through and falls
+    // back to `interaction` — hydrate on first user intent.
     const source = `
       "use client";
       export function Counter() { return null; }
@@ -168,7 +171,42 @@ describe("transformUseClientModule", () => {
       chunkUrl: "/Counter.tsx",
     });
     expect(result?.code).toContain(
-      `typeof client === "string" ? client : "load"`,
+      `typeof client === "string" ? client : "interaction"`,
+    );
+  });
+
+  test("shim resolves a default `prefetch` trigger per the defaults table", () => {
+    // Prefetch (chunk download) is split from hydrate (mount): the
+    // `interaction` default warms on `visible` so the first click is
+    // instant. Authors override via the `prefetch` prop, which the shim
+    // destructures out and forwards as a `prefetch=` attribute.
+    const source = `
+      "use client";
+      export function Counter() { return null; }
+    `;
+    const result = transformUseClientModule(source, "/Counter.tsx", {
+      chunkUrl: "/Counter.tsx",
+    });
+    expect(result?.code).toContain(`interaction: "visible"`);
+    expect(result?.code).toContain(
+      `typeof prefetch === "string" ? prefetch : (__PREFETCH_DEFAULTS[__when]`,
+    );
+    expect(result?.code).toContain('"prefetch": __pf');
+  });
+
+  test("shim renders no SSR markup for an `only` island (empty shell)", () => {
+    const source = `
+      "use client";
+      export function BrowserOnly() { return null; }
+    `;
+    const result = transformUseClientModule(source, "/BrowserOnly.tsx", {
+      chunkUrl: "/BrowserOnly.tsx",
+    });
+    // The child render + the `ssr` gate are both guarded on `__only`, so an
+    // `only` island emits `<plumix-island>` with no children.
+    expect(result?.code).toContain('const __only = __when === "only"');
+    expect(result?.code).toContain(
+      `__only ? null : __c(__orig["BrowserOnly"], wrapped)`,
     );
   });
 
@@ -189,9 +227,9 @@ describe("transformUseClientModule", () => {
     // — the custom element's `deserializeProps` expects this shape
     // so Date/Map/Set/etc. survive the round-trip.
     expect(result?.code).toContain("__ser(rest)");
-    // The shim destructures `client` out before forwarding so the
-    // strategy slot doesn't leak into the props attribute either.
-    expect(result?.code).toContain("const { client, ...rest }");
+    // The shim destructures `client` + `prefetch` out before forwarding so
+    // neither strategy slot leaks into the props attribute.
+    expect(result?.code).toContain("const { client, prefetch, ...rest }");
   });
 
   test("returns null for files without the directive (no-op transform)", () => {

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -136,13 +136,17 @@ export function transformUseClientModule(
     // Plain JSON.stringify would silently coerce them.
     `import { serializeProps as __ser } from "plumix/blocks";`,
     `import * as __orig from ${origUrl};`,
+    // Default prefetch trigger per hydration trigger. `interaction`'s
+    // `visible` default is the one that makes the first click feel instant
+    // — the chunk is warm before the user reaches the island.
+    `const __PREFETCH_DEFAULTS = { load: "load", idle: "load", visible: "visible", interaction: "visible", only: "load" };`,
     // `wrapped` is the full prop set fed to the SSR'd Component (with
     // React-element props replaced by <plumix-static-slot> wrappers).
     // `rest` is the JSON-safe subset for the serialized `props=`
     // attribute — element props are excluded and bridged via
     // StaticHtml on hydrate.
     `function __split(props) {`,
-    `  const { client, ...rest } = props ?? {};`,
+    `  const { client, prefetch, ...rest } = props ?? {};`,
     `  const slots = [];`,
     `  const wrapped = {};`,
     `  for (const k of Object.keys(rest)) {`,
@@ -155,7 +159,7 @@ export function transformUseClientModule(
     `      wrapped[k] = v;`,
     `    }`,
     `  }`,
-    `  return { client, rest, wrapped, slots };`,
+    `  return { client, prefetch, rest, wrapped, slots };`,
     `}`,
   ];
   for (const finding of findings) {
@@ -167,15 +171,24 @@ export function transformUseClientModule(
       : `export function ${name}(props)`;
     lines.push(
       `${exportPrefix} {`,
-      `  const { client, rest, wrapped, slots } = __split(props);`,
+      `  const { client, prefetch, rest, wrapped, slots } = __split(props);`,
+      // Default hydration trigger is `interaction` — hydrate on first user
+      // intent, replay the event. Authors opt into eager/visible/idle
+      // explicitly; the common case pays for JS only when engaged.
+      `  const __when = typeof client === "string" ? client : "interaction";`,
+      `  const __pf = typeof prefetch === "string" ? prefetch : (__PREFETCH_DEFAULTS[__when] || "load");`,
+      // `only` skips SSR entirely: empty shell, no `ssr` gate attribute, the
+      // client renders into it on connect.
+      `  const __only = __when === "only";`,
       `  return __c("plumix-island", {`,
       `    "chunk-url": ${chunkUrl},`,
       `    "component-export": ${targetLiteral},`,
-      `    "client": typeof client === "string" ? client : "load",`,
+      `    "client": __when,`,
+      `    "prefetch": __pf,`,
       `    "props": __ser(rest),`,
       `    "slots": slots.length ? slots.join(",") : null,`,
-      `    "ssr": "",`,
-      `  }, __c(__orig[${targetLiteral}], wrapped));`,
+      `    "ssr": __only ? null : "",`,
+      `  }, __only ? null : __c(__orig[${targetLiteral}], wrapped));`,
       `}`,
     );
   }

--- a/packages/plumix/src/vite/islands-chunk-size.test.ts
+++ b/packages/plumix/src/vite/islands-chunk-size.test.ts
@@ -13,10 +13,15 @@ type ViteManifest = Record<string, { readonly file: string }>;
 // modules the generated `.plumix/islands-*-entry.ts` inputs re-export)
 // through Vite with the plugin's load-bearing options
 // (`preserveEntrySignatures: "strict"`, prod minify) and asserts the
-// element chunk stays under the issue's 3 KB gz ceiling. A regression
-// that pulls React back into the element chunk blows it to ~60 KB and
-// fails here.
-const ELEMENT_CHUNK_CEILING_BYTES = 3 * 1024;
+// element chunk stays under the ceiling. A regression that pulls React back
+// into the element chunk blows it to ~60 KB and fails here.
+//
+// The chunk carries the custom element + all five hydration strategies
+// (load/idle/visible/interaction/only) + the prefetch wiring + prop
+// (de)serialization — measured at ~3.5 KB gz (was ~2.4 KB with only
+// `load`). 4 KB leaves headroom for a strategy or two while still catching
+// React (~60 KB) instantly.
+const ELEMENT_CHUNK_CEILING_BYTES = 4 * 1024;
 // A real Vite build — give it room beyond vitest's 5s default.
 const BUILD_TIMEOUT_MS = 30_000;
 


### PR DESCRIPTION
Adds the four deferred hydration strategies on top of the load-only islands MVP, plus a prefetch/hydrate split that lets a chunk warm on one trigger and mount on another. The default authoring surface (`"use client"` + `client="…"`) now hydrates on first interaction and replays the triggering event, so a page whose islands all defer ships 0 KB of React until the user engages.

`idle` (capped `requestIdleCallback`), `visible` (IntersectionObserver on the element with a 200px default margin + an already-visible pre-check), `interaction`, and `only` join the existing `load` on `window.Plumix`. Each may return a teardown the element runs on `disconnectedCallback`, so an island removed before its trigger doesn't leak an observer or listener.

**Prefetch / hydrate split (the lever Astro and Nuxt lack)**

`prefetch` is a trigger separate from `client`: it warms the component + renderer chunks via `import()` without mounting. Defaults derive from `client` (`interaction` → `visible`), so the chunk is already cached when the user clicks and hydration becomes pure CPU. The element skips the extra registration when hydration is immediate (`load`/`only`) or the two triggers match.

**Interaction event replay**

A single document-level capture listener suppresses the dead-DOM event, then replays it after mount inside `requestAnimationFrame`. The event is reconstructed via its own constructor (so `KeyboardEvent` data survives), focus events restore `.focus()` instead of double-dispatching, and events that arrive while the chunk is still loading are queued and replayed in order.

**Bootstrap ordering fix**

`bootstrapIslandRuntime` now sets the renderer URL before defining the custom element. Defining it synchronously upgrades any SSR'd `<plumix-island>` already in the DOM, and an eager (`load`/`only`) island hydrates in `connectedCallback` — previously against a null renderer URL.

Default `client` is now `interaction`, and `only` islands emit an empty shell (no SSR markup, no `ssr` gate). The eager element runtime stays React-free at ~3.5 KB gz; the chunk-size guard moves 3 → 4 KB to fit the added strategies. Nested interaction-within-interaction islands are intentionally out of scope (single-level is fully covered).

Source-level Astro/Nuxt/TanStack comparison, real chunk figures, the per-strategy spec, and a reproducible Playwright harness are documented in the issue:
- https://github.com/withplumix/plumix/issues/522#issuecomment-4546552068
- https://github.com/withplumix/plumix/issues/522#issuecomment-4546649325

Closes #522
