### PR TITLE
feat(admin): surface transform-scope variations in the block action bar

### DIFF
--- a/packages/admin/src/editor/available-transforms.test.ts
+++ b/packages/admin/src/editor/available-transforms.test.ts
@@ -70,4 +70,59 @@ describe("availableTransforms", () => {
       options.find((o) => o.targetName === "core/heading")?.targetTitle,
     ).toBe("Heading");
   });
+
+  test("surfaces a transform-scoped variation of the source block as a same-block option", () => {
+    const registry = createBlockRegistry([
+      spec({
+        name: "core/columns",
+        title: "Columns",
+        variations: [
+          {
+            slug: "two-up",
+            title: "Two up",
+            attrs: { layout: "split" },
+            scope: ["transform"],
+          },
+          {
+            slug: "three-up",
+            title: "Three up",
+            attrs: { layout: "three" },
+            scope: ["transform"],
+          },
+          {
+            slug: "inserter-only",
+            title: "Inserter only",
+            attrs: { layout: "rare" },
+          },
+        ],
+      }),
+    ]);
+    const options = availableTransforms("core/columns", registry);
+    expect(options.map((o) => `${o.targetName}:${o.targetTitle}`)).toEqual([
+      "core/columns:Two up",
+      "core/columns:Three up",
+    ]);
+  });
+
+  test("variation-scoped transform applies the variation attrs over the current ones via mapAttrs", () => {
+    const registry = createBlockRegistry([
+      spec({
+        name: "core/columns",
+        title: "Columns",
+        variations: [
+          {
+            slug: "two-up",
+            title: "Two up",
+            attrs: { layout: "split" },
+            scope: ["transform"],
+          },
+        ],
+      }),
+    ]);
+    const [option] = availableTransforms("core/columns", registry);
+    expect(option?.mapAttrs?.({ layout: "stale", other: "kept" })).toEqual({
+      layout: "split",
+      other: "kept",
+    });
+  });
 });

--- a/packages/admin/src/editor/available-transforms.ts
+++ b/packages/admin/src/editor/available-transforms.ts
@@ -15,10 +15,25 @@ export function availableTransforms(
   registry: BlockRegistry,
 ): readonly TransformOption[] {
   const resolved = resolveBlockTransforms(sourceName, Array.from(registry));
-  return resolved.map((entry) => ({
+  const fromTransforms: TransformOption[] = resolved.map((entry) => ({
     targetName: entry.target,
     targetTitle: registry.get(entry.target)?.title ?? entry.target,
     mapAttrs: entry.mapAttrs,
     mode: entry.mode,
   }));
+  // Transform-scoped variations surface as same-block transforms. The
+  // editor's transform handler dispatches `replace` with `targetName`
+  // identical to the source — Puck's reducer treats that as an in-place
+  // attr swap. `mapAttrs` overlays the variation's attrs on top of the
+  // instance so other props the user set survive the morph.
+  const sourceSpec = registry.get(sourceName);
+  const variationOptions: TransformOption[] =
+    sourceSpec?.variations
+      ?.filter((v) => v.scope?.includes("transform"))
+      .map((variation) => ({
+        targetName: sourceName,
+        targetTitle: variation.title,
+        mapAttrs: (current) => ({ ...current, ...(variation.attrs ?? {}) }),
+      })) ?? [];
+  return [...variationOptions, ...fromTransforms];
 }


### PR DESCRIPTION
Variations declared \`scope: ["transform"]\` (the type accepted in #650) now appear in the
existing transform action bar. Clicking morphs the instance in place by overlaying the
variation's \`attrs\` on top of the current props, preserving every other key the user set.

**No change to the transform-handler shape**

\`availableTransforms\` returns the variation transforms first (above the cross-block
transforms), each with \`targetName === sourceName\` and a \`mapAttrs\` that returns
\`{ ...current, ...variation.attrs }\`. The existing \`PlumixBlockActions\` handler dispatches
\`replace\` with the same target name, which Puck treats as an in-place attr swap.

**innerBlocks transformation deferred**

Transform-scope variations apply attrs only. The block-scope picker (#650) remains the
surface for picking variations whose distinguishing feature is the slot body.

Refs #633