### PR TITLE
feat(admin): live thumbnails inside the block-scope picker

### DIFF
--- a/packages/admin/src/editor/BlockScopePicker.test.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.test.tsx
@@ -3,12 +3,16 @@ import { userEvent } from "@testing-library/user-event";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import type { BlockVariation } from "@plumix/blocks";
+import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
 import { BlockScopePicker } from "./BlockScopePicker.js";
 
 afterEach(() => {
   cleanup();
 });
+
+const blocks = createBlockRegistry([]);
+const patterns = createPatternRegistry([]);
 
 const twoUp: BlockVariation = {
   slug: "two-up",
@@ -31,7 +35,10 @@ describe("BlockScopePicker", () => {
     render(
       <BlockScopePicker
         blockTitle="Columns"
+        parentBlockName="core/columns"
         variations={[twoUp, threeUp]}
+        blocks={blocks}
+        patterns={patterns}
         onSelect={vi.fn()}
         onDismiss={vi.fn()}
       />,
@@ -45,12 +52,35 @@ describe("BlockScopePicker", () => {
     ).toBeDefined();
   });
 
+  test("renders a live thumbnail for each card keyed on parent + slug", () => {
+    render(
+      <BlockScopePicker
+        blockTitle="Columns"
+        parentBlockName="core/columns"
+        variations={[twoUp, threeUp]}
+        blocks={blocks}
+        patterns={patterns}
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByTestId("plumix-variation-thumbnail-core/columns:two-up"),
+    ).toBeDefined();
+    expect(
+      screen.getByTestId("plumix-variation-thumbnail-core/columns:three-up"),
+    ).toBeDefined();
+  });
+
   test("clicking a card calls onSelect with the chosen variation", async () => {
     const onSelect = vi.fn();
     render(
       <BlockScopePicker
         blockTitle="Columns"
+        parentBlockName="core/columns"
         variations={[twoUp, threeUp]}
+        blocks={blocks}
+        patterns={patterns}
         onSelect={onSelect}
         onDismiss={vi.fn()}
       />,
@@ -66,7 +96,10 @@ describe("BlockScopePicker", () => {
     render(
       <BlockScopePicker
         blockTitle="Columns"
+        parentBlockName="core/columns"
         variations={[twoUp]}
+        blocks={blocks}
+        patterns={patterns}
         onSelect={vi.fn()}
         onDismiss={onDismiss}
       />,

--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -7,11 +7,20 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog.js";
 
-import type { BlockVariation } from "@plumix/blocks";
+import type {
+  BlockRegistry,
+  BlockVariation,
+  PatternRegistry,
+} from "@plumix/blocks";
+
+import { VariationThumbnail } from "./VariationThumbnail.js";
 
 interface BlockScopePickerProps {
   readonly blockTitle: string;
+  readonly parentBlockName: string;
   readonly variations: readonly BlockVariation[];
+  readonly blocks: BlockRegistry;
+  readonly patterns: PatternRegistry;
   readonly onSelect: (variation: BlockVariation) => void;
   readonly onDismiss: () => void;
 }
@@ -19,12 +28,12 @@ interface BlockScopePickerProps {
 // Block-scope picker — opens after inserting a parent block whose
 // variations include any `scope: ["block"]`. The author picks a layout;
 // cancel inserts the bare block with its declared defaults.
-//
-// TODO(#637): replace the textual card body with the live thumbnail
-// path used by the patterns sidebar (lazy-mount + scaled render).
 export function BlockScopePicker({
   blockTitle,
+  parentBlockName,
   variations,
+  blocks,
+  patterns,
   onSelect,
   onDismiss,
 }: BlockScopePickerProps): ReactElement | null {
@@ -54,7 +63,7 @@ export function BlockScopePicker({
               <div
                 role="button"
                 tabIndex={0}
-                className="hover:bg-muted/40 flex w-full flex-col gap-1 rounded border p-3 text-left focus:outline-none focus-visible:ring"
+                className="hover:bg-muted/40 flex w-full flex-col gap-2 rounded border p-3 text-left focus:outline-none focus-visible:ring"
                 data-testid={`plumix-block-scope-picker-card-${variation.slug}`}
                 onClick={() => onSelect(variation)}
                 onKeyDown={(e) => {
@@ -64,6 +73,14 @@ export function BlockScopePicker({
                   }
                 }}
               >
+                <div className="overflow-hidden rounded">
+                  <VariationThumbnail
+                    parentBlockName={parentBlockName}
+                    variation={variation}
+                    blocks={blocks}
+                    patterns={patterns}
+                  />
+                </div>
                 <span className="text-sm font-medium">{variation.title}</span>
                 {variation.description ? (
                   <span className="text-muted-foreground text-xs">

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -754,7 +754,10 @@ function PlumixBlocksTab({
       {pendingPick ? (
         <BlockScopePicker
           blockTitle={pendingPick.entry.title}
+          parentBlockName={pendingPick.entry.name}
           variations={pendingPick.variations}
+          blocks={registry}
+          patterns={patternRegistry}
           onSelect={handlePickerSelect}
           onDismiss={handlePickerDismiss}
         />

--- a/packages/admin/src/editor/VariationThumbnail.test.tsx
+++ b/packages/admin/src/editor/VariationThumbnail.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import type { BlockVariation } from "@plumix/blocks";
+import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
+
+import { VariationThumbnail } from "./VariationThumbnail.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const blocks = createBlockRegistry([]);
+const patterns = createPatternRegistry([]);
+
+describe("VariationThumbnail", () => {
+  test("emits a test-id keyed on parent block + variation slug", () => {
+    const variation: BlockVariation = {
+      slug: "two-up",
+      title: "Two up",
+      attrs: { layout: "split" },
+    };
+    render(
+      <VariationThumbnail
+        parentBlockName="core/columns"
+        variation={variation}
+        blocks={blocks}
+        patterns={patterns}
+      />,
+    );
+    expect(
+      screen.getByTestId("plumix-variation-thumbnail-core/columns:two-up"),
+    ).toBeDefined();
+  });
+});

--- a/packages/admin/src/editor/VariationThumbnail.tsx
+++ b/packages/admin/src/editor/VariationThumbnail.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from "react";
+
+import type {
+  BlockNode,
+  BlockRegistry,
+  BlockVariation,
+  PatternRegistry,
+} from "@plumix/blocks";
+import { renderBlockTree } from "@plumix/blocks";
+
+interface VariationThumbnailProps {
+  readonly parentBlockName: string;
+  readonly variation: BlockVariation;
+  readonly blocks: BlockRegistry;
+  readonly patterns: PatternRegistry;
+}
+
+// Live thumbnail for the block-scope picker. Wraps the variation's
+// preview body in a single parent-block node so the walker renders it
+// through the same path as patterns + page content. `example.attrs` /
+// `example.innerBlocks` take precedence when supplied (the slice #651
+// preview-override contract).
+export function VariationThumbnail({
+  parentBlockName,
+  variation,
+  blocks,
+  patterns,
+}: VariationThumbnailProps): ReactElement {
+  const previewAttrs = variation.example?.attrs ?? variation.attrs ?? {};
+  const previewInner =
+    variation.example?.innerBlocks ?? variation.innerBlocks ?? [];
+  const node: BlockNode = {
+    id: `${parentBlockName}-${variation.slug}`,
+    name: parentBlockName,
+    attrs: { ...previewAttrs, content: previewInner },
+  };
+  return (
+    <div
+      className="pointer-events-none"
+      data-testid={`plumix-variation-thumbnail-${parentBlockName}:${variation.slug}`}
+    >
+      {renderBlockTree([node], blocks, { patterns })}
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the text-only card body in \`BlockScopePicker\` with a live \`VariationThumbnail\` that
walks the parent block wrapping the variation's preview body. Authors see what each layout
looks like before picking instead of guessing from the title alone — closes the deferred
follow-up the original picker slice (#650) tracked.

**Adapter shape mirrors PatternThumbnail**

\`VariationThumbnail\` wraps the variation in a single parent-block node whose attrs include
\`content: previewInner\`, then renders through \`renderBlockTree\` — the same path the patterns
sidebar uses. \`example.attrs\` / \`example.innerBlocks\` (the #651 preview-override contract) take
precedence when set, so loader-backed variations still show recognisable preview content
without rendering the live data source.

Refs #633