### PR TITLE
feat: activate copy-mode pattern insert on the sidebar

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -38,6 +38,7 @@ import type {
   ResponsiveStyleSlot,
   ThemeTokens,
 } from "@plumix/blocks";
+import type { PatternManifestEntry } from "@plumix/core/manifest";
 import { createBlockRegistry, expandBlockVariations } from "@plumix/blocks";
 
 import type { TransformOption } from "./available-transforms.js";
@@ -46,6 +47,7 @@ import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { BlockIcon } from "./BlockIcon.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
+import { insertPatternCopy } from "./insert-pattern.js";
 import { mergePropsAtSelector } from "./merge-variation-attrs.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
@@ -555,6 +557,17 @@ function PlumixBlocksTab({
 
   const patterns = useMemo(() => getPatterns(), []);
 
+  const handlePatternInsert = useCallback(
+    (pattern: PatternManifestEntry): void => {
+      puck.dispatch({
+        type: "setData",
+        data: (previous) =>
+          insertPatternCopy(previous, pattern.content, previous.content.length),
+      });
+    },
+    [puck],
+  );
+
   return (
     <div className="flex flex-col">
       <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
@@ -572,7 +585,7 @@ function PlumixBlocksTab({
           </li>
         ))}
       </ul>
-      <PatternsSection patterns={patterns} />
+      <PatternsSection patterns={patterns} onSelect={handlePatternInsert} />
     </div>
   );
 }

--- a/packages/admin/src/editor/PatternsSection.test.tsx
+++ b/packages/admin/src/editor/PatternsSection.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, test } from "vitest";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { PatternsSection } from "./PatternsSection.js";
 
@@ -7,15 +8,20 @@ afterEach(() => {
   cleanup();
 });
 
