### PR TITLE
feat(admin): render lazy-mounted thumbnails for variation rows in the sidebar

### DIFF
--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -14,11 +14,8 @@ import type {
 } from "@plumix/blocks";
 
 import { LazyMount } from "./LazyMount.js";
+import { THUMBNAIL_MIN_HEIGHT } from "./thumbnail-min-height.js";
 import { VariationThumbnail } from "./VariationThumbnail.js";
-
-// Reserves space so the placeholder isn't a zero-height target that
-// intersects the viewport on first paint and defeats the lazy mount.
-const THUMBNAIL_MIN_HEIGHT = 120;
 
 interface BlockScopePickerProps {
   readonly blockTitle: string;

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -53,12 +53,12 @@ import type { SlashMenuItem } from "./slash-menu-items.js";
 import { AutosaveStatusPill } from "./AutosaveStatus.js";
 import { deriveBlockIdentity } from "./block-identity.js";
 import { BlockActionsPanel } from "./BlockActionsPanel.js";
-import { BlockIcon } from "./BlockIcon.js";
 import { BlockScopePicker } from "./BlockScopePicker.js";
 import { buildCopyPatternSource } from "./build-copy-pattern-source.js";
 import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { insertPattern } from "./insert-pattern.js";
 import { dispatchVariationInsert } from "./insert-variation.js";
+import { InsertableEntryRow } from "./InsertableEntryRow.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { PatternRefProvider } from "./PatternRefPreview.js";
@@ -710,15 +710,12 @@ function PlumixBlocksTab({
       <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
         {entries.map((entry) => (
           <li key={entry.slug}>
-            <button
-              type="button"
-              className="hover:bg-muted flex w-full items-center gap-2 rounded border px-3 py-2 text-left text-sm"
-              data-testid={`plumix-blocks-tab-item-${entry.slug}`}
+            <InsertableEntryRow
+              entry={entry}
+              blocks={registry}
+              patterns={patternRegistry}
               onClick={() => handleInsert(entry)}
-            >
-              <BlockIcon name={entry.icon} />
-              <span className="truncate">{entry.title}</span>
-            </button>
+            />
           </li>
         ))}
       </ul>

--- a/packages/admin/src/editor/InsertableEntryRow.test.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.test.tsx
@@ -1,0 +1,103 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { InsertableBlockEntry } from "@plumix/blocks";
+import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
+
+import { InsertableEntryRow } from "./InsertableEntryRow.js";
+
+interface FakeObserverHandle {
+  readonly callback: IntersectionObserverCallback;
+}
+
+let observers: FakeObserverHandle[];
+
+beforeEach(() => {
+  observers = [];
+  class FakeObserver {
+    constructor(public readonly callback: IntersectionObserverCallback) {
+      observers.push({ callback });
+    }
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
+  }
+  vi.stubGlobal("IntersectionObserver", FakeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function intersect(): void {
+  const entry = {
+    isIntersecting: true,
+    intersectionRatio: 1,
+    target: document.createElement("div"),
+    boundingClientRect: {} as DOMRectReadOnly,
+    intersectionRect: {} as DOMRectReadOnly,
+    rootBounds: null,
+    time: 0,
+  } satisfies IntersectionObserverEntry;
+  act(() => {
+    for (const o of observers) o.callback([entry], {} as IntersectionObserver);
+  });
+}
+
+const blocks = createBlockRegistry([]);
+const patterns = createPatternRegistry([]);
+
+describe("InsertableEntryRow", () => {
+  test("renders a plain block as a single-line row without a thumbnail", () => {
+    const entry: InsertableBlockEntry = {
+      name: "core/heading",
+      slug: "core/heading",
+      title: "Heading",
+      icon: "Heading",
+    };
+    render(
+      <InsertableEntryRow
+        entry={entry}
+        blocks={blocks}
+        patterns={patterns}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByTestId("plumix-blocks-tab-item-core/heading"),
+    ).toBeDefined();
+    expect(
+      screen.queryByTestId(
+        "plumix-blocks-tab-thumbnail-placeholder-core/heading",
+      ),
+    ).toBeNull();
+  });
+
+  test("renders a variation as a two-line card with a lazy-mounted thumbnail placeholder", () => {
+    const entry: InsertableBlockEntry = {
+      name: "core/list",
+      slug: "bullet",
+      title: "Bulleted list",
+      attrs: { variant: "bullet" },
+    };
+    render(
+      <InsertableEntryRow
+        entry={entry}
+        blocks={blocks}
+        patterns={patterns}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByTestId(
+        "plumix-blocks-tab-thumbnail-placeholder-core/list:bullet",
+      ),
+    ).toBeDefined();
+    intersect();
+    expect(
+      screen.getByTestId("plumix-variation-thumbnail-core/list:bullet"),
+    ).toBeDefined();
+  });
+});

--- a/packages/admin/src/editor/InsertableEntryRow.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from "react";
+
+import type {
+  BlockRegistry,
+  InsertableBlockEntry,
+  PatternRegistry,
+} from "@plumix/blocks";
+
+import { BlockIcon } from "./BlockIcon.js";
+import { LazyMount } from "./LazyMount.js";
+import { THUMBNAIL_MIN_HEIGHT } from "./thumbnail-min-height.js";
+import { VariationThumbnail } from "./VariationThumbnail.js";
+
+interface InsertableEntryRowProps {
+  readonly entry: InsertableBlockEntry;
+  readonly blocks: BlockRegistry;
+  readonly patterns: PatternRegistry;
+  readonly onClick: () => void;
+}
+
+// `expandBlockVariations` emits a parent block entry with `slug === name`
+// and every variation entry with the variation's own raw slug — the
+// inequality is the cheapest "is this a variation?" check at the row.
+function isVariation(entry: InsertableBlockEntry): boolean {
+  return entry.slug !== entry.name;
+}
+
+export function InsertableEntryRow({
+  entry,
+  blocks,
+  patterns,
+  onClick,
+}: InsertableEntryRowProps): ReactElement {
+  if (!isVariation(entry)) {
+    return (
+      <button
+        type="button"
+        className="hover:bg-muted flex w-full items-center gap-2 rounded border px-3 py-2 text-left text-sm"
+        data-testid={`plumix-blocks-tab-item-${entry.slug}`}
+        onClick={onClick}
+      >
+        <BlockIcon name={entry.icon} />
+        <span className="truncate">{entry.title}</span>
+      </button>
+    );
+  }
+  // `<div role="button">` rather than `<button>` — the live thumbnail can
+  // contain interactive HTML (a variation that embeds `core/button`), and
+  // the spec forbids interactive descendants inside `<button>`. Mirrors
+  // BlockScopePicker's card posture.
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className="hover:bg-muted flex w-full flex-col gap-2 rounded border p-2 text-left text-sm focus:outline-none focus-visible:ring"
+      data-testid={`plumix-blocks-tab-item-${entry.slug}`}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+    >
+      <LazyMount
+        placeholderTestId={`plumix-blocks-tab-thumbnail-placeholder-${entry.name}:${entry.slug}`}
+        minHeight={THUMBNAIL_MIN_HEIGHT}
+      >
+        <div className="pointer-events-none overflow-hidden rounded">
+          <VariationThumbnail
+            parentBlockName={entry.name}
+            variation={entry}
+            blocks={blocks}
+            patterns={patterns}
+          />
+        </div>
+      </LazyMount>
+      <span className="flex items-center gap-2 truncate">
+        <BlockIcon name={entry.icon} />
+        <span className="truncate">{entry.title}</span>
+      </span>
+    </div>
+  );
+}

--- a/packages/admin/src/editor/PatternsSection.tsx
+++ b/packages/admin/src/editor/PatternsSection.tsx
@@ -6,6 +6,7 @@ import type { PatternManifestEntry } from "@plumix/core/manifest";
 
 import { LazyMount } from "./LazyMount.js";
 import { PatternThumbnail } from "./PatternThumbnail.js";
+import { THUMBNAIL_MIN_HEIGHT } from "./thumbnail-min-height.js";
 
 interface PatternsSectionProps {
   readonly patterns: readonly PatternManifestEntry[];
@@ -13,10 +14,6 @@ interface PatternsSectionProps {
   readonly blocks: BlockRegistry;
   readonly patternRegistry: PatternRegistry;
 }
-
-// Reserved space so the IntersectionObserver placeholder consumes its
-// target dimensions and doesn't trip on first paint.
-const ROW_THUMB_MIN_HEIGHT = 120;
 
 const UNCATEGORIZED = "uncategorized";
 
@@ -81,7 +78,7 @@ export function PatternsSection({
                 >
                   <LazyMount
                     placeholderTestId={`plumix-patterns-row-placeholder-${entry.name}`}
-                    minHeight={ROW_THUMB_MIN_HEIGHT}
+                    minHeight={THUMBNAIL_MIN_HEIGHT}
                   >
                     <div className="overflow-hidden rounded">
                       <PatternThumbnail

--- a/packages/admin/src/editor/thumbnail-min-height.ts
+++ b/packages/admin/src/editor/thumbnail-min-height.ts
@@ -1,0 +1,5 @@
+// Reserves space so the lazy-mount placeholder isn't a zero-height
+// target that intersects the viewport on first paint and short-circuits
+// the deferral. Shared by every block / variation / pattern row that
+// gates a Thumbnail render behind LazyMount.
+export const THUMBNAIL_MIN_HEIGHT = 120;


### PR DESCRIPTION
The sidebar's plain block rows stay single-line; variation entries (`slug !== name` per
`expandBlockVariations`) now render as two-line cards with a lazy-mounted `VariationThumbnail`
above the icon + title row. Closes the PRD #637 promise that inserter cards consume the
`example` preview override — the sidebar is the second consumer (block-scope picker was the
first, in #653/#656).

**The variation card is a `<div role=\"button\">`, not a `<button>`**

A live `VariationThumbnail` can embed interactive blocks (a variation whose `innerBlocks`
contain `core/button`). The HTML spec forbids interactive descendants inside `<button>`; the
spec-safe pattern is `<div role=\"button\" tabIndex={0}>` with explicit Enter/Space handlers.
Same posture `BlockScopePicker` already uses for the same reason.

**`THUMBNAIL_MIN_HEIGHT` lifted to a shared module**

`PatternsSection`, `BlockScopePicker`, and now `InsertableEntryRow` all reserve 120 px of
placeholder height so the LazyMount target doesn't intersect on first paint. The three
consumers each carried their own constant; per the project's catalog-hygiene rule (2+
consumers → catalog), all three now import from `thumbnail-min-height.ts`.

**Known follow-ups flagged here, not folded in**

- The FakeObserver harness has now drifted to four identical copies (LazyMount, PatternsSection,
  BlockScopePicker, InsertableEntryRow). Senpai flagged this on #656 already — cost has flipped
  toward extraction. Own PR.
- The sidebar's `<li key>` and item `data-testid` still use raw `entry.slug`. Two unrelated
  blocks shipping a variation with the same slug (`bullet`, say) would collide. Pre-existing on
  `main`; not introduced by this slice but worth tightening to `${name}/${slug}` form gated to
  the variation branch. Own PR.