### PR TITLE
feat: locale-aware email subject + body for magic-link and email-change

### DIFF
--- a/packages/core/src/auth/email-change/request.ts
+++ b/packages/core/src/auth/email-change/request.ts
@@ -4,6 +4,7 @@ import type { Mailer } from "../mailer/types.js";
 import { and, eq, ne } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { users } from "../../db/schema/users.js";
+import { emailStringsFor } from "../email/messages.js";
 import { generateToken, hashToken } from "../tokens.js";
 import { EmailChangeError } from "./errors.js";
 
@@ -24,6 +25,12 @@ export interface RequestEmailChangeInput {
   readonly mailer: Mailer;
   readonly siteName: string;
   readonly ttlSeconds?: number;
+  /**
+   * Locale for the email body. Post-auth flow: caller passes
+   * `user.meta.locale`. Falls back to English when omitted or unknown.
+   * See `auth/email/messages.ts`.
+   */
+  readonly locale?: string;
   /**
    * Optional logger for swallowed mailer errors. Same rationale as
    * magic-link: never throw out of the request — the verification
@@ -112,16 +119,17 @@ export async function requestEmailChange(
   verifyUrl.searchParams.set("token", token);
 
   try {
+    const strings = emailStringsFor(input.locale);
     await input.mailer.send({
       to: newEmail,
-      subject: `Confirm your new email for ${input.siteName}`,
-      text: composeText(
-        input.siteName,
-        user.email,
+      subject: strings.emailChange.subject(input.siteName),
+      text: strings.emailChange.body({
+        siteName: input.siteName,
+        oldEmail: user.email,
         newEmail,
-        verifyUrl.toString(),
+        url: verifyUrl.toString(),
         ttlSeconds,
-      ),
+      }),
     });
   } catch (error) {
     // Don't leak transport failures to the caller — the request still
@@ -131,27 +139,4 @@ export async function requestEmailChange(
   }
 
   return { user, token, expiresAt };
-}
-
-function composeText(
-  siteName: string,
-  oldEmail: string,
-  newEmail: string,
-  url: string,
-  ttlSeconds: number,
-): string {
-  return [
-    `Someone — hopefully you — asked to change the email on your ${siteName} account.`,
-    "",
-    `From: ${oldEmail}`,
-    `To:   ${newEmail}`,
-    "",
-    `Confirm the change by opening this link:`,
-    "",
-    url,
-    "",
-    `The link expires in ${Math.round(ttlSeconds / 3600)} hour(s).`,
-    "",
-    `If you didn't request this, you can ignore this email — your account stays on ${oldEmail}.`,
-  ].join("\n");
 }

--- a/packages/core/src/auth/email/messages.ts
+++ b/packages/core/src/auth/email/messages.ts
@@ -1,0 +1,124 @@
+// Locale-keyed email subject + body fragments. Plumix's emails go out
+// pre-auth (magic-link) or to a user whose locale we know (email-change),
+// so the table is keyed by locale code with English as the fallback.
+//
+// Hand-rolled rather than going through Lingui's server-side `setupI18n`
+// — emails are a small, slow-moving surface; the operator cost of
+// maintaining a separate server catalog (loaded via `load-catalog.ts`,
+// merged into a per-locale `i18n` instance, accessed via `_()`) wasn't
+// worth it for ~10 strings. Promote to Lingui when a fifth or sixth
+// transactional email lands and the table starts duplicating chrome.
+
+interface MagicLinkMessages {
+  readonly subject: (siteName: string) => string;
+  readonly body: (siteName: string, url: string, ttlSeconds: number) => string;
+}
+
+interface EmailChangeMessages {
+  readonly subject: (siteName: string) => string;
+  readonly body: (args: {
+    readonly siteName: string;
+    readonly oldEmail: string;
+    readonly newEmail: string;
+    readonly url: string;
+    readonly ttlSeconds: number;
+  }) => string;
+}
+
+interface EmailLocaleStrings {
+  readonly magicLink: MagicLinkMessages;
+  readonly emailChange: EmailChangeMessages;
+}
+
+const en: EmailLocaleStrings = {
+  magicLink: {
+    subject: (siteName) => `Sign in to ${siteName}`,
+    body: (siteName, url, ttlSeconds) =>
+      [
+        `Sign in to ${siteName} by opening this link:`,
+        "",
+        url,
+        "",
+        `The link expires in ${Math.round(ttlSeconds / 60)} minutes.`,
+        "",
+        "If you didn't request this, you can ignore this email.",
+      ].join("\n"),
+  },
+  emailChange: {
+    subject: (siteName) => `Confirm your new email for ${siteName}`,
+    body: ({ siteName, oldEmail, newEmail, url, ttlSeconds }) =>
+      [
+        `Someone — hopefully you — asked to change the email on your ${siteName} account.`,
+        "",
+        `From: ${oldEmail}`,
+        `To:   ${newEmail}`,
+        "",
+        "Confirm the change by opening this link:",
+        "",
+        url,
+        "",
+        `The link expires in ${Math.round(ttlSeconds / 3600)} hour${
+          Math.round(ttlSeconds / 3600) === 1 ? "" : "s"
+        }.`,
+        "",
+        `If you didn't request this, you can ignore this email — your account stays on ${oldEmail}.`,
+      ].join("\n"),
+  },
+};
+
+const de: EmailLocaleStrings = {
+  magicLink: {
+    subject: (siteName) => `Bei ${siteName} anmelden`,
+    body: (siteName, url, ttlSeconds) =>
+      [
+        `Melden Sie sich bei ${siteName} über diesen Link an:`,
+        "",
+        url,
+        "",
+        `Der Link läuft in ${Math.round(ttlSeconds / 60)} Minuten ab.`,
+        "",
+        "Falls Sie dies nicht angefordert haben, können Sie diese E-Mail ignorieren.",
+      ].join("\n"),
+  },
+  emailChange: {
+    subject: (siteName) => `Bestätigen Sie Ihre neue E-Mail für ${siteName}`,
+    body: ({ siteName, oldEmail, newEmail, url, ttlSeconds }) =>
+      [
+        `Jemand — hoffentlich Sie — hat darum gebeten, die E-Mail-Adresse Ihres ${siteName}-Kontos zu ändern.`,
+        "",
+        `Von: ${oldEmail}`,
+        `An:  ${newEmail}`,
+        "",
+        "Bestätigen Sie die Änderung über diesen Link:",
+        "",
+        url,
+        "",
+        `Der Link läuft in ${Math.round(ttlSeconds / 3600)} Stunde${
+          Math.round(ttlSeconds / 3600) === 1 ? "" : "n"
+        } ab.`,
+        "",
+        `Falls Sie dies nicht angefordert haben, können Sie diese E-Mail ignorieren — Ihr Konto bleibt bei ${oldEmail}.`,
+      ].join("\n"),
+  },
+};
+
+// Locale-fallback chain: exact match → base-language (e.g. `de-AT` → `de`)
+// → English. Same shape as `findEnabledLocale` for consistency without
+// importing the registry (avoids coupling auth/email to i18n/locale-registry
+// which only the public-route resolver consumes).
+const LOCALES = { en, de } satisfies Record<string, EmailLocaleStrings>;
+type LocaleKey = keyof typeof LOCALES;
+
+function isLocaleKey(value: string): value is LocaleKey {
+  return value in LOCALES;
+}
+
+export function emailStringsFor(
+  locale: string | undefined,
+): EmailLocaleStrings {
+  if (!locale) return en;
+  if (isLocaleKey(locale)) return LOCALES[locale];
+  const base = locale.split("-")[0];
+  if (base && isLocaleKey(base)) return LOCALES[base];
+  return en;
+}

--- a/packages/core/src/auth/magic-link/request.test.ts
+++ b/packages/core/src/auth/magic-link/request.test.ts
@@ -254,4 +254,47 @@ describe("requestMagicLink", () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  test("renders the email body in the recipient's locale when supplied", async () => {
+    // Pre-auth flow: the caller (routes.ts) supplies the resolved
+    // admin-shell locale. With "de", subject + body should be German.
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({
+      email: "klaus@example.com",
+      role: "editor",
+    });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "klaus@example.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test Site",
+      locale: "de",
+    });
+
+    const [message] = sent;
+    expect(message?.subject).toBe("Bei Test Site anmelden");
+    expect(message?.text).toContain("Melden Sie sich bei Test Site");
+  });
+
+  test("falls back to English when locale is omitted or unknown", async () => {
+    const db = await createTestDb();
+    await userFactory.transient({ db }).create({
+      email: "fallback@example.com",
+      role: "editor",
+    });
+    const { mailer, sent } = captureMailer();
+
+    await requestMagicLink(db, {
+      email: "fallback@example.com",
+      origin: "https://cms.example",
+      mailer,
+      siteName: "Test Site",
+      locale: "xx-INVALID",
+    });
+
+    const [message] = sent;
+    expect(message?.subject).toBe("Sign in to Test Site");
+  });
 });

--- a/packages/core/src/auth/magic-link/request.ts
+++ b/packages/core/src/auth/magic-link/request.ts
@@ -4,6 +4,7 @@ import { eq } from "../../db/index.js";
 import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { users } from "../../db/schema/users.js";
+import { emailStringsFor } from "../email/messages.js";
 import { extractDomain } from "../identity.js";
 import { generateToken, hashToken } from "../tokens.js";
 
@@ -27,6 +28,13 @@ interface RequestMagicLinkInput {
   readonly mailer: Mailer;
   readonly siteName: string;
   readonly ttlSeconds?: number;
+  /**
+   * Locale for the email body. Pre-auth flow: caller supplies the
+   * resolved admin-shell locale (Accept-Language fallback chain) since
+   * the recipient has no stored preference yet. Falls back to English
+   * when omitted or unknown. See `auth/email/messages.ts`.
+   */
+  readonly locale?: string;
   /**
    * Optional logger for swallowed mailer errors. The function never
    * throws (so the response can stay shape-identical on every code
@@ -145,10 +153,15 @@ async function issueAndSend(
     // Plain-text body only. Branded HTML / template rendering is the
     // operator's call — they wrap their `Mailer` adapter and template
     // however they like. Plumix is not in the email-design business.
+    const strings = emailStringsFor(input.locale);
     await input.mailer.send({
       to: target.email,
-      subject: `Sign in to ${input.siteName}`,
-      text: composeText(input.siteName, verifyUrl.toString(), ttlSeconds),
+      subject: strings.magicLink.subject(input.siteName),
+      text: strings.magicLink.body(
+        input.siteName,
+        verifyUrl.toString(),
+        ttlSeconds,
+      ),
     });
   } catch (error) {
     // Swallow toward the caller — surfacing this would leak that the
@@ -156,22 +169,6 @@ async function issueAndSend(
     // the failure (otherwise broken mail config would be silent).
     input.logger?.warn("magic_link_mailer_failed", { error });
   }
-}
-
-function composeText(
-  siteName: string,
-  url: string,
-  ttlSeconds: number,
-): string {
-  return [
-    `Sign in to ${siteName} by opening this link:`,
-    "",
-    url,
-    "",
-    `The link expires in ${Math.round(ttlSeconds / 60)} minutes.`,
-    "",
-    "If you didn't request this, you can ignore this email.",
-  ].join("\n");
 }
 
 function timingDelay(): Promise<void> {

--- a/packages/core/src/auth/magic-link/routes.ts
+++ b/packages/core/src/auth/magic-link/routes.ts
@@ -72,6 +72,13 @@ export async function handleMagicLinkRequest(
       mailer: ctx.mailer,
       siteName: app.config.auth.magicLink.siteName,
       ttlSeconds: app.config.auth.magicLink.ttlSeconds,
+      // Pre-auth magic-link: `ctx.locale` is whatever the public-route
+      // resolver returned (override → site default — no Accept-Language
+      // by design). For a recipient who has no `user.meta.locale` yet
+      // this is the best signal we have without client-supplied input.
+      // Future: accept `lang` in the request body so the login form's
+      // dropdown choice flows through to the email.
+      locale: ctx.locale.code,
       logger: ctx.logger,
       bootstrapAllowed: ctx.bootstrapAllowed,
     });

--- a/packages/core/src/rpc/procedures/user/request-email-change.ts
+++ b/packages/core/src/rpc/procedures/user/request-email-change.ts
@@ -60,6 +60,14 @@ export const requestEmailChangeProc = base
         origin: context.origin,
         mailer: context.mailer,
         siteName: context.siteName,
+        // Email body locale follows the recipient's persisted preference
+        // (`user.meta.locale`), not the actor's. An admin in English
+        // editing a German user's email still mails the German user
+        // in German.
+        locale:
+          typeof target.meta.locale === "string"
+            ? target.meta.locale
+            : undefined,
         logger: context.logger,
       });
 


### PR DESCRIPTION
Closes #792. WP `switch_to_locale($user_locale)` parity for plumix's
two transactional emails. Caller supplies the recipient's locale via
optional `locale` field; falls back to English when omitted or unknown.

**Approach**

Hand-rolled `auth/email/messages.ts` table (~120 LOC) instead of
server-side Lingui `setupI18n`. Trade-off documented at the top of the
file: emails are a small slow-moving surface; the cost of threading
admin's compiled catalog through to Workers wasn't worth it for ~10
strings. Promote to Lingui when more transactional emails land OR when
more than two languages need bodies. Locale-fallback chain already
shipped: exact → base-language (`de-AT` → `de`) → English.

**Translations**

`en` (source) + `de` (hand-translated). Native-speaker review
recommended before commissioning further locales.

**Caller plumbing**

- Magic-link routes pass `ctx.locale.code` (pre-auth public-route
  resolver chain: override → user.meta → site default). Future work:
  accept `lang` in the magic-link request body so the login form's
  dropdown choice flows through pre-auth.
- Email-change procedure passes the recipient's `user.meta.locale`
  (not the actor's) — admin-in-English editing a German user mails the
  German user in German.

**Reviewer findings applied**

- Senpai correctness fix: pluralization gate uses `Math.round(...) === 1`
  not raw quotient (was rendering "1 hours" for TTLs that round to 1)
- Senpai German rephrase: "unter `${oldEmail}`" → "bei `${oldEmail}`"
- Simplifier: `const LOCALES = { en, de } satisfies Record<...>` with
  type-guard helper for safe strict-mode indexing
- 2 new tests pin the locale routing (de subject + xx-INVALID fallback)

Fixes #792