### PR TITLE
feat: lift ctx.user + queriedEntry into the SSR provider

### DIFF
--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -8,10 +8,26 @@ import type { ThemeTokens } from "../styles/types.js";
 import { renderBlockTree } from "../render-block-tree.js";
 import { RendererError } from "./errors.js";
 
+// `@plumix/core` depends on `@plumix/blocks`, not the reverse — these
+// mirror `AuthenticatedUser` / `ResolvedEntity` structurally.
+export interface RendererUser {
+  readonly id: number;
+  readonly email: string;
+  readonly role: string;
+  readonly meta: Record<string, unknown>;
+}
+
+export type RendererQueriedEntry =
+  | { readonly kind: "entry"; readonly id: number }
+  | { readonly kind: "term"; readonly id: number }
+  | { readonly kind: "archive"; readonly entryType: string };
+
 export interface PlumixContextValue {
   readonly registry: BlockRegistry;
   readonly tokens?: ThemeTokens;
   readonly loaderData?: ResolvedBlockLoaders;
+  readonly user?: RendererUser | null;
+  readonly queriedEntry?: RendererQueriedEntry | null;
 }
 
 const PlumixContext = createContext<PlumixContextValue | null>(null);
@@ -50,4 +66,12 @@ export function BlockRenderer({
 
 export function useTokens(): ThemeTokens | undefined {
   return usePlumixContext("useTokens").tokens;
+}
+
+export function useUser(): RendererUser | null {
+  return usePlumixContext("useUser").user ?? null;
+}
+
+export function useQueriedEntry(): RendererQueriedEntry | null {
+  return usePlumixContext("useQueriedEntry").queriedEntry ?? null;
 }

--- a/packages/blocks/src/renderer/renderer.test.tsx
+++ b/packages/blocks/src/renderer/renderer.test.tsx
@@ -2,7 +2,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 
 import { createBlockRegistry } from "../block-registry.js";
-import { BlockRenderer, PlumixProvider, useTokens } from "./index.js";
+import {
+  BlockRenderer,
+  PlumixProvider,
+  useQueriedEntry,
+  useTokens,
+  useUser,
+} from "./index.js";
 
 const headingRegistry = createBlockRegistry([
   {
@@ -62,5 +68,79 @@ describe("useTokens", () => {
       return null;
     }
     expect(() => renderToStaticMarkup(<Probe />)).toThrow(/PlumixProvider/);
+  });
+});
+
+describe("useUser", () => {
+  test("returns the user from the active provider", () => {
+    const user = {
+      id: 12,
+      email: "author@example.com",
+      role: "author",
+      meta: {},
+    };
+
+    function Probe() {
+      const result = useUser();
+      return <span data-testid="probe">{JSON.stringify(result)}</span>;
+    }
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: headingRegistry, user }}>
+        <Probe />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("author@example.com");
+  });
+
+  test("returns null when the provider has no user", () => {
+    function Probe() {
+      const result = useUser();
+      return <span data-testid="probe">{result === null ? "anon" : "x"}</span>;
+    }
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: headingRegistry }}>
+        <Probe />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("anon");
+  });
+});
+
+describe("useQueriedEntry", () => {
+  test("returns the queried entry from the active provider", () => {
+    const queriedEntry = { kind: "entry" as const, id: 42 };
+
+    function Probe() {
+      const result = useQueriedEntry();
+      return <span data-testid="probe">{JSON.stringify(result)}</span>;
+    }
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: headingRegistry, queriedEntry }}>
+        <Probe />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("&quot;kind&quot;:&quot;entry&quot;");
+    expect(html).toContain("&quot;id&quot;:42");
+  });
+
+  test("returns null when the provider has no queried entry", () => {
+    function Probe() {
+      const result = useQueriedEntry();
+      return <span data-testid="probe">{result === null ? "none" : "x"}</span>;
+    }
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: headingRegistry }}>
+        <Probe />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("none");
   });
 });

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -399,9 +399,6 @@ export function withUser<TSchema extends Record<string, unknown>>(
       can: makeAuthCan(resolver, user, tokenScopes),
     },
     oauthProviders: ctx.oauthProviders,
-    // Public-route paths skip `withUser` and keep the site default; admin /
-    // RPC paths land here once auth resolves, so step 2 of the chain
-    // (user.meta.locale) is only reachable from this seam.
     locale: resolveLocale({ request: ctx.request, user, i18n: ctx.i18n }),
   };
 }

