### PR TITLE
feat(core): wrap shared validation messages in vMessage for translation

### DIFF
--- a/packages/core/src/rpc/validation.test.ts
+++ b/packages/core/src/rpc/validation.test.ts
@@ -1,7 +1,46 @@
 import * as v from "valibot";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 
-import { idParam, idPathParam } from "./validation.js";
+import {
+  emailField,
+  idParam,
+  idPathParam,
+  nameField,
+  setI18nResolver,
+} from "./validation.js";
+
+describe("shared schema messages — translatable via setI18nResolver", () => {
+  afterEach(() => setI18nResolver(null));
+
+  test("emailField resolves through the registered resolver", () => {
+    setI18nResolver((d) => `[de] ${d.id}`);
+    const result = v.safeParse(emailField, "");
+    expect(result.success).toBe(false);
+    const messages = result.issues?.map((i) => i.message) ?? [];
+    // Whichever leaf fires (minLength or email), the message comes from
+    // the resolver — proof the shared schema is no longer hardcoded.
+    expect(messages.some((m) => m.startsWith("[de] validate."))).toBe(true);
+  });
+
+  test("nameField max-length resolves via the resolver with the expected id", () => {
+    setI18nResolver((d) => `name-err:${d.id}`);
+    const result = v.safeParse(nameField, "x".repeat(201));
+    expect(result.success).toBe(false);
+    // Capturing the id catches descriptor renames; a typo in
+    // `validate.name.maxLength` would surface here, not just in
+    // catalog tooling.
+    expect(result.issues?.[0]?.message).toBe(
+      "name-err:validate.name.maxLength",
+    );
+  });
+
+  test("idPathParam regex error resolves via the resolver", () => {
+    setI18nResolver((d) => `id-err:${d.id}`);
+    const result = v.safeParse(idPathParam, "abc");
+    expect(result.success).toBe(false);
+    expect(result.issues?.[0]?.message).toBe("id-err:validate.id.format");
+  });
+});
 
 describe("idParam", () => {
   test("accepts positive integers", () => {

--- a/packages/core/src/rpc/validation.ts
+++ b/packages/core/src/rpc/validation.ts
@@ -1,4 +1,7 @@
+import type { MessageDescriptor } from "@lingui/core";
 import * as v from "valibot";
+
+import { vMessage } from "./vmessage.js";
 
 export { setI18nResolver, vMessage } from "./vmessage.js";
 export type { I18nResolver } from "./vmessage.js";
@@ -6,24 +9,45 @@ export type { I18nResolver } from "./vmessage.js";
 // Shared leaf-level field schemas. Consumed server-side by RPC procedure
 // input schemas AND client-side by admin forms — same rules on both ends so
 // a submit that passes client validation can't then fail server validation
-// on shape alone. Messages are user-facing: they surface unchanged in admin
-// forms and in RPC error payloads when validation rejects.
+// on shape alone. Messages flow through `vMessage` so admin's `bootI18n`
+// resolver can translate them; descriptors are inlined plain literals (not
+// `defineMessage(...)`) because core builds with plain `tsc`, no Lingui
+// macro pass.
 //
-// These shared-schema messages stay in English. Wrapping them in
-// `vMessage(defineMessage(...))` requires the `@lingui/core/macro`
-// runtime, which depends on babel-plugin-lingui-macro processing —
-// core's plain `tsc` build can't run that. Per-callsite admin schemas
-// (mailer, allowed-domains, users/create, auth/device, login) DO use
-// `vMessage` and translate. Server-side schema translation is its own
-// slice, requiring a lingui pipeline for the core package.
+// Per-callsite procedure schemas (`procedures/auth/**/schemas.ts`) stay in
+// English — they only surface to direct RPC consumers, not admin forms,
+// which build their own client-side schemas with locally-wrapped messages.
+
+const M = {
+  emailRequired: {
+    id: "validate.email.required",
+    message: "Enter an email address.",
+  },
+  emailMaxLength: {
+    id: "validate.email.maxLength",
+    message: "Email is too long.",
+  },
+  emailInvalid: {
+    id: "validate.email.invalid",
+    message: "Enter a valid email address.",
+  },
+  nameMaxLength: {
+    id: "validate.name.maxLength",
+    message: "Name is too long.",
+  },
+  idFormat: {
+    id: "validate.id.format",
+    message: "id must be a positive decimal integer",
+  },
+} satisfies Record<string, MessageDescriptor>;
 
 /** RFC 5321 caps email at 254 chars. */
 export const emailField = v.pipe(
   v.string(),
   v.trim(),
-  v.minLength(1, "Enter an email address."),
-  v.maxLength(254, "Email is too long."),
-  v.email("Enter a valid email address."),
+  v.minLength(1, vMessage(M.emailRequired)),
+  v.maxLength(254, vMessage(M.emailMaxLength)),
+  v.email(vMessage(M.emailInvalid)),
 );
 
 /** Display name. Empty is allowed at the schema level; required-ness is
@@ -31,7 +55,7 @@ export const emailField = v.pipe(
 export const nameField = v.pipe(
   v.string(),
   v.trim(),
-  v.maxLength(200, "Name is too long."),
+  v.maxLength(200, vMessage(M.nameMaxLength)),
 );
 
 /**
@@ -54,7 +78,7 @@ export const idParam = v.pipe(
  */
 export const idPathParam = v.pipe(
   v.string(),
-  v.regex(/^[1-9]\d*$/, "id must be a positive decimal integer"),
+  v.regex(/^[1-9]\d*$/, vMessage(M.idFormat)),
   v.transform((s) => Number(s)),
   v.number(),
   v.integer(),


### PR DESCRIPTION
Closes #763. `emailField`, `nameField`, and `idPathParam` error messages now flow through the `vMessage` resolver registered by admin's `bootI18n` — admin sees translated "Enter an email address." / "Name is too long." tooltips in non-English locales, while server-side and unconfigured-admin paths keep returning the source English via `vMessage`'s built-in fallback.

**Hoisted descriptor map**

Descriptors hoist into a top-of-file `M` map (mirrors the convention in `packages/admin/src/components/profile/api-tokens-card.tsx`). Each `v.minLength` / `v.maxLength` / `v.email` / `v.regex` callsite collapses to a single `vMessage(M.foo)` reference, and the id↔message pairing lives in one block where translators and catalog tooling can scan it.

**Plain object literals, not `defineMessage`**

`packages/core` builds with plain `tsc` (no Lingui macro pass), so the runtime form must be a bare `MessageDescriptor` object. The blog plugin's hand-authored labels already use the same pattern. Admin-side callsites continue to use `defineMessage(...)` so they remain `lingui extract` -visible.

**Per-callsite schemas deferred — admin doesn't import them**

Spot-checked the claim before scoping down:
- `packages/admin/src/routes/_authenticated/allowed-domains/index.tsx:76-97` — admin defines its own `createFormSchema` with locally-wrapped messages and explicitly comments that it mirrors the server schema rather than importing it
- `packages/admin/src/routes/_authenticated/auth/device.tsx:116-141` — admin's `approveSchema` is hand-rolled; the server-side `deviceFlowApproveInputSchema` is never imported into admin
- `grep -rn "from \"@plumix/core/rpc/procedures" packages/admin/src/` returned zero matches

So per-callsite procedure schemas (`packages/core/src/rpc/procedures/auth/**/schemas.ts`) only surface to direct RPC API consumers — devs/scripts, not user form tooltips. The header comment in `validation.ts` documents this so a future contributor doesn't reflexively wrap them. A second sweep can land if a tracker for translated RPC error payloads opens.

**Stale comment correction**

The previous header in `validation.ts` claimed `vMessage(defineMessage(...))` required the Babel macro and that's why core stayed in English. The first claim is wrong — plain descriptors work, as the blog plugin already demonstrates. Both are now superseded.

Refs #763