### PR TITLE
feat(admin): wrap users list + share ROLE_LABEL + memoize useLabel

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -26,6 +26,7 @@ const STRICT_WRAPPED_FILES = [
   "src/routes/_authenticated/mailer/index.tsx",
   "src/routes/_authenticated/settings/$page.tsx",
   "src/routes/_authenticated/settings/index.tsx",
+  "src/routes/_authenticated/users/index.tsx",
   // `src/lib/breadcrumbs.ts` is intentionally excluded — `Create {singular}`
   // / `Edit {singular}` literals there need a `Crumb`-shape rework to
   // carry placeholder values before strict mode can enforce.

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -14,9 +14,19 @@ msgstr ""
 "Language-Team: \n"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.noName"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.active"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -35,6 +45,11 @@ msgid "allowedDomains.add.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.invite"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.addNew"
 msgstr "Neu hinzufügen"
@@ -50,8 +65,13 @@ msgid "breadcrumb.admin"
 msgstr "Verwaltung"
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/lib/user-role-labels.ts
 msgid "userRole.admin"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.roleFilter.all"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -60,7 +80,7 @@ msgid "allowedDomains.title"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/lib/user-role-labels.ts
 msgid "userRole.author"
 msgstr ""
 
@@ -85,6 +105,11 @@ msgid "login.magicLink.sent.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.empty.description"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.list.title"
 msgstr ""
@@ -100,7 +125,7 @@ msgid "login.oauth.continueWith"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/lib/user-role-labels.ts
 msgid "userRole.contributor"
 msgstr ""
 
@@ -112,6 +137,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.loadFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.loadFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -140,6 +170,11 @@ msgid "breadcrumb.create"
 msgstr "Erstellen"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.created"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.dashboard"
 msgstr "Übersicht"
@@ -152,6 +187,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.row.deleteAria"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.disabled"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -175,7 +215,7 @@ msgid "breadcrumb.editUser"
 msgstr "Benutzer bearbeiten"
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/lib/user-role-labels.ts
 msgid "userRole.editor"
 msgstr ""
 
@@ -220,8 +260,18 @@ msgid "allowedDomains.add.placeholder"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.roleFilter.aria"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.sent.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.empty.invite"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -235,8 +285,18 @@ msgid "profile.language.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.lastSignIn"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.loading"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -247,6 +307,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.lastSignIn.never"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -272,6 +337,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.empty.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.empty.title"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -310,6 +380,11 @@ msgid "mailer.test.recipient.label"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.role"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.submit.idle"
 msgstr ""
@@ -322,6 +397,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.submit.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.searchPlaceholder"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -390,7 +470,12 @@ msgid "menu.signOut.pending"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.status"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/user-role-labels.ts
 msgid "userRole.subscriber"
 msgstr ""
 
@@ -441,6 +526,16 @@ msgid "allowedDomains.add.description"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.user"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.users"
 msgstr "Benutzer"
@@ -458,6 +553,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.tile.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.you"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -14,10 +14,20 @@ msgstr ""
 "Language-Team: \n"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.noName"
+msgstr "(no name)"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr "{count, plural, one {# group} other {# groups}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.active"
+msgstr "Active"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
@@ -36,6 +46,11 @@ msgid "allowedDomains.add.title"
 msgstr "Add domain"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.invite"
+msgstr "Add new"
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.addNew"
 msgstr "Add new"
@@ -51,9 +66,14 @@ msgid "breadcrumb.admin"
 msgstr "Admin"
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/lib/user-role-labels.ts
 msgid "userRole.admin"
 msgstr "Administrator"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.roleFilter.all"
+msgstr "All roles"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
@@ -61,7 +81,7 @@ msgid "allowedDomains.title"
 msgstr "Allowed domains"
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/lib/user-role-labels.ts
 msgid "userRole.author"
 msgstr "Author"
 
@@ -86,6 +106,11 @@ msgid "login.magicLink.sent.title"
 msgstr "Check your email"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.empty.description"
+msgstr "Clear the filter, or invite someone new to join."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.list.title"
 msgstr "Configured domains"
@@ -101,7 +126,7 @@ msgid "login.oauth.continueWith"
 msgstr "Continue with {label}"
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/lib/user-role-labels.ts
 msgid "userRole.contributor"
 msgstr "Contributor"
 
@@ -117,6 +142,11 @@ msgstr "Core ships no settings by design — plugins (or your own plumix.config)
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.loadFailed"
 msgstr "Couldn't load these settings. Try again."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.loadFailed"
+msgstr "Couldn't load users. Try again."
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
@@ -144,6 +174,11 @@ msgid "breadcrumb.create"
 msgstr "Create"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.created"
+msgstr "Created"
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.dashboard"
 msgstr "Dashboard"
@@ -157,6 +192,11 @@ msgstr "Default role"
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.row.deleteAria"
 msgstr "Delete {domain}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.disabled"
+msgstr "Disabled"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
@@ -179,7 +219,7 @@ msgid "breadcrumb.editUser"
 msgstr "Edit user"
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/lib/user-role-labels.ts
 msgid "userRole.editor"
 msgstr "Editor"
 
@@ -226,10 +266,20 @@ msgid "allowedDomains.add.placeholder"
 msgstr "example.com"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.roleFilter.aria"
+msgstr "Filter by role"
+
+#. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.magicLink.sent.description"
 msgstr "If an account exists for this email, we sent a sign-in link. The link "
 "expires in 15 minutes."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.empty.invite"
+msgstr "Invite user"
 
 #. js-lingui-explicit-id
 #: src/components/locale-switcher.tsx
@@ -242,9 +292,19 @@ msgid "profile.language.title"
 msgstr "Language"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.lastSignIn"
+msgstr "Last sign-in"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.loading"
 msgstr "Loading settings"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.loading"
+msgstr "Loading users"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
@@ -255,6 +315,11 @@ msgstr "Loading…"
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.title"
 msgstr "Mailer"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.lastSignIn.never"
+msgstr "Never"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
@@ -282,6 +347,11 @@ msgstr "No mailer adapter is configured. Pass a `mailer:` to `plumix({...})` "
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.empty.title"
 msgstr "No settings registered yet"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.empty.title"
+msgstr "No users match your filter"
 
 #. js-lingui-explicit-id
 #: src/routes/__root.tsx
@@ -319,6 +389,11 @@ msgid "mailer.test.recipient.label"
 msgstr "Recipient"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.role"
+msgstr "Role"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.submit.idle"
 msgstr "Save changes"
@@ -332,6 +407,11 @@ msgstr "Saved."
 #: src/routes/_authenticated/settings/$page.tsx
 msgid "settings.page.submit.pending"
 msgstr "Saving…"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.searchPlaceholder"
+msgstr "Search by email…"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -402,7 +482,12 @@ msgid "menu.signOut.pending"
 msgstr "Signing out…"
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/allowed-domains/index.tsx
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.status"
+msgstr "Status"
+
+#. js-lingui-explicit-id
+#: src/lib/user-role-labels.ts
 msgid "userRole.subscriber"
 msgstr "Subscriber"
 
@@ -460,6 +545,16 @@ msgid "allowedDomains.add.description"
 msgstr "Use the bare domain — no protocol, no path."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.column.user"
+msgstr "User"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.title"
+msgstr "Users"
+
+#. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
 msgid "breadcrumb.users"
 msgstr "Users"
@@ -478,6 +573,11 @@ msgstr "What would you like to work on today?"
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.tile.description"
 msgstr "Write, edit, and publish {labelLower}."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/users/index.tsx
+msgid "users.list.row.you"
+msgstr "You"
 
 #. js-lingui-explicit-id
 #: src/components/profile/language-card.tsx

--- a/packages/admin/src/lib/use-label.ts
+++ b/packages/admin/src/lib/use-label.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useLingui } from "@lingui/react";
 
 import type { Label } from "@plumix/core/i18n";
