### PR TITLE
feat(plumix): copy plugin catalogs into admin assets

### DIFF
--- a/packages/core/src/plugin/define.ts
+++ b/packages/core/src/plugin/define.ts
@@ -20,9 +20,12 @@ export interface PluginI18nSlot {
    *  site's enabled locales before any URL is generated — declaring
    *  more locales than the site enables doesn't expand the dropdown. */
   readonly locales: readonly string[];
-  /** Directory containing the compiled `<locale>.json` catalogs,
+  /** Directory containing the compiled `<locale>.mjs` catalogs,
    *  relative to the plugin's package root. Admin (via slice 17
-   *  #697) resolves and lazy-loads catalogs from here. */
+   *  #697) resolves and lazy-loads catalogs from here. Workspace
+   *  plugins' catalogs are baked into the admin bundle via
+   *  `import.meta.glob`; third-party plugins are reached via the
+   *  manifest's `pluginI18n[id].catalogs[locale]` URL. */
   readonly catalogPath: string;
 }
 

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -397,6 +397,9 @@ async function stageAdminAssets(
     await cp(ADMIN_SOURCE_DIR, dest, { recursive: true });
   }
   const chunks = await stagePluginChunks(dest, plugins, projectRoot);
+  // Separate from chunk staging: a server-side-only plugin (no `adminChunk`)
+  // can still contribute admin-rendered labels and needs its catalogs shipped.
+  await stagePluginCatalogs(dest, plugins, manifest, projectRoot);
   // Plugins that ship `adminEntry` (TS source) get assembled into a
   // single per-site bundle with the runtime alias seam. Legacy
   // `adminChunk` (pre-built JS) plugins keep their existing path.
@@ -473,6 +476,66 @@ async function stagePluginChunks(
   );
   chunks.push(...staged);
   return chunks;
+}
+
+// Copies each plugin's compiled `<catalogPath>/<locale>.mjs` to the
+// admin-served path `buildManifest` published in `pluginI18n[id].catalogs[locale]`
+// — admin's runtime loader (#697) does `import(url)` against same-origin paths
+// under the default CSP. A missing `.mjs` for a manifest-declared locale is a
+// build-time error; the runtime's `descriptor.message` fallback only catches
+// post-fetch failures.
+async function stagePluginCatalogs(
+  adminDest: string,
+  plugins: readonly AnyPluginDescriptor[],
+  manifest: PlumixManifest,
+  projectRoot: string,
+): Promise<void> {
+  const pluginI18n = manifest.pluginI18n;
+  if (!pluginI18n) return;
+  await Promise.all(
+    plugins.map(async (plugin) => {
+      const entry = pluginI18n[plugin.id];
+      // No manifest entry = no `i18n` slot, or every declared locale
+      // was filtered out by site-locale intersection in `buildManifest`.
+      if (!entry || !plugin.i18n) return;
+      const { catalogPath } = plugin.i18n;
+      // TODO(#697 follow-up): `catalogPath` is documented as
+      // plugin-package-root-relative but currently resolves against
+      // the consumer's `projectRoot`. Workspace plugins land their
+      // catalogs at `packages/plugins/<id>/locales/<locale>.mjs`,
+      // which is invisible from the consumer's root — they're already
+      // baked into admin via `import.meta.glob` in `i18n-boot.ts`,
+      // so missing-here skips silently. Third-party plugins shipped
+      // via npm need a `createRequire(projectRoot).resolve` mechanism
+      // before they can reach this copy path; tracked as a follow-up.
+      const candidate = isAbsolute(catalogPath)
+        ? catalogPath
+        : resolve(projectRoot, catalogPath);
+      try {
+        await stat(candidate);
+      } catch {
+        return;
+      }
+      const localeDestDir = resolve(adminDest, "plugins", plugin.id, "locales");
+      await mkdir(localeDestDir, { recursive: true });
+      await Promise.all(
+        Object.keys(entry.catalogs).map(async (locale) => {
+          const sourceFile = resolve(candidate, `${locale}.mjs`);
+          try {
+            await stat(sourceFile);
+          } catch {
+            throw VitePluginError.adminAssetNotFound({
+              pluginId: plugin.id,
+              field: `i18n.catalogs[${locale}]`,
+              declared: `${catalogPath}/${locale}.mjs`,
+              resolved: sourceFile,
+            });
+          }
+          await copyFile(sourceFile, resolve(localeDestDir, `${locale}.mjs`));
+        }),
+      );
+    }),
+  );
 }
 
 async function resolvePluginAsset(


### PR DESCRIPTION
Adds the missing bundler-copy step for the #697 plugin-i18n runtime registry. `buildManifest` already emits `pluginI18n[id].catalogs[locale]: URL` and admin's `createPluginCatalogLoader` already fetches those URLs at boot, but the URLs pointed at nothing — third-party plugins (npm-installed) shipped their compiled `<locale>.mjs` artifacts inside their package, out of reach of admin's runtime fetch.

**`stagePluginCatalogs`**

Runs alongside `stagePluginChunks` in `stageAdminAssets`. Iterates the plugin list, looks up each plugin's manifest entry, and copies `<plugin.i18n.catalogPath>/<locale>.mjs` to `<adminDest>/plugins/<id>/locales/<locale>.mjs` — matching the URL pattern `buildManifest` emits. The pattern is duplicated across `core/manifest.ts` (URL emission) and `plumix/vite/index.ts` (copy destination); a shared helper is a sensible follow-up.

**Failure modes**

- **Per-locale missing file** (directory exists but a declared locale didn't compile) fails the build via `VitePluginError.adminAssetNotFound`. The runtime's `descriptor.message` fallback only catches post-fetch failures.
- **Per-plugin missing directory** silently skips. Workspace plugins declare `catalogPath: "./locales"` relative to their own package root, which doesn't resolve under the consumer's `projectRoot` — they're already baked into the admin bundle via the `import.meta.glob` in `i18n-boot.ts`, so skipping is correct today.

**Known follow-up**

Third-party plugins (npm-installed) need a `createRequire(projectRoot)`-based resolution to reach `node_modules/<plugin>/locales/<locale>.mjs`. Tracked in the TODO at the resolution site. The current `projectRoot`-relative resolution is consistent with how `adminEntry` / `adminChunk` resolve, but `catalogPath`'s authoring intent is package-root-relative per the JSDoc — squaring the two requires a plugin-package-root marker on the descriptor or a name-from-id convention. Out of scope for this slice.

**Stale JSDoc fix**

`PluginI18nSlot.catalogPath` doc said `.json` (Lingui's compiled output is `.mjs`); also clarifies the workspace-via-glob / third-party-via-URL split.

Refs #697