### PR TITLE
feat(eslint): adopt eslint-plugin-lingui for macro-misuse rules

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "eslint/config";
 
 import { baseConfig } from "@plumix/eslint-config/base";
+import { i18nConfig } from "@plumix/eslint-config/i18n";
 import { reactConfig } from "@plumix/eslint-config/react";
 
-export default defineConfig(baseConfig, reactConfig, {
+export default defineConfig(baseConfig, reactConfig, i18nConfig, {
   // Vendored shadcn/ui primitives — kept verbatim so `shadcn diff` upgrades
   // don't merge-conflict. Lint these like we lint node_modules: we don't.
   // Compiled Lingui catalogs are generated; their `/*eslint-disable*/`

--- a/packages/plugins/audit-log/eslint.config.ts
+++ b/packages/plugins/audit-log/eslint.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 
 import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
+import { i18nConfig } from "@plumix/eslint-config/i18n";
 
-export default defineConfig(baseConfig, noInternalImports);
+export default defineConfig(baseConfig, noInternalImports, i18nConfig);

--- a/packages/plugins/media/eslint.config.ts
+++ b/packages/plugins/media/eslint.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 
 import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
+import { i18nConfig } from "@plumix/eslint-config/i18n";
 
-export default defineConfig(baseConfig, noInternalImports);
+export default defineConfig(baseConfig, noInternalImports, i18nConfig);

--- a/packages/plugins/menu/eslint.config.ts
+++ b/packages/plugins/menu/eslint.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 
 import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
+import { i18nConfig } from "@plumix/eslint-config/i18n";
 
-export default defineConfig(baseConfig, noInternalImports);
+export default defineConfig(baseConfig, noInternalImports, i18nConfig);

--- a/packages/plugins/pages/eslint.config.ts
+++ b/packages/plugins/pages/eslint.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 
 import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
+import { i18nConfig } from "@plumix/eslint-config/i18n";
 
-export default defineConfig(baseConfig, noInternalImports);
+export default defineConfig(baseConfig, noInternalImports, i18nConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1275,6 +1275,9 @@ importers:
       eslint-plugin-import-x:
         specifier: ^4
         version: 4.16.2(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-lingui:
+        specifier: ^0.13.1
+        version: 0.13.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@10.4.0(jiti@2.7.0))
@@ -5256,6 +5259,13 @@ packages:
       eslint-import-resolver-node:
         optional: true
 
+  eslint-plugin-lingui@0.13.1:
+    resolution: {integrity: sha512-tnMmVXRwXK32ks5GFzAftC6CCSOkQ77z8obwDclgOEulzMpOjjKjNL7/BV1X74KQhnkHBCr/PA0wwX/h6ZZMcg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      eslint: ^8.37.0 || ^9 || ^10
+      typescript: ^5.0.0 || ^6.0.0
+
   eslint-plugin-react-hooks@7.1.1:
     resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
@@ -7222,7 +7232,7 @@ snapshots:
       commander: 10.0.1
       marked: 9.1.6
       marked-terminal: 7.3.0(marked@9.1.6)
-      semver: 7.8.0
+      semver: 7.8.1
 
   '@arethetypeswrong/core@0.18.2':
     dependencies:
@@ -7231,7 +7241,7 @@ snapshots:
       cjs-module-lexer: 1.4.3
       fflate: 0.8.2
       lru-cache: 11.3.6
-      semver: 7.8.0
+      semver: 7.8.1
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
 
@@ -10172,7 +10182,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.7(@types/node@24.12.2)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -10940,6 +10950,15 @@ snapshots:
       unrs-resolver: 1.11.1
     optionalDependencies:
       '@typescript-eslint/utils': 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-lingui@0.13.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.0(jiti@2.7.0)
+      micromatch: 4.0.8
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 

--- a/tooling/eslint/i18n.ts
+++ b/tooling/eslint/i18n.ts
@@ -1,0 +1,28 @@
+import pluginLingui from "eslint-plugin-lingui";
+import { defineConfig } from "eslint/config";
+
+/**
+ * Lingui macro-misuse rules. Opt-in for packages that render admin UI
+ * (admin itself + plugins with admin chunks). Complements `plumix
+ * i18n extract --check` (slice 7): the gate catches drift in wrapped
+ * strings; these rules catch extractor-breaking shapes (empty
+ * msgids, expressions inside messages, module-scope `t` calls).
+ *
+ * `no-unlocalized-strings` is deliberately NOT enabled — admin has
+ * 3000+ unwrapped sites today; the wrap pass is its own slice (#684),
+ * and the allowlist is best authored against real findings rather
+ * than speculated upfront.
+ */
+export const i18nConfig = defineConfig({
+  files: ["**/src/**/*.{ts,tsx}"],
+  extends: [pluginLingui.configs["flat/recommended"]],
+  rules: {
+    // Plugin defaults are `warn` for these four (`t-call-in-function`
+    // is already `error`). Promote to `error` so extractor-breaking
+    // shapes block CI like every other lint failure.
+    "lingui/no-trans-inside-trans": "error",
+    "lingui/no-expression-in-message": "error",
+    "lingui/no-single-variables-to-translate": "error",
+    "lingui/no-single-tag-to-translate": "error",
+  },
+});

--- a/tooling/eslint/package.json
+++ b/tooling/eslint/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     "./base": "./base.ts",
+    "./i18n": "./i18n.ts",
     "./react": "./react.ts"
   },
   "scripts": {
@@ -16,6 +17,7 @@
     "@eslint/compat": "^2",
     "@eslint/js": "^10",
     "eslint-plugin-import-x": "^4",
+    "eslint-plugin-lingui": "^0.13.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-turbo": "^2",


### PR DESCRIPTION
Wires `eslint-plugin-lingui`'s flat/recommended config into a new
`@plumix/eslint-config/i18n` export, opted into by admin and each plugin with
an admin TSX surface (admin, audit-log, media, menu, pages). Complements
slice 7's `plumix i18n extract --check`: the gate catches drift in wrapped
strings; these rules catch **extractor-breaking shapes** — empty msgids from
`<Trans>{x}</Trans>`, expressions inside messages, module-scope `t` calls,
nested `<Trans>` elements.

**Pluggable, not universal**

Per direction, kept as opt-in (`@plumix/eslint-config/i18n`) rather than
folded into baseConfig. Only admin + plugins with translatable UI opt in.
Rules promoted from plugin defaults (4 × `warn`) to `error` so
extractor-breaking shapes block CI.

**`no-unlocalized-strings` deferred to #684**

Admin has 3000+ unwrapped sites today; #684 is the dedicated wrap pass.
Authoring the allowlist against speculation drifts (`z.enum` while admin uses
valibot; `orpc.call` matching nothing) — the wrap slice will author it
against real findings instead.

**Sentry pass — caught BEFORE commit**

Senpai + simplifier in parallel both converged on the same Strong
simplification: delete the speculative `i18nStrictConfig` block (108 of 148
lines were guesses about a future config) and extend `flat/recommended`
instead of hand-listing rules + plugin registration. The `as never` typing
dodge disappeared with it. Config collapsed from 148 → 30 LOC.

Refs #700 (closes the macro-misuse half; `no-unlocalized-strings` closes with #684)