### PR TITLE
fix(blocks,core): make ThemeTokenEntry.value optional

### DIFF
--- a/packages/admin/src/editor/TokenSwatchList.test.tsx
+++ b/packages/admin/src/editor/TokenSwatchList.test.tsx
@@ -50,6 +50,22 @@ describe("TokenSwatchList", () => {
     expect(swatch.style.backgroundColor).toBe("rgb(0, 112, 243)");
   });
 
+  test("renders a colorless swatch when the token has no value (label-only)", () => {
+    const labelOnly: ThemeTokenGroup = { brand: { label: "Brand" } };
+    render(
+      <TokenSwatchList
+        tokens={labelOnly}
+        value=""
+        onChange={vi.fn()}
+        testIdPrefix="bg"
+        ariaLabel="Background color"
+      />,
+    );
+
+    const swatch = screen.getByTestId("bg-swatch-brand");
+    expect(swatch.style.backgroundColor).toBe("");
+  });
+
   test("marks the active token as the checked radio", () => {
     render(
       <TokenSwatchList

--- a/packages/blocks/src/styles/style-emitter.test.ts
+++ b/packages/blocks/src/styles/style-emitter.test.ts
@@ -20,6 +20,16 @@ describe("tokenIdToCssVar", () => {
       "var(--plumix-spacing-xl)",
     );
   });
+
+  test("returns a CSS variable reference without fallback when the token is registered with no value (label-only)", () => {
+    const tokens: ThemeTokens = {
+      spacing: { lg: { label: "Large" } },
+    };
+
+    expect(tokenIdToCssVar("lg", "spacing", tokens)).toBe(
+      "var(--plumix-spacing-lg)",
+    );
+  });
 });
 
 describe("emitBlockStyleCss", () => {

--- a/packages/blocks/src/styles/types.ts
+++ b/packages/blocks/src/styles/types.ts
@@ -1,11 +1,10 @@
 /**
- * One entry in a token group. `value` is the CSS value the browser
- * receives (hex/rgb for colors, length string for spacing, etc.).
- * `label` is the human-readable name the Inspector picker shows;
- * defaults to the slug when omitted.
+ * One entry in a token group. `value` is the CSS literal written as
+ * the `var(..., <fallback>)`; omit when `:root` provides it. `label`
+ * is the Inspector display name; defaults to the slug.
  */
 export interface ThemeTokenEntry {
-  readonly value: string;
+  readonly value?: string;
   readonly label?: string;
 }
 

--- a/packages/core/src/theme-tokens.test.ts
+++ b/packages/core/src/theme-tokens.test.ts
@@ -18,6 +18,15 @@ describe("defineTheme tokens validation", () => {
     ).not.toThrow();
   });
 
+  test("accepts a token entry with no value (label-only)", () => {
+    expect(() =>
+      defineTheme({
+        templates: { index: Stub },
+        tokens: { colors: { brand: { label: "Brand" } } },
+      }),
+    ).not.toThrow();
+  });
+
   test("rejects a slug with CSS-breaking characters", () => {
     expect(() =>
       defineTheme({

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -189,14 +189,12 @@ function validateTokens(tokens: ThemeTokens): void {
       if (!TOKEN_SLUG_RE.test(slug)) {
         throw ThemeError.invalidTokenSlug({ group, slug });
       }
-      if (
-        typeof entry.value !== "string" ||
-        TOKEN_VALUE_FORBIDDEN_CHARS.test(entry.value)
-      ) {
+      if (entry.value === undefined) continue;
+      if (TOKEN_VALUE_FORBIDDEN_CHARS.test(entry.value)) {
         throw ThemeError.invalidTokenValue({
           group,
           slug,
-          value: String(entry.value),
+          value: entry.value,
         });
       }
     }


### PR DESCRIPTION
The emitter already falls back to `var(--plumix-{cat}-{id})` when a token's `value` is absent, but the required `value: string` type forced themes into tautological boilerplate like `{ value: "var(--plumix-colors-base)", label: "Base" }`. When the theme dev owns `:root` with real CSS variables, the registry can be names-only.

**Type widening + one validator tweak**

`ThemeTokenEntry.value` is now optional. `validateTokens` skips the value check when undefined and drops the redundant `typeof entry.value !== "string"` guard — TypeScript already narrows past the undefined check. The emitter (`tokenIdToCssVar`) already handled this correctly with `entry?.value !== undefined`, so no behavior change there.

**Admin swatch fallback**

`TokenSwatchList` renders `style={{ backgroundColor: entry.value }}` — React drops the property when undefined, leaving a clean bordered colorless swatch as the natural placeholder. A test pins the behavior.

Before:

```ts
tokens: {
  colors: {
    base: { value: "var(--plumix-colors-base)", label: "Base" },
    contrast: { value: "var(--plumix-colors-contrast)", label: "Contrast" },
  },
}
```

After:

```ts
tokens: {
  colors: {
    base: { label: "Base" },
    contrast: { label: "Contrast" },
  },
}
```

Surfaces FRICTION F9 from the theme-starter spike.

Fixes #584