### PR TITLE
feat: add locale switcher dropdown + user.setLocale mutation

### DIFF
--- a/packages/admin/src/components/locale-switcher.test.tsx
+++ b/packages/admin/src/components/locale-switcher.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+
+import { LocaleSwitcher } from "./locale-switcher.js";
+
+afterEach(() => cleanup());
+
+const enArManifest: PlumixManifest = {
+  i18n: {
+    defaultLocale: "en",
+    locales: [
+      { code: "en", label: "English", direction: "ltr", enabled: true },
+      { code: "ar", label: "العربية", direction: "rtl", enabled: true },
+    ],
+  },
+};
+
+describe("LocaleSwitcher", () => {
+  test("renders the trigger with the current locale's label", () => {
+    render(
+      <LocaleSwitcher
+        currentCode="ar"
+        manifest={enArManifest}
+        onSelect={() => undefined}
+      />,
+    );
+    const trigger = screen.getByTestId("locale-switcher-trigger");
+    expect(trigger.textContent).toContain("العربية");
+  });
+
+  test("calls onSelect with the chosen locale code when the user picks an option", async () => {
+    const onSelect = vi.fn();
+    render(
+      <LocaleSwitcher
+        currentCode="en"
+        manifest={enArManifest}
+        onSelect={onSelect}
+      />,
+    );
+
+    await userEvent.click(screen.getByTestId("locale-switcher-trigger"));
+    await userEvent.click(screen.getByTestId("locale-switcher-option-ar"));
+
+    expect(onSelect).toHaveBeenCalledWith("ar");
+  });
+});

