### PR TITLE
fix(core): route /page/N to the front-page ahead of plugin catch-alls

### DIFF
--- a/packages/core/src/route/compile.test.ts
+++ b/packages/core/src/route/compile.test.ts
@@ -4,13 +4,19 @@ import { HookRegistry } from "../hooks/registry.js";
 import { definePlugin } from "../plugin/define.js";
 import { createPluginRegistry } from "../plugin/manifest.js";
 import { installPlugins } from "../plugin/register.js";
-import { compileRouteMap } from "./compile.js";
+import { compileRouteMap, FRAMEWORK_FRONT_PAGE_PATTERN } from "./compile.js";
 
 async function buildRegistry(plugins: ReturnType<typeof definePlugin>[]) {
   const hooks = new HookRegistry();
   const registry = createPluginRegistry();
   await installPlugins({ hooks, plugins, registry });
   return registry;
+}
+
+function pluginRoutes(registry: ReturnType<typeof createPluginRegistry>) {
+  return compileRouteMap(registry).filter(
+    (rule) => rule.rawPattern !== FRAMEWORK_FRONT_PAGE_PATTERN,
+  );
 }
 
 describe("compileRouteMap", () => {
@@ -89,7 +95,7 @@ describe("compileRouteMap", () => {
         });
       }),
     ]);
-    const map = compileRouteMap(registry);
+    const map = pluginRoutes(registry);
     expect(map.map((r) => r.rawPattern)).toEqual([
       "/r/:term/page/:page",
       "/r/:term",
@@ -104,7 +110,7 @@ describe("compileRouteMap", () => {
         ctx.registerTermTaxonomy("topic", { label: "Topics" });
       }),
     ]);
-    expect(compileRouteMap(registry).map((r) => r.rawPattern)).toEqual([
+    expect(pluginRoutes(registry).map((r) => r.rawPattern)).toEqual([
       "/topic/:term/page/:page",
       "/topic/:term",
     ]);
@@ -119,7 +125,7 @@ describe("compileRouteMap", () => {
         });
       }),
     ]);
-    expect(compileRouteMap(registry)).toHaveLength(0);
+    expect(pluginRoutes(registry)).toHaveLength(0);
   });
 
   test("taxonomy rule beats colliding entry-type single on slug match (WP-faithful)", async () => {
@@ -183,7 +189,7 @@ describe("compileRouteMap", () => {
         ctx.registerEntryType("post", { label: "Posts", isPublic: true });
       }),
     ]);
-    const map = compileRouteMap(registry);
+    const map = pluginRoutes(registry);
     expect(map).toHaveLength(1);
     expect(map[0]?.rawPattern).toBe("/post/:slug");
     expect(map[0]?.intent).toEqual({ kind: "single", entryType: "post" });
@@ -224,7 +230,7 @@ describe("compileRouteMap", () => {
         });
       }),
     ]);
-    const map = compileRouteMap(registry);
+    const map = pluginRoutes(registry);
     const patterns = map.map((r) => r.rawPattern);
     expect(patterns).toEqual(["/shop/page/:page", "/shop", "/shop/:slug"]);
     expect(map[0]?.intent).toEqual({ kind: "archive", entryType: "product" });
@@ -243,8 +249,7 @@ describe("compileRouteMap", () => {
         });
       }),
     ]);
-    const map = compileRouteMap(registry);
-    expect(map.map((r) => r.rawPattern)).toEqual([
+    expect(pluginRoutes(registry).map((r) => r.rawPattern)).toEqual([
       "/store/page/:page",
       "/store",
       "/p/:slug",
@@ -260,7 +265,7 @@ describe("compileRouteMap", () => {
         });
       }),
     ]);
-    expect(compileRouteMap(registry)).toHaveLength(0);
+    expect(pluginRoutes(registry)).toHaveLength(0);
   });
 
   test("registerRewriteRule lands ahead of auto rules via default priority", async () => {
@@ -277,7 +282,7 @@ describe("compileRouteMap", () => {
         });
       }),
     ]);
-    const map = compileRouteMap(registry);
+    const map = pluginRoutes(registry);
     expect(map[0]?.rawPattern).toBe("/docs/:category/:slug");
     expect(map[0]?.priority).toBe(10);
     expect(map[1]?.rawPattern).toBe("/docs/:slug");
@@ -329,8 +334,10 @@ describe("compileRouteMap", () => {
         ctx.registerRewriteRule("/b", { kind: "single", entryType: "x" });
       }),
     ]);
-    const map = compileRouteMap(registry);
-    expect(map.map((r) => r.rawPattern)).toEqual(["/a", "/b"]);
+    expect(pluginRoutes(registry).map((r) => r.rawPattern)).toEqual([
+      "/a",
+      "/b",
+    ]);
   });
 
   test("isPublic defaults to true — omitting it still generates routes", async () => {
@@ -339,7 +346,7 @@ describe("compileRouteMap", () => {
         ctx.registerEntryType("article", { label: "Articles" });
       }),
     ]);
-    expect(compileRouteMap(registry).map((r) => r.rawPattern)).toEqual([
+    expect(pluginRoutes(registry).map((r) => r.rawPattern)).toEqual([
       "/article/:slug",
     ]);
   });
@@ -357,9 +364,17 @@ describe("compileRouteMap", () => {
         );
       }),
     ]);
-    const map = compileRouteMap(registry);
+    const map = pluginRoutes(registry);
     expect(map[0]?.rawPattern).toBe("/post/featured");
     expect(map[0]?.priority).toBe(5);
