### PR TITLE
feat(plumix): add `plumix i18n extract --check` CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm knip
 
+  i18n:
+    name: i18n
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: pnpm i18n:check
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev": "turbo watch dev --continue",
     "format": "turbo run format --continue -- --cache --cache-location .cache/.prettiercache",
     "format:fix": "turbo run format --continue -- --write --cache --cache-location .cache/.prettiercache",
+    "i18n:check": "turbo run i18n:check",
     "knip": "knip",
     "lint": "turbo run lint --continue -- --cache --cache-location .cache/.eslintcache",
     "lint:fix": "turbo run lint --continue -- --fix --cache --cache-location .cache/.eslintcache",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -8,6 +8,7 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules playwright-report test-results",
     "dev": "vite",
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path .prettierignore",
+    "i18n:check": "node ../plumix/bin/plumix.mjs i18n extract --check",
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile --namespace es",
     "lint": "eslint",

--- a/packages/core/src/cli/errors.ts
+++ b/packages/core/src/cli/errors.ts
@@ -12,7 +12,9 @@ type CliErrorCode =
   | "config_not_found_explicit"
   | "config_not_found_default"
   | "config_load_failed"
-  | "config_invalid";
+  | "config_invalid"
+  | "i18n_check_drift"
+  | "tooling_command_no_app";
 
 export class CliError extends Error {
   static {
@@ -185,6 +187,24 @@ export class CliError extends Error {
       "config_invalid",
       `Invalid config shape in ${ctx.configPath}`,
       "Default export must be the return value of plumix({ ... }) or defineConfig({ ... }).",
+      undefined,
+    );
+  }
+
+  static toolingCommandNoApp(ctx: { command: string }): CliError {
+    return new CliError(
+      "tooling_command_no_app",
+      `plumix ${ctx.command}: ctx.app is not available — tooling commands run without a config`,
+      "If this command needs the runtime app, dispatch it through the normal config-loading path.",
+      undefined,
+    );
+  }
+
+  static i18nCheckDrift(ctx: { ids: readonly string[] }): CliError {
+    return new CliError(
+      "i18n_check_drift",
+      `Translation catalogs out of sync — ${ctx.ids.length} new msgid(s) in source but not in committed .po:\n  ${ctx.ids.join("\n  ")}`,
+      "Run `plumix i18n extract` locally and commit the updated `.po` file(s).",
       undefined,
     );
   }

--- a/packages/plumix/src/cli/commands/i18n.test.ts
+++ b/packages/plumix/src/cli/commands/i18n.test.ts
@@ -1,4 +1,11 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -76,5 +83,105 @@ describe("i18nCommand", () => {
     await expect(
       i18nCommand.run(ctx({ cwd: dir, argv: ["extract"] })),
     ).rejects.toThrow(/@lingui\/cli not found/);
+  });
+
+  describe("extract --check", () => {
+    test("throws + restores .po contents when extract drifted the file", async () => {
+      const localesDir = join(dir, "locales");
+      mkdirSync(localesDir, { recursive: true });
+      const enPo = join(localesDir, "en.po");
+      const before = 'msgid ""\nmsgstr "header"\n';
+      writeFileSync(enPo, before);
+
+      vi.spyOn(i18nDeps, "resolveLinguiCliBin").mockReturnValue(
+        "/fake/lingui.js",
+      );
+      vi.spyOn(i18nDeps, "spawnInherit").mockImplementation(() => {
+        writeFileSync(enPo, before + '\nmsgid "new.string"\nmsgstr ""\n');
+        return Promise.resolve();
+      });
+
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["extract", "--check"] })),
+      ).rejects.toThrow(/drift|out of sync/i);
+
+      // Working tree must be clean after a failed --check so CI doesn't
+      // surface unstaged changes from the gate itself.
+      expect(readFileSync(enPo, "utf8")).toBe(before);
+    });
+
+    test("detects new msgids folded across continuation lines (>80 chars)", async () => {
+      const localesDir = join(dir, "locales");
+      mkdirSync(localesDir, { recursive: true });
+      const enPo = join(localesDir, "en.po");
+      const before = 'msgid ""\nmsgstr "header"\n';
+      writeFileSync(enPo, before);
+
+      vi.spyOn(i18nDeps, "resolveLinguiCliBin").mockReturnValue(
+        "/fake/lingui.js",
+      );
+      // pofile-ts folds long msgids: emit one with the same continuation
+      // shape lingui produces (`msgid ""` followed by `"..."` lines).
+      vi.spyOn(i18nDeps, "spawnInherit").mockImplementation(() => {
+        writeFileSync(
+          enPo,
+          before +
+            '\nmsgid ""\n"block.variations.cover.hero.split-layout."\n"with-tall-image.fullwidth"\nmsgstr ""\n',
+        );
+        return Promise.resolve();
+      });
+
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["extract", "--check"] })),
+      ).rejects.toThrow(
+        /block\.variations\.cover\.hero\.split-layout\.with-tall-image\.fullwidth/,
+      );
+    });
+
+    test("treats a new .po written by extract as drift and cleans it up", async () => {
+      const localesDir = join(dir, "locales");
+      mkdirSync(localesDir, { recursive: true });
+      const dePo = join(localesDir, "de.po");
+
+      vi.spyOn(i18nDeps, "resolveLinguiCliBin").mockReturnValue(
+        "/fake/lingui.js",
+      );
+      vi.spyOn(i18nDeps, "spawnInherit").mockImplementation(() => {
+        writeFileSync(
+          dePo,
+          'msgid ""\nmsgstr "header"\n\nmsgid "freshly.added"\nmsgstr ""\n',
+        );
+        return Promise.resolve();
+      });
+
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["extract", "--check"] })),
+      ).rejects.toThrow(/drift|out of sync/i);
+
+      // New file must be removed so the gate doesn't leave it staged in CI.
+      expect(existsSync(dePo)).toBe(false);
+    });
+
+    test("strips `--check` before invoking lingui (the flag is plumix's own)", async () => {
+      const localesDir = join(dir, "locales");
+      mkdirSync(localesDir, { recursive: true });
+      writeFileSync(join(localesDir, "en.po"), 'msgid ""\nmsgstr "header"\n');
+
+      vi.spyOn(i18nDeps, "resolveLinguiCliBin").mockReturnValue(
+        "/fake/lingui.js",
+      );
+      const spawn = vi
+        .spyOn(i18nDeps, "spawnInherit")
+        .mockResolvedValue(undefined);
+
+      await i18nCommand.run(ctx({ cwd: dir, argv: ["extract", "--check"] }));
+
+      // Lingui itself must never see `--check` (plumix's flag).
+      expect(spawn).toHaveBeenCalledWith(
+        process.execPath,
+        ["/fake/lingui.js", "extract"],
+        { cwd: dir },
+      );
+    });
   });
 });

