### PR TITLE
feat(admin): backport mailer error helper to Label union shape

### DIFF
--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -361,7 +361,7 @@ msgid "userInvite.error.fallback"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/mailer/index.tsx
+#: src/lib/mailer-errors.ts
 msgid "mailer.test.error.fallback"
 msgstr ""
 
@@ -677,7 +677,7 @@ msgid "settings.page.empty.title"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/mailer/index.tsx
+#: src/lib/mailer-errors.ts
 msgid "mailer.test.error.notConfigured"
 msgstr ""
 
@@ -922,7 +922,7 @@ msgid "auth.device.lookup.description"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/mailer/index.tsx
+#: src/lib/mailer-errors.ts
 msgid "mailer.test.error.sendFailed"
 msgstr ""
 

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -370,7 +370,7 @@ msgid "userInvite.error.fallback"
 msgstr "Couldn't send invite. Try again."
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/mailer/index.tsx
+#: src/lib/mailer-errors.ts
 msgid "mailer.test.error.fallback"
 msgstr "Couldn't send the test message. Try again."
 
@@ -694,7 +694,7 @@ msgid "settings.page.empty.title"
 msgstr "No groups on this page"
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/mailer/index.tsx
+#: src/lib/mailer-errors.ts
 msgid "mailer.test.error.notConfigured"
 msgstr "No mailer adapter is configured. Pass a `mailer:` to `plumix({...})` "
 "(e.g. consoleMailer() for dev, or your Resend/Postmark/SES wrapper)."
@@ -949,7 +949,7 @@ msgstr "The CLI shows an 8-character code split with a dash — \"ABCD-EFGH\". "
 "Letters and digits only, no zeros or ones."
 
 #. js-lingui-explicit-id
-#: src/routes/_authenticated/mailer/index.tsx
+#: src/lib/mailer-errors.ts
 msgid "mailer.test.error.sendFailed"
 msgstr "The mailer adapter threw an error during send. Check the worker logs "
 "for the underlying error."

--- a/packages/admin/src/lib/mailer-errors.test.ts
+++ b/packages/admin/src/lib/mailer-errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+
+import { testSendErrorMessage } from "./mailer-errors.js";
+
+describe("testSendErrorMessage", () => {
+  test("known `mailer_not_configured` reason resolves to the localized descriptor", () => {
+    const err = { data: { reason: "mailer_not_configured" } };
+    const result = testSendErrorMessage(err);
+    expect(typeof result).toBe("object");
+    expect(result).toMatchObject({ id: "mailer.test.error.notConfigured" });
+  });
+
+  test("known `mailer_send_failed` reason resolves to the localized descriptor", () => {
+    const err = { data: { reason: "mailer_send_failed" } };
+    const result = testSendErrorMessage(err);
+    expect(result).toMatchObject({ id: "mailer.test.error.sendFailed" });
+  });
+
+  test("raw `Error` returns the plugin-author message as a string", () => {
+    // Critical: this is the behavior the previous synthetic-descriptor
+    // shape (`{id:"mailer.test.error.runtime", message: err.message}`)
+    // masked — it returned an unextracted descriptor that emitted a
+    // Lingui `_missing` event on every render. The union shape returns
+    // the raw string so the render-site discriminator skips Lingui
+    // entirely for plugin-author text.
+    const result = testSendErrorMessage(new Error("plugin-author copy"));
+    expect(typeof result).toBe("string");
+    expect(result).toBe("plugin-author copy");
+  });
+
+  test("unrecognized shape falls back to the translatable retry message", () => {
+    const result = testSendErrorMessage({ random: "shape" });
+    expect(result).toMatchObject({ id: "mailer.test.error.fallback" });
+  });
+
+  test("undefined / null fall back to the translatable retry message", () => {
+    expect(testSendErrorMessage(undefined)).toMatchObject({
+      id: "mailer.test.error.fallback",
+    });
+    expect(testSendErrorMessage(null)).toMatchObject({
+      id: "mailer.test.error.fallback",
+    });
+  });
+});

