### PR TITLE
feat(core): add title + titleTemplate to DocumentManifest

### DIFF
--- a/packages/core/src/document-merge.test.ts
+++ b/packages/core/src/document-merge.test.ts
@@ -82,4 +82,29 @@ describe("mergeDocumentManifest", () => {
       { rel: "preconnect", href: "https://cdn.example" },
     ]);
   });
+
+  test("template title overrides theme title (last-wins)", () => {
+    const merged = mergeDocumentManifest(
+      { title: "Theme Default" },
+      { title: "Template Title" },
+    );
+    expect(merged.title).toBe("Template Title");
+  });
+
+  test("titleTemplate carries from theme when template doesn't redefine it", () => {
+    const merged = mergeDocumentManifest(
+      { titleTemplate: "%s · Site" },
+      { title: "Hello" },
+    );
+    expect(merged.titleTemplate).toBe("%s · Site");
+    expect(merged.title).toBe("Hello");
+  });
+
+  test("titleAbsolute is preserved from the template fragment", () => {
+    const merged = mergeDocumentManifest(
+      { titleTemplate: "%s · Site" },
+      { title: "Home", titleAbsolute: true },
+    );
+    expect(merged.titleAbsolute).toBe(true);
+  });
 });

--- a/packages/core/src/document-merge.ts
+++ b/packages/core/src/document-merge.ts
@@ -28,6 +28,9 @@ export function mergeDocumentManifest(
     link: concatArrays(theme.link, fragment?.link),
     meta: concatArrays(theme.meta, fragment?.meta),
     script: concatArrays(theme.script, fragment?.script),
+    title: fragment?.title ?? theme.title,
+    titleTemplate: fragment?.titleTemplate ?? theme.titleTemplate,
+    titleAbsolute: fragment?.titleAbsolute ?? theme.titleAbsolute,
   };
 }
 

--- a/packages/core/src/route/render/compose-title.test.ts
+++ b/packages/core/src/route/render/compose-title.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+
+import type { TitleTemplate } from "../../theme.js";
+import { composeTitle } from "./compose-title.js";
+
+const defaults = {
+  templateTitle: undefined as string | undefined,
+  templateAbsolute: false,
+  themeTitleTemplate: undefined as TitleTemplate | undefined,
+  resolverTitle: "Resolver",
+};
+
+const compose = (overrides: Partial<typeof defaults>): string =>
+  composeTitle({ ...defaults, ...overrides });
+
+describe("composeTitle", () => {
+  test("string titleTemplate substitutes %s with the template title", () => {
+    expect(
+      compose({ templateTitle: "Hello", themeTitleTemplate: "%s · Site" }),
+    ).toBe("Hello · Site");
+  });
+
+  test("function titleTemplate receives the template title", () => {
+    expect(
+      compose({
+        templateTitle: "Hello",
+        themeTitleTemplate: (title) => (title ? `${title} · Site` : "Site"),
+      }),
+    ).toBe("Hello · Site");
+  });
+
+  test("function titleTemplate receives undefined when no template supplies title", () => {
+    expect(
+      compose({
+        themeTitleTemplate: (title) => title ?? "Site Default",
+      }),
+    ).toBe("Site Default");
+  });
+
+  test("string titleTemplate with no template title falls back to resolver", () => {
+    expect(compose({ themeTitleTemplate: "%s · Site" })).toBe("Resolver");
+  });
+
+  test("titleAbsolute: true bypasses titleTemplate", () => {
+    expect(
+      compose({
+        templateTitle: "Home",
+        templateAbsolute: true,
+        themeTitleTemplate: "%s · Site",
+      }),
+    ).toBe("Home");
+  });
+
+  test("titleAbsolute: true with no template title falls through to resolver", () => {
+    expect(
+      compose({ templateAbsolute: true, themeTitleTemplate: "%s · Site" }),
+    ).toBe("Resolver");
+  });
+
+  test("no titleTemplate, no template title → resolver title (back-compat)", () => {
+    expect(compose({})).toBe("Resolver");
+  });
+
+  test("no titleTemplate, template-supplied title wins", () => {
+    expect(compose({ templateTitle: "Template" })).toBe("Template");
+  });
+
+  test("string template substitutes every %s occurrence", () => {
+    expect(
+      compose({ templateTitle: "Hello", themeTitleTemplate: "%s — %s" }),
+    ).toBe("Hello — Hello");
+  });
+});

