### PR TITLE
feat(blocks): export defineEntryContent for seed and migration callers

### DIFF
--- a/packages/blocks/src/entry-content.test.ts
+++ b/packages/blocks/src/entry-content.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest";
+
+import { defineEntryContent, isEntryContent } from "./entry-content.js";
+
+describe("defineEntryContent", () => {
+  test("produces an envelope that the isEntryContent guard accepts", () => {
+    const content = defineEntryContent([
+      { id: "h", name: "core/heading", attrs: { text: "Hi" } },
+    ]);
+    expect(isEntryContent(content)).toBe(true);
+  });
+});

--- a/packages/blocks/src/entry-content.ts
+++ b/packages/blocks/src/entry-content.ts
@@ -6,6 +6,15 @@ export interface EntryContent {
   readonly blocks: readonly BlockNode[];
 }
 
+/**
+ * Stamp a `BlockNode[]` with the current envelope so externally-built
+ * content (seeds, migrations, fixtures) survives the runtime
+ * `isEntryContent` guard instead of silently rendering blank (#607).
+ */
+export function defineEntryContent(blocks: readonly BlockNode[]): EntryContent {
+  return { version: "plumix.v2", blocks };
+}
+
 export function isEntryContent(value: unknown): value is EntryContent {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as { version?: unknown; blocks?: unknown };

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -36,7 +36,7 @@ export type {
 } from "./render-block-tree.js";
 
 // ─── Entry-content envelope ─────────────────────────────────────────────────
-export { isEntryContent } from "./entry-content.js";
+export { defineEntryContent, isEntryContent } from "./entry-content.js";
 export type { EntryContent } from "./entry-content.js";
 
 // ─── Per-block SSR loaders ──────────────────────────────────────────────────

--- a/packages/plumix/src/blocks/index.ts
+++ b/packages/plumix/src/blocks/index.ts
@@ -13,6 +13,7 @@ export {
   coreMarks,
   createBlockRegistry,
   defineBlock,
+  defineEntryContent,
   isEntryContent,
   isBlockNodeArray,
   renderBlockTree,


### PR DESCRIPTION
Hand-written seed SQL, drizzle seeders, fixture imports, and migrations from other CMSes have to produce the `{ version: "plumix.v2", blocks: [...] }` envelope themselves. Today, omitting `version` (or typoing it) is silently rejected by the runtime `isEntryContent` guard, `resolve.ts` sets `contentBlocks: null`, and the entry renders with its chrome but no body — a footgun that only surfaces as blank content with no log, error, or warning.

**Typed envelope helper**

```ts
import { defineEntryContent } from "plumix/blocks";

const content = defineEntryContent([
  { id: "h", name: "core/heading", attrs: { text: "Hello" } },
]);
// → { version: "plumix.v2", blocks: [...] }
```

Callers stamp the envelope once and lean on the literal-typed `version: "plumix.v2"` to catch typos at compile time instead of at visual inspection. Re-exported through both `@plumix/blocks` (workspace-internal) and `plumix/blocks` (consumer-facing) so plugin/theme/app code can reach it via the conventional import path.

**Why not migrate the existing inline literal in admin's editor**

The RPC `content` schema is `v.record(v.string(), v.unknown())` — a mutable `Record<string, unknown>`. The strict `EntryContent` from this PR (readonly props + literal `version`) isn't assignable to it. That collision between `@plumix/blocks/EntryContent` (strict envelope) and `@plumix/core/db/schema/EntryContent` (loose record alias) is pre-existing and out of scope here.

Issue #607 listed two other fix options (dev-mode warning, normalize-on-read). Those address the same silent-failure class from the read side; this PR ships the write-side primitive that prevents the failure in the first place. Either of the read-side options can land separately if/when the gap surfaces in practice.

Fixes #607