### PR TITLE
fix!: ship idiomatic permalink defaults for pages and blog plugins

### DIFF
--- a/packages/plugins/blog/src/index.test.ts
+++ b/packages/plugins/blog/src/index.test.ts
@@ -19,6 +19,12 @@ describe("@plumix/plugin-blog", () => {
     expect(post?.registeredBy).toBe("blog");
   });
 
+  test("serves posts under the plural /posts collection", async () => {
+    const { registry } = await install();
+    const post = registry.entryTypes.get("post");
+    expect(post?.rewrite).toEqual({ slug: "posts" });
+  });
+
   test("registers category as a hierarchical taxonomy with admin column", async () => {
     const { registry } = await install();
     const category = registry.termTaxonomies.get("category");

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -11,6 +11,7 @@ export const blog = definePlugin("blog", (ctx) => {
     isHierarchical: false,
     isPublic: true,
     hasArchive: true,
+    rewrite: { slug: "posts" },
     capabilityType: "post",
     menuIcon: "file-text",
   });

--- a/packages/plugins/pages/src/index.test.ts
+++ b/packages/plugins/pages/src/index.test.ts
@@ -19,6 +19,12 @@ describe("@plumix/plugin-pages", () => {
     expect(page?.registeredBy).toBe("pages");
   });
 
+  test("serves pages at the URL root via empty rewrite.slug", async () => {
+    const { registry } = await install();
+    const page = registry.entryTypes.get("page");
+    expect(page?.rewrite).toEqual({ slug: "" });
+  });
+
   test("registers no taxonomies", async () => {
     const { registry } = await install();
     expect(registry.termTaxonomies.size).toBe(0);

--- a/packages/plugins/pages/src/index.ts
+++ b/packages/plugins/pages/src/index.ts
@@ -10,6 +10,7 @@ export const pages = definePlugin("pages", (ctx) => {
     isHierarchical: true,
     isPublic: true,
     hasArchive: false,
+    rewrite: { slug: "" },
     capabilityType: "page",
     menuIcon: "layout",
   });


### PR DESCRIPTION
Default public URLs for the pages and blog plugins were developer-facing slugs (`/page/about`, `/post/balboa`) inherited from the entry-type name fallback. They now mirror WP/Ghost/Hugo conventions: pages resolve at the URL root, blog posts under the plural collection.

```
                                  before              after
@plumix/plugin-pages
  page slug "about"               /page/about         /about
  nested "about/team"             /page/about/team    /about/team

@plumix/plugin-blog
  archive                         /post               /posts
  post slug "balboa"              /post/balboa        /posts/balboa
  archive page 2                  /post/page/2        /posts/page/2
```

**Names are unchanged**

Entry-type names stay `post` and `page`, so DB rows, capability strings (`entry:post:*`, `entry:page:*`), and admin URLs (`/entries/posts`, `/entries/pages`) are unaffected. Only the **public URL slug** changes.

**Order independence**

Pages with `rewrite.slug: ""` auto-generate `/:path+` which previously shadowed blog's `/posts/:slug` under URLPattern first-match-wins, making resolution depend on `plugins:` array order. The catch-all priority demotion shipped with #618 (#605) keeps siblings deterministic, so this PR doesn't reintroduce the order-dependence footgun.

**Breaking change**

Hardcoded `/post/<slug>` and `/page/<slug>` links break. Consumers that need the old paths can opt back in per entry type:

```ts
ctx.registerEntryType("post", {
  // …
  rewrite: { slug: "post" },
});
```

Tests pin the new defaults on both plugins; full workspace (plugin-pages 4/4, plugin-blog 6/6, downstream dependents) green.

Fixes #604