### PR TITLE
feat(core): opt-in block-loader prefetch on listing templates

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1270,6 +1270,135 @@ describe("resolvePublicRoute — archive through theme", () => {
     expect(body).toContain("Second");
   });
 
+  test("archive with `prefetchListingLoaders` resolves block loaders for every entry", async () => {
+    const probePlugin = definePlugin("acme-listing-probe", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/listing-probe",
+          loaders: {
+            marker: (args: { readonly attrs: Record<string, unknown> }) => {
+              const tag =
+                typeof args.attrs.tag === "string" ? args.attrs.tag : "?";
+              return Promise.resolve(`loaded-${tag}`);
+            },
+          },
+          render: ({ loaders }) => <span>{loaders.marker}</span>,
+        }),
+      );
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: defineTemplate({
+          prefetchListingLoaders: true,
+          render: ({ data }) => (
+            <ul>
+              {data.entries.map((entry: ResolvedEntry) =>
+                entry.contentBlocks ? (
+                  <li key={entry.id}>
+                    <BlockRenderer content={entry.contentBlocks} />
+                  </li>
+                ) : null,
+              )}
+            </ul>
+          ),
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, probePlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "alpha",
+      title: "Alpha",
+      content: {
+        version: "plumix.v2",
+        blocks: [
+          { id: "alpha-1", name: "acme/listing-probe", attrs: { tag: "a" } },
+        ],
+      },
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-05-01"),
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "beta",
+      title: "Beta",
+      content: {
+        version: "plumix.v2",
+        blocks: [
+          { id: "beta-1", name: "acme/listing-probe", attrs: { tag: "b" } },
+        ],
+      },
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date("2026-05-02"),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain("loaded-a");
+    expect(body).toContain("loaded-b");
+  });
+
+  test("archive without `prefetchListingLoaders` leaves listing block loaders unresolved", async () => {
+    const probePlugin = definePlugin("acme-listing-probe-off", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "acme/listing-probe-off",
+          loaders: { marker: () => Promise.resolve("loader-fired") },
+          render: ({ loaders }) => (
+            <span data-testid="probe">{loaders.marker}</span>
+          ),
+        }),
+      );
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) =>
+              entry.contentBlocks ? (
+                <li key={entry.id}>
+                  <BlockRenderer content={entry.contentBlocks} />
+                </li>
+              ) : null,
+            )}
+          </ul>
+        ),
+      },
+    });
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, probePlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "gamma",
+      title: "Gamma",
+      content: {
+        version: "plumix.v2",
+        blocks: [{ id: "g-1", name: "acme/listing-probe-off", attrs: {} }],
+      },
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    // Block rendered (probe testid present) but loader never fired
+    // (marker text absent — `loaders.marker` was undefined at runtime).
+    expect(body).toContain('data-testid="probe"');
+    expect(body).not.toContain("loader-fired");
+  });
+
   test("excludes published entries with NULL publishedAt from the archive", async () => {
     const theme = defineTheme({
       templates: {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -3,7 +3,7 @@ import { createElement } from "react";
 import { renderToString } from "react-dom/server";
 
 import type {
-  EntryContent,
+  BlockNode,
   LoaderErrorEvent,
   ResolvedBlockLoaders,
 } from "@plumix/blocks";
@@ -78,7 +78,7 @@ export async function renderThroughTheme({
     ctx,
     deps,
   });
-  const loaderData = await prefetchEntryLoaders(ctx, data);
+  const loaderData = await prefetchEntryLoaders(ctx, data, template);
   return renderTree({
     ctx,
     document: renderDocument,
@@ -153,17 +153,14 @@ export async function renderErrorThroughTheme({
   });
 }
 
-// v1 only pre-resolves loaders on the single-entry path. Listing
-// shapes (archive / taxonomy / front-page) carry entry arrays but
-// their templates render summaries, not block trees — a future slice
-// can broaden coverage once a real consumer needs it.
 async function prefetchEntryLoaders(
   ctx: AppContext,
   data: TemplateData,
+  template: Template<TemplateData>,
 ): Promise<ResolvedBlockLoaders | undefined> {
-  const content = singleEntryContent(data);
-  if (!content) return undefined;
-  return resolveBlockLoaders(content.blocks, ctx.blocks, ctx, {
+  const blocks = collectLoaderBlocks(data, template);
+  if (blocks.length === 0) return undefined;
+  return resolveBlockLoaders(blocks, ctx.blocks, ctx, {
     // Fire-and-forget bridge into the framework filter so plugins can
     // subscribe via `addFilter("blocks:loader:error", ...)`. `applyFilter`
     // is async; we don't await (the loader resolver shouldn't back-pressure
@@ -184,8 +181,14 @@ async function prefetchEntryLoaders(
   });
 }
 
-function singleEntryContent(data: TemplateData): EntryContent | null {
-  return "entry" in data ? data.entry.contentBlocks : null;
+function collectLoaderBlocks(
+  data: TemplateData,
+  template: Template<TemplateData>,
+): readonly BlockNode[] {
+  if ("entry" in data) return data.entry.contentBlocks?.blocks ?? [];
+  if (!("entries" in data)) return [];
+  if (!template.prefetchListingLoaders) return [];
+  return data.entries.flatMap((e) => e.contentBlocks?.blocks ?? []);
 }
 
 interface ResolveDocumentArgs {

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -79,6 +79,13 @@ export interface Template<
 > extends TemplateDepDeclarations {
   readonly render: TemplateRender<TData>;
   readonly document?: TemplateDocument<TData>;
+  /**
+   * Cost is `O(entries × loaders/entry)`. Assumes `node.id` is unique
+   * across all entries' block trees — editor content satisfies this;
+   * bulk imports must ensure unique ids or sibling loader data
+   * silently collides in the per-id result map.
+   */
+  readonly prefetchListingLoaders?: boolean;
   readonly [PLUMIX_TEMPLATE_BRAND]: true;
 }
 
@@ -87,6 +94,7 @@ interface DefineTemplateConfig<
 > extends TemplateDepDeclarations {
   readonly render: TemplateRender<TData>;
   readonly document?: TemplateDocument<TData>;
+  readonly prefetchListingLoaders?: boolean;
 }
 
 export function defineTemplate<TData extends TemplateData = TemplateData>(


### PR DESCRIPTION
Block loaders previously only resolved on the single-entry path. A loader-bearing block inside an entry's content tree rendered with undefined loader data when reached via an archive, taxonomy, or front-page listing — by-design v1 ("`v1 only pre-resolves loaders on the single-entry path...`"), but the theme-starter spike's FRICTION F6 surfaced it as the first real consumer scenario.

**Template-level opt-in**

`defineTemplate({ prefetchListingLoaders: true })` flattens every entry's `contentBlocks.blocks` into a single `resolveBlockLoaders` call before render, preserving the existing parallel-resolution shape. Off by default — loader cost is `O(entries × loaders/entry)` and most listing templates render summaries without loader-bearing blocks.

```ts
defineTemplate({
  prefetchListingLoaders: true,
  render: ({ data }) => (
    <ul>
      {data.entries.map((entry) =>
        entry.contentBlocks ? (
          <li key={entry.id}><BlockRenderer content={entry.contentBlocks} /></li>
        ) : null,
      )}
    </ul>
  ),
});
```

**Single-entry path behaviorally unchanged**

The existing single-entry route now flows through the same `collectLoaderBlocks` helper; `new Map()` vs `undefined` both surface as `undefined` at the renderer's `loaderData?.get(node.id)` lookup, so the previous tests at `render-template.test.tsx:1178` still bind.

**Caveat — node-id uniqueness across entries**

`resolveBlockLoaders` keys results by `node.id`. With a single flat resolution across all entries, two entries that share a `node.id` overwrite each other in the result map. Editor content satisfies uniqueness; bulk imports must ensure unique ids or sibling loader data silently collides. Documented on the flag's JSDoc.

Two tracers cover both axes: opt-in renders loader data per entry; opt-off renders the same probe block but with the loader text absent (verified to bite by temporarily removing the gate during development).

Fixes #583