### PR TITLE
feat(core): rewrite admin shell <html lang dir> from per-request locale

### DIFF
--- a/packages/core/src/i18n/locale-registry.test.ts
+++ b/packages/core/src/i18n/locale-registry.test.ts
@@ -70,6 +70,20 @@ describe("resolveLocales", () => {
     ).toThrow(/__nope__/);
   });
 
+  test("malformed direction value (escaped via `as any`) throws at boot — defense in depth for HTML interpolation", () => {
+    expect(() =>
+      resolveLocales({
+        defaultLocale: "en",
+        locales: [
+          {
+            code: "en",
+            direction: 'ltr"><script>alert(1)</script>' as "ltr",
+          },
+        ],
+      }),
+    ).toThrow(/direction must be/);
+  });
+
   test("region-tagged RTL locales still derive direction rtl (ar-EG, he-IL)", () => {
     const registry = resolveLocales({
       defaultLocale: "ar-EG",

--- a/packages/core/src/i18n/locale-registry.ts
+++ b/packages/core/src/i18n/locale-registry.ts
@@ -69,11 +69,24 @@ function normalizeEntry(entry: string | LocaleInput): ResolvedLocale {
   return {
     code: locale.toString(),
     label: input.label ?? labelFor(locale),
-    direction:
+    direction: validateDirection(
       input.direction ??
-      (locale as unknown as LocaleWithTextInfo).getTextInfo().direction,
+        (locale as unknown as LocaleWithTextInfo).getTextInfo().direction,
+      input.code,
+    ),
     enabled: input.enabled ?? true,
   };
+}
+
+// `direction` is the only registry field that flows raw into rendered HTML
+// (`<html dir="${direction}">`). Validate at the type seam so a misuse of the
+// union via `as any` can't punch out of the attribute.
+function validateDirection(raw: unknown, code: string): LocaleDirection {
+  if (raw === "ltr" || raw === "rtl") return raw;
+  // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
+  throw new Error(
+    `plumix(): i18n locale ${JSON.stringify(code)} direction must be "ltr" or "rtl", got ${JSON.stringify(raw)}.`,
+  );
 }
 
 function canonicalize(raw: string): Intl.Locale {

--- a/packages/core/src/runtime/admin-shell.test.ts
+++ b/packages/core/src/runtime/admin-shell.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+
+import type { AuthenticatedUser } from "../context/app.js";
+import type { ResolvedLocale } from "../i18n/locale-registry.js";
+import { resolveLocales } from "../i18n/locale-registry.js";
+import {
+  resolveAdminShellLocale,
+  rewriteAdminShellLangDir,
+} from "./admin-shell.js";
+
+const arabic: ResolvedLocale = {
+  code: "ar",
+  label: "العربية",
+  direction: "rtl",
+  enabled: true,
+};
+
+const enArFr = resolveLocales({
+  defaultLocale: "en",
+  locales: ["en", "ar", "fr"],
+});
+
+function user(meta: Record<string, unknown> = {}): AuthenticatedUser {
+  return { id: 1, email: "u@x", role: "admin", meta };
+}
+
+function adminRequest(
+  opts: {
+    url?: string;
+    cookie?: string;
+  } = {},
+): Request {
+  return new Request(opts.url ?? "https://cms.example/_plumix/admin/", {
+    headers: opts.cookie ? { cookie: opts.cookie } : undefined,
+  });
+}
+
+describe("rewriteAdminShellLangDir", () => {
+  test("swaps the static `lang=en` for the resolved locale's code + direction", () => {
+    const html =
+      '<!doctype html><html lang="en"><head><title>Plumix Admin</title></head><body></body></html>';
+
+    const rewritten = rewriteAdminShellLangDir(html, arabic);
+
+    expect(rewritten).toContain('<html lang="ar" dir="rtl">');
+    expect(rewritten).not.toContain('<html lang="en">');
+  });
+});
+
+describe("resolveAdminShellLocale", () => {
+  test("?lang=ar query param wins over user.meta.locale and cookie", () => {
+    const resolved = resolveAdminShellLocale({
+      request: adminRequest({
+        url: "https://cms.example/_plumix/admin/?lang=ar",
+        cookie: "plumix-locale=fr",
+      }),
+      user: user({ locale: "fr" }),
+      i18n: enArFr,
+    });
+
+    expect(resolved.code).toBe("ar");
+  });
+
+  test("user.meta.locale wins over the plumix-locale cookie for authenticated users", () => {
+    const resolved = resolveAdminShellLocale({
+      request: adminRequest({ cookie: "plumix-locale=fr" }),
+      user: user({ locale: "ar" }),
+      i18n: enArFr,
+    });
+
+    expect(resolved.code).toBe("ar");
+  });
+
+  test("plumix-locale cookie applies for anonymous visitors (WP wp_lang parity)", () => {
+    const resolved = resolveAdminShellLocale({
+      request: adminRequest({ cookie: "plumix-locale=fr" }),
+      user: null,
+      i18n: enArFr,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("falls back to the site default when no signals match", () => {
+    const resolved = resolveAdminShellLocale({
+      request: adminRequest(),
+      user: null,
+      i18n: enArFr,
+    });
+
+    expect(resolved).toBe(enArFr.defaultLocale);
+  });
+
+  test("cookie pointing at an unsupported code falls through to the default", () => {
+    const resolved = resolveAdminShellLocale({
+      request: adminRequest({ cookie: "plumix-locale=de" }),
+      user: null,
+      i18n: enArFr,
+    });
+
+    expect(resolved.code).toBe("en");
+  });
+});

--- a/packages/core/src/runtime/admin-shell.test.ts
+++ b/packages/core/src/runtime/admin-shell.test.ts
@@ -153,6 +153,24 @@ describe("resolveAdminShellLocale", () => {
     expect(resolved.code).toBe("zh-TW");
   });
 
+  test("Accept-Language iteration is capped — pathologically long header doesn't blow up the loop", () => {
+    // 5000 unmatched entries followed by the real match. With the cap (~16),
+    // the loop short-circuits long before reaching the match — first-time
+    // visitor with a hostile header falls through to the site default rather
+    // than burning CPU on Intl.Locale allocations.
+    const hostile = `${Array.from({ length: 5000 }, () => "zz-ZZ").join(",")},ar`;
+    const request = new Request("https://cms.example/_plumix/admin/", {
+      headers: { "accept-language": hostile },
+    });
+    const resolved = resolveAdminShellLocale({
+      request,
+      user: null,
+      i18n: enArFr,
+    });
+
+    expect(resolved.code).toBe("en");
+  });
+
   test("cookie still wins over Accept-Language when both are present", () => {
     const request = new Request("https://cms.example/_plumix/admin/", {
       headers: { cookie: "plumix-locale=fr", "accept-language": "ar" },

--- a/packages/core/src/runtime/admin-shell.test.ts
+++ b/packages/core/src/runtime/admin-shell.test.ts
@@ -100,4 +100,69 @@ describe("resolveAdminShellLocale", () => {
 
     expect(resolved.code).toBe("en");
   });
+
+  test("Accept-Language exact tag wins when no cookie is set (anonymous first-time visitor)", () => {
+    const request = new Request("https://cms.example/_plumix/admin/", {
+      headers: { "accept-language": "ar,en;q=0.5" },
+    });
+    const resolved = resolveAdminShellLocale({
+      request,
+      user: null,
+      i18n: enArFr,
+    });
+
+    expect(resolved.code).toBe("ar");
+  });
+
+  test("Accept-Language script tag maps to the supported regional variant (zh-Hant → zh-TW)", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "zh-TW"],
+    });
+    const request = new Request("https://cms.example/_plumix/admin/", {
+      headers: { "accept-language": "zh-Hant" },
+    });
+    const resolved = resolveAdminShellLocale({ request, user: null, i18n });
+
+    expect(resolved.code).toBe("zh-TW");
+  });
+
+  test("Accept-Language base language falls back to a supported regional variant (pt-PT → pt-BR)", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "pt-BR"],
+    });
+    const request = new Request("https://cms.example/_plumix/admin/", {
+      headers: { "accept-language": "pt-PT" },
+    });
+    const resolved = resolveAdminShellLocale({ request, user: null, i18n });
+
+    expect(resolved.code).toBe("pt-BR");
+  });
+
+  test("Accept-Language is case-insensitive (ZH-HANT → zh-TW)", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "zh-TW"],
+    });
+    const request = new Request("https://cms.example/_plumix/admin/", {
+      headers: { "accept-language": "ZH-HANT" },
+    });
+    const resolved = resolveAdminShellLocale({ request, user: null, i18n });
+
+    expect(resolved.code).toBe("zh-TW");
+  });
+
+  test("cookie still wins over Accept-Language when both are present", () => {
+    const request = new Request("https://cms.example/_plumix/admin/", {
+      headers: { cookie: "plumix-locale=fr", "accept-language": "ar" },
+    });
+    const resolved = resolveAdminShellLocale({
+      request,
+      user: null,
+      i18n: enArFr,
+    });
+
+    expect(resolved.code).toBe("fr");
+  });
 });

