### PR TITLE
feat: extend block variations with innerBlocks default body for the content slot

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -54,7 +54,7 @@ import { BlockIcon } from "./BlockIcon.js";
 import { buildCopyPatternSource } from "./build-copy-pattern-source.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { insertPattern } from "./insert-pattern.js";
-import { mergePropsAtSelector } from "./merge-variation-attrs.js";
+import { insertVariation } from "./insert-variation.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { PatternRefProvider } from "./PatternRefPreview.js";
@@ -624,25 +624,11 @@ function PlumixBlocksTab({
 
   const handleInsert = useCallback(
     (entry: InsertableBlockEntry): void => {
-      const index = puck.appState.data.content.length;
       puck.dispatch({
-        type: "insert",
-        componentType: entry.name,
-        destinationZone: PUCK_ROOT_ZONE,
-        destinationIndex: index,
+        type: "setData",
+        data: (previous) =>
+          insertVariation(previous, entry, previous.content.length),
       });
-      const variationAttrs = entry.attrs;
-      if (variationAttrs !== undefined) {
-        puck.dispatch({
-          type: "setData",
-          data: (previous) =>
-            mergePropsAtSelector(
-              previous,
-              { zone: PUCK_ROOT_ZONE, index },
-              variationAttrs,
-            ),
-        });
-      }
     },
     [puck],
   );
@@ -821,20 +807,16 @@ function PlumixCanvasWithSlashMenu({
       );
       if (item.kind === "block") {
         const { entry } = item;
+        // Variation insert operates on the root content array; nested
+        // zones fall back to end-of-document so innerBlocks (which must
+        // sit in a top-level slot the walker recognises) never land in
+        // the wrong shape.
+        const insertIndex =
+          zone === PUCK_ROOT_ZONE ? index : puck.appState.data.content.length;
         puck.dispatch({
-          type: "insert",
-          componentType: entry.name,
-          destinationZone: zone,
-          destinationIndex: index,
+          type: "setData",
+          data: (previous) => insertVariation(previous, entry, insertIndex),
         });
-        const variationAttrs = entry.attrs;
-        if (variationAttrs !== undefined) {
-          puck.dispatch({
-            type: "setData",
-            data: (previous) =>
-              mergePropsAtSelector(previous, { zone, index }, variationAttrs),
-          });
-        }
       } else {
         // The pattern insert primitive operates on the root content
         // array; nextInsertPoint may have returned a nested zone for

--- a/packages/admin/src/editor/insert-variation.test.ts
+++ b/packages/admin/src/editor/insert-variation.test.ts
@@ -1,0 +1,60 @@
+import type { Data } from "@puckeditor/core";
+import { describe, expect, test } from "vitest";
+
+import type { InsertableBlockEntry } from "@plumix/blocks";
+
+import { insertVariation } from "./insert-variation.js";
+import { puckDataToBlockTree } from "./puck-to-block-tree.js";
+
+function emptyData(): Data {
+  return { content: [], root: { props: {} } };
+}
+
+describe("insertVariation", () => {
+  test("inserts a parent block whose Puck slot carries innerBlocks the walker can read back", () => {
+    const entry: InsertableBlockEntry = {
+      name: "core/group",
+      slug: "core/group/with-heading",
+      title: "Group with heading",
+      attrs: { layout: "stack" },
+      innerBlocks: [
+        { id: "src-h", name: "core/heading", attrs: { level: 2, text: "Hi" } },
+      ],
+    };
+    const after = insertVariation(emptyData(), entry, 0);
+    const tree = puckDataToBlockTree(after);
+    expect(tree).toHaveLength(1);
+    const parent = tree[0];
+    expect(parent?.name).toBe("core/group");
+    expect(parent?.attrs?.layout).toBe("stack");
+    const slot = parent?.attrs?.content as readonly { name: string }[];
+    expect(slot).toHaveLength(1);
+    expect(slot[0]?.name).toBe("core/heading");
+  });
+
+  test("does not mutate source innerBlocks and ID-rewrites on every insert", () => {
+    const heading = {
+      id: "src-h",
+      name: "core/heading",
+      attrs: { level: 2 },
+    } as const;
+    const entry: InsertableBlockEntry = {
+      name: "core/group",
+      slug: "core/group/with-heading",
+      title: "Group with heading",
+      innerBlocks: [heading],
+    };
+    const first = insertVariation(emptyData(), entry, 0);
+    const second = insertVariation(emptyData(), entry, 0);
+    const firstTree = puckDataToBlockTree(first);
+    const secondTree = puckDataToBlockTree(second);
+    const firstSlot = firstTree[0]?.attrs?.content as readonly { id: string }[];
+    const secondSlot = secondTree[0]?.attrs?.content as readonly {
+      id: string;
+    }[];
+    expect(firstSlot[0]?.id).not.toBe(secondSlot[0]?.id);
+    expect(firstSlot[0]?.id).not.toBe("src-h");
+    expect(heading.id).toBe("src-h");
+    expect(heading.attrs).toEqual({ level: 2 });
+  });
+});

--- a/packages/admin/src/editor/insert-variation.ts
+++ b/packages/admin/src/editor/insert-variation.ts
@@ -1,0 +1,33 @@
+import type { ComponentData, Data } from "@puckeditor/core";
+
+import type { InsertableBlockEntry } from "@plumix/blocks";
+import { rewriteBlockNodeIds } from "@plumix/blocks";
+
+import { blockNodesToPuckContent } from "./entry-content.js";
+
+const CONTENT_SLOT_KEY = "content";
+
+// Variations declare default child blocks via `innerBlocks`; on insert
+// the engine slots them into the parent block's conventional `content`
+// key as ComponentData[] — the shape Puck's slot fields read back from
+// `puckDataToBlockTree` and the save path. ID rewrite keeps repeated
+// insertions of the same variation from sharing React keys.
+export function insertVariation(
+  data: Data,
+  entry: InsertableBlockEntry,
+  index: number,
+): Data {
+  const props: Record<string, unknown> = { ...(entry.attrs ?? {}) };
+  if (entry.innerBlocks && entry.innerBlocks.length > 0) {
+    props[CONTENT_SLOT_KEY] = blockNodesToPuckContent(
+      rewriteBlockNodeIds(entry.innerBlocks),
+    );
+  }
+  const inserted: ComponentData = {
+    type: entry.name,
+    props: props as ComponentData["props"],
+  };
+  const next = [...data.content];
+  next.splice(index, 0, inserted);
+  return { ...data, content: next };
+}

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { BlockLoaderRecord } from "./loaders.js";
-import type { BlockNodeComponent } from "./render-block-tree.js";
+import type { BlockNode, BlockNodeComponent } from "./render-block-tree.js";
 
 export interface BlockInputOption {
   readonly label: string;
@@ -22,6 +22,12 @@ export interface BlockVariation {
   readonly description?: string;
   readonly keywords?: readonly string[];
   readonly attrs?: Readonly<Record<string, unknown>>;
+  // Default body for the parent block's conventional `content` slot.
+  // Inserted as a deep-cloned, ID-rewritten tree — source remains
+  // unmutated across insertions. Validated against the block registry
+  // at commit time so unknown block names / undeclared attrs surface
+  // at boot with parent + variation + path traces.
+  readonly innerBlocks?: readonly BlockNode[];
 }
 
 /**

--- a/packages/blocks/src/commit-block-variations.test.ts
+++ b/packages/blocks/src/commit-block-variations.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry, defineBlock } from "./block-registry.js";
+import { commitBlockVariations } from "./commit-block-variations.js";
+import { headingBlock } from "./heading/index.js";
+
+describe("commitBlockVariations", () => {
+  test("accepts a registry whose variations carry no innerBlocks", () => {
+    const blocks = createBlockRegistry([headingBlock]);
+    expect(() => commitBlockVariations(blocks)).not.toThrow();
+  });
+
+  test("rejects an innerBlocks node referencing an unknown block", () => {
+    const group = defineBlock({
+      name: "core/group-test",
+      title: "Group",
+      inputs: [{ name: "content", type: "slot" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "with-ghost",
+          title: "With ghost",
+          innerBlocks: [{ id: "g1", name: "core/ghost", attrs: {} }],
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([group, headingBlock]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "with-ghost" of "core\/group-test" at innerBlocks\[0\] references unknown block "core\/ghost"/,
+    );
+  });
+
+  test("rejects an innerBlocks node with an undeclared attr", () => {
+    const group = defineBlock({
+      name: "core/group-test",
+      title: "Group",
+      inputs: [{ name: "content", type: "slot" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "bad-attr",
+          title: "Bad attr",
+          innerBlocks: [
+            {
+              id: "h1",
+              name: "core/heading",
+              attrs: { level: 2, ghost: true },
+            },
+          ],
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([group, headingBlock]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "bad-attr" of "core\/group-test" at innerBlocks\[0\] uses undeclared attr "ghost" on block "core\/heading"/,
+    );
+  });
+
+  test("rejects innerBlocks declared on a block that has no content slot", () => {
+    const heading = defineBlock({
+      name: "x-test/leaf",
+      title: "Leaf",
+      inputs: [{ name: "text", type: "text" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "with-children",
+          title: "With children",
+          innerBlocks: [{ id: "h", name: "core/heading", attrs: {} }],
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([heading, headingBlock]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "with-children" of "x-test\/leaf" declares innerBlocks but the parent block has no "content" slot input/,
+    );
+  });
+
+  test("rejects variation.attrs whose keys aren't declared inputs on the parent block", () => {
+    const group = defineBlock({
+      name: "x-test/group",
+      title: "Group",
+      inputs: [{ name: "content", type: "slot" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "rogue-attr",
+          title: "Rogue attr",
+          attrs: { layout: "stack" },
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([group, headingBlock]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "rogue-attr" of "x-test\/group" at variation\.attrs uses undeclared attr "layout" on block "x-test\/group"/,
+    );
+  });
+
+  test("recurses into slot-shaped attrs to validate nested innerBlocks", () => {
+    const group = defineBlock({
+      name: "core/group-test",
+      title: "Group",
+      inputs: [{ name: "content", type: "slot" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "nested-ghost",
+          title: "Nested ghost",
+          innerBlocks: [
+            {
+              id: "g1",
+              name: "core/group-test",
+              attrs: {
+                content: [{ id: "x", name: "core/ghost", attrs: {} }],
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([group, headingBlock]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /innerBlocks\[0\]\.content\[0\] references unknown block "core\/ghost"/,
+    );
+  });
+});

--- a/packages/blocks/src/commit-block-variations.ts
+++ b/packages/blocks/src/commit-block-variations.ts
@@ -1,0 +1,84 @@
+import type { BlockRegistry } from "./block-registry.js";
+import type { BlockNode } from "./render-block-tree.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+import { BlockVariationError } from "./variation-errors.js";
+
+export function commitBlockVariations(blocks: BlockRegistry): void {
+  for (const spec of blocks) {
+    if (!spec.variations) continue;
+    const declared = spec.inputs
+      ? new Set(spec.inputs.map((input) => input.name))
+      : undefined;
+    const hasContentSlot = spec.inputs?.some(
+      (input) => input.name === "content" && input.type === "slot",
+    );
+    for (const variation of spec.variations) {
+      if (variation.attrs && declared) {
+        for (const key of Object.keys(variation.attrs)) {
+          if (!declared.has(key)) {
+            throw BlockVariationError.undeclaredAttr(
+              spec.name,
+              variation.slug,
+              "variation.attrs",
+              spec.name,
+              key,
+            );
+          }
+        }
+      }
+      if (variation.innerBlocks && variation.innerBlocks.length > 0) {
+        if (!hasContentSlot) {
+          throw BlockVariationError.missingContentSlot(
+            spec.name,
+            variation.slug,
+          );
+        }
+        walk(
+          spec.name,
+          variation.slug,
+          variation.innerBlocks,
+          "innerBlocks",
+          blocks,
+        );
+      }
+    }
+  }
+}
+
+function walk(
+  parentBlock: string,
+  variationSlug: string,
+  nodes: readonly BlockNode[],
+  basePath: string,
+  blocks: BlockRegistry,
+): void {
+  nodes.forEach((node, i) => {
+    const path = `${basePath}[${i}]`;
+    const spec = blocks.get(node.name);
+    if (!spec) {
+      throw BlockVariationError.unknownBlock(
+        parentBlock,
+        variationSlug,
+        path,
+        node.name,
+      );
+    }
+    const declared = spec.inputs
+      ? new Set(spec.inputs.map((input) => input.name))
+      : undefined;
+    for (const [key, value] of Object.entries(node.attrs ?? {})) {
+      if (declared && !declared.has(key)) {
+        throw BlockVariationError.undeclaredAttr(
+          parentBlock,
+          variationSlug,
+          path,
+          node.name,
+          key,
+        );
+      }
+      if (isBlockNodeArray(value)) {
+        walk(parentBlock, variationSlug, value, `${path}.${key}`, blocks);
+      }
+    }
+  });
+}

--- a/packages/blocks/src/expand-block-variations.ts
+++ b/packages/blocks/src/expand-block-variations.ts
@@ -1,4 +1,5 @@
 import type { BlockSpec } from "./block-registry.js";
+import type { BlockNode } from "./render-block-tree.js";
 
 export interface InsertableBlockEntry {
   readonly name: string;
@@ -9,6 +10,9 @@ export interface InsertableBlockEntry {
   readonly icon?: string;
   readonly keywords?: readonly string[];
   readonly attrs?: Readonly<Record<string, unknown>>;
+  // Default body for the parent block's conventional `content` slot.
+  // Caller deep-clones + ID-rewrites before merging into a block instance.
+  readonly innerBlocks?: readonly BlockNode[];
 }
 
 export function expandBlockVariations(
@@ -27,6 +31,7 @@ export function expandBlockVariations(
           icon: v.icon,
           keywords: v.keywords,
           attrs: v.attrs,
+          innerBlocks: v.innerBlocks,
         });
       }
       continue;

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -79,6 +79,8 @@ export type {
 export { PatternRegistryError } from "./pattern-errors.js";
 export { serializePatternSource } from "./serialize-pattern-source.js";
 export type { SerializePatternSourceOptions } from "./serialize-pattern-source.js";
+export { commitBlockVariations } from "./commit-block-variations.js";
+export { BlockVariationError } from "./variation-errors.js";
 
 // ─── Validation ─────────────────────────────────────────────────────────────
 export { validateEntryContent } from "./validate-content.js";

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -1,6 +1,7 @@
 import type { BlockRegistry } from "./block-registry.js";
 import type { BlockNode } from "./render-block-tree.js";
 import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
+import { commitBlockVariations } from "./commit-block-variations.js";
 import { PatternRegistryError } from "./pattern-errors.js";
 import { isBlockNodeArray } from "./render-block-tree.js";
 import { validateEntryContent } from "./validate-content.js";
@@ -149,6 +150,10 @@ export function commitPatterns(
   patterns: PatternRegistry,
   blocks: BlockRegistry,
 ): PatternRegistry {
+  // Variations carry their own author-defined trees (`innerBlocks`);
+  // validating them alongside patterns means a single boot pass catches
+  // drift in every author-supplied tree against the block registry.
+  commitBlockVariations(blocks);
   for (const pattern of patterns) {
     const result = validateEntryContent(
       { version: "plumix.v2", blocks: pattern.content },

--- a/packages/blocks/src/variation-errors.ts
+++ b/packages/blocks/src/variation-errors.ts
@@ -1,0 +1,41 @@
+export class BlockVariationError extends Error {
+  static {
+    BlockVariationError.prototype.name = "BlockVariationError";
+  }
+
+  private constructor(message: string) {
+    super(message);
+  }
+
+  static unknownBlock(
+    parentBlock: string,
+    variationSlug: string,
+    path: string,
+    unknownName: string,
+  ): BlockVariationError {
+    return new BlockVariationError(
+      `Variation "${variationSlug}" of "${parentBlock}" at ${path} references unknown block "${unknownName}".`,
+    );
+  }
+
+  static undeclaredAttr(
+    parentBlock: string,
+    variationSlug: string,
+    path: string,
+    blockName: string,
+    attrKey: string,
+  ): BlockVariationError {
+    return new BlockVariationError(
+      `Variation "${variationSlug}" of "${parentBlock}" at ${path} uses undeclared attr "${attrKey}" on block "${blockName}".`,
+    );
+  }
+
+  static missingContentSlot(
+    parentBlock: string,
+    variationSlug: string,
+  ): BlockVariationError {
+    return new BlockVariationError(
+      `Variation "${variationSlug}" of "${parentBlock}" declares innerBlocks but the parent block has no "content" slot input.`,
+    );
+  }
+}

--- a/packages/core/src/runtime/app-variation-validation.test.ts
+++ b/packages/core/src/runtime/app-variation-validation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+
+import { defineBlock } from "@plumix/blocks";
+
+import { auth } from "../auth/config.js";
+import { plumix } from "../config.js";
+import { definePlugin } from "../plugin/define.js";
+import { defineTheme } from "../theme.js";
+import { buildApp } from "./app.js";
+
+const stubAdapter = {
+  name: "test" as const,
+  buildFetchHandler: () => () => new Response("stub"),
+};
+const stubDatabase = { kind: "test", connect: () => ({ db: {} }) } as const;
+const stubAuth = auth({
+  passkey: { rpName: "t", rpId: "t", origin: "https://t" },
+});
+const stubTheme = defineTheme({ templates: { index: () => null } });
+
+describe("buildApp — block variation boot validation", () => {
+  test("rejects a plugin variation whose innerBlocks reference an unknown block", async () => {
+    const badPlugin = definePlugin("bad-variations", (ctx) => {
+      ctx.registerBlock(
+        defineBlock({
+          name: "x-test/group",
+          title: "Test Group",
+          inputs: [{ name: "content", type: "slot" }],
+          render: () => null,
+          variations: [
+            {
+              slug: "with-ghost",
+              title: "With ghost",
+              innerBlocks: [{ id: "g1", name: "core/ghost", attrs: {} }],
+            },
+          ],
+        }),
+      );
+    });
+    await expect(
+      buildApp(
+        plumix({
+          runtime: stubAdapter,
+          database: stubDatabase,
+          auth: stubAuth,
+          theme: stubTheme,
+          plugins: [badPlugin],
+        }),
+      ),
+    ).rejects.toThrow(
+      /Variation "with-ghost" of "x-test\/group" at innerBlocks\[0\] references unknown block "core\/ghost"/,
+    );
+  });
+});

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -3,6 +3,7 @@ import { RPCHandler } from "@orpc/server/fetch";
 import type { BlockRegistry, HtmlAllowlist, MarkSpec } from "@plumix/blocks";
 import {
   buildHtmlAllowlist,
+  commitBlockVariations,
   coreBlocks,
   coreMarks,
   createBlockRegistry,
@@ -236,6 +237,10 @@ export async function buildApp(
     ({ spec }) => spec,
   );
   const blocks = createBlockRegistry([...coreBlocks, ...pluginBlockSpecs]);
+  // Boot validation: every variation's `innerBlocks` is walked against
+  // the committed registry. Unknown block names and undeclared attrs
+  // throw structured errors here rather than producing render junk later.
+  commitBlockVariations(blocks);
 
   const pluginMarkSpecs = Array.from(registry.markSpecs.values()).map(
     ({ spec }) => spec,


### PR DESCRIPTION
Container blocks (`core/group`, `core/callout`, `core/details`) can now ship variations
that arrive on the canvas with default child blocks pre-populated in the conventional
`content` slot, instead of empty containers the user has to build by hand. `BlockVariation`
gains an optional `innerBlocks: readonly BlockNode[]` field declared via the typed `block()`
helper from #626 — same data model patterns use.

**Boot-time validation in `buildApp`**

`commitBlockVariations(blocks)` runs in `runtime/app.ts` right after `createBlockRegistry`.
It walks every variation against the committed registry and throws structured
`BlockVariationError` for: unknown block name in `innerBlocks`, undeclared attr (on a child
node or on `variation.attrs` itself), and `innerBlocks` declared against a parent block
without a `"content"` slot input. Plugin drift fails at app construction with a parent +
variation + path trace, not as render junk at request time.

**Pure Puck-shape insert primitive**

`insertVariation(data, entry, index): Data` is the editor insert path. It converts
`innerBlocks` through `blockNodesToPuckContent` so slot values land as `ComponentData[]`
— the shape Puck slot fields, `puckDataToBlockTree`, and the save round-trip already
expect. `rewriteBlockNodeIds` runs on every insert so repeated insertions of the same
variation never share React keys, and source trees stay unmutated. Both sidebar and
slash-menu insert handlers in `EditorLayout` route through this primitive via a single
`setData` dispatch.

Fixes #634