### PR TITLE
feat(core,plumix): top-level vite passthrough in plumix.config.ts

### DIFF
--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -86,6 +86,19 @@ test("plumix() requires mailer when auth.magicLink is configured", () => {
   ).toThrow(/magicLink.*requires.*mailer/);
 });
 
+test("plumix() preserves top-level vite passthrough for the Vite layer to consume", () => {
+  const probe = { name: "probe" };
+  const config = plumix({
+    runtime,
+    database,
+    auth: authConfig,
+    theme,
+    vite: { plugins: [probe], optimizeDeps: { exclude: ["x"] } },
+  });
+  expect(config.vite?.plugins).toEqual([probe]);
+  expect(config.vite?.optimizeDeps).toEqual({ exclude: ["x"] });
+});
+
 test("plumix() accepts auth.magicLink when paired with a top-level mailer", () => {
   const authWithMagicLink = auth({
     passkey: {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -53,6 +53,11 @@ export interface PlumixConfigInput {
   readonly blocks?: {
     readonly htmlAllowlist?: HtmlAllowlistOverride;
   };
+  /**
+   * Passthrough merged with plumix's own Vite config via `mergeConfig`.
+   * Structural so core stays Vite-dep-free.
+   */
+  readonly vite?: Readonly<Record<string, unknown>>;
 }
 
 export interface PlumixConfig {
@@ -68,6 +73,7 @@ export interface PlumixConfig {
   readonly blocks?: {
     readonly htmlAllowlist?: HtmlAllowlistOverride;
   };
+  readonly vite?: Readonly<Record<string, unknown>>;
 }
 
 export function plumix(config: PlumixConfigInput): PlumixConfig {
@@ -92,6 +98,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
     theme: config.theme,
     plugins: config.plugins ?? [],
     blocks: config.blocks,
+    vite: config.vite,
   };
 }
 

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -10,7 +10,8 @@ import {
 } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Plugin } from "vite";
+import type { Plugin, UserConfig } from "vite";
+import { mergeConfig } from "vite";
 
 import type {
   AnyPluginDescriptor,
@@ -79,7 +80,7 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     // doesn't depend on `process.env` being populated — CF Workers'
     // process.env is empty by default and the helper would otherwise
     // fall back to localhost on every deployed request.
-    config(userConfig, env) {
+    async config(userConfig, env) {
       const define = {
         "process.env.WORKERS_CI": JSON.stringify(process.env.WORKERS_CI ?? ""),
         "process.env.WORKERS_CI_BRANCH": JSON.stringify(
@@ -153,9 +154,25 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
       // Default publicDir to `.plumix/public` only when the user hasn't
       // set one — Vite merges the returned object with `userConfig`, so
       // we keep theirs by omitting the key entirely.
-      const base = { define, build, environments, resolve: resolveOpts };
-      if (userConfig.publicDir !== undefined) return base;
-      return { ...base, publicDir: ".plumix/public" };
+      const base: Partial<UserConfig> = {
+        define,
+        build,
+        environments,
+        resolve: resolveOpts,
+      };
+      if (userConfig.publicDir === undefined) {
+        base.publicDir = ".plumix/public";
+      }
+      // TODO: triple loadConfig per cold start (config + buildStart + CLI).
+      // Cache via a closure once moduleCache:false in load-config.ts is
+      // safe to relax.
+      const { config } = await loadConfig(scanRoot, options.configFile);
+      return config.vite
+        ? (mergeConfig(
+            base,
+            config.vite as Partial<UserConfig>,
+          ) as Partial<UserConfig>)
+        : base;
     },
     configResolved(config) {
       root = config.root;

--- a/packages/plumix/src/vite/merge-plumix-vite.test.ts
+++ b/packages/plumix/src/vite/merge-plumix-vite.test.ts
@@ -1,0 +1,38 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { plumix } from "./index.js";
+
+describe("plumix() vite plugin — `config()` merges plumix.config.vite", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "plumix-vite-merge-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("plugins declared in plumix.config.ts.vite reach the returned config", async () => {
+    const configPath = join(dir, "plumix.config.mjs");
+    writeFileSync(
+      configPath,
+      `export default {
+        runtime: { name: 'x', buildFetchHandler: () => () => new Response('ok') },
+        database: { kind: 'x' },
+        auth: { passkey: {} },
+        vite: { plugins: [{ name: 'tailwindcss-probe' }] },
+      };`,
+      "utf8",
+    );
+    const plugin = plumix({ configFile: configPath });
+    const result = await (
+      plugin.config as (userConfig: unknown, env: unknown) => Promise<unknown>
+    )({ root: dir }, { command: "serve", mode: "development" });
+    const merged = result as { plugins?: readonly { name?: string }[] };
+    expect(merged.plugins?.map((p) => p.name)).toContain("tailwindcss-probe");
+  });
+});


### PR DESCRIPTION
Themes (and any user) can register Vite plugins + arbitrary Vite options once at the top of `plumix.config.ts`, applying framework-wide. Mirrors `astro.config.mjs.vite` and `nuxt.config.ts.vite` — Tailwind, custom transforms, `optimizeDeps`, etc. all flow through one place.

```ts
// plumix.config.ts
import tailwindcss from "@tailwindcss/vite";

export default plumix({
  runtime, database, auth, theme,
  vite: { plugins: [tailwindcss()] },
});
```

**API surface stays minimal**

`@plumix/core` gains an optional `vite?: Readonly<Record<string, unknown>>` on `PlumixConfigInput`/`PlumixConfig`. Structural so core stays Vite-dep-free; the plumix Vite plugin in `@plumix/plumix` narrows on the way in. No new `ctx.addVitePlugin` API and no `defineTheme({ vitePlugins })` — one consumer-facing field at the top of the config.

**Merge via Vite's own `mergeConfig`**

`plumix()` Vite plugin's `config()` hook is now async: loads the user's plumix config and threads `config.vite` through Vite's `mergeConfig` (arrays concat, objects deep-merge) before returning the base. Plumix's `environments.client.build.rollupOptions.input` and `define` survive; the user adds without clobbering.

Known follow-up flagged in code: `loadConfig` now runs three times per cold start (once here, once via `emitPlumixSources`, once in `buildStart`'s regenerate). `moduleCache: false` in `load-config.ts` makes each one a real reparse. A closure-scoped cache is the natural next step but out of scope for this slice.

Surfaces FRICTION F4 from the theme-starter spike.

Fixes #575