### PR TITLE
feat: plumix i18n verify CLI + plugin drift gates + translator workflow doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ A headless CMS for the edge, built on Cloudflare Workers.
   overrides.
 - [Plugin author guide](./plugin-author.md) — registering metaboxes,
   blocks, field types, RPC routers from a plugin.
+- [Translation guide](./translation.md) — adding a locale, reading
+  `.po` entries, ICU plurals, RTL smoke-testing.
 
 ## Reference
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -1,0 +1,83 @@
+# Translating plumix
+
+Plumix UI ships in English (`en`) as the source locale. Adding a new locale is a translation pull request — no engineering needed.
+
+## What to translate
+
+Six packages own translatable strings:
+
+| Package                    | Catalog                                          |
+| -------------------------- | ------------------------------------------------ |
+| `@plumix/admin`            | `packages/admin/locales/{locale}.po`             |
+| `@plumix/plugin-pages`     | `packages/plugins/pages/locales/{locale}.po`     |
+| `@plumix/plugin-blog`      | `packages/plugins/blog/locales/{locale}.po`      |
+| `@plumix/plugin-menu`      | `packages/plugins/menu/locales/{locale}.po`      |
+| `@plumix/plugin-media`     | `packages/plugins/media/locales/{locale}.po`     |
+| `@plumix/plugin-audit-log` | `packages/plugins/audit-log/locales/{locale}.po` |
+
+Plugin catalogs are hand-authored from the plugin manifest; `@plumix/admin` is Lingui-extracted from source. A locale is "complete" when it covers all six. The maintainer flips `enabled: true` in the registry once coverage meets the quality bar — no automated threshold.
+
+## Adding a new locale
+
+1. Pick a code from BCP-47 (`uk`, `ar`, `pt-BR`, `zh-Hans`, …). Match a code already supported by Lingui's plural rules — see [Lingui locales](https://lingui.dev/ref/locale).
+2. Copy `en.po` to `{code}.po` in each of the six packages.
+3. Fill in `msgstr ""` for each entry. Leave `msgid` and `msgctxt` untouched.
+4. Verify locally:
+
+   ```sh
+   pnpm i18n:check       # source ↔ catalog drift across all packages
+   pnpm i18n:extract     # admin only — regenerates from current source
+   pnpm i18n:compile     # builds the runtime catalog files
+   pnpm dev              # smoke-test in the admin UI with ?lang={code}
+   ```
+
+5. Open a PR. The CI gates `i18n` and `i18n ratchet` must pass.
+
+## How to read a `.po` entry
+
+```po
+#. context for translator: post type singular name
+#: src/admin/MenusShell.tsx
+msgctxt "post type singular name"
+msgid "plugin.blog.post.singular"
+msgstr "Post"
+```
+
+- `#.` — translator comment. Explains placeholders (`{name}` = "the user's display name") or context. Read it.
+- `#:` — source location. Where the string surfaces. Useful for finding the screen.
+- `msgctxt` — semantic disambiguator. The same English word can have two `msgid`s if it means different things (e.g. `Trash` as a status noun vs. as a verb). Translate each `msgctxt` independently.
+- `msgid` — the source string OR an explicit id like `plugin.blog.post.singular`.
+- `msgstr` — your translation goes here.
+
+## Placeholders and pluralization
+
+ICU MessageFormat. Common shapes:
+
+```po
+# Simple placeholder — translate around the {name} token verbatim.
+msgid "Welcome, {name}"
+msgstr "Bienvenido, {name}"
+
+# Plural form — adjust the cases to your locale's plural rules.
+msgid "{count, plural, one {# revision} other {# revisions}}"
+msgstr "{count, plural, one {# revisión} other {# revisiones}}"
+```
+
+Slavic locales (`uk`, `ru`, `pl`) use four plural cases (`one`, `few`, `many`, `other`); Lingui's `Intl.PluralRules`-backed runtime picks the right form per number. Arabic uses six. Adjust the cases — don't drop any.
+
+## RTL locales
+
+For RTL languages (`ar`, `he`, `fa`, `ur`), plumix's runtime sets `<html dir="rtl">` and Radix's `DirectionProvider` flips chrome automatically. Translate naturally; the layout takes care of itself. After completing the catalog, smoke-test every admin route — RTL regressions surface during real navigation, not via unit tests.
+
+## Catalog drift
+
+The `pnpm i18n:check` gate fails if source adds a new descriptor without a matching `msgid` in `en.po`. The engineering team owns updating `en.po`; ping in the PR if you spot the gap. The gate reports both directions:
+
+- `+ msgid` — declared in source, missing from `en.po`. Translators won't see it.
+- `- msgid` — present in `en.po`, no source declaration. Orphaned translation work.
+
+To preserve a translation for a string that was removed from source, mark its entry obsolete with `#~ msgid "..."`. The gate skips obsolete entries, so the translation stays in the file without tripping orphan detection.
+
+## Where to ask
+
+Translation questions land in the PR review. Architecture and process: open a GitHub Discussion before starting on a sizeable locale (admin core alone is ~640 strings).

