### PR TITLE
feat: mount pre-auth locale switcher on bootstrap and accept-invite

### DIFF
--- a/packages/admin/src/routes/_auth/-locale-param.test.ts
+++ b/packages/admin/src/routes/_auth/-locale-param.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { buildLocaleCookie } from "@plumix/core/i18n";
 
-import { nextSearchForLang, writeLocaleCookie } from "./-locale-param.js";
+import {
+  buildLocaleSwitchUrl,
+  nextSearchForLang,
+  writeLocaleCookie,
+} from "./-locale-param.js";
 
 describe("nextSearchForLang", () => {
   test("sets `?lang=` to the chosen code", () => {
@@ -32,6 +36,27 @@ describe("nextSearchForLang", () => {
       oauth_error: "access_denied",
       redirect_to: "/",
     });
+  });
+});
+
+describe("buildLocaleSwitchUrl", () => {
+  test("emits `?lang=<code>` against the current pathname", () => {
+    expect(buildLocaleSwitchUrl({}, "uk")).toBe(
+      `${window.location.pathname}?lang=uk`,
+    );
+  });
+
+  test("preserves sibling search params and coerces numeric values", () => {
+    // Mirrors login's `email_change_success` round-trip: TanStack
+    // Router's search parser hands back number-typed values that need
+    // to land in `URLSearchParams` as strings.
+    const url = buildLocaleSwitchUrl(
+      { redirect_to: "/", email_change_success: 1 },
+      "de",
+    );
+    expect(url).toContain("lang=de");
+    expect(url).toContain("redirect_to=%2F");
+    expect(url).toContain("email_change_success=1");
   });
 });
 

--- a/packages/admin/src/routes/_auth/-locale-param.ts
+++ b/packages/admin/src/routes/_auth/-locale-param.ts
@@ -13,6 +13,22 @@ export function nextSearchForLang(
   return { ...rest, lang: nextCode };
 }
 
