### PR TITLE
feat: add pre-auth locale dropdown to login form

### DIFF
--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -1658,6 +1658,11 @@ msgid "userEdit.delete.reassign.keepAsIs"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/login-locale-switcher.tsx
+msgid "login.locale.aria"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/locale-switcher.tsx
 msgid "profile.language.aria"
 msgstr ""
@@ -2374,6 +2379,7 @@ msgstr ""
 msgid "profile.sessions.revoke.button"
 msgstr ""
 
+#. name: the user-chosen token nickname (e.g. 'CI deploy key')
 #. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.revoke.title"
@@ -3124,6 +3130,7 @@ msgstr ""
 msgid "editor.revisions.diff.field.title"
 msgstr ""
 
+#. name: the user-chosen token nickname (e.g. 'CI deploy key')
 #. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.secret.title"

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -1685,6 +1685,11 @@ msgid "userEdit.delete.reassign.keepAsIs"
 msgstr "Keep entries as-is (none to reassign)"
 
 #. js-lingui-explicit-id
+#: src/components/login-locale-switcher.tsx
+msgid "login.locale.aria"
+msgstr "Language"
+
+#. js-lingui-explicit-id
 #: src/components/locale-switcher.tsx
 msgid "profile.language.aria"
 msgstr "Language"
@@ -2411,6 +2416,7 @@ msgstr "Revoke"
 msgid "profile.sessions.revoke.button"
 msgstr "Revoke"
 
+#. name: the user-chosen token nickname (e.g. 'CI deploy key')
 #. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.revoke.title"
@@ -3186,6 +3192,7 @@ msgstr "Title"
 msgid "editor.revisions.diff.field.title"
 msgstr "Title"
 
+#. name: the user-chosen token nickname (e.g. 'CI deploy key')
 #. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.secret.title"

--- a/packages/admin/src/components/login-locale-switcher.test.tsx
+++ b/packages/admin/src/components/login-locale-switcher.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+
+import { renderWithI18n } from "../../test/render-with-i18n.js";
+import { LoginLocaleSwitcher } from "./login-locale-switcher.js";
+
+afterEach(() => cleanup());
+
+const enOnlyManifest: PlumixManifest = {
+  i18n: {
+    defaultLocale: "en",
+    locales: [
+      { code: "en", label: "English", direction: "ltr", enabled: true },
+    ],
+  },
+};
+
+const enUkManifest: PlumixManifest = {
+  i18n: {
+    defaultLocale: "en",
+    locales: [
+      { code: "en", label: "English", direction: "ltr", enabled: true },
+      { code: "uk", label: "Українська", direction: "ltr", enabled: true },
+    ],
+  },
+};
+
+describe("LoginLocaleSwitcher", () => {
+  test("renders nothing when only one locale is enabled", () => {
+    // Single-locale installs don't need a switcher; rendering one would
+    // be visual noise on the login form.
+    const { container } = renderWithI18n(
+      <LoginLocaleSwitcher
+        currentCode="en"
+        manifest={enOnlyManifest}
+        onSelect={() => undefined}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId("login-locale-switcher-trigger")).toBeNull();
+  });
+
+  test("renders a trigger labelled with the current locale", () => {
+    renderWithI18n(
+      <LoginLocaleSwitcher
+        currentCode="uk"
+        manifest={enUkManifest}
+        onSelect={() => undefined}
+      />,
+    );
+    const trigger = screen.getByTestId("login-locale-switcher-trigger");
+    expect(trigger.textContent).toContain("Українська");
+  });
+
+  test("calls onSelect with the chosen locale code when the user picks an option", async () => {
+    const onSelect = vi.fn();
+    renderWithI18n(
+      <LoginLocaleSwitcher
+        currentCode="en"
+        manifest={enUkManifest}
+        onSelect={onSelect}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("login-locale-switcher-trigger"));
+    await userEvent.click(
+      screen.getByTestId("login-locale-switcher-option-uk"),
+    );
+    expect(onSelect).toHaveBeenCalledWith("uk");
+  });
+});

