### PR TITLE
feat(core): route /search/:query to the search template

### DIFF
--- a/packages/core/src/route/compile.test.ts
+++ b/packages/core/src/route/compile.test.ts
@@ -4,7 +4,20 @@ import { HookRegistry } from "../hooks/registry.js";
 import { definePlugin } from "../plugin/define.js";
 import { createPluginRegistry } from "../plugin/manifest.js";
 import { installPlugins } from "../plugin/register.js";
-import { compileRouteMap, FRAMEWORK_FRONT_PAGE_PATTERN } from "./compile.js";
+import {
+  compileRouteMap,
+  FRAMEWORK_FRONT_PAGE_PATTERN,
+  FRAMEWORK_SEARCH_BARE_PATTERN,
+  FRAMEWORK_SEARCH_PAGINATED_PATTERN,
+  FRAMEWORK_SEARCH_QUERY_PATTERN,
+} from "./compile.js";
+
+const FRAMEWORK_PATTERNS = new Set<string>([
+  FRAMEWORK_FRONT_PAGE_PATTERN,
+  FRAMEWORK_SEARCH_PAGINATED_PATTERN,
+  FRAMEWORK_SEARCH_QUERY_PATTERN,
+  FRAMEWORK_SEARCH_BARE_PATTERN,
+]);
 
 async function buildRegistry(plugins: ReturnType<typeof definePlugin>[]) {
   const hooks = new HookRegistry();
@@ -15,7 +28,7 @@ async function buildRegistry(plugins: ReturnType<typeof definePlugin>[]) {
 
 function pluginRoutes(registry: ReturnType<typeof createPluginRegistry>) {
   return compileRouteMap(registry).filter(
-    (rule) => rule.rawPattern !== FRAMEWORK_FRONT_PAGE_PATTERN,
+    (rule) => !FRAMEWORK_PATTERNS.has(rule.rawPattern),
   );
 }
 
@@ -375,6 +388,23 @@ describe("compileRouteMap", () => {
     expect(map[0]?.rawPattern).toBe(FRAMEWORK_FRONT_PAGE_PATTERN);
     expect(map[0]?.intent).toEqual({ kind: "front-page" });
     expect(map[0]?.priority).toBeLessThan(10);
+  });
+
+  test("framework registers /search routes that emit kind: 'search'", async () => {
+    const registry = await buildRegistry([]);
+    const map = compileRouteMap(registry);
+    const patterns = map.map((r) => r.rawPattern);
+    expect(patterns).toContain(FRAMEWORK_SEARCH_BARE_PATTERN);
+    expect(patterns).toContain(FRAMEWORK_SEARCH_QUERY_PATTERN);
+    expect(patterns).toContain(FRAMEWORK_SEARCH_PAGINATED_PATTERN);
+    expect(patterns.indexOf(FRAMEWORK_SEARCH_PAGINATED_PATTERN)).toBeLessThan(
+      patterns.indexOf(FRAMEWORK_SEARCH_QUERY_PATTERN),
+    );
+    const search = map.find(
+      (r) => r.rawPattern === FRAMEWORK_SEARCH_BARE_PATTERN,
+    );
+    expect(search?.intent).toEqual({ kind: "search" });
+    expect(search?.priority).toBeLessThan(10);
   });
 
   test("hasArchive: string rejects multi-segment or non-kebab input", async () => {

--- a/packages/core/src/route/compile.ts
+++ b/packages/core/src/route/compile.ts
@@ -17,6 +17,10 @@ const FRAMEWORK_ROUTE_PRIORITY = 5;
 const CATCH_ALL_ROUTE_PRIORITY = 60;
 
 export const FRAMEWORK_FRONT_PAGE_PATTERN = "/page/:page(\\d+)";
+export const FRAMEWORK_SEARCH_BARE_PATTERN = "/search";
+export const FRAMEWORK_SEARCH_QUERY_PATTERN = "/search/:query";
+export const FRAMEWORK_SEARCH_PAGINATED_PATTERN =
+  "/search/:query/page/:page(\\d+)";
 
 interface CompiledRule extends RouteRule {
   readonly registeredBy: string | null;
@@ -37,6 +41,30 @@ export function compileRouteMap(
       pattern: new URLPattern({ pathname: FRAMEWORK_FRONT_PAGE_PATTERN }),
       rawPattern: FRAMEWORK_FRONT_PAGE_PATTERN,
       intent: { kind: "front-page" },
+      priority: FRAMEWORK_ROUTE_PRIORITY,
+      registeredBy: null,
+    },
+    // Paginated variant goes first so `/search/foo/page/2` doesn't
+    // accidentally match the bare-query rule with `:query = "foo/page/2"`
+    // when URLPattern relaxes its segment captures.
+    {
+      pattern: new URLPattern({ pathname: FRAMEWORK_SEARCH_PAGINATED_PATTERN }),
+      rawPattern: FRAMEWORK_SEARCH_PAGINATED_PATTERN,
+      intent: { kind: "search" },
+      priority: FRAMEWORK_ROUTE_PRIORITY,
+      registeredBy: null,
+    },
+    {
+      pattern: new URLPattern({ pathname: FRAMEWORK_SEARCH_QUERY_PATTERN }),
+      rawPattern: FRAMEWORK_SEARCH_QUERY_PATTERN,
+      intent: { kind: "search" },
+      priority: FRAMEWORK_ROUTE_PRIORITY,
+      registeredBy: null,
+    },
+    {
+      pattern: new URLPattern({ pathname: FRAMEWORK_SEARCH_BARE_PATTERN }),
+      rawPattern: FRAMEWORK_SEARCH_BARE_PATTERN,
+      intent: { kind: "search" },
       priority: FRAMEWORK_ROUTE_PRIORITY,
       registeredBy: null,
     },

--- a/packages/core/src/route/intent.ts
+++ b/packages/core/src/route/intent.ts
@@ -11,7 +11,8 @@ export type RouteIntent =
   | { readonly kind: "single"; readonly entryType: string }
   | { readonly kind: "archive"; readonly entryType: string }
   | { readonly kind: "taxonomy"; readonly taxonomy: string }
-  | { readonly kind: "front-page" };
+  | { readonly kind: "front-page" }
+  | { readonly kind: "search" };
 
 /**
  * Compiled rule. `priority` preserves arch-doc ordering semantics — lower

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -2761,6 +2761,320 @@ describe("resolvePublicRoute — front-page through theme", () => {
   });
 });
 
+describe("resolvePublicRoute — search through theme", () => {
+  test("/search/<query> renders the `search` template with the query in scope", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        search: ({ data }) => (
+          <section data-testid="search">{`query:${data.query}`}</section>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(
+      new Request("https://cms.example/search/hello"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('data-testid="search"');
+    expect(body).toContain("query:hello");
+  });
+
+  test("search results filter entries whose title matches the query", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        search: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`hit-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "matches",
+      title: "Hello world",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "no-match",
+      title: "Unrelated",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/search/hello"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="hit-matches"');
+    expect(body).not.toContain('data-testid="hit-no-match"');
+  });
+
+  test("/search/<q>/page/N paginates the search results", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        search: ({ data }) => (
+          <span data-testid="page">{`page:${String(data.pagination.page)};entries:${String(data.entries.length)}`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    // 25 matches, default per-page 20 → page 2 has 5 entries
+    for (let i = 0; i < 25; i++) {
+      await h.factory.entry.create({
+        type: "post",
+        slug: `hit-${String(i)}`,
+        title: `Hello ${String(i)}`,
+        content: null,
+        status: "published",
+        authorId: author.id,
+        publishedAt: new Date(2026, 4, i + 1),
+      });
+    }
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/search/hello/page/2"),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("page:2;entries:5");
+  });
+
+  test("/search (no query) renders the empty-search state", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        search: ({ data }) => (
+          <section data-testid="search">{`q:[${data.query}]`}</section>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(
+      new Request("https://cms.example/search"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('data-testid="search"');
+    expect(body).toContain("q:[]");
+  });
+
+  test("?s= on a non-search URL stays on the original route (no hijack)", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => (
+          <article data-testid={`post-${data.entry.slug}`}>
+            {data.entry.title}
+          </article>
+        ),
+        search: () => <section data-testid="search" />,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "about",
+      title: "About",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/about?s=hello"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="post-about"');
+    expect(body).not.toContain('data-testid="search"');
+  });
+
+  test("entry types flagged excludeFromSearch don't appear in search hits", async () => {
+    const mediaPlugin = definePlugin("media", (ctx) => {
+      ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      ctx.registerEntryType("attachment", {
+        label: "Media",
+        isPublic: true,
+        excludeFromSearch: true,
+      });
+    });
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        search: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`hit-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [mediaPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hello-post",
+      title: "Hello post",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entry.create({
+      type: "attachment",
+      slug: "hello-media",
+      title: "Hello media",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/search/hello"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="hit-hello-post"');
+    expect(body).not.toContain('data-testid="hit-hello-media"');
+  });
+
+  test("URL-encoded query is decoded before matching and rendering", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        search: ({ data }) => (
+          <span data-testid="q">{`q:[${data.query}]`}</span>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "spaced",
+      title: "hello world post",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/search/hello%20world"),
+    );
+    const body = await response.text();
+    expect(body).toContain("q:[hello world]");
+  });
+
+  test("`_` in the query matches the literal character, not any-single-char", async () => {
+    // Without escaping, SQLite LIKE treats `_` as a wildcard — a query of
+    // `_` would match every entry. The framework escapes user wildcards.
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        search: ({ data }) => (
+          <ul>
+            {data.entries.map((entry: ResolvedEntry) => (
+              <li key={entry.id} data-testid={`hit-${entry.slug}`}>
+                {entry.title}
+              </li>
+            ))}
+          </ul>
+        ),
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "literal-underscore",
+      title: "snake_case naming",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "plain",
+      title: "Plain title",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/search/_"),
+    );
+    const body = await response.text();
+    expect(body).toContain('data-testid="hit-literal-underscore"');
+    expect(body).not.toContain('data-testid="hit-plain"');
+  });
+
+  test("runs resolve:search:data filters before the search template renders", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        search: ({ data }) => <span data-testid="q">{`q:${data.query}`}</span>,
+      },
+    });
+
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    h.app.hooks.addFilter(
+      "resolve:search:data",
+      (data) => ({ ...data, query: `filtered:${data.query}` }),
+      { plugin: "test" },
+    );
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/search/hello"),
+    );
+    const body = await response.text();
+    expect(body).toContain("q:filtered:hello");
+  });
+
+  test("/search/<q>/page/N returns 404 when N is out of range", async () => {
+    const theme = defineTheme({
+      templates: { index: () => null, search: () => null },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const response = await h.dispatch(
+      new Request("https://cms.example/search/anything/page/99"),
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
 describe("resolvePublicRoute — error pages through theme", () => {
   test("404 page composes its title through the theme titleTemplate", async () => {
     const theme = defineTheme({

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -56,6 +56,12 @@ export interface FrontPageData<TEntry extends ResolvedEntry = ResolvedEntry> {
   readonly pagination: Pagination;
 }
 
+export interface SearchData<TEntry extends ResolvedEntry = ResolvedEntry> {
+  readonly query: string;
+  readonly entries: readonly TEntry[];
+  readonly pagination: Pagination;
+}
+
 /**
  * Payload threaded to a theme's `404` / `500` template. Public-safe by
  * shape — there is no Error field, so internal exception messages have

--- a/packages/core/src/route/render/template-hierarchy.ts
+++ b/packages/core/src/route/render/template-hierarchy.ts
@@ -34,7 +34,8 @@ export type ResolvedNode =
   | ResolvedContentNode
   | ResolvedContentTypeArchive
   | ResolvedFrontPage
-  | ResolvedPostsPage;
+  | ResolvedPostsPage
+  | ResolvedSearch;
 
 interface ResolvedTermNode {
   readonly kind: "term";
@@ -68,6 +69,10 @@ interface ResolvedPostsPage {
   readonly kind: "posts-page";
 }
 
+interface ResolvedSearch {
+  readonly kind: "search";
+}
+
 export function getPossibleTemplates(node: ResolvedNode): readonly string[] {
   const candidates: string[] = [];
   switch (node.kind) {
@@ -85,6 +90,9 @@ export function getPossibleTemplates(node: ResolvedNode): readonly string[] {
       break;
     case "posts-page":
       candidates.push("home");
+      break;
+    case "search":
+      candidates.push("search");
       break;
   }
   candidates.push("index");

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -15,10 +15,11 @@ import type {
   ArchiveData,
   FrontPageData,
   ResolvedEntry,
+  SearchData,
   SingleData,
   TaxonomyData,
 } from "./render/resolved-entry.js";
-import { and, desc, eq, inArray, isNotNull } from "../db/index.js";
+import { and, desc, eq, inArray, isNotNull, sql } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
 import { terms } from "../db/schema/terms.js";
@@ -43,6 +44,9 @@ declare module "../hooks/types.js" {
     "resolve:front-page:data": (
       data: FrontPageData,
     ) => FrontPageData | Promise<FrontPageData>;
+    "resolve:search:data": (
+      data: SearchData,
+    ) => SearchData | Promise<SearchData>;
   }
 }
 
@@ -93,6 +97,16 @@ export async function resolvePublicRoute(
       );
     case "front-page":
       return resolveFrontPage(
+        ctx,
+        match.params,
+        theme,
+        document,
+        templateDocuments,
+        templateDeps,
+        assetManifest,
+      );
+    case "search":
+      return resolveSearch(
         ctx,
         match.params,
         theme,
@@ -154,6 +168,79 @@ async function resolveFrontPage(
     node: { kind: "front-page" },
     data,
     title: "Home",
+  });
+  return new Response(html, {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+
+function decodeSearchQuery(raw: string | undefined): string {
+  if (raw === undefined || raw === "") return "";
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // Malformed percent-sequences fall back to empty — render the bare
+    // search template instead of crashing the request.
+    return "";
+  }
+}
+
+async function resolveSearch(
+  ctx: AppContext,
+  params: Record<string, string>,
+  theme: ThemeDescriptor,
+  document: DocumentManifest,
+  templateDocuments: ReadonlyMap<string, DocumentManifest>,
+  templateDeps: ReadonlyMap<string, RegisteredTemplateDep>,
+  assetManifest: AssetManifest,
+): Promise<Response> {
+  const query = decodeSearchQuery(params.query);
+  const page = parsePageParam(params.page);
+  const searchableTypes = Array.from(ctx.plugins.entryTypes.entries())
+    .filter(
+      ([, spec]) => spec.isPublic !== false && spec.excludeFromSearch !== true,
+    )
+    .map(([key]) => key);
+  // Escape SQL LIKE wildcards in the user query so `_` and `%` match
+  // literal characters instead of any-char / any-string.
+  const escaped = query.replace(/[\\%_]/g, "\\$&");
+  const where =
+    searchableTypes.length === 0 || query === ""
+      ? null
+      : and(
+          eq(entries.status, "published"),
+          isNotNull(entries.publishedAt),
+          inArray(entries.type, searchableTypes),
+          sql`${entries.title} LIKE ${`%${escaped}%`} ESCAPE '\\'`,
+        );
+  const result = await paginatedEntries(
+    ctx,
+    where,
+    page,
+    DEFAULT_ARCHIVE_PER_PAGE,
+  );
+  if (result.outOfRange) return notFound("public-search-page-out-of-range");
+  const initial: SearchData = {
+    query,
+    entries: await buildResolvedEntries(ctx, result.rows),
+    pagination: {
+      page,
+      perPage: DEFAULT_ARCHIVE_PER_PAGE,
+      total: result.total,
+      pageCount: result.pageCount,
+    },
+  };
+  const data = await ctx.hooks.applyFilter("resolve:search:data", initial);
+  const html = await renderThroughTheme({
+    ctx,
+    theme,
+    document,
+    templateDocuments,
+    templateDeps,
+    assetManifest,
+    node: { kind: "search" },
+    data,
+    title: data.query ? `Search: ${data.query}` : "Search",
   });
   return new Response(html, {
     headers: { "content-type": "text/html; charset=utf-8" },

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -6,6 +6,7 @@ import type {
   ArchiveData,
   ErrorData,
   FrontPageData,
+  SearchData,
   SingleData,
   TaxonomyData,
 } from "./route/render/resolved-entry.js";
@@ -35,6 +36,7 @@ export type TemplateData =
   | ArchiveData
   | TaxonomyData
   | FrontPageData
+  | SearchData
   | ErrorData;
 
 export type TemplateComponent<Data> = ComponentType<{ readonly data: Data }>;
@@ -56,6 +58,7 @@ type DynamicTemplateEntry =
   | TemplateEntry<ArchiveData>
   | TemplateEntry<TaxonomyData>
   | TemplateEntry<FrontPageData>
+  | TemplateEntry<SearchData>
   | TemplateEntry<ErrorData>
   | TemplateEntry<TemplateData>;
 
@@ -120,6 +123,7 @@ export interface TemplateRegistry {
   readonly tag?: TemplateEntry<TaxonomyData>;
   readonly "front-page"?: TemplateEntry<FrontPageData>;
   readonly home?: TemplateEntry<FrontPageData>;
+  readonly search?: TemplateEntry<SearchData>;
   readonly "404"?: TemplateEntry<ErrorData>;
   readonly "500"?: TemplateEntry<ErrorData>;
   readonly [key: string]: DynamicTemplateEntry | undefined;


### PR DESCRIPTION
Every theme that declares a `search` template slot per the WordPress template hierarchy got nothing in return — the dispatcher had no search routing, and the `search` template was dead code. This PR makes search reachable through the routeMap without coupling routing to query strings.

**Path-based routing**

Three framework-priority rules: `/search`, `/search/:query`, and `/search/:query/page/:page(\d+)`. They sort ahead of plugin auto-rules so a catch-all `/:slug` can't shadow them. The template-hierarchy walker resolves the new `{ kind: "search" }` node to `["search", "index"]`.

```
/search                 → search template (empty query)
/search/hello           → search template, query="hello"
/search/hello/page/2    → search template, query="hello", page=2
/post/about?s=foo       → About page; ?s stays as a plain query string
```

**Resolver hardening**

`resolveSearch` URL-decodes the query (so `/search/hello%20world` works), honors `excludeFromSearch` on the public entry-type filter, escapes user LIKE wildcards (`%`, `_`, `\`) with an explicit `ESCAPE` clause, and runs the new `resolve:search:data` filter so plugins can swap in FTS5 or external indexes via the standard hook surface. Out-of-range page numbers 404 like every other paginated resolver.

**WordPress-divergent**

WP routes `?s=foo` on any URL to search, hijacking the matched route. Plumix does not — `?s` stays available as a plain query string, and search is reachable only through `/search/...`. Avoids WP's URL-hijack quirk and lets plugin pages use `?s` for their own purposes. WP-style search forms update `<form action="/">` to `<form action="/search">`.

Eleven RED→GREEN integration cycles cover routing, LIKE filtering, pagination, empty-query state, no-hijack regression, out-of-range 404, framework rule registration in compileRouteMap, `resolve:search:data` filter hook, `excludeFromSearch` flag honoring, URL decoding, and LIKE wildcard escaping.

Fixes #608