### PR TITLE
feat: add withContext helper for translator-facing context (msgctxt)

### DIFF
--- a/packages/core/src/i18n/context.test.ts
+++ b/packages/core/src/i18n/context.test.ts
@@ -1,0 +1,49 @@
+import type { MessageDescriptor } from "@lingui/core";
+import { setupI18n } from "@lingui/core";
+import { describe, expect, test } from "vitest";
+
+import { withContext } from "./context.js";
+import { resolveLabel } from "./label.js";
+
+describe("withContext", () => {
+  test("last-write-wins when the source descriptor already carries a context", () => {
+    const source: MessageDescriptor & { context: string } = {
+      id: "post.singular",
+      message: "Post",
+      context: "old",
+    };
+    expect(withContext(source, "noun").context).toBe("noun");
+  });
+
+  test("preserves other descriptor fields like `comment` through the wrap", () => {
+    const tagged = withContext(
+      {
+        id: "post.singular",
+        message: "Post",
+        comment: "Singular post-type label.",
+      },
+      "noun",
+    );
+    expect(tagged.comment).toBe("Singular post-type label.");
+    expect(tagged.context).toBe("noun");
+  });
+
+  test("resolves through resolveLabel — context is translator metadata only", () => {
+    const instance = setupI18n({
+      locale: "de",
+      messages: { de: { "post.singular": "Beitrag" } },
+    });
+    const tagged = withContext(
+      { id: "post.singular", message: "Post" },
+      "noun",
+    );
+    expect(resolveLabel(tagged, instance)).toBe("Beitrag");
+  });
+
+  test("empty-string context lands on the descriptor as-is", () => {
+    // `format-po` drops falsy `msgctxt` from emitted catalogs (gettext
+    // convention). The helper itself doesn't normalize; if a caller
+    // ever needs to "unset" a context, this is how.
+    expect(withContext({ id: "x", message: "X" }, "").context).toBe("");
+  });
+});

