### PR TITLE
feat(core): add tx helper for context-disambiguated i18n descriptors

### DIFF
--- a/docs/plugin-author.md
+++ b/docs/plugin-author.md
@@ -229,6 +229,29 @@ Without comments, translators guess at placeholder semantics — a
 template like `{label} {kind} failed` is meaningless until you know
 `label` is plugin-author-supplied and `kind` is a protocol identifier.
 
+### Disambiguating polysemes
+
+English collapses several CMS terms across grammatical categories: `Post`
+(noun: content type / verb: publish), `Draft`, `Tag`, `Comment`, `Read`,
+`Home`, `Order`. Target locales split them into distinct words; a catalog
+with one entry per polyseme produces visible wrong renderings.
+
+Attach a `context:` field — Lingui emits `msgctxt` in the `.po`, gettext's
+mechanism for splitting a source string into per-sense buckets (WordPress
+`_x()` parity). Three helpers, same emission:
+
+| Helper | When to use |
+|---|---|
+| `withContext(desc, ctx)` | Plugin label tables with explicit ids — wraps an existing descriptor literal so the table source reads one entry per line. |
+| `defineMessage({ ..., context })` | Admin descriptors — the Babel macro extracts `context:` directly. |
+| `tx({ message, context })` / `` tx`Post`("noun") `` | Ad-hoc plugin runtime — tagged-template form is the terse one-liner. |
+
+When a polyseme appears inside an action phrase whose English verb makes
+the sense unambiguous in every locale (`Add Post`, `Edit Tag`, `Search
+Tags…`), it's fine to omit `context:` — but call the convention out
+explicitly with a block comment on the label table so the reviewer trail
+is documented.
+
 ### Hand-authored catalogs
 
 First-party plugins hand-author `locales/en.po` because manifest labels

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -1294,6 +1294,7 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "entry status"
 msgid "entries.list.statusFilter.draft"
 msgstr ""
 

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -1313,6 +1313,7 @@ msgstr "Done"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "entry status"
 msgid "entries.list.statusFilter.draft"
 msgstr "Draft"
 

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -158,6 +158,7 @@ const M = {
   statusDraft: defineMessage({
     id: "entries.list.statusFilter.draft",
     message: "Draft",
+    context: "entry status",
   }),
   statusScheduled: defineMessage({
     id: "entries.list.statusFilter.scheduled",

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -27,3 +27,4 @@ export type {
   ResolvedLocale,
 } from "./locale-registry.js";
 export { resolveLocale } from "./resolve-locale.js";
+export { tx } from "./tx.js";

--- a/packages/core/src/i18n/tx.test.ts
+++ b/packages/core/src/i18n/tx.test.ts
@@ -1,0 +1,65 @@
+import { setupI18n } from "@lingui/core";
+import { describe, expect, test } from "vitest";
+
+import { resolveLabel } from "./label.js";
+import { tx } from "./tx.js";
+
+describe("tx", () => {
+  test("object form returns a descriptor with the given context", () => {
+    const tagged = tx({ message: "Post", context: "noun" });
+    expect(tagged.message).toBe("Post");
+    expect(tagged.context).toBe("noun");
+  });
+
+  test("object form preserves optional id and comment fields", () => {
+    const tagged = tx({
+      id: "post.singular",
+      message: "Post",
+      context: "noun",
+      comment: "Singular post-type label.",
+    });
+    expect(tagged.id).toBe("post.singular");
+    expect(tagged.comment).toBe("Singular post-type label.");
+    expect(tagged.context).toBe("noun");
+  });
+
+  test("tagged-template form curries: tx`Post`('noun') → descriptor", () => {
+    const tagged = tx`Post`("noun");
+    expect(tagged.message).toBe("Post");
+    expect(tagged.context).toBe("noun");
+  });
+
+  test("tagged-template form interpolates values into the message", () => {
+    const verb = "Publish";
+    const tagged = tx`${verb} this`("verb");
+    expect(tagged.message).toBe("Publish this");
+    expect(tagged.context).toBe("verb");
+  });
+
+  test("tagged-template form handles multiple interpolations", () => {
+    const verb = "Publish";
+    const noun = "post";
+    const tagged = tx`${verb} this ${noun}`("verb");
+    expect(tagged.message).toBe("Publish this post");
+  });
+
+  test("resolves through resolveLabel — context is translator metadata only", () => {
+    const instance = setupI18n({
+      locale: "de",
+      messages: { de: { "post.singular.noun": "Beitrag" } },
+    });
+    const tagged = tx({
+      id: "post.singular.noun",
+      message: "Post",
+      context: "noun",
+    });
+    expect(resolveLabel(tagged, instance)).toBe("Beitrag");
+  });
+
+  test("same message + different context yield distinct descriptors", () => {
+    const noun = tx({ message: "Post", context: "noun" });
+    const verb = tx({ message: "Post", context: "verb" });
+    expect(noun.context).not.toBe(verb.context);
+    expect(noun.message).toBe(verb.message);
+  });
+});

--- a/packages/core/src/i18n/tx.ts
+++ b/packages/core/src/i18n/tx.ts
@@ -1,0 +1,59 @@
+// Lingui's `MessageDescriptor` requires `id`; the tagged-template form
+// of `tx` produces a descriptor without one (Lingui derives the runtime
+// key from message+context at extract time, gettext-style). Use a
+// relaxed shape so both authoring paths typecheck.
+interface TxDescriptor {
+  readonly id?: string;
+  readonly message: string;
+  readonly context: string;
+  readonly comment?: string;
+}
+
+interface TxObjectInput {
+  readonly message: string;
+  readonly context: string;
+  readonly id?: string;
+  readonly comment?: string;
+}
+
+/** Context-tagged descriptor shorthand for disambiguating polysemes
+ *  (gettext `msgctxt` / WP `_x()` parity). Two forms:
+ *
+ *  ```ts
+ *  tx({ message: "Post", context: "noun" })   // object
+ *  tx`Post`("noun")                            // tagged template
+ *  ```
+ *
+ *  Same message with different `context` produces distinct catalog
+ *  entries — translators get separate buckets for noun/verb senses
+ *  that collide in English. */
+export function tx<T extends TxObjectInput>(input: T): T;
+export function tx(
+  strings: TemplateStringsArray,
+  ...values: readonly unknown[]
+): (context: string) => TxDescriptor;
+export function tx<T extends TxObjectInput>(
+  arg: T | TemplateStringsArray,
+  ...values: readonly unknown[]
+): T | ((context: string) => TxDescriptor) {
+  if (isTemplateStrings(arg)) {
+    const message = assembleTemplate(arg, values);
+    return (context: string) => ({ message, context });
+  }
+  return { ...arg };
+}
+
+function isTemplateStrings(value: unknown): value is TemplateStringsArray {
+  return Array.isArray(value) && "raw" in value;
+}
+
+function assembleTemplate(
+  strings: TemplateStringsArray,
+  values: readonly unknown[],
+): string {
+  let out = strings[0] ?? "";
+  for (let i = 0; i < values.length; i += 1) {
+    out += String(values[i]) + (strings[i + 1] ?? "");
+  }
+  return out;
+}

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -18,6 +18,12 @@ import { definePlugin } from "plumix/plugin";
 // see the `X-Generator: hand-authored` header. `withContext` is not
 // macro-visible, so any future `lingui extract` integration here would
 // regress those lines silently.
+//
+// Action-phrase labels (`Add Post`, `Edit Tag`) intentionally OMIT
+// context — the leading English verb fixes the polyseme as a noun in
+// every target locale, matching WP gettext convention (only the
+// standalone singular/plural carry `_x()`). See
+// `docs/plugin-author.md#disambiguating-polysemes`.
 const POST_LABELS = {
   singular: withContext(
     { id: "plugin.blog.post.singular", message: "Post" },

--- a/packages/plumix/src/i18n/index.ts
+++ b/packages/plumix/src/i18n/index.ts
@@ -9,6 +9,7 @@ export {
   formatRelative,
   labelSourceText,
   resolveLabel,
+  tx,
   withContext,
   type FormatRelativeOptions,
   type Label,


### PR DESCRIPTION
Introduces `tx` as a context-bearing descriptor shorthand for polyseme
disambiguation — gettext `msgctxt` / WP `_x()` parity, the mechanism that
splits a single English source string into per-sense translation buckets.

```ts
tx({ message: "Post", context: "noun" })   // object
tx`Post`("noun")                            // tagged-template curry
```

Translators get distinct entries for noun/verb senses that collide in
English (`Post` the content type vs. `Post` the publish verb, `Draft` the
entity vs. `Draft` the verb, etc.).

**Polyseme sweep**

The repo-wide audit of the seven known polysemes (`Post`, `Draft`, `Tag`,
`Comment`, `Read`, `Home`, `Order`) surfaced two action items:

- Admin's standalone `Draft` status filter now carries `context: "entry
  status"`; `.po` files gain the matching `msgctxt` line via re-extract.
- Blog plugin's action-phrase labels (`Add Post`, `Edit Tag`, `Search
  Tags…`) intentionally omit context — the leading English verb fixes
  the polyseme as a noun in every target locale, matching WP gettext
  convention (only standalone singular/plural carry `_x()`). A block
  comment at the top of the label tables documents the decision.

`Comment`, `Read`, `Home`, `Order` have no current occurrences in i18n
message fields — flagged for future contributors via the docs entry.

**Choice matrix**

Three helpers, same `msgctxt` emission, different call-site shapes. The
new docs subsection (`docs/plugin-author.md#disambiguating-polysemes`)
sets the convention:

| Helper | When |
|---|---|
| `withContext(desc, ctx)` | Plugin label tables with explicit ids — table source reads one entry per line. |
| `defineMessage({ ..., context })` | Admin descriptors — the Babel macro extracts `context:` directly. |
| `tx` | Ad-hoc plugin runtime — tagged-template is the terse one-liner. |

Fixes #760