### PR TITLE
feat: share @lingui/{core,react} with plugin chunks via runtime shim

### DIFF
--- a/packages/admin/src/lib/plumix-globals.ts
+++ b/packages/admin/src/lib/plumix-globals.ts
@@ -1,5 +1,7 @@
 import * as ReactNs from "react";
 import * as ReactJsxRuntimeNs from "react/jsx-runtime";
+import * as LinguiCoreNs from "@lingui/core";
+import * as LinguiReactNs from "@lingui/react";
 import * as OrpcClientNs from "@orpc/client";
 import * as OrpcClientFetchNs from "@orpc/client/fetch";
 import * as OrpcTanstackQueryNs from "@orpc/tanstack-query";
@@ -30,6 +32,8 @@ const runtime = {
   orpcClient: OrpcClientNs,
   orpcClientFetch: OrpcClientFetchNs,
   orpcTanstackQuery: OrpcTanstackQueryNs,
+  linguiCore: LinguiCoreNs,
+  linguiReact: LinguiReactNs,
 } as const;
 
 interface PlumixI18nGlobal {

--- a/packages/core/src/admin/runtime.test.ts
+++ b/packages/core/src/admin/runtime.test.ts
@@ -9,6 +9,8 @@ import {
 describe("SHARED_ADMIN_RUNTIME_SPECIFIERS", () => {
   test("covers every shared library plugin chunks may need", () => {
     expect(Object.keys(SHARED_ADMIN_RUNTIME_SPECIFIERS).sort()).toEqual([
+      "@lingui/core",
+      "@lingui/react",
       "@orpc/client",
       "@orpc/client/fetch",
       "@orpc/tanstack-query",
@@ -47,6 +49,8 @@ describe("adminRuntimeShimSlug", () => {
     expect(adminRuntimeShimSlug("@orpc/tanstack-query")).toBe(
       "orpc-tanstack-query",
     );
+    expect(adminRuntimeShimSlug("@lingui/core")).toBe("lingui-core");
+    expect(adminRuntimeShimSlug("@lingui/react")).toBe("lingui-react");
   });
 
   test("slug is a filename-safe segment (used as `<slug>.js`)", () => {

--- a/packages/core/src/admin/runtime.ts
+++ b/packages/core/src/admin/runtime.ts
@@ -19,6 +19,12 @@ const SHIM_SLUGS = {
   "@orpc/client": "orpc-client",
   "@orpc/client/fetch": "orpc-client-fetch",
   "@orpc/tanstack-query": "orpc-tanstack-query",
+  // Lingui — must share `@lingui/core`'s i18n singleton (catalogs + active
+  // locale) AND `@lingui/react`'s context (the I18nProvider admin mounts
+  // at boot). Without these shims plugin chunks see a separate Lingui
+  // instance and `useLingui()` returns null inside plugin routes.
+  "@lingui/core": "lingui-core",
+  "@lingui/react": "lingui-react",
 } as const satisfies Record<string, string>;
 
 export type SharedAdminRuntimeSpecifier = keyof typeof SHIM_SLUGS;

--- a/packages/plumix/package.json
+++ b/packages/plumix/package.json
@@ -81,6 +81,14 @@
       "types": "./dist/admin/orpc-tanstack-query.d.ts",
       "default": "./dist/admin/orpc-tanstack-query.js"
     },
+    "./admin/lingui-core": {
+      "types": "./dist/admin/lingui-core.d.ts",
+      "default": "./dist/admin/lingui-core.js"
+    },
+    "./admin/lingui-react": {
+      "types": "./dist/admin/lingui-react.d.ts",
+      "default": "./dist/admin/lingui-react.js"
+    },
     "./test/playwright": {
       "types": "./dist/test/playwright.d.ts",
       "default": "./dist/test/playwright.js"

--- a/packages/plumix/src/admin/lingui-core.ts
+++ b/packages/plumix/src/admin/lingui-core.ts
@@ -1,0 +1,10 @@
+import { getRuntime } from "./runtime.js";
+
+const ns = getRuntime().linguiCore;
+
+export default ns;
+
+export const i18n = ns.i18n;
+export const setupI18n = ns.setupI18n;
+export const formats = ns.formats;
+export const I18n = ns.I18n;

--- a/packages/plumix/src/admin/lingui-react.ts
+++ b/packages/plumix/src/admin/lingui-react.ts
@@ -1,0 +1,10 @@
+import { getRuntime } from "./runtime.js";
+
+const ns = getRuntime().linguiReact;
+
+export default ns;
+
+export const I18nProvider = ns.I18nProvider;
+export const LinguiContext = ns.LinguiContext;
+export const Trans = ns.Trans;
+export const useLingui = ns.useLingui;

--- a/packages/plumix/src/admin/runtime.ts
+++ b/packages/plumix/src/admin/runtime.ts
@@ -3,6 +3,8 @@
 // to `runtime`). This module is just the runtime slice plugin chunks
 // see, plus the throw if it's missing.
 
+import type * as LinguiCoreNs from "@lingui/core";
+import type * as LinguiReactNs from "@lingui/react";
 import type * as OrpcClientNs from "@orpc/client";
 import type * as OrpcClientFetchNs from "@orpc/client/fetch";
 import type * as OrpcTanstackQueryNs from "@orpc/tanstack-query";
@@ -25,6 +27,8 @@ export interface PlumixAdminRuntime {
   readonly orpcClient: typeof OrpcClientNs;
   readonly orpcClientFetch: typeof OrpcClientFetchNs;
   readonly orpcTanstackQuery: typeof OrpcTanstackQueryNs;
+  readonly linguiCore: typeof LinguiCoreNs;
+  readonly linguiReact: typeof LinguiReactNs;
 }
 
 export interface PlumixGlobal {

--- a/packages/plumix/src/admin/shim-drift.test.ts
+++ b/packages/plumix/src/admin/shim-drift.test.ts
@@ -1,5 +1,7 @@
 import * as ReactNs from "react";
 import * as ReactJsxRuntimeNs from "react/jsx-runtime";
+import * as LinguiCoreNs from "@lingui/core";
+import * as LinguiReactNs from "@lingui/react";
 import * as OrpcClientNs from "@orpc/client";
 import * as OrpcClientFetchNs from "@orpc/client/fetch";
 import * as OrpcTanstackQueryNs from "@orpc/tanstack-query";
@@ -26,6 +28,8 @@ beforeAll(() => {
       orpcClient: OrpcClientNs,
       orpcClientFetch: OrpcClientFetchNs,
       orpcTanstackQuery: OrpcTanstackQueryNs,
+      linguiCore: LinguiCoreNs,
+      linguiReact: LinguiReactNs,
     },
   };
 });
@@ -232,6 +236,16 @@ const SHIMS: readonly ShimSpec[] = [
       // a plugin actually wants it.
       "experimental_serializableStreamedQuery",
     ]),
+  },
+  {
+    name: "@lingui/core",
+    upstream: LinguiCoreNs,
+    load: () => import("./lingui-core.js"),
+  },
+  {
+    name: "@lingui/react",
+    upstream: LinguiReactNs,
+    load: () => import("./lingui-react.js"),
   },
 ];
 

--- a/packages/plumix/src/i18n/index.ts
+++ b/packages/plumix/src/i18n/index.ts
@@ -13,5 +13,9 @@ export {
   type FormatRelativeOptions,
   type Label,
 } from "@plumix/core/i18n";
+// `@lingui/*` re-exports are bare specifiers — the plugin-chunk
+// bundler rewrites them to `plumix/admin/lingui-*` via
+// `SHARED_ADMIN_RUNTIME_SPECIFIERS` so plugin chunks share admin's
+// i18n singleton + provider. Admin/server import the real packages.
 export { i18n, type MessageDescriptor } from "@lingui/core";
-export { I18nProvider, Trans } from "@lingui/react";
+export { I18nProvider, Trans, useLingui } from "@lingui/react";


### PR DESCRIPTION
Closes #777. Plugin admin chunks have been bundling their own `@lingui/react` instance, separate from admin's. Admin's `<I18nProvider>` lives in admin's instance, so `useLingui()` inside a plugin chunk reads from a different React-context instance and returns `null` — the destructure throws at first render and the plugin route 500s under admin's error boundary.

Extend the existing runtime shim contract (which already shares React, react-dom, react-router, react-query, orpc with plugin chunks) to also share `@lingui/core` and `@lingui/react`.

**Contract additions**

- `SHARED_ADMIN_RUNTIME_SPECIFIERS` gains `@lingui/core: "lingui-core"` and `@lingui/react: "lingui-react"`. The plumix plugin-chunk bundler already aliases every specifier in this map at build time, so no bundler change is needed.
- `plumix/admin/lingui-core` + `plumix/admin/lingui-react` shim files delegate through `getRuntime()` (same shape as the 9 existing shims).
- `window.plumix.runtime` gains `linguiCore` + `linguiReact` namespaces seeded by admin's own `import * as` of the real packages.
- `PlumixAdminRuntime` interface widens to type the new fields.

**`plumix/i18n` keeps plain `@lingui/*` re-exports**

The bare specifiers in `plumix/i18n`'s source are what the plugin-chunk bundler rewrites — admin and server consumers (which don't go through that bundler) resolve to the real packages directly. Also restores the `useLingui` re-export that was reverted in #776 — it now resolves to the shimmed instance for plugin chunks instead of a phantom new context.

**Drift detection**

`shim-drift.test.ts` adds entries for both new shims with no `knownGaps`. Upstream additions to either Lingui package surface in CI rather than silently leaking past plugin chunks.

**Unblocks**

- #761 (menu plugin admin UI translation)
- #762 (media plugin admin UI translation + `FRIENDLY_ERRORS` map)
- The runtime-render piece of #770 (catalog discovery already works via slice #697; the rendering piece needs this)

Refs #777