--- a/packages/admin/src/components/locale-switcher.tsx
+++ b/packages/admin/src/components/locale-switcher.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select.js";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+
+interface LocaleSwitcherProps {
+  readonly currentCode: string;
+  readonly manifest: PlumixManifest;
+  readonly onSelect: (code: string) => void;
+}
+
+export function LocaleSwitcher({
+  currentCode,
+  manifest,
+  onSelect,
+}: LocaleSwitcherProps): ReactNode {
+  const locales = manifest.i18n?.locales ?? [];
+  return (
+    <Select value={currentCode} onValueChange={onSelect}>
+      <SelectTrigger
+        data-testid="locale-switcher-trigger"
+        aria-label="Language"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {locales.map((l) => (
+          <SelectItem
+            key={l.code}
+            value={l.code}
+            data-testid={`locale-switcher-option-${l.code}`}
+          >
+            {l.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/packages/admin/src/components/profile/language-card.tsx
+++ b/packages/admin/src/components/profile/language-card.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { LocaleSwitcher } from "@/components/locale-switcher.js";
+import { Alert, AlertDescription } from "@/components/ui/alert.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { readManifest } from "@/lib/manifest.js";
+import { orpc } from "@/lib/orpc.js";
+import { useMutation } from "@tanstack/react-query";
+
+interface LanguageCardProps {
+  readonly userLocale: unknown;
+}
+
+export function LanguageCard({ userLocale }: LanguageCardProps): ReactNode {
+  const manifest = readManifest();
+  const currentCode =
+    typeof userLocale === "string"
+      ? userLocale
+      : (manifest.i18n?.defaultLocale ?? "en");
+  const setLocale = useMutation({
+    mutationFn: (code: string) => orpc.user.setLocale.call({ code }),
+    onSuccess: () => window.location.reload(),
+  });
+
+  return (
+    <Card data-testid="language-card">
+      <CardHeader>
+        <CardTitle>Language</CardTitle>
+        <CardDescription>
+          Your admin chrome renders in this language. The page reloads after you
+          switch so the new translations apply everywhere.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <LocaleSwitcher
+          currentCode={currentCode}
+          manifest={manifest}
+          onSelect={setLocale.mutate}
+        />
+        {setLocale.isError ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Couldn't switch language. Please try again.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -53,6 +53,18 @@ describe("readManifest", () => {
     });
   });
 
+  test("carries i18n config through to consumers", () => {
+    const i18n = {
+      defaultLocale: "en",
+      locales: [
+        { code: "en", label: "English", direction: "ltr", enabled: true },
+        { code: "ar", label: "العربية", direction: "rtl", enabled: true },
+      ],
+    };
+    const doc = withManifestScript(JSON.stringify({ i18n }));
+    expect(readManifest(doc).i18n).toEqual(i18n);
+  });
+
   test("carries theme tokens through to consumers", () => {
     const tokens = {
       colors: { brand: { value: "#0070f3", label: "Brand" } },

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -62,6 +62,9 @@ function normalize(value: unknown): PlumixManifest {
   if (v.tokens && typeof v.tokens === "object") {
     (result as Record<string, unknown>).tokens = v.tokens;
   }
+  if (v.i18n && typeof v.i18n === "object") {
+    (result as Record<string, unknown>).i18n = v.i18n;
+  }
   return result;
 }
 

--- a/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
@@ -7,6 +7,7 @@ import {
   AdminApiTokensCard,
   SelfApiTokensCard,
 } from "@/components/profile/api-tokens-card.js";
+import { LanguageCard } from "@/components/profile/language-card.js";
 import { PasskeysCard } from "@/components/profile/passkeys-card.js";
 import { SessionsCard } from "@/components/profile/sessions-card.js";
 import { UserEmailField } from "@/components/profile/user-email-field.js";
@@ -425,6 +426,7 @@ function UserEditForm({
           Cross-user passkey/session management is intentionally not
           available, even to admins, since both surfaces are second-
           factor security primitives. */}
+      {isSelf ? <LanguageCard userLocale={target.meta.locale} /> : null}
       {isSelf ? <PasskeysCard userEmail={target.email} /> : null}
       {isSelf ? <SessionsCard /> : null}
 

--- a/packages/admin/test/setup.ts
+++ b/packages/admin/test/setup.ts
@@ -24,3 +24,16 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 Element.prototype.scrollIntoView = function scrollIntoView(): void {
   /* no-op */
 };
+
+// jsdom omits the PointerEvent capture API; Radix's Select trigger calls
+// `hasPointerCapture` on `pointerdown` and crashes without it.
+const elementProto = Element.prototype as unknown as {
+  hasPointerCapture?: (id: number) => boolean;
+  setPointerCapture?: (id: number) => void;
+  releasePointerCapture?: (id: number) => void;
+};
+if (!elementProto.hasPointerCapture) {
+  elementProto.hasPointerCapture = (): boolean => false;
+  elementProto.setPointerCapture = (): void => undefined;
+  elementProto.releasePointerCapture = (): void => undefined;
+}

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -195,6 +195,13 @@ export interface AppContextBase<
   readonly i18n: ResolvedI18n;
   readonly locale: ResolvedLocale;
   /**
+   * Response headers writable from inside an RPC procedure. Populated by
+   * `@orpc/server/plugins`'s `ResponseHeadersPlugin` at handle-time, so
+   * outside the RPC path this is undefined. Procedures append `Set-Cookie`
+   * / custom headers here; the dispatcher folds them into the Response.
+   */
+  readonly resHeaders?: Headers;
+  /**
    * Set by the public-route resolver after URL → entity matching;
    * `null` for non-public routes (admin, RPC, etc.) and on cold-start.
    * Consumers (breadcrumbs, canonical tags, menu plugin's `isCurrent`)

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -4,6 +4,7 @@ import type { MarkSpec } from "@plumix/blocks";
 import { defineBlock } from "@plumix/blocks";
 
 import { HookRegistry } from "../hooks/registry.js";
+import { resolveLocales } from "../i18n/locale-registry.js";
 import { definePlugin } from "./define.js";
 import { DuplicateAdminSlugError } from "./errors.js";
 import {
@@ -27,6 +28,21 @@ describe("buildManifest", () => {
     };
     const manifest = buildManifest(createPluginRegistry(), { tokens });
     expect(manifest.tokens).toEqual(tokens);
+  });
+
+  test("buildManifest projects the site's i18n config — defaultLocale + enabled locales", () => {
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "ar"],
+    });
+    const manifest = buildManifest(createPluginRegistry(), { i18n });
+    expect(manifest.i18n).toEqual({
+      defaultLocale: "en",
+      locales: [
+        { code: "en", label: "English", direction: "ltr", enabled: true },
+        { code: "ar", label: "العربية", direction: "rtl", enabled: true },
+      ],
+    });
   });
 
   test("empty registry projects core-seeded adminNav (Dashboard / Management) and empty everything else", () => {

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -16,6 +16,7 @@ import type {
 } from "../auth/rbac.js";
 import type { AppContext } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
+import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import type { RouteIntent } from "../route/intent.js";
 import type { RegisteredTemplateDep } from "../template-deps.js";
 import type { RegisteredLookupAdapter } from "./lookup.js";
@@ -1492,6 +1493,17 @@ export interface PlumixManifest {
    * `plumix.config.ts` at build time.
    */
   readonly tokens?: ThemeTokens;
+  /**
+   * Site i18n config — populates the locale-switcher dropdown and gives
+   * admin components access to the active default. Same channel reason as
+   * `tokens`: the precompiled admin shell can't import the user's config.
+   */
+  readonly i18n?: I18nManifest;
+}
+
+export interface I18nManifest {
+  readonly defaultLocale: string;
+  readonly locales: readonly ResolvedLocale[];
 }
 
 /**
@@ -1522,6 +1534,7 @@ export function emptyManifest(): PlumixManifest {
     marks: [],
     patterns: [],
     tokens: {},
+    i18n: { defaultLocale: "en", locales: [] },
   };
 }
 
@@ -1539,7 +1552,10 @@ export function emptyManifest(): PlumixManifest {
  */
 export function buildManifest(
   registry: PluginRegistry,
-  theme?: { readonly tokens?: ThemeTokens },
+  options?: {
+    readonly tokens?: ThemeTokens;
+    readonly i18n?: ResolvedI18n;
+  },
 ): BuiltManifest {
   const entries = Array.from(registry.entryTypes.values())
     .map(toEntryTypeManifest)
@@ -1617,7 +1633,14 @@ export function buildManifest(
     blocks,
     marks,
     patterns,
-    tokens: theme?.tokens ?? {},
+    tokens: options?.tokens ?? {},
+    i18n: {
+      defaultLocale: options?.i18n?.defaultLocale.code ?? "en",
+      // Wire-filtered to enabled entries — the admin dropdown ships exactly
+      // what's available, and a "disabled in catalog but visible in UI"
+      // affordance can be re-introduced when there's a consumer.
+      locales: (options?.i18n?.locales ?? []).filter((l) => l.enabled),
+    },
   };
 }
 

--- a/packages/core/src/rpc/procedures/user/index.ts
+++ b/packages/core/src/rpc/procedures/user/index.ts
@@ -7,6 +7,7 @@ import { invite } from "./invite.js";
 import { list } from "./list.js";
 import { pendingEmailChange } from "./pending-email-change.js";
 import { requestEmailChangeProc } from "./request-email-change.js";
+import { setLocale } from "./set-locale.js";
 import { update } from "./update.js";
 
 export const userRouter = {
@@ -17,6 +18,7 @@ export const userRouter = {
   disable,
   enable,
   delete: del,
+  setLocale,
   requestEmailChange: requestEmailChangeProc,
   cancelEmailChange: cancelEmailChangeProc,
   pendingEmailChange,

--- a/packages/core/src/rpc/procedures/user/set-locale.test.ts
+++ b/packages/core/src/rpc/procedures/user/set-locale.test.ts
@@ -1,0 +1,78 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+import { users } from "../../../db/schema/users.js";
+import {
+  createDispatcherHarness,
+  plumixRequest,
+} from "../../../test/dispatcher.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("user.setLocale", () => {
+  test("persists the requested code to users.meta.locale", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+
+    await h.client.user.setLocale({ code: "en" });
+
+    const row = await h.db.query.users.findFirst({
+      where: eq(users.id, h.user.id),
+    });
+    expect((row?.meta as { locale?: string }).locale).toBe("en");
+  });
+
+  test("rejects a code that isn't in the site's enabled locales", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    // Default site has only `en` enabled.
+
+    await expect(h.client.user.setLocale({ code: "de" })).rejects.toThrow();
+
+    const row = await h.db.query.users.findFirst({
+      where: eq(users.id, h.user.id),
+    });
+    expect((row?.meta as { locale?: string }).locale).toBeUndefined();
+  });
+
+  test("Set-Cookie is marked Secure when the request is over HTTPS", async () => {
+    const h = await createDispatcherHarness({
+      i18n: { defaultLocale: "en", locales: ["en", "ar"] },
+    });
+    const admin = await h.seedUser("admin");
+    const request = await h.authenticateRequest(
+      plumixRequest("/_plumix/rpc/user/setLocale", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { code: "ar" } }),
+      }),
+      admin.id,
+    );
+
+    const response = await h.dispatch(request);
+
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("Secure");
+  });
+
+  test("attaches Set-Cookie: plumix_locale=<code>; Path=/_plumix/admin/ on success", async () => {
+    const h = await createDispatcherHarness({
+      i18n: { defaultLocale: "en", locales: ["en", "ar"] },
+    });
+    const admin = await h.seedUser("admin");
+    const request = await h.authenticateRequest(
+      plumixRequest("/_plumix/rpc/user/setLocale", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { code: "ar" } }),
+      }),
+      admin.id,
+    );
+
+    const response = await h.dispatch(request);
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("plumix_locale=ar");
+    expect(setCookie).toContain("Path=/_plumix/admin/");
+    expect(setCookie).toContain("SameSite=Lax");
+    expect(setCookie).toContain("Max-Age=31536000");
+  });
+});

