### PR TITLE
refactor(admin): use shadcn Button for picker + starter modal escape actions

### DIFF
--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button.js";
 import {
   Dialog,
   DialogContent,
@@ -102,14 +103,14 @@ export function BlockScopePicker({
           ))}
         </ul>
         <div className="flex justify-end">
-          <button
-            type="button"
-            className="text-muted-foreground hover:text-foreground text-sm underline-offset-2 hover:underline"
+          <Button
+            variant="ghost"
+            size="sm"
             data-testid="plumix-block-scope-picker-cancel"
             onClick={onDismiss}
           >
             Cancel
-          </button>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/admin/src/editor/StarterModal.tsx
+++ b/packages/admin/src/editor/StarterModal.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button.js";
 import {
   Dialog,
   DialogContent,
@@ -79,14 +80,14 @@ export function StarterModal({
           ))}
         </ul>
         <div className="flex justify-end">
-          <button
-            type="button"
-            className="text-muted-foreground hover:text-foreground text-sm underline-offset-2 hover:underline"
+          <Button
+            variant="ghost"
+            size="sm"
             data-testid="plumix-starter-modal-start-blank"
             onClick={onDismiss}
           >
             Start from blank
-          </button>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
`BlockScopePicker`'s Cancel and `StarterModal`'s "Start from blank" both used a hand-rolled
`<button>` with link-style classes (`text-muted-foreground hover:text-foreground text-sm
underline-offset-2 hover:underline`). The codebase has a real shadcn `<Button>` primitive,
and every other dialog Cancel in admin uses one of its variants. Closes senpai M5 from #655
plus its M1 follow-up flagged on this slice's senpai pass (StarterModal carried the literal
same anti-pattern; landing them together).

**Both switch to `variant="ghost" size="sm"`**

Ghost matches the original muted text-color register, and matches `StaleDraftDialog`'s
tertiary-action treatment. Neither modal pairs the escape action with a primary footer
button (the primary action in both is the grid above) — that's the discriminator the
codebase uses between `ghost` (no paired primary) and `outline` (paired with a `default`
Cancel/Save tier).

Existing tests on both modals (`plumix-block-scope-picker-cancel` /
`plumix-starter-modal-start-blank`) still pass — testid + click semantics preserved.