+const noop = vi.fn();
+
 describe("PatternsSection", () => {
   test("renders nothing when no patterns are registered", () => {
-    const { container } = render(<PatternsSection patterns={[]} />);
+    const { container } = render(
+      <PatternsSection patterns={[]} onSelect={noop} />,
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
   test("renders title rows for each pattern, grouped under category headers", () => {
     render(
       <PatternsSection
+        onSelect={noop}
         patterns={[
           {
             name: "starter/hero",
@@ -58,6 +64,7 @@ describe("PatternsSection", () => {
   test("patterns without a category fall under an 'uncategorized' group", () => {
     render(
       <PatternsSection
+        onSelect={noop}
         patterns={[{ name: "x/anon", title: "Anonymous", content: [] }]}
       />,
     );
@@ -68,5 +75,23 @@ describe("PatternsSection", () => {
     expect(
       screen.getByTestId("plumix-patterns-row-x/anon"),
     ).toBeInTheDocument();
+  });
+
+  test("clicking a pattern row invokes onSelect with the pattern entry", async () => {
+    const onSelect = vi.fn();
+    const hero = {
+      name: "starter/hero",
+      title: "Hero",
+      category: "hero" as const,
+      content: [],
+    };
+    render(<PatternsSection patterns={[hero]} onSelect={onSelect} />);
+
+    await userEvent.click(
+      screen.getByTestId("plumix-patterns-row-starter/hero"),
+    );
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(hero);
   });
 });

--- a/packages/admin/src/editor/PatternsSection.tsx
+++ b/packages/admin/src/editor/PatternsSection.tsx
@@ -5,12 +5,14 @@ import type { PatternManifestEntry } from "@plumix/core/manifest";
 
 interface PatternsSectionProps {
   readonly patterns: readonly PatternManifestEntry[];
+  readonly onSelect: (pattern: PatternManifestEntry) => void;
 }
 
 const UNCATEGORIZED = "uncategorized";
 
 export function PatternsSection({
   patterns,
+  onSelect,
 }: PatternsSectionProps): ReactElement | null {
   const grouped = useMemo(() => {
     const map = new Map<string, PatternManifestEntry[]>();
@@ -48,12 +50,14 @@ export function PatternsSection({
           <ul className="flex flex-col gap-1">
             {entries.map((entry) => (
               <li key={entry.name}>
-                <div
-                  className="text-foreground w-full rounded border px-3 py-2 text-left text-sm"
+                <button
+                  type="button"
+                  className="text-foreground hover:bg-muted w-full rounded border px-3 py-2 text-left text-sm"
                   data-testid={`plumix-patterns-row-${entry.name}`}
+                  onClick={() => onSelect(entry)}
                 >
                   {entry.title}
-                </div>
+                </button>
               </li>
             ))}
           </ul>

--- a/packages/admin/src/editor/insert-pattern.test.ts
+++ b/packages/admin/src/editor/insert-pattern.test.ts
@@ -1,0 +1,78 @@
+import type { Data } from "@puckeditor/core";
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+
+import { insertPatternCopy } from "./insert-pattern.js";
+
+const blank: Data = { content: [], root: {} };
+
+const heading = (id: string, text: string): BlockNode => ({
+  id,
+  name: "core/heading",
+  attrs: { level: 1, text },
+});
+
+function texts(data: Data): readonly unknown[] {
+  return data.content.map((c) => (c.props as { text?: unknown }).text);
+}
+
+function ids(data: Data): readonly unknown[] {
+  return data.content.map((c) => (c.props as { id?: unknown }).id);
+}
+
+describe("insertPatternCopy", () => {
+  test("appends the pattern body at the destination index", () => {
+    const pattern: readonly BlockNode[] = [
+      heading("p1", "Hero"),
+      heading("p2", "Tagline"),
+    ];
+
+    const next = insertPatternCopy(blank, pattern, 0);
+
+    expect(next.content).toHaveLength(2);
+    expect(next.content[0]?.type).toBe("core/heading");
+    expect(texts(next)).toEqual(["Hero", "Tagline"]);
+  });
+
+  test("splices into the middle of existing content", () => {
+    const existing: Data = {
+      content: [
+        { type: "core/p", props: { id: "a", text: "before" } },
+        { type: "core/p", props: { id: "b", text: "after" } },
+      ],
+      root: {},
+    };
+    const pattern: readonly BlockNode[] = [heading("p1", "Middle")];
+
+    const next = insertPatternCopy(existing, pattern, 1);
+
+    expect(texts(next)).toEqual(["before", "Middle", "after"]);
+  });
+
+  test("rewrites ids so two inserts of the same pattern produce distinct ids", () => {
+    const pattern: readonly BlockNode[] = [heading("p1", "Hero")];
+
+    const first = insertPatternCopy(blank, pattern, 0);
+    const second = insertPatternCopy(blank, pattern, 0);
+
+    const firstId = ids(first)[0];
+    const secondId = ids(second)[0];
+    expect(firstId).not.toBe("p1");
+    expect(secondId).not.toBe("p1");
+    expect(firstId).not.toBe(secondId);
+  });
+
+  test("preserves data.root and existing content reference shape", () => {
+    const existing: Data = {
+      content: [{ type: "core/p", props: { id: "a", text: "x" } }],
+      root: { props: { title: "Page" } },
+    };
+    const pattern: readonly BlockNode[] = [heading("p1", "Hero")];
+
+    const next = insertPatternCopy(existing, pattern, 1);
+
+    expect(next.root).toEqual({ props: { title: "Page" } });
+    expect(existing.content).toHaveLength(1);
+  });
+});

--- a/packages/admin/src/editor/insert-pattern.ts
+++ b/packages/admin/src/editor/insert-pattern.ts
@@ -1,0 +1,17 @@
+import type { Data } from "@puckeditor/core";
+
+import type { BlockNode } from "@plumix/blocks";
+import { rewriteBlockNodeIds } from "@plumix/blocks";
+
+import { blockNodesToPuckContent } from "./entry-content.js";
+
+export function insertPatternCopy(
+  data: Data,
+  content: readonly BlockNode[],
+  destinationIndex: number,
+): Data {
+  const puckContent = blockNodesToPuckContent(rewriteBlockNodeIds(content));
+  const next = [...data.content];
+  next.splice(destinationIndex, 0, ...puckContent);
+  return { ...data, content: next };
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -26,6 +26,7 @@ export {
   isBlockNodeArray,
   renderBlockTree,
 } from "./render-block-tree.js";
+export { rewriteBlockNodeIds } from "./rewrite-node-ids.js";
 export type {
   BlockContext,
   BlockNode,

--- a/packages/blocks/src/rewrite-node-ids.test.ts
+++ b/packages/blocks/src/rewrite-node-ids.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "./render-block-tree.js";
+import { rewriteBlockNodeIds } from "./rewrite-node-ids.js";
+
+const heading = (id: string, text: string): BlockNode => ({
+  id,
+  name: "core/heading",
+  attrs: { text },
+});
+
+describe("rewriteBlockNodeIds", () => {
+  test("replaces every node id with a fresh, non-empty string", () => {
+    const input: readonly BlockNode[] = [
+      heading("p1", "A"),
+      heading("p2", "B"),
+    ];
+
+    const out = rewriteBlockNodeIds(input);
+
+    expect(out).toHaveLength(2);
+    expect(out[0]?.id).not.toBe("p1");
+    expect(out[1]?.id).not.toBe("p2");
+    expect(out[0]?.id.length).toBeGreaterThan(0);
+    expect(out[1]?.id.length).toBeGreaterThan(0);
+  });
+
+  test("produces ids that are unique within the rewritten tree", () => {
+    const input: readonly BlockNode[] = [
+      heading("p1", "A"),
+      heading("p1", "B"),
+      heading("p1", "C"),
+    ];
+
+    const out = rewriteBlockNodeIds(input);
+    const ids = out.map((n) => n.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("recurses into slot children carried inside attrs", () => {
+    const input: readonly BlockNode[] = [
+      {
+        id: "group-1",
+        name: "core/group",
+        attrs: {
+          layout: "stack",
+          content: [heading("h-1", "Inner"), heading("h-2", "Inner 2")],
+        },
+      },
+    ];
+
+    const out = rewriteBlockNodeIds(input);
+    const root = out[0];
+    const innerContent = root?.attrs?.content as readonly BlockNode[];
+
+    expect(root?.id).not.toBe("group-1");
+    expect(innerContent[0]?.id).not.toBe("h-1");
+    expect(innerContent[1]?.id).not.toBe("h-2");
+
+    const allIds = [
+      root?.id,
+      innerContent[0]?.id,
+      innerContent[1]?.id,
+    ] as string[];
+    expect(new Set(allIds).size).toBe(3);
+  });
+
+  test("does not mutate the input tree or its nested slot arrays", () => {
+    const slotChild = heading("h-orig", "Inner");
+    const root: BlockNode = {
+      id: "g-orig",
+      name: "core/group",
+      attrs: { content: [slotChild] },
+    };
+    const input: readonly BlockNode[] = [root];
+    const snapshot = JSON.stringify(input);
+
+    rewriteBlockNodeIds(input);
+
+    expect(JSON.stringify(input)).toBe(snapshot);
+    expect(root.id).toBe("g-orig");
+    expect(slotChild.id).toBe("h-orig");
+  });
+
+  test("repeated calls on the same input produce distinct id sets", () => {
+    const input: readonly BlockNode[] = [
+      heading("p1", "A"),
+      heading("p2", "B"),
+    ];
+
+    const first = rewriteBlockNodeIds(input).map((n) => n.id);
+    const second = rewriteBlockNodeIds(input).map((n) => n.id);
+
+    expect(first).not.toEqual(second);
+  });
+
+  test("preserves the `style` slot at both top-level and inside nested slot children", () => {
+    const innerStyle = { large: { "color.background": "primary" } };
+    const rootStyle = { large: { "spacing.padding": "lg" } };
+    const input: readonly BlockNode[] = [
+      {
+        id: "g-1",
+        name: "core/group",
+        style: rootStyle,
+        attrs: {
+          content: [
+            { id: "h-1", name: "core/heading", style: innerStyle, attrs: {} },
+          ],
+        },
+      },
+    ];
+
+    const out = rewriteBlockNodeIds(input);
+    const root = out[0];
+    const innerContent = root?.attrs?.content as readonly BlockNode[];
+
+    expect(root?.style).toEqual(rootStyle);
+    expect(innerContent[0]?.style).toEqual(innerStyle);
+  });
+});

--- a/packages/blocks/src/rewrite-node-ids.ts
+++ b/packages/blocks/src/rewrite-node-ids.ts
@@ -1,0 +1,33 @@
+import type { BlockNode } from "./render-block-tree.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+
+// 12 chars × 64 = 72 bits entropy — ample for React keys with no
+// realistic collision risk over a page's edit lifetime. The 64-char
+// URL-safe alphabet plus `byte & 63` masking avoids modulo bias.
+const ID_ALPHABET =
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
+const ID_LENGTH = 12;
+
+function freshId(): string {
+  const bytes = new Uint8Array(ID_LENGTH);
+  globalThis.crypto.getRandomValues(bytes);
+  let out = "";
+  for (const byte of bytes) {
+    out += ID_ALPHABET.charAt(byte & 63);
+  }
+  return out;
+}
+
+export function rewriteBlockNodeIds(
+  nodes: readonly BlockNode[],
+): readonly BlockNode[] {
+  return nodes.map((node) => {
+    const nextAttrs: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node.attrs ?? {})) {
+      nextAttrs[key] = isBlockNodeArray(value)
+        ? rewriteBlockNodeIds(value)
+        : value;
+    }
+    return { ...node, id: freshId(), attrs: nextAttrs };
+  });
+}


### PR DESCRIPTION
Activates the click-to-insert path that #639 deferred. The Patterns sidebar's title rows become buttons; clicking one splices a deep-cloned, ID-rewritten copy of the pattern body into the document.

**ID rewriter (`@plumix/blocks`)**

A pure depth-first walk that replaces every `node.id` with a fresh 72-bit ID generated via `crypto.getRandomValues` against a 64-char URL-safe alphabet. Style slots and other attrs survive verbatim; nested slot arrays are recursed and rewritten. Source trees are never mutated. The same primitive will be reused by Detach (#627) and the starter-modal seed (#631).

**Copy-mode insert primitive (`@plumix/admin`)**

`insertPatternCopy(data, content, destinationIndex)` is a pure `Data` transform that runs the rewriter, converts via the existing `blockNodesToPuckContent`, and splices the resulting `ComponentData[]` into `data.content` at the destination. Invoked inside a `puck.dispatch({ type: "setData" })` callback in `EditorLayout`'s `handlePatternInsert`.

**Reference-mode patterns stay click-inert**

The `manifest.patterns` wire format does not yet carry the `insert` field, so every entry is implicitly copy-mode in this slice. Reference mode activates in #627.

**Known divergence from the slash menu**

Both the per-block sidebar and the new pattern button append to the end of the document. The slash menu remains the selection-aware path via `nextInsertPoint`. Bringing the sidebars under the same primitive is a separate follow-up and out of scope here.

Refs #625
Refs #638