@@ -6,8 +7,18 @@ import { resolveLabel } from "@plumix/core/i18n";
 /** Pulls the active Lingui locale and returns a label resolver that
  *  flattens `Label` (string | MessageDescriptor) to a rendered string.
  *  Use at every manifest-label render site so plain strings and
- *  Lingui descriptors round-trip identically. */
+ *  Lingui descriptors round-trip identically. Memoized on `locale` so
+ *  consumers can safely include the returned function in `useMemo` /
+ *  `useCallback` dep arrays without invalidating on every render —
+ *  same shape as `useFormatters`. */
 export function useLabel(): (label: Label) => string {
   const { i18n } = useLingui();
-  return (label) => resolveLabel(label, i18n);
+  const locale = i18n.locale;
+  return useMemo(
+    () => (label) => resolveLabel(label, i18n),
+    // `i18n` is the stable Lingui-context object; depending on `locale`
+    // forces re-creation only on locale flip.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [locale],
+  );
 }

--- a/packages/admin/src/lib/user-role-labels.ts
+++ b/packages/admin/src/lib/user-role-labels.ts
@@ -1,0 +1,27 @@
+import type { MessageDescriptor } from "@lingui/core";
+import { defineMessage } from "@lingui/core/macro";
+
+import type { UserRole } from "@plumix/core/schema";
+
+/**
+ * Translatable display labels for `UserRole`. Lives in `@/lib` because
+ * the same descriptors render in every users-adjacent surface:
+ * `/users` list, `/users/create`, `/users/$id/edit`, and the
+ * `/allowed-domains` default-role picker.
+ *
+ * The `userRole.*` IDs are workspace-wide — keep callsites importing
+ * from this module rather than redefining the record.
+ */
+export const ROLE_LABEL: Record<UserRole, MessageDescriptor> = {
+  subscriber: defineMessage({
+    id: "userRole.subscriber",
+    message: "Subscriber",
+  }),
+  contributor: defineMessage({
+    id: "userRole.contributor",
+    message: "Contributor",
+  }),
+  author: defineMessage({ id: "userRole.author", message: "Author" }),
+  editor: defineMessage({ id: "userRole.editor", message: "Editor" }),
+  admin: defineMessage({ id: "userRole.admin", message: "Administrator" }),
+};

