### PR TITLE
fix(core,plugin-menu): expose TemplateDepRegistry augmentations

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,6 @@
+// Side-effect: exposes core's `TemplateDepRegistry` augmentation.
+import "./template-deps-core.js";
+
 export * from "./admin/index.js";
 export * from "./auth/index.js";
 export * from "./cli/index.js";

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -235,6 +235,25 @@ export interface PluginSetupContextBase {
    * function. The `kind` must match a key in the augmentable
    * `TemplateDepRegistry` interface; two plugins registering the
    * same `kind` is a boot-time error.
+   *
+   * **Augmenting `TemplateDepRegistry` so consumers see the kind.**
+   * TypeScript only merges the augmentation when the file declaring
+   * it is in the consumer's tsc program. The pattern depends on where
+   * the plugin lives:
+   *
+   * - **Workspace-package plugin** (e.g. `@plumix/plugin-menu`): put
+   *   the `declare module "plumix/plugin"` block alongside the
+   *   result type the plugin exports from `/server`. Themes import
+   *   the result type from `/server`, which pulls the augmentation
+   *   in too. Avoid the main entry — themes that only touch `/server`
+   *   types never load it.
+   *
+   * - **Consumer-local plugin** (defined inline in the consumer's
+   *   source, e.g. `playground/plugins/post-navigation.ts`): the
+   *   theme can't import from the consumer (wrong dep direction).
+   *   Put the `declare module` block in a shared types file (e.g.
+   *   `plumix-types.d.ts`) that both the consumer's plumix config
+   *   and the theme entry import as a side effect.
    */
   registerTemplateDep<TKind extends keyof TemplateDepRegistry>(
     kind: TKind,

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -4,15 +4,6 @@ import type { ResolvedMenu, ResolvedMenuItem } from "./server/types.js";
 import { createMenuRouter } from "./rpc.js";
 import { getMenuByName } from "./server/getMenuByName.js";
 
-// Register the `menus` template-dep kind so themes can declare
-// `defineTemplate({ menus: ["primary", "footer"], render })` and the
-// framework batches loads per request via the registered loader below.
-declare module "plumix/plugin" {
-  interface TemplateDepRegistry {
-    menus: { slug: string; result: ResolvedMenu };
-  }
-}
-
 // `@plumix/plugin-menu` augments the core option shapes with
 // menu-eligibility flags and the hook registries with three menu
 // hooks. TypeScript surfaces all of these only when this plugin is

--- a/packages/plugins/menu/src/server/types.ts
+++ b/packages/plugins/menu/src/server/types.ts
@@ -81,6 +81,14 @@ export interface ResolvedMenu {
   readonly items: readonly ResolvedMenuItem[];
 }
 
+// Lives here (not main entry) so themes pulling /server types pick
+// up the augmentation without a side-effect import on the main entry.
+declare module "plumix/plugin" {
+  interface TemplateDepRegistry {
+    menus: { slug: string; result: ResolvedMenu };
+  }
+}
+
 /**
  * Theme-side input for `registerMenuLocation`. The label appears in the
  * admin Locations panel (slice 7+); description is optional helper text.


### PR DESCRIPTION
TypeScript module augmentations only merge when the augmenting file is in the consumer's tsc program. Two flavors of the same bug bit external consumers — themes saw `Property 'settings' does not exist on TemplateRenderArgs` (or `menus`) at strict tsc despite the runtime working fine.

**Core `settings` reaches the public barrel**

`packages/core/src/template-deps-core.ts` declares the `settings` `TemplateDepRegistry` augmentation but the file wasn't referenced from `src/index.ts`. External consumers of `plumix` didn't load it. Added a side-effect `import "./template-deps-core.js"` in the barrel; the file was already pulled in by `runtime/app.ts`, so no bundle delta.

**Menu plugin augmentation reachable from `/server`**

`@plumix/plugin-menu` declared `menus` in its main entry. Themes that imported only from `/server` (for `ResolvedMenu` types) never triggered it. Moved the `declare module "plumix/plugin"` block from `src/index.ts` into `src/server/types.ts`, which is loaded by both surfaces (`import type { ResolvedMenu }` from main, re-export from `/server/index.ts`).

**Consumer-local plugin pattern documented**

The third flavor (inline-in-consumer plugins like `playground/plugins/post-navigation.ts`) has no import path from theme back to consumer. Documented on `registerTemplateDep`'s JSDoc: put the `declare module` block in a shared `plumix-types.d.ts` imported as a side effect by both the plumix config and the theme entry.

Fixes #579