### PR TITLE
feat(admin): wrap allowed-domains chrome + lock into i18n ratchet

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -21,6 +21,7 @@ const STRICT_WRAPPED_FILES = [
   "src/lib/use-label.ts",
   "src/routes/__root.tsx",
   "src/routes/_auth/login.tsx",
+  "src/routes/_authenticated/allowed-domains/index.tsx",
   "src/routes/_authenticated/index.tsx",
   "src/routes/_authenticated/mailer/index.tsx",
   "src/routes/_authenticated/settings/$page.tsx",

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -20,8 +20,18 @@ msgid "settings.pageSummary"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.submit.idle"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.title"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -30,9 +40,29 @@ msgid "breadcrumb.addNew"
 msgstr "Neu hinzufügen"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.submit.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.admin"
 msgstr "Verwaltung"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.admin"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.author"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -45,13 +75,33 @@ msgid "dashboard.tile.browse"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.deleteCancel"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.sent.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.list.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.deleteConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.oauth.continueWith"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.contributor"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -67,6 +117,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.saveFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.error.fallback"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -90,6 +145,26 @@ msgid "breadcrumb.dashboard"
 msgstr "Übersicht"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.defaultRole.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.deleteAria"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.disabled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.domain.label"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.edit"
 msgstr "Bearbeiten"
@@ -98,6 +173,11 @@ msgstr "Bearbeiten"
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.editUser"
 msgstr "Benutzer bearbeiten"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.editor"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -110,8 +190,18 @@ msgid "login.emailChange.success"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.description"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.submit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.enabled"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -123,6 +213,11 @@ msgstr ""
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.entries"
 msgstr "Einträge"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.placeholder"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -145,6 +240,11 @@ msgid "settings.page.loading"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.list.loading"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.title"
 msgstr ""
@@ -152,6 +252,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.list.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -285,6 +390,11 @@ msgid "menu.signOut.pending"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.subscriber"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.terms"
 msgstr "Begriffe"
@@ -300,6 +410,11 @@ msgid "mailer.description"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.error.domainExists"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.test.error.sendFailed"
 msgstr ""
@@ -310,6 +425,7 @@ msgid "notFound.description"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.test.tsx
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.empty.description"
 msgstr ""
@@ -317,6 +433,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.description"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -20,10 +20,20 @@ msgid "settings.pageSummary"
 msgstr "{count, plural, one {# group} other {# groups}}"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.submit.idle"
+msgstr "Add"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.description"
 msgstr "Add a plugin that registers a post type (e.g. "
 "<0>@plumix/plugin-blog</0>) to see it here."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.title"
+msgstr "Add domain"
 
 #. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
@@ -31,9 +41,29 @@ msgid "breadcrumb.addNew"
 msgstr "Add new"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.submit.pending"
+msgstr "Adding…"
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.admin"
 msgstr "Admin"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.admin"
+msgstr "Administrator"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.title"
+msgstr "Allowed domains"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.author"
+msgstr "Author"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -46,14 +76,34 @@ msgid "dashboard.tile.browse"
 msgstr "Browse {labelLower}"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.deleteCancel"
+msgstr "Cancel"
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.sent.title"
 msgstr "Check your email"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.list.title"
+msgstr "Configured domains"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.deleteConfirm"
+msgstr "Confirm delete"
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.oauth.continueWith"
 msgstr "Continue with {label}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.contributor"
+msgstr "Contributor"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
@@ -72,6 +122,11 @@ msgstr "Couldn't load these settings. Try again."
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.saveFailed"
 msgstr "Couldn't save settings."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.error.fallback"
+msgstr "Couldn't save the domain. Try again."
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -94,6 +149,26 @@ msgid "breadcrumb.dashboard"
 msgstr "Dashboard"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.defaultRole.label"
+msgstr "Default role"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.deleteAria"
+msgstr "Delete {domain}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.disabled"
+msgstr "Disabled"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.domain.label"
+msgstr "Domain"
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.edit"
 msgstr "Edit"
@@ -102,6 +177,11 @@ msgstr "Edit"
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.editUser"
 msgstr "Edit user"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.editor"
+msgstr "Editor"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -114,9 +194,21 @@ msgid "login.emailChange.success"
 msgstr "Email confirmed. Sign in with the new address."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.description"
+msgstr "Email domains permitted to sign up via OAuth. New OAuth accounts are "
+"created with the role set here. Disabled rows reject signup but "
+"preserve their role mapping."
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.submit"
 msgstr "Email me a link"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.row.enabled"
+msgstr "Enabled"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -127,6 +219,11 @@ msgstr "Enter your email above first."
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.entries"
 msgstr "Entries"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.placeholder"
+msgstr "example.com"
 
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
@@ -150,6 +247,11 @@ msgid "settings.page.loading"
 msgstr "Loading settings"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.list.loading"
+msgstr "Loading…"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.title"
 msgstr "Mailer"
@@ -158,6 +260,12 @@ msgstr "Mailer"
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.empty.title"
 msgstr "No content types yet"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.list.empty"
+msgstr "No domains configured. OAuth signup is closed until at least one "
+"enabled domain is added."
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
@@ -294,6 +402,11 @@ msgid "menu.signOut.pending"
 msgstr "Signing out…"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "userRole.subscriber"
+msgstr "Subscriber"
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.terms"
 msgstr "Terms"
@@ -312,6 +425,11 @@ msgstr "Test that the configured outbound-email transport actually delivers. "
 "into the shared mailer."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.error.domainExists"
+msgstr "That domain is already configured."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.test.error.sendFailed"
 msgstr "The mailer adapter threw an error during send. Check the worker logs "
@@ -324,6 +442,7 @@ msgstr "The page you're looking for doesn't exist or the resource isn't "
 "registered. Check the URL and try again."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/settings/$page.test.tsx
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.empty.description"
 msgstr "This settings page doesn't reference any registered groups yet. Plugins "
@@ -334,6 +453,11 @@ msgstr "This settings page doesn't reference any registered groups yet. Plugins 
 #: src/routes/_auth/login.tsx
 msgid "login.description"
 msgstr "Use a passkey, get a one-time email link, or continue with a provider."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/allowed-domains/index.tsx
+msgid "allowedDomains.add.description"
+msgstr "Use the bare domain — no protocol, no path."
 
 #. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts

--- a/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
+++ b/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
@@ -1,3 +1,4 @@
+import type { MessageDescriptor } from "@lingui/core";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
@@ -28,13 +29,17 @@ import {
 import { Toggle } from "@/components/ui/toggle.js";
 import { hasCap } from "@/lib/caps.js";
 import { orpc } from "@/lib/orpc.js";
+import { useLabel } from "@/lib/use-label.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
+import { defineMessage } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { Trash2 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
 
+import type { Label } from "@plumix/core/i18n";
 import type { AllowedDomain, UserRole } from "@plumix/core/schema";
 
 const USER_ROLES = [
@@ -45,13 +50,43 @@ const USER_ROLES = [
   "admin",
 ] as const satisfies readonly UserRole[];
 
-const ROLE_LABEL: Record<UserRole, string> = {
-  subscriber: "Subscriber",
-  contributor: "Contributor",
-  author: "Author",
-  editor: "Editor",
-  admin: "Administrator",
+// `userRole.*` IDs are workspace-wide. The upcoming `users/*.tsx`
+// slices (#684) reuse these descriptors verbatim — when those wraps
+// land, hoist this record to a shared module rather than redefining.
+const ROLE_LABEL: Record<UserRole, MessageDescriptor> = {
+  subscriber: defineMessage({
+    id: "userRole.subscriber",
+    message: "Subscriber",
+  }),
+  contributor: defineMessage({
+    id: "userRole.contributor",
+    message: "Contributor",
+  }),
+  author: defineMessage({ id: "userRole.author", message: "Author" }),
+  editor: defineMessage({ id: "userRole.editor", message: "Editor" }),
+  admin: defineMessage({ id: "userRole.admin", message: "Administrator" }),
 };
+
+// Descriptors that need runtime indirection — used outside JSX (string
+// props, aria labels with placeholders, state setters).
+const M = {
+  domainPlaceholder: defineMessage({
+    id: "allowedDomains.add.placeholder",
+    message: "example.com",
+  }),
+  deleteAria: defineMessage({
+    id: "allowedDomains.row.deleteAria",
+    message: "Delete {domain}",
+  }),
+  errDomainExists: defineMessage({
+    id: "allowedDomains.error.domainExists",
+    message: "That domain is already configured.",
+  }),
+  errFallback: defineMessage({
+    id: "allowedDomains.error.fallback",
+    message: "Couldn't save the domain. Try again.",
+  }),
+} satisfies Record<string, MessageDescriptor>;
 
 // Mirrors the server schema in
 // packages/core/src/rpc/procedures/auth/allowed-domains/schemas.ts.
@@ -63,6 +98,9 @@ const createFormSchema = v.object({
     v.string(),
     v.trim(),
     v.toLowerCase(),
+    // TODO(slice 9 vMessage): swap to a translatable validator message
+    // once the lazy `t` descriptor pattern lands in `@plumix/core`.
+    // eslint-disable-next-line lingui/no-unlocalized-strings
     v.regex(DOMAIN_REGEX, "Enter a valid hostname (e.g. example.com)."),
   ),
   defaultRole: v.picklist(USER_ROLES),
@@ -79,8 +117,10 @@ export const Route = createFileRoute("/_authenticated/allowed-domains/")({
 });
 
 function AllowedDomainsRoute(): ReactNode {
+  const label = useLabel();
   const queryClient = useQueryClient();
-  const [serverError, setServerError] = useState<string | null>(null);
+  // String branch is plugin-author text rendered verbatim.
+  const [serverError, setServerError] = useState<Label | null>(null);
 
   const list = useQuery(
     orpc.auth.allowedDomains.list.queryOptions({ input: {} }),
@@ -134,22 +174,28 @@ function AllowedDomainsRoute(): ReactNode {
           className="text-2xl font-semibold"
           data-testid="allowed-domains-heading"
         >
-          Allowed domains
+          <Trans id="allowedDomains.title" message="Allowed domains" />
         </h1>
         <p className="text-muted-foreground text-sm">
-          Email domains permitted to sign up via OAuth. New OAuth accounts are
-          created with the role set here. Disabled rows reject signup but
-          preserve their role mapping.
+          <Trans
+            id="allowedDomains.description"
+            message="Email domains permitted to sign up via OAuth. New OAuth accounts are created with the role set here. Disabled rows reject signup but preserve their role mapping."
+          />
         </p>
       </header>
 
       <Card>
         <CardHeader>
           <CardTitle>
-            <h2 className="text-base font-semibold">Add domain</h2>
+            <h2 className="text-base font-semibold">
+              <Trans id="allowedDomains.add.title" message="Add domain" />
+            </h2>
           </CardTitle>
           <CardDescription>
-            Use the bare domain — no protocol, no path.
+            <Trans
+              id="allowedDomains.add.description"
+              message="Use the bare domain — no protocol, no path."
+            />
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -163,11 +209,16 @@ function AllowedDomainsRoute(): ReactNode {
                 name="domain"
                 render={({ field }) => (
                   <FormItem className="flex-1">
-                    <FormLabel>Domain</FormLabel>
+                    <FormLabel>
+                      <Trans
+                        id="allowedDomains.add.domain.label"
+                        message="Domain"
+                      />
+                    </FormLabel>
                     <FormControl>
                       <Input
                         type="text"
-                        placeholder="example.com"
+                        placeholder={label(M.domainPlaceholder)}
                         autoComplete="off"
                         spellCheck={false}
                         data-testid="allowed-domains-domain-input"
@@ -184,7 +235,12 @@ function AllowedDomainsRoute(): ReactNode {
                 name="defaultRole"
                 render={({ field }) => (
                   <FormItem className="sm:w-48">
-                    <FormLabel>Default role</FormLabel>
+                    <FormLabel>
+                      <Trans
+                        id="allowedDomains.add.defaultRole.label"
+                        message="Default role"
+                      />
+                    </FormLabel>
                     <FormControl>
                       <Select
                         value={field.value}
@@ -197,7 +253,7 @@ function AllowedDomainsRoute(): ReactNode {
                         <SelectContent>
                           {USER_ROLES.map((role) => (
                             <SelectItem key={role} value={role}>
-                              {ROLE_LABEL[role]}
+                              {label(ROLE_LABEL[role])}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -212,7 +268,14 @@ function AllowedDomainsRoute(): ReactNode {
                 disabled={create.isPending}
                 data-testid="allowed-domains-add-button"
               >
-                {create.isPending ? "Adding…" : "Add"}
+                {create.isPending ? (
+                  <Trans
+                    id="allowedDomains.add.submit.pending"
+                    message="Adding…"
+                  />
+                ) : (
+                  <Trans id="allowedDomains.add.submit.idle" message="Add" />
+                )}
               </Button>
             </form>
           </Form>
@@ -222,7 +285,7 @@ function AllowedDomainsRoute(): ReactNode {
               className="mt-4"
               data-testid="allowed-domains-error"
             >
-              <AlertDescription>{serverError}</AlertDescription>
+              <AlertDescription>{label(serverError)}</AlertDescription>
             </Alert>
           ) : null}
         </CardContent>
@@ -231,7 +294,12 @@ function AllowedDomainsRoute(): ReactNode {
       <Card>
         <CardHeader>
           <CardTitle>
-            <h2 className="text-base font-semibold">Configured domains</h2>
+            <h2 className="text-base font-semibold">
+              <Trans
+                id="allowedDomains.list.title"
+                message="Configured domains"
+              />
+            </h2>
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -240,15 +308,17 @@ function AllowedDomainsRoute(): ReactNode {
               className="text-muted-foreground text-sm"
               data-testid="allowed-domains-loading"
             >
-              Loading…
+              <Trans id="allowedDomains.list.loading" message="Loading…" />
             </p>
           ) : (list.data ?? []).length === 0 ? (
             <p
               className="text-muted-foreground text-sm"
               data-testid="allowed-domains-empty"
             >
-              No domains configured. OAuth signup is closed until at least one
-              enabled domain is added.
+              <Trans
+                id="allowedDomains.list.empty"
+                message="No domains configured. OAuth signup is closed until at least one enabled domain is added."
+              />
             </p>
           ) : (
             <ul
@@ -292,6 +362,8 @@ function DomainRow({
   onDelete: () => void;
   busy: boolean;
 }): ReactNode {
+  const { i18n } = useLingui();
+  const label = useLabel();
   const [confirming, setConfirming] = useState(false);
   return (
     <li
@@ -314,7 +386,7 @@ function DomainRow({
           <SelectContent>
             {USER_ROLES.map((role) => (
               <SelectItem key={role} value={role}>
-                {ROLE_LABEL[role]}
+                {label(ROLE_LABEL[role])}
               </SelectItem>
             ))}
           </SelectContent>
@@ -327,7 +399,11 @@ function DomainRow({
           disabled={busy}
           data-testid={`allowed-domains-row-toggle-${row.domain}`}
         >
-          {row.isEnabled ? "Enabled" : "Disabled"}
+          {row.isEnabled ? (
+            <Trans id="allowedDomains.row.enabled" message="Enabled" />
+          ) : (
+            <Trans id="allowedDomains.row.disabled" message="Disabled" />
+          )}
         </Toggle>
         {confirming ? (
           <>
@@ -342,7 +418,10 @@ function DomainRow({
               disabled={busy}
               data-testid={`allowed-domains-row-delete-confirm-${row.domain}`}
             >
-              Confirm delete
+              <Trans
+                id="allowedDomains.row.deleteConfirm"
+                message="Confirm delete"
+              />
             </Button>
             <Button
               type="button"
@@ -352,7 +431,7 @@ function DomainRow({
               disabled={busy}
               data-testid={`allowed-domains-row-delete-cancel-${row.domain}`}
             >
-              Cancel
+              <Trans id="allowedDomains.row.deleteCancel" message="Cancel" />
             </Button>
           </>
         ) : (
@@ -362,7 +441,11 @@ function DomainRow({
             size="icon"
             onClick={() => setConfirming(true)}
             disabled={busy}
-            aria-label={`Delete ${row.domain}`}
+            aria-label={i18n._(
+              M.deleteAria.id,
+              { domain: row.domain },
+              { message: M.deleteAria.message },
+            )}
             data-testid={`allowed-domains-row-delete-${row.domain}`}
           >
             <Trash2 className="size-4" />
@@ -373,13 +456,11 @@ function DomainRow({
   );
 }
 
-function mapError(err: unknown): string {
+function mapError(err: unknown): Label {
   if (err && typeof err === "object" && "data" in err) {
     const data = (err as { data?: { reason?: string } }).data;
-    if (data?.reason === "domain_exists") {
-      return "That domain is already configured.";
-    }
+    if (data?.reason === "domain_exists") return M.errDomainExists;
   }
   if (err instanceof Error) return err.message;
-  return "Couldn't save the domain. Try again.";
+  return M.errFallback;
 }

--- a/tooling/eslint/i18n.ts
+++ b/tooling/eslint/i18n.ts
@@ -57,6 +57,10 @@ export const i18nStrictOverrides: Linter.Config = {
           // Error / loading discriminator codes returned from async
           // mutations (passkey errors, query states, etc.).
           "^(unknown|pending|idle|loading|success|error)$",
+          // User-role identifiers (valibot picklist discriminators) —
+          // matches `UserRole` from `@plumix/core/schema`. The role's
+          // display label lives in a separate `MessageDescriptor`.
+          "^(subscriber|contributor|author|editor|admin)$",
         ],
         // Bare strings compile via `new RegExp(s)`; the `{regex:{pattern,flags?}}`
         // form is required only when flags are needed. Most entries are


### PR DESCRIPTION
Wrap the 14 user-visible strings on `/allowed-domains` and add the route to admin's strict-mode ratchet (#700). Surface-by-surface expansion of #684.

**`useLabel` over inlined `i18n._`**

The existing `useLabel()` helper (`src/lib/use-label.ts`) collapses every `i18n._(d.id, undefined, { message: d.message })` call to a `label(d)` one-liner. This is the same render path admin already established for manifest labels — every new ratchet'd file should reuse it instead of re-implementing the 3-arg form. `mapError` returns `Label` (the `string | MessageDescriptor` type from `@plumix/core/i18n`); `serverError` state follows suit.

**`ROLE_LABEL` widening + cross-slice intent**

`ROLE_LABEL` widens from `Record<UserRole, string>` to `Record<UserRole, MessageDescriptor>`. The `userRole.*` IDs are workspace-wide — when the upcoming `users/*.tsx` slices land, hoist this record to a shared module rather than redefining. Comment in source pins the intent so the next slice doesn't fork the catalog.

**ICU placeholder in the row aria-label**

`<Button aria-label>` takes a string prop, so the per-row delete uses `i18n._(M.deleteAria.id, { domain: row.domain }, { message: "Delete {domain}" })`. Validated against `[[lingui-icu-brace-escape]]` — single-brace `{domain}` is a valid ICU placeholder, not a literal-brace footgun.

**Strict allowlist additions, scoped**

- `^(subscriber|contributor|author|editor|admin)$` to `ignore` regex — `UserRole` picklist discriminators that the rule was flagging as raw literals. Strict enough that no incidental UI string ("Administrator" ≠ "admin") would match.
- The `v.regex` validator message stays English per the deferred slice 9 vMessage pattern. Suppressed inline at its one callsite (`eslint-disable-next-line lingui/no-unlocalized-strings`) rather than workspace-wide so future ratchet'd files still catch validator literals that need translation. Senpai flagged the workspace-wide form as defeating-its-own-gate.

**Catalog**

`lingui extract --clean` updated `en.po` to 90 entries. `de.po` 90 / 79 missing — translation seed is the #685 track.

Refs #684