### PR TITLE
feat(core): widen EntryTypeOptions.labels.{singular,plural} to Label

### DIFF
--- a/packages/admin/src/lib/breadcrumbs.test.ts
+++ b/packages/admin/src/lib/breadcrumbs.test.ts
@@ -1,3 +1,4 @@
+import type { MessageDescriptor } from "@lingui/core";
 import { i18n } from "@lingui/core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -141,6 +142,32 @@ describe("pathToCrumbs", () => {
     const editLeaf = pathToCrumbs("/terms/category/7/edit").at(-1);
     expect(typeof editLeaf?.label).toBe("object");
     expect(editLeaf?.values).toEqual({ singular: "category" });
+  });
+
+  test("descriptor-typed labels.singular resolves through the locale", () => {
+    // A plugin emitting `labels.singular: defineMessage({...})` should
+    // see the descriptor flow through to the same `i18n._` resolution
+    // path as every other Label-typed crumb field. The pre-widening
+    // call site did `(tax?.labels?.singular ?? label).toLowerCase()`
+    // which throws on an object — and crucially the schema forced
+    // singular to be `string`, blocking the descriptor variant
+    // entirely. This test pins the behavior post-widening: a
+    // descriptor-typed singular resolves to its `.message` string
+    // before the lowercase pass.
+    const descriptor: MessageDescriptor = {
+      id: "test.taxonomy.singular",
+      message: "Category",
+    };
+    const tax = FIXTURE.termTaxonomies?.[0];
+    if (!tax?.labels) throw new Error("fixture invariant violated");
+    const original = tax.labels.singular;
+    (tax.labels as { singular: unknown }).singular = descriptor;
+    try {
+      const createLeaf = pathToCrumbs("/terms/category/create").at(-1);
+      expect(createLeaf?.values).toEqual({ singular: "category" });
+    } finally {
+      (tax.labels as { singular: unknown }).singular = original;
+    }
   });
 
   test("users edit: list crumb is a link", () => {

--- a/packages/admin/src/lib/breadcrumbs.ts
+++ b/packages/admin/src/lib/breadcrumbs.ts
@@ -1,5 +1,9 @@
 import type { MessageDescriptor } from "@lingui/core";
+import { i18n } from "@lingui/core";
 import { defineMessage } from "@lingui/core/macro";
+
+import type { Label } from "@plumix/core/i18n";
+import { resolveLabel } from "@plumix/core/i18n";
 
 import {
   findEntryTypeBySlug,
@@ -10,10 +14,12 @@ import {
 
 export interface Crumb {
   /**
-   * Either a `MessageDescriptor` (for chrome-owned labels like "Dashboard",
-   * "Entries") or a plain string (for manifest-derived labels like an
-   * entry type's plural). Slice 5/#674 widens manifest labels to descriptors
-   * too — when that lands, this type can narrow to `MessageDescriptor`.
+   * Either a `MessageDescriptor` (chrome-owned labels) or a plain
+   * string (manifest-derived labels that plugin authors haven't
+   * migrated to `defineMessage(...)` yet). Both variants resolve
+   * through `i18n._` at render time in `shell-header.tsx`; never
+   * narrows because plain-string manifest labels remain a valid
+   * `Label` per #730.
    */
   readonly label: string | MessageDescriptor;
   /** ICU placeholder values threaded into `i18n._` at render time —
@@ -86,7 +92,7 @@ function entriesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const slug = parts[1];
   if (slug === undefined) return [{ label: M.entries }];
   const entry = findEntryTypeBySlug(slug);
-  const label = entry?.labels?.plural ?? entry?.label ?? slug;
+  const label: Label = entry?.labels?.plural ?? entry?.label ?? slug;
   const list: Crumb = { label, to: `/entries/${slug}` };
   if (parts[2] === "create")
     return [{ label: M.entries }, list, { label: M.create }];
@@ -99,8 +105,11 @@ function taxonomiesCrumbs(parts: readonly string[]): readonly Crumb[] {
   const name = parts[1];
   if (name === undefined) return [{ label: M.terms }];
   const tax = findTermTaxonomyByName(name);
-  const label = tax?.label ?? name;
-  const singular = (tax?.labels?.singular ?? label).toLowerCase();
+  const label: Label = tax?.label ?? name;
+  const singular = resolveLabel(
+    tax?.labels?.singular ?? label,
+    i18n,
+  ).toLowerCase();
   const list: Crumb = { label, to: `/terms/${name}` };
   if (parts[2] === "create")
     return [

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -367,9 +367,10 @@ function ContentListRoute(): ReactNode {
   const canNext = rows.length === PAGE_SIZE;
 
   const renderLabel = useLabel();
-  const typeLabel = renderLabel(entryType.label);
-  const pluralLabel = entryType.labels?.plural ?? typeLabel;
-  const singularLabel = entryType.labels?.singular ?? typeLabel;
+  const pluralLabel = renderLabel(entryType.labels?.plural ?? entryType.label);
+  const singularLabel = renderLabel(
+    entryType.labels?.singular ?? entryType.label,
+  );
   const pluralLower = pluralLabel.toLowerCase();
   const singularLower = singularLabel.toLowerCase();
 

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -55,7 +55,7 @@ function DashboardIndex(): ReactNode {
       {tiles.length > 0 ? (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {tiles.map((pt) => {
-            const label = pt.labels?.plural ?? renderLabel(pt.label);
+            const label = renderLabel(pt.labels?.plural ?? pt.label);
             const labelLower = label.toLowerCase();
             return (
               <Card key={pt.name} data-testid={`dashboard-tile-${pt.name}`}>

--- a/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
@@ -31,6 +31,7 @@ import {
   termMetaBoxesForTermTaxonomy,
 } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { useLabel } from "@/lib/use-label.js";
 import {
   useMutation,
   useQuery,
@@ -172,6 +173,7 @@ function EditTermContent({
 }): ReactNode {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const renderLabel = useLabel();
   const [serverError, setServerError] = useState<string | null>(null);
   const { user } = Route.useRouteContext();
   const metaBoxes = termMetaBoxesForTermTaxonomy(
@@ -224,8 +226,8 @@ function EditTermContent({
     },
   });
 
-  const singularLower = (
-    taxonomy.labels?.singular ?? taxonomy.label
+  const singularLower = renderLabel(
+    taxonomy.labels?.singular ?? taxonomy.label,
   ).toLowerCase();
 
   return (

--- a/packages/admin/src/routes/_authenticated/terms/$name/create.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/create.tsx
@@ -12,6 +12,7 @@ import {
 import { hasCap } from "@/lib/caps.js";
 import { findTermTaxonomyByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { useLabel } from "@/lib/use-label.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -57,6 +58,7 @@ function NewTermRoute(): ReactNode {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { taxonomy } = Route.useRouteContext();
+  const renderLabel = useLabel();
   const [serverError, setServerError] = useState<string | null>(null);
 
   // For hierarchical termTaxonomies we pull the existing term set so the
@@ -112,8 +114,8 @@ function NewTermRoute(): ReactNode {
     },
   });
 
-  const singularLower = (
-    taxonomy.labels?.singular ?? taxonomy.label
+  const singularLower = renderLabel(
+    taxonomy.labels?.singular ?? taxonomy.label,
   ).toLowerCase();
 
   return (

--- a/packages/admin/src/routes/_authenticated/terms/$name/index.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/index.tsx
@@ -17,6 +17,7 @@ import {
 import { hasCap } from "@/lib/caps.js";
 import { findTermTaxonomyByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import { useLabel } from "@/lib/use-label.js";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
@@ -131,6 +132,7 @@ function useTaxonomyListNavActions(): TaxonomyListNavActions {
 function TaxonomyListRoute(): ReactNode {
   const search = Route.useSearch();
   const { user, taxonomy } = Route.useRouteContext();
+  const renderLabel = useLabel();
   const isHierarchical = taxonomy.isHierarchical === true;
   const pageSize = isHierarchical ? TREE_PAGE_SIZE : FLAT_PAGE_SIZE;
 
@@ -163,10 +165,10 @@ function TaxonomyListRoute(): ReactNode {
   const canNext = (rawRows?.length ?? 0) === pageSize;
 
   const canEdit = hasCap(user.capabilities, `term:${taxonomy.name}:edit`);
-  const singularLower = (
-    taxonomy.labels?.singular ?? taxonomy.label
+  const singularLower = renderLabel(
+    taxonomy.labels?.singular ?? taxonomy.label,
   ).toLowerCase();
-  const pluralLower = taxonomy.label.toLowerCase();
+  const pluralLower = renderLabel(taxonomy.label).toLowerCase();
 
   const columns = useMemo<ColumnDef<TermRow>[]>(() => {
     return [

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -913,8 +913,8 @@ function PlainFormRouteInner({
     parentId: entry.parentId,
   };
 
-  const singular = (
-    entryType.labels?.singular ?? renderLabel(entryType.label)
+  const singular = renderLabel(
+    entryType.labels?.singular ?? entryType.label,
   ).toLowerCase();
   // PlainFormLayout takes a rendered string headline; ICU placeholder
   // substitution via the 3-arg `i18n._` form.

--- a/packages/admin/src/routes/_editor/entries/$slug/create.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/create.tsx
@@ -78,7 +78,7 @@ function CreateEntryRoute(): ReactNode {
         id="editor.entry.create.pending"
         message="Creating new {singular}…"
         values={{
-          singular: entryType.labels?.singular ?? renderLabel(entryType.label),
+          singular: renderLabel(entryType.labels?.singular ?? entryType.label),
         }}
       />
     </div>

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -35,8 +35,8 @@ export interface EntryTypeOptions {
    * irregular plurals should set `labels.plural` explicitly.
    */
   readonly labels?: {
-    readonly singular?: string;
-    readonly plural?: string;
+    readonly singular?: Label;
+    readonly plural?: Label;
   };
   readonly description?: string;
   readonly supports?: readonly string[];
@@ -73,7 +73,7 @@ export interface EntryTypeOptions {
 
 export interface TermTaxonomyOptions {
   readonly label: string;
-  readonly labels?: { readonly singular?: string };
+  readonly labels?: { readonly singular?: Label };
   readonly description?: string;
   readonly isHierarchical?: boolean;
   readonly entryTypes?: readonly string[];
@@ -1212,8 +1212,8 @@ export interface EntryTypeManifestEntry {
   readonly adminSlug: string;
   readonly label: Label;
   readonly labels?: {
-    readonly singular?: string;
-    readonly plural?: string;
+    readonly singular?: Label;
+    readonly plural?: Label;
   };
   readonly description?: string;
   readonly supports?: readonly string[];
@@ -1358,7 +1358,7 @@ export interface UserMetaBoxManifestEntry extends MetaBoxBaseManifestEntry {
 export interface TermTaxonomyManifestEntry {
   readonly name: string;
   readonly label: string;
-  readonly labels?: { readonly singular?: string };
+  readonly labels?: { readonly singular?: Label };
   readonly description?: string;
   readonly isHierarchical?: boolean;
   readonly entryTypes?: readonly string[];
@@ -2168,7 +2168,10 @@ function toEntryTypeManifest(pt: RegisteredEntryType): EntryTypeManifestEntry {
   const visibility = resolveEntryTypeVisibility(pt);
   return {
     name,
-    adminSlug: deriveAdminSlug(name, labels?.plural),
+    adminSlug: deriveAdminSlug(
+      name,
+      labels?.plural !== undefined ? labelSourceText(labels.plural) : undefined,
+    ),
     label,
     labels,
     description,

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -316,7 +316,9 @@ async function resolveTaxonomy(
       databaseId: term.id,
     },
     data,
-    title: taxonomy?.labels?.singular ?? taxonomy?.label ?? term.name,
+    title: taxonomy
+      ? labelSourceText(taxonomy.labels?.singular ?? taxonomy.label)
+      : term.name,
   });
   return new Response(html, {
     headers: { "content-type": "text/html; charset=utf-8" },
@@ -397,10 +399,9 @@ async function resolveArchive(
   // SSR-side: descriptor labels fall back to source text until the
   // ctx.i18n route wiring lands (slice 11 #680 covered tRPC errors;
   // route titles pending).
-  const title =
-    registered?.labels?.plural ??
-    (registered ? labelSourceText(registered.label) : undefined) ??
-    intent.entryType;
+  const title = registered
+    ? labelSourceText(registered.labels?.plural ?? registered.label)
+    : intent.entryType;
 
   const initial: ArchiveData = {
     contentType: intent.entryType,

--- a/packages/plugins/menu/src/server/eligibility.ts
+++ b/packages/plugins/menu/src/server/eligibility.ts
@@ -72,7 +72,7 @@ export function getEligibleMenuKinds(registry: PluginRegistry): PickerTab[] {
 interface MenuEligibleEntryType {
   readonly name: string;
   readonly label: Label;
-  readonly labels?: { readonly plural?: string };
+  readonly labels?: { readonly plural?: Label };
   readonly isPublic?: boolean;
   readonly isShownInMenus?: boolean;
   readonly menuPickerLabel?: string;
@@ -85,14 +85,13 @@ function isMenuEligibleType(entryType: MenuEligibleEntryType): boolean {
 function pickerLabelForEntryType(entryType: MenuEligibleEntryType): string {
   return (
     entryType.menuPickerLabel ??
-    entryType.labels?.plural ??
-    labelSourceText(entryType.label)
+    labelSourceText(entryType.labels?.plural ?? entryType.label)
   );
 }
 
 interface MenuEligibleTaxonomy {
   readonly name: string;
-  readonly label: string;
+  readonly label: Label;
   readonly isPublic?: boolean;
   readonly isShownInMenus?: boolean;
   readonly menuPickerLabel?: string;
@@ -103,5 +102,5 @@ function isMenuEligibleTaxonomy(taxonomy: MenuEligibleTaxonomy): boolean {
 }
 
 function pickerLabelForTaxonomy(taxonomy: MenuEligibleTaxonomy): string {
-  return taxonomy.menuPickerLabel ?? taxonomy.label;
+  return taxonomy.menuPickerLabel ?? labelSourceText(taxonomy.label);
 }


### PR DESCRIPTION
Closes #730. Manifest-derived `labels.singular` / `labels.plural` (entry types + term taxonomies) now accept either a string or a `MessageDescriptor`. Plain strings still satisfy `Label`, so every built-in plugin keeps emitting raw English labels unchanged — opt-in `defineMessage(...)` migration is left to plugin authors.

**Coalesce-and-render call sites flip**

`labels?.singular ?? renderLabel(label)` → `renderLabel(labels?.singular ?? label)`. The union flows through the resolver once instead of bypassing it on the manifest branch. Six admin sites updated; `breadcrumbs.ts` (React-free) resolves through `@lingui/core`'s global instance because the consumer needs the result snapshotted into `Crumb.values` for ICU substitution.

**Server-side flatten via `labelSourceText`**

`deriveAdminSlug` (admin URL derivation) and the archive / term-archive SSR title fallbacks take a descriptor in, emit a string out via `labelSourceText(...)`. The slug stays ASCII-stable; the SSR `<title>` takes the source-locale message (no user-locale on the server-side render path here).

**Plugin-menu mirror types widen**

The plugin's local `MenuEligibleEntryType` / `MenuEligibleTaxonomy` interfaces mirror the manifest shape, so they widen too. Two callsites switch from direct `.plural` reads to `labelSourceText(...)`.

**Tracer test**

`breadcrumbs.test.ts` adds a test that drops a `MessageDescriptor` into `labels.singular` and asserts the crumb's `values.singular` resolves to the lowercased English message. Pre-widening it threw `TypeError: ... .toLowerCase is not a function` on the descriptor object — RED → GREEN through this PR.

**Deferred to follow-ups**

- `packages/core/src/rpc/procedures/entry/lookup.ts:122` (`Untitled ${row.type}` server-side fallback): widening the lookup RPC wire shape + persisted `cached.label` touches DB-cached meta and admin's reference picker. Separate design slice.
- Built-in plugin manifest emit migration to `defineMessage(...)` — independent once a plugin author wants their type to localize.

Closes #730 Refs #725