### PR TITLE
feat(core): add user-locale resolution (WP determine_locale parity)

### DIFF
--- a/packages/core/src/auth/auth-can-scopes.test.ts
+++ b/packages/core/src/auth/auth-can-scopes.test.ts
@@ -26,7 +26,7 @@ function buildCtx(args: {
   });
   return withUser(
     baseCtx,
-    { id: 1, email: "u@cms.example", role: args.role },
+    { id: 1, email: "u@cms.example", role: args.role, meta: {} },
     args.tokenScopes ?? null,
   );
 }

--- a/packages/core/src/auth/passkey/routes.ts
+++ b/packages/core/src/auth/passkey/routes.ts
@@ -269,7 +269,14 @@ export async function handlePasskeyRegisterVerify(
           deviceType: credential.deviceType,
           isBackedUp: credential.isBackedUp,
         },
-        { actor: { id: user.id, email: user.email, role: user.role } },
+        {
+          actor: {
+            id: user.id,
+            email: user.email,
+            role: user.role,
+            meta: user.meta,
+          },
+        },
       );
       await ctx.hooks.doAction("user:signed_in", user, {
         method: "passkey",
@@ -497,7 +504,14 @@ export async function handleInviteRegisterVerify(
         deviceType: credential.deviceType,
         isBackedUp: credential.isBackedUp,
       },
-      { actor: { id: user.id, email: user.email, role: user.role } },
+      {
+        actor: {
+          id: user.id,
+          email: user.email,
+          role: user.role,
+          meta: user.meta,
+        },
+      },
     );
     await ctx.hooks.doAction("user:signed_in", user, {
       method: "invite",

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -9,7 +9,7 @@ import type { KnownCapability } from "../auth/rbac.js";
 import type * as coreSchema from "../db/schema/index.js";
 import type { UserRole } from "../db/schema/users.js";
 import type { HookExecutor } from "../hooks/registry.js";
-import type { ResolvedI18n } from "../i18n/locale-registry.js";
+import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
 import type { ResolvedEntity } from "../route/current.js";
 import type { OAuthProviderSummary } from "../runtime/app.js";
@@ -22,6 +22,7 @@ import type {
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 import { resolveLocales } from "../i18n/locale-registry.js";
+import { resolveLocale } from "../i18n/resolve-locale.js";
 
 const EMPTY_BLOCK_REGISTRY: BlockRegistry = createBlockRegistry([]);
 const EMPTY_MARK_LIST: readonly MarkSpec[] = Object.freeze([]);
@@ -39,6 +40,7 @@ export interface AuthenticatedUser {
   readonly id: number;
   readonly email: string;
   readonly role: UserRole;
+  readonly meta: Record<string, unknown>;
 }
 
 export interface Logger {
@@ -191,6 +193,7 @@ export interface AppContextBase<
    */
   readonly siteName?: string;
   readonly i18n: ResolvedI18n;
+  readonly locale: ResolvedLocale;
   /**
    * Set by the public-route resolver after URL → entity matching;
    * `null` for non-public routes (admin, RPC, etc.) and on cold-start.
@@ -315,6 +318,8 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
   const resolver = createCapabilityResolver(args.plugins);
   const user = args.user ?? null;
   const tokenScopes = args.tokenScopes ?? null;
+  const i18n = args.i18n ?? DEFAULT_I18N;
+  const locale = resolveLocale({ request: args.request, user, i18n });
   const base: AppContextBase<TSchema> = {
     db: args.db,
     env: args.env,
@@ -334,7 +339,8 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     storage: args.storage,
     imageDelivery: args.imageDelivery,
     mailer: args.mailer,
-    i18n: args.i18n ?? DEFAULT_I18N,
+    i18n,
+    locale,
     oauthProviders: args.oauthProviders ?? [],
     authenticator: args.authenticator ?? defaultAuthenticator(),
     bootstrapAllowed: args.bootstrapAllowed ?? false,
@@ -386,6 +392,10 @@ export function withUser<TSchema extends Record<string, unknown>>(
       can: makeAuthCan(resolver, user, tokenScopes),
     },
     oauthProviders: ctx.oauthProviders,
+    // Public-route paths skip `withUser` and keep the site default; admin /
+    // RPC paths land here once auth resolves, so step 2 of the chain
+    // (user.meta.locale) is only reachable from this seam.
+    locale: resolveLocale({ request: ctx.request, user, i18n: ctx.i18n }),
   };
 }
 

--- a/packages/core/src/context/with-user-locale.test.ts
+++ b/packages/core/src/context/with-user-locale.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry } from "../hooks/registry.js";
+import { resolveLocales } from "../i18n/locale-registry.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { createAppContext, withUser } from "./app.js";
+
+describe("withUser — locale re-resolution", () => {
+  test("re-resolves ctx.locale once a user is attached so user.meta.locale wins", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "fr"],
+    });
+    const baseCtx = createAppContext({
+      db: {} as never,
+      env: {},
+      request: new Request("https://cms.example/"),
+      hooks: new HookRegistry(),
+      plugins: createPluginRegistry(),
+      i18n,
+    });
+    expect(baseCtx.locale.code).toBe("en");
+
+    const authed = withUser(baseCtx, {
+      id: 1,
+      email: "u@cms.example",
+      role: "admin",
+      meta: { locale: "fr" },
+    });
+
+    expect(authed.locale.code).toBe("fr");
+  });
+});

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -3,6 +3,8 @@ export type {
   I18nInput,
   LocaleDirection,
   LocaleInput,
+  LocaleResolverOverride,
   ResolvedI18n,
   ResolvedLocale,
 } from "./locale-registry.js";
+export { resolveLocale } from "./resolve-locale.js";

--- a/packages/core/src/i18n/locale-registry.ts
+++ b/packages/core/src/i18n/locale-registry.ts
@@ -1,3 +1,5 @@
+import type { AuthenticatedUser } from "../context/app.js";
+
 export type LocaleDirection = "ltr" | "rtl";
 
 export interface LocaleInput {
@@ -10,7 +12,16 @@ export interface LocaleInput {
 export interface I18nInput {
   readonly defaultLocale: string;
   readonly locales: readonly (string | LocaleInput)[];
+  readonly resolveLocale?: LocaleResolverOverride;
 }
+
+// Escape hatch for sites that want Accept-Language detection, URL-prefix
+// routing, or any other resolution model WP doesn't do natively. Return
+// `null` to fall through; out-of-registry / disabled returns are also ignored.
+export type LocaleResolverOverride = (
+  request: Request,
+  user: AuthenticatedUser | null,
+) => ResolvedLocale | null;
 
 export interface ResolvedLocale {
   readonly code: string;
@@ -22,6 +33,7 @@ export interface ResolvedLocale {
 export interface ResolvedI18n {
   readonly defaultLocale: ResolvedLocale;
   readonly locales: readonly ResolvedLocale[];
+  readonly resolveLocale?: LocaleResolverOverride;
 }
 
 // `Intl.Locale.prototype.getTextInfo()` shipped in V8/Node/Workers but the
@@ -47,7 +59,7 @@ export function resolveLocales(input: I18nInput): ResolvedI18n {
       `plumix(): i18n.defaultLocale ${JSON.stringify(input.defaultLocale)} cannot be marked enabled:false.`,
     );
   }
-  return { defaultLocale, locales };
+  return { defaultLocale, locales, resolveLocale: input.resolveLocale };
 }
 
 function normalizeEntry(entry: string | LocaleInput): ResolvedLocale {
@@ -77,6 +89,24 @@ function canonicalize(raw: string): Intl.Locale {
 
 function canonicalizeLocaleCode(raw: string): string {
   return canonicalize(raw).toString();
+}
+
+/**
+ * Match a code from an untrusted source (user.meta, override return) against
+ * the registry. Canonicalizes the input so `"en_US"` / `"en-us"` still find
+ * an `"en-US"` entry. Returns the registry entry only if it's enabled.
+ */
+export function findEnabledLocale(
+  i18n: ResolvedI18n,
+  rawCode: string,
+): ResolvedLocale | null {
+  let code: string;
+  try {
+    code = canonicalizeLocaleCode(rawCode);
+  } catch {
+    return null;
+  }
+  return i18n.locales.find((l) => l.code === code && l.enabled) ?? null;
 }
 
 // `Intl.DisplayNames` rejects some valid BCP 47 tags its constructor doesn't

--- a/packages/core/src/i18n/resolve-locale.test.ts
+++ b/packages/core/src/i18n/resolve-locale.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "vitest";
+
+import type { AuthenticatedUser } from "../context/app.js";
+import { resolveLocales } from "./locale-registry.js";
+import { resolveLocale } from "./resolve-locale.js";
+
+const enFr = resolveLocales({
+  defaultLocale: "en",
+  locales: ["en", "fr"],
+});
+
+const REQUEST = new Request("https://cms.example/post");
+
+function user(meta: Record<string, unknown> = {}): AuthenticatedUser {
+  return { id: 1, email: "u@x", role: "admin", meta };
+}
+
+describe("resolveLocale", () => {
+  test("anonymous request returns the site defaultLocale (WP get_locale parity)", () => {
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: null,
+      i18n: enFr,
+    });
+    expect(resolved).toBe(enFr.defaultLocale);
+  });
+
+  test("override returning a registry locale short-circuits the chain", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "ar"],
+      resolveLocale: () => ({
+        code: "ar",
+        label: "Arabic",
+        direction: "rtl",
+        enabled: true,
+      }),
+    });
+
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: user({ locale: "en" }),
+      i18n,
+    });
+
+    expect(resolved.code).toBe("ar");
+  });
+
+  test("override returning null falls through to the rest of the chain", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "fr"],
+      resolveLocale: () => null,
+    });
+
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: user({ locale: "fr" }),
+      i18n,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("override returning a code not in the registry is ignored", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "fr"],
+      resolveLocale: () => ({
+        code: "de",
+        label: "German",
+        direction: "ltr",
+        enabled: true,
+      }),
+    });
+
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: user({ locale: "fr" }),
+      i18n,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("override pointing at a disabled-in-registry locale is ignored", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", { code: "fr", enabled: false }],
+      resolveLocale: () => ({
+        code: "fr",
+        label: "French",
+        direction: "ltr",
+        enabled: true,
+      }),
+    });
+
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: null,
+      i18n,
+    });
+
+    expect(resolved.code).toBe("en");
+  });
+
+  test("user.meta.locale for an unsupported code falls through to site default", () => {
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: user({ locale: "de" }),
+      i18n: enFr,
+    });
+    expect(resolved.code).toBe("en");
+  });
+
+  test("user.meta.locale pointing at a disabled locale falls through", () => {
+    const enFrDisabled = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", { code: "fr", enabled: false }],
+    });
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: user({ locale: "fr" }),
+      i18n: enFrDisabled,
+    });
+    expect(resolved.code).toBe("en");
+  });
+
+  test("user.meta.locale wins over site default (WP get_user_locale parity)", () => {
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: user({ locale: "fr" }),
+      i18n: enFr,
+    });
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("user.meta.locale canonicalizes ('en_us' matches an 'en-US' registry entry)", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en-US",
+      locales: ["en-US", "fr"],
+    });
+    const resolved = resolveLocale({
+      request: REQUEST,
+      user: user({ locale: "en_us" }),
+      i18n,
+    });
+    expect(resolved.code).toBe("en-US");
+  });
+});

