### PR TITLE
feat: widen field, block, and pattern label slots to Label union

### DIFF
--- a/packages/admin/src/editor/BlockActionsPanel.tsx
+++ b/packages/admin/src/editor/BlockActionsPanel.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { useMemo } from "react";
+import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
 
 import type { BlockRegistry } from "@plumix/blocks";
@@ -30,6 +31,7 @@ export function BlockActionsPanel({
   onDelete,
   onCopyJson,
 }: BlockActionsPanelProps): ReactElement | null {
+  const renderLabel = useLabel();
   const options = useMemo(
     () => (specName ? availableTransforms(specName, registry) : []),
     [specName, registry],
@@ -65,11 +67,11 @@ export function BlockActionsPanel({
               className="truncate text-sm font-medium"
               data-testid="block-actions-identity-title"
             >
-              {identity.title}
+              {renderLabel(identity.title)}
             </div>
             {identity.description ? (
               <div className="text-muted-foreground truncate text-xs">
-                {identity.description}
+                {renderLabel(identity.description)}
               </div>
             ) : null}
           </div>
@@ -89,7 +91,7 @@ export function BlockActionsPanel({
                   className="rounded border px-2 py-1 text-xs"
                   data-testid={`block-action-transform-${option.key}`}
                 >
-                  {option.targetTitle}
+                  {renderLabel(option.targetTitle)}
                 </button>
               </li>
             ))}

--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog.js";
+import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
 
 import type {
@@ -41,6 +42,7 @@ export function BlockScopePicker({
   onSelect,
   onDismiss,
 }: BlockScopePickerProps): ReactElement | null {
+  const renderLabel = useLabel();
   if (variations.length === 0) return null;
   return (
     <Dialog
@@ -104,10 +106,12 @@ export function BlockScopePicker({
                     />
                   </div>
                 </LazyMount>
-                <span className="text-sm font-medium">{variation.title}</span>
+                <span className="text-sm font-medium">
+                  {renderLabel(variation.title)}
+                </span>
                 {variation.description ? (
                   <span className="text-muted-foreground text-xs">
-                    {variation.description}
+                    {renderLabel(variation.description)}
                   </span>
                 ) : null}
               </div>

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -744,6 +744,7 @@ function PlumixBlocksTab({
   patterns,
 }: PlumixBlocksTabProps): ReactElement {
   const puck = usePuck();
+  const renderLabel = useLabel();
   const [pendingPick, setPendingPick] = useState<PendingPick | undefined>();
   const entries = useMemo(() => {
     const eligible: BlockSpec[] = [];
@@ -850,7 +851,7 @@ function PlumixBlocksTab({
       />
       {pendingPick ? (
         <BlockScopePicker
-          blockTitle={pendingPick.entry.title}
+          blockTitle={renderLabel(pendingPick.entry.title)}
           parentBlockName={pendingPick.entry.name}
           variations={pendingPick.variations}
           blocks={registry}

--- a/packages/admin/src/editor/InsertableEntryRow.test.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import type { InsertableBlockEntry } from "@plumix/blocks";
 import { createBlockRegistry, createPatternRegistry } from "@plumix/blocks";
 
+import { renderWithI18n } from "../../test/render-with-i18n.js";
 import { InsertableEntryRow } from "./InsertableEntryRow.js";
 import { installFakeIntersectionObserver } from "./intersection-observer-harness.js";
 
@@ -28,7 +29,7 @@ describe("InsertableEntryRow", () => {
       slug: "bullet",
       title: "Bulleted tabs",
     };
-    render(
+    renderWithI18n(
       <>
         <InsertableEntryRow
           entry={listBullet}
@@ -59,7 +60,7 @@ describe("InsertableEntryRow", () => {
       title: "Heading",
       icon: "Heading",
     };
-    render(
+    renderWithI18n(
       <InsertableEntryRow
         entry={entry}
         blocks={blocks}
@@ -84,7 +85,7 @@ describe("InsertableEntryRow", () => {
       title: "Bulleted list",
       attrs: { variant: "bullet" },
     };
-    render(
+    renderWithI18n(
       <InsertableEntryRow
         entry={entry}
         blocks={blocks}

--- a/packages/admin/src/editor/InsertableEntryRow.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { useLabel } from "@/lib/use-label.js";
 
 import type {
   BlockRegistry,
@@ -25,6 +26,7 @@ export function InsertableEntryRow({
   patterns,
   onClick,
 }: InsertableEntryRowProps): ReactElement {
+  const renderLabel = useLabel();
   if (!isVariation(entry)) {
     return (
       <button
@@ -34,7 +36,7 @@ export function InsertableEntryRow({
         onClick={onClick}
       >
         <BlockIcon name={entry.icon} />
-        <span className="truncate">{entry.title}</span>
+        <span className="truncate">{renderLabel(entry.title)}</span>
       </button>
     );
   }
@@ -74,7 +76,7 @@ export function InsertableEntryRow({
       </LazyMount>
       <span className="flex items-center gap-2 truncate">
         <BlockIcon name={entry.icon} />
-        <span className="truncate">{entry.title}</span>
+        <span className="truncate">{renderLabel(entry.title)}</span>
       </span>
     </div>
   );

--- a/packages/admin/src/editor/PatternRefPreview.tsx
+++ b/packages/admin/src/editor/PatternRefPreview.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { createContext, useCallback, useContext, useMemo } from "react";
+import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
 import { usePuck } from "@puckeditor/core";
 import { Link, Unlink } from "lucide-react";
@@ -38,6 +39,7 @@ interface PatternRefPreviewProps {
 export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
   const ctx = useContext(PatternRefContext);
   const puck = usePuck();
+  const renderLabel = useLabel();
   const slug = props.slug ?? "";
   const pattern = ctx?.patterns.get(slug);
 
@@ -96,7 +98,7 @@ export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
     >
       <div className="text-foreground flex items-center gap-2 bg-blue-500/10 px-3 py-1 text-xs">
         <Link className="h-3 w-3" aria-hidden />
-        <span className="flex-1">{pattern.title}</span>
+        <span className="flex-1">{renderLabel(pattern.title)}</span>
         <button
           type="button"
           onClick={handleCopySlug}

--- a/packages/admin/src/editor/PatternsSection.tsx
+++ b/packages/admin/src/editor/PatternsSection.tsx
@@ -103,7 +103,7 @@ export function PatternsSection({
                       />
                     </div>
                   </LazyMount>
-                  <span className="truncate">{entry.title}</span>
+                  <span className="truncate">{label(entry.title)}</span>
                 </div>
               </li>
             ))}

--- a/packages/admin/src/editor/SlashMenuPanel.tsx
+++ b/packages/admin/src/editor/SlashMenuPanel.tsx
@@ -14,6 +14,7 @@ import { Trans } from "@lingui/react";
 import { Command as CommandPrimitive } from "cmdk";
 
 import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
+import type { Label } from "@plumix/core/i18n";
 
 import type { SlashMenuItem } from "./slash-menu-items.js";
 import { entryKey, isVariation } from "./is-variation.js";
@@ -52,6 +53,7 @@ function renderMember(
   onSelect: (item: SlashMenuItem) => void,
   blocks: BlockRegistry,
   patterns: PatternRegistry,
+  renderLabel: (label: Label) => string,
 ): ReactElement {
   if (item.kind === "pattern") {
     const { entry } = item;
@@ -80,7 +82,7 @@ function renderMember(
             data-testid={`slash-menu-pattern-card-placeholder-${entry.name}`}
           />
         )}
-        <span className="text-sm font-medium">{entry.title}</span>
+        <span className="text-sm font-medium">{renderLabel(entry.title)}</span>
       </CommandItem>
     );
   }
@@ -111,7 +113,7 @@ function renderMember(
             />
           </div>
         </LazyMount>
-        <span className="text-sm font-medium">{entry.title}</span>
+        <span className="text-sm font-medium">{renderLabel(entry.title)}</span>
       </CommandItem>
     );
   }
@@ -124,10 +126,10 @@ function renderMember(
       className="flex items-start gap-2"
     >
       <span className="flex min-w-0 flex-col">
-        <span className="text-sm font-medium">{entry.title}</span>
+        <span className="text-sm font-medium">{renderLabel(entry.title)}</span>
         {entry.description ? (
           <span className="text-muted-foreground text-xs">
-            {entry.description}
+            {renderLabel(entry.description)}
           </span>
         ) : null}
       </span>
@@ -189,7 +191,7 @@ export function SlashMenuPanel({
             data-testid={`slash-menu-group-${category}`}
           >
             {members.map((item) =>
-              renderMember(item, onSelect, blocks, patterns),
+              renderMember(item, onSelect, blocks, patterns, label),
             )}
           </CommandGroup>
         ))}

--- a/packages/admin/src/editor/StarterModal.test.tsx
+++ b/packages/admin/src/editor/StarterModal.test.tsx
@@ -43,7 +43,7 @@ const cta: PatternManifestEntry = {
 
 describe("StarterModal", () => {
   test("renders nothing when there are no candidates", () => {
-    const { container } = render(
+    const { container } = renderWithI18n(
       <StarterModal
         candidates={[]}
         blocks={blocks}

--- a/packages/admin/src/editor/StarterModal.tsx
+++ b/packages/admin/src/editor/StarterModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog.js";
+import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
 
 import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
@@ -29,6 +30,7 @@ export function StarterModal({
   onSelect,
   onDismiss,
 }: StarterModalProps): ReactElement | null {
+  const renderLabel = useLabel();
   if (candidates.length === 0) return null;
 
   return (
@@ -80,7 +82,9 @@ export function StarterModal({
                     patterns={patterns}
                   />
                 </div>
-                <span className="text-sm font-medium">{entry.title}</span>
+                <span className="text-sm font-medium">
+                  {renderLabel(entry.title)}
+                </span>
               </div>
             </li>
           ))}

--- a/packages/admin/src/editor/available-transforms.ts
+++ b/packages/admin/src/editor/available-transforms.ts
@@ -1,4 +1,5 @@
 import type { BlockRegistry, BlockShortcutMode } from "@plumix/blocks";
+import type { Label } from "@plumix/core/i18n";
 import { resolveBlockTransforms } from "@plumix/blocks";
 
 export interface TransformOption {
@@ -8,7 +9,7 @@ export interface TransformOption {
   // them distinct.
   readonly key: string;
   readonly targetName: string;
-  readonly targetTitle: string;
+  readonly targetTitle: Label;
   readonly mapAttrs?: (
     attrs: Readonly<Record<string, unknown>>,
   ) => Readonly<Record<string, unknown>>;

--- a/packages/admin/src/editor/block-adapter.ts
+++ b/packages/admin/src/editor/block-adapter.ts
@@ -1,9 +1,11 @@
 import type { Config } from "@puckeditor/core";
 import type { Extensions } from "@tiptap/core";
 import { createElement, Fragment } from "react";
+import { i18n } from "@lingui/core";
 
 import type { BlockSpec } from "@plumix/blocks";
 import { DEFAULT_BLOCK_CONTEXT } from "@plumix/blocks";
+import { resolveLabel } from "@plumix/core/i18n";
 
 import { translateFields } from "./field-type-translator.js";
 import { PatternRefPreview } from "./PatternRefPreview.js";
@@ -22,7 +24,7 @@ export function blockSpecsToPuckComponents(
   for (const spec of specs) {
     if (spec.name === PATTERN_REF_BLOCK) {
       out[spec.name] = {
-        label: spec.title ?? spec.name,
+        label: spec.title ? resolveLabel(spec.title, i18n) : spec.name,
         fields: spec.inputs ? translateFields(spec.inputs, options) : {},
         defaultProps: spec.defaults,
         render: (props) =>
@@ -34,7 +36,7 @@ export function blockSpecsToPuckComponents(
       continue;
     }
     out[spec.name] = {
-      label: spec.title ?? spec.name,
+      label: spec.title ? resolveLabel(spec.title, i18n) : spec.name,
       fields: spec.inputs ? translateFields(spec.inputs, options) : {},
       defaultProps: spec.defaults,
       render: (props) =>

--- a/packages/admin/src/editor/block-identity.ts
+++ b/packages/admin/src/editor/block-identity.ts
@@ -1,10 +1,11 @@
 import type { BlockSpec } from "@plumix/blocks";
+import type { Label } from "@plumix/core/i18n";
 import { resolveActiveVariation } from "@plumix/blocks";
 
 export interface BlockIdentity {
-  readonly title: string;
+  readonly title: Label;
   readonly icon?: string;
-  readonly description?: string;
+  readonly description?: Label;
 }
 
 // Variations override the parent block's display identity on instances

--- a/packages/admin/src/editor/field-type-translator.ts
+++ b/packages/admin/src/editor/field-type-translator.ts
@@ -4,6 +4,7 @@ import { i18n } from "@lingui/core";
 import { defineMessage } from "@lingui/core/macro";
 
 import type { BlockInput } from "@plumix/blocks";
+import { resolveLabel } from "@plumix/core/i18n";
 
 const YES_LABEL = defineMessage({
   id: "fieldTypes.boolean.yes",
@@ -26,27 +27,32 @@ export function translateField(
   input: BlockInput,
   options: TranslateFieldOptions = {},
 ): Fields[string] {
+  // Puck's Fields shape is `label: string`. Resolve at adapter-
+  // construction time (per route-module evaluation) — `language-card.tsx`
+  // calls `window.location.reload()` on locale change, reseating the
+  // route module and re-resolving every label.
+  const label = input.label ? resolveLabel(input.label, i18n) : undefined;
   switch (input.type) {
     case "text":
     case "textarea":
     case "number":
-      return { type: input.type, label: input.label };
+      return { type: input.type, label };
     case "select":
     case "radio":
       return {
         type: input.type,
-        label: input.label,
+        label,
         options: (input.options ?? []).map((opt) => ({
-          label: opt.label,
+          label: resolveLabel(opt.label, i18n),
           value: opt.value,
         })),
       };
     case "slot":
-      return { type: "slot", label: input.label };
+      return { type: "slot", label };
     case "richtext":
       return {
         type: "richtext",
-        label: input.label,
+        label,
         // contentEditable: true lets authors type directly on the canvas
         // (Puck's inline-edit mode); without it the field is sidebar-only,
         // which is the wrong UX for a paragraph body.
@@ -61,7 +67,7 @@ export function translateField(
       // text input that returns strings the block's `=== true` check rejects.
       return {
         type: "radio",
-        label: input.label,
+        label,
         options: [
           { label: i18n._(YES_LABEL), value: true },
           { label: i18n._(NO_LABEL), value: false },
@@ -76,7 +82,7 @@ export function translateField(
           `[plumix:admin] field-type-translator: unknown input type "${input.type}" — falling back to text. Register the type via ctx.registerFieldType or pick a Puck-native type.`,
         );
       }
-      return { type: "text", label: input.label };
+      return { type: "text", label };
   }
 }
 

--- a/packages/admin/src/editor/slash-menu-items.test.ts
+++ b/packages/admin/src/editor/slash-menu-items.test.ts
@@ -49,6 +49,25 @@ describe("resolveSlashMenuItems", () => {
     ).toBe("layout");
   });
 
+  test("matches a descriptor title via its source-locale message", () => {
+    // Slash-menu search keys on `labelSourceText(entry.title)` so plugin
+    // authors can pass `MessageDescriptor` titles without breaking the
+    // matcher. Search stays locale-stable regardless of UI locale.
+    const registry = createBlockRegistry([
+      spec({
+        name: "acme/hero",
+        title: { id: "block.acme.hero.title", message: "Hero banner" },
+      }),
+    ]);
+
+    const items = resolveSlashMenuItems(registry, {
+      capabilities: new Set(),
+      query: "hero",
+    });
+
+    expect(items.map((i) => i.entry.name)).toEqual(["acme/hero"]);
+  });
+
   test("matches blocks by title (substring) and name (substring), case-insensitive", () => {
     const registry = createBlockRegistry([
       spec({ name: "core/heading", title: "Heading" }),

--- a/packages/admin/src/editor/slash-menu-items.ts
+++ b/packages/admin/src/editor/slash-menu-items.ts
@@ -5,6 +5,7 @@ import type {
 } from "@plumix/blocks";
 import type { PatternManifestEntry } from "@plumix/core/manifest";
 import { expandBlockVariations } from "@plumix/blocks";
+import { labelSourceText } from "@plumix/core/i18n";
 
 import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 
@@ -72,10 +73,19 @@ function isInsertableForCapabilities(
 // surface category as an alias today. Prefix semantics mirror the
 // keyword scorer so typing "her" matches a pattern with category
 // "hero", not just the exact slug.
+// Search keys the source-locale (English) representation regardless of
+// UI locale. `labelSourceText` returns `message` for descriptors and
+// the string itself for plain strings — keeps matching predictable.
 function matchScore(item: SlashMenuItem, needle: string): number {
   const { entry } = item;
-  if (entry.title.toLowerCase().includes(needle)) return TITLE_MATCH;
-  if (entry.keywords?.some((k) => k.toLowerCase().startsWith(needle))) {
+  if (labelSourceText(entry.title).toLowerCase().includes(needle)) {
+    return TITLE_MATCH;
+  }
+  if (
+    entry.keywords?.some((k) =>
+      labelSourceText(k).toLowerCase().startsWith(needle),
+    )
+  ) {
     return KEYWORD_MATCH;
   }
   if (

--- a/packages/blocks/src/block-registry.test.ts
+++ b/packages/blocks/src/block-registry.test.ts
@@ -78,4 +78,39 @@ describe("defineBlock", () => {
 
     expect(spec.defaults).toEqual({ level: 2, text: "Untitled" });
   });
+
+  test("text slots accept MessageDescriptor for translation", () => {
+    // The four BlockSpec text slots (`title`, `description`,
+    // `placeholder`, `keywords[]`) and BlockVariation (`title`,
+    // `description`, `keywords[]`) widen to `Label` so plugin authors
+    // can pass Lingui descriptors. String callers still work
+    // (backwards-compat through the union).
+    const spec = defineBlock({
+      name: "acme/hero",
+      title: { id: "block.hero.title", message: "Hero" },
+      description: { id: "block.hero.description", message: "A hero block." },
+      keywords: [
+        "banner",
+        { id: "block.hero.kw.cta", message: "call to action" },
+      ],
+      render: noopRender,
+      variations: [
+        {
+          slug: "split",
+          title: { id: "block.hero.split.title", message: "Split Hero" },
+          description: {
+            id: "block.hero.split.description",
+            message: "Two columns.",
+          },
+          keywords: ["split"],
+        },
+      ],
+    });
+
+    expect(spec.title).toEqual({ id: "block.hero.title", message: "Hero" });
+    expect(spec.variations?.[0]?.title).toEqual({
+      id: "block.hero.split.title",
+      message: "Split Hero",
+    });
+  });
 });

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -1,17 +1,18 @@
 import type { ReactNode } from "react";
 
+import type { Label } from "./i18n-label.js";
 import type { BlockLoaderRecord } from "./loaders.js";
 import type { BlockNode, BlockNodeComponent } from "./render-block-tree.js";
 
 export interface BlockInputOption {
-  readonly label: string;
+  readonly label: Label;
   readonly value: string | number | boolean;
 }
 
 export interface BlockInput {
   readonly name: string;
   readonly type: string;
-  readonly label?: string;
+  readonly label?: Label;
   readonly options?: readonly BlockInputOption[];
 }
 
@@ -31,10 +32,10 @@ export type BlockVariationIsActive =
 
 export interface BlockVariation {
   readonly slug: string;
-  readonly title: string;
+  readonly title: Label;
   readonly icon?: string;
-  readonly description?: string;
-  readonly keywords?: readonly string[];
+  readonly description?: Label;
+  readonly keywords?: readonly Label[];
   readonly attrs?: Readonly<Record<string, unknown>>;
   // Default body for the parent block's conventional `content` slot.
   // Inserted as a deep-cloned, ID-rewritten tree — source remains
@@ -96,9 +97,9 @@ export interface BlockSpec<
   Loaders extends BlockLoaderRecord = BlockLoaderRecord,
 > {
   readonly name: string;
-  readonly title?: string;
-  readonly description?: string;
-  readonly keywords?: readonly string[];
+  readonly title?: Label;
+  readonly description?: Label;
+  readonly keywords?: readonly Label[];
   readonly icon?: string;
   readonly category?: string;
   readonly inserter?: boolean;

--- a/packages/blocks/src/expand-block-variations.ts
+++ b/packages/blocks/src/expand-block-variations.ts
@@ -1,14 +1,15 @@
 import type { BlockSpec, BlockVariationExample } from "./block-registry.js";
+import type { Label } from "./i18n-label.js";
 import type { BlockNode } from "./render-block-tree.js";
 
 export interface InsertableBlockEntry {
   readonly name: string;
   readonly slug: string;
-  readonly title: string;
-  readonly description?: string;
+  readonly title: Label;
+  readonly description?: Label;
   readonly category?: string;
   readonly icon?: string;
-  readonly keywords?: readonly string[];
+  readonly keywords?: readonly Label[];
   readonly attrs?: Readonly<Record<string, unknown>>;
   // Default body for the parent block's conventional `content` slot.
   // Caller deep-clones + ID-rewrites before merging into a block instance.

--- a/packages/blocks/src/heading/index.tsx
+++ b/packages/blocks/src/heading/index.tsx
@@ -3,17 +3,28 @@ import { createElement } from "react";
 
 import { defineBlock } from "../block-registry.js";
 
+// Proving-ground conversion to MessageDescriptor literals. Admin's
+// adapter resolves `Label` slots via `resolveLabel(label, i18n)` at
+// adapter-construction time; locale changes reload the route so a single
+// resolution per route-module evaluation is sufficient. Catalog extraction
+// from `@plumix/blocks` is a follow-up — until wired, ids fall back to
+// `descriptor.message` in every locale. Other core blocks remain on plain
+// strings until they need to translate.
 export const headingBlock = defineBlock({
   name: "core/heading",
-  title: "Heading",
+  title: { id: "block.core.heading.title", message: "Heading" },
   icon: "Heading",
   category: "text",
   inputs: [
-    { name: "text", type: "text", label: "Text" },
+    {
+      name: "text",
+      type: "text",
+      label: { id: "block.core.heading.input.text", message: "Text" },
+    },
     {
       name: "level",
       type: "select",
-      label: "Level",
+      label: { id: "block.core.heading.input.level", message: "Level" },
       options: [
         { label: "H1", value: 1 },
         { label: "H2", value: 2 },

--- a/packages/blocks/src/i18n-label.ts
+++ b/packages/blocks/src/i18n-label.ts
@@ -1,0 +1,13 @@
+// Structurally compatible with `@plumix/core/i18n`'s `Label` —
+// `@plumix/core` depends on `@plumix/blocks`, not the other way around
+// (see `loaders.ts`), so this package can't import from it. Mirrors the
+// extractor-visible fields of Lingui's `MessageDescriptor` (id, message,
+// comment); plugin authors pass core's `Label` here and TS structural
+// typing accepts the assignment.
+interface MessageDescriptorLike {
+  readonly id: string;
+  readonly message?: string;
+  readonly comment?: string;
+}
+
+export type Label = string | MessageDescriptorLike;

--- a/packages/blocks/src/pattern-registry.ts
+++ b/packages/blocks/src/pattern-registry.ts
@@ -1,4 +1,5 @@
 import type { BlockRegistry } from "./block-registry.js";
+import type { Label } from "./i18n-label.js";
 import type { BlockNode } from "./render-block-tree.js";
 import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
 import { commitBlockVariations } from "./commit-block-variations.js";
@@ -51,9 +52,9 @@ export type PatternTarget = "post-content";
 
 export interface BlockPattern {
   readonly name: string;
-  readonly title: string;
+  readonly title: Label;
   readonly category?: keyof PatternCategoryRegistry;
-  readonly keywords?: readonly string[];
+  readonly keywords?: readonly Label[];
   // Defaults to "copy" when unset — the inserter splices a deep-cloned
   // body. "reference" inserts a single `core/pattern-ref` node the
   // walker resolves at render.

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1605,11 +1605,11 @@ export interface FieldTypeManifestEntry {
 
 export interface BlockManifestEntry {
   readonly name: string;
-  readonly title: string;
+  readonly title: Label;
   readonly category?: string;
   readonly icon?: string;
-  readonly description?: string;
-  readonly keywords?: readonly string[];
+  readonly description?: Label;
+  readonly keywords?: readonly Label[];
   readonly inserter?: boolean;
   readonly variations?: readonly BlockVariation[];
 }
@@ -1627,9 +1627,9 @@ export interface MarkManifestEntry {
 
 export interface PatternManifestEntry {
   readonly name: string;
-  readonly title: string;
+  readonly title: Label;
   readonly category?: string;
-  readonly keywords?: readonly string[];
+  readonly keywords?: readonly Label[];
   // `buildManifest` always populates this with the spec's value or
   // `"copy"`; consumers that read raw manifest fixtures may still see
   // `undefined`.


### PR DESCRIPTION
Plugin authors can now pass `MessageDescriptor` literals (not just
strings) into the user-visible text slots on `BlockSpec`, `BlockVariation`,
`BlockInput`, `BlockInputOption`, `BlockPattern`, and the manifest
projections that ship them to admin. The `Label` union (`string |
MessageDescriptor`) means existing string callers keep working — this is
a non-breaking widening.

**Slot inventory**

- `@plumix/blocks` `BlockSpec`: `title`, `description`, `keywords`
- `BlockVariation`: `title`, `description`, `keywords`
- `BlockInput.label`, `BlockInputOption.label`
- `BlockPattern`: `title`, `keywords`
- `@plumix/core` manifest `BlockManifestEntry` + `PatternManifestEntry`
  mirror the wire shape

`@plumix/blocks` defines a local structural `Label` (mirroring core's
shape) because `@plumix/core` depends on `@plumix/blocks`, not vice
versa — TS structural typing accepts assignments in both directions.

**Admin consumer pattern**

- Render-time sites (`BlockActionsPanel`, `BlockScopePicker`,
  `EditorLayout`, `InsertableEntryRow`, `PatternRefPreview`,
  `PatternsSection`, `SlashMenuPanel`, `StarterModal`) wrap each `Label`
  with `useLabel()` to flatten at render.
- Adapter-time sites (`block-adapter`, `field-type-translator`) resolve
  via `resolveLabel(label, i18n)` at route-module evaluation — locale
  switches reload the route so a single resolution per session is
  sufficient.
- Search-time keys (`slash-menu-items`) use `labelSourceText` so search
  stays locale-stable regardless of UI locale, matching the convention
  in Webflow / Gutenberg.

**Proving ground**

`headingBlock` converts its `title` + `text` / `level` input labels to
descriptor literals as the canary. Catalog extraction from
`@plumix/blocks` is a follow-up; until wired, ids fall back to
`descriptor.message` in every locale. Other core blocks stay on plain
strings until they need to translate.

Fixes #765