### PR TITLE
fix: remaining RTL stragglers — MenuItemEditor paddingLeft + users text-right

### DIFF
--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -341,7 +341,7 @@ function buildColumns({
     },
     {
       accessorKey: "lastSignInAt",
-      meta: { className: "text-right" },
+      meta: { className: "text-end" },
       header: label(M.columnLastSignIn),
       cell: ({ row }) => {
         const value = row.original.lastSignInAt;
@@ -361,7 +361,7 @@ function buildColumns({
     },
     {
       accessorKey: "createdAt",
-      meta: { className: "text-right" },
+      meta: { className: "text-end" },
       header: label(M.columnCreated),
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">

--- a/packages/plugins/menu/src/admin/MenuItemEditor.tsx
+++ b/packages/plugins/menu/src/admin/MenuItemEditor.tsx
@@ -567,7 +567,9 @@ function SortableTreeRow({
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
-    paddingLeft: `${String(depth * INDENTATION_WIDTH)}px`,
+    // `paddingInlineStart` flips with `<html dir>` so the tree indent
+    // reads correctly in RTL admin (Arabic indent reverses).
+    paddingInlineStart: `${String(depth * INDENTATION_WIDTH)}px`,
     opacity: isUnauthorized ? 0.5 : undefined,
   };
   const displayLabel = item.title ?? item.resolvedLabel;


### PR DESCRIPTION
Closes #800. Three sites the #787 sweep missed:

- `packages/plugins/menu/src/admin/MenuItemEditor.tsx:570` — inline `paddingLeft` for tree indent → `paddingInlineStart`
- `packages/admin/src/routes/_authenticated/users/index.tsx:344,364` — `text-right` → `text-end` on table cells

The ESLint guard from #787 only catches `className` string literals; it doesn't flag inline style props or table-meta literals.

Fixes #800