--- a/packages/core/src/route/render/compose-title.ts
+++ b/packages/core/src/route/render/compose-title.ts
@@ -1,0 +1,33 @@
+import type { TitleTemplate } from "../../theme.js";
+
+interface ComposeTitleArgs {
+  readonly templateTitle: string | undefined;
+  readonly templateAbsolute: boolean;
+  readonly themeTitleTemplate: TitleTemplate | undefined;
+  /** Resolver-computed default — back-compat fallback when nothing else fires. */
+  readonly resolverTitle: string;
+}
+
+export function composeTitle({
+  templateTitle,
+  templateAbsolute,
+  themeTitleTemplate,
+  resolverTitle,
+}: ComposeTitleArgs): string {
+  if (templateAbsolute) {
+    return templateTitle ?? resolverTitle;
+  }
+  if (themeTitleTemplate !== undefined) {
+    if (typeof themeTitleTemplate === "function") {
+      return themeTitleTemplate(templateTitle);
+    }
+    // Avoid unhead's `"%s · Site"` → `" · Site"` orphan-separator footgun:
+    // string form falls back to the resolver title when there's nothing
+    // to substitute. Themes that need full control reach for the function.
+    if (templateTitle === undefined) {
+      return resolverTitle;
+    }
+    return themeTitleTemplate.replaceAll("%s", templateTitle);
+  }
+  return templateTitle ?? resolverTitle;
+}

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -952,6 +952,171 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(slotIdx).toBeLessThan(closingBodyIdx);
   });
 
