### PR TITLE
feat(core): wire theme.tokens into PlumixProvider on render

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -1175,6 +1175,46 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain('data-plumix-block="core/heading"');
   });
 
+  test("theme tokens reach the block walker — styled blocks emit `var(--plumix-…)` fallbacks", async () => {
+    const theme = defineTheme({
+      tokens: { colors: { brand: { value: "#abc" } } },
+      templates: {
+        index: () => null,
+        single: ({ data }) =>
+          data.entry.contentBlocks ? (
+            <BlockRenderer content={data.entry.contentBlocks} />
+          ) : null,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "styled",
+      title: "Styled",
+      content: {
+        version: "plumix.v2",
+        blocks: [
+          {
+            id: "s",
+            name: "core/heading",
+            attrs: { text: "Hi" },
+            style: { large: { background: "brand" } },
+          },
+        ],
+      },
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/styled"),
+    );
+    expect(await response.text()).toContain("var(--plumix-color-brand, #abc)");
+  });
+
   test("dispatcher pre-resolves block loaders before render — render() sees the resolved data", async () => {
     const probePlugin = definePlugin("acme-probe", (ctx) => {
       ctx.registerBlock(

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -6,6 +6,7 @@ import type {
   BlockNode,
   LoaderErrorEvent,
   ResolvedBlockLoaders,
+  ThemeTokens,
 } from "@plumix/blocks";
 import { resolveBlockLoaders } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
@@ -88,6 +89,7 @@ export async function renderThroughTheme({
     template,
     deps,
     loaderData,
+    tokens: theme.tokens,
   });
 }
 
@@ -150,6 +152,7 @@ export async function renderErrorThroughTheme({
     template,
     deps,
     loaderData: undefined,
+    tokens: theme.tokens,
   });
 }
 
@@ -229,6 +232,7 @@ interface RenderTreeArgs {
   readonly template: Template<TemplateData>;
   readonly deps: Record<string, Record<string, unknown>>;
   readonly loaderData: ResolvedBlockLoaders | undefined;
+  readonly tokens: ThemeTokens | undefined;
 }
 
 // React 19 reorders every child of `<head>` (metadata first, scripts /
@@ -245,6 +249,7 @@ function renderTree({
   title,
   template,
   deps,
+  tokens,
   loaderData,
 }: RenderTreeArgs): string {
   // Adapter FC wraps `template.render({ data, ctx, ...deps })` so it
@@ -258,7 +263,7 @@ function renderTree({
   const TemplateAdapter = (): ReactNode =>
     template.render({ ...deps, data, ctx });
   const templateTree: ReactNode = createElement(PlumixProvider, {
-    value: { registry: ctx.blocks, loaderData },
+    value: { registry: ctx.blocks, tokens, loaderData },
     children: createElement(TemplateAdapter),
   });
   const rendered = renderToString(templateTree);


### PR DESCRIPTION
Blocks styled with token IDs in the admin (`style: { large: { background: "brand" } }`) rendered without styling on the frontend. `PlumixProvider` was constructed with `{ registry, loaderData }` only, so `tokens` was undefined in the renderer context and the walker's `node.style && tokens` gate at `render-block-tree.ts` always skipped style emission — regardless of what was declared in `defineTheme({ tokens })`.

**Render half of FRICTION F3**

Threads `theme.tokens` through `renderTree` into the provider's value. Both render paths (`renderThroughTheme` + `renderErrorThroughTheme`) now pass `theme.tokens`, so the walker sees the token registry and emits a wrapper `<style>` containing `var(--plumix-color-brand, <value>)` for styled blocks.

```ts
defineTheme({
  tokens: { colors: { brand: { value: "#abc" } } },
  templates: { ... },
});
// → <style>.plumix-block-<id> { background: var(--plumix-color-brand, #abc); }</style>
```

Themes without `tokens` stay identical — the field flows as `undefined` and the walker's gate still skips. Verified by the existing tokens-less integration tests in this file.

**Admin half is a follow-up**

This PR closes the first two of #574's four acceptance items (PlumixProvider receives tokens; styled blocks emit CSS vars). The admin-side delivery — `PlumixManifest` carrying tokens through to `StyleTab`/`TokenSwatchList` so the picker shows the consumer's real palette instead of the hardcoded `sampleTokens` — is the second half and lands as a follow-up.

Refs #574