### PR TITLE
feat(admin): wrap shell + dashboard + login + profile chrome i18n

### DIFF
--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -8,6 +8,158 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.dashboard"
+msgstr "Übersicht"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.entries"
+msgstr "Einträge"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.terms"
+msgstr "Begriffe"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.users"
+msgstr "Benutzer"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.settings"
+msgstr "Einstellungen"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.profile"
+msgstr "Profil"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.admin"
+msgstr "Verwaltung"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.create"
+msgstr "Erstellen"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.edit"
+msgstr "Bearbeiten"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.addNew"
+msgstr "Neu hinzufügen"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.editUser"
+msgstr "Benutzer bearbeiten"
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.welcome"
+msgstr "Willkommen, {greeting}"
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.tagline"
+msgstr "Woran möchten Sie heute arbeiten?"
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.tile.description"
+msgstr "{labelLower} schreiben, bearbeiten und veröffentlichen."
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.tile.browse"
+msgstr "{labelLower} durchsuchen"
+
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.title"
 msgstr "Noch keine Inhaltstypen"
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.empty.description"
+msgstr "Fügen Sie ein Plugin hinzu, das einen Beitragstyp registriert (z. B. <0>@plumix/plugin-blog</0>), damit dieser hier erscheint."
+
+#: src/components/shell/user-menu.tsx
+msgid "menu.profile"
+msgstr "Profil"
+
+#: src/components/shell/user-menu.tsx
+msgid "menu.settings"
+msgstr "Einstellungen"
+
+#: src/components/shell/user-menu.tsx
+msgid "menu.signOut"
+msgstr "Abmelden"
+
+#: src/components/shell/user-menu.tsx
+msgid "menu.signOut.pending"
+msgstr "Wird abgemeldet…"
+
+#: src/components/locale-switcher.tsx
+msgid "profile.language.aria"
+msgstr "Sprache"
+
+#: src/components/profile/language-card.tsx
+msgid "profile.language.title"
+msgstr "Sprache"
+
+#: src/components/profile/language-card.tsx
+msgid "profile.language.description"
+msgstr "Die Admin-Oberfläche wird in dieser Sprache angezeigt. Die Seite lädt nach dem Wechsel neu, damit die neuen Übersetzungen überall greifen."
+
+#: src/components/profile/language-card.tsx
+msgid "profile.language.error"
+msgstr "Sprache konnte nicht gewechselt werden. Bitte erneut versuchen."
+
+#: src/routes/_auth/login.tsx
+msgid "login.title"
+msgstr "Anmelden"
+
+#: src/routes/_auth/login.tsx
+msgid "login.description"
+msgstr "Verwenden Sie einen Passkey, lassen Sie sich einen einmaligen Anmeldelink schicken oder fahren Sie mit einem Anbieter fort."
+
+#: src/routes/_auth/login.tsx
+msgid "login.email.label"
+msgstr "E-Mail"
+
+#: src/routes/_auth/login.tsx
+msgid "login.passkey.submit"
+msgstr "Mit Passkey anmelden"
+
+#: src/routes/_auth/login.tsx
+msgid "login.passkey.pending"
+msgstr "Wird angemeldet…"
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.submit"
+msgstr "Per E-Mail-Link"
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.pending"
+msgstr "Wird gesendet…"
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.emailRequired"
+msgstr "Bitte zuerst eine E-Mail-Adresse oben eingeben."
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.sent.title"
+msgstr "Prüfen Sie Ihre E-Mails"
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.sent.description"
+msgstr "Falls für diese E-Mail-Adresse ein Konto existiert, haben wir einen Anmeldelink gesendet. Der Link läuft in 15 Minuten ab."
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.back"
+msgstr "Zurück"
+
+#: src/routes/_auth/login.tsx
+msgid "login.emailChange.success"
+msgstr "E-Mail bestätigt. Bitte mit der neuen Adresse anmelden."
+
+#: src/routes/_auth/login.tsx
+msgid "login.oauth.separator"
+msgstr "oder"
+
+#: src/routes/_auth/login.tsx
+msgid "login.oauth.continueWith"
+msgstr "Mit {label} fortfahren"

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -8,6 +8,158 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.dashboard"
+msgstr "Dashboard"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.entries"
+msgstr "Entries"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.terms"
+msgstr "Terms"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.users"
+msgstr "Users"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.settings"
+msgstr "Settings"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.profile"
+msgstr "Profile"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.admin"
+msgstr "Admin"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.create"
+msgstr "Create"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.edit"
+msgstr "Edit"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.addNew"
+msgstr "Add new"
+
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.editUser"
+msgstr "Edit user"
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.welcome"
+msgstr "Welcome, {greeting}"
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.tagline"
+msgstr "What would you like to work on today?"
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.tile.description"
+msgstr "Write, edit, and publish {labelLower}."
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.tile.browse"
+msgstr "Browse {labelLower}"
+
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.title"
 msgstr "No content types yet"
