### PR TITLE
refactor: close five senpai followups from the variations cleanup PR

### DIFF
--- a/packages/admin/src/editor/BlockActionsPanel.test.tsx
+++ b/packages/admin/src/editor/BlockActionsPanel.test.tsx
@@ -220,6 +220,42 @@ describe("BlockActionsPanel", () => {
     expect(screen.getByTestId("block-actions-identity")).toBeDefined();
   });
 
+  test("renders two transform-scope variations of the same block as distinct buttons", () => {
+    const columnsWithTwoVariations = createBlockRegistry([
+      spec({
+        name: "core/columns",
+        title: "Columns",
+        variations: [
+          {
+            slug: "two-up",
+            title: "Two up",
+            attrs: { layout: "split" },
+            scope: ["transform"],
+          },
+          {
+            slug: "three-up",
+            title: "Three up",
+            attrs: { layout: "three" },
+            scope: ["transform"],
+          },
+        ],
+      }),
+    ]);
+    render(
+      <BlockActionsPanel
+        specName="core/columns"
+        registry={columnsWithTwoVariations}
+        onTransform={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByTestId("block-action-transform-variation:two-up"),
+    ).toHaveTextContent("Two up");
+    expect(
+      screen.getByTestId("block-action-transform-variation:three-up"),
+    ).toHaveTextContent("Three up");
+  });
+
   test("renders identity header even when identity.icon is undefined — neutral fallback glyph", () => {
     const noTransforms = createBlockRegistry([
       spec({ name: "core/spacer", title: "Spacer" }),

--- a/packages/admin/src/editor/insert-variation.test.ts
+++ b/packages/admin/src/editor/insert-variation.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, test } from "vitest";
+import type { Data, PuckAction } from "@puckeditor/core";
+import { describe, expect, test, vi } from "vitest";
 
 import type { BlockNode, InsertableBlockEntry } from "@plumix/blocks";
 
-import { computeVariationMergeAttrs } from "./insert-variation.js";
+import {
+  computeVariationMergeAttrs,
+  dispatchVariationInsert,
+} from "./insert-variation.js";
+import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 
 describe("computeVariationMergeAttrs", () => {
   test("returns the entry's plain attrs when no innerBlocks are declared", () => {
@@ -65,5 +70,79 @@ describe("computeVariationMergeAttrs", () => {
     expect(first[0]?.props.id).not.toBe(second[0]?.props.id);
     expect(heading.id).toBe("src-h");
     expect(heading.attrs).toEqual({ level: 2 });
+  });
+});
+
+function getSetDataReducer(
+  action: PuckAction | undefined,
+): (previous: Data) => Data {
+  if (action?.type !== "setData") {
+    throw new Error("expected setData dispatch");
+  }
+  return action.data as (previous: Data) => Data;
+}
+
+describe("dispatchVariationInsert", () => {
+  test("dispatches a single `insert` for a bare entry with no attrs and no innerBlocks", () => {
+    const dispatch = vi.fn<(action: PuckAction) => void>();
+    const entry: InsertableBlockEntry = {
+      name: "core/rich-text",
+      slug: "core/rich-text",
+      title: "Rich text",
+    };
+    dispatchVariationInsert(dispatch, entry, 0);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+      type: "insert",
+      componentType: "core/rich-text",
+      destinationZone: PUCK_ROOT_ZONE,
+      destinationIndex: 0,
+    });
+  });
+
+  test("setData merge overlays the variation attrs at the supplied index, after the insert", () => {
+    const dispatch = vi.fn<(action: PuckAction) => void>();
+    const entry: InsertableBlockEntry = {
+      name: "core/list",
+      slug: "core/list/bullet",
+      title: "Bulleted",
+      attrs: { variant: "bullet" },
+    };
+    dispatchVariationInsert(dispatch, entry, 1);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch.mock.calls[0]?.[0]?.type).toBe("insert");
+    const reduce = getSetDataReducer(dispatch.mock.calls[1]?.[0]);
+    const previous: Data = {
+      content: [
+        { type: "x", props: { id: "x-0" } },
+        { type: "core/list", props: { id: "list-1" } },
+      ],
+      root: { props: {} },
+    };
+    const next = reduce(previous);
+    expect((next.content[1]?.props as { variant?: string }).variant).toBe(
+      "bullet",
+    );
+  });
+
+  test("converts innerBlocks to ComponentData[] under the conventional `content` slot", () => {
+    const dispatch = vi.fn<(action: PuckAction) => void>();
+    const entry: InsertableBlockEntry = {
+      name: "core/group",
+      slug: "core/group/with-heading",
+      title: "Group with heading",
+      innerBlocks: [{ id: "h1", name: "core/heading", attrs: { level: 2 } }],
+    };
+    dispatchVariationInsert(dispatch, entry, 0);
+    const reduce = getSetDataReducer(dispatch.mock.calls[1]?.[0]);
+    const previous: Data = {
+      content: [{ type: "core/group", props: { id: "group-0" } }],
+      root: { props: {} },
+    };
+    const next = reduce(previous);
+    const slot = (next.content[0]?.props as { content?: readonly unknown[] })
+      .content;
+    expect(Array.isArray(slot)).toBe(true);
+    expect((slot as readonly { type: string }[])[0]?.type).toBe("core/heading");
   });
 });

--- a/packages/blocks/src/commit-block-variations.test.ts
+++ b/packages/blocks/src/commit-block-variations.test.ts
@@ -72,7 +72,7 @@ describe("commitBlockVariations", () => {
     });
     const blocks = createBlockRegistry([heading, headingBlock]);
     expect(() => commitBlockVariations(blocks)).toThrow(
-      /Variation "with-children" of "x-test\/leaf" declares innerBlocks but the parent block has no "content" slot input/,
+      /Variation "with-children" of "x-test\/leaf" declares innerBlocks at innerBlocks but the parent block has no "content" slot input/,
     );
   });
 
@@ -153,7 +153,7 @@ describe("commitBlockVariations", () => {
     });
     const blocks = createBlockRegistry([leaf, headingBlock]);
     expect(() => commitBlockVariations(blocks)).toThrow(
-      /Variation "with-example-children" of "x-test\/leaf" declares innerBlocks but the parent block has no "content" slot input/,
+      /Variation "with-example-children" of "x-test\/leaf" declares innerBlocks at example\.innerBlocks but the parent block has no "content" slot input/,
     );
   });
 
