### PR TITLE
feat: add plumix i18n init scaffolder for per-package lingui setup

### DIFF
--- a/packages/core/src/cli/errors.ts
+++ b/packages/core/src/cli/errors.ts
@@ -14,6 +14,8 @@ type CliErrorCode =
   | "config_load_failed"
   | "config_invalid"
   | "i18n_check_drift"
+  | "i18n_init_no_package_json"
+  | "i18n_init_invalid_package_json"
   | "tooling_command_no_app";
 
 export class CliError extends Error {
@@ -206,6 +208,27 @@ export class CliError extends Error {
       `Translation catalogs out of sync — ${ctx.ids.length} msgid(s) drifted (+ added, - removed):\n  ${ctx.ids.join("\n  ")}`,
       "Run `plumix i18n extract` locally and commit the updated `.po` file(s).",
       undefined,
+    );
+  }
+
+  static i18nInitNoPackageJson(ctx: { cwd: string }): CliError {
+    return new CliError(
+      "i18n_init_no_package_json",
+      `No package.json at ${ctx.cwd}`,
+      "Run `plumix i18n init` from a package root, or scaffold one first with `pnpm init`.",
+      undefined,
+    );
+  }
+
+  static i18nInitInvalidPackageJson(ctx: {
+    cwd: string;
+    cause: unknown;
+  }): CliError {
+    return new CliError(
+      "i18n_init_invalid_package_json",
+      `Cannot parse package.json at ${ctx.cwd}`,
+      "Fix the JSON syntax before re-running `plumix i18n init` — refusing to overwrite a malformed file.",
+      ctx.cause,
     );
   }
 }

--- a/packages/plumix/src/cli/commands/i18n.test.ts
+++ b/packages/plumix/src/cli/commands/i18n.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { CommandContext, PlumixApp } from "@plumix/core";
 