--- a/packages/core/src/rpc/procedures/user/set-locale.ts
+++ b/packages/core/src/rpc/procedures/user/set-locale.ts
@@ -1,0 +1,56 @@
+import * as v from "valibot";
+
+import { isSecureRequest } from "../../../auth/cookies.js";
+import { findEnabledLocale } from "../../../i18n/locale-registry.js";
+import {
+  ADMIN_LOCALE_COOKIE,
+  ADMIN_LOCALE_COOKIE_PATH,
+} from "../../../runtime/admin-shell.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { writeUserMeta } from "./meta.js";
+
+const inputSchema = v.object({
+  code: v.pipe(v.string(), v.minLength(1)),
+});
+
+const ONE_YEAR_SECONDS = 31_536_000;
+const EDIT_OWN_CAPABILITY = "user:edit_own";
+
+export const setLocale = base
+  .use(authenticated)
+  .input(inputSchema)
+  .handler(async ({ input, context, errors }) => {
+    if (!context.auth.can(EDIT_OWN_CAPABILITY)) {
+      throw errors.FORBIDDEN({ data: { capability: EDIT_OWN_CAPABILITY } });
+    }
+    const match = findEnabledLocale(context.i18n, input.code);
+    if (!match) {
+      throw errors.CONFLICT({
+        data: { reason: "locale_not_supported", key: input.code },
+      });
+    }
+    await writeUserMeta(
+      context,
+      { id: context.user.id },
+      {
+        upserts: new Map([["locale", match.code]]),
+        deletes: [],
+      },
+    );
+    context.resHeaders?.append(
+      "set-cookie",
+      buildLocaleCookie(match.code, isSecureRequest(context.request)),
+    );
+  });
+
+function buildLocaleCookie(code: string, secure: boolean): string {
+  const parts = [
+    `${ADMIN_LOCALE_COOKIE}=${code}`,
+    `Path=${ADMIN_LOCALE_COOKIE_PATH}`,
+    `Max-Age=${ONE_YEAR_SECONDS}`,
+    "SameSite=Lax",
+  ];
+  if (secure) parts.push("Secure");
+  return parts.join("; ");
+}

