### PR TITLE
feat(core)!: flatten template-dep declarations + compose semantics

### DIFF
--- a/packages/core/src/plugin/errors.ts
+++ b/packages/core/src/plugin/errors.ts
@@ -30,7 +30,8 @@ type PluginContextErrorCode =
   | "meta_box_too_many_fields"
   | "meta_box_field_invalid_key"
   | "meta_box_field_duplicate_key"
-  | "meta_box_field_reserved_key";
+  | "meta_box_field_reserved_key"
+  | "template_dep_kind_reserved";
 
 interface PluginContextErrorFields {
   pluginId?: string;
@@ -202,6 +203,19 @@ export class PluginContextError extends Error {
       `Settings page "${ctx.name}" lists a group more than once; ` +
         `each group may appear at most once per page.`,
       { identifierName: ctx.name },
+    );
+  }
+
+  static templateDepKindReserved(ctx: {
+    pluginId: string;
+    kind: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "template_dep_kind_reserved",
+      `Plugin "${ctx.pluginId}" registered template dep kind "${ctx.kind}" — ` +
+        `that name is reserved by the framework (theme or template uses it ` +
+        `for something else). Pick a different name; see #614.`,
+      ctx,
     );
   }
 

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -45,6 +45,7 @@ import {
   deriveTermTaxonomyCapabilities,
 } from "../auth/rbac.js";
 import { DEFAULT_REWRITE_RULE_PRIORITY } from "../route/compile.js";
