### PR TITLE
feat(admin): wrap mailer test page + lock into i18n ratchet

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -22,6 +22,7 @@ const STRICT_WRAPPED_FILES = [
   "src/routes/__root.tsx",
   "src/routes/_auth/login.tsx",
   "src/routes/_authenticated/index.tsx",
+  "src/routes/_authenticated/mailer/index.tsx",
   "src/routes/_authenticated/settings/index.tsx",
   // `src/lib/breadcrumbs.ts` is intentionally excluded — `Create {singular}`
   // / `Edit {singular}` literals there need a `Crumb`-shape rework to

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -60,6 +60,11 @@ msgid "settings.empty.description"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.error.fallback"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/profile/language-card.tsx
 msgid "profile.language.error"
 msgstr ""
@@ -125,8 +130,18 @@ msgid "profile.language.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.error.notConfigured"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -137,6 +152,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/__root.tsx
 msgid "notFound.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.recipient.placeholder"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -155,8 +175,33 @@ msgid "menu.profile"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.recipient.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.submit.idle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.submit.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.description"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -203,6 +248,21 @@ msgstr ""
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.terms"
 msgstr "Begriffe"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.feedback.ok"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.error.sendFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/__root.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -64,6 +64,11 @@ msgstr "Core ships no settings by design — plugins (or your own plumix.config)
 "card per page."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.error.fallback"
+msgstr "Couldn't send the test message. Try again."
+
+#. js-lingui-explicit-id
 #: src/components/profile/language-card.tsx
 msgid "profile.language.error"
 msgstr "Couldn't switch language. Please try again."
@@ -130,9 +135,20 @@ msgid "profile.language.title"
 msgstr "Language"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.title"
+msgstr "Mailer"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.title"
 msgstr "No content types yet"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.error.notConfigured"
+msgstr "No mailer adapter is configured. Pass a `mailer:` to `plumix({...})` "
+"(e.g. consoleMailer() for dev, or your Resend/Postmark/SES wrapper)."
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
@@ -143,6 +159,11 @@ msgstr "No settings registered yet"
 #: src/routes/__root.tsx
 msgid "notFound.title"
 msgstr "Not found"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.recipient.placeholder"
+msgstr "ops@example.com"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -160,9 +181,37 @@ msgid "menu.profile"
 msgstr "Profile"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.recipient.label"
+msgstr "Recipient"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.title"
+msgstr "Send a test message"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.submit.idle"
+msgstr "Send test"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.submit.pending"
+msgstr "Sending…"
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.pending"
 msgstr "Sending…"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.description"
+msgstr "Sends a one-off message via the same transport magic-link uses. "
+"Failures surface here verbatim — distinct from the magic-link request "
+"flow, which intentionally swallows mailer errors so the response shape "
+"can't leak whether an email is registered."
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
@@ -208,6 +257,25 @@ msgstr "Signing out…"
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.terms"
 msgstr "Terms"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.feedback.ok"
+msgstr "Test message sent to {to}. If it doesn't arrive within a minute, check "
+"your transport adapter's logs."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.description"
+msgstr "Test that the configured outbound-email transport actually delivers. "
+"Used by magic-link sign-in, invite emails, and any plugin that opts "
+"into the shared mailer."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/mailer/index.tsx
+msgid "mailer.test.error.sendFailed"
+msgstr "The mailer adapter threw an error during send. Check the worker logs "
+"for the underlying error."
 
 #. js-lingui-explicit-id
 #: src/routes/__root.tsx

--- a/packages/admin/src/routes/_authenticated/mailer/index.tsx
+++ b/packages/admin/src/routes/_authenticated/mailer/index.tsx
@@ -1,3 +1,4 @@
+import type { MessageDescriptor } from "@lingui/core";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
@@ -22,6 +23,8 @@ import { hasCap } from "@/lib/caps.js";
 import { extractReason } from "@/lib/orpc-errors.js";
 import { orpc } from "@/lib/orpc.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
+import { defineMessage } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
@@ -32,9 +35,33 @@ const formSchema = v.object({
     v.string(),
     v.trim(),
     v.toLowerCase(),
+    // TODO(slice 9 vMessage): swap to a translatable validator message
+    // once the lazy `t` descriptor pattern lands in `@plumix/core`. The
+    // current literal renders in English regardless of admin locale.
     v.email("Enter a valid email address."),
   ),
 });