@@ -174,6 +174,27 @@ describe("commitBlockVariations", () => {
     const blocks = createBlockRegistry([block]);
     expect(() => commitBlockVariations(blocks)).toThrow(
       /Variation "no-attrs" of "x-test\/empty-transform" is scoped "transform" but declares no attrs to apply/,
+    );
+  });
+
+  test("rejects a transform-scope variation whose attrs object is empty — same no-op shape", () => {
+    const block = defineBlock({
+      name: "x-test/empty-transform",
+      title: "Empty Transform",
+      inputs: [{ name: "layout", type: "text" }],
+      render: () => null,
+      variations: [
+        {
+          slug: "empty-attrs",
+          title: "Empty attrs",
+          attrs: {},
+          scope: ["transform"],
+        },
+      ],
+    });
+    const blocks = createBlockRegistry([block]);
+    expect(() => commitBlockVariations(blocks)).toThrow(
+      /Variation "empty-attrs" of "x-test\/empty-transform" is scoped "transform" but declares no attrs to apply/,
     );
   });
 

--- a/packages/blocks/src/commit-block-variations.ts
+++ b/packages/blocks/src/commit-block-variations.ts
@@ -29,7 +29,10 @@ export function commitBlockVariations(blocks: BlockRegistry): void {
           }
         }
       }
