### PR TITLE
refactor(admin): apply #703 simplifier-pass findings

### DIFF
--- a/packages/admin/test/lingui-macro-stub.ts
+++ b/packages/admin/test/lingui-macro-stub.ts
@@ -1,17 +1,5 @@
-/**
- * Test-mode stub for `@lingui/core/macro`.
- *
- * Production builds transform `defineMessage({ id, message })` calls
- * via `@lingui/vite-plugin` + `@rolldown/plugin-babel` (configured in
- * `vite.config.ts`). Vitest runs through vite-node's transform path
- * which doesn't reliably invoke the Babel preset on plain `.ts`
- * imports — the real macro entrypoint then throws at module load
- * trying to use `babel-plugin-macros` as a runtime fallback.
- *
- * Aliasing the macro to this passthrough mirrors what the Babel
- * transform would have produced (the descriptor object literal). See
- * `vitest.config.ts` for the alias wiring.
- */
+// Test-mode passthrough for `@lingui/core/macro`. See `vitest.config.ts`
+// for the alias wiring and rationale.
 import type { MessageDescriptor } from "@lingui/core";
 
 export function defineMessage(
@@ -19,5 +7,3 @@ export function defineMessage(
 ): MessageDescriptor {
   return descriptor;
 }
-
-export const msg = defineMessage;

--- a/packages/admin/vite.config.ts
+++ b/packages/admin/vite.config.ts
@@ -16,6 +16,10 @@ import { ADMIN_BASE_PATH } from "./src/lib/constants.js";
 const ADMIN_DEV_PORT = 5174;
 const BACKEND_URL = process.env.PLUMIX_BACKEND_URL ?? "http://localhost:5173";
 
+// Explicit cwd so tools evaluating this config from the repo root
+// (knip) still find `packages/admin/lingui.config.ts`.
+const PACKAGE_DIR = fileURLToPath(new URL(".", import.meta.url));
+
 export default defineConfig({
   base: `${ADMIN_BASE_PATH}/`,
   // tanstackRouter must run before @vitejs/plugin-react. quoteStyle +
@@ -29,20 +33,9 @@ export default defineConfig({
     }),
     tailwindcss(),
     react(),
-    // `@lingui/vite-plugin` compiles catalogs on-the-fly during dev and
-    // emits per-locale chunks for prod. `@rolldown/plugin-babel` runs
-    // Lingui's macro transform (`defineMessage`, `t`, `<Trans>`, etc.)
-    // alongside plugin-react v6's OXC pipeline — v6 dropped its own
-    // Babel hook, so this is the canonical path back. Both need an
-    // explicit `cwd` so tools evaluating this config from the repo
-    // root (knip) still find `packages/admin/lingui.config.ts`.
-    lingui({ cwd: fileURLToPath(new URL(".", import.meta.url)) }),
+    lingui({ cwd: PACKAGE_DIR }),
     babel({
-      presets: [
-        linguiTransformerBabelPreset(undefined, {
-          cwd: fileURLToPath(new URL(".", import.meta.url)),
-        }),
-      ],
+      presets: [linguiTransformerBabelPreset(undefined, { cwd: PACKAGE_DIR })],
     }),
   ],
   server: {


### PR DESCRIPTION
Retrospective simplifier pass on the vite-plugin adoption PR (#703). Pure
cosmetic / dead-code cleanup, no behavior change. -29 / +8 LOC.

- Lift shared `PACKAGE_DIR` const in `vite.config.ts` instead of computing
  `fileURLToPath(new URL(".", import.meta.url))` twice. Makes the shared-cwd
  invariant structural rather than textual.
- Trim the 7-line block comment above the lingui plugins to the single
  non-obvious WHY (the knip cwd anchor). The plugin-react v6 dropped-Babel
  rationale lives in #703's PR description; vite.config.ts shouldn't re-state
  plugin docs.
- Drop `export const msg = defineMessage` from `test/lingui-macro-stub.ts` —
  `msg` is imported nowhere in the admin tree. Speculative scaffolding;
  regrows in one line if needed.
- Consolidate the duplicated explanation between the stub file's 12-line
  JSDoc and `vitest.config.ts`'s alias comment. The alias site is the natural
  anchor (where the wiring lives); the stub now just points back.

Refs #701