### PR TITLE
feat(admin): wrap settings index chrome + lock into i18n ratchet

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -22,6 +22,7 @@ const STRICT_WRAPPED_FILES = [
   "src/routes/__root.tsx",
   "src/routes/_auth/login.tsx",
   "src/routes/_authenticated/index.tsx",
+  "src/routes/_authenticated/settings/index.tsx",
   // `src/lib/breadcrumbs.ts` is intentionally excluded — `Create {singular}`
   // / `Edit {singular}` literals there need a `Crumb`-shape rework to
   // carry placeholder values before strict mode can enforce.

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -13,45 +13,26 @@ msgstr ""
 "Last-Translator: \n"
 "Language-Team: \n"
 
-#. Hand-maintained: defined in src/lib/breadcrumbs.ts as a plain
-#. descriptor (no macro), so `lingui extract` cannot discover it.
 #. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
+#: src/routes/_authenticated/settings/index.test.tsx
+#: src/routes/_authenticated/settings/index.tsx
+msgid "settings.pageSummary"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.description"
 msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.addNew"
+msgstr "Neu hinzufügen"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.admin"
+msgstr "Verwaltung"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -74,9 +55,34 @@ msgid "login.oauth.continueWith"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/index.tsx
+msgid "settings.empty.description"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/profile/language-card.tsx
 msgid "profile.language.error"
 msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.create"
+msgstr "Erstellen"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.dashboard"
+msgstr "Übersicht"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.edit"
+msgstr "Bearbeiten"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.editUser"
+msgstr "Benutzer bearbeiten"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -99,6 +105,11 @@ msgid "login.magicLink.emailRequired"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.entries"
+msgstr "Einträge"
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.sent.description"
 msgstr ""
@@ -119,6 +130,11 @@ msgid "dashboard.empty.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/index.tsx
+msgid "settings.empty.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/__root.tsx
 msgid "notFound.title"
 msgstr ""
@@ -129,6 +145,11 @@ msgid "login.oauth.separator"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.profile"
+msgstr "Profil"
+
+#. js-lingui-explicit-id
 #: src/components/shell/user-menu.tsx
 msgid "menu.profile"
 msgstr ""
@@ -137,6 +158,16 @@ msgstr ""
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.pending"
 msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/index.tsx
+msgid "settings.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.settings"
+msgstr "Einstellungen"
 
 #. js-lingui-explicit-id
 #: src/components/shell/user-menu.tsx
@@ -169,6 +200,11 @@ msgid "menu.signOut.pending"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.terms"
+msgstr "Begriffe"
+
+#. js-lingui-explicit-id
 #: src/routes/__root.tsx
 msgid "notFound.description"
 msgstr ""
@@ -177,6 +213,11 @@ msgstr ""
 #: src/routes/_auth/login.tsx
 msgid "login.description"
 msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.users"
+msgstr "Benutzer"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
@@ -197,58 +238,3 @@ msgstr ""
 #: src/components/profile/language-card.tsx
 msgid "profile.language.description"
 msgstr ""
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.addNew"
-msgstr "Neu hinzufügen"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.admin"
-msgstr "Verwaltung"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.create"
-msgstr "Erstellen"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.dashboard"
-msgstr "Übersicht"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.edit"
-msgstr "Bearbeiten"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.editUser"
-msgstr "Benutzer bearbeiten"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.entries"
-msgstr "Einträge"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.profile"
-msgstr "Profil"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.settings"
-msgstr "Einstellungen"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.terms"
-msgstr "Begriffe"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.users"
-msgstr "Benutzer"

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -13,46 +13,27 @@ msgstr ""
 "Last-Translator: \n"
 "Language-Team: \n"
 
-#. Hand-maintained: defined in src/lib/breadcrumbs.ts as a plain
-#. descriptor (no macro), so `lingui extract` cannot discover it.
 #. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
+#: src/routes/_authenticated/settings/index.test.tsx
+#: src/routes/_authenticated/settings/index.tsx
+msgid "settings.pageSummary"
+msgstr "{count, plural, one {# group} other {# groups}}"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.description"
 msgstr "Add a plugin that registers a post type (e.g. "
 "<0>@plumix/plugin-blog</0>) to see it here."
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.addNew"
+msgstr "Add new"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.admin"
+msgstr "Admin"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -75,9 +56,37 @@ msgid "login.oauth.continueWith"
 msgstr "Continue with {label}"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/index.tsx
+msgid "settings.empty.description"
+msgstr "Core ships no settings by design — plugins (or your own plumix.config) "
+"declare pages + groups via <0>ctx.registerSettingsPage</0> and "
+"<1>ctx.registerSettingsGroup</1>. Registered pages appear here with one "
+"card per page."
+
+#. js-lingui-explicit-id
 #: src/components/profile/language-card.tsx
 msgid "profile.language.error"
 msgstr "Couldn't switch language. Please try again."
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.create"
+msgstr "Create"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.dashboard"
+msgstr "Dashboard"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.edit"
+msgstr "Edit"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.editUser"
+msgstr "Edit user"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -98,6 +107,11 @@ msgstr "Email me a link"
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.emailRequired"
 msgstr "Enter your email above first."
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.entries"
+msgstr "Entries"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -121,6 +135,11 @@ msgid "dashboard.empty.title"
 msgstr "No content types yet"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/index.tsx
+msgid "settings.empty.title"
+msgstr "No settings registered yet"
+
+#. js-lingui-explicit-id
 #: src/routes/__root.tsx
 msgid "notFound.title"
 msgstr "Not found"
@@ -131,6 +150,11 @@ msgid "login.oauth.separator"
 msgstr "or"
 
 #. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.profile"
+msgstr "Profile"
+
+#. js-lingui-explicit-id
 #: src/components/shell/user-menu.tsx
 msgid "menu.profile"
 msgstr "Profile"
@@ -139,6 +163,16 @@ msgstr "Profile"
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.pending"
 msgstr "Sending…"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/index.tsx
+msgid "settings.title"
+msgstr "Settings"
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.settings"
+msgstr "Settings"
 
 #. js-lingui-explicit-id
 #: src/components/shell/user-menu.tsx
@@ -171,6 +205,11 @@ msgid "menu.signOut.pending"
 msgstr "Signing out…"
 
 #. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.terms"
+msgstr "Terms"
+
+#. js-lingui-explicit-id
 #: src/routes/__root.tsx
 msgid "notFound.description"
 msgstr "The page you're looking for doesn't exist or the resource isn't "
@@ -180,6 +219,11 @@ msgstr "The page you're looking for doesn't exist or the resource isn't "
 #: src/routes/_auth/login.tsx
 msgid "login.description"
 msgstr "Use a passkey, get a one-time email link, or continue with a provider."
+
+#. js-lingui-explicit-id
+#: src/lib/breadcrumbs.ts
+msgid "breadcrumb.users"
+msgstr "Users"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
@@ -201,58 +245,3 @@ msgstr "Write, edit, and publish {labelLower}."
 msgid "profile.language.description"
 msgstr "Your admin chrome renders in this language. The page reloads after you "
 "switch so the new translations apply everywhere."
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.addNew"
-msgstr "Add new"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.admin"
-msgstr "Admin"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.create"
-msgstr "Create"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.dashboard"
-msgstr "Dashboard"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.edit"
-msgstr "Edit"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.editUser"
-msgstr "Edit user"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.entries"
-msgstr "Entries"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.profile"
-msgstr "Profile"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.settings"
-msgstr "Settings"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.terms"
-msgstr "Terms"
-
-#. js-lingui-explicit-id
-#: src/lib/breadcrumbs.ts
-msgid "breadcrumb.users"
-msgstr "Users"

--- a/packages/admin/src/routes/_authenticated/settings/index.test.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.test.tsx
@@ -1,0 +1,65 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider, Trans } from "@lingui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test } from "vitest";
+
+// Pins the ICU plural compile path used by `settings.pageSummary` in
+// `settings/index.tsx`. Lingui v6's runtime `<Trans>` evaluates ICU
+// `{count, plural, ...}` via `@lingui/message-utils` at render time —
+// admin doesn't wire `@lingui/react/macro`, so the runtime path is
+// the canonical way to ship a plural here. This test guards against
+// a future Lingui upgrade silently dropping the runtime ICU path.
+
+beforeEach(() => {
+  i18n.load({ en: {} });
+  i18n.activate("en");
+});
+
+afterEach(() => cleanup());
+
+const PLURAL = "{count, plural, one {# group} other {# groups}}";
+
+test("settings.pageSummary renders the singular form for 1 group", () => {
+  render(
+    <I18nProvider i18n={i18n}>
+      <span data-testid="summary">
+        <Trans
+          id="settings.pageSummary"
+          message={PLURAL}
+          values={{ count: 1 }}
+        />
+      </span>
+    </I18nProvider>,
+  );
+  expect(screen.getByTestId("summary").textContent).toBe("1 group");
+});
+
+test("settings.pageSummary renders the plural form for >1 groups", () => {
+  render(
+    <I18nProvider i18n={i18n}>
+      <span data-testid="summary">
+        <Trans
+          id="settings.pageSummary"
+          message={PLURAL}
+          values={{ count: 4 }}
+        />
+      </span>
+    </I18nProvider>,
+  );
+  expect(screen.getByTestId("summary").textContent).toBe("4 groups");
+});
+
+test("settings.pageSummary renders the plural form for 0 groups", () => {
+  render(
+    <I18nProvider i18n={i18n}>
+      <span data-testid="summary">
+        <Trans
+          id="settings.pageSummary"
+          message={PLURAL}
+          values={{ count: 0 }}
+        />
+      </span>
+    </I18nProvider>,
+  );
+  expect(screen.getByTestId("summary").textContent).toBe("0 groups");
+});

