### PR TITLE
feat: live thumbnail render + lazy mount + preview override for patterns

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -437,7 +437,11 @@ export function PlumixEditorLayout({
           className="grid flex-1 grid-cols-[minmax(0,1fr)] overflow-hidden md:grid-cols-[260px_minmax(0,1fr)_320px]"
           data-testid="plumix-editor-cols"
         >
-          <BlocksBody registry={registry} capabilities={capabilities} />
+          <BlocksBody
+            registry={registry}
+            patternRegistry={patternRegistry}
+            capabilities={capabilities}
+          />
           {isPreview ? (
             // Puck's `permissions` strips drag / insert / delete / dup /
             // edit, but Tiptap inside rich-text fields keeps its own
@@ -474,10 +478,15 @@ export function PlumixEditorLayout({
 
 interface BlocksBodyProps {
   readonly registry: BlockRegistry;
+  readonly patternRegistry: PatternRegistry;
   readonly capabilities: ReadonlySet<string>;
 }
 
-function BlocksBody({ registry, capabilities }: BlocksBodyProps): ReactElement {
+function BlocksBody({
+  registry,
+  patternRegistry,
+  capabilities,
+}: BlocksBodyProps): ReactElement {
   const isMobile = useIsMobile();
   const content = (
     <Tabs defaultValue="blocks" className="h-full">
@@ -495,7 +504,11 @@ function BlocksBody({ registry, capabilities }: BlocksBodyProps): ReactElement {
         </TabsList>
       </div>
       <TabsContent value="blocks">
-        <PlumixBlocksTab registry={registry} capabilities={capabilities} />
+        <PlumixBlocksTab
+          registry={registry}
+          patternRegistry={patternRegistry}
+          capabilities={capabilities}
+        />
       </TabsContent>
       <TabsContent value="outline">
         <Puck.Outline />
@@ -530,11 +543,13 @@ function BlocksBody({ registry, capabilities }: BlocksBodyProps): ReactElement {
 
 interface PlumixBlocksTabProps {
   readonly registry: BlockRegistry;
+  readonly patternRegistry: PatternRegistry;
   readonly capabilities: ReadonlySet<string>;
 }
 
 function PlumixBlocksTab({
   registry,
+  patternRegistry,
   capabilities,
 }: PlumixBlocksTabProps): ReactElement {
   const puck = usePuck();
@@ -603,7 +618,12 @@ function PlumixBlocksTab({
           </li>
         ))}
       </ul>
-      <PatternsSection patterns={patterns} onSelect={handlePatternInsert} />
+      <PatternsSection
+        patterns={patterns}
+        onSelect={handlePatternInsert}
+        blocks={registry}
+        patternRegistry={patternRegistry}
+      />
     </div>
   );
 }

--- a/packages/admin/src/editor/LazyMount.test.tsx
+++ b/packages/admin/src/editor/LazyMount.test.tsx
@@ -1,0 +1,76 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { LazyMount } from "./LazyMount.js";
+
+interface IOInit {
+  readonly callback: IntersectionObserverCallback;
+}
+
+let observers: IOInit[];
+
+beforeEach(() => {
+  observers = [];
+  class FakeObserver {
+    constructor(public readonly callback: IntersectionObserverCallback) {
+      observers.push({ callback });
+    }
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
+  }
+  vi.stubGlobal("IntersectionObserver", FakeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function intersect(): void {
+  const entry = {
+    isIntersecting: true,
+    intersectionRatio: 1,
+    target: document.createElement("div"),
+    boundingClientRect: {} as DOMRectReadOnly,
+    intersectionRect: {} as DOMRectReadOnly,
+    rootBounds: null,
+    time: 0,
+  } satisfies IntersectionObserverEntry;
+  act(() => {
+    for (const o of observers) {
+      o.callback(
+        [entry],
+        // The real type expects an IntersectionObserver instance; the
+        // children don't read from it.
+        null as unknown as IntersectionObserver,
+      );
+    }
+  });
+}
+
+describe("LazyMount", () => {
+  test("does not render children until the placeholder enters the viewport", () => {
+    render(
+      <LazyMount placeholderTestId="placeholder">
+        <span data-testid="payload">payload</span>
+      </LazyMount>,
+    );
+
+    expect(screen.queryByTestId("payload")).toBeNull();
+    expect(screen.getByTestId("placeholder")).toBeInTheDocument();
+  });
+
+  test("renders children after the observer reports intersection", () => {
+    render(
+      <LazyMount placeholderTestId="placeholder">
+        <span data-testid="payload">payload</span>
+      </LazyMount>,
+    );
+
+    intersect();
+
+    expect(screen.getByTestId("payload")).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/editor/LazyMount.tsx
+++ b/packages/admin/src/editor/LazyMount.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+
+interface LazyMountProps {
+  readonly children: ReactNode;
+  readonly placeholderTestId?: string;
+  // Reserve space so the placeholder consumes its target dimensions —
+  // a zero-height placeholder intersects the viewport on first paint
+  // and defeats the lazy mount.
+  readonly minHeight?: number;
+}
+
+export function LazyMount({
+  children,
+  placeholderTestId,
+  minHeight,
+}: LazyMountProps): ReactElement {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (visible) return;
+    const target = ref.current;
+    if (!target) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        setVisible(true);
+        observer.disconnect();
+      }
+    });
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [visible]);
+
+  if (visible) return <>{children}</>;
+
+  return (
+    <div
+      ref={ref}
+      data-testid={placeholderTestId}
+      style={minHeight === undefined ? undefined : { minHeight }}
+    />
+  );
+}

--- a/packages/admin/src/editor/PatternThumbnail.test.tsx
+++ b/packages/admin/src/editor/PatternThumbnail.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+import {
+  createBlockRegistry,
+  createPatternRegistry,
+  defineBlock,
+} from "@plumix/blocks";
+
+import { PatternThumbnail } from "./PatternThumbnail.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const blank: PatternManifestEntry = {
+  name: "x/blank",
+  title: "Blank",
+  content: [],
+};
+
+const heading = defineBlock({
+  name: "core/heading",
+  render: ({ attrs }) => {
+    const text = (attrs as { readonly text?: string }).text ?? "";
+    return <h1>{text}</h1>;
+  },
+});
+const blocks = createBlockRegistry([heading]);
+const patterns = createPatternRegistry([]);
+
+describe("PatternThumbnail", () => {
+  test("renders an <img> when the pattern declares a preview override", () => {
+    const pattern: PatternManifestEntry = {
+      ...blank,
+      preview: {
+        src: "/hero.png",
+        width: 1400,
+        height: 900,
+        alt: "Hero preview",
+      },
+    };
+
+    render(
+      <PatternThumbnail
+        pattern={pattern}
+        blocks={blocks}
+        patterns={patterns}
+      />,
+    );
+
+    const img = screen.getByTestId(`plumix-pattern-thumbnail-${pattern.name}`);
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute("src", "/hero.png");
+    expect(img).toHaveAttribute("width", "1400");
+    expect(img).toHaveAttribute("height", "900");
+    expect(img).toHaveAttribute("alt", "Hero preview");
+  });
+
+  test("renders the pattern body via the walker when no preview override is set", () => {
+    const pattern: PatternManifestEntry = {
+      name: "x/live",
+      title: "Live",
+      content: [
+        { id: "h", name: "core/heading", attrs: { text: "Live render" } },
+      ],
+    };
+
+    render(
+      <PatternThumbnail
+        pattern={pattern}
+        blocks={blocks}
+        patterns={patterns}
+      />,
+    );
+
+    const container = screen.getByTestId(
+      `plumix-pattern-thumbnail-${pattern.name}`,
+    );
+    expect(container).toHaveTextContent("Live render");
+  });
+});

--- a/packages/admin/src/editor/PatternThumbnail.tsx
+++ b/packages/admin/src/editor/PatternThumbnail.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from "react";
+
+import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+import { renderBlockTree } from "@plumix/blocks";
+
+interface PatternThumbnailProps {
+  readonly pattern: PatternManifestEntry;
+  readonly blocks: BlockRegistry;
+  readonly patterns: PatternRegistry;
+}
+
+export function PatternThumbnail({
+  pattern,
+  blocks,
+  patterns,
+}: PatternThumbnailProps): ReactElement {
+  const testId = `plumix-pattern-thumbnail-${pattern.name}`;
+  const { preview } = pattern;
+  if (preview) {
+    return (
+      <img
+        src={preview.src}
+        width={preview.width}
+        height={preview.height}
+        alt={preview.alt ?? ""}
+        data-testid={testId}
+      />
+    );
+  }
+  // pointer-events-none swallows clicks on interactive descendants so
+  // they don't compete with the row's onClick selecting the pattern.
+  return (
+    <div className="pointer-events-none" data-testid={testId}>
+      {renderBlockTree(pattern.content, blocks, { patterns })}
+    </div>
+  );
+}

--- a/packages/admin/src/editor/PatternsSection.test.tsx
+++ b/packages/admin/src/editor/PatternsSection.test.tsx
@@ -1,19 +1,70 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
 import { PatternsSection } from "./PatternsSection.js";
 
-afterEach(() => {
-  cleanup();
+interface QueuedObserver {
+  readonly callback: IntersectionObserverCallback;
+  readonly target: Element;
+}
+
+let observers: QueuedObserver[];
+
+beforeEach(() => {
+  observers = [];
+  class FakeObserver {
+    constructor(public readonly callback: IntersectionObserverCallback) {}
+    observe = (target: Element): void => {
+      observers.push({ callback: this.callback, target });
+    };
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
+  }
+  vi.stubGlobal("IntersectionObserver", FakeObserver);
 });
 
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+// Flushes every queued observer with an intersecting entry — mirrors
+// the pattern in LazyMount.test.tsx so React state updates land inside
+// act() and the warning-free assertion path is consistent.
+function intersectAll(): void {
+  act(() => {
+    for (const { callback, target } of observers) {
+      const entry = {
+        isIntersecting: true,
+        intersectionRatio: 1,
+        target,
+        boundingClientRect: {} as DOMRectReadOnly,
+        intersectionRect: {} as DOMRectReadOnly,
+        rootBounds: null,
+        time: 0,
+      } satisfies IntersectionObserverEntry;
+      callback([entry], null as unknown as IntersectionObserver);
+    }
+  });
+}
+
 const noop = vi.fn();
+const blocks = createBlockRegistry([]);
+const patterns = createPatternRegistry([]);
 
 describe("PatternsSection", () => {
   test("renders nothing when no patterns are registered", () => {
     const { container } = render(
-      <PatternsSection patterns={[]} onSelect={noop} />,
+      <PatternsSection
+        patterns={[]}
+        onSelect={noop}
+        blocks={blocks}
+        patternRegistry={patterns}
+      />,
     );
     expect(container).toBeEmptyDOMElement();
   });
@@ -22,6 +73,8 @@ describe("PatternsSection", () => {
     render(
       <PatternsSection
         onSelect={noop}
+        blocks={blocks}
+        patternRegistry={patterns}
         patterns={[
           {
             name: "starter/hero",
@@ -65,6 +118,8 @@ describe("PatternsSection", () => {
     render(
       <PatternsSection
         onSelect={noop}
+        blocks={blocks}
+        patternRegistry={patterns}
         patterns={[{ name: "x/anon", title: "Anonymous", content: [] }]}
       />,
     );
@@ -77,6 +132,57 @@ describe("PatternsSection", () => {
     ).toBeInTheDocument();
   });
 
+  test("renders a thumbnail card for each pattern after the row intersects the viewport", () => {
+    const hero = {
+      name: "starter/hero",
+      title: "Hero",
+      preview: {
+        src: "/hero.png",
+        width: 200,
+        height: 120,
+        alt: "Hero preview",
+      },
+      content: [],
+    };
+    const cta = {
+      name: "starter/cta",
+      title: "CTA",
+      preview: {
+        src: "/cta.png",
+        width: 200,
+        height: 120,
+        alt: "CTA preview",
+      },
+      content: [],
+    };
+
+    render(
+      <PatternsSection
+        patterns={[hero, cta]}
+        onSelect={noop}
+        blocks={blocks}
+        patternRegistry={patterns}
+      />,
+    );
+
+    // Pre-intersection: only placeholders, no thumbnails.
+    expect(
+      screen.queryByTestId(`plumix-pattern-thumbnail-${hero.name}`),
+    ).toBeNull();
+    expect(
+      screen.getByTestId(`plumix-patterns-row-placeholder-${hero.name}`),
+    ).toBeInTheDocument();
+
+    intersectAll();
+
+    expect(
+      screen.getByTestId(`plumix-pattern-thumbnail-${hero.name}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`plumix-pattern-thumbnail-${cta.name}`),
+    ).toBeInTheDocument();
+  });
+
   test("clicking a pattern row invokes onSelect with the pattern entry", async () => {
     const onSelect = vi.fn();
     const hero = {
@@ -85,7 +191,14 @@ describe("PatternsSection", () => {
       category: "hero" as const,
       content: [],
     };
-    render(<PatternsSection patterns={[hero]} onSelect={onSelect} />);
+    render(
+      <PatternsSection
+        patterns={[hero]}
+        onSelect={onSelect}
+        blocks={blocks}
+        patternRegistry={patterns}
+      />,
+    );
 
     await userEvent.click(
       screen.getByTestId("plumix-patterns-row-starter/hero"),

--- a/packages/admin/src/editor/PatternsSection.tsx
+++ b/packages/admin/src/editor/PatternsSection.tsx
@@ -1,18 +1,30 @@
 import type { ReactElement } from "react";
 import { useMemo } from "react";
 
+import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
 import type { PatternManifestEntry } from "@plumix/core/manifest";
+
+import { LazyMount } from "./LazyMount.js";
+import { PatternThumbnail } from "./PatternThumbnail.js";
 
 interface PatternsSectionProps {
   readonly patterns: readonly PatternManifestEntry[];
   readonly onSelect: (pattern: PatternManifestEntry) => void;
+  readonly blocks: BlockRegistry;
+  readonly patternRegistry: PatternRegistry;
 }
+
+// Reserved space so the IntersectionObserver placeholder consumes its
+// target dimensions and doesn't trip on first paint.
+const ROW_THUMB_MIN_HEIGHT = 120;
 
 const UNCATEGORIZED = "uncategorized";
 
 export function PatternsSection({
   patterns,
   onSelect,
+  blocks,
+  patternRegistry,
 }: PatternsSectionProps): ReactElement | null {
   const grouped = useMemo(() => {
     const map = new Map<string, PatternManifestEntry[]>();
@@ -50,14 +62,37 @@ export function PatternsSection({
           <ul className="flex flex-col gap-1">
             {entries.map((entry) => (
               <li key={entry.name}>
-                <button
-                  type="button"
-                  className="text-foreground hover:bg-muted w-full rounded border px-3 py-2 text-left text-sm"
+                {/* `<div role="button">` rather than `<button>` because
+                    the live thumbnail can render its own interactive
+                    HTML — nested <button>/<a> in a real <button> is
+                    invalid and the inner element steals focus. */}
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className="text-foreground hover:bg-muted flex w-full flex-col gap-1 rounded border p-2 text-left text-sm focus:outline-none focus-visible:ring"
                   data-testid={`plumix-patterns-row-${entry.name}`}
                   onClick={() => onSelect(entry)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onSelect(entry);
+                    }
+                  }}
                 >
-                  {entry.title}
-                </button>
+                  <LazyMount
+                    placeholderTestId={`plumix-patterns-row-placeholder-${entry.name}`}
+                    minHeight={ROW_THUMB_MIN_HEIGHT}
+                  >
+                    <div className="overflow-hidden rounded">
+                      <PatternThumbnail
+                        pattern={entry}
+                        blocks={blocks}
+                        patterns={patternRegistry}
+                      />
+                    </div>
+                  </LazyMount>
+                  <span className="truncate">{entry.title}</span>
+                </div>
               </li>
             ))}
           </ul>

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -72,6 +72,7 @@ export type {
   BlockTypeRegistry,
   PatternCategoryRegistry,
   PatternInsertMode,
+  PatternPreview,
   PatternRegistry,
 } from "./pattern-registry.js";
 export { PatternRegistryError } from "./pattern-errors.js";

--- a/packages/blocks/src/pattern-registry.test.ts
+++ b/packages/blocks/src/pattern-registry.test.ts
@@ -56,6 +56,27 @@ describe("definePattern", () => {
     expect(pattern.content.map((n) => n.id)).toEqual(["p1", "p2"]);
   });
 
+  test("preserves the preview override field with width, height, and optional alt", () => {
+    const pattern = definePattern({
+      name: "x/preview",
+      title: "P",
+      content: [],
+      preview: {
+        src: "./hero.png",
+        width: 1400,
+        height: 900,
+        alt: "Hero preview",
+      },
+    });
+
+    expect(pattern.preview).toEqual({
+      src: "./hero.png",
+      width: 1400,
+      height: 900,
+      alt: "Hero preview",
+    });
+  });
+
   test("preserves the insert mode field — copy + reference both round-trip", () => {
     const copy = definePattern({
       name: "x/copy",

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -38,6 +38,13 @@ type AttrsFor<TName extends string> = TName extends keyof BlockTypeRegistry
 
 export type PatternInsertMode = "copy" | "reference";
 
+export interface PatternPreview {
+  readonly src: string;
+  readonly width: number;
+  readonly height: number;
+  readonly alt?: string;
+}
+
 export interface BlockPattern {
   readonly name: string;
   readonly title: string;
@@ -46,6 +53,9 @@ export interface BlockPattern {
   // body. "reference" inserts a single `core/pattern-ref` node the
   // walker resolves at render.
   readonly insert?: PatternInsertMode;
+  // Static preview override. When set, the inserter renders an <img>
+  // at the declared dimensions instead of live-rendering `content`.
+  readonly preview?: PatternPreview;
   readonly content: readonly BlockNode[];
 }
 

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -1374,6 +1374,43 @@ describe("buildManifest visibility projection", () => {
     });
   });
 
+  test("projects the preview override through the manifest when set, omits it otherwise", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerPattern({
+        name: "acme/hero",
+        title: "Hero",
+        content: [],
+        preview: {
+          src: "./hero.png",
+          width: 1400,
+          height: 900,
+          alt: "Hero preview",
+        },
+      });
+      ctx.registerPattern({
+        name: "acme/plain",
+        title: "Plain",
+        content: [],
+      });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+
+    expect(
+      manifest.patterns.find((p) => p.name === "acme/hero")?.preview,
+    ).toEqual({
+      src: "./hero.png",
+      width: 1400,
+      height: 900,
+      alt: "Hero preview",
+    });
+    expect(
+      manifest.patterns.find((p) => p.name === "acme/plain")?.preview,
+    ).toBeUndefined();
+  });
+
   test("projects pattern insert mode through the manifest, defaulting to copy", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("acme", (ctx) => {

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -5,6 +5,7 @@ import type {
   BlockVariation,
   MarkSpec,
   PatternInsertMode,
+  PatternPreview,
   ThemeTokens,
 } from "@plumix/blocks";
 
@@ -1457,6 +1458,7 @@ export interface PatternManifestEntry {
   // `"copy"`; consumers that read raw manifest fixtures may still see
   // `undefined`.
   readonly insert?: PatternInsertMode;
+  readonly preview?: PatternPreview;
   readonly content: readonly BlockNode[];
 }
 
@@ -2254,8 +2256,15 @@ function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
 }
 
 function toPatternEntry(pattern: RegisteredPattern): PatternManifestEntry {
-  const { name, title, category, content, insert } = pattern.spec;
-  return { name, title, category, insert: insert ?? "copy", content };
+  const { name, title, category, content, insert, preview } = pattern.spec;
+  return {
+    name,
+    title,
+    category,
+    insert: insert ?? "copy",
+    preview,
+    content,
+  };
 }
 
 function toMarkEntry(mark: RegisteredMark): MarkManifestEntry {


### PR DESCRIPTION
Pattern sidebar rows now render a thumbnail card next to the title. When the author declares a static `preview: { src, width, height, alt? }` on `definePattern`, the card renders an `<img>`; otherwise the card live-renders the resolved body via the same walker SSR uses. Rows mount lazily — until the row's placeholder intersects the sidebar viewport an empty `<div>` reserving the row's vertical space is rendered in its place, so an N-pattern library doesn't render N walker trees on editor boot.

**Hardening from review**

The row is `<div role="button" tabIndex={0}>` with `Enter`/`Space` `onKeyDown` rather than `<button>`, because the live thumbnail can legitimately render its own `<button>` / `<a>` — nested interactive HTML is invalid and steals focus. The thumbnail body wraps the walker output in `pointer-events-none` so interactive descendants don't intercept the row's click. `LazyMount` accepts a `minHeight` that the sidebar passes (`ROW_THUMB_MIN_HEIGHT = 120`) so the placeholder reserves space — otherwise a zero-height placeholder intersects the viewport on first paint and the lazy mount is inert.

**Required registries on the public surface**

`PatternThumbnail` and `PatternsSection` no longer accept `blocks` and `patternRegistry` as optional. The only call site in `EditorLayout` already plumbs both unconditionally from the empty-registry defaults; making them required removes a silent `null` return path if a future caller forgets to plumb them.

Refs #625
Refs #628