--- a/packages/plumix/src/cli/commands/i18n.ts
+++ b/packages/plumix/src/cli/commands/i18n.ts
@@ -1,8 +1,9 @@
+import { readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import type { CommandDefinition } from "@plumix/core";
+import type { CommandContext, CommandDefinition } from "@plumix/core";
 import { CliError, spawnInherit } from "@plumix/core";
 
 const SUPPORTED = ["extract", "compile"] as const;
@@ -33,16 +34,112 @@ export const i18nCommand: CommandDefinition = {
         supported: [...SUPPORTED],
       });
     }
-    // Mirror migrate.ts: spawn `process.execPath` with a resolved
-    // binary path so the command works on Windows (where `npx`/`lingui`
-    // are .cmd shims that `spawn` without `shell: true` can't find).
-    await i18nDeps.spawnInherit(
-      process.execPath,
-      [bin, sub, ...ctx.argv.slice(1)],
-      { cwd: ctx.cwd },
-    );
+    const rest = ctx.argv.slice(1);
+    // `--check` is plumix's own flag (slice 7 CI gate). Snapshot the
+    // `.po` files, run extract, compare active msgid sets, restore — so
+    // a failed gate exits non-zero with a clean working tree.
+    if (sub === "extract" && rest.includes("--check")) {
+      await runExtractCheck(ctx, bin, rest);
+      return;
+    }
+    // Mirror migrate.ts: spawn `process.execPath` with a resolved bin
+    // path so the command works on Windows (where `lingui`/`npx` are
+    // .cmd shims that `spawn` without `shell: true` can't find).
+    await i18nDeps.spawnInherit(process.execPath, [bin, sub, ...rest], {
+      cwd: ctx.cwd,
+    });
   },
 };