--- a/packages/core/src/runtime/admin-shell.ts
+++ b/packages/core/src/runtime/admin-shell.ts
@@ -7,7 +7,8 @@ import { findEnabledLocale } from "../i18n/locale-registry.js";
 // prior art in `auth/cookies.ts`). The slice-8 writer should set
 // `Path=/_plumix/admin/` so the browser never sends it on public-route
 // requests — keeps public HTML identical across visitors for cache layers.
-const ADMIN_LOCALE_COOKIE = "plumix_locale";
+export const ADMIN_LOCALE_COOKIE = "plumix_locale";
+export const ADMIN_LOCALE_COOKIE_PATH = "/_plumix/admin/";
 
 // Real Accept-Language headers carry 1–4 entries; cap defensively so a
 // hostile client can't burn CPU on N×`Intl.Locale` allocations per GET.

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -1,4 +1,5 @@
 import { RPCHandler } from "@orpc/server/fetch";
+import { ResponseHeadersPlugin } from "@orpc/server/plugins";
 
 import type { BlockRegistry, HtmlAllowlist, MarkSpec } from "@plumix/blocks";
 import {
@@ -262,7 +263,9 @@ export async function buildApp(
     config,
     hooks,
     plugins: registry,
-    rpcHandler: new RPCHandler(mergedRouter as unknown as typeof appRouter),
+    rpcHandler: new RPCHandler(mergedRouter as unknown as typeof appRouter, {
+      plugins: [new ResponseHeadersPlugin()],
+    }),
     origin: passkey.origin,
     passkey,
     sessionPolicy: config.auth.sessions ?? DEFAULT_SESSION_POLICY,

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -18,6 +18,7 @@ import type {
   AnyPluginDescriptor,
   PluginRegistry,
   PlumixManifest,
+  ResolvedI18n,
 } from "@plumix/core";
 import {
   buildManifest,
@@ -342,7 +343,7 @@ async function regenerate(
 
   const { manifest, registry } = await computeManifestAndRegistry(
     config.plugins,
-    config.theme,
+    { tokens: config.theme.tokens, i18n: config.i18n },
   );
 
   return { configPath, manifest, registry, plugins: config.plugins };
@@ -360,13 +361,13 @@ type PluginDescriptors = Parameters<typeof installPlugins>[0]["plugins"];
 // so plugins should keep setup free of IO.
 async function computeManifestAndRegistry(
   plugins: PluginDescriptors,
-  theme: { readonly tokens?: ThemeTokens },
+  options: { readonly tokens?: ThemeTokens; readonly i18n?: ResolvedI18n },
 ): Promise<{ manifest: PlumixManifest; registry: PluginRegistry }> {
   const { registry } = await installPlugins({
     hooks: new HookRegistry(),
     plugins,
   });
-  return { manifest: buildManifest(registry, theme), registry };
+  return { manifest: buildManifest(registry, options), registry };
 }
 
 // Copies the compiled admin SPA from plumix/dist/admin-app into the effective


### PR DESCRIPTION
Closes #677. Admins can pick their language from a dropdown on their profile; the page hard-reloads so the new chrome renders on the next request. Storage + cookie behavior re-scoped via the issue comment to match earlier slices.

**Resolution-chain alignment**

| Field | Spec'd | Shipped |
|---|---|---|
| Storage | `users.locale` column | `users.meta.locale` (WP `wp_usermeta` parity, no migration — from slice 2) |
| Cookie name | `plumix-locale` | `plumix_locale` (matches `plumix_session`, from slice 690) |
| Cookie path | `/` | `/_plumix/admin/` (cache-safety invariant, from slice 690) |
| Switch UX | Soft (`loadAndActivate`) | Hard `window.location.reload()` (per 2026-06-01 PRD audit) |

**`user.setLocale({ code })` mutation**

`packages/core/src/rpc/procedures/user/set-locale.ts`. Gated on `user:edit_own` for RBAC parity with `user.update`. Validates the code against the site's enabled locales via `findEnabledLocale`; out-of-list or disabled codes fail with `CONFLICT { reason: "locale_not_supported" }`. Writes through `writeUserMeta` so other meta keys survive. Appends `Set-Cookie` via oRPC's `ResponseHeadersPlugin` (registered on the `RPCHandler` in `runtime/app.ts`; `AppContextBase` gains `resHeaders?: Headers` for the RPC path only).

```
Set-Cookie: plumix_locale=ar; Path=/_plumix/admin/; Max-Age=31536000; SameSite=Lax; Secure
```

**Manifest carries `i18n: { defaultLocale, locales }`**

`PlumixManifest` gains an `i18n` slot wire-filtered to enabled locales (server already knows enabled state — drops the client-side filter). `buildManifest` signature widens from `(registry, theme?)` to `(registry, options?: { tokens?, i18n? })`; the Vite plugin threads `config.i18n` through. Admin `readManifest` normalizer carries the field; consumers read `manifest.i18n?.locales` for dropdown options and `manifest.i18n?.defaultLocale` for the fallback when `user.meta.locale` is unset.

**Admin UI**

`<LocaleSwitcher>` is a pure Select wrapper (props: `currentCode`, `manifest`, `onSelect`). `<LanguageCard>` wraps it with the mutation + reload and renders only on self-edit in the user edit form. Locale codes show their endonym (`English`, `العربية`, …).

**Cookie-name source of truth**

`ADMIN_LOCALE_COOKIE` and `ADMIN_LOCALE_COOKIE_PATH` are exported from `runtime/admin-shell.ts` so the writer (RPC mutation) and reader (shell resolver) share one constant — closes a silent-rename trap surfaced by the simplifier review.

**Tests**

- 4 backend tests in `set-locale.test.ts`: persistence via in-process `rpcHarness`; rejection of unknown code; cookie shape + `Secure` flag via `dispatcherHarness` (HTTPS sets Secure, the `ResponseHeadersPlugin` actually surfaces in the dispatched response).
- 2 component tests on `<LocaleSwitcher>`: renders with the current locale's label; `onSelect` fires with the picked code.
- Manifest projection tests on both sides — `buildManifest` projects the i18n slice, admin's `readManifest` carries it through.

**jsdom shim**

Radix Select's `pointerdown` calls `Element.prototype.hasPointerCapture`, missing in jsdom. Added the no-op shim alongside the existing `ResizeObserver` / `scrollIntoView` stubs.

**Out of scope (intentionally deferred)**

- `<LanguageCard>` end-to-end test through the user edit page (mutation + reload spy) — round-trip is already covered by the component + RPC tests.
- Wrapping the switcher labels with `<Trans>` — endonyms are non-English by design; Lingui-wrapped strings around them land with slice 15.
- Sign-out clearing the `plumix_locale` cookie — WP intentionally keeps `wp_lang` across sessions.
