### PR TITLE
feat(admin): per-plugin catalog runtime registry — fetch + merge on boot

### DIFF
--- a/packages/admin/src/lib/i18n-boot.ts
+++ b/packages/admin/src/lib/i18n-boot.ts
@@ -1,6 +1,9 @@
 import type { Messages } from "@lingui/core";
 import { i18n } from "@lingui/core";
 
+import { readManifest } from "./manifest.js";
+import { createPluginCatalogLoader } from "./plugin-catalogs.js";
+
 // Admin's own compiled catalogs. Vite expands the glob at build time
 // into a `path → () => import(path)` map. Adding a locale (drop a
 // `.po`, run `pnpm i18n:compile`) appears here automatically.
@@ -8,12 +11,9 @@ const ADMIN_CATALOGS = import.meta.glob<{ messages: Messages }>(
   "../../locales/*.mjs",
 );
 
-// First-party plugin catalogs shipped via workspace deps. Same glob
-// mechanism: any plugin under `packages/plugins/*/locales/*.mjs`
-// gets merged into the active locale alongside admin chrome. Slice
-// 17 (#697) wires the equivalent for third-party plugins via
-// manifest URLs + runtime fetch — this static path covers the
-// workspace-bundled case at zero runtime cost.
+// First-party workspace plugins ship catalogs via static glob —
+// admin reads them at zero runtime cost. Third-party plugins (not
+// in the workspace) load via manifest URLs, fanned in below.
 const PLUGIN_CATALOGS = import.meta.glob<{ messages: Messages }>(
   "../../../plugins/*/locales/*.mjs",
 );
