### PR TITLE
feat: extend block variations with isActive matchers + per-instance identity readback

### DIFF
--- a/packages/admin/src/editor/BlockActionsPanel.test.tsx
+++ b/packages/admin/src/editor/BlockActionsPanel.test.tsx
@@ -175,4 +175,65 @@ describe("BlockActionsPanel", () => {
     expect(screen.queryByTestId("block-actions-list")).toBeNull();
     expect(screen.getByTestId("block-action-delete")).toBeDefined();
   });
+
+  test("renders the identity header with title and description when supplied", () => {
+    const noTransforms = createBlockRegistry([
+      spec({ name: "core/spacer", title: "Spacer" }),
+    ]);
+
+    render(
+      <BlockActionsPanel
+        specName="core/spacer"
+        registry={noTransforms}
+        identity={{
+          title: "Bulleted list",
+          icon: "List",
+          description: "Disc bullets",
+        }}
+        onTransform={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("block-actions-identity")).toBeDefined();
+    expect(
+      screen.getByTestId("block-actions-identity-title"),
+    ).toHaveTextContent("Bulleted list");
+  });
+
+  test("renders the panel when only identity is set — no transforms, no extras", () => {
+    const noTransforms = createBlockRegistry([
+      spec({ name: "core/spacer", title: "Spacer" }),
+    ]);
+
+    render(
+      <BlockActionsPanel
+        specName="core/spacer"
+        registry={noTransforms}
+        identity={{ title: "Spacer" }}
+        onTransform={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("block-actions-panel")).toBeDefined();
+    expect(screen.getByTestId("block-actions-identity")).toBeDefined();
+  });
+
+  test("renders identity header even when identity.icon is undefined — neutral fallback glyph", () => {
+    const noTransforms = createBlockRegistry([
+      spec({ name: "core/spacer", title: "Spacer" }),
+    ]);
+
+    render(
+      <BlockActionsPanel
+        specName="core/spacer"
+        registry={noTransforms}
+        identity={{ title: "No-icon block" }}
+        onTransform={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("block-actions-identity-title"),
+    ).toHaveTextContent("No-icon block");
+  });
 });

--- a/packages/admin/src/editor/BlockActionsPanel.tsx
+++ b/packages/admin/src/editor/BlockActionsPanel.tsx
@@ -4,11 +4,16 @@ import { useMemo } from "react";
 import type { BlockRegistry } from "@plumix/blocks";
 
 import type { TransformOption } from "./available-transforms.js";
+import type { BlockIdentity } from "./block-identity.js";
 import { availableTransforms } from "./available-transforms.js";
+import { BlockIcon } from "./BlockIcon.js";
 
 interface BlockActionsPanelProps {
   readonly specName: string | undefined;
   readonly registry: BlockRegistry;
+  // Live identity for the selected instance — variation override or
+  // parent block. Caller memoizes against the instance's attrs.
+  readonly identity?: BlockIdentity;
   readonly onTransform: (option: TransformOption) => void;
   readonly onDuplicate?: () => void;
   readonly onDelete?: () => void;
@@ -18,6 +23,7 @@ interface BlockActionsPanelProps {
 export function BlockActionsPanel({
   specName,
   registry,
+  identity,
   onTransform,
   onDuplicate,
   onDelete,
@@ -40,10 +46,31 @@ export function BlockActionsPanel({
   }
 
   const hasExtras = Boolean(onDuplicate ?? onDelete ?? onCopyJson);
-  if (options.length === 0 && !hasExtras) return null;
+  if (options.length === 0 && !hasExtras && !identity) return null;
 
   return (
     <div className="space-y-2 border-b p-4" data-testid="block-actions-panel">
+      {identity ? (
+        <div
+          className="flex items-center gap-2"
+          data-testid="block-actions-identity"
+        >
+          <BlockIcon name={identity.icon} />
+          <div className="min-w-0 flex-1">
+            <div
+              className="truncate text-sm font-medium"
+              data-testid="block-actions-identity-title"
+            >
+              {identity.title}
+            </div>
+            {identity.description ? (
+              <div className="text-muted-foreground truncate text-xs">
+                {identity.description}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
       {options.length > 0 ? (
         <div className="space-y-1">
           <div className="text-muted-foreground text-xs">Transform to</div>

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -51,6 +51,7 @@ import {
 import type { TransformOption } from "./available-transforms.js";
 import type { SlashMenuItem } from "./slash-menu-items.js";
 import { AutosaveStatusPill } from "./AutosaveStatus.js";
+import { deriveBlockIdentity } from "./block-identity.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { BlockIcon } from "./BlockIcon.js";
 import { BlockScopePicker } from "./BlockScopePicker.js";
@@ -1115,10 +1116,21 @@ function PlumixBlockActions({
       });
   }, [selectedItem]);
 
+  const identity = useMemo(() => {
+    if (!selectedItem) return undefined;
+    const spec = registry.get(selectedItem.type);
+    if (!spec) return undefined;
+    return deriveBlockIdentity(
+      spec,
+      selectedItem.props as Record<string, unknown>,
+    );
+  }, [selectedItem, registry]);
+
   return (
     <BlockActionsPanel
       specName={selectedItem?.type}
       registry={registry}
+      identity={identity}
       onTransform={handleTransform}
       onDuplicate={handleDuplicate}
       onDelete={handleDelete}

--- a/packages/admin/src/editor/block-identity.test.ts
+++ b/packages/admin/src/editor/block-identity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+import { defineBlock } from "@plumix/blocks";
+
+import { deriveBlockIdentity } from "./block-identity.js";
+
+describe("deriveBlockIdentity", () => {
+  test("falls back to the parent block when no variation matches", () => {
+    const spec = defineBlock({
+      name: "core/heading",
+      title: "Heading",
+      icon: "Heading",
+      description: "Section heading",
+      render: () => null,
+    });
+    expect(deriveBlockIdentity(spec, { level: 2 })).toEqual({
+      title: "Heading",
+      icon: "Heading",
+      description: "Section heading",
+    });
+  });
+
+  test("uses the active variation's title and icon when isActive matches", () => {
+    const spec = defineBlock({
+      name: "core/list",
+      title: "List",
+      icon: "List",
+      render: () => null,
+      variations: [
+        {
+          slug: "bullet",
+          title: "Bulleted list",
+          icon: "List",
+          description: "Disc bullets",
+          attrs: { variant: "bullet" },
+          isActive: ["variant"],
+        },
+      ],
+    });
+    expect(deriveBlockIdentity(spec, { variant: "bullet" })).toEqual({
+      title: "Bulleted list",
+      icon: "List",
+      description: "Disc bullets",
+    });
+  });
+});

--- a/packages/admin/src/editor/block-identity.ts
+++ b/packages/admin/src/editor/block-identity.ts
@@ -1,0 +1,30 @@
+import type { BlockSpec } from "@plumix/blocks";
+import { resolveActiveVariation } from "@plumix/blocks";
+
+export interface BlockIdentity {
+  readonly title: string;
+  readonly icon?: string;
+  readonly description?: string;
+}
+
+// Variations override the parent block's display identity on instances
+// whose `attrs` match the variation's `isActive` matcher. Saved entries
+// stay anonymous — identity is re-derived on every render.
+export function deriveBlockIdentity(
+  spec: BlockSpec,
+  attrs: Readonly<Record<string, unknown>>,
+): BlockIdentity {
+  const variation = resolveActiveVariation(spec, attrs);
+  if (variation) {
+    return {
+      title: variation.title,
+      icon: variation.icon ?? spec.icon,
+      description: variation.description ?? spec.description,
+    };
+  }
+  return {
+    title: spec.title ?? spec.name,
+    icon: spec.icon,
+    description: spec.description,
+  };
+}

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -22,6 +22,13 @@ export interface BlockVariationExample {
   readonly innerBlocks?: readonly BlockNode[];
 }
 
+export type BlockVariationIsActive =
+  | readonly string[]
+  | ((
+      blockAttrs: Readonly<Record<string, unknown>>,
+      variationAttrs: Readonly<Record<string, unknown>>,
+    ) => boolean);
+
 export interface BlockVariation {
   readonly slug: string;
   readonly title: string;
@@ -46,6 +53,11 @@ export interface BlockVariation {
   // `attrs` + `innerBlocks` — useful when the runtime body relies on an
   // async loader and the preview needs static content.
   readonly example?: BlockVariationExample;
+  // Per-instance identity matcher. `string[]` lists attr names whose
+  // values on the block instance must equal the variation's `attrs`
+  // value for the same name; among ties the longest list wins, then
+  // registration order. Function matchers run first-true wins.
+  readonly isActive?: BlockVariationIsActive;
 }
 
 /**

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -81,6 +81,8 @@ export type {
   PatternTarget,
 } from "./pattern-registry.js";
 export { PatternRegistryError } from "./pattern-errors.js";
+export { resolveActiveVariation } from "./resolve-active-variation.js";
+export type { BlockVariationIsActive } from "./block-registry.js";
 export { serializePatternSource } from "./serialize-pattern-source.js";
 export type { SerializePatternSourceOptions } from "./serialize-pattern-source.js";
 export { commitBlockVariations } from "./commit-block-variations.js";

--- a/packages/blocks/src/resolve-active-variation.test.ts
+++ b/packages/blocks/src/resolve-active-variation.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { defineBlock } from "./block-registry.js";
+import { resolveActiveVariation } from "./resolve-active-variation.js";
+
+const warnSpy = vi.spyOn(console, "warn");
+
+beforeEach(() => {
+  warnSpy.mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  warnSpy.mockReset();
+});
+
+describe("resolveActiveVariation", () => {
+  test("returns undefined when the block declares no variations", () => {
+    const spec = defineBlock({
+      name: "x-test/leaf",
+      title: "Leaf",
+      render: () => null,
+    });
+    expect(resolveActiveVariation(spec, { text: "x" })).toBeUndefined();
+  });
+
+  test("string[] matcher returns the variation when every listed attr equals the variation's attrs", () => {
+    const spec = defineBlock({
+      name: "core/list",
+      title: "List",
+      render: () => null,
+      variations: [
+        {
+          slug: "bullet",
+          title: "Bulleted",
+          attrs: { variant: "bullet" },
+          isActive: ["variant"],
+        },
+      ],
+    });
+    const match = resolveActiveVariation(spec, { variant: "bullet" });
+    expect(match?.slug).toBe("bullet");
+  });
+
+  test("string[] matcher returns undefined when an attr value differs", () => {
+    const spec = defineBlock({
+      name: "core/list",
+      title: "List",
+      render: () => null,
+      variations: [
+        {
+          slug: "bullet",
+          title: "Bulleted",
+          attrs: { variant: "bullet" },
+          isActive: ["variant"],
+        },
+      ],
+    });
+    expect(
+      resolveActiveVariation(spec, { variant: "numbered" }),
+    ).toBeUndefined();
+  });
+
+  test("string[] specificity: the variation with the longest matching list wins", () => {
+    const spec = defineBlock({
+      name: "core/columns",
+      title: "Columns",
+      render: () => null,
+      variations: [
+        {
+          slug: "two-up",
+          title: "Two up",
+          attrs: { layout: "split" },
+          isActive: ["layout"],
+        },
+        {
+          slug: "two-up-equal",
+          title: "Two up equal",
+          attrs: { layout: "split", ratio: "50-50" },
+          isActive: ["layout", "ratio"],
+        },
+      ],
+    });
+    const match = resolveActiveVariation(spec, {
+      layout: "split",
+      ratio: "50-50",
+    });
+    expect(match?.slug).toBe("two-up-equal");
+  });
+
+  test("string[] tie of equal length is broken by registration order — first wins", () => {
+    const spec = defineBlock({
+      name: "core/badge",
+      title: "Badge",
+      render: () => null,
+      variations: [
+        {
+          slug: "rounded-primary",
+          title: "Rounded primary",
+          attrs: { shape: "round", color: "primary" },
+          isActive: ["shape", "color"],
+        },
+        {
+          slug: "rounded-primary-alt",
+          title: "Rounded primary alt",
+          attrs: { shape: "round", color: "primary" },
+          isActive: ["shape", "color"],
+        },
+      ],
+    });
+    const match = resolveActiveVariation(spec, {
+      shape: "round",
+      color: "primary",
+    });
+    expect(match?.slug).toBe("rounded-primary");
+  });
+
+  test("function matcher returns the first variation whose predicate is true", () => {
+    const spec = defineBlock({
+      name: "core/quote",
+      title: "Quote",
+      render: () => null,
+      variations: [
+        {
+          slug: "long",
+          title: "Long quote",
+          isActive: (attrs) =>
+            typeof attrs.text === "string" && attrs.text.length > 100,
+        },
+        {
+          slug: "short",
+          title: "Short quote",
+          isActive: (attrs) =>
+            typeof attrs.text === "string" && attrs.text.length <= 100,
+        },
+      ],
+    });
+    const short = resolveActiveVariation(spec, { text: "hi" });
+    expect(short?.slug).toBe("short");
+    const long = resolveActiveVariation(spec, { text: "x".repeat(200) });
+    expect(long?.slug).toBe("long");
+  });
+
+  test("function matcher that throws is treated as false and surfaced via console.warn", () => {
+    const spec = defineBlock({
+      name: "core/quote",
+      title: "Quote",
+      render: () => null,
+      variations: [
+        {
+          slug: "boom",
+          title: "Boom",
+          isActive: () => {
+            throw new Error("nope");
+          },
+        },
+        {
+          slug: "fallback",
+          title: "Fallback",
+          isActive: () => true,
+        },
+      ],
+    });
+    const match = resolveActiveVariation(spec, {});
+    expect(match?.slug).toBe("fallback");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("core/quote"),
+      expect.stringContaining("boom"),
+      expect.any(Error),
+    );
+  });
+});

--- a/packages/blocks/src/resolve-active-variation.test.ts
+++ b/packages/blocks/src/resolve-active-variation.test.ts
@@ -140,6 +140,76 @@ describe("resolveActiveVariation", () => {
     expect(long?.slug).toBe("long");
   });
 
+  test("string[] matcher uses structural equality so nested-object attrs match across renders", () => {
+    const spec = defineBlock({
+      name: "core/columns",
+      title: "Columns",
+      render: () => null,
+      variations: [
+        {
+          slug: "split",
+          title: "Split",
+          attrs: { layout: { type: "split" } },
+          isActive: ["layout"],
+        },
+      ],
+    });
+    const match = resolveActiveVariation(spec, {
+      layout: { type: "split" },
+    });
+    expect(match?.slug).toBe("split");
+  });
+
+  test("string[] matcher skips keys absent from variation.attrs so padding can't inflate specificity", () => {
+    const spec = defineBlock({
+      name: "core/list",
+      title: "List",
+      render: () => null,
+      variations: [
+        {
+          slug: "tight",
+          title: "Tight",
+          attrs: { variant: "bullet" },
+          isActive: ["variant"],
+        },
+        {
+          slug: "padded",
+          title: "Padded",
+          attrs: { variant: "bullet" },
+          isActive: ["variant", "extra", "extra2"],
+        },
+      ],
+    });
+    const match = resolveActiveVariation(spec, { variant: "bullet" });
+    expect(match?.slug).toBe("tight");
+  });
+
+  test("a true function matcher short-circuits — wins over a later string[] matcher of higher specificity", () => {
+    // Pinned semantics: function matchers run first-true-wins in
+    // registration order. A function predicate that returns true wins
+    // even when a later string[] matcher would be more specific.
+    const spec = defineBlock({
+      name: "core/badge",
+      title: "Badge",
+      render: () => null,
+      variations: [
+        {
+          slug: "permissive-fn",
+          title: "Permissive function",
+          isActive: () => true,
+        },
+        {
+          slug: "specific-array",
+          title: "Specific array",
+          attrs: { a: 1, b: 2, c: 3 },
+          isActive: ["a", "b", "c"],
+        },
+      ],
+    });
+    const match = resolveActiveVariation(spec, { a: 1, b: 2, c: 3 });
+    expect(match?.slug).toBe("permissive-fn");
+  });
+
   test("function matcher that throws is treated as false and surfaced via console.warn", () => {
     const spec = defineBlock({
       name: "core/quote",

--- a/packages/blocks/src/resolve-active-variation.ts
+++ b/packages/blocks/src/resolve-active-variation.ts
@@ -1,12 +1,5 @@
 import type { BlockSpec, BlockVariation } from "./block-registry.js";
 
-function readAttr(
-  attrs: Readonly<Record<string, unknown>>,
-  key: string,
-): unknown {
-  return attrs[key];
-}
-
 export function resolveActiveVariation(
   spec: BlockSpec,
   blockAttrs: Readonly<Record<string, unknown>>,
@@ -16,30 +9,42 @@ export function resolveActiveVariation(
   for (const variation of spec.variations) {
     const matcher = variation.isActive;
     if (!matcher) continue;
-    if (typeof matcher !== "function") {
-      const keys: readonly string[] = matcher;
-      const matchAttrs = variation.attrs ?? {};
-      const allMatch = keys.every(
-        (key) => readAttr(blockAttrs, key) === readAttr(matchAttrs, key),
-      );
-      if (!allMatch) continue;
-      const length = keys.length;
-      if (!bestArrayMatch || length > bestArrayMatch.length) {
-        bestArrayMatch = { variation, length };
+    if (typeof matcher === "function") {
+      try {
+        if (matcher(blockAttrs, variation.attrs ?? {})) return variation;
+      } catch (error) {
+        console.warn(
+          `[plumix:resolve-active-variation] ${spec.name}`,
+          variation.slug,
+          error,
+        );
       }
       continue;
     }
-    try {
-      if (matcher(blockAttrs, variation.attrs ?? {})) {
-        return variation;
-      }
-    } catch (error) {
-      console.warn(
-        `[plumix:resolve-active-variation] ${spec.name}`,
-        variation.slug,
-        error,
-      );
+    const matchAttrs = variation.attrs ?? {};
+    // Constraining keys: a key listed in `isActive` only counts when
+    // the variation actually declares a value for it. Keys that aren't
+    // declared on either side would otherwise inflate specificity via
+    // `undefined === undefined`. Structural compare (JSON-serialised)
+    // catches nested-object attrs whose references differ across
+    // renders — entry content is JSON anyway, so deep equality is the
+    // honest baseline.
+    const constraining = matcher.filter((key) => key in matchAttrs);
+    if (constraining.length === 0) continue;
+    const allMatch = constraining.every((key) =>
+      structuralEquals(blockAttrs[key], matchAttrs[key]),
+    );
+    if (!allMatch) continue;
+    if (!bestArrayMatch || constraining.length > bestArrayMatch.length) {
+      bestArrayMatch = { variation, length: constraining.length };
     }
   }
   return bestArrayMatch?.variation;
+}
+
+function structuralEquals(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/packages/blocks/src/resolve-active-variation.ts
+++ b/packages/blocks/src/resolve-active-variation.ts
@@ -1,0 +1,45 @@
+import type { BlockSpec, BlockVariation } from "./block-registry.js";
+
+function readAttr(
+  attrs: Readonly<Record<string, unknown>>,
+  key: string,
+): unknown {
+  return attrs[key];
+}
+
+export function resolveActiveVariation(
+  spec: BlockSpec,
+  blockAttrs: Readonly<Record<string, unknown>>,
+): BlockVariation | undefined {
+  if (!spec.variations) return undefined;
+  let bestArrayMatch: { variation: BlockVariation; length: number } | undefined;
+  for (const variation of spec.variations) {
+    const matcher = variation.isActive;
+    if (!matcher) continue;
+    if (typeof matcher !== "function") {
+      const keys: readonly string[] = matcher;
+      const matchAttrs = variation.attrs ?? {};
+      const allMatch = keys.every(
+        (key) => readAttr(blockAttrs, key) === readAttr(matchAttrs, key),
+      );
+      if (!allMatch) continue;
+      const length = keys.length;
+      if (!bestArrayMatch || length > bestArrayMatch.length) {
+        bestArrayMatch = { variation, length };
+      }
+      continue;
+    }
+    try {
+      if (matcher(blockAttrs, variation.attrs ?? {})) {
+        return variation;
+      }
+    } catch (error) {
+      console.warn(
+        `[plumix:resolve-active-variation] ${spec.name}`,
+        variation.slug,
+        error,
+      );
+    }
+  }
+  return bestArrayMatch?.variation;
+}


### PR DESCRIPTION
Variations can now declare per-instance identity: the inspector header reads back the active
variation's title, icon, and description so authors editing a saved Bullet List no longer see
the generic \"List\" label. Adds optional \`BlockVariation.isActive\` matchers and the pure
resolver + identity adapter that surfaces them in the editor.

**Specificity rule mirrors WordPress**

\`string[]\` matchers list attr names whose values on the instance must equal the variation's
\`attrs\` for the same names. Among multiple matching variations, the longest list wins;
equal-length ties break by registration order. Function matchers \`(blockAttrs, variationAttrs) => boolean\`
fire first-true wins; a throw is caught with a \`console.warn\` naming the parent block + variation
slug and treated as false so a broken predicate degrades to the parent block's identity rather
than crashing the inspector.

**Identity is re-derived on every render**

\`deriveBlockIdentity(spec, attrs)\` returns the active variation's title / icon / description
when one matches, falling back to the parent block when none does. Saved entries stay
anonymous — no slug stamp on the persisted body — so renaming or removing a variation later
doesn't break stored entries.

Fixes #635