### PR TITLE
feat(core): compile /page/N for the front-page (URL convention parity)

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -2052,6 +2052,47 @@ describe("resolvePublicRoute — front-page through theme", () => {
     expect(body).not.toContain('data-testid="row-no-date"');
   });
 
+  test("/page/N renders the front-page on page N", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": ({ data }) => (
+          <span data-testid="page">{`page:${String(data.pagination.page)}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "p",
+      title: "P",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/page/1"),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("page:1");
+  });
+
+  test("/page/0 on the front-page is out-of-range 404", async () => {
+    const theme = defineTheme({
+      templates: { index: () => null, "front-page": () => null },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/page/0"),
+    );
+    expect(response.status).toBe(404);
+  });
+
   test("plugin-registered `/` rewrite rule wins over front-page synthesis", async () => {
     const homepagePlugin = definePlugin("homepage", (ctx) => {
       ctx.registerEntryType("post", { label: "Posts", isPublic: true });

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -91,6 +91,7 @@ export async function resolvePublicRoute(
     case "front-page":
       return resolveFrontPage(
         ctx,
+        match.params,
         theme,
         document,
         templateDocuments,
@@ -102,13 +103,14 @@ export async function resolvePublicRoute(
 
 async function resolveFrontPage(
   ctx: AppContext,
+  params: Record<string, string>,
   theme: ThemeDescriptor,
   document: DocumentManifest,
   templateDocuments: ReadonlyMap<string, DocumentManifest>,
   templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
   assetManifest: AssetManifest,
 ): Promise<Response> {
-  const page = 1;
+  const page = parsePageParam(params.page);
   const publicTypes = Array.from(ctx.plugins.entryTypes.entries())
     .filter(([, spec]) => spec.isPublic !== false)
     .map(([key]) => key);
@@ -126,6 +128,7 @@ async function resolveFrontPage(
     page,
     DEFAULT_ARCHIVE_PER_PAGE,
   );
+  if (result.outOfRange) return notFound("public-front-page-page-out-of-range");
 
   const initial: FrontPageData = {
     entries: await buildResolvedEntries(ctx, result.rows),

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -264,10 +264,11 @@ async function resolvePublicRouteOrFallback(
       assetManifest,
     );
   }
-  if (url.pathname === "/") {
+  const frontPageParams = matchFrontPagePathname(url.pathname);
+  if (frontPageParams !== null) {
     return resolvePublicRoute(
       ctx,
-      { intent: { kind: "front-page" }, params: {} },
+      { intent: { kind: "front-page" }, params: frontPageParams },
       theme,
       document,
       templateDocuments,
@@ -276,6 +277,17 @@ async function resolvePublicRouteOrFallback(
     );
   }
   return notFound("public-route-not-found");
+}
+
+const FRONT_PAGE_PAGINATED = new URLPattern({ pathname: "/page/:page" });
+
+function matchFrontPagePathname(
+  pathname: string,
+): Record<string, string> | null {
+  if (pathname === "/") return {};
+  const match = FRONT_PAGE_PAGINATED.exec({ pathname });
+  const page = match?.pathname.groups.page;
+  return page === undefined ? null : { page };
 }
 
 interface PluginRawRouteMatch {


### PR DESCRIPTION
Archive and taxonomy compile a paginated `${basePattern}/page/:page` rule, but the front-page had no equivalent. The URL a theme author naturally picks (matching WordPress's `/blog/page/2` and plumix's own archive convention) silently 404'd, even though `FrontPageData.pagination` was populated.

**Path-based pagination via dispatcher fallback**

The dispatcher's `/` literal check becomes `matchFrontPagePathname`, returning `{}` for `/` or `{ page: "N" }` for `/page/N`. The lookup fires only when no compiled rule matched, so a plugin-registered single route on `/page/:slug` (e.g. a `page` entry type) still wins.

**Out-of-range parity with archive/taxonomy**

`resolveFrontPage` now threads `match.params` through, parses `params.page` via the existing `parsePageParam` helper, and returns `notFound("public-front-page-page-out-of-range")` on `/page/0` or `/page/<too-big>` — exact parallel to archive and taxonomy.

Surfaces FRICTION F20 from the theme-starter spike.

Fixes #578