--- a/packages/admin/src/lib/mailer-errors.ts
+++ b/packages/admin/src/lib/mailer-errors.ts
@@ -1,0 +1,36 @@
+import type { MessageDescriptor } from "@lingui/core";
+import { defineMessage } from "@lingui/core/macro";
+
+import type { Label } from "@plumix/core/i18n";
+
+import { extractReason } from "./orpc-errors.js";
+
+const M = {
+  notConfigured: defineMessage({
+    id: "mailer.test.error.notConfigured",
+    message:
+      "No mailer adapter is configured. Pass a `mailer:` to `plumix({...})` (e.g. consoleMailer() for dev, or your Resend/Postmark/SES wrapper).",
+  }),
+  sendFailed: defineMessage({
+    id: "mailer.test.error.sendFailed",
+    message:
+      "The mailer adapter threw an error during send. Check the worker logs for the underlying error.",
+  }),
+  fallback: defineMessage({
+    id: "mailer.test.error.fallback",
+    message: "Couldn't send the test message. Try again.",
+  }),
+} satisfies Record<string, MessageDescriptor>;
+
+/** Map an `orpc.auth.mailer.testSend` failure to a renderable label.
+ *  Known oRPC reasons resolve to a translated descriptor; raw `Error`
+ *  text from plugin-author throws surfaces verbatim via the string
+ *  branch of `Label`; everything else falls through to the generic
+ *  retry message. */
+export function testSendErrorMessage(err: unknown): Label {
+  const reason = extractReason(err);
+  if (reason === "mailer_not_configured") return M.notConfigured;
+  if (reason === "mailer_send_failed") return M.sendFailed;
+  if (err instanceof Error) return err.message;
+  return M.fallback;
+}

--- a/packages/admin/src/routes/_authenticated/mailer/index.tsx
+++ b/packages/admin/src/routes/_authenticated/mailer/index.tsx
@@ -20,24 +20,26 @@ import {
 } from "@/components/ui/form.js";
 import { Input } from "@/components/ui/input.js";
 import { hasCap } from "@/lib/caps.js";
-import { extractReason } from "@/lib/orpc-errors.js";
+import { testSendErrorMessage } from "@/lib/mailer-errors.js";
 import { orpc } from "@/lib/orpc.js";
+import { useLabel } from "@/lib/use-label.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
 import { defineMessage } from "@lingui/core/macro";
-import { Trans, useLingui } from "@lingui/react";
+import { Trans } from "@lingui/react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
+
+import type { Label } from "@plumix/core/i18n";
 
 const formSchema = v.object({
   to: v.pipe(
     v.string(),
     v.trim(),
     v.toLowerCase(),
-    // TODO(slice 9 vMessage): swap to a translatable validator message
-    // once the lazy `t` descriptor pattern lands in `@plumix/core`. The
-    // current literal renders in English regardless of admin locale.
+    // TODO(#721 vMessage): swap to a translatable validator message
+    // once the lazy `t` descriptor pattern lands in `@plumix/core`.
     v.email("Enter a valid email address."),
   ),
 });
@@ -46,20 +48,6 @@ const M = {
   placeholder: defineMessage({
     id: "mailer.test.recipient.placeholder",
     message: "ops@example.com",
-  }),
-  errNotConfigured: defineMessage({
-    id: "mailer.test.error.notConfigured",
-    message:
-      "No mailer adapter is configured. Pass a `mailer:` to `plumix({...})` (e.g. consoleMailer() for dev, or your Resend/Postmark/SES wrapper).",
-  }),
-  errSendFailed: defineMessage({
-    id: "mailer.test.error.sendFailed",
-    message:
-      "The mailer adapter threw an error during send. Check the worker logs for the underlying error.",
-  }),
-  errFallback: defineMessage({
-    id: "mailer.test.error.fallback",
-    message: "Couldn't send the test message. Try again.",
   }),
 } satisfies Record<string, MessageDescriptor>;
 
