### PR TITLE
feat(admin): wrap settings page route + lock into i18n ratchet

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -23,6 +23,7 @@ const STRICT_WRAPPED_FILES = [
   "src/routes/_auth/login.tsx",
   "src/routes/_authenticated/index.tsx",
   "src/routes/_authenticated/mailer/index.tsx",
+  "src/routes/_authenticated/settings/$page.tsx",
   "src/routes/_authenticated/settings/index.tsx",
   // `src/lib/breadcrumbs.ts` is intentionally excluded — `Create {singular}`
   // / `Edit {singular}` literals there need a `Crumb`-shape rework to

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -60,6 +60,16 @@ msgid "settings.empty.description"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.loadFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.saveFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.test.error.fallback"
 msgstr ""
@@ -130,6 +140,11 @@ msgid "profile.language.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.loading"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.title"
 msgstr ""
@@ -137,6 +152,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.empty.title"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -152,6 +172,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/__root.tsx
 msgid "notFound.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.notFound.title"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -177,6 +202,21 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.test.recipient.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.submit.idle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.saved"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.submit.pending"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -267,6 +307,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/__root.tsx
 msgid "notFound.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.empty.description"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -64,6 +64,16 @@ msgstr "Core ships no settings by design — plugins (or your own plumix.config)
 "card per page."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.loadFailed"
+msgstr "Couldn't load these settings. Try again."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.saveFailed"
+msgstr "Couldn't save settings."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.test.error.fallback"
 msgstr "Couldn't send the test message. Try again."
@@ -135,6 +145,11 @@ msgid "profile.language.title"
 msgstr "Language"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.loading"
+msgstr "Loading settings"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.title"
 msgstr "Mailer"
@@ -143,6 +158,11 @@ msgstr "Mailer"
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.title"
 msgstr "No content types yet"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.empty.title"
+msgstr "No groups on this page"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -158,6 +178,11 @@ msgstr "No settings registered yet"
 #. js-lingui-explicit-id
 #: src/routes/__root.tsx
 msgid "notFound.title"
+msgstr "Not found"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.notFound.title"
 msgstr "Not found"
 
 #. js-lingui-explicit-id
@@ -184,6 +209,21 @@ msgstr "Profile"
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.test.recipient.label"
 msgstr "Recipient"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.submit.idle"
+msgstr "Save changes"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.saved"
+msgstr "Saved."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.submit.pending"
+msgstr "Saving…"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -282,6 +322,13 @@ msgstr "The mailer adapter threw an error during send. Check the worker logs "
 msgid "notFound.description"
 msgstr "The page you're looking for doesn't exist or the resource isn't "
 "registered. Check the URL and try again."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.tsx
+msgid "settings.page.empty.description"
+msgstr "This settings page doesn't reference any registered groups yet. Plugins "
+"compose pages with <0>ctx.registerSettingsPage(name, { groups: [...] "
+"})</0>."
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx

--- a/packages/admin/src/routes/_authenticated/settings/$page.test.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/$page.test.tsx
@@ -1,0 +1,45 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider, Trans } from "@lingui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+// Regression guard for `settings.page.empty.description`: literal `{` /
+// `}` characters in the source `message` are treated as ICU placeholder
+// openers by Lingui's MessageFormat compiler, which throws `invalid
+// syntax` and falls back to the source string. The fix is the ICU
+// `quote-literal` escape — `'{'` / `'}'`. This test fails if the source
+// regresses to bare braces by asserting (a) the rendered output keeps
+// the literal braces verbatim and (b) no parse error fires.
+
+beforeEach(() => {
+  i18n.load({ en: {} });
+  i18n.activate("en");
+});
+
+afterEach(() => cleanup());
+
+const MESSAGE =
+  "Plugins compose pages with <0>ctx.registerSettingsPage(name, '{' groups: [...] '}')</0>.";
+
+test("empty-state description renders literal braces from the ICU-escaped source", () => {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  render(
+    <I18nProvider i18n={i18n}>
+      <span data-testid="desc">
+        <Trans
+          id="settings.page.empty.description"
+          message={MESSAGE}
+          components={{ 0: <code data-testid="code" /> }}
+        />
+      </span>
+    </I18nProvider>,
+  );
+
+  expect(screen.getByTestId("code").textContent).toBe(
+    "ctx.registerSettingsPage(name, { groups: [...] })",
+  );
+  expect(errorSpy).not.toHaveBeenCalled();
+
+  errorSpy.mockRestore();
+});

