### PR TITLE
feat(admin): render lazy-mounted variation thumbnails in the slash menu

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -59,6 +59,7 @@ import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { insertPattern } from "./insert-pattern.js";
 import { dispatchVariationInsert } from "./insert-variation.js";
 import { InsertableEntryRow } from "./InsertableEntryRow.js";
+import { isVariation } from "./is-variation.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { PatternRefProvider } from "./PatternRefPreview.js";
@@ -649,7 +650,7 @@ function PlumixBlocksTab({
       // variations the user can still pick, open the picker. Otherwise
       // (no variations, or all capability-gated out) fall through to
       // bare insert with `blockSpec.defaults`.
-      if (entry.slug === entry.name) {
+      if (!isVariation(entry)) {
         const blockScoped = resolveBlockScopeVariations(
           registry,
           entry.name,
@@ -994,6 +995,8 @@ function PlumixCanvasWithSlashMenu({
             onQueryChange={setQuery}
             onSelect={handleSelect}
             onDismiss={() => setOpen(false)}
+            blocks={registry}
+            patterns={patternRegistry}
           />
         </DialogContent>
       </Dialog>

--- a/packages/admin/src/editor/InsertableEntryRow.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@plumix/blocks";
 
 import { BlockIcon } from "./BlockIcon.js";
+import { isVariation } from "./is-variation.js";
 import { LazyMount } from "./LazyMount.js";
 import { THUMBNAIL_MIN_HEIGHT } from "./thumbnail-min-height.js";
 import { VariationThumbnail } from "./VariationThumbnail.js";
@@ -16,13 +17,6 @@ interface InsertableEntryRowProps {
   readonly blocks: BlockRegistry;
   readonly patterns: PatternRegistry;
   readonly onClick: () => void;
-}
-
-// `expandBlockVariations` emits a parent block entry with `slug === name`
-// and every variation entry with the variation's own raw slug — the
-// inequality is the cheapest "is this a variation?" check at the row.
-function isVariation(entry: InsertableBlockEntry): boolean {
-  return entry.slug !== entry.name;
 }
 
 export function InsertableEntryRow({
@@ -66,7 +60,10 @@ export function InsertableEntryRow({
         placeholderTestId={`plumix-blocks-tab-thumbnail-placeholder-${entry.name}:${entry.slug}`}
         minHeight={THUMBNAIL_MIN_HEIGHT}
       >
-        <div className="pointer-events-none overflow-hidden rounded">
+        <div
+          aria-hidden
+          className="pointer-events-none overflow-hidden rounded"
+        >
           <VariationThumbnail
             parentBlockName={entry.name}
             variation={entry}

--- a/packages/admin/src/editor/SlashMenuPanel.test.tsx
+++ b/packages/admin/src/editor/SlashMenuPanel.test.tsx
@@ -1,13 +1,54 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
 import type { SlashMenuItem } from "./slash-menu-items.js";
 import { SlashMenuPanel } from "./SlashMenuPanel.js";
 
+interface FakeObserverHandle {
+  readonly callback: IntersectionObserverCallback;
+}
+
+let observers: FakeObserverHandle[];
+
+beforeEach(() => {
+  observers = [];
+  class FakeObserver {
+    constructor(public readonly callback: IntersectionObserverCallback) {
+      observers.push({ callback });
+    }
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
+  }
+  vi.stubGlobal("IntersectionObserver", FakeObserver);
+});
+
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
+
+function intersect(): void {
+  const entry = {
+    isIntersecting: true,
+    intersectionRatio: 1,
+    target: document.createElement("div"),
+    boundingClientRect: {} as DOMRectReadOnly,
+    intersectionRect: {} as DOMRectReadOnly,
+    rootBounds: null,
+    time: 0,
+  } satisfies IntersectionObserverEntry;
+  act(() => {
+    for (const o of observers) o.callback([entry], {} as IntersectionObserver);
+  });
+}
+
+const blocks = createBlockRegistry([]);
+const patterns = createPatternRegistry([]);
 
 const heading: SlashMenuItem = {
   kind: "block",
@@ -41,6 +82,19 @@ const heroPattern: SlashMenuItem = {
   },
 };
 
+// `expandBlockVariations` emits the variation's own raw slug — keep the
+// fixture aligned with production output (see InsertableEntryRow.tsx).
+const bulletListVariation: SlashMenuItem = {
+  kind: "block",
+  entry: {
+    name: "core/list",
+    slug: "bullet",
+    title: "Bulleted list",
+    attrs: { variant: "bullet" },
+    category: "lists",
+  },
+};
+
 const noop = vi.fn();
 
 describe("SlashMenuPanel", () => {
@@ -52,6 +106,8 @@ describe("SlashMenuPanel", () => {
         onQueryChange={noop}
         onSelect={noop}
         onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
       />,
     );
 
@@ -70,6 +126,8 @@ describe("SlashMenuPanel", () => {
         onQueryChange={noop}
         onSelect={noop}
         onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
       />,
     );
 
@@ -86,6 +144,8 @@ describe("SlashMenuPanel", () => {
         onQueryChange={noop}
         onSelect={noop}
         onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
       />,
     );
 
@@ -102,6 +162,8 @@ describe("SlashMenuPanel", () => {
         onQueryChange={noop}
         onSelect={onSelect}
         onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
       />,
     );
 
@@ -120,6 +182,8 @@ describe("SlashMenuPanel", () => {
         onQueryChange={onQueryChange}
         onSelect={noop}
         onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
       />,
     );
 
@@ -140,6 +204,8 @@ describe("SlashMenuPanel", () => {
         onQueryChange={noop}
         onSelect={noop}
         onDismiss={onDismiss}
+        blocks={blocks}
+        patterns={patterns}
       />,
     );
 
@@ -159,6 +225,8 @@ describe("SlashMenuPanel", () => {
         onQueryChange={noop}
         onSelect={onSelect}
         onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
       />,
     );
 
@@ -166,5 +234,43 @@ describe("SlashMenuPanel", () => {
     await user.keyboard("{Enter}");
 
     expect(onSelect).toHaveBeenCalledWith(heading);
+  });
+
+  test("variation block items get a lazy-mounted thumbnail placeholder before scroll-in", () => {
+    render(
+      <SlashMenuPanel
+        items={[bulletListVariation]}
+        query=""
+        onQueryChange={noop}
+        onSelect={noop}
+        onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
+      />,
+    );
+    expect(
+      screen.getByTestId("slash-menu-thumbnail-placeholder-core/list:bullet"),
+    ).toBeDefined();
+    expect(
+      screen.queryByTestId("plumix-variation-thumbnail-core/list:bullet"),
+    ).toBeNull();
+  });
+
+  test("variation block items mount the live thumbnail once the placeholder intersects", () => {
+    render(
+      <SlashMenuPanel
+        items={[bulletListVariation]}
+        query=""
+        onQueryChange={noop}
+        onSelect={noop}
+        onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
+      />,
+    );
+    intersect();
+    expect(
+      screen.getByTestId("plumix-variation-thumbnail-core/list:bullet"),
+    ).toBeDefined();
   });
 });

--- a/packages/admin/src/editor/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/SlashMenuPanel.tsx
@@ -9,7 +9,13 @@ import {
 } from "@/components/ui/command.js";
 import { Command as CommandPrimitive } from "cmdk";
 
+import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
+
 import type { SlashMenuItem } from "./slash-menu-items.js";
+import { isVariation } from "./is-variation.js";
+import { LazyMount } from "./LazyMount.js";
+import { SLASH_THUMBNAIL_MIN_HEIGHT } from "./thumbnail-min-height.js";
+import { VariationThumbnail } from "./VariationThumbnail.js";
 
 interface SlashMenuPanelProps {
   readonly items: readonly SlashMenuItem[];
@@ -17,6 +23,8 @@ interface SlashMenuPanelProps {
   readonly onQueryChange: (query: string) => void;
   readonly onSelect: (item: SlashMenuItem) => void;
   readonly onDismiss: () => void;
+  readonly blocks: BlockRegistry;
+  readonly patterns: PatternRegistry;
 }
 
 const UNCATEGORIZED = "other";
@@ -24,6 +32,8 @@ const UNCATEGORIZED = "other";
 function renderMember(
   item: SlashMenuItem,
   onSelect: (item: SlashMenuItem) => void,
+  blocks: BlockRegistry,
+  patterns: PatternRegistry,
 ): ReactElement {
   if (item.kind === "pattern") {
     const { entry } = item;
@@ -57,6 +67,35 @@ function renderMember(
     );
   }
   const { entry } = item;
+  if (isVariation(entry)) {
+    return (
+      <CommandItem
+        key={entry.slug}
+        value={entry.slug}
+        data-testid={`slash-menu-item-${entry.slug}`}
+        onSelect={() => onSelect(item)}
+        className="flex flex-col items-start gap-1 px-2 py-2"
+      >
+        <LazyMount
+          placeholderTestId={`slash-menu-thumbnail-placeholder-${entry.name}:${entry.slug}`}
+          minHeight={SLASH_THUMBNAIL_MIN_HEIGHT}
+        >
+          <div
+            aria-hidden
+            className="pointer-events-none h-12 w-full overflow-hidden rounded"
+          >
+            <VariationThumbnail
+              parentBlockName={entry.name}
+              variation={entry}
+              blocks={blocks}
+              patterns={patterns}
+            />
+          </div>
+        </LazyMount>
+        <span className="text-sm font-medium">{entry.title}</span>
+      </CommandItem>
+    );
+  }
   return (
     <CommandItem
       key={entry.slug}
@@ -83,6 +122,8 @@ export function SlashMenuPanel({
   onQueryChange,
   onSelect,
   onDismiss,
+  blocks,
+  patterns,
 }: SlashMenuPanelProps): ReactElement {
   const buckets = useMemo(() => {
     const map = new Map<string, SlashMenuItem[]>();
@@ -123,7 +164,9 @@ export function SlashMenuPanel({
             heading={category}
             data-testid={`slash-menu-group-${category}`}
           >
-            {members.map((item) => renderMember(item, onSelect))}
+            {members.map((item) =>
+              renderMember(item, onSelect, blocks, patterns),
+            )}
           </CommandGroup>
         ))}
       </CommandList>

--- a/packages/admin/src/editor/is-variation.ts
+++ b/packages/admin/src/editor/is-variation.ts
@@ -1,0 +1,8 @@
+import type { InsertableBlockEntry } from "@plumix/blocks";
+
+// `expandBlockVariations` emits a parent block entry with `slug === name`
+// and every variation entry with the variation's own raw slug — the
+// inequality is the cheapest "is this a variation?" check at the row.
+export function isVariation(entry: InsertableBlockEntry): boolean {
+  return entry.slug !== entry.name;
+}

--- a/packages/admin/src/editor/thumbnail-min-height.ts
+++ b/packages/admin/src/editor/thumbnail-min-height.ts
@@ -3,3 +3,8 @@
 // the deferral. Shared by every block / variation / pattern row that
 // gates a Thumbnail render behind LazyMount.
 export const THUMBNAIL_MIN_HEIGHT = 120;
+
+// Matches the `h-12` strip the slash-menu card uses so block + pattern +
+// variation previews all line up at the same height inside the slash
+// menu's narrow column.
+export const SLASH_THUMBNAIL_MIN_HEIGHT = 48;


### PR DESCRIPTION
Plain blocks in the slash menu keep their single-line rows; pattern entries keep the existing
two-line preview card. Variation block items (`slug !== name` per `expandBlockVariations`) now
render as a two-line cmdk `CommandItem` with a 48 px lazy-mounted `VariationThumbnail` strip
— the same height the pattern card already uses, so all three shapes line up inside the
slash menu's narrow column. Completes the thumbnail parity work the patterns sidebar,
block-scope picker, and inserter sidebar already have.

**A11y: the thumbnail wrapper is `aria-hidden`**

A live `VariationThumbnail` can embed interactive blocks (`core/button`), and the HTML spec
forbids interactive descendants inside cmdk's `role=\"option\"` ancestor. `aria-hidden` +
`pointer-events-none` on the wrapper makes screen readers skip the subtree and routes clicks
to the row's `onSelect`. The sidebar's `InsertableEntryRow` got the same treatment for the
same reason.

**`isVariation` is now a single-source predicate**

Three call sites used the same `entry.slug !== entry.name` check (sidebar, slash menu, and
`PlumixBlocksTab.handleInsert`). All three now import from `is-variation.ts`, so a future
change to `expandBlockVariations`'s emission shape only has to be hunted in one place.

**Follow-up flagged, not folded in**

The `FakeObserver` test harness is now in 5 places (`LazyMount`, `PatternsSection`,
`BlockScopePicker`, `InsertableEntryRow`, `SlashMenuPanel`). Senpai has flagged extraction
twice; cost-benefit has clearly flipped. Own PR.