### PR TITLE
feat: pattern-includes-pattern composition + cycle detection

### DIFF
--- a/packages/blocks/src/pattern-errors.ts
+++ b/packages/blocks/src/pattern-errors.ts
@@ -41,4 +41,10 @@ export class PatternRegistryError extends Error {
       `Pattern "${patternName}" at ${path} references unregistered pattern "${targetSlug}".`,
     );
   }
+
+  static cycle(chain: readonly string[]): PatternRegistryError {
+    return new PatternRegistryError(
+      `Pattern reference cycle: ${chain.join(" → ")}.`,
+    );
+  }
 }

--- a/packages/blocks/src/pattern-registry.test.ts
+++ b/packages/blocks/src/pattern-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 
+import type { BlockNode } from "./render-block-tree.js";
 import { createBlockRegistry, defineBlock } from "./block-registry.js";
 import {
   block,
@@ -261,5 +262,129 @@ describe("commitPatterns", () => {
     const patterns = createPatternRegistry([target, wrapper]);
 
     expect(() => commitPatterns(patterns, refBlocks)).not.toThrow();
+  });
+
+  test("throws on a pattern-ref cycle, naming the full chain of involved slugs", () => {
+    const ref = defineBlock({
+      name: "core/pattern-ref",
+      inserter: false,
+      inputs: [{ name: "slug", type: "text" }],
+      render: () => null,
+    });
+    const refBlocks = createBlockRegistry([ref]);
+    const a = definePattern({
+      name: "starter/a",
+      title: "A",
+      content: [block("core/pattern-ref", { slug: "starter/b" })],
+    });
+    const b = definePattern({
+      name: "starter/b",
+      title: "B",
+      content: [block("core/pattern-ref", { slug: "starter/c" })],
+    });
+    const c = definePattern({
+      name: "starter/c",
+      title: "C",
+      content: [block("core/pattern-ref", { slug: "starter/a" })],
+    });
+    const patterns = createPatternRegistry([a, b, c]);
+
+    expect(() => commitPatterns(patterns, refBlocks)).toThrow(
+      /starter\/a.*starter\/b.*starter\/c.*starter\/a/,
+    );
+  });
+
+  test("inlines core/pattern-ref nodes inside pattern bodies — resolved registry contains no refs", () => {
+    const ref = defineBlock({
+      name: "core/pattern-ref",
+      inserter: false,
+      inputs: [{ name: "slug", type: "text" }],
+      render: () => null,
+    });
+    const heading = defineBlock({
+      name: "core/heading",
+      inputs: [{ name: "text", type: "text" }],
+      render: () => null,
+    });
+    const refBlocks = createBlockRegistry([ref, heading]);
+    const inner = definePattern({
+      name: "starter/inner",
+      title: "Inner",
+      content: [block("core/heading", { text: "From inner" })],
+    });
+    const outer = definePattern({
+      name: "starter/outer",
+      title: "Outer",
+      content: [
+        block("core/heading", { text: "Outer top" }),
+        block("core/pattern-ref", { slug: "starter/inner" }),
+        block("core/heading", { text: "Outer bottom" }),
+      ],
+    });
+    const patterns = createPatternRegistry([inner, outer]);
+
+    const resolved = commitPatterns(patterns, refBlocks);
+    const resolvedOuter = resolved.get("starter/outer");
+
+    expect(resolvedOuter?.content.map((n) => n.name)).toEqual([
+      "core/heading",
+      "core/heading",
+      "core/heading",
+    ]);
+    const texts = resolvedOuter?.content.map((n) => n.attrs?.text);
+    expect(texts).toEqual(["Outer top", "From inner", "Outer bottom"]);
+  });
+
+  test("post-commit invariant: no pattern body contains a core/pattern-ref node at any depth", () => {
+    const ref = defineBlock({
+      name: "core/pattern-ref",
+      inserter: false,
+      inputs: [{ name: "slug", type: "text" }],
+      render: () => null,
+    });
+    const group = defineBlock({
+      name: "core/group",
+      inputs: [{ name: "content", type: "slot" }],
+      render: () => null,
+    });
+    const heading = defineBlock({
+      name: "core/heading",
+      inputs: [{ name: "text", type: "text" }],
+      render: () => null,
+    });
+    const refBlocks = createBlockRegistry([ref, group, heading]);
+    const inner = definePattern({
+      name: "starter/inner",
+      title: "Inner",
+      content: [block("core/heading", { text: "Inner" })],
+    });
+    const outer = definePattern({
+      name: "starter/outer-nested",
+      title: "Outer",
+      content: [
+        block("core/group", {
+          content: [block("core/pattern-ref", { slug: "starter/inner" })],
+        }),
+      ],
+    });
+    const patterns = createPatternRegistry([inner, outer]);
+
+    const resolved = commitPatterns(patterns, refBlocks);
+
+    function containsRef(nodes: readonly BlockNode[]): boolean {
+      for (const node of nodes) {
+        if (node.name === "core/pattern-ref") return true;
+        for (const value of Object.values(node.attrs ?? {})) {
+          if (Array.isArray(value) && containsRef(value as BlockNode[])) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    for (const pattern of resolved) {
+      expect(containsRef(pattern.content)).toBe(false);
+    }
   });
 });

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -140,7 +140,76 @@ export function commitPatterns(
     validateAttrs(pattern.name, pattern.content, "blocks", blocks);
     validatePatternRefs(pattern.name, pattern.content, "blocks", patterns);
   }
-  return patterns;
+  // Phase 2: walk every pattern body and inline-expand core/pattern-ref
+  // nodes so the resolved registry is flat — the entry-level walker
+  // never recurses into pattern-body refs at render. Per-host stacks
+  // catch ref cycles with the full chain.
+  const resolved: BlockPattern[] = [];
+  for (const pattern of patterns) {
+    const inlined = inlinePatternRefs(pattern.content, patterns, [
+      pattern.name,
+    ]);
+    resolved.push(
+      inlined === pattern.content
+        ? pattern
+        : Object.freeze({ ...pattern, content: inlined }),
+    );
+  }
+  return createPatternRegistry(resolved);
+}
+
+function inlinePatternRefs(
+  nodes: readonly BlockNode[],
+  patterns: PatternRegistry,
+  chain: readonly string[],
+): readonly BlockNode[] {
+  let changed = false;
+  const out: BlockNode[] = [];
+  for (const node of nodes) {
+    if (node.name === PATTERN_REF_BLOCK_NAME) {
+      const slug = node.attrs?.slug;
+      const target = typeof slug === "string" ? patterns.get(slug) : undefined;
+      if (target) {
+        if (chain.includes(target.name)) {
+          throw PatternRegistryError.cycle([...chain, target.name]);
+        }
+        const expanded = inlinePatternRefs(target.content, patterns, [
+          ...chain,
+          target.name,
+        ]);
+        out.push(...expanded);
+        changed = true;
+        continue;
+      }
+    }
+    const nextAttrs = inlineRefsInAttrs(node.attrs, patterns, chain);
+    if (nextAttrs !== node.attrs) {
+      out.push({ ...node, attrs: nextAttrs });
+      changed = true;
+    } else {
+      out.push(node);
+    }
+  }
+  return changed ? out : nodes;
+}
+
+function inlineRefsInAttrs(
+  attrs: Readonly<Record<string, unknown>> | undefined,
+  patterns: PatternRegistry,
+  chain: readonly string[],
+): Readonly<Record<string, unknown>> | undefined {
+  if (!attrs) return attrs;
+  let mutated: Record<string, unknown> | undefined;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (isBlockNodeArray(value)) {
+      const next = inlinePatternRefs(value, patterns, chain);
+      if (next !== value) {
+        mutated ??= { ...attrs };
+        mutated[key] = next;
+      }
+    }
+  }
+  return mutated ?? attrs;
 }
 
 function validatePatternRefs(


### PR DESCRIPTION
Adds Phase 2 of the boot-time commit. After per-pattern validation, `commitPatterns` walks every pattern body, inline-expands every `core/pattern-ref` node, and returns a new `PatternRegistry` whose bodies contain no refs. Pattern-includes-pattern composition (TT5's `<!-- wp:pattern -->`) now works natively in code; the SSR walker never recurses into pattern-body refs at render.

**Inlining + cycle guard**

A per-host chain accumulates as the walker descends through refs. When a ref's target is already on the chain, `PatternRegistryError.cycle(chain)` throws at boot with the full path (`A → B → C → A`). Refs nested inside slot attrs recurse correctly. The post-commit invariant — that no pattern body, at any depth, contains a `core/pattern-ref` node — is asserted explicitly.

**Walker behavior unchanged**

Entry-level refs (a `core/pattern-ref` persisted in `entry.content`) still resolve at render via the single-level lookup from #641. After this slice, that lookup is guaranteed to land in a flat tree by construction — SSR cost stays O(1) per ref node.

Refs #625
Refs #630