### PR TITLE
feat: open a starter pattern modal when a new entry has empty content

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -62,12 +62,18 @@ import { puckDataToBlockTree } from "./puck-to-block-tree.js";
 import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 import { nextInsertPoint, resolveSlashMenuItems } from "./slash-menu-items.js";
 import { SlashMenuPanel } from "./SlashMenuPanel.js";
+import { StarterModal } from "./StarterModal.js";
 import { StyleTab } from "./StyleTab.js";
+import { useStarterModalState } from "./use-starter-modal-state.js";
 import { viewportWidthToBucket } from "./viewport-bucket.js";
 
 interface PlumixEditorLayoutProps {
   readonly registry?: BlockRegistry;
   readonly patternRegistry?: PatternRegistry;
+  // Pre-filtered starter patterns surfaced in the entry-create modal.
+  // Route owns the filter (entry type / capability); the layout just
+  // renders what it's given.
+  readonly starterCandidates?: readonly PatternManifestEntry[];
   readonly capabilities?: ReadonlySet<string>;
   readonly tokens?: ThemeTokens;
   readonly children?: ReactNode;
@@ -108,6 +114,9 @@ interface PlumixEditorLayoutProps {
 
 const EMPTY_REGISTRY: BlockRegistry = createBlockRegistry([]);
 const EMPTY_PATTERN_REGISTRY: PatternRegistry = createPatternRegistry([]);
+const EMPTY_STARTER_CANDIDATES: readonly PatternManifestEntry[] = Object.freeze(
+  [],
+);
 const EMPTY_CAPS: ReadonlySet<string> = new Set();
 const EMPTY_TOKENS: ThemeTokens = {};
 
@@ -153,11 +162,18 @@ interface CanvasToolbarProps {
   // null clears the manual override so the canvas tracks fit-to-screen
   // again. Numeric values pin the zoom level until cleared.
   readonly onZoomChange: (next: number | null) => void;
+  // Visible only while the entry is empty AND starter candidates exist
+  // — re-summons the starter modal after a dismissal so authors can
+  // change their mind before they start building.
+  readonly canReopenStarter: boolean;
+  readonly onReopenStarter: () => void;
 }
 
 function CanvasToolbar({
   zoom,
   onZoomChange,
+  canReopenStarter,
+  onReopenStarter,
 }: CanvasToolbarProps): ReactElement {
   const puck = usePuck();
   const { viewports } = puck.appState.ui;
@@ -258,6 +274,19 @@ function CanvasToolbar({
       >
         {Math.round(zoom * 100)}%
       </span>
+      {canReopenStarter ? (
+        <>
+          <div className="bg-border h-5 w-px" aria-hidden />
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-foreground inline-flex h-7 items-center rounded-md px-2 text-xs"
+            data-testid="plumix-editor-replace-starter"
+            onClick={onReopenStarter}
+          >
+            Pick a starter…
+          </button>
+        </>
+      ) : null}
     </div>
   );
 }
@@ -347,6 +376,7 @@ function DraftActions({ draftMode }: DraftActionsProps): ReactElement {
 export function PlumixEditorLayout({
   registry = EMPTY_REGISTRY,
   patternRegistry = EMPTY_PATTERN_REGISTRY,
+  starterCandidates = EMPTY_STARTER_CANDIDATES,
   capabilities = EMPTY_CAPS,
   tokens = EMPTY_TOKENS,
   title,
@@ -461,16 +491,20 @@ export function PlumixEditorLayout({
               <div className="pointer-events-none h-full">
                 <PlumixCanvasWithSlashMenu
                   registry={registry}
+                  patternRegistry={patternRegistry}
                   capabilities={capabilities}
                   patterns={patterns}
+                  starterCandidates={starterCandidates}
                 />
               </div>
             </div>
           ) : (
             <PlumixCanvasWithSlashMenu
               registry={registry}
+              patternRegistry={patternRegistry}
               capabilities={capabilities}
               patterns={patterns}
+              starterCandidates={starterCandidates}
             />
           )}
           <InspectorBody registry={registry} tokens={tokens} />
@@ -690,18 +724,42 @@ function InspectorBody({ registry, tokens }: InspectorBodyProps): ReactElement {
 
 interface PlumixCanvasWithSlashMenuProps {
   readonly registry: BlockRegistry;
+  readonly patternRegistry: PatternRegistry;
   readonly capabilities: ReadonlySet<string>;
   readonly patterns: readonly PatternManifestEntry[];
+  readonly starterCandidates: readonly PatternManifestEntry[];
 }
 
 function PlumixCanvasWithSlashMenu({
   registry,
+  patternRegistry,
   capabilities,
   patterns,
+  starterCandidates,
 }: PlumixCanvasWithSlashMenuProps): ReactElement {
   const puck = usePuck();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  // Captured once at mount: the modal's initial open state must reflect
+  // the entry as it was loaded, not later state changes that follow a
+  // pattern seed.
+  const [initiallyEmpty] = useState(
+    () => puck.appState.data.content.length === 0,
+  );
+  const starterState = useStarterModalState({
+    initiallyEmpty,
+    candidates: starterCandidates,
+  });
+  const handleStarterSelect = useCallback(
+    (pattern: PatternManifestEntry): void => {
+      puck.dispatch({
+        type: "setData",
+        data: (previous) => insertPattern(previous, pattern, 0),
+      });
+      starterState.dismiss();
+    },
+    [puck, starterState],
+  );
 
   const items = useMemo(
     () => resolveSlashMenuItems(registry, { capabilities, query, patterns }),
@@ -811,7 +869,15 @@ function PlumixCanvasWithSlashMenu({
       className="flex min-h-0 flex-col"
       data-testid="plumix-editor-canvas-column"
     >
-      <CanvasToolbar zoom={zoom} onZoomChange={setManualZoom} />
+      <CanvasToolbar
+        zoom={zoom}
+        onZoomChange={setManualZoom}
+        canReopenStarter={
+          puck.appState.data.content.length === 0 &&
+          starterCandidates.length > 0
+        }
+        onReopenStarter={starterState.reopen}
+      />
       <main
         ref={mainRef}
         className="bg-muted/30 flex-1 overflow-auto px-8 py-6"
@@ -849,6 +915,15 @@ function PlumixCanvasWithSlashMenu({
           />
         </DialogContent>
       </Dialog>
+      {starterState.open ? (
+        <StarterModal
+          candidates={starterCandidates}
+          blocks={registry}
+          patterns={patternRegistry}
+          onSelect={handleStarterSelect}
+          onDismiss={starterState.dismiss}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/admin/src/editor/StarterModal.test.tsx
+++ b/packages/admin/src/editor/StarterModal.test.tsx
@@ -1,0 +1,138 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
+
+import { StarterModal } from "./StarterModal.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const blocks = createBlockRegistry([]);
+const patternRegistry = createPatternRegistry([]);
+
+const hero: PatternManifestEntry = {
+  name: "starter/hero",
+  title: "Hero start",
+  content: [],
+  target: "post-content",
+  preview: {
+    src: "/hero.png",
+    width: 400,
+    height: 240,
+    alt: "Hero preview",
+  },
+};
+
+const cta: PatternManifestEntry = {
+  name: "starter/cta",
+  title: "CTA start",
+  content: [],
+  target: "post-content",
+  preview: {
+    src: "/cta.png",
+    width: 400,
+    height: 240,
+    alt: "CTA preview",
+  },
+};
+
+describe("StarterModal", () => {
+  test("renders nothing when there are no candidates", () => {
+    const { container } = render(
+      <StarterModal
+        candidates={[]}
+        blocks={blocks}
+        patterns={patternRegistry}
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("renders one card per candidate plus a Start-from-blank action", () => {
+    render(
+      <StarterModal
+        candidates={[hero, cta]}
+        blocks={blocks}
+        patterns={patternRegistry}
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("plumix-starter-modal")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("plumix-starter-modal-card-starter/hero"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("plumix-starter-modal-card-starter/cta"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("plumix-starter-modal-start-blank"),
+    ).toBeInTheDocument();
+  });
+
+  test("clicking a card calls onSelect with the chosen pattern", async () => {
+    const onSelect = vi.fn();
+    render(
+      <StarterModal
+        candidates={[hero, cta]}
+        blocks={blocks}
+        patterns={patternRegistry}
+        onSelect={onSelect}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByTestId("plumix-starter-modal-card-starter/cta"),
+    );
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(cta);
+  });
+
+  test("pressing Enter on a focused card calls onSelect (keyboard path)", async () => {
+    const onSelect = vi.fn();
+    render(
+      <StarterModal
+        candidates={[hero]}
+        blocks={blocks}
+        patterns={patternRegistry}
+        onSelect={onSelect}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    const card = screen.getByTestId(`plumix-starter-modal-card-${hero.name}`);
+    card.focus();
+    await userEvent.keyboard("{Enter}");
+
+    expect(onSelect).toHaveBeenCalledWith(hero);
+  });
+
+  test("clicking Start from blank calls onDismiss", async () => {
+    const onDismiss = vi.fn();
+    render(
+      <StarterModal
+        candidates={[hero]}
+        blocks={blocks}
+        patterns={patternRegistry}
+        onSelect={vi.fn()}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByTestId("plumix-starter-modal-start-blank"),
+    );
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/admin/src/editor/StarterModal.tsx
+++ b/packages/admin/src/editor/StarterModal.tsx
@@ -1,0 +1,94 @@
+import type { ReactElement } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
+
+import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+
+import { PatternThumbnail } from "./PatternThumbnail.js";
+
+interface StarterModalProps {
+  readonly candidates: readonly PatternManifestEntry[];
+  readonly blocks: BlockRegistry;
+  readonly patterns: PatternRegistry;
+  readonly onSelect: (pattern: PatternManifestEntry) => void;
+  readonly onDismiss: () => void;
+}
+
+export function StarterModal({
+  candidates,
+  blocks,
+  patterns,
+  onSelect,
+  onDismiss,
+}: StarterModalProps): ReactElement | null {
+  if (candidates.length === 0) return null;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onDismiss();
+      }}
+    >
+      <DialogContent
+        className="max-w-3xl"
+        data-testid="plumix-starter-modal"
+        showCloseButton={false}
+      >
+        <DialogHeader>
+          <DialogTitle>Start from a pattern</DialogTitle>
+          <DialogDescription>
+            Pick a starting layout, or begin from a blank canvas.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {candidates.map((entry) => (
+            <li key={entry.name}>
+              {/* `<div role="button">` rather than `<button>` — the
+                  live thumbnail can contain interactive HTML. Same
+                  posture as the sidebar row. */}
+              <div
+                role="button"
+                tabIndex={0}
+                className="hover:bg-muted/40 flex w-full flex-col gap-2 rounded border p-2 text-left focus:outline-none focus-visible:ring"
+                data-testid={`plumix-starter-modal-card-${entry.name}`}
+                onClick={() => onSelect(entry)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelect(entry);
+                  }
+                }}
+              >
+                <div className="pointer-events-none overflow-hidden rounded">
+                  <PatternThumbnail
+                    pattern={entry}
+                    blocks={blocks}
+                    patterns={patterns}
+                  />
+                </div>
+                <span className="text-sm font-medium">{entry.title}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-foreground text-sm underline-offset-2 hover:underline"
+            data-testid="plumix-starter-modal-start-blank"
+            onClick={onDismiss}
+          >
+            Start from blank
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/admin/src/editor/select-starter-patterns.test.ts
+++ b/packages/admin/src/editor/select-starter-patterns.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+
+import { selectStarterPatterns } from "./select-starter-patterns.js";
+
+const blank = (
+  overrides: Partial<PatternManifestEntry> & { readonly name: string },
+): PatternManifestEntry => ({
+  title: overrides.name,
+  content: [],
+  ...overrides,
+});
+
+describe("selectStarterPatterns", () => {
+  test("includes only patterns with target === 'post-content'", () => {
+    const candidates = selectStarterPatterns(
+      [
+        blank({ name: "starter/in", target: "post-content" }),
+        blank({ name: "starter/no-target" }),
+      ],
+      "page",
+    );
+
+    expect(candidates.map((p) => p.name)).toEqual(["starter/in"]);
+  });
+
+  test("filters by entryTypes when set; accepts when unset", () => {
+    const candidates = selectStarterPatterns(
+      [
+        blank({
+          name: "starter/page-only",
+          target: "post-content",
+          entryTypes: ["page"],
+        }),
+        blank({
+          name: "starter/post-only",
+          target: "post-content",
+          entryTypes: ["post"],
+        }),
+        blank({ name: "starter/any-type", target: "post-content" }),
+      ],
+      "page",
+    );
+
+    expect(candidates.map((p) => p.name).sort()).toEqual([
+      "starter/any-type",
+      "starter/page-only",
+    ]);
+  });
+
+  test("sorts by priority asc, then name asc", () => {
+    const candidates = selectStarterPatterns(
+      [
+        blank({
+          name: "starter/zeta",
+          target: "post-content",
+          priority: 1,
+        }),
+        blank({
+          name: "starter/alpha",
+          target: "post-content",
+          priority: 1,
+        }),
+        blank({ name: "starter/no-prio", target: "post-content" }),
+        blank({
+          name: "starter/high",
+          target: "post-content",
+          priority: -5,
+        }),
+      ],
+      "page",
+    );
+
+    expect(candidates.map((p) => p.name)).toEqual([
+      "starter/high",
+      "starter/alpha",
+      "starter/zeta",
+      "starter/no-prio",
+    ]);
+  });
+});

--- a/packages/admin/src/editor/select-starter-patterns.ts
+++ b/packages/admin/src/editor/select-starter-patterns.ts
@@ -1,0 +1,15 @@
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+import { byPriorityThen } from "@plumix/core/manifest";
+
+export function selectStarterPatterns(
+  patterns: readonly PatternManifestEntry[],
+  entryType: string,
+): readonly PatternManifestEntry[] {
+  return patterns
+    .filter(
+      (p) =>
+        p.target === "post-content" &&
+        (p.entryTypes === undefined || p.entryTypes.includes(entryType)),
+    )
+    .sort(byPriorityThen((p) => p.name));
+}

--- a/packages/admin/src/editor/use-starter-modal-state.test.ts
+++ b/packages/admin/src/editor/use-starter-modal-state.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+
+import { useStarterModalState } from "./use-starter-modal-state.js";
+
+const blank = (name: string): PatternManifestEntry => ({
+  name,
+  title: name,
+  content: [],
+  target: "post-content",
+});
+
+describe("useStarterModalState", () => {
+  test("opens when the entry is initially empty and candidates exist", () => {
+    const { result } = renderHook(() =>
+      useStarterModalState({
+        initiallyEmpty: true,
+        candidates: [blank("a")],
+      }),
+    );
+
+    expect(result.current.open).toBe(true);
+  });
+
+  test("stays closed when the entry has content even with candidates", () => {
+    const { result } = renderHook(() =>
+      useStarterModalState({
+        initiallyEmpty: false,
+        candidates: [blank("a")],
+      }),
+    );
+
+    expect(result.current.open).toBe(false);
+  });
+
+  test("stays closed when there are no candidates", () => {
+    const { result } = renderHook(() =>
+      useStarterModalState({
+        initiallyEmpty: true,
+        candidates: [],
+      }),
+    );
+
+    expect(result.current.open).toBe(false);
+  });
+
+  test("dismiss closes; reopen reopens when candidates exist", () => {
+    const { result } = renderHook(() =>
+      useStarterModalState({
+        initiallyEmpty: true,
+        candidates: [blank("a")],
+      }),
+    );
+
+    act(() => result.current.dismiss());
+    expect(result.current.open).toBe(false);
+
+    act(() => result.current.reopen());
+    expect(result.current.open).toBe(true);
+  });
+
+  test("reopen is a no-op when there are no candidates", () => {
+    const { result } = renderHook(() =>
+      useStarterModalState({
+        initiallyEmpty: true,
+        candidates: [],
+      }),
+    );
+
+    act(() => result.current.reopen());
+    expect(result.current.open).toBe(false);
+  });
+});

--- a/packages/admin/src/editor/use-starter-modal-state.ts
+++ b/packages/admin/src/editor/use-starter-modal-state.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+
+import type { PatternManifestEntry } from "@plumix/core/manifest";
+
+interface UseStarterModalStateOptions {
+  readonly initiallyEmpty: boolean;
+  readonly candidates: readonly PatternManifestEntry[];
+}
+
+interface StarterModalState {
+  readonly open: boolean;
+  readonly dismiss: () => void;
+  readonly reopen: () => void;
+}
+
+export function useStarterModalState({
+  initiallyEmpty,
+  candidates,
+}: UseStarterModalStateOptions): StarterModalState {
+  const [open, setOpen] = useState(initiallyEmpty && candidates.length > 0);
+
+  const dismiss = useCallback(() => setOpen(false), []);
+  const reopen = useCallback(() => {
+    if (candidates.length > 0) setOpen(true);
+  }, [candidates]);
+
+  return { open, dismiss, reopen };
+}

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -17,6 +17,7 @@ import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
 import { resolveEditorMode } from "@/editor/resolve-editor-mode.js";
 import { PreviewBanner } from "@/editor/revisions/PreviewBanner.js";
 import { useRevisionsTrigger } from "@/editor/revisions/use-revisions-trigger.js";
+import { selectStarterPatterns } from "@/editor/select-starter-patterns.js";
 import { StaleDraftDialog } from "@/editor/StaleDraftDialog.js";
 import {
   entryMetaBoxesForType,
@@ -225,6 +226,11 @@ function PuckSpikeRouteInner({
   userId,
   backHref,
 }: PuckSpikeRouteInnerProps): ReactNode {
+  const starterCandidates = useMemo(
+    () =>
+      entryType ? selectStarterPatterns(getPatterns(), entryType.name) : [],
+    [entryType],
+  );
   const entryTypeName = entryType?.name;
   // `preview: true` overlays any existing autosave onto the live row
   // and decorates the response with `_preview`. For types/users
@@ -567,6 +573,7 @@ function PuckSpikeRouteInner({
       <PlumixEditorLayout
         registry={registry}
         patternRegistry={patternRegistry}
+        starterCandidates={starterCandidates}
         capabilities={capabilitySet}
         tokens={themeTokens}
         title={title}
@@ -598,6 +605,7 @@ function PuckSpikeRouteInner({
       revisionsTrigger,
       coAuthors,
       draftModeProp,
+      starterCandidates,
     ],
   );
 
@@ -737,6 +745,8 @@ function PuckPreviewRouteInner({
   const revisionAuthor =
     revision.authorName ?? revision.authorEmail ?? `#${String(revisionId)}`;
   const Layout = useCallback(
+    // Preview mode never opens the starter modal — the entry being
+    // previewed is always pre-populated.
     (): ReactElement => (
       <PlumixEditorLayout
         registry={registry}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -74,6 +74,7 @@ export type {
   PatternInsertMode,
   PatternPreview,
   PatternRegistry,
+  PatternTarget,
 } from "./pattern-registry.js";
 export { PatternRegistryError } from "./pattern-errors.js";
 

--- a/packages/blocks/src/pattern-registry.test.ts
+++ b/packages/blocks/src/pattern-registry.test.ts
@@ -56,6 +56,21 @@ describe("definePattern", () => {
     expect(pattern.content.map((n) => n.id)).toEqual(["p1", "p2"]);
   });
 
+  test("preserves the starter-modal fields — target, entryTypes, priority", () => {
+    const pattern = definePattern({
+      name: "starter/page-blank",
+      title: "Blank page",
+      content: [],
+      target: "post-content",
+      entryTypes: ["page"],
+      priority: 5,
+    });
+
+    expect(pattern.target).toBe("post-content");
+    expect(pattern.entryTypes).toEqual(["page"]);
+    expect(pattern.priority).toBe(5);
+  });
+
   test("preserves the preview override field with width, height, and optional alt", () => {
     const pattern = definePattern({
       name: "x/preview",

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -45,6 +45,8 @@ export interface PatternPreview {
   readonly alt?: string;
 }
 
+export type PatternTarget = "post-content";
+
 export interface BlockPattern {
   readonly name: string;
   readonly title: string;
@@ -57,6 +59,13 @@ export interface BlockPattern {
   // Static preview override. When set, the inserter renders an <img>
   // at the declared dimensions instead of live-rendering `content`.
   readonly preview?: PatternPreview;
+  // Marks the pattern as eligible for the starter modal when the
+  // matching entry type is being authored from scratch.
+  readonly target?: PatternTarget;
+  readonly entryTypes?: readonly string[];
+  // Lower numbers float to the top of the starter modal; ties break
+  // alphabetically by name.
+  readonly priority?: number;
   readonly content: readonly BlockNode[];
 }
 

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -1374,6 +1374,28 @@ describe("buildManifest visibility projection", () => {
     });
   });
 
+  test("projects the starter-modal fields — target, entryTypes, priority — through the manifest", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("acme", (ctx) => {
+      ctx.registerPattern({
+        name: "acme/page-blank",
+        title: "Blank page",
+        content: [],
+        target: "post-content",
+        entryTypes: ["page"],
+        priority: 5,
+      });
+    });
+
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    const entry = manifest.patterns.find((p) => p.name === "acme/page-blank");
+
+    expect(entry?.target).toBe("post-content");
+    expect(entry?.entryTypes).toEqual(["page"]);
+    expect(entry?.priority).toBe(5);
+  });
+
   test("projects the preview override through the manifest when set, omits it otherwise", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("acme", (ctx) => {

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -6,6 +6,7 @@ import type {
   MarkSpec,
   PatternInsertMode,
   PatternPreview,
+  PatternTarget,
   ThemeTokens,
 } from "@plumix/blocks";
 
@@ -1460,6 +1461,9 @@ export interface PatternManifestEntry {
   // `undefined`.
   readonly insert?: PatternInsertMode;
   readonly preview?: PatternPreview;
+  readonly target?: PatternTarget;
+  readonly entryTypes?: readonly string[];
+  readonly priority?: number;
   readonly content: readonly BlockNode[];
 }
 
@@ -2257,8 +2261,18 @@ function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {
 }
 
 function toPatternEntry(pattern: RegisteredPattern): PatternManifestEntry {
-  const { name, title, category, keywords, content, insert, preview } =
-    pattern.spec;
+  const {
+    name,
+    title,
+    category,
+    keywords,
+    content,
+    insert,
+    preview,
+    target,
+    entryTypes,
+    priority,
+  } = pattern.spec;
   return {
     name,
     title,
@@ -2266,6 +2280,9 @@ function toPatternEntry(pattern: RegisteredPattern): PatternManifestEntry {
     keywords,
     insert: insert ?? "copy",
     preview,
+    target,
+    entryTypes,
+    priority,
     content,
   };
 }


### PR DESCRIPTION
Adds the blank-page-killer surface. When the editor mounts on an entry with empty content and the manifest carries at least one pattern marked `target: "post-content"` for the entry's type, a modal opens automatically with a grid of starter candidates. Clicking a card seeds the entry via the existing `insertPattern` primitive (copy or reference, per `pattern.insert`) and dismisses; "Start from blank" and ESC dismiss without seeding. A "Pick a starter…" button surfaces on the canvas toolbar exactly while content stays empty and candidates exist, re-summoning the modal after a dismissal.

**New pattern fields**

Patterns declare eligibility via `target?: "post-content"`, `entryTypes?: readonly string[]` (omit to accept every type), and `priority?: number` (lower floats higher). All three project through `PatternManifestEntry` alongside the existing copy/reference + preview channels. Filtering and sorting live in a pure `selectStarterPatterns(patterns, entryType)` module; sort reuses the project-wide `byPriorityThen` helper that entry types, term taxonomies, and settings pages already use.

**State machine**

`useStarterModalState` captures `initiallyEmpty` once at mount via a lazy `useState` initializer — frozen, so post-seed dispatches don't reopen the modal. The Replace button's visibility is a live check against `puck.appState.data.content.length`, so once the user types anything the button disappears. Preview-mode routes never thread `starterCandidates`, so the default empty array guarantees the modal stays closed when previewing a populated revision.

Refs #625
Refs #631