+  test("theme-level titleTemplate (string) composes the per-template title", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          document: ({ data }) => ({ title: data.entry.title }),
+          render: ({ data }) => <article>{data.entry.title}</article>,
+        }),
+      },
+      document: { titleTemplate: "%s · Plumix Starter" },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "title-tmpl-string",
+      title: "Hello world",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/title-tmpl-string"),
+    );
+    const body = await response.text();
+    expect(body).toContain("<title>Hello world · Plumix Starter</title>");
+  });
+
+  test("titleTemplate function receives undefined when template doesn't supply title", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: defineTemplate({
+          render: ({ data }) => (
+            <ul>
+              {data.entries.map((entry: ResolvedEntry) => (
+                <li key={entry.id}>{entry.title}</li>
+              ))}
+            </ul>
+          ),
+        }),
+      },
+      document: {
+        titleTemplate: (title) => title ?? "Plumix Starter Archive",
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "any",
+      title: "Any",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain("<title>Plumix Starter Archive</title>");
+  });
+
+  test("titleAbsolute: true bypasses the theme titleTemplate", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": defineTemplate({
+          document: () => ({ title: "Plumix Starter", titleAbsolute: true }),
+          render: () => <section data-testid="front-page" />,
+        }),
+      },
+      document: { titleTemplate: "%s · Plumix Starter" },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    const body = await response.text();
+    expect(body).toContain("<title>Plumix Starter</title>");
+    expect(body).not.toContain("Plumix Starter · Plumix Starter");
+  });
+
+  test("per-template titleTemplate overrides theme-level titleTemplate", async () => {
+    // A template fragment can supply its own composition pattern that
+    // wins over the theme's site-wide template.
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          document: ({ data }) => ({
+            title: data.entry.title,
+            titleTemplate: "%s | Per-Template",
+          }),
+          render: ({ data }) => <article>{data.entry.title}</article>,
+        }),
+      },
+      document: { titleTemplate: "%s · Theme Default" },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "tmpl-override",
+      title: "Override",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/tmpl-override"),
+    );
+    const body = await response.text();
+    expect(body).toContain("<title>Override | Per-Template</title>");
+    expect(body).not.toContain("Theme Default");
+  });
+
+  test("backwards-compat: no titleTemplate, no template title — resolver title wins", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "backcompat",
+      title: "Resolver Title",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/backcompat"),
+    );
+    const body = await response.text();
+    expect(body).toContain("<title>Resolver Title</title>");
+  });
+
+  test("theme-level document.title supplies a default when no template participates", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": () => <section data-testid="front-page" />,
+      },
+      document: { title: "Plumix Starter" },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    const body = await response.text();
+    expect(body).toContain("<title>Plumix Starter</title>");
+  });
+
   test("template-rendered <title> wins over framework default title", async () => {
     const theme = defineTheme({
       templates: {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -34,6 +34,7 @@ import {
 import { normalizeTemplate } from "../../template.js";
 import { validateDocumentManifest } from "../../theme.js";
 import { bundledCssTags } from "./asset-manifest.js";
+import { composeTitle } from "./compose-title.js";
 import { injectIslandsBootstrap } from "./inject-islands-bootstrap.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -85,7 +86,12 @@ export async function renderThroughTheme({
     document: renderDocument,
     assetManifest,
     data,
-    title,
+    title: composeTitle({
+      templateTitle: renderDocument.title,
+      templateAbsolute: renderDocument.titleAbsolute === true,
+      themeTitleTemplate: renderDocument.titleTemplate,
+      resolverTitle: title,
+    }),
     template,
     deps,
     loaderData,
@@ -148,7 +154,12 @@ export async function renderErrorThroughTheme({
     document: renderDocument,
     assetManifest,
     data,
-    title: variant.title,
+    title: composeTitle({
+      templateTitle: renderDocument.title,
+      templateAbsolute: renderDocument.titleAbsolute === true,
+      themeTitleTemplate: renderDocument.titleTemplate,
+      resolverTitle: variant.title,
+    }),
     template,
     deps,
     loaderData: undefined,

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -93,6 +93,15 @@ export type DocumentScript = Omit<
   readonly dangerouslySetInnerHTML?: { readonly __html: string };
 };
 
+/**
+ * Function form receives `string | undefined` so themes can pick a
+ * default for archive / search / 404 templates — mirrors unhead's
+ * `resolveTitleTemplate`.
+ */
+export type TitleTemplate =
+  | string
+  | ((title: string | undefined) => string);
+
 export interface DocumentManifest {
   readonly html?: Omit<
     DocumentTag<"html">,
@@ -105,6 +114,10 @@ export interface DocumentManifest {
   readonly link?: readonly DocumentLink[];
   readonly meta?: readonly DocumentMeta[];
   readonly script?: readonly DocumentScript[];
+  readonly title?: string;
+  readonly titleTemplate?: TitleTemplate;
+  /** Per-template opt-out of `titleTemplate` (Next.js `title.absolute`). */
+  readonly titleAbsolute?: boolean;
 }
 
 export interface TemplateRegistry {


### PR DESCRIPTION
`DocumentManifest` now carries `title`, `titleTemplate`, and `titleAbsolute`, so a theme can install a site-wide title composition pattern and templates can supply the slot it consumes. The resolver-computed title stays as the back-compat fallback when nothing else participates.

**Composition Rule**

Per-template `title` flows through theme `titleTemplate` unless `titleAbsolute: true`. The function form receives `string | undefined` so themes can pick a default for archive / search / 404 templates that don't name their own — mirrors unhead's `resolveTitleTemplate`. String form (`"%s · Site"`) falls back to the resolver title when no template title is supplied, dodging unhead's `" · Site"` orphan-separator footgun.

**API**

```ts
// theme level
defineTheme({
  document: {
    titleTemplate: "%s · Plumix Starter",
    // or:
    titleTemplate: (title) =>
      title ? `${title} · Plumix Starter` : "Plumix Starter",
  },
});

// template level
defineTemplate({
  document: ({ data }) => ({
    title: data.entry.title,
    titleAbsolute: false, // opt-out for the homepage
  }),
});
```

`mergeDocumentManifest` carries the new scalar fields last-wins from the template fragment, so a per-template `titleTemplate` can override the theme's site-wide pattern.

Composition lives in a pure `composeTitle` helper with nine unit tests; six dispatcher tests lock the wiring through the merge path.

Fixes #613