+/** Pins `?lang=` so the next SSR resolves to the chosen locale
+ *  before the cookie is visible on the wire, preserving sibling
+ *  search params (`oauth_error`, `redirect_to`, etc.). */
+export function buildLocaleSwitchUrl(
+  currentSearch: Record<string, unknown>,
+  nextCode: string,
+): string {
+  const nextSearch = nextSearchForLang(currentSearch, nextCode);
+  const params = new URLSearchParams();
+  for (const [k, raw] of Object.entries(nextSearch)) {
+    if (typeof raw === "string") params.set(k, raw);
+    else if (typeof raw === "number") params.set(k, String(raw));
+  }
+  return `${window.location.pathname}?${params.toString()}`;
+}
+
 /** `secure` defaults to the current scheme; tests pass `false` to
  *  bypass HTTPS-only enforcement in jsdom. */
 export function writeLocaleCookie(

--- a/packages/admin/src/routes/_auth/-schemas.ts
+++ b/packages/admin/src/routes/_auth/-schemas.ts
@@ -25,3 +25,10 @@ export const bootstrapSchema = v.object({
   email: emailField,
   name: v.optional(nameField, ""),
 });
+
+// Server-side `resolveAdminShellLocale` reads `?lang=` directly to set
+// `<html lang dir>` on the initial SSR; routes that mount the pre-auth
+// dropdown extend this so `Route.useSearch()` hands the value back.
+export const langOnlySearchSchema = v.object({
+  lang: v.optional(v.string()),
+});

--- a/packages/admin/src/routes/_auth/accept-invite/$token.tsx
+++ b/packages/admin/src/routes/_auth/accept-invite/$token.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { LoginLocaleSwitcher } from "@/components/login-locale-switcher.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Button } from "@/components/ui/button.js";
 import {
@@ -18,13 +19,17 @@ import {
   FormMessage,
 } from "@/components/ui/form.js";
 import { Input } from "@/components/ui/input.js";
+import { readManifest } from "@/lib/manifest.js";
 import { PasskeyError, usePasskeyErrorMessage } from "@/lib/passkey-errors.js";
 import { acceptInviteWithPasskey } from "@/lib/passkey.js";
 import { SESSION_QUERY_KEY, sessionQueryOptions } from "@/lib/session.js";
-import { Trans } from "@lingui/react";
+import { Trans, useLingui } from "@lingui/react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
+
+import { buildLocaleSwitchUrl, writeLocaleCookie } from "../-locale-param.js";
+import { langOnlySearchSchema } from "../-schemas.js";
 
 // The invite flow lands unauthenticated users here — any existing session
 // is a red flag (you don't accept an invite while already signed in, and
@@ -32,6 +37,7 @@ import { useForm } from "react-hook-form";
 // them to the dashboard; if they want to switch accounts they can sign
 // out first.
 export const Route = createFileRoute("/_auth/accept-invite/$token")({
+  validateSearch: langOnlySearchSchema,
   beforeLoad: async ({ context }) => {
     const session = await context.queryClient.ensureQueryData(
       sessionQueryOptions(),
@@ -47,8 +53,16 @@ export const Route = createFileRoute("/_auth/accept-invite/$token")({
 function AcceptInviteRoute(): ReactNode {
   const renderPasskeyError = usePasskeyErrorMessage();
   const { token } = Route.useParams();
+  const search = Route.useSearch();
+  const manifest = readManifest();
+  const { i18n } = useLingui();
   const router = useRouter();
   const [errorCode, setErrorCode] = useState<string | null>(null);
+
+  const handleLocaleSelect = (code: string): void => {
+    writeLocaleCookie(code);
+    window.location.assign(buildLocaleSwitchUrl(search, code));
+  };
 
   const accept = useMutation({
     mutationFn: (input: { name?: string }) =>
@@ -148,6 +162,11 @@ function AcceptInviteRoute(): ReactNode {
             </Button>
           </form>
         </Form>
+        <LoginLocaleSwitcher
+          currentCode={i18n.locale}
+          manifest={manifest}
+          onSelect={handleLocaleSelect}
+        />
       </CardContent>
     </Card>
   );

--- a/packages/admin/src/routes/_auth/bootstrap.tsx
+++ b/packages/admin/src/routes/_auth/bootstrap.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { LoginLocaleSwitcher } from "@/components/login-locale-switcher.js";
 import { Alert, AlertDescription } from "@/components/ui/alert.js";
 import { Button } from "@/components/ui/button.js";
 import {
@@ -18,18 +19,21 @@ import {
   FormMessage,
 } from "@/components/ui/form.js";
 import { Input } from "@/components/ui/input.js";
+import { readManifest } from "@/lib/manifest.js";
 import { PasskeyError, usePasskeyErrorMessage } from "@/lib/passkey-errors.js";
 import { registerWithPasskey } from "@/lib/passkey.js";
 import { SESSION_QUERY_KEY, sessionQueryOptions } from "@/lib/session.js";
 import { valibotResolver } from "@hookform/resolvers/valibot";
-import { Trans } from "@lingui/react";
+import { Trans, useLingui } from "@lingui/react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 
-import { bootstrapSchema } from "./-schemas.js";
+import { buildLocaleSwitchUrl, writeLocaleCookie } from "./-locale-param.js";
+import { bootstrapSchema, langOnlySearchSchema } from "./-schemas.js";
 
 export const Route = createFileRoute("/_auth/bootstrap")({
+  validateSearch: langOnlySearchSchema,
   beforeLoad: async ({ context }) => {
     const session = await context.queryClient.ensureQueryData(
       sessionQueryOptions(),
@@ -48,7 +52,15 @@ export const Route = createFileRoute("/_auth/bootstrap")({
 function BootstrapRoute(): ReactNode {
   const renderPasskeyError = usePasskeyErrorMessage();
   const router = useRouter();
+  const search = Route.useSearch();
+  const manifest = readManifest();
+  const { i18n } = useLingui();
   const [errorCode, setErrorCode] = useState<string | null>(null);
+
+  const handleLocaleSelect = (code: string): void => {
+    writeLocaleCookie(code);
+    window.location.assign(buildLocaleSwitchUrl(search, code));
+  };
 
   const createAccount = useMutation({
     mutationFn: registerWithPasskey,
@@ -161,6 +173,11 @@ function BootstrapRoute(): ReactNode {
             </Button>
           </form>
         </Form>
+        <LoginLocaleSwitcher
+          currentCode={i18n.locale}
+          manifest={manifest}
+          onSelect={handleLocaleSelect}
+        />
       </CardContent>
     </Card>
   );

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -39,7 +39,7 @@ import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
 
-import { nextSearchForLang, writeLocaleCookie } from "./-locale-param.js";
+import { buildLocaleSwitchUrl, writeLocaleCookie } from "./-locale-param.js";
 import { loginSchema } from "./-schemas.js";
 
 const loginSearchSchema = v.object({
@@ -135,20 +135,13 @@ function LoginRoute(): ReactNode {
     magicLink.mutate({ email });
   };
 
-  // Persist the pick via cookie (WP `wp_lang` parity, scoped to admin
-  // path so public-route caching stays clean) AND pin the URL so the
-  // first reload resolves to the same locale before the cookie is
-  // visible on the next request. Full page reload — admin shell is
-  // server-rendered with `<html lang dir>` per the resolved locale.
+  // Persist via cookie (WP `wp_lang` parity, admin-path scoped so the
+  // public-route cache stays clean) AND pin `?lang=` so the first SSR
+  // after reload resolves to the same locale before the cookie is on
+  // the wire.
   const handleLocaleSelect = (code: string): void => {
     writeLocaleCookie(code);
-    const nextSearch = nextSearchForLang(search, code);
-    const params = new URLSearchParams();
-    for (const [k, raw] of Object.entries(nextSearch)) {
-      if (typeof raw === "string") params.set(k, raw);
-      else if (typeof raw === "number") params.set(k, String(raw));
-    }
-    window.location.assign(`${window.location.pathname}?${params.toString()}`);
+    window.location.assign(buildLocaleSwitchUrl(search, code));
   };
 
   const oauthErrorMessage = renderOAuthError(search.oauth_error);


### PR DESCRIPTION
Login already shows a `<LoginLocaleSwitcher>` so users can flip locale before submitting
credentials. First-admin bootstrap and invited-user signup landed without it — those visitors
were stuck in whatever Accept-Language tier the SSR resolved on initial GET, with no client-side
flip until after auth.

**Three-site convergence on one helper**

Extract `buildLocaleSwitchUrl(search, code)` from `login.tsx`'s inline body into the colocated
`-locale-param.ts` (tested against the basic + sibling-preservation cases). All three routes now
read:

```tsx
const handleLocaleSelect = (code: string): void => {
  writeLocaleCookie(code);
  window.location.assign(buildLocaleSwitchUrl(search, code));
};
```

Add a shared `langOnlySearchSchema` to `-schemas.ts` for the two new routes' `validateSearch` —
both only need `?lang=`, so they share the minimal valibot object instead of duplicating it. The
SSR resolver in `runtime/admin-shell.ts` already consumed `?lang=` independent of the client
schema; this just lets `Route.useSearch()` hand the value back.

Fixes #802