### PR TITLE
feat(core): add title + titleTemplate to DocumentManifest

### DIFF
--- a/packages/core/src/document-merge.ts
+++ b/packages/core/src/document-merge.ts
@@ -28,6 +28,8 @@ export function mergeDocumentManifest(
     link: concatArrays(theme.link, fragment?.link),
     meta: concatArrays(theme.meta, fragment?.meta),
     script: concatArrays(theme.script, fragment?.script),
+    title: fragment?.title ?? theme.title,
+    titleTemplate: fragment?.titleTemplate ?? theme.titleTemplate,
   };
 }
 

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -952,6 +952,208 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(slotIdx).toBeLessThan(closingBodyIdx);
   });
 
+  test("theme-level string titleTemplate composes the per-template title", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          document: ({ data }) => ({ title: data.entry.title }),
+          render: ({ data }) => <article>{data.entry.title}</article>,
+        }),
+      },
+      document: { titleTemplate: "%s · Plumix Starter" },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "title-tmpl-string",
+      title: "Hello world",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/title-tmpl-string"),
+    );
+    const body = await response.text();
+    expect(body).toContain("<title>Hello world · Plumix Starter</title>");
+  });
+
+  test("function titleTemplate receives the per-template title", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          document: ({ data }) => ({ title: data.entry.title }),
+          render: ({ data }) => <article>{data.entry.title}</article>,
+        }),
+      },
+      document: {
+        titleTemplate: (title) => (title ? `${title} | Plumix` : "Plumix"),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "title-tmpl-fn",
+      title: "Hello",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/title-tmpl-fn"),
+    );
+    const body = await response.text();
+    expect(body).toContain("<title>Hello | Plumix</title>");
+  });
+
+  test("function titleTemplate receives undefined when template supplies no title", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: defineTemplate({
+          render: ({ data }) => (
+            <ul>
+              {data.entries.map((entry: ResolvedEntry) => (
+                <li key={entry.id}>{entry.title}</li>
+              ))}
+            </ul>
+          ),
+        }),
+      },
+      document: {
+        titleTemplate: (title) => title ?? "Plumix Archive",
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "x",
+      title: "X",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    expect(body).toContain("<title>Plumix Archive</title>");
+  });
+
+  test("string titleTemplate with no template title falls back to the resolver title", async () => {
+    // Avoid unhead's "%s · Site" → " · Site" orphan-separator: when the
+    // template doesn't name its own title and the theme uses string form,
+    // the resolver-computed title still renders bare.
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: defineTemplate({
+          render: ({ data }) => (
+            <ul>
+              {data.entries.map((entry: ResolvedEntry) => (
+                <li key={entry.id}>{entry.title}</li>
+              ))}
+            </ul>
+          ),
+        }),
+      },
+      document: { titleTemplate: "%s · Plumix" },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "x",
+      title: "X",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/post"));
+    const body = await response.text();
+    // Resolver-computed archive title is "Posts" (label/plural); string
+    // template skips substitution and the bare resolver title renders.
+    expect(body).toContain("<title>Posts</title>");
+    expect(body).not.toContain(" · Plumix");
+  });
+
+  test("back-compat: theme without titleTemplate or document.title renders resolver title", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "backcompat",
+      title: "Resolver Title",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/backcompat"),
+    );
+    const body = await response.text();
+    expect(body).toContain("<title>Resolver Title</title>");
+  });
+
+  test("per-template titleTemplate overrides the theme-level titleTemplate", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          document: ({ data }) => ({
+            title: data.entry.title,
+            titleTemplate: "%s | Per-Template",
+          }),
+          render: ({ data }) => <article>{data.entry.title}</article>,
+        }),
+      },
+      document: { titleTemplate: "%s · Theme" },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "override",
+      title: "Override",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/override"),
+    );
+    const body = await response.text();
+    expect(body).toContain("<title>Override | Per-Template</title>");
+    expect(body).not.toContain("Theme");
+  });
+
   test("template-rendered <title> wins over framework default title", async () => {
     const theme = defineTheme({
       templates: {
@@ -2473,6 +2675,24 @@ describe("resolvePublicRoute — front-page through theme", () => {
 });
 
 describe("resolvePublicRoute — error pages through theme", () => {
+  test("404 page composes its title through the theme titleTemplate", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "404": () => <main data-testid="four-oh-four" />,
+      },
+      document: { titleTemplate: "%s · Plumix" },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(
+      new Request("https://cms.example/never-existed"),
+    );
+    expect(response.status).toBe(404);
+    const body = await response.text();
+    expect(body).toContain("<title>Not Found · Plumix</title>");
+  });
+
   test("registered `404` template renders for an unmatched URL", async () => {
     const theme = defineTheme({
       templates: {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -85,12 +85,23 @@ export async function renderThroughTheme({
     document: renderDocument,
     assetManifest,
     data,
-    title,
+    title: composeTitle(renderDocument, title),
     template,
     deps,
     loaderData,
     tokens: theme.tokens,
   });
+}
+
+// String form falls back to the resolver title instead of substituting
+// `undefined`, dodging unhead's `"%s · Site"` → `" · Site"` orphan separator.
+function composeTitle(document: DocumentManifest, fallback: string): string {
+  const { title, titleTemplate } = document;
+  if (typeof titleTemplate === "function") return titleTemplate(title);
+  if (typeof titleTemplate === "string" && title !== undefined) {
+    return titleTemplate.replaceAll("%s", title);
+  }
+  return title ?? fallback;
 }
 
 interface RenderErrorArgs {
@@ -148,7 +159,12 @@ export async function renderErrorThroughTheme({
     document: renderDocument,
     assetManifest,
     data,
-    title: variant.title,
+    // Seed variant.title so theme titleTemplate composes a final string;
+    // an error template's own `title` still wins via the `??`.
+    title: composeTitle(
+      { ...renderDocument, title: renderDocument.title ?? variant.title },
+      variant.title,
+    ),
     template,
     deps,
     loaderData: undefined,

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -105,6 +105,8 @@ export interface DocumentManifest {
   readonly link?: readonly DocumentLink[];
   readonly meta?: readonly DocumentMeta[];
   readonly script?: readonly DocumentScript[];
+  readonly title?: string;
+  readonly titleTemplate?: string | ((title: string | undefined) => string);
 }
 
 export interface TemplateRegistry {


### PR DESCRIPTION
`DocumentManifest` now carries `title` and `titleTemplate`, so a theme can install a site-wide title composition pattern and templates can supply the slot it consumes. The framework's resolver-computed title stays as the back-compat fallback when nothing else participates.

**Composition Rules**

- Per-template `title` flows through theme `titleTemplate` — string form substitutes every `%s`.
- Function form receives `string | undefined` so a theme can pick its own default for archive / search / 404 templates that don't name their own — mirrors unhead's `resolveTitleTemplate`.
- String form falls back to the resolver title when no template title is supplied, dodging unhead's `" · Site"` orphan-separator footgun.
- A per-template `titleTemplate` overrides the theme's site-wide pattern.
- 404 / 500 pages compose too: the variant title (`Not Found` / `Internal Server Error`) is seeded as the manifest `title` so themes get `<title>Not Found · Site</title>` without every error template having to participate.

**API**

```ts
defineTheme({
  document: {
    titleTemplate: "%s · Plumix Starter",
    // or, for full control:
    titleTemplate: (title) =>
      title ? `${title} · Plumix Starter` : "Plumix Starter",
  },
});

defineTemplate({
  document: ({ data }) => ({ title: data.entry.title }),
  render: ({ data }) => <article>{data.entry.title}</article>,
});
```

**Scope decision vs. the issue spec**

`titleAbsolute` (borrowed from Next.js `metadata.title.absolute`) is intentionally not pulled in. The function form already covers the homepage case — a theme can return the bare site name when `title` is `undefined`, or branch inside the function on a sentinel. Themes can also render `<title>...</title>` directly in JSX and rely on React 19 hoisting, which already wins via the existing hoisted-title path. Aligns with Nuxt / unhead, which have no equivalent.

Seven dispatcher integration tests lock the behavior through public HTML output. Driven via TDD red-green-refactor.

Fixes #613