+
+async function runExtractCheck(
+  ctx: CommandContext,
+  bin: string,
+  rest: readonly string[],
+): Promise<void> {
+  const localesDir = resolve(ctx.cwd, "locales");
+  const snapshot = new Map<string, string>();
+  for (const path of listPoFiles(localesDir)) {
+    snapshot.set(path, readFileSync(path, "utf8"));
+  }
+  const knownIds = new Set<string>();
+  for (const content of snapshot.values()) {
+    for (const id of activeMsgids(content)) knownIds.add(id);
+  }
+  // Not forwarding `--clean`: that would obsolete hand-authored entries
+  // (e.g., descriptors not discoverable by the macro extractor) and
+  // false-positive every gate run. We catch new msgids; deletions are
+  // caught by code review on the source change.
+  const forwarded = rest.filter((a) => a !== "--check");
+  try {
+    await i18nDeps.spawnInherit(
+      process.execPath,
+      [bin, "extract", ...forwarded],
+      { cwd: ctx.cwd },
+    );
+    const introduced = new Set<string>();
+    for (const path of listPoFiles(localesDir)) {
+      for (const id of activeMsgids(readFileSync(path, "utf8"))) {
+        if (!knownIds.has(id)) introduced.add(id);
+      }
+    }
+    if (introduced.size > 0) {
+      throw CliError.i18nCheckDrift({ ids: [...introduced].sort() });
+    }
+  } finally {
+    for (const [path, content] of snapshot) writeFileSync(path, content);
+    for (const path of listPoFiles(localesDir)) {
+      if (!snapshot.has(path)) rmSync(path);
+    }
+  }
+}
+
+/** Extract active (non-obsolete) msgid values from a .po file. Handles
+ *  the multi-line / continuation form that `pofile-ts` folds long
+ *  strings into (msgid "" followed by "..." continuation lines) so the
+ *  gate doesn't silently miss folded entries on Windows (CRLF) or for
+ *  long explicit-ids past the 80-char default fold threshold. */
+function activeMsgids(content: string): readonly string[] {
+  const ids: string[] = [];
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    // `#~` marks obsolete; not gated.
+    if (line.startsWith("#~")) continue;
+    if (!line.startsWith("msgid ")) continue;
+    // Collect the `"..."` payload from this line plus every following
+    // continuation line that starts with `"`.
+    let buf = line.slice("msgid ".length);
+    let next = lines[i + 1];
+    while (next?.startsWith('"') === true) {
+      buf += next;
+      i += 1;
+      next = lines[i + 1];
+    }
+    const id = decodeQuoted(buf);
+    if (id !== "") ids.push(id);
+  }
+  return ids;
+}
+
+/** Decode one or more concatenated `"..."` segments from a .po line.
+ *  `pofile-ts` writes plain double-quoted strings with backslash
+ *  escapes for `\n`, `\t`, `\\`, `\"`. */
+function decodeQuoted(buf: string): string {
+  const segments = buf.match(/"((?:\\.|[^"\\])*)"/g);
+  if (!segments) return "";
+  return segments.map((s) => s.slice(1, -1).replace(/\\(.)/g, "$1")).join("");
+}
+
+function listPoFiles(dir: string): readonly string[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((d) => d.isFile() && d.name.endsWith(".po"))
+      .map((d) => join(dir, d.name));
+  } catch {
+    return [];
+  }
+}
 
 function resolveLinguiCliBin(cwd: string): string | null {
   // Consumer's own @lingui/cli takes precedence (so they can pin a

--- a/packages/plumix/src/cli/index.ts
+++ b/packages/plumix/src/cli/index.ts
@@ -113,6 +113,34 @@ export async function run(argv: readonly string[]): Promise<void> {
     return;
   }
 
+  // `i18n` is tooling — runs from any package directory (admin, plugins,
+  // themes) regardless of whether the cwd is a plumix consumer project.
+  // No `plumix.config.ts` means no app + no runtime; dispatch directly.
+  if (args.command === "i18n") {
+    const command = BUILT_IN_COMMANDS.get("i18n");
+    if (!command) throw CliError.unknownCommand({ command: args.command });
+    // Proxy so any future refactor that reads `ctx.app` from i18n fails
+    // loud at the access site rather than silently NPE'ing inside a
+    // method call. The cast is structural (`app` is non-optional on
+    // CommandContext); the runtime guard is the real safety net.
+    const sentinel = new Proxy(
+      {},
+      {
+        get(): never {
+          throw CliError.toolingCommandNoApp({ command: "i18n" });
+        },
+      },
+    ) as never;
+    await command.run({
+      app: sentinel,
+      cwd: args.cwd,
+      configPath: "",
+      argv: args.rest,
+      runtimeMigrate: {},
+    });
+    return;
+  }
+
   const loaded = await loadConfig(args.cwd, args.config);
   const runtimeModule = await loadRuntimeCommands(
     loaded.config.runtime,

--- a/turbo.json
+++ b/turbo.json
@@ -44,6 +44,10 @@
     },
     "attw": {
       "dependsOn": ["build"]
+    },
+    "i18n:check": {
+      "dependsOn": ["plumix#build"],
+      "cache": false
     }
   },
   "globalPassThroughEnv": [


### PR DESCRIPTION
Adds a `--check` flag to `plumix i18n extract` that fails CI when source
strings drift from committed `.po` catalogs. Wired into a new `i18n` CI job
that runs on every PR alongside lint/typecheck/test.

**Gate semantics**

`--check` snapshots `<cwd>/locales/*.po` in memory, runs lingui's extract,
parses the active msgid set from each resulting catalog (skipping `#~`
obsolete blocks), and surfaces any msgid that source introduced without a
corresponding committed entry. The .po contents are restored in a `finally`
so a failed gate leaves the working tree clean — CI never sees unstaged
changes from the gate itself.

`--clean` is deliberately not forwarded to lingui. Forwarding it would
obsolete every hand-authored msgid (admin's 11 breadcrumb descriptors lingui
can't discover without the macro pipeline) and false-positive every gate run
on an in-sync repo. The accepted trade: source-side deletions don't fail the
gate; they land via code review on the source change instead. A future slice
that wires per-plugin catalog parsing of the `js-lingui-explicit-id` marker
can flip `--clean` back on for cleanly-extracted packages.

**Folded msgid handling**

`pofile-ts` folds msgids longer than 80 characters into the multi-line form:

```
msgid ""
"block.variations.cover.hero.split-layout."
"with-tall-image.fullwidth"
```

The parser collects continuation lines and decodes the concatenated quoted
segments. Without this, a long explicit-id would pass through the gate
silently — locked in by `i18n.test.ts`'s folded-msgid case.

**Tooling-command dispatch**

`plumix i18n` is package tooling — runs from admin, plugin, or theme
directories regardless of whether a `plumix.config.ts` exists. The CLI
dispatcher special-cases `i18n` to skip `loadConfig` + `buildApp`. `ctx.app`
becomes a Proxy that throws via `CliError.toolingCommandNoApp` on any
property access, so future refactors that touch `ctx.app` from a tooling
command fail loud at the access site rather than NPE'ing inside a method
call.

**CI wiring**

A new `i18n` job mirrors the lint/test job shape and runs `pnpm i18n:check`,
which fans out via `turbo run i18n:check` with `dependsOn: ["plumix#build"]`
and `cache: false` (the gate inspects state outside the task graph). The
admin's `i18n:check` script invokes the bin by path (`node
../plumix/bin/plumix.mjs i18n extract --check`) to avoid the circular
`plumix ↔ @plumix/admin` workspace dep.

Refs #676