@@ -75,11 +63,9 @@ export const Route = createFileRoute("/_authenticated/mailer/")({
 
 function MailerRoute(): ReactNode {
   const { user } = Route.useRouteContext();
-  const { i18n } = useLingui();
+  const label = useLabel();
   const [feedback, setFeedback] = useState<
-    | { kind: "ok"; to: string }
-    | { kind: "error"; message: MessageDescriptor }
-    | null
+    { kind: "ok"; to: string } | { kind: "error"; message: Label } | null
   >(null);
 
   const form = useForm({
@@ -150,9 +136,7 @@ function MailerRoute(): ReactNode {
                       <Input
                         type="email"
                         autoComplete="email"
-                        placeholder={i18n._(M.placeholder.id, undefined, {
-                          message: M.placeholder.message,
-                        })}
+                        placeholder={label(M.placeholder)}
                         disabled={testSend.isPending}
                         data-testid="mailer-test-recipient"
                         {...field}
@@ -176,11 +160,7 @@ function MailerRoute(): ReactNode {
               ) : null}
               {feedback?.kind === "error" ? (
                 <Alert variant="destructive" data-testid="mailer-test-error">
-                  <AlertDescription>
-                    {i18n._(feedback.message.id, undefined, {
-                      message: feedback.message.message,
-                    })}
-                  </AlertDescription>
+                  <AlertDescription>{label(feedback.message)}</AlertDescription>
                 </Alert>
               ) : null}
 
@@ -203,18 +183,4 @@ function MailerRoute(): ReactNode {
       </Card>
     </div>
   );
-}
-
-function testSendErrorMessage(err: unknown): MessageDescriptor {
-  const reason = extractReason(err);
-  if (reason === "mailer_not_configured") return M.errNotConfigured;
-  if (reason === "mailer_send_failed") return M.errSendFailed;
-  // Non-tagged Error: inline `{id, message}` isn't visited by `lingui
-  // extract` (only macro callsites are), so this id is never registered
-  // and `i18n._` falls through to `err.message` verbatim — the right
-  // shape for plugin-author text until a translatable error path lands.
-  if (err instanceof Error) {
-    return { id: "mailer.test.error.runtime", message: err.message };
-  }
-  return M.errFallback;
 }


### PR DESCRIPTION
PR #711 shipped `testSendErrorMessage` with a synthetic `MessageDescriptor` for the runtime-`Error` branch — `{id: "mailer.test.error.runtime", message: err.message}`. `lingui extract` doesn't visit inline `{id, message}` literals, so the id was never registered; `i18n._(descriptor)` looked up `messages[id]`, missed, emitted a `_missing` event, and fell through to `descriptor.message`. Visible output correct, event noise wrong.

Every later slice (settings/$page, allowed-domains, users/create, users/$id/edit, auth/device) adopted the canonical `MessageDescriptor | string` union shape per `[[runtime-error-descriptor-shape]]`. This PR backports the mailer.

**Extracted to `lib/mailer-errors.ts`**

Mirrors the sibling pattern (`magic-link-errors.ts`, `oauth-errors.ts`, `passkey-errors.ts`). New helper returns `Label` (`string | MessageDescriptor` from `@plumix/core/i18n`). Five colocated unit tests pin each branch:

- Known `mailer_not_configured` reason → `notConfigured` descriptor
- Known `mailer_send_failed` reason → `sendFailed` descriptor  
- Raw `Error` → `err.message` as string (the load-bearing behavioral change)
- Unknown shape → `fallback` descriptor
- `undefined` / `null` → `fallback` descriptor

**Consumer refactor**

`feedback` state's error branch widens to `message: Label`. Render uses `useLabel()` (`label(feedback.message)`) instead of the inlined `i18n._(d.id, undefined, { message: d.message })` — per `[[use-label-helper]]`. `useLabel` does the `typeof === "string"` discriminator internally. `M.placeholder` also routes through `label()` for consistency; `useLingui` import dropped.

**Catalog**

`lingui extract --clean` regenerated. `mailer.test.error.runtime` never landed in the catalog (inline literals aren't extracted), so no delta on that ID.

Fixes #723