### PR TITLE
feat: deliver theme tokens to admin StyleTab via manifest channel

### DIFF
--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -52,6 +52,14 @@ describe("readManifest", () => {
     });
   });
 
+  test("carries theme tokens through to consumers", () => {
+    const tokens = {
+      colors: { brand: { value: "#0070f3", label: "Brand" } },
+    };
+    const doc = withManifestScript(JSON.stringify({ tokens }));
+    expect(readManifest(doc).tokens).toEqual(tokens);
+  });
+
   test("empty payload falls back to empty manifest", () => {
     const doc = withManifestScript("");
     expect(readManifest(doc)).toEqual({});

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -1,3 +1,4 @@
+import type { ThemeTokens } from "@plumix/blocks";
 import type {
   AdminNavGroup,
   AdminNavItem,
@@ -56,10 +57,17 @@ function normalize(value: unknown): PlumixManifest {
       (result as Record<string, unknown>)[key] = v[key];
     }
   }
+  if (v.tokens && typeof v.tokens === "object") {
+    (result as Record<string, unknown>).tokens = v.tokens;
+  }
   return result;
 }
 
 const manifest: PlumixManifest = readManifest();
+
+export function getThemeTokens(source: PlumixManifest = manifest): ThemeTokens {
+  return source.tokens ?? {};
+}
 
 export function findEntryTypeBySlug(
   slug: string,

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -17,7 +17,11 @@ import { resolveEditorMode } from "@/editor/resolve-editor-mode.js";
 import { PreviewBanner } from "@/editor/revisions/PreviewBanner.js";
 import { useRevisionsTrigger } from "@/editor/revisions/use-revisions-trigger.js";
 import { StaleDraftDialog } from "@/editor/StaleDraftDialog.js";
-import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
+import {
+  entryMetaBoxesForType,
+  findEntryTypeBySlug,
+  getThemeTokens,
+} from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
 import { formatRelativeTime } from "@/lib/relative-time.js";
@@ -32,7 +36,6 @@ import {
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import * as v from "valibot";
 
-import type { ThemeTokens } from "@plumix/blocks";
 import type { EntryTypeManifestEntry } from "@plumix/core/manifest";
 import { coreMarkExtensions, createBlockRegistry } from "@plumix/blocks";
 import { idPathParam } from "@plumix/core/validation";
@@ -65,26 +68,7 @@ function isStaleConflictError(err: unknown): boolean {
   return data.reason === "stale_expected_updated_at";
 }
 
-const sampleTokens: ThemeTokens = {
-  colors: {
-    background: { value: "#ffffff", label: "Background" },
-    surface: { value: "#f4f4f5", label: "Surface" },
-    brand: { value: "#0070f3", label: "Brand" },
-    ink: { value: "#111111", label: "Ink" },
-  },
-  spacing: {
-    none: { value: "0", label: "None" },
-    sm: { value: "0.5rem", label: "Small" },
-    md: { value: "1rem", label: "Medium" },
-    lg: { value: "2rem", label: "Large" },
-  },
-  typography: {
-    sm: { value: "0.875rem", label: "Small" },
-    md: { value: "1rem", label: "Medium" },
-    lg: { value: "1.25rem", label: "Large" },
-    xl: { value: "1.5rem", label: "Extra large" },
-  },
-};
+const themeTokens = getThemeTokens();
 
 registerCoreBlocks();
 const runtimeBlocks = getRegisteredBlocks();
@@ -580,7 +564,7 @@ function PuckSpikeRouteInner({
       <PlumixEditorLayout
         registry={registry}
         capabilities={capabilitySet}
-        tokens={sampleTokens}
+        tokens={themeTokens}
         title={title}
         onTitleChange={handleTitleChange}
         backHref={backHref}
@@ -753,7 +737,7 @@ function PuckPreviewRouteInner({
       <PlumixEditorLayout
         registry={registry}
         capabilities={capabilitySet}
-        tokens={sampleTokens}
+        tokens={themeTokens}
         title={revision.title}
         onTitleChange={() => undefined}
         backHref={backHref}

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -21,6 +21,14 @@ import {
 import { installPlugins } from "./register.js";
 
 describe("buildManifest", () => {
+  test("carries theme.tokens through to the admin manifest channel", () => {
+    const tokens = {
+      colors: { brand: { value: "#0070f3", label: "Brand" } },
+    };
+    const manifest = buildManifest(createPluginRegistry(), { tokens });
+    expect(manifest.tokens).toEqual(tokens);
+  });
+
   test("empty registry projects core-seeded adminNav (Dashboard / Management) and empty everything else", () => {
     const manifest = buildManifest(createPluginRegistry());
     expect(manifest.entryTypes).toEqual([]);

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1,4 +1,9 @@
-import type { BlockSpec, BlockVariation, MarkSpec } from "@plumix/blocks";
+import type {
+  BlockSpec,
+  BlockVariation,
+  MarkSpec,
+  ThemeTokens,
+} from "@plumix/blocks";
 
 import type {
   EntryTypeCapabilityOverrides,
@@ -1451,6 +1456,12 @@ export interface PlumixManifest {
   readonly fieldTypes?: readonly FieldTypeManifestEntry[];
   readonly blocks?: readonly BlockManifestEntry[];
   readonly marks?: readonly MarkManifestEntry[];
+  /**
+   * Theme tokens from `defineTheme({ tokens })`. Routed through the
+   * manifest channel because the precompiled admin shell can't import
+   * `plumix.config.ts` at build time.
+   */
+  readonly tokens?: ThemeTokens;
 }
 
 /**
@@ -1479,6 +1490,7 @@ export function emptyManifest(): PlumixManifest {
     fieldTypes: [],
     blocks: [],
     marks: [],
+    tokens: {},
   };
 }
 
@@ -1494,7 +1506,10 @@ export function emptyManifest(): PlumixManifest {
  * admin slug — the admin router can't disambiguate `/entries/$slug` in that
  * case, and catching it at build time is cheaper than a 404 at runtime.
  */
-export function buildManifest(registry: PluginRegistry): BuiltManifest {
+export function buildManifest(
+  registry: PluginRegistry,
+  theme?: { readonly tokens?: ThemeTokens },
+): BuiltManifest {
   const entries = Array.from(registry.entryTypes.values())
     .map(toEntryTypeManifest)
     .sort(byPriorityThen((e) => e.name));
@@ -1567,6 +1582,7 @@ export function buildManifest(registry: PluginRegistry): BuiltManifest {
     fieldTypes,
     blocks,
     marks,
+    tokens: theme?.tokens ?? {},
   };
 }
 

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url";
 import type { Plugin, UserConfig } from "vite";
 import { mergeConfig } from "vite";
 
+import type { ThemeTokens } from "@plumix/blocks";
 import type {
   AnyPluginDescriptor,
   PluginRegistry,
@@ -332,6 +333,7 @@ async function regenerate(
 
   const { manifest, registry } = await computeManifestAndRegistry(
     config.plugins,
+    config.theme,
   );
 
   return { configPath, manifest, registry, plugins: config.plugins };
@@ -349,12 +351,13 @@ type PluginDescriptors = Parameters<typeof installPlugins>[0]["plugins"];
 // so plugins should keep setup free of IO.
 async function computeManifestAndRegistry(
   plugins: PluginDescriptors,
+  theme: { readonly tokens?: ThemeTokens },
 ): Promise<{ manifest: PlumixManifest; registry: PluginRegistry }> {
   const { registry } = await installPlugins({
     hooks: new HookRegistry(),
     plugins,
   });
-  return { manifest: buildManifest(registry), registry };
+  return { manifest: buildManifest(registry, theme), registry };
 }
 
 // Copies the compiled admin SPA from plumix/dist/admin-app into the effective


### PR DESCRIPTION
The block-style picker (`StyleTab` / `TokenSwatchList`) used a hardcoded `sampleTokens` constant — authors picked tokens the renderer didn't know about, and the round-trip silently mismatched. The render half of #574 shipped in #599; this lands the admin half on the same channel every other admin-extensible surface uses.

**Manifest carries theme tokens**

`PlumixManifest` gains an optional `tokens: ThemeTokens` field; `buildManifest` accepts an optional theme arg and projects `theme.tokens` into it; the plumix Vite plugin forwards `config.theme` so the consumer's `defineTheme({ tokens })` lands in the wire payload.

```ts
// before — admin shipped a hardcoded sample
const sampleTokens: ThemeTokens = {
  colors: { background: { value: "#ffffff", label: "Background" }, ... },
  spacing: { sm: { value: "0.5rem", label: "Small" }, ... },
  typography: { ... },
};
<PlumixStyleTab tokens={sampleTokens} />

// after — manifest delivery
import { getThemeTokens } from "@/lib/manifest.js";
const themeTokens = getThemeTokens();
<PlumixStyleTab tokens={themeTokens} />
```

**Admin reads from the manifest**

Admin's `normalize()` passes the `tokens` object through alongside the existing array-only normalizer. A new `getThemeTokens()` helper mirrors the per-field reader pattern (`findEntryTypeBySlug`, `visibleEntryTypes`, ...) and defaults to `{}` so swatch pickers degrade gracefully when no tokens are configured.

The acceptance criteria from the issue land:
- `PlumixManifest` carries `tokens: ThemeTokens | undefined` ✓
- `StyleTab` reads from the manifest, not the hardcoded constant ✓
- Token changes in `defineTheme({ tokens })` reflect in the admin picker after rebuild + reload ✓
- `sampleTokens` constant deleted from `edit.tsx` ✓

Backwards-compatible: existing `buildManifest(registry)` calls keep working (`theme` is optional); a manifest payload without `tokens` reads as `{}` at the admin.

Fixes #600