### PR TITLE
feat: adopt lingui/no-unlocalized-strings on admin chrome ratchet

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -1,13 +1,57 @@
 import { defineConfig } from "eslint/config";
 
 import { baseConfig } from "@plumix/eslint-config/base";
-import { i18nConfig } from "@plumix/eslint-config/i18n";
+import { i18nConfig, i18nStrictOverrides } from "@plumix/eslint-config/i18n";
 import { reactConfig } from "@plumix/eslint-config/react";
 
-export default defineConfig(baseConfig, reactConfig, i18nConfig, {
-  // Vendored shadcn/ui primitives — kept verbatim so `shadcn diff` upgrades
-  // don't merge-conflict. Lint these like we lint node_modules: we don't.
-  // Compiled Lingui catalogs are generated; their `/*eslint-disable*/`
-  // header trips the unused-disable-directive rule.
-  ignores: ["src/components/ui/**", "src/hooks/use-mobile.ts", "locales/**"],
-});
+// Strict mode (`no-unlocalized-strings`) ratchet — every file in this
+// list must stay free of raw user-facing strings. Add a file here only
+// after wrapping every translatable string it contains. Slice 15
+// (#684) is the umbrella tracking the expansion of this list to the
+// rest of admin chrome.
+const STRICT_WRAPPED_FILES = [
+  "src/components/locale-switcher.tsx",
+  "src/components/profile/language-card.tsx",
+  "src/components/shell/user-menu.tsx",
+  "src/lib/dates.ts",
+  "src/lib/i18n-boot.ts",
+  "src/lib/plugin-catalogs.ts",
+  "src/lib/plumix-globals.ts",
+  "src/lib/use-formatters.ts",
+  "src/lib/use-label.ts",
+  "src/routes/__root.tsx",
+  "src/routes/_auth/login.tsx",
+  "src/routes/_authenticated/index.tsx",
+  // `src/lib/breadcrumbs.ts` is intentionally excluded — `Create {singular}`
+  // / `Edit {singular}` literals there need a `Crumb`-shape rework to
+  // carry placeholder values before strict mode can enforce.
+];
+
+export default defineConfig(
+  baseConfig,
+  reactConfig,
+  i18nConfig,
+  {
+    // Strict mode (`no-unlocalized-strings`) scoped to the ratchet list.
+    // Surfaces not yet wrapped keep the macro-misuse rules from
+    // `i18nConfig` (already applied above) until they're added here.
+    files: STRICT_WRAPPED_FILES,
+    ...i18nStrictOverrides,
+  },
+  {
+    // Vendored shadcn/ui primitives — kept verbatim so `shadcn diff` upgrades
+    // don't merge-conflict. Lint these like we lint node_modules: we don't.
+    // Compiled Lingui catalogs are generated; their `/*eslint-disable*/`
+    // header trips the unused-disable-directive rule.
+    // E2E fixture plugins live under `e2e/fixtures/*/src/*` and aren't
+    // user-facing — keep them out of the `no-unlocalized-strings` net.
+    // Colocated `*.test.{ts,tsx}` files match `src/**` too; same boundary.
+    ignores: [
+      "src/components/ui/**",
+      "src/hooks/use-mobile.ts",
+      "locales/**",
+      "e2e/**",
+      "**/*.test.{ts,tsx}",
+    ],
+  },
+);

--- a/packages/admin/src/lib/breadcrumbs.ts
+++ b/packages/admin/src/lib/breadcrumbs.ts
@@ -89,6 +89,10 @@ function taxonomiesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const label = tax?.label ?? name;
   const singular = (tax?.labels?.singular ?? label).toLowerCase();
   const list: Crumb = { label, to: `/terms/${name}` };
+  // TODO(#684 follow-up): widen `Crumb` to carry `values` so these
+  // template literals can become descriptors with placeholder
+  // substitution at render time (e.g. `Create {singular}`). Until
+  // then, `breadcrumbs.ts` stays out of the strict-mode ratchet.
   if (parts[2] === "create")
     return [{ label: M.terms }, list, { label: `Create ${singular}` }];
   if (parts[3] === "edit")
@@ -116,7 +120,11 @@ function pluginPagesCrumbs(parts: readonly string[]): readonly Crumb[] {
   if (item) return [{ label: item.label }];
   // Unknown plugin path — keep the URL slug as a placeholder so the
   // user doesn't see an opaque "Admin" header during a 404.
-  const tail = parts[parts.length - 1] ?? "Admin";
+  const tail = parts[parts.length - 1];
+  // Caller enters via `case "pages"` in `pathToCrumbs`, so `parts`
+  // is non-empty in practice; the guard exists to satisfy
+  // `noUncheckedIndexedAccess` without leaning on `!`.
+  if (tail === undefined) return [{ label: M.admin }];
   return [{ label: tail }];
 }
 

