### PR TITLE
feat: interleave block patterns into the slash menu

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -363,6 +363,7 @@ export function PlumixEditorLayout({
   const isPreview = previewBanner !== undefined;
   const isDraftMode = draftMode !== undefined;
   const showDraftBanner = isDraftMode && draftMode.hasPendingDraft;
+  const patterns = useMemo(() => getPatterns(), []);
   const refContextValue = useMemo(
     () => ({ patterns: patternRegistry, blocks: registry }),
     [patternRegistry, registry],
@@ -441,6 +442,7 @@ export function PlumixEditorLayout({
             registry={registry}
             patternRegistry={patternRegistry}
             capabilities={capabilities}
+            patterns={patterns}
           />
           {isPreview ? (
             // Puck's `permissions` strips drag / insert / delete / dup /
@@ -460,6 +462,7 @@ export function PlumixEditorLayout({
                 <PlumixCanvasWithSlashMenu
                   registry={registry}
                   capabilities={capabilities}
+                  patterns={patterns}
                 />
               </div>
             </div>
@@ -467,6 +470,7 @@ export function PlumixEditorLayout({
             <PlumixCanvasWithSlashMenu
               registry={registry}
               capabilities={capabilities}
+              patterns={patterns}
             />
           )}
           <InspectorBody registry={registry} tokens={tokens} />
@@ -480,12 +484,14 @@ interface BlocksBodyProps {
   readonly registry: BlockRegistry;
   readonly patternRegistry: PatternRegistry;
   readonly capabilities: ReadonlySet<string>;
+  readonly patterns: readonly PatternManifestEntry[];
 }
 
 function BlocksBody({
   registry,
   patternRegistry,
   capabilities,
+  patterns,
 }: BlocksBodyProps): ReactElement {
   const isMobile = useIsMobile();
   const content = (
@@ -508,6 +514,7 @@ function BlocksBody({
           registry={registry}
           patternRegistry={patternRegistry}
           capabilities={capabilities}
+          patterns={patterns}
         />
       </TabsContent>
       <TabsContent value="outline">
@@ -545,12 +552,14 @@ interface PlumixBlocksTabProps {
   readonly registry: BlockRegistry;
   readonly patternRegistry: PatternRegistry;
   readonly capabilities: ReadonlySet<string>;
+  readonly patterns: readonly PatternManifestEntry[];
 }
 
 function PlumixBlocksTab({
   registry,
   patternRegistry,
   capabilities,
+  patterns,
 }: PlumixBlocksTabProps): ReactElement {
   const puck = usePuck();
   const entries = useMemo(() => {
@@ -587,8 +596,6 @@ function PlumixBlocksTab({
     },
     [puck],
   );
-
-  const patterns = useMemo(() => getPatterns(), []);
 
   const handlePatternInsert = useCallback(
     (pattern: PatternManifestEntry): void => {
@@ -684,19 +691,21 @@ function InspectorBody({ registry, tokens }: InspectorBodyProps): ReactElement {
 interface PlumixCanvasWithSlashMenuProps {
   readonly registry: BlockRegistry;
   readonly capabilities: ReadonlySet<string>;
+  readonly patterns: readonly PatternManifestEntry[];
 }
 
 function PlumixCanvasWithSlashMenu({
   registry,
   capabilities,
+  patterns,
 }: PlumixCanvasWithSlashMenuProps): ReactElement {
   const puck = usePuck();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
 
   const items = useMemo(
-    () => resolveSlashMenuItems(registry, { capabilities, query }),
-    [registry, capabilities, query],
+    () => resolveSlashMenuItems(registry, { capabilities, query, patterns }),
+    [registry, capabilities, query, patterns],
   );
 
   const handleCanvasKeyDown = useCallback(
@@ -732,18 +741,32 @@ function PlumixCanvasWithSlashMenu({
         itemSelector,
         puck.appState.data.content.length,
       );
-      puck.dispatch({
-        type: "insert",
-        componentType: item.name,
-        destinationZone: zone,
-        destinationIndex: index,
-      });
-      const variationAttrs = item.attrs;
-      if (variationAttrs !== undefined) {
+      if (item.kind === "block") {
+        const { entry } = item;
+        puck.dispatch({
+          type: "insert",
+          componentType: entry.name,
+          destinationZone: zone,
+          destinationIndex: index,
+        });
+        const variationAttrs = entry.attrs;
+        if (variationAttrs !== undefined) {
+          puck.dispatch({
+            type: "setData",
+            data: (previous) =>
+              mergePropsAtSelector(previous, { zone, index }, variationAttrs),
+          });
+        }
+      } else {
+        // The pattern insert primitive operates on the root content
+        // array; nextInsertPoint may have returned a nested zone for
+        // selection-aware placement, but pattern insertion at non-root
+        // zones is deferred — fall back to end-of-document.
+        const insertIndex =
+          zone === PUCK_ROOT_ZONE ? index : puck.appState.data.content.length;
         puck.dispatch({
           type: "setData",
-          data: (previous) =>
-            mergePropsAtSelector(previous, { zone, index }, variationAttrs),
+          data: (previous) => insertPattern(previous, item.entry, insertIndex),
         });
       }
       setOpen(false);
@@ -811,9 +834,10 @@ function PlumixCanvasWithSlashMenu({
           showCloseButton={false}
         >
           <DialogHeader className="sr-only">
-            <DialogTitle>Insert block</DialogTitle>
+            <DialogTitle>Insert block or pattern</DialogTitle>
             <DialogDescription>
-              Search blocks by title or keyword and press Enter to insert.
+              Search blocks and patterns by title or keyword and press Enter to
+              insert.
             </DialogDescription>
           </DialogHeader>
           <SlashMenuPanel

--- a/packages/admin/src/editor/SlashMenuPanel.test.tsx
+++ b/packages/admin/src/editor/SlashMenuPanel.test.tsx
@@ -10,24 +10,58 @@ afterEach(() => {
 });
 
 const heading: SlashMenuItem = {
-  name: "core/heading",
-  slug: "core/heading",
-  title: "Heading",
-  description: "Section title",
-  category: "typography",
+  kind: "block",
+  entry: {
+    name: "core/heading",
+    slug: "core/heading",
+    title: "Heading",
+    description: "Section title",
+    category: "typography",
+  },
 };
 
 const quote: SlashMenuItem = {
-  name: "core/quote",
-  slug: "core/quote",
-  title: "Quote",
-  description: "Pull quote",
-  category: "typography",
+  kind: "block",
+  entry: {
+    name: "core/quote",
+    slug: "core/quote",
+    title: "Quote",
+    description: "Pull quote",
+    category: "typography",
+  },
+};
+
+const heroPattern: SlashMenuItem = {
+  kind: "pattern",
+  entry: {
+    name: "starter/hero",
+    title: "Hero",
+    category: "hero",
+    content: [],
+  },
 };
 
 const noop = vi.fn();
 
 describe("SlashMenuPanel", () => {
+  test("marks pattern entries with a distinct card-style testid", () => {
+    render(
+      <SlashMenuPanel
+        items={[heading, heroPattern]}
+        query=""
+        onQueryChange={noop}
+        onSelect={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    // Blocks keep the single-line row id; patterns get a card id.
+    expect(screen.getByTestId("slash-menu-item-core/heading")).toBeDefined();
+    expect(
+      screen.getByTestId("slash-menu-pattern-card-starter/hero"),
+    ).toBeDefined();
+  });
+
   test("renders one item per resolved entry with stable testids and category headings", () => {
     render(
       <SlashMenuPanel

--- a/packages/admin/src/editor/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/SlashMenuPanel.tsx
@@ -21,6 +21,62 @@ interface SlashMenuPanelProps {
 
 const UNCATEGORIZED = "other";
 
+function renderMember(
+  item: SlashMenuItem,
+  onSelect: (item: SlashMenuItem) => void,
+): ReactElement {
+  if (item.kind === "pattern") {
+    const { entry } = item;
+    return (
+      <CommandItem
+        key={entry.name}
+        value={entry.name}
+        data-testid={`slash-menu-pattern-card-${entry.name}`}
+        onSelect={() => onSelect(item)}
+        className="flex flex-col items-start gap-1 px-2 py-2"
+      >
+        {/* Fixed-aspect strip keeps two-line cards a stable height
+            regardless of the author's preview dimensions. The fallback
+            is a neutral placeholder — the title below carries the label,
+            so doubling it in the strip would just be visual noise. */}
+        {entry.preview ? (
+          <img
+            src={entry.preview.src}
+            alt={entry.preview.alt ?? ""}
+            className="h-12 w-full rounded object-cover"
+          />
+        ) : (
+          <span
+            aria-hidden
+            className="bg-muted h-12 w-full rounded"
+            data-testid={`slash-menu-pattern-card-placeholder-${entry.name}`}
+          />
+        )}
+        <span className="text-sm font-medium">{entry.title}</span>
+      </CommandItem>
+    );
+  }
+  const { entry } = item;
+  return (
+    <CommandItem
+      key={entry.slug}
+      value={entry.slug}
+      data-testid={`slash-menu-item-${entry.slug}`}
+      onSelect={() => onSelect(item)}
+      className="flex items-start gap-2"
+    >
+      <span className="flex min-w-0 flex-col">
+        <span className="text-sm font-medium">{entry.title}</span>
+        {entry.description ? (
+          <span className="text-muted-foreground text-xs">
+            {entry.description}
+          </span>
+        ) : null}
+      </span>
+    </CommandItem>
+  );
+}
+
 export function SlashMenuPanel({
   items,
   query,
@@ -31,7 +87,7 @@ export function SlashMenuPanel({
   const buckets = useMemo(() => {
     const map = new Map<string, SlashMenuItem[]>();
     for (const item of items) {
-      const key = item.category ?? UNCATEGORIZED;
+      const key = item.entry.category ?? UNCATEGORIZED;
       const bucket = map.get(key) ?? [];
       bucket.push(item);
       map.set(key, bucket);
@@ -57,36 +113,17 @@ export function SlashMenuPanel({
         data-testid="slash-menu-input"
         autoFocus
         className="sr-only"
-        aria-label="Search blocks"
+        aria-label="Search blocks and patterns"
       />
       <CommandList>
-        <CommandEmpty data-testid="slash-menu-empty">
-          No blocks found
-        </CommandEmpty>
+        <CommandEmpty data-testid="slash-menu-empty">No matches</CommandEmpty>
         {buckets.map(([category, members]) => (
           <CommandGroup
             key={category}
             heading={category}
             data-testid={`slash-menu-group-${category}`}
           >
-            {members.map((item) => (
-              <CommandItem
-                key={item.slug}
-                value={item.slug}
-                data-testid={`slash-menu-item-${item.slug}`}
-                onSelect={() => onSelect(item)}
-                className="flex items-start gap-2"
-              >
-                <span className="flex min-w-0 flex-col">
-                  <span className="text-sm font-medium">{item.title}</span>
-                  {item.description ? (
-                    <span className="text-muted-foreground text-xs">
-                      {item.description}
-                    </span>
-                  ) : null}
-                </span>
-              </CommandItem>
-            ))}
+            {members.map((item) => renderMember(item, onSelect))}
           </CommandGroup>
         ))}
       </CommandList>

--- a/packages/admin/src/editor/slash-menu-items.test.ts
+++ b/packages/admin/src/editor/slash-menu-items.test.ts
@@ -14,6 +14,21 @@ function spec(partial: Partial<BlockSpec> & { name: string }): BlockSpec {
 }
 
 describe("resolveSlashMenuItems", () => {
+  test("wraps each block in a discriminated `{ kind: 'block', entry }` shape", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", title: "Heading" }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "",
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.kind).toBe("block");
+    expect(items[0]?.entry.name).toBe("core/heading");
+  });
+
   test("projects every block in the registry into a SlashMenuItem", () => {
     const registry = createBlockRegistry([
       spec({ name: "core/heading", title: "Heading", category: "typography" }),
@@ -25,13 +40,13 @@ describe("resolveSlashMenuItems", () => {
       query: "",
     });
 
-    expect(items.map((i) => i.name).sort()).toEqual([
+    expect(items.map((i) => i.entry.name).sort()).toEqual([
       "core/columns",
       "core/heading",
     ]);
-    expect(items.find((i) => i.name === "core/columns")?.category).toBe(
-      "layout",
-    );
+    expect(
+      items.find((i) => i.entry.name === "core/columns")?.entry.category,
+    ).toBe("layout");
   });
 
   test("matches blocks by title (substring) and name (substring), case-insensitive", () => {
@@ -44,13 +59,13 @@ describe("resolveSlashMenuItems", () => {
       capabilities: new Set(),
       query: "HEAD",
     });
-    expect(byTitle.map((i) => i.name)).toEqual(["core/heading"]);
+    expect(byTitle.map((i) => i.entry.name)).toEqual(["core/heading"]);
 
     const byName = resolveSlashMenuItems(registry, {
       capabilities: new Set(),
       query: "paragraph",
     });
-    expect(byName.map((i) => i.name)).toEqual(["core/paragraph"]);
+    expect(byName.map((i) => i.entry.name)).toEqual(["core/paragraph"]);
   });
 
   test("matches keywords by prefix (alias semantics), not substring", () => {
@@ -66,13 +81,13 @@ describe("resolveSlashMenuItems", () => {
       capabilities: new Set(),
       query: "block",
     });
-    expect(prefixMatch.map((i) => i.name)).toEqual(["x/pull"]);
+    expect(prefixMatch.map((i) => i.entry.name)).toEqual(["x/pull"]);
 
     const substringNonMatch = resolveSlashMenuItems(registry, {
       capabilities: new Set(),
       query: "quote",
     });
-    expect(substringNonMatch.map((i) => i.name)).toEqual([]);
+    expect(substringNonMatch.map((i) => i.entry.name)).toEqual([]);
   });
 
   test("omits blocks whose `capability` is not present in the viewer's capability set", () => {
@@ -85,13 +100,13 @@ describe("resolveSlashMenuItems", () => {
       capabilities: new Set(),
       query: "",
     });
-    expect(restricted.map((i) => i.name)).toEqual(["core/heading"]);
+    expect(restricted.map((i) => i.entry.name)).toEqual(["core/heading"]);
 
     const elevated = resolveSlashMenuItems(registry, {
       capabilities: new Set(["edit_html"]),
       query: "",
     });
-    expect(elevated.map((i) => i.name).sort()).toEqual([
+    expect(elevated.map((i) => i.entry.name).sort()).toEqual([
       "core/heading",
       "core/html",
     ]);
@@ -109,7 +124,7 @@ describe("resolveSlashMenuItems", () => {
       query: "quote",
     });
 
-    expect(items.map((i) => i.name)).toEqual([
+    expect(items.map((i) => i.entry.name)).toEqual([
       "z/title",
       "z/keyword",
       "core/quote",
@@ -127,10 +142,12 @@ describe("resolveSlashMenuItems", () => {
       query: "",
     });
 
-    expect(items.find((i) => i.name === "core/spacer")?.title).toBe(
+    expect(items.find((i) => i.entry.name === "core/spacer")?.entry.title).toBe(
       "core/spacer",
     );
-    expect(items.find((i) => i.name === "core/heading")?.title).toBe("Heading");
+    expect(
+      items.find((i) => i.entry.name === "core/heading")?.entry.title,
+    ).toBe("Heading");
   });
 
   test("omits specs declared with `inserter: false` so structural-children stay out of the menu", () => {
@@ -153,7 +170,7 @@ describe("resolveSlashMenuItems", () => {
       query: "",
     });
 
-    expect(items.map((i) => i.name)).toEqual(["core/table"]);
+    expect(items.map((i) => i.entry.name)).toEqual(["core/table"]);
   });
 
   test("keeps specs that omit `inserter` (default shown) and specs that opt in with `inserter: true`", () => {
@@ -167,7 +184,10 @@ describe("resolveSlashMenuItems", () => {
       query: "",
     });
 
-    expect(items.map((i) => i.name).sort()).toEqual(["a/default", "a/opt-in"]);
+    expect(items.map((i) => i.entry.name).sort()).toEqual([
+      "a/default",
+      "a/opt-in",
+    ]);
   });
 
   test("emits one item per variation when a block declares variations, slugs distinguish them", () => {
@@ -196,14 +216,100 @@ describe("resolveSlashMenuItems", () => {
       query: "",
     });
 
-    expect(items.map((i) => i.slug)).toEqual(["bullet", "numbered"]);
-    expect(items.map((i) => i.title)).toEqual([
+    const blockEntries = items.flatMap((i) =>
+      i.kind === "block" ? [i.entry] : [],
+    );
+    expect(blockEntries.map((e) => e.slug)).toEqual(["bullet", "numbered"]);
+    expect(blockEntries.map((e) => e.title)).toEqual([
       "Bulleted list",
       "Numbered list",
     ]);
-    expect(items.every((i) => i.name === "core/list")).toBe(true);
-    expect(items[0]?.attrs).toEqual({ variant: "bullet" });
-    expect(items[1]?.attrs).toEqual({ variant: "numbered" });
+    expect(blockEntries.every((e) => e.name === "core/list")).toBe(true);
+    expect(blockEntries[0]?.attrs).toEqual({ variant: "bullet" });
+    expect(blockEntries[1]?.attrs).toEqual({ variant: "numbered" });
+  });
+
+  test("interleaves pattern entries from the patterns option as `{ kind: 'pattern', entry }`", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", title: "Heading" }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "",
+      patterns: [
+        {
+          name: "starter/hero",
+          title: "Hero",
+          category: "hero",
+          content: [],
+        },
+        {
+          name: "starter/cta",
+          title: "Call to action",
+          category: "cta",
+          content: [],
+        },
+      ],
+    });
+
+    const patterns = items.filter((i) => i.kind === "pattern");
+    expect(patterns.map((i) => i.entry.name).sort()).toEqual([
+      "starter/cta",
+      "starter/hero",
+    ]);
+    expect(items.some((i) => i.kind === "block")).toBe(true);
+  });
+
+  test("matches pattern entries by title, name, category, and keywords", () => {
+    const registry = createBlockRegistry([]);
+
+    const matches = (query: string, expected: string[]): void => {
+      const items = resolveSlashMenuItems(registry, {
+        capabilities: new Set(),
+        query,
+        patterns: [
+          {
+            name: "starter/hero-cta",
+            title: "Hero with CTA",
+            category: "hero",
+            keywords: ["landing"],
+            content: [],
+          },
+          {
+            name: "starter/footer",
+            title: "Footer",
+            category: "footer",
+            content: [],
+          },
+        ],
+      });
+      expect(items.map((i) => i.entry.name).sort()).toEqual(expected.sort());
+    };
+
+    matches("hero", ["starter/hero-cta"]);
+    matches("footer", ["starter/footer"]);
+    matches("landing", ["starter/hero-cta"]);
+    matches("starter/footer", ["starter/footer"]);
+  });
+
+  test("matches a pattern by category prefix when title/name/keywords don't carry the token", () => {
+    const registry = createBlockRegistry([]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "head",
+      patterns: [
+        {
+          name: "starter/site-top",
+          title: "Site top",
+          category: "header",
+          content: [],
+        },
+      ],
+    });
+
+    expect(items.map((i) => i.entry.name)).toEqual(["starter/site-top"]);
   });
 
   test("treats whitespace-only queries as empty (no filtering)", () => {

--- a/packages/admin/src/editor/slash-menu-items.ts
+++ b/packages/admin/src/editor/slash-menu-items.ts
@@ -3,17 +3,21 @@ import type {
   BlockSpec,
   InsertableBlockEntry,
 } from "@plumix/blocks";
+import type { PatternManifestEntry } from "@plumix/core/manifest";
 import { expandBlockVariations } from "@plumix/blocks";
 
 import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 
 export { PUCK_ROOT_ZONE };
 
-export type SlashMenuItem = InsertableBlockEntry;
+export type SlashMenuItem =
+  | { readonly kind: "block"; readonly entry: InsertableBlockEntry }
+  | { readonly kind: "pattern"; readonly entry: PatternManifestEntry };
 
 interface ResolveSlashMenuItemsOptions {
   readonly capabilities: ReadonlySet<string>;
   readonly query: string;
+  readonly patterns?: readonly PatternManifestEntry[];
 }
 
 const TITLE_MATCH = 3;
@@ -22,7 +26,7 @@ const NAME_MATCH = 1;
 
 export function resolveSlashMenuItems(
   registry: BlockRegistry,
-  { capabilities, query }: ResolveSlashMenuItemsOptions,
+  { capabilities, query, patterns }: ResolveSlashMenuItemsOptions,
 ): readonly SlashMenuItem[] {
   const needle = query.trim().toLowerCase();
   const scored: { item: SlashMenuItem; score: number }[] = [];
@@ -34,13 +38,20 @@ export function resolveSlashMenuItems(
     eligibleSpecs.push(spec);
   }
 
-  for (const item of expandBlockVariations(eligibleSpecs)) {
+  function pushScored(item: SlashMenuItem): void {
     if (needle === "") {
       scored.push({ item, score: 0 });
-      continue;
+      return;
     }
     const score = matchScore(item, needle);
     if (score > 0) scored.push({ item, score });
+  }
+
+  for (const entry of expandBlockVariations(eligibleSpecs)) {
+    pushScored({ kind: "block", entry });
+  }
+  for (const entry of patterns ?? []) {
+    pushScored({ kind: "pattern", entry });
   }
 
   if (needle !== "") {
@@ -57,12 +68,23 @@ function isInsertableForCapabilities(
   return capabilities.has(spec.capability);
 }
 
+// Category-as-keyword matches patterns only — block entries don't
+// surface category as an alias today. Prefix semantics mirror the
+// keyword scorer so typing "her" matches a pattern with category
+// "hero", not just the exact slug.
 function matchScore(item: SlashMenuItem, needle: string): number {
-  if (item.title.toLowerCase().includes(needle)) return TITLE_MATCH;
-  if (item.keywords?.some((k) => k.toLowerCase().startsWith(needle))) {
+  const { entry } = item;
+  if (entry.title.toLowerCase().includes(needle)) return TITLE_MATCH;
+  if (entry.keywords?.some((k) => k.toLowerCase().startsWith(needle))) {
     return KEYWORD_MATCH;
   }
-  if (item.name.toLowerCase().includes(needle)) return NAME_MATCH;
+  if (
+    item.kind === "pattern" &&
+    entry.category?.toLowerCase().startsWith(needle)
+  ) {
+    return KEYWORD_MATCH;
+  }
+  if (entry.name.toLowerCase().includes(needle)) return NAME_MATCH;
   return 0;
 }
 

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -49,6 +49,7 @@ export interface BlockPattern {
   readonly name: string;
   readonly title: string;
   readonly category?: keyof PatternCategoryRegistry;
+  readonly keywords?: readonly string[];
   // Defaults to "copy" when unset — the inserter splices a deep-cloned
   // body. "reference" inserts a single `core/pattern-ref` node the
   // walker resolves at render.

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1454,6 +1454,7 @@ export interface PatternManifestEntry {
   readonly name: string;
   readonly title: string;
   readonly category?: string;
+  readonly keywords?: readonly string[];
   // `buildManifest` always populates this with the spec's value or
   // `"copy"`; consumers that read raw manifest fixtures may still see
   // `undefined`.
@@ -2256,11 +2257,13 @@ function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
 }
 
 function toPatternEntry(pattern: RegisteredPattern): PatternManifestEntry {
-  const { name, title, category, content, insert, preview } = pattern.spec;
+  const { name, title, category, keywords, content, insert, preview } =
+    pattern.spec;
   return {
     name,
     title,
     category,
+    keywords,
     insert: insert ?? "copy",
     preview,
     content,


### PR DESCRIPTION
Slash menu now mixes pattern entries with block entries under a single discriminated `SlashMenuItem` (`{ kind: "block" | "pattern", entry }`). Block selection keeps the existing `puck.dispatch` flow; pattern selection routes through `insertPattern` (copy or reference based on `pattern.insert`), inserted at the cursor's root-zone position.

**Pattern scoring**

Pattern entries match against title (substring), keywords (prefix), category (prefix), and name (substring) — mirroring the block scorer with one extra clause. Pattern `keywords` are shipped through `BlockPattern` → `PatternManifestEntry` → `buildManifest` projection, symmetric with the existing `BlockManifestEntry.keywords` channel.

**Two-line pattern cards**

In the panel, block entries keep their single-line row. Pattern entries render as two-line cards with a fixed-aspect preview strip — an `<img>` when `pattern.preview` is set, an unstyled neutral placeholder otherwise (the title label below carries the copy, so the placeholder stays empty rather than duplicating it). Dialog title, description, ARIA label, and empty-state copy now cover blocks and patterns.

**Nested-zone deferral**

When the user has a block selected inside a slot, pattern insertion falls back to end-of-document at the root zone. `nextInsertPoint`'s nested-zone result is intentionally clamped for patterns; the carve-out is documented inline so a future slice can lift it without re-discovering the trade-off.

Refs #625
Refs #629