-import { i18nCommand, i18nDeps } from "./i18n.js";
+import { i18nCommand, i18nDeps, LINGUI_DEP_RANGE } from "./i18n.js";
 
 function fakeApp(): PlumixApp {
   return {
@@ -221,6 +221,148 @@ describe("i18nCommand", () => {
         process.execPath,
         ["/fake/lingui.js", "extract", "--clean"],
         { cwd: dir },
+      );
+    });
+  });
+
+  describe("init", () => {
+    interface PartialPackageJson {
+      scripts?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    }
+    const readPkg = (cwd: string): PartialPackageJson =>
+      JSON.parse(
+        readFileSync(join(cwd, "package.json"), "utf8"),
+      ) as PartialPackageJson;
+
+    beforeEach(() => {
+      // `report.info` writes to stdout; silence it in tests.
+      vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    });
+
+    test("scaffolds lingui.config.ts at the package root", async () => {
+      await i18nCommand.run(ctx({ cwd: dir, argv: ["init"] }));
+      const configPath = join(dir, "lingui.config.ts");
+      expect(existsSync(configPath)).toBe(true);
+      const config = readFileSync(configPath, "utf8");
+      expect(config).toContain('sourceLocale: "en"');
+      expect(config).toContain('path: "<rootDir>/locales/{locale}"');
+      expect(config).toContain('include: ["src"]');
+      expect(config).toContain("formatter({ lineNumbers: false })");
+    });
+
+    test("scaffolds scripts/i18n-compile-check.mjs with the parse-error gate", async () => {
+      await i18nCommand.run(ctx({ cwd: dir, argv: ["init"] }));
+      const scriptPath = join(dir, "scripts", "i18n-compile-check.mjs");
+      expect(existsSync(scriptPath)).toBe(true);
+      const script = readFileSync(scriptPath, "utf8");
+      // Same contract as admin's: spawn `lingui compile` without
+      // `--strict` (the args array literally doesn't include it),
+      // grep stdout for "Compilation error", exit 1 on parse error.
+      expect(script).toMatch(/spawn\([\s\S]*"lingui",\s*"compile"/);
+      expect(script).not.toMatch(/"--strict"/);
+      expect(script).toMatch(/Compilation error/);
+    });
+
+    test("patches package.json with i18n scripts pinned to LINGUI_DEP_RANGE", async () => {
+      await i18nCommand.run(ctx({ cwd: dir, argv: ["init"] }));
+      const pkg = readPkg(dir);
+      expect(pkg.scripts).toMatchObject({
+        "i18n:extract": "lingui extract",
+        "i18n:compile": "lingui compile --namespace es",
+        "i18n:check": "plumix i18n extract --check",
+      });
+      // Pinning to the constant — a version bump must be a deliberate
+      // test change so the gate against silent drift stays loud.
+      expect(pkg.devDependencies?.["@lingui/cli"]).toBe(LINGUI_DEP_RANGE);
+      expect(pkg.devDependencies?.["@lingui/format-po"]).toBe(LINGUI_DEP_RANGE);
+    });
+
+    test("re-running init preserves user edits to scaffolded files", async () => {
+      await i18nCommand.run(ctx({ cwd: dir, argv: ["init"] }));
+      const scriptBefore = readFileSync(
+        join(dir, "scripts", "i18n-compile-check.mjs"),
+        "utf8",
+      );
+      const pkgBefore = readFileSync(join(dir, "package.json"), "utf8");
+
+      // Mutate the scaffolded files; re-running init must not clobber.
+      writeFileSync(join(dir, "lingui.config.ts"), "// user edit\n");
+
+      await i18nCommand.run(ctx({ cwd: dir, argv: ["init"] }));
+
+      expect(readFileSync(join(dir, "lingui.config.ts"), "utf8")).toBe(
+        "// user edit\n",
+      );
+      // The other targets were already in place, so they stay identical.
+      expect(
+        readFileSync(join(dir, "scripts", "i18n-compile-check.mjs"), "utf8"),
+      ).toBe(scriptBefore);
+      expect(readFileSync(join(dir, "package.json"), "utf8")).toBe(pkgBefore);
+    });
+
+    test("preserves user scripts and devDeps when patching package.json", async () => {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify(
+          {
+            name: "test",
+            scripts: { build: "tsc", test: "vitest" },
+            devDependencies: { typescript: "^5" },
+          },
+          null,
+          2,
+        ),
+      );
+
+      await i18nCommand.run(ctx({ cwd: dir, argv: ["init"] }));
+
+      const pkg = readPkg(dir);
+      expect(pkg.scripts?.build).toBe("tsc");
+      expect(pkg.scripts?.test).toBe("vitest");
+      expect(pkg.devDependencies?.typescript).toBe("^5");
+      expect(pkg.scripts?.["i18n:extract"]).toBe("lingui extract");
+      expect(pkg.devDependencies?.["@lingui/cli"]).toBe(LINGUI_DEP_RANGE);
+    });
+
+    test("user values win on collision — never overwrite a customized script", async () => {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify(
+          {
+            name: "test",
+            scripts: { "i18n:extract": "my-custom-extract" },
+            devDependencies: { "@lingui/cli": "5.0.0" },
+          },
+          null,
+          2,
+        ),
+      );
+
+      await i18nCommand.run(ctx({ cwd: dir, argv: ["init"] }));
+
+      const pkg = readPkg(dir);
+      expect(pkg.scripts?.["i18n:extract"]).toBe("my-custom-extract");
+      expect(pkg.devDependencies?.["@lingui/cli"]).toBe("5.0.0");
+    });
+
+    test("errors clearly when package.json is missing", async () => {
+      rmSync(join(dir, "package.json"));
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["init"] })),
+      ).rejects.toThrow(/No package\.json at /);
+      // Other targets still landed before the package.json step — that's
+      // fine; re-running after `pnpm init` completes the scaffold.
+    });
+
+    test("refuses to overwrite a malformed package.json", async () => {
+      writeFileSync(join(dir, "package.json"), "{ not valid json");
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["init"] })),
+      ).rejects.toThrow(/Cannot parse package\.json/);
+      // The broken file is left untouched for the user to fix.
+      expect(readFileSync(join(dir, "package.json"), "utf8")).toBe(
+        "{ not valid json",
       );
     });
   });

--- a/packages/plumix/src/cli/commands/i18n.ts
+++ b/packages/plumix/src/cli/commands/i18n.ts
@@ -1,4 +1,11 @@
-import { readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -6,7 +13,10 @@ import { pathToFileURL } from "node:url";
 import type { CommandContext, CommandDefinition } from "@plumix/core";
 import { CliError, spawnInherit } from "@plumix/core";
 
-const SUPPORTED = ["extract", "compile"] as const;
+import { report } from "../report.js";
+
+const SUPPORTED = ["extract", "compile", "init"] as const;
+export const LINGUI_DEP_RANGE = "^6.2.0";
 
 export const i18nCommand: CommandDefinition = {
   describe: "Extract translation strings (.po) and compile to runtime catalogs",
@@ -18,6 +28,10 @@ export const i18nCommand: CommandDefinition = {
         subcommand: "(missing)",
         supported: [...SUPPORTED],
       });
+    }
+    if (sub === "init") {
+      runInit(ctx);
+      return;
     }
     if (sub !== "extract" && sub !== "compile") {
       throw CliError.unknownSubcommand({
@@ -50,6 +64,161 @@ export const i18nCommand: CommandDefinition = {
     });
   },
 };