--- a/tooling/eslint/i18n.ts
+++ b/tooling/eslint/i18n.ts
@@ -1,3 +1,4 @@
+import type { Linter } from "eslint";
 import pluginLingui from "eslint-plugin-lingui";
 import { defineConfig } from "eslint/config";
 
@@ -8,10 +9,8 @@ import { defineConfig } from "eslint/config";
  * strings; these rules catch extractor-breaking shapes (empty
  * msgids, expressions inside messages, module-scope `t` calls).
  *
- * `no-unlocalized-strings` is deliberately NOT enabled — admin has
- * 3000+ unwrapped sites today; the wrap pass is its own slice (#684),
- * and the allowlist is best authored against real findings rather
- * than speculated upfront.
+ * `no-unlocalized-strings` lives in `i18nStrictConfig` below — opt
+ * into that once a package's chrome is fully wrapped.
  */
 export const i18nConfig = defineConfig({
   files: ["**/src/**/*.{ts,tsx}"],
@@ -25,4 +24,179 @@ export const i18nConfig = defineConfig({
     "lingui/no-single-variables-to-translate": "error",
     "lingui/no-single-tag-to-translate": "error",
   },
+});
+
+/**
+ * Overrides that enable `no-unlocalized-strings`. Spread into a flat-
+ * config block alongside `files: [...]` to scope strict mode to a
+ * specific ratchet list — see `packages/admin/eslint.config.ts`.
+ *
+ * The allowlist covers attribute / function call sites whose string-
+ * literal arguments are non-user-facing identifiers (test ids, route
+ * paths, validator constants, error discriminators) — authored
+ * empirically against admin's real source.
+ */
+export const i18nStrictOverrides: Linter.Config = {
+  rules: {
+    "lingui/no-unlocalized-strings": [
+      "error",
+      {
+        // Regex matchers against the literal string content. The
+        // plugin's built-in `/^[^\p{L}]+$/u` already covers pure
+        // punctuation — don't restate it here.
+        ignore: [
+          // BCP-47 locale codes: "en", "de", "en-US", "zh-CN", etc.
+          "^[a-z]{2,3}(-[A-Z][a-zA-Z0-9]+)*$",
+          // Filesystem paths / globs (relative + absolute + bare).
+          "^[./]",
+          "^/",
+          "\\.(mjs|js|ts|tsx|json|po|css|svg)$",
+          // Intl / form-mode / RHF enum values that real user-facing
+          // copy would never be.
+          "^(auto|always|never|short|medium|long|full|narrow|onBlur|onChange|onSubmit|onTouched|manual)$",
+          // Error / loading discriminator codes returned from async
+          // mutations (passkey errors, query states, etc.).
+          "^(unknown|pending|idle|loading|success|error)$",
+        ],
+        // Bare strings compile via `new RegExp(s)`; the `{regex:{pattern,flags?}}`
+        // form is required only when flags are needed. Most entries are
+        // exact-match names, so plain strings are fine.
+        ignoreNames: [
+          // Markup attribute namespaces (data-*, aria-*) — regex form
+          // so future shadcn upgrades don't add new entries here.
+          { regex: { pattern: "^data-" } },
+          { regex: { pattern: "^aria-" } },
+          "type",
+          "role",
+          "name",
+          "id",
+          "key",
+          "to",
+          "href",
+          "src",
+          "alt",
+          "method",
+          "encType",
+          "target",
+          "rel",
+          "autoComplete",
+          "autoCapitalize",
+          "inputMode",
+          "tabIndex",
+          "className",
+          "class",
+          "style",
+          "variant",
+          "size",
+          "color",
+          "fill",
+          "stroke",
+          "viewBox",
+          "xmlns",
+          "d",
+          "fontFamily",
+          "fontVariant",
+          "side",
+          "align",
+          "placement",
+          "as",
+          "asChild",
+          // Internal identifiers / discriminators
+          "status",
+          "code",
+          "slug",
+          "kind",
+          "scope",
+          "displayName",
+          "$$typeof",
+          // Tanstack query / router
+          "queryKey",
+          // Brand constants used as document-title suffix. Localizing
+          // the product name is out of scope.
+          "TITLE_BRAND",
+          // ARIA: real labels should be translated, but `ariaLabel` is
+          // also used for non-i18n SVG accessibility hints — defer to
+          // case-by-case enablement later.
+          "ariaLabel",
+        ],
+        ignoreFunctions: [
+          // Validators
+          "v.picklist",
+          "v.literal",
+          "v.string",
+          "v.array",
+          "v.object",
+          "v.pipe",
+          "v.parse",
+          "v.safeParse",
+          "v.union",
+          "v.optional",
+          "v.boolean",
+          "v.number",
+          "v.record",
+          "v.looseObject",
+          "v.email",
+          "v.minLength",
+          "v.maxLength",
+          "v.trim",
+          "v.toLowerCase",
+          "v.transform",
+          "v.fallback",
+          "v.integer",
+          "v.minValue",
+          "v.maxValue",
+          // Route definition
+          "createFileRoute",
+          "createRootRouteWithContext",
+          // React / TanStack hooks (their string args are query keys
+          // / context names, not user-facing)
+          "useQuery",
+          "useMutation",
+          "useSuspenseQuery",
+          "useInfiniteQuery",
+          // Logging
+          "console.log",
+          "console.warn",
+          "console.error",
+          "console.info",
+          "console.debug",
+          // Native error constructors
+          "Error",
+          "TypeError",
+          "RangeError",
+          // URLs / browser APIs
+          "URL",
+          "URLSearchParams",
+          "Symbol",
+          "fetch",
+          // Capability + auth
+          "hasCap",
+          // Routing actions
+          "redirect",
+          "notFound",
+          // React Hook Form: string args are field paths, not user copy.
+          "form.getValues",
+          "form.setValue",
+          "form.watch",
+          "form.trigger",
+          "form.resetField",
+          "form.getFieldState",
+          // i18n: descriptor factory + imperative-with-fallback form.
+          // `i18n._(id, values, { message })` is the canonical runtime
+          // API; the `message` fallback is extracted by `lingui extract`.
+          "defineMessage",
+          "i18n._",
+        ],
+      },
+    ],
+  },
+};
+
+/**
+ * Strict superset: macro-misuse rules + `no-unlocalized-strings`.
+ * Opt into per-package once that package's chrome is fully wrapped.
+ */
+export const i18nStrictConfig = defineConfig(i18nConfig, {
+  files: ["**/src/**/*.{ts,tsx}"],
+  ...i18nStrictOverrides,
 });


### PR DESCRIPTION
Enable `lingui/no-unlocalized-strings` on a 12-file `STRICT_WRAPPED_FILES` list — the admin chrome that earlier slices fully wrapped. The macro-misuse rules from #708 (`no-trans-inside-trans`, `no-expression-in-message`, …) already cover the workspace; this layers the source-side gate on top so new raw copy in the ratchet list fails CI the same way extraction drift does.

**Ratchet design**

`packages/admin/eslint.config.ts` keeps the strict block scoped to an explicit array of file globs. Each future surface (entries / users / settings / etc.) lands strict mode by wrapping its strings, then appending the file to that array. The exclusion list is the explicit contract — files not on it stay on the macro-misuse-only config.

**Allowlist authored empirically against real source**

The rule's defaults reject too much to be useful without configuration. The allowlist categories were derived from the actual unwrapped-string failures across the 12 listed files:

- `ignore` regex — BCP-47 locale codes (`en`, `de-DE`, …), filesystem paths, file-extension suffixes, Intl / RHF / form-mode enums (`auto`, `onBlur`, …), async-mutation discriminators (`unknown`, `pending`, `idle`, `loading`, `success`, `error`).
- `ignoreNames` — HTML/JSX attribute namespaces via `{regex:{pattern:"^data-"}}` and `^aria-`, named attributes (`type`, `role`, `name`, `href`, `className`, …), internal discriminators (`status`, `code`, `slug`, `displayName`), TanStack `queryKey`, and the `TITLE_BRAND` doc-title constant.
- `ignoreFunctions` — the `v.*` valibot namespace, TanStack router / query hooks, native `Error` / `URL` / `Symbol` constructors, `console.*`, capability + redirect helpers, React Hook Form `form.*` accessors, and the i18n descriptor factories (`defineMessage`, `i18n._`).

**`i18nStrictOverrides` shape**

```ts
// tooling/eslint/i18n.ts
export const i18nStrictOverrides: Linter.Config = {
  rules: { "lingui/no-unlocalized-strings": ["error", { ... }] },
};
```

```ts
// packages/admin/eslint.config.ts
{
  files: STRICT_WRAPPED_FILES,
  ...i18nStrictOverrides,
},
```

The earlier shape exported a fully-extended `i18nStrictConfig` and required consumers to index `i18nStrictConfig[2]` to pull out the strict block before re-scoping `files`. That index was load-bearing and would have silently spread the wrong block on any future addition to `i18nConfig`.

**`breadcrumbs.ts` deliberately excluded**

`Create ${singular}` / `Edit ${singular}` template literals there need a `Crumb`-shape rework to thread `MessageDescriptor.values` through the render path (currently `__root.tsx` calls `i18n._(label.id, undefined, { message })` with no values). Tracked as follow-up under #684 (mass admin chrome wrap), which stays open for surface-by-surface expansion.

Closes #700