### PR TITLE
feat: add translator comments to two missed api-tokens placeholders

### DIFF
--- a/packages/admin/src/components/profile/api-tokens-card.tsx
+++ b/packages/admin/src/components/profile/api-tokens-card.tsx
@@ -456,6 +456,7 @@ function ApiTokensCardView({
                 id="apiTokens.revoke.title"
                 message='Revoke "{name}"?'
                 values={{ name: revokeTarget?.name ?? "" }}
+                comment="name: the user-chosen token nickname (e.g. 'CI deploy key')"
               />
             </AlertDialogTitle>
             <AlertDialogDescription>
@@ -743,6 +744,7 @@ function SecretShownDialog({
               id="apiTokens.secret.title"
               message='Token "{name}" minted'
               values={{ name }}
+              comment="name: the user-chosen token nickname (e.g. 'CI deploy key')"
             />
           </AlertDialogTitle>
           <AlertDialogDescription>


### PR DESCRIPTION
Two `<Trans>` calls in `api-tokens-card.tsx` carry an ICU placeholder
(`Revoke "{name}"?` and `Token "{name}" minted`) but missed the `comment=`
prop in #782's sweep — the audit-verify script flagged them as the only
real misses (the other three flagged sites were test fixtures using a
`message={PLURAL}` variable).

Both placeholders interpolate the user-chosen token nickname; the comment
matches the established convention from #782.

Refs #767