### PR TITLE
feat(core): support theme-level templateDeps on defineTheme

### DIFF
--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -26,7 +26,10 @@ import type { AssetManifest } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
 import { mergeDocumentManifest } from "../../document-merge.js";
-import { loadTemplateDeps } from "../../template-deps.js";
+import {
+  loadTemplateDeps,
+  mergeTemplateDepDeclarations,
+} from "../../template-deps.js";
 import { normalizeTemplate } from "../../template.js";
 import { validateDocumentManifest } from "../../theme.js";
 import { bundledCssTags } from "./asset-manifest.js";
@@ -58,11 +61,11 @@ export async function renderThroughTheme({
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const { template, slot } = pickTemplate(theme.templates, candidates);
-  // Load every dep the template declared in parallel before render.
-  // Loader failures don't 500 the page — `loadTemplateDeps` swallows
-  // them, logs via `ctx.logger.error`, and seeds an empty map.
   const deps = await loadTemplateDeps(
-    template as unknown as Record<string, unknown>,
+    mergeTemplateDepDeclarations(
+      theme.templateDeps,
+      template as unknown as Record<string, unknown>,
+    ),
     templateDeps,
     ctx,
   );
@@ -121,10 +124,11 @@ export async function renderErrorThroughTheme({
   const variant = ERROR_VARIANTS[kind];
   const raw = theme.templates[variant.key] ?? variant.fallback;
   const template = normalizeTemplate(raw, variant.key);
-  // Error templates can declare deps too — loader failures still log
-  // + empty-map fallback so a 404/500 render never escalates.
   const deps = await loadTemplateDeps(
-    template as unknown as Record<string, unknown>,
+    mergeTemplateDepDeclarations(
+      theme.templateDeps,
+      template as unknown as Record<string, unknown>,
+    ),
     templateDeps,
     ctx,
   );

--- a/packages/core/src/template-deps.test.tsx
+++ b/packages/core/src/template-deps.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import type { RegisteredTemplateDep } from "./template-deps.js";
 import { auth } from "./auth/config.js";
 import { plumix } from "./config.js";
+import { settings as settingsSchema } from "./db/schema/settings.js";
 import { definePlugin } from "./plugin/define.js";
 import { DuplicateRegistrationError } from "./plugin/errors.js";
 import { buildApp } from "./runtime/app.js";
@@ -356,6 +357,105 @@ describe("core settings dep", () => {
       new Request("https://cms.example/post/settings-flow"),
     );
     expect(await after.text()).toContain("Plumix Demo");
+  });
+});
+
+function pickString(bag: unknown, key: string): string {
+  if (bag === null || typeof bag !== "object") return "";
+  const value = (bag as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : "";
+}
+
+const blogTypePlugin = definePlugin("blog", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+});
+
+describe("theme-level templateDeps", () => {
+  test("declarations on `defineTheme` reach every template's render args", async () => {
+    const theme = defineTheme({
+      templateDeps: { settings: ["site-info"] },
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          render: (args) =>
+            pickString(args.settings?.["site-info"], "title") || "Untitled",
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({
+      plugins: [blogTypePlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "from-theme",
+      title: "From Theme",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.db.insert(settingsSchema).values({
+      group: "site-info",
+      key: "title",
+      value: "Plumix Demo",
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/from-theme"),
+    );
+    expect(await response.text()).toContain("Plumix Demo");
+  });
+
+  test("per-template slugs union with theme-level slugs of the same kind", async () => {
+    const theme = defineTheme({
+      templateDeps: { settings: ["site-info"] },
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          settings: ["author-info"],
+          render: (args) => (
+            <article>
+              {pickString(args.settings?.["site-info"], "title")}
+              {"|"}
+              {pickString(args.settings?.["author-info"], "name")}
+            </article>
+          ),
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({
+      plugins: [blogTypePlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "union",
+      title: "Union",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.db
+      .insert(settingsSchema)
+      .values([
+        { group: "site-info", key: "title", value: "Plumix" },
+        { group: "author-info", key: "name", value: "Ada" },
+      ]);
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/union"),
+    );
+    const body = await response.text();
+    expect(body).toContain("Plumix");
+    expect(body).toContain("Ada");
   });
 });
 

--- a/packages/core/src/template-deps.test.tsx
+++ b/packages/core/src/template-deps.test.tsx
@@ -443,12 +443,10 @@ describe("theme-level templateDeps", () => {
       authorId: author.id,
       publishedAt: new Date(),
     });
-    await h.db
-      .insert(settingsSchema)
-      .values([
-        { group: "site-info", key: "title", value: "Plumix" },
-        { group: "author-info", key: "name", value: "Ada" },
-      ]);
+    await h.db.insert(settingsSchema).values([
+      { group: "site-info", key: "title", value: "Plumix" },
+      { group: "author-info", key: "name", value: "Ada" },
+    ]);
 
     const response = await h.dispatch(
       new Request("https://cms.example/post/union"),

--- a/packages/core/src/template-deps.ts
+++ b/packages/core/src/template-deps.ts
@@ -1,5 +1,8 @@
 import type { AppContext } from "./context/app.js";
-import type { TemplateDepRegistry } from "./template.js";
+import type {
+  TemplateDepDeclarations,
+  TemplateDepRegistry,
+} from "./template.js";
 
 /**
  * Loader signature for a template dep. Receives the slugs declared by
@@ -29,6 +32,33 @@ export interface RegisteredTemplateDep {
   readonly load: UntypedTemplateDepLoader;
   /** Plugin id, or `null` for core-registered deps (e.g. `settings`). */
   readonly registeredBy: string | null;
+}
+
+/**
+ * Combine the theme's global dep declarations with the matched
+ * template's own. Same-kind slug arrays union (Set-based dedup); the
+ * result has the same shape as a template's declarations and can be
+ * fed straight into `loadTemplateDeps`.
+ */
+export function mergeTemplateDepDeclarations(
+  themeDeps: TemplateDepDeclarations | undefined,
+  template: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, readonly string[]>> {
+  const result: Record<string, readonly string[]> = {};
+  for (const [kind, value] of Object.entries(template)) {
+    if (Array.isArray(value)) result[kind] = value as readonly string[];
+  }
+  if (!themeDeps) return result;
+  for (const [kind, slugs] of Object.entries(themeDeps)) {
+    if (!Array.isArray(slugs)) continue;
+    const existing = result[kind];
+    const themeSlugs = slugs as readonly string[];
+    result[kind] =
+      existing === undefined
+        ? themeSlugs
+        : Array.from(new Set([...existing, ...themeSlugs]));
+  }
+  return result;
 }
 
 /**

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -9,7 +9,7 @@ import type {
   SingleData,
   TaxonomyData,
 } from "./route/render/resolved-entry.js";
-import type { Template } from "./template.js";
+import type { Template, TemplateDepDeclarations } from "./template.js";
 import { ThemeError, ThemeRegistrationError } from "./theme-errors.js";
 
 // `theme:document` is a boot-time filter chain. `buildApp` fires it once,
@@ -135,6 +135,12 @@ export interface ThemeDescriptor {
    * resolves them through its normal graph and emits hashed bundles.
    */
   readonly css?: readonly string[];
+  /**
+   * Dep declarations applied to every template. Per-template slugs of
+   * the same kind union (dedup'd) with these; a global `settings:
+   * ["general"]` reaches templates that never declared `settings`.
+   */
+  readonly templateDeps?: TemplateDepDeclarations;
 }
 
 const TOKEN_SLUG_RE = /^[a-z][a-z0-9-]*$/;


### PR DESCRIPTION
Themes had to repeat the same `menus: [...], settings: [...]` declaration on every chrome-bearing template — the starter spike has 8 such templates, so adding one global dep meant 8 edits.

**`templateDeps` on `defineTheme`**

`defineTheme` now accepts an optional `templateDeps: TemplateDepDeclarations`. Slug arrays apply to every template. Per-template declarations of the same kind union (Set-dedup'd) with the theme-level slugs — a template can add its own without losing the globals.

```ts
defineTheme({
  templateDeps: { settings: ["site-info"], menus: ["primary", "footer"] },
  templates: {
    index: defineTemplate({
      render: ({ settings, menus }) => <Layout ... />,
    }),
    single: defineTemplate({
      settings: ["author-info"],  // unions with theme-level
      render: ({ settings, menus }) => ...,
    }),
  },
});
```

**Merge happens once, before loadTemplateDeps**

The new `mergeTemplateDepDeclarations` helper is called from `renderThroughTheme` and `renderErrorThroughTheme` before the existing `loadTemplateDeps`. The loader itself sees a single union-shaped record and treats it exactly like a template's own declarations — no change to the loader, no change to the registered loader contract.

Surfaces FRICTION F18 from the theme-starter spike.

Fixes #585