+
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.empty.description"
+msgstr "Add a plugin that registers a post type (e.g. <0>@plumix/plugin-blog</0>) to see it here."
+
+#: src/components/shell/user-menu.tsx
+msgid "menu.profile"
+msgstr "Profile"
+
+#: src/components/shell/user-menu.tsx
+msgid "menu.settings"
+msgstr "Settings"
+
+#: src/components/shell/user-menu.tsx
+msgid "menu.signOut"
+msgstr "Sign out"
+
+#: src/components/shell/user-menu.tsx
+msgid "menu.signOut.pending"
+msgstr "Signing out…"
+
+#: src/components/locale-switcher.tsx
+msgid "profile.language.aria"
+msgstr "Language"
+
+#: src/components/profile/language-card.tsx
+msgid "profile.language.title"
+msgstr "Language"
+
+#: src/components/profile/language-card.tsx
+msgid "profile.language.description"
+msgstr "Your admin chrome renders in this language. The page reloads after you switch so the new translations apply everywhere."
+
+#: src/components/profile/language-card.tsx
+msgid "profile.language.error"
+msgstr "Couldn't switch language. Please try again."
+
+#: src/routes/_auth/login.tsx
+msgid "login.title"
+msgstr "Sign in"
+
+#: src/routes/_auth/login.tsx
+msgid "login.description"
+msgstr "Use a passkey, get a one-time email link, or continue with a provider."
+
+#: src/routes/_auth/login.tsx
+msgid "login.email.label"
+msgstr "Email"
+
+#: src/routes/_auth/login.tsx
+msgid "login.passkey.submit"
+msgstr "Sign in with passkey"
+
+#: src/routes/_auth/login.tsx
+msgid "login.passkey.pending"
+msgstr "Signing in…"
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.submit"
+msgstr "Email me a link"
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.pending"
+msgstr "Sending…"
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.emailRequired"
+msgstr "Enter your email above first."
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.sent.title"
+msgstr "Check your email"
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.sent.description"
+msgstr "If an account exists for this email, we sent a sign-in link. The link expires in 15 minutes."
+
+#: src/routes/_auth/login.tsx
+msgid "login.magicLink.back"
+msgstr "Back"
+
+#: src/routes/_auth/login.tsx
+msgid "login.emailChange.success"
+msgstr "Email confirmed. Sign in with the new address."
+
+#: src/routes/_auth/login.tsx
+msgid "login.oauth.separator"
+msgstr "or"
+
+#: src/routes/_auth/login.tsx
+msgid "login.oauth.continueWith"
+msgstr "Continue with {label}"

--- a/packages/admin/src/components/locale-switcher.test.tsx
+++ b/packages/admin/src/components/locale-switcher.test.tsx
@@ -1,10 +1,17 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { PlumixManifest } from "@plumix/core/manifest";
 
 import { LocaleSwitcher } from "./locale-switcher.js";
+
+beforeEach(() => {
+  i18n.load({ en: {} });
+  i18n.activate("en");
+});
 
 afterEach(() => cleanup());
 
@@ -18,9 +25,13 @@ const enArManifest: PlumixManifest = {
   },
 };
 
