### PR TITLE
refactor: disambiguate Trash polyseme with Lingui context

### DIFF
--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -1658,13 +1658,13 @@ msgid "userEdit.delete.reassign.keepAsIs"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/components/login-locale-switcher.tsx
-msgid "login.locale.aria"
+#: src/components/locale-switcher.tsx
+msgid "profile.language.aria"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/components/locale-switcher.tsx
-msgid "profile.language.aria"
+#: src/components/login-locale-switcher.tsx
+msgid "login.locale.aria"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -3153,16 +3153,19 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
-msgid "entries.list.statusFilter.trash"
-msgstr ""
-
-#. js-lingui-explicit-id
-#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
 msgid "entries.list.row.trash"
 msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "entry status"
+msgid "entries.list.statusFilter.trash"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
 msgid "entries.list.row.trashing"
 msgstr ""
 

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -1685,13 +1685,13 @@ msgid "userEdit.delete.reassign.keepAsIs"
 msgstr "Keep entries as-is (none to reassign)"
 
 #. js-lingui-explicit-id
-#: src/components/login-locale-switcher.tsx
-msgid "login.locale.aria"
+#: src/components/locale-switcher.tsx
+msgid "profile.language.aria"
 msgstr "Language"
 
 #. js-lingui-explicit-id
-#: src/components/locale-switcher.tsx
-msgid "profile.language.aria"
+#: src/components/login-locale-switcher.tsx
+msgid "login.locale.aria"
 msgstr "Language"
 
 #. js-lingui-explicit-id
@@ -3216,16 +3216,19 @@ msgstr "Transform to"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
-msgid "entries.list.statusFilter.trash"
-msgstr "Trash"
-
-#. js-lingui-explicit-id
-#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
 msgid "entries.list.row.trash"
 msgstr "Trash"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "entry status"
+msgid "entries.list.statusFilter.trash"
+msgstr "Trash"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
 msgid "entries.list.row.trashing"
 msgstr "Trashing…"
 

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -167,6 +167,7 @@ const M = {
   statusTrash: defineMessage({
     id: "entries.list.statusFilter.trash",
     message: "Trash",
+    context: "entry status",
   }),
   authorAll: defineMessage({
     id: "entries.list.authorFilter.all",
@@ -201,10 +202,12 @@ const M = {
   rowTrash: defineMessage({
     id: "entries.list.row.trash",
     message: "Trash",
+    context: "action verb",
   }),
   rowTrashing: defineMessage({
     id: "entries.list.row.trashing",
     message: "Trashing…",
+    context: "action verb",
   }),
   // Search placeholder / load error / loading aria / taxonomy filter
   // chrome resolve via the WP-style cascade — `labels[<key>]` when the

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -168,6 +168,8 @@ async function resolveFrontPage(
 
     node: { kind: "front-page" },
     data,
+    // Public-route content i18n is a deferred userland seam; "Home"
+    // (site root) stays English here.
     title: "Home",
   });
   return new Response(html, {


### PR DESCRIPTION
Admin's entry list has three descriptors that all read `Trash` in English — `statusTrash`
(noun, list filter), `rowTrash` (verb, row action), `rowTrashing` (verb, progress). Without
`context:`, translators see three msgids with identical source strings and translate them
identically, which is wrong in any language where the noun/verb forms diverge (most non-English).

**Context disambiguation matching the Draft precedent**

`statusTrash` now carries `context: "entry status"`, mirroring the existing `statusDraft` pattern.
`rowTrash` and `rowTrashing` carry `context: "action verb"`. Lingui's extractor emits matching
`msgctxt` lines into both `en.po` and `de.po`.

Closes the polyseme sweep the 2026-06-03 audit deferred. The other audit-flagged words turned
out to be no-ops in source: `Read` and `Order` don't appear in any user-facing site; `Comment` is
deferred until a comments plugin exists; `Home` only surfaces at one site (the front-page route's
theme title) which is a deferred userland-plugin seam — a comment documents the deferral.

Fixes #798