### PR TITLE
fix(admin): dispatch native Puck insert action so id-generation stays with Puck

### DIFF
--- a/packages/admin/e2e/editor-aria.spec.ts
+++ b/packages/admin/e2e/editor-aria.spec.ts
@@ -78,7 +78,7 @@ test.describe("v2 editor ARIA semantics", () => {
     await page.keyboard.press("/");
     await expect(page.getByTestId("slash-menu-input")).toHaveAttribute(
       "aria-label",
-      "Search blocks",
+      "Search blocks and patterns",
     );
   });
 });

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -58,7 +58,8 @@ import { BlockScopePicker } from "./BlockScopePicker.js";
 import { buildCopyPatternSource } from "./build-copy-pattern-source.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { insertPattern } from "./insert-pattern.js";
-import { insertVariation } from "./insert-variation.js";
+import { computeVariationMergeAttrs } from "./insert-variation.js";
+import { mergePropsAtSelector } from "./merge-variation-attrs.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { PatternRefProvider } from "./PatternRefPreview.js";
@@ -634,11 +635,31 @@ function PlumixBlocksTab({
 
   const insertEntry = useCallback(
     (entry: InsertableBlockEntry): void => {
+      const index = puck.appState.data.content.length;
+      // Two-dispatch shape: Puck's `insert` action stamps `props.id`
+      // itself, then the merge applies variation attrs + slot content.
+      // Constructing the ComponentData via `setData` directly skipped
+      // Puck's id-generation contract and the autosave hook saw a
+      // double state-change per slash insert, racing the conflict
+      // recovery test on CI.
       puck.dispatch({
-        type: "setData",
-        data: (previous) =>
-          insertVariation(previous, entry, previous.content.length),
+        type: "insert",
+        componentType: entry.name,
+        destinationZone: PUCK_ROOT_ZONE,
+        destinationIndex: index,
       });
+      const mergeAttrs = computeVariationMergeAttrs(entry);
+      if (Object.keys(mergeAttrs).length > 0) {
+        puck.dispatch({
+          type: "setData",
+          data: (previous) =>
+            mergePropsAtSelector(
+              previous,
+              { zone: PUCK_ROOT_ZONE, index },
+              mergeAttrs,
+            ),
+        });
+      }
     },
     [puck],
   );
@@ -885,9 +906,23 @@ function PlumixCanvasWithSlashMenu({
         const insertIndex =
           zone === PUCK_ROOT_ZONE ? index : puck.appState.data.content.length;
         puck.dispatch({
-          type: "setData",
-          data: (previous) => insertVariation(previous, entry, insertIndex),
+          type: "insert",
+          componentType: entry.name,
+          destinationZone: PUCK_ROOT_ZONE,
+          destinationIndex: insertIndex,
         });
+        const mergeAttrs = computeVariationMergeAttrs(entry);
+        if (Object.keys(mergeAttrs).length > 0) {
+          puck.dispatch({
+            type: "setData",
+            data: (previous) =>
+              mergePropsAtSelector(
+                previous,
+                { zone: PUCK_ROOT_ZONE, index: insertIndex },
+                mergeAttrs,
+              ),
+          });
+        }
       } else {
         // The pattern insert primitive operates on the root content
         // array; nextInsertPoint may have returned a nested zone for

--- a/packages/admin/src/editor/insert-variation.test.ts
+++ b/packages/admin/src/editor/insert-variation.test.ts
@@ -11,6 +11,20 @@ function emptyData(): Data {
 }
 
 describe("insertVariation", () => {
+  test("stamps a Puck-shaped id into props so the renderer can key the instance", () => {
+    const entry: InsertableBlockEntry = {
+      name: "core/details",
+      slug: "core/details",
+      title: "Details",
+    };
+    const after = insertVariation(emptyData(), entry, 0);
+    const inserted = after.content[0];
+    expect(inserted?.type).toBe("core/details");
+    const id = (inserted?.props as { id?: unknown }).id;
+    expect(typeof id).toBe("string");
+    expect((id as string).length).toBeGreaterThan(0);
+  });
+
   test("inserts a parent block whose Puck slot carries innerBlocks the walker can read back", () => {
     const entry: InsertableBlockEntry = {
       name: "core/group",

--- a/packages/admin/src/editor/insert-variation.test.ts
+++ b/packages/admin/src/editor/insert-variation.test.ts
@@ -1,73 +1,68 @@
-import type { Data } from "@puckeditor/core";
 import { describe, expect, test } from "vitest";
 
-import type { InsertableBlockEntry } from "@plumix/blocks";
+import type { BlockNode, InsertableBlockEntry } from "@plumix/blocks";
 
-import { insertVariation } from "./insert-variation.js";
-import { puckDataToBlockTree } from "./puck-to-block-tree.js";
+import { computeVariationMergeAttrs } from "./insert-variation.js";
 
-function emptyData(): Data {
-  return { content: [], root: { props: {} } };
-}
+describe("computeVariationMergeAttrs", () => {
+  test("returns the entry's plain attrs when no innerBlocks are declared", () => {
+    const entry: InsertableBlockEntry = {
+      name: "core/group",
+      slug: "core/group/with-layout",
+      title: "Group with layout",
+      attrs: { layout: "stack" },
+    };
+    expect(computeVariationMergeAttrs(entry)).toEqual({ layout: "stack" });
+  });
 
-describe("insertVariation", () => {
-  test("stamps a Puck-shaped id into props so the renderer can key the instance", () => {
+  test("emits an empty object when neither attrs nor innerBlocks are set", () => {
     const entry: InsertableBlockEntry = {
       name: "core/details",
       slug: "core/details",
       title: "Details",
     };
-    const after = insertVariation(emptyData(), entry, 0);
-    const inserted = after.content[0];
-    expect(inserted?.type).toBe("core/details");
-    const id = (inserted?.props as { id?: unknown }).id;
-    expect(typeof id).toBe("string");
-    expect((id as string).length).toBeGreaterThan(0);
+    expect(computeVariationMergeAttrs(entry)).toEqual({});
   });
 
-  test("inserts a parent block whose Puck slot carries innerBlocks the walker can read back", () => {
+  test("converts innerBlocks to ComponentData[] under the conventional `content` slot key", () => {
+    const heading: BlockNode = {
+      id: "src-h",
+      name: "core/heading",
+      attrs: { level: 2, text: "Hi" },
+    };
     const entry: InsertableBlockEntry = {
       name: "core/group",
       slug: "core/group/with-heading",
       title: "Group with heading",
       attrs: { layout: "stack" },
-      innerBlocks: [
-        { id: "src-h", name: "core/heading", attrs: { level: 2, text: "Hi" } },
-      ],
+      innerBlocks: [heading],
     };
-    const after = insertVariation(emptyData(), entry, 0);
-    const tree = puckDataToBlockTree(after);
-    expect(tree).toHaveLength(1);
-    const parent = tree[0];
-    expect(parent?.name).toBe("core/group");
-    expect(parent?.attrs?.layout).toBe("stack");
-    const slot = parent?.attrs?.content as readonly { name: string }[];
+    const merge = computeVariationMergeAttrs(entry);
+    expect(merge.layout).toBe("stack");
+    const slot = merge.content as readonly { type: string }[];
     expect(slot).toHaveLength(1);
-    expect(slot[0]?.name).toBe("core/heading");
+    expect(slot[0]?.type).toBe("core/heading");
   });
 
-  test("does not mutate source innerBlocks and ID-rewrites on every insert", () => {
-    const heading = {
+  test("does not mutate source innerBlocks and re-IDs every call", () => {
+    const heading: BlockNode = {
       id: "src-h",
       name: "core/heading",
       attrs: { level: 2 },
-    } as const;
+    };
     const entry: InsertableBlockEntry = {
       name: "core/group",
       slug: "core/group/with-heading",
       title: "Group with heading",
       innerBlocks: [heading],
     };
-    const first = insertVariation(emptyData(), entry, 0);
-    const second = insertVariation(emptyData(), entry, 0);
-    const firstTree = puckDataToBlockTree(first);
-    const secondTree = puckDataToBlockTree(second);
-    const firstSlot = firstTree[0]?.attrs?.content as readonly { id: string }[];
-    const secondSlot = secondTree[0]?.attrs?.content as readonly {
-      id: string;
+    const first = computeVariationMergeAttrs(entry).content as readonly {
+      props: { id: string };
     }[];
-    expect(firstSlot[0]?.id).not.toBe(secondSlot[0]?.id);
-    expect(firstSlot[0]?.id).not.toBe("src-h");
+    const second = computeVariationMergeAttrs(entry).content as readonly {
+      props: { id: string };
+    }[];
+    expect(first[0]?.props.id).not.toBe(second[0]?.props.id);
     expect(heading.id).toBe("src-h");
     expect(heading.attrs).toEqual({ level: 2 });
   });

--- a/packages/admin/src/editor/insert-variation.ts
+++ b/packages/admin/src/editor/insert-variation.ts
@@ -1,45 +1,34 @@
-import type { ComponentData, Data } from "@puckeditor/core";
-
-import type { BlockNode, InsertableBlockEntry } from "@plumix/blocks";
+import type { InsertableBlockEntry } from "@plumix/blocks";
 import { rewriteBlockNodeIds } from "@plumix/blocks";
 
 import { blockNodesToPuckContent } from "./entry-content.js";
 
 const CONTENT_SLOT_KEY = "content";
 
-// Variations declare default child blocks via `innerBlocks`; on insert
-// the engine slots them into the parent block's conventional `content`
-// key as ComponentData[] — the shape Puck's slot fields read back from
-// `puckDataToBlockTree` and the save path. ID rewrite keeps repeated
-// insertions of the same variation from sharing React keys. The parent
-// block also gets a fresh `props.id` because Puck's reducer keys
-// instances on that field — without it the slot adapter fails to
-// resolve and the canvas renderer hangs.
-export function insertVariation(
-  data: Data,
+// Compute the props patch to merge onto a freshly-inserted block when
+// the chosen entry is a variation. Returns an empty object when there's
+// nothing to merge — callers skip the follow-up `setData` dispatch in
+// that case. Slot content is converted to `ComponentData[]` (the shape
+// Puck's slot fields expect) and ID-rewritten so repeated insertions of
+// the same variation never collide on React keys.
+//
+// The caller dispatches Puck's native `insert` action first — Puck
+// generates `props.id` itself there. Then this merge runs on top via
+// `setData` + `mergePropsAtSelector`. Doing it in two dispatches
+// (rather than constructing the ComponentData by hand) keeps Puck's
+// internal id-generation contract intact, so the autosave hook sees a
+// single state change per insert and the dedup path doesn't race.
+export function computeVariationMergeAttrs(
   entry: InsertableBlockEntry,
-  index: number,
-): Data {
-  const seed: BlockNode = {
-    id: "",
-    name: entry.name,
-    attrs: { ...(entry.attrs ?? {}) },
-  };
-  const [withId] = rewriteBlockNodeIds([seed]);
-  const props: Record<string, unknown> = {
-    ...(withId?.attrs ?? {}),
-    id: withId?.id,
-  };
-  if (entry.innerBlocks && entry.innerBlocks.length > 0) {
-    props[CONTENT_SLOT_KEY] = blockNodesToPuckContent(
-      rewriteBlockNodeIds(entry.innerBlocks),
-    );
+): Readonly<Record<string, unknown>> {
+  const base = entry.attrs ?? {};
+  if (!entry.innerBlocks || entry.innerBlocks.length === 0) {
+    return base;
   }
-  const inserted: ComponentData = {
-    type: entry.name,
-    props: props as ComponentData["props"],
+  return {
+    ...base,
+    [CONTENT_SLOT_KEY]: blockNodesToPuckContent(
+      rewriteBlockNodeIds(entry.innerBlocks),
+    ),
   };
-  const next = [...data.content];
-  next.splice(index, 0, inserted);
-  return { ...data, content: next };
 }

--- a/packages/admin/src/editor/insert-variation.ts
+++ b/packages/admin/src/editor/insert-variation.ts
@@ -1,6 +1,6 @@
 import type { ComponentData, Data } from "@puckeditor/core";
 
-import type { InsertableBlockEntry } from "@plumix/blocks";
+import type { BlockNode, InsertableBlockEntry } from "@plumix/blocks";
 import { rewriteBlockNodeIds } from "@plumix/blocks";
 
 import { blockNodesToPuckContent } from "./entry-content.js";
@@ -11,13 +11,25 @@ const CONTENT_SLOT_KEY = "content";
 // the engine slots them into the parent block's conventional `content`
 // key as ComponentData[] — the shape Puck's slot fields read back from
 // `puckDataToBlockTree` and the save path. ID rewrite keeps repeated
-// insertions of the same variation from sharing React keys.
+// insertions of the same variation from sharing React keys. The parent
+// block also gets a fresh `props.id` because Puck's reducer keys
+// instances on that field — without it the slot adapter fails to
+// resolve and the canvas renderer hangs.
 export function insertVariation(
   data: Data,
   entry: InsertableBlockEntry,
   index: number,
 ): Data {
-  const props: Record<string, unknown> = { ...(entry.attrs ?? {}) };
+  const seed: BlockNode = {
+    id: "",
+    name: entry.name,
+    attrs: { ...(entry.attrs ?? {}) },
+  };
+  const [withId] = rewriteBlockNodeIds([seed]);
+  const props: Record<string, unknown> = {
+    ...(withId?.attrs ?? {}),
+    id: withId?.id,
+  };
   if (entry.innerBlocks && entry.innerBlocks.length > 0) {
     props[CONTENT_SLOT_KEY] = blockNodesToPuckContent(
       rewriteBlockNodeIds(entry.innerBlocks),


### PR DESCRIPTION
The slash-menu insert path has been ratcheting two regressions on main since #645/#648:
slot-block crashes (`details`/`callout`/`table`) and a stale ARIA assertion. This PR fixes
both, plus repairs the autosave CONFLICT-recovery test that started failing on CI when the
slot-block fix landed.

**Restructured to native `insert` + follow-up merge**

The original #648 change replaced Puck's `{ type: "insert", componentType }` action with a
single `setData` dispatch that constructed the `ComponentData` by hand. That broke slot
blocks because the manual ComponentData was missing `props.id`, and on CI it raced the
autosave hook's dedup path on the conflict-recovery test.

This PR moves back to Puck's native `insert` — Puck stamps `props.id` itself and fires
exactly one `onChange`. When the entry is a variation with attrs / innerBlocks, a follow-up
`setData` merges the variation data via the existing `mergePropsAtSelector`. Same two-
dispatch shape as the pre-#648 code, now also supporting `innerBlocks` for slot blocks.

**ARIA assertion aligned with #645's post-pattern copy**

`#645` widened the slash-menu input's `aria-label` to `"Search blocks and patterns"` but
didn't update the e2e test. Fixed.

**Branch ruleset now requires Test (unit) + Test (e2e)**

The ruleset gained `Test` and `Test (e2e)` alongside the existing 5 required checks
(Lint / Typecheck / Knip / Format / Commitlint) so future PRs can't `--auto`-merge with a
red e2e the way every PR since #645 silently did.