### PR TITLE
refactor(admin): extract installFakeIntersectionObserver across editor tests

### DIFF
--- a/packages/admin/src/editor/BlockScopePicker.test.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.test.tsx
@@ -1,51 +1,18 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import type { BlockVariation } from "@plumix/blocks";
 import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
 import { BlockScopePicker } from "./BlockScopePicker.js";
+import { installFakeIntersectionObserver } from "./intersection-observer-harness.js";
 
-interface FakeObserverHandle {
-  readonly callback: IntersectionObserverCallback;
-}
-
-let observers: FakeObserverHandle[];
-
-beforeEach(() => {
-  observers = [];
-  class FakeObserver {
-    constructor(public readonly callback: IntersectionObserverCallback) {
-      observers.push({ callback });
-    }
-    observe = vi.fn();
-    unobserve = vi.fn();
-    disconnect = vi.fn();
-    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
-  }
-  vi.stubGlobal("IntersectionObserver", FakeObserver);
-});
+const { intersect } = installFakeIntersectionObserver();
 
 afterEach(() => {
   cleanup();
-  vi.unstubAllGlobals();
 });
-
-function intersect(): void {
-  const entry = {
-    isIntersecting: true,
-    intersectionRatio: 1,
-    target: document.createElement("div"),
-    boundingClientRect: {} as DOMRectReadOnly,
-    intersectionRect: {} as DOMRectReadOnly,
-    rootBounds: null,
-    time: 0,
-  } satisfies IntersectionObserverEntry;
-  act(() => {
-    for (const o of observers) o.callback([entry], {} as IntersectionObserver);
-  });
-}
 
 const blocks = createBlockRegistry([]);
 const patterns = createPatternRegistry([]);

--- a/packages/admin/src/editor/InsertableEntryRow.test.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.test.tsx
@@ -1,50 +1,17 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import type { InsertableBlockEntry } from "@plumix/blocks";
 import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
 import { InsertableEntryRow } from "./InsertableEntryRow.js";
+import { installFakeIntersectionObserver } from "./intersection-observer-harness.js";
 
-interface FakeObserverHandle {
-  readonly callback: IntersectionObserverCallback;
-}
-
-let observers: FakeObserverHandle[];
-
-beforeEach(() => {
-  observers = [];
-  class FakeObserver {
-    constructor(public readonly callback: IntersectionObserverCallback) {
-      observers.push({ callback });
-    }
-    observe = vi.fn();
-    unobserve = vi.fn();
-    disconnect = vi.fn();
-    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
-  }
-  vi.stubGlobal("IntersectionObserver", FakeObserver);
-});
+const { intersect } = installFakeIntersectionObserver();
 
 afterEach(() => {
   cleanup();
-  vi.unstubAllGlobals();
 });
-
-function intersect(): void {
-  const entry = {
-    isIntersecting: true,
-    intersectionRatio: 1,
-    target: document.createElement("div"),
-    boundingClientRect: {} as DOMRectReadOnly,
-    intersectionRect: {} as DOMRectReadOnly,
-    rootBounds: null,
-    time: 0,
-  } satisfies IntersectionObserverEntry;
-  act(() => {
-    for (const o of observers) o.callback([entry], {} as IntersectionObserver);
-  });
-}
 
 const blocks = createBlockRegistry([]);
 const patterns = createPatternRegistry([]);

--- a/packages/admin/src/editor/LazyMount.test.tsx
+++ b/packages/admin/src/editor/LazyMount.test.tsx
@@ -1,54 +1,14 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
 
+import { installFakeIntersectionObserver } from "./intersection-observer-harness.js";
 import { LazyMount } from "./LazyMount.js";
 