--- a/packages/core/src/i18n/context.ts
+++ b/packages/core/src/i18n/context.ts
@@ -1,0 +1,13 @@
+import type { MessageDescriptor } from "@lingui/core";
+
+/** Attach a Lingui translation context (`msgctxt` in `.po`). Use when
+ *  identical English text needs distinct translations — e.g. `Post` as
+ *  a noun vs `Post a comment` as a verb. WP authors will recognize
+ *  this as `_x()`. Translator-facing metadata only; runtime resolution
+ *  still keys on `id`. */
+export function withContext<T extends MessageDescriptor>(
+  descriptor: T,
+  context: string,
+): T & { readonly context: string } {
+  return { ...descriptor, context };
+}

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,3 +1,4 @@
+export { withContext } from "./context.js";
 export {
   formatDate,
   formatNumber,

--- a/packages/plugins/blog/locales/en.po
+++ b/packages/plugins/blog/locales/en.po
@@ -10,31 +10,37 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/index.ts
+msgctxt "post type general name"
 msgid "plugin.blog.post.plural"
 msgstr "Posts"
 
 #. js-lingui-explicit-id
 #: src/index.ts
+msgctxt "post type singular name"
 msgid "plugin.blog.post.singular"
 msgstr "Post"
 
 #. js-lingui-explicit-id
 #: src/index.ts
+msgctxt "taxonomy general name"
 msgid "plugin.blog.category.plural"
 msgstr "Categories"
 
 #. js-lingui-explicit-id
 #: src/index.ts
+msgctxt "taxonomy singular name"
 msgid "plugin.blog.category.singular"
 msgstr "Category"
 
 #. js-lingui-explicit-id
 #: src/index.ts
+msgctxt "taxonomy general name"
 msgid "plugin.blog.tag.plural"
 msgstr "Tags"
 
 #. js-lingui-explicit-id
 #: src/index.ts
+msgctxt "taxonomy singular name"
 msgid "plugin.blog.tag.singular"
 msgstr "Tag"
 

--- a/packages/plugins/blog/src/index.test.ts
+++ b/packages/plugins/blog/src/index.test.ts
@@ -15,6 +15,7 @@ describe("@plumix/plugin-blog", () => {
     expect(post?.label).toEqual({
       id: "plugin.blog.post.plural",
       message: "Posts",
+      context: "post type general name",
     });
     expect(post?.isPublic).toBe(true);
     expect(post?.hasArchive).toBe(true);

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -1,4 +1,5 @@
 import type { EntryTypeLabels, TermTaxonomyLabels } from "plumix/plugin";
+import { withContext } from "plumix/i18n";
 import { definePlugin } from "plumix/plugin";
 
 // Plain descriptor literals — server-side plugin code can't run the
@@ -11,9 +12,21 @@ import { definePlugin } from "plumix/plugin";
 // schema so typo-renames silently falling through to the generic
 // fallback aren't possible.
 
+// Singular/plural carry WP `_x()` contexts so verb-shaped reuses
+// (`Post a comment`, `Draft this`) can diverge in translation.
+// The matching `msgctxt` lines in `locales/en.po` are hand-authored —
+// see the `X-Generator: hand-authored` header. `withContext` is not
+// macro-visible, so any future `lingui extract` integration here would
+// regress those lines silently.
 const POST_LABELS = {
-  singular: { id: "plugin.blog.post.singular", message: "Post" },
-  plural: { id: "plugin.blog.post.plural", message: "Posts" },
+  singular: withContext(
+    { id: "plugin.blog.post.singular", message: "Post" },
+    "post type singular name",
+  ),
+  plural: withContext(
+    { id: "plugin.blog.post.plural", message: "Posts" },
+    "post type general name",
+  ),
   addNewItem: { id: "plugin.blog.post.addNewItem", message: "Add Post" },
   editItem: { id: "plugin.blog.post.editItem", message: "Edit Post" },
   newItem: { id: "plugin.blog.post.newItem", message: "New Post" },
@@ -40,7 +53,10 @@ const POST_LABELS = {
 } satisfies EntryTypeLabels;
 
 const CATEGORY_LABELS = {
-  singular: { id: "plugin.blog.category.singular", message: "Category" },
+  singular: withContext(
+    { id: "plugin.blog.category.singular", message: "Category" },
+    "taxonomy singular name",
+  ),
   addNewItem: {
     id: "plugin.blog.category.addNewItem",
     message: "Add Category",
@@ -72,7 +88,10 @@ const CATEGORY_LABELS = {
 } satisfies TermTaxonomyLabels;
 
 const TAG_LABELS = {
-  singular: { id: "plugin.blog.tag.singular", message: "Tag" },
+  singular: withContext(
+    { id: "plugin.blog.tag.singular", message: "Tag" },
+    "taxonomy singular name",
+  ),
   addNewItem: { id: "plugin.blog.tag.addNewItem", message: "Add Tag" },
   editItem: { id: "plugin.blog.tag.editItem", message: "Edit Tag" },
   searchItems: {
@@ -90,11 +109,14 @@ const TAG_LABELS = {
 // Plural for the term-taxonomy root `label` field — `TermTaxonomyLabels`
 // doesn't include `plural` (taxonomies only carry singular on the
 // labels table), so the plural lives alongside the table.
-const CATEGORY_PLURAL = {
-  id: "plugin.blog.category.plural",
-  message: "Categories",
-};
-const TAG_PLURAL = { id: "plugin.blog.tag.plural", message: "Tags" };
+const CATEGORY_PLURAL = withContext(
+  { id: "plugin.blog.category.plural", message: "Categories" },
+  "taxonomy general name",
+);
+const TAG_PLURAL = withContext(
+  { id: "plugin.blog.tag.plural", message: "Tags" },
+  "taxonomy general name",
+);
 
 export const blog = definePlugin("blog", {
   i18n: {

--- a/packages/plumix/src/i18n/index.ts
+++ b/packages/plumix/src/i18n/index.ts
@@ -5,6 +5,7 @@ export {
   formatRelative,
   labelSourceText,
   resolveLabel,
+  withContext,
   type FormatRelativeOptions,
   type Label,
 } from "@plumix/core";

--- a/packages/plumix/src/i18n/round-trip.test.tsx
+++ b/packages/plumix/src/i18n/round-trip.test.tsx
@@ -2,7 +2,7 @@ import { i18n } from "@lingui/core";
 import { renderToString } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 
-import { I18nProvider, Trans } from "./index.js";
+import { I18nProvider, Trans, withContext } from "./index.js";
 
 describe("plumix/i18n — Lingui round-trip", () => {
   test("Trans renders the German message when the de catalog is active", () => {
@@ -19,5 +19,13 @@ describe("plumix/i18n — Lingui round-trip", () => {
     );
 
     expect(html).toContain("Übersicht");
+  });
+
+  test("withContext is re-exported as a runtime helper from plumix/i18n", () => {
+    const tagged = withContext(
+      { id: "post.singular", message: "Post" },
+      "noun",
+    );
+    expect(tagged.context).toBe("noun");
   });
 });


### PR DESCRIPTION
Closes #760 partial — proving-ground slice. Adds `withContext(descriptor, context)` to `@plumix/core/i18n` (re-exported from `plumix/i18n`) so Lingui descriptors can carry the same translator-facing disambiguation field WordPress's `_x()` produces. First adoption: `@plumix/plugin-blog`'s six root labels.

`withContext` is metadata-only — `resolveLabel` / `i18n._()` continue to key on `id`. The catalog gains `msgctxt` lines so translators see two distinct entries when the same English `message` (e.g. `Post` the noun vs `Post` the verb) appears in different senses.

**Adoption shape**

Before:

```ts
const POST_LABELS = {
  singular: { id: "plugin.blog.post.singular", message: "Post" },
  plural: { id: "plugin.blog.post.plural", message: "Posts" },
  // …
}
```

After:

```ts
const POST_LABELS = {
  singular: withContext(
    { id: "plugin.blog.post.singular", message: "Post" },
    "post type singular name",
  ),
  plural: withContext(
    { id: "plugin.blog.post.plural", message: "Posts" },
    "post type general name",
  ),
  // …
}
```

The four context strings (\`post type singular name\`, \`post type general name\`, \`taxonomy singular name\`, \`taxonomy general name\`) match WordPress's `register_post_type` / `register_taxonomy` idiom verbatim — anyone who has translated a WP plugin will recognize them.

**Catalog round-trip**

`packages/plugins/blog/locales/en.po` is hand-authored (per the `X-Generator: hand-authored` header). The six new `msgctxt` lines are added inline. Round-trip is safe because every entry carries `js-lingui-explicit-id`, so the runtime lookup key stays the `msgid` even with `msgctxt` present — adding context will not silently re-key existing translations.

**Extraction tripwire**

`withContext(...)` is not macro-visible. If anyone later wires `lingui extract` into the blog plugin without routing through `@lingui/macro`, the extractor will emit catalog entries without `msgctxt` and silently regress the disambiguation. The blog plugin's index file flags this in the comment block above `POST_LABELS`.

**Manifest payload**

`toEntryTypeManifest` / `toTermTaxonomyEntry` spread labels verbatim, so `context` rides into the SSR'd admin manifest payload (~30 extra bytes per descriptor × 6 = ~180 bytes total). Accepted — translator metadata is not sensitive. Worth revisiting if the field grows or if manifest payload size becomes a concern.

**Follow-ups (in #760)**

- Full admin polyseme sweep — sister issues #761, #762, #765, #767 each consume `withContext` as they wrap their respective surfaces (menu UI, media UI, field builders, translator-comment convention).
- `WP_CONTEXT` constants — once two or more plugins adopt the same four strings, consolidate to named exports.
- A user-facing docs entry (the i18n notes added in this slice live in `docs/reference/` which is gitignored — needs a real docs location).