--- a/packages/core/src/cli/errors.ts
+++ b/packages/core/src/cli/errors.ts
@@ -14,6 +14,7 @@ type CliErrorCode =
   | "config_load_failed"
   | "config_invalid"
   | "i18n_check_drift"
+  | "i18n_verify_drift"
   | "i18n_init_no_package_json"
   | "i18n_init_invalid_package_json"
   | "tooling_command_no_app";
@@ -207,6 +208,22 @@ export class CliError extends Error {
       "i18n_check_drift",
       `Translation catalogs out of sync — ${ctx.ids.length} msgid(s) drifted (+ added, - removed):\n  ${ctx.ids.join("\n  ")}`,
       "Run `plumix i18n extract` locally and commit the updated `.po` file(s).",
+      undefined,
+    );
+  }
+
+  static i18nVerifyDrift(ctx: {
+    missingInCatalog: readonly string[];
+    orphanedInCatalog: readonly string[];
+  }): CliError {
+    const lines: string[] = [];
+    for (const id of ctx.missingInCatalog) lines.push(`+ ${id}`);
+    for (const id of ctx.orphanedInCatalog) lines.push(`- ${id}`);
+    const total = ctx.missingInCatalog.length + ctx.orphanedInCatalog.length;
+    return new CliError(
+      "i18n_verify_drift",
+      `Source ↔ catalog drift — ${total} msgid(s) (+ missing from catalog, - orphaned in catalog):\n  ${lines.join("\n  ")}`,
+      "Add missing entries to `locales/en.po` (translators won't see them otherwise) and drop orphaned ones (dead translation work).",
       undefined,
     );
   }

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile --namespace es",
+    "i18n:check": "plumix i18n verify",
     "attw": "attw --pack . --profile esm-only",
     "build": "node scripts/i18n-compile-check.mjs && tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules",