--- a/packages/admin/src/routes/_authenticated/settings/$page.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/$page.tsx
@@ -1,3 +1,4 @@
+import type { MessageDescriptor } from "@lingui/core";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { FormEditSkeleton } from "@/components/form/edit-skeleton.js";
@@ -25,6 +26,8 @@ import {
   groupsForSettingsPage,
 } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { defineMessage } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react";
 import {
   useMutation,
   useQueryClient,
@@ -38,6 +41,28 @@ import type {
   SettingsPageManifestEntry,
 } from "@plumix/core/manifest";
 import { seedFromMetaBoxes } from "@plumix/core/manifest";
+
+// Descriptors that need runtime indirection — used outside JSX (aria
+// string, state setters). Pure-JSX strings stay inline at their `<Trans>`
+// callsite per the rest of admin's style.
+const M = {
+  loadingAria: defineMessage({
+    id: "settings.page.loading",
+    message: "Loading settings",
+  }),
+  loadFailed: defineMessage({
+    id: "settings.page.loadFailed",
+    message: "Couldn't load these settings. Try again.",
+  }),
+  saved: defineMessage({
+    id: "settings.page.saved",
+    message: "Saved.",
+  }),
+  saveFailed: defineMessage({
+    id: "settings.page.saveFailed",
+    message: "Couldn't save settings.",
+  }),
+} satisfies Record<string, MessageDescriptor>;
 
 export const Route = createFileRoute("/_authenticated/settings/$page")({
   beforeLoad: ({ context, params }): { page: SettingsPageManifestEntry } => {
@@ -67,17 +92,26 @@ export const Route = createFileRoute("/_authenticated/settings/$page")({
       ),
     );
   },
-  pendingComponent: () => (
-    <FormEditSkeleton
-      ariaLabel="Loading settings"
-      testId="settings-page-loading"
-    />
-  ),
-  errorComponent: () => (
-    <NotFoundPlaceholder message="Couldn't load these settings. Try again." />
-  ),
+  pendingComponent: SettingsPageLoading,
+  errorComponent: SettingsPageLoadError,
   component: SettingsPageRoute,
 });
+
+function SettingsPageLoading(): ReactNode {
+  const { i18n } = useLingui();
+  return (
+    <FormEditSkeleton
+      ariaLabel={i18n._(M.loadingAria.id, undefined, {
+        message: M.loadingAria.message,
+      })}
+      testId="settings-page-loading"
+    />
+  );
+}
+
+function SettingsPageLoadError(): ReactNode {
+  return <NotFoundPlaceholder message={M.loadFailed} />;
+}
 
 function SettingsPageRoute(): ReactNode {
   const { page } = Route.useRouteContext();
@@ -113,9 +147,13 @@ function SettingsGroupCard({
 }: {
   readonly group: SettingsGroupManifestEntry;
 }): ReactNode {
+  const { i18n } = useLingui();
   const queryClient = useQueryClient();
-  const [serverError, setServerError] = useState<string | null>(null);
-  const [saveNotice, setSaveNotice] = useState<string | null>(null);
+  // String branch is plugin-author text rendered verbatim.
+  const [serverError, setServerError] = useState<
+    MessageDescriptor | string | null
+  >(null);
+  const [saveNotice, setSaveNotice] = useState<MessageDescriptor | null>(null);
 
   const { data: stored } = useSuspenseQuery(
     orpc.settings.get.queryOptions({ input: { group: group.name } }),
@@ -145,12 +183,10 @@ function SettingsGroupCard({
           input: { group: group.name },
         }).queryKey,
       });
-      setSaveNotice("Saved.");
+      setSaveNotice(M.saved);
     },
     onError: (err) => {
-      setServerError(
-        err instanceof Error ? err.message : "Couldn't save settings.",
-      );
+      setServerError(err instanceof Error ? err.message : M.saveFailed);
     },
   });
 
@@ -200,7 +236,13 @@ function SettingsGroupCard({
                 role="alert"
                 data-testid={`settings-server-error-${group.name}`}
               >
-                <AlertDescription>{serverError}</AlertDescription>
+                <AlertDescription>
+                  {typeof serverError === "string"
+                    ? serverError
+                    : i18n._(serverError.id, undefined, {
+                        message: serverError.message,
+                      })}
+                </AlertDescription>
               </Alert>
             ) : null}
 
@@ -210,7 +252,11 @@ function SettingsGroupCard({
                 aria-live="polite"
                 data-testid={`settings-save-notice-${group.name}`}
               >
-                <AlertDescription>{saveNotice}</AlertDescription>
+                <AlertDescription>
+                  {i18n._(saveNotice.id, undefined, {
+                    message: saveNotice.message,
+                  })}
+                </AlertDescription>
               </Alert>
             ) : null}
           </CardContent>
