### PR TITLE
refactor(core): apply slice 5 sentry-pass findings

### DIFF
--- a/packages/admin/src/components/shell/app-sidebar.tsx
+++ b/packages/admin/src/components/shell/app-sidebar.tsx
@@ -73,7 +73,10 @@ export function AppSidebar({
                     : Puzzle;
                   return (
                     <SidebarMenuItem key={item.to}>
-                      <SidebarMenuButton asChild tooltip={item.label}>
+                      <SidebarMenuButton
+                        asChild
+                        tooltip={renderLabel(item.label)}
+                      >
                         <Link
                           to={item.to}
                           activeProps={{ "data-active": "true" }}

--- a/packages/admin/src/lib/i18n-boot.ts
+++ b/packages/admin/src/lib/i18n-boot.ts
@@ -23,10 +23,6 @@ const PLUGIN_CATALOGS = import.meta.glob<{ messages: Messages }>(
 // back here. Mirrors `lingui.config.ts:sourceLocale`.
 const SOURCE_LOCALE = "en";
 
-function adminCatalogPath(locale: string): string {
-  return `../../locales/${locale}.mjs`;
-}
-
 /** Load and activate the compiled catalog for the user's active locale.
  *  Merges admin's own catalog with every workspace plugin catalog
  *  that has a matching `<locale>.mjs`. The admin shell rewrites
@@ -38,8 +34,8 @@ function adminCatalogPath(locale: string): string {
  *  throws, never blanks. */
 export async function bootI18n(): Promise<void> {
   const tag = document.documentElement.lang.toLowerCase().split("-")[0] ?? "";
-  const requested = ADMIN_CATALOGS[adminCatalogPath(tag)];
-  const fallback = ADMIN_CATALOGS[adminCatalogPath(SOURCE_LOCALE)];
+  const requested = ADMIN_CATALOGS[`../../locales/${tag}.mjs`];
+  const fallback = ADMIN_CATALOGS[`../../locales/${SOURCE_LOCALE}.mjs`];
   const adminLoader = requested ?? fallback;
   if (!adminLoader) return;
   const locale = requested ? tag : SOURCE_LOCALE;

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -367,9 +367,9 @@ function ContentListRoute(): ReactNode {
   const canNext = rows.length === PAGE_SIZE;
 
   const renderLabel = useLabel();
-  const pluralLabel = entryType.labels?.plural ?? renderLabel(entryType.label);
-  const singularLabel =
-    entryType.labels?.singular ?? renderLabel(entryType.label);
+  const typeLabel = renderLabel(entryType.label);
+  const pluralLabel = entryType.labels?.plural ?? typeLabel;
+  const singularLabel = entryType.labels?.singular ?? typeLabel;
   const pluralLower = pluralLabel.toLowerCase();
   const singularLower = singularLabel.toLowerCase();
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -4,7 +4,7 @@ export {
   formatRelative,
   type FormatRelativeOptions,
 } from "./format.js";
-export { resolveLabel, type Label } from "./label.js";
+export { labelSourceText, resolveLabel, type Label } from "./label.js";
 export {
   CatalogParseError,
   createCatalogLoader,

--- a/packages/core/src/i18n/label.ts
+++ b/packages/core/src/i18n/label.ts
@@ -6,11 +6,18 @@ import type { I18n, MessageDescriptor } from "@lingui/core";
  *  go through `resolveLabel` to flatten both to a string. */
 export type Label = string | MessageDescriptor;
 
-/** Resolve a `Label` to a rendered string against the given `i18n`
- *  instance. Strings pass through; descriptors hit Lingui's resolver,
- *  which falls back to `descriptor.message` when the active catalog
- *  has no translation for the id. */
+/** Flatten `Label` → string via Lingui's resolver. */
 export function resolveLabel(label: Label, instance: I18n): string {
   if (typeof label === "string") return label;
   return instance._(label);
+}
+
+/** Source-locale form of a `Label`. SSR-side companion to
+ *  `resolveLabel` for contexts without an `i18n` instance — server
+ *  sort comparators, route titles, plugin-eligibility predicates.
+ *  Plain strings pass through; descriptors return `.message` (the
+ *  English source the descriptor was authored with). */
+export function labelSourceText(label: Label): string {
+  if (typeof label === "string") return label;
+  return label.message ?? "";
 }

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -21,6 +21,7 @@ import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import type { RouteIntent } from "../route/intent.js";
 import type { RegisteredTemplateDep } from "../template-deps.js";
 import type { RegisteredLookupAdapter } from "./lookup.js";
+import { labelSourceText } from "../i18n/label.js";
 import { DuplicateAdminSlugError, PluginDefinitionError } from "./errors.js";
 
 export interface EntryTypeOptions {
@@ -1817,14 +1818,9 @@ function compareByOrderThenLabel(
 ): number {
   const ao = a.order ?? Number.POSITIVE_INFINITY;
   const bo = b.order ?? Number.POSITIVE_INFINITY;
-  // Server-side sort uses `descriptor.message` (source-locale form)
-  // as the comparable key. The runtime sort in admin can re-sort by
-  // the locale-resolved string once labels are rendered.
-  const aLabel =
-    typeof a.label === "string" ? a.label : (a.label.message ?? "");
-  const bLabel =
-    typeof b.label === "string" ? b.label : (b.label.message ?? "");
-  return ao - bo || aLabel.localeCompare(bLabel);
+  return (
+    ao - bo || labelSourceText(a.label).localeCompare(labelSourceText(b.label))
+  );
 }
 
 function compareByPriorityThenId(

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -24,6 +24,7 @@ import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
 import { terms } from "../db/schema/terms.js";
 import { users } from "../db/schema/users.js";
+import { labelSourceText } from "../i18n/label.js";
 import { notFound } from "../runtime/http.js";
 import { paginate } from "./paginate.js";
 import { findEntryByPath, findTermByPath } from "./path-chain.js";
@@ -393,17 +394,13 @@ async function resolveArchive(
   // reads it.
   ctx.resolvedEntity = { kind: "archive", entryType: intent.entryType };
 
-  // Take `descriptor.message` as the SSR fallback for descriptor-form
-  // labels until the SSR-side `ctx.i18n` wiring lands (slice 11 #680
-  // closed core's tRPC translation; SSR title resolution is pending).
-  const registeredLabel: string | undefined =
-    registered === undefined
-      ? undefined
-      : typeof registered.label === "string"
-        ? registered.label
-        : registered.label.message;
+  // SSR-side: descriptor labels fall back to source text until the
+  // ctx.i18n route wiring lands (slice 11 #680 covered tRPC errors;
+  // route titles pending).
   const title =
-    registered?.labels?.plural ?? registeredLabel ?? intent.entryType;
+    registered?.labels?.plural ??
+    (registered ? labelSourceText(registered.label) : undefined) ??
+    intent.entryType;
 
   const initial: ArchiveData = {
     contentType: intent.entryType,

--- a/packages/plugins/menu/src/server/eligibility.ts
+++ b/packages/plugins/menu/src/server/eligibility.ts
@@ -1,4 +1,6 @@
+import type { Label } from "plumix/i18n";
 import type { PluginRegistry } from "plumix/plugin";
+import { labelSourceText } from "plumix/i18n";
 
 /**
  * One picker tab in the admin's "Add menu items" rail. The tab label
@@ -69,7 +71,7 @@ export function getEligibleMenuKinds(registry: PluginRegistry): PickerTab[] {
 
 interface MenuEligibleEntryType {
   readonly name: string;
-  readonly label: string | { readonly id?: string; readonly message?: string };
+  readonly label: Label;
   readonly labels?: { readonly plural?: string };
   readonly isPublic?: boolean;
   readonly isShownInMenus?: boolean;
@@ -81,14 +83,11 @@ function isMenuEligibleType(entryType: MenuEligibleEntryType): boolean {
 }
 
 function pickerLabelForEntryType(entryType: MenuEligibleEntryType): string {
-  // Server-side tab label uses `descriptor.message` (English fallback)
-  // for descriptor-form labels — SSR-side `ctx.t` resolution is a
-  // future slice. Plain strings pass through unchanged.
-  const labelText =
-    typeof entryType.label === "string"
-      ? entryType.label
-      : (entryType.label.message ?? entryType.name);
-  return entryType.menuPickerLabel ?? entryType.labels?.plural ?? labelText;
+  return (
+    entryType.menuPickerLabel ??
+    entryType.labels?.plural ??
+    labelSourceText(entryType.label)
+  );
 }
 
 interface MenuEligibleTaxonomy {

--- a/packages/plumix/src/i18n/index.ts
+++ b/packages/plumix/src/i18n/index.ts
@@ -3,7 +3,10 @@ export {
   formatDate,
   formatNumber,
   formatRelative,
+  labelSourceText,
+  resolveLabel,
   type FormatRelativeOptions,
+  type Label,
 } from "@plumix/core";
-export { i18n } from "@lingui/core";
+export { i18n, type MessageDescriptor } from "@lingui/core";
 export { I18nProvider, Trans } from "@lingui/react";


### PR DESCRIPTION
Retrospective sentry-skills pass on the merged slice 5 (#704) — I skipped
this on the original PR; these are the actionable findings consolidated.
Behavior-preserving except the sidebar tooltip fix.

**Sidebar collapsed-rail tooltip rendered `[object Object]` for descriptor labels**

`SidebarMenuButton`'s `tooltip` prop is a string; the slice-5 widening exposed
`Label` directly. Plain strings still rendered correctly so admin UI tests
didn't catch it. Resolved via `renderLabel(item.label)`.

**`labelSourceText` helper consolidates three SSR-side branches**

Three independently-authored "string-or-descriptor → source-locale string"
ternaries landed in slice 5 — `manifest.ts`'s sort comparator,
`route/resolve.ts`'s archive title fallback, `plugin-menu`'s tab-label
predicate. Each was slightly different (`?? ""` vs `?? entryType.name`). Now
one helper in `@plumix/core/i18n`:

```ts
export function labelSourceText(label: Label): string {
  if (typeof label === "string") return label;
  return label.message ?? "";
}
```

**`@plumix/core` declares `"sideEffects": false`**

Tree-shaking of `load-catalog.ts`'s `node:fs/promises` import out of admin's
browser bundle was relying on bundler escape analysis. Now contractual.
Closes the regression class the `AsyncLocalStorage is not a constructor`
crash on PR #702 sat in.

**`plumix/i18n` re-exports the contract**

`Label`, `resolveLabel`, `labelSourceText`, and `MessageDescriptor` now flow
through `plumix/i18n`. Workspace plugins don't need direct `@plumix/core` or
`@lingui/core` imports to consume label types. `@plumix/plugin-menu` migrated
and drops its inline structural copy of `Label` (which was strictly looser
than the real type — fields marked optional that aren't).

**Misc cleanups**
- `compareByOrderThenLabel` + `resolve.ts` archive title use the new helper
- Entries list called `useLabel(entryType.label)` twice on the same input — hoisted
- `adminCatalogPath` one-liner helper inlined in `i18n-boot.ts`
- Stale "admin-side re-sort" comment dropped (promised behavior that didn't exist)

Refs #674