### PR TITLE
feat: reference-mode patterns + core/pattern-ref + Detach

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -35,11 +35,16 @@ import type {
   BlockRegistry,
   BlockSpec,
   InsertableBlockEntry,
+  PatternRegistry,
   ResponsiveStyleSlot,
   ThemeTokens,
 } from "@plumix/blocks";
 import type { PatternManifestEntry } from "@plumix/core/manifest";
-import { createBlockRegistry, expandBlockVariations } from "@plumix/blocks";
+import {
+  createBlockRegistry,
+  createPatternRegistry,
+  expandBlockVariations,
+} from "@plumix/blocks";
 
 import type { TransformOption } from "./available-transforms.js";
 import type { SlashMenuItem } from "./slash-menu-items.js";
@@ -47,10 +52,11 @@ import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { BlockIcon } from "./BlockIcon.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
-import { insertPatternCopy } from "./insert-pattern.js";
+import { insertPattern } from "./insert-pattern.js";
 import { mergePropsAtSelector } from "./merge-variation-attrs.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
+import { PatternRefProvider } from "./PatternRefPreview.js";
 import { PatternsSection } from "./PatternsSection.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
 import { PUCK_ROOT_ZONE } from "./puck-zones.js";
@@ -61,6 +67,7 @@ import { viewportWidthToBucket } from "./viewport-bucket.js";
 
 interface PlumixEditorLayoutProps {
   readonly registry?: BlockRegistry;
+  readonly patternRegistry?: PatternRegistry;
   readonly capabilities?: ReadonlySet<string>;
   readonly tokens?: ThemeTokens;
   readonly children?: ReactNode;
@@ -100,6 +107,7 @@ interface PlumixEditorLayoutProps {
 }
 
 const EMPTY_REGISTRY: BlockRegistry = createBlockRegistry([]);
+const EMPTY_PATTERN_REGISTRY: PatternRegistry = createPatternRegistry([]);
 const EMPTY_CAPS: ReadonlySet<string> = new Set();
 const EMPTY_TOKENS: ThemeTokens = {};
 
@@ -338,6 +346,7 @@ function DraftActions({ draftMode }: DraftActionsProps): ReactElement {
 
 export function PlumixEditorLayout({
   registry = EMPTY_REGISTRY,
+  patternRegistry = EMPTY_PATTERN_REGISTRY,
   capabilities = EMPTY_CAPS,
   tokens = EMPTY_TOKENS,
   title,
@@ -354,103 +363,112 @@ export function PlumixEditorLayout({
   const isPreview = previewBanner !== undefined;
   const isDraftMode = draftMode !== undefined;
   const showDraftBanner = isDraftMode && draftMode.hasPendingDraft;
+  const refContextValue = useMemo(
+    () => ({ patterns: patternRegistry, blocks: registry }),
+    [patternRegistry, registry],
+  );
   return (
-    <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
-      {previewBanner}
-      {showDraftBanner ? (
-        // Static banner — no `role="status"` because a live region
-        // containing a button gets re-announced on every state change,
-        // which makes the Discard button noisy for screen readers.
-        // Dark-mode contrast: `amber-900/30` background pairs with
-        // `amber-100` text at ~4.5:1 (AA for normal text); the original
-        // `amber-950/40` measured ~3.8:1.
-        <div
-          data-testid="unpublished-changes-banner"
-          className="flex shrink-0 items-center gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:bg-amber-900/30 dark:text-amber-100"
-        >
-          <span className="font-medium">
-            You have unpublished draft changes.
-          </span>
-          <span>Click Publish to push them live, or Discard to revert.</span>
-          <Button
-            variant="ghost"
-            size="sm"
-            data-testid="unpublished-changes-banner-discard"
-            onClick={draftMode.onDiscardDraft}
-            disabled={draftMode.isDiscarding}
-            className="ml-auto"
+    <PatternRefProvider value={refContextValue}>
+      <div className="flex h-dvh flex-col" data-testid="plumix-editor-layout">
+        {previewBanner}
+        {showDraftBanner ? (
+          // Static banner — no `role="status"` because a live region
+          // containing a button gets re-announced on every state change,
+          // which makes the Discard button noisy for screen readers.
+          // Dark-mode contrast: `amber-900/30` background pairs with
+          // `amber-100` text at ~4.5:1 (AA for normal text); the original
+          // `amber-950/40` measured ~3.8:1.
+          <div
+            data-testid="unpublished-changes-banner"
+            className="flex shrink-0 items-center gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:bg-amber-900/30 dark:text-amber-100"
           >
-            {draftMode.isDiscarding ? "Discarding…" : "Discard"}
-          </Button>
-        </div>
-      ) : null}
-      <header
-        className="bg-background flex h-12 shrink-0 items-center gap-3 border-b px-4"
-        data-testid="plumix-editor-header"
-      >
-        <a
-          href={backHref}
-          aria-label="Back to list"
-          className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border text-sm"
-          data-testid="plumix-editor-back-button"
-        >
-          ←
-        </a>
-        <input
-          type="text"
-          placeholder="Untitled"
-          aria-label="Entry title"
-          className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent px-2 text-base font-medium outline-none disabled:cursor-not-allowed disabled:opacity-60"
-          data-testid="plumix-editor-title-input"
-          value={title}
-          onChange={(e) => onTitleChange(e.target.value)}
-          disabled={isPreview}
-        />
-        {isPreview ? null : <AutosaveStatusPill />}
-        {isPreview ? null : coAuthorIndicator}
-        {revisionsTrigger}
-        {isPreview ? null : isDraftMode ? (
-          <DraftActions draftMode={draftMode} />
-        ) : (
-          <LivePublishButton
-            onPublish={onPublish}
-            isPublishing={isPublishing}
-            isPublished={isPublished}
-          />
-        )}
-      </header>
-      <div
-        className="grid flex-1 grid-cols-[minmax(0,1fr)] overflow-hidden md:grid-cols-[260px_minmax(0,1fr)_320px]"
-        data-testid="plumix-editor-cols"
-      >
-        <BlocksBody registry={registry} capabilities={capabilities} />
-        {isPreview ? (
-          // Puck's `permissions` strips drag / insert / delete / dup /
-          // edit, but Tiptap inside rich-text fields keeps its own
-          // `editable: true`. Cover the canvas with a transparent
-          // overlay so the user can't type into rich-text without
-          // realising preview mode skips autosave.
-          <div className="relative" data-testid="plumix-editor-preview-shield">
-            <div
-              aria-hidden
-              className="bg-background/0 pointer-events-auto absolute inset-0 z-10"
-            />
-            <div className="pointer-events-none h-full">
-              <PlumixCanvasWithSlashMenu
-                registry={registry}
-                capabilities={capabilities}
-              />
-            </div>
+            <span className="font-medium">
+              You have unpublished draft changes.
+            </span>
+            <span>Click Publish to push them live, or Discard to revert.</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              data-testid="unpublished-changes-banner-discard"
+              onClick={draftMode.onDiscardDraft}
+              disabled={draftMode.isDiscarding}
+              className="ml-auto"
+            >
+              {draftMode.isDiscarding ? "Discarding…" : "Discard"}
+            </Button>
           </div>
-        ) : (
-          <PlumixCanvasWithSlashMenu
-            registry={registry}
-            capabilities={capabilities}
+        ) : null}
+        <header
+          className="bg-background flex h-12 shrink-0 items-center gap-3 border-b px-4"
+          data-testid="plumix-editor-header"
+        >
+          <a
+            href={backHref}
+            aria-label="Back to list"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border text-sm"
+            data-testid="plumix-editor-back-button"
+          >
+            ←
+          </a>
+          <input
+            type="text"
+            placeholder="Untitled"
+            aria-label="Entry title"
+            className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent px-2 text-base font-medium outline-none disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="plumix-editor-title-input"
+            value={title}
+            onChange={(e) => onTitleChange(e.target.value)}
+            disabled={isPreview}
           />
-        )}
-        <InspectorBody registry={registry} tokens={tokens} />
+          {isPreview ? null : <AutosaveStatusPill />}
+          {isPreview ? null : coAuthorIndicator}
+          {revisionsTrigger}
+          {isPreview ? null : isDraftMode ? (
+            <DraftActions draftMode={draftMode} />
+          ) : (
+            <LivePublishButton
+              onPublish={onPublish}
+              isPublishing={isPublishing}
+              isPublished={isPublished}
+            />
+          )}
+        </header>
+        <div
+          className="grid flex-1 grid-cols-[minmax(0,1fr)] overflow-hidden md:grid-cols-[260px_minmax(0,1fr)_320px]"
+          data-testid="plumix-editor-cols"
+        >
+          <BlocksBody registry={registry} capabilities={capabilities} />
+          {isPreview ? (
+            // Puck's `permissions` strips drag / insert / delete / dup /
+            // edit, but Tiptap inside rich-text fields keeps its own
+            // `editable: true`. Cover the canvas with a transparent
+            // overlay so the user can't type into rich-text without
+            // realising preview mode skips autosave.
+            <div
+              className="relative"
+              data-testid="plumix-editor-preview-shield"
+            >
+              <div
+                aria-hidden
+                className="bg-background/0 pointer-events-auto absolute inset-0 z-10"
+              />
+              <div className="pointer-events-none h-full">
+                <PlumixCanvasWithSlashMenu
+                  registry={registry}
+                  capabilities={capabilities}
+                />
+              </div>
+            </div>
+          ) : (
+            <PlumixCanvasWithSlashMenu
+              registry={registry}
+              capabilities={capabilities}
+            />
+          )}
+          <InspectorBody registry={registry} tokens={tokens} />
+        </div>
       </div>
-    </div>
+    </PatternRefProvider>
   );
 }
 
@@ -562,7 +580,7 @@ function PlumixBlocksTab({
       puck.dispatch({
         type: "setData",
         data: (previous) =>
-          insertPatternCopy(previous, pattern.content, previous.content.length),
+          insertPattern(previous, pattern, previous.content.length),
       });
     },
     [puck],

--- a/packages/admin/src/editor/PatternRefPreview.tsx
+++ b/packages/admin/src/editor/PatternRefPreview.tsx
@@ -1,0 +1,114 @@
+import type { ReactElement } from "react";
+import { createContext, useCallback, useContext, useMemo } from "react";
+import { usePuck } from "@puckeditor/core";
+import { Link, Unlink } from "lucide-react";
+
+import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
+import { renderBlockTree } from "@plumix/blocks";
+
+import { detachPatternRef } from "./detach-pattern-ref.js";
+
+interface PatternRefContextValue {
+  readonly patterns: PatternRegistry;
+  readonly blocks: BlockRegistry;
+}
+
+const PatternRefContext = createContext<PatternRefContextValue | null>(null);
+
+export function PatternRefProvider({
+  value,
+  children,
+}: {
+  readonly value: PatternRefContextValue;
+  readonly children: ReactElement;
+}): ReactElement {
+  return (
+    <PatternRefContext.Provider value={value}>
+      {children}
+    </PatternRefContext.Provider>
+  );
+}
+
+interface PatternRefPreviewProps {
+  readonly slug?: string;
+  readonly id?: string;
+}
+
+export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
+  const ctx = useContext(PatternRefContext);
+  const puck = usePuck();
+  const slug = props.slug ?? "";
+  const pattern = ctx?.patterns.get(slug);
+
+  const body = useMemo(() => {
+    if (!pattern || !ctx) return null;
+    return renderBlockTree(pattern.content, ctx.blocks, {
+      patterns: ctx.patterns,
+    });
+  }, [pattern, ctx]);
+
+  const handleDetach = useCallback(() => {
+    if (!ctx) return;
+    puck.dispatch({
+      type: "setData",
+      data: (previous) => {
+        const idx = previous.content.findIndex(
+          (c) =>
+            c.type === "core/pattern-ref" &&
+            (c.props as { id?: string }).id === props.id,
+        );
+        if (idx === -1) return previous;
+        return detachPatternRef(previous, idx, ctx.patterns);
+      },
+    });
+  }, [ctx, puck, props.id]);
+
+  const handleCopySlug = useCallback(() => {
+    void navigator.clipboard.writeText(slug);
+  }, [slug]);
+
+  if (!pattern) {
+    return (
+      <div
+        className="text-muted-foreground rounded border border-dashed p-4 text-sm"
+        data-pattern-ref={slug}
+        data-pattern-ref-state="unresolved"
+        data-testid={`plumix-pattern-ref-unresolved-${slug}`}
+      >
+        Pattern not registered: <code>{slug}</code>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative rounded border-2 border-blue-500/30"
+      data-pattern-ref={slug}
+      data-pattern-ref-state="resolved"
+      data-testid={`plumix-pattern-ref-${slug}`}
+    >
+      <div className="text-foreground flex items-center gap-2 bg-blue-500/10 px-3 py-1 text-xs">
+        <Link className="h-3 w-3" aria-hidden />
+        <span className="flex-1">{pattern.title}</span>
+        <button
+          type="button"
+          onClick={handleCopySlug}
+          className="hover:underline"
+          data-testid="plumix-pattern-ref-copy-slug"
+        >
+          Open source
+        </button>
+        <button
+          type="button"
+          onClick={handleDetach}
+          className="hover:bg-background flex items-center gap-1 rounded px-2 py-0.5"
+          data-testid="plumix-pattern-ref-detach"
+        >
+          <Unlink className="h-3 w-3" aria-hidden />
+          Detach
+        </button>
+      </div>
+      <div className="pointer-events-none p-3">{body}</div>
+    </div>
+  );
+}

--- a/packages/admin/src/editor/admin-pattern-registry.ts
+++ b/packages/admin/src/editor/admin-pattern-registry.ts
@@ -1,0 +1,14 @@
+import type { BlockPattern, PatternRegistry } from "@plumix/blocks";
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+import { createPatternRegistry } from "@plumix/blocks";
+
+// PatternManifestEntry and BlockPattern are structurally identical apart
+// from `category`'s type-level narrowing — the manifest projects the
+// already-frozen body verbatim, so re-running `definePattern` would
+// re-walk the tree pointlessly. We construct the registry directly.
+export function buildAdminPatternRegistry(
+  entries: readonly PatternManifestEntry[],
+): PatternRegistry {
+  const patterns = entries as unknown as readonly BlockPattern[];
+  return createPatternRegistry(patterns);
+}

--- a/packages/admin/src/editor/block-adapter.ts
+++ b/packages/admin/src/editor/block-adapter.ts
@@ -6,6 +6,9 @@ import type { BlockSpec } from "@plumix/blocks";
 import { DEFAULT_BLOCK_CONTEXT } from "@plumix/blocks";
 
 import { translateFields } from "./field-type-translator.js";
+import { PatternRefPreview } from "./PatternRefPreview.js";
+
+const PATTERN_REF_BLOCK = "core/pattern-ref";
 
 interface BlockAdapterOptions {
   readonly richtextExtensions?: Extensions;
@@ -17,6 +20,19 @@ export function blockSpecsToPuckComponents(
 ): Config["components"] {
   const out: Config["components"] = {};
   for (const spec of specs) {
+    if (spec.name === PATTERN_REF_BLOCK) {
+      out[spec.name] = {
+        label: spec.title ?? spec.name,
+        fields: spec.inputs ? translateFields(spec.inputs, options) : {},
+        defaultProps: spec.defaults,
+        render: (props) =>
+          createElement(PatternRefPreview, {
+            slug: (props as { slug?: string }).slug,
+            id: (props as { id?: string }).id,
+          }),
+      };
+      continue;
+    }
     out[spec.name] = {
       label: spec.title ?? spec.name,
       fields: spec.inputs ? translateFields(spec.inputs, options) : {},

--- a/packages/admin/src/editor/detach-pattern-ref.test.ts
+++ b/packages/admin/src/editor/detach-pattern-ref.test.ts
@@ -1,0 +1,101 @@
+import type { Data } from "@puckeditor/core";
+import { describe, expect, test } from "vitest";
+
+import { createPatternRegistry, definePattern } from "@plumix/blocks";
+
+import { detachPatternRef } from "./detach-pattern-ref.js";
+
+const refNode = (id: string, slug: string) => ({
+  type: "core/pattern-ref",
+  props: { id, slug },
+});
+
+const otherNode = (id: string, text: string) => ({
+  type: "core/p",
+  props: { id, text },
+});
+
+const heroPattern = definePattern({
+  name: "starter/hero",
+  title: "Hero",
+  content: [
+    { id: "h-1", name: "core/heading", attrs: { level: 1, text: "Hero" } },
+    { id: "h-2", name: "core/paragraph", attrs: { text: "Lead" } },
+  ],
+});
+
+describe("detachPatternRef", () => {
+  const patterns = createPatternRegistry([heroPattern]);
+
+  test("replaces the ref node at the selected index with the resolved body", () => {
+    const data: Data = {
+      content: [
+        otherNode("a", "before"),
+        refNode("ref-1", "starter/hero"),
+        otherNode("b", "after"),
+      ],
+      root: {},
+    };
+
+    const next = detachPatternRef(data, 1, patterns);
+
+    expect(next.content.map((c) => c.type)).toEqual([
+      "core/p",
+      "core/heading",
+      "core/paragraph",
+      "core/p",
+    ]);
+  });
+
+  test("rewrites ids on the inlined body so two detaches of the same slug do not collide", () => {
+    const data: Data = {
+      content: [
+        refNode("ref-1", "starter/hero"),
+        refNode("ref-2", "starter/hero"),
+      ],
+      root: {},
+    };
+
+    const detachedFirst = detachPatternRef(data, 0, patterns);
+    const detachedBoth = detachPatternRef(detachedFirst, 2, patterns);
+
+    const ids = detachedBoth.content.map(
+      (c) => (c.props as { id?: string }).id,
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("returns the data unchanged when the selected node is not a pattern-ref", () => {
+    const data: Data = {
+      content: [otherNode("a", "plain")],
+      root: {},
+    };
+
+    const next = detachPatternRef(data, 0, patterns);
+
+    expect(next).toBe(data);
+  });
+
+  test("returns the data unchanged when the slug is not registered", () => {
+    const data: Data = {
+      content: [refNode("ref-1", "missing/slug")],
+      root: {},
+    };
+
+    const next = detachPatternRef(data, 0, patterns);
+
+    expect(next).toBe(data);
+  });
+
+  test("does not mutate the input data or content array", () => {
+    const data: Data = {
+      content: [refNode("ref-1", "starter/hero")],
+      root: {},
+    };
+    const snapshot = JSON.stringify(data);
+
+    detachPatternRef(data, 0, patterns);
+
+    expect(JSON.stringify(data)).toBe(snapshot);
+  });
+});

--- a/packages/admin/src/editor/detach-pattern-ref.ts
+++ b/packages/admin/src/editor/detach-pattern-ref.ts
@@ -1,0 +1,27 @@
+import type { Data } from "@puckeditor/core";
+
+import type { PatternRegistry } from "@plumix/blocks";
+import { rewriteBlockNodeIds } from "@plumix/blocks";
+
+import { blockNodesToPuckContent } from "./entry-content.js";
+
+const PATTERN_REF_BLOCK = "core/pattern-ref";
+
+export function detachPatternRef(
+  data: Data,
+  index: number,
+  patterns: PatternRegistry,
+): Data {
+  const target = data.content[index];
+  if (target?.type !== PATTERN_REF_BLOCK) return data;
+  const slug = (target.props as { slug?: unknown }).slug;
+  if (typeof slug !== "string") return data;
+  const pattern = patterns.get(slug);
+  if (!pattern) return data;
+  const expanded = blockNodesToPuckContent(
+    rewriteBlockNodeIds(pattern.content),
+  );
+  const next = [...data.content];
+  next.splice(index, 1, ...expanded);
+  return { ...data, content: next };
+}

--- a/packages/admin/src/editor/insert-pattern.test.ts
+++ b/packages/admin/src/editor/insert-pattern.test.ts
@@ -2,8 +2,13 @@ import type { Data } from "@puckeditor/core";
 import { describe, expect, test } from "vitest";
 
 import type { BlockNode } from "@plumix/blocks";
+import type { PatternManifestEntry } from "@plumix/core/manifest";
 
-import { insertPatternCopy } from "./insert-pattern.js";
+import {
+  insertPattern,
+  insertPatternCopy,
+  insertPatternReference,
+} from "./insert-pattern.js";
 
 const blank: Data = { content: [], root: {} };
 
@@ -74,5 +79,76 @@ describe("insertPatternCopy", () => {
 
     expect(next.root).toEqual({ props: { title: "Page" } });
     expect(existing.content).toHaveLength(1);
+  });
+});
+
+describe("insertPatternReference", () => {
+  test("splices a single core/pattern-ref node carrying the target slug", () => {
+    const next = insertPatternReference(blank, "starter/hero", 0);
+
+    expect(next.content).toHaveLength(1);
+    const node = next.content[0];
+    expect(node?.type).toBe("core/pattern-ref");
+    expect((node?.props as { slug?: unknown }).slug).toBe("starter/hero");
+  });
+
+  test("produces a fresh id on every call (two refs to the same slug do not collide)", () => {
+    const first = insertPatternReference(blank, "starter/hero", 0);
+    const second = insertPatternReference(blank, "starter/hero", 0);
+
+    const firstId = (first.content[0]?.props as { id?: unknown }).id;
+    const secondId = (second.content[0]?.props as { id?: unknown }).id;
+    expect(typeof firstId).toBe("string");
+    expect(typeof secondId).toBe("string");
+    expect(firstId).not.toBe(secondId);
+  });
+
+  test("splices into the middle of existing content without mutating input", () => {
+    const existing: Data = {
+      content: [
+        { type: "core/p", props: { id: "a", text: "before" } },
+        { type: "core/p", props: { id: "b", text: "after" } },
+      ],
+      root: {},
+    };
+
+    const next = insertPatternReference(existing, "starter/hero", 1);
+
+    expect(next.content.map((c) => c.type)).toEqual([
+      "core/p",
+      "core/pattern-ref",
+      "core/p",
+    ]);
+    expect(existing.content).toHaveLength(2);
+  });
+});
+
+describe("insertPattern (mode dispatcher)", () => {
+  const copyPattern: PatternManifestEntry = {
+    name: "starter/hero",
+    title: "Hero",
+    insert: "copy",
+    content: [heading("p1", "Hello")],
+  };
+
+  const refPattern: PatternManifestEntry = {
+    name: "starter/footer",
+    title: "Footer",
+    insert: "reference",
+    content: [heading("p1", "Should not be inlined")],
+  };
+
+  test("copy mode splices the inlined body", () => {
+    const next = insertPattern(blank, copyPattern, 0);
+    expect(next.content[0]?.type).toBe("core/heading");
+  });
+
+  test("reference mode splices a single core/pattern-ref carrying the slug", () => {
+    const next = insertPattern(blank, refPattern, 0);
+    expect(next.content).toHaveLength(1);
+    expect(next.content[0]?.type).toBe("core/pattern-ref");
+    expect((next.content[0]?.props as { slug?: unknown }).slug).toBe(
+      "starter/footer",
+    );
   });
 });

--- a/packages/admin/src/editor/insert-pattern.ts
+++ b/packages/admin/src/editor/insert-pattern.ts
@@ -1,9 +1,24 @@
 import type { Data } from "@puckeditor/core";
 
 import type { BlockNode } from "@plumix/blocks";
+import type { PatternManifestEntry } from "@plumix/core/manifest";
 import { rewriteBlockNodeIds } from "@plumix/blocks";
 
 import { blockNodesToPuckContent } from "./entry-content.js";
+
+const PATTERN_REF_BLOCK = "core/pattern-ref";
+
+export function insertPattern(
+  data: Data,
+  pattern: PatternManifestEntry,
+  destinationIndex: number,
+): Data {
+  // Default to copy when the manifest entry doesn't carry an explicit
+  // insert mode (older payloads, hand-written test fixtures).
+  return pattern.insert === "reference"
+    ? insertPatternReference(data, pattern.name, destinationIndex)
+    : insertPatternCopy(data, pattern.content, destinationIndex);
+}
 
 export function insertPatternCopy(
   data: Data,
@@ -13,5 +28,21 @@ export function insertPatternCopy(
   const puckContent = blockNodesToPuckContent(rewriteBlockNodeIds(content));
   const next = [...data.content];
   next.splice(destinationIndex, 0, ...puckContent);
+  return { ...data, content: next };
+}
+
+export function insertPatternReference(
+  data: Data,
+  slug: string,
+  destinationIndex: number,
+): Data {
+  const refNode: BlockNode = {
+    id: "",
+    name: PATTERN_REF_BLOCK,
+    attrs: { slug },
+  };
+  const [puckRef] = blockNodesToPuckContent(rewriteBlockNodeIds([refNode]));
+  const next = [...data.content];
+  if (puckRef) next.splice(destinationIndex, 0, puckRef);
   return { ...data, content: next };
 }

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -3,6 +3,7 @@ import type { Config, Data } from "@puckeditor/core";
 import type { ReactElement, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PlainFormLayout } from "@/components/editor/plain-form-layout.js";
+import { buildAdminPatternRegistry } from "@/editor/admin-pattern-registry.js";
 import { AutosaveStatusContext } from "@/editor/AutosaveStatus.js";
 import { blockSpecsToPuckComponents } from "@/editor/block-adapter.js";
 import { CoAuthorIndicator } from "@/editor/CoAuthorIndicator.js";
@@ -20,6 +21,7 @@ import { StaleDraftDialog } from "@/editor/StaleDraftDialog.js";
 import {
   entryMetaBoxesForType,
   findEntryTypeBySlug,
+  getPatterns,
   getThemeTokens,
 } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
@@ -73,6 +75,7 @@ const themeTokens = getThemeTokens();
 registerCoreBlocks();
 const runtimeBlocks = getRegisteredBlocks();
 const registry = createBlockRegistry(runtimeBlocks);
+const patternRegistry = buildAdminPatternRegistry(getPatterns());
 const config: Config = {
   components: blockSpecsToPuckComponents(runtimeBlocks, {
     // Puck types `extensions` as a mutable array; spread the readonly
@@ -563,6 +566,7 @@ function PuckSpikeRouteInner({
     (): ReactElement => (
       <PlumixEditorLayout
         registry={registry}
+        patternRegistry={patternRegistry}
         capabilities={capabilitySet}
         tokens={themeTokens}
         title={title}
@@ -736,6 +740,7 @@ function PuckPreviewRouteInner({
     (): ReactElement => (
       <PlumixEditorLayout
         registry={registry}
+        patternRegistry={patternRegistry}
         capabilities={capabilitySet}
         tokens={themeTokens}
         title={revision.title}

--- a/packages/blocks/src/core-blocks.test.ts
+++ b/packages/blocks/src/core-blocks.test.ts
@@ -81,6 +81,7 @@ describe("coreBlocks", () => {
       "core/table-body-row",
       "core/table-header-cell",
       "core/table-cell",
+      "core/pattern-ref",
     ]);
 
     for (const spec of coreBlocks) {
@@ -95,5 +96,12 @@ describe("coreBlocks", () => {
       coreBlocks.filter((s) => s.inserter === false).map((s) => s.name),
     );
     expect(hidden).toEqual(contentOnlyNames);
+  });
+
+  test("registers core/pattern-ref with a `slug` input declared", () => {
+    const ref = coreBlocks.find((b) => b.name === "core/pattern-ref");
+    expect(ref).toBeDefined();
+    expect(ref?.inserter).toBe(false);
+    expect(ref?.inputs?.map((i) => i.name)).toEqual(["slug"]);
   });
 });

--- a/packages/blocks/src/core-blocks.ts
+++ b/packages/blocks/src/core-blocks.ts
@@ -7,6 +7,7 @@ import { columnsBlock } from "./columns/index.js";
 import { detailsBlock } from "./details/index.js";
 import { groupBlock } from "./group/index.js";
 import { headingBlock } from "./heading/index.js";
+import { patternRefBlock } from "./pattern-ref/index.js";
 import { quoteBlock } from "./quote/index.js";
 import { richTextBlock } from "./rich-text/index.js";
 import { separatorBlock } from "./separator/index.js";
@@ -37,4 +38,5 @@ export const coreBlocks: readonly BlockSpec[] = Object.freeze([
   tableBodyRowBlock,
   tableHeaderCellBlock,
   tableCellBlock,
+  patternRefBlock,
 ]);

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -71,6 +71,7 @@ export type {
   BlockPattern,
   BlockTypeRegistry,
   PatternCategoryRegistry,
+  PatternInsertMode,
   PatternRegistry,
 } from "./pattern-registry.js";
 export { PatternRegistryError } from "./pattern-errors.js";

--- a/packages/blocks/src/pattern-errors.ts
+++ b/packages/blocks/src/pattern-errors.ts
@@ -31,4 +31,14 @@ export class PatternRegistryError extends Error {
       `Pattern "${patternName}" at ${path} uses undeclared attr "${attrKey}" on block "${blockName}".`,
     );
   }
+
+  static unresolvedRef(
+    patternName: string,
+    path: string,
+    targetSlug: string,
+  ): PatternRegistryError {
+    return new PatternRegistryError(
+      `Pattern "${patternName}" at ${path} references unregistered pattern "${targetSlug}".`,
+    );
+  }
 }

--- a/packages/blocks/src/pattern-ref/index.tsx
+++ b/packages/blocks/src/pattern-ref/index.tsx
@@ -1,0 +1,13 @@
+import { defineBlock } from "../block-registry.js";
+
+// Reference to a registered pattern. Walker special-cases this name
+// and renders the resolved body; this spec exists so the registry
+// recognises the block and the admin's Puck adapter has a target to
+// map. Render returns nothing because walker resolution overrides it.
+export const patternRefBlock = defineBlock({
+  name: "core/pattern-ref",
+  title: "Pattern reference",
+  inserter: false,
+  inputs: [{ name: "slug", type: "text", label: "Slug" }],
+  render: () => null,
+});

--- a/packages/blocks/src/pattern-registry.test.ts
+++ b/packages/blocks/src/pattern-registry.test.ts
@@ -55,6 +55,24 @@ describe("definePattern", () => {
     expect(pattern.content.map((n) => n.id)).toEqual(["p1", "p2"]);
   });
 
+  test("preserves the insert mode field — copy + reference both round-trip", () => {
+    const copy = definePattern({
+      name: "x/copy",
+      title: "C",
+      content: [],
+      insert: "copy",
+    });
+    const ref = definePattern({
+      name: "x/ref",
+      title: "R",
+      content: [],
+      insert: "reference",
+    });
+
+    expect(copy.insert).toBe("copy");
+    expect(ref.insert).toBe("reference");
+  });
+
   test("typed category registry accepts seeded defaults and augmented categories", () => {
     // Seeded default categories compile.
     definePattern({ name: "x/a", title: "A", category: "hero", content: [] });
@@ -200,5 +218,48 @@ describe("commitPatterns", () => {
     expect(() => commitPatterns(patterns, strictBlocks)).toThrow(
       /starter\/attrs-mismatch.*garbage/,
     );
+  });
+
+  test("throws when a pattern body references an unregistered pattern via core/pattern-ref", () => {
+    const ref = defineBlock({
+      name: "core/pattern-ref",
+      inserter: false,
+      inputs: [{ name: "slug", type: "text" }],
+      render: () => null,
+    });
+    const refBlocks = createBlockRegistry([ref]);
+    const wrapper = definePattern({
+      name: "starter/wrapper",
+      title: "Wrapper",
+      content: [block("core/pattern-ref", { slug: "starter/missing" })],
+    });
+    const patterns = createPatternRegistry([wrapper]);
+
+    expect(() => commitPatterns(patterns, refBlocks)).toThrow(
+      /starter\/wrapper.*starter\/missing/,
+    );
+  });
+
+  test("accepts pattern bodies whose pattern-ref targets ARE registered", () => {
+    const ref = defineBlock({
+      name: "core/pattern-ref",
+      inserter: false,
+      inputs: [{ name: "slug", type: "text" }],
+      render: () => null,
+    });
+    const refBlocks = createBlockRegistry([ref]);
+    const target = definePattern({
+      name: "starter/target",
+      title: "Target",
+      content: [],
+    });
+    const wrapper = definePattern({
+      name: "starter/wrapper-ok",
+      title: "Wrapper",
+      content: [block("core/pattern-ref", { slug: "starter/target" })],
+    });
+    const patterns = createPatternRegistry([target, wrapper]);
+
+    expect(() => commitPatterns(patterns, refBlocks)).not.toThrow();
   });
 });

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -36,10 +36,16 @@ type AttrsFor<TName extends string> = TName extends keyof BlockTypeRegistry
   ? BlockTypeRegistry[TName]
   : Readonly<Record<string, unknown>>;
 
+export type PatternInsertMode = "copy" | "reference";
+
 export interface BlockPattern {
   readonly name: string;
   readonly title: string;
   readonly category?: keyof PatternCategoryRegistry;
+  // Defaults to "copy" when unset — the inserter splices a deep-cloned
+  // body. "reference" inserts a single `core/pattern-ref` node the
+  // walker resolves at render.
+  readonly insert?: PatternInsertMode;
   readonly content: readonly BlockNode[];
 }
 
@@ -112,6 +118,8 @@ export function createPatternRegistry(
   });
 }
 
+const PATTERN_REF_BLOCK_NAME = "core/pattern-ref";
+
 export function commitPatterns(
   patterns: PatternRegistry,
   blocks: BlockRegistry,
@@ -130,8 +138,32 @@ export function commitPatterns(
       );
     }
     validateAttrs(pattern.name, pattern.content, "blocks", blocks);
+    validatePatternRefs(pattern.name, pattern.content, "blocks", patterns);
   }
   return patterns;
+}
+
+function validatePatternRefs(
+  patternName: string,
+  nodes: readonly BlockNode[],
+  basePath: string,
+  patterns: PatternRegistry,
+): void {
+  nodes.forEach((node, i) => {
+    const path = `${basePath}[${i}]`;
+    if (node.name === PATTERN_REF_BLOCK_NAME) {
+      const slug = node.attrs?.slug;
+      if (typeof slug === "string" && !patterns.has(slug)) {
+        throw PatternRegistryError.unresolvedRef(patternName, path, slug);
+      }
+      return;
+    }
+    for (const [key, value] of Object.entries(node.attrs ?? {})) {
+      if (isBlockNodeArray(value)) {
+        validatePatternRefs(patternName, value, `${path}.${key}`, patterns);
+      }
+    }
+  });
 }
 
 function validateAttrs(

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import type { ResolvedBlockLoaders } from "./loaders.js";
 import type { BlockContext, BlockNode } from "./render-block-tree.js";
 import { createBlockRegistry } from "./block-registry.js";
+import { createPatternRegistry, definePattern } from "./pattern-registry.js";
 import { renderBlockTree } from "./render-block-tree.js";
 
 function withProductionEnv<T>(fn: () => T): T {
@@ -603,6 +604,112 @@ describe("renderBlockTree", () => {
 
       expect(html).toBe("");
       expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("core/pattern-ref resolution", () => {
+    const refRegistry = createBlockRegistry([
+      {
+        name: "core/pattern-ref",
+        inserter: false,
+        render: () => null,
+      },
+      {
+        name: "core/heading",
+        render: ({ attrs }) =>
+          createElement("h1", null, (attrs as { text: string }).text),
+      },
+    ]);
+
+    test("resolves a known slug to the registered pattern's content", () => {
+      const patterns = createPatternRegistry([
+        definePattern({
+          name: "starter/hero",
+          title: "Hero",
+          content: [
+            { id: "h-1", name: "core/heading", attrs: { text: "Resolved" } },
+          ],
+        }),
+      ]);
+      const tree: readonly BlockNode[] = [
+        {
+          id: "ref-1",
+          name: "core/pattern-ref",
+          attrs: { slug: "starter/hero" },
+        },
+      ];
+
+      const html = renderToStaticMarkup(
+        renderBlockTree(tree, refRegistry, { patterns }),
+      );
+
+      expect(html).toContain("Resolved");
+    });
+
+    test("dev: unknown slug renders a placeholder + logs a console.warn naming the slug", () => {
+      const patterns = createPatternRegistry([]);
+      const tree: readonly BlockNode[] = [
+        {
+          id: "ref-1",
+          name: "core/pattern-ref",
+          attrs: { slug: "nope/missing" },
+        },
+      ];
+      const warn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      const html = renderToStaticMarkup(
+        renderBlockTree(tree, refRegistry, { patterns }),
+      );
+
+      expect(html).toContain("data-plumix-unresolved-pattern-ref");
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("nope/missing"),
+      );
+      warn.mockRestore();
+    });
+
+    test("prod: unknown slug renders nothing (no DOM, still a console.warn)", () => {
+      // Distinct slug so the once-per-registry de-dup of the dev-mode
+      // test above doesn't suppress this assertion.
+      const patterns = createPatternRegistry([]);
+      const tree: readonly BlockNode[] = [
+        {
+          id: "ref-1",
+          name: "core/pattern-ref",
+          attrs: { slug: "nope/prod-missing" },
+        },
+      ];
+      const warn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      const html = withProductionEnv(() =>
+        renderToStaticMarkup(renderBlockTree(tree, refRegistry, { patterns })),
+      );
+
+      expect(html).toBe("");
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("nope/prod-missing"),
+      );
+      warn.mockRestore();
+    });
+
+    test("renders nothing for a ref when no pattern registry is supplied", () => {
+      const tree: readonly BlockNode[] = [
+        {
+          id: "ref-1",
+          name: "core/pattern-ref",
+          attrs: { slug: "anything" },
+        },
+      ];
+
+      const html = withProductionEnv(() =>
+        renderToStaticMarkup(renderBlockTree(tree, refRegistry)),
+      );
+
+      expect(html).toBe("");
     });
   });
 });

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -7,9 +7,12 @@ import type {
   ResolvedBlockLoaders,
   ResolvedLoaders,
 } from "./loaders.js";
+import type { PatternRegistry } from "./pattern-registry.js";
 import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
 import type { ThemeTokens } from "./styles/types.js";
 import { emitBlockStyleCss } from "./styles/style-emitter.js";
+
+const PATTERN_REF_BLOCK = "core/pattern-ref";
 
 /**
  * Threaded through `renderBlockTree` recursion. Block components introspect
@@ -52,6 +55,7 @@ export interface RenderBlockTreeOptions {
   readonly tokens?: ThemeTokens;
   readonly hooks?: BlockRenderHooks;
   readonly loaderData?: ResolvedBlockLoaders;
+  readonly patterns?: PatternRegistry;
 }
 
 export interface BlockNodeRenderProps<
@@ -143,6 +147,7 @@ interface WalkerEnv {
   readonly tokens: ThemeTokens | undefined;
   readonly hooks: BlockRenderHooks | undefined;
   readonly loaderData: ResolvedBlockLoaders | undefined;
+  readonly patterns: PatternRegistry | undefined;
 }
 
 function renderNodes(
@@ -164,6 +169,9 @@ function renderNode(
   context: BlockContext,
 ): ReactNode {
   const { registry, devState, tokens, loaderData } = env;
+  if (node.name === PATTERN_REF_BLOCK) {
+    return renderPatternRef(node, env, context);
+  }
   const spec = registry.get(node.name);
   if (!spec) {
     return createElement(
@@ -217,6 +225,42 @@ function renderNode(
 
 const EMPTY_LOADERS: Readonly<Record<string, unknown>> = Object.freeze({});
 
+function renderPatternRef(
+  node: BlockNode,
+  env: WalkerEnv,
+  context: BlockContext,
+): ReactNode {
+  const slug = typeof node.attrs?.slug === "string" ? node.attrs.slug : "";
+  const resolved = env.patterns?.get(slug);
+  if (resolved) {
+    return createElement(
+      Fragment,
+      { key: node.id },
+      renderNodes(resolved.content, env, context),
+    );
+  }
+  return createElement(
+    Fragment,
+    { key: node.id },
+    renderUnresolvedPatternRef(slug, env.devState),
+  );
+}
+
+function renderUnresolvedPatternRef(
+  slug: string,
+  devState: DevWarnState,
+): ReactNode {
+  const key = `pattern-ref:${slug}`;
+  if (!devState.seen.has(key)) {
+    devState.seen.add(key);
+    console.warn(`[plumix:blocks] Unresolved pattern reference: ${slug}`);
+  }
+  if (!isDevMode()) return null;
+  return createElement("template", {
+    "data-plumix-unresolved-pattern-ref": slug,
+  });
+}
+
 export function renderBlockTree(
   nodes: readonly BlockNode[],
   registry: BlockRegistry,
@@ -228,6 +272,7 @@ export function renderBlockTree(
     tokens: options?.tokens,
     hooks: options?.hooks,
     loaderData: options?.loaderData,
+    patterns: options?.patterns,
   };
   return renderNodes(nodes, env, DEFAULT_BLOCK_CONTEXT);
 }

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -1373,4 +1373,32 @@ describe("buildManifest visibility projection", () => {
       title: "Zeta",
     });
   });
+
+  test("projects pattern insert mode through the manifest, defaulting to copy", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerPattern({
+        name: "acme/hero",
+        title: "Hero",
+        content: [],
+        // insert omitted — defaults to copy
+      });
+      ctx.registerPattern({
+        name: "acme/footer",
+        title: "Footer",
+        content: [],
+        insert: "reference",
+      });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+
+    expect(manifest.patterns.find((p) => p.name === "acme/hero")?.insert).toBe(
+      "copy",
+    );
+    expect(
+      manifest.patterns.find((p) => p.name === "acme/footer")?.insert,
+    ).toBe("reference");
+  });
 });

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -4,6 +4,7 @@ import type {
   BlockSpec,
   BlockVariation,
   MarkSpec,
+  PatternInsertMode,
   ThemeTokens,
 } from "@plumix/blocks";
 
@@ -1452,6 +1453,10 @@ export interface PatternManifestEntry {
   readonly name: string;
   readonly title: string;
   readonly category?: string;
+  // `buildManifest` always populates this with the spec's value or
+  // `"copy"`; consumers that read raw manifest fixtures may still see
+  // `undefined`.
+  readonly insert?: PatternInsertMode;
   readonly content: readonly BlockNode[];
 }
 
@@ -2249,8 +2254,8 @@ function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
 }
 
 function toPatternEntry(pattern: RegisteredPattern): PatternManifestEntry {
-  const { name, title, category, content } = pattern.spec;
-  return { name, title, category, content };
+  const { name, title, category, content, insert } = pattern.spec;
+  return { name, title, category, insert: insert ?? "copy", content };
 }
 
 function toMarkEntry(mark: RegisteredMark): MarkManifestEntry {


### PR DESCRIPTION
Adds reference-mode patterns to the Puck editor. `definePattern({ insert: "reference" })` makes a pattern insert as a single `core/pattern-ref` node instead of an inlined body. The walker resolves refs at SSR, the Puck adapter renders a live preview wrapped with a Detach toolbar, and the commit phase rejects pattern bodies that reference unregistered slugs.

**Walker resolution**

`RenderBlockTreeOptions.patterns` (a `PatternRegistry`) is consumed by a new branch in `renderNode` for `core/pattern-ref`. Resolved slugs render the pattern's body recursively in the same walker pass; unresolved slugs emit a dev placeholder + `console.warn` and render nothing in production, mirroring the existing `renderUnknown` contract.

**Commit phase**

A second pre-flight (`validatePatternRefs`) walks each pattern's body, finds every `core/pattern-ref` node, and throws a `PatternRegistryError.unresolvedRef(parent, path, missingSlug)` when the target isn't registered. Inline expansion of pattern-includes-pattern composition is deferred to #630; this slice gates the unsafe state.

**Editor surface**

`PatternRefPreview` is a Puck component (registered via a special case in `blockSpecsToPuckComponents`) that resolves the slug against a React context-provided `PatternRegistry` and renders the body through `renderBlockTree`. The header carries `Open source` (clipboard-copies the slug) and `Detach`. Detach is a pure data transform (`detachPatternRef(data, index, patterns)`) that looks up the body, runs the shared `rewriteBlockNodeIds`, and splices in place of the ref. The admin builds the in-memory pattern registry once at module load from `manifest.patterns`.

**Sidebar dispatch**

`PatternsSection.onSelect` now flows through a unified `insertPattern` dispatcher that reads `pattern.insert` and routes to either `insertPatternCopy` (existing) or `insertPatternReference` (new). The manifest field defaults to `"copy"` so existing fixtures keep working.

Refs #625
Refs #627