### PR TITLE
refactor(admin): lazy-mount variation thumbnails in the block-scope picker

### DIFF
--- a/packages/admin/src/editor/BlockScopePicker.test.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.test.tsx
@@ -1,15 +1,51 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { BlockVariation } from "@plumix/blocks";
 import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
 import { BlockScopePicker } from "./BlockScopePicker.js";
 
+interface FakeObserverHandle {
+  readonly callback: IntersectionObserverCallback;
+}
+
+let observers: FakeObserverHandle[];
+
+beforeEach(() => {
+  observers = [];
+  class FakeObserver {
+    constructor(public readonly callback: IntersectionObserverCallback) {
+      observers.push({ callback });
+    }
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
+  }
+  vi.stubGlobal("IntersectionObserver", FakeObserver);
+});
+
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
+
+function intersect(): void {
+  const entry = {
+    isIntersecting: true,
+    intersectionRatio: 1,
+    target: document.createElement("div"),
+    boundingClientRect: {} as DOMRectReadOnly,
+    intersectionRect: {} as DOMRectReadOnly,
+    rootBounds: null,
+    time: 0,
+  } satisfies IntersectionObserverEntry;
+  act(() => {
+    for (const o of observers) o.callback([entry], {} as IntersectionObserver);
+  });
+}
 
 const blocks = createBlockRegistry([]);
 const patterns = createPatternRegistry([]);
@@ -52,7 +88,7 @@ describe("BlockScopePicker", () => {
     ).toBeDefined();
   });
 
-  test("renders a live thumbnail for each card keyed on parent + slug", () => {
+  test("renders a placeholder for each thumbnail before the card scrolls into view", () => {
     render(
       <BlockScopePicker
         blockTitle="Columns"
@@ -65,10 +101,33 @@ describe("BlockScopePicker", () => {
       />,
     );
     expect(
-      screen.getByTestId("plumix-variation-thumbnail-core/columns:two-up"),
+      screen.getByTestId(
+        "plumix-block-scope-picker-thumbnail-placeholder-core/columns:two-up",
+      ),
     ).toBeDefined();
     expect(
-      screen.getByTestId("plumix-variation-thumbnail-core/columns:three-up"),
+      screen.queryByTestId("plumix-variation-thumbnail-core/columns:two-up"),
+    ).toBeNull();
+  });
+
+  test("mounts the live thumbnail once the placeholder intersects the viewport", () => {
+    render(
+      <BlockScopePicker
+        blockTitle="Columns"
+        parentBlockName="core/columns"
+        variations={[twoUp]}
+        blocks={blocks}
+        patterns={patterns}
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("plumix-variation-thumbnail-core/columns:two-up"),
+    ).toBeNull();
+    intersect();
+    expect(
+      screen.getByTestId("plumix-variation-thumbnail-core/columns:two-up"),
     ).toBeDefined();
   });
 

--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -13,7 +13,12 @@ import type {
   PatternRegistry,
 } from "@plumix/blocks";
 
+import { LazyMount } from "./LazyMount.js";
 import { VariationThumbnail } from "./VariationThumbnail.js";
+
+// Reserves space so the placeholder isn't a zero-height target that
+// intersects the viewport on first paint and defeats the lazy mount.
+const THUMBNAIL_MIN_HEIGHT = 120;
 
 interface BlockScopePickerProps {
   readonly blockTitle: string;
@@ -73,14 +78,19 @@ export function BlockScopePicker({
                   }
                 }}
               >
-                <div className="overflow-hidden rounded">
-                  <VariationThumbnail
-                    parentBlockName={parentBlockName}
-                    variation={variation}
-                    blocks={blocks}
-                    patterns={patterns}
-                  />
-                </div>
+                <LazyMount
+                  placeholderTestId={`plumix-block-scope-picker-thumbnail-placeholder-${parentBlockName}:${variation.slug}`}
+                  minHeight={THUMBNAIL_MIN_HEIGHT}
+                >
+                  <div className="overflow-hidden rounded">
+                    <VariationThumbnail
+                      parentBlockName={parentBlockName}
+                      variation={variation}
+                      blocks={blocks}
+                      patterns={patterns}
+                    />
+                  </div>
+                </LazyMount>
                 <span className="text-sm font-medium">{variation.title}</span>
                 {variation.description ? (
                   <span className="text-muted-foreground text-xs">


### PR DESCRIPTION
Wraps each `VariationThumbnail` in `LazyMount` so the block-scope picker only renders the
preview tree once the card scrolls into view. Closes the perf parity PRD #636 promised but
#653 deferred — the patterns sidebar already uses the same lazy-mount + scaled-render path.

**Placeholder identity matches the live thumbnail's**

The placeholder `data-testid` keys on `${parentBlockName}:${variation.slug}` instead of slug
alone, mirroring `VariationThumbnail`'s identity scheme. Without that parity, pre/post-
intersection tests stop lining up 1:1 the moment a future picker surface exposes variations
from multiple parent blocks. A reserved 120 px (matches `PatternsSection.ROW_THUMB_MIN_HEIGHT`)
keeps the placeholder from collapsing into a zero-height target the `IntersectionObserver`
would fire on at first paint.

**Deferred follow-up: extract the FakeObserver harness**

`LazyMount.test.tsx`, `PatternsSection.test.tsx`, and now `BlockScopePicker.test.tsx` all
roll their own near-identical `IntersectionObserver` stub. Three sites flip the cost/benefit
toward extraction; the right home is `packages/admin/test/intersection-observer-harness.ts`
per the project's test-layout rule for cross-suite helpers. Out of scope for this slice —
the duplication already exists on `main`.