### PR TITLE
feat(core): configurable archivePerPage per entry type and term taxonomy

### DIFF
--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -53,6 +53,8 @@ export interface EntryTypeOptions {
     readonly maxRevisions?: number;
     readonly autosaveIntervalSeconds?: number;
   };
+  /** Page size for this type's archive route. Default 20. */
+  readonly archivePerPage?: number;
 }
 
 export interface TermTaxonomyOptions {
@@ -73,6 +75,8 @@ export interface TermTaxonomyOptions {
   };
   readonly capabilities?: TermTaxonomyCapabilityOverrides;
   readonly menuIcon?: string;
+  /** Page size for this taxonomy's term archives. Default 20. */
+  readonly archivePerPage?: number;
 }
 
 export function resolveEntryTypeVisibility(options: EntryTypeOptions): {

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1276,6 +1276,43 @@ describe("resolvePublicRoute — archive through theme", () => {
     expect(body).toContain("page:2;entries:5");
   });
 
+  test("entry type's `archivePerPage` overrides the default page size on the archive", async () => {
+    const smallPagePlugin = definePlugin("small-page", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+        archivePerPage: 5,
+      });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <span data-testid="per-page">{`perPage:${String(data.pagination.perPage)}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [smallPagePlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "p",
+      title: "P",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    expect(await response.text()).toContain("perPage:5");
+  });
+
   test("archive-{type} specificity wins over `archive` and `index`", async () => {
     const theme = defineTheme({
       templates: {
@@ -1500,6 +1537,61 @@ describe("resolvePublicRoute — taxonomy through theme", () => {
     expect(body).toContain('data-testid="term-name"');
     expect(body).toContain("News");
     expect(body).toContain("Story A");
+  });
+
+  test("taxonomy's `archivePerPage` overrides the default page size on term archives", async () => {
+    const smallPageTaxonomy = definePlugin("small-page-tax", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+      });
+      ctx.registerTermTaxonomy("topic", {
+        label: "Topics",
+        labels: { singular: "Topic" },
+        entryTypes: ["post"],
+        isHierarchical: false,
+        archivePerPage: 3,
+      });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        taxonomy: ({ data }) => (
+          <span data-testid="per-page">{`perPage:${String(data.pagination.perPage)}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [smallPageTaxonomy],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.term.create({
+      taxonomy: "topic",
+      slug: "news",
+      name: "News",
+    });
+    const entry = await h.factory.entry.create({
+      type: "post",
+      slug: "t",
+      title: "T",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entryTerm.create({
+      entryId: entry.id,
+      termId: term.id,
+      sortOrder: 0,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/topic/news"),
+    );
+    expect(await response.text()).toContain("perPage:3");
   });
 
   test("excludes published entries with NULL publishedAt from the term archive", async () => {

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -43,7 +43,7 @@ declare module "../hooks/types.js" {
   }
 }
 
-const ARCHIVE_LIMIT = 20;
+const DEFAULT_ARCHIVE_PER_PAGE = 20;
 
 export async function resolvePublicRoute(
   ctx: AppContext,
@@ -120,13 +120,18 @@ async function resolveFrontPage(
           isNotNull(entries.publishedAt),
           inArray(entries.type, publicTypes),
         );
-  const result = await paginatedEntries(ctx, where, page);
+  const result = await paginatedEntries(
+    ctx,
+    where,
+    page,
+    DEFAULT_ARCHIVE_PER_PAGE,
+  );
 
   const initial: FrontPageData = {
     entries: await buildResolvedEntries(ctx, result.rows),
     pagination: {
       page,
-      perPage: ARCHIVE_LIMIT,
+      perPage: DEFAULT_ARCHIVE_PER_PAGE,
       total: result.total,
       pageCount: result.pageCount,
     },
@@ -186,7 +191,8 @@ async function resolveTaxonomy(
           ),
         );
 
-  const result = await paginatedEntries(ctx, where, page);
+  const perPage = taxonomy?.archivePerPage ?? DEFAULT_ARCHIVE_PER_PAGE;
+  const result = await paginatedEntries(ctx, where, page, perPage);
   if (result.outOfRange) return notFound("public-term-page-out-of-range");
 
   const initial: TaxonomyData = {
@@ -195,7 +201,7 @@ async function resolveTaxonomy(
     entries: await buildResolvedEntries(ctx, result.rows),
     pagination: {
       page,
-      perPage: ARCHIVE_LIMIT,
+      perPage,
       total: result.total,
       pageCount: result.pageCount,
     },
@@ -284,7 +290,9 @@ async function resolveArchive(
     isNotNull(entries.publishedAt),
   );
 
-  const result = await paginatedEntries(ctx, where, page);
+  const registered = ctx.plugins.entryTypes.get(intent.entryType);
+  const perPage = registered?.archivePerPage ?? DEFAULT_ARCHIVE_PER_PAGE;
+  const result = await paginatedEntries(ctx, where, page, perPage);
   if (result.outOfRange) return notFound("public-archive-page-out-of-range");
 
   // Set after the query so a thrown query doesn't leave a stale entity
@@ -292,7 +300,6 @@ async function resolveArchive(
   // reads it.
   ctx.resolvedEntity = { kind: "archive", entryType: intent.entryType };
 
-  const registered = ctx.plugins.entryTypes.get(intent.entryType);
   const title =
     registered?.labels?.plural ?? registered?.label ?? intent.entryType;
 
@@ -301,7 +308,7 @@ async function resolveArchive(
     entries: await buildResolvedEntries(ctx, result.rows),
     pagination: {
       page,
-      perPage: ARCHIVE_LIMIT,
+      perPage,
       total: result.total,
       pageCount: result.pageCount,
     },
@@ -434,6 +441,7 @@ async function paginatedEntries(
   ctx: AppContext,
   where: SQL | null | undefined,
   page: number,
+  perPage: number,
 ): Promise<{
   readonly rows: readonly Entry[];
   readonly outOfRange: boolean;
@@ -441,7 +449,7 @@ async function paginatedEntries(
   readonly pageCount: number;
 }> {
   if (where == null) {
-    const slice = paginate({ page, perPage: ARCHIVE_LIMIT, total: 0 });
+    const slice = paginate({ page, perPage, total: 0 });
     return {
       rows: [],
       outOfRange: slice.outOfRange,
@@ -456,7 +464,7 @@ async function paginatedEntries(
     .where(where);
   const total = totalRow[0]?.total ?? 0;
 
-  const slice = paginate({ page, perPage: ARCHIVE_LIMIT, total });
+  const slice = paginate({ page, perPage, total });
   if (slice.outOfRange) {
     return {
       rows: [],


### PR DESCRIPTION
`packages/core/src/route/resolve.ts` hardcoded `ARCHIVE_LIMIT = 20` as the page size for every archive route. Themes couldn't tune it per entry type or per term taxonomy ("32 per page on a portfolio archive, 10 per page on the blog index"), and the constant didn't match WordPress's `posts_per_page` shape that theme authors expect.

**Optional `archivePerPage` on registration**

Both `EntryTypeOptions` and `TermTaxonomyOptions` gain an optional `archivePerPage?: number`. `resolveArchive` reads from the registered entry type's option; `resolveTaxonomy` from the taxonomy's. Default stays 20 — no breaking change for callers that don't set it.

`resolveFrontPage` mixes all public types so no single matching type's option applies — it stays on the default. `paginatedEntries` gains a `perPage` parameter (it already used `paginate({ perPage })` internally).

Surfaces FRICTION F19 from the theme-starter spike.

Fixes #582