### PR TITLE
feat(core): add per-request resolveLocale chain + ctx.locale render flip

### DIFF
--- a/packages/core/src/auth/auth-can-scopes.test.ts
+++ b/packages/core/src/auth/auth-can-scopes.test.ts
@@ -26,7 +26,7 @@ function buildCtx(args: {
   });
   return withUser(
     baseCtx,
-    { id: 1, email: "u@cms.example", role: args.role },
+    { id: 1, email: "u@cms.example", role: args.role, meta: {} },
     args.tokenScopes ?? null,
   );
 }

--- a/packages/core/src/auth/passkey/routes.ts
+++ b/packages/core/src/auth/passkey/routes.ts
@@ -269,7 +269,14 @@ export async function handlePasskeyRegisterVerify(
           deviceType: credential.deviceType,
           isBackedUp: credential.isBackedUp,
         },
-        { actor: { id: user.id, email: user.email, role: user.role } },
+        {
+          actor: {
+            id: user.id,
+            email: user.email,
+            role: user.role,
+            meta: user.meta,
+          },
+        },
       );
       await ctx.hooks.doAction("user:signed_in", user, {
         method: "passkey",
@@ -497,7 +504,14 @@ export async function handleInviteRegisterVerify(
         deviceType: credential.deviceType,
         isBackedUp: credential.isBackedUp,
       },
-      { actor: { id: user.id, email: user.email, role: user.role } },
+      {
+        actor: {
+          id: user.id,
+          email: user.email,
+          role: user.role,
+          meta: user.meta,
+        },
+      },
     );
     await ctx.hooks.doAction("user:signed_in", user, {
       method: "invite",

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -9,7 +9,7 @@ import type { KnownCapability } from "../auth/rbac.js";
 import type * as coreSchema from "../db/schema/index.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { HookExecutor } from "../hooks/registry.js";
-import type { ResolvedI18n } from "../i18n/locale-registry.js";
+import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
 import type { ResolvedEntity } from "../route/current.js";
 import type { OAuthProviderSummary } from "../runtime/app.js";
@@ -22,6 +22,7 @@ import type {
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 import { resolveLocales } from "../i18n/locale-registry.js";
+import { resolveLocale } from "../i18n/resolve-locale.js";
 
 const EMPTY_BLOCK_REGISTRY: BlockRegistry = createBlockRegistry([]);
 const EMPTY_MARK_LIST: readonly MarkSpec[] = Object.freeze([]);
@@ -39,6 +40,7 @@ export interface AuthenticatedUser {
   readonly id: number;
   readonly email: string;
   readonly role: UserRole;
+  readonly meta: Record<string, unknown>;
 }
 
 export interface Logger {
@@ -191,6 +193,7 @@ export interface AppContextBase<
    */
   readonly siteName?: string;
   readonly i18n: ResolvedI18n;
+  readonly locale: ResolvedLocale;
   /**
    * Set by the public-route resolver after URL → entity matching;
    * `null` for non-public routes (admin, RPC, etc.) and on cold-start.
@@ -315,6 +318,8 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
   const resolver = createCapabilityResolver(args.plugins);
   const user = args.user ?? null;
   const tokenScopes = args.tokenScopes ?? null;
+  const i18n = args.i18n ?? DEFAULT_I18N;
+  const locale = resolveLocale({ request: args.request, user, i18n });
   const base: AppContextBase<TSchema> = {
     db: args.db,
     env: args.env,
@@ -334,7 +339,8 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     storage: args.storage,
     imageDelivery: args.imageDelivery,
     mailer: args.mailer,
-    i18n: args.i18n ?? DEFAULT_I18N,
+    i18n,
+    locale,
     oauthProviders: args.oauthProviders ?? [],
     authenticator: args.authenticator ?? defaultAuthenticator(),
     bootstrapAllowed: args.bootstrapAllowed ?? false,
@@ -386,6 +392,10 @@ export function withUser<TSchema extends Record<string, unknown>>(
       can: makeAuthCan(resolver, user, tokenScopes),
     },
     oauthProviders: ctx.oauthProviders,
+    // Re-resolve locale now that the user is known — production paths build
+    // the AppContext before auth, so step 1 (user.meta.locale) is only
+    // reachable from here.
+    locale: resolveLocale({ request: ctx.request, user, i18n: ctx.i18n }),
   };
 }
 

--- a/packages/core/src/context/with-user-locale.test.ts
+++ b/packages/core/src/context/with-user-locale.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry } from "../hooks/registry.js";
+import { resolveLocales } from "../i18n/locale-registry.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { createAppContext, withUser } from "./app.js";
+
+// Production builds the AppContext before authentication runs; `ctx.locale`
+// starts off resolved with `user: null`. `withUser` (called from the
+// dispatcher + RPC middleware after auth) is the only place where step 1
+// of the resolver — `user.meta.locale` — can fire.
+
+describe("withUser — locale re-resolution", () => {
+  test("re-resolves ctx.locale once a user is attached so user.meta.locale wins", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "fr"],
+    });
+    const baseCtx = createAppContext({
+      db: {} as never,
+      env: {},
+      request: new Request("https://cms.example/", {
+        headers: { "accept-language": "en" },
+      }),
+      hooks: new HookRegistry(),
+      plugins: createPluginRegistry(),
+      i18n,
+    });
+    expect(baseCtx.locale.code).toBe("en");
+
+    const authed = withUser(baseCtx, {
+      id: 1,
+      email: "u@cms.example",
+      role: "admin",
+      meta: { locale: "fr" },
+    });
+
+    expect(authed.locale.code).toBe("fr");
+  });
+});

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -6,3 +6,4 @@ export type {
   ResolvedI18n,
   ResolvedLocale,
 } from "./locale-registry.js";
+export { resolveLocale } from "./resolve-locale.js";

--- a/packages/core/src/i18n/locale-registry.test.ts
+++ b/packages/core/src/i18n/locale-registry.test.ts
@@ -70,6 +70,17 @@ describe("resolveLocales", () => {
     ).toThrow(/__nope__/);
   });
 
+  test("resolveLocale override on the input passes through to the registry", () => {
+    const override = () => null;
+    const registry = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en"],
+      resolveLocale: override,
+    });
+
+    expect(registry.resolveLocale).toBe(override);
+  });
+
   test("region-tagged RTL locales still derive direction rtl (ar-EG, he-IL)", () => {
     const registry = resolveLocales({
       defaultLocale: "ar-EG",

--- a/packages/core/src/i18n/locale-registry.ts
+++ b/packages/core/src/i18n/locale-registry.ts
@@ -10,7 +10,13 @@ export interface LocaleInput {
 export interface I18nInput {
   readonly defaultLocale: string;
   readonly locales: readonly (string | LocaleInput)[];
+  readonly resolveLocale?: LocaleResolverOverride;
 }
+
+export type LocaleResolverOverride = (
+  request: Request,
+  user: { readonly meta: Record<string, unknown> } | null,
+) => ResolvedLocale | null;
 
 export interface ResolvedLocale {
   readonly code: string;
@@ -22,6 +28,7 @@ export interface ResolvedLocale {
 export interface ResolvedI18n {
   readonly defaultLocale: ResolvedLocale;
   readonly locales: readonly ResolvedLocale[];
+  readonly resolveLocale?: LocaleResolverOverride;
 }
 
 // `Intl.Locale.prototype.getTextInfo()` shipped in V8/Node/Workers but the
@@ -47,7 +54,7 @@ export function resolveLocales(input: I18nInput): ResolvedI18n {
       `plumix(): i18n.defaultLocale ${JSON.stringify(input.defaultLocale)} cannot be marked enabled:false.`,
     );
   }
-  return { defaultLocale, locales };
+  return { defaultLocale, locales, resolveLocale: input.resolveLocale };
 }
 
 function normalizeEntry(entry: string | LocaleInput): ResolvedLocale {

--- a/packages/core/src/i18n/resolve-locale.test.ts
+++ b/packages/core/src/i18n/resolve-locale.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "vitest";
+
+import type { AuthenticatedUser } from "../context/app.js";
+import { resolveLocales } from "./locale-registry.js";
+import { resolveLocale } from "./resolve-locale.js";
+
+function user(meta: Record<string, unknown> = {}): AuthenticatedUser {
+  return { id: 1, email: "u@x", role: "admin", meta };
+}
+
+const enFr = resolveLocales({
+  defaultLocale: "en",
+  locales: ["en", "fr"],
+});
+
+function request(headers: Record<string, string> = {}): Request {
+  return new Request("https://cms.example/post", { headers });
+}
+
+describe("resolveLocale", () => {
+  test("falls back to the site defaultLocale when no signals match", () => {
+    const resolved = resolveLocale({
+      request: new Request("https://cms.example/post"),
+      user: null,
+      i18n: enFr,
+    });
+
+    expect(resolved).toBe(enFr.defaultLocale);
+  });
+
+  test("script tags map to the supported region (zh-Hant → zh-TW, zh-Hans → zh-CN)", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "zh-TW", "zh-CN"],
+    });
+
+    expect(
+      resolveLocale({
+        request: request({ "accept-language": "zh-Hant" }),
+        user: null,
+        i18n,
+      }).code,
+    ).toBe("zh-TW");
+    expect(
+      resolveLocale({
+        request: request({ "accept-language": "zh-Hans" }),
+        user: null,
+        i18n,
+      }).code,
+    ).toBe("zh-CN");
+  });
+
+  test("Accept-Language tags are matched case-insensitively (ZH-HANT → zh-TW)", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "zh-TW"],
+    });
+
+    const resolved = resolveLocale({
+      request: request({ "accept-language": "ZH-HANT" }),
+      user: null,
+      i18n,
+    });
+
+    expect(resolved.code).toBe("zh-TW");
+  });
+
+  test("base-language map falls through to the supported regional variant (pt-PT → pt-BR)", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "pt-BR"],
+    });
+
+    const resolved = resolveLocale({
+      request: request({ "accept-language": "pt-PT" }),
+      user: null,
+      i18n,
+    });
+
+    expect(resolved.code).toBe("pt-BR");
+  });
+
+  test("override returning a registry entry short-circuits the 4-step chain", () => {
+    const arEn = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "ar"],
+      resolveLocale: (_req, _u) =>
+        arEn.locales.find((l) => l.code === "ar") ?? null,
+    });
+
+    const resolved = resolveLocale({
+      request: request({ "accept-language": "en" }),
+      user: user({ locale: "en" }),
+      i18n: arEn,
+    });
+
+    expect(resolved.code).toBe("ar");
+  });
+
+  test("override returning null falls through to the default chain", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "fr"],
+      resolveLocale: () => null,
+    });
+
+    const resolved = resolveLocale({
+      request: request({ "accept-language": "fr" }),
+      user: null,
+      i18n,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("override returning a code not in the registry is ignored", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "fr"],
+      resolveLocale: () => ({
+        code: "de",
+        label: "German",
+        direction: "ltr",
+        enabled: true,
+      }),
+    });
+
+    const resolved = resolveLocale({
+      request: request({ "accept-language": "fr" }),
+      user: null,
+      i18n,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("user.meta.locale wins over cookie + Accept-Language (WP get_user_locale parity)", () => {
+    const resolved = resolveLocale({
+      request: request({
+        "accept-language": "en",
+        cookie: "plumix-locale=en",
+      }),
+      user: user({ locale: "fr" }),
+      i18n: enFr,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("user.meta.locale pointing at a disabled locale falls through", () => {
+    const enFrDisabled = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", { code: "fr", enabled: false }],
+    });
+
+    const resolved = resolveLocale({
+      request: request(),
+      user: user({ locale: "fr" }),
+      i18n: enFrDisabled,
+    });
+
+    expect(resolved.code).toBe("en");
+  });
+
+  test("plumix-locale cookie wins over Accept-Language", () => {
+    const resolved = resolveLocale({
+      request: request({
+        "accept-language": "fr",
+        cookie: "plumix-locale=en",
+      }),
+      user: null,
+      i18n: enFr,
+    });
+
+    expect(resolved.code).toBe("en");
+  });
+
+  test("plumix-locale cookie with an unsupported code falls through to header", () => {
+    const resolved = resolveLocale({
+      request: request({
+        "accept-language": "fr",
+        cookie: "plumix-locale=de",
+      }),
+      user: null,
+      i18n: enFr,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("plumix-locale cookie pointing at a disabled locale falls through", () => {
+    const enFrDisabled = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", { code: "fr", enabled: false }],
+    });
+
+    const resolved = resolveLocale({
+      request: request({ cookie: "plumix-locale=fr" }),
+      user: null,
+      i18n: enFrDisabled,
+    });
+
+    expect(resolved.code).toBe("en");
+  });
+
+  test("Accept-Language q-factor wins over list order", () => {
+    const enAr = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "ar"],
+    });
+
+    const resolved = resolveLocale({
+      request: request({ "accept-language": "en;q=0.5, ar;q=0.9" }),
+      user: null,
+      i18n: enAr,
+    });
+
+    expect(resolved.code).toBe("ar");
+  });
+
+  test("Accept-Language exact canonical tag wins over default", () => {
+    const resolved = resolveLocale({
+      request: request({ "accept-language": "fr" }),
+      user: null,
+      i18n: enFr,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
+});

--- a/packages/core/src/i18n/resolve-locale.ts
+++ b/packages/core/src/i18n/resolve-locale.ts
@@ -1,0 +1,114 @@
+import type { AuthenticatedUser } from "../context/app.js";
+import type { ResolvedI18n, ResolvedLocale } from "./locale-registry.js";
+import { readSessionCookie } from "../auth/cookies.js";
+
+const LOCALE_COOKIE = "plumix-locale";
+
+interface ResolveLocaleArgs {
+  readonly request: Request;
+  readonly user: AuthenticatedUser | null;
+  readonly i18n: ResolvedI18n;
+}
+
+// WP `determine_locale()` parity: signed-in user beats anonymous-visitor
+// signals. Order: operator override → user.meta.locale → cookie → header → default.
+export function resolveLocale(args: ResolveLocaleArgs): ResolvedLocale {
+  const fromOverride = matchOverride(args);
+  if (fromOverride) return fromOverride;
+  const fromUser = matchUserMeta(args.user, args.i18n);
+  if (fromUser) return fromUser;
+  const fromCookie = matchCookie(args.request, args.i18n);
+  if (fromCookie) return fromCookie;
+  const fromHeader = matchAcceptLanguage(args.request, args.i18n);
+  if (fromHeader) return fromHeader;
+  return args.i18n.defaultLocale;
+}
+
+function matchOverride(args: ResolveLocaleArgs): ResolvedLocale | null {
+  const returned = args.i18n.resolveLocale?.(args.request, args.user);
+  if (!returned) return null;
+  // Trust boundary: the override may have hand-built a locale; require it
+  // to be the same enabled entry the rest of the chain would return.
+  return (
+    args.i18n.locales.find((l) => l.code === returned.code && l.enabled) ?? null
+  );
+}
+
+function matchUserMeta(
+  user: AuthenticatedUser | null,
+  i18n: ResolvedI18n,
+): ResolvedLocale | null {
+  const code = user?.meta.locale;
+  if (typeof code !== "string") return null;
+  return i18n.locales.find((l) => l.code === code && l.enabled) ?? null;
+}
+
+function matchCookie(
+  request: Request,
+  i18n: ResolvedI18n,
+): ResolvedLocale | null {
+  const code = readSessionCookie(request, LOCALE_COOKIE);
+  if (!code) return null;
+  return i18n.locales.find((l) => l.code === code && l.enabled) ?? null;
+}
+
+// Region-tag fallbacks: browsers send `zh-Hant`/`zh-Hans`/`pt-PT`, operators
+// configure `zh-TW`/`zh-CN`/`pt-BR`. Without these, a `pt-PT` visitor on a
+// `pt-BR` site falls all the way through to English.
+const SCRIPT_LANGUAGE_MAP: Record<string, string> = {
+  "zh-Hant": "zh-TW",
+  "zh-Hans": "zh-CN",
+};
+
+const BASE_LANGUAGE_MAP: Record<string, string> = {
+  "pt-PT": "pt-BR",
+};
+
+function matchAcceptLanguage(
+  request: Request,
+  i18n: ResolvedI18n,
+): ResolvedLocale | null {
+  const header = request.headers.get("accept-language");
+  if (!header) return null;
+  for (const tag of parseAcceptLanguage(header)) {
+    const hit = matchTag(tag, i18n);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function matchTag(tag: string, i18n: ResolvedI18n): ResolvedLocale | null {
+  const enabled = i18n.locales.filter((l) => l.enabled);
+  return (
+    enabled.find((l) => l.code === tag) ??
+    enabled.find((l) => l.code === SCRIPT_LANGUAGE_MAP[tag]) ??
+    enabled.find((l) => l.code === BASE_LANGUAGE_MAP[tag]) ??
+    null
+  );
+}
+
+function parseAcceptLanguage(header: string): string[] {
+  return header
+    .split(",")
+    .map((entry) => {
+      const [tagPart, ...params] = entry.split(";");
+      const tag = canonicalTag(tagPart?.trim() ?? "");
+      const qParam = params.find((p) => p.trim().startsWith("q="));
+      const q = qParam ? Number(qParam.trim().slice(2)) : 1;
+      return { tag, q: Number.isFinite(q) ? q : 0 };
+    })
+    .filter(({ tag, q }) => tag && q > 0)
+    .sort((a, b) => b.q - a.q)
+    .map(({ tag }) => tag);
+}
+
+function canonicalTag(raw: string): string {
+  // RFC 4647 says tags are case-insensitive; browsers usually emit canonical
+  // form but spec-conformant clients sometimes don't. Fall back to the raw
+  // string on `*`, `und`, or any input Intl.Locale rejects.
+  try {
+    return new Intl.Locale(raw).toString();
+  } catch {
+    return raw;
+  }
+}

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -262,6 +262,39 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain("<body>");
   });
 
+  test("Accept-Language drives ctx.locale → <html lang dir> on an LTR-default site", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin],
+      theme,
+      i18n: { defaultLocale: "en", locales: ["en", "ar"] },
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "header",
+      title: "Header",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/header", {
+        headers: { "accept-language": "ar" },
+      }),
+    );
+    const body = await response.text();
+    expect(body).toContain('<html lang="ar" dir="rtl">');
+  });
+
   test("site's i18n defaultLocale drives <html lang dir> (RTL example)", async () => {
     const theme = defineTheme({
       templates: {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -287,7 +287,7 @@ function renderTree({
 
   const scripts = groupScriptsByPosition(document.script);
 
-  const { code, direction } = ctx.i18n.defaultLocale;
+  const { code, direction } = ctx.locale;
   const htmlAttrs = renderAttrs({
     lang: code,
     dir: direction,

--- a/packages/core/src/rpc/authenticated.ts
+++ b/packages/core/src/rpc/authenticated.ts
@@ -14,10 +14,10 @@ export const authenticated = base.middleware(
     );
     if (!result) throw errors.UNAUTHORIZED();
 
-    const { id, email, role } = result.user;
+    const { id, email, role, meta } = result.user;
     const tokenScopes = result.tokenScopes ?? null;
     return next({
-      context: withUser(context, { id, email, role }, tokenScopes),
+      context: withUser(context, { id, email, role, meta }, tokenScopes),
     });
   },
 );

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -324,9 +324,9 @@ async function dispatchPluginRawRoute(
   const result = await ctx.authenticator.authenticate(ctx.request, ctx.db);
   if (!result) return jsonResponse({ error: "unauthorized" }, { status: 401 });
 
-  const { id, email, role } = result.user;
+  const { id, email, role, meta } = result.user;
   const tokenScopes = result.tokenScopes ?? null;
-  const authedCtx = withUser(ctx, { id, email, role }, tokenScopes);
+  const authedCtx = withUser(ctx, { id, email, role, meta }, tokenScopes);
 
   if (gate === "authenticated") {
     return route.handler(authedCtx.request, authedCtx);

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -187,7 +187,7 @@ function withRequest(
     marks: app.marks,
     logger: silentLogger,
     user: user
-      ? { id: user.id, email: user.email, role: user.role }
+      ? { id: user.id, email: user.email, role: user.role, meta: user.meta }
       : undefined,
     assets,
     storage,

--- a/packages/plugins/audit-log/src/rpc.test.ts
+++ b/packages/plugins/audit-log/src/rpc.test.ts
@@ -84,7 +84,7 @@ function buildContext(role: UserRole): AppContext {
     request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
     hooks: new HookRegistry(),
     plugins: registry,
-    user: { id: user.id, email: user.email, role: user.role },
+    user: { id: user.id, email: user.email, role: user.role, meta: {} },
     authenticator: stubAuthenticator(user),
     origin: "https://cms.example",
   });

--- a/packages/plugins/audit-log/src/server/auditEvents.test.ts
+++ b/packages/plugins/audit-log/src/server/auditEvents.test.ts
@@ -113,6 +113,7 @@ const adminUser: AuthenticatedUser = {
   id: 7,
   email: "alice@example.com",
   role: "admin",
+  meta: {},
 };
 const subjectUser = {
   id: 42,

--- a/packages/plugins/audit-log/src/server/auditExtension.test.ts
+++ b/packages/plugins/audit-log/src/server/auditExtension.test.ts
@@ -64,6 +64,7 @@ const adminUser: AuthenticatedUser = {
   id: 7,
   email: "alice@example.com",
   role: "admin",
+  meta: {},
 };
 
 describe("createAuditExtension", () => {

--- a/packages/plugins/menu/src/hooks.test.ts
+++ b/packages/plugins/menu/src/hooks.test.ts
@@ -65,7 +65,7 @@ async function setup(): Promise<Bundle> {
     request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
     hooks,
     plugins: registry,
-    user: { id: user.id, email: user.email, role: user.role },
+    user: { id: user.id, email: user.email, role: user.role, meta: {} },
     authenticator: stubAuthenticator(user),
     origin: "https://cms.example",
   });

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -96,7 +96,7 @@ async function buildHarness(role: UserRole = "editor"): Promise<Harness> {
     request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
     hooks,
     plugins: registry,
-    user: { id: user.id, email: user.email, role: user.role },
+    user: { id: user.id, email: user.email, role: user.role, meta: {} },
     authenticator: stubAuthenticator(user),
     origin: "https://cms.example",
   });


### PR DESCRIPTION
Closes #671 — second slice of the i18n epic. Every request resolves to a per-request locale via the WordPress `determine_locale()` chain, and the SSR renderer flips from "site default" to `ctx.locale`. Demoable: `Accept-Language: ar` on an `en`-default site supporting `ar` now produces an RTL Arabic shell; `users.meta.locale` overrides the header on authenticated paths.

**Locale storage follows WP, not a new column**

Per a maintainer call-out on the issue, user locale lives in `users.meta.locale` (mirroring `wp_usermeta`'s `locale` key) — no migration. The JSON `meta` column already exists from #62.

**`resolveLocale` chain**

Five steps, each skipping disabled locales:

1. Operator override (`plumix({ i18n: { resolveLocale } })`). Return value is validated against the registry — an override returning a code not in `locales` is ignored rather than trusted.
2. `user.meta.locale` (WP `get_user_locale` parity).
3. `plumix-locale` cookie.
4. `Accept-Language` with q-factor sort + per-tag three-tier matcher: exact canonical → `SCRIPT_LANGUAGE_MAP` (`zh-Hant` → `zh-TW`, `zh-Hans` → `zh-CN`) → `BASE_LANGUAGE_MAP` (`pt-PT` → `pt-BR`). Tags canonicalize through `Intl.Locale`, so `ZH-HANT` matches.
5. Site `defaultLocale`.

**Resolved at the auth boundary, not at request entry**

The Cloudflare adapter builds `AppContext` before authentication runs — `ctx.user` is `null` at `createAppContext` time. Resolving locale only there would never reach step 2 in production. `withUser` (called from the dispatcher + the RPC `authenticated` middleware once auth resolves) re-runs `resolveLocale` with the now-known user, so the signed-in path actually sees `user.meta.locale`. Held by a direct test against `withUser` (`with-user-locale.test.ts`).

**`AuthenticatedUser.meta` exposed**

The schema column already exists and is selected by the session join. Threading it through `AuthenticatedUser` is the seam every consumer reads from. Seven construction sites updated across core (`runtime/dispatcher.ts`, `rpc/authenticated.ts`, two passkey routes, `test/dispatcher.ts`, `auth-can-scopes.test.ts`) and plugins (`audit-log`, `menu` test harnesses).

**Render contract**

Before:

```tsx
const { code, direction } = ctx.i18n.defaultLocale;
```

After:

```tsx
const { code, direction } = ctx.locale;
```

`document.html` continues to spread last; theme/template overrides for `html.lang` / `html.dir` still win. New integration test: site `defaultLocale: "en"`, request `Accept-Language: ar` → `<html lang="ar" dir="rtl">`.