--- a/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
+++ b/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
@@ -30,6 +30,7 @@ import { Toggle } from "@/components/ui/toggle.js";
 import { hasCap } from "@/lib/caps.js";
 import { orpc } from "@/lib/orpc.js";
 import { useLabel } from "@/lib/use-label.js";
+import { ROLE_LABEL } from "@/lib/user-role-labels.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
 import { defineMessage } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react";
@@ -49,23 +50,6 @@ const USER_ROLES = [
   "editor",
   "admin",
 ] as const satisfies readonly UserRole[];
-
-// `userRole.*` IDs are workspace-wide. The upcoming `users/*.tsx`
-// slices (#684) reuse these descriptors verbatim — when those wraps
-// land, hoist this record to a shared module rather than redefining.
-const ROLE_LABEL: Record<UserRole, MessageDescriptor> = {
-  subscriber: defineMessage({
-    id: "userRole.subscriber",
-    message: "Subscriber",
-  }),
-  contributor: defineMessage({
-    id: "userRole.contributor",
-    message: "Contributor",
-  }),
-  author: defineMessage({ id: "userRole.author", message: "Author" }),
-  editor: defineMessage({ id: "userRole.editor", message: "Editor" }),
-  admin: defineMessage({ id: "userRole.admin", message: "Administrator" }),
-};
 
 // Descriptors that need runtime indirection — used outside JSX (string
 // props, aria labels with placeholders, state setters).

--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -1,3 +1,4 @@
+import type { MessageDescriptor } from "@lingui/core";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
@@ -25,11 +26,16 @@ import { hasCap } from "@/lib/caps.js";
 import { toDate } from "@/lib/dates.js";
 import { orpc } from "@/lib/orpc.js";
 import { useFormatters } from "@/lib/use-formatters.js";
+import { useLabel } from "@/lib/use-label.js";
+import { ROLE_LABEL } from "@/lib/user-role-labels.js";
+import { defineMessage } from "@lingui/core/macro";
+import { Trans } from "@lingui/react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { Plus, UserPlus } from "lucide-react";
 import * as v from "valibot";
 
+import type { Label } from "@plumix/core/i18n";
 import type { User, UserRole } from "@plumix/core/schema";
 
 import { USER_ROLES } from "./-constants.js";
@@ -71,22 +77,42 @@ const ROLE_VARIANT: Record<UserRole, "default" | "secondary" | "outline"> = {
   subscriber: "outline",
 };
 
