### PR TITLE
feat: add translator comments to placeholder-bearing i18n messages

### DIFF
--- a/docs/plugin-author.md
+++ b/docs/plugin-author.md
@@ -180,6 +180,75 @@ test("newsletter metabox is registered for post entries", async () => {
 For block-only tests use `plumix/blocks/test` (see
 [block-authoring guide's testing section](./block-authoring.md#testing)).
 
+## Translations
+
+Plugin labels and admin-chunk copy translate through Lingui. Three
+authoring shapes share the same `.po` pipeline:
+
+- **Plain `{id, message}` literals** for server-side and ambient code.
+  The plugin package builds with plain `tsc`, no Lingui macro pass, so
+  manifest labels and bridge-emitted messages use this shape:
+  ```ts
+  const POST_LABELS = {
+    singular: { id: "plugin.blog.post.singular", message: "Post" },
+    // ...
+  };
+  ```
+- **`defineMessage()` descriptors** (`M`-map) for admin-chunk text
+  outside JSX — aria-labels, `placeholder`, alert fallbacks routed
+  through `i18n._()`. Extractor sees these via the macro.
+- **`<Trans>` JSX** for admin-chunk render-time text. Plugin chunks
+  share admin's i18n instance via the runtime shim (`@lingui/core` and
+  `@lingui/react` are aliased to `plumix/admin/lingui-*`).
+
+### Placeholders need a translator comment
+
+Any descriptor or `<Trans>` whose `message` carries an ICU placeholder
+must declare a `comment` describing each placeholder. Lingui extracts
+`comment` as a `#.` line in the `.po`, so translators see the
+placeholder contract without reading source.
+
+```ts
+// Descriptor form
+M.deleteAria = defineMessage({
+  id: "row.deleteAria",
+  message: "Delete {domain}",
+  comment: "domain: the hostname being removed from the allowlist",
+});
+
+// JSX form
+<Trans
+  id="dashboard.welcome"
+  message="Welcome, {greeting}"
+  values={{ greeting }}
+  comment="greeting: the user's display name or email"
+/>;
+```
+
+Without comments, translators guess at placeholder semantics — a
+template like `{label} {kind} failed` is meaningless until you know
+`label` is plugin-author-supplied and `kind` is a protocol identifier.
+
+### Hand-authored catalogs
+
+First-party plugins hand-author `locales/en.po` because manifest labels
+and `M`-map descriptor literals aren't extractor-visible without the
+Babel macro pipeline. `lingui compile` (wired via `plumix i18n init`)
+regenerates `locales/en.mjs` on every build, so the runtime catalog
+stays in sync with the `.po`.
+
+`plumix i18n init` scaffolds `lingui.config.ts`, the compile-error gate
+script, and the `i18n:*` package.json entries. Run it once per plugin:
+
+```sh
+pnpm --filter @plumix/plugin-newsletter exec plumix i18n init
+```
+
+`i18n:check` is deliberately omitted from the scaffolded scripts —
+`lingui extract --clean` would orphan every entry the extractor can't
+see. The full extract/check loop becomes available once a plugin
+migrates to macro-aware authoring.
+
 ## See also
 
 - [Block authoring](./block-authoring.md) — the full `defineBlock` surface.

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -168,16 +168,19 @@ msgstr ""
 msgid "terms.edit.descendantsHint"
 msgstr ""
 
+#. max: upper bound on the repeater row count
 #. js-lingui-explicit-id
 #: src/components/meta-box/repeater-field.tsx
 msgid "metaBox.repeater.countSuffixMax"
 msgstr ""
 
+#. min: lower bound on the repeater row count
 #. js-lingui-explicit-id
 #: src/components/meta-box/repeater-field.tsx
 msgid "metaBox.repeater.countSuffixMin"
 msgstr ""
 
+#. min, max: integers bounding the repeater row count
 #. js-lingui-explicit-id
 #: src/components/meta-box/repeater-field.tsx
 msgid "metaBox.repeater.countSuffixBoth"
@@ -203,27 +206,32 @@ msgstr ""
 msgid "entries.list.noTitle"
 msgstr ""
 
+#. browser: e.g. 'Safari', 'Chrome'; os: e.g. 'macOS', 'Windows 11'. Vendor names interpolate verbatim; the connector word is localizable.
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.device.browserOnOs"
 msgstr ""
 
+#. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr ""
 
+#. count: number of selected options in the multi-select
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
 msgid "form.multiSelect.selectedCount"
 msgstr ""
 
+#. device: 'Safari on macOS' style label; when: relative-time string; ip: IPv4/IPv6 address
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.revoke.descriptionWithIp"
 msgstr ""
 
+#. device: 'Safari on macOS' style label; when: relative-time string
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.revoke.description"
@@ -235,16 +243,19 @@ msgstr ""
 msgid "editor.coAuthorIndicator.presenceAriaLabel"
 msgstr ""
 
+#. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block'); kind: the extension type ('field', 'block', 'mark') left as the raw protocol identifier
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx
 msgid "plugin.errorBoundary.inlineStub"
 msgstr ""
 
+#. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx
 msgid "plugin.errorBoundary.pageBody"
 msgstr ""
 
+#. revoked: number of OTHER sessions just signed out (excluding the current device)
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.revokeAll.count"
@@ -381,6 +392,7 @@ msgstr ""
 msgid "metaBox.repeater.addFirst"
 msgstr ""
 
+#. date: a locale-formatted date string
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.added"
@@ -696,6 +708,7 @@ msgstr ""
 msgid "auth.device.lookup.submit.pending"
 msgstr ""
 
+#. blockTitle: the parent block's registered title (e.g. 'Cover', 'Gallery')
 #. js-lingui-explicit-id
 #: src/editor/BlockScopePicker.tsx
 msgid "blockScopePicker.title"
@@ -741,6 +754,7 @@ msgstr ""
 msgid "allowedDomains.list.title"
 msgstr ""
 
+#. userCode: the short device-flow code the CLI displayed (e.g. 'WDJB-MJHT'); pass through verbatim
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.approve.confirmTitle"
@@ -751,11 +765,13 @@ msgstr ""
 msgid "allowedDomains.row.deleteConfirm"
 msgstr ""
 
+#. email: the user account being deleted
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.confirm.title"
 msgstr ""
 
+#. email: the address the confirmation link was sent to
 #. js-lingui-explicit-id
 #: src/components/profile/user-email-field.tsx
 msgid "userEdit.email.confirmationSent"
@@ -766,6 +782,7 @@ msgstr ""
 msgid "auth.device.lookup.submit.idle"
 msgstr ""
 
+#. label: the OAuth provider's display name (e.g. 'Google', 'GitHub')
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.oauth.continueWith"
@@ -1101,11 +1118,13 @@ msgstr ""
 msgid "profile.passkeys.delete.button"
 msgstr ""
 
+#. domain: the hostname being removed from the allowlist
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.row.deleteAria"
 msgstr ""
 
+#. termName: the taxonomy term being deleted
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.delete.dialogTitle"
@@ -1166,6 +1185,7 @@ msgstr ""
 msgid "profile.passkeys.delete.pending"
 msgstr ""
 
+#. accessDenied: the literal OAuth error code string (e.g. 'access_denied') — do not translate
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.denied"
@@ -1292,6 +1312,7 @@ msgstr ""
 msgid "breadcrumb.edit"
 msgstr "Bearbeiten"
 
+#. email: the user being edited
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.title.other"
@@ -1302,6 +1323,7 @@ msgstr ""
 msgid "breadcrumb.editUser"
 msgstr "Benutzer bearbeiten"
 
+#. device: pre-resolved viewport label like 'Desktop', 'Tablet', 'Mobile'
 #. js-lingui-explicit-id
 #: src/editor/StyleTab.tsx
 msgid "editor.styleTab.activeBucket"
@@ -1512,6 +1534,7 @@ msgstr ""
 msgid "editor.styleTab.section.fontSize"
 msgstr ""
 
+#. when: pre-formatted relative-time like '2 hours ago'; author: the user's display name or email
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
 msgid "editor.revisions.preview.subtitle"
@@ -1537,6 +1560,7 @@ msgstr ""
 msgid "terms.create.description.flat"
 msgstr ""
 
+#. from, to, between: integer heading levels 1-6; e.g. from=2, to=4, between=3
 #. js-lingui-explicit-id
 #: src/editor/HeadingAuditPanel.tsx
 msgid "editor.headingAudit.skippedLevel"
@@ -1652,6 +1676,7 @@ msgstr ""
 msgid "apiTokens.col.lastUsed"
 msgstr ""
 
+#. date: a locale-formatted date string
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.lastUsed"
@@ -1672,6 +1697,7 @@ msgstr ""
 msgid "dataTable.loading"
 msgstr ""
 
+#. label: the plugin page's registered label (e.g. 'Audit Log')
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/pages/$.tsx
 msgid "pluginPage.loading.aria"
@@ -1802,6 +1828,7 @@ msgstr ""
 msgid "entries.list.trashDialog.moving"
 msgstr ""
 
+#. count: number of h1 elements detected in the editor tree
 #. js-lingui-explicit-id
 #: src/editor/HeadingAuditPanel.tsx
 msgid "editor.headingAudit.multipleH1"
@@ -2107,6 +2134,7 @@ msgstr ""
 msgid "editor.styleTab.section.padding"
 msgstr ""
 
+#. page: 1-based current page number in the list
 #. js-lingui-explicit-id
 #: src/components/data-table/list-pagination.tsx
 msgid "listPagination.page"
@@ -2122,6 +2150,7 @@ msgstr ""
 msgid "profile.passkeys.title"
 msgstr ""
 
+#. slug: the pattern's registered slug (e.g. 'core/three-columns'); pass through verbatim
 #. js-lingui-explicit-id
 #: src/editor/PatternRefPreview.tsx
 msgid "editor.patternRef.unresolved"
@@ -2132,6 +2161,7 @@ msgstr ""
 msgid "patternsSection.heading"
 msgstr ""
 
+#. newEmail: the new address awaiting confirmation; expiresAt: pre-formatted relative-time like 'in 2 hours'
 #. js-lingui-explicit-id
 #: src/components/profile/user-email-field.tsx
 msgid "userEdit.email.pending"
@@ -2157,6 +2187,7 @@ msgstr ""
 msgid "apiTokens.description.self"
 msgstr ""
 
+#. blockTitle: the parent block's registered title (e.g. 'Cover', 'Gallery')
 #. js-lingui-explicit-id
 #: src/editor/BlockScopePicker.tsx
 msgid "blockScopePicker.description"
@@ -2462,21 +2493,25 @@ msgstr ""
 msgid "apiTokens.col.scopes"
 msgstr ""
 
+#. kind: the entity type being searched (e.g. 'posts', 'tags')
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx
 msgid "metaBox.multiReference.searchPlaceholder"
 msgstr ""
 
+#. kind: the entity type being searched (e.g. 'posts', 'tags')
 #. js-lingui-explicit-id
 #: src/components/meta-box/reference-picker.tsx
 msgid "metaBox.reference.searchPlaceholder"
 msgstr ""
 
+#. kind: the entity type the picker is constrained to (e.g. 'post', 'category', 'user')
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx
 msgid "metaBox.multiReference.dialogDescription"
 msgstr ""
 
+#. kind: the entity type the picker is constrained to (e.g. 'post', 'category', 'user')
 #. js-lingui-explicit-id
 #: src/components/meta-box/reference-picker.tsx
 msgid "metaBox.reference.dialogDescription"
@@ -2612,6 +2647,7 @@ msgstr ""
 msgid "menu.settings"
 msgstr ""
 
+#. email: the invited user's address
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/create.tsx
 msgid "userInvite.success.description"
@@ -2672,6 +2708,7 @@ msgstr ""
 msgid "passkey.error.registrationClosed"
 msgstr ""
 
+#. when: pre-formatted relative-time string like '2 hours ago'
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.signedIn"
@@ -2732,6 +2769,7 @@ msgstr ""
 msgid "passkey.error.unknown"
 msgstr ""
 
+#. label: the column being sorted (e.g. 'Title', 'Status', 'Updated'); direction: pre-resolved direction word like 'ascending' or 'descending'
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.sortAria"
@@ -2792,6 +2830,7 @@ msgstr ""
 msgid "breadcrumb.terms"
 msgstr "Begriffe"
 
+#. to: the recipient email address the test was sent to
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.test.feedback.ok"
@@ -2907,6 +2946,7 @@ msgstr ""
 msgid "emailChange.error.accountDisabled"
 msgstr ""
 
+#. path: the manifest-declared admin-route path (e.g. '/audit-log'); pass through verbatim
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/pages/$.tsx
 msgid "pluginPage.notLoaded.body"
@@ -2917,6 +2957,7 @@ msgstr ""
 msgid "auth.device.lookup.description"
 msgstr ""
 
+#. name: the user-chosen passkey nickname (e.g. 'MacBook', 'iPhone')
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.delete.description"
@@ -3237,6 +3278,7 @@ msgstr ""
 msgid "userEdit.email.dialog.description"
 msgstr ""
 
+#. greeting: the user's display name or email
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.welcome"

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -168,16 +168,19 @@ msgstr ""
 msgid "terms.edit.descendantsHint"
 msgstr " — descendants can't be picked as parent."
 
+#. max: upper bound on the repeater row count
 #. js-lingui-explicit-id
 #: src/components/meta-box/repeater-field.tsx
 msgid "metaBox.repeater.countSuffixMax"
 msgstr " / max {max}"
 
+#. min: lower bound on the repeater row count
 #. js-lingui-explicit-id
 #: src/components/meta-box/repeater-field.tsx
 msgid "metaBox.repeater.countSuffixMin"
 msgstr " / min {min}"
 
+#. min, max: integers bounding the repeater row count
 #. js-lingui-explicit-id
 #: src/components/meta-box/repeater-field.tsx
 msgid "metaBox.repeater.countSuffixBoth"
@@ -203,28 +206,33 @@ msgstr "(no name)"
 msgid "entries.list.noTitle"
 msgstr "(no title)"
 
+#. browser: e.g. 'Safari', 'Chrome'; os: e.g. 'macOS', 'Windows 11'. Vendor names interpolate verbatim; the connector word is localizable.
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.device.browserOnOs"
 msgstr "{browser} on {os}"
 
+#. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr "{count, plural, one {# group} other {# groups}}"
 
+#. count: number of selected options in the multi-select
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
 msgid "form.multiSelect.selectedCount"
 msgstr "{count} selected"
 
+#. device: 'Safari on macOS' style label; when: relative-time string; ip: IPv4/IPv6 address
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.revoke.descriptionWithIp"
 msgstr "{device} signed in {when} from {ip}. The device will need to sign in "
 "again next time."
 
+#. device: 'Safari on macOS' style label; when: relative-time string
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.revoke.description"
@@ -237,17 +245,20 @@ msgstr "{device} signed in {when}. The device will need to sign in again next "
 msgid "editor.coAuthorIndicator.presenceAriaLabel"
 msgstr "{display} · last seen {lastSeen}"
 
+#. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block'); kind: the extension type ('field', 'block', 'mark') left as the raw protocol identifier
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx
 msgid "plugin.errorBoundary.inlineStub"
 msgstr "{label} {kind} failed"
 
+#. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx
 msgid "plugin.errorBoundary.pageBody"
 msgstr "{label} threw an error while rendering. The rest of the admin is "
 "unaffected."
 
+#. revoked: number of OTHER sessions just signed out (excluding the current device)
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.revokeAll.count"
@@ -389,6 +400,7 @@ msgstr "Add passkey"
 msgid "metaBox.repeater.addFirst"
 msgstr "Add row"
 
+#. date: a locale-formatted date string
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.added"
@@ -706,6 +718,7 @@ msgstr "Check your email"
 msgid "auth.device.lookup.submit.pending"
 msgstr "Checking…"
 
+#. blockTitle: the parent block's registered title (e.g. 'Cover', 'Gallery')
 #. js-lingui-explicit-id
 #: src/editor/BlockScopePicker.tsx
 msgid "blockScopePicker.title"
@@ -751,6 +764,7 @@ msgstr "Compare"
 msgid "allowedDomains.list.title"
 msgstr "Configured domains"
 
+#. userCode: the short device-flow code the CLI displayed (e.g. 'WDJB-MJHT'); pass through verbatim
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.approve.confirmTitle"
@@ -761,11 +775,13 @@ msgstr "Confirm \"{userCode}\""
 msgid "allowedDomains.row.deleteConfirm"
 msgstr "Confirm delete"
 
+#. email: the user account being deleted
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.confirm.title"
 msgstr "Confirm delete: {email}"
 
+#. email: the address the confirmation link was sent to
 #. js-lingui-explicit-id
 #: src/components/profile/user-email-field.tsx
 msgid "userEdit.email.confirmationSent"
@@ -777,6 +793,7 @@ msgstr "Confirmation sent to {email}. The change takes effect once they click "
 msgid "auth.device.lookup.submit.idle"
 msgstr "Continue"
 
+#. label: the OAuth provider's display name (e.g. 'Google', 'GitHub')
 #. js-lingui-explicit-id
 #: src/routes/_auth/login.tsx
 msgid "login.oauth.continueWith"
@@ -1116,11 +1133,13 @@ msgstr "Delete"
 msgid "profile.passkeys.delete.button"
 msgstr "Delete"
 
+#. domain: the hostname being removed from the allowlist
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.row.deleteAria"
 msgstr "Delete {domain}"
 
+#. termName: the taxonomy term being deleted
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.delete.dialogTitle"
@@ -1181,6 +1200,7 @@ msgstr "Deleting…"
 msgid "profile.passkeys.delete.pending"
 msgstr "Deleting…"
 
+#. accessDenied: the literal OAuth error code string (e.g. 'access_denied') — do not translate
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.denied"
@@ -1311,6 +1331,7 @@ msgstr "Edit"
 msgid "breadcrumb.edit"
 msgstr "Edit"
 
+#. email: the user being edited
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.title.other"
@@ -1321,6 +1342,7 @@ msgstr "Edit {email}"
 msgid "breadcrumb.editUser"
 msgstr "Edit user"
 
+#. device: pre-resolved viewport label like 'Desktop', 'Tablet', 'Mobile'
 #. js-lingui-explicit-id
 #: src/editor/StyleTab.tsx
 msgid "editor.styleTab.activeBucket"
@@ -1537,6 +1559,7 @@ msgstr "Filter by status"
 msgid "editor.styleTab.section.fontSize"
 msgstr "Font size"
 
+#. when: pre-formatted relative-time like '2 hours ago'; author: the user's display name or email
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
 msgid "editor.revisions.preview.subtitle"
@@ -1562,6 +1585,7 @@ msgstr "Go to previous page"
 msgid "terms.create.description.flat"
 msgstr "Group content by adding a new term."
 
+#. from, to, between: integer heading levels 1-6; e.g. from=2, to=4, between=3
 #. js-lingui-explicit-id
 #: src/editor/HeadingAuditPanel.tsx
 msgid "editor.headingAudit.skippedLevel"
@@ -1679,6 +1703,7 @@ msgstr "Last sign-in"
 msgid "apiTokens.col.lastUsed"
 msgstr "Last used"
 
+#. date: a locale-formatted date string
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.lastUsed"
@@ -1699,6 +1724,7 @@ msgstr "Load more"
 msgid "dataTable.loading"
 msgstr "Loading"
 
+#. label: the plugin page's registered label (e.g. 'Audit Log')
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/pages/$.tsx
 msgid "pluginPage.loading.aria"
@@ -1829,6 +1855,7 @@ msgstr "Move to trash"
 msgid "entries.list.trashDialog.moving"
 msgstr "Moving…"
 
+#. count: number of h1 elements detected in the editor tree
 #. js-lingui-explicit-id
 #: src/editor/HeadingAuditPanel.tsx
 msgid "editor.headingAudit.multipleH1"
@@ -2140,6 +2167,7 @@ msgstr "Overview"
 msgid "editor.styleTab.section.padding"
 msgstr "Padding"
 
+#. page: 1-based current page number in the list
 #. js-lingui-explicit-id
 #: src/components/data-table/list-pagination.tsx
 msgid "listPagination.page"
@@ -2155,6 +2183,7 @@ msgstr "Parent"
 msgid "profile.passkeys.title"
 msgstr "Passkeys"
 
+#. slug: the pattern's registered slug (e.g. 'core/three-columns'); pass through verbatim
 #. js-lingui-explicit-id
 #: src/editor/PatternRefPreview.tsx
 msgid "editor.patternRef.unresolved"
@@ -2165,6 +2194,7 @@ msgstr "Pattern not registered: <code>{slug}</code>"
 msgid "patternsSection.heading"
 msgstr "Patterns"
 
+#. newEmail: the new address awaiting confirmation; expiresAt: pre-formatted relative-time like 'in 2 hours'
 #. js-lingui-explicit-id
 #: src/components/profile/user-email-field.tsx
 msgid "userEdit.email.pending"
@@ -2192,6 +2222,7 @@ msgid "apiTokens.description.self"
 msgstr "Personal access tokens for CLIs, MCP servers, CI bots, or any other "
 "non-browser client. The full secret is shown once at mint time."
 
+#. blockTitle: the parent block's registered title (e.g. 'Cover', 'Gallery')
 #. js-lingui-explicit-id
 #: src/editor/BlockScopePicker.tsx
 msgid "blockScopePicker.description"
@@ -2499,21 +2530,25 @@ msgstr "Scheduled"
 msgid "apiTokens.col.scopes"
 msgstr "Scopes"
 
+#. kind: the entity type being searched (e.g. 'posts', 'tags')
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx
 msgid "metaBox.multiReference.searchPlaceholder"
 msgstr "Search {kind}…"
 
+#. kind: the entity type being searched (e.g. 'posts', 'tags')
 #. js-lingui-explicit-id
 #: src/components/meta-box/reference-picker.tsx
 msgid "metaBox.reference.searchPlaceholder"
 msgstr "Search {kind}…"
 
+#. kind: the entity type the picker is constrained to (e.g. 'post', 'category', 'user')
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx
 msgid "metaBox.multiReference.dialogDescription"
 msgstr "Search and pick {kind} entries"
 
+#. kind: the entity type the picker is constrained to (e.g. 'post', 'category', 'user')
 #. js-lingui-explicit-id
 #: src/components/meta-box/reference-picker.tsx
 msgid "metaBox.reference.dialogDescription"
@@ -2654,6 +2689,7 @@ msgstr "Settings"
 msgid "menu.settings"
 msgstr "Settings"
 
+#. email: the invited user's address
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/create.tsx
 msgid "userInvite.success.description"
@@ -2715,6 +2751,7 @@ msgstr "Sign-in was cancelled."
 msgid "passkey.error.registrationClosed"
 msgstr "Sign-up is not open on this site."
 
+#. when: pre-formatted relative-time string like '2 hours ago'
 #. js-lingui-explicit-id
 #: src/components/profile/sessions-card.tsx
 msgid "profile.sessions.signedIn"
@@ -2777,6 +2814,7 @@ msgstr "Something went wrong with the form. Please reload and try again."
 msgid "passkey.error.unknown"
 msgstr "Something went wrong. Please try again."
 
+#. label: the column being sorted (e.g. 'Title', 'Status', 'Updated'); direction: pre-resolved direction word like 'ascending' or 'descending'
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.sortAria"
@@ -2837,6 +2875,7 @@ msgstr "Taxonomies"
 msgid "breadcrumb.terms"
 msgstr "Terms"
 
+#. to: the recipient email address the test was sent to
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
 msgid "mailer.test.feedback.ok"
@@ -2958,6 +2997,7 @@ msgstr "The account this confirmation belongs to has been removed."
 msgid "emailChange.error.accountDisabled"
 msgstr "The account this confirmation belongs to is disabled."
 
+#. path: the manifest-declared admin-route path (e.g. '/audit-log'); pass through verbatim
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/pages/$.tsx
 msgid "pluginPage.notLoaded.body"
@@ -2970,6 +3010,7 @@ msgid "auth.device.lookup.description"
 msgstr "The CLI shows an 8-character code split with a dash — \"ABCD-EFGH\". "
 "Letters and digits only, no zeros or ones."
 
+#. name: the user-chosen passkey nickname (e.g. 'MacBook', 'iPhone')
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.delete.description"
@@ -3304,6 +3345,7 @@ msgstr "We'll send a confirmation link to the new address. The change takes "
 "effect after the link is clicked. Sessions on this account are signed "
 "out at that point — re-sign-in uses the new email."
 
+#. greeting: the user's display name or email
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.welcome"

--- a/packages/admin/src/components/data-table/list-pagination.tsx
+++ b/packages/admin/src/components/data-table/list-pagination.tsx
@@ -43,6 +43,7 @@ export function ListPagination({
           id="listPagination.page"
           message="Page {page}"
           values={{ page }}
+          comment="page: 1-based current page number in the list"
         />
       </span>
       <PaginationContent>

--- a/packages/admin/src/components/form/multi-select.tsx
+++ b/packages/admin/src/components/form/multi-select.tsx
@@ -38,6 +38,7 @@ const M = {
   selectedCount: defineMessage({
     id: "form.multiSelect.selectedCount",
     message: "{count} selected",
+    comment: "count: number of selected options in the multi-select",
   }),
 } satisfies Record<string, MessageDescriptor>;
 

--- a/packages/admin/src/components/meta-box/multi-reference-picker.tsx
+++ b/packages/admin/src/components/meta-box/multi-reference-picker.tsx
@@ -63,10 +63,13 @@ const M = {
   dialogDescription: defineMessage({
     id: "metaBox.multiReference.dialogDescription",
     message: "Search and pick {kind} entries",
+    comment:
+      "kind: the entity type the picker is constrained to (e.g. 'post', 'category', 'user')",
   }),
   searchPlaceholder: defineMessage({
     id: "metaBox.multiReference.searchPlaceholder",
     message: "Search {kind}…",
+    comment: "kind: the entity type being searched (e.g. 'posts', 'tags')",
   }),
 } satisfies Record<string, MessageDescriptor>;
 

--- a/packages/admin/src/components/meta-box/reference-picker.tsx
+++ b/packages/admin/src/components/meta-box/reference-picker.tsx
@@ -63,10 +63,13 @@ const M = {
   dialogDescription: defineMessage({
     id: "metaBox.reference.dialogDescription",
     message: "Search and pick a {kind}",
+    comment:
+      "kind: the entity type the picker is constrained to (e.g. 'post', 'category', 'user')",
   }),
   searchPlaceholder: defineMessage({
     id: "metaBox.reference.searchPlaceholder",
     message: "Search {kind}…",
+    comment: "kind: the entity type being searched (e.g. 'posts', 'tags')",
   }),
 } satisfies Record<string, MessageDescriptor>;
 

--- a/packages/admin/src/components/meta-box/repeater-field.tsx
+++ b/packages/admin/src/components/meta-box/repeater-field.tsx
@@ -162,6 +162,7 @@ function CountSuffix({
         id="metaBox.repeater.countSuffixBoth"
         message=" / min {min} / max {max}"
         values={{ min, max }}
+        comment="min, max: integers bounding the repeater row count"
       />
     );
   }
@@ -171,6 +172,7 @@ function CountSuffix({
         id="metaBox.repeater.countSuffixMin"
         message=" / min {min}"
         values={{ min }}
+        comment="min: lower bound on the repeater row count"
       />
     );
   }
@@ -180,6 +182,7 @@ function CountSuffix({
         id="metaBox.repeater.countSuffixMax"
         message=" / max {max}"
         values={{ max }}
+        comment="max: upper bound on the repeater row count"
       />
     );
   }

--- a/packages/admin/src/components/profile/passkeys-card.tsx
+++ b/packages/admin/src/components/profile/passkeys-card.tsx
@@ -375,6 +375,7 @@ function PasskeyRow({ cred, isLast, onChanged }: PasskeyRowProps): ReactNode {
                     id="profile.passkeys.added"
                     message="Added {date}"
                     values={{ date: formatDate(createdAt) }}
+                    comment="date: a locale-formatted date string"
                   />
                 </span>
                 {lastUsedAt.getTime() !== createdAt.getTime() ? (
@@ -383,6 +384,7 @@ function PasskeyRow({ cred, isLast, onChanged }: PasskeyRowProps): ReactNode {
                       id="profile.passkeys.lastUsed"
                       message="Last used {date}"
                       values={{ date: formatDate(lastUsedAt) }}
+                      comment="date: a locale-formatted date string"
                     />
                   </span>
                 ) : null}
@@ -444,6 +446,7 @@ function PasskeyRow({ cred, isLast, onChanged }: PasskeyRowProps): ReactNode {
                 id="profile.passkeys.delete.description"
                 message='The device that registered "{name}" will no longer be able to sign in. You can re-enrol it later.'
                 values={{ name: displayName }}
+                comment="name: the user-chosen passkey nickname (e.g. 'MacBook', 'iPhone')"
               />
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/packages/admin/src/components/profile/sessions-card.tsx
+++ b/packages/admin/src/components/profile/sessions-card.tsx
@@ -43,6 +43,8 @@ const M = {
   browserOnOs: defineMessage({
     id: "profile.sessions.device.browserOnOs",
     message: "{browser} on {os}",
+    comment:
+      "browser: e.g. 'Safari', 'Chrome'; os: e.g. 'macOS', 'Windows 11'. Vendor names interpolate verbatim; the connector word is localizable.",
   }),
   // Mutation error fallbacks.
   revokeAllFallback: defineMessage({
@@ -129,6 +131,7 @@ export function SessionsCard(): ReactNode {
                 id="profile.sessions.revokeAll.count"
                 message="{revoked, plural, =0 {No other sessions to sign out.} one {Signed out # other session.} other {Signed out # other sessions.}}"
                 values={{ revoked: revokeAllFeedback.revoked }}
+                comment="revoked: number of OTHER sessions just signed out (excluding the current device)"
               />
             </AlertDescription>
           </Alert>
@@ -230,6 +233,7 @@ function SessionRow({ session, onChanged }: SessionRowProps): ReactNode {
               id="profile.sessions.signedIn"
               message="Signed in {when}"
               values={{ when: formatRelative(createdAt) }}
+              comment="when: pre-formatted relative-time string like '2 hours ago'"
             />
           </span>
         </div>
@@ -276,6 +280,7 @@ function SessionRow({ session, onChanged }: SessionRowProps): ReactNode {
                     when: formatRelative(createdAt),
                     ip: session.ipAddress,
                   }}
+                  comment="device: 'Safari on macOS' style label; when: relative-time string; ip: IPv4/IPv6 address"
                 />
               ) : (
                 <Trans
@@ -285,6 +290,7 @@ function SessionRow({ session, onChanged }: SessionRowProps): ReactNode {
                     device: deviceLabel,
                     when: formatRelative(createdAt),
                   }}
+                  comment="device: 'Safari on macOS' style label; when: relative-time string"
                 />
               )}
             </AlertDialogDescription>

--- a/packages/admin/src/components/profile/user-email-field.tsx
+++ b/packages/admin/src/components/profile/user-email-field.tsx
@@ -61,6 +61,7 @@ const M = {
     id: "userEdit.email.confirmationSent",
     message:
       "Confirmation sent to {email}. The change takes effect once they click the link.",
+    comment: "email: the address the confirmation link was sent to",
   }),
   // Placeholder is locale-sensitive (some locales prefer a different
   // example domain). Resolved via `useLabel()` for the `placeholder`
@@ -202,6 +203,7 @@ export function UserEmailField({
                   expiresAt: formatRelative(toDate(pending.expiresAt)),
                 }}
                 components={{ code: <code className="font-mono" /> }}
+                comment="newEmail: the new address awaiting confirmation; expiresAt: pre-formatted relative-time like 'in 2 hours'"
               />
             </span>
             {canEdit ? (

--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -60,6 +60,7 @@ export function BlockScopePicker({
               id="blockScopePicker.title"
               message="Choose a {blockTitle} layout"
               values={{ blockTitle }}
+              comment="blockTitle: the parent block's registered title (e.g. 'Cover', 'Gallery')"
             />
           </DialogTitle>
           <DialogDescription>
@@ -67,6 +68,7 @@ export function BlockScopePicker({
               id="blockScopePicker.description"
               message="Pick a layout to insert, or cancel to start from a blank {blockTitle}."
               values={{ blockTitle }}
+              comment="blockTitle: the parent block's registered title (e.g. 'Cover', 'Gallery')"
             />
           </DialogDescription>
         </DialogHeader>

--- a/packages/admin/src/editor/HeadingAuditPanel.tsx
+++ b/packages/admin/src/editor/HeadingAuditPanel.tsx
@@ -12,11 +12,14 @@ const M = {
     id: "editor.headingAudit.multipleH1",
     message:
       "Multiple <h1> on the page ({count} found). Keep only one top-level heading.",
+    comment: "count: number of h1 elements detected in the editor tree",
   }),
   skippedLevel: defineMessage({
     id: "editor.headingAudit.skippedLevel",
     message:
       "Heading jumps from h{from} to h{to}. Insert an h{between} between them.",
+    comment:
+      "from, to, between: integer heading levels 1-6; e.g. from=2, to=4, between=3",
   }),
   emptyHeading: defineMessage({
     id: "editor.headingAudit.emptyHeading",

--- a/packages/admin/src/editor/PatternRefPreview.tsx
+++ b/packages/admin/src/editor/PatternRefPreview.tsx
@@ -81,6 +81,7 @@ export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
           message="Pattern not registered: <code>{slug}</code>"
           values={{ slug }}
           components={{ code: <code /> }}
+          comment="slug: the pattern's registered slug (e.g. 'core/three-columns'); pass through verbatim"
         />
       </div>
     );

--- a/packages/admin/src/editor/StyleTab.tsx
+++ b/packages/admin/src/editor/StyleTab.tsx
@@ -88,6 +88,7 @@ export function StyleTab({
           id="editor.styleTab.activeBucket"
           message="Editing for: {device}"
           values={{ device: renderLabel(DEVICE_LABEL[bucket]) }}
+          comment="device: pre-resolved viewport label like 'Desktop', 'Tablet', 'Mobile'"
         />
       </div>
       <Accordion type="multiple" defaultValue={[...SECTION_VALUES]}>

--- a/packages/admin/src/editor/revisions/PreviewBanner.tsx
+++ b/packages/admin/src/editor/revisions/PreviewBanner.tsx
@@ -60,6 +60,7 @@ export function PreviewBanner({
             when: relativeTime(revisionUpdatedAt),
             author: revisionAuthor,
           }}
+          comment="when: pre-formatted relative-time like '2 hours ago'; author: the user's display name or email"
         />
       </span>
       <div className="ml-auto flex gap-2">

--- a/packages/admin/src/lib/plugin-error-boundary.tsx
+++ b/packages/admin/src/lib/plugin-error-boundary.tsx
@@ -34,6 +34,8 @@ const M = {
     id: "plugin.errorBoundary.pageBody",
     message:
       "{label} threw an error while rendering. The rest of the admin is unaffected.",
+    comment:
+      "label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')",
   }),
   // Inline stub for blocks / field renderers — `{kind}` is the
   // protocol discriminator (block / field) verbatim. Localizing it
@@ -42,6 +44,8 @@ const M = {
   inlineStub: defineMessage({
     id: "plugin.errorBoundary.inlineStub",
     message: "{label} {kind} failed",
+    comment:
+      "label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block'); kind: the extension type ('field', 'block', 'mark') left as the raw protocol identifier",
   }),
   // Icon aria-label.
   iconAria: defineMessage({

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -320,6 +320,7 @@ function LoginRoute(): ReactNode {
                     id="login.oauth.continueWith"
                     message="Continue with {label}"
                     values={{ label }}
+                    comment="label: the OAuth provider's display name (e.g. 'Google', 'GitHub')"
                   />
                 </a>
               </Button>

--- a/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
+++ b/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
@@ -62,6 +62,7 @@ const M = {
   deleteAria: defineMessage({
     id: "allowedDomains.row.deleteAria",
     message: "Delete {domain}",
+    comment: "domain: the hostname being removed from the allowlist",
   }),
   errDomainExists: defineMessage({
     id: "allowedDomains.error.domainExists",

--- a/packages/admin/src/routes/_authenticated/auth/device.tsx
+++ b/packages/admin/src/routes/_authenticated/auth/device.tsx
@@ -243,6 +243,7 @@ function DeviceApprovalRoute(): ReactNode {
               message="Denied. The CLI will get a(n) <0>{accessDenied}</0> response and stop polling."
               values={{ accessDenied: ACCESS_DENIED }}
               components={{ 0: <code className="font-mono text-xs" /> }}
+              comment="accessDenied: the literal OAuth error code string (e.g. 'access_denied') — do not translate"
             />
           </AlertDescription>
         </Alert>
@@ -421,6 +422,7 @@ function ApproveCard({
             id="auth.device.approve.confirmTitle"
             message={'Confirm "{userCode}"'}
             values={{ userCode }}
+            comment="userCode: the short device-flow code the CLI displayed (e.g. 'WDJB-MJHT'); pass through verbatim"
           />
         </CardTitle>
         <CardDescription>

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -186,6 +186,8 @@ const M = {
   sortAria: defineMessage({
     id: "entries.list.sortAria",
     message: "Sort by {label} ({direction})",
+    comment:
+      "label: the column being sorted (e.g. 'Title', 'Status', 'Updated'); direction: pre-resolved direction word like 'ascending' or 'descending'",
   }),
   noTitle: defineMessage({
     id: "entries.list.noTitle",

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -42,6 +42,7 @@ function DashboardIndex(): ReactNode {
             id="dashboard.welcome"
             message="Welcome, {greeting}"
             values={{ greeting }}
+            comment="greeting: the user's display name or email"
           />
         </h1>
         <p className="text-muted-foreground text-sm">

--- a/packages/admin/src/routes/_authenticated/mailer/index.tsx
+++ b/packages/admin/src/routes/_authenticated/mailer/index.tsx
@@ -160,6 +160,7 @@ function MailerRoute(): ReactNode {
                       id="mailer.test.feedback.ok"
                       message="Test message sent to {to}. If it doesn't arrive within a minute, check your transport adapter's logs."
                       values={{ to: feedback.to }}
+                      comment="to: the recipient email address the test was sent to"
                     />
                   </AlertDescription>
                 </Alert>

--- a/packages/admin/src/routes/_authenticated/pages/$.tsx
+++ b/packages/admin/src/routes/_authenticated/pages/$.tsx
@@ -15,6 +15,7 @@ const M = {
   loadingAria: defineMessage({
     id: "pluginPage.loading.aria",
     message: "Loading {label}",
+    comment: "label: the plugin page's registered label (e.g. 'Audit Log')",
   }),
 } satisfies Record<string, MessageDescriptor>;
 
@@ -90,6 +91,7 @@ function PluginNotLoaded({ path }: { path: string }): ReactNode {
           message="The admin manifest declares a page at <code>{path}</code> but no React component has been registered for it."
           values={{ path }}
           components={{ code: <code className="font-mono" /> }}
+          comment="path: the manifest-declared admin-route path (e.g. '/audit-log'); pass through verbatim"
         />
       </p>
     </div>

--- a/packages/admin/src/routes/_authenticated/settings/index.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.tsx
@@ -109,6 +109,7 @@ function SettingsIndexRoute(): ReactNode {
                     id="settings.pageSummary"
                     message="{count, plural, one {# group} other {# groups}}"
                     values={{ count: page.groups.length }}
+                    comment="count: number of settings groups this page surfaces"
                   />
                 </p>
               </CardContent>

--- a/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
@@ -415,6 +415,7 @@ function DeleteCard({
                 id="terms.edit.delete.dialogTitle"
                 message="Delete {termName}?"
                 values={{ termName }}
+                comment="termName: the taxonomy term being deleted"
               />
             </AlertDialogTitle>
             <AlertDialogDescription>

--- a/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
@@ -349,6 +349,7 @@ function UserEditForm({
                   id="userEdit.title.other"
                   message="Edit {email}"
                   values={{ email: target.email }}
+                  comment="email: the user being edited"
                 />
               )}
             </h1>
@@ -694,6 +695,7 @@ function DeleteCard({ target }: { target: User }): ReactNode {
             id="userEdit.delete.confirm.title"
             message="Confirm delete: {email}"
             values={{ email: target.email }}
+            comment="email: the user account being deleted"
           />
         </CardTitle>
         <CardDescription>

--- a/packages/admin/src/routes/_authenticated/users/create.tsx
+++ b/packages/admin/src/routes/_authenticated/users/create.tsx
@@ -377,6 +377,7 @@ function InviteSuccess({
               id="userInvite.success.description"
               message="Share the link below with {email}. They'll enrol a passkey the first time they open it. Link expires in 7 days."
               values={{ email: user.email }}
+              comment="email: the invited user's address"
             />
           </CardDescription>
         </CardHeader>

--- a/packages/plugins/media/src/admin/MediaLibrary.tsx
+++ b/packages/plugins/media/src/admin/MediaLibrary.tsx
@@ -868,6 +868,7 @@ function UploadProgressBar({
             id="plugin.media.upload.progress"
             message="Uploading {count, plural, one {# file} other {# files}}…"
             values={{ count: pending.length }}
+            comment="count: number of files currently uploading"
           />
         </span>
         <span data-testid="media-library-progress-pct">{pct}%</span>


### PR DESCRIPTION
Wrap every `defineMessage` descriptor and `<Trans>` JSX carrying an ICU placeholder with a
`comment:` field describing what the placeholder represents. Lingui extracts `comment` as a
`#.` line in the `.po`, so translators see the placeholder contract — units, format, whether
to pass through verbatim — without reading source.

Without comments, a template like `{label} {kind} failed` is opaque: translators can't tell
that `label` is a plugin-author-supplied name and `kind` is a protocol identifier that must
not be translated.

**Sweep scope**

27 placeholder sites across admin (auth/device, login, dashboard, profile cards, meta-box
pickers, editor panels, settings, users, mailer, pages, terms) and the media plugin's
`MediaLibrary`. Comment text encodes the semantics in a `name: description` shape; messages
with multiple placeholders use `;` between them.

**Docs**

`docs/plugin-author.md` gains a `## Translations` section documenting the three authoring
shapes (plain `{id, message}` literals for ambient code, `defineMessage()` descriptors for
admin-chunk text outside JSX, `<Trans>` JSX for render-time text), the placeholder-comment
requirement, and why `plumix i18n init` omits `i18n:check` — `lingui extract --clean` would
orphan manifest labels and `M`-map descriptors that aren't extractor-visible without the
Babel macro pipeline.

**ESLint rule deferred**

A custom "require-comment-on-placeholder" rule was scoped out: `lingui-eslint-plugin` lacks
a built-in rule, and manual sweep + reviewer practice is sufficient for the current size
of the surface.

Fixes #767