-      if (variation.scope?.includes("transform") && !variation.attrs) {
+      if (
+        variation.scope?.includes("transform") &&
+        (!variation.attrs || Object.keys(variation.attrs).length === 0)
+      ) {
         throw BlockVariationError.transformScopeMissingAttrs(
           spec.name,
           variation.slug,
@@ -54,6 +57,7 @@ export function commitBlockVariations(blocks: BlockRegistry): void {
           throw BlockVariationError.missingContentSlot(
             spec.name,
             variation.slug,
+            path,
           );
         }
         walk(spec.name, variation.slug, nodes, path, blocks);

--- a/packages/blocks/src/expand-block-variations.test.ts
+++ b/packages/blocks/src/expand-block-variations.test.ts
@@ -104,6 +104,10 @@ describe("expandBlockVariations", () => {
           {
             slug: "transform-only",
             title: "Transform only",
+            // Mirrors a real boot — commitBlockVariations rejects a
+            // transform-scope variation without attrs, so the fixture
+            // carries one even though this test only exercises expansion.
+            attrs: { variant: "transform" },
             scope: ["transform"],
           },
         ],

--- a/packages/blocks/src/variation-errors.ts
+++ b/packages/blocks/src/variation-errors.ts
@@ -33,9 +33,10 @@ export class BlockVariationError extends Error {
   static missingContentSlot(
     parentBlock: string,
     variationSlug: string,
+    path: string,
   ): BlockVariationError {
     return new BlockVariationError(
-      `Variation "${variationSlug}" of "${parentBlock}" declares innerBlocks but the parent block has no "content" slot input.`,
+      `Variation "${variationSlug}" of "${parentBlock}" declares innerBlocks at ${path} but the parent block has no "content" slot input.`,
     );
   }
 


### PR DESCRIPTION
Closes the five MEDIUMs senpai raised against PR #655 (which was itself the catch-up cleanup
for the four unreviewed variations PRs). All five are small, all five land here.

**Boot validation now catches `attrs: {}`**

`transformScopeMissingAttrs` previously gated on `!variation.attrs`. The empty-object shape
slipped through even though the error message promised to reject "no attrs to apply" — same
no-op the action-bar would render. The gate now also rejects `Object.keys(variation.attrs).length === 0`.

**`missingContentSlot` carries the path**

After #655 unified `innerBlocks` and `example.innerBlocks` through a single `guardWalk`, the
error message could no longer tell the user which side triggered. The factory now interpolates
the path; both existing assertions updated to match (`...declares innerBlocks at innerBlocks
but...` vs `...at example.innerBlocks but...`).

**`dispatchVariationInsert` gains unit coverage**

The helper #654/#655 added was only exercised by e2e. Three unit tests now cover the contract
via a `vi.fn<(action: PuckAction) => void>()` mock:
- bare entry fires one `insert` at the root zone (asserts `destinationZone` + `destinationIndex`)
- entry with attrs fires the `insert` first, then a `setData` whose reducer overlays attrs at
  the supplied index (asserted by calling the reducer on a synthetic `Data`)
- entry with `innerBlocks` serialises the slot to `ComponentData[]` under `content`

A small `getSetDataReducer(action)` helper shares the type-guard + cast between the two
reducer-asserting tests.

**Panel-level regression test for the H2 fix**

`BlockActionsPanel` renders `core/columns` with two `scope: ["transform"]` variations; the
test asserts both `block-action-transform-variation:two-up` and
`block-action-transform-variation:three-up` testids resolve with the right titles. If
`option.key` ever reverts to `targetName`, this fails loud — one React key + one test-id
can't satisfy two `getByTestId` calls.

The remaining touch is a stale fixture comment update in `expand-block-variations.test.ts`:
the `transform-only` variation now carries `attrs: { variant: "transform" }` so the fixture
stays a realistic config the tightened gate wouldn't reject.