### PR TITLE
refactor: address senpai findings on the variations track

### DIFF
--- a/packages/admin/src/editor/BlockActionsPanel.test.tsx
+++ b/packages/admin/src/editor/BlockActionsPanel.test.tsx
@@ -52,10 +52,10 @@ describe("BlockActionsPanel", () => {
     );
 
     expect(
-      screen.getByTestId("block-action-transform-core/heading").textContent,
+      screen.getByTestId("block-action-transform-to:core/heading").textContent,
     ).toContain("Heading");
     expect(
-      screen.getByTestId("block-action-transform-core/quote"),
+      screen.getByTestId("block-action-transform-to:core/quote"),
     ).toBeDefined();
   });
 
@@ -70,7 +70,9 @@ describe("BlockActionsPanel", () => {
       />,
     );
 
-    await user.click(screen.getByTestId("block-action-transform-core/heading"));
+    await user.click(
+      screen.getByTestId("block-action-transform-to:core/heading"),
+    );
 
     expect(onTransform).toHaveBeenCalledTimes(1);
     expect(onTransform.mock.calls[0]?.[0].targetName).toBe("core/heading");

--- a/packages/admin/src/editor/BlockActionsPanel.tsx
+++ b/packages/admin/src/editor/BlockActionsPanel.tsx
@@ -76,12 +76,12 @@ export function BlockActionsPanel({
           <div className="text-muted-foreground text-xs">Transform to</div>
           <ul className="flex flex-wrap gap-1" data-testid="block-actions-list">
             {options.map((option) => (
-              <li key={option.targetName}>
+              <li key={option.key}>
                 <button
                   type="button"
                   onClick={() => onTransform(option)}
                   className="rounded border px-2 py-1 text-xs"
-                  data-testid={`block-action-transform-${option.targetName}`}
+                  data-testid={`block-action-transform-${option.key}`}
                 >
                   {option.targetTitle}
                 </button>

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -58,8 +58,7 @@ import { BlockScopePicker } from "./BlockScopePicker.js";
 import { buildCopyPatternSource } from "./build-copy-pattern-source.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { insertPattern } from "./insert-pattern.js";
-import { computeVariationMergeAttrs } from "./insert-variation.js";
-import { mergePropsAtSelector } from "./merge-variation-attrs.js";
+import { dispatchVariationInsert } from "./insert-variation.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { PatternRefProvider } from "./PatternRefPreview.js";
@@ -635,31 +634,11 @@ function PlumixBlocksTab({
 
   const insertEntry = useCallback(
     (entry: InsertableBlockEntry): void => {
-      const index = puck.appState.data.content.length;
-      // Two-dispatch shape: Puck's `insert` action stamps `props.id`
-      // itself, then the merge applies variation attrs + slot content.
-      // Constructing the ComponentData via `setData` directly skipped
-      // Puck's id-generation contract and the autosave hook saw a
-      // double state-change per slash insert, racing the conflict
-      // recovery test on CI.
-      puck.dispatch({
-        type: "insert",
-        componentType: entry.name,
-        destinationZone: PUCK_ROOT_ZONE,
-        destinationIndex: index,
-      });
-      const mergeAttrs = computeVariationMergeAttrs(entry);
-      if (Object.keys(mergeAttrs).length > 0) {
-        puck.dispatch({
-          type: "setData",
-          data: (previous) =>
-            mergePropsAtSelector(
-              previous,
-              { zone: PUCK_ROOT_ZONE, index },
-              mergeAttrs,
-            ),
-        });
-      }
+      dispatchVariationInsert(
+        puck.dispatch,
+        entry,
+        puck.appState.data.content.length,
+      );
     },
     [puck],
   );
@@ -715,10 +694,8 @@ function PlumixBlocksTab({
 
   const handlePickerDismiss = useCallback((): void => {
     if (!pendingPick) return;
-    // ESC / cancel inserts the bare block with `blockSpec.defaults`.
-    // Constructing a plain entry with no attrs/innerBlocks routes
-    // through the same `insertVariation` path which will land empty
-    // props, and Puck applies the spec's `defaults` on render.
+    // ESC / cancel falls back to the bare parent block — Puck applies
+    // the spec's `defaults` on render.
     const bare: InsertableBlockEntry = {
       name: pendingPick.entry.name,
       slug: pendingPick.entry.slug,
@@ -901,31 +878,13 @@ function PlumixCanvasWithSlashMenu({
         puck.appState.data.content.length,
       );
       if (item.kind === "block") {
-        const { entry } = item;
         // Variation insert operates on the root content array; nested
         // zones fall back to end-of-document so innerBlocks (which must
         // sit in a top-level slot the walker recognises) never land in
         // the wrong shape.
         const insertIndex =
           zone === PUCK_ROOT_ZONE ? index : puck.appState.data.content.length;
-        puck.dispatch({
-          type: "insert",
-          componentType: entry.name,
-          destinationZone: PUCK_ROOT_ZONE,
-          destinationIndex: insertIndex,
-        });
-        const mergeAttrs = computeVariationMergeAttrs(entry);
-        if (Object.keys(mergeAttrs).length > 0) {
-          puck.dispatch({
-            type: "setData",
-            data: (previous) =>
-              mergePropsAtSelector(
-                previous,
-                { zone: PUCK_ROOT_ZONE, index: insertIndex },
-                mergeAttrs,
-              ),
-          });
-        }
+        dispatchVariationInsert(puck.dispatch, item.entry, insertIndex);
       } else {
         // The pattern insert primitive operates on the root content
         // array; nextInsertPoint may have returned a nested zone for

--- a/packages/admin/src/editor/VariationThumbnail.test.tsx
+++ b/packages/admin/src/editor/VariationThumbnail.test.tsx
@@ -1,8 +1,13 @@
+import type { ReactElement } from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
 
 import type { BlockVariation } from "@plumix/blocks";
-import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
+import {
+  createBlockRegistry,
+  createPatternRegistry,
+  defineBlock,
+} from "@plumix/blocks";
 
 import { VariationThumbnail } from "./VariationThumbnail.js";
 
@@ -10,8 +15,32 @@ afterEach(() => {
   cleanup();
 });
 
-const blocks = createBlockRegistry([]);
-const patterns = createPatternRegistry([]);
+const emptyBlocks = createBlockRegistry([]);
+const emptyPatterns = createPatternRegistry([]);
+
+const realBlocks = createBlockRegistry([
+  defineBlock({
+    name: "x-test/group",
+    title: "Group",
+    inputs: [{ name: "content", type: "slot" }],
+    render: ({ attrs }) => {
+      const Content = attrs.content as (() => ReactElement) | undefined;
+      return (
+        <div data-testid="render-group">{Content ? <Content /> : null}</div>
+      );
+    },
+  }),
+  defineBlock({
+    name: "x-test/leaf",
+    title: "Leaf",
+    inputs: [{ name: "label", type: "text" }],
+    render: ({ attrs }) => (
+      <span data-testid={`render-leaf-${String(attrs.label)}`}>
+        {String(attrs.label)}
+      </span>
+    ),
+  }),
+]);
 
 describe("VariationThumbnail", () => {
   test("emits a test-id keyed on parent block + variation slug", () => {
@@ -24,12 +53,56 @@ describe("VariationThumbnail", () => {
       <VariationThumbnail
         parentBlockName="core/columns"
         variation={variation}
-        blocks={blocks}
-        patterns={patterns}
+        blocks={emptyBlocks}
+        patterns={emptyPatterns}
       />,
     );
     expect(
       screen.getByTestId("plumix-variation-thumbnail-core/columns:two-up"),
     ).toBeDefined();
+  });
+
+  test("renders the runtime innerBlocks when no example override is set", () => {
+    const variation: BlockVariation = {
+      slug: "runtime",
+      title: "Runtime",
+      innerBlocks: [
+        { id: "leaf-1", name: "x-test/leaf", attrs: { label: "runtime" } },
+      ],
+    };
+    render(
+      <VariationThumbnail
+        parentBlockName="x-test/group"
+        variation={variation}
+        blocks={realBlocks}
+        patterns={emptyPatterns}
+      />,
+    );
+    expect(screen.getByTestId("render-leaf-runtime")).toBeDefined();
+  });
+
+  test("renders example.innerBlocks instead of variation.innerBlocks when both are set", () => {
+    const variation: BlockVariation = {
+      slug: "with-example",
+      title: "With example",
+      innerBlocks: [
+        { id: "leaf-r", name: "x-test/leaf", attrs: { label: "runtime" } },
+      ],
+      example: {
+        innerBlocks: [
+          { id: "leaf-e", name: "x-test/leaf", attrs: { label: "example" } },
+        ],
+      },
+    };
+    render(
+      <VariationThumbnail
+        parentBlockName="x-test/group"
+        variation={variation}
+        blocks={realBlocks}
+        patterns={emptyPatterns}
+      />,
+    );
+    expect(screen.queryByTestId("render-leaf-runtime")).toBeNull();
+    expect(screen.getByTestId("render-leaf-example")).toBeDefined();
   });
 });

--- a/packages/admin/src/editor/VariationThumbnail.tsx
+++ b/packages/admin/src/editor/VariationThumbnail.tsx
@@ -6,7 +6,7 @@ import type {
   BlockVariation,
   PatternRegistry,
 } from "@plumix/blocks";
-import { renderBlockTree } from "@plumix/blocks";
+import { renderBlockTree, resolveVariationPreview } from "@plumix/blocks";
 
 interface VariationThumbnailProps {
   readonly parentBlockName: string;
@@ -26,13 +26,11 @@ export function VariationThumbnail({
   blocks,
   patterns,
 }: VariationThumbnailProps): ReactElement {
-  const previewAttrs = variation.example?.attrs ?? variation.attrs ?? {};
-  const previewInner =
-    variation.example?.innerBlocks ?? variation.innerBlocks ?? [];
+  const preview = resolveVariationPreview(variation);
   const node: BlockNode = {
     id: `${parentBlockName}-${variation.slug}`,
     name: parentBlockName,
-    attrs: { ...previewAttrs, content: previewInner },
+    attrs: { ...preview.attrs, content: preview.innerBlocks },
   };
   return (
     <div

--- a/packages/admin/src/editor/available-transforms.test.ts
+++ b/packages/admin/src/editor/available-transforms.test.ts
@@ -104,6 +104,33 @@ describe("availableTransforms", () => {
     ]);
   });
 
+  test("emits a stable, unique key per option so React + getByTestId don't collide on multiple same-block variations", () => {
+    const registry = createBlockRegistry([
+      spec({
+        name: "core/columns",
+        title: "Columns",
+        variations: [
+          {
+            slug: "two-up",
+            title: "Two up",
+            attrs: { layout: "split" },
+            scope: ["transform"],
+          },
+          {
+            slug: "three-up",
+            title: "Three up",
+            attrs: { layout: "three" },
+            scope: ["transform"],
+          },
+        ],
+      }),
+    ]);
+    const keys = availableTransforms("core/columns", registry).map(
+      (o) => o.key,
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
   test("variation-scoped transform applies the variation attrs over the current ones via mapAttrs", () => {
     const registry = createBlockRegistry([
       spec({

--- a/packages/admin/src/editor/available-transforms.ts
+++ b/packages/admin/src/editor/available-transforms.ts
@@ -2,6 +2,11 @@ import type { BlockRegistry, BlockShortcutMode } from "@plumix/blocks";
 import { resolveBlockTransforms } from "@plumix/blocks";
 
 export interface TransformOption {
+  // Stable identifier for the option — React key + `data-testid` suffix.
+  // Multiple transform-scope variations of the same block all share
+  // `targetName === sourceName`, so the variation slug is what keeps
+  // them distinct.
+  readonly key: string;
   readonly targetName: string;
   readonly targetTitle: string;
   readonly mapAttrs?: (
@@ -16,6 +21,7 @@ export function availableTransforms(
 ): readonly TransformOption[] {
   const resolved = resolveBlockTransforms(sourceName, Array.from(registry));
   const fromTransforms: TransformOption[] = resolved.map((entry) => ({
+    key: `to:${entry.target}`,
     targetName: entry.target,
     targetTitle: registry.get(entry.target)?.title ?? entry.target,
     mapAttrs: entry.mapAttrs,
@@ -31,6 +37,7 @@ export function availableTransforms(
     sourceSpec?.variations
       ?.filter((v) => v.scope?.includes("transform"))
       .map((variation) => ({
+        key: `variation:${variation.slug}`,
         targetName: sourceName,
         targetTitle: variation.title,
         mapAttrs: (current) => ({ ...current, ...(variation.attrs ?? {}) }),

--- a/packages/admin/src/editor/insert-variation.ts
+++ b/packages/admin/src/editor/insert-variation.ts
@@ -1,7 +1,11 @@
+import type { PuckAction } from "@puckeditor/core";
+
 import type { InsertableBlockEntry } from "@plumix/blocks";
 import { rewriteBlockNodeIds } from "@plumix/blocks";
 
 import { blockNodesToPuckContent } from "./entry-content.js";
+import { mergePropsAtSelector } from "./merge-variation-attrs.js";
+import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 
 const CONTENT_SLOT_KEY = "content";
 
@@ -31,4 +35,32 @@ export function computeVariationMergeAttrs(
       rewriteBlockNodeIds(entry.innerBlocks),
     ),
   };
+}
+
+// Two-dispatch insert at the root zone: Puck's `insert` stamps
+// `props.id`, then the variation merge overlays attrs + slot content via
+// `mergePropsAtSelector`. The follow-up `setData` is skipped when the
+// entry has nothing to merge, so plain block inserts stay single-action.
+export function dispatchVariationInsert(
+  dispatch: (action: PuckAction) => void,
+  entry: InsertableBlockEntry,
+  index: number,
+): void {
+  dispatch({
+    type: "insert",
+    componentType: entry.name,
+    destinationZone: PUCK_ROOT_ZONE,
+    destinationIndex: index,
+  });
+  const mergeAttrs = computeVariationMergeAttrs(entry);
+  if (Object.keys(mergeAttrs).length === 0) return;
+  dispatch({
+    type: "setData",
+    data: (previous) =>
+      mergePropsAtSelector(
+        previous,
+        { zone: PUCK_ROOT_ZONE, index },
+        mergeAttrs,
+      ),
+  });
 }

--- a/packages/blocks/src/commit-block-variations.test.ts
+++ b/packages/blocks/src/commit-block-variations.test.ts
@@ -115,6 +115,68 @@ describe("commitBlockVariations", () => {
     );
   });
 
+  test("rejects example.attrs whose keys aren't declared inputs on the parent block", () => {
+    const group = defineBlock({
+      name: "x-test/group",
+      title: "Group",
+      inputs: [{ name: "content", type: "slot" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "rogue-example-attr",
+          title: "Rogue example attr",
+          example: { attrs: { ghost: "x" } },
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([group, headingBlock]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "rogue-example-attr" of "x-test\/group" at example\.attrs uses undeclared attr "ghost" on block "x-test\/group"/,
+    );
+  });
+
+  test("rejects example.innerBlocks declared on a block that has no content slot", () => {
+    const leaf = defineBlock({
+      name: "x-test/leaf",
+      title: "Leaf",
+      inputs: [{ name: "text", type: "text" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "with-example-children",
+          title: "With example children",
+          example: {
+            innerBlocks: [{ id: "h", name: "core/heading", attrs: {} }],
+          },
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([leaf, headingBlock]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "with-example-children" of "x-test\/leaf" declares innerBlocks but the parent block has no "content" slot input/,
+    );
+  });
+
+  test("rejects a transform-scope variation with no attrs to apply", () => {
+    const block = defineBlock({
+      name: "x-test/empty-transform",
+      title: "Empty Transform",
+      inputs: [{ name: "layout", type: "text" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "no-attrs",
+          title: "No attrs",
+          scope: ["transform"],
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([block]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "no-attrs" of "x-test\/empty-transform" is scoped "transform" but declares no attrs to apply/,
+    );
+  });
+
   test("validates example.innerBlocks against the block registry", () => {
     const group = defineBlock({
       name: "x-test/group",

--- a/packages/blocks/src/commit-block-variations.ts
+++ b/packages/blocks/src/commit-block-variations.ts
@@ -29,43 +29,62 @@ export function commitBlockVariations(blocks: BlockRegistry): void {
           }
         }
       }
-      if (variation.attrs && declared) {
-        for (const key of Object.keys(variation.attrs)) {
-          if (!declared.has(key)) {
-            throw BlockVariationError.undeclaredAttr(
-              spec.name,
-              variation.slug,
-              "variation.attrs",
-              spec.name,
-              key,
-            );
-          }
-        }
+      if (variation.scope?.includes("transform") && !variation.attrs) {
+        throw BlockVariationError.transformScopeMissingAttrs(
+          spec.name,
+          variation.slug,
+        );
       }
-      if (variation.innerBlocks && variation.innerBlocks.length > 0) {
+      checkAttrKeys(
+        spec.name,
+        variation.slug,
+        "variation.attrs",
+        variation.attrs,
+        declared,
+      );
+      checkAttrKeys(
+        spec.name,
+        variation.slug,
+        "example.attrs",
+        variation.example?.attrs,
+        declared,
+      );
+      const guardWalk = (nodes: readonly BlockNode[], path: string): void => {
         if (!hasContentSlot) {
           throw BlockVariationError.missingContentSlot(
             spec.name,
             variation.slug,
           );
         }
-        walk(
-          spec.name,
-          variation.slug,
-          variation.innerBlocks,
-          "innerBlocks",
-          blocks,
-        );
+        walk(spec.name, variation.slug, nodes, path, blocks);
+      };
+      if (variation.innerBlocks && variation.innerBlocks.length > 0) {
+        guardWalk(variation.innerBlocks, "innerBlocks");
       }
       if (variation.example?.innerBlocks) {
-        walk(
-          spec.name,
-          variation.slug,
-          variation.example.innerBlocks,
-          "example.innerBlocks",
-          blocks,
-        );
+        guardWalk(variation.example.innerBlocks, "example.innerBlocks");
       }
+    }
+  }
+}
+
+function checkAttrKeys(
+  parentBlock: string,
+  variationSlug: string,
+  path: string,
+  attrs: Readonly<Record<string, unknown>> | undefined,
+  declared: ReadonlySet<string> | undefined,
+): void {
+  if (!attrs || !declared) return;
+  for (const key of Object.keys(attrs)) {
+    if (!declared.has(key)) {
+      throw BlockVariationError.undeclaredAttr(
+        parentBlock,
+        variationSlug,
+        path,
+        parentBlock,
+        key,
+      );
     }
   }
 }

--- a/packages/blocks/src/expand-block-variations.ts
+++ b/packages/blocks/src/expand-block-variations.ts
@@ -61,18 +61,27 @@ export function expandBlockVariations(
   return out;
 }
 
-// Resolves the preview data for a variation entry: example overrides
-// applied on top of the runtime attrs/innerBlocks. Used by preview
-// surfaces (inserter cards, block-scope picker thumbnails) — never by
-// insertion paths.
-export function resolveVariationPreview(entry: InsertableBlockEntry): {
+// Structural shape shared by InsertableBlockEntry and BlockVariation —
+// both carry runtime `attrs`/`innerBlocks` plus an optional `example`
+// preview override. Typing the helper against the shape (not the
+// concrete entry type) lets the block-scope picker thumbnail resolve
+// previews straight from a BlockVariation.
+export interface VariationPreviewSource {
+  readonly attrs?: Readonly<Record<string, unknown>>;
+  readonly innerBlocks?: readonly BlockNode[];
+  readonly example?: BlockVariationExample;
+}
+
+// Resolves the preview data for a variation: example overrides applied
+// on top of the runtime attrs/innerBlocks. Used by preview surfaces
+// (inserter cards, block-scope picker thumbnails) — never by insertion
+// paths.
+export function resolveVariationPreview(source: VariationPreviewSource): {
   readonly attrs: Readonly<Record<string, unknown>>;
   readonly innerBlocks: readonly BlockNode[];
 } {
-  const baseAttrs = entry.attrs ?? {};
-  const baseInner = entry.innerBlocks ?? [];
   return {
-    attrs: entry.example?.attrs ?? baseAttrs,
-    innerBlocks: entry.example?.innerBlocks ?? baseInner,
+    attrs: source.example?.attrs ?? source.attrs ?? {},
+    innerBlocks: source.example?.innerBlocks ?? source.innerBlocks ?? [],
   };
 }

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -61,7 +61,10 @@ export {
   expandBlockVariations,
   resolveVariationPreview,
 } from "./expand-block-variations.js";
-export type { InsertableBlockEntry } from "./expand-block-variations.js";
+export type {
+  InsertableBlockEntry,
+  VariationPreviewSource,
+} from "./expand-block-variations.js";
 export type { BlockVariationExample } from "./block-registry.js";
 
 // ─── Pattern registry primitives ────────────────────────────────────────────

--- a/packages/blocks/src/variation-errors.ts
+++ b/packages/blocks/src/variation-errors.ts
@@ -48,4 +48,13 @@ export class BlockVariationError extends Error {
       `Variation "${variationSlug}" of "${parentBlock}" declares scope value "${value}" outside the allowed union ("inserter" | "block" | "transform").`,
     );
   }
+
+  static transformScopeMissingAttrs(
+    parentBlock: string,
+    variationSlug: string,
+  ): BlockVariationError {
+    return new BlockVariationError(
+      `Variation "${variationSlug}" of "${parentBlock}" is scoped "transform" but declares no attrs to apply — the action-bar entry would be a no-op.`,
+    );
+  }
 }


### PR DESCRIPTION
Folds in the senpai + simplifier passes that should have run pre-commit on #651, #652, #653,
and #654. Eight findings closed; two deferred for product calls.

**H1 — Unified preview resolution**

\`resolveVariationPreview\` (from #651) and \`VariationThumbnail\` (from #653) were carrying
parallel \`example?.attrs ?? attrs ?? {}\` ladders over different parameter types. Widened the
helper to a structural \`VariationPreviewSource { attrs?, innerBlocks?, example? }\`; the
thumbnail now calls it. \`InsertableBlockEntry\` consumers still type-check unchanged.

**H2 — Stable \`TransformOption.key\` fixes React + testid collisions**

Two transform-scope variations on the same block produced colliding React keys and
\`data-testid\`s. Added \`TransformOption.key\` (\`to:<name>\` for block transforms,
\`variation:<slug>\` for variation transforms); panel keyed on it instead of
\`targetName\`.

**H4 + M1 + M4 — Tighter boot validation**

\`commit-block-variations\` now rejects:
- \`example.attrs\` keys not declared on the parent block (H4)
- \`scope: [\"transform\"]\` variations with no \`attrs\` to apply (M1) — would render a no-op button
- \`example.innerBlocks\` on a block without a \`content\` slot input (M4)

All paths share one \`checkAttrKeys\` helper; \`example.innerBlocks\` now reuses the
\`hasContentSlot\` gate.

**M3 — Real render assertions on \`VariationThumbnail\`**

The original test only asserted the test-id with an empty registry. Added two tests against
a real registry: one verifying runtime \`innerBlocks\` render, the other verifying
\`example.innerBlocks\` wins over the runtime body when both are set.

**M2 — Stale comment cleanup**

The \`insertVariation\` symbol was removed by #654; the comment in \`handlePickerDismiss\` still
referenced it. Trimmed to the load-bearing WHY.

**Simplifier wins folded in**

- \`dispatchVariationInsert(puck.dispatch, entry, index)\` owns the two-dispatch shape #654
  introduced; \`PlumixBlocksTab\` and \`PlumixCanvasWithSlashMenu\` both call it.

**Deferred (product calls)**

- **H3** — \`InsertableBlockEntry.example\` field has no readers in main (only \`BlockVariation.example\` is
  consumed). Either thread it to inserter-card thumbnails or trim. Needs a UX decision.
- **M5 / M6** — Picker cancel button styling + inserter-card description for block-scope
  parents. Tracked as UX follow-ups.

Verification: full gate green (11 turbo tasks across @plumix/blocks + @plumix/admin). All four
PRs' touched code now covered by tests; 13 files changed, 302 +/87 −.