+  });
+
+  test("framework registers /page/:page(\\d+) ahead of plugin rules", async () => {
+    const registry = await buildRegistry([]);
+    const map = compileRouteMap(registry);
+    expect(map[0]?.rawPattern).toBe(FRAMEWORK_FRONT_PAGE_PATTERN);
+    expect(map[0]?.intent).toEqual({ kind: "front-page" });
+    expect(map[0]?.priority).toBeLessThan(10);
   });
 
   test("hasArchive: string rejects multi-segment or non-kebab input", async () => {

--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -8,6 +8,11 @@ import { RouteCompileError } from "./errors.js";
 
 const AUTO_ROUTE_PRIORITY = 50;
 export const DEFAULT_REWRITE_RULE_PRIORITY = 10;
+// Framework-owned routes sort ahead of explicit rewrites so a plugin's
+// catch-all can't shadow `/page/N`.
+const FRAMEWORK_ROUTE_PRIORITY = 5;
+
+export const FRAMEWORK_FRONT_PAGE_PATTERN = "/page/:page(\\d+)";
 
 interface CompiledRule extends RouteRule {
   readonly registeredBy: string | null;
@@ -22,7 +27,16 @@ interface CompiledRule extends RouteRule {
 export function compileRouteMap(
   registry: PluginRegistry,
 ): readonly RouteRule[] {
-  const rules: CompiledRule[] = [];
+  const rules: CompiledRule[] = [
+    {
+      // `(\d+)` lets a hierarchical pages plugin keep `/page/:path+`.
+      pattern: new URLPattern({ pathname: FRAMEWORK_FRONT_PAGE_PATTERN }),
+      rawPattern: FRAMEWORK_FRONT_PAGE_PATTERN,
+      intent: { kind: "front-page" },
+      priority: FRAMEWORK_ROUTE_PRIORITY,
+      registeredBy: null,
+    },
+  ];
 
   // Taxonomies emit before entry types so that a slug collision (e.g. a
   // post type with `rewrite.slug: 'category'` shadowing a `category`

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -2601,6 +2601,43 @@ describe("resolvePublicRoute — front-page through theme", () => {
     expect(response.status).toBe(404);
   });
 
+  test("/page/N is not shadowed by a plugin that grabs the `/page/:slug` auto-route", async () => {
+    // The `page` entry type auto-generates `/page/:slug`, which would
+    // otherwise swallow `/page/1`.
+    const pagesPlugin = definePlugin("pages", (ctx) => {
+      ctx.registerEntryType("page", { label: "Pages", isPublic: true });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        "front-page": ({ data }) => (
+          <span data-testid="page">{`page:${String(data.pagination.page)}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, pagesPlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "p",
+      title: "P",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/page/1"),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("page:1");
+  });
+
   test("plugin-registered `/` rewrite rule wins over front-page synthesis", async () => {
     const homepagePlugin = definePlugin("homepage", (ctx) => {
       ctx.registerEntryType("post", { label: "Posts", isPublic: true });

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -264,11 +264,10 @@ async function resolvePublicRouteOrFallback(
       assetManifest,
     );
   }
-  const frontPageParams = matchFrontPagePathname(url.pathname);
-  if (frontPageParams !== null) {
+  if (url.pathname === "/") {
     return resolvePublicRoute(
       ctx,
-      { intent: { kind: "front-page" }, params: frontPageParams },
+      { intent: { kind: "front-page" }, params: {} },
       theme,
       document,
       templateDocuments,
@@ -277,17 +276,6 @@ async function resolvePublicRouteOrFallback(
     );
   }
   return notFound("public-route-not-found");
-}
-
-const FRONT_PAGE_PAGINATED = new URLPattern({ pathname: "/page/:page" });
-
-function matchFrontPagePathname(
-  pathname: string,
-): Record<string, string> | null {
-  if (pathname === "/") return {};
-  const match = FRONT_PAGE_PAGINATED.exec({ pathname });
-  const page = match?.pathname.groups.page;
-  return page === undefined ? null : { page };
 }
 
 interface PluginRawRouteMatch {


### PR DESCRIPTION
`/page/N` now renders the paginated front-page regardless of what plugins claim. Previously, any plugin whose auto-generated single resolver matched the `/page/` prefix — most obviously an entry type named `page`, whose default `baseSlug` yields `/page/:slug` — swallowed the URL, looked up an entry slugged `"N"`, and 404'd. The dispatcher's hardcoded fallback never fired.

**Framework Route**

`/page/:page(\d+)` lives in the compiled routeMap at framework priority (5), ahead of explicit-rewrite default (10) and auto rules (50). The numeric `(\d+)` constraint preserves `/page/about` flowing to a hierarchical pages plugin's `/page/:path+`: only literal page indices claim the framework rule.

**Dispatcher Cleanup**

`FRONT_PAGE_PAGINATED` and `matchFrontPagePathname` are gone — routing is the routeMap's job now. The only remaining synthesis is the bare `/` short-circuit.

```ts
// before: paginated path lived in the dispatcher fallback
const FRONT_PAGE_PAGINATED = new URLPattern({ pathname: "/page/:page" });
// after: in compile.ts, alongside auto entry/taxonomy rules
const FRAMEWORK_FRONT_PAGE_PATTERN = "/page/:page(\\d+)";
```

Two new tests: a dispatcher tracer (`/page/1` survives a `page` entry type), and a compile test locking the framework rule's position and priority.

Fixes #603