### PR TITLE
feat(core): support per-request DocumentManifest resolver on defineTemplate

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -463,6 +463,53 @@ describe("resolvePublicRoute — single entry through theme", () => {
     );
   });
 
+  test("template `document` accepts a function that receives the render args and renders per-request", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          document: ({ data }) => ({
+            meta: [
+              {
+                property: "og:description",
+                content: `desc:${data.entry.title}`,
+              },
+            ],
+          }),
+          render: ({ data }) => <article>{data.entry.title}</article>,
+        }),
+      },
+      document: {
+        meta: [{ name: "theme-color", content: "#0ea5e9" }],
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "dyn",
+      title: "Dynamic Title",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/dyn"),
+    );
+    const body = await response.text();
+    const headSection = body.slice(
+      body.indexOf("<head>"),
+      body.indexOf("</head>"),
+    );
+    expect(headSection).toContain(
+      '<meta property="og:description" content="desc:Dynamic Title"',
+    );
+    expect(headSection).toContain('<meta name="theme-color"');
+  });
+
   test("templates without a document fragment fall back to the theme-wide document", async () => {
     // Locks the contract: a template that doesn't declare its own
     // fragment shouldn't pay any per-template cost — and shouldn't

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -25,8 +25,10 @@ import type {
 import type { AssetManifest } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
+import { mergeDocumentManifest } from "../../document-merge.js";
 import { loadTemplateDeps } from "../../template-deps.js";
 import { normalizeTemplate } from "../../template.js";
+import { validateDocumentManifest } from "../../theme.js";
 import { bundledCssTags } from "./asset-manifest.js";
 import { injectIslandsBootstrap } from "./inject-islands-bootstrap.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
@@ -56,9 +58,6 @@ export async function renderThroughTheme({
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const { template, slot } = pickTemplate(theme.templates, candidates);
-  // Per-template fragment is precomputed at boot; fall back to the
-  // theme-wide document when the template didn't declare its own.
-  const renderDocument = templateDocuments.get(slot) ?? document;
   // Load every dep the template declared in parallel before render.
   // Loader failures don't 500 the page — `loadTemplateDeps` swallows
   // them, logs via `ctx.logger.error`, and seeds an empty map.
@@ -67,6 +66,15 @@ export async function renderThroughTheme({
     templateDeps,
     ctx,
   );
+  const renderDocument = resolveRenderDocument({
+    template,
+    slot,
+    document,
+    templateDocuments,
+    data,
+    ctx,
+    deps,
+  });
   const loaderData = await prefetchEntryLoaders(ctx, data);
   return renderTree({
     ctx,
@@ -113,7 +121,6 @@ export async function renderErrorThroughTheme({
   const variant = ERROR_VARIANTS[kind];
   const raw = theme.templates[variant.key] ?? variant.fallback;
   const template = normalizeTemplate(raw, variant.key);
-  const renderDocument = templateDocuments.get(variant.key) ?? document;
   // Error templates can declare deps too — loader failures still log
   // + empty-map fallback so a 404/500 render never escalates.
   const deps = await loadTemplateDeps(
@@ -121,6 +128,15 @@ export async function renderErrorThroughTheme({
     templateDeps,
     ctx,
   );
+  const renderDocument = resolveRenderDocument({
+    template,
+    slot: variant.key,
+    document,
+    templateDocuments,
+    data,
+    ctx,
+    deps,
+  });
   return renderTree({
     ctx,
     document: renderDocument,
@@ -166,6 +182,35 @@ async function prefetchEntryLoaders(
 
 function singleEntryContent(data: TemplateData): EntryContent | null {
   return "entry" in data ? data.entry.contentBlocks : null;
+}
+
+interface ResolveDocumentArgs {
+  readonly template: Template<TemplateData>;
+  readonly slot: string;
+  readonly document: DocumentManifest;
+  readonly templateDocuments: ReadonlyMap<string, DocumentManifest>;
+  readonly data: TemplateData;
+  readonly ctx: AppContext;
+  readonly deps: Record<string, Record<string, unknown>>;
+}
+
+function resolveRenderDocument({
+  template,
+  slot,
+  document,
+  templateDocuments,
+  data,
+  ctx,
+  deps,
+}: ResolveDocumentArgs): DocumentManifest {
+  const fragment = template.document;
+  if (typeof fragment !== "function") {
+    return templateDocuments.get(slot) ?? document;
+  }
+  const resolved = fragment({ ...deps, data, ctx });
+  const merged = mergeDocumentManifest(document, resolved);
+  validateDocumentManifest(merged, slot);
+  return merged;
 }
 
 interface RenderTreeArgs {

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -302,6 +302,10 @@ function buildTemplateDocuments(
       // `app.document` (already deep-frozen).
       continue;
     }
+    if (typeof value.document === "function") {
+      // Resolved per-request by the renderer; nothing to precompute.
+      continue;
+    }
     const merged = mergeDocumentManifest(themeDocument, value.document);
     validateDocumentManifest(merged, slot);
     result.set(slot, deepFreezeManifest(merged));

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -58,14 +58,17 @@ export type TemplateRender<TData extends TemplateData> = (
 ) => ReactNode;
 
 /**
+ * Literal manifest is merged at boot; function form is called per
+ * request with the same args `render` sees.
+ */
+export type TemplateDocument<TData extends TemplateData> =
+  | DocumentManifest
+  | ((args: TemplateRenderArgs<TData>) => DocumentManifest);
+
+/**
  * Output of `defineTemplate`. The brand symbol is non-enumerable so
  * it doesn't pollute `Object.keys` / JSON serialization but stays
  * load-bearing for runtime identification via `isTemplate`.
- *
- * `document` is the optional per-template fragment merged with the
- * theme's site-wide document at boot. Per-request renders look up the
- * already-merged result keyed by the matched template slot — zero
- * runtime merge cost.
  *
  * Dep declarations (`[K in keyof TemplateDepRegistry]?`) live directly
  * on the template object so the framework's per-request dispatch can
@@ -75,7 +78,7 @@ export interface Template<
   TData extends TemplateData = TemplateData,
 > extends TemplateDepDeclarations {
   readonly render: TemplateRender<TData>;
-  readonly document?: DocumentManifest;
+  readonly document?: TemplateDocument<TData>;
   readonly [PLUMIX_TEMPLATE_BRAND]: true;
 }
 
@@ -83,7 +86,7 @@ interface DefineTemplateConfig<
   TData extends TemplateData,
 > extends TemplateDepDeclarations {
   readonly render: TemplateRender<TData>;
-  readonly document?: DocumentManifest;
+  readonly document?: TemplateDocument<TData>;
 }
 
 export function defineTemplate<TData extends TemplateData = TemplateData>(


### PR DESCRIPTION
`defineTemplate({ document })` only accepted a literal `DocumentManifest` precomputed and merged with the theme document at boot. Static fragments work — a 404 template's `{ meta: [{ name: "robots", content: "noindex,nofollow" }] }` renders — but per-request meta like `og:description` computed from `data.entry.excerpt` had no path through.

**Function-form document resolver**

`Template.document` now accepts either a literal `DocumentManifest` or a resolver `(args) => DocumentManifest`. The resolver receives the same args `render` sees (`{ data, ctx, ...deps }`), goes through the existing `mergeDocumentManifest` against the theme document, and runs through `validateDocumentManifest` — exact same safety contract as the static path.

**Boot skips, renderer resolves**

`buildTemplateDocuments` skips function-form templates at boot. The renderer extracts a `resolveRenderDocument` helper called from both `renderThroughTheme` and `renderErrorThroughTheme` that picks the precomputed map for literals or invokes the resolver for functions.

```ts
// Static — unchanged
defineTemplate({
  document: { meta: [{ name: "robots", content: "noindex,nofollow" }] },
  render: () => ...,
});

// Dynamic — new
defineTemplate<SingleData>({
  document: ({ data }) => ({
    meta: [{ property: "og:description", content: data.entry.excerpt ?? "" }],
  }),
  render: ({ data }) => <article>{data.entry.title}</article>,
});
```

Surfaces FRICTION F17 from the theme-starter spike.

Fixes #581