+
+const M = {
+  placeholder: defineMessage({
+    id: "mailer.test.recipient.placeholder",
+    message: "ops@example.com",
+  }),
+  errNotConfigured: defineMessage({
+    id: "mailer.test.error.notConfigured",
+    message:
+      "No mailer adapter is configured. Pass a `mailer:` to `plumix({...})` (e.g. consoleMailer() for dev, or your Resend/Postmark/SES wrapper).",
+  }),
+  errSendFailed: defineMessage({
+    id: "mailer.test.error.sendFailed",
+    message:
+      "The mailer adapter threw an error during send. Check the worker logs for the underlying error.",
+  }),
+  errFallback: defineMessage({
+    id: "mailer.test.error.fallback",
+    message: "Couldn't send the test message. Try again.",
+  }),
+} satisfies Record<string, MessageDescriptor>;
 
 export const Route = createFileRoute("/_authenticated/mailer/")({
   beforeLoad: ({ context }) => {
@@ -48,8 +75,11 @@ export const Route = createFileRoute("/_authenticated/mailer/")({
 
 function MailerRoute(): ReactNode {
   const { user } = Route.useRouteContext();
+  const { i18n } = useLingui();
   const [feedback, setFeedback] = useState<
-    { kind: "ok"; to: string } | { kind: "error"; message: string } | null
+    | { kind: "ok"; to: string }
+    | { kind: "error"; message: MessageDescriptor }
+    | null
   >(null);
 
   const form = useForm({
@@ -68,7 +98,7 @@ function MailerRoute(): ReactNode {
       setFeedback({ kind: "ok", to: variables.to });
     },
     onError: (err) => {
-      setFeedback({ kind: "error", message: formatTestSendError(err) });
+      setFeedback({ kind: "error", message: testSendErrorMessage(err) });
     },
   });
 
@@ -80,23 +110,26 @@ function MailerRoute(): ReactNode {
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
       <header className="flex flex-col gap-1">
         <h1 className="text-2xl font-semibold" data-testid="mailer-heading">
-          Mailer
+          <Trans id="mailer.title" message="Mailer" />
         </h1>
         <p className="text-muted-foreground text-sm">
-          Test that the configured outbound-email transport actually delivers.
-          Used by magic-link sign-in, invite emails, and any plugin that opts
-          into the shared mailer.
+          <Trans
+            id="mailer.description"
+            message="Test that the configured outbound-email transport actually delivers. Used by magic-link sign-in, invite emails, and any plugin that opts into the shared mailer."
+          />
         </p>
       </header>
 
       <Card>
         <CardHeader>
-          <CardTitle>Send a test message</CardTitle>
+          <CardTitle>
+            <Trans id="mailer.test.title" message="Send a test message" />
+          </CardTitle>
           <CardDescription>
-            Sends a one-off message via the same transport magic-link uses.
-            Failures surface here verbatim — distinct from the magic-link
-            request flow, which intentionally swallows mailer errors so the
-            response shape can't leak whether an email is registered.
+            <Trans
+              id="mailer.test.description"
+              message="Sends a one-off message via the same transport magic-link uses. Failures surface here verbatim — distinct from the magic-link request flow, which intentionally swallows mailer errors so the response shape can't leak whether an email is registered."
+            />
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -107,12 +140,19 @@ function MailerRoute(): ReactNode {
                 name="to"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Recipient</FormLabel>
+                    <FormLabel>
+                      <Trans
+                        id="mailer.test.recipient.label"
+                        message="Recipient"
+                      />
+                    </FormLabel>
                     <FormControl>
                       <Input
                         type="email"
                         autoComplete="email"
-                        placeholder="ops@example.com"
+                        placeholder={i18n._(M.placeholder.id, undefined, {
+                          message: M.placeholder.message,
+                        })}
                         disabled={testSend.isPending}
                         data-testid="mailer-test-recipient"
                         {...field}
@@ -126,14 +166,21 @@ function MailerRoute(): ReactNode {
               {feedback?.kind === "ok" ? (
                 <Alert data-testid="mailer-test-feedback">
                   <AlertDescription>
-                    Test message sent to {feedback.to}. If it doesn't arrive
-                    within a minute, check your transport adapter's logs.
+                    <Trans
+                      id="mailer.test.feedback.ok"
+                      message="Test message sent to {to}. If it doesn't arrive within a minute, check your transport adapter's logs."
+                      values={{ to: feedback.to }}
+                    />
                   </AlertDescription>
                 </Alert>
               ) : null}
               {feedback?.kind === "error" ? (
                 <Alert variant="destructive" data-testid="mailer-test-error">
-                  <AlertDescription>{feedback.message}</AlertDescription>
+                  <AlertDescription>
+                    {i18n._(feedback.message.id, undefined, {
+                      message: feedback.message.message,
+                    })}
+                  </AlertDescription>
                 </Alert>
               ) : null}
 
@@ -143,7 +190,11 @@ function MailerRoute(): ReactNode {
                   disabled={testSend.isPending}
                   data-testid="mailer-test-submit"
                 >
-                  {testSend.isPending ? "Sending…" : "Send test"}
+                  {testSend.isPending ? (
+                    <Trans id="mailer.test.submit.pending" message="Sending…" />
+                  ) : (
+                    <Trans id="mailer.test.submit.idle" message="Send test" />
+                  )}
                 </Button>
               </div>
             </form>
@@ -154,20 +205,16 @@ function MailerRoute(): ReactNode {
   );
 }
 
-function formatTestSendError(err: unknown): string {
+function testSendErrorMessage(err: unknown): MessageDescriptor {
   const reason = extractReason(err);
-  if (reason === "mailer_not_configured") {
-    return (
-      "No mailer adapter is configured. Pass a `mailer:` to `plumix({...})` " +
-      "(e.g. consoleMailer() for dev, or your Resend/Postmark/SES wrapper)."
-    );
+  if (reason === "mailer_not_configured") return M.errNotConfigured;
+  if (reason === "mailer_send_failed") return M.errSendFailed;
+  // Non-tagged Error: inline `{id, message}` isn't visited by `lingui
+  // extract` (only macro callsites are), so this id is never registered
+  // and `i18n._` falls through to `err.message` verbatim — the right
+  // shape for plugin-author text until a translatable error path lands.
+  if (err instanceof Error) {
+    return { id: "mailer.test.error.runtime", message: err.message };
   }
-  if (reason === "mailer_send_failed") {
-    return (
-      "The mailer adapter threw an error during send. Check the worker logs " +
-      "for the underlying error."
-    );
-  }
-  if (err instanceof Error) return err.message;
-  return "Couldn't send the test message. Try again.";
+  return M.errFallback;
 }


### PR DESCRIPTION
Wrap the 9 user-visible strings on the mailer test page (`/mailer`) and add the route to admin's strict-mode ratchet (#700). Surface-by-surface expansion of #684's mass chrome wrap.

**Descriptor-returning error helper**

`testSendErrorMessage` now returns a `MessageDescriptor` instead of a plain string. The three mapped reasons resolve to extracted catalog entries. The non-tagged `Error` branch returns an inline `{id, message}` literal — `lingui extract` only visits macro callsites, so the id is never registered and `i18n._` falls through to `err.message` verbatim. That's the right shape for plugin-author runtime text until a translatable error path lands.

**Module-scope descriptors consolidated**

Four `defineMessage` constants now live in a single `const M = {...} satisfies Record<string, MessageDescriptor>` block at the top of the file, matching the `breadcrumbs.ts` style. Recipient placeholder flows through `i18n._` since `<Input placeholder>` takes a string prop, not a node.

**Deferred: valibot validator message**

`v.email("Enter a valid email address.")` stays English with a TODO pointing to the still-unbuilt slice 9 vMessage pattern. The schema lives at module scope, so a translatable literal isn't available until `@plumix/core` ships the lazy `t` descriptor pipeline. The `v.email` callsite is allowlisted by the strict rule's `ignoreFunctions`, so this doesn't block the ratchet entry.

**Catalog**

`lingui extract --clean` updated `en.po` to 57 entries. `de.po` 57 / 46 missing — translation seed is the #685 track.

Refs #684