--- a/packages/admin/src/components/login-locale-switcher.tsx
+++ b/packages/admin/src/components/login-locale-switcher.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select.js";
+import { useLingui } from "@lingui/react";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+
+interface LoginLocaleSwitcherProps {
+  readonly currentCode: string;
+  readonly manifest: PlumixManifest;
+  readonly onSelect: (code: string) => void;
+}
+
+/** Pre-auth locale picker shown beneath the login form. Pure
+ *  presentational — the route wires the URL `?lang=` ↔ `currentCode`
+ *  via `useSearch` / `useNavigate`. No cookie, no localStorage per the
+ *  design constraint that pre-auth state can't fragment the public
+ *  cache. The post-auth equivalent (`<LocaleSwitcher>`) ships the same
+ *  shape but persists to `user.meta.locale` via RPC instead. */
+export function LoginLocaleSwitcher({
+  currentCode,
+  manifest,
+  onSelect,
+}: LoginLocaleSwitcherProps): ReactNode {
+  const { i18n } = useLingui();
+  const locales = manifest.i18n?.locales ?? [];
+  if (locales.length <= 1) return null;
+  return (
+    <Select value={currentCode} onValueChange={onSelect}>
+      <SelectTrigger
+        data-testid="login-locale-switcher-trigger"
+        aria-label={i18n._("login.locale.aria", undefined, {
+          message: "Language",
+        })}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {locales.map((l) => (
+          <SelectItem
+            key={l.code}
+            value={l.code}
+            data-testid={`login-locale-switcher-option-${l.code}`}
+          >
+            {l.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/packages/admin/src/routes/_auth/-locale-param.test.ts
+++ b/packages/admin/src/routes/_auth/-locale-param.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  buildLocaleCookie,
+  nextSearchForLang,
+  writeLocaleCookie,
+} from "./-locale-param.js";
+
+describe("nextSearchForLang", () => {
+  test("sets `?lang=` to the chosen code", () => {
+    expect(nextSearchForLang({}, "uk")).toEqual({ lang: "uk" });
+  });
+
+  test("sets `?lang=` even when the chosen code is the site default", () => {
+    // The user's currently-rendered locale may have come from
+    // Accept-Language (the admin shell's 4th-tier fallback), so the
+    // site default isn't necessarily what they see. Picking "en"
+    // explicitly must pin the URL or the next reload reverts to
+    // whatever Accept-Language resolves.
+    expect(nextSearchForLang({ lang: "uk" }, "en")).toEqual({ lang: "en" });
+  });
+
+  test("preserves sibling query params across changes", () => {
+    // The login route carries `oauth_error`, `magic_link_error`,
+    // `email_change_success` and similar; a locale flip must not
+    // strip them.
+    expect(
+      nextSearchForLang(
+        { lang: "uk", oauth_error: "access_denied", redirect_to: "/" },
+        "en",
+      ),
+    ).toEqual({
+      lang: "en",
+      oauth_error: "access_denied",
+      redirect_to: "/",
+    });
+  });
+});
+
+describe("buildLocaleCookie", () => {
+  test("serializes the full cookie attribute set without Secure", () => {
+    // Matches the post-auth `user.setLocale` server writer; a drift
+    // means pre-auth picks and post-auth picks would write different
+    // cookies and break each other's persistence.
+    expect(buildLocaleCookie("uk", false)).toBe(
+      "plumix_locale=uk; Path=/_plumix/admin/; Max-Age=31536000; SameSite=Lax",
+    );
+  });
+
+  test("appends Secure when called over HTTPS", () => {
+    expect(buildLocaleCookie("uk", true)).toBe(
+      "plumix_locale=uk; Path=/_plumix/admin/; Max-Age=31536000; SameSite=Lax; Secure",
+    );
+  });
+
+  // Note: `code` is written raw to match the server-side builder
+  // (`packages/core/src/rpc/procedures/user/set-locale.ts:47-56`). The
+  // dropdown is the validation seam — only registry-matched codes reach
+  // either builder, so smuggling defense lives upstream.
+});
+
+describe("writeLocaleCookie", () => {
+  // jsdom respects the cookie `Path` attribute, so `document.cookie` at
+  // the test's location `/` won't read a cookie scoped to
+  // `/_plumix/admin/`. Spy on the setter to capture the raw write.
+  let writes: string[] = [];
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    Document.prototype,
+    "cookie",
+  );
+
+  beforeEach(() => {
+    writes = [];
+    Object.defineProperty(document, "cookie", {
+      configurable: true,
+      get: () => writes.join("; "),
+      set: (value: string) => writes.push(value),
+    });
+  });
+
+  afterEach(() => {
+    if (originalDescriptor)
+      Object.defineProperty(Document.prototype, "cookie", originalDescriptor);
+  });
+
+  test("writes the cookie string to document.cookie", () => {
+    writeLocaleCookie("uk", { secure: false });
+    expect(writes).toEqual([buildLocaleCookie("uk", false)]);
+  });
+});

--- a/packages/admin/src/routes/_auth/-locale-param.ts
+++ b/packages/admin/src/routes/_auth/-locale-param.ts
@@ -1,0 +1,54 @@
+/** Builds the next search-param object when the login locale dropdown
+ *  changes. Always sets `?lang=`, even when the chosen code matches
+ *  the site default, because the admin shell's Accept-Language fallback
+ *  may otherwise resolve the request to something other than the
+ *  user's pick on reload. */
+export function nextSearchForLang(
+  currentSearch: Record<string, unknown>,
+  nextCode: string,
+): Record<string, unknown> {
+  const { lang: _drop, ...rest } = currentSearch;
+  return { ...rest, lang: nextCode };
+}
+
+// Invariant: keep these in lockstep with `ADMIN_LOCALE_COOKIE` /
+// `ADMIN_LOCALE_COOKIE_PATH` in `packages/core/src/runtime/admin-shell.ts`
+// and `ONE_YEAR_SECONDS` in
+// `packages/core/src/rpc/procedures/user/set-locale.ts`. A drift means
+// the pre-auth cookie this writes won't be read by the SSR resolver, or
+// the post-auth user.setLocale will write under a different name and
+// the two persistence paths diverge. No subpath export from `@plumix/core`
+// covers these yet; drop the duplication once one lands.
+const ADMIN_LOCALE_COOKIE = "plumix_locale";
+const ADMIN_LOCALE_COOKIE_PATH = "/_plumix/admin/";
+const ONE_YEAR_SECONDS = 31_536_000;
+
+/** Serializes a `plumix_locale` cookie string with the same attributes
+ *  the post-auth `user.setLocale` server writer uses, so a pick at
+ *  login and a later pick in profile produce byte-identical persistence.
+ *  `code` is written raw (matching server semantics); the dropdown is
+ *  the validation seam — only registry-matched codes reach here. */
+export function buildLocaleCookie(code: string, secure: boolean): string {
+  /* eslint-disable lingui/no-unlocalized-strings -- HTTP cookie attributes, not user-visible text */
+  const parts = [
+    `${ADMIN_LOCALE_COOKIE}=${code}`,
+    `Path=${ADMIN_LOCALE_COOKIE_PATH}`,
+    `Max-Age=${ONE_YEAR_SECONDS}`,
+    "SameSite=Lax",
+  ];
+  if (secure) parts.push("Secure");
+  /* eslint-enable lingui/no-unlocalized-strings */
+  return parts.join("; ");
+}
+
+/** Side-effect wrapper. `secure` defaults to the current scheme; tests
+ *  pass `false` to bypass HTTPS-only enforcement in jsdom. */
+export function writeLocaleCookie(
+  code: string,
+  options: { readonly secure?: boolean } = {},
+): void {
+  const secure =
+    options.secure ??
+    (typeof location !== "undefined" && location.protocol === "https:");
+  document.cookie = buildLocaleCookie(code, secure);
+}

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { LoginLocaleSwitcher } from "@/components/login-locale-switcher.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Button } from "@/components/ui/button.js";
 import {
@@ -25,6 +26,7 @@ import {
   requestMagicLink,
   useMagicLinkRequestErrorMessage,
 } from "@/lib/magic-link.js";
+import { readManifest } from "@/lib/manifest.js";
 import { useOAuthErrorMessage } from "@/lib/oauth-errors.js";
 import { orpc } from "@/lib/orpc.js";
 import { PasskeyError, usePasskeyErrorMessage } from "@/lib/passkey-errors.js";
@@ -37,6 +39,7 @@ import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
 
+import { nextSearchForLang, writeLocaleCookie } from "./-locale-param.js";
 import { loginSchema } from "./-schemas.js";
 
 const loginSearchSchema = v.object({
@@ -49,6 +52,10 @@ const loginSearchSchema = v.object({
   // a boolean — pinning to `v.string()` here would error the route
   // when the verify route emits a numeric-looking flag.
   email_change_success: v.optional(v.union([v.string(), v.number()])),
+  // Pre-auth locale override. Server-side `resolveAdminShellLocale`
+  // consumes this same param to set `<html lang dir>`; the dropdown
+  // below lets the user flip it from inside the form.
+  lang: v.optional(v.string()),
 });
 
 export const Route = createFileRoute("/_auth/login")({
@@ -68,6 +75,7 @@ export const Route = createFileRoute("/_auth/login")({
 function LoginRoute(): ReactNode {
   const router = useRouter();
   const search = Route.useSearch();
+  const manifest = readManifest();
   const { i18n } = useLingui();
   const renderPasskeyError = usePasskeyErrorMessage();
   const renderMagicLinkError = useMagicLinkErrorMessage();
@@ -125,6 +133,22 @@ function LoginRoute(): ReactNode {
       return;
     }
     magicLink.mutate({ email });
+  };
+
+  // Persist the pick via cookie (WP `wp_lang` parity, scoped to admin
+  // path so public-route caching stays clean) AND pin the URL so the
+  // first reload resolves to the same locale before the cookie is
+  // visible on the next request. Full page reload — admin shell is
+  // server-rendered with `<html lang dir>` per the resolved locale.
+  const handleLocaleSelect = (code: string): void => {
+    writeLocaleCookie(code);
+    const nextSearch = nextSearchForLang(search, code);
+    const params = new URLSearchParams();
+    for (const [k, raw] of Object.entries(nextSearch)) {
+      if (typeof raw === "string") params.set(k, raw);
+      else if (typeof raw === "number") params.set(k, String(raw));
+    }
+    window.location.assign(`${window.location.pathname}?${params.toString()}`);
   };
 
   const oauthErrorMessage = renderOAuthError(search.oauth_error);
@@ -327,6 +351,11 @@ function LoginRoute(): ReactNode {
             ))}
           </div>
         ) : null}
+        <LoginLocaleSwitcher
+          currentCode={i18n.locale}
+          manifest={manifest}
+          onSelect={handleLocaleSelect}
+        />
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Closes #769 (option B + D from the issue spec). The server-side `?lang=`
resolution was already wired in `resolveAdminShellLocale`; this PR adds
the user-facing flip mechanism — a shadcn Select beneath the login form
that updates the URL, writes the persistence cookie, and reloads.

**WP `wp_lang` parity via the `plumix_locale` cookie**

WP `wp-login.php:537-539` writes a `wp_lang` cookie on any GET with
`?wp_lang=`. Plumix's `resolveAdminShellLocale` already has a
`plumix_locale` cookie slot (tier 3, after query and `user.meta`) but no
pre-auth writer existed; only the post-auth `user.setLocale` RPC wrote
it.

`writeLocaleCookie` (called from `handleLocaleSelect` before the URL
flip + reload) closes the gap. Attributes are byte-identical to the
server-side `user.setLocale` builder so a pick at login and a later
pick in profile produce the same persistence cookie. Picks now survive
across visits even without `?lang=` in the URL.

**Source of truth for `currentCode`**

The dropdown reads `i18n.locale` (what Lingui has actually loaded,
sourced from `<html lang>` set by SSR) — **not** a URL-derived guess.
The admin shell's 4-tier resolution (query → `user.meta` → cookie →
Accept-Language → default) means a German browser landing on `/login`
with no `?lang=` renders in German; the dropdown must reflect that.

**`nextSearchForLang` always sets `?lang=`**

Even when the chosen code matches the site default. Earlier draft
removed the param on default for "clean URLs" — but that breaks the
Accept-Language case: picking "English" with a German browser would
reload to an `?lang=`-less URL, Accept-Language would win again, and
the user would be stuck in German. Pinning the URL is the only way to
honor the pick on first reload; the cookie keeps it across subsequent
visits.

**Cross-CMS comparison**

| | WordPress | emdash | Plumix |
|---|---|---|---|
| Param | `?wp_lang=` | n/a (admin English-only) | `?lang=` |
| Cookie | writes server-side on GET | n/a | writes client-side on dropdown change |
| Lifetime | session (browser-close) | n/a | 1 year (matches setLocale precedent) |
| HttpOnly | yes | n/a | no (matches plumix setLocale precedent) |
| Dropdown | yes | n/a | yes |

WP confirmed via [`wp-login.php` source](https://raw.githubusercontent.com/WordPress/wordpress-develop/trunk/src/wp-login.php).
emdash admin UI is itself unwrapped today per [emdash-cms/emdash#80](https://github.com/emdash-cms/emdash/issues/80).

Fixes #769