--- a/packages/core/src/context/with-user-locale.test.ts
+++ b/packages/core/src/context/with-user-locale.test.ts
@@ -14,7 +14,7 @@ describe("withUser — locale re-resolution", () => {
     const baseCtx = createAppContext({
       db: {} as never,
       env: {},
-      request: new Request("https://cms.example/"),
+      request: new Request("https://cms.example/_plumix/admin/"),
       hooks: new HookRegistry(),
       plugins: createPluginRegistry(),
       i18n,

--- a/packages/core/src/i18n/resolve-locale.test.ts
+++ b/packages/core/src/i18n/resolve-locale.test.ts
@@ -66,7 +66,7 @@ describe("resolveLocale", () => {
     });
 
     const resolved = resolveLocale({
-      request: REQUEST,
+      request: adminRequest(),
       user: user({ locale: "fr" }),
       i18n,
     });
@@ -87,7 +87,7 @@ describe("resolveLocale", () => {
     });
 
     const resolved = resolveLocale({
-      request: REQUEST,
+      request: adminRequest(),
       user: user({ locale: "fr" }),
       i18n,
     });
@@ -138,13 +138,22 @@ describe("resolveLocale", () => {
     expect(resolved.code).toBe("en");
   });
 
-  test("user.meta.locale wins over site default (WP get_user_locale parity)", () => {
+  test("user.meta.locale wins over site default on admin paths (WP get_user_locale parity)", () => {
+    const resolved = resolveLocale({
+      request: adminRequest(),
+      user: user({ locale: "fr" }),
+      i18n: enFr,
+    });
+    expect(resolved.code).toBe("fr");
+  });
+
+  test("user.meta.locale is ignored on public paths so CDN caching stays per-URL (WP frontend/admin split)", () => {
     const resolved = resolveLocale({
       request: REQUEST,
       user: user({ locale: "fr" }),
       i18n: enFr,
     });
-    expect(resolved.code).toBe("fr");
+    expect(resolved.code).toBe("en");
   });
 
   test("plumix_locale cookie applies for anonymous visitors (WP wp_lang parity)", () => {

--- a/packages/core/src/i18n/resolve-locale.ts
+++ b/packages/core/src/i18n/resolve-locale.ts
@@ -27,18 +27,21 @@ export function resolveLocale({
 
   const override = i18n.resolveLocale?.(request, user);
   const url = new URL(request.url);
-  // Path-gate Accept-Language to `/_plumix/*` so public-route HTML stays
-  // identical per URL — CDN cache keys must not fragment by browser locale.
-  // The cookie is already path-gated by the browser via its `Path=/_plumix/`
-  // attribute; we don't re-check the URL for it.
+  // Path-gate to `/_plumix/*` so public-route HTML stays identical per URL —
+  // CDN cache keys must not fragment by browser locale or admin-user prefs,
+  // and the public site is the WP-style frontend zone where user.meta.locale
+  // is irrelevant. The cookie is already path-gated by the browser via its
+  // `Path=/_plumix/` attribute; we don't re-check the URL for it.
   const onInternalPath = url.pathname.startsWith("/_plumix/");
+  const userLocale =
+    onInternalPath && typeof user?.meta.locale === "string"
+      ? user.meta.locale
+      : null;
 
   return (
     resolveCode(override?.code) ??
     resolveCode(url.searchParams.get("lang")) ??
-    resolveCode(
-      typeof user?.meta.locale === "string" ? user.meta.locale : null,
-    ) ??
+    resolveCode(userLocale) ??
     resolveCode(readSessionCookie(request, ADMIN_LOCALE_COOKIE)) ??
     (onInternalPath ? matchAcceptLanguage(request, i18n) : null) ??
     i18n.defaultLocale

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -337,8 +337,9 @@ describe("resolvePublicRoute — single entry through theme", () => {
     );
     const response = await h.dispatch(request, author);
     const body = await response.text();
-    // Even with user.meta.locale = "ar", public routes don't call
-    // `withUser`, so `ctx.locale` stays at the site default.
+    // Even with user.meta.locale = "ar", `resolveLocale` path-gates the
+    // user-locale lookup to `/_plumix/*` — public-route HTML stays at the
+    // site default so CDN cache keys don't fragment by admin-user prefs.
     expect(body).toContain('<html lang="en" dir="ltr">');
   });
 

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -279,7 +279,13 @@ function renderTree({
   const TemplateAdapter = (): ReactNode =>
     template.render({ ...deps, data, ctx });
   const templateTree: ReactNode = createElement(PlumixProvider, {
-    value: { registry: ctx.blocks, tokens, loaderData },
+    value: {
+      registry: ctx.blocks,
+      tokens,
+      loaderData,
+      user: ctx.user,
+      queriedEntry: ctx.resolvedEntity,
+    },
     children: createElement(TemplateAdapter),
   });
   const rendered = renderToString(templateTree);

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -33,6 +33,7 @@ import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
 import { rewriteAdminShellLangDir } from "./admin-shell.js";
 import { forbidden, jsonResponse, methodNotAllowed, notFound } from "./http.js";
+import { loadUserForPublicRequest } from "./load-user-for-public-request.js";
 
 const RPC_PREFIX = "/_plumix/rpc";
 const ADMIN_PREFIX = "/_plumix/admin";
@@ -189,6 +190,7 @@ async function dispatchPublicRoute(
   const templateDeps = app.plugins.templateDeps;
   const assetManifest = app.assetManifest;
   try {
+    ctx = await loadUserForPublicRequest(ctx);
     const response = await resolvePublicRouteOrFallback(app, ctx, url);
     if (response.status === 404) {
       const html = await renderErrorThroughTheme({

--- a/packages/core/src/runtime/load-user-for-public-request.test.ts
+++ b/packages/core/src/runtime/load-user-for-public-request.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { AuthResult } from "../auth/authenticator.js";
+import type { AppContext, AuthenticatedUser } from "../context/app.js";
+import { resolveLocales } from "../i18n/locale-registry.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { createDispatcherHarness, plumixRequest } from "../test/dispatcher.js";
+import { loadUserForPublicRequest } from "./load-user-for-public-request.js";
+
+const i18n = resolveLocales({ defaultLocale: "en", locales: ["en"] });
+
+const authenticatedUser: AuthenticatedUser = {
+  id: 7,
+  email: "editor@example.com",
+  role: "editor",
+  meta: {},
+};
+
+describe("loadUserForPublicRequest", () => {
+  test("returns the ctx unchanged and skips authentication when the request has no plumix_session cookie", async () => {
+    const authenticate = vi.fn();
+    const ctx = {
+      request: new Request("https://example.com/"),
+      user: null,
+      authenticator: { authenticate },
+    } as unknown as AppContext;
+
+    const result = await loadUserForPublicRequest(ctx);
+
+    expect(result).toBe(ctx);
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+
+  test("returns ctx unchanged when the cookie is present but the authenticator rejects it (expired or orphaned session)", async () => {
+    const authenticate = vi.fn().mockResolvedValue(null);
+    const ctx = {
+      request: new Request("https://example.com/", {
+        headers: { Cookie: "plumix_session=stale" },
+      }),
+      db: {},
+      user: null,
+      plugins: createPluginRegistry(),
+      i18n,
+      authenticator: { authenticate },
+    } as unknown as AppContext;
+
+    const result = await loadUserForPublicRequest(ctx);
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(result).toBe(ctx);
+    expect(result.user).toBeNull();
+  });
+
+  test("authenticates once and returns ctx with user populated when the request carries a plumix_session cookie", async () => {
+    const authenticate = vi.fn().mockResolvedValue({
+      user: authenticatedUser,
+      tokenScopes: null,
+    });
+    const ctx = {
+      request: new Request("https://example.com/", {
+        headers: { Cookie: "plumix_session=abc" },
+      }),
+      db: {},
+      user: null,
+      plugins: createPluginRegistry(),
+      i18n,
+      authenticator: { authenticate },
+    } as unknown as AppContext;
+
+    const result = await loadUserForPublicRequest(ctx);
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(result.user).toEqual(authenticatedUser);
+  });
+});
+
+describe("dispatchPublicRoute → loadUserForPublicRequest wiring", () => {
+  test("anonymous public request never invokes the authenticator (zero added DB hits)", async () => {
+    const authenticate =
+      vi.fn<(request: Request) => Promise<AuthResult | null>>();
+    const h = await createDispatcherHarness({
+      authenticator: { authenticate },
+    });
+
+    await h.dispatch(plumixRequest("/", { method: "GET" }));
+
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+
+  test("authenticated public request invokes the authenticator exactly once", async () => {
+    const authenticate = vi.fn<
+      (request: Request) => Promise<AuthResult | null>
+    >(() => Promise.resolve(null));
+    const h = await createDispatcherHarness({
+      authenticator: { authenticate },
+    });
+    const user = await h.seedUser("editor");
+    const request = await h.authenticateRequest(
+      plumixRequest("/", { method: "GET" }),
+      user.id,
+    );
+
+    await h.dispatch(request);
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+  });
+
+  test("authenticator throwing on a public request degrades through the existing error boundary instead of escaping the dispatcher", async () => {
+    const h = await createDispatcherHarness({
+      authenticator: {
+        authenticate: () => Promise.reject(new Error("db blip")),
+      },
+    });
+    const user = await h.seedUser("editor");
+    const request = await h.authenticateRequest(
+      plumixRequest("/", { method: "GET" }),
+      user.id,
+    );
+
+    const response = await h.dispatch(request);
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/packages/core/src/runtime/load-user-for-public-request.ts
+++ b/packages/core/src/runtime/load-user-for-public-request.ts
@@ -1,0 +1,16 @@
+import type { AppContext } from "../context/app.js";
+import { readSessionCookie } from "../auth/cookies.js";
+import { withUser } from "../context/app.js";
+
+export async function loadUserForPublicRequest(
+  ctx: AppContext,
+): Promise<AppContext> {
+  if (readSessionCookie(ctx.request) === null) {
+    return ctx;
+  }
+  const result = await ctx.authenticator.authenticate(ctx.request, ctx.db);
+  if (result === null) {
+    return ctx;
+  }
+  return withUser(ctx, result.user, result.tokenScopes ?? null);
+}


### PR DESCRIPTION
First prerequisite for #663 (frontend admin bar). The slice lifts the authenticated user and the queried entry into the template-facing React context so theme code can render auth-aware HTML, and adds a cookie-presence fast-path so anonymous public traffic continues to pay zero session-lookup cost.

**Cookie fast-path on public dispatch**

`dispatchPublicRoute` now calls a new `loadUserForPublicRequest(ctx)` deep module before resolving the route. With no `plumix_session` cookie present it short-circuits and returns the ctx unchanged — anonymous traffic skips the authenticator entirely. With a cookie present it calls `ctx.authenticator.authenticate()` and `withUser()`. The call lives inside the existing try/catch so an authenticator throw (DB blip, malformed credential) degrades through the public-route error boundary instead of escaping the dispatcher.

**Template-facing hooks**

`PlumixContextValue` gains optional `user` and `queriedEntry`. Two new hooks export alongside `useTokens()`:

```ts
import { useUser, useQueriedEntry } from "@plumix/blocks";

const user = useUser();              // RendererUser | null
const queried = useQueriedEntry();    // RendererQueriedEntry | null — entry / term / archive
```

`RendererUser` and `RendererQueriedEntry` mirror core's `AuthenticatedUser` and `ResolvedEntity` structurally — re-declared in `@plumix/blocks` because `@plumix/core` depends on it, not the reverse. `renderThroughTheme()` threads `ctx.user` and `ctx.resolvedEntity` into the provider value at the existing call site.

**Locale resolver: `user.meta.locale` is now path-gated**

Before this slice, `ctx.user` was never populated on public routes, so the dispatcher discipline ("public routes skip `withUser`") was what kept the user's stored locale from leaking into the public site. Once `loadUserForPublicRequest` started populating `ctx.user` on public routes, that discipline became a leak — the existing render-template test asserting "authenticated visitor of a public URL still sees the site default" caught it immediately.

The fix moves the WP frontend/admin split out of the dispatcher and into `resolveLocale` itself: `user.meta.locale` is now admin-zone-only, gated to `/_plumix/*` alongside the existing `Accept-Language` gate. Calling `withUser` from any path is now safe. The corresponding stale comment in `withUser` is dropped.

```
resolveLocale precedence (unchanged ordering, narrower step 3):
  1. override            — any path
  2. ?lang= query        — any path
  3. user.meta.locale    — /_plumix/* only  ← narrowed
  4. plumix_locale cookie— browser-gated to /_plumix/
  5. Accept-Language     — /_plumix/* only
  6. site defaultLocale
```

Fixes #664