### PR TITLE
refactor(core): share plugin-catalog URL/path helpers across both ends

### DIFF
--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -15,6 +15,8 @@ import {
   injectManifestIntoHtml,
   MANIFEST_SCRIPT_ID,
   manifestEntryVisibility,
+  pluginCatalogStagedPath,
+  pluginCatalogUrl,
   resolveEntryTypeVisibility,
   resolveTermTaxonomyVisibility,
   serializeManifestScript,
@@ -57,6 +59,19 @@ describe("buildManifest", () => {
         },
       },
     });
+  });
+
+  test("pluginCatalogUrl stays in lockstep with pluginCatalogStagedPath", () => {
+    // Both ends of the runtime fetch (manifest URL emission + bundler
+    // copy destination) consume the same helper. A pattern change must
+    // flip both consumers at once or admin's `import()` resolves to a
+    // 404 — pin the symmetry so a refactor can't drift them apart.
+    expect(pluginCatalogUrl("my-plugin", "de")).toBe(
+      `/_plumix/admin/${pluginCatalogStagedPath("my-plugin", "de")}`,
+    );
+    expect(pluginCatalogStagedPath("my-plugin", "de")).toBe(
+      "plugins/my-plugin/locales/de.mjs",
+    );
   });
 
   test("buildManifest omits pluginI18n when no plugin declares an i18n slot", () => {

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1521,6 +1521,28 @@ export type PluginI18nManifest = Readonly<
   Record<string, { readonly catalogs: Readonly<Record<string, string>> }>
 >;
 
+/** URL the admin runtime fetches to load a plugin's compiled catalog
+ *  for a given locale. Same-origin under `/_plumix/admin/...` so the
+ *  default CSP `script-src 'self'` covers the dynamic import. Widening
+ *  to absolute URLs (CDN-hosted catalogs) would need a CSP review.
+ *
+ *  Paired with `pluginCatalogStagedPath` — the plumix Vite plugin stages
+ *  each plugin's `.mjs` at that filesystem path so the URL resolves. */
+export function pluginCatalogUrl(pluginId: string, locale: string): string {
+  return `/_plumix/admin/${pluginCatalogStagedPath(pluginId, locale)}`;
+}
+
+/** Filesystem path (relative to the admin asset root) where the plumix
+ *  Vite plugin must stage `<plugin.i18n.catalogPath>/<locale>.mjs`.
+ *  Mirrors `pluginCatalogUrl` so a single edit retargets both ends of
+ *  the runtime fetch. */
+export function pluginCatalogStagedPath(
+  pluginId: string,
+  locale: string,
+): string {
+  return `plugins/${pluginId}/locales/${locale}.mjs`;
+}
+
 export interface I18nManifest {
   readonly defaultLocale: string;
   readonly locales: readonly ResolvedLocale[];
@@ -1691,12 +1713,7 @@ function projectPluginI18n(
       // i18n configured, trust the plugin's list so tests without
       // site config still exercise the URL shape.
       if (siteLocales.size > 0 && !siteLocales.has(locale)) continue;
-      // URL is intentionally same-origin (`/_plumix/admin/...`) so
-      // default CSP `script-src 'self'` covers the dynamic import.
-      // Widening to absolute URLs (CDN-hosted catalogs) would need
-      // a CSP review.
-      catalogs[locale] =
-        `/_plumix/admin/plugins/${plugin.id}/locales/${locale}.mjs`;
+      catalogs[locale] = pluginCatalogUrl(plugin.id, locale);
     }
     // Skip plugins whose entire locale set was intersected/dropped —
     // a manifest entry with empty catalogs is wire noise that admin's

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -27,6 +27,7 @@ import {
   HookRegistry,
   injectManifestIntoHtml,
   installPlugins,
+  pluginCatalogStagedPath,
 } from "@plumix/core";
 
 import type { DiscoveredIsland } from "./island-transform.js";
@@ -516,8 +517,6 @@ async function stagePluginCatalogs(
       } catch {
         return;
       }
-      const localeDestDir = resolve(adminDest, "plugins", plugin.id, "locales");
-      await mkdir(localeDestDir, { recursive: true });
       await Promise.all(
         Object.keys(entry.catalogs).map(async (locale) => {
           const sourceFile = resolve(candidate, `${locale}.mjs`);
@@ -531,7 +530,12 @@ async function stagePluginCatalogs(
               resolved: sourceFile,
             });
           }
-          await copyFile(sourceFile, resolve(localeDestDir, `${locale}.mjs`));
+          const destFile = resolve(
+            adminDest,
+            pluginCatalogStagedPath(plugin.id, locale),
+          );
+          await mkdir(dirname(destFile), { recursive: true });
+          await copyFile(sourceFile, destFile);
         }),
       );
     }),


### PR DESCRIPTION
The URL the admin runtime fetches (`buildManifest` → `pluginI18n[id].catalogs[locale]`) and the filesystem path the plumix Vite plugin stages catalogs at (`stagePluginCatalogs` → `<adminDest>/plugins/<id>/locales/<locale>.mjs`) both hard-coded the same string template. A refactor on either side (content hashing, moving under `/_plumix/admin/i18n/...`, etc.) had to be applied in lockstep or admin's `import(url)` resolved to a 404 — the runtime's `descriptor.message` fallback would mask the break in production.

**Two new helpers in `@plumix/core`**

```ts
pluginCatalogStagedPath(pluginId, locale)
  // → `plugins/<id>/locales/<locale>.mjs` (admin-asset-root relative)

pluginCatalogUrl(pluginId, locale)
  // → `/_plumix/admin/${pluginCatalogStagedPath(...)}` (runtime fetch URL)
```

`projectPluginI18n` (URL emission, `packages/core/src/plugin/manifest.ts`) and `stagePluginCatalogs` (copy destination, `packages/plumix/src/vite/index.ts`) now both route through them. Future moves edit one place; both consumers stay in sync.

**Regression guard**

New `manifest.test.ts` case pins the URL/staged-path symmetry so a future drift fails fast at unit-test time rather than at runtime in production.

Refs #697