### PR TITLE
feat: widen metabox + settings label slots to the Label union

### DIFF
--- a/packages/admin/src/components/editor/plain-form-layout.tsx
+++ b/packages/admin/src/components/editor/plain-form-layout.tsx
@@ -193,7 +193,9 @@ export function PlainFormLayout({
                   {renderLabel(box.label)}
                 </h2>
                 {box.description ? (
-                  <CardDescription>{box.description}</CardDescription>
+                  <CardDescription>
+                    {renderLabel(box.description)}
+                  </CardDescription>
                 ) : null}
               </CardHeader>
               <CardContent className="flex flex-col gap-4">

--- a/packages/admin/src/components/meta-box/meta-box-field.tsx
+++ b/packages/admin/src/components/meta-box/meta-box-field.tsx
@@ -92,7 +92,7 @@ export function MetaBoxField({
               </div>
               {field.description ? (
                 <FormDescription data-testid={`${testIdPrefix}-description`}>
-                  {field.description}
+                  {renderLabel(field.description)}
                 </FormDescription>
               ) : null}
               <FormMessage />
@@ -114,7 +114,7 @@ export function MetaBoxField({
             </FormControl>
             {field.description ? (
               <FormDescription data-testid={`${testIdPrefix}-description`}>
-                {field.description}
+                {renderLabel(field.description)}
               </FormDescription>
             ) : null}
             <FormMessage />
@@ -152,6 +152,9 @@ function renderNativeInput({
   renderLabel: ReturnType<typeof useLabel>;
 }): ReactNode {
   const labelText = renderLabel(field.label);
+  const placeholderText = field.placeholder
+    ? renderLabel(field.placeholder)
+    : undefined;
   // Plugin-supplied field renderers slot in here, BEFORE the built-in
   // switch. A plugin's admin chunk calls `window.plumix.
   // registerPluginFieldType(inputType, Component)` at module load —
@@ -198,7 +201,7 @@ function renderNativeInput({
         {...common}
         value={asString(rhf.value)}
         maxLength={field.maxLength}
-        placeholder={field.placeholder}
+        placeholder={placeholderText}
         rows={3}
         onChange={(e) => {
           rhf.onChange(e.target.value);
@@ -214,7 +217,7 @@ function renderNativeInput({
         {...common}
         type="number"
         value={asNumberInputValue(rhf.value)}
-        placeholder={field.placeholder}
+        placeholder={placeholderText}
         min={field.min}
         max={field.max}
         step={field.step ?? 1}
@@ -523,7 +526,7 @@ function renderNativeInput({
       {...common}
       type={htmlType}
       value={asString(rhf.value)}
-      placeholder={field.placeholder}
+      placeholder={placeholderText}
       maxLength={field.maxLength}
       onChange={(e) => {
         rhf.onChange(e.target.value);

--- a/packages/admin/src/components/meta-box/meta-box.tsx
+++ b/packages/admin/src/components/meta-box/meta-box.tsx
@@ -63,7 +63,7 @@ export function MetaBoxCard({
           </h2>
         </CardTitle>
         {box.description ? (
-          <CardDescription>{box.description}</CardDescription>
+          <CardDescription>{renderLabel(box.description)}</CardDescription>
         ) : null}
       </CardHeader>
       <CardContent>
@@ -107,7 +107,7 @@ export function MetaBoxAccordionItem({
       <AccordionContent className="px-4 pb-4">
         {box.description ? (
           <p className="text-muted-foreground mb-3 text-sm">
-            {box.description}
+            {renderLabel(box.description)}
           </p>
         ) : null}
         <div className="flex flex-col gap-4">

--- a/packages/admin/src/routes/_authenticated/settings/$page.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/$page.tsx
@@ -124,6 +124,7 @@ function SettingsPageLoadError(): ReactNode {
 function SettingsPageRoute(): ReactNode {
   const { page } = Route.useRouteContext();
   const groups = groupsForSettingsPage(page);
+  const renderLabel = useLabel();
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
@@ -132,10 +133,12 @@ function SettingsPageRoute(): ReactNode {
           className="text-2xl font-semibold"
           data-testid="settings-page-heading"
         >
-          {page.label}
+          {renderLabel(page.label)}
         </h1>
         {page.description ? (
-          <p className="text-muted-foreground text-sm">{page.description}</p>
+          <p className="text-muted-foreground text-sm">
+            {renderLabel(page.description)}
+          </p>
         ) : null}
       </header>
 
@@ -223,7 +226,9 @@ function SettingsGroupCard({
               </h2>
             </CardTitle>
             {group.description ? (
-              <CardDescription>{group.description}</CardDescription>
+              <CardDescription>
+                {renderLabel(group.description)}
+              </CardDescription>
             ) : null}
           </CardHeader>
           <CardContent className="flex flex-col gap-4">

--- a/packages/admin/src/routes/_authenticated/settings/index.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/empty.js";
 import { hasCap } from "@/lib/caps.js";
 import { visibleSettingsPages } from "@/lib/manifest.js";
+import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { Settings as SettingsIcon } from "lucide-react";
@@ -36,6 +37,7 @@ export const Route = createFileRoute("/_authenticated/settings/")({
 function SettingsIndexRoute(): ReactNode {
   const { user } = Route.useRouteContext();
   const pages = visibleSettingsPages(user.capabilities);
+  const renderLabel = useLabel();
 
   const heading = (
     <h1 className="text-2xl font-semibold" data-testid="settings-heading">
@@ -91,10 +93,14 @@ function SettingsIndexRoute(): ReactNode {
             <Card className="hover:border-primary transition-colors">
               <CardHeader>
                 <CardTitle>
-                  <h2 className="text-base font-semibold">{page.label}</h2>
+                  <h2 className="text-base font-semibold">
+                    {renderLabel(page.label)}
+                  </h2>
                 </CardTitle>
                 {page.description ? (
-                  <CardDescription>{page.description}</CardDescription>
+                  <CardDescription>
+                    {renderLabel(page.description)}
+                  </CardDescription>
                 ) : null}
               </CardHeader>
               <CardContent>

--- a/packages/core/src/plugin/fields/checkbox.ts
+++ b/packages/core/src/plugin/fields/checkbox.ts
@@ -1,10 +1,11 @@
+import type { Label } from "../../i18n/label.js";
 import type { CheckboxMetaBoxField, MetaBoxFieldSpan } from "../manifest.js";
 
 export interface CheckboxFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: boolean;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/color.ts
+++ b/packages/core/src/plugin/fields/color.ts
@@ -1,10 +1,11 @@
+import type { Label } from "../../i18n/label.js";
 import type { ColorMetaBoxField, MetaBoxFieldSpan } from "../manifest.js";
 
 export interface ColorFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   /** Hex string `#xxxxxx` (or `#xxx` shorthand). Must match `HEX_COLOR`. */
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;

--- a/packages/core/src/plugin/fields/date.ts
+++ b/packages/core/src/plugin/fields/date.ts
@@ -1,14 +1,15 @@
+import type { Label } from "../../i18n/label.js";
 import type { DateMetaBoxField, MetaBoxFieldSpan } from "../manifest.js";
 
 export interface DateFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   /** ISO 8601 date string `YYYY-MM-DD`. Lower bound applied client-side. */
   readonly min?: string;
   /** ISO 8601 date string `YYYY-MM-DD`. Upper bound applied client-side. */
   readonly max?: string;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/datetime.ts
+++ b/packages/core/src/plugin/fields/datetime.ts
@@ -1,14 +1,15 @@
+import type { Label } from "../../i18n/label.js";
 import type { DateTimeMetaBoxField, MetaBoxFieldSpan } from "../manifest.js";
 
 export interface DateTimeFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   /** ISO 8601 datetime-local string (`YYYY-MM-DDTHH:MM`). */
   readonly min?: string;
   /** ISO 8601 datetime-local string (`YYYY-MM-DDTHH:MM`). */
   readonly max?: string;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/email.ts
+++ b/packages/core/src/plugin/fields/email.ts
@@ -1,12 +1,13 @@
+import type { Label } from "../../i18n/label.js";
 import type { EmailMetaBoxField, MetaBoxFieldSpan } from "../manifest.js";
 
 export interface EmailFieldOptions {
   readonly key: string;
-  readonly label: string;
-  readonly placeholder?: string;
+  readonly label: Label;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/entry-list.ts
+++ b/packages/core/src/plugin/fields/entry-list.ts
@@ -1,11 +1,12 @@
+import type { Label } from "../../i18n/label.js";
 import type { EntryListMetaBoxField, MetaBoxFieldSpan } from "../manifest.js";
 import type { EntryFieldScope } from "./entry.js";
 
 export interface EntryListFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: readonly string[];
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/entry.ts
+++ b/packages/core/src/plugin/fields/entry.ts
@@ -1,3 +1,4 @@
+import type { Label } from "../../i18n/label.js";
 import type {
   EntryReferenceMetaBoxField,
   MetaBoxFieldSpan,
@@ -25,9 +26,9 @@ export interface EntryFieldScope {
 
 export interface EntryFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/json.ts
+++ b/packages/core/src/plugin/fields/json.ts
@@ -1,10 +1,11 @@
+import type { Label } from "../../i18n/label.js";
 import type { JsonMetaBoxField, MetaBoxFieldSpan } from "../manifest.js";
 
 export interface JsonFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: unknown;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/multiselect.ts
+++ b/packages/core/src/plugin/fields/multiselect.ts
@@ -1,3 +1,4 @@
+import type { Label } from "../../i18n/label.js";
 import type {
   MetaBoxFieldOption,
   MetaBoxFieldSpan,
@@ -6,10 +7,10 @@ import type {
 
 export interface MultiselectFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly options: readonly MetaBoxFieldOption[];
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: readonly string[];
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/number.ts
+++ b/packages/core/src/plugin/fields/number.ts
@@ -1,14 +1,15 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, NumberMetaBoxField } from "../manifest.js";
 
 export interface NumberFieldOptions {
   readonly key: string;
-  readonly label: string;
-  readonly placeholder?: string;
+  readonly label: Label;
+  readonly placeholder?: Label;
   readonly min?: number;
   readonly max?: number;
   readonly step?: number;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: number;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/password.ts
+++ b/packages/core/src/plugin/fields/password.ts
@@ -1,12 +1,13 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, PasswordMetaBoxField } from "../manifest.js";
 
 export interface PasswordFieldOptions {
   readonly key: string;
-  readonly label: string;
-  readonly placeholder?: string;
+  readonly label: Label;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/radio.ts
+++ b/packages/core/src/plugin/fields/radio.ts
@@ -1,3 +1,4 @@
+import type { Label } from "../../i18n/label.js";
 import type {
   MetaBoxFieldOption,
   MetaBoxFieldSpan,
@@ -6,10 +7,10 @@ import type {
 
 export interface RadioFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly options: readonly MetaBoxFieldOption[];
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/range.ts
+++ b/packages/core/src/plugin/fields/range.ts
@@ -1,14 +1,15 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, RangeMetaBoxField } from "../manifest.js";
 import { FieldConfigError } from "./errors.js";
 
 export interface RangeFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly min: number;
   readonly max: number;
   readonly step?: number;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: number;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/repeater.ts
+++ b/packages/core/src/plugin/fields/repeater.ts
@@ -1,3 +1,4 @@
+import type { Label } from "../../i18n/label.js";
 import type {
   MetaBoxField,
   MetaBoxFieldSpan,
@@ -8,9 +9,9 @@ import { walkRepeaterRows } from "./repeater-validate.js";
 
 export interface RepeaterFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: unknown;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/richtext.ts
+++ b/packages/core/src/plugin/fields/richtext.ts
@@ -1,12 +1,13 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, RichtextMetaBoxField } from "../manifest.js";
 import { walkRichtextDoc } from "./richtext-validate.js";
 
 /** Per-field options for `richtext()`. See `RichtextMetaBoxField`. */
 export interface RichtextFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: unknown;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/select.ts
+++ b/packages/core/src/plugin/fields/select.ts
@@ -1,3 +1,4 @@
+import type { Label } from "../../i18n/label.js";
 import type {
   MetaBoxFieldOption,
   MetaBoxFieldSpan,
@@ -6,10 +7,10 @@ import type {
 
 export interface SelectFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly options: readonly MetaBoxFieldOption[];
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/term-list.ts
+++ b/packages/core/src/plugin/fields/term-list.ts
@@ -1,11 +1,12 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, TermListMetaBoxField } from "../manifest.js";
 import type { TermFieldScope } from "./term.js";
 
 export interface TermListFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: readonly string[];
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/term.ts
+++ b/packages/core/src/plugin/fields/term.ts
@@ -1,3 +1,4 @@
+import type { Label } from "../../i18n/label.js";
 import type {
   MetaBoxFieldSpan,
   TermReferenceMetaBoxField,
@@ -20,9 +21,9 @@ export interface TermFieldScope {
 
 export interface TermFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/text.test.ts
+++ b/packages/core/src/plugin/fields/text.test.ts
@@ -73,6 +73,32 @@ describe("text() field builder", () => {
     });
   });
 
+  test("accepts MessageDescriptor for label, placeholder, description", () => {
+    const labelDescriptor = { id: "field.title.label", message: "Title" };
+    const placeholderDescriptor = {
+      id: "field.title.placeholder",
+      message: "Enter a title",
+    };
+    const descriptionDescriptor = {
+      id: "field.title.description",
+      message: "Shown at the top of the entry",
+    };
+
+    const field = text({
+      key: "title",
+      label: labelDescriptor,
+      placeholder: placeholderDescriptor,
+      description: descriptionDescriptor,
+    });
+
+    // Descriptors travel through unchanged — the renderer resolves them
+    // at the consume site via useLabel(). Pinning identity here catches
+    // any accidental .toString() / spread that would lose the id.
+    expect(field.label).toBe(labelDescriptor);
+    expect(field.placeholder).toBe(placeholderDescriptor);
+    expect(field.description).toBe(descriptionDescriptor);
+  });
+
   test("survives manifest serialization with the right wire shape", async () => {
     const hooks = new HookRegistry();
     const plugin = definePlugin("test", (ctx) => {

--- a/packages/core/src/plugin/fields/text.ts
+++ b/packages/core/src/plugin/fields/text.ts
@@ -1,3 +1,4 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, TextMetaBoxField } from "../manifest.js";
 
 /**
@@ -9,11 +10,11 @@ import type { MetaBoxFieldSpan, TextMetaBoxField } from "../manifest.js";
  */
 export interface TextFieldOptions {
   readonly key: string;
-  readonly label: string;
-  readonly placeholder?: string;
+  readonly label: Label;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/textarea.ts
+++ b/packages/core/src/plugin/fields/textarea.ts
@@ -1,12 +1,13 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, TextareaMetaBoxField } from "../manifest.js";
 
 export interface TextareaFieldOptions {
   readonly key: string;
-  readonly label: string;
-  readonly placeholder?: string;
+  readonly label: Label;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/time.ts
+++ b/packages/core/src/plugin/fields/time.ts
@@ -1,14 +1,15 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, TimeMetaBoxField } from "../manifest.js";
 
 export interface TimeFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   /** Lower bound `HH:MM` (with optional `:SS`). */
   readonly min?: string;
   /** Upper bound `HH:MM` (with optional `:SS`). */
   readonly max?: string;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/url.ts
+++ b/packages/core/src/plugin/fields/url.ts
@@ -1,12 +1,13 @@
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, UrlMetaBoxField } from "../manifest.js";
 
 export interface UrlFieldOptions {
   readonly key: string;
-  readonly label: string;
-  readonly placeholder?: string;
+  readonly label: Label;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/user-list.ts
+++ b/packages/core/src/plugin/fields/user-list.ts
@@ -1,12 +1,13 @@
 import type { UserRole } from "../../db/schema/users.js";
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, UserListMetaBoxField } from "../manifest.js";
 import type { UserFieldScope } from "./user.js";
 
 export interface UserListFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: readonly string[];
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/fields/user.ts
+++ b/packages/core/src/plugin/fields/user.ts
@@ -1,4 +1,5 @@
 import type { UserRole } from "../../db/schema/users.js";
+import type { Label } from "../../i18n/label.js";
 import type { MetaBoxFieldSpan, UserMetaBoxField } from "../manifest.js";
 
 /**
@@ -20,9 +21,9 @@ export interface UserFieldScope {
 
 export interface UserFieldOptions {
   readonly key: string;
-  readonly label: string;
+  readonly label: Label;
   readonly required?: boolean;
-  readonly description?: string;
+  readonly description?: Label;
   readonly default?: string;
   readonly span?: MetaBoxFieldSpan;
   readonly capability?: string;

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -336,7 +336,7 @@ export interface MetaBoxFieldBase {
   /** Default surfaced in the admin form when the key has no saved value. */
   readonly default?: unknown;
   /** Optional help text rendered under the label on every input type. */
-  readonly description?: string;
+  readonly description?: Label;
   /** Renders `required` on the native input; server validation is separate. */
   readonly required?: boolean;
   /**
@@ -366,7 +366,7 @@ export interface MetaBoxFieldBase {
 export interface TextMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "text";
   readonly type: "string";
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
 }
 
@@ -374,7 +374,7 @@ export interface TextMetaBoxField extends MetaBoxFieldBase {
 export interface TextareaMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "textarea";
   readonly type: "string";
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
 }
 
@@ -382,7 +382,7 @@ export interface TextareaMetaBoxField extends MetaBoxFieldBase {
 export interface NumberMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "number";
   readonly type: "number";
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly min?: number;
   readonly max?: number;
   readonly step?: number;
@@ -392,7 +392,7 @@ export interface NumberMetaBoxField extends MetaBoxFieldBase {
 export interface EmailMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "email";
   readonly type: "string";
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
 }
 
@@ -400,7 +400,7 @@ export interface EmailMetaBoxField extends MetaBoxFieldBase {
 export interface UrlMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "url";
   readonly type: "string";
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
 }
 
@@ -412,7 +412,7 @@ export interface UrlMetaBoxField extends MetaBoxFieldBase {
 export interface PasswordMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: "password";
   readonly type: "string";
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
 }
 
@@ -748,7 +748,7 @@ export interface CheckboxMetaBoxField extends MetaBoxFieldBase {
  */
 export interface LegacyMetaBoxField extends MetaBoxFieldBase {
   readonly inputType: string;
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
   readonly min?: number;
   readonly max?: number;
@@ -817,7 +817,7 @@ export type MetaBoxField =
  */
 export interface MetaBoxBaseOptions {
   readonly label: Label;
-  readonly description?: string;
+  readonly description?: Label;
   readonly priority?: number;
   readonly capability?: string;
   readonly fields: readonly MetaBoxField[];
@@ -913,8 +913,8 @@ export type SettingsGroupOptions = MetaBoxBaseOptions;
  * referenced from multiple pages if useful).
  */
 export interface SettingsPageOptions {
-  readonly label: string;
-  readonly description?: string;
+  readonly label: Label;
+  readonly description?: Label;
   readonly groups: readonly string[];
   /**
    * Admin menu ordering. Unspecified positions sort last (in
@@ -1425,9 +1425,9 @@ export interface MetaBoxFieldManifestEntry {
   readonly label: Label;
   readonly type: MetaScalarType;
   readonly inputType: string;
-  readonly description?: string;
+  readonly description?: Label;
   readonly required?: boolean;
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
   /**
    * Lower bound. `number` carries it as a number; `date` / `datetime`
@@ -1476,7 +1476,7 @@ export interface MetaBoxFieldManifestEntry {
  */
 export interface MetaBoxBaseManifestEntry {
   readonly label: Label;
-  readonly description?: string;
+  readonly description?: Label;
   readonly priority?: number;
   readonly capability?: string;
   readonly fields: readonly MetaBoxFieldManifestEntry[];
@@ -1556,8 +1556,8 @@ export interface SettingsGroupManifestEntry extends MetaBoxBaseManifestEntry {
  */
 export interface SettingsPageManifestEntry {
   readonly name: string;
-  readonly label: string;
-  readonly description?: string;
+  readonly label: Label;
+  readonly description?: Label;
   readonly groups: readonly string[];
   readonly priority?: number;
 }
@@ -2614,7 +2614,7 @@ function toMarkEntry(mark: RegisteredMark): MarkManifestEntry {
 // ISO-string bounds while `number` stores numeric bounds; the wire
 // shape mirrors that union and renderers branch on `inputType`.
 interface MetaBoxFieldOptionView {
-  readonly placeholder?: string;
+  readonly placeholder?: Label;
   readonly maxLength?: number;
   readonly min?: number | string;
   readonly max?: number | string;


### PR DESCRIPTION
Phase 1 of #765. Plugin authors can now pass a `MessageDescriptor` anywhere a metabox field or settings-page slot used to accept only a string — labels, placeholders, descriptions, and field-options all widen to the `Label` union. Existing string callers stay untouched because `Label = string | MessageDescriptor`.

**Widened surface — runtime + wire**

`MetaBoxFieldBase.description?` and per-input-type `placeholder?` (text/textarea/number/email/url/password/Legacy) now accept `Label`. Their wire counterparts on `MetaBoxFieldManifestEntry` mirror the change. `MetaBoxBaseOptions/ManifestEntry.description?` (the shared "card of fields" shape used by entry/term/user meta boxes and settings groups) and `SettingsPageOptions/ManifestEntry.label + .description?` follow suit.

**Field-builder option interfaces**

All 24 caller-side interfaces under `packages/core/src/plugin/fields/` widen `label` / `placeholder?` / `description?` to `Label`. The mechanical-edit pattern is uniform; one symbolic descriptor-passthrough test in `text.test.ts` pins the contract (per [[tdd-vertical-slicing]] — one test on the canonical builder covers the per-file repetition).

**Admin renderer adoption**

`MetaBoxField.tsx` hoists `placeholderText` once at the top of `renderNativeInput` (mirrors the existing `labelText` line) so the three native-input branches each pass a string through. The four other meta-box-aware surfaces (`meta-box.tsx` Card + Accordion variants, `plain-form-layout.tsx`, `settings/index.tsx`, `settings/$page.tsx`) thread `useLabel()` into their `description` and `label` render sites.

**Deferred to phase 2**

Block widening — `BlockSpec`, `BlockVariation`, `BlockInputOption`, `BlockPattern`, plus their manifest-entry mirrors and the ~15+ admin editor render sites (inserter card, variation picker, slash menu, pattern picker, transform menu, block actions panel, etc.) — is a deliberately separate follow-up. The mechanical edit pattern is the same but the admin surface is foreign code with its own test sweep; bundling the two would produce an unreviewable PR.

Refs #765