-const ROLE_LABEL: Record<UserRole, string> = {
-  admin: "Administrator",
-  editor: "Editor",
-  author: "Author",
-  contributor: "Contributor",
-  subscriber: "Subscriber",
-};
-
-const ROLE_FILTER_OPTIONS: { value: RoleFilter; label: string }[] = [
-  { value: "all", label: "All roles" },
-  ...USER_ROLES.map((role) => ({ value: role, label: ROLE_LABEL[role] })),
-];
-
-const dateFormatter = new Intl.DateTimeFormat(undefined, {
-  dateStyle: "medium",
-});
+const M = {
+  searchPlaceholder: defineMessage({
+    id: "users.list.searchPlaceholder",
+    message: "Search by email…",
+  }),
+  loadingLabel: defineMessage({
+    id: "users.list.loading",
+    message: "Loading users",
+  }),
+  loadFailed: defineMessage({
+    id: "users.list.loadFailed",
+    message: "Couldn't load users. Try again.",
+  }),
+  roleFilterAria: defineMessage({
+    id: "users.list.roleFilter.aria",
+    message: "Filter by role",
+  }),
+  roleFilterAll: defineMessage({
+    id: "users.list.roleFilter.all",
+    message: "All roles",
+  }),
+  columnUser: defineMessage({ id: "users.list.column.user", message: "User" }),
+  columnRole: defineMessage({ id: "users.list.column.role", message: "Role" }),
+  columnStatus: defineMessage({
+    id: "users.list.column.status",
+    message: "Status",
+  }),
+  columnLastSignIn: defineMessage({
+    id: "users.list.column.lastSignIn",
+    message: "Last sign-in",
+  }),
+  columnCreated: defineMessage({
+    id: "users.list.column.created",
+    message: "Created",
+  }),
+} satisfies Record<string, MessageDescriptor>;
 
 export const Route = createFileRoute("/_authenticated/users/")({
   validateSearch: (search) => v.parse(searchSchema, search),
@@ -134,6 +160,7 @@ function useUsersListNavActions(): UsersListNavActions {
 function UsersListRoute(): ReactNode {
   const search = Route.useSearch();
   const { user } = Route.useRouteContext();
+  const label = useLabel();
 
   const query = useQuery(
     orpc.user.list.queryOptions({
@@ -148,7 +175,7 @@ function UsersListRoute(): ReactNode {
 
   const { setRole, setPage, setSearch } = useUsersListNavActions();
 
-  const rows: readonly UserListRow[] = query.data ?? [];
+  const rows = query.data ?? [];
   const canPrev = search.page > 1;
   // Heuristic "next page exists": full page came back. `user.list` doesn't
   // return a total, same tradeoff as `entry.list` — accept the occasional
@@ -160,10 +187,16 @@ function UsersListRoute(): ReactNode {
   // `beforeLoad` for defense-in-depth.
   const canInvite = hasCap(user.capabilities, "user:create");
 
-  const { formatRelative } = useFormatters();
+  const { formatDate, formatRelative } = useFormatters();
   const columns = useMemo(
-    () => buildColumns({ currentUserId: user.id, formatRelative }),
-    [user.id, formatRelative],
+    () =>
+      buildColumns({
+        currentUserId: user.id,
+        formatDate,
+        formatRelative,
+        label,
+      }),
+    [user.id, formatDate, formatRelative, label],
   );
 
   return (
@@ -174,14 +207,14 @@ function UsersListRoute(): ReactNode {
             data-testid="users-list-heading"
             className="text-2xl font-semibold"
           >
-            Users
+            <Trans id="users.list.title" message="Users" />
           </h1>
         </div>
         {canInvite ? (
           <Button asChild>
             <Link to="/users/create" data-testid="users-list-invite-button">
               <UserPlus />
-              Add new
+              <Trans id="users.list.invite" message="Add new" />
             </Link>
           </Button>
         ) : null}
@@ -196,7 +229,7 @@ function UsersListRoute(): ReactNode {
             // desynchronising from the URL.
             key={search.q ?? ""}
             initialValue={search.q ?? ""}
-            placeholder="Search by email…"
+            placeholder={label(M.searchPlaceholder)}
             testId="users-list-search-input"
             onCommit={setSearch}
           />
@@ -206,9 +239,9 @@ function UsersListRoute(): ReactNode {
       {query.isError ? (
         <Alert variant="destructive">
           <AlertDescription>
-            {query.error instanceof Error
-              ? query.error.message
-              : "Couldn't load users. Try again."}
+            {label(
+              query.error instanceof Error ? query.error.message : M.loadFailed,
+            )}
           </AlertDescription>
         </Alert>
       ) : (
@@ -216,7 +249,7 @@ function UsersListRoute(): ReactNode {
           columns={columns}
           data={rows}
           isLoading={query.isPending}
-          loadingLabel="Loading users"
+          loadingLabel={label(M.loadingLabel)}
           emptyState={<EmptyState canInvite={canInvite} />}
         />
       )}
@@ -243,15 +276,19 @@ type UserListRow = User & {
 
 function buildColumns({
   currentUserId,
+  formatDate,
   formatRelative,
+  label,
 }: {
   currentUserId: number;
+  formatDate: (value: Date, options?: Intl.DateTimeFormatOptions) => string;
   formatRelative: (value: Date) => string;
+  label: (l: Label) => string;
 }): ColumnDef<UserListRow>[] {
   return [
     {
       accessorKey: "name",
-      header: "User",
+      header: label(M.columnUser),
       cell: ({ row }) => {
         const u = row.original;
         const isSelf = u.id === currentUserId;
@@ -262,11 +299,13 @@ function buildColumns({
           >
             <span className="flex items-center gap-2 font-medium">
               {u.name ?? (
-                <span className="text-muted-foreground italic">(no name)</span>
+                <span className="text-muted-foreground italic">
+                  <Trans id="users.list.row.noName" message="(no name)" />
+                </span>
               )}
               {isSelf ? (
                 <Badge variant="outline" className="text-xs">
-                  You
+                  <Trans id="users.list.row.you" message="You" />
                 </Badge>
               ) : null}
             </span>
@@ -277,21 +316,25 @@ function buildColumns({
     },
     {
       accessorKey: "role",
-      header: "Role",
+      header: label(M.columnRole),
       cell: ({ row }) => (
         <Badge variant={ROLE_VARIANT[row.original.role]} className="capitalize">
-          {ROLE_LABEL[row.original.role]}
+          {label(ROLE_LABEL[row.original.role])}
         </Badge>
       ),
     },
     {
       accessorKey: "disabledAt",
-      header: "Status",
+      header: label(M.columnStatus),
       cell: ({ row }) => {
         const disabled = row.original.disabledAt != null;
         return (
           <Badge variant={disabled ? "destructive" : "secondary"}>
-            {disabled ? "Disabled" : "Active"}
+            {disabled ? (
+              <Trans id="users.list.row.disabled" message="Disabled" />
+            ) : (
+              <Trans id="users.list.row.active" message="Active" />
+            )}
           </Badge>
         );
       },
@@ -299,12 +342,14 @@ function buildColumns({
     {
       accessorKey: "lastSignInAt",
       meta: { className: "text-right" },
-      header: "Last sign-in",
+      header: label(M.columnLastSignIn),
       cell: ({ row }) => {
         const value = row.original.lastSignInAt;
         if (value == null) {
           return (
-            <span className="text-muted-foreground text-sm italic">Never</span>
+            <span className="text-muted-foreground text-sm italic">
+              <Trans id="users.list.row.lastSignIn.never" message="Never" />
+            </span>
           );
         }
         return (
@@ -317,10 +362,10 @@ function buildColumns({
     {
       accessorKey: "createdAt",
       meta: { className: "text-right" },
-      header: "Created",
+      header: label(M.columnCreated),
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">
-          {dateFormatter.format(toDate(row.original.createdAt))}
+          {formatDate(toDate(row.original.createdAt), { dateStyle: "medium" })}
         </span>
       ),
     },
@@ -334,6 +379,7 @@ function RoleFilter({
   value: RoleFilter;
   onChange: (next: RoleFilter) => void;
 }): ReactNode {
+  const label = useLabel();
   return (
     <Select
       value={value}
@@ -343,20 +389,23 @@ function RoleFilter({
     >
       <SelectTrigger
         size="sm"
-        aria-label="Filter by role"
+        aria-label={label(M.roleFilterAria)}
         data-testid="users-role-filter"
         className="w-[180px]"
       >
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        {ROLE_FILTER_OPTIONS.map((opt) => (
+        <SelectItem value="all" data-testid="users-role-filter-all">
+          {label(M.roleFilterAll)}
+        </SelectItem>
+        {USER_ROLES.map((role) => (
           <SelectItem
-            key={opt.value}
-            value={opt.value}
-            data-testid={`users-role-filter-${opt.value}`}
+            key={role}
+            value={role}
+            data-testid={`users-role-filter-${role}`}
           >
-            {opt.label}
+            {label(ROLE_LABEL[role])}
           </SelectItem>
         ))}
       </SelectContent>
@@ -368,9 +417,17 @@ function EmptyState({ canInvite }: { canInvite: boolean }): ReactNode {
   return (
     <Empty data-testid="users-list-empty-state" className="border">
       <EmptyHeader>
-        <EmptyTitle>No users match your filter</EmptyTitle>
+        <EmptyTitle>
+          <Trans
+            id="users.list.empty.title"
+            message="No users match your filter"
+          />
+        </EmptyTitle>
         <EmptyDescription>
-          Clear the filter, or invite someone new to join.
+          <Trans
+            id="users.list.empty.description"
+            message="Clear the filter, or invite someone new to join."
+          />
         </EmptyDescription>
       </EmptyHeader>
       <EmptyContent>
@@ -378,13 +435,13 @@ function EmptyState({ canInvite }: { canInvite: boolean }): ReactNode {
           <Button asChild>
             <Link to="/users/create">
               <Plus />
-              Invite user
+              <Trans id="users.list.empty.invite" message="Invite user" />
             </Link>
           </Button>
         ) : (
           <Button disabled>
             <Plus />
-            Invite user
+            <Trans id="users.list.empty.invite" message="Invite user" />
           </Button>
         )}
       </EmptyContent>

--- a/tooling/eslint/i18n.ts
+++ b/tooling/eslint/i18n.ts
@@ -61,6 +61,12 @@ export const i18nStrictOverrides: Linter.Config = {
           // matches `UserRole` from `@plumix/core/schema`. The role's
           // display label lives in a separate `MessageDescriptor`.
           "^(subscriber|contributor|author|editor|admin)$",
+          // shadcn primitive variant values used everywhere as
+          // attribute / record values: `<Badge variant="outline">`,
+          // `Record<Role, "default" | "secondary" | …>`. The `variant`
+          // attribute itself is in `ignoreNames`, but values inside a
+          // record literal need a content match.
+          "^(default|secondary|outline|ghost|destructive|link)$",
         ],
         // Bare strings compile via `new RegExp(s)`; the `{regex:{pattern,flags?}}`
         // form is required only when flags are needed. Most entries are
@@ -116,8 +122,9 @@ export const i18nStrictOverrides: Linter.Config = {
           "scope",
           "displayName",
           "$$typeof",
-          // Tanstack query / router
+          // Tanstack query / router / table
           "queryKey",
+          "accessorKey",
           // Brand constants used as document-title suffix. Localizing
           // the product name is out of scope.
           "TITLE_BRAND",


### PR DESCRIPTION
Wrap the 20 user-visible strings on `/users` and add the route to admin's strict-mode ratchet (#700). Surface-by-surface expansion of #684.

**Shared `ROLE_LABEL` module**

New `packages/admin/src/lib/user-role-labels.ts` owns the `userRole.*` `MessageDescriptor` record. Allowed-domains drops its local copy and imports from the new home; future `users/create.tsx` and `users/$id/edit.tsx` slices will too. The `userRole.*` IDs are catalog-stable (extract is idempotent across the move).

**`useLabel` now memoized — preserves TanStack Table column memoization**

Without this, the `useMemo(() => buildColumns({..., label}), [..., label])` dep array would rebuild columns every parent render, busting TanStack Table's internal column/header memoization. `useLabel` now mirrors `useFormatters` — `useMemo` on `i18n.locale`. Single-line behavior fix in the helper, benefits every future caller. Caught by senpai.

**Locale-aware date formatter**

The module-scope `const dateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: "medium" })` was locale-blind — bound to the browser locale at module load, not the active Lingui locale. The "Created" column now resolves through `useFormatters().formatDate`, threaded into `buildColumns` like `formatRelative`.

**Strict allowlist additions, scoped to genuine workspace patterns**

- `accessorKey` → `ignoreNames` (TanStack Table convention; the value is a data-key path, never user copy). Parallels the existing `queryKey` entry.
- `^(default|secondary|outline|ghost|destructive|link)$` → `ignore` regex (shadcn primitive variant values used both as JSX attributes AND as record values like `Record<Role, "default" | "outline">`; the `variant` attribute itself was already in `ignoreNames`, but values inside record literals need content matching).

**Catalog**

`lingui extract --clean` updated `en.po` to 110 entries. `de.po` 110 / 99 missing — translation seed is the #685 track.

Refs #684