### PR TITLE
feat(core): add catalog loader deep module

### DIFF
--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,3 +1,10 @@
+export {
+  CatalogParseError,
+  createCatalogLoader,
+  type CatalogJSON,
+  type CatalogLoader,
+  type LoadCatalogInput,
+} from "./load-catalog.js";
 export { resolveLocales } from "./locale-registry.js";
 export type {
   I18nInput,

--- a/packages/core/src/i18n/load-catalog.test.ts
+++ b/packages/core/src/i18n/load-catalog.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { createCatalogLoader } from "./load-catalog.js";
+
+describe("createCatalogLoader", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "plumix-catalog-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns the parsed JSON catalog when the file exists", async () => {
+    writeFileSync(
+      join(dir, "de.json"),
+      JSON.stringify({ "menu.signOut": ["Abmelden"] }),
+    );
+    const load = createCatalogLoader();
+
+    expect(await load({ locale: "de", bundledPath: dir })).toEqual({
+      "menu.signOut": ["Abmelden"],
+    });
+  });
+
+  test("returns null when the catalog file is missing", async () => {
+    const load = createCatalogLoader();
+    expect(await load({ locale: "zz", bundledPath: dir })).toBeNull();
+  });
+
+  test("throws a structured error naming the file on malformed JSON", async () => {
+    writeFileSync(join(dir, "de.json"), "{ not valid json");
+    const load = createCatalogLoader();
+
+    await expect(load({ locale: "de", bundledPath: dir })).rejects.toThrow(
+      /de\.json/,
+    );
+  });
+
+  test("caches misses: a file appearing after the first lookup stays null", async () => {
+    const load = createCatalogLoader();
+    const args = { locale: "de", bundledPath: dir };
+
+    expect(await load(args)).toBeNull();
+    writeFileSync(join(dir, "de.json"), JSON.stringify({ a: ["1"] }));
+    expect(await load(args)).toBeNull();
+  });
+
+  test("invalidates the cache when the file's mtime advances", async () => {
+    const path = join(dir, "de.json");
+    writeFileSync(path, JSON.stringify({ a: ["1"] }));
+    const load = createCatalogLoader();
+    const args = { locale: "de", bundledPath: dir };
+
+    const first = await load(args);
+    const future = new Date(Date.now() + 60_000);
+    writeFileSync(path, JSON.stringify({ a: ["2"] }));
+    utimesSync(path, future, future);
+
+    expect(first).toEqual({ a: ["1"] });
+    expect(await load(args)).toEqual({ a: ["2"] });
+  });
+});

--- a/packages/core/src/i18n/load-catalog.ts
+++ b/packages/core/src/i18n/load-catalog.ts
@@ -1,0 +1,84 @@
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+/** Shape `@lingui/cli compile --namespace json` produces: each msgid
+ *  maps to a string (plain messages) or an array of tokens (messages
+ *  with placeholders / JSX). Structural match for Lingui's `Messages`
+ *  type — kept free of `@lingui/core` to avoid pulling Lingui into
+ *  `@plumix/core`'s dep tree; consumers can pass the result straight
+ *  to `i18n.load(locale, catalog)`. */
+export type CatalogJSON = Readonly<
+  Record<string, string | readonly (string | readonly unknown[])[]>
+>;
+
+export interface LoadCatalogInput {
+  readonly locale: string;
+  readonly bundledPath: string;
+}
+
+export type CatalogLoader = (
+  input: LoadCatalogInput,
+) => Promise<CatalogJSON | null>;
+
+export class CatalogParseError extends Error {
+  readonly path: string;
+  constructor(path: string, cause: unknown) {
+    super(`Failed to parse catalog: ${path}`, { cause });
+    this.name = "CatalogParseError";
+    this.path = path;
+  }
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
+
+// Hit carries the parsed catalog plus the mtime that minted it; miss
+// short-circuits future calls without re-stat'ing.
+type CacheEntry =
+  | {
+      readonly kind: "hit";
+      readonly mtimeMs: number;
+      readonly catalog: CatalogJSON;
+    }
+  | { readonly kind: "miss" };
+
+export function createCatalogLoader(): CatalogLoader {
+  const cache = new Map<string, CacheEntry>();
+  return async (input) => {
+    const path = join(input.bundledPath, `${input.locale}.json`);
+    const cached = cache.get(path);
+    if (cached?.kind === "miss") return null;
+    let mtimeMs: number;
+    try {
+      mtimeMs = (await stat(path)).mtimeMs;
+    } catch (error) {
+      if (isFileNotFound(error)) {
+        cache.set(path, { kind: "miss" });
+        return null;
+      }
+      throw error;
+    }
+    if (cached?.kind === "hit" && cached.mtimeMs === mtimeMs) {
+      return cached.catalog;
+    }
+    // Best-effort under concurrent replacement: a file swapped between
+    // `stat` and `readFile` ends up cached against the pre-swap mtime,
+    // self-healing on the next call. Acceptable for the boot-time
+    // catalog posture.
+    const content = await readFile(path, "utf8");
+    let catalog: CatalogJSON;
+    try {
+      catalog = JSON.parse(content) as CatalogJSON;
+    } catch (cause) {
+      throw new CatalogParseError(path, cause);
+    }
+    cache.set(path, { kind: "hit", mtimeMs, catalog });
+    return catalog;
+  };
+}


### PR DESCRIPTION
Adds `createCatalogLoader()` to `@plumix/core` — a server-side filesystem-
backed loader resolving `<bundledPath>/<locale>.json` to the JSON shape
`lingui compile --namespace json` produces. Designed for the SSR consumer
track (theme rendering, server-side `ctx.t` error resolution) and the
per-plugin manifest pipeline slice 5 (#674) layers on next.

**Cache semantics**

Each loader instance owns its cache:

- **Positive hits** key by resolved path + mtime. A second call re-stats; if
  mtime is unchanged it returns the cached catalog without re-reading or
  re-parsing. If mtime advances, the cache evicts and re-reads.
- **Negative cache is sticky**. Once a locale is missed, subsequent calls
  return `null` without re-stat'ing. New locales appearing post-boot need a
  process restart — same posture WordPress takes with its translation files.

**`CatalogJSON` is structural**

```ts
export type CatalogJSON = Readonly<
  Record<string, string | readonly (string | readonly unknown[])[]>
>;
```

Matches Lingui's `Messages` shape (plain strings for unparameterized msgids,
nested token arrays for placeholders / JSX) but doesn't import from
`@lingui/core` — keeping Lingui out of `@plumix/core`'s dep tree. Consumers
pass the result straight to `i18n.load(locale, catalog)` without adapter
plumbing.

**Slice scope clarification**

The original acceptance criterion "refactor slice 3's admin-catalog SSR
loading" was dropped — slice 3 never shipped that path, and slice 6's admin
runtime now uses `import.meta.glob` over `.mjs` chunks (Vite-friendly,
code-split per locale). `loadCatalog` is a pure addition serving SSR
consumers; admin keeps its independent client-side loader.

Refs #673