### PR TITLE
feat(core): widen manifest label types + plug plugin catalogs into admin boot

### DIFF
--- a/packages/admin/src/components/shell/app-sidebar.tsx
+++ b/packages/admin/src/components/shell/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar.js";
 import { visibleAdminNav } from "@/lib/manifest.js";
+import { useLabel } from "@/lib/use-label.js";
 import { Link } from "@tanstack/react-router";
 import {
   Calendar,
@@ -57,6 +58,7 @@ export function AppSidebar({
   capabilities: readonly string[];
 }): ReactNode {
   const groups = visibleAdminNav(capabilities);
+  const renderLabel = useLabel();
   return (
     <Sidebar collapsible="icon" variant="inset">
       <SidebarContent>
@@ -78,7 +80,7 @@ export function AppSidebar({
                           activeOptions={{ exact: item.exact ?? false }}
                         >
                           <Icon />
-                          <span>{item.label}</span>
+                          <span>{renderLabel(item.label)}</span>
                         </Link>
                       </SidebarMenuButton>
                     </SidebarMenuItem>

--- a/packages/admin/src/lib/i18n-boot.ts
+++ b/packages/admin/src/lib/i18n-boot.ts
@@ -1,12 +1,21 @@
 import type { Messages } from "@lingui/core";
 import { i18n } from "@lingui/core";
 
-// Vite expands the glob at build time into a `path → () => import(path)`
-// map covering every compiled catalog on disk. Adding a locale (drop a
-// `.po`, run `pnpm i18n:compile`) appears here automatically — no
-// constant to keep in sync, no allowlist to extend.
-const CATALOGS = import.meta.glob<{ messages: Messages }>(
+// Admin's own compiled catalogs. Vite expands the glob at build time
+// into a `path → () => import(path)` map. Adding a locale (drop a
+// `.po`, run `pnpm i18n:compile`) appears here automatically.
+const ADMIN_CATALOGS = import.meta.glob<{ messages: Messages }>(
   "../../locales/*.mjs",
+);
+
+// First-party plugin catalogs shipped via workspace deps. Same glob
+// mechanism: any plugin under `packages/plugins/*/locales/*.mjs`
+// gets merged into the active locale alongside admin chrome. Slice
+// 17 (#697) wires the equivalent for third-party plugins via
+// manifest URLs + runtime fetch — this static path covers the
+// workspace-bundled case at zero runtime cost.
+const PLUGIN_CATALOGS = import.meta.glob<{ messages: Messages }>(
+  "../../../plugins/*/locales/*.mjs",
 );
 
 // Source locale: the language `descriptor.message` strings are authored
@@ -14,25 +23,46 @@ const CATALOGS = import.meta.glob<{ messages: Messages }>(
 // back here. Mirrors `lingui.config.ts:sourceLocale`.
 const SOURCE_LOCALE = "en";
 
-function catalogPath(locale: string): string {
+function adminCatalogPath(locale: string): string {
   return `../../locales/${locale}.mjs`;
 }
 
 /** Load and activate the compiled catalog for the user's active locale.
- *  The admin shell rewrites `<html lang>` server-side (slice 4) to the
- *  user's `meta.locale`; we normalize (lowercase + region-strip) and
- *  look up the matching catalog loader. Unknown locales fall back to
- *  the source locale. A missing source catalog (e.g., a dev boot
- *  before `pnpm i18n:compile` has ever run) leaves Lingui in its
- *  descriptor-message fallback mode — never throws, never blanks. */
+ *  Merges admin's own catalog with every workspace plugin catalog
+ *  that has a matching `<locale>.mjs`. The admin shell rewrites
+ *  `<html lang>` server-side (slice 4) to the user's `meta.locale`;
+ *  we normalize (lowercase + region-strip) and look up matching
+ *  loaders. Unknown locales fall back to the source locale. A missing
+ *  source catalog (e.g., a dev boot before any package has compiled)
+ *  leaves Lingui in its descriptor-message fallback mode — never
+ *  throws, never blanks. */
 export async function bootI18n(): Promise<void> {
   const tag = document.documentElement.lang.toLowerCase().split("-")[0] ?? "";
-  const requested = CATALOGS[catalogPath(tag)];
-  const fallback = CATALOGS[catalogPath(SOURCE_LOCALE)];
-  const loader = requested ?? fallback;
-  if (!loader) return;
+  const requested = ADMIN_CATALOGS[adminCatalogPath(tag)];
+  const fallback = ADMIN_CATALOGS[adminCatalogPath(SOURCE_LOCALE)];
+  const adminLoader = requested ?? fallback;
+  if (!adminLoader) return;
   const locale = requested ? tag : SOURCE_LOCALE;
-  const { messages } = await loader();
-  i18n.load(locale, messages);
+
+  const adminMessages = (await adminLoader()).messages;
+  const pluginMessages = await loadPluginCatalogs(locale);
+  // Merge: plugin keys can't collide with admin's (admin uses
+  // `breadcrumb.*` / `menu.*` / etc.; plugins use `plugin.<id>.*`),
+  // so a flat spread is the right shape. If a future collision is a
+  // real concern, namespacing happens at authoring time.
+  i18n.load(locale, { ...adminMessages, ...pluginMessages });
   i18n.activate(locale);
+}
+
+async function loadPluginCatalogs(locale: string): Promise<Messages> {
+  const merged: Messages = {};
+  for (const [path, loader] of Object.entries(PLUGIN_CATALOGS)) {
+    // `../../../plugins/<id>/locales/<locale>.mjs` — match the
+    // requested locale's filename. No fallback at the plugin layer;
+    // missing translations fall through to `descriptor.message`.
+    if (!path.endsWith(`/locales/${locale}.mjs`)) continue;
+    const mod = await loader();
+    Object.assign(merged, mod.messages);
+  }
+  return merged;
 }

--- a/packages/admin/src/lib/use-label.ts
+++ b/packages/admin/src/lib/use-label.ts
@@ -1,0 +1,13 @@
+import { useLingui } from "@lingui/react";
+
+import type { Label } from "@plumix/core/i18n";
+import { resolveLabel } from "@plumix/core/i18n";
+
+/** Pulls the active Lingui locale and returns a label resolver that
+ *  flattens `Label` (string | MessageDescriptor) to a rendered string.
+ *  Use at every manifest-label render site so plain strings and
+ *  Lingui descriptors round-trip identically. */
+export function useLabel(): (label: Label) => string {
+  const { i18n } = useLingui();
+  return (label) => resolveLabel(label, i18n);
+}

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -38,6 +38,7 @@ import { toDate } from "@/lib/dates.js";
 import { findEntryTypeBySlug, findTermTaxonomyByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { buildFilterTermOptions } from "@/lib/terms.js";
+import { useLabel } from "@/lib/use-label.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
@@ -365,8 +366,10 @@ function ContentListRoute(): ReactNode {
   // doesn't expose a total count today; accept the edge case until it does.
   const canNext = rows.length === PAGE_SIZE;
 
-  const pluralLabel = entryType.labels?.plural ?? entryType.label;
-  const singularLabel = entryType.labels?.singular ?? entryType.label;
+  const renderLabel = useLabel();
+  const pluralLabel = entryType.labels?.plural ?? renderLabel(entryType.label);
+  const singularLabel =
+    entryType.labels?.singular ?? renderLabel(entryType.label);
   const pluralLower = pluralLabel.toLowerCase();
   const singularLower = singularLabel.toLowerCase();
 

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/empty.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import { visibleEntryTypes } from "@/lib/manifest.js";
+import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, FileText, Puzzle } from "lucide-react";
@@ -28,6 +29,7 @@ function DashboardIndex(): ReactNode {
   const { user } = Route.useRouteContext();
   const greeting = user.name ?? user.email;
   const tiles = visibleEntryTypes(user.capabilities);
+  const renderLabel = useLabel();
 
   return (
     <div className="flex flex-col gap-6">
@@ -53,7 +55,7 @@ function DashboardIndex(): ReactNode {
       {tiles.length > 0 ? (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {tiles.map((pt) => {
-            const label = pt.labels?.plural ?? pt.label;
+            const label = pt.labels?.plural ?? renderLabel(pt.label);
             const labelLower = label.toLowerCase();
             return (
               <Card key={pt.name} data-testid={`dashboard-tile-${pt.name}`}>

--- a/packages/admin/src/routes/_authenticated/pages/$.tsx
+++ b/packages/admin/src/routes/_authenticated/pages/$.tsx
@@ -5,6 +5,7 @@ import { hasCap } from "@/lib/caps.js";
 import { findPluginPageByPath } from "@/lib/manifest.js";
 import { PluginErrorBoundary } from "@/lib/plugin-error-boundary.js";
 import { getPluginPage } from "@/lib/plugin-registry.js";
+import { useLabel } from "@/lib/use-label.js";
 import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authenticated/pages/$")({
@@ -33,6 +34,8 @@ export const Route = createFileRoute("/_authenticated/pages/$")({
 
 function PluginPageRoute(): ReactNode {
   const { navItem } = Route.useRouteContext();
+  const renderLabel = useLabel();
+  const labelText = renderLabel(navItem.label);
   // navItem.to is `/pages/<plugin-path>` — derive the plugin's own
   // path for registry lookup.
   const pluginPath = navItem.to.replace(/^\/pages/, "");
@@ -41,11 +44,11 @@ function PluginPageRoute(): ReactNode {
     return <PluginNotLoaded path={pluginPath} />;
   }
   return (
-    <PluginErrorBoundary kind="page" pluginLabel={navItem.label}>
+    <PluginErrorBoundary kind="page" pluginLabel={labelText}>
       <Suspense
         fallback={
           <FormEditSkeleton
-            ariaLabel={`Loading ${navItem.label}`}
+            ariaLabel={`Loading ${labelText}`}
             testId={`plugin-page__loading__${pluginPath}`}
           />
         }

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -28,6 +28,7 @@ import {
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
 import { useFormatters } from "@/lib/use-formatters.js";
+import { useLabel } from "@/lib/use-label.js";
 import { ORPCError } from "@orpc/client";
 import { Puck } from "@puckeditor/core";
 import {
@@ -813,6 +814,7 @@ function PlainFormRouteInner({
   supportsRevisions,
   capabilities,
 }: PlainFormRouteInnerProps): ReactNode {
+  const renderLabel = useLabel();
   const { data: entry } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id } }),
   );
@@ -876,7 +878,7 @@ function PlainFormRouteInner({
       key={String(id)}
       initialValues={initialValues}
       metaBoxes={metaBoxes}
-      headline={`Edit ${(entryType.labels?.singular ?? entryType.label).toLowerCase()}`}
+      headline={`Edit ${(entryType.labels?.singular ?? renderLabel(entryType.label)).toLowerCase()}`}
       isSubmitting={updateMutation.isPending}
       serverError={updateMutation.isPending ? null : serverError}
       autosaveMs={500}

--- a/packages/admin/src/routes/_editor/entries/$slug/create.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/create.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import { hasCap } from "@/lib/caps.js";
 import { findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { useLabel } from "@/lib/use-label.js";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
 
@@ -28,6 +29,7 @@ export const Route = createFileRoute("/_editor/entries/$slug/create")({
 
 function CreateEntryRoute(): ReactNode {
   const { entryType } = Route.useRouteContext();
+  const renderLabel = useLabel();
   const navigate = useNavigate();
   // The route mounts once per visit; create the draft, redirect, done.
   // The redirect lands in edit.tsx which then handles autosave.
@@ -61,7 +63,7 @@ function CreateEntryRoute(): ReactNode {
       className="text-muted-foreground flex flex-1 items-center justify-center text-sm"
       data-testid="create-entry-pending"
     >
-      Creating new {entryType.labels?.singular ?? entryType.label}…
+      Creating new {entryType.labels?.singular ?? renderLabel(entryType.label)}…
     </div>
   );
 }

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -4,6 +4,7 @@ export {
   formatRelative,
   type FormatRelativeOptions,
 } from "./format.js";
+export { resolveLabel, type Label } from "./label.js";
 export {
   CatalogParseError,
   createCatalogLoader,

--- a/packages/core/src/i18n/label.test.ts
+++ b/packages/core/src/i18n/label.test.ts
@@ -1,0 +1,27 @@
+import { i18n, setupI18n } from "@lingui/core";
+import { describe, expect, test } from "vitest";
+
+import { resolveLabel } from "./label.js";
+
+describe("resolveLabel", () => {
+  test("returns plain strings unchanged", () => {
+    expect(resolveLabel("Pages", i18n)).toBe("Pages");
+  });
+
+  test("resolves a MessageDescriptor against the active catalog", () => {
+    const instance = setupI18n({
+      locale: "de",
+      messages: { de: { "page.label": "Seiten" } },
+    });
+    expect(resolveLabel({ id: "page.label", message: "Pages" }, instance)).toBe(
+      "Seiten",
+    );
+  });
+
+  test("falls back to descriptor.message when the catalog has no translation", () => {
+    const instance = setupI18n({ locale: "de", messages: { de: {} } });
+    expect(resolveLabel({ id: "page.label", message: "Pages" }, instance)).toBe(
+      "Pages",
+    );
+  });
+});

--- a/packages/core/src/i18n/label.ts
+++ b/packages/core/src/i18n/label.ts
@@ -1,0 +1,16 @@
+import type { I18n, MessageDescriptor } from "@lingui/core";
+
+/** Manifest label fields accept either a plain string (legacy / static
+ *  labels that don't need translation) or a Lingui `MessageDescriptor`
+ *  (produced by `t\`...\`` or `defineMessage({ ... })`). Render sites
+ *  go through `resolveLabel` to flatten both to a string. */
+export type Label = string | MessageDescriptor;
+
+/** Resolve a `Label` to a rendered string against the given `i18n`
+ *  instance. Strings pass through; descriptors hit Lingui's resolver,
+ *  which falls back to `descriptor.message` when the active catalog
+ *  has no translation for the id. */
+export function resolveLabel(label: Label, instance: I18n): string {
+  if (typeof label === "string") return label;
+  return instance._(label);
+}

--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -11,6 +11,21 @@ export type PluginProvides = (
   ctx: PluginProvidesContext,
 ) => void | Promise<void>;
 
+export interface PluginI18nSlot {
+  /** Source locale every msgid is authored in. Mirrors lingui.config
+   *  but lives on the manifest so admin can resolve plugin catalog
+   *  paths without re-parsing the plugin's lingui config at runtime. */
+  readonly sourceLocale: string;
+  /** Locales the plugin ships catalogs for. Intersected with the
+   *  site's enabled locales before any URL is generated — declaring
+   *  more locales than the site enables doesn't expand the dropdown. */
+  readonly locales: readonly string[];
+  /** Directory containing the compiled `<locale>.json` catalogs,
+   *  relative to the plugin's package root. Admin (via slice 17
+   *  #697) resolves and lazy-loads catalogs from here. */
+  readonly catalogPath: string;
+}
+
 export interface PluginDescriptor<TConfig = undefined> {
   readonly id: string;
   readonly version?: string;
@@ -18,6 +33,10 @@ export interface PluginDescriptor<TConfig = undefined> {
   readonly setup: PluginSetup<TConfig>;
   readonly schema?: Record<string, unknown>;
   readonly schemaModule?: string;
+  /** Translation catalog declaration — opts the plugin into the i18n
+   *  pipeline. Omit to keep all labels rendered as their authored
+   *  strings (no translation lookup, no catalog discovery). */
+  readonly i18n?: PluginI18nSlot;
   /**
    * Path to the plugin's admin entry — a TypeScript/TSX module that
    * imports React from the bare specifier and registers components via
@@ -42,6 +61,7 @@ export interface DefinePluginOptions {
   readonly adminChunk?: string;
   readonly adminCss?: string;
   readonly adminPeerVersion?: string;
+  readonly i18n?: PluginI18nSlot;
 }
 
 export interface DefinePluginInput<TConfig> extends DefinePluginOptions {
@@ -96,6 +116,7 @@ export function definePlugin<TConfig = undefined>(
       adminChunk: legacyOptions?.adminChunk,
       adminCss: legacyOptions?.adminCss,
       adminPeerVersion: legacyOptions?.adminPeerVersion,
+      i18n: legacyOptions?.i18n,
     };
   }
   if (legacyOptions !== undefined) {
@@ -113,6 +134,7 @@ export function definePlugin<TConfig = undefined>(
     adminChunk: setupOrInput.adminChunk,
     adminCss: setupOrInput.adminCss,
     adminPeerVersion: setupOrInput.adminPeerVersion,
+    i18n: setupOrInput.i18n,
   };
 }
 

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -16,6 +16,7 @@ import type {
 } from "../auth/rbac.js";
 import type { AppContext } from "../context/app.js";
 import type { UserRole } from "../db/schema/users.js";
+import type { Label } from "../i18n/label.js";
 import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import type { RouteIntent } from "../route/intent.js";
 import type { RegisteredTemplateDep } from "../template-deps.js";
@@ -23,7 +24,7 @@ import type { RegisteredLookupAdapter } from "./lookup.js";
 import { DuplicateAdminSlugError, PluginDefinitionError } from "./errors.js";
 
 export interface EntryTypeOptions {
-  readonly label: string;
+  readonly label: Label;
   /**
    * Human-readable label variants. `plural` also drives the admin URL slug
    * (`/entries/<slugified-plural>`) unless overridden; omit it and the slug
@@ -1207,7 +1208,7 @@ export function findUserMetaField(
 export interface EntryTypeManifestEntry {
   readonly name: string;
   readonly adminSlug: string;
-  readonly label: string;
+  readonly label: Label;
   readonly labels?: {
     readonly singular?: string;
     readonly plural?: string;
@@ -1407,7 +1408,7 @@ export interface SettingsPageManifestEntry {
  */
 export interface AdminNavItem {
   readonly to: string;
-  readonly label: string;
+  readonly label: Label;
   readonly order?: number;
   readonly capability?: string;
   readonly icon?: PluginComponentRef;
@@ -1811,12 +1812,19 @@ function addAdminPageNavItems(
 }
 
 function compareByOrderThenLabel(
-  a: { order?: number; label: string },
-  b: { order?: number; label: string },
+  a: { order?: number; label: Label },
+  b: { order?: number; label: Label },
 ): number {
   const ao = a.order ?? Number.POSITIVE_INFINITY;
   const bo = b.order ?? Number.POSITIVE_INFINITY;
-  return ao - bo || a.label.localeCompare(b.label);
+  // Server-side sort uses `descriptor.message` (source-locale form)
+  // as the comparable key. The runtime sort in admin can re-sort by
+  // the locale-resolved string once labels are rendered.
+  const aLabel =
+    typeof a.label === "string" ? a.label : (a.label.message ?? "");
+  const bLabel =
+    typeof b.label === "string" ? b.label : (b.label.message ?? "");
+  return ao - bo || aLabel.localeCompare(bLabel);
 }
 
 function compareByPriorityThenId(

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -393,8 +393,17 @@ async function resolveArchive(
   // reads it.
   ctx.resolvedEntity = { kind: "archive", entryType: intent.entryType };
 
+  // Take `descriptor.message` as the SSR fallback for descriptor-form
+  // labels until the SSR-side `ctx.i18n` wiring lands (slice 11 #680
+  // closed core's tRPC translation; SSR title resolution is pending).
+  const registeredLabel: string | undefined =
+    registered === undefined
+      ? undefined
+      : typeof registered.label === "string"
+        ? registered.label
+        : registered.label.message;
   const title =
-    registered?.labels?.plural ?? registered?.label ?? intent.entryType;
+    registered?.labels?.plural ?? registeredLabel ?? intent.entryType;
 
   const initial: ArchiveData = {
     contentType: intent.entryType,

--- a/packages/plugins/menu/src/server/eligibility.ts
+++ b/packages/plugins/menu/src/server/eligibility.ts
@@ -69,7 +69,7 @@ export function getEligibleMenuKinds(registry: PluginRegistry): PickerTab[] {
 
 interface MenuEligibleEntryType {
   readonly name: string;
-  readonly label: string;
+  readonly label: string | { readonly id?: string; readonly message?: string };
   readonly labels?: { readonly plural?: string };
   readonly isPublic?: boolean;
   readonly isShownInMenus?: boolean;
@@ -81,9 +81,14 @@ function isMenuEligibleType(entryType: MenuEligibleEntryType): boolean {
 }
 
 function pickerLabelForEntryType(entryType: MenuEligibleEntryType): string {
-  return (
-    entryType.menuPickerLabel ?? entryType.labels?.plural ?? entryType.label
-  );
+  // Server-side tab label uses `descriptor.message` (English fallback)
+  // for descriptor-form labels — SSR-side `ctx.t` resolution is a
+  // future slice. Plain strings pass through unchanged.
+  const labelText =
+    typeof entryType.label === "string"
+      ? entryType.label
+      : (entryType.label.message ?? entryType.name);
+  return entryType.menuPickerLabel ?? entryType.labels?.plural ?? labelText;
 }
 
 interface MenuEligibleTaxonomy {

--- a/packages/plugins/pages/locales/de.mjs
+++ b/packages/plugins/pages/locales/de.mjs
@@ -1,0 +1,3 @@
+/*eslint-disable*/ export const messages = JSON.parse(
+  '{"plugin.pages.label":["Seiten"]}',
+);

--- a/packages/plugins/pages/locales/de.po
+++ b/packages/plugins/pages/locales/de.po
@@ -1,0 +1,14 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-01\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (plugin definition is server-side, no Babel pass)\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. js-lingui-explicit-id
+#: src/index.ts
+msgid "plugin.pages.label"
+msgstr "Seiten"

--- a/packages/plugins/pages/locales/en.mjs
+++ b/packages/plugins/pages/locales/en.mjs
@@ -1,0 +1,3 @@
+/*eslint-disable*/ export const messages = JSON.parse(
+  '{"plugin.pages.label":["Pages"]}',
+);

--- a/packages/plugins/pages/locales/en.po
+++ b/packages/plugins/pages/locales/en.po
@@ -1,0 +1,14 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-01\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (plugin definition is server-side, no Babel pass)\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. js-lingui-explicit-id
+#: src/index.ts
+msgid "plugin.pages.label"
+msgstr "Pages"

--- a/packages/plugins/pages/package.json
+++ b/packages/plugins/pages/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@lingui/core": "catalog:",
     "@playwright/test": "catalog:",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",

--- a/packages/plugins/pages/src/index.test.ts
+++ b/packages/plugins/pages/src/index.test.ts
@@ -12,7 +12,12 @@ describe("@plumix/plugin-pages", () => {
     const { registry } = await install();
     const page = registry.entryTypes.get("page");
     expect(page).toBeDefined();
-    expect(page?.label).toBe("Pages");
+    // Label is a `MessageDescriptor` (slice 5 #674): plugins ship
+    // descriptors so admin can resolve the translated string at render.
+    expect(page?.label).toEqual({
+      id: "plugin.pages.label",
+      message: "Pages",
+    });
     expect(page?.isHierarchical).toBe(true);
     expect(page?.isPublic).toBe(true);
     expect(page?.hasArchive).toBe(false);

--- a/packages/plugins/pages/src/index.ts
+++ b/packages/plugins/pages/src/index.ts
@@ -1,17 +1,35 @@
+import type { MessageDescriptor } from "@lingui/core";
 import { definePlugin } from "plumix/plugin";
 
-export const pages = definePlugin("pages", (ctx) => {
-  ctx.registerEntryType("page", {
-    label: "Pages",
-    labels: { singular: "Page", plural: "Pages" },
-    description: "Hierarchical static pages",
-    supports: ["title", "editor", "slug", "excerpt", "revisions", "autosave"],
-    versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
-    isHierarchical: true,
-    isPublic: true,
-    hasArchive: false,
-    rewrite: { slug: "" },
-    capabilityType: "page",
-    menuIcon: "layout",
-  });
+// Plain descriptor literal: plugin definitions are evaluated server-
+// side (worker / SSR) where no Babel pipeline transforms macros.
+// Admin's chrome code (browser via Vite + babel preset) uses
+// `defineMessage(...)` macro freely; server-side plugin code uses
+// the literal form. The manifest payload is identical either way.
+const PAGES_LABEL = {
+  id: "plugin.pages.label",
+  message: "Pages",
+} satisfies MessageDescriptor;
+
+export const pages = definePlugin("pages", {
+  i18n: {
+    sourceLocale: "en",
+    locales: ["en", "de"],
+    catalogPath: "./locales",
+  },
+  setup: (ctx) => {
+    ctx.registerEntryType("page", {
+      label: PAGES_LABEL,
+      labels: { singular: "Page", plural: "Pages" },
+      description: "Hierarchical static pages",
+      supports: ["title", "editor", "slug", "excerpt", "revisions", "autosave"],
+      versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
+      isHierarchical: true,
+      isPublic: true,
+      hasArchive: false,
+      rewrite: { slug: "" },
+      capabilityType: "page",
+      menuIcon: "layout",
+    });
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,6 +1014,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.2
+      '@lingui/core':
+        specifier: 'catalog:'
+        version: 6.2.0
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.59.1
@@ -10169,7 +10172,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@24.12.2)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.7':
     dependencies:


### PR DESCRIPTION
Slice 5 (#674) end-to-end. Lands the typed contract, widens the consuming
label fields, threads `i18n` through the plugin descriptor, and ships the
proving ground: admin renders "Seiten" for `Accept-Language: de` because
plugin-pages's catalog gets statically discovered + merged into the active
Lingui instance at boot. Production de chunk verified to contain "Seiten".

**Typed primitives (`@plumix/core/i18n`)**

```ts
export type Label = string | MessageDescriptor;
export function resolveLabel(label: Label, instance: I18n): string;
```

Three TDD cycles: plain string passthrough, catalog hit, missing-translation
fallback to `descriptor.message`.

**Manifest field widening**

`EntryTypeOptions.label`, `EntryTypeManifestEntry.label`, `AdminNavItem.label`
all widen from `string` to `Label`. Server-side sort uses
`descriptor.message` as the comparable key (locale-resolved sort can happen
in admin once labels are rendered). The remaining 7 of the original 10 label
fields stay as `string` for now — same widening is mechanical when each
surface needs translation; not blocking this slice's user-visible payoff.

**`PluginDescriptor.i18n` slot**

```ts
i18n?: {
  sourceLocale: string;
  locales: readonly string[];
  catalogPath: string;
}
```

Threaded through `definePlugin`'s factory (both legacy 3-arg and input
forms). Plugin-pages declares it.

**Admin render adapter**

New `useLabel()` hook in admin pulls the active Lingui locale and returns a
resolver. 6 admin sites migrated: sidebar, entries list, dashboard tiles,
dashboard-tile description, plugin page route, edit headline, create
pending screen.

**Plugin-pages proving ground**

`@plumix/plugin-pages` switches its entry label from `"Pages"` (string) to
`{ id: "plugin.pages.label", message: "Pages" }` (descriptor literal — the
plugin definition is server-side so it can't use the macro form). Declares
the `i18n` manifest slot. Ships hand-authored `locales/{en,de}.po` (single
msgid + English/German) and matching compiled `locales/{en,de}.mjs`.

**Static plugin-catalog discovery in admin boot**

`bootI18n` extends its `import.meta.glob` to also pick up
`packages/plugins/*/locales/*.mjs`. First-party workspace plugins ship
their catalogs at zero runtime cost; admin merges them into the active
Lingui instance alongside its own chrome catalog. Plugin keys can't
collide with admin's by convention (admin uses `breadcrumb.*` / `menu.*`,
plugins use `plugin.<id>.*`), so a flat merge is the right shape.

Third-party plugins (not workspace-bundled) need #697's runtime registry
to fetch catalogs over HTTP. The static path here is the workspace-plugin
fast path the PRD called for; both will coexist.

Closes #674