--- a/packages/admin/src/routes/_authenticated/settings/index.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.tsx
@@ -15,12 +15,9 @@ import {
 } from "@/components/ui/empty.js";
 import { hasCap } from "@/lib/caps.js";
 import { visibleSettingsPages } from "@/lib/manifest.js";
+import { Trans } from "@lingui/react";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { Settings as SettingsIcon } from "lucide-react";
-
-function pageSummary(groupCount: number): string {
-  return `${groupCount} ${groupCount === 1 ? "group" : "groups"}`;
-}
 
 export const Route = createFileRoute("/_authenticated/settings/")({
   // The settings surface is admin-only at the floor — `settings:manage`
@@ -40,30 +37,37 @@ function SettingsIndexRoute(): ReactNode {
   const { user } = Route.useRouteContext();
   const pages = visibleSettingsPages(user.capabilities);
 
+  const heading = (
+    <h1 className="text-2xl font-semibold" data-testid="settings-heading">
+      <Trans id="settings.title" message="Settings" />
+    </h1>
+  );
+
   if (pages.length === 0) {
     return (
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
-        <h1 className="text-2xl font-semibold" data-testid="settings-heading">
-          Settings
-        </h1>
+        {heading}
         <Card data-testid="settings-empty-state">
           <Empty>
             <EmptyHeader>
               <EmptyMedia variant="icon">
                 <SettingsIcon />
               </EmptyMedia>
-              <EmptyTitle>No settings registered yet</EmptyTitle>
+              <EmptyTitle>
+                <Trans
+                  id="settings.empty.title"
+                  message="No settings registered yet"
+                />
+              </EmptyTitle>
               <EmptyDescription>
-                Core ships no settings by design — plugins (or your own
-                plumix.config) declare pages + groups via{" "}
-                <code className="font-mono text-xs">
-                  ctx.registerSettingsPage
-                </code>{" "}
-                and{" "}
-                <code className="font-mono text-xs">
-                  ctx.registerSettingsGroup
-                </code>
-                . Registered pages appear here with one card per page.
+                <Trans
+                  id="settings.empty.description"
+                  message="Core ships no settings by design — plugins (or your own plumix.config) declare pages + groups via <0>ctx.registerSettingsPage</0> and <1>ctx.registerSettingsGroup</1>. Registered pages appear here with one card per page."
+                  components={{
+                    0: <code className="font-mono text-xs" />,
+                    1: <code className="font-mono text-xs" />,
+                  }}
+                />
               </EmptyDescription>
             </EmptyHeader>
           </Empty>
@@ -74,9 +78,7 @@ function SettingsIndexRoute(): ReactNode {
 
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
-      <h1 className="text-2xl font-semibold" data-testid="settings-heading">
-        Settings
-      </h1>
+      {heading}
       <div className="grid gap-3" data-testid="settings-page-list">
         {pages.map((page) => (
           <Link
@@ -97,7 +99,11 @@ function SettingsIndexRoute(): ReactNode {
               </CardHeader>
               <CardContent>
                 <p className="text-muted-foreground text-xs">
-                  {pageSummary(page.groups.length)}
+                  <Trans
+                    id="settings.pageSummary"
+                    message="{count, plural, one {# group} other {# groups}}"
+                    values={{ count: page.groups.length }}
+                  />
                 </p>
               </CardContent>
             </Card>


### PR DESCRIPTION
Wrap the 5 user-visible strings and 1 `group / groups` plural on the settings list page (`/settings`) and add the route to admin's strict-mode ratchet (#700). Surface-by-surface expansion of #684's mass chrome wrap.

**ICU plural via runtime `<Trans>`**

The page-count summary is the first ICU plural in admin's catalog. Admin runs `<Trans>` from `@lingui/react` (the runtime export, not `@lingui/react/macro`), so the JSX-side `<Plural>` macro isn't available. The runtime ICU expression — evaluated by `@lingui/message-utils` at render time — is the canonical fit:

```tsx
<Trans
  id="settings.pageSummary"
  message="{count, plural, one {# group} other {# groups}}"
  values={{ count: page.groups.length }}
/>
```

**Smoke tests pin the compile path**

Three colocated tests (`index.test.tsx`) cover `count=1` → "1 group", `count=4` → "4 groups", `count=0` → "0 groups". The cardinal-zero case is the load-bearing one — English routes 0 through `cardinal-other`, so a future Lingui upgrade dropping runtime ICU evaluation would fail with a self-describing test name rather than render `# group` as a literal.

**Catalog**

`lingui extract --clean` regenerates `en.po` to 45 source entries and `de.po` to 45 / 34 missing. The remaining German translations are the #685 (translation seed) track, not this PR.

Refs #684