--- a/packages/plugins/blog/package.json
+++ b/packages/plugins/blog/package.json
@@ -40,6 +40,7 @@
   "scripts": {
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile --namespace es",
+    "i18n:check": "plumix i18n verify",
     "attw": "attw --pack . --profile esm-only",
     "build": "node scripts/i18n-compile-check.mjs && tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules",

--- a/packages/plugins/media/package.json
+++ b/packages/plugins/media/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile --namespace es",
+    "i18n:check": "plumix i18n verify",
     "attw": "attw --pack . --profile esm-only",
     "build": "node scripts/i18n-compile-check.mjs && tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules e2e/playwright-report e2e/test-results",

--- a/packages/plugins/menu/package.json
+++ b/packages/plugins/menu/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile --namespace es",
+    "i18n:check": "plumix i18n verify",
     "attw": "attw --pack . --profile esm-only",
     "build": "node scripts/i18n-compile-check.mjs && tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules e2e/playwright-report e2e/test-results",

--- a/packages/plugins/pages/package.json
+++ b/packages/plugins/pages/package.json
@@ -40,6 +40,7 @@
   "scripts": {
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile --namespace es",
+    "i18n:check": "plumix i18n verify",
     "attw": "attw --pack . --profile esm-only",
     "build": "node scripts/i18n-compile-check.mjs && tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules",

--- a/packages/plumix/src/cli/commands/i18n.test.ts
+++ b/packages/plumix/src/cli/commands/i18n.test.ts
@@ -12,7 +12,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { CommandContext, PlumixApp } from "@plumix/core";
 
-import { i18nCommand, i18nDeps, LINGUI_DEP_RANGE } from "./i18n.js";
+import {
+  computeIdDrift,
+  i18nCommand,
+  i18nDeps,
+  LINGUI_DEP_RANGE,
+  sourceDescriptorIds,
+} from "./i18n.js";
 
 function fakeApp(): PlumixApp {
   return {
@@ -35,6 +41,110 @@ function ctx(
     ...overrides,
   };
 }
+
+describe("sourceDescriptorIds", () => {
+  test("finds an id in a plain object literal that also has message", () => {
+    const ids = sourceDescriptorIds(
+      'const M = { foo: { id: "plugin.blog.post.singular", message: "Post" } };',
+    );
+    expect([...ids]).toEqual(["plugin.blog.post.singular"]);
+  });
+
+  test("finds an id inside withContext({ id, message }, ctx)", () => {
+    const ids = sourceDescriptorIds(
+      'const POST = withContext({ id: "plugin.blog.post.singular", message: "Post" }, "post type singular name");',
+    );
+    expect([...ids]).toEqual(["plugin.blog.post.singular"]);
+  });
+
+  test("finds an id inside defineMessage({...}) spanning multiple lines", () => {
+    const ids = sourceDescriptorIds(
+      `defineMessage({
+         id: "entries.list.row.trash",
+         message: "Trash",
+         context: "action verb",
+       })`,
+    );
+    expect([...ids]).toEqual(["entries.list.row.trash"]);
+  });
+
+  test("ignores object literals that have id but no message", () => {
+    // e.g. <Trans id="x" /> as a runtime ref, or { id: 1 } DB record
+    const ids = sourceDescriptorIds('const ref = { id: "some.id" };');
+    expect([...ids]).toEqual([]);
+  });
+
+  test('finds an id in a <Trans id="..." message="..." /> JSX element', () => {
+    const ids = sourceDescriptorIds(
+      `<Trans id="plugin.auditLog.column.actor" message="Actor" />`,
+    );
+    expect([...ids]).toEqual(["plugin.auditLog.column.actor"]);
+  });
+
+  test("finds an id in a multiline <Trans> tag", () => {
+    const ids = sourceDescriptorIds(
+      `<Trans
+         id="entries.list.statusFilter.draft"
+         message="Draft"
+         context="entry status"
+       />`,
+    );
+    expect([...ids]).toEqual(["entries.list.statusFilter.draft"]);
+  });
+
+  test("does NOT match an outer { id: ... } whose message: lives in a nested child block", () => {
+    // Real false positive: a nav-group descriptor `{ id: "library",
+    // label: { id: "...", message: "Library" } }` has both keys but
+    // `message:` belongs to a nested object, so the outer `id:` is not
+    // a translation descriptor.
+    const ids = sourceDescriptorIds(`{
+       id: "library",
+       label: { id: "core.adminNav.library", message: "Library" },
+       priority: 150,
+     }`);
+    expect([...ids]).toEqual(["core.adminNav.library"]);
+  });
+
+  test("collects every descriptor in a file (no duplicates)", () => {
+    const ids = sourceDescriptorIds(
+      `const A = { id: "a.x", message: "A" };
+       const B = { id: "b.y", message: "B" };
+       const C = { id: "a.x", message: "duplicate" };`,
+    );
+    expect([...ids].sort()).toEqual(["a.x", "b.y"]);
+  });
+});
+
+describe("computeIdDrift", () => {
+  test("returns empty arrays when source and catalog ids match exactly", () => {
+    const drift = computeIdDrift(new Set(["a.x", "b.y"]), ["a.x", "b.y"]);
+    expect(drift).toEqual({ missingInCatalog: [], orphanedInCatalog: [] });
+  });
+
+  test("flags an id declared in source but absent from the catalog", () => {
+    const drift = computeIdDrift(new Set(["a.x", "b.y"]), ["a.x"]);
+    expect(drift).toEqual({
+      missingInCatalog: ["b.y"],
+      orphanedInCatalog: [],
+    });
+  });
+
+  test("flags a msgid in the catalog with no source declaration", () => {
+    const drift = computeIdDrift(new Set(["a.x"]), ["a.x", "b.y"]);
+    expect(drift).toEqual({
+      missingInCatalog: [],
+      orphanedInCatalog: ["b.y"],
+    });
+  });
+
+  test("sorts both lists for stable CI output", () => {
+    const drift = computeIdDrift(new Set(["c", "a"]), ["d", "b"]);
+    expect(drift).toEqual({
+      missingInCatalog: ["a", "c"],
+      orphanedInCatalog: ["b", "d"],
+    });
+  });
+});
 
 describe("i18nCommand", () => {
   let dir: string;
@@ -83,6 +193,59 @@ describe("i18nCommand", () => {
     await expect(
       i18nCommand.run(ctx({ cwd: dir, argv: ["extract"] })),
     ).rejects.toThrow(/@lingui\/cli not found/);
+  });
+
+  describe("verify", () => {
+    function seedPlugin(args: {
+      readonly sourceIds: readonly string[];
+      readonly catalogIds: readonly string[];
+    }): void {
+      const localesDir = join(dir, "locales");
+      const srcDir = join(dir, "src");
+      mkdirSync(localesDir, { recursive: true });
+      mkdirSync(srcDir, { recursive: true });
+      const src = args.sourceIds
+        .map(
+          (id) =>
+            `const _${id.replace(/\W/g, "_")} = { id: "${id}", message: "msg" };`,
+        )
+        .join("\n");
+      writeFileSync(join(srcDir, "index.ts"), src);
+      const po = `msgid ""\nmsgstr ""\n\n${args.catalogIds
+        .map((id) => `msgid "${id}"\nmsgstr ""`)
+        .join("\n\n")}\n`;
+      writeFileSync(join(localesDir, "en.po"), po);
+    }
+
+    test("passes silently when source ids and catalog msgids match", async () => {
+      seedPlugin({
+        sourceIds: ["plugin.x.foo", "plugin.x.bar"],
+        catalogIds: ["plugin.x.foo", "plugin.x.bar"],
+      });
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["verify"] })),
+      ).resolves.toBeUndefined();
+    });
+
+    test("throws a drift error listing ids missing from the catalog", async () => {
+      seedPlugin({
+        sourceIds: ["plugin.x.foo", "plugin.x.bar"],
+        catalogIds: ["plugin.x.foo"],
+      });
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["verify"] })),
+      ).rejects.toThrow(/plugin\.x\.bar/);
+    });
+
+    test("throws on orphaned msgids in the catalog with no source declaration", async () => {
+      seedPlugin({
+        sourceIds: ["plugin.x.foo"],
+        catalogIds: ["plugin.x.foo", "plugin.x.dead"],
+      });
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["verify"] })),
+      ).rejects.toThrow(/plugin\.x\.dead/);
+    });
   });
 
   describe("extract --check", () => {
@@ -270,7 +433,7 @@ describe("i18nCommand", () => {
       expect(pkg.scripts).toMatchObject({
         "i18n:extract": "lingui extract",
         "i18n:compile": "lingui compile --namespace es",
-        "i18n:check": "plumix i18n extract --check",
+        "i18n:check": "plumix i18n verify",
       });
       // Pinning to the constant — a version bump must be a deliberate
       // test change so the gate against silent drift stays loud.

--- a/packages/plumix/src/cli/commands/i18n.ts
+++ b/packages/plumix/src/cli/commands/i18n.ts
@@ -15,7 +15,7 @@ import { CliError, spawnInherit } from "@plumix/core";
 
 import { report } from "../report.js";
 
-const SUPPORTED = ["extract", "compile", "init"] as const;
+const SUPPORTED = ["extract", "compile", "init", "verify"] as const;
 export const LINGUI_DEP_RANGE = "^6.2.0";
 
 export const i18nCommand: CommandDefinition = {
@@ -31,6 +31,10 @@ export const i18nCommand: CommandDefinition = {
     }
     if (sub === "init") {
       runInit(ctx);
+      return;
+    }
+    if (sub === "verify") {
+      runVerify(ctx);
       return;
     }
     if (sub !== "extract" && sub !== "compile") {
@@ -203,7 +207,11 @@ function mergePackageJson(pkg: PackageJsonShape): {
   const newScripts: Record<string, string> = {
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile --namespace es",
-    "i18n:check": "plumix i18n extract --check",
+    // `verify` is the source↔catalog drift gate — works for both
+    // lingui-extracted catalogs and the hand-authored manifest pattern
+    // plumix's own plugins use. Catches JSX `<Trans id="..." message="...">`
+    // and object-literal `{ id, message }` descriptors uniformly.
+    "i18n:check": "plumix i18n verify",
   };
   const newDeps: Record<string, string> = {
     "@lingui/cli": LINGUI_DEP_RANGE,
@@ -275,6 +283,155 @@ async function runExtractCheck(
       if (!snapshot.has(path)) rmSync(path);
     }
   }
+}
+
+/** Drift gate for hand-authored plugin catalogs. Unlike `extract --check`
+ *  (which assumes the Lingui extractor sees every descriptor), `verify`
+ *  scans source for any `{ id, message }`-shape literal — so descriptors
+ *  wrapped in `withContext(...)` or declared as plain manifest fields
+ *  count too. Exits non-zero with a sorted drift report when source and
+ *  `locales/en.po` disagree. */
+function runVerify(ctx: CommandContext): void {
+  const localesDir = resolve(ctx.cwd, "locales");
+  const srcDir = resolve(ctx.cwd, "src");
+  const sourceIds = new Set<string>();
+  for (const file of listSourceFiles(srcDir)) {
+    for (const id of sourceDescriptorIds(readFileSync(file, "utf8"))) {
+      sourceIds.add(id);
+    }
+  }
+  const catalogIds: string[] = [];
+  for (const path of listPoFiles(localesDir)) {
+    for (const id of activeMsgids(readFileSync(path, "utf8"))) {
+      catalogIds.push(id);
+    }
+  }
+  const drift = computeIdDrift(sourceIds, catalogIds);
+  if (drift.missingInCatalog.length > 0 || drift.orphanedInCatalog.length > 0) {
+    throw CliError.i18nVerifyDrift(drift);
+  }
+}
+
+function listSourceFiles(dir: string): readonly string[] {
+  const out: string[] = [];
+  try {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === "node_modules" || e.name === "dist") continue;
+        out.push(...listSourceFiles(full));
+      } else if (
+        e.isFile() &&
+        (e.name.endsWith(".ts") || e.name.endsWith(".tsx")) &&
+        // Test files often declare fixture descriptors (`{ id: "test.x",
+        // message: "fixture" }`) that shouldn't count as shipped strings.
+        // Gate scope is production source.
+        !e.name.endsWith(".test.ts") &&
+        !e.name.endsWith(".test.tsx")
+      ) {
+        out.push(full);
+      }
+    }
+  } catch {
+    // Missing src/ dir is fine — a package may ship catalogs without code yet.
+  }
+  return out;
+}
+
+/** Sorted so CI failures read deterministically. `missingInCatalog`
+ *  blocks translators from seeing the string; `orphanedInCatalog` is
+ *  dead translation work. */
+export function computeIdDrift(
+  sourceIds: ReadonlySet<string>,
+  catalogIds: readonly string[],
+): { missingInCatalog: string[]; orphanedInCatalog: string[] } {
+  const catalog = new Set(catalogIds);
+  const missingInCatalog: string[] = [];
+  const orphanedInCatalog: string[] = [];
+  for (const id of sourceIds) if (!catalog.has(id)) missingInCatalog.push(id);
+  for (const id of catalog) if (!sourceIds.has(id)) orphanedInCatalog.push(id);
+  return {
+    missingInCatalog: missingInCatalog.sort(),
+    orphanedInCatalog: orphanedInCatalog.sort(),
+  };
+}
+
+/** Finds `{ id: "...", message: "..." }`-shaped descriptor literals
+ *  (covers `defineMessage`, `withContext`, manifest objects) and
+ *  `<Trans id="..." message="..." />` JSX. `id` and `message` must be
+ *  siblings at the same nesting depth — a nav-group descriptor like
+ *  `{ id: "x", label: { id, message } }` doesn't count. Dynamic ids
+ *  (`id: prefix + ".x"`) are ignored — neither the extractor nor the
+ *  catalog can represent them. */
+export function sourceDescriptorIds(text: string): ReadonlySet<string> {
+  const ids = new Set<string>();
+  // Object-literal form: `id: "X"` — accept only when the enclosing
+  // `{...}` has `message:` at the SAME nesting depth (a sibling `id:`
+  // next to a nested `label: { id, message }` is a nav-group descriptor,
+  // not a translation descriptor).
+  const objRe = /\bid:\s*["']([^"'\n]+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = objRe.exec(text)) !== null) {
+    if (hasSiblingMessageKey(text, m.index)) ids.add(m[1] ?? "");
+  }
+  // JSX-attribute form: `id="X"` inside a `<Trans ... message="..." />`
+  // (or `<Trans ... message={...} />`) tag, possibly across multiple
+  // lines. The tag begins with the most recent `<` to the left and ends
+  // at the next `>` (no nested elements inside an opening tag).
+  const jsxRe = /\bid=["']([^"'\n]+)["']/g;
+  while ((m = jsxRe.exec(text)) !== null) {
+    const tag = enclosingJsxTag(text, m.index);
+    if (tag && /\bmessage[:=]/.test(tag)) ids.add(m[1] ?? "");
+  }
+  ids.delete("");
+  return ids;
+}
+
+function hasSiblingMessageKey(text: string, pos: number): boolean {
+  // Find the nearest unbalanced `{` to the left of pos.
+  let depth = 0;
+  let start = -1;
+  for (let i = pos; i >= 0; i--) {
+    const c = text[i];
+    if (c === "}") depth += 1;
+    else if (c === "{") {
+      if (depth === 0) {
+        start = i;
+        break;
+      }
+      depth -= 1;
+    }
+  }
+  if (start === -1) return false;
+  // Scan forward from `start`, tracking nested `{...}` depth. Match
+  // `message:` only when depth === 1 (sibling level of the `{` body).
+  depth = 0;
+  for (let i = start; i < text.length; i++) {
+    const c = text[i];
+    if (c === "{") depth += 1;
+    else if (c === "}") {
+      depth -= 1;
+      if (depth === 0) return false;
+    } else if (
+      depth === 1 &&
+      text.startsWith("message", i) &&
+      /\s*:/.test(text.slice(i + "message".length))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Opening JSX tags don't nest, so a simple `<...>` window is enough. */
+function enclosingJsxTag(text: string, pos: number): string | null {
+  const lt = text.lastIndexOf("<", pos);
+  if (lt === -1) return null;
+  const gt = text.indexOf(">", pos);
+  if (gt === -1) return null;
+  // Reject the case where another tag closed between `lt` and `pos`.
+  if (text.lastIndexOf(">", pos - 1) > lt) return null;
+  return text.slice(lt, gt + 1);
 }
 
 /** Extract active (non-obsolete) msgid values from a .po file. Handles


### PR DESCRIPTION
Close the engineering side of translator-readiness so the next i18n step is content seeding
(#685), not code.

**The gap**

Plumix's first-party plugins declare msgids via `withContext({ id, message }, ctx)` from the
plugin manifest — a pattern Lingui's extractor doesn't recognise. Running `extract --check`
(the admin drift gate) on these catalogs would demote every manifest-declared msgid to
obsolete. Result: no automated source↔catalog gate ran across the 5 plugin catalogs translators
will actually work with.

**`plumix i18n verify`**

A hand-authored-catalog-friendly drift gate. Scans source for any `{ id, message }` object
literal AND `<Trans id="..." message="...">` JSX, with same-depth nesting so a nav-group
descriptor `{ id: "library", label: { id, message } }` doesn't false-positive on the outer
`id`. Wired as `i18n:check` in all 5 plugins. Updates the `plumix i18n init` scaffolder
template so new plugins inherit the right gate.

Test files are excluded from the source scan — fixture descriptors with synthetic ids
shouldn't count as shipped strings.

**Translator workflow doc**

`docs/translation.md` (linked from `docs/README.md`) — locale selection, `.po` anatomy, ICU
plurals, RTL smoke-testing, the `+ / -` drift legend, the `#~` obsolete marker for preserving
removed translations. Concise; reads like a one-sitting on-ramp.

**Verified**

`pnpm i18n:check` runs across all 6 packages green. Full suite (1789 core + 519 admin + 5
plugin) + typecheck + lint + format pass. 15 new tests cover the source-scan + drift-diff +
verify-orchestration cycles, TDD'd one cycle at a time.

After this lands, the only remaining i18n work is #685 (seed translations for `uk` + `ar`) —
translator labor, not engineering.