### PR TITLE
fix(plugins,core): root-resolved pages and pluralized posts permalinks

### DIFF
--- a/packages/core/src/route/compile.test.ts
+++ b/packages/core/src/route/compile.test.ts
@@ -362,6 +362,97 @@ describe("compileRouteMap", () => {
     expect(map[0]?.priority).toBe(5);
   });
 
+  test("empty rewrite.slug emits the root catch-all at lower precedence than non-empty auto rules", async () => {
+    const registry = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+          rewrite: { slug: "" },
+        });
+      }),
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", {
+          label: "Posts",
+          isPublic: true,
+          hasArchive: true,
+          rewrite: { slug: "posts" },
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    // `/:path+` is greedy — it must sort after every non-catch-all rule
+    // so consumer plugin ordering can't shadow other plugins' singles
+    // and archives.
+    expect(patterns).toEqual([
+      "/posts/page/:page",
+      "/posts",
+      "/posts/:slug",
+      "/:path+",
+    ]);
+    expect(map.at(-1)?.priority).toBeGreaterThan(50);
+  });
+
+  test("empty rewrite.slug catch-all sorts last regardless of registration order", async () => {
+    const registryPagesFirst = await buildRegistry([
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+          rewrite: { slug: "" },
+        });
+      }),
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", {
+          label: "Posts",
+          isPublic: true,
+          hasArchive: true,
+          rewrite: { slug: "posts" },
+        });
+      }),
+    ]);
+    const registryBlogFirst = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", {
+          label: "Posts",
+          isPublic: true,
+          hasArchive: true,
+          rewrite: { slug: "posts" },
+        });
+      }),
+      definePlugin("pages", (ctx) => {
+        ctx.registerEntryType("page", {
+          label: "Pages",
+          isPublic: true,
+          isHierarchical: true,
+          rewrite: { slug: "" },
+        });
+      }),
+    ]);
+    const tail = (rs: ReturnType<typeof compileRouteMap>) =>
+      rs.at(-1)?.rawPattern;
+    expect(tail(compileRouteMap(registryPagesFirst))).toBe("/:path+");
+    expect(tail(compileRouteMap(registryBlogFirst))).toBe("/:path+");
+  });
+
+  test("flat empty-slug entry type also emits its single at catch-all priority", async () => {
+    const registry = await buildRegistry([
+      definePlugin("docs", (ctx) => {
+        ctx.registerEntryType("doc", {
+          label: "Docs",
+          isPublic: true,
+          rewrite: { slug: "" },
+        });
+      }),
+    ]);
+    const map = compileRouteMap(registry);
+    expect(map.map((r) => r.rawPattern)).toEqual(["/:slug"]);
+    expect(map[0]?.priority).toBeGreaterThan(50);
+  });
+
   test("hasArchive: string rejects multi-segment or non-kebab input", async () => {
     const bad = await buildRegistry([
       definePlugin("x", (ctx) => {

--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -7,6 +7,11 @@ import type { RouteIntent, RouteRule } from "./intent.js";
 import { RouteCompileError } from "./errors.js";
 
 const AUTO_ROUTE_PRIORITY = 50;
+// Empty rewrite.slug claims root paths — `/:path+` or `/:slug` — which
+// would otherwise greedy-match every other plugin's auto rule under
+// URLPattern's first-match-wins. Demote so non-catch-all rules always
+// match first regardless of plugin registration order.
+const CATCH_ALL_ROUTE_PRIORITY = 60;
 export const DEFAULT_REWRITE_RULE_PRIORITY = 10;
 
 interface CompiledRule extends RouteRule {
@@ -97,7 +102,7 @@ function autoRulesForEntryType(entryType: RegisteredEntryType): CompiledRule[] {
     pattern: new URLPattern({ pathname: singlePattern }),
     rawPattern: singlePattern,
     intent: { kind: "single", entryType: entryType.name },
-    priority: AUTO_ROUTE_PRIORITY,
+    priority: baseSlug === "" ? CATCH_ALL_ROUTE_PRIORITY : AUTO_ROUTE_PRIORITY,
     registeredBy: entryType.registeredBy,
   });
 

--- a/packages/plugins/blog/src/index.test.ts
+++ b/packages/plugins/blog/src/index.test.ts
@@ -19,6 +19,11 @@ describe("@plumix/plugin-blog", () => {
     expect(post?.registeredBy).toBe("blog");
   });
 
+  test("posts permalinks use the plural `posts` base — /posts/:slug, /posts archive", async () => {
+    const { registry } = await install();
+    expect(registry.entryTypes.get("post")?.rewrite).toEqual({ slug: "posts" });
+  });
+
   test("registers category as a hierarchical taxonomy with admin column", async () => {
     const { registry } = await install();
     const category = registry.termTaxonomies.get("category");

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -13,6 +13,7 @@ export const blog = definePlugin("blog", (ctx) => {
     hasArchive: true,
     capabilityType: "post",
     menuIcon: "file-text",
+    rewrite: { slug: "posts" },
   });
 
   ctx.registerTermTaxonomy("category", {

--- a/packages/plugins/pages/src/index.test.ts
+++ b/packages/plugins/pages/src/index.test.ts
@@ -19,6 +19,11 @@ describe("@plumix/plugin-pages", () => {
     expect(page?.registeredBy).toBe("pages");
   });
 
+  test("pages resolve at root — empty rewrite.slug yields /:path+ pattern", async () => {
+    const { registry } = await install();
+    expect(registry.entryTypes.get("page")?.rewrite).toEqual({ slug: "" });
+  });
+
   test("registers no taxonomies", async () => {
     const { registry } = await install();
     expect(registry.termTaxonomies.size).toBe(0);

--- a/packages/plugins/pages/src/index.ts
+++ b/packages/plugins/pages/src/index.ts
@@ -12,5 +12,6 @@ export const pages = definePlugin("pages", (ctx) => {
     hasArchive: false,
     capabilityType: "page",
     menuIcon: "layout",
+    rewrite: { slug: "" },
   });
 });


### PR DESCRIPTION
Default plugin URLs now match modern CMS conventions — `@plumix/plugin-pages` resolves at root (`/about`, `/about/team`) and `@plumix/plugin-blog` uses the plural base (`/posts`, `/posts/balboa`, `/posts/page/2`). Demoting the empty-slug catch-all priority makes the new defaults safe regardless of plugin registration order.

**Permalink shapes**

```
before                                after
@plumix/plugin-pages
/page/about                           /about
/page/about/team                      /about/team

@plumix/plugin-blog
/post                                 /posts
/post/balboa                          /posts/balboa
/post/page/2                          /posts/page/2
```

Plugins that want the old shape can opt back in with `rewrite: { slug: "post" }` or `rewrite: { slug: "page" }`.

**Catch-all priority**

`compileRouteMap` already supported `rewrite.slug: ""` (single pattern compiles to `/:path+` or `/:slug` via the `baseSlug === ""` branch). But every auto rule sat at `AUTO_ROUTE_PRIORITY = 50`, so under URLPattern's first-match-wins iteration `/posts` could land on the page resolver instead of the blog archive whenever pages registered first — a registration-order footgun, not a real route.

Empty-slug singles now sort at a new `CATCH_ALL_ROUTE_PRIORITY = 60`. Any non-catch-all auto rule (taxonomy, post-type single/archive) is guaranteed to match first regardless of consumer plugin order.

**Tests**

- `compile.test.ts`: catch-all sorts last, sorts last under both `[blog, pages]` and `[pages, blog]` orderings, flat empty-slug entry types use the demoted priority too.
- `@plumix/plugin-blog`, `@plumix/plugin-pages`: assert the new `rewrite` defaults.
- Smoke-booted `examples/blog` confirmed `/posts` → 200, `/post` → 404, `/about` → 200, `/page/about` → 404.

BREAKING CHANGE: URLs shipped by the default plugins have moved. Consumers with hardcoded `/post/<slug>` or `/page/<slug>` links must update to `/posts/<slug>` and `/<slug>`.