--- a/packages/core/src/i18n/resolve-locale.ts
+++ b/packages/core/src/i18n/resolve-locale.ts
@@ -1,0 +1,29 @@
+import type { AuthenticatedUser } from "../context/app.js";
+import type { ResolvedI18n, ResolvedLocale } from "./locale-registry.js";
+import { findEnabledLocale } from "./locale-registry.js";
+
+interface ResolveLocaleArgs {
+  readonly request: Request;
+  readonly user: AuthenticatedUser | null;
+  readonly i18n: ResolvedI18n;
+}
+
+// WP `determine_locale()` parity: operator override → user.meta.locale →
+// site default. No cookie, no Accept-Language — those fragment public cache
+// keys; layer them back via the override slot if needed.
+export function resolveLocale({
+  request,
+  user,
+  i18n,
+}: ResolveLocaleArgs): ResolvedLocale {
+  const override = i18n.resolveLocale?.(request, user);
+  if (override) {
+    const match = findEnabledLocale(i18n, override.code);
+    if (match) return match;
+  }
+  if (typeof user?.meta.locale === "string") {
+    const match = findEnabledLocale(i18n, user.meta.locale);
+    if (match) return match;
+  }
+  return i18n.defaultLocale;
+}

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -262,6 +262,86 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain("<body>");
   });
 
