### PR TITLE
feat: add block patterns foundation

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -26,6 +26,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs.js";
 import { useIsMobile } from "@/hooks/use-mobile.js";
+import { getPatterns } from "@/lib/manifest.js";
 import { cn } from "@/lib/utils.js";
 import { Puck, usePuck } from "@puckeditor/core";
 import { Minus, Monitor, Plus, Smartphone, Tablet } from "lucide-react";
@@ -48,6 +49,7 @@ import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { mergePropsAtSelector } from "./merge-variation-attrs.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
+import { PatternsSection } from "./PatternsSection.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
 import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 import { nextInsertPoint, resolveSlashMenuItems } from "./slash-menu-items.js";
@@ -551,22 +553,27 @@ function PlumixBlocksTab({
     [puck],
   );
 
+  const patterns = useMemo(() => getPatterns(), []);
+
   return (
-    <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
-      {entries.map((entry) => (
-        <li key={entry.slug}>
-          <button
-            type="button"
-            className="hover:bg-muted flex w-full items-center gap-2 rounded border px-3 py-2 text-left text-sm"
-            data-testid={`plumix-blocks-tab-item-${entry.slug}`}
-            onClick={() => handleInsert(entry)}
-          >
-            <BlockIcon name={entry.icon} />
-            <span className="truncate">{entry.title}</span>
-          </button>
-        </li>
-      ))}
-    </ul>
+    <div className="flex flex-col">
+      <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
+        {entries.map((entry) => (
+          <li key={entry.slug}>
+            <button
+              type="button"
+              className="hover:bg-muted flex w-full items-center gap-2 rounded border px-3 py-2 text-left text-sm"
+              data-testid={`plumix-blocks-tab-item-${entry.slug}`}
+              onClick={() => handleInsert(entry)}
+            >
+              <BlockIcon name={entry.icon} />
+              <span className="truncate">{entry.title}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <PatternsSection patterns={patterns} />
+    </div>
   );
 }
 

--- a/packages/admin/src/editor/PatternsSection.test.tsx
+++ b/packages/admin/src/editor/PatternsSection.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { PatternsSection } from "./PatternsSection.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PatternsSection", () => {
+  test("renders nothing when no patterns are registered", () => {
+    const { container } = render(<PatternsSection patterns={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("renders title rows for each pattern, grouped under category headers", () => {
+    render(
+      <PatternsSection
+        patterns={[
+          {
+            name: "starter/hero",
+            title: "Hero CTA",
+            category: "hero",
+            content: [],
+          },
+          {
+            name: "starter/big-cta",
+            title: "Big CTA",
+            category: "cta",
+            content: [],
+          },
+          {
+            name: "starter/min-hero",
+            title: "Minimal Hero",
+            category: "hero",
+            content: [],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("plumix-patterns-section")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("plumix-patterns-group-hero"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("plumix-patterns-group-cta")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("plumix-patterns-row-starter/hero"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("plumix-patterns-row-starter/big-cta"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("plumix-patterns-row-starter/min-hero"),
+    ).toBeInTheDocument();
+  });
+
+  test("patterns without a category fall under an 'uncategorized' group", () => {
+    render(
+      <PatternsSection
+        patterns={[{ name: "x/anon", title: "Anonymous", content: [] }]}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("plumix-patterns-group-uncategorized"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("plumix-patterns-row-x/anon"),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/editor/PatternsSection.tsx
+++ b/packages/admin/src/editor/PatternsSection.tsx
@@ -1,0 +1,64 @@
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+
+interface PatternsSectionProps {
+  readonly patterns: readonly PatternManifestEntry[];
+}
+
+const UNCATEGORIZED = "uncategorized";
+
+export function PatternsSection({
+  patterns,
+}: PatternsSectionProps): ReactElement | null {
+  const grouped = useMemo(() => {
+    const map = new Map<string, PatternManifestEntry[]>();
+    for (const pattern of patterns) {
+      const key = pattern.category ?? UNCATEGORIZED;
+      const bucket = map.get(key);
+      if (bucket) {
+        bucket.push(pattern);
+      } else {
+        map.set(key, [pattern]);
+      }
+    }
+    return map;
+  }, [patterns]);
+
+  if (patterns.length === 0) return null;
+
+  return (
+    <section
+      className="flex flex-col gap-3 border-t p-4"
+      data-testid="plumix-patterns-section"
+    >
+      <h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        Patterns
+      </h3>
+      {Array.from(grouped.entries()).map(([category, entries]) => (
+        <div
+          key={category}
+          data-testid={`plumix-patterns-group-${category}`}
+          className="flex flex-col gap-1"
+        >
+          <h4 className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
+            {category}
+          </h4>
+          <ul className="flex flex-col gap-1">
+            {entries.map((entry) => (
+              <li key={entry.name}>
+                <div
+                  className="text-foreground w-full rounded border px-3 py-2 text-left text-sm"
+                  data-testid={`plumix-patterns-row-${entry.name}`}
+                >
+                  {entry.title}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -13,6 +13,7 @@ import {
   findSettingsGroupByName,
   findSettingsPageByName,
   findTermTaxonomyByName,
+  getPatterns,
   groupsForSettingsPage,
   readManifest,
   visibleEntryTypes,
@@ -493,5 +494,46 @@ describe("findSettingsPageByName + visibleSettingsPages + findSettingsGroupByNam
     expect(groupsForSettingsPage(orphan, source).map((g) => g.name)).toEqual([
       "identity",
     ]);
+  });
+});
+
+describe("getPatterns", () => {
+  test("readManifest carries the patterns slice through normalization", () => {
+    const doc = withManifestScript(
+      JSON.stringify({
+        patterns: [
+          {
+            name: "starter/hero",
+            title: "Hero",
+            category: "hero",
+            content: [],
+          },
+          {
+            name: "starter/cta",
+            title: "CTA",
+            category: "cta",
+            content: [],
+          },
+        ],
+      }),
+    );
+
+    expect(readManifest(doc).patterns).toEqual([
+      { name: "starter/hero", title: "Hero", category: "hero", content: [] },
+      { name: "starter/cta", title: "CTA", category: "cta", content: [] },
+    ]);
+  });
+
+  test("getPatterns returns the manifest patterns list, defaulting to empty", () => {
+    expect(getPatterns({ patterns: [] })).toEqual([]);
+    expect(getPatterns({})).toEqual([]);
+
+    const heroEntry = {
+      name: "x/h",
+      title: "Hero",
+      category: "hero" as const,
+      content: [],
+    };
+    expect(getPatterns({ patterns: [heroEntry] })).toEqual([heroEntry]);
   });
 });

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -4,6 +4,7 @@ import type {
   AdminNavItem,
   EntryMetaBoxManifestEntry,
   EntryTypeManifestEntry,
+  PatternManifestEntry,
   PlumixManifest,
   SettingsGroupManifestEntry,
   SettingsPageManifestEntry,
@@ -46,6 +47,7 @@ const KNOWN_ARRAY_FIELDS = [
   "fieldTypes",
   "blocks",
   "marks",
+  "patterns",
 ] as const satisfies readonly (keyof PlumixManifest)[];
 
 function normalize(value: unknown): PlumixManifest {
@@ -67,6 +69,12 @@ const manifest: PlumixManifest = readManifest();
 
 export function getThemeTokens(source: PlumixManifest = manifest): ThemeTokens {
   return source.tokens ?? {};
+}
+
+export function getPatterns(
+  source: PlumixManifest = manifest,
+): readonly PatternManifestEntry[] {
+  return source.patterns ?? [];
 }
 
 export function findEntryTypeBySlug(

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -59,6 +59,21 @@ export type { ResolvedTransformTarget } from "./transforms.js";
 export { expandBlockVariations } from "./expand-block-variations.js";
 export type { InsertableBlockEntry } from "./expand-block-variations.js";
 
+// ─── Pattern registry primitives ────────────────────────────────────────────
+export {
+  block,
+  commitPatterns,
+  createPatternRegistry,
+  definePattern,
+} from "./pattern-registry.js";
+export type {
+  BlockPattern,
+  BlockTypeRegistry,
+  PatternCategoryRegistry,
+  PatternRegistry,
+} from "./pattern-registry.js";
+export { PatternRegistryError } from "./pattern-errors.js";
+
 // ─── Validation ─────────────────────────────────────────────────────────────
 export { validateEntryContent } from "./validate-content.js";
 export type { BlockContentValidationResult } from "./validate-content.js";

--- a/packages/blocks/src/pattern-errors.ts
+++ b/packages/blocks/src/pattern-errors.ts
@@ -1,0 +1,34 @@
+export class PatternRegistryError extends Error {
+  static {
+    PatternRegistryError.prototype.name = "PatternRegistryError";
+  }
+
+  private constructor(message: string) {
+    super(message);
+  }
+
+  static duplicateSlug(slug: string): PatternRegistryError {
+    return new PatternRegistryError(`Duplicate pattern slug: ${slug}`);
+  }
+
+  static invalidBody(
+    patternName: string,
+    path: string,
+    detail: string,
+  ): PatternRegistryError {
+    return new PatternRegistryError(
+      `Pattern "${patternName}" is invalid at ${path}: ${detail}`,
+    );
+  }
+
+  static undeclaredAttr(
+    patternName: string,
+    path: string,
+    blockName: string,
+    attrKey: string,
+  ): PatternRegistryError {
+    return new PatternRegistryError(
+      `Pattern "${patternName}" at ${path} uses undeclared attr "${attrKey}" on block "${blockName}".`,
+    );
+  }
+}

--- a/packages/blocks/src/pattern-registry.test.ts
+++ b/packages/blocks/src/pattern-registry.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry, defineBlock } from "./block-registry.js";
+import {
+  block,
+  commitPatterns,
+  createPatternRegistry,
+  definePattern,
+} from "./pattern-registry.js";
+
+// Test-scoped augmentations — exercise that downstream consumers can
+// extend both registries via `declare module`.
+declare module "./pattern-registry.js" {
+  interface BlockTypeRegistry {
+    "test/strict-heading": {
+      readonly level: 1 | 2 | 3;
+      readonly text: string;
+    };
+  }
+  interface PatternCategoryRegistry {
+    "test-category": true;
+  }
+}
+
+describe("definePattern", () => {
+  test("returns the spec with the supplied fields and is frozen", () => {
+    const pattern = definePattern({
+      name: "starter/hero",
+      title: "Hero",
+      category: "hero",
+      content: [],
+    });
+
+    expect(pattern.name).toBe("starter/hero");
+    expect(pattern.title).toBe("Hero");
+    expect(pattern.category).toBe("hero");
+    expect(pattern.content).toEqual([]);
+    expect(Object.isFrozen(pattern)).toBe(true);
+  });
+
+  test("assigns sequential pattern-local IDs to nodes, regardless of definition order", () => {
+    // Defining another pattern first must NOT affect the IDs of the
+    // second pattern's nodes — they're scoped to the pattern body.
+    definePattern({
+      name: "x/unused",
+      title: "Unused",
+      content: [block("core/h", { level: 1 }), block("core/h", { level: 2 })],
+    });
+    const pattern = definePattern({
+      name: "x/hero",
+      title: "Hero",
+      content: [block("core/h", { level: 1 }), block("core/p", { text: "x" })],
+    });
+
+    expect(pattern.content.map((n) => n.id)).toEqual(["p1", "p2"]);
+  });
+
+  test("typed category registry accepts seeded defaults and augmented categories", () => {
+    // Seeded default categories compile.
+    definePattern({ name: "x/a", title: "A", category: "hero", content: [] });
+    definePattern({ name: "x/b", title: "B", category: "cta", content: [] });
+    definePattern({
+      name: "x/c",
+      title: "C",
+      category: "footer",
+      content: [],
+    });
+
+    // Test-scoped augmented category compiles.
+    definePattern({
+      name: "x/aug",
+      title: "Aug",
+      category: "test-category",
+      content: [],
+    });
+
+    definePattern({
+      name: "x/bad",
+      title: "Bad",
+      // @ts-expect-error - "unknown-category" not in PatternCategoryRegistry
+      category: "unknown-category",
+      content: [],
+    });
+  });
+});
+
+describe("block()", () => {
+  test("produces a BlockNode with the supplied name and attrs", () => {
+    const node = block("core/heading", { level: 1, text: "Hello" });
+
+    expect(node.name).toBe("core/heading");
+    expect(node.attrs).toEqual({ level: 1, text: "Hello" });
+  });
+
+  test("typed registry narrows attrs for augmented names and rejects wrong shapes", () => {
+    // Augmented name → narrowed attrs (compiles).
+    const ok = block("test/strict-heading", { level: 1, text: "Hi" });
+    expect(ok.name).toBe("test/strict-heading");
+
+    // @ts-expect-error - level is not 1 | 2 | 3
+    block("test/strict-heading", { level: 7, text: "x" });
+
+    // @ts-expect-error - missing required `text`
+    block("test/strict-heading", { level: 1 });
+
+    // Unregistered name → loose attrs fallback (compiles).
+    const loose = block("acme/unregistered", { anything: 123 });
+    expect(loose.name).toBe("acme/unregistered");
+  });
+});
+
+describe("createPatternRegistry", () => {
+  test("looks up a registered pattern by slug", () => {
+    const hero = definePattern({
+      name: "starter/hero",
+      title: "Hero",
+      content: [],
+    });
+    const registry = createPatternRegistry([hero]);
+
+    expect(registry.get("starter/hero")).toBe(hero);
+    expect(registry.has("starter/hero")).toBe(true);
+    expect(registry.has("acme/missing")).toBe(false);
+    expect(registry.size).toBe(1);
+  });
+
+  test("iteration yields patterns in insertion order", () => {
+    const hero = definePattern({ name: "a/hero", title: "Hero", content: [] });
+    const cta = definePattern({ name: "a/cta", title: "CTA", content: [] });
+    const footer = definePattern({
+      name: "a/footer",
+      title: "Footer",
+      content: [],
+    });
+    const registry = createPatternRegistry([hero, cta, footer]);
+
+    expect([...registry].map((p) => p.name)).toEqual([
+      "a/hero",
+      "a/cta",
+      "a/footer",
+    ]);
+  });
+
+  test("throws on duplicate slug, naming the slug", () => {
+    const a = definePattern({ name: "x/y", title: "A", content: [] });
+    const b = definePattern({ name: "x/y", title: "B", content: [] });
+
+    expect(() => createPatternRegistry([a, b])).toThrow(/x\/y/);
+  });
+});
+
+describe("commitPatterns", () => {
+  const heading = defineBlock({
+    name: "core/heading",
+    render: () => null,
+  });
+  const blocks = createBlockRegistry([heading]);
+
+  test("happy path: returns the registry when every block in every pattern body is registered", () => {
+    const hero = definePattern({
+      name: "starter/hero",
+      title: "Hero",
+      content: [block("core/heading", { level: 1, text: "Hi" })],
+    });
+    const patterns = createPatternRegistry([hero]);
+
+    const resolved = commitPatterns(patterns, blocks);
+
+    expect(resolved.get("starter/hero")).toBe(hero);
+    expect(resolved.size).toBe(1);
+  });
+
+  test("throws when a pattern body references an unknown block, naming the pattern slug and the missing block", () => {
+    const broken = definePattern({
+      name: "starter/broken",
+      title: "Broken",
+      content: [block("acme/missing", {})],
+    });
+    const patterns = createPatternRegistry([broken]);
+
+    expect(() => commitPatterns(patterns, blocks)).toThrow(
+      /starter\/broken.*acme\/missing/,
+    );
+  });
+
+  test("throws when a pattern body uses an attr key the block's inputs do not declare", () => {
+    const headingWithInputs = defineBlock({
+      name: "core/heading-strict",
+      inputs: [{ name: "level", type: "select", options: [] }],
+      render: () => null,
+    });
+    const strictBlocks = createBlockRegistry([headingWithInputs]);
+    const broken = definePattern({
+      name: "starter/attrs-mismatch",
+      title: "Broken",
+      content: [block("core/heading-strict", { level: 1, garbage: "x" })],
+    });
+    const patterns = createPatternRegistry([broken]);
+
+    expect(() => commitPatterns(patterns, strictBlocks)).toThrow(
+      /starter\/attrs-mismatch.*garbage/,
+    );
+  });
+});

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -1,0 +1,167 @@
+import type { BlockRegistry } from "./block-registry.js";
+import type { BlockNode } from "./render-block-tree.js";
+import { PatternRegistryError } from "./pattern-errors.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+import { validateEntryContent } from "./validate-content.js";
+
+/**
+ * Augmentable registry mapping block name → attrs shape. Plugins and
+ * themes extend it via `declare module "@plumix/blocks"` so the `block()`
+ * helper can narrow attrs at compile time for known block names.
+ *
+ * Unknown names fall back to a loose `Record<string, unknown>` — see
+ * `AttrsFor` below — so call sites with names the registry hasn't seen
+ * still compile.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- module-augmentation seam; consumers extend via `declare module`.
+export interface BlockTypeRegistry {}
+
+/**
+ * Augmentable registry of pattern category slugs. The 8 default
+ * categories ship as the seed; plugins / themes augment to add their
+ * own.
+ */
+export interface PatternCategoryRegistry {
+  readonly hero: true;
+  readonly cta: true;
+  readonly features: true;
+  readonly testimonials: true;
+  readonly pricing: true;
+  readonly header: true;
+  readonly footer: true;
+  readonly content: true;
+}
+
+type AttrsFor<TName extends string> = TName extends keyof BlockTypeRegistry
+  ? BlockTypeRegistry[TName]
+  : Readonly<Record<string, unknown>>;
+
+export interface BlockPattern {
+  readonly name: string;
+  readonly title: string;
+  readonly category?: keyof PatternCategoryRegistry;
+  readonly content: readonly BlockNode[];
+}
+
+// Pattern-local ID assignment. `block()` writes a junk placeholder ID;
+// `definePattern` walks the tree and reassigns `p1, p2, ...` so IDs
+// are deterministic per pattern body regardless of how many other
+// patterns were defined before this one. Insert paths (slice #638)
+// rewrite IDs again — pattern.content IDs only serve React keys
+// during preview.
+const PLACEHOLDER_ID = "";
+
+export function definePattern(spec: BlockPattern): BlockPattern {
+  return Object.freeze({ ...spec, content: assignPatternIds(spec.content) });
+}
+
+export function block<TName extends string>(
+  name: TName,
+  attrs: AttrsFor<TName>,
+  options?: { readonly id?: string },
+): BlockNode {
+  return {
+    id: options?.id ?? PLACEHOLDER_ID,
+    name,
+    attrs,
+  };
+}
+
+function assignPatternIds(nodes: readonly BlockNode[]): readonly BlockNode[] {
+  let counter = 0;
+  function walk(input: readonly BlockNode[]): readonly BlockNode[] {
+    return input.map((node) => {
+      const next: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(node.attrs ?? {})) {
+        next[key] = isBlockNodeArray(value) ? walk(value) : value;
+      }
+      return {
+        ...node,
+        id: node.id || `p${++counter}`,
+        attrs: next,
+      };
+    });
+  }
+  return walk(nodes);
+}
+
+export interface PatternRegistry {
+  get(slug: string): BlockPattern | undefined;
+  has(slug: string): boolean;
+  readonly size: number;
+  [Symbol.iterator](): IterableIterator<BlockPattern>;
+}
+
+export function createPatternRegistry(
+  patterns: readonly BlockPattern[] = [],
+): PatternRegistry {
+  const map = new Map<string, BlockPattern>();
+  for (const pattern of patterns) {
+    if (map.has(pattern.name)) {
+      throw PatternRegistryError.duplicateSlug(pattern.name);
+    }
+    map.set(pattern.name, pattern);
+  }
+  return Object.freeze({
+    get: (slug: string) => map.get(slug),
+    has: (slug: string) => map.has(slug),
+    get size() {
+      return map.size;
+    },
+    [Symbol.iterator]: () => map.values(),
+  });
+}
+
+export function commitPatterns(
+  patterns: PatternRegistry,
+  blocks: BlockRegistry,
+): PatternRegistry {
+  for (const pattern of patterns) {
+    const result = validateEntryContent(
+      { version: "plumix.v2", blocks: pattern.content },
+      blocks,
+    );
+    if (!result.ok) {
+      const first = result.errors[0];
+      throw PatternRegistryError.invalidBody(
+        pattern.name,
+        first?.path ?? "?",
+        first?.message ?? "validation failed",
+      );
+    }
+    validateAttrs(pattern.name, pattern.content, "blocks", blocks);
+  }
+  return patterns;
+}
+
+function validateAttrs(
+  patternName: string,
+  nodes: readonly BlockNode[],
+  basePath: string,
+  blocks: BlockRegistry,
+): void {
+  nodes.forEach((node, i) => {
+    const path = `${basePath}[${i}]`;
+    const spec = blocks.get(node.name);
+    // Block-name existence is the validateEntryContent layer's job.
+    // Attr-key check only fires when the block declares inputs; slot
+    // recursion runs either way so inputless wrapper blocks don't hide
+    // unknown attrs deeper in the tree.
+    const declared = spec?.inputs
+      ? new Set(spec.inputs.map((input) => input.name))
+      : undefined;
+    for (const [key, value] of Object.entries(node.attrs ?? {})) {
+      if (declared && !declared.has(key)) {
+        throw PatternRegistryError.undeclaredAttr(
+          patternName,
+          path,
+          node.name,
+          key,
+        );
+      }
+      if (isBlockNodeArray(value)) {
+        validateAttrs(patternName, value, `${path}.${key}`, blocks);
+      }
+    }
+  });
+}

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -1340,4 +1340,37 @@ describe("buildManifest visibility projection", () => {
     expect(tax?.isPublic).toBe(false);
     expect(tax?.showInSidebar).toBe(false);
   });
+
+  test("projects registered patterns into manifest.patterns sorted by name", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerPattern({
+        name: "acme/zeta",
+        title: "Zeta",
+        category: "hero",
+        content: [],
+      });
+      ctx.registerPattern({
+        name: "acme/alpha",
+        title: "Alpha",
+        category: "cta",
+        content: [],
+      });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+
+    expect(manifest.patterns).toHaveLength(2);
+    expect(manifest.patterns[0]).toMatchObject({
+      name: "acme/alpha",
+      title: "Alpha",
+      category: "cta",
+      content: [],
+    });
+    expect(manifest.patterns[1]).toMatchObject({
+      name: "acme/zeta",
+      title: "Zeta",
+    });
+  });
 });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1,4 +1,6 @@
 import type {
+  BlockNode,
+  BlockPattern,
   BlockSpec,
   BlockVariation,
   MarkSpec,
@@ -1057,6 +1059,11 @@ export interface RegisteredMark {
   readonly registeredBy: string;
 }
 
+export interface RegisteredPattern {
+  readonly spec: BlockPattern;
+  readonly registeredBy: string;
+}
+
 export interface PluginRegistry {
   readonly entryTypes: ReadonlyMap<string, RegisteredEntryType>;
   readonly termTaxonomies: ReadonlyMap<string, RegisteredTermTaxonomy>;
@@ -1074,6 +1081,7 @@ export interface PluginRegistry {
   readonly fieldTypes: ReadonlyMap<string, RegisteredFieldType>;
   readonly blockSpecs: ReadonlyMap<string, RegisteredBlock>;
   readonly markSpecs: ReadonlyMap<string, RegisteredMark>;
+  readonly patternSpecs: ReadonlyMap<string, RegisteredPattern>;
   readonly lookupAdapters: ReadonlyMap<string, RegisteredLookupAdapter>;
   readonly scheduledTasks: readonly RegisteredScheduledTask[];
   readonly templateDeps: ReadonlyMap<string, RegisteredTemplateDep>;
@@ -1096,6 +1104,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly fieldTypes: Map<string, RegisteredFieldType>;
   readonly blockSpecs: Map<string, RegisteredBlock>;
   readonly markSpecs: Map<string, RegisteredMark>;
+  readonly patternSpecs: Map<string, RegisteredPattern>;
   readonly lookupAdapters: Map<string, RegisteredLookupAdapter>;
   readonly scheduledTasks: RegisteredScheduledTask[];
   readonly templateDeps: Map<string, RegisteredTemplateDep>;
@@ -1119,6 +1128,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     fieldTypes: new Map(),
     blockSpecs: new Map(),
     markSpecs: new Map(),
+    patternSpecs: new Map(),
     lookupAdapters: new Map(),
     scheduledTasks: [],
     templateDeps: new Map(),
@@ -1438,6 +1448,13 @@ export interface MarkManifestEntry {
   readonly adminSchema?: string;
 }
 
+export interface PatternManifestEntry {
+  readonly name: string;
+  readonly title: string;
+  readonly category?: string;
+  readonly content: readonly BlockNode[];
+}
+
 /**
  * Wire-shipped manifest payload. Every field is optional on the type
  * so test fixtures can declare just the slice they exercise; the
@@ -1456,6 +1473,7 @@ export interface PlumixManifest {
   readonly fieldTypes?: readonly FieldTypeManifestEntry[];
   readonly blocks?: readonly BlockManifestEntry[];
   readonly marks?: readonly MarkManifestEntry[];
+  readonly patterns?: readonly PatternManifestEntry[];
   /**
    * Theme tokens from `defineTheme({ tokens })`. Routed through the
    * manifest channel because the precompiled admin shell can't import
@@ -1490,6 +1508,7 @@ export function emptyManifest(): PlumixManifest {
     fieldTypes: [],
     blocks: [],
     marks: [],
+    patterns: [],
     tokens: {},
   };
 }
@@ -1570,6 +1589,9 @@ export function buildManifest(
   const marks = Array.from(registry.markSpecs.values())
     .map(toMarkEntry)
     .sort((a, b) => a.name.localeCompare(b.name));
+  const patterns = Array.from(registry.patternSpecs.values())
+    .map(toPatternEntry)
+    .sort((a, b) => a.name.localeCompare(b.name));
   return {
     entryTypes: entries,
     termTaxonomies,
@@ -1582,6 +1604,7 @@ export function buildManifest(
     fieldTypes,
     blocks,
     marks,
+    patterns,
     tokens: theme?.tokens ?? {},
   };
 }
@@ -2223,6 +2246,11 @@ function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
     inserter,
     variations,
   };
+}
+
+function toPatternEntry(pattern: RegisteredPattern): PatternManifestEntry {
+  const { name, title, category, content } = pattern.spec;
+  return { name, title, category, content };
 }
 
 function toMarkEntry(mark: RegisteredMark): MarkManifestEntry {

--- a/packages/core/src/plugin/register.test.ts
+++ b/packages/core/src/plugin/register.test.ts
@@ -909,3 +909,37 @@ describe("registerScheduledTask", () => {
     expect(registry.scheduledTasks[0]?.cron).toBeUndefined();
   });
 });
+
+describe("registerPattern", () => {
+  test("stores the registered pattern keyed by slug, tagged with the plugin id", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerPattern({
+        name: "acme/hero",
+        title: "Hero",
+        category: "hero",
+        content: [],
+      });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+
+    expect(registry.patternSpecs.has("acme/hero")).toBe(true);
+    expect(registry.patternSpecs.get("acme/hero")?.registeredBy).toBe("acme");
+    expect(registry.patternSpecs.get("acme/hero")?.spec.title).toBe("Hero");
+  });
+
+  test("throws when two plugins register the same pattern slug", async () => {
+    const hooks = new HookRegistry();
+    const a = definePlugin("a", (ctx) => {
+      ctx.registerPattern({ name: "shared/hero", title: "A", content: [] });
+    });
+    const b = definePlugin("b", (ctx) => {
+      ctx.registerPattern({ name: "shared/hero", title: "B", content: [] });
+    });
+
+    await expect(installPlugins({ hooks, plugins: [a, b] })).rejects.toThrow(
+      DuplicateRegistrationError,
+    );
+  });
+});

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -1,4 +1,4 @@
-import type { BlockSpec, MarkSpec } from "@plumix/blocks";
+import type { BlockPattern, BlockSpec, MarkSpec } from "@plumix/blocks";
 
 import type { DerivedCapability } from "../auth/rbac.js";
 import type { AppContext } from "../context/app.js";
@@ -195,6 +195,13 @@ export interface PluginSetupContextBase {
    * rejected; the convention for plugin marks is `pluginId/markName`.
    */
   registerMark(spec: MarkSpec): void;
+  /**
+   * Register a `BlockPattern` produced by `definePattern` from
+   * `plumix/blocks`. Plugin- and theme-contributed patterns merge into
+   * the per-app pattern registry at `buildApp` time. Duplicate slugs
+   * across plugins throw — patterns are not silently overridden.
+   */
+  registerPattern(spec: BlockPattern): void;
   /**
    * Register a `LookupAdapter` for a reference target kind. The
    * `kind` matches the `referenceTarget.kind` carried on a reference
@@ -545,6 +552,16 @@ export function createPluginSetupContext({
         });
       }
       registry.markSpecs.set(spec.name, { spec, registeredBy: pluginId });
+    },
+
+    registerPattern: (spec) => {
+      if (registry.patternSpecs.has(spec.name)) {
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "pattern",
+          identifier: spec.name,
+        });
+      }
+      registry.patternSpecs.set(spec.name, { spec, registeredBy: pluginId });
     },
 
     registerLookupAdapter: (options) => {


### PR DESCRIPTION
Adds the foundation slice of the block-patterns track — plugins and themes can declare patterns via `definePattern` + the typed `block()` helper, register them with `ctx.registerPattern`, and see them surface as title rows in the editor's left sidebar grouped by category. Display-only in this slice; clicking a row is a no-op until the copy-mode insert path lands in #638.

**Authoring API**

A frozen `BlockPattern { name, title, category?, content }` declared with `definePattern`. The `content` tree is built via `block(name, attrs, options?)` typed against an augmentable `BlockTypeRegistry`; unknown block names fall back to a loose attrs shape so call sites with names the registry has not yet seen still compile. `PatternCategoryRegistry` ships 8 seeded categories — `hero`, `cta`, `features`, `testimonials`, `pricing`, `header`, `footer`, `content` — and is augmentable for plugin-defined categories. `definePattern` walks the content tree and assigns pattern-local sequential IDs so node identifiers stay deterministic regardless of how many patterns were defined before this one.

**Validation at boot**

`createPatternRegistry` throws on duplicate slug. `commitPatterns` walks each pattern body, validates block names against the block registry via the existing `validateEntryContent` primitive, and checks attr keys against the declaring block's inputs. Slot recursion runs regardless of whether the parent declares inputs so inputless wrapper blocks do not hide unknown attrs deeper in the tree.

**Manifest + sidebar**

`PluginSetupContext` gains `registerPattern(spec)`; the plugin registry adds a `patternSpecs` Map and `buildManifest` projects it into a new `manifest.patterns` slice sorted by name. The admin reader extends `KNOWN_ARRAY_FIELDS` and exposes `getPatterns()`; `PatternsSection` renders the patterns below the existing block list inside the Blocks tab.

Refs #625
Refs #626