+function renderInProvider(node: React.ReactNode) {
+  return render(<I18nProvider i18n={i18n}>{node}</I18nProvider>);
+}
+
 describe("LocaleSwitcher", () => {
   test("renders the trigger with the current locale's label", () => {
-    render(
+    renderInProvider(
       <LocaleSwitcher
         currentCode="ar"
         manifest={enArManifest}
@@ -33,7 +44,7 @@ describe("LocaleSwitcher", () => {
 
   test("calls onSelect with the chosen locale code when the user picks an option", async () => {
     const onSelect = vi.fn();
-    render(
+    renderInProvider(
       <LocaleSwitcher
         currentCode="en"
         manifest={enArManifest}

--- a/packages/admin/src/components/locale-switcher.tsx
+++ b/packages/admin/src/components/locale-switcher.tsx
@@ -6,6 +6,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select.js";
+import { useLingui } from "@lingui/react";
 
 import type { PlumixManifest } from "@plumix/core/manifest";
 
@@ -20,12 +21,15 @@ export function LocaleSwitcher({
   manifest,
   onSelect,
 }: LocaleSwitcherProps): ReactNode {
+  const { i18n } = useLingui();
   const locales = manifest.i18n?.locales ?? [];
   return (
     <Select value={currentCode} onValueChange={onSelect}>
       <SelectTrigger
         data-testid="locale-switcher-trigger"
-        aria-label="Language"
+        aria-label={i18n._("profile.language.aria", undefined, {
+          message: "Language",
+        })}
       >
         <SelectValue />
       </SelectTrigger>

--- a/packages/admin/src/components/profile/language-card.tsx
+++ b/packages/admin/src/components/profile/language-card.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card.js";
 import { readManifest } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { Trans } from "@lingui/react";
 import { useMutation } from "@tanstack/react-query";
 
 interface LanguageCardProps {
@@ -30,10 +31,14 @@ export function LanguageCard({ userLocale }: LanguageCardProps): ReactNode {
   return (
     <Card data-testid="language-card">
       <CardHeader>
-        <CardTitle>Language</CardTitle>
+        <CardTitle>
+          <Trans id="profile.language.title" message="Language" />
+        </CardTitle>
         <CardDescription>
-          Your admin chrome renders in this language. The page reloads after you
-          switch so the new translations apply everywhere.
+          <Trans
+            id="profile.language.description"
+            message="Your admin chrome renders in this language. The page reloads after you switch so the new translations apply everywhere."
+          />
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
@@ -45,7 +50,10 @@ export function LanguageCard({ userLocale }: LanguageCardProps): ReactNode {
         {setLocale.isError ? (
           <Alert variant="destructive">
             <AlertDescription>
-              Couldn't switch language. Please try again.
+              <Trans
+                id="profile.language.error"
+                message="Couldn't switch language. Please try again."
+              />
             </AlertDescription>
           </Alert>
         ) : null}

--- a/packages/admin/src/components/shell/shell-header.tsx
+++ b/packages/admin/src/components/shell/shell-header.tsx
@@ -11,6 +11,7 @@ import {
 import { Separator } from "@/components/ui/separator.js";
 import { SidebarTrigger } from "@/components/ui/sidebar.js";
 import { pathToCrumbs } from "@/lib/breadcrumbs.js";
+import { useLingui } from "@lingui/react";
 import { Link, useRouterState } from "@tanstack/react-router";
 
 function useBreadcrumbs(): readonly Crumb[] {
@@ -22,6 +23,11 @@ function useBreadcrumbs(): readonly Crumb[] {
 
 export function ShellHeader(): ReactNode {
   const crumbs = useBreadcrumbs();
+  const { i18n } = useLingui();
+  const text = (label: Crumb["label"]): string =>
+    typeof label === "string"
+      ? label
+      : i18n._(label.id, undefined, { message: label.message });
   return (
     <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
       <SidebarTrigger className="-ml-1" />
@@ -30,21 +36,22 @@ export function ShellHeader(): ReactNode {
         <BreadcrumbList>
           {crumbs.map((crumb, index) => {
             const isLast = index === crumbs.length - 1;
+            const label = text(crumb.label);
             return (
-              <Fragment key={`${String(index)}-${crumb.label}`}>
+              <Fragment key={`${String(index)}-${label}`}>
                 {index > 0 ? <BreadcrumbSeparator /> : null}
                 <BreadcrumbItem>
                   {isLast ? (
-                    <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                    <BreadcrumbPage>{label}</BreadcrumbPage>
                   ) : crumb.to !== undefined ? (
                     <Link
                       to={crumb.to}
                       className="text-muted-foreground hover:text-foreground transition-colors"
                     >
-                      {crumb.label}
+                      {label}
                     </Link>
                   ) : (
-                    <span className="text-muted-foreground">{crumb.label}</span>
+                    <span className="text-muted-foreground">{label}</span>
                   )}
                 </BreadcrumbItem>
               </Fragment>

--- a/packages/admin/src/components/shell/user-menu.tsx
+++ b/packages/admin/src/components/shell/user-menu.tsx
@@ -12,6 +12,7 @@ import {
 import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar.js";
 import { signOut } from "@/lib/passkey.js";
 import { SESSION_QUERY_KEY } from "@/lib/session.js";
+import { Trans } from "@lingui/react";
 import { useMutation } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { ChevronsUpDown, LogOut, Settings, User } from "lucide-react";
@@ -100,21 +101,26 @@ export function UserMenu({ user }: { user: UserIdentity }): ReactNode {
           <DropdownMenuItem asChild>
             <Link to="/profile" data-testid="user-menu-profile-link">
               <User className="size-4" />
-              Profile
+              <Trans id="menu.profile" message="Profile" />
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem disabled>
             <Settings className="size-4" />
-            Settings
+            <Trans id="menu.settings" message="Settings" />
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={() => signOutMutation.mutate()}
           disabled={signOutMutation.isPending}
+          data-testid="user-menu-sign-out"
         >
           <LogOut className="size-4" />
-          {signOutMutation.isPending ? "Signing out…" : "Sign out"}
+          {signOutMutation.isPending ? (
+            <Trans id="menu.signOut.pending" message="Signing out…" />
+          ) : (
+            <Trans id="menu.signOut" message="Sign out" />
+          )}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/packages/admin/src/lib/breadcrumbs.test.ts
+++ b/packages/admin/src/lib/breadcrumbs.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { i18n } from "@lingui/core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { PlumixManifest } from "@plumix/core/manifest";
 
+import type { Crumb } from "./breadcrumbs.js";
 import type * as ManifestLib from "./manifest.js";
 import { pathToCrumbs } from "./breadcrumbs.js";
 
@@ -30,39 +32,63 @@ const PLUGIN_PAGES: { readonly to: string; readonly label: string }[] = [
   { to: "/pages/media", label: "Media Library" },
 ];
 
-vi.mock("./manifest.js", async (importOriginal) => {
-  const real = await importOriginal<typeof ManifestLib>();
-  return {
-    ...real,
-    findEntryTypeBySlug: (slug: string) =>
-      FIXTURE.entryTypes?.find((e) => e.adminSlug === slug),
-    findTermTaxonomyByName: (name: string) =>
-      FIXTURE.termTaxonomies?.find((t) => t.name === name),
-    findSettingsPageByName: (name: string) =>
-      FIXTURE.settingsPages?.find((p) => p.name === name),
-    findPluginPageByPath: (to: string) => PLUGIN_PAGES.find((p) => p.to === to),
-  };
+vi.mock(
+  "./manifest.js",
+  async (importOriginal): Promise<typeof ManifestLib> => {
+    const actual = await importOriginal<typeof ManifestLib>();
+    return {
+      ...actual,
+      findEntryTypeBySlug: (slug: string) =>
+        FIXTURE.entryTypes?.find((e) => e.adminSlug === slug),
+      findTermTaxonomyByName: (name: string) =>
+        FIXTURE.termTaxonomies?.find((t) => t.name === name),
+      findSettingsPageByName: (name: string) =>
+        FIXTURE.settingsPages?.find((p) => p.name === name),
+      findPluginPageByPath: (path: string) =>
+        PLUGIN_PAGES.find((p) => p.to === path),
+    };
+  },
+);
+
+beforeEach(() => {
+  // Source-locale renders use `descriptor.message` directly; explicit en
+  // catalog keeps the resolver on the cheap path.
+  i18n.load({ en: {} });
+  i18n.activate("en");
 });
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
+function labels(crumbs: readonly Crumb[]): readonly {
+  label: string;
+  to?: string;
+}[] {
+  return crumbs.map((c) => ({
+    label:
+      typeof c.label === "string"
+        ? c.label
+        : i18n._(c.label.id, undefined, { message: c.label.message }),
+    ...(c.to !== undefined ? { to: c.to } : {}),
+  }));
+}
+
 describe("pathToCrumbs", () => {
   test("dashboard", () => {
-    expect(pathToCrumbs("/")).toEqual([{ label: "Dashboard" }]);
-    expect(pathToCrumbs("")).toEqual([{ label: "Dashboard" }]);
+    expect(labels(pathToCrumbs("/"))).toEqual([{ label: "Dashboard" }]);
+    expect(labels(pathToCrumbs(""))).toEqual([{ label: "Dashboard" }]);
   });
 
   test("entries list resolves the plural label from manifest (no link on leaf)", () => {
-    expect(pathToCrumbs("/entries/posts")).toEqual([
+    expect(labels(pathToCrumbs("/entries/posts"))).toEqual([
       { label: "Entries" },
       { label: "Posts" },
     ]);
   });
 
   test("entries create: list crumb is a link, action crumb is leaf", () => {
-    expect(pathToCrumbs("/entries/posts/create")).toEqual([
+    expect(labels(pathToCrumbs("/entries/posts/create"))).toEqual([
       { label: "Entries" },
       { label: "Posts", to: "/entries/posts" },
       { label: "Create" },
@@ -70,7 +96,7 @@ describe("pathToCrumbs", () => {
   });
 
   test("entries edit: list crumb is a link, edit crumb is leaf", () => {
-    expect(pathToCrumbs("/entries/posts/42/edit")).toEqual([
+    expect(labels(pathToCrumbs("/entries/posts/42/edit"))).toEqual([
       { label: "Entries" },
       { label: "Posts", to: "/entries/posts" },
       { label: "Edit" },
@@ -78,14 +104,14 @@ describe("pathToCrumbs", () => {
   });
 
   test("entries with unknown slug falls back to the raw segment", () => {
-    expect(pathToCrumbs("/entries/widgets")).toEqual([
+    expect(labels(pathToCrumbs("/entries/widgets"))).toEqual([
       { label: "Entries" },
       { label: "widgets" },
     ]);
   });
 
   test("terms create: taxonomy crumb is a link", () => {
-    expect(pathToCrumbs("/terms/category/create")).toEqual([
+    expect(labels(pathToCrumbs("/terms/category/create"))).toEqual([
       { label: "Terms" },
       { label: "Categories", to: "/terms/category" },
       { label: "Create category" },
@@ -93,7 +119,7 @@ describe("pathToCrumbs", () => {
   });
 
   test("terms edit: taxonomy crumb is a link, action uses singular label", () => {
-    expect(pathToCrumbs("/terms/category/7/edit")).toEqual([
+    expect(labels(pathToCrumbs("/terms/category/7/edit"))).toEqual([
       { label: "Terms" },
       { label: "Categories", to: "/terms/category" },
       { label: "Edit category" },
@@ -101,31 +127,52 @@ describe("pathToCrumbs", () => {
   });
 
   test("users edit: list crumb is a link", () => {
-    expect(pathToCrumbs("/users/3/edit")).toEqual([
+    expect(labels(pathToCrumbs("/users/3/edit"))).toEqual([
       { label: "Users", to: "/users" },
       { label: "Edit user" },
     ]);
   });
 
   test("settings list + page", () => {
-    expect(pathToCrumbs("/settings")).toEqual([{ label: "Settings" }]);
-    expect(pathToCrumbs("/settings/general")).toEqual([
+    expect(labels(pathToCrumbs("/settings"))).toEqual([{ label: "Settings" }]);
+    expect(labels(pathToCrumbs("/settings/general"))).toEqual([
       { label: "Settings", to: "/settings" },
       { label: "General" },
     ]);
   });
 
   test("profile + plugin pages", () => {
-    expect(pathToCrumbs("/profile")).toEqual([{ label: "Profile" }]);
+    expect(labels(pathToCrumbs("/profile"))).toEqual([{ label: "Profile" }]);
     // Registered plugin page → resolves to its declared label, no
     // synthetic "Pages" parent (would collide with the entry-type Pages
     // surface in the user's sidebar).
-    expect(pathToCrumbs("/pages/media")).toEqual([{ label: "Media Library" }]);
+    expect(labels(pathToCrumbs("/pages/media"))).toEqual([
+      { label: "Media Library" },
+    ]);
     // Unregistered plugin path → fall back to URL slug, still no parent.
-    expect(pathToCrumbs("/pages/unknown")).toEqual([{ label: "unknown" }]);
+    expect(labels(pathToCrumbs("/pages/unknown"))).toEqual([
+      { label: "unknown" },
+    ]);
   });
 
   test("unknown top-level segment falls back to Admin", () => {
-    expect(pathToCrumbs("/whatever")).toEqual([{ label: "Admin" }]);
+    expect(labels(pathToCrumbs("/whatever"))).toEqual([{ label: "Admin" }]);
+  });
+
+  test("translated labels resolve via active catalog", () => {
+    i18n.load({
+      en: {},
+      de: {
+        "breadcrumb.dashboard": "Übersicht",
+        "breadcrumb.entries": "Einträge",
+        "breadcrumb.create": "Erstellen",
+      },
+    });
+    i18n.activate("de");
+    expect(labels(pathToCrumbs("/entries/posts/create"))).toEqual([
+      { label: "Einträge" },
+      { label: "Posts", to: "/entries/posts" }, // manifest-derived, untranslated
+      { label: "Erstellen" },
+    ]);
   });
 });

--- a/packages/admin/src/lib/breadcrumbs.ts
+++ b/packages/admin/src/lib/breadcrumbs.ts
@@ -1,3 +1,5 @@
+import type { MessageDescriptor } from "@lingui/core";
+
 import {
   findEntryTypeBySlug,
   findPluginPageByPath,
@@ -6,12 +8,32 @@ import {
 } from "./manifest.js";
 
 export interface Crumb {
-  readonly label: string;
+  /**
+   * Either a `MessageDescriptor` (for chrome-owned labels like "Dashboard",
+   * "Entries") or a plain string (for manifest-derived labels like an
+   * entry type's plural). Slice 5/#674 widens manifest labels to descriptors
+   * too — when that lands, this type can narrow to `MessageDescriptor`.
+   */
+  readonly label: string | MessageDescriptor;
   /** Absolute admin path for non-leaf crumbs that link to a real list
    *  page. Omitted for group labels (no list route exists) and for
    *  the leaf crumb. */
   readonly to?: string;
 }
+
+const M = {
+  dashboard: { id: "breadcrumb.dashboard", message: "Dashboard" },
+  entries: { id: "breadcrumb.entries", message: "Entries" },
+  terms: { id: "breadcrumb.terms", message: "Terms" },
+  users: { id: "breadcrumb.users", message: "Users" },
+  settings: { id: "breadcrumb.settings", message: "Settings" },
+  profile: { id: "breadcrumb.profile", message: "Profile" },
+  admin: { id: "breadcrumb.admin", message: "Admin" },
+  create: { id: "breadcrumb.create", message: "Create" },
+  edit: { id: "breadcrumb.edit", message: "Edit" },
+  addNew: { id: "breadcrumb.addNew", message: "Add new" },
+  editUser: { id: "breadcrumb.editUser", message: "Edit user" },
+} satisfies Record<string, MessageDescriptor>;
 
 /**
  * Pathname → breadcrumb trail. Resolves entry-type / taxonomy / settings
@@ -21,9 +43,9 @@ export interface Crumb {
  * (which only reads the leaf label).
  */
 export function pathToCrumbs(pathname: string): readonly Crumb[] {
-  if (pathname === "/") return [{ label: "Dashboard" }];
+  if (pathname === "/") return [{ label: M.dashboard }];
   const parts = pathname.split("/").filter((p) => p.length > 0);
-  if (parts.length === 0) return [{ label: "Dashboard" }];
+  if (parts.length === 0) return [{ label: M.dashboard }];
 
   switch (parts[0]) {
     case "entries":
@@ -35,47 +57,47 @@ export function pathToCrumbs(pathname: string): readonly Crumb[] {
     case "settings":
       return settingsCrumbs(parts);
     case "profile":
-      return [{ label: "Profile" }];
+      return [{ label: M.profile }];
     case "pages":
       return pluginPagesCrumbs(parts);
     default:
-      return [{ label: "Admin" }];
+      return [{ label: M.admin }];
   }
 }
 
 function entriesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const slug = parts[1];
-  if (slug === undefined) return [{ label: "Entries" }];
+  if (slug === undefined) return [{ label: M.entries }];
   const entry = findEntryTypeBySlug(slug);
   const label = entry?.labels?.plural ?? entry?.label ?? slug;
   const list: Crumb = { label, to: `/entries/${slug}` };
   if (parts[2] === "create")
-    return [{ label: "Entries" }, list, { label: "Create" }];
+    return [{ label: M.entries }, list, { label: M.create }];
   if (parts[3] === "edit")
-    return [{ label: "Entries" }, list, { label: "Edit" }];
-  return [{ label: "Entries" }, { ...list, to: undefined }];
+    return [{ label: M.entries }, list, { label: M.edit }];
+  return [{ label: M.entries }, { ...list, to: undefined }];
 }
 
 function taxonomiesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const name = parts[1];
-  if (name === undefined) return [{ label: "Terms" }];
+  if (name === undefined) return [{ label: M.terms }];
   const tax = findTermTaxonomyByName(name);
   const label = tax?.label ?? name;
   const singular = (tax?.labels?.singular ?? label).toLowerCase();
   const list: Crumb = { label, to: `/terms/${name}` };
   if (parts[2] === "create")
-    return [{ label: "Terms" }, list, { label: `Create ${singular}` }];
+    return [{ label: M.terms }, list, { label: `Create ${singular}` }];
   if (parts[3] === "edit")
-    return [{ label: "Terms" }, list, { label: `Edit ${singular}` }];
-  return [{ label: "Terms" }, { ...list, to: undefined }];
+    return [{ label: M.terms }, list, { label: `Edit ${singular}` }];
+  return [{ label: M.terms }, { ...list, to: undefined }];
 }
 
 function usersCrumbs(parts: readonly string[]): readonly Crumb[] {
-  if (parts[1] === undefined) return [{ label: "Users" }];
-  const usersList: Crumb = { label: "Users", to: "/users" };
-  if (parts[1] === "create") return [usersList, { label: "Add new" }];
-  if (parts[2] === "edit") return [usersList, { label: "Edit user" }];
-  return [{ label: "Users" }];
+  if (parts[1] === undefined) return [{ label: M.users }];
+  const usersList: Crumb = { label: M.users, to: "/users" };
+  if (parts[1] === "create") return [usersList, { label: M.addNew }];
+  if (parts[2] === "edit") return [usersList, { label: M.editUser }];
+  return [{ label: M.users }];
 }
 
 function pluginPagesCrumbs(parts: readonly string[]): readonly Crumb[] {
@@ -96,10 +118,10 @@ function pluginPagesCrumbs(parts: readonly string[]): readonly Crumb[] {
 
 function settingsCrumbs(parts: readonly string[]): readonly Crumb[] {
   const name = parts[1];
-  if (name === undefined) return [{ label: "Settings" }];
+  if (name === undefined) return [{ label: M.settings }];
   const page = findSettingsPageByName(name);
   return [
-    { label: "Settings", to: "/settings" },
+    { label: M.settings, to: "/settings" },
     { label: page?.label ?? name },
   ];
 }

--- a/packages/admin/src/routes/__root.tsx
+++ b/packages/admin/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { pathToCrumbs } from "@/lib/breadcrumbs.js";
 import { sessionQueryOptions } from "@/lib/session.js";
+import { Trans, useLingui } from "@lingui/react";
 import {
   createRootRouteWithContext,
   Outlet,
@@ -35,11 +36,20 @@ function useDocumentTitle(): void {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
+  const { i18n } = useLingui();
   useEffect(() => {
     const crumbs = pathToCrumbs(pathname);
     const leaf = crumbs[crumbs.length - 1];
-    document.title = leaf ? `${leaf.label} · ${TITLE_BRAND}` : TITLE_BRAND;
-  }, [pathname]);
+    if (!leaf) {
+      document.title = TITLE_BRAND;
+      return;
+    }
+    const label =
+      typeof leaf.label === "string"
+        ? leaf.label
+        : i18n._(leaf.label.id, undefined, { message: leaf.label.message });
+    document.title = `${label} · ${TITLE_BRAND}`;
+  }, [pathname, i18n]);
 }
 
 function NotFound(): ReactNode {
@@ -48,10 +58,14 @@ function NotFound(): ReactNode {
       data-testid="not-found-page"
       className="flex h-screen flex-col items-center justify-center gap-2 p-6 text-center"
     >
-      <h1 className="text-2xl font-semibold">Not found</h1>
+      <h1 className="text-2xl font-semibold">
+        <Trans id="notFound.title" message="Not found" />
+      </h1>
       <p className="text-muted-foreground text-sm">
-        The page you're looking for doesn't exist or the resource isn't
-        registered. Check the URL and try again.
+        <Trans
+          id="notFound.description"
+          message="The page you're looking for doesn't exist or the resource isn't registered. Check the URL and try again."
+        />
       </p>
     </div>
   );

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -31,6 +31,7 @@ import { getPasskeyErrorMessage, PasskeyError } from "@/lib/passkey-errors.js";
 import { signInWithPasskey } from "@/lib/passkey.js";
 import { SESSION_QUERY_KEY, sessionQueryOptions } from "@/lib/session.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
+import { Trans, useLingui } from "@lingui/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
@@ -67,6 +68,7 @@ export const Route = createFileRoute("/_auth/login")({
 function LoginRoute(): ReactNode {
   const router = useRouter();
   const search = Route.useSearch();
+  const { i18n } = useLingui();
   const [passkeyError, setPasskeyError] = useState<string | null>(null);
   const [magicLinkSent, setMagicLinkSent] = useState(false);
   const [magicLinkError, setMagicLinkError] = useState<string | null>(null);
@@ -110,7 +112,11 @@ function LoginRoute(): ReactNode {
   const onMagicLinkClick = (): void => {
     const email = form.getValues("email").trim();
     if (!email) {
-      setMagicLinkError("Enter your email above first.");
+      setMagicLinkError(
+        i18n._("login.magicLink.emailRequired", undefined, {
+          message: "Enter your email above first.",
+        }),
+      );
       return;
     }
     magicLink.mutate({ email });
@@ -133,11 +139,18 @@ function LoginRoute(): ReactNode {
       <Card data-testid="login-magic-link-sent">
         <CardHeader>
           <CardTitle>
-            <h1 data-testid="login-heading">Check your email</h1>
+            <h1 data-testid="login-heading">
+              <Trans
+                id="login.magicLink.sent.title"
+                message="Check your email"
+              />
+            </h1>
           </CardTitle>
           <CardDescription>
-            If an account exists for this email, we sent a sign-in link. The
-            link expires in 15 minutes.
+            <Trans
+              id="login.magicLink.sent.description"
+              message="If an account exists for this email, we sent a sign-in link. The link expires in 15 minutes."
+            />
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -147,7 +160,7 @@ function LoginRoute(): ReactNode {
             onClick={() => setMagicLinkSent(false)}
             data-testid="login-magic-link-back"
           >
-            Back
+            <Trans id="login.magicLink.back" message="Back" />
           </Button>
         </CardContent>
       </Card>
@@ -158,10 +171,15 @@ function LoginRoute(): ReactNode {
     <Card>
       <CardHeader>
         <CardTitle>
-          <h1 data-testid="login-heading">Sign in</h1>
+          <h1 data-testid="login-heading">
+            <Trans id="login.title" message="Sign in" />
+          </h1>
         </CardTitle>
         <CardDescription>
-          Use a passkey, get a one-time email link, or continue with a provider.
+          <Trans
+            id="login.description"
+            message="Use a passkey, get a one-time email link, or continue with a provider."
+          />
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -172,7 +190,9 @@ function LoginRoute(): ReactNode {
               name="email"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Email</FormLabel>
+                  <FormLabel>
+                    <Trans id="login.email.label" message="Email" />
+                  </FormLabel>
                   <FormControl>
                     <Input
                       type="email"
@@ -219,7 +239,10 @@ function LoginRoute(): ReactNode {
             {emailChangeSuccess ? (
               <Alert data-testid="login-email-change-success">
                 <AlertDescription>
-                  Email confirmed. Sign in with the new address.
+                  <Trans
+                    id="login.emailChange.success"
+                    message="Email confirmed. Sign in with the new address."
+                  />
                 </AlertDescription>
               </Alert>
             ) : null}
@@ -240,7 +263,14 @@ function LoginRoute(): ReactNode {
                 disabled={signIn.isPending || magicLink.isPending}
                 data-testid="login-passkey-submit"
               >
-                {signIn.isPending ? "Signing in…" : "Sign in with passkey"}
+                {signIn.isPending ? (
+                  <Trans id="login.passkey.pending" message="Signing in…" />
+                ) : (
+                  <Trans
+                    id="login.passkey.submit"
+                    message="Sign in with passkey"
+                  />
+                )}
               </Button>
               <Button
                 type="button"
@@ -250,7 +280,14 @@ function LoginRoute(): ReactNode {
                 disabled={signIn.isPending || magicLink.isPending}
                 data-testid="login-magic-link-submit"
               >
-                {magicLink.isPending ? "Sending…" : "Email me a link"}
+                {magicLink.isPending ? (
+                  <Trans id="login.magicLink.pending" message="Sending…" />
+                ) : (
+                  <Trans
+                    id="login.magicLink.submit"
+                    message="Email me a link"
+                  />
+                )}
               </Button>
             </div>
           </form>
@@ -264,7 +301,7 @@ function LoginRoute(): ReactNode {
             <div className="flex items-center gap-2">
               <Separator className="flex-1" />
               <span className="text-muted-foreground text-xs tracking-wide uppercase">
-                or
+                <Trans id="login.oauth.separator" message="or" />
               </span>
               <Separator className="flex-1" />
             </div>
@@ -276,7 +313,11 @@ function LoginRoute(): ReactNode {
                 data-testid={`login-oauth-${key}`}
               >
                 <a href={`/_plumix/auth/oauth/${key}/start`}>
-                  Continue with {label}
+                  <Trans
+                    id="login.oauth.continueWith"
+                    message="Continue with {label}"
+                    values={{ label }}
+                  />
                 </a>
               </Button>
             ))}

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -36,10 +36,17 @@ function DashboardIndex(): ReactNode {
           data-testid="dashboard-welcome-heading"
           className="text-2xl font-semibold"
         >
-          Welcome, {greeting}
+          <Trans
+            id="dashboard.welcome"
+            message="Welcome, {greeting}"
+            values={{ greeting }}
+          />
         </h1>
         <p className="text-muted-foreground text-sm">
-          What would you like to work on today?
+          <Trans
+            id="dashboard.tagline"
+            message="What would you like to work on today?"
+          />
         </p>
       </div>
 
@@ -56,8 +63,13 @@ function DashboardIndex(): ReactNode {
                   </div>
                   <CardTitle>{label}</CardTitle>
                   <CardDescription>
-                    {pt.description ??
-                      `Write, edit, and publish ${labelLower}.`}
+                    {pt.description ?? (
+                      <Trans
+                        id="dashboard.tile.description"
+                        message="Write, edit, and publish {labelLower}."
+                        values={{ labelLower }}
+                      />
+                    )}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -68,7 +80,11 @@ function DashboardIndex(): ReactNode {
                       search={ENTRIES_LIST_DEFAULT_SEARCH}
                       data-testid={`dashboard-tile-${pt.name}-link`}
                     >
-                      Browse {labelLower}
+                      <Trans
+                        id="dashboard.tile.browse"
+                        message="Browse {labelLower}"
+                        values={{ labelLower }}
+                      />
                       <ArrowRight />
                     </Link>
                   </Button>
@@ -91,8 +107,11 @@ function DashboardIndex(): ReactNode {
                 />
               </EmptyTitle>
               <EmptyDescription>
-                Add a plugin that registers a post type (e.g.{" "}
-                <code>@plumix/plugin-blog</code>) to see it here.
+                <Trans
+                  id="dashboard.empty.description"
+                  message="Add a plugin that registers a post type (e.g. <0>@plumix/plugin-blog</0>) to see it here."
+                  components={{ 0: <code /> }}
+                />
               </EmptyDescription>
             </EmptyHeader>
           </Empty>


### PR DESCRIPTION
First chunk of #684 (mass admin chrome wrap). Broadened mid-PR per maintainer guidance: no reason to split mechanical `<Trans>` wraps across many small PRs. Covers every chrome surface that doesn't depend on router-state mocking or manifest-label widening (#674).

**Wrapped surfaces**

- `lib/breadcrumbs.ts` — `Crumb.label` widened to `string | MessageDescriptor`. Static labels (Dashboard, Entries, Terms, Users, Settings, Profile, Admin, Create, Edit, Add new, Edit user) ship as descriptors; manifest-derived labels (entry-type plural, taxonomy label) stay strings until #674 widens manifest labels.
- `components/shell/shell-header.tsx` — resolves the new descriptor shape via `useLingui().i18n._()`.
- `components/shell/user-menu.tsx` — Profile, Settings, Sign out, Signing out…
- `components/locale-switcher.tsx` — `aria-label="Language"` via `i18n._()`.
- `components/profile/language-card.tsx` — title, description, error.
- `routes/_authenticated/index.tsx` — welcome heading, tagline, tile description with `{labelLower}` interpolation, tile browse-link, empty-state title + description (with a `<code>` slot via Lingui's `components` prop).
- `routes/_auth/login.tsx` — title, description, email label, both buttons (submit + pending), magic-link sent screen, email-change success message, OAuth separator + "Continue with {label}".

**Shape change — `Crumb.label`**

Before:

```ts
export interface Crumb { readonly label: string; readonly to?: string; }
```

After:

```ts
export interface Crumb {
  readonly label: string | MessageDescriptor;
  readonly to?: string;
}
```

Consumers resolve via `i18n._(label.id, undefined, { message: label.message })`. The string branch covers manifest-derived labels until #674's widening lands.

**41 catalog entries in `packages/admin/locales/{en,de}.po`**

Hand-authored. Slice 6 (#675) will regenerate via `plumix i18n extract` and ship compiled output that also installs the production runtime compiler — fixing the pre-existing footgun where `dashboard.welcome` would render the literal `Welcome, {greeting}` in a production build today.

**Out of scope (deferred to surface-scoped PRs)**

- User edit form (`users/$id/edit.tsx`) + profile cards (`passkeys-card`, `api-tokens-card`, `sessions-card`, `user-email-field`) — large surfaces, per-card PRs.
- Entries / users / settings / terms list + edit routes — each its own PR.
- Sidebar + admin nav labels — wait for manifest-label widening (#674).
- Error-message helper modules (`lib/passkey-errors.ts`, `lib/magic-link-errors.ts`, etc.) — return strings; wrapping needs threading via `i18n` per consumer site.

Refs #684