### PR TITLE
feat(core): expose entry permalink on ResolvedEntry.url

### DIFF
--- a/packages/core/src/route/permalink.test.ts
+++ b/packages/core/src/route/permalink.test.ts
@@ -7,7 +7,11 @@ import { definePlugin } from "../plugin/define.js";
 import { createPluginRegistry } from "../plugin/manifest.js";
 import { installPlugins } from "../plugin/register.js";
 import { adminUser, createTestDb, factoriesFor } from "../test/index.js";
-import { buildEntryPermalink, buildTermArchiveUrl } from "./permalink.js";
+import {
+  buildEntryPermalink,
+  buildEntryPermalinkSync,
+  buildTermArchiveUrl,
+} from "./permalink.js";
 
 async function buildRegistry(
   plugins: ReturnType<typeof definePlugin>[],
@@ -256,6 +260,117 @@ describe("buildEntryPermalink", () => {
     expect(await buildEntryPermalink(ctx, { type: "post", slug: "./.." })).toBe(
       "/post",
     );
+  });
+});
+
+describe("buildEntryPermalinkSync", () => {
+  // Locks the sync slice's branches — the async permalink builder now
+  // delegates here for the no-DB cases, so a regression here ripples
+  // out to listing URLs, sitemap, canonical tags, and the menu plugin.
+
+  test("non-hierarchical type returns the substituted URL", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(buildEntryPermalinkSync(ctx, { type: "post", slug: "hi" })).toBe(
+      "/post/hi",
+    );
+  });
+
+  test("hierarchical type with parentId=null returns the top-level URL", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      buildEntryPermalinkSync(ctx, {
+        type: "page",
+        slug: "about",
+        parentId: null,
+      }),
+    ).toBe("/page/about");
+  });
+
+  test("hierarchical with rewrite.isHierarchical:false flattens regardless of parentId", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+          rewrite: { slug: "page", isHierarchical: false },
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      buildEntryPermalinkSync(ctx, {
+        type: "page",
+        slug: "leaf",
+        parentId: 7,
+      }),
+    ).toBe("/page/leaf");
+  });
+
+  test("hierarchical with a non-null parentId returns null (defers to async ancestor walk)", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      buildEntryPermalinkSync(ctx, {
+        type: "page",
+        slug: "leaf",
+        parentId: 7,
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for isPublic:false types", async () => {
+    const registry = await buildRegistry([
+      definePlugin("internal", (ctx) => {
+        ctx.registerEntryType("hidden", { label: "Hidden", isPublic: false });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      buildEntryPermalinkSync(ctx, { type: "hidden", slug: "x" }),
+    ).toBeNull();
+  });
+
+  test("returns null for unregistered types", async () => {
+    const registry = await buildRegistry([]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+
+    expect(
+      buildEntryPermalinkSync(ctx, { type: "ghost", slug: "x" }),
+    ).toBeNull();
   });
 });
 

--- a/packages/core/src/route/permalink.ts
+++ b/packages/core/src/route/permalink.ts
@@ -30,20 +30,17 @@ export async function buildEntryPermalink(
   },
   options?: { readonly ancestorSlugs?: readonly string[] },
 ): Promise<string | null> {
+  const sync = buildEntryPermalinkSync(ctx, entry);
+  if (sync !== null) return sync;
   const entryType = ctx.plugins.entryTypes.get(entry.type);
+  // sync returned null → either unregistered / isPublic:false (real null) or
+  // hierarchical needing the ancestor walk. Re-check the predicate to split.
   if (!entryType || entryType.isPublic === false) return null;
-
-  const baseSlug = entryTypeBaseSlug(entryType);
   const parentId = entry.parentId ?? null;
-
-  if (!shouldNestUnderEntryParent(entryType, parentId)) {
-    return joinSegments([baseSlug, entry.slug]);
-  }
-
-  // shouldNestUnderEntryParent guarantees parentId is non-null here.
+  if (!shouldNestUnderEntryParent(entryType, parentId)) return null;
   const ancestors =
     options?.ancestorSlugs ?? (await loadAncestorSlugs(ctx, parentId));
-  return joinSegments([baseSlug, ...ancestors, entry.slug]);
+  return joinSegments([entryTypeBaseSlug(entryType), ...ancestors, entry.slug]);
 }
 
 /**
@@ -73,6 +70,26 @@ export async function buildTermArchiveUrl(
   const ancestors =
     options?.ancestorSlugs ?? (await loadTermAncestorSlugs(ctx, parentId));
   return joinSegments([baseSlug, ...ancestors, term.slug]);
+}
+
+/**
+ * Sync subset of `buildEntryPermalink`; returns `null` when an ancestor
+ * chain lookup is required so callers (e.g., `buildResolvedEntries`)
+ * can avoid the per-entry CTE.
+ */
+export function buildEntryPermalinkSync(
+  ctx: AppContext,
+  entry: {
+    readonly type: string;
+    readonly slug: string;
+    readonly parentId?: number | null;
+  },
+): string | null {
+  const entryType = ctx.plugins.entryTypes.get(entry.type);
+  if (!entryType || entryType.isPublic === false) return null;
+  if (shouldNestUnderEntryParent(entryType, entry.parentId ?? null))
+    return null;
+  return joinSegments([entryTypeBaseSlug(entryType), entry.slug]);
 }
 
 function entryTypeBaseSlug(entryType: RegisteredEntryType): string {

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1270,6 +1270,35 @@ describe("resolvePublicRoute — archive through theme", () => {
     expect(body).toContain("Second");
   });
 
+  test("archive listing exposes `entry.url` to templates", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id}>{entry.url}</li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "alpha",
+      title: "Alpha",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    expect(await response.text()).toContain("/post/alpha");
+  });
+
   test("archive with `prefetchListingLoaders` resolves block loaders for every entry", async () => {
     const probePlugin = definePlugin("acme-listing-probe", (ctx) => {
       ctx.registerBlock(

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -13,10 +13,14 @@ export interface ResolvedAuthor {
 // `content` stays loose so non-blocks serializers (TipTap, etc.) keep
 // working; `contentBlocks` is the narrowed `EntryContent` (null when
 // the stored JSON fails the shape check).
+//
+// `url` is null when an ancestor-chain DB walk is required — hierarchical
+// types with a non-null parentId await a follow-up batched resolver.
 export interface ResolvedEntry extends Entry {
   readonly contentBlocks: EntryContent | null;
   readonly terms: readonly Term[];
   readonly author: ResolvedAuthor;
+  readonly url: string | null;
 }
 
 // Per-kind data shapes are generic over the entry projection so theme

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -26,6 +26,7 @@ import { users } from "../db/schema/users.js";
 import { notFound } from "../runtime/http.js";
 import { paginate } from "./paginate.js";
 import { findEntryByPath, findTermByPath } from "./path-chain.js";
+import { buildEntryPermalinkSync } from "./permalink.js";
 import { renderThroughTheme } from "./render/render-template.js";
 
 declare module "../hooks/types.js" {
@@ -388,6 +389,7 @@ async function buildResolvedEntries(
       contentBlocks: isEntryContent(row.content) ? row.content : null,
       terms: termsByEntryId.get(row.id) ?? [],
       author,
+      url: buildEntryPermalinkSync(ctx, row),
     };
   });
 }


### PR DESCRIPTION
Themes had no per-entry URL on listings — `ResolvedEntry` carried `terms` and `author` but not a permalink. The async `buildEntryPermalink` exists but is per-entry + DB-backed, so calling it inside `buildResolvedEntries` would be the N+1 the project's no-N+1 rule explicitly forbids. The starter spike worked around it by hardcoding `/post/${slug}`, which 404'd for non-post types (FRICTION F5 + F14).

**Sync permalink slice powers `ResolvedEntry.url`**

A new `buildEntryPermalinkSync` returns a URL whenever no ancestor-chain lookup is required — non-hierarchical types, hierarchical with `parentId === null`, and hierarchical with `rewrite.isHierarchical: false`. Otherwise it returns `null` and the async path (or a follow-up batched resolver) handles the ancestor walk. `buildResolvedEntries` calls it for every row, so every listing entry surfaces a `url` field with zero DB hits.

```ts
// theme — no more per-type knowledge
<a href={entry.url ?? "#"}>{entry.title}</a>
```

**Single source of truth for the no-DB path**

`buildEntryPermalink` now delegates to `buildEntryPermalinkSync` first and only walks ancestors on a sync null. Removes the drift trap where adding a new permalink-suppressing flag would have to be patched in both helpers.

**Scope: non-hierarchical (+ trivial hierarchical sub-cases). Batched hierarchical and term URLs are out of scope for this PR.**

Hierarchical entries with a real parent surface as `url: null` in this PR — themes use `entry.url ?? fallback`. Batched hierarchical resolution lands as a follow-up so the per-entry CTE doesn't ship as an accidental N+1.

Coverage: 6 new unit tests on `buildEntryPermalinkSync` (every branch — non-hierarchical, top-level hierarchical, `rewrite.isHierarchical: false`, hierarchical with parent → null, `isPublic: false` → null, unregistered → null) plus one wiring tracer asserting the URL surfaces through the resolver into the archive template's render args. All 9 existing async permalink tests pass against the refactored delegation.

Fixes #576