### PR TITLE
refactor(admin): namespace variation row keys + testids per parent block

### DIFF
--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -59,6 +59,9 @@ export function BlockScopePicker({
             {blockTitle}.
           </DialogDescription>
         </DialogHeader>
+        {/* Raw `variation.slug` is safe here — the picker scopes to one
+           parent block at a time and a BlockSpec can't declare two
+           variations with the same slug. */}
         <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {variations.map((variation) => (
             <li key={variation.slug}>

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -59,7 +59,7 @@ import { HeadingAuditPanel } from "./HeadingAuditPanel.js";
 import { insertPattern } from "./insert-pattern.js";
 import { dispatchVariationInsert } from "./insert-variation.js";
 import { InsertableEntryRow } from "./InsertableEntryRow.js";
-import { isVariation } from "./is-variation.js";
+import { entryKey, isVariation } from "./is-variation.js";
 import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { PatternRefProvider } from "./PatternRefPreview.js";
@@ -710,7 +710,7 @@ function PlumixBlocksTab({
     <div className="flex flex-col">
       <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
         {entries.map((entry) => (
-          <li key={entry.slug}>
+          <li key={entryKey(entry)}>
             <InsertableEntryRow
               entry={entry}
               blocks={registry}

--- a/packages/admin/src/editor/InsertableEntryRow.test.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.test.tsx
@@ -17,6 +17,41 @@ const blocks = createBlockRegistry([]);
 const patterns = createPatternRegistry([]);
 
 describe("InsertableEntryRow", () => {
+  test("two variations sharing a slug across different parents get distinct testids", () => {
+    const listBullet: InsertableBlockEntry = {
+      name: "core/list",
+      slug: "bullet",
+      title: "Bulleted list",
+    };
+    const tabsBullet: InsertableBlockEntry = {
+      name: "core/tabs",
+      slug: "bullet",
+      title: "Bulleted tabs",
+    };
+    render(
+      <>
+        <InsertableEntryRow
+          entry={listBullet}
+          blocks={blocks}
+          patterns={patterns}
+          onClick={vi.fn()}
+        />
+        <InsertableEntryRow
+          entry={tabsBullet}
+          blocks={blocks}
+          patterns={patterns}
+          onClick={vi.fn()}
+        />
+      </>,
+    );
+    expect(
+      screen.getByTestId("plumix-blocks-tab-item-core/list/bullet"),
+    ).toBeDefined();
+    expect(
+      screen.getByTestId("plumix-blocks-tab-item-core/tabs/bullet"),
+    ).toBeDefined();
+  });
+
   test("renders a plain block as a single-line row without a thumbnail", () => {
     const entry: InsertableBlockEntry = {
       name: "core/heading",

--- a/packages/admin/src/editor/InsertableEntryRow.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.tsx
@@ -7,7 +7,7 @@ import type {
 } from "@plumix/blocks";
 
 import { BlockIcon } from "./BlockIcon.js";
-import { isVariation } from "./is-variation.js";
+import { entryKey, isVariation } from "./is-variation.js";
 import { LazyMount } from "./LazyMount.js";
 import { THUMBNAIL_MIN_HEIGHT } from "./thumbnail-min-height.js";
 import { VariationThumbnail } from "./VariationThumbnail.js";
@@ -30,7 +30,7 @@ export function InsertableEntryRow({
       <button
         type="button"
         className="hover:bg-muted flex w-full items-center gap-2 rounded border px-3 py-2 text-left text-sm"
-        data-testid={`plumix-blocks-tab-item-${entry.slug}`}
+        data-testid={`plumix-blocks-tab-item-${entryKey(entry)}`}
         onClick={onClick}
       >
         <BlockIcon name={entry.icon} />
@@ -47,7 +47,7 @@ export function InsertableEntryRow({
       role="button"
       tabIndex={0}
       className="hover:bg-muted flex w-full flex-col gap-2 rounded border p-2 text-left text-sm focus:outline-none focus-visible:ring"
-      data-testid={`plumix-blocks-tab-item-${entry.slug}`}
+      data-testid={`plumix-blocks-tab-item-${entryKey(entry)}`}
       onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/packages/admin/src/editor/SlashMenuPanel.test.tsx
+++ b/packages/admin/src/editor/SlashMenuPanel.test.tsx
@@ -65,6 +65,44 @@ const bulletListVariation: SlashMenuItem = {
 const noop = vi.fn();
 
 describe("SlashMenuPanel", () => {
+  test("two variations sharing a slug across different parents get distinct testids", () => {
+    const listBullet: SlashMenuItem = {
+      kind: "block",
+      entry: {
+        name: "core/list",
+        slug: "bullet",
+        title: "Bulleted list",
+        category: "lists",
+      },
+    };
+    const tabsBullet: SlashMenuItem = {
+      kind: "block",
+      entry: {
+        name: "core/tabs",
+        slug: "bullet",
+        title: "Bulleted tabs",
+        category: "tabs",
+      },
+    };
+    render(
+      <SlashMenuPanel
+        items={[listBullet, tabsBullet]}
+        query=""
+        onQueryChange={noop}
+        onSelect={noop}
+        onDismiss={noop}
+        blocks={blocks}
+        patterns={patterns}
+      />,
+    );
+    expect(
+      screen.getByTestId("slash-menu-item-core/list/bullet"),
+    ).toBeDefined();
+    expect(
+      screen.getByTestId("slash-menu-item-core/tabs/bullet"),
+    ).toBeDefined();
+  });
+
   test("marks pattern entries with a distinct card-style testid", () => {
     render(
       <SlashMenuPanel

--- a/packages/admin/src/editor/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/SlashMenuPanel.tsx
@@ -12,7 +12,7 @@ import { Command as CommandPrimitive } from "cmdk";
 import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
 
 import type { SlashMenuItem } from "./slash-menu-items.js";
-import { isVariation } from "./is-variation.js";
+import { entryKey, isVariation } from "./is-variation.js";
 import { LazyMount } from "./LazyMount.js";
 import { SLASH_THUMBNAIL_MIN_HEIGHT } from "./thumbnail-min-height.js";
 import { VariationThumbnail } from "./VariationThumbnail.js";
@@ -67,12 +67,13 @@ function renderMember(
     );
   }
   const { entry } = item;
+  const key = entryKey(entry);
   if (isVariation(entry)) {
     return (
       <CommandItem
-        key={entry.slug}
-        value={entry.slug}
-        data-testid={`slash-menu-item-${entry.slug}`}
+        key={key}
+        value={key}
+        data-testid={`slash-menu-item-${key}`}
         onSelect={() => onSelect(item)}
         className="flex flex-col items-start gap-1 px-2 py-2"
       >
@@ -98,9 +99,9 @@ function renderMember(
   }
   return (
     <CommandItem
-      key={entry.slug}
-      value={entry.slug}
-      data-testid={`slash-menu-item-${entry.slug}`}
+      key={key}
+      value={key}
+      data-testid={`slash-menu-item-${key}`}
       onSelect={() => onSelect(item)}
       className="flex items-start gap-2"
     >

--- a/packages/admin/src/editor/is-variation.ts
+++ b/packages/admin/src/editor/is-variation.ts
@@ -6,3 +6,11 @@ import type { InsertableBlockEntry } from "@plumix/blocks";
 export function isVariation(entry: InsertableBlockEntry): boolean {
   return entry.slug !== entry.name;
 }
+
+// Stable identifier for React keys + `data-testid` suffixes. Plain block
+// entries use their slug (which equals the name, e.g. `core/heading`).
+// Variation entries get namespaced under the parent — two blocks both
+// shipping a `bullet` variation would otherwise collide on raw slug.
+export function entryKey(entry: InsertableBlockEntry): string {
+  return isVariation(entry) ? `${entry.name}/${entry.slug}` : entry.slug;
+}

--- a/packages/blocks/src/expand-block-variations.test.ts
+++ b/packages/blocks/src/expand-block-variations.test.ts
@@ -155,4 +155,28 @@ describe("expandBlockVariations", () => {
       dataSrc: "static-preview",
     });
   });
+
+  test("variation entries emit the variation's raw slug, never namespaced under the parent", () => {
+    // The admin's `entryKey` helper relies on this — it namespaces by
+    // joining `${entry.name}/${entry.slug}`, which would double-prefix
+    // if the producer ever emitted `slug = ${name}/${variation.slug}`.
+    const entries = expandBlockVariations([
+      block({
+        name: "core/list",
+        title: "List",
+        variations: [
+          { slug: "bullet", title: "Bulleted", attrs: { variant: "bullet" } },
+          {
+            slug: "numbered",
+            title: "Numbered",
+            attrs: { variant: "numbered" },
+          },
+        ],
+      }),
+    ]);
+    for (const entry of entries) {
+      expect(entry.slug.startsWith(`${entry.name}/`)).toBe(false);
+    }
+    expect(entries.map((e) => e.slug)).toEqual(["bullet", "numbered"]);
+  });
 });


### PR DESCRIPTION
Two unrelated block specs shipping a variation with the same slug — say both `core/list` and
`core/tabs` declaring a `bullet` variation — collided on three things in the sidebar and
slash menu: React's `<li key>`, the `data-testid` suffix, and (latent bug) cmdk's internal
`value`-keyed selection map. Senpai M2 from #658 — this PR closes it.

**`entryKey(entry)` — single-source identity**

New helper in `is-variation.ts`. Plain block entries (`slug === name`) return the raw slug,
unchanged. Variation entries return `${name}/${slug}`. Three call sites swap to it:
`<li key>` in the sidebar, `data-testid` in `InsertableEntryRow`, and key + value + testid
in `SlashMenuPanel`'s two `CommandItem` branches.

Plain-block e2e (`plumix-blocks-tab-item-test/fake`) keeps passing — for plain blocks
`entryKey === slug` because `isVariation` returns false.

**Senpai pre-commit findings folded in**

- `BlockScopePicker` keeps using `variation.slug` directly. Added a comment explaining why
  that's collision-safe there — the picker only opens for one parent at a time, so the
  cross-parent collision class doesn't apply.
- Producer-invariant test on `expand-block-variations.test.ts` asserting variation entries
  never emit a slug already prefixed with the parent name. Pins the assumption `entryKey`
  relies on; a future producer change that double-prefixes the slug would trip the test
  instead of silently mangling testids.