### PR TITLE
fix(plumix): widen SSR transform gate to .js/.jsx islands

### DIFF
--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -213,7 +213,16 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     transform(code, id, options) {
       if (!options?.ssr) return null;
       if (id.endsWith(ORIG_QUERY)) return null;
-      if (!id.endsWith(".tsx") && !id.endsWith(".ts")) return null;
+      // `.js`/`.jsx` covers theme-shipped islands compiled by tsc — the
+      // `"use client"` directive survives in the dist file (#606).
+      if (
+        !id.endsWith(".tsx") &&
+        !id.endsWith(".ts") &&
+        !id.endsWith(".jsx") &&
+        !id.endsWith(".js")
+      ) {
+        return null;
+      }
       if (!code.includes("use client")) return null;
       const chunkUrl = resolveIslandChunkUrl(id, command, root);
       const result = transformUseClientModule(code, id, { chunkUrl });

--- a/packages/plumix/src/vite/plugin-transform.test.ts
+++ b/packages/plumix/src/vite/plugin-transform.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+
+import { plumix } from "./index.js";
+
+describe("plumix vite plugin — SSR transform on .js islands", () => {
+  test("a .js `use client` module is rewritten to the island wrapper", async () => {
+    const plugin = plumix();
+    const code = `"use client";
+import { useState } from "react";
+export function CopyLink() {
+  const [copied, setCopied] = useState(false);
+  return null;
+}
+`;
+    const id = "/abs/packages/themes/starter/dist/islands/CopyLink.js";
+
+    // Vite typing: `transform` is a function-or-object union; cast through
+    // unknown so the test fails loudly if the shape ever changes.
+    const transform = plugin.transform as unknown as (
+      code: string,
+      id: string,
+      options: { ssr: boolean },
+    ) => unknown;
+    const result = await transform(code, id, { ssr: true });
+
+    if (typeof result !== "object" || result === null || !("code" in result)) {
+      throw new Error("transform returned unexpected shape");
+    }
+    expect(result.code).toContain("plumix-island");
+  });
+});


### PR DESCRIPTION
Workspace-symlinked themes ship `"use client"` modules pre-compiled by tsc, so their dist files end in `.js`/`.jsx` rather than `.ts`/`.tsx`. The plumix Vite plugin's SSR transform gate only accepted `.ts`/`.tsx`, so theme islands rendered as plain DOM at runtime — no `<plumix-island>` wrapper, no hydration, no chunk-URL bootstrap. The scanner from #597 already walks symlinked deps and adds the islands to `rollupOptions.input`, so the per-island client chunks are emitted correctly; only the SSR rewrite was being skipped.

**Gate**

The extension allowlist now includes `.js`/`.jsx`. The `options?.ssr` guard and the `code.includes("use client")` cheap filter still narrow the workload: only modules SSR'd into the worker env that mention the directive get further inspection, and `findUseClientIslands` rejects anything where `"use client"` isn't the leading statement. Published deps that happen to contain the string in a comment pay one AST parse and bail.

```ts
// before
if (!id.endsWith(".tsx") && !id.endsWith(".ts")) return null;

// after
if (
  !id.endsWith(".tsx") && !id.endsWith(".ts") &&
  !id.endsWith(".jsx") && !id.endsWith(".js")
) return null;
```

**Test**

New tracer invokes `plumix().transform` directly against a `.js` "use client" fixture and asserts the `<plumix-island>` wrapper marker appears in the rewritten output. The `options?.ssr` invariant means client builds never see the wrapper (would otherwise infinite-loop on hydrate); not directly tested, unchanged by this patch.

Fixes #606