### PR TITLE
refactor(admin): invert i18n strict ratchet to a denylist

### DIFF
--- a/packages/admin/eslint.config.ts
+++ b/packages/admin/eslint.config.ts
@@ -1,76 +1,86 @@
 import { defineConfig } from "eslint/config";
 
 import { baseConfig } from "@plumix/eslint-config/base";
-import { i18nConfig, i18nStrictOverrides } from "@plumix/eslint-config/i18n";
+import { i18nStrictConfig } from "@plumix/eslint-config/i18n";
 import { reactConfig } from "@plumix/eslint-config/react";
 
-// Strict mode (`no-unlocalized-strings`) ratchet — every file in this
-// list must stay free of raw user-facing strings. Add a file here only
-// after wrapping every translatable string it contains. Slice 15
-// (#684) is the umbrella tracking the expansion of this list to the
-// rest of admin chrome.
-const STRICT_WRAPPED_FILES = [
-  "src/components/data-table/data-table.tsx",
-  "src/components/data-table/list-pagination.tsx",
-  "src/components/form/search-input.tsx",
-  "src/components/locale-switcher.tsx",
-  "src/components/meta-box/meta-box-field.tsx",
-  "src/components/meta-box/meta-box.tsx",
-  "src/components/meta-box/multi-reference-picker.tsx",
-  "src/components/meta-box/plugin-field-error-boundary.tsx",
-  "src/components/meta-box/reference-picker.tsx",
-  "src/components/meta-box/repeater-field.tsx",
-  "src/components/profile/language-card.tsx",
-  "src/components/profile/api-tokens-card.tsx",
-  "src/components/profile/passkeys-card.tsx",
-  "src/components/profile/sessions-card.tsx",
-  "src/components/profile/user-email-field.tsx",
-  "src/components/shell/user-menu.tsx",
-  "src/components/editor/entry-tree.ts",
-  "src/components/taxonomy/term-form.tsx",
-  "src/components/taxonomy/tree.ts",
-  "src/editor/BlockActionsPanel.tsx",
-  "src/editor/BlockScopePicker.tsx",
-  "src/editor/PatternsSection.tsx",
-  "src/editor/SlashMenuPanel.tsx",
-  "src/editor/StarterModal.tsx",
-  "src/lib/breadcrumbs.ts",
-  "src/lib/dates.ts",
-  "src/lib/i18n-boot.ts",
-  "src/lib/plugin-catalogs.ts",
-  "src/lib/plumix-globals.ts",
-  "src/lib/use-formatters.ts",
-  "src/lib/use-label.ts",
-  "src/routes/__root.tsx",
-  "src/routes/_editor.tsx",
-  "src/routes/_editor/entries/$slug/$id/edit.tsx",
-  "src/routes/_editor/entries/$slug/create.tsx",
-  "src/routes/_auth/-schemas.ts",
-  "src/routes/_auth/accept-invite/$token.tsx",
-  "src/routes/_auth/bootstrap.tsx",
-  "src/routes/_auth/login.tsx",
-  "src/routes/_authenticated/allowed-domains/index.tsx",
-  "src/routes/_authenticated/auth/device.tsx",
-  "src/routes/_authenticated/index.tsx",
-  "src/routes/_authenticated/mailer/index.tsx",
-  "src/routes/_authenticated/settings/$page.tsx",
-  "src/routes/_authenticated/settings/index.tsx",
-  "src/routes/_authenticated/users/$id/edit.tsx",
-  "src/routes/_authenticated/users/create.tsx",
-  "src/routes/_authenticated/users/index.tsx",
+// `lingui/no-unlocalized-strings` is on for `src/**` by default. The
+// list below opts surfaces out until their strings are wrapped — wrap
+// a surface, drop its entry. When empty, delete the override block
+// (the `defineConfig` spread below) and the gate is implicit.
+const STRICT_UNWRAPPED_FILES = [
+  "src/App.tsx",
+  "src/components/editor/plain-form-layout.tsx",
+  "src/components/editor/post-editor-form.ts",
+  "src/components/form/multi-select.tsx",
+  "src/components/meta-box/meta-box-grid.ts",
+  "src/components/shell/app-sidebar.tsx",
+  "src/components/shell/shell-header.tsx",
+  "src/editor/AutosaveStatus.tsx",
+  "src/editor/available-transforms.ts",
+  "src/editor/block-adapter.ts",
+  "src/editor/build-copy-pattern-source.ts",
+  "src/editor/derive-pattern-slug.ts",
+  "src/editor/detach-pattern-ref.ts",
+  "src/editor/detect-stale-autosave.ts",
+  "src/editor/EditorLayout.tsx",
+  "src/editor/field-type-translator.ts",
+  "src/editor/HeadingAuditPanel.tsx",
+  "src/editor/insert-pattern.ts",
+  "src/editor/insert-variation.ts",
+  "src/editor/intersection-observer-harness.ts",
+  "src/editor/PatternRefPreview.tsx",
+  "src/editor/puck-to-block-tree.ts",
+  "src/editor/puck-zones.ts",
+  "src/editor/resolve-editor-mode.ts",
+  "src/editor/revisions/diff.ts",
+  "src/editor/revisions/PreviewBanner.tsx",
+  "src/editor/revisions/RevisionDiffDialog.tsx",
+  "src/editor/revisions/RevisionDiffPanel.tsx",
+  "src/editor/revisions/RevisionsSheet.tsx",
+  "src/editor/StaleDraftDialog.tsx",
+  "src/editor/StyleTab.tsx",
+  "src/editor/TokenSwatchList.tsx",
+  "src/editor/viewport-bucket.ts",
+  "src/lib/email-change-errors.ts",
+  "src/lib/entries.ts",
+  "src/lib/errors.ts",
+  "src/lib/magic-link-errors.ts",
+  "src/lib/magic-link.ts",
+  "src/lib/manifest.ts",
+  "src/lib/oauth-errors.ts",
+  "src/lib/passkey-errors.ts",
+  "src/lib/passkey.ts",
+  "src/lib/plugin-error-boundary.tsx",
+  "src/lib/plugin-registry.ts",
+  "src/lib/wait-for-plugin-chunks.ts",
+  "src/providers/router.ts",
+  "src/providers/theme.tsx",
+  "src/routes/_authenticated/entries/$slug/index.tsx",
+  "src/routes/_authenticated/pages/$.tsx",
+  "src/routes/_authenticated/terms/$name/-errors.ts",
+  "src/routes/_authenticated/terms/$name/$id/edit.tsx",
+  "src/routes/_authenticated/terms/$name/create.tsx",
+  "src/routes/_authenticated/terms/$name/index.tsx",
 ];
 
 export default defineConfig(
   baseConfig,
   reactConfig,
-  i18nConfig,
-  {
-    // Strict mode (`no-unlocalized-strings`) scoped to the ratchet list.
-    // Surfaces not yet wrapped keep the macro-misuse rules from
-    // `i18nConfig` (already applied above) until they're added here.
-    files: STRICT_WRAPPED_FILES,
-    ...i18nStrictOverrides,
-  },
+  i18nStrictConfig,
+  // ESLint flat config rejects `files: []`; the conditional spread
+  // omits the override block when the seed shrinks to empty.
+  ...(STRICT_UNWRAPPED_FILES.length > 0
+    ? [
+        {
+          // Only `no-unlocalized-strings` relaxes here; macro-misuse
+          // rules from `i18nStrictConfig` (no-trans-inside-trans, …)
+          // still apply.
+          files: STRICT_UNWRAPPED_FILES,
+          rules: { "lingui/no-unlocalized-strings": "off" },
+        },
+      ]
+    : []),
   {
     // Vendored shadcn/ui primitives — kept verbatim so `shadcn diff` upgrades
     // don't merge-conflict. Lint these like we lint node_modules: we don't.


### PR DESCRIPTION
The per-file `STRICT_WRAPPED_FILES` allowlist had grown to ~50 entries and added two-to-five lines per wrap PR. Flip it: `lingui/no-unlocalized-strings` is on for `src/**` by default; the new `STRICT_UNWRAPPED_FILES` opts surfaces out until they wrap. As wraps land, entries leave the list. When empty, the override block deletes and the gate is implicit.

**Seeded by probing an empty denylist**

Ran lint with `STRICT_UNWRAPPED_FILES = []` and captured every file that fired the rule. 52 entries — exactly the remaining unwrapped admin source files (editor shell + revisions UI, `lib/*-errors.ts` adapters, passkey / magic-link helpers, shell sidebar/header, providers, `App.tsx`, the terms / entries / pages routes). Every previously-wrapped surface from #725 is now covered implicitly.

**Conditional spread handles the empty-collapse**

ESLint flat config rejects `files: []`. The override block is spread conditionally on `STRICT_UNWRAPPED_FILES.length > 0`, so when the seed shrinks to empty, removing the array literal collapses the spread to nothing and `i18nStrictConfig`'s strict default is the only gate left. No further config surgery needed at the finish line.

**Macro-misuse rules unaffected**

Only `no-unlocalized-strings` relaxes for denylisted files. `no-trans-inside-trans`, `no-expression-in-message`, `no-single-variables-to-translate`, `no-single-tag-to-translate` all still apply across `src/**` — that contract from #708 is untouched.

**Follow-up worth tracking (not in this PR)**

Stale denylist entries (files fully wrapped where the entry was never deleted) would silently leave the rule off. A CI step that re-runs lint with the seed elided and reports zero-impact entries would close that loop; cheap to add later when the list is small enough that a probe completes in under a minute.

Refs #725