### PR TITLE
refactor(admin): silence react-hooks/incompatible-library lint warnings

### DIFF
--- a/packages/admin/src/components/data-table/data-table.tsx
+++ b/packages/admin/src/components/data-table/data-table.tsx
@@ -48,6 +48,11 @@ export function DataTable<TData>({
   /** Screen-reader label for the loading region when `isLoading`. */
   readonly loadingLabel?: string;
 }): ReactNode {
+  // `useReactTable` returns a non-stable table instance — React Compiler
+  // can't memoize the surrounding render. The instance is the documented
+  // contract (its methods and state are read by row/cell components)
+  // so there's no equivalent subscription-style API to migrate to.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: data as TData[],
     columns,

--- a/packages/admin/src/components/profile/api-tokens-card.tsx
+++ b/packages/admin/src/components/profile/api-tokens-card.tsx
@@ -50,7 +50,7 @@ import { parseScopesText } from "@/lib/scopes.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Copy, Plus } from "lucide-react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import * as v from "valibot";
 
 // Renders the API-token surface for a target user. Two modes:
@@ -429,7 +429,7 @@ function CreateTokenForm({
     },
     mode: "onBlur",
   });
-  const scopeMode = form.watch("scopeMode");
+  const scopeMode = useWatch({ control: form.control, name: "scopeMode" });
 
   return (
     <Form {...form}>

--- a/packages/admin/src/routes/_authenticated/auth/device.tsx
+++ b/packages/admin/src/routes/_authenticated/auth/device.tsx
@@ -25,7 +25,7 @@ import { parseScopesText } from "@/lib/scopes.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import * as v from "valibot";
 
 // Admin-side approval page for OAuth 2.0 Device Authorization Grant
@@ -260,7 +260,7 @@ function ApproveCard({
     },
     mode: "onBlur",
   });
-  const scopeMode = form.watch("scopeMode");
+  const scopeMode = useWatch({ control: form.control, name: "scopeMode" });
 
   const approve = useMutation({
     mutationFn: (input: {


### PR DESCRIPTION
Fixes #694. Three `react-hooks/incompatible-library` warnings on admin lint — same warning code, different root causes, different fixes.

**`form.watch()` → `useWatch({ control, name })`**

`form.watch(name)` returns a non-stable function so React Compiler skips memoization of the surrounding component. The subscription-style `useWatch` API returns a memoizable value; behavior is identical for the read-only pattern these two sites use.

- `components/profile/api-tokens-card.tsx`
- `routes/_authenticated/auth/device.tsx`

**`useReactTable` — per-call suppress with rationale**

`useReactTable` returns a table instance whose methods read from the hook's internal state. There's no subscription-style alternative — the instance IS the contract. Suppress with a comment explaining the trade-off; the warning is technically correct but the alternative (restructuring data-table to drop useReactTable) is far larger than the value of memoization on a render path that already does its own row-keying.

- `components/data-table/data-table.tsx`

Net: `pnpm lint` runs clean — zero warnings, zero errors.