+  test("public route stays on site default — Accept-Language is intentionally ignored (WP get_locale parity)", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin],
+      theme,
+      i18n: { defaultLocale: "en", locales: ["en", "ar"] },
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "cacheable",
+      title: "Cacheable",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/cacheable", {
+        headers: { "accept-language": "ar" },
+      }),
+    );
+    const body = await response.text();
+    // Site default wins — public HTML is identical for every visitor, so
+    // CDN caching by URL alone is correct without `Vary: Accept-Language`.
+    expect(body).toContain('<html lang="en" dir="ltr">');
+  });
+
+  test("authenticated visitor of a public URL still sees the site default (WP frontend vs admin split)", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin],
+      theme,
+      i18n: { defaultLocale: "en", locales: ["en", "ar"] },
+    });
+    const author = await h.seedUser("admin");
+
+    // Persist `meta.locale: "ar"` directly. The session join already
+    // surfaces it on `users.meta`; no admin RPC exists yet (slice 3 of #669).
+    const { users } = await import("../../db/schema/users.js");
+    const { eq } = await import("drizzle-orm");
+    await h.db
+      .update(users)
+      .set({ meta: { locale: "ar" } })
+      .where(eq(users.id, author.id));
+
+    await h.factory.entry.create({
+      type: "post",
+      slug: "public",
+      title: "Public",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const request = await h.authenticateRequest(
+      new Request("https://cms.example/post/public"),
+      author.id,
+    );
+    const response = await h.dispatch(request, author);
+    const body = await response.text();
+    // Even with user.meta.locale = "ar", public routes don't call
+    // `withUser`, so `ctx.locale` stays at the site default.
+    expect(body).toContain('<html lang="en" dir="ltr">');
+  });
+
   test("site's i18n defaultLocale drives <html lang dir> (RTL example)", async () => {
     const theme = defineTheme({
       templates: {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -287,7 +287,7 @@ function renderTree({
 
   const scripts = groupScriptsByPosition(document.script);
 
-  const { code, direction } = ctx.i18n.defaultLocale;
+  const { code, direction } = ctx.locale;
   const htmlAttrs = renderAttrs({
     lang: code,
     dir: direction,

--- a/packages/core/src/rpc/authenticated.ts
+++ b/packages/core/src/rpc/authenticated.ts
@@ -14,10 +14,10 @@ export const authenticated = base.middleware(
     );
     if (!result) throw errors.UNAUTHORIZED();
 
-    const { id, email, role } = result.user;
+    const { id, email, role, meta } = result.user;
     const tokenScopes = result.tokenScopes ?? null;
     return next({
-      context: withUser(context, { id, email, role }, tokenScopes),
+      context: withUser(context, { id, email, role, meta }, tokenScopes),
     });
   },
 );

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -324,9 +324,9 @@ async function dispatchPluginRawRoute(
   const result = await ctx.authenticator.authenticate(ctx.request, ctx.db);
   if (!result) return jsonResponse({ error: "unauthorized" }, { status: 401 });
 
-  const { id, email, role } = result.user;
+  const { id, email, role, meta } = result.user;
   const tokenScopes = result.tokenScopes ?? null;
-  const authedCtx = withUser(ctx, { id, email, role }, tokenScopes);
+  const authedCtx = withUser(ctx, { id, email, role, meta }, tokenScopes);
 
   if (gate === "authenticated") {
     return route.handler(authedCtx.request, authedCtx);

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -187,7 +187,7 @@ function withRequest(
     marks: app.marks,
     logger: silentLogger,
     user: user
-      ? { id: user.id, email: user.email, role: user.role }
+      ? { id: user.id, email: user.email, role: user.role, meta: user.meta }
       : undefined,
     assets,
     storage,

--- a/packages/plugins/audit-log/src/rpc.test.ts
+++ b/packages/plugins/audit-log/src/rpc.test.ts
@@ -84,7 +84,7 @@ function buildContext(role: UserRole): AppContext {
     request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
     hooks: new HookRegistry(),
     plugins: registry,
-    user: { id: user.id, email: user.email, role: user.role },
+    user: { id: user.id, email: user.email, role: user.role, meta: {} },
     authenticator: stubAuthenticator(user),
     origin: "https://cms.example",
   });

--- a/packages/plugins/audit-log/src/server/auditEvents.test.ts
+++ b/packages/plugins/audit-log/src/server/auditEvents.test.ts
@@ -113,6 +113,7 @@ const adminUser: AuthenticatedUser = {
   id: 7,
   email: "alice@example.com",
   role: "admin",
+  meta: {},
 };
 const subjectUser = {
   id: 42,

--- a/packages/plugins/audit-log/src/server/auditExtension.test.ts
+++ b/packages/plugins/audit-log/src/server/auditExtension.test.ts
@@ -64,6 +64,7 @@ const adminUser: AuthenticatedUser = {
   id: 7,
   email: "alice@example.com",
   role: "admin",
+  meta: {},
 };
 
 describe("createAuditExtension", () => {

--- a/packages/plugins/menu/src/hooks.test.ts
+++ b/packages/plugins/menu/src/hooks.test.ts
@@ -65,7 +65,7 @@ async function setup(): Promise<Bundle> {
     request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
     hooks,
     plugins: registry,
-    user: { id: user.id, email: user.email, role: user.role },
+    user: { id: user.id, email: user.email, role: user.role, meta: {} },
     authenticator: stubAuthenticator(user),
     origin: "https://cms.example",
   });

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -96,7 +96,7 @@ async function buildHarness(role: UserRole = "editor"): Promise<Harness> {
     request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
     hooks,
     plugins: registry,
-    user: { id: user.id, email: user.email, role: user.role },
+    user: { id: user.id, email: user.email, role: user.role, meta: {} },
     authenticator: stubAuthenticator(user),
     origin: "https://cms.example",
   });


### PR DESCRIPTION
Closes #671 — second slice of the i18n epic, re-scoped to match WordPress's actual `determine_locale()`. See the PRD addendum on #669 for what changed and why; PR #687 (the earlier attempt with cookie + `Accept-Language` chain) was closed for not matching WP.

**3-step chain**

```
resolveLocale(req, user, i18n):
  1. operator override (validated against the registry; out-of-list / disabled returns ignored)
  2. user.meta.locale (admin/RPC paths only via withUser re-resolve)
  3. site defaultLocale
```

No cookie. No `Accept-Language`. No 3-tier matcher. WP's `get_locale()` is site-only on the frontend; `get_user_locale()` only applies in admin / authenticated AJAX. The override slot is the seam an opt-in userland plugin uses to layer those signals back on if a deployment wants them.

**Public frontend stays on the site default → cacheable**

Identical HTML for every visitor regardless of `Accept-Language`. No `Vary` headache, no URL routing required. Held by an integration test: site `defaultLocale: "en"`, request with `Accept-Language: ar` → `<html lang="en" dir="ltr">`. A second integration test pins the same invariant for an authenticated admin with `users.meta.locale: "ar"` hitting a public URL — public routes never call `withUser`, so the user's preference doesn't leak into the frontend cache.

**Storage = `users.meta.locale` (WP `wp_usermeta` parity)**

No migration. `AuthenticatedUser` gains `readonly meta: Record<string, unknown>` so the resolver reads `user.meta.locale` without a separate DB lookup; the column was already selected by the session join. Seven construction sites updated (passkey × 2, dispatcher, RPC middleware, test dispatcher, audit-log + menu test harnesses).

**Resolves at the auth boundary**

`createAppContext` runs before auth in the Cloudflare adapter (`ctx.user` is `null`). `withUser` — called from `dispatcher.ts` (auth-gated routes) and `rpc/authenticated.ts` (RPC middleware) — re-runs `resolveLocale` once the user is known. Public-route handlers never call `withUser`, so the public path stays on the site default.

**Render contract**

Before:

```tsx
const { code, direction } = ctx.i18n.defaultLocale;
```

After:

```tsx
const { code, direction } = ctx.locale;
```

`document.html` still spreads last, so theme/template `html.lang` / `html.dir` overrides win.

**Code shape**

`resolve-locale.ts` is ~25 lines: override → user.meta.locale → default, each candidate funneled through `findEnabledLocale` which canonicalizes BCP 47 codes (`"en_us"` matches an `"en-US"` registry entry). `I18nInput` gains an optional `resolveLocale` callback; `LocaleResolverOverride` sees the real `AuthenticatedUser` so override authors can read `role` / `id`.

**Tests** (10 in `resolve-locale.test.ts`, 1 in `with-user-locale.test.ts`, 2 new in `render-template.test.tsx`)

Each chain step in isolation, override validation against the registry (out-of-list + disabled-locale both rejected), user.meta canonicalization, `withUser` re-resolve, public-route stays-on-default for anon and authed visitors.

**Admin SPA shell `<html lang dir>`**

Out of scope here — the admin's `packages/admin/index.html` is a static asset shipped through the Cloudflare ASSETS binding. A separate slice will rewrite or inject `lang/dir` from `ctx.locale` at dispatch time. Tracked in #669 follow-ups.
