### PR TITLE
feat(core): add typed contentBlocks accessor on ResolvedEntry

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1,7 +1,6 @@
 import { useId } from "react";
 import { describe, expect, test } from "vitest";
 
-import type { EntryContent } from "@plumix/blocks";
 import { defineBlock } from "@plumix/blocks";
 import { BlockRenderer } from "@plumix/blocks/renderer";
 
@@ -1028,15 +1027,79 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(headSection).not.toContain("httpEquiv");
   });
 
+  test("theme reads entry.contentBlocks without a cast", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => (
+          <span data-testid="blocks">
+            {`blocks:${String(data.entry.contentBlocks?.blocks.length ?? 0)}`}
+          </span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "typed",
+      title: "Typed",
+      content: {
+        version: "plumix.v2",
+        blocks: [
+          { id: "a", name: "core/heading", attrs: { text: "Hi" } },
+          { id: "b", name: "core/paragraph", attrs: { text: "ok" } },
+        ],
+      },
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/typed"),
+    );
+    expect(await response.text()).toContain("blocks:2");
+  });
+
+  test("contentBlocks is null when stored content doesn't match the EntryContent shape", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => (
+          <span data-testid="result">
+            {`isNull:${String(data.entry.contentBlocks === null)}`}
+          </span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.db.insert(entriesTable).values({
+      type: "post",
+      slug: "bad",
+      title: "Bad",
+      content: { not: "valid" },
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/bad"),
+    );
+    expect(await response.text()).toContain("isNull:true");
+  });
+
   test("template can render <BlockRenderer/> against the entry's content tree", async () => {
     const theme = defineTheme({
       templates: {
         index: () => null,
         single: ({ data }) =>
-          data.entry.content ? (
-            <BlockRenderer
-              content={data.entry.content as unknown as EntryContent}
-            />
+          data.entry.contentBlocks ? (
+            <BlockRenderer content={data.entry.contentBlocks} />
           ) : null,
       },
     });
@@ -1081,10 +1144,8 @@ describe("resolvePublicRoute — single entry through theme", () => {
       templates: {
         index: () => null,
         single: ({ data }) =>
-          data.entry.content ? (
-            <BlockRenderer
-              content={data.entry.content as unknown as EntryContent}
-            />
+          data.entry.contentBlocks ? (
+            <BlockRenderer content={data.entry.contentBlocks} />
           ) : null,
       },
     });

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -7,7 +7,7 @@ import type {
   LoaderErrorEvent,
   ResolvedBlockLoaders,
 } from "@plumix/blocks";
-import { isEntryContent, resolveBlockLoaders } from "@plumix/blocks";
+import { resolveBlockLoaders } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { AppContext } from "../../context/app.js";
@@ -165,9 +165,7 @@ async function prefetchEntryLoaders(
 }
 
 function singleEntryContent(data: TemplateData): EntryContent | null {
-  const candidate =
-    (data as { entry?: { content?: unknown } }).entry?.content ?? null;
-  return isEntryContent(candidate) ? candidate : null;
+  return "entry" in data ? data.entry.contentBlocks : null;
 }
 
 interface RenderTreeArgs {

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -1,3 +1,5 @@
+import type { EntryContent } from "@plumix/blocks";
+
 import type { Entry } from "../../db/schema/entries.js";
 import type { Term } from "../../db/schema/terms.js";
 
@@ -8,7 +10,11 @@ export interface ResolvedAuthor {
   readonly avatarUrl: string | null;
 }
 
+// `content` stays loose so non-blocks serializers (TipTap, etc.) keep
+// working; `contentBlocks` is the narrowed `EntryContent` (null when
+// the stored JSON fails the shape check).
 export interface ResolvedEntry extends Entry {
+  readonly contentBlocks: EntryContent | null;
   readonly terms: readonly Term[];
   readonly author: ResolvedAuthor;
 }

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -1,6 +1,8 @@
 import type { SQL } from "drizzle-orm";
 import { count } from "drizzle-orm";
 
+import { isEntryContent } from "@plumix/blocks";
+
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
@@ -381,7 +383,12 @@ async function buildResolvedEntries(
         `buildResolvedEntries: entry ${String(row.id)} references missing author ${String(row.authorId)}`,
       );
     }
-    return { ...row, terms: termsByEntryId.get(row.id) ?? [], author };
+    return {
+      ...row,
+      contentBlocks: isEntryContent(row.content) ? row.content : null,
+      terms: termsByEntryId.get(row.id) ?? [],
+      author,
+    };
   });
 }
 


### PR DESCRIPTION
Themes had to cast `data.entry.content as unknown as EntryContent` before handing it to `<BlockRenderer />` — the schema's loose `Record<string, unknown>` doesn't narrow to the plumix-v2 block tree shape.

**Typed accessor parsed once at the boundary**

`ResolvedEntry` gains `contentBlocks: EntryContent | null`, populated in `buildResolvedEntries` by running `row.content` through the existing `isEntryContent` guard from `@plumix/blocks`. Themes call `<BlockRenderer content={data.entry.contentBlocks} />` with no cast. Falls back to `null` when the stored JSON doesn't match the shape (silent — matches the prior behavior of `singleEntryContent`).

**`content` stays loose for non-blocks paths**

The original `content` field stays as the schema's `Record<string, unknown>` so non-blocks consumers (the TipTap renderer used by the test harness, custom serializers) keep working. `singleEntryContent` in `render-template.tsx` now reads the narrowed `entry.contentBlocks` directly — the prior structural cast + re-guard is gone.

Surfaces FRICTION F11 from the theme-starter spike.

Fixes #580