### PR TITLE
fix(core): make @plumix/core/i18n barrel browser-safe

### DIFF
--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -10,13 +10,13 @@ export {
   GENERIC_TERM_TAXONOMY_LABELS,
 } from "./generic-type-labels.js";
 export { labelSourceText, resolveLabel, type Label } from "./label.js";
-export {
-  CatalogParseError,
-  createCatalogLoader,
-  type CatalogJSON,
-  type CatalogLoader,
-  type LoadCatalogInput,
-} from "./load-catalog.js";
+// `load-catalog` is intentionally NOT re-exported from the public barrel:
+// it depends on `node:fs/promises` / `node:path`, which esbuild can't
+// resolve in browser/playground builds (plugin admin chunks, themes).
+// Server-side consumers import it directly via the deep path. Mirrors
+// the [[core-subpath-imports]] root-barrel constraint at the next layer
+// down — the i18n surface must stay browser-safe because plumix/i18n
+// re-exports from it.
 export { resolveLocales } from "./locale-registry.js";
 export type {
   I18nInput,

--- a/packages/core/src/i18n/load-catalog.ts
+++ b/packages/core/src/i18n/load-catalog.ts
@@ -6,19 +6,24 @@ import { join } from "node:path";
  *  with placeholders / JSX). Structural match for Lingui's `Messages`
  *  type — kept free of `@lingui/core` to avoid pulling Lingui into
  *  `@plumix/core`'s dep tree; consumers can pass the result straight
- *  to `i18n.load(locale, catalog)`. */
-export type CatalogJSON = Readonly<
+ *  to `i18n.load(locale, catalog)`.
+ *
+ *  Internal because load-catalog is server-only and the i18n barrel
+ *  intentionally stays browser-safe ([[core-subpath-imports]]). A
+ *  future server consumer that imports load-catalog.ts directly picks
+ *  the type up via TypeScript inference from `createCatalogLoader`'s
+ *  return type.
+ */
+type CatalogJSON = Readonly<
   Record<string, string | readonly (string | readonly unknown[])[]>
 >;
 
-export interface LoadCatalogInput {
+interface LoadCatalogInput {
   readonly locale: string;
   readonly bundledPath: string;
 }
 
-export type CatalogLoader = (
-  input: LoadCatalogInput,
-) => Promise<CatalogJSON | null>;
+type CatalogLoader = (input: LoadCatalogInput) => Promise<CatalogJSON | null>;
 
 export class CatalogParseError extends Error {
   readonly path: string;

--- a/packages/plumix/src/i18n/index.ts
+++ b/packages/plumix/src/i18n/index.ts
@@ -1,4 +1,8 @@
 // Macros (`t`, `plural`, `select`) land with the extractor in #675.
+// Subpath import — the root `@plumix/core` barrel drags `context/stores.js`
+// (`AsyncLocalStorage` from `node:async_hooks`) into the browser bundle,
+// which esbuild can't resolve at admin/playground build time. See
+// [[core-subpath-imports]].
 export {
   formatDate,
   formatNumber,
@@ -8,6 +12,6 @@ export {
   withContext,
   type FormatRelativeOptions,
   type Label,
-} from "@plumix/core";
+} from "@plumix/core/i18n";
 export { i18n, type MessageDescriptor } from "@lingui/core";
 export { I18nProvider, Trans } from "@lingui/react";


### PR DESCRIPTION
`@plumix/core/i18n` re-exports `load-catalog`, which imports `node:fs/promises` + `node:path`. `plumix/i18n` then re-exports from `@plumix/core/i18n`, so any browser-side consumer (admin, plugin admin chunks, themes) drags the server-only module into the build. Admin's own pipeline externalizes `node:*` and tolerated it; plugin playgrounds use the same `plumix build` themes will, where esbuild fails on resolution at build time.

Drop `load-catalog` from the `i18n` barrel. Server-side consumers import `load-catalog.ts` directly via the deep path. No external consumer used the barrel-re-exported symbols today, so this is purely tightening the public surface to what's browser-safe. Same precedent as the root `@plumix/core` barrel ([[core-subpath-imports]]).

Switch `plumix/i18n`'s own re-export source from `@plumix/core` (root barrel, drags `AsyncLocalStorage`) to `@plumix/core/i18n` (now safe).

**Caught while wiring plugin runtime translation**

This branch originally bundled the menu plugin admin UI i18n work (#761). That work blocked on a deeper architectural issue: plugin chunks bundle their own `@lingui/react` and lack a shared-context shim with admin's instance, so `useLingui()` returns `null` inside plugin chunks. The Lingui runtime shim — adding `@lingui/react` to `window.plumix.runtime` alongside React / react-router / react-query / orpc — is its own slice. This PR keeps just the browser-safety fix that surfaced en route.

Branch left named `feat/i18n-menu-admin-ui` since the diff is small and the original task tracking is preserved in the issue trail.

Refs #761