-interface IOInit {
-  readonly callback: IntersectionObserverCallback;
-}
-
-let observers: IOInit[];
-
-beforeEach(() => {
-  observers = [];
-  class FakeObserver {
-    constructor(public readonly callback: IntersectionObserverCallback) {
-      observers.push({ callback });
-    }
-    observe = vi.fn();
-    unobserve = vi.fn();
-    disconnect = vi.fn();
-    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
-  }
-  vi.stubGlobal("IntersectionObserver", FakeObserver);
-});
+const { intersect } = installFakeIntersectionObserver();
 
 afterEach(() => {
   cleanup();
-  vi.unstubAllGlobals();
 });
-
-function intersect(): void {
-  const entry = {
-    isIntersecting: true,
-    intersectionRatio: 1,
-    target: document.createElement("div"),
-    boundingClientRect: {} as DOMRectReadOnly,
-    intersectionRect: {} as DOMRectReadOnly,
-    rootBounds: null,
-    time: 0,
-  } satisfies IntersectionObserverEntry;
-  act(() => {
-    for (const o of observers) {
-      o.callback(
-        [entry],
-        // The real type expects an IntersectionObserver instance; the
-        // children don't read from it.
-        null as unknown as IntersectionObserver,
-      );
-    }
-  });
-}
 
 describe("LazyMount", () => {
   test("does not render children until the placeholder enters the viewport", () => {

--- a/packages/admin/src/editor/PatternsSection.test.tsx
+++ b/packages/admin/src/editor/PatternsSection.test.tsx
@@ -1,56 +1,17 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
+import { installFakeIntersectionObserver } from "./intersection-observer-harness.js";
 import { PatternsSection } from "./PatternsSection.js";
 
-interface QueuedObserver {
-  readonly callback: IntersectionObserverCallback;
-  readonly target: Element;
-}
-
-let observers: QueuedObserver[];
-
-beforeEach(() => {
-  observers = [];
-  class FakeObserver {
-    constructor(public readonly callback: IntersectionObserverCallback) {}
-    observe = (target: Element): void => {
-      observers.push({ callback: this.callback, target });
-    };
-    unobserve = vi.fn();
-    disconnect = vi.fn();
-    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
-  }
-  vi.stubGlobal("IntersectionObserver", FakeObserver);
-});
+const { intersect: intersectAll } = installFakeIntersectionObserver();
 
 afterEach(() => {
   cleanup();
-  vi.unstubAllGlobals();
 });
-
-// Flushes every queued observer with an intersecting entry — mirrors
-// the pattern in LazyMount.test.tsx so React state updates land inside
-// act() and the warning-free assertion path is consistent.
-function intersectAll(): void {
-  act(() => {
-    for (const { callback, target } of observers) {
-      const entry = {
-        isIntersecting: true,
-        intersectionRatio: 1,
-        target,
-        boundingClientRect: {} as DOMRectReadOnly,
-        intersectionRect: {} as DOMRectReadOnly,
-        rootBounds: null,
-        time: 0,
-      } satisfies IntersectionObserverEntry;
-      callback([entry], null as unknown as IntersectionObserver);
-    }
-  });
-}
 
 const noop = vi.fn();
 const blocks = createBlockRegistry([]);

--- a/packages/admin/src/editor/SlashMenuPanel.test.tsx
+++ b/packages/admin/src/editor/SlashMenuPanel.test.tsx
@@ -1,51 +1,18 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
 import type { SlashMenuItem } from "./slash-menu-items.js";
+import { installFakeIntersectionObserver } from "./intersection-observer-harness.js";
 import { SlashMenuPanel } from "./SlashMenuPanel.js";
 
-interface FakeObserverHandle {
-  readonly callback: IntersectionObserverCallback;
-}
-
-let observers: FakeObserverHandle[];
-
-beforeEach(() => {
-  observers = [];
-  class FakeObserver {
-    constructor(public readonly callback: IntersectionObserverCallback) {
-      observers.push({ callback });
-    }
-    observe = vi.fn();
-    unobserve = vi.fn();
-    disconnect = vi.fn();
-    takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
-  }
-  vi.stubGlobal("IntersectionObserver", FakeObserver);
-});
+const { intersect } = installFakeIntersectionObserver();
 
 afterEach(() => {
   cleanup();
-  vi.unstubAllGlobals();
 });
-
-function intersect(): void {
-  const entry = {
-    isIntersecting: true,
-    intersectionRatio: 1,
-    target: document.createElement("div"),
-    boundingClientRect: {} as DOMRectReadOnly,
-    intersectionRect: {} as DOMRectReadOnly,
-    rootBounds: null,
-    time: 0,
-  } satisfies IntersectionObserverEntry;
-  act(() => {
-    for (const o of observers) o.callback([entry], {} as IntersectionObserver);
-  });
-}
 
 const blocks = createBlockRegistry([]);
 const patterns = createPatternRegistry([]);

--- a/packages/admin/src/editor/intersection-observer-harness.ts
+++ b/packages/admin/src/editor/intersection-observer-harness.ts
@@ -1,0 +1,56 @@
+import { act } from "@testing-library/react";
+import { afterEach, beforeEach, vi } from "vitest";
+
+interface ObservedEntry {
+  readonly callback: IntersectionObserverCallback;
+  readonly target: Element;
+}
+
+interface IntersectionObserverHarness {
+  intersect: () => void;
+}
+
+// Call at module top-level — the fixture registers its own `beforeEach` /
+// `afterEach`, which vitest only accepts outside a running test. Not
+// safe under `test.concurrent`: `observations` is file-scoped, so two
+// tests running in parallel would share one observer queue.
+export function installFakeIntersectionObserver(): IntersectionObserverHarness {
+  const observations: ObservedEntry[] = [];
+
+  beforeEach(() => {
+    observations.length = 0;
+    class FakeObserver {
+      constructor(public readonly callback: IntersectionObserverCallback) {}
+      observe = (target: Element): void => {
+        observations.push({ callback: this.callback, target });
+      };
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+      takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
+    }
+    vi.stubGlobal("IntersectionObserver", FakeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  return {
+    intersect: () => {
+      act(() => {
+        for (const { callback, target } of observations) {
+          const entry = {
+            isIntersecting: true,
+            intersectionRatio: 1,
+            target,
+            boundingClientRect: {} as DOMRectReadOnly,
+            intersectionRect: {} as DOMRectReadOnly,
+            rootBounds: null,
+            time: 0,
+          } satisfies IntersectionObserverEntry;
+          callback([entry], null as unknown as IntersectionObserver);
+        }
+      });
+    },
+  };
+}


### PR DESCRIPTION
Five editor test files (`LazyMount`, `PatternsSection`, `BlockScopePicker`,
`InsertableEntryRow`, `SlashMenuPanel`) had grown near-identical copies of the same
`FakeObserver` test harness — ~40 lines each, with `PatternsSection`'s variant capturing the
observed target while the other four synthesised one. Senpai flagged the duplication twice;
this PR closes the loop. Net: 198 lines removed, 76 added.

**The harness owns its own hooks**

`installFakeIntersectionObserver()` is called once at module top-level in each test file and
returns `{ intersect }`. Internally it registers its own `beforeEach` (install the global
stub, clear the observation queue) and `afterEach` (`vi.unstubAllGlobals()`); each consumer
keeps its own `afterEach(cleanup)` for React.

The harness captures the real observed target (PatternsSection's pre-existing behavior). The
four sites that didn't assert on target keep working without changes; the one that did keeps
working without changes.

**Senpai pre-commit findings folded in**

- `observations` is `const` + reset via `observations.length = 0`. A future
  `prefer-const` autofix can't silently break per-test isolation by reaching for a
  load-bearing `let`.
- Inline comment notes the harness is unsafe under `test.concurrent` — `observations` is
  file-scoped, so a parallel-test contributor doesn't reach for it here without thinking.

The wider interface (read-only `observedCount` for future tests asserting "how many
observers got registered") is deferred until a real consumer asks.