### PR TITLE
perf(plumix): skip pluginI18n URLs for admin-bundled plugins

### DIFF
--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -74,6 +74,47 @@ describe("buildManifest", () => {
     );
   });
 
+  test("buildManifest skips pluginI18n URLs for ids in adminBundledPluginIds", () => {
+    // Admin's `import.meta.glob("../../../plugins/*/locales/*.mjs")` in
+    // `i18n-boot.ts` already bakes workspace plugin catalogs into the
+    // bundle. Emitting URLs for them would mean admin double-loads —
+    // once via the inlined glob, again via the runtime URL fetch.
+    // The bundler signals which ids admin already covers;
+    // `projectPluginI18n` drops them.
+    const bundled = definePlugin("bundled-plug", {
+      i18n: {
+        sourceLocale: "en",
+        locales: ["en", "de"],
+        catalogPath: "./locales",
+      },
+      setup: () => undefined,
+    });
+    const thirdParty = definePlugin("third-party-plug", {
+      i18n: {
+        sourceLocale: "en",
+        locales: ["en", "de"],
+        catalogPath: "./locales",
+      },
+      setup: () => undefined,
+    });
+    const i18n = resolveLocales({
+      defaultLocale: "en",
+      locales: ["en", "de"],
+    });
+    const manifest = buildManifest(createPluginRegistry(), {
+      i18n,
+      plugins: [bundled, thirdParty],
+      adminBundledPluginIds: new Set(["bundled-plug"]),
+    });
+    expect(manifest.pluginI18n).toEqual({
+      "third-party-plug": {
+        catalogs: {
+          de: "/_plumix/admin/plugins/third-party-plug/locales/de.mjs",
+        },
+      },
+    });
+  });
+
   test("buildManifest omits pluginI18n when no plugin declares an i18n slot", () => {
     const plugin = definePlugin("untranslated", () => undefined);
     const manifest = buildManifest(createPluginRegistry(), {

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1602,6 +1602,15 @@ export function buildManifest(
       readonly id: string;
       readonly i18n?: PluginI18nSlot;
     }[];
+    /** Plugin ids whose catalogs admin already bakes into its bundle
+     *  via `import.meta.glob("../../../plugins/*"/locales/*.mjs")` —
+     *  emitting URLs for them double-loads at runtime. The plumix
+     *  vite plugin computes this set by inspecting which plugins
+     *  resolve through the `@plumix/plugin-<id>` convention against
+     *  the consumer's `node_modules`. Empty / omitted means every
+     *  i18n-slot plugin gets a URL. Only consulted alongside
+     *  `plugins`; passing this set without `plugins` is a no-op. */
+    readonly adminBundledPluginIds?: ReadonlySet<string>;
   },
 ): BuiltManifest {
   const entries = Array.from(registry.entryTypes.values())
@@ -1688,7 +1697,11 @@ export function buildManifest(
       // affordance can be re-introduced when there's a consumer.
       locales: (options?.i18n?.locales ?? []).filter((l) => l.enabled),
     },
-    pluginI18n: projectPluginI18n(options?.plugins, options?.i18n),
+    pluginI18n: projectPluginI18n(
+      options?.plugins,
+      options?.i18n,
+      options?.adminBundledPluginIds,
+    ),
   };
 }
 
@@ -1697,6 +1710,7 @@ function projectPluginI18n(
     | readonly { readonly id: string; readonly i18n?: PluginI18nSlot }[]
     | undefined,
   siteI18n: ResolvedI18n | undefined,
+  adminBundledPluginIds: ReadonlySet<string> | undefined,
 ): PluginI18nManifest {
   if (!plugins) return {};
   const siteLocales = new Set(
@@ -1705,6 +1719,9 @@ function projectPluginI18n(
   const out: Record<string, { catalogs: Record<string, string> }> = {};
   for (const plugin of plugins) {
     if (!plugin.i18n) continue;
+    // Workspace plugins are baked into admin via `import.meta.glob` —
+    // emitting URLs would mean admin double-loads at boot.
+    if (adminBundledPluginIds?.has(plugin.id)) continue;
     const catalogs: Record<string, string> = {};
     for (const locale of plugin.i18n.locales) {
       if (locale === plugin.i18n.sourceLocale) continue;

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -44,7 +44,10 @@ import {
   transformUseClientModule,
 } from "./island-transform.js";
 import { plumixPathAliases } from "./path-aliases.js";
-import { findPluginPackageRoot } from "./plugin-catalog-resolve.js";
+import {
+  findPluginPackageRoot,
+  isWorkspaceSymlinkedPlugin,
+} from "./plugin-catalog-resolve.js";
 import { stageUserPublic } from "./public-staging.js";
 
 // `import.meta.url` for this module lives at plumix/dist/vite/index.js in
@@ -346,6 +349,7 @@ async function regenerate(
   const { manifest, registry } = await computeManifestAndRegistry(
     config.plugins,
     { tokens: config.theme.tokens, i18n: config.i18n },
+    cwd,
   );
 
   return { configPath, manifest, registry, plugins: config.plugins };
@@ -364,16 +368,48 @@ type PluginDescriptors = Parameters<typeof installPlugins>[0]["plugins"];
 async function computeManifestAndRegistry(
   plugins: PluginDescriptors,
   options: { readonly tokens?: ThemeTokens; readonly i18n?: ResolvedI18n },
+  projectRoot: string,
 ): Promise<{ manifest: PlumixManifest; registry: PluginRegistry }> {
   const { registry } = await installPlugins({
     hooks: new HookRegistry(),
     plugins,
   });
+  // Plugins whose `@plumix/plugin-<id>` package is a pnpm symlink in
+  // `node_modules` are workspace-mounted — admin's `import.meta.glob`
+  // already bakes their catalogs into the bundle. Skipping URL
+  // emission for them avoids a runtime double-load (#724).
+  //
+  // Caveat: the bundler's symlink detection here and admin's pre-baked
+  // glob are computed at different times. If `packages/plumix/dist/admin-app`
+  // is stale (a new workspace plugin was added since the last plumix
+  // build), the symlink exists but admin's glob doesn't cover it —
+  // the plugin's strings fall back to `descriptor.message` silently.
+  // Rebuild plumix to refresh. The warning below makes that
+  // debuggable.
+  const adminBundledPluginIds = new Set(
+    plugins
+      .filter(
+        (p) =>
+          p.i18n !== undefined &&
+          isWorkspaceSymlinkedPlugin({ pluginId: p.id, projectRoot }),
+      )
+      .map((p) => p.id),
+  );
+  if (adminBundledPluginIds.size > 0) {
+    // eslint-disable-next-line no-console -- build-time dev signal
+    console.info(
+      `[plumix] skipping pluginI18n URLs for workspace-bundled plugins (admin's import.meta.glob is expected to cover): ${Array.from(adminBundledPluginIds).join(", ")}`,
+    );
+  }
   // Forward plugin descriptors so `buildManifest` can emit
   // `pluginI18n` URL maps for plugins declaring an `i18n` slot
   // (slice 17 #697 runtime catalog registry).
   return {
-    manifest: buildManifest(registry, { ...options, plugins }),
+    manifest: buildManifest(registry, {
+      ...options,
+      plugins,
+      adminBundledPluginIds,
+    }),
     registry,
   };
 }

--- a/packages/plumix/src/vite/plugin-catalog-resolve.test.ts
+++ b/packages/plumix/src/vite/plugin-catalog-resolve.test.ts
@@ -1,9 +1,19 @@
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { findPluginPackageRoot } from "./plugin-catalog-resolve.js";
+import {
+  findPluginPackageRoot,
+  isWorkspaceSymlinkedPlugin,
+} from "./plugin-catalog-resolve.js";
 
 describe("findPluginPackageRoot", () => {
   test("resolves via the `@plumix/plugin-<id>` convention", () => {
@@ -81,6 +91,57 @@ describe("findPluginPackageRoot — real FS", () => {
 
     const root = findPluginPackageRoot({ pluginId: "real", projectRoot });
     expect(root).toBe(pluginDir);
+  });
+
+  test("isWorkspaceSymlinkedPlugin returns true when the package dir is a symlink (pnpm workspace)", async () => {
+    // pnpm symlinks `node_modules/@plumix/plugin-real` to the
+    // workspace's `packages/plugins/real`. The `lstat` check
+    // distinguishes a real symlink from a symlinked ancestor path
+    // (which macOS tmpdir always exhibits).
+    const realPluginDir = join(projectRoot, "packages/plugins/real");
+    await mkdir(realPluginDir, { recursive: true });
+    await writeFile(
+      join(realPluginDir, "package.json"),
+      JSON.stringify({
+        name: "@plumix/plugin-real",
+        type: "module",
+        exports: { "./package.json": "./package.json" },
+      }),
+    );
+    const scopeDir = join(projectRoot, "node_modules/@plumix");
+    await mkdir(scopeDir, { recursive: true });
+    await symlink(realPluginDir, join(scopeDir, "plugin-real"), "dir");
+
+    expect(isWorkspaceSymlinkedPlugin({ pluginId: "real", projectRoot })).toBe(
+      true,
+    );
+  });
+
+  test("isWorkspaceSymlinkedPlugin returns false for a real (non-symlink) install", async () => {
+    // Third-party npm install — no symlink, real directory.
+    const pluginDir = join(projectRoot, "node_modules/@plumix/plugin-vendor");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@plumix/plugin-vendor",
+        type: "module",
+        exports: { "./package.json": "./package.json" },
+      }),
+    );
+
+    expect(
+      isWorkspaceSymlinkedPlugin({ pluginId: "vendor", projectRoot }),
+    ).toBe(false);
+  });
+
+  test("isWorkspaceSymlinkedPlugin returns false when the package isn't found at all", () => {
+    // `lstatSync` throws ENOENT; the helper's catch swallows it and
+    // returns false. Distinct from the "real install" path above,
+    // which exercises the `isSymbolicLink() === false` branch.
+    expect(isWorkspaceSymlinkedPlugin({ pluginId: "ghost", projectRoot })).toBe(
+      false,
+    );
   });
 
   test("returns null when a plugin package omits exports.['./package.json']", async () => {

--- a/packages/plumix/src/vite/plugin-catalog-resolve.ts
+++ b/packages/plumix/src/vite/plugin-catalog-resolve.ts
@@ -1,3 +1,4 @@
+import { lstatSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 
@@ -36,4 +37,41 @@ export function findPluginPackageRoot(input: {
     }
   }
   return null;
+}
+
+/**
+ * Detect whether a plugin is loaded via a pnpm workspace symlink — i.e.,
+ * `node_modules/@plumix/plugin-<id>` is itself a symlink to a sibling
+ * monorepo package. Used by the manifest layer to skip URL emission
+ * for plugins admin already bakes into its bundle via
+ * `import.meta.glob("../../../plugins/*"/locales/*.mjs")`.
+ *
+ * Intentionally scoped to the `@plumix/plugin-<id>` convention only —
+ * admin's glob covers `packages/plugins/*` in the plumix monorepo,
+ * which by convention houses `@plumix/`-scoped plugins. Workspace
+ * plugins under a different convention (`plumix-plugin-<id>`,
+ * community forks) aren't covered by admin's glob either, so emitting
+ * a URL for them is correct.
+ *
+ * Inspects the symlink at `node_modules/@plumix/plugin-<id>` directly
+ * with `lstat` — `require.resolve` would follow the symlink and yield
+ * the realpath, defeating the check. `lstat` on the path itself
+ * reports `isSymbolicLink()` for the dir-entry, ignoring symlinked
+ * ancestors (macOS tmpdir).
+ */
+export function isWorkspaceSymlinkedPlugin(input: {
+  readonly pluginId: string;
+  readonly projectRoot: string;
+}): boolean {
+  const symlinkPath = resolve(
+    input.projectRoot,
+    "node_modules",
+    "@plumix",
+    `plugin-${input.pluginId}`,
+  );
+  try {
+    return lstatSync(symlinkPath).isSymbolicLink();
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Admin's `import.meta.glob("../../../plugins/*/locales/*.mjs")` in `i18n-boot.ts` bakes the monorepo's workspace plugin catalogs into the bundle at admin's build time. Emitting URLs for those same plugins in `manifest.pluginI18n` causes admin to double-load: once via the inlined glob, again via the runtime URL fetch. `Object.assign` semantics make the merge idempotent — wasted bandwidth, not broken — but a key-collision load-order flip is one regression away.

**Detection**

The plumix vite plugin now detects workspace-symlinked plugins via `lstatSync` on `<projectRoot>/node_modules/@plumix/plugin-<id>` and passes the set to `buildManifest` as `adminBundledPluginIds`. `projectPluginI18n` drops them from the emitted manifest; `stagePluginCatalogs` follows automatically (it iterates `pluginI18n` for the copy step).

`lstatSync` not `realpath` — macOS tmpdir symlinks `/var/folders` → `/private/var/folders`, so any path beneath it would false-positive a realpath comparison. `lstat` reports `isSymbolicLink()` on the dir entry itself, ignoring symlinked ancestors.

**Naming + docs (Senpai S2 + N4 + N7)**

- Option name `adminBundledPluginIds` describes the semantic ("admin already covers these"), not the detection mechanism. A future first-party-plugin-pack tarball could feed the same set without renaming.
- JSDoc on `isWorkspaceSymlinkedPlugin` documents the `@plumix/plugin-*` scoping — admin's glob is conventionally scoped to that namespace, so workspace plugins under `plumix-plugin-<id>` correctly fall through to URL emission.
- `adminBundledPluginIds` requires `plugins` to take effect (it's a filter target). Documented.

**Cheap dev warning (Senpai S1)**

The skip's correctness depends on the invariant "admin's pre-baked glob covers the bundler-detected set". When a new workspace plugin is added without rebuilding plumix, the invariant drifts and translations fall back to source-locale silently. The build now logs an info-level `[plumix] skipping pluginI18n URLs for workspace-bundled plugins: <ids>` so the cause is grep-able in 30 seconds.

The stronger mitigation (resolve symlink target + verify it's inside admin's expected glob root) is deferred — adds complexity for a dev-time-only failure mode whose remedy (`pnpm -F plumix build`) is normal.

**Deferred: integration test (Senpai S3)**

The manifest projection + detection helper are individually unit-tested. The wire from bundler → `computeManifestAndRegistry` → `buildManifest` → manifest output isn't pinned end-to-end. Extracting `computeManifestAndRegistry` for test isolation is bigger than the value it delivers today.

Fixes #724