### PR TITLE
feat(plumix): discover workspace-symlinked islands under node_modules

### DIFF
--- a/packages/plumix/src/vite/island-transform.test.ts
+++ b/packages/plumix/src/vite/island-transform.test.ts
@@ -9,8 +9,14 @@ import {
 
 function fixtureFs(
   files: Record<string, string>,
-  dirs: readonly string[] = [],
+  options: {
+    readonly dirs?: readonly string[];
+    /** `linkPath → realTarget` mapping for symlinks. Reads/lists at linkPath transparently resolve to realTarget. */
+    readonly links?: Readonly<Record<string, string>>;
+  } = {},
 ): ScannerFs {
+  const dirs = options.dirs ?? [];
+  const links = options.links ?? {};
   const dirSet = new Set<string>(dirs);
   for (const path of Object.keys(files)) {
     let cur = "/";
@@ -19,6 +25,22 @@ function fixtureFs(
       dirSet.add(cur);
     }
   }
+  for (const linkPath of Object.keys(links)) {
+    let cur = "/";
+    for (const part of linkPath.split("/").filter(Boolean).slice(0, -1)) {
+      cur = cur === "/" ? `/${part}` : `${cur}/${part}`;
+      dirSet.add(cur);
+    }
+  }
+  const resolveSymlinks = (path: string): string => {
+    for (const [linkPath, target] of Object.entries(links)) {
+      if (path === linkPath) return target;
+      if (path.startsWith(`${linkPath}/`)) {
+        return `${target}${path.slice(linkPath.length)}`;
+      }
+    }
+    return path;
+  };
   const childrenOf = (dirPath: string) => {
     const out: { name: string; isDirectory: boolean }[] = [];
     const prefix = dirPath === "/" ? "/" : `${dirPath}/`;
@@ -32,20 +54,32 @@ function fixtureFs(
       const fullChild = `${prefix}${next}`;
       out.push({ name: next, isDirectory: dirSet.has(fullChild) });
     }
+    for (const linkPath of Object.keys(links)) {
+      if (!linkPath.startsWith(prefix)) continue;
+      const rest = linkPath.slice(prefix.length);
+      const next = rest.split("/")[0];
+      if (!next || seen.has(next)) continue;
+      seen.add(next);
+      out.push({ name: next, isDirectory: true });
+    }
     return out;
   };
   return {
     readDir: (path) => {
-      if (!dirSet.has(path) && path !== "/") {
+      const resolved = resolveSymlinks(path);
+      if (!dirSet.has(resolved) && resolved !== "/") {
         throw new Error(`no such dir: ${path}`);
       }
-      return childrenOf(path);
+      return childrenOf(resolved);
     },
     readFile: (path) => {
-      const content = files[path];
+      const resolved = resolveSymlinks(path);
+      const content = files[resolved];
       if (content === undefined) throw new Error(`no such file: ${path}`);
       return content;
     },
+    isSymlink: (path) => Object.prototype.hasOwnProperty.call(links, path),
+    realPath: (path) => resolveSymlinks(path),
   };
 }
 
@@ -302,6 +336,46 @@ describe("scanUserSources", () => {
     expect(new Set(islands.map((i) => i.sourcePath))).toEqual(
       new Set(["/app/src/a/A.tsx", "/app/src/b/B.tsx"]),
     );
+  });
+
+  test("does NOT follow symlinks that land in another node_modules (pnpm store)", () => {
+    // pnpm wires every dep — including published — as a symlink; only
+    // workspace targets realpath outside node_modules.
+    const fs = fixtureFs(
+      {
+        "/app/src/page.tsx": `import {} from "lodash";`,
+        "/app/node_modules/.pnpm/lodash@4/node_modules/lodash/i.tsx": `"use client"; export function Bad() { return null; }`,
+      },
+      {
+        links: {
+          "/app/node_modules/lodash":
+            "/app/node_modules/.pnpm/lodash@4/node_modules/lodash",
+        },
+      },
+    );
+    expect(scanUserSources("/app", fs)).toEqual([]);
+  });
+
+  test("descends into symlinked workspace packages under node_modules", () => {
+    const fs = fixtureFs(
+      {
+        "/app/src/page.tsx": `import { CopyLink } from "@plumix/theme-starter";`,
+        "/workspace/themes/starter/src/islands/CopyLink.tsx": `"use client"; export function CopyLink() { return null; }`,
+      },
+      {
+        links: {
+          "/app/node_modules/@plumix/theme-starter":
+            "/workspace/themes/starter",
+        },
+      },
+    );
+    const islands = scanUserSources("/app", fs);
+    expect(islands).toEqual([
+      {
+        sourcePath: "/workspace/themes/starter/src/islands/CopyLink.tsx",
+        exportName: "CopyLink",
+      },
+    ]);
   });
 
   test("ignores files that don't mention `use client` (cheap pre-filter)", () => {

--- a/packages/plumix/src/vite/island-transform.ts
+++ b/packages/plumix/src/vite/island-transform.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { extname, join } from "node:path";
 import ts from "typescript";
 
@@ -215,6 +215,9 @@ export interface DiscoveredIsland {
 export interface ScannerFs {
   readDir(path: string): readonly { name: string; isDirectory: boolean }[];
   readFile(path: string): string;
+  isSymlink(path: string): boolean;
+  /** Resolves a symlink to its target; identity for plain paths. */
+  realPath(path: string): string;
 }
 
 const SCANNABLE_EXTS: ReadonlySet<string> = new Set([".ts", ".tsx"]);
@@ -229,27 +232,29 @@ const SKIP_DIRS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Walks `cwd` recursively, runs `findUseClientIslands` on every
- * `.ts`/`.tsx` source it sees (skipping the noise dirs above), and
- * surfaces every discovered island.
- *
- * v1 only walks the user's `cwd`. Island declarations in published npm
- * packages (under `node_modules`) are out of scope; a follow-up can opt
- * in via an explicit package list once the use case surfaces.
+ * Walks `cwd` and any workspace-symlinked packages under `node_modules`
+ * so a theme or plugin can ship `"use client"` files in its own `src/`
+ * without explicit registration. The `walkSymlinkedDeps` realpath gate
+ * keeps the scan out of the pnpm store.
  */
 export function scanUserSources(
   cwd: string,
   fs: ScannerFs = nodeFs,
 ): readonly DiscoveredIsland[] {
   const islands: DiscoveredIsland[] = [];
-  walk(cwd, fs, (filePath, source) => {
-    for (const finding of findUseClientIslands(source)) {
-      islands.push({
-        sourcePath: toPosix(filePath),
-        exportName: finding.exportName,
-      });
-    }
-  });
+  walk(
+    cwd,
+    fs,
+    (filePath, source) => {
+      for (const finding of findUseClientIslands(source)) {
+        islands.push({
+          sourcePath: toPosix(filePath),
+          exportName: finding.exportName,
+        });
+      }
+    },
+    true,
+  );
   return islands;
 }
 
@@ -257,6 +262,7 @@ function walk(
   dirPath: string,
   fs: ScannerFs,
   visit: (filePath: string, source: string) => void,
+  followSymlinks: boolean,
 ): void {
   let entries: readonly { name: string; isDirectory: boolean }[];
   try {
@@ -267,8 +273,12 @@ function walk(
   for (const entry of entries) {
     const full = join(dirPath, entry.name);
     if (entry.isDirectory) {
+      if (entry.name === "node_modules") {
+        if (followSymlinks) walkSymlinkedDeps(full, fs, visit);
+        continue;
+      }
       if (SKIP_DIRS.has(entry.name)) continue;
-      walk(full, fs, visit);
+      walk(full, fs, visit, followSymlinks);
       continue;
     }
     if (!SCANNABLE_EXTS.has(extname(entry.name))) continue;
@@ -286,6 +296,38 @@ function walk(
   }
 }
 
+// pnpm symlinks every dep — workspace AND published — so isSymlink
+// alone can't tell them apart. Discriminator: a workspace dep
+// realpaths outside any `node_modules` segment; a published dep
+// realpaths back into `.pnpm/<pkg>@<ver>/node_modules/<pkg>`.
+function walkSymlinkedDeps(
+  nodeModulesPath: string,
+  fs: ScannerFs,
+  visit: (filePath: string, source: string) => void,
+): void {
+  let entries: readonly { name: string; isDirectory: boolean }[];
+  try {
+    entries = fs.readDir(nodeModulesPath);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory) continue;
+    if (entry.name.startsWith(".")) continue;
+    const full = join(nodeModulesPath, entry.name);
+    if (entry.name.startsWith("@")) {
+      walkSymlinkedDeps(full, fs, visit);
+      continue;
+    }
+    if (!fs.isSymlink(full)) continue;
+    const target = fs.realPath(full);
+    if (target.includes("/node_modules/")) continue;
+    // Walk the realpath so recorded paths match what Vite emits after
+    // its default `preserveSymlinks: false` resolution.
+    walk(target, fs, visit, false);
+  }
+}
+
 function toPosix(path: string): string {
   return path.replace(/\\/g, "/");
 }
@@ -297,4 +339,18 @@ const nodeFs: ScannerFs = {
       isDirectory: entry.isDirectory(),
     })),
   readFile: (path) => readFileSync(path, "utf8"),
+  isSymlink: (path) => {
+    try {
+      return lstatSync(path).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  },
+  realPath: (path) => {
+    try {
+      return realpathSync(path);
+    } catch {
+      return path;
+    }
+  },
 };


### PR DESCRIPTION
`scanUserSources` skipped `node_modules` outright, so a theme or plugin shipping a `"use client"` file in its own `src/` was invisible to the island scan — no per-island chunk emitted, SSR rendered without the `<plumix-island>` wrapper, and the islands runtime script never injected. Blocked the whole interactive-UI-in-a-theme story (FRICTION F12).

```ts
// works now — a theme can ship its own islands and just be imported
// from the consumer; no `registerIsland`, no `defineTheme({ islands })`.
// packages/themes/starter/src/index.tsx
import { CopyLink } from "./islands/CopyLink.js"; // "use client"
```

**Realpath-location gate, not isSymlink**

When the walker hits `node_modules`, it dispatches to `walkSymlinkedDeps` which follows the directory only when the entry is a symlink whose realpath lives OUTSIDE any `/node_modules/` segment. That discriminator is load-bearing: pnpm wires every dep — workspace AND published — as a symlink under the consumer's `node_modules`, so an `isSymlink`-only check would pull `.pnpm/<pkg>@<ver>/node_modules/<pkg>` published-source into the scan (measured ~34k files on the project's own `examples/minimal`). Workspace targets realpath to `<repo>/packages/...`; pnpm published targets realpath back into `.pnpm/.../node_modules/` and stay skipped.

**Followed targets walk with `followSymlinks: false`**

Once inside a workspace package, its own `node_modules` is just more pnpm-store noise. Skipping it keeps the scan bounded and avoids accidental walks through transitive deps.

`ScannerFs` gains `isSymlink(path)` + `realPath(path)`; production `nodeFs` wraps `lstatSync` + `realpathSync` with try/catch fallbacks so broken symlinks (mid-install pnpm state) skip gracefully rather than crashing the dev server.

Tests cover the workspace-discovery happy path plus a regression for the pnpm-store-skipped invariant (a fixture consumer whose `node_modules/lodash` symlinks into `node_modules/.pnpm/lodash@4/...` returns `[]`).

Fixes #577