+
+/** Scaffold the i18n config + scripts at the package root. Each target
+ *  is idempotent (skip-if-exists); package.json gets a non-destructive
+ *  merge so pre-existing scripts/devDeps survive. Errors loudly if
+ *  package.json is missing or malformed rather than silently creating
+ *  one — `init` is a "set up i18n in this package" command, not "make
+ *  a package." */
+function runInit(ctx: CommandContext): void {
+  report.info("Plumix i18n init");
+
+  const configPath = resolve(ctx.cwd, "lingui.config.ts");
+  const wroteConfig = !existsSync(configPath);
+  if (wroteConfig) writeFileSync(configPath, LINGUI_CONFIG_TEMPLATE);
+  report.info(
+    `  lingui.config.ts:                ${wroteConfig ? "created" : "exists, skipped"}`,
+  );
+
+  const scriptDir = resolve(ctx.cwd, "scripts");
+  const scriptPath = resolve(scriptDir, "i18n-compile-check.mjs");
+  const wroteScript = !existsSync(scriptPath);
+  if (wroteScript) {
+    mkdirSync(scriptDir, { recursive: true });
+    writeFileSync(scriptPath, COMPILE_CHECK_TEMPLATE);
+  }
+  report.info(
+    `  scripts/i18n-compile-check.mjs:  ${wroteScript ? "created" : "exists, skipped"}`,
+  );
+
+  const pkgPath = resolve(ctx.cwd, "package.json");
+  const pkg = readRequiredPackageJson(pkgPath, ctx.cwd);
+  const { merged, changed } = mergePackageJson(pkg);
+  if (changed) {
+    writeFileSync(pkgPath, `${JSON.stringify(merged, null, 2)}\n`);
+  }
+  report.info(
+    `  package.json:                    ${changed ? "patched" : "no changes"}`,
+  );
+}
+
+const LINGUI_CONFIG_TEMPLATE = `import { defineConfig } from "@lingui/cli";
+import { formatter } from "@lingui/format-po";
+
+export default defineConfig({
+  sourceLocale: "en",
+  locales: ["en"],
+  catalogs: [
+    {
+      path: "<rootDir>/locales/{locale}",
+      include: ["src"],
+    },
+  ],
+  format: formatter({ lineNumbers: false }),
+});
+`;
+
+// Cloned from packages/admin/scripts/i18n-compile-check.mjs — the
+// canonical contract: spawn \`lingui compile\` (no --strict), grep
+// stdout for "Compilation error", fail on parse errors but let missing
+// translations fall back silently.
+const COMPILE_CHECK_TEMPLATE = `#!/usr/bin/env node
+// Lingui's \`compile --strict\` fails on BOTH parse errors AND missing
+// translations. Most projects want parse errors to fail (ICU brace
+// mistakes etc.) but missing translations to fall back silently — the
+// source locale is ground truth and per-locale seeding is a separate
+// track.
+//
+// Spawn \`lingui compile\` (no --strict), stream its output, then exit
+// 1 if "Compilation error" appears anywhere — that's the marker for a
+// parse failure regardless of strict mode.
+import { spawn } from "node:child_process";
+
+const child = spawn(
+  "pnpm",
+  ["exec", "lingui", "compile", "--namespace", "es"],
+  { stdio: ["inherit", "pipe", "pipe"] },
+);
+
+let buffered = "";
+const tee = (stream, into) => {
+  stream.on("data", (chunk) => {
+    buffered += chunk.toString();
+    into.write(chunk);
+  });
+};
+tee(child.stdout, process.stdout);
+tee(child.stderr, process.stderr);
+
+child.on("exit", (code) => {
+  if (code !== 0) process.exit(code ?? 1);
+  if (/Compilation error/.test(buffered)) {
+    process.stderr.write(
+      "\\ni18n-compile-check: parse error detected — failing build.\\n",
+    );
+    process.exit(1);
+  }
+});
+`;
+
+interface PackageJsonShape {
+  scripts?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+/** Read package.json, raising a CliError on missing or malformed input.
+ *  Silent fallback would clobber a user's broken file with a synthetic
+ *  one or scaffold into a directory that isn't actually a package. */
+function readRequiredPackageJson(
+  pkgPath: string,
+  cwd: string,
+): PackageJsonShape {
+  let raw: string;
+  try {
+    raw = readFileSync(pkgPath, "utf8");
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") {
+      throw CliError.i18nInitNoPackageJson({ cwd });
+    }
+    throw cause;
+  }
+  try {
+    return JSON.parse(raw) as PackageJsonShape;
+  } catch (cause) {
+    throw CliError.i18nInitInvalidPackageJson({ cwd, cause });
+  }
+}
+
+/** Non-destructive merge: only the new keys we'd add are introduced,
+ *  pre-existing user values win on collision, and `changed` is true
+ *  iff at least one key would actually be inserted. Comparing inserted
+ *  keys directly avoids the JSON-stringify reorder trap that would
+ *  rewrite the file for cosmetic key-order changes. */
+function mergePackageJson(pkg: PackageJsonShape): {
+  merged: PackageJsonShape;
+  changed: boolean;
+} {
+  const newScripts: Record<string, string> = {
+    "i18n:extract": "lingui extract",
+    "i18n:compile": "lingui compile --namespace es",
+    "i18n:check": "plumix i18n extract --check",
+  };
+  const newDeps: Record<string, string> = {
+    "@lingui/cli": LINGUI_DEP_RANGE,
+    "@lingui/format-po": LINGUI_DEP_RANGE,
+  };
+  const scripts: Record<string, string> = { ...newScripts, ...pkg.scripts };
+  const devDependencies: Record<string, string> = {
+    ...newDeps,
+    ...pkg.devDependencies,
+  };
+  const changed =
+    Object.keys(newScripts).some((k) => !(k in (pkg.scripts ?? {}))) ||
+    Object.keys(newDeps).some((k) => !(k in (pkg.devDependencies ?? {})));
+  return { merged: { ...pkg, scripts, devDependencies }, changed };
+}
 
 async function runExtractCheck(
   ctx: CommandContext,


### PR DESCRIPTION
Closes #766. Adds the third `plumix i18n` subcommand alongside `extract` and `compile`. Running `plumix i18n init` from any package root writes `lingui.config.ts`, `scripts/i18n-compile-check.mjs`, and patches `package.json` with the three `i18n:*` scripts + `@lingui/cli` / `@lingui/format-po` devDeps — the same setup admin's build has, now reusable in any first-party or third-party plugin.

**Idempotent per-target writes**

Each scaffolded file uses `existsSync`-skip semantics. Re-running `init` after a user has tweaked their `lingui.config.ts` or `scripts/i18n-compile-check.mjs` is a no-op for those files.

For `package.json`, the merge is non-destructive: pre-existing scripts and devDeps win on key collision, and the file is rewritten only when at least one *new* key would actually be inserted. That avoids the JSON-stringify reorder trap where the merge runs structurally clean but a top-level key reorder would have rewritten the file purely for cosmetics.

**Loud errors on missing or malformed `package.json`**

Two new `CliError` factories — `i18n_init_no_package_json` and `i18n_init_invalid_package_json`. Silent fallback would either clobber a user's broken file with a synthetic one, or scaffold a half-package in whatever directory the command was misfired from.

```
$ plumix i18n init
Error: No package.json at /tmp/empty
Hint: Run `plumix i18n init` from a package root, or scaffold one first with `pnpm init`.
```

```
$ plumix i18n init
Error: Cannot parse package.json at /Users/me/projects/broken
Hint: Fix the JSON syntax before re-running `plumix i18n init` — refusing to overwrite a malformed file.
```

**Per-target CLI feedback**

Matches the doctor command's `report.info` convention so the idempotent re-run is observably-correct instead of silent:

```
Plumix i18n init
  lingui.config.ts:                exists, skipped
  scripts/i18n-compile-check.mjs:  exists, skipped
  package.json:                    no changes
```

**Compile-check template carries admin's teaching comment**

The scaffolded `scripts/i18n-compile-check.mjs` includes admin's full header comment block explaining why `--strict` is avoided (parse errors should fail, missing translations should fall back to source). Users reading their own script for the first time get the same context the admin script was designed around.

**Follow-ups (under #770)**

- Drift-detector test that fails CI when the inline templates diverge from `packages/admin/lingui.config.ts` / `packages/admin/scripts/i18n-compile-check.mjs` content
- Version-pin test that asserts `LINGUI_DEP_RANGE` matches admin's `@lingui/cli` / `@lingui/format-po` range so a workspace upgrade doesn't silently leave the scaffolder behind
- `--force` flag deliberately deferred per the "no safety nets the user didn't ask for" rule; `rm <file> && plumix i18n init` is two characters more for unambiguous semantics

Refs #766