### PR TITLE
fix(blocks): reject malformed core/pattern-ref slugs at commit time

### DIFF
--- a/packages/blocks/src/pattern-errors.ts
+++ b/packages/blocks/src/pattern-errors.ts
@@ -47,4 +47,10 @@ export class PatternRegistryError extends Error {
       `Pattern reference cycle: ${chain.join(" → ")}.`,
     );
   }
+
+  static malformedRef(patternName: string, path: string): PatternRegistryError {
+    return new PatternRegistryError(
+      `Pattern "${patternName}" at ${path} has a core/pattern-ref node with a missing or non-string slug.`,
+    );
+  }
 }

--- a/packages/blocks/src/pattern-registry.test.ts
+++ b/packages/blocks/src/pattern-registry.test.ts
@@ -264,6 +264,26 @@ describe("commitPatterns", () => {
     expect(() => commitPatterns(patterns, refBlocks)).not.toThrow();
   });
 
+  test("throws on a malformed core/pattern-ref (missing or non-string slug)", () => {
+    const ref = defineBlock({
+      name: "core/pattern-ref",
+      inserter: false,
+      inputs: [{ name: "slug", type: "text" }],
+      render: () => null,
+    });
+    const refBlocks = createBlockRegistry([ref]);
+    const broken = definePattern({
+      name: "starter/broken-ref",
+      title: "Broken",
+      content: [block("core/pattern-ref", { slug: 123 })],
+    });
+    const patterns = createPatternRegistry([broken]);
+
+    expect(() => commitPatterns(patterns, refBlocks)).toThrow(
+      /starter\/broken-ref.*missing or non-string slug/,
+    );
+  });
+
   test("throws on a pattern-ref cycle, naming the full chain of involved slugs", () => {
     const ref = defineBlock({
       name: "core/pattern-ref",

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -222,7 +222,13 @@ function validatePatternRefs(
     const path = `${basePath}[${i}]`;
     if (node.name === PATTERN_REF_BLOCK_NAME) {
       const slug = node.attrs?.slug;
-      if (typeof slug === "string" && !patterns.has(slug)) {
+      // Strict gate keeps the Phase-2 invariant honest: a ref the
+      // inliner can't substitute would otherwise survive into the
+      // resolved registry as a dangling node.
+      if (typeof slug !== "string" || slug.length === 0) {
+        throw PatternRegistryError.malformedRef(patternName, path);
+      }
+      if (!patterns.has(slug)) {
         throw PatternRegistryError.unresolvedRef(patternName, path, slug);
       }
       return;


### PR DESCRIPTION
Catch-up review on #642 surfaced that `validatePatternRefs` only fired the unresolved-ref error when `typeof slug === "string"`. A `core/pattern-ref` node with a missing, empty, or non-string `slug` attr silently passed validation AND fell through `inlinePatternRefs` (the `target` lookup returned `undefined`, the node fell to the "keep as-is" branch), leaving a dangling ref in the resolved registry — breaking the Phase-2 invariant that no pattern body contains a `core/pattern-ref` at any depth.

**Strict gate at validation**

The validator now throws `PatternRegistryError.malformedRef(patternName, path)` when the `slug` attr is missing, an empty string, or not a string. The unresolved-ref check still runs after for correctly-typed slugs that point at unregistered patterns.

Refs #625
Refs #630