@@ -220,7 +266,11 @@ function SettingsGroupCard({
               disabled={save.isPending}
               data-testid={`settings-submit-${group.name}`}
             >
-              {save.isPending ? "Saving…" : "Save changes"}
+              {save.isPending ? (
+                <Trans id="settings.page.submit.pending" message="Saving…" />
+              ) : (
+                <Trans id="settings.page.submit.idle" message="Save changes" />
+              )}
             </Button>
           </div>
         </form>
@@ -234,14 +284,23 @@ function EmptyPagePlaceholder(): ReactNode {
     <Card>
       <Empty>
         <EmptyHeader>
-          <EmptyTitle>No groups on this page</EmptyTitle>
+          <EmptyTitle>
+            <Trans
+              id="settings.page.empty.title"
+              message="No groups on this page"
+            />
+          </EmptyTitle>
           <EmptyDescription>
-            This settings page doesn't reference any registered groups yet.
-            Plugins compose pages with{" "}
-            <code className="font-mono text-xs">
-              ctx.registerSettingsPage(name, {"{"} groups: [...] {"}"})
-            </code>
-            .
+            <Trans
+              id="settings.page.empty.description"
+              // Literal `{` / `}` in the source would be parsed as ICU
+              // placeholders by Lingui's MessageFormat compiler at
+              // render time, throwing `invalid syntax` and falling back
+              // to the source string. Escape with single-quotes —
+              // `'{' ... '}'` — the ICU `quote-literal` convention.
+              message="This settings page doesn't reference any registered groups yet. Plugins compose pages with <0>ctx.registerSettingsPage(name, '{' groups: [...] '}')</0>."
+              components={{ 0: <code className="font-mono text-xs" /> }}
+            />
           </EmptyDescription>
         </EmptyHeader>
       </Empty>
@@ -249,11 +308,20 @@ function EmptyPagePlaceholder(): ReactNode {
   );
 }
 
-function NotFoundPlaceholder({ message }: { message: string }): ReactNode {
+function NotFoundPlaceholder({
+  message,
+}: {
+  readonly message: MessageDescriptor;
+}): ReactNode {
+  const { i18n } = useLingui();
   return (
     <div className="flex flex-col gap-2">
-      <h1 className="text-2xl font-semibold">Not found</h1>
-      <p className="text-muted-foreground text-sm">{message}</p>
+      <h1 className="text-2xl font-semibold">
+        <Trans id="settings.page.notFound.title" message="Not found" />
+      </h1>
+      <p className="text-muted-foreground text-sm">
+        {i18n._(message.id, undefined, { message: message.message })}
+      </p>
     </div>
   );
 }

--- a/tooling/eslint/i18n.ts
+++ b/tooling/eslint/i18n.ts
@@ -66,6 +66,9 @@ export const i18nStrictOverrides: Linter.Config = {
           // so future shadcn upgrades don't add new entries here.
           { regex: { pattern: "^data-" } },
           { regex: { pattern: "^aria-" } },
+          // Admin convention: `testId` prop is forwarded to `data-testid`
+          // by primitives like `FormEditSkeleton`.
+          "testId",
           "type",
           "role",
           "name",


### PR DESCRIPTION
Wrap the 8 user-visible strings on the per-page settings route (`/settings/$page`) and add the route to admin's strict-mode ratchet (#700). Surface-by-surface expansion of #684.

**Hook-using error / pending components**

`pendingComponent` and `errorComponent` lift out of their inline arrows into named `SettingsPageLoading` / `SettingsPageLoadError` components so they can call `useLingui()`. The inline-arrow form had no hook access. `NotFoundPlaceholder` now takes a `MessageDescriptor` instead of a string.

**`serverError` discriminated union**

```ts
useState<MessageDescriptor | string | null>(null);
```

The string branch carries plugin-author `err.message` verbatim; the descriptor branch carries the translatable fallback. The synthetic-descriptor shape used by the mailer slice (`{id: "*.runtime", message: err.message}`) is intentionally not repeated here — the string-discriminated union is honest about the boundary and avoids spurious Lingui `missing` events. Worth backporting to mailer in a follow-up.

**ICU brace escape (correctness fix)**

The empty-state description embeds a literal `ctx.registerSettingsPage(name, { groups: [...] })`. Bare `{` / `}` in the ICU message string would be parsed as MessageFormat placeholders by Lingui's compiler at render time — `invalid syntax` thrown to `console.error`, then fallback to the source string. Fixed via the ICU `quote-literal` convention:

```tsx
message="...compose pages with <0>ctx.registerSettingsPage(name, '{' groups: [...] '}')</0>."
```

New colocated smoke test (`$page.test.tsx`) pins the rendered output + asserts `console.error` never fires.

**`testId` prop allowlisted**

`FormEditSkeleton` and other admin primitives forward `testId` to `data-testid`; the strict rule was firing on the literal `"settings-page-loading"`. Added to `tooling/eslint/i18n.ts`'s `ignoreNames` next to the `data-*` / `aria-*` regex — the convention is workspace-wide.

**Catalog**

`lingui extract --clean` updated `en.po` to 66 entries. `de.po` 66 / 55 missing — translation seed is the #685 track.

Refs #684