### PR TITLE
feat: add BlockVariation.example preview override

### DIFF
--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -17,6 +17,11 @@ export interface BlockInput {
 
 export type BlockVariationScope = "inserter" | "block" | "transform";
 
+export interface BlockVariationExample {
+  readonly attrs?: Readonly<Record<string, unknown>>;
+  readonly innerBlocks?: readonly BlockNode[];
+}
+
 export interface BlockVariation {
   readonly slug: string;
   readonly title: string;
@@ -35,6 +40,12 @@ export interface BlockVariation {
   // from all surfaces — useful as a readback-only identity for stored
   // instances referenced by `isActive`.
   readonly scope?: readonly BlockVariationScope[];
+  // Preview-only override for inserter card / block-scope picker. When
+  // set, preview surfaces render `example.attrs` / `example.innerBlocks`
+  // instead of the runtime values. Insertion still uses the runtime
+  // `attrs` + `innerBlocks` — useful when the runtime body relies on an
+  // async loader and the preview needs static content.
+  readonly example?: BlockVariationExample;
 }
 
 /**

--- a/packages/blocks/src/commit-block-variations.test.ts
+++ b/packages/blocks/src/commit-block-variations.test.ts
@@ -115,6 +115,28 @@ describe("commitBlockVariations", () => {
     );
   });
 
+  test("validates example.innerBlocks against the block registry", () => {
+    const group = defineBlock({
+      name: "x-test/group",
+      title: "Group",
+      inputs: [{ name: "content", type: "slot" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "with-example",
+          title: "With example",
+          example: {
+            innerBlocks: [{ id: "g1", name: "core/ghost", attrs: {} }],
+          },
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([group, headingBlock]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "with-example" of "x-test\/group" at example\.innerBlocks\[0\] references unknown block "core\/ghost"/,
+    );
+  });
+
   test("recurses into slot-shaped attrs to validate nested innerBlocks", () => {
     const group = defineBlock({
       name: "core/group-test",

--- a/packages/blocks/src/commit-block-variations.ts
+++ b/packages/blocks/src/commit-block-variations.ts
@@ -57,6 +57,15 @@ export function commitBlockVariations(blocks: BlockRegistry): void {
           blocks,
         );
       }
+      if (variation.example?.innerBlocks) {
+        walk(
+          spec.name,
+          variation.slug,
+          variation.example.innerBlocks,
+          "example.innerBlocks",
+          blocks,
+        );
+      }
     }
   }
 }

--- a/packages/blocks/src/expand-block-variations.test.ts
+++ b/packages/blocks/src/expand-block-variations.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "vitest";
 
 import type { BlockSpec } from "./block-registry.js";
-import { expandBlockVariations } from "./expand-block-variations.js";
+import {
+  expandBlockVariations,
+  resolveVariationPreview,
+} from "./expand-block-variations.js";
 
 function block(spec: Partial<BlockSpec> & { name: string }): BlockSpec {
   return { render: () => null, ...spec };
@@ -107,5 +110,45 @@ describe("expandBlockVariations", () => {
       }),
     ]);
     expect(entries.map((e) => e.slug)).toEqual(["bullet"]);
+  });
+
+  test("carries variation.example through to InsertableBlockEntry.example for preview overrides", () => {
+    const entries = expandBlockVariations([
+      block({
+        name: "core/columns",
+        title: "Columns",
+        variations: [
+          {
+            slug: "loader-backed",
+            title: "Loader-backed",
+            attrs: { dataSrc: "/api/things" },
+            example: { attrs: { dataSrc: "static-preview" } },
+          },
+        ],
+      }),
+    ]);
+    expect(entries[0]?.example?.attrs).toEqual({ dataSrc: "static-preview" });
+  });
+
+  test("resolveVariationPreview uses example overrides for preview but leaves entry runtime data untouched", () => {
+    const [entry] = expandBlockVariations([
+      block({
+        name: "core/columns",
+        title: "Columns",
+        variations: [
+          {
+            slug: "loader-backed",
+            title: "Loader-backed",
+            attrs: { dataSrc: "/api/things" },
+            example: { attrs: { dataSrc: "static-preview" } },
+          },
+        ],
+      }),
+    ]);
+    expect(entry?.attrs).toEqual({ dataSrc: "/api/things" });
+    if (!entry) throw new Error("expected variation entry");
+    expect(resolveVariationPreview(entry).attrs).toEqual({
+      dataSrc: "static-preview",
+    });
   });
 });

--- a/packages/blocks/src/expand-block-variations.ts
+++ b/packages/blocks/src/expand-block-variations.ts
@@ -1,4 +1,4 @@
-import type { BlockSpec } from "./block-registry.js";
+import type { BlockSpec, BlockVariationExample } from "./block-registry.js";
 import type { BlockNode } from "./render-block-tree.js";
 
 export interface InsertableBlockEntry {
@@ -13,6 +13,9 @@ export interface InsertableBlockEntry {
   // Default body for the parent block's conventional `content` slot.
   // Caller deep-clones + ID-rewrites before merging into a block instance.
   readonly innerBlocks?: readonly BlockNode[];
+  // Preview-only override for inserter card / picker card rendering.
+  // Insertion paths still use `attrs` + `innerBlocks` above.
+  readonly example?: BlockVariationExample;
 }
 
 export function expandBlockVariations(
@@ -36,6 +39,7 @@ export function expandBlockVariations(
         keywords: v.keywords,
         attrs: v.attrs,
         innerBlocks: v.innerBlocks,
+        example: v.example,
       });
     }
     // The parent block becomes its own inserter card when:
@@ -55,4 +59,20 @@ export function expandBlockVariations(
     }
   }
   return out;
+}
+
+// Resolves the preview data for a variation entry: example overrides
+// applied on top of the runtime attrs/innerBlocks. Used by preview
+// surfaces (inserter cards, block-scope picker thumbnails) — never by
+// insertion paths.
+export function resolveVariationPreview(entry: InsertableBlockEntry): {
+  readonly attrs: Readonly<Record<string, unknown>>;
+  readonly innerBlocks: readonly BlockNode[];
+} {
+  const baseAttrs = entry.attrs ?? {};
+  const baseInner = entry.innerBlocks ?? [];
+  return {
+    attrs: entry.example?.attrs ?? baseAttrs,
+    innerBlocks: entry.example?.innerBlocks ?? baseInner,
+  };
 }

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -57,8 +57,12 @@ export type {
 // ─── Transforms + insertable expansion ─────────────────────────────────────
 export { resolveBlockTransforms } from "./transforms.js";
 export type { ResolvedTransformTarget } from "./transforms.js";
-export { expandBlockVariations } from "./expand-block-variations.js";
+export {
+  expandBlockVariations,
+  resolveVariationPreview,
+} from "./expand-block-variations.js";
 export type { InsertableBlockEntry } from "./expand-block-variations.js";
+export type { BlockVariationExample } from "./block-registry.js";
 
 // ─── Pattern registry primitives ────────────────────────────────────────────
 export {


### PR DESCRIPTION
Adds optional \`example: { attrs?, innerBlocks? }\` to BlockVariation. Preview surfaces
(inserter cards, block-scope picker) consume \`example\` as overrides on top of the variation's
runtime data — useful when the runtime body relies on an async loader and the preview needs
static, recognisable content. Insertion paths are unchanged.

**Boot-time validation walks example.innerBlocks**

\`commitBlockVariations\` walks \`example.innerBlocks\` against the block registry with the same
structured-error path \`variation.innerBlocks\` uses. Stale examples fail at boot with parent +
variation + path traces rather than producing broken previews at request time.

**Preview path divorced from insertion**

New pure helper \`resolveVariationPreview(entry)\` returns the preview data for a given
\`InsertableBlockEntry\`: \`example.attrs\` / \`example.innerBlocks\` when supplied, runtime values
otherwise. Preview surfaces call it; insertion paths keep using \`entry.attrs\` /
\`entry.innerBlocks\` directly via \`insertVariation\`.

Fixes #637