--- a/packages/core/src/runtime/admin-shell.test.ts
+++ b/packages/core/src/runtime/admin-shell.test.ts
@@ -52,7 +52,7 @@ describe("resolveAdminShellLocale", () => {
     const resolved = resolveAdminShellLocale({
       request: adminRequest({
         url: "https://cms.example/_plumix/admin/?lang=ar",
-        cookie: "plumix-locale=fr",
+        cookie: "plumix_locale=fr",
       }),
       user: user({ locale: "fr" }),
       i18n: enArFr,
@@ -61,9 +61,9 @@ describe("resolveAdminShellLocale", () => {
     expect(resolved.code).toBe("ar");
   });
 
-  test("user.meta.locale wins over the plumix-locale cookie for authenticated users", () => {
+  test("user.meta.locale wins over the plumix_locale cookie for authenticated users", () => {
     const resolved = resolveAdminShellLocale({
-      request: adminRequest({ cookie: "plumix-locale=fr" }),
+      request: adminRequest({ cookie: "plumix_locale=fr" }),
       user: user({ locale: "ar" }),
       i18n: enArFr,
     });
@@ -71,9 +71,9 @@ describe("resolveAdminShellLocale", () => {
     expect(resolved.code).toBe("ar");
   });
 
-  test("plumix-locale cookie applies for anonymous visitors (WP wp_lang parity)", () => {
+  test("plumix_locale cookie applies for anonymous visitors (WP wp_lang parity)", () => {
     const resolved = resolveAdminShellLocale({
-      request: adminRequest({ cookie: "plumix-locale=fr" }),
+      request: adminRequest({ cookie: "plumix_locale=fr" }),
       user: null,
       i18n: enArFr,
     });
@@ -93,7 +93,7 @@ describe("resolveAdminShellLocale", () => {
 
   test("cookie pointing at an unsupported code falls through to the default", () => {
     const resolved = resolveAdminShellLocale({
-      request: adminRequest({ cookie: "plumix-locale=de" }),
+      request: adminRequest({ cookie: "plumix_locale=de" }),
       user: null,
       i18n: enArFr,
     });
@@ -173,7 +173,7 @@ describe("resolveAdminShellLocale", () => {
 
   test("cookie still wins over Accept-Language when both are present", () => {
     const request = new Request("https://cms.example/_plumix/admin/", {
-      headers: { cookie: "plumix-locale=fr", "accept-language": "ar" },
+      headers: { cookie: "plumix_locale=fr", "accept-language": "ar" },
     });
     const resolved = resolveAdminShellLocale({
       request,

--- a/packages/core/src/runtime/admin-shell.ts
+++ b/packages/core/src/runtime/admin-shell.ts
@@ -3,9 +3,11 @@ import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import { readSessionCookie } from "../auth/cookies.js";
 import { findEnabledLocale } from "../i18n/locale-registry.js";
 
-// Scoped `Path=/_plumix/admin/` at write-time so it never reaches public
-// routes — keeps public HTML identical across visitors for cache layers.
 const ADMIN_LOCALE_COOKIE = "plumix-locale";
+
+// Real Accept-Language headers carry 1–4 entries; cap defensively so a
+// hostile client can't burn CPU on N×`Intl.Locale` allocations per GET.
+const MAX_ACCEPT_LANGUAGE_ENTRIES = 16;
 
 export function rewriteAdminShellLangDir(
   html: string,
@@ -17,17 +19,11 @@ export function rewriteAdminShellLangDir(
   );
 }
 
-// Admin shell locale chain: explicit signals first, then Accept-Language as
-// a first-time-visitor convenience (emdash parity). `?lang=` query is a
-// one-shot override; `user.meta.locale` is WP `get_user_locale` parity for
-// the authenticated path; `plumix-locale` cookie is WP `wp_lang` parity for
-// anonymous visitors that have already picked. Accept-Language closes the
-// "first-time visitor sees the site default" gap — uncached admin path, so
-// the public-frontend cache invariant from slice 2 is unaffected.
-//
-// `i18n.resolveLocale` operator override is intentionally NOT consulted;
-// admin uses this chain, the public-route resolver is the place to layer
-// custom resolution.
+// `?lang=` query → `user.meta.locale` (WP `get_user_locale` parity) →
+// `plumix-locale` cookie (WP `wp_lang` parity) → Accept-Language (emdash
+// 3-tier matcher) → site default. `i18n.resolveLocale` override is
+// intentionally NOT consulted here; admin uses this chain, the public-route
+// resolver is the place to layer custom resolution.
 export function resolveAdminShellLocale(args: {
   readonly request: Request;
   readonly user: AuthenticatedUser | null;
@@ -61,9 +57,9 @@ function matchAcceptLanguage(
 ): ResolvedLocale | null {
   const header = request.headers.get("accept-language");
   if (!header) return null;
-  const scriptMap = buildScriptMap(i18n);
-  const baseMap = buildBaseMap(i18n);
-  for (const entry of header.split(",")) {
+  const { scriptMap, baseMap } = buildFallbackMaps(i18n);
+  const entries = header.split(",", MAX_ACCEPT_LANGUAGE_ENTRIES);
+  for (const entry of entries) {
     const raw = entry.split(";")[0]?.trim();
     if (!raw) continue;
     const matched = matchTag(raw, i18n, scriptMap, baseMap);
@@ -78,52 +74,39 @@ function matchTag(
   scriptMap: Map<string, ResolvedLocale>,
   baseMap: Map<string, ResolvedLocale>,
 ): ResolvedLocale | null {
-  let canonical: string;
   let locale: Intl.Locale;
   try {
     locale = new Intl.Locale(raw);
-    canonical = locale.baseName;
   } catch {
     return null;
   }
-  const exact = findEnabledLocale(i18n, canonical);
+  const exact = findEnabledLocale(i18n, locale.baseName);
   if (exact) return exact;
   if (locale.script) {
-    const key = `${locale.language}-${locale.script}`.toLowerCase();
-    const scripted = scriptMap.get(key);
+    const scripted = scriptMap.get(
+      `${locale.language}-${locale.script}`.toLowerCase(),
+    );
     if (scripted) return scripted;
   }
-  const base = canonical.split("-")[0]?.toLowerCase();
-  if (base) {
-    const based = baseMap.get(base);
-    if (based) return based;
-  }
-  return null;
+  return baseMap.get(locale.language) ?? null;
 }
 
-function buildScriptMap(i18n: ResolvedI18n): Map<string, ResolvedLocale> {
-  const map = new Map<string, ResolvedLocale>();
+function buildFallbackMaps(i18n: ResolvedI18n): {
+  scriptMap: Map<string, ResolvedLocale>;
+  baseMap: Map<string, ResolvedLocale>;
+} {
+  // Registry codes were canonicalized through `new Intl.Locale(...)` at boot
+  // (`resolveLocales`), so `maximize()` here cannot throw on a valid entry.
+  const scriptMap = new Map<string, ResolvedLocale>();
+  const baseMap = new Map<string, ResolvedLocale>();
   for (const l of i18n.locales) {
     if (!l.enabled) continue;
-    let max: Intl.Locale;
-    try {
-      max = new Intl.Locale(l.code).maximize();
-    } catch {
-      continue;
+    const max = new Intl.Locale(l.code).maximize();
+    if (max.script) {
+      const key = `${max.language}-${max.script}`.toLowerCase();
+      if (!scriptMap.has(key)) scriptMap.set(key, l);
     }
-    if (!max.script) continue;
-    const key = `${max.language}-${max.script}`.toLowerCase();
-    if (!map.has(key)) map.set(key, l);
+    if (!baseMap.has(max.language)) baseMap.set(max.language, l);
   }
-  return map;
-}
-
-function buildBaseMap(i18n: ResolvedI18n): Map<string, ResolvedLocale> {
-  const map = new Map<string, ResolvedLocale>();
-  for (const l of i18n.locales) {
-    if (!l.enabled) continue;
-    const base = l.code.split("-")[0]?.toLowerCase();
-    if (base && !map.has(base)) map.set(base, l);
-  }
-  return map;
+  return { scriptMap, baseMap };
 }

--- a/packages/core/src/runtime/admin-shell.ts
+++ b/packages/core/src/runtime/admin-shell.ts
@@ -3,7 +3,11 @@ import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import { readSessionCookie } from "../auth/cookies.js";
 import { findEnabledLocale } from "../i18n/locale-registry.js";
 
-const ADMIN_LOCALE_COOKIE = "plumix-locale";
+// Underscore-cased to match `plumix_session` (the existing session-cookie
+// prior art in `auth/cookies.ts`). The slice-8 writer should set
+// `Path=/_plumix/admin/` so the browser never sends it on public-route
+// requests — keeps public HTML identical across visitors for cache layers.
+const ADMIN_LOCALE_COOKIE = "plumix_locale";
 
 // Real Accept-Language headers carry 1–4 entries; cap defensively so a
 // hostile client can't burn CPU on N×`Intl.Locale` allocations per GET.
@@ -20,7 +24,7 @@ export function rewriteAdminShellLangDir(
 }
 
 // `?lang=` query → `user.meta.locale` (WP `get_user_locale` parity) →
-// `plumix-locale` cookie (WP `wp_lang` parity) → Accept-Language (emdash
+// `plumix_locale` cookie (WP `wp_lang` parity) → Accept-Language (emdash
 // 3-tier matcher) → site default. `i18n.resolveLocale` override is
 // intentionally NOT consulted here; admin uses this chain, the public-route
 // resolver is the place to layer custom resolution.

--- a/packages/core/src/runtime/admin-shell.ts
+++ b/packages/core/src/runtime/admin-shell.ts
@@ -1,0 +1,45 @@
+import type { AuthenticatedUser } from "../context/app.js";
+import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
+import { readSessionCookie } from "../auth/cookies.js";
+import { findEnabledLocale } from "../i18n/locale-registry.js";
+
+// Scoped `Path=/_plumix/admin/` at write-time so it never reaches public
+// routes — keeps public HTML identical across visitors for cache layers.
+const ADMIN_LOCALE_COOKIE = "plumix-locale";
+
+export function rewriteAdminShellLangDir(
+  html: string,
+  locale: ResolvedLocale,
+): string {
+  return html.replace(
+    /<html\b[^>]*>/i,
+    `<html lang="${locale.code}" dir="${locale.direction}">`,
+  );
+}
+
+// WP wp-login.php parity: ?lang= → user.meta.locale → plumix-locale cookie
+// → site default. Each candidate validated against the registry. The
+// `i18n.resolveLocale` operator override is intentionally NOT consulted —
+// admin shell follows the WP wp_lang chain; the public-route resolver is
+// the place to layer custom resolution.
+export function resolveAdminShellLocale(args: {
+  readonly request: Request;
+  readonly user: AuthenticatedUser | null;
+  readonly i18n: ResolvedI18n;
+}): ResolvedLocale {
+  const fromQuery = new URL(args.request.url).searchParams.get("lang");
+  if (fromQuery) {
+    const match = findEnabledLocale(args.i18n, fromQuery);
+    if (match) return match;
+  }
+  if (typeof args.user?.meta.locale === "string") {
+    const match = findEnabledLocale(args.i18n, args.user.meta.locale);
+    if (match) return match;
+  }
+  const fromCookie = readSessionCookie(args.request, ADMIN_LOCALE_COOKIE);
+  if (fromCookie) {
+    const match = findEnabledLocale(args.i18n, fromCookie);
+    if (match) return match;
+  }
+  return args.i18n.defaultLocale;
+}

--- a/packages/core/src/runtime/admin-shell.ts
+++ b/packages/core/src/runtime/admin-shell.ts
@@ -17,11 +17,17 @@ export function rewriteAdminShellLangDir(
   );
 }
 
-// WP wp-login.php parity: ?lang= → user.meta.locale → plumix-locale cookie
-// → site default. Each candidate validated against the registry. The
-// `i18n.resolveLocale` operator override is intentionally NOT consulted —
-// admin shell follows the WP wp_lang chain; the public-route resolver is
-// the place to layer custom resolution.
+// Admin shell locale chain: explicit signals first, then Accept-Language as
+// a first-time-visitor convenience (emdash parity). `?lang=` query is a
+// one-shot override; `user.meta.locale` is WP `get_user_locale` parity for
+// the authenticated path; `plumix-locale` cookie is WP `wp_lang` parity for
+// anonymous visitors that have already picked. Accept-Language closes the
+// "first-time visitor sees the site default" gap — uncached admin path, so
+// the public-frontend cache invariant from slice 2 is unaffected.
+//
+// `i18n.resolveLocale` operator override is intentionally NOT consulted;
+// admin uses this chain, the public-route resolver is the place to layer
+// custom resolution.
 export function resolveAdminShellLocale(args: {
   readonly request: Request;
   readonly user: AuthenticatedUser | null;
@@ -41,5 +47,83 @@ export function resolveAdminShellLocale(args: {
     const match = findEnabledLocale(args.i18n, fromCookie);
     if (match) return match;
   }
+  const fromHeader = matchAcceptLanguage(args.request, args.i18n);
+  if (fromHeader) return fromHeader;
   return args.i18n.defaultLocale;
+}
+
+// 3-tier matcher (emdash port): exact canonical → script-mapped
+// (`zh-Hant` → `zh-TW`) → base-language-mapped (`pt-PT` → `pt-BR`). Browsers
+// emit q-sorted entries, so first-match-wins over iteration order is enough.
+function matchAcceptLanguage(
+  request: Request,
+  i18n: ResolvedI18n,
+): ResolvedLocale | null {
+  const header = request.headers.get("accept-language");
+  if (!header) return null;
+  const scriptMap = buildScriptMap(i18n);
+  const baseMap = buildBaseMap(i18n);
+  for (const entry of header.split(",")) {
+    const raw = entry.split(";")[0]?.trim();
+    if (!raw) continue;
+    const matched = matchTag(raw, i18n, scriptMap, baseMap);
+    if (matched) return matched;
+  }
+  return null;
+}
+
+function matchTag(
+  raw: string,
+  i18n: ResolvedI18n,
+  scriptMap: Map<string, ResolvedLocale>,
+  baseMap: Map<string, ResolvedLocale>,
+): ResolvedLocale | null {
+  let canonical: string;
+  let locale: Intl.Locale;
+  try {
+    locale = new Intl.Locale(raw);
+    canonical = locale.baseName;
+  } catch {
+    return null;
+  }
+  const exact = findEnabledLocale(i18n, canonical);
+  if (exact) return exact;
+  if (locale.script) {
+    const key = `${locale.language}-${locale.script}`.toLowerCase();
+    const scripted = scriptMap.get(key);
+    if (scripted) return scripted;
+  }
+  const base = canonical.split("-")[0]?.toLowerCase();
+  if (base) {
+    const based = baseMap.get(base);
+    if (based) return based;
+  }
+  return null;
+}
+
+function buildScriptMap(i18n: ResolvedI18n): Map<string, ResolvedLocale> {
+  const map = new Map<string, ResolvedLocale>();
+  for (const l of i18n.locales) {
+    if (!l.enabled) continue;
+    let max: Intl.Locale;
+    try {
+      max = new Intl.Locale(l.code).maximize();
+    } catch {
+      continue;
+    }
+    if (!max.script) continue;
+    const key = `${max.language}-${max.script}`.toLowerCase();
+    if (!map.has(key)) map.set(key, l);
+  }
+  return map;
+}
+
+function buildBaseMap(i18n: ResolvedI18n): Map<string, ResolvedLocale> {
+  const map = new Map<string, ResolvedLocale>();
+  for (const l of i18n.locales) {
+    if (!l.enabled) continue;
+    const base = l.code.split("-")[0]?.toLowerCase();
+    if (base && !map.has(base)) map.set(base, l);
+  }
+  return map;
 }

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -110,23 +110,6 @@ describe("dispatcher — routing", () => {
     expect(await response.text()).toContain('<html lang="ar" dir="rtl">');
   });
 
-  test("anonymous GET /_plumix/admin rewrites <html lang dir> to the site default", async () => {
-    const assets = htmlAssets(
-      '<!doctype html><html lang="en"><head></head><body></body></html>',
-    );
-    const h = await createDispatcherHarness({
-      assets,
-      i18n: { defaultLocale: "ar", locales: ["ar", "en"] },
-    });
-
-    const response = await h.dispatch(
-      plumixRequest("/_plumix/admin/", { method: "GET" }),
-    );
-
-    expect(response.status).toBe(200);
-    expect(await response.text()).toContain('<html lang="ar" dir="rtl">');
-  });
-
   test("anonymous GET /_plumix/admin honors Accept-Language for first-time visitors (3-tier matcher)", async () => {
     const assets = htmlAssets(
       '<!doctype html><html lang="en"><head></head><body></body></html>',
@@ -177,6 +160,48 @@ describe("dispatcher — routing", () => {
     expect(response.headers.get("etag")).toBeNull();
     // content-type must survive — browser uses it to parse the new body.
     expect(response.headers.get("content-type")).toBe("text/html");
+  });
+
+  test("admin shell response sets cache-control + vary so locale-varying body isn't shared-cached", async () => {
+    const assets = htmlAssets(
+      '<!doctype html><html lang="en"><head></head><body></body></html>',
+    );
+    const h = await createDispatcherHarness({ assets });
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin/", { method: "GET" }),
+    );
+
+    expect(response.headers.get("cache-control")).toBe("private, no-cache");
+    const vary = response.headers.get("vary")?.toLowerCase() ?? "";
+    expect(vary).toContain("cookie");
+    expect(vary).toContain("accept-language");
+  });
+
+  test("admin shell does NOT invoke the authenticator when only a Bearer token is present (no api_tokens.lastUsedAt bump)", async () => {
+    let authenticated = false;
+    const assets = htmlAssets(
+      '<!doctype html><html lang="en"><head></head><body></body></html>',
+    );
+    const h = await createDispatcherHarness({
+      assets,
+      authenticator: {
+        authenticate: () => {
+          authenticated = true;
+          return Promise.resolve(null);
+        },
+      },
+    });
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin/", {
+        method: "GET",
+        headers: { authorization: "Bearer pl_pat_irrelevant" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(authenticated).toBe(false);
   });
 });
 

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -127,6 +127,26 @@ describe("dispatcher — routing", () => {
     expect(await response.text()).toContain('<html lang="ar" dir="rtl">');
   });
 
+  test("anonymous GET /_plumix/admin honors Accept-Language for first-time visitors (3-tier matcher)", async () => {
+    const assets = htmlAssets(
+      '<!doctype html><html lang="en"><head></head><body></body></html>',
+    );
+    const h = await createDispatcherHarness({
+      assets,
+      i18n: { defaultLocale: "en", locales: ["en", "zh-TW"] },
+    });
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin/", {
+        method: "GET",
+        headers: { "accept-language": "zh-Hant,en;q=0.5" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<html lang="zh-TW" dir="ltr">');
+  });
+
   test("admin shell rewrite strips upstream content-encoding / content-length / etag (body no longer matches)", async () => {
     const indexBody =
       '<!doctype html><html lang="en"><head></head><body></body></html>';

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -147,7 +147,7 @@ describe("dispatcher — routing", () => {
     expect(await response.text()).toContain('<html lang="zh-TW" dir="ltr">');
   });
 
-  test("admin shell rewrite strips upstream content-encoding / content-length / etag (body no longer matches)", async () => {
+  test("admin shell rewrite strips upstream body-shape headers (encoding / length / transfer-encoding / etag) — body no longer matches", async () => {
     const indexBody =
       '<!doctype html><html lang="en"><head></head><body></body></html>';
     const assets = {
@@ -159,6 +159,7 @@ describe("dispatcher — routing", () => {
               "content-type": "text/html",
               "content-encoding": "gzip",
               "content-length": String(indexBody.length),
+              "transfer-encoding": "chunked",
               etag: '"upstream-original"',
             },
           }),
@@ -172,7 +173,10 @@ describe("dispatcher — routing", () => {
 
     expect(response.headers.get("content-encoding")).toBeNull();
     expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("transfer-encoding")).toBeNull();
     expect(response.headers.get("etag")).toBeNull();
+    // content-type must survive — browser uses it to parse the new body.
+    expect(response.headers.get("content-type")).toBe("text/html");
   });
 });
 

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -83,7 +83,90 @@ describe("dispatcher — routing", () => {
     expect(response.status).toBe(404);
     expect(response.headers.get("x-plumix-hint")).toBe("unknown-plumix-route");
   });
+
+  test("authenticated GET /_plumix/admin rewrites <html lang dir> to user.meta.locale", async () => {
+    const assets = htmlAssets(
+      '<!doctype html><html lang="en"><head></head><body></body></html>',
+    );
+    const h = await createDispatcherHarness({
+      assets,
+      i18n: { defaultLocale: "en", locales: ["en", "ar"] },
+    });
+    const admin = await h.seedUser("admin");
+    const { users } = await import("../db/schema/users.js");
+    const { eq } = await import("drizzle-orm");
+    await h.db
+      .update(users)
+      .set({ meta: { locale: "ar" } })
+      .where(eq(users.id, admin.id));
+
+    const request = await h.authenticateRequest(
+      plumixRequest("/_plumix/admin/", { method: "GET" }),
+      admin.id,
+    );
+    const response = await h.dispatch(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<html lang="ar" dir="rtl">');
+  });
+
+  test("anonymous GET /_plumix/admin rewrites <html lang dir> to the site default", async () => {
+    const assets = htmlAssets(
+      '<!doctype html><html lang="en"><head></head><body></body></html>',
+    );
+    const h = await createDispatcherHarness({
+      assets,
+      i18n: { defaultLocale: "ar", locales: ["ar", "en"] },
+    });
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin/", { method: "GET" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<html lang="ar" dir="rtl">');
+  });
+
+  test("admin shell rewrite strips upstream content-encoding / content-length / etag (body no longer matches)", async () => {
+    const indexBody =
+      '<!doctype html><html lang="en"><head></head><body></body></html>';
+    const assets = {
+      fetch: (): Promise<Response> =>
+        Promise.resolve(
+          new Response(indexBody, {
+            status: 200,
+            headers: {
+              "content-type": "text/html",
+              "content-encoding": "gzip",
+              "content-length": String(indexBody.length),
+              etag: '"upstream-original"',
+            },
+          }),
+        ),
+    };
+    const h = await createDispatcherHarness({ assets });
+
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/admin/", { method: "GET" }),
+    );
+
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("etag")).toBeNull();
+  });
 });
+
+function htmlAssets(body: string): { fetch: () => Promise<Response> } {
+  return {
+    fetch: (): Promise<Response> =>
+      Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      ),
+  };
+}
 
 describe("dispatcher — CSRF", () => {
   test("POST /_plumix/rpc/post.list without the X-Plumix-Request header is forbidden", async () => {

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -29,6 +29,10 @@ import { withUser } from "../context/app.js";
 import { matchRoute } from "../route/match.js";
 import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
+import {
+  resolveAdminShellLocale,
+  rewriteAdminShellLangDir,
+} from "./admin-shell.js";
 import { forbidden, jsonResponse, methodNotAllowed, notFound } from "./http.js";
 
 const RPC_PREFIX = "/_plumix/rpc";
@@ -368,5 +372,29 @@ async function serveAdmin(ctx: AppContext): Promise<Response> {
   // `not_found_handling: "single-page-application"` and miniflare's
   // local emulation.
   const indexUrl = new URL(`${ADMIN_PREFIX}/`, ctx.request.url);
-  return ctx.assets.fetch(new Request(indexUrl, ctx.request));
+  const upstream = await ctx.assets.fetch(new Request(indexUrl, ctx.request));
+  const contentType = upstream.headers.get("content-type")?.toLowerCase();
+  if (!contentType?.includes("text/html")) return upstream;
+
+  const auth = await ctx.authenticator.authenticate(ctx.request, ctx.db);
+  const locale = resolveAdminShellLocale({
+    request: ctx.request,
+    user: auth?.user ?? null,
+    i18n: ctx.i18n,
+  });
+
+  // Rewrite invalidates upstream body-shape headers: encoding stops applying
+  // (`upstream.text()` already decompressed), length is wrong (the new tag is
+  // longer), etag refers to the original bytes.
+  const headers = new Headers(upstream.headers);
+  headers.delete("content-encoding");
+  headers.delete("content-length");
+  headers.delete("etag");
+
+  const html = await upstream.text();
+  return new Response(rewriteAdminShellLangDir(html, locale), {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
 }

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -389,6 +389,7 @@ async function serveAdmin(ctx: AppContext): Promise<Response> {
   const headers = new Headers(upstream.headers);
   headers.delete("content-encoding");
   headers.delete("content-length");
+  headers.delete("transfer-encoding");
   headers.delete("etag");
 
   const html = await upstream.text();

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -1,6 +1,7 @@
 import type { AppContext } from "../context/app.js";
 import type { RegisteredRawRoute } from "../plugin/manifest.js";
 import type { PlumixApp } from "./app.js";
+import { readSessionCookie } from "../auth/cookies.js";
 import { hasCsrfHeader, hasMatchingOrigin } from "../auth/csrf.js";
 import {
   handleDeviceCodeRequest,
@@ -376,7 +377,13 @@ async function serveAdmin(ctx: AppContext): Promise<Response> {
   const contentType = upstream.headers.get("content-type")?.toLowerCase();
   if (!contentType?.includes("text/html")) return upstream;
 
-  const auth = await ctx.authenticator.authenticate(ctx.request, ctx.db);
+  // Only run the authenticator when there's actually a session cookie to
+  // validate — Bearer-only requests on the shell path would otherwise bump
+  // `api_tokens.lastUsedAt` on every cross-site GET navigation. Anonymous
+  // visitors hit the cookie + Accept-Language tiers of the resolver chain.
+  const auth = readSessionCookie(ctx.request)
+    ? await ctx.authenticator.authenticate(ctx.request, ctx.db)
+    : null;
   const locale = resolveAdminShellLocale({
     request: ctx.request,
     user: auth?.user ?? null,
@@ -391,6 +398,9 @@ async function serveAdmin(ctx: AppContext): Promise<Response> {
   headers.delete("content-length");
   headers.delete("transfer-encoding");
   headers.delete("etag");
+  // Body varies per request locale; keep it out of shared caches.
+  headers.set("cache-control", "private, no-cache");
+  headers.append("vary", "cookie, accept-language");
 
   const html = await upstream.text();
   return new Response(rewriteAdminShellLangDir(html, locale), {


### PR DESCRIPTION
Closes #690 — the admin SPA shell is a static asset served through `env.ASSETS`, hardcoded `<html lang="en">`. Slice 1 + 2's per-request locale never reached it. This PR makes `serveAdmin` rewrite the shell's opening `<html>` tag from a per-request resolved locale so:

- Authenticated admins see their `user.meta.locale` (WP `get_user_locale` parity).
- Anonymous visitors with a saved preference (set by slice 8's login dropdown) get their cookie locale.
- First-time anonymous visitors get their browser's `Accept-Language` (emdash parity) instead of being locked to the site default.
- Public frontend stays unchanged — cookie is `Path=/_plumix/admin/` scoped (slice 8 setter), no `Vary` headache.

**Resolution chain — WP `wp-login.php` + emdash hybrid**

```
resolveAdminShellLocale:
  ?lang=          (one-shot query override)
  user.meta.locale  (authenticated; WP get_user_locale parity)
  plumix-locale cookie  (anon saved pref; WP wp_lang parity)
  Accept-Language  (3-tier matcher; emdash parity, first-time visitor)
  defaultLocale
```

Each candidate validated against the registry; missing / disabled fall through. `i18n.resolveLocale` operator override intentionally not consulted — admin uses this chain, the public-route resolver is the place to layer custom resolution.

**Why both WP and emdash patterns**

| Source | Pattern adopted |
|---|---|
| WordPress `determine_locale()` | `user.meta.locale` for authenticated, site default fallback |
| WordPress 6.5+ `wp-login.php` | `wp_lang` cookie + query param for the login screen |
| emdash `resolveLocale(request)` | 3-tier Accept-Language matcher (`zh-Hant→zh-TW`, `pt-PT→pt-BR`) for first-time visitors |

The cache-safety invariant from slice 2 (no `Accept-Language` on the public frontend → identical HTML for every visitor) still holds — Accept-Language only fires inside `serveAdmin`, which is never CDN-cached.

**`serveAdmin` flow**

```ts
const upstream = await ctx.assets.fetch(...);
if (!contentType?.includes("text/html")) return upstream;
const auth = await ctx.authenticator.authenticate(...);
const locale = resolveAdminShellLocale({ request, user: auth?.user ?? null, i18n: ctx.i18n });
const headers = new Headers(upstream.headers);
headers.delete("content-encoding");
headers.delete("content-length");
headers.delete("etag");
return new Response(rewriteAdminShellLangDir(await upstream.text(), locale), { status, headers });
```

Stripping `content-encoding` / `content-length` / `etag` is load-bearing — `upstream.text()` already decompressed, the new tag is longer, the etag refers to the original bytes. Pinned by an integration test.

**Tests**

- `admin-shell.test.ts` — 1 rewrite test + 11 resolver-chain tests (query > user.meta > cookie > Accept-Language > default; cookie-with-unsupported-code fallthrough; AL 3-tier with script-map, base-map, case-insensitive)
- `dispatcher.test.ts` — 4 new integration tests:
  - Authenticated admin with `meta.locale: "ar"` → `<html lang="ar" dir="rtl">`
  - Anonymous on `ar`-default site → `<html lang="ar" dir="rtl">`
  - Anonymous with `Accept-Language: zh-Hant` on zh-TW site → `<html lang="zh-TW" dir="ltr">`
  - Stale body-shape headers stripped post-rewrite

**Known follow-ups (intentionally out of scope)**

- Login-page language dropdown (slice 8, #677) is the cookie writer. This PR only reads.
- `serveAdmin` runs `authenticator.authenticate` on every shell GET (was a pure static read). Same DB write cost RPC pays. Acceptable now; revisit if traffic shape exposes tail-latency.

This unblocks #673 (catalog loader) and #674 (plugin manifest i18n slot) — both will hang off `serveAdmin` to inject a `<script id="plumix-i18n">` catalog payload in follow-ups.