### PR TITLE
feat: scope-aware variation expansion + block-scope picker on insert

### DIFF
--- a/packages/admin/src/editor/BlockScopePicker.test.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { BlockVariation } from "@plumix/blocks";
+
+import { BlockScopePicker } from "./BlockScopePicker.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const twoUp: BlockVariation = {
+  slug: "two-up",
+  title: "Two up",
+  description: "Two equal columns",
+  attrs: { layout: "split" },
+  scope: ["block"],
+};
+
+const threeUp: BlockVariation = {
+  slug: "three-up",
+  title: "Three up",
+  description: "Three equal columns",
+  attrs: { layout: "three" },
+  scope: ["block"],
+};
+
+describe("BlockScopePicker", () => {
+  test("renders one card per variation with title and description", () => {
+    render(
+      <BlockScopePicker
+        blockTitle="Columns"
+        variations={[twoUp, threeUp]}
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("plumix-block-scope-picker")).toBeDefined();
+    expect(
+      screen.getByTestId("plumix-block-scope-picker-card-two-up"),
+    ).toBeDefined();
+    expect(
+      screen.getByTestId("plumix-block-scope-picker-card-three-up"),
+    ).toBeDefined();
+  });
+
+  test("clicking a card calls onSelect with the chosen variation", async () => {
+    const onSelect = vi.fn();
+    render(
+      <BlockScopePicker
+        blockTitle="Columns"
+        variations={[twoUp, threeUp]}
+        onSelect={onSelect}
+        onDismiss={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByTestId("plumix-block-scope-picker-card-three-up"),
+    );
+    expect(onSelect).toHaveBeenCalledWith(threeUp);
+  });
+
+  test("clicking the cancel link calls onDismiss", async () => {
+    const onDismiss = vi.fn();
+    render(
+      <BlockScopePicker
+        blockTitle="Columns"
+        variations={[twoUp]}
+        onSelect={vi.fn()}
+        onDismiss={onDismiss}
+      />,
+    );
+    await userEvent.click(
+      screen.getByTestId("plumix-block-scope-picker-cancel"),
+    );
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -1,0 +1,90 @@
+import type { ReactElement } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
+
+import type { BlockVariation } from "@plumix/blocks";
+
+interface BlockScopePickerProps {
+  readonly blockTitle: string;
+  readonly variations: readonly BlockVariation[];
+  readonly onSelect: (variation: BlockVariation) => void;
+  readonly onDismiss: () => void;
+}
+
+// Block-scope picker — opens after inserting a parent block whose
+// variations include any `scope: ["block"]`. The author picks a layout;
+// cancel inserts the bare block with its declared defaults.
+//
+// TODO(#637): replace the textual card body with the live thumbnail
+// path used by the patterns sidebar (lazy-mount + scaled render).
+export function BlockScopePicker({
+  blockTitle,
+  variations,
+  onSelect,
+  onDismiss,
+}: BlockScopePickerProps): ReactElement | null {
+  if (variations.length === 0) return null;
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onDismiss();
+      }}
+    >
+      <DialogContent
+        className="max-w-3xl"
+        data-testid="plumix-block-scope-picker"
+        showCloseButton={false}
+      >
+        <DialogHeader>
+          <DialogTitle>Choose a {blockTitle} layout</DialogTitle>
+          <DialogDescription>
+            Pick a layout to insert, or cancel to start from a blank{" "}
+            {blockTitle}.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {variations.map((variation) => (
+            <li key={variation.slug}>
+              <div
+                role="button"
+                tabIndex={0}
+                className="hover:bg-muted/40 flex w-full flex-col gap-1 rounded border p-3 text-left focus:outline-none focus-visible:ring"
+                data-testid={`plumix-block-scope-picker-card-${variation.slug}`}
+                onClick={() => onSelect(variation)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelect(variation);
+                  }
+                }}
+              >
+                <span className="text-sm font-medium">{variation.title}</span>
+                {variation.description ? (
+                  <span className="text-muted-foreground text-xs">
+                    {variation.description}
+                  </span>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-foreground text-sm underline-offset-2 hover:underline"
+            data-testid="plumix-block-scope-picker-cancel"
+            onClick={onDismiss}
+          >
+            Cancel
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -34,6 +34,7 @@ import { Minus, Monitor, Plus, Smartphone, Tablet } from "lucide-react";
 import type {
   BlockRegistry,
   BlockSpec,
+  BlockVariation,
   InsertableBlockEntry,
   PatternRegistry,
   ResponsiveStyleSlot,
@@ -44,6 +45,7 @@ import {
   createBlockRegistry,
   createPatternRegistry,
   expandBlockVariations,
+  resolveBlockScopeVariations,
 } from "@plumix/blocks";
 
 import type { TransformOption } from "./available-transforms.js";
@@ -51,6 +53,7 @@ import type { SlashMenuItem } from "./slash-menu-items.js";
 import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
 import { BlockIcon } from "./BlockIcon.js";
+import { BlockScopePicker } from "./BlockScopePicker.js";
 import { buildCopyPatternSource } from "./build-copy-pattern-source.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { insertPattern } from "./insert-pattern.js";
@@ -605,6 +608,11 @@ interface PlumixBlocksTabProps {
   readonly patterns: readonly PatternManifestEntry[];
 }
 
+interface PendingPick {
+  readonly entry: InsertableBlockEntry;
+  readonly variations: readonly BlockVariation[];
+}
+
 function PlumixBlocksTab({
   registry,
   patternRegistry,
@@ -612,6 +620,7 @@ function PlumixBlocksTab({
   patterns,
 }: PlumixBlocksTabProps): ReactElement {
   const puck = usePuck();
+  const [pendingPick, setPendingPick] = useState<PendingPick | undefined>();
   const entries = useMemo(() => {
     const eligible: BlockSpec[] = [];
     for (const spec of registry) {
@@ -622,7 +631,7 @@ function PlumixBlocksTab({
     return expandBlockVariations(eligible);
   }, [registry, capabilities]);
 
-  const handleInsert = useCallback(
+  const insertEntry = useCallback(
     (entry: InsertableBlockEntry): void => {
       puck.dispatch({
         type: "setData",
@@ -631,6 +640,28 @@ function PlumixBlocksTab({
       });
     },
     [puck],
+  );
+
+  const handleInsert = useCallback(
+    (entry: InsertableBlockEntry): void => {
+      // Parent-block card: if the block declares any `scope: ["block"]`
+      // variations the user can still pick, open the picker. Otherwise
+      // (no variations, or all capability-gated out) fall through to
+      // bare insert with `blockSpec.defaults`.
+      if (entry.slug === entry.name) {
+        const blockScoped = resolveBlockScopeVariations(
+          registry,
+          entry.name,
+          capabilities,
+        );
+        if (blockScoped.length > 0) {
+          setPendingPick({ entry, variations: blockScoped });
+          return;
+        }
+      }
+      insertEntry(entry);
+    },
+    [insertEntry, registry, capabilities],
   );
 
   const handlePatternInsert = useCallback(
@@ -643,6 +674,37 @@ function PlumixBlocksTab({
     },
     [puck],
   );
+
+  const handlePickerSelect = useCallback(
+    (variation: BlockVariation): void => {
+      if (!pendingPick) return;
+      const picked: InsertableBlockEntry = {
+        name: pendingPick.entry.name,
+        slug: `${pendingPick.entry.name}/${variation.slug}`,
+        title: variation.title,
+        attrs: variation.attrs,
+        innerBlocks: variation.innerBlocks,
+      };
+      insertEntry(picked);
+      setPendingPick(undefined);
+    },
+    [insertEntry, pendingPick],
+  );
+
+  const handlePickerDismiss = useCallback((): void => {
+    if (!pendingPick) return;
+    // ESC / cancel inserts the bare block with `blockSpec.defaults`.
+    // Constructing a plain entry with no attrs/innerBlocks routes
+    // through the same `insertVariation` path which will land empty
+    // props, and Puck applies the spec's `defaults` on render.
+    const bare: InsertableBlockEntry = {
+      name: pendingPick.entry.name,
+      slug: pendingPick.entry.slug,
+      title: pendingPick.entry.title,
+    };
+    insertEntry(bare);
+    setPendingPick(undefined);
+  }, [insertEntry, pendingPick]);
 
   return (
     <div className="flex flex-col">
@@ -667,6 +729,14 @@ function PlumixBlocksTab({
         blocks={registry}
         patternRegistry={patternRegistry}
       />
+      {pendingPick ? (
+        <BlockScopePicker
+          blockTitle={pendingPick.entry.title}
+          variations={pendingPick.variations}
+          onSelect={handlePickerSelect}
+          onDismiss={handlePickerDismiss}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -15,6 +15,8 @@ export interface BlockInput {
   readonly options?: readonly BlockInputOption[];
 }
 
+export type BlockVariationScope = "inserter" | "block" | "transform";
+
 export interface BlockVariation {
   readonly slug: string;
   readonly title: string;
@@ -28,6 +30,11 @@ export interface BlockVariation {
   // at commit time so unknown block names / undeclared attrs surface
   // at boot with parent + variation + path traces.
   readonly innerBlocks?: readonly BlockNode[];
+  // Surfaces the variation in the inserter (default), via a block-scope
+  // picker, or as a transform target. Empty array hides the variation
+  // from all surfaces — useful as a readback-only identity for stored
+  // instances referenced by `isActive`.
+  readonly scope?: readonly BlockVariationScope[];
 }
 
 /**

--- a/packages/blocks/src/block-scope-variations.test.ts
+++ b/packages/blocks/src/block-scope-variations.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry, defineBlock } from "./block-registry.js";
+import { resolveBlockScopeVariations } from "./block-scope-variations.js";
+
+describe("resolveBlockScopeVariations", () => {
+  test("returns an empty list when the block declares no variations", () => {
+    const blocks = createBlockRegistry([
+      defineBlock({ name: "core/spacer", title: "Spacer", render: () => null }),
+    ]);
+    expect(resolveBlockScopeVariations(blocks, "core/spacer")).toEqual([]);
+  });
+
+  test("returns only variations whose scope includes 'block'", () => {
+    const blocks = createBlockRegistry([
+      defineBlock({
+        name: "core/columns",
+        title: "Columns",
+        render: () => null,
+        variations: [
+          {
+            slug: "two-up",
+            title: "Two up",
+            attrs: { layout: "split" },
+            scope: ["block"],
+          },
+          {
+            slug: "three-up",
+            title: "Three up",
+            attrs: { layout: "three" },
+            scope: ["block"],
+          },
+          {
+            slug: "rare",
+            title: "Rare",
+            attrs: { layout: "rare" },
+            scope: ["inserter"],
+          },
+        ],
+      }),
+    ]);
+    const list = resolveBlockScopeVariations(blocks, "core/columns");
+    expect(list.map((v) => v.slug)).toEqual(["two-up", "three-up"]);
+  });
+
+  test("respects capability gating — skips variations whose parent block's capability the user lacks", () => {
+    const blocks = createBlockRegistry([
+      defineBlock({
+        name: "core/restricted",
+        title: "Restricted",
+        capability: "publish:posts",
+        render: () => null,
+        variations: [
+          {
+            slug: "restricted-variation",
+            title: "Restricted variation",
+            attrs: { layout: "x" },
+            scope: ["block"],
+          },
+        ],
+      }),
+    ]);
+    expect(
+      resolveBlockScopeVariations(blocks, "core/restricted", new Set()),
+    ).toEqual([]);
+    expect(
+      resolveBlockScopeVariations(
+        blocks,
+        "core/restricted",
+        new Set(["publish:posts"]),
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/blocks/src/block-scope-variations.ts
+++ b/packages/blocks/src/block-scope-variations.ts
@@ -1,0 +1,18 @@
+import type { BlockRegistry, BlockVariation } from "./block-registry.js";
+
+// Lookup helper for the editor's block-scope picker. Returns the
+// variations a host should list when the user inserts a parent block
+// with any `scope: ["block"]` variations. Capabilities filter the
+// parent block's gate.
+export function resolveBlockScopeVariations(
+  blocks: BlockRegistry,
+  blockName: string,
+  capabilities?: ReadonlySet<string>,
+): readonly BlockVariation[] {
+  const spec = blocks.get(blockName);
+  if (!spec?.variations) return [];
+  if (spec.capability && capabilities && !capabilities.has(spec.capability)) {
+    return [];
+  }
+  return spec.variations.filter((v) => v.scope?.includes("block"));
+}

--- a/packages/blocks/src/commit-block-variations.test.ts
+++ b/packages/blocks/src/commit-block-variations.test.ts
@@ -96,6 +96,25 @@ describe("commitBlockVariations", () => {
     );
   });
 
+  test("rejects scope values outside the declared union", () => {
+    const block = defineBlock({
+      name: "x-test/scoped",
+      title: "Scoped",
+      render: () => null,
+      variations: [
+        {
+          slug: "rogue-scope",
+          title: "Rogue scope",
+          scope: ["banner" as "inserter"],
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([block]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "rogue-scope" of "x-test\/scoped" declares scope value "banner" outside the allowed union/,
+    );
+  });
+
   test("recurses into slot-shaped attrs to validate nested innerBlocks", () => {
     const group = defineBlock({
       name: "core/group-test",

--- a/packages/blocks/src/commit-block-variations.ts
+++ b/packages/blocks/src/commit-block-variations.ts
@@ -13,6 +13,22 @@ export function commitBlockVariations(blocks: BlockRegistry): void {
       (input) => input.name === "content" && input.type === "slot",
     );
     for (const variation of spec.variations) {
+      if (variation.scope) {
+        for (const value of variation.scope) {
+          // Cast through `string` so the union-narrow doesn't tell
+          // eslint "this is dead code" — the gate exists for plugins
+          // (untyped JS) and dynamic-shape payloads that fall through
+          // the compile-time union.
+          const v = value as string;
+          if (v !== "inserter" && v !== "block" && v !== "transform") {
+            throw BlockVariationError.invalidScope(
+              spec.name,
+              variation.slug,
+              v,
+            );
+          }
+        }
+      }
       if (variation.attrs && declared) {
         for (const key of Object.keys(variation.attrs)) {
           if (!declared.has(key)) {

--- a/packages/blocks/src/expand-block-variations.test.ts
+++ b/packages/blocks/src/expand-block-variations.test.ts
@@ -54,4 +54,58 @@ describe("expandBlockVariations", () => {
       "core/heading",
     ]);
   });
+
+  test("omits variations scoped only to block-picker — the parent block stands in for the inserter card", () => {
+    const entries = expandBlockVariations([
+      block({
+        name: "core/columns",
+        title: "Columns",
+        variations: [
+          {
+            slug: "two-up",
+            title: "Two up",
+            attrs: { layout: "split" },
+            scope: ["block"],
+          },
+          {
+            slug: "three-up",
+            title: "Three up",
+            attrs: { layout: "three" },
+            scope: ["block"],
+          },
+        ],
+      }),
+    ]);
+    expect(entries.map((e) => e.slug)).toEqual(["core/columns"]);
+    expect(entries[0]?.name).toBe("core/columns");
+  });
+
+  test("respects explicit `scope: ['inserter']` and skips variations with empty scope", () => {
+    const entries = expandBlockVariations([
+      block({
+        name: "core/list",
+        title: "List",
+        variations: [
+          {
+            slug: "bullet",
+            title: "Bulleted",
+            attrs: { variant: "bullet" },
+            scope: ["inserter"],
+          },
+          {
+            slug: "hidden",
+            title: "Hidden",
+            attrs: { variant: "hidden" },
+            scope: [],
+          },
+          {
+            slug: "transform-only",
+            title: "Transform only",
+            scope: ["transform"],
+          },
+        ],
+      }),
+    ]);
+    expect(entries.map((e) => e.slug)).toEqual(["bullet"]);
+  });
 });

--- a/packages/blocks/src/expand-block-variations.ts
+++ b/packages/blocks/src/expand-block-variations.ts
@@ -20,31 +20,39 @@ export function expandBlockVariations(
 ): readonly InsertableBlockEntry[] {
   const out: InsertableBlockEntry[] = [];
   for (const spec of specs) {
-    if (spec.variations && spec.variations.length > 0) {
-      for (const v of spec.variations) {
-        out.push({
-          name: spec.name,
-          slug: v.slug,
-          title: v.title,
-          description: v.description,
-          category: spec.category,
-          icon: v.icon,
-          keywords: v.keywords,
-          attrs: v.attrs,
-          innerBlocks: v.innerBlocks,
-        });
-      }
-      continue;
+    const variations = spec.variations ?? [];
+    const inserterVariations = variations.filter((v) =>
+      (v.scope ?? ["inserter"]).includes("inserter"),
+    );
+    const hasBlockScoped = variations.some((v) => v.scope?.includes("block"));
+    for (const v of inserterVariations) {
+      out.push({
+        name: spec.name,
+        slug: v.slug,
+        title: v.title,
+        description: v.description,
+        category: spec.category,
+        icon: v.icon,
+        keywords: v.keywords,
+        attrs: v.attrs,
+        innerBlocks: v.innerBlocks,
+      });
     }
-    out.push({
-      name: spec.name,
-      slug: spec.name,
-      title: spec.title ?? spec.name,
-      description: spec.description,
-      category: spec.category,
-      icon: spec.icon,
-      keywords: spec.keywords,
-    });
+    // The parent block becomes its own inserter card when:
+    //   - no variations exist (the original baseline), or
+    //   - at least one variation is block-scoped (so the user can land
+    //     on a picker that lists the layout choices).
+    if (variations.length === 0 || hasBlockScoped) {
+      out.push({
+        name: spec.name,
+        slug: spec.name,
+        title: spec.title ?? spec.name,
+        description: spec.description,
+        category: spec.category,
+        icon: spec.icon,
+        keywords: spec.keywords,
+      });
+    }
   }
   return out;
 }

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -81,6 +81,8 @@ export { serializePatternSource } from "./serialize-pattern-source.js";
 export type { SerializePatternSourceOptions } from "./serialize-pattern-source.js";
 export { commitBlockVariations } from "./commit-block-variations.js";
 export { BlockVariationError } from "./variation-errors.js";
+export { resolveBlockScopeVariations } from "./block-scope-variations.js";
+export type { BlockVariationScope } from "./block-registry.js";
 
 // ─── Validation ─────────────────────────────────────────────────────────────
 export { validateEntryContent } from "./validate-content.js";

--- a/packages/blocks/src/variation-errors.ts
+++ b/packages/blocks/src/variation-errors.ts
@@ -38,4 +38,14 @@ export class BlockVariationError extends Error {
       `Variation "${variationSlug}" of "${parentBlock}" declares innerBlocks but the parent block has no "content" slot input.`,
     );
   }
+
+  static invalidScope(
+    parentBlock: string,
+    variationSlug: string,
+    value: string,
+  ): BlockVariationError {
+    return new BlockVariationError(
+      `Variation "${variationSlug}" of "${parentBlock}" declares scope value "${value}" outside the allowed union ("inserter" | "block" | "transform").`,
+    );
+  }
 }


### PR DESCRIPTION
Adds optional \`BlockVariation.scope: readonly (\"inserter\" | \"block\" | \"transform\")[]\`
defaulting to \`[\"inserter\"]\`. Container blocks (\`core/columns\`, \`core/cover\`) can now collapse
N layout variations into a single inserter card; clicking it opens a layout picker, instead
of dumping N separate cards into the slash menu and sidebar.

**Boot-time scope union enforcement**

\`commitBlockVariations\` rejects scope values outside the union with a structured
\`BlockVariationError.invalidScope\` naming the parent block + variation slug. \`scope: []\` is
allowed and surfaces nowhere — useful as a readback-only identity for stored instances
referenced by \`isActive\`.

**Block-scope picker reuses \`insertVariation\`**

The shadcn Dialog lists each block-scoped variation as a card with title and description.
Selection inserts the variation's merged attrs + ID-rewritten \`innerBlocks\` via the same
\`insertVariation\` primitive #634 shipped. ESC / Cancel inserts the bare block with
\`blockSpec.defaults\`. Capability gating skips the picker entirely when the parent block's
capability isn't in the user's grant set.

**Live thumbnails deferred**

The patterns thumbnail path takes \`BlockNode[]\`; a variation preview (parent block wrapping
innerBlocks) needs an adapter that isn't required to ship the contract. Tracked as a
follow-up — the picker cards currently render title + description text.

Fixes #636