### PR TITLE
feat: wrap user-supplied placeholders in <bdi> for RTL bidi isolation

### DIFF
--- a/packages/admin/src/components/profile/api-tokens-card.tsx
+++ b/packages/admin/src/components/profile/api-tokens-card.tsx
@@ -285,6 +285,9 @@ function ApiTokensCardView({
   } | null>(null);
   const [revokeError, setRevokeError] = useState<Label | null>(null);
 
+  // Hoisted: lingui/no-expression-in-message rejects member exprs inline.
+  const bdiRevokeName = <bdi>{revokeTarget?.name ?? ""}</bdi>;
+
   return (
     <Card data-testid="api-tokens-card">
       <CardHeader>
@@ -455,7 +458,7 @@ function ApiTokensCardView({
               <Trans
                 id="apiTokens.revoke.title"
                 message='Revoke "{name}"?'
-                values={{ name: revokeTarget?.name ?? "" }}
+                values={{ name: bdiRevokeName }}
                 comment="name: the user-chosen token nickname (e.g. 'CI deploy key')"
               />
             </AlertDialogTitle>
@@ -743,7 +746,7 @@ function SecretShownDialog({
             <Trans
               id="apiTokens.secret.title"
               message='Token "{name}" minted'
-              values={{ name }}
+              values={{ name: <bdi>{name}</bdi> }}
               comment="name: the user-chosen token nickname (e.g. 'CI deploy key')"
             />
           </AlertDialogTitle>

--- a/packages/admin/src/components/profile/passkeys-card.tsx
+++ b/packages/admin/src/components/profile/passkeys-card.tsx
@@ -445,7 +445,7 @@ function PasskeyRow({ cred, isLast, onChanged }: PasskeyRowProps): ReactNode {
               <Trans
                 id="profile.passkeys.delete.description"
                 message='The device that registered "{name}" will no longer be able to sign in. You can re-enrol it later.'
-                values={{ name: displayName }}
+                values={{ name: <bdi>{displayName}</bdi> }}
                 comment="name: the user-chosen passkey nickname (e.g. 'MacBook', 'iPhone')"
               />
             </AlertDialogDescription>

--- a/packages/admin/src/components/profile/sessions-card.tsx
+++ b/packages/admin/src/components/profile/sessions-card.tsx
@@ -276,7 +276,7 @@ function SessionRow({ session, onChanged }: SessionRowProps): ReactNode {
                   id="profile.sessions.revoke.descriptionWithIp"
                   message="{device} signed in {when} from {ip}. The device will need to sign in again next time."
                   values={{
-                    device: deviceLabel,
+                    device: <bdi>{deviceLabel}</bdi>,
                     when: formatRelative(createdAt),
                     ip: session.ipAddress,
                   }}
@@ -287,7 +287,7 @@ function SessionRow({ session, onChanged }: SessionRowProps): ReactNode {
                   id="profile.sessions.revoke.description"
                   message="{device} signed in {when}. The device will need to sign in again next time."
                   values={{
-                    device: deviceLabel,
+                    device: <bdi>{deviceLabel}</bdi>,
                     when: formatRelative(createdAt),
                   }}
                   comment="device: 'Safari on macOS' style label; when: relative-time string"

--- a/packages/admin/src/components/profile/user-email-field.tsx
+++ b/packages/admin/src/components/profile/user-email-field.tsx
@@ -155,6 +155,9 @@ export function UserEmailField({
     },
   });
 
+  // Hoisted: lingui/no-expression-in-message rejects member exprs inline.
+  const bdiPendingNewEmail = pending ? <bdi>{pending.newEmail}</bdi> : null;
+
   return (
     <div className="flex flex-col gap-2">
       <UILabel>
@@ -199,7 +202,7 @@ export function UserEmailField({
                 id="userEdit.email.pending"
                 message="Pending change to <code>{newEmail}</code> — expires {expiresAt}"
                 values={{
-                  newEmail: pending.newEmail,
+                  newEmail: bdiPendingNewEmail,
                   expiresAt: formatRelative(toDate(pending.expiresAt)),
                 }}
                 components={{ code: <code className="font-mono" /> }}

--- a/packages/admin/src/editor/BlockScopePicker.tsx
+++ b/packages/admin/src/editor/BlockScopePicker.tsx
@@ -61,7 +61,7 @@ export function BlockScopePicker({
             <Trans
               id="blockScopePicker.title"
               message="Choose a {blockTitle} layout"
-              values={{ blockTitle }}
+              values={{ blockTitle: <bdi>{blockTitle}</bdi> }}
               comment="blockTitle: the parent block's registered title (e.g. 'Cover', 'Gallery')"
             />
           </DialogTitle>
@@ -69,7 +69,7 @@ export function BlockScopePicker({
             <Trans
               id="blockScopePicker.description"
               message="Pick a layout to insert, or cancel to start from a blank {blockTitle}."
-              values={{ blockTitle }}
+              values={{ blockTitle: <bdi>{blockTitle}</bdi> }}
               comment="blockTitle: the parent block's registered title (e.g. 'Cover', 'Gallery')"
             />
           </DialogDescription>

--- a/packages/admin/src/editor/revisions/PreviewBanner.tsx
+++ b/packages/admin/src/editor/revisions/PreviewBanner.tsx
@@ -58,7 +58,7 @@ export function PreviewBanner({
           message="from {when} by {author}"
           values={{
             when: relativeTime(revisionUpdatedAt),
-            author: revisionAuthor,
+            author: <bdi>{revisionAuthor}</bdi>,
           }}
           comment="when: pre-formatted relative-time like '2 hours ago'; author: the user's display name or email"
         />

--- a/packages/admin/src/routes/_auth/login.tsx
+++ b/packages/admin/src/routes/_auth/login.tsx
@@ -335,7 +335,7 @@ function LoginRoute(): ReactNode {
                   <Trans
                     id="login.oauth.continueWith"
                     message="Continue with {label}"
-                    values={{ label }}
+                    values={{ label: <bdi>{label}</bdi> }}
                     comment="label: the OAuth provider's display name (e.g. 'Google', 'GitHub')"
                   />
                 </a>

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -41,7 +41,7 @@ function DashboardIndex(): ReactNode {
           <Trans
             id="dashboard.welcome"
             message="Welcome, {greeting}"
-            values={{ greeting }}
+            values={{ greeting: <bdi>{greeting}</bdi> }}
             comment="greeting: the user's display name or email"
           />
         </h1>

--- a/packages/admin/src/routes/_authenticated/mailer/index.tsx
+++ b/packages/admin/src/routes/_authenticated/mailer/index.tsx
@@ -98,6 +98,10 @@ function MailerRoute(): ReactNode {
     testSend.mutate({ to: value.to });
   });
 
+  // Hoisted: lingui/no-expression-in-message rejects member exprs inline.
+  const bdiFeedbackTo =
+    feedback?.kind === "ok" ? <bdi>{feedback.to}</bdi> : null;
+
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
       <header className="flex flex-col gap-1">
@@ -159,7 +163,7 @@ function MailerRoute(): ReactNode {
                     <Trans
                       id="mailer.test.feedback.ok"
                       message="Test message sent to {to}. If it doesn't arrive within a minute, check your transport adapter's logs."
-                      values={{ to: feedback.to }}
+                      values={{ to: bdiFeedbackTo }}
                       comment="to: the recipient email address the test was sent to"
                     />
                   </AlertDescription>

--- a/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
@@ -414,7 +414,7 @@ function DeleteCard({
               <Trans
                 id="terms.edit.delete.dialogTitle"
                 message="Delete {termName}?"
-                values={{ termName }}
+                values={{ termName: <bdi>{termName}</bdi> }}
                 comment="termName: the taxonomy term being deleted"
               />
             </AlertDialogTitle>

--- a/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
@@ -326,6 +326,9 @@ function UserEditForm({
     updateUser.mutate(value);
   });
 
+  // Hoisted: lingui/no-expression-in-message rejects member exprs inline.
+  const bdiEmail = <bdi>{target.email}</bdi>;
+
   return (
     <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
       <Link
@@ -348,7 +351,7 @@ function UserEditForm({
                 <Trans
                   id="userEdit.title.other"
                   message="Edit {email}"
-                  values={{ email: target.email }}
+                  values={{ email: bdiEmail }}
                   comment="email: the user being edited"
                 />
               )}
@@ -658,6 +661,9 @@ function DeleteCard({ target }: { target: User }): ReactNode {
     },
   });
 
+  // Hoisted: lingui/no-expression-in-message rejects member exprs inline.
+  const bdiEmail = <bdi>{target.email}</bdi>;
+
   if (!confirming) {
     return (
       <Card className="border-destructive/50">
@@ -694,7 +700,7 @@ function DeleteCard({ target }: { target: User }): ReactNode {
           <Trans
             id="userEdit.delete.confirm.title"
             message="Confirm delete: {email}"
-            values={{ email: target.email }}
+            values={{ email: bdiEmail }}
             comment="email: the user account being deleted"
           />
         </CardTitle>

--- a/packages/admin/src/routes/_authenticated/users/create.tsx
+++ b/packages/admin/src/routes/_authenticated/users/create.tsx
@@ -363,6 +363,9 @@ function InviteSuccess({
     }
   };
 
+  // Hoisted: lingui/no-expression-in-message rejects member exprs inline.
+  const bdiEmail = <bdi>{user.email}</bdi>;
+
   return (
     <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
       <Card>
@@ -376,7 +379,7 @@ function InviteSuccess({
             <Trans
               id="userInvite.success.description"
               message="Share the link below with {email}. They'll enrol a passkey the first time they open it. Link expires in 7 days."
-              values={{ email: user.email }}
+              values={{ email: bdiEmail }}
               comment="email: the invited user's address"
             />
           </CardDescription>


### PR DESCRIPTION
Translated text with user-supplied interpolations — display names, emails, taxonomy term names,
operator-configured labels — can leak direction in RTL locales when LTR content mixes with RTL
chrome. The WP/Gutenberg defensive baseline is to wrap the interpolated JSX value in `<bdi>` so
the browser isolates its bidi level from the surrounding text.

**16 placeholder sites across 12 files**

Tokens wrapped: `{greeting}`, `{author}`, `{email}`, `{newEmail}`, `{name}` (token + passkey
nicknames), `{termName}`, `{to}` (test-mailer recipient), `{label}` (OAuth provider),
`{blockTitle}` (plugin-registered block), `{device}` (UA-parser output — defensive since UA
strings are attacker-controllable).

System-generated tokens stay un-wrapped: `{count}`, `{ip}`, `{slug}`, `{userCode}`,
relative-time strings — all ASCII-only or already i18n-runtime-formatted.

**Hoist where the placeholder value is a member expression**

Where the value is already a plain identifier (`label`, `revisionAuthor`, `deviceLabel`,
`blockTitle`, `greeting`, `termName`, `name`), wrap inline:
```tsx
values={{ greeting: <bdi>{greeting}</bdi> }}
```

Where the value is a member expression (`target.email`, `pending.newEmail`, `feedback.to`,
`revokeTarget?.name`), hoist to a `const` before the JSX return — `lingui/no-expression-in-message`
ESLint rule rejects the inline form:
```tsx
const bdiEmail = <bdi>{target.email}</bdi>;
...
values={{ email: bdiEmail }}
```

Catalog impact: zero (`lingui extract` no-op). All 519 admin tests + typecheck + lint + format
pass.

Fixes #793