@@ -23,15 +23,28 @@ const PLUGIN_CATALOGS = import.meta.glob<{ messages: Messages }>(
 // back here. Mirrors `lingui.config.ts:sourceLocale`.
 const SOURCE_LOCALE = "en";
 
+type PluginCatalogLoader = (pluginId: string, locale: string) => Promise<void>;
+
+const NOOP_LOADER: PluginCatalogLoader = () => Promise.resolve();
+
+/** Module-level handle so admin code (and plugin chunks via the
+ *  `window.plumix.i18n.loadPluginCatalog` global) can reach the
+ *  manifest-bound loader installed by `bootI18n`. Pre-boot calls
+ *  hit the no-op default; post-boot they go through the cache. */
+export const pluginCatalogLoaderRef: { current: PluginCatalogLoader } = {
+  current: NOOP_LOADER,
+};
+
 /** Load and activate the compiled catalog for the user's active locale.
  *  Merges admin's own catalog with every workspace plugin catalog
- *  that has a matching `<locale>.mjs`. The admin shell rewrites
- *  `<html lang>` server-side (slice 4) to the user's `meta.locale`;
- *  we normalize (lowercase + region-strip) and look up matching
- *  loaders. Unknown locales fall back to the source locale. A missing
- *  source catalog (e.g., a dev boot before any package has compiled)
- *  leaves Lingui in its descriptor-message fallback mode — never
- *  throws, never blanks. */
+ *  that has a matching `<locale>.mjs`, then fans out manifest-driven
+ *  fetches for third-party plugin catalogs (slice 17 #697). The admin
+ *  shell rewrites `<html lang>` server-side (slice 4) to the user's
+ *  `meta.locale`; we normalize (lowercase + region-strip) and look up
+ *  matching loaders. Unknown locales fall back to the source locale.
+ *  A missing source catalog (e.g., a dev boot before any package has
+ *  compiled) leaves Lingui in its descriptor-message fallback mode —
+ *  never throws, never blanks. */
 export async function bootI18n(): Promise<void> {
   const tag = document.documentElement.lang.toLowerCase().split("-")[0] ?? "";
   const requested = ADMIN_CATALOGS[`../../locales/${tag}.mjs`];
@@ -41,16 +54,31 @@ export async function bootI18n(): Promise<void> {
   const locale = requested ? tag : SOURCE_LOCALE;
 
   const adminMessages = (await adminLoader()).messages;
-  const pluginMessages = await loadPluginCatalogs(locale);
-  // Merge: plugin keys can't collide with admin's (admin uses
-  // `breadcrumb.*` / `menu.*` / etc.; plugins use `plugin.<id>.*`),
-  // so a flat spread is the right shape. If a future collision is a
-  // real concern, namespacing happens at authoring time.
-  i18n.load(locale, { ...adminMessages, ...pluginMessages });
+  const workspaceMessages = await loadWorkspacePluginCatalogs(locale);
+  // Workspace plugins merged first, admin chrome second so admin
+  // wins on collision. Slice 5's note had the opposite order; chrome
+  // stability matters more than letting a plugin override
+  // `breadcrumb.dashboard`. Workspace-plugin collisions on
+  // admin-namespaced keys are a build-time concern (future linter,
+  // not enforced here yet).
+  i18n.load(locale, { ...workspaceMessages, ...adminMessages });
   i18n.activate(locale);
+
+  // Third-party plugins: manifest-driven runtime fetch + merge.
+  const pluginI18n = readManifest().pluginI18n ?? {};
+  pluginCatalogLoaderRef.current = createPluginCatalogLoader({
+    manifest: pluginI18n,
+  });
+  // Fan out fetches in parallel. The loader never rejects (failures
+  // swallow inside), so a broken plugin can't block the mount.
+  await Promise.all(
+    Object.keys(pluginI18n).map((id) =>
+      pluginCatalogLoaderRef.current(id, locale),
+    ),
+  );
 }
 
-async function loadPluginCatalogs(locale: string): Promise<Messages> {
+async function loadWorkspacePluginCatalogs(locale: string): Promise<Messages> {
   const merged: Messages = {};
   for (const [path, loader] of Object.entries(PLUGIN_CATALOGS)) {
     // `../../../plugins/<id>/locales/<locale>.mjs` — match the

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -65,6 +65,9 @@ function normalize(value: unknown): PlumixManifest {
   if (v.i18n && typeof v.i18n === "object") {
     (result as Record<string, unknown>).i18n = v.i18n;
   }
+  if (v.pluginI18n && typeof v.pluginI18n === "object") {
+    (result as Record<string, unknown>).pluginI18n = v.pluginI18n;
+  }
   return result;
 }
 

--- a/packages/admin/src/lib/plugin-catalogs.test.ts
+++ b/packages/admin/src/lib/plugin-catalogs.test.ts
@@ -1,0 +1,82 @@
+import { i18n } from "@lingui/core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createPluginCatalogLoader } from "./plugin-catalogs.js";
+
+describe("createPluginCatalogLoader", () => {
+  beforeEach(() => {
+    i18n.load({ de: {} });
+    i18n.activate("de");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("is a no-op when the manifest has no URL for that (plugin, locale)", async () => {
+    const importCatalog = vi.fn();
+    const load = createPluginCatalogLoader({
+      manifest: { plugin_x: { catalogs: { de: "/de.mjs" } } },
+      importCatalog,
+    });
+
+    await load("plugin_y", "de"); // unknown plugin
+    await load("plugin_x", "fr"); // known plugin, unknown locale
+
+    expect(importCatalog).not.toHaveBeenCalled();
+  });
+
+  test("swallows fetch failures + logs; the failing plugin falls back to descriptor.message", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const importCatalog = vi.fn(() => Promise.reject(new Error("net down")));
+    const load = createPluginCatalogLoader({
+      manifest: { plugin_x: { catalogs: { de: "/de.mjs" } } },
+      importCatalog,
+    });
+
+    await expect(load("plugin_x", "de")).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("plugin_x"),
+      expect.any(Error),
+    );
+  });
+
+  test("caches per (pluginId, locale): repeat calls don't re-import", async () => {
+    const importCatalog = vi.fn(() =>
+      Promise.resolve({ messages: { foo: ["bar"] } }),
+    );
+    const load = createPluginCatalogLoader({
+      manifest: { plugin_x: { catalogs: { de: "/de.mjs" } } },
+      importCatalog,
+    });
+
+    await load("plugin_x", "de");
+    await load("plugin_x", "de");
+    await load("plugin_x", "de");
+
+    expect(importCatalog).toHaveBeenCalledTimes(1);
+  });
+
+  test("imports the catalog URL and merges messages into the active locale", async () => {
+    const importCatalog = vi.fn(() =>
+      Promise.resolve({ messages: { "plugin.x.label": ["Translated"] } }),
+    );
+    const load = createPluginCatalogLoader({
+      manifest: {
+        plugin_x: {
+          catalogs: { de: "/_plumix/admin/plugins/plugin_x/locales/de.mjs" },
+        },
+      },
+      importCatalog,
+    });
+
+    await load("plugin_x", "de");
+
+    expect(importCatalog).toHaveBeenCalledWith(
+      "/_plumix/admin/plugins/plugin_x/locales/de.mjs",
+    );
+    expect(i18n.messages["plugin.x.label"]).toEqual(["Translated"]);
+  });
+});

--- a/packages/admin/src/lib/plugin-catalogs.ts
+++ b/packages/admin/src/lib/plugin-catalogs.ts
@@ -1,0 +1,61 @@
+import type { Messages } from "@lingui/core";
+import { i18n } from "@lingui/core";
+
+import type { PluginI18nManifest } from "@plumix/core/manifest";
+
+interface PluginCatalogLoaderInput {
+  readonly manifest: PluginI18nManifest;
+  readonly importCatalog?: (url: string) => Promise<{ messages: Messages }>;
+}
+
+/** Build a `loadPluginCatalog(pluginId, locale)` function bound to a
+ *  manifest snapshot. Resolves the URL declared in
+ *  `manifest[pluginId].catalogs[locale]` via dynamic `import()` (the
+ *  catalog is a standard ES module — `export const messages = {...}`),
+ *  and merges the loaded `messages` into the active Lingui instance.
+ *  No-op when the manifest doesn't declare a URL for that (plugin,
+ *  locale): missing catalog means the plugin's `<Trans>` calls fall
+ *  through to `descriptor.message`. */
+export function createPluginCatalogLoader({
+  manifest,
+  importCatalog = (url) => import(/* @vite-ignore */ url),
+}: PluginCatalogLoaderInput): (
+  pluginId: string,
+  locale: string,
+) => Promise<void> {
+  // Cache by `(pluginId, locale)` so repeat calls (e.g., a chunk that
+  // re-mounts) don't refetch. Storing the in-flight promise also
+  // dedups concurrent calls.
+  const inflight = new Map<string, Promise<void>>();
+  return function loadPluginCatalog(pluginId, locale) {
+    const url = manifest[pluginId]?.catalogs[locale];
+    if (!url) return Promise.resolve();
+    const key = `${pluginId}|${locale}`;
+    const cached = inflight.get(key);
+    if (cached) return cached;
+    // The IIFE never rejects: failures swallow inside the catch. The
+    // boot path (`Promise.all` in `bootI18n`) relies on this — a
+    // single broken plugin must not abort the mount. Pulling the
+    // try/catch out of this closure would silently break that
+    // contract.
+    const promise = (async () => {
+      try {
+        const mod = await importCatalog(url);
+        // `i18n.load(locale, messages)` merges via Object.assign
+        // internally — no need to spread `i18n.messages` (which is
+        // the *active* locale's bucket, not `locale`'s; spreading
+        // would copy active strings into the wrong bucket when this
+        // is called for a non-active locale, e.g., via
+        // `window.plumix.i18n.loadPluginCatalog`).
+        i18n.load(locale, mod.messages);
+      } catch (error) {
+        console.error(
+          `[plumix] failed to load catalog for ${pluginId} (${locale})`,
+          error,
+        );
+      }
+    })();
+    inflight.set(key, promise);
+    return promise;
+  };
+}

--- a/packages/admin/src/lib/plumix-globals.ts
+++ b/packages/admin/src/lib/plumix-globals.ts
@@ -8,6 +8,7 @@ import * as ReactRouterNs from "@tanstack/react-router";
 import * as ReactDomNs from "react-dom";
 import * as ReactDomClientNs from "react-dom/client";
 
+import { pluginCatalogLoaderRef } from "./i18n-boot.js";
 import {
   registerPluginBlock,
   registerPluginBlockEditor,
@@ -31,6 +32,17 @@ const runtime = {
   orpcTanstackQuery: OrpcTanstackQueryNs,
 } as const;
 
+interface PlumixI18nGlobal {
+  /** Load a third-party plugin's compiled catalog for the active
+   *  locale. Plugins that mount admin chunks after initial boot call
+   *  this from their entry to merge their catalog into the same
+   *  Lingui instance the admin uses. */
+  readonly loadPluginCatalog: (
+    pluginId: string,
+    locale: string,
+  ) => Promise<void>;
+}
+
 declare global {
   interface Window {
     plumix?: {
@@ -41,6 +53,7 @@ declare global {
       readonly registerPluginBlock: typeof registerPluginBlock;
       readonly registerPluginMarkSchema: typeof registerPluginMarkSchema;
       readonly runtime: typeof runtime;
+      readonly i18n: PlumixI18nGlobal;
     };
   }
 }
@@ -56,5 +69,15 @@ export function bootPlumixGlobals(): void {
     registerPluginBlock,
     registerPluginMarkSchema,
     runtime,
+    // Indirection through the ref so the manifest-bound loader
+    // installed by `bootI18n` is reachable from plugin chunks that
+    // load post-boot. Pre-boot callers hit the no-op default; the
+    // call is then a silent miss (the chunk's `<Trans>` falls back
+    // to `descriptor.message`). Plugin authors should call this
+    // from `useEffect`, not module top-level.
+    i18n: {
+      loadPluginCatalog: (pluginId, locale) =>
+        pluginCatalogLoaderRef.current(pluginId, locale),
+    },
   };
 }

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -30,6 +30,43 @@ describe("buildManifest", () => {
     expect(manifest.tokens).toEqual(tokens);
   });
 
+  test("buildManifest projects plugin i18n catalog URLs intersected with site locales", () => {
+    const plugin = definePlugin("translated", {
+      i18n: {
+        sourceLocale: "en",
+        locales: ["en", "de", "fr"],
+        catalogPath: "./locales",
+      },
+      setup: () => undefined,
+    });
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "de"],
+    });
+    const manifest = buildManifest(createPluginRegistry(), {
+      i18n,
+      plugins: [plugin],
+    });
+    // German is in both plugin.locales and site.locales → URL emitted.
+    // English is the source locale → no URL (Lingui renders descriptor.message).
+    // French is plugin-declared but not site-enabled → dropped.
+    expect(manifest.pluginI18n).toEqual({
+      translated: {
+        catalogs: {
+          de: "/_plumix/admin/plugins/translated/locales/de.mjs",
+        },
+      },
+    });
+  });
+
+  test("buildManifest omits pluginI18n when no plugin declares an i18n slot", () => {
+    const plugin = definePlugin("untranslated", () => undefined);
+    const manifest = buildManifest(createPluginRegistry(), {
+      plugins: [plugin],
+    });
+    expect(manifest.pluginI18n).toEqual({});
+  });
+
   test("buildManifest projects the site's i18n config — defaultLocale + enabled locales", () => {
     const i18n = resolveLocales({
       defaultLocale: "en",

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -20,6 +20,7 @@ import type { Label } from "../i18n/label.js";
 import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import type { RouteIntent } from "../route/intent.js";
 import type { RegisteredTemplateDep } from "../template-deps.js";
+import type { PluginI18nSlot } from "./define.js";
 import type { RegisteredLookupAdapter } from "./lookup.js";
 import { labelSourceText } from "../i18n/label.js";
 import { DuplicateAdminSlugError, PluginDefinitionError } from "./errors.js";
@@ -1501,7 +1502,24 @@ export interface PlumixManifest {
    * `tokens`: the precompiled admin shell can't import the user's config.
    */
   readonly i18n?: I18nManifest;
+  /**
+   * Per-plugin catalog URL maps for the i18n runtime registry (#697).
+   * Admin fetches `pluginI18n[id].catalogs[locale]` at boot, merges the
+   * loaded `messages` into the active Lingui instance. The source
+   * locale never has an entry (Lingui returns `descriptor.message`
+   * when active === source). Locales are intersected with the site's
+   * enabled list before emission. Plugins without an `i18n` slot
+   * don't appear here.
+   */
+  readonly pluginI18n?: PluginI18nManifest;
 }
+
+/** Per-plugin catalog URL maps. Flat record keyed by plugin id so
+ *  `manifest.pluginI18n[id]` is direct lookup; admin reads this
+ *  shape verbatim. */
+export type PluginI18nManifest = Readonly<
+  Record<string, { readonly catalogs: Readonly<Record<string, string>> }>
+>;
 
 export interface I18nManifest {
   readonly defaultLocale: string;
@@ -1537,6 +1555,7 @@ export function emptyManifest(): PlumixManifest {
     patterns: [],
     tokens: {},
     i18n: { defaultLocale: "en", locales: [] },
+    pluginI18n: {},
   };
 }
 
@@ -1557,6 +1576,10 @@ export function buildManifest(
   options?: {
     readonly tokens?: ThemeTokens;
     readonly i18n?: ResolvedI18n;
+    readonly plugins?: readonly {
+      readonly id: string;
+      readonly i18n?: PluginI18nSlot;
+    }[];
   },
 ): BuiltManifest {
   const entries = Array.from(registry.entryTypes.values())
@@ -1643,7 +1666,44 @@ export function buildManifest(
       // affordance can be re-introduced when there's a consumer.
       locales: (options?.i18n?.locales ?? []).filter((l) => l.enabled),
     },
+    pluginI18n: projectPluginI18n(options?.plugins, options?.i18n),
   };
+}
+
+function projectPluginI18n(
+  plugins:
+    | readonly { readonly id: string; readonly i18n?: PluginI18nSlot }[]
+    | undefined,
+  siteI18n: ResolvedI18n | undefined,
+): PluginI18nManifest {
+  if (!plugins) return {};
+  const siteLocales = new Set(
+    (siteI18n?.locales ?? []).filter((l) => l.enabled).map((l) => l.code),
+  );
+  const out: Record<string, { catalogs: Record<string, string> }> = {};
+  for (const plugin of plugins) {
+    if (!plugin.i18n) continue;
+    const catalogs: Record<string, string> = {};
+    for (const locale of plugin.i18n.locales) {
+      if (locale === plugin.i18n.sourceLocale) continue;
+      // Site-locale intersection: when the site declares i18n,
+      // emit URLs only for locales it has enabled. With no site
+      // i18n configured, trust the plugin's list so tests without
+      // site config still exercise the URL shape.
+      if (siteLocales.size > 0 && !siteLocales.has(locale)) continue;
+      // URL is intentionally same-origin (`/_plumix/admin/...`) so
+      // default CSP `script-src 'self'` covers the dynamic import.
+      // Widening to absolute URLs (CDN-hosted catalogs) would need
+      // a CSP review.
+      catalogs[locale] =
+        `/_plumix/admin/plugins/${plugin.id}/locales/${locale}.mjs`;
+    }
+    // Skip plugins whose entire locale set was intersected/dropped —
+    // a manifest entry with empty catalogs is wire noise that admin's
+    // boot loop would still iterate.
+    if (Object.keys(catalogs).length > 0) out[plugin.id] = { catalogs };
+  }
+  return out;
 }
 
 interface MutableAdminNavGroup {

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -367,7 +367,13 @@ async function computeManifestAndRegistry(
     hooks: new HookRegistry(),
     plugins,
   });
-  return { manifest: buildManifest(registry, options), registry };
+  // Forward plugin descriptors so `buildManifest` can emit
+  // `pluginI18n` URL maps for plugins declaring an `i18n` slot
+  // (slice 17 #697 runtime catalog registry).
+  return {
+    manifest: buildManifest(registry, { ...options, plugins }),
+    registry,
+  };
 }
 
 // Copies the compiled admin SPA from plumix/dist/admin-app into the effective


### PR DESCRIPTION
Slice 17 (#697) — runtime portion. Closes the third-party plugin i18n story
(slice 5 covered the workspace path via static `import.meta.glob`; this adds
the third-party path via manifest URLs + runtime fetch).

**Manifest schema**

```ts
pluginI18n: { [id]: { catalogs: { [locale]: url } } }
```

`buildManifest()` emits it from each plugin descriptor's `i18n` slot. URLs
are intentionally same-origin (`/_plumix/admin/plugins/<id>/locales/<locale>.mjs`)
so default CSP `script-src 'self'` covers the dynamic import. Source locale
skipped (Lingui returns `descriptor.message` when active === source).
Locales intersected with the site's enabled list; plugins whose entire
locale set drops out are omitted entirely.

**Runtime registry**

```ts
const loadPluginCatalog = createPluginCatalogLoader({ manifest });
await loadPluginCatalog("plugin_x", "de");
```

Dynamic `import()` of the URL → merges `messages` into the active Lingui
instance via `i18n.load(locale, messages)`. Per-(pluginId, locale) in-flight
Promise cache. Failures swallow + log; admin still mounts.

**Boot integration**

`bootI18n` reads `manifest.pluginI18n`, binds the loader to the snapshot,
fans out fetches via `Promise.all`. Workspace-plugin merge order flipped
from slice 5's: admin chrome wins on collision (`breadcrumb.dashboard`
etc. shouldn't be overridable by a plugin).

`window.plumix.i18n.loadPluginCatalog(pluginId, locale)` exposed via
`pluginCatalogLoaderRef` indirection — chunks loaded post-boot reuse the
same cache. Pre-boot callers hit the no-op default; plugin authors should
call from `useEffect`, not module top-level.

**Sentry pass — caught + fixed BEFORE commit (per the workflow lesson)**

| Reviewer | Finding | Fix |
|---|---|---|
| Senpai M1 | `readManifest()` normalizer dropped `pluginI18n` | Added to normalizer |
| Senpai M2 | Vite plugin didn't forward `plugins` to `buildManifest` | Threaded through |
| Senpai M3 | `{ ...i18n.messages, ...mod.messages }` copies wrong locale's bucket | Just `i18n.load(locale, messages)` — Lingui merges internally |
| Simplifier S2 | Mutable binding + getter | Collapsed to `pluginCatalogLoaderRef` |
| Simplifier S3 | Duplicate "source locale" reasoning | One canonical comment |
| Senpai N5 | Empty catalog entries emitted as wire noise | Skip when intersection is empty |
| Senpai N2 | `emptyManifest()` missing the new field | Added `pluginI18n: {}` |

**TDD**: 4 cycles on `createPluginCatalogLoader` + 2 new `buildManifest` tests. All 74 workspace tasks pass.

**Deferred to follow-up** (#697 stays open):
- Plumix Vite plugin copying plugin `.mjs` files to served paths
- E2E proving ground with a real third-party-shaped plugin

The runtime registry is fully testable + production-correct once the
bundler serves the URLs the manifest references.

Refs #697