### PR TITLE
refactor: consolidate locale-cookie constants into @plumix/core/i18n

### DIFF
--- a/packages/admin/src/routes/_auth/-locale-param.test.ts
+++ b/packages/admin/src/routes/_auth/-locale-param.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import {
-  buildLocaleCookie,
-  nextSearchForLang,
-  writeLocaleCookie,
-} from "./-locale-param.js";
+import { buildLocaleCookie } from "@plumix/core/i18n";
+
+import { nextSearchForLang, writeLocaleCookie } from "./-locale-param.js";
 
 describe("nextSearchForLang", () => {
   test("sets `?lang=` to the chosen code", () => {
@@ -35,28 +33,6 @@ describe("nextSearchForLang", () => {
       redirect_to: "/",
     });
   });
-});
-
-describe("buildLocaleCookie", () => {
-  test("serializes the full cookie attribute set without Secure", () => {
-    // Matches the post-auth `user.setLocale` server writer; a drift
-    // means pre-auth picks and post-auth picks would write different
-    // cookies and break each other's persistence.
-    expect(buildLocaleCookie("uk", false)).toBe(
-      "plumix_locale=uk; Path=/_plumix/admin/; Max-Age=31536000; SameSite=Lax",
-    );
-  });
-
-  test("appends Secure when called over HTTPS", () => {
-    expect(buildLocaleCookie("uk", true)).toBe(
-      "plumix_locale=uk; Path=/_plumix/admin/; Max-Age=31536000; SameSite=Lax; Secure",
-    );
-  });
-
-  // Note: `code` is written raw to match the server-side builder
-  // (`packages/core/src/rpc/procedures/user/set-locale.ts:47-56`). The
-  // dropdown is the validation seam — only registry-matched codes reach
-  // either builder, so smuggling defense lives upstream.
 });
 
 describe("writeLocaleCookie", () => {

--- a/packages/admin/src/routes/_auth/-locale-param.ts
+++ b/packages/admin/src/routes/_auth/-locale-param.ts
@@ -1,3 +1,5 @@
+import { buildLocaleCookie } from "@plumix/core/i18n";
+
 /** Builds the next search-param object when the login locale dropdown
  *  changes. Always sets `?lang=`, even when the chosen code matches
  *  the site default, because the admin shell's Accept-Language fallback
@@ -11,38 +13,8 @@ export function nextSearchForLang(
   return { ...rest, lang: nextCode };
 }
 
-// Invariant: keep these in lockstep with `ADMIN_LOCALE_COOKIE` /
-// `ADMIN_LOCALE_COOKIE_PATH` in `packages/core/src/runtime/admin-shell.ts`
-// and `ONE_YEAR_SECONDS` in
-// `packages/core/src/rpc/procedures/user/set-locale.ts`. A drift means
-// the pre-auth cookie this writes won't be read by the SSR resolver, or
-// the post-auth user.setLocale will write under a different name and
-// the two persistence paths diverge. No subpath export from `@plumix/core`
-// covers these yet; drop the duplication once one lands.
-const ADMIN_LOCALE_COOKIE = "plumix_locale";
-const ADMIN_LOCALE_COOKIE_PATH = "/_plumix/admin/";
-const ONE_YEAR_SECONDS = 31_536_000;
-
-/** Serializes a `plumix_locale` cookie string with the same attributes
- *  the post-auth `user.setLocale` server writer uses, so a pick at
- *  login and a later pick in profile produce byte-identical persistence.
- *  `code` is written raw (matching server semantics); the dropdown is
- *  the validation seam — only registry-matched codes reach here. */
-export function buildLocaleCookie(code: string, secure: boolean): string {
-  /* eslint-disable lingui/no-unlocalized-strings -- HTTP cookie attributes, not user-visible text */
-  const parts = [
-    `${ADMIN_LOCALE_COOKIE}=${code}`,
-    `Path=${ADMIN_LOCALE_COOKIE_PATH}`,
-    `Max-Age=${ONE_YEAR_SECONDS}`,
-    "SameSite=Lax",
-  ];
-  if (secure) parts.push("Secure");
-  /* eslint-enable lingui/no-unlocalized-strings */
-  return parts.join("; ");
-}
-
-/** Side-effect wrapper. `secure` defaults to the current scheme; tests
- *  pass `false` to bypass HTTPS-only enforcement in jsdom. */
+/** `secure` defaults to the current scheme; tests pass `false` to
+ *  bypass HTTPS-only enforcement in jsdom. */
 export function writeLocaleCookie(
   code: string,
   options: { readonly secure?: boolean } = {},

--- a/packages/core/src/i18n/cookie.test.ts
+++ b/packages/core/src/i18n/cookie.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { buildLocaleCookie } from "./cookie.js";
+
+// Three writers must produce byte-identical cookies — the pre-auth login
+// dropdown (`document.cookie =`), the post-auth `user.setLocale` RPC
+// (`Set-Cookie` header), and any future writer. The reader in
+// `runtime/admin-shell.ts` pins the name; pin the full string here so
+// drift surfaces immediately rather than as a silent persistence split.
+
+describe("buildLocaleCookie", () => {
+  test("serializes the full cookie attribute set without Secure", () => {
+    expect(buildLocaleCookie("uk", false)).toBe(
+      "plumix_locale=uk; Path=/_plumix/admin/; Max-Age=31536000; SameSite=Lax",
+    );
+  });
+
+  test("appends Secure when called over HTTPS", () => {
+    expect(buildLocaleCookie("uk", true)).toBe(
+      "plumix_locale=uk; Path=/_plumix/admin/; Max-Age=31536000; SameSite=Lax; Secure",
+    );
+  });
+});

--- a/packages/core/src/i18n/cookie.ts
+++ b/packages/core/src/i18n/cookie.ts
@@ -1,0 +1,21 @@
+// Underscore-cased to match `plumix_session` prior art in `auth/cookies.ts`.
+// `Path=/_plumix/admin/` keeps the browser from sending the cookie on
+// public-route requests — public HTML stays identical across visitors so
+// cache layers don't fragment.
+export const ADMIN_LOCALE_COOKIE = "plumix_locale";
+const ADMIN_LOCALE_COOKIE_PATH = "/_plumix/admin/";
+const ONE_YEAR_SECONDS = 31_536_000;
+
+/** `code` is written raw — caller is the validation seam (only
+ *  registry-matched codes should reach here). `Secure` is appended only
+ *  over HTTPS; jsdom tests pass `false` to bypass. */
+export function buildLocaleCookie(code: string, secure: boolean): string {
+  const parts = [
+    `${ADMIN_LOCALE_COOKIE}=${code}`,
+    `Path=${ADMIN_LOCALE_COOKIE_PATH}`,
+    `Max-Age=${ONE_YEAR_SECONDS}`,
+    "SameSite=Lax",
+  ];
+  if (secure) parts.push("Secure");
+  return parts.join("; ");
+}

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,4 +1,5 @@
 export { withContext } from "./context.js";
+export { buildLocaleCookie } from "./cookie.js";
 export {
   formatDate,
   formatNumber,

--- a/packages/core/src/rpc/procedures/user/set-locale.ts
+++ b/packages/core/src/rpc/procedures/user/set-locale.ts
@@ -1,11 +1,8 @@
 import * as v from "valibot";
 
 import { isSecureRequest } from "../../../auth/cookies.js";
+import { buildLocaleCookie } from "../../../i18n/cookie.js";
 import { findEnabledLocale } from "../../../i18n/locale-registry.js";
-import {
-  ADMIN_LOCALE_COOKIE,
-  ADMIN_LOCALE_COOKIE_PATH,
-} from "../../../runtime/admin-shell.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { writeUserMeta } from "./meta.js";
@@ -14,7 +11,6 @@ const inputSchema = v.object({
   code: v.pipe(v.string(), v.minLength(1)),
 });
 
-const ONE_YEAR_SECONDS = 31_536_000;
 const EDIT_OWN_CAPABILITY = "user:edit_own";
 
 export const setLocale = base
@@ -43,14 +39,3 @@ export const setLocale = base
       buildLocaleCookie(match.code, isSecureRequest(context.request)),
     );
   });
-
-function buildLocaleCookie(code: string, secure: boolean): string {
-  const parts = [
-    `${ADMIN_LOCALE_COOKIE}=${code}`,
-    `Path=${ADMIN_LOCALE_COOKIE_PATH}`,
-    `Max-Age=${ONE_YEAR_SECONDS}`,
-    "SameSite=Lax",
-  ];
-  if (secure) parts.push("Secure");
-  return parts.join("; ");
-}

--- a/packages/core/src/runtime/admin-shell.ts
+++ b/packages/core/src/runtime/admin-shell.ts
@@ -1,14 +1,8 @@
 import type { AuthenticatedUser } from "../context/app.js";
 import type { ResolvedI18n, ResolvedLocale } from "../i18n/locale-registry.js";
 import { readSessionCookie } from "../auth/cookies.js";
+import { ADMIN_LOCALE_COOKIE } from "../i18n/cookie.js";
 import { findEnabledLocale } from "../i18n/locale-registry.js";
-
-// Underscore-cased to match `plumix_session` (the existing session-cookie
-// prior art in `auth/cookies.ts`). The slice-8 writer should set
-// `Path=/_plumix/admin/` so the browser never sends it on public-route
-// requests — keeps public HTML identical across visitors for cache layers.
-export const ADMIN_LOCALE_COOKIE = "plumix_locale";
-export const ADMIN_LOCALE_COOKIE_PATH = "/_plumix/admin/";
 
 // Real Accept-Language headers carry 1–4 entries; cap defensively so a
 // hostile client can't burn CPU on N×`Intl.Locale` allocations per GET.


### PR DESCRIPTION
Extract the duplicated `ADMIN_LOCALE_COOKIE` / `ADMIN_LOCALE_COOKIE_PATH` / `ONE_YEAR_SECONDS`
constants and the duplicated `buildLocaleCookie` builder into `packages/core/src/i18n/cookie.ts`,
re-exported via the existing `@plumix/core/i18n` subpath. The three writers/readers — the SSR
resolver in `runtime/admin-shell.ts`, the `user.setLocale` RPC, and the pre-auth login dropdown
in admin — now converge on one module, so drift between pre-auth and post-auth persistence is
structurally impossible instead of being guarded by a lockstep invariant comment. No behavior
change.

**Byte-string contract moves with the module**

The canonical `buildLocaleCookie` assertion now lives in a colocated `packages/core/src/i18n/cookie.test.ts` next to the function it pins. Admin's `-locale-param.test.ts` keeps `nextSearchForLang` + `writeLocaleCookie` and pulls `buildLocaleCookie` from `@plumix/core/i18n` for the round-trip assertion only. Previously the only byte-string assertion lived cross-package in the admin test by historical accident.

Fixes #803