### PR TITLE
feat(plumix): resolve plugin catalogPath via npm-name convention

### DIFF
--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -33,7 +33,8 @@
     "./schema": {
       "types": "./dist/db/schema.d.ts",
       "default": "./dist/db/schema.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/plugins/blog/package.json
+++ b/packages/plugins/blog/package.json
@@ -25,7 +25,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/plugins/media/package.json
+++ b/packages/plugins/media/package.json
@@ -29,7 +29,8 @@
     "./fields": {
       "types": "./dist/fields.d.ts",
       "default": "./dist/fields.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/plugins/menu/package.json
+++ b/packages/plugins/menu/package.json
@@ -29,7 +29,8 @@
     "./server": {
       "types": "./dist/server/index.d.ts",
       "default": "./dist/server/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/plugins/pages/package.json
+++ b/packages/plugins/pages/package.json
@@ -25,7 +25,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -44,6 +44,7 @@ import {
   transformUseClientModule,
 } from "./island-transform.js";
 import { plumixPathAliases } from "./path-aliases.js";
+import { findPluginPackageRoot } from "./plugin-catalog-resolve.js";
 import { stageUserPublic } from "./public-staging.js";
 
 // `import.meta.url` for this module lives at plumix/dist/vite/index.js in
@@ -500,22 +501,23 @@ async function stagePluginCatalogs(
       // was filtered out by site-locale intersection in `buildManifest`.
       if (!entry || !plugin.i18n) return;
       const { catalogPath } = plugin.i18n;
-      // TODO(#697 follow-up): `catalogPath` is documented as
-      // plugin-package-root-relative but currently resolves against
-      // the consumer's `projectRoot`. Workspace plugins land their
-      // catalogs at `packages/plugins/<id>/locales/<locale>.mjs`,
-      // which is invisible from the consumer's root — they're already
-      // baked into admin via `import.meta.glob` in `i18n-boot.ts`,
-      // so missing-here skips silently. Third-party plugins shipped
-      // via npm need a `createRequire(projectRoot).resolve` mechanism
-      // before they can reach this copy path; tracked as a follow-up.
-      const candidate = isAbsolute(catalogPath)
-        ? catalogPath
-        : resolve(projectRoot, catalogPath);
-      try {
-        await stat(candidate);
-      } catch {
-        return;
+      const candidate = await resolveCatalogDir(
+        plugin.id,
+        catalogPath,
+        projectRoot,
+      );
+      if (candidate === null) {
+        // `buildManifest` already committed to emitting catalog URLs
+        // for this plugin — if the resolver can't reach the source
+        // directory, admin's runtime fetch will 404 in production.
+        // Fail the build with the same error shape `adminChunk` /
+        // `adminCss` use so plugin authors see it during `plumix build`.
+        throw VitePluginError.adminAssetNotFound({
+          pluginId: plugin.id,
+          field: "i18n.catalogPath",
+          declared: catalogPath,
+          resolved: catalogPath,
+        });
       }
       await Promise.all(
         Object.keys(entry.catalogs).map(async (locale) => {
@@ -540,6 +542,36 @@ async function stagePluginCatalogs(
       );
     }),
   );
+}
+
+// Resolve the per-plugin catalog source directory. The npm-name
+// convention (workspace + npm-installed plugins) is the only supported
+// path; absolute `catalogPath` values are honored verbatim. Returns
+// `null` when nothing resolves to an existing directory —
+// `stagePluginCatalogs` then throws `adminAssetNotFound` because the
+// manifest already committed to a URL admin will fetch.
+async function resolveCatalogDir(
+  pluginId: string,
+  catalogPath: string,
+  projectRoot: string,
+): Promise<string | null> {
+  if (isAbsolute(catalogPath)) {
+    try {
+      await stat(catalogPath);
+      return catalogPath;
+    } catch {
+      return null;
+    }
+  }
+  const conventional = findPluginPackageRoot({ pluginId, projectRoot });
+  if (conventional === null) return null;
+  const dir = resolve(conventional, catalogPath);
+  try {
+    await stat(dir);
+    return dir;
+  } catch {
+    return null;
+  }
 }
 
 async function resolvePluginAsset(

--- a/packages/plumix/src/vite/plugin-catalog-resolve.test.ts
+++ b/packages/plumix/src/vite/plugin-catalog-resolve.test.ts
@@ -1,0 +1,123 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { findPluginPackageRoot } from "./plugin-catalog-resolve.js";
+
+describe("findPluginPackageRoot", () => {
+  test("resolves via the `@plumix/plugin-<id>` convention", () => {
+    const requireFrom = makeRequireFrom({
+      "@plumix/plugin-pages/package.json":
+        "/site/node_modules/@plumix/plugin-pages/package.json",
+    });
+    const root = findPluginPackageRoot({
+      pluginId: "pages",
+      projectRoot: "/site",
+      requireFrom,
+    });
+    expect(root).toBe("/site/node_modules/@plumix/plugin-pages");
+  });
+
+  test("falls back to `plumix-plugin-<id>` when the @plumix scope misses", () => {
+    const requireFrom = makeRequireFrom({
+      "plumix-plugin-translate/package.json":
+        "/site/node_modules/plumix-plugin-translate/package.json",
+    });
+    const root = findPluginPackageRoot({
+      pluginId: "translate",
+      projectRoot: "/site",
+      requireFrom,
+    });
+    expect(root).toBe("/site/node_modules/plumix-plugin-translate");
+  });
+
+  test("returns null when no naming convention resolves", () => {
+    const requireFrom = makeRequireFrom({});
+    const root = findPluginPackageRoot({
+      pluginId: "phantom",
+      projectRoot: "/site",
+      requireFrom,
+    });
+    expect(root).toBeNull();
+  });
+});
+
+// Integration coverage against real Node module resolution. The seam-
+// based tests above don't exercise the `exports` enforcement
+// (`ERR_PACKAGE_PATH_NOT_EXPORTED`) that Node applies in production —
+// if a plugin's `package.json` doesn't expose `./package.json` in its
+// `exports` map, `require.resolve("<name>/package.json")` throws and
+// the unit tests miss the regression. These fixtures drive the
+// production `createRequire` path against a tmpdir layout.
+describe("findPluginPackageRoot — real FS", () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    // `realpath` because macOS tmpdir symlinks `/var/folders` →
+    // `/private/var/folders`; Node's resolver canonicalizes, so the
+    // returned root would otherwise differ from `pluginDir` literal.
+    projectRoot = await realpath(
+      await mkdtemp(join(tmpdir(), "plumix-plugin-resolve-")),
+    );
+    await writeFile(join(projectRoot, "package.json"), JSON.stringify({}));
+  });
+
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  test("resolves a real `@plumix/plugin-<id>` package via exports.['./package.json']", async () => {
+    const pluginDir = join(projectRoot, "node_modules/@plumix/plugin-real");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@plumix/plugin-real",
+        type: "module",
+        exports: { "./package.json": "./package.json" },
+      }),
+    );
+
+    const root = findPluginPackageRoot({ pluginId: "real", projectRoot });
+    expect(root).toBe(pluginDir);
+  });
+
+  test("returns null when a plugin package omits exports.['./package.json']", async () => {
+    // Regression pin: if a plugin author forgets to expose the
+    // subpath, Node throws `ERR_PACKAGE_PATH_NOT_EXPORTED` and the
+    // resolver must return null — silently fall through to the loud-
+    // failure path in `stagePluginCatalogs`.
+    const pluginDir = join(projectRoot, "node_modules/@plumix/plugin-locked");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@plumix/plugin-locked",
+        type: "module",
+        exports: { ".": "./index.js" },
+      }),
+    );
+
+    const root = findPluginPackageRoot({ pluginId: "locked", projectRoot });
+    expect(root).toBeNull();
+  });
+});
+
+// Minimal createRequire stub for resolution tests. Maps known package
+// specifiers to their resolved absolute paths; unknown specifiers
+// throw the same MODULE_NOT_FOUND shape Node's resolver emits, which
+// the resolver branches on.
+function makeRequireFrom(
+  resolutions: Readonly<Record<string, string>>,
+): (filename: string) => { resolve: (id: string) => string } {
+  return () => ({
+    resolve: (id: string): string => {
+      const hit = resolutions[id];
+      if (hit !== undefined) return hit;
+      throw Object.assign(new Error(`Cannot find module '${id}'`), {
+        code: "MODULE_NOT_FOUND",
+      });
+    },
+  });
+}

--- a/packages/plumix/src/vite/plugin-catalog-resolve.ts
+++ b/packages/plumix/src/vite/plugin-catalog-resolve.ts
@@ -1,0 +1,42 @@
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+
+export interface FindPluginPackageRootInput {
+  readonly pluginId: string;
+  readonly projectRoot: string;
+  /** Test seam. Production passes `createRequire` from `node:module`. */
+  readonly requireFrom?: (filename: string) => {
+    readonly resolve: (id: string) => string;
+  };
+}
+
+/**
+ * Find the absolute path of a plugin's installed package root, used by
+ * the bundler to resolve `i18n.catalogPath` against the plugin's own
+ * directory (not the consumer's `projectRoot`).
+ *
+ * Tries known npm-name conventions in order — `@plumix/plugin-<id>`
+ * for first-party plugins. Returns `null` if no convention resolves.
+ */
+export function findPluginPackageRoot(
+  input: FindPluginPackageRootInput,
+): string | null {
+  const { pluginId, projectRoot } = input;
+  const requireFrom = input.requireFrom ?? createRequire;
+  const require = requireFrom(resolve(projectRoot, "package.json"));
+  // First-party scope first; community plugins follow the unscoped
+  // `plumix-plugin-<id>` convention. Anything else needs to declare
+  // its own resolution path, out of scope for this slice.
+  const candidates = [
+    `@plumix/plugin-${pluginId}`,
+    `plumix-plugin-${pluginId}`,
+  ];
+  for (const name of candidates) {
+    try {
+      return dirname(require.resolve(`${name}/package.json`));
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}

--- a/packages/plumix/src/vite/plugin-catalog-resolve.ts
+++ b/packages/plumix/src/vite/plugin-catalog-resolve.ts
@@ -1,26 +1,23 @@
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 
-export interface FindPluginPackageRootInput {
-  readonly pluginId: string;
-  readonly projectRoot: string;
-  /** Test seam. Production passes `createRequire` from `node:module`. */
-  readonly requireFrom?: (filename: string) => {
-    readonly resolve: (id: string) => string;
-  };
-}
-
 /**
  * Find the absolute path of a plugin's installed package root, used by
  * the bundler to resolve `i18n.catalogPath` against the plugin's own
  * directory (not the consumer's `projectRoot`).
  *
  * Tries known npm-name conventions in order — `@plumix/plugin-<id>`
- * for first-party plugins. Returns `null` if no convention resolves.
+ * for first-party plugins, `plumix-plugin-<id>` for community plugins.
+ * Returns `null` if no convention resolves. `requireFrom` is a test
+ * seam; production passes `createRequire` from `node:module`.
  */
-export function findPluginPackageRoot(
-  input: FindPluginPackageRootInput,
-): string | null {
+export function findPluginPackageRoot(input: {
+  readonly pluginId: string;
+  readonly projectRoot: string;
+  readonly requireFrom?: (filename: string) => {
+    readonly resolve: (id: string) => string;
+  };
+}): string | null {
   const { pluginId, projectRoot } = input;
   const requireFrom = input.requireFrom ?? createRequire;
   const require = requireFrom(resolve(projectRoot, "package.json"));


### PR DESCRIPTION
`stagePluginCatalogs` from #718 left a TODO at the resolution site: `catalogPath` is documented as plugin-package-root-relative but resolved against the consumer's `projectRoot`. Workspace plugins slid through because admin's `import.meta.glob` in `i18n-boot.ts` already loaded their catalogs; third-party (npm-installed) plugins have no such build-time glob and would have shipped manifest URLs pointing at nothing.

**Resolver shape**

New `findPluginPackageRoot` (in `plugin-catalog-resolve.ts`) tries two npm-name conventions: `@plumix/plugin-<id>` for first-party and `plumix-plugin-<id>` for community plugins. Mirrors the Babel (`@babel/preset-<name>` / `babel-preset-<name>`) and ESLint plugin-discovery patterns. `require.resolve("<name>/package.json")` follows pnpm symlinks transparently, so workspace plugins land on their real package directory with the same code path.

**`exports.['./package.json']` contract — added to every first-party plugin**

Senpai caught a real production bug: `require.resolve("<name>/package.json")` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` in production because Node enforces `exports` since v12.7+. None of the five first-party plugin packages exposed `./package.json` in their `exports` map; the seam-based unit test missed it because the fake `requireFrom` didn't enforce `exports`. Added `"./package.json": "./package.json"` to `@plumix/plugin-{audit-log,blog,media,menu,pages}` — documented as part of the plugin-authoring contract.

**Real-FS integration test**

A `tmpdir`-fixture test drives the production `createRequire` path against a real plugin layout, including the negative case (plugin that omits `exports.['./package.json']` → resolver returns `null`). Catches `exports` regressions the seam-based test would miss.

**Behavior changes**

- Dropped the dead `projectRoot`-relative fallback in `resolveCatalogDir`. The contract on `catalogPath` is unambiguously plugin-package-root-relative; the fallback was silent contract-violation tolerance.
- `stagePluginCatalogs` now throws `adminAssetNotFound` when the resolver returns `null` — the manifest already committed to emitting URLs for that plugin, so a silent skip would ship a 404 to production. Symmetric with the per-locale fail-loud one branch further down.

**On the #697 e2e proving-ground acceptance criterion**

`[[test-selectors]]` rules out `getByText` and asserting on rendered translation strings as fragile (translators can pick different wording). The actual behavior worth covering — manifest URL emission → bundler stage → runtime fetch → `i18n.messages` merge — is already unit-tested across `manifest.test.ts`, this PR's new `plugin-catalog-resolve.test.ts`, and `plugin-catalogs.test.ts`. The remaining gap (full browser-level locale-flip rendering a plugin's translated text) isn't worth a brittle e2e against translator output. Recommend retiring that AC item.

Refs #697