+import { RESERVED_DEP_KIND_NAMES } from "../template-deps.js";
 import { DuplicateRegistrationError, PluginContextError } from "./errors.js";
 import { CORE_RPC_NAMESPACES } from "./manifest.js";
 import {
@@ -600,6 +601,14 @@ export function createPluginSetupContext({
     },
 
     registerTemplateDep: (kind, { load }) => {
+      if (RESERVED_DEP_KIND_NAMES.has(kind)) {
+        // Reserved framework keys would silently no-op at request time
+        // since the merger skips them on theme/template traversal.
+        throw PluginContextError.templateDepKindReserved({
+          pluginId,
+          kind,
+        });
+      }
       const existing = registry.templateDeps.get(kind);
       if (existing) {
         throw DuplicateRegistrationError.alreadyRegistered({

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -64,7 +64,7 @@ export async function renderThroughTheme({
   const { template, slot } = pickTemplate(theme.templates, candidates);
   const deps = await loadTemplateDeps(
     mergeTemplateDepDeclarations(
-      theme.templateDeps,
+      theme,
       template as unknown as Record<string, unknown>,
     ),
     templateDeps,
@@ -139,7 +139,7 @@ export async function renderErrorThroughTheme({
   const template = normalizeTemplate(raw, variant.key);
   const deps = await loadTemplateDeps(
     mergeTemplateDepDeclarations(
-      theme.templateDeps,
+      theme,
       template as unknown as Record<string, unknown>,
     ),
     templateDeps,

--- a/packages/core/src/template-deps.test.tsx
+++ b/packages/core/src/template-deps.test.tsx
@@ -102,6 +102,28 @@ describe("ctx.registerTemplateDep", () => {
     expect(app.plugins.templateDeps.get("test-thing")?.registeredBy).toBe("a");
     expect(app.plugins.templateDeps.get("test-other")?.registeredBy).toBe("b");
   });
+
+  test("rejects registration when the dep kind collides with a framework key", async () => {
+    const offender = definePlugin("offender", (ctx) => {
+      // `render` is a framework-reserved key on every template; a dep
+      // kind by that name would silently no-op at request time since
+      // the merger skips it.
+      ctx.registerTemplateDep("render" as never, {
+        load: () => Promise.resolve({}),
+      });
+    });
+    await expect(
+      buildApp(
+        plumix({
+          runtime: stubAdapter,
+          database: stubDatabase,
+          auth: stubAuth,
+          theme: stubTheme,
+          plugins: [offender],
+        }),
+      ),
+    ).rejects.toThrow(/reserved/i);
+  });
 });
 
 const captureLogger = () => {
@@ -374,10 +396,10 @@ const blogTypePlugin = definePlugin("blog", (ctx) => {
   });
 });
 
-describe("theme-level templateDeps", () => {
-  test("declarations on `defineTheme` reach every template's render args", async () => {
+describe("theme-level flat dep declarations", () => {
+  test("dep slugs declared at the flat root of defineTheme reach the render args", async () => {
     const theme = defineTheme({
-      templateDeps: { settings: ["site-info"] },
+      settings: ["site-info"],
       templates: {
         index: () => null,
         single: defineTemplate({
@@ -393,8 +415,8 @@ describe("theme-level templateDeps", () => {
     const author = await h.seedUser("admin");
     await h.factory.entry.create({
       type: "post",
-      slug: "from-theme",
-      title: "From Theme",
+      slug: "from-flat-theme",
+      title: "From Flat Theme",
       content: null,
       status: "published",
       authorId: author.id,
@@ -407,23 +429,26 @@ describe("theme-level templateDeps", () => {
     });
 
     const response = await h.dispatch(
-      new Request("https://cms.example/post/from-theme"),
+      new Request("https://cms.example/post/from-flat-theme"),
     );
     expect(await response.text()).toContain("Plumix Demo");
   });
 
-  test("per-template slugs union with theme-level slugs of the same kind", async () => {
+  test("template array form replaces the theme's slugs for that kind", async () => {
+    // Override semantics: the matched template's `settings: ["author-info"]`
+    // takes the entire slot — `site-info` is NOT inherited from the
+    // theme. To extend instead, use the function form (TDD #3).
     const theme = defineTheme({
-      templateDeps: { settings: ["site-info"] },
+      settings: ["site-info"],
       templates: {
         index: () => null,
         single: defineTemplate({
           settings: ["author-info"],
           render: (args) => (
             <article>
-              {pickString(args.settings?.["site-info"], "title")}
+              {`site:${pickString(args.settings?.["site-info"], "title")}`}
               {"|"}
-              {pickString(args.settings?.["author-info"], "name")}
+              {`author:${pickString(args.settings?.["author-info"], "name")}`}
             </article>
           ),
         }),
@@ -436,8 +461,8 @@ describe("theme-level templateDeps", () => {
     const author = await h.seedUser("admin");
     await h.factory.entry.create({
       type: "post",
-      slug: "union",
-      title: "Union",
+      slug: "override",
+      title: "Override",
       content: null,
       status: "published",
       authorId: author.id,
@@ -449,11 +474,119 @@ describe("theme-level templateDeps", () => {
     ]);
 
     const response = await h.dispatch(
-      new Request("https://cms.example/post/union"),
+      new Request("https://cms.example/post/override"),
     );
     const body = await response.text();
-    expect(body).toContain("Plumix");
-    expect(body).toContain("Ada");
+    expect(body).toContain("author:Ada");
+    expect(body).not.toContain("site:Plumix");
+  });
+
+  test("template function form receives parent slugs and can extend them", async () => {
+    const theme = defineTheme({
+      settings: ["site-info"],
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          settings: (prev: readonly string[]) => [...prev, "author-info"],
+          render: (args) => (
+            <article>
+              {`site:${pickString(args.settings?.["site-info"], "title")}`}
+              {"|"}
+              {`author:${pickString(args.settings?.["author-info"], "name")}`}
+            </article>
+          ),
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({
+      plugins: [blogTypePlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "extend",
+      title: "Extend",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.db.insert(settingsSchema).values([
+      { group: "site-info", key: "title", value: "Plumix" },
+      { group: "author-info", key: "name", value: "Ada" },
+    ]);
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/extend"),
+    );
+    const body = await response.text();
+    expect(body).toContain("site:Plumix");
+    expect(body).toContain("author:Ada");
+  });
+
+  test("template empty array disables the dep for that template", async () => {
+    const theme = defineTheme({
+      settings: ["site-info"],
+      templates: {
+        index: () => null,
+        single: defineTemplate({
+          settings: [],
+          render: (args) =>
+            args.settings === undefined
+              ? "disabled"
+              : `loaded:${JSON.stringify(args.settings)}`,
+        }),
+      },
+    });
+    const h = await createDispatcherHarness({
+      plugins: [blogTypePlugin],
+      theme,
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "disable",
+      title: "Disable",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.db.insert(settingsSchema).values({
+      group: "site-info",
+      key: "title",
+      value: "Plumix",
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/disable"),
+    );
+    const body = await response.text();
+    expect(body).toContain("disabled");
+    expect(body).not.toContain("Plumix");
+  });
+
+  test("function-form dep on the theme root throws at defineTheme (no parent)", () => {
+    // The function form means "given the parent, return the next." The
+    // theme root has no parent — declaring a function there is always a
+    // mistake. Reject at boot so it doesn't silently no-op like
+    // pre-#614 templateDeps.
+    const bad = {
+      settings: (prev: readonly string[]) => [...prev, "general"],
+      templates: { index: () => null },
+    } as unknown as Parameters<typeof defineTheme>[0];
+    expect(() => defineTheme(bad)).toThrow(/function/i);
+  });
+
+  test("legacy nested `templateDeps: {}` on the theme throws at defineTheme", () => {
+    // Pre-#614 shape. The runtime guard makes sure migrations don't
+    // silently no-op when consumers forget to lift the keys to root.
+    const legacy = {
+      templateDeps: { settings: ["site-info"] },
+      templates: { index: () => null },
+    } as unknown as Parameters<typeof defineTheme>[0];
+    expect(() => defineTheme(legacy)).toThrow(/templateDeps/);
   });
 });
 

--- a/packages/core/src/template-deps.ts
+++ b/packages/core/src/template-deps.ts
@@ -34,29 +34,50 @@ export interface RegisteredTemplateDep {
   readonly registeredBy: string | null;
 }
 
+// Framework-owned keys on a theme or template object — `mergeTemplate…`
+// must skip them so values like `render` (a function on every template)
+// and `css` (an array on every theme) don't accidentally read as
+// dep-kind declarations. `registerTemplateDep` rejects these as kinds
+// too, so the runtime is the single source of truth for the policy.
+const RESERVED_THEME_KEYS = new Set(["templates", "document", "tokens", "css"]);
+const RESERVED_TEMPLATE_KEYS = new Set([
+  "render",
+  "document",
+  "prefetchListingLoaders",
+]);
+export const RESERVED_DEP_KIND_NAMES: ReadonlySet<string> = new Set([
+  ...RESERVED_THEME_KEYS,
+  ...RESERVED_TEMPLATE_KEYS,
+]);
+
 /**
- * Combine the theme's global dep declarations with the matched
- * template's own. Same-kind slug arrays union (Set-based dedup); the
- * result has the same shape as a template's declarations and can be
- * fed straight into `loadTemplateDeps`.
+ * Combine theme + template dep declarations. The template's own
+ * declaration for a kind replaces the theme's; absent declarations
+ * inherit. Extending the inherited set is opt-in via the function
+ * form (`menus: (prev) => [...prev, "x"]`).
  */
 export function mergeTemplateDepDeclarations(
   themeDeps: TemplateDepDeclarations | undefined,
   template: Readonly<Record<string, unknown>>,
 ): Readonly<Record<string, readonly string[]>> {
   const result: Record<string, readonly string[]> = {};
-  for (const [kind, value] of Object.entries(template)) {
-    if (Array.isArray(value)) result[kind] = value as readonly string[];
+  if (themeDeps) {
+    for (const [kind, value] of Object.entries(themeDeps)) {
+      if (RESERVED_THEME_KEYS.has(kind)) continue;
+      if (Array.isArray(value)) result[kind] = value as readonly string[];
+    }
   }
-  if (!themeDeps) return result;
-  for (const [kind, slugs] of Object.entries(themeDeps)) {
-    if (!Array.isArray(slugs)) continue;
-    const existing = result[kind];
-    const themeSlugs = slugs as readonly string[];
-    result[kind] =
-      existing === undefined
-        ? themeSlugs
-        : Array.from(new Set([...existing, ...themeSlugs]));
+  for (const [kind, value] of Object.entries(template)) {
+    if (RESERVED_TEMPLATE_KEYS.has(kind)) continue;
+    if (Array.isArray(value)) {
+      result[kind] = value as readonly string[];
+    } else if (typeof value === "function") {
+      const prev = result[kind] ?? [];
+      const next = (value as (prev: readonly string[]) => readonly string[])(
+        prev,
+      );
+      if (Array.isArray(next)) result[kind] = next;
+    }
   }
   return result;
 }

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -27,12 +27,18 @@ const PLUMIX_TEMPLATE_BRAND: unique symbol = Symbol("plumix.template");
 export interface TemplateDepRegistry {}
 
 /**
- * Per-kind declarations on a template — array of slugs the template
- * needs the framework to load before render. Optional per kind so a
- * template can opt into just the deps it uses.
+ * Per-kind declarations on a theme or template. An array replaces the
+ * inherited value (override); a function `(prev) => next` receives the
+ * theme's slugs and returns the composed set (extend / filter); an
+ * empty array disables the dep for that template; an omitted kind
+ * inherits unchanged.
  */
 export type TemplateDepDeclarations = {
-  readonly [K in keyof TemplateDepRegistry]?: readonly TemplateDepRegistry[K]["slug"][];
+  readonly [K in keyof TemplateDepRegistry]?:
+    | readonly TemplateDepRegistry[K]["slug"][]
+    | ((
+        prev: readonly TemplateDepRegistry[K]["slug"][],
+      ) => readonly TemplateDepRegistry[K]["slug"][]);
 };
 
 /**

--- a/packages/core/src/theme-errors.ts
+++ b/packages/core/src/theme-errors.ts
@@ -1,6 +1,8 @@
 type ThemeRegistrationCode =
   | "missing_theme"
   | "missing_index_template"
+  | "legacy_template_deps_shape"
+  | "theme_dep_function_form"
   | "document_invalid_link"
   | "document_invalid_script"
   | "invalid_template";
@@ -33,6 +35,27 @@ export class ThemeRegistrationError extends Error {
       `Theme registration: \`templates.index\` is required. Every theme ` +
         `must declare an \`index\` template — it is the final fallback the ` +
         `template hierarchy walks to when no more-specific template matches.`,
+    );
+  }
+
+  static legacyTemplateDepsShape(): ThemeRegistrationError {
+    return new ThemeRegistrationError(
+      "legacy_template_deps_shape",
+      `Theme registration: \`templateDeps: { ... }\` is no longer accepted. ` +
+        `Lift dep kinds to the flat root of \`defineTheme\` instead — e.g. ` +
+        `\`defineTheme({ menus: ["primary"], settings: ["general"], templates: { ... } })\`. ` +
+        `Templates compose via the array (replace) or function (extend) form ` +
+        `per kind; see #614.`,
+    );
+  }
+
+  static themeDepFunctionForm(kind: string): ThemeRegistrationError {
+    return new ThemeRegistrationError(
+      "theme_dep_function_form",
+      `Theme registration: dep kind \`${kind}\` was declared as a function. ` +
+        `The function form means "given the parent, return the next" — but the ` +
+        `theme root has no parent. Use a plain array at the theme level; the ` +
+        `function form is for per-template extension (see #614).`,
     );
   }
 

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -11,6 +11,7 @@ import type {
   TaxonomyData,
 } from "./route/render/resolved-entry.js";
 import type { Template, TemplateDepDeclarations } from "./template.js";
+import { RESERVED_DEP_KIND_NAMES } from "./template-deps.js";
 import { ThemeError, ThemeRegistrationError } from "./theme-errors.js";
 
 // `theme:document` is a boot-time filter chain. `buildApp` fires it once,
@@ -129,7 +130,7 @@ export interface TemplateRegistry {
   readonly [key: string]: DynamicTemplateEntry | undefined;
 }
 
-export interface ThemeDescriptor {
+export interface ThemeDescriptor extends TemplateDepDeclarations {
   readonly templates: TemplateRegistry;
   readonly document?: DocumentManifest;
   readonly tokens?: ThemeTokens;
@@ -141,12 +142,6 @@ export interface ThemeDescriptor {
    * resolves them through its normal graph and emits hashed bundles.
    */
   readonly css?: readonly string[];
-  /**
-   * Dep declarations applied to every template. Per-template slugs of
-   * the same kind union (dedup'd) with these; a global `settings:
-   * ["general"]` reaches templates that never declared `settings`.
-   */
-  readonly templateDeps?: TemplateDepDeclarations;
 }
 
 const TOKEN_SLUG_RE = /^[a-z][a-z0-9-]*$/;
@@ -159,6 +154,18 @@ export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
   const templates = descriptor.templates as Readonly<Record<string, unknown>>;
   if (!templates.index) {
     throw ThemeRegistrationError.missingIndexTemplate();
+  }
+  if ("templateDeps" in descriptor) {
+    throw ThemeRegistrationError.legacyTemplateDepsShape();
+  }
+  // Function-form deps are template-only: they need a parent. The theme
+  // root has none, so reject the form here instead of letting it silently
+  // no-op.
+  for (const [key, value] of Object.entries(descriptor)) {
+    if (RESERVED_DEP_KIND_NAMES.has(key)) continue;
+    if (typeof value === "function") {
+      throw ThemeRegistrationError.themeDepFunctionForm(key);
+    }
   }
   if (descriptor.tokens) {
     validateTokens(descriptor.tokens);


### PR DESCRIPTION
Template deps used to live in two API positions — `defineTheme({ templateDeps: { ... } })` on the theme but flat at the root of `defineTemplate({ ... })`. Composition was always a deduped union, so a template could extend the theme's set but never override or filter it. This PR flattens both layers and gives templates a Vite/TanStack-style `T | ((prev: T) => T)` compose semantics per dep kind.

**API**

```ts
// before
defineTheme({
  templateDeps: { menus: ["primary", "footer"], settings: ["general"] },
  templates: { ... },
});
defineTemplate({
  postNav: ["main"],
  render: ({ menus, settings, postNav }) => ...,
});

// after
defineTheme({
  menus: ["primary", "footer"],
  settings: ["general"],
  templates: { ... },
});

defineTemplate({                                           // inherits unchanged
  render: ({ menus, settings }) => ...,
});

defineTemplate({                                           // extend (function form)
  menus: (prev) => [...prev, "post-meta"],
});

defineTemplate({                                           // override (array form)
  menus: ["primary"],
});

defineTemplate({                                           // disable
  menus: [],
});

defineTemplate({                                           // filter
  settings: (prev) => prev.filter((g) => g !== "reading"),
});
```

**Guardrails**

The flat shape opens collisions between dep kinds and framework keys. Three boot-time errors close the gap:

- `registerTemplateDep("render", ...)` (or any framework-reserved key — `render`, `document`, `templates`, `tokens`, `css`, `prefetchListingLoaders`) throws via `PluginContextError.templateDepKindReserved`. The merger would silently skip these otherwise.
- `defineTheme({ settings: (prev) => ... })` throws via `ThemeRegistrationError.themeDepFunctionForm` — the theme root has no parent to receive.
- Legacy `defineTheme({ templateDeps: { ... } })` throws via `ThemeRegistrationError.legacyTemplateDepsShape` with the migration text inline so silent no-ops surface on first boot.

Eight RED→GREEN integration cycles cover: the tracer (flat root reaches render), array override, function extend, empty-array disable, reserved-key rejection, theme function-form rejection, and legacy-nested rejection.

**Migration**

BREAKING CHANGE. Pre-1.0, so a clean break:

- Move `templateDeps: { X }` → flat root keys on `defineTheme`.
- If a template was relying on union semantics (extend), rewrite as `(prev) => [...prev, "extra"]`.

The theme-starter spike will be migrated in a follow-up PR.

Fixes #614