### PR TITLE
fix(core): sort empty-slug catch-alls after sibling auto rules

### DIFF
--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -11,6 +11,10 @@ export const DEFAULT_REWRITE_RULE_PRIORITY = 10;
 // Framework-owned routes sort ahead of explicit rewrites so a plugin's
 // catch-all can't shadow `/page/N`.
 const FRAMEWORK_ROUTE_PRIORITY = 5;
+// Empty-baseSlug single patterns (`/:slug` or `/:path+`) match everything
+// at the URL root, so they sort after sibling-plugin auto rules to keep
+// resolution order-independent.
+const CATCH_ALL_ROUTE_PRIORITY = 60;
 
 export const FRAMEWORK_FRONT_PAGE_PATTERN = "/page/:page(\\d+)";
 
@@ -111,7 +115,7 @@ function autoRulesForEntryType(entryType: RegisteredEntryType): CompiledRule[] {
     pattern: new URLPattern({ pathname: singlePattern }),
     rawPattern: singlePattern,
     intent: { kind: "single", entryType: entryType.name },
-    priority: AUTO_ROUTE_PRIORITY,
+    priority: baseSlug === "" ? CATCH_ALL_ROUTE_PRIORITY : AUTO_ROUTE_PRIORITY,
     registeredBy: entryType.registeredBy,
   });
 

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -2638,6 +2638,56 @@ describe("resolvePublicRoute — front-page through theme", () => {
     expect(await response.text()).toContain("page:1");
   });
 
+  test("blog archive at /posts resolves even when a pages plugin's empty-slug catch-all registers first", async () => {
+    // With `rewrite.slug: ""`, the pages plugin auto-registers `/:slug`
+    // (or `/:path+` hierarchical). Sharing AUTO_ROUTE_PRIORITY (50) with
+    // blog's `/posts` archive made resolution depend on plugin order —
+    // `[pages, blog]` would 404 because pages' catch-all matched first
+    // and the page resolver missed slug "posts".
+    const pagesPlugin = definePlugin("pages", (ctx) => {
+      ctx.registerEntryType("page", {
+        label: "Pages",
+        isPublic: true,
+        rewrite: { slug: "" },
+      });
+    });
+    const blogPostsPlugin = definePlugin("blog-posts", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        isPublic: true,
+        hasArchive: true,
+        rewrite: { slug: "posts" },
+      });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        archive: ({ data }) => (
+          <span data-testid="archive">{`type:${data.contentType}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [pagesPlugin, blogPostsPlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hello",
+      title: "Hello",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(new Request("https://cms.example/posts"));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("type:post");
+  });
+
   test("plugin-registered `/` rewrite rule wins over front-page synthesis", async () => {
     const homepagePlugin = definePlugin("homepage", (ctx) => {
       ctx.registerEntryType("post", { label: "Posts", isPublic: true });


### PR DESCRIPTION
An entry type registered with `rewrite.slug: ""` auto-generates `/:slug` (or `/:path+` hierarchical), which matches everything at the URL root. Sharing `AUTO_ROUTE_PRIORITY = 50` with sibling plugins' more-specific auto rules made URL resolution depend on `plugins:` array order — `[pages, blog]` would 404 on `/posts` because pages' catch-all matched first and the page resolver missed slug `"posts"`.

**Catch-All Priority**

`CATCH_ALL_ROUTE_PRIORITY = 60` lands between auto rules (50) and an unused slot. Empty-baseSlug singles emit at that priority so non-catch-all auto rules (specific singles, archives, taxonomies) always sort first regardless of registration order. Entry types with a non-empty `baseSlug` keep priority 50; explicit `registerRewriteRule` entries stay at 10 and still beat both.

```
DEFAULT_REWRITE_RULE_PRIORITY  = 10  // explicit registerRewriteRule
AUTO_ROUTE_PRIORITY            = 50  // single/archive/taxonomy with a baseSlug
CATCH_ALL_ROUTE_PRIORITY       = 60  // empty-baseSlug single (new)
```

**Unblocks #604**

The idiomatic permalink defaults for plugin-pages/plugin-blog can't ship without this priority structure — they want `rewrite.slug: ""` as the pages default, and any consumer reordering `plugins:` would footgun on a silent 404.

One dispatcher integration tracer locks the order-independence; full core suite (1678 tests) still green.

Fixes #605