### PR TITLE
feat: copy a selection to the clipboard as a paste-ready definePattern source

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -51,6 +51,7 @@ import type { SlashMenuItem } from "./slash-menu-items.js";
 import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { BlockIcon } from "./BlockIcon.js";
+import { buildCopyPatternSource } from "./build-copy-pattern-source.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { insertPattern } from "./insert-pattern.js";
 import { mergePropsAtSelector } from "./merge-variation-attrs.js";
@@ -167,6 +168,9 @@ interface CanvasToolbarProps {
   // change their mind before they start building.
   readonly canReopenStarter: boolean;
   readonly onReopenStarter: () => void;
+  // Writes the current selection (or whole doc when no selection) to
+  // the clipboard as a paste-ready `definePattern({...})` snippet.
+  readonly onCopyAsPatternSource: () => void;
 }
 
 function CanvasToolbar({
@@ -174,6 +178,7 @@ function CanvasToolbar({
   onZoomChange,
   canReopenStarter,
   onReopenStarter,
+  onCopyAsPatternSource,
 }: CanvasToolbarProps): ReactElement {
   const puck = usePuck();
   const { viewports } = puck.appState.ui;
@@ -287,6 +292,15 @@ function CanvasToolbar({
           </button>
         </>
       ) : null}
+      <div className="bg-border h-5 w-px" aria-hidden />
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground inline-flex h-7 items-center rounded-md px-2 text-xs"
+        data-testid="plumix-editor-copy-as-pattern-source"
+        onClick={onCopyAsPatternSource}
+      >
+        Copy as pattern source
+      </button>
     </div>
   );
 }
@@ -495,6 +509,7 @@ export function PlumixEditorLayout({
                   capabilities={capabilities}
                   patterns={patterns}
                   starterCandidates={starterCandidates}
+                  entryTitle={title}
                 />
               </div>
             </div>
@@ -505,6 +520,7 @@ export function PlumixEditorLayout({
               capabilities={capabilities}
               patterns={patterns}
               starterCandidates={starterCandidates}
+              entryTitle={title}
             />
           )}
           <InspectorBody registry={registry} tokens={tokens} />
@@ -728,6 +744,9 @@ interface PlumixCanvasWithSlashMenuProps {
   readonly capabilities: ReadonlySet<string>;
   readonly patterns: readonly PatternManifestEntry[];
   readonly starterCandidates: readonly PatternManifestEntry[];
+  // Entry title — drives both the emitted snippet's `title` field and
+  // its derived `name` slug for the Copy-as-pattern-source action.
+  readonly entryTitle: string;
 }
 
 function PlumixCanvasWithSlashMenu({
@@ -736,6 +755,7 @@ function PlumixCanvasWithSlashMenu({
   capabilities,
   patterns,
   starterCandidates,
+  entryTitle,
 }: PlumixCanvasWithSlashMenuProps): ReactElement {
   const puck = usePuck();
   const [open, setOpen] = useState(false);
@@ -864,6 +884,20 @@ function PlumixCanvasWithSlashMenu({
     mainInnerWidth > 0 ? Math.min(1, mainInnerWidth / viewportPx) : 1;
   const zoom = manualZoom ?? fitZoom;
 
+  const handleCopyAsPatternSource = useCallback((): void => {
+    const source = buildCopyPatternSource({
+      title: entryTitle,
+      data: puck.appState.data,
+      selectedItem: puck.selectedItem ?? null,
+    });
+    navigator.clipboard.writeText(source).catch((error: unknown) => {
+      console.error(
+        "[plumix:copy-as-pattern-source] clipboard write failed:",
+        error,
+      );
+    });
+  }, [puck, entryTitle]);
+
   return (
     <div
       className="flex min-h-0 flex-col"
@@ -877,6 +911,7 @@ function PlumixCanvasWithSlashMenu({
           starterCandidates.length > 0
         }
         onReopenStarter={starterState.reopen}
+        onCopyAsPatternSource={handleCopyAsPatternSource}
       />
       <main
         ref={mainRef}

--- a/packages/admin/src/editor/build-copy-pattern-source.test.ts
+++ b/packages/admin/src/editor/build-copy-pattern-source.test.ts
@@ -1,0 +1,46 @@
+import type { ComponentData, Data } from "@puckeditor/core";
+import { describe, expect, test } from "vitest";
+
+import { buildCopyPatternSource } from "./build-copy-pattern-source.js";
+
+const data: Pick<Data, "content"> = {
+  content: [
+    { type: "core/heading", props: { id: "h1", text: "Title", level: 2 } },
+    { type: "core/rich-text", props: { id: "p1", html: "<p>Body</p>" } },
+  ] as Data["content"],
+};
+
+describe("buildCopyPatternSource", () => {
+  test("serializes the whole document when no item is selected", () => {
+    const source = buildCopyPatternSource({
+      title: "My Hero",
+      data,
+      selectedItem: null,
+    });
+    expect(source).toContain('name: "starter/my-hero"');
+    expect(source).toContain('title: "My Hero"');
+    expect(source).toContain('block("core/heading"');
+    expect(source).toContain('block("core/rich-text"');
+  });
+
+  test("serializes only the selected subtree when one is selected", () => {
+    const selectedItem = data.content[0] as ComponentData;
+    const source = buildCopyPatternSource({
+      title: "Heading",
+      data,
+      selectedItem,
+    });
+    expect(source).toContain('block("core/heading"');
+    expect(source).not.toContain('block("core/rich-text"');
+  });
+
+  test("substitutes a placeholder title when the entry is untitled", () => {
+    const source = buildCopyPatternSource({
+      title: "",
+      data,
+      selectedItem: null,
+    });
+    expect(source).toContain('name: "starter/untitled"');
+    expect(source).toContain('title: "Untitled"');
+  });
+});

--- a/packages/admin/src/editor/build-copy-pattern-source.ts
+++ b/packages/admin/src/editor/build-copy-pattern-source.ts
@@ -1,0 +1,25 @@
+import type { ComponentData, Data } from "@puckeditor/core";
+
+import { serializePatternSource } from "@plumix/blocks";
+
+import { derivePatternSlug } from "./derive-pattern-slug.js";
+import { puckDataToBlockTree } from "./puck-to-block-tree.js";
+
+interface BuildCopyPatternSourceArgs {
+  readonly title: string;
+  readonly data: Pick<Data, "content">;
+  readonly selectedItem: ComponentData | null;
+}
+
+export function buildCopyPatternSource({
+  title,
+  data,
+  selectedItem,
+}: BuildCopyPatternSourceArgs): string {
+  const content = selectedItem ? [selectedItem] : data.content;
+  const nodes = puckDataToBlockTree({ content });
+  return serializePatternSource(nodes, {
+    slug: derivePatternSlug(title),
+    title: title.trim() || "Untitled",
+  });
+}

--- a/packages/admin/src/editor/derive-pattern-slug.test.ts
+++ b/packages/admin/src/editor/derive-pattern-slug.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import { derivePatternSlug } from "./derive-pattern-slug.js";
+
+describe("derivePatternSlug", () => {
+  test("kebabs a plain title under the starter namespace", () => {
+    expect(derivePatternSlug("Hero Section")).toBe("starter/hero-section");
+  });
+
+  test("collapses non-alphanumeric runs to single hyphens and lowercases", () => {
+    expect(derivePatternSlug("My Awesome 2026 Hero!")).toBe(
+      "starter/my-awesome-2026-hero",
+    );
+  });
+
+  test("falls back to starter/untitled when the title strips to nothing", () => {
+    expect(derivePatternSlug("")).toBe("starter/untitled");
+    expect(derivePatternSlug("!!! ??? ---")).toBe("starter/untitled");
+  });
+
+  test("trims leading and trailing hyphens off the derived suffix", () => {
+    expect(derivePatternSlug("  Hello  ")).toBe("starter/hello");
+    expect(derivePatternSlug("-foo-")).toBe("starter/foo");
+  });
+});

--- a/packages/admin/src/editor/derive-pattern-slug.ts
+++ b/packages/admin/src/editor/derive-pattern-slug.ts
@@ -1,0 +1,10 @@
+// Best-effort kebab — the emitted snippet is a starting point the
+// author edits, so the namespace ("starter/") and fallback slug
+// ("untitled") are placeholders, not invariants.
+export function derivePatternSlug(title: string): string {
+  const suffix = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `starter/${suffix || "untitled"}`;
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -77,6 +77,8 @@ export type {
   PatternTarget,
 } from "./pattern-registry.js";
 export { PatternRegistryError } from "./pattern-errors.js";
+export { serializePatternSource } from "./serialize-pattern-source.js";
+export type { SerializePatternSourceOptions } from "./serialize-pattern-source.js";
 
 // ─── Validation ─────────────────────────────────────────────────────────────
 export { validateEntryContent } from "./validate-content.js";

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -1,5 +1,6 @@
 import type { BlockRegistry } from "./block-registry.js";
 import type { BlockNode } from "./render-block-tree.js";
+import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
 import { PatternRegistryError } from "./pattern-errors.js";
 import { isBlockNodeArray } from "./render-block-tree.js";
 import { validateEntryContent } from "./validate-content.js";
@@ -84,13 +85,17 @@ export function definePattern(spec: BlockPattern): BlockPattern {
 export function block<TName extends string>(
   name: TName,
   attrs: AttrsFor<TName>,
-  options?: { readonly id?: string },
+  options?: {
+    readonly id?: string;
+    readonly style?: ResponsiveStyleSlot;
+  },
 ): BlockNode {
-  return {
+  const base: BlockNode = {
     id: options?.id ?? PLACEHOLDER_ID,
     name,
     attrs,
   };
+  return options?.style ? { ...base, style: options.style } : base;
 }
 
 function assignPatternIds(nodes: readonly BlockNode[]): readonly BlockNode[] {

--- a/packages/blocks/src/serialize-pattern-source.test.ts
+++ b/packages/blocks/src/serialize-pattern-source.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "./render-block-tree.js";
+import { createBlockRegistry } from "./block-registry.js";
+import { headingBlock } from "./heading/index.js";
+import {
+  block,
+  commitPatterns,
+  createPatternRegistry,
+  definePattern,
+} from "./pattern-registry.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+import { richTextBlock } from "./rich-text/index.js";
+import { serializePatternSource } from "./serialize-pattern-source.js";
+
+function stripIds(nodes: readonly BlockNode[]): unknown {
+  return nodes.map((node) => {
+    const attrs: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node.attrs ?? {})) {
+      attrs[key] = isBlockNodeArray(value) ? stripIds(value) : value;
+    }
+    return { name: node.name, attrs };
+  });
+}
+
+function evalPatternSource(source: string): readonly BlockNode[] {
+  const match = /definePattern\(([\s\S]*?)\);\n$/.exec(source);
+  if (!match) throw new Error("emit shape did not match definePattern(...);");
+  // Compiling the emitted snippet is the whole point of the round-trip
+  // contract — eslint-disable is the price.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const factory = new Function(
+    "block",
+    "definePattern",
+    `return definePattern(${match[1]});`,
+  ) as (
+    b: typeof block,
+    d: typeof definePattern,
+  ) => {
+    content: readonly BlockNode[];
+  };
+  return factory(block, definePattern).content;
+}
+
+describe("serializePatternSource", () => {
+  test("emits a definePattern shell for an empty body", () => {
+    const out = serializePatternSource([]);
+    expect(out).toContain(
+      'import { block, definePattern } from "plumix/blocks"',
+    );
+    expect(out).toContain("definePattern({");
+    expect(out).toContain('name: "starter/untitled"');
+    expect(out).toContain('title: "Untitled"');
+    expect(out).toContain("content: [],");
+  });
+
+  test("emits one block() call per node with primitive attrs", () => {
+    const out = serializePatternSource([
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: { level: 2, text: "Hello", featured: true, anchor: null },
+      },
+    ]);
+    expect(out).toContain('block("core/heading", {');
+    expect(out).toContain("level: 2,");
+    expect(out).toContain('text: "Hello",');
+    expect(out).toContain("featured: true,");
+    expect(out).toContain("anchor: null,");
+  });
+
+  test("escapes string attrs so the emitted source parses", () => {
+    const out = serializePatternSource([
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: {
+          text: 'He said "hi" then \\n broke',
+          subtitle: "line\nbreak\ttab",
+          glyph: "★ é",
+        },
+      },
+    ]);
+    expect(out).toContain('"He said \\"hi\\" then \\\\n broke"');
+    expect(out).toContain('"line\\nbreak\\ttab"');
+    expect(out).toContain('"★ é"');
+  });
+
+  test("renders nested slot arrays as inline block() calls", () => {
+    const out = serializePatternSource([
+      {
+        id: "g1",
+        name: "core/group",
+        attrs: {
+          children: [
+            { id: "h1", name: "core/heading", attrs: { level: 2 } },
+            {
+              id: "g2",
+              name: "core/group",
+              attrs: {
+                children: [
+                  {
+                    id: "p1",
+                    name: "core/rich-text",
+                    attrs: { html: "<p>x</p>" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    // Outer group opens with `children: [` and contains two nested block() calls,
+    // one of which is itself a group whose `children` is another nested block().
+    expect(out).toContain("children: [");
+    expect(out).toMatch(
+      /block\("core\/group", \{[\s\S]*block\("core\/heading"/,
+    );
+    expect(out).toMatch(
+      /block\("core\/group", \{[\s\S]*block\("core\/group", \{[\s\S]*block\("core\/rich-text"/,
+    );
+  });
+
+  test("drops `id` from emitted attrs — `block()` owns IDs via the options bag", () => {
+    const out = serializePatternSource([
+      {
+        id: "puck-0",
+        name: "core/heading",
+        attrs: { id: "puck-0", level: 2, text: "Hi" },
+      },
+    ]);
+    expect(out).not.toContain("id:");
+    expect(out).toContain("level: 2,");
+    expect(out).toContain('text: "Hi",');
+  });
+
+  test("emits node.style via the block() options bag", () => {
+    const out = serializePatternSource([
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: { level: 2 },
+        style: { large: { marginTop: "16px" } },
+      },
+    ]);
+    expect(out).toMatch(
+      /block\("core\/heading", \{[\s\S]*?\}, \{ style: \{[\s\S]*?"marginTop":\s*"16px"/,
+    );
+  });
+
+  test("round-trips: evaluated source produces a structurally equal tree modulo IDs", () => {
+    const input: readonly BlockNode[] = [
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: { level: 2, text: 'A "quoted" heading' },
+      },
+      {
+        id: "g1",
+        name: "core/group",
+        attrs: {
+          children: [
+            {
+              id: "p1",
+              name: "core/rich-text",
+              attrs: { html: "<p>line\nbreak</p>", emphasis: true },
+            },
+          ],
+        },
+      },
+    ];
+    const out = serializePatternSource(input);
+    const parsed = evalPatternSource(out);
+    expect(stripIds(parsed)).toEqual(stripIds(input));
+  });
+
+  test("the emitted snippet survives commitPatterns against a real block registry", () => {
+    // Tree shape the toolbar produces after `puckDataToBlockTree` —
+    // both `node.id` and `attrs.id` are populated, mirroring Puck's
+    // props flattening.
+    const tree: readonly BlockNode[] = [
+      {
+        id: "puck-0",
+        name: "core/heading",
+        attrs: { id: "puck-0", level: 2, text: "Hello" },
+      },
+      {
+        id: "puck-1",
+        name: "core/rich-text",
+        attrs: { id: "puck-1", body: "<p>Body</p>" },
+      },
+    ];
+    const out = serializePatternSource(tree, {
+      slug: "starter/round-trip",
+      title: "Round trip",
+    });
+    const parsed = evalPatternSource(out);
+    const blocks = createBlockRegistry([headingBlock, richTextBlock]);
+    const pattern = definePattern({
+      name: "starter/round-trip",
+      title: "Round trip",
+      content: parsed,
+    });
+    expect(() =>
+      commitPatterns(createPatternRegistry([pattern]), blocks),
+    ).not.toThrow();
+  });
+});

--- a/packages/blocks/src/serialize-pattern-source.ts
+++ b/packages/blocks/src/serialize-pattern-source.ts
@@ -1,0 +1,56 @@
+import type { BlockNode } from "./render-block-tree.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+
+export interface SerializePatternSourceOptions {
+  readonly slug?: string;
+  readonly title?: string;
+}
+
+const INDENT = "  ";
+
+export function serializePatternSource(
+  nodes: readonly BlockNode[],
+  options: SerializePatternSourceOptions = {},
+): string {
+  const slug = options.slug ?? "starter/untitled";
+  const title = options.title ?? "Untitled";
+  return [
+    `import { block, definePattern } from "plumix/blocks";`,
+    ``,
+    `export const pattern = definePattern({`,
+    `${INDENT}name: ${JSON.stringify(slug)},`,
+    `${INDENT}title: ${JSON.stringify(title)},`,
+    `${INDENT}content: ${renderValue(nodes, 1)},`,
+    `});`,
+    ``,
+  ].join("\n");
+}
+
+function renderNode(node: BlockNode, depth: number): string {
+  const pad = INDENT.repeat(depth);
+  const inner = INDENT.repeat(depth + 1);
+  // Drop the `id` key — Puck's flattening puts the node ID into attrs,
+  // but no block declares `id` as an input so `commitPatterns` rejects
+  // pasted snippets that carry it. `block()` writes the ID itself.
+  const attrEntries = Object.entries(node.attrs ?? {}).filter(
+    ([key]) => key !== "id",
+  );
+  const tail = node.style ? `, { style: ${JSON.stringify(node.style)} }` : "";
+  if (attrEntries.length === 0) {
+    return `${pad}block(${JSON.stringify(node.name)}, {}${tail})`;
+  }
+  const lines = attrEntries.map(
+    ([key, value]) => `${inner}${key}: ${renderValue(value, depth + 1)},`,
+  );
+  return `${pad}block(${JSON.stringify(node.name)}, {\n${lines.join("\n")}\n${pad}}${tail})`;
+}
+
+function renderValue(value: unknown, depth: number): string {
+  if (isBlockNodeArray(value)) {
+    if (value.length === 0) return "[]";
+    const pad = INDENT.repeat(depth);
+    const children = value.map((n) => renderNode(n, depth + 1)).join(",\n");
+    return `[\n${children},\n${pad}]`;
+  }
+  return JSON.stringify(value);
+}


### PR DESCRIPTION
Adds a "Copy as pattern source" action to the editor canvas toolbar. Clicking it serializes
the current selection (or the whole document body when nothing is selected) into a
paste-ready `definePattern({ ... })` snippet using `block()` notation, and writes it to the
clipboard. Authors can build a layout in the visual editor, copy it, and drop the snippet
into a theme package — closing the loop between editor authoring and code-defined patterns.

**Round-trip is gated by `commitPatterns`, not just `definePattern`**

The serializer drops the `id` key Puck flattens into `attrs` — no block declares `id` as an
input, so a pasted snippet that carried it would fail `commitPatterns`'s `validateAttrs`
gate. The round-trip test now evaluates the emitted snippet and runs it through
`commitPatterns` against a real `BlockRegistry` (heading + rich-text), so the
"paste-ready" claim is verified end-to-end.

**`block()` gains a `style` option for node-level styles**

`block(name, attrs, options)` now accepts `style?: ResponsiveStyleSlot` alongside `id?`.
Pattern bodies that originate from a styled selection round-trip without losing the
StyleTab overrides — the serializer emits `block("name", { ... }, { style: { ... } })`
whenever `node.style` is present.

Fixes #632