### PR TITLE
refactor(eslint): extract pluginConfig helper for first-party plugin packages

### DIFF
--- a/packages/plugins/audit-log/eslint.config.ts
+++ b/packages/plugins/audit-log/eslint.config.ts
@@ -1,15 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
-import { i18nConfig } from "@plumix/eslint-config/i18n";
-import { reactConfig } from "@plumix/eslint-config/react";
+import { pluginConfig } from "@plumix/eslint-config/plugin";
 
-export default defineConfig(
-  baseConfig,
-  reactConfig,
-  noInternalImports,
-  i18nConfig,
-  // Compiled Lingui catalogs ship with /* eslint-disable */ headers;
-  // tripping the unused-disable check on every build adds no signal.
-  { ignores: ["locales/**"] },
-);
+export default defineConfig(...pluginConfig());

--- a/packages/plugins/blog/eslint.config.ts
+++ b/packages/plugins/blog/eslint.config.ts
@@ -1,13 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
-import { reactConfig } from "@plumix/eslint-config/react";
+import { pluginConfig } from "@plumix/eslint-config/plugin";
 
-export default defineConfig(
-  baseConfig,
-  reactConfig,
-  noInternalImports,
-  // Compiled Lingui catalogs ship with /* eslint-disable */ headers;
-  // tripping the unused-disable check on every build adds no signal.
-  { ignores: ["locales/**"] },
-);
+export default defineConfig(...pluginConfig());

--- a/packages/plugins/media/eslint.config.ts
+++ b/packages/plugins/media/eslint.config.ts
@@ -1,15 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
-import { i18nConfig } from "@plumix/eslint-config/i18n";
-import { reactConfig } from "@plumix/eslint-config/react";
+import { pluginConfig } from "@plumix/eslint-config/plugin";
 
-export default defineConfig(
-  baseConfig,
-  reactConfig,
-  noInternalImports,
-  i18nConfig,
-  // Compiled Lingui catalogs ship with /* eslint-disable */ headers;
-  // tripping the unused-disable check on every build adds no signal.
-  { ignores: ["locales/**"] },
-);
+export default defineConfig(...pluginConfig());

--- a/packages/plugins/menu/eslint.config.ts
+++ b/packages/plugins/menu/eslint.config.ts
@@ -1,15 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
-import { i18nConfig } from "@plumix/eslint-config/i18n";
-import { reactConfig } from "@plumix/eslint-config/react";
+import { pluginConfig } from "@plumix/eslint-config/plugin";
 
-export default defineConfig(
-  baseConfig,
-  reactConfig,
-  noInternalImports,
-  i18nConfig,
-  // Compiled Lingui catalogs ship with /* eslint-disable */ headers;
-  // tripping the unused-disable check on every build adds no signal.
-  { ignores: ["locales/**"] },
-);
+export default defineConfig(...pluginConfig());

--- a/packages/plugins/pages/eslint.config.ts
+++ b/packages/plugins/pages/eslint.config.ts
@@ -1,15 +1,5 @@
 import { defineConfig } from "eslint/config";
 
-import { baseConfig, noInternalImports } from "@plumix/eslint-config/base";
-import { i18nConfig } from "@plumix/eslint-config/i18n";
-import { reactConfig } from "@plumix/eslint-config/react";
+import { pluginConfig } from "@plumix/eslint-config/plugin";
 
-export default defineConfig(
-  baseConfig,
-  reactConfig,
-  noInternalImports,
-  i18nConfig,
-  // Compiled Lingui catalogs ship with /* eslint-disable */ headers;
-  // tripping the unused-disable check on every build adds no signal.
-  { ignores: ["locales/**"] },
-);
+export default defineConfig(...pluginConfig());

--- a/tooling/eslint/package.json
+++ b/tooling/eslint/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./base": "./base.ts",
     "./i18n": "./i18n.ts",
+    "./plugin": "./plugin.ts",
     "./react": "./react.ts"
   },
   "scripts": {

--- a/tooling/eslint/plugin.ts
+++ b/tooling/eslint/plugin.ts
@@ -1,0 +1,23 @@
+import type { Linter } from "eslint";
+
+import { baseConfig, noInternalImports } from "./base.js";
+import { i18nConfig } from "./i18n.js";
+import { reactConfig } from "./react.js";
+
+/**
+ * Shared ESLint flat-config bundle for first-party plumix plugin
+ * packages. Composes `baseConfig + reactConfig + noInternalImports +
+ * i18nConfig + locales-ignore` so consumer files collapse to a single
+ * spread.
+ */
+export function pluginConfig(): readonly Linter.Config[] {
+  return [
+    ...baseConfig,
+    ...reactConfig,
+    ...noInternalImports,
+    ...i18nConfig,
+    // Compiled Lingui catalogs ship with /* eslint-disable */ headers;
+    // tripping the unused-disable check on every build adds no signal.
+    { ignores: ["locales/**"] },
+  ];
+}


### PR DESCRIPTION
Five plugin `eslint.config.ts` files were nearly byte-identical 5-arg
`defineConfig` invocations. Extracts a single `pluginConfig()` from
`@plumix/eslint-config/plugin` that composes `baseConfig + reactConfig +
noInternalImports + i18nConfig + locales-ignore`; consumers collapse to
`defineConfig(...pluginConfig())`.

**Blog's `{ i18n: false }` opt-out was stale.** Empirically verified
(senpai's review): blog passes lint clean with `i18nConfig` enabled —
the config only carries macro-misuse rules (`no-trans-inside-trans`,
`no-expression-in-message`, `no-single-variables-to-translate`,
`no-single-tag-to-translate`); `no-unlocalized-strings` lives in
`i18nStrictConfig` which plugins don't extend. Dropping the option
keeps the helper at its minimum-viable shape per
[[no-safety-nets-unasked]] — re-add later if a real divergence appears.

Addresses simplifier #4 from #788.