### PR TITLE
feat: declare admin_bar:nodes filter and render the bar shell

### DIFF
--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -45,7 +45,7 @@ export function PlumixProvider({
   children,
 }: {
   readonly value: PlumixContextValue;
-  readonly children: ReactNode;
+  readonly children?: ReactNode;
 }): ReactNode {
   return (
     <PlumixContext.Provider value={value}>{children}</PlumixContext.Provider>

--- a/packages/core/src/admin-bar/collect.test.ts
+++ b/packages/core/src/admin-bar/collect.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { AdminBarNode, BarRenderContext } from "./types.js";
+import { HookRegistry } from "../hooks/registry.js";
+import { collectAdminBarNodes } from "./collect.js";
+
+const baseCtx: BarRenderContext = {
+  user: { id: 1, email: "u@x", role: "admin", meta: {} },
+  queriedEntry: null,
+  request: new Request("https://cms.example/"),
+};
+
+describe("collectAdminBarNodes", () => {
+  test("returns an empty array when no handlers are registered", () => {
+    const hooks = new HookRegistry();
+
+    const nodes = collectAdminBarNodes(hooks, baseCtx);
+
+    expect(nodes).toEqual([]);
+  });
+
+  test("isolates a throwing handler so the chain continues with the prior good state", () => {
+    const errors: unknown[] = [];
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation((_msg, err) => {
+        errors.push(err);
+      });
+    try {
+      const hooks = new HookRegistry();
+      hooks.addFilter(
+        "admin_bar:nodes",
+        (nodes) => [...nodes, { id: "site", title: "Site", group: "root" }],
+        { plugin: "first" },
+      );
+      hooks.addFilter(
+        "admin_bar:nodes",
+        () => {
+          throw new Error("boom");
+        },
+        { plugin: "blowup" },
+      );
+      hooks.addFilter(
+        "admin_bar:nodes",
+        (nodes) => [...nodes, { id: "edit", title: "Edit", group: "primary" }],
+        { plugin: "third" },
+      );
+
+      const nodes = collectAdminBarNodes(hooks, baseCtx);
+
+      expect(nodes).toEqual([
+        { id: "site", title: "Site", group: "root" },
+        { id: "edit", title: "Edit", group: "primary" },
+      ]);
+      expect(errors).toHaveLength(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("warns on within-handler duplicate ids in a single contribution", () => {
+    const warnings: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((msg: string) => {
+        warnings.push(msg);
+      });
+    try {
+      const hooks = new HookRegistry();
+      hooks.addFilter("admin_bar:nodes", (nodes) => [
+        ...nodes,
+        { id: "edit", title: "Edit (first)", group: "primary" },
+        { id: "edit", title: "Edit (second)", group: "primary" },
+      ]);
+
+      const nodes = collectAdminBarNodes(hooks, baseCtx);
+
+      expect(nodes).toEqual([
+        { id: "edit", title: "Edit (second)", group: "primary" },
+      ]);
+      expect(warnings.some((w) => w.includes("edit"))).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test.each([
+    ["string", "oops"],
+    ["null", null],
+    ["undefined", undefined],
+    ["number", 42],
+    ["object", { not: "an array" }],
+  ])(
+    "discards a handler that returns %s and continues with the prior good state",
+    (_label, badReturn) => {
+      const errorCalls: number[] = [];
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+        errorCalls.push(1);
+      });
+      try {
+        const hooks = new HookRegistry();
+        hooks.addFilter(
+          "admin_bar:nodes",
+          (nodes) => [...nodes, { id: "site", title: "Site", group: "root" }],
+          { plugin: "first" },
+        );
+        hooks.addFilter(
+          "admin_bar:nodes",
+          () => badReturn as unknown as readonly AdminBarNode[],
+          { plugin: "bad" },
+        );
+        hooks.addFilter(
+          "admin_bar:nodes",
+          (nodes) => [
+            ...nodes,
+            { id: "edit", title: "Edit", group: "primary" },
+          ],
+          { plugin: "third" },
+        );
+
+        const nodes = collectAdminBarNodes(hooks, baseCtx);
+
+        expect(nodes).toEqual([
+          { id: "site", title: "Site", group: "root" },
+          { id: "edit", title: "Edit", group: "primary" },
+        ]);
+        expect(errorCalls).toHaveLength(1);
+      } finally {
+        errorSpy.mockRestore();
+      }
+    },
+  );
+
+  test("dedupes nodes that share an id (last-wins) and warns once per collision", () => {
+    const warnings: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((msg: string) => {
+        warnings.push(msg);
+      });
+    try {
+      const hooks = new HookRegistry();
+      hooks.addFilter("admin_bar:nodes", (nodes) => [
+        ...nodes,
+        { id: "site", title: "Site (first)", group: "root" },
+        { id: "edit", title: "Edit", group: "primary" },
+      ]);
+      hooks.addFilter("admin_bar:nodes", (nodes) => [
+        ...nodes,
+        { id: "site", title: "Site (override)", group: "root" },
+      ]);
+
+      const nodes = collectAdminBarNodes(hooks, baseCtx);
+
+      expect(nodes).toEqual([
+        { id: "site", title: "Site (override)", group: "root" },
+        { id: "edit", title: "Edit", group: "primary" },
+      ]);
+      expect(warnings.some((w) => w.includes("site"))).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("flows registered handlers' contributions through in priority order", () => {
+    const hooks = new HookRegistry();
+    hooks.addFilter("admin_bar:nodes", (nodes) => [
+      ...nodes,
+      { id: "site", title: "Site", group: "root" },
+    ]);
+    hooks.addFilter("admin_bar:nodes", (nodes) => [
+      ...nodes,
+      { id: "edit", title: "Edit", group: "primary" },
+    ]);
+
+    const nodes = collectAdminBarNodes(hooks, baseCtx);
+
+    expect(nodes).toEqual([
+      { id: "site", title: "Site", group: "root" },
+      { id: "edit", title: "Edit", group: "primary" },
+    ]);
+  });
+});

--- a/packages/core/src/admin-bar/collect.ts
+++ b/packages/core/src/admin-bar/collect.ts
@@ -1,0 +1,40 @@
+import type { HookExecutor } from "../hooks/registry.js";
+import type { AdminBarNode, BarRenderContext } from "./types.js";
+
+export function collectAdminBarNodes(
+  hooks: HookExecutor,
+  ctx: BarRenderContext,
+): readonly AdminBarNode[] {
+  let nodes: readonly AdminBarNode[] = [];
+  for (const { fn, plugin } of hooks.getFilterHandlers("admin_bar:nodes")) {
+    try {
+      const next = fn(nodes, ctx);
+      if (Array.isArray(next)) {
+        nodes = next;
+      } else {
+        console.error(
+          `[plumix] admin_bar:nodes handler returned non-array plugin=${plugin ?? "core"}; contribution discarded`,
+        );
+      }
+    } catch (error) {
+      console.error(
+        `[plumix] admin_bar:nodes handler failed plugin=${plugin ?? "core"}`,
+        error,
+      );
+    }
+  }
+  return dedupeById(nodes);
+}
+
+function dedupeById(nodes: readonly AdminBarNode[]): readonly AdminBarNode[] {
+  const byId = new Map<string, AdminBarNode>();
+  for (const node of nodes) {
+    if (byId.has(node.id)) {
+      console.warn(
+        `[plumix] admin_bar: duplicate node id "${node.id}" — last contributor wins`,
+      );
+    }
+    byId.set(node.id, node);
+  }
+  return [...byId.values()];
+}

--- a/packages/core/src/admin-bar/component.test.tsx
+++ b/packages/core/src/admin-bar/component.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry } from "@plumix/blocks";
+import { PlumixProvider } from "@plumix/blocks/renderer";
+
+import { HookRegistry } from "../hooks/registry.js";
+import { PlumixAdminBar } from "./component.js";
+
+const emptyRegistry = createBlockRegistry([]);
+
+const user = {
+  id: 7,
+  email: "editor@cms.example",
+  role: "editor",
+  meta: {},
+};
+
+const request = new Request("https://cms.example/");
+
+describe("PlumixAdminBar", () => {
+  test("renders nothing when user is null", () => {
+    const hooks = new HookRegistry();
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user: null }}>
+        <PlumixAdminBar hooks={hooks} request={request} />
+      </PlumixProvider>,
+    );
+
+    expect(html).toBe("");
+  });
+
+  test("renders a <header data-testid='plumix-admin-bar'> when user is populated", () => {
+    const hooks = new HookRegistry();
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar hooks={hooks} request={request} />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain('data-testid="plumix-admin-bar"');
+  });
+});

--- a/packages/core/src/admin-bar/component.tsx
+++ b/packages/core/src/admin-bar/component.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+import { useQueriedEntry, useUser } from "@plumix/blocks/renderer";
+
+import type { AuthenticatedUser } from "../context/app.js";
+import type { HookExecutor } from "../hooks/registry.js";
+import { collectAdminBarNodes } from "./collect.js";
+
+interface PlumixAdminBarProps {
+  readonly hooks: HookExecutor;
+  readonly request: Request;
+}
+
+export function PlumixAdminBar({
+  hooks,
+  request,
+}: PlumixAdminBarProps): ReactNode {
+  const user = useUser();
+  const queriedEntry = useQueriedEntry();
+  if (user === null) return null;
+  // Renderer types widen these structurally to keep blocks free of core.
+  collectAdminBarNodes(hooks, {
+    user: user as AuthenticatedUser,
+    queriedEntry,
+    request,
+  });
+  return <header data-testid="plumix-admin-bar" />;
+}

--- a/packages/core/src/admin-bar/types.ts
+++ b/packages/core/src/admin-bar/types.ts
@@ -1,0 +1,35 @@
+import type { AuthenticatedUser } from "../context/app.js";
+import type { ResolvedEntity } from "../route/current.ts";
+
+export const ADMIN_BAR_GROUPS = [
+  "primary",
+  "secondary",
+  "+new",
+  "account",
+  "root",
+] as const;
+
+export type AdminBarGroup = (typeof ADMIN_BAR_GROUPS)[number];
+
+export interface AdminBarNode {
+  readonly id: string;
+  readonly title: string;
+  readonly href?: string;
+  readonly group: AdminBarGroup;
+  readonly parent?: string;
+}
+
+export interface BarRenderContext {
+  readonly user: AuthenticatedUser;
+  readonly queriedEntry: ResolvedEntity | null;
+  readonly request: Request;
+}
+
+declare module "../hooks/types.js" {
+  interface FilterRegistry {
+    "admin_bar:nodes": (
+      nodes: readonly AdminBarNode[],
+      ctx: BarRenderContext,
+    ) => readonly AdminBarNode[];
+  }
+}

--- a/packages/core/src/hooks/registry.test.ts
+++ b/packages/core/src/hooks/registry.test.ts
@@ -126,6 +126,46 @@ describe("applyFilterSync", () => {
   });
 });
 
+describe("getFilterHandlers", () => {
+  test("returns an empty array when no filters are registered", () => {
+    const registry = new HookRegistry();
+    expect(registry.getFilterHandlers("test:passthrough")).toEqual([]);
+  });
+
+  test("returns handlers sorted by priority (lower first) then insertion order", () => {
+    const registry = new HookRegistry();
+    const fnB = (v: string) => v + "-b";
+    const fnA = (v: string) => v + "-a";
+    const fnC = (v: string) => v + "-c";
+    registry.addFilter("test:passthrough", fnB, {
+      priority: 100,
+      plugin: "b",
+    });
+    registry.addFilter("test:passthrough", fnA, { priority: 50, plugin: "a" });
+    registry.addFilter("test:passthrough", fnC, {
+      priority: 100,
+      plugin: "c",
+    });
+
+    const [first, ...rest] = registry.getFilterHandlers("test:passthrough");
+    if (!first) throw new Error("expected at least one handler");
+
+    expect(first.plugin).toBe("a");
+    expect(first.fn("start")).toBe("start-a");
+    expect(rest.map((h) => h.plugin)).toEqual(["b", "c"]);
+  });
+
+  test("plugin is null when handler is registered without one", () => {
+    const registry = new HookRegistry();
+    registry.addFilter("test:passthrough", (v) => v);
+
+    const [first] = registry.getFilterHandlers("test:passthrough");
+    if (!first) throw new Error("expected at least one handler");
+
+    expect(first.plugin).toBeNull();
+  });
+});
+
 describe("doAction", () => {
   test("invokes all handlers even if one throws", async () => {
     const registry = new HookRegistry({

--- a/packages/core/src/hooks/registry.ts
+++ b/packages/core/src/hooks/registry.ts
@@ -45,6 +45,18 @@ export interface HookExecutor {
     input: FilterInput<TName>,
     ...rest: FilterRest<TName>
   ): FilterInput<TName>;
+  /**
+   * Sorted snapshot of a filter's registered handlers — for surfaces that
+   * want full per-handler control (try/catch boundary, return-shape
+   * validation, custom accumulator) instead of the linear pipeline that
+   * `applyFilterSync` provides. Admin-bar is the first consumer.
+   */
+  getFilterHandlers<TName extends FilterName>(
+    name: TName,
+  ): readonly {
+    readonly fn: FilterFn<TName>;
+    readonly plugin: string | null;
+  }[];
   doAction<TName extends ActionName>(
     name: TName,
     ...args: ActionArgs<TName>
@@ -147,6 +159,20 @@ export class HookRegistry implements HookExecutor {
       current = next;
     }
     return current as FilterInput<TName>;
+  }
+
+  getFilterHandlers<TName extends FilterName>(
+    name: TName,
+  ): readonly {
+    readonly fn: FilterFn<TName>;
+    readonly plugin: string | null;
+  }[] {
+    const entries = this.#filters.get(name);
+    if (!entries || entries.length === 0) return [];
+    return sortEntries(entries).map((entry) => ({
+      fn: entry.fn as FilterFn<TName>,
+      plugin: entry.plugin,
+    }));
   }
 
   async doAction<TName extends ActionName>(

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -343,6 +343,62 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain('<html lang="en" dir="ltr">');
   });
 
+  test("authenticated public render carries the PlumixAdminBar empty shell", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "public",
+      title: "Public",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const request = await h.authenticateRequest(
+      new Request("https://cms.example/post/public"),
+      author.id,
+    );
+    const response = await h.dispatch(request);
+    const body = await response.text();
+
+    expect(body).toContain('data-testid="plumix-admin-bar"');
+  });
+
+  test("anonymous public render does NOT carry the PlumixAdminBar", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "public",
+      title: "Public",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/public"),
+    );
+    const body = await response.text();
+
+    expect(body).not.toContain('data-testid="plumix-admin-bar"');
+  });
+
   test("site's i18n defaultLocale drives <html lang dir> (RTL example)", async () => {
     const theme = defineTheme({
       templates: {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -26,6 +26,7 @@ import type {
 import type { AssetManifest } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
+import { PlumixAdminBar } from "../../admin-bar/component.js";
 import { mergeDocumentManifest } from "../../document-merge.js";
 import {
   loadTemplateDeps,
@@ -278,16 +279,20 @@ function renderTree({
   // silently clobber the canonical args.
   const TemplateAdapter = (): ReactNode =>
     template.render({ ...deps, data, ctx });
-  const templateTree: ReactNode = createElement(PlumixProvider, {
-    value: {
-      registry: ctx.blocks,
-      tokens,
-      loaderData,
-      user: ctx.user,
-      queriedEntry: ctx.resolvedEntity,
+  const templateTree: ReactNode = createElement(
+    PlumixProvider,
+    {
+      value: {
+        registry: ctx.blocks,
+        tokens,
+        loaderData,
+        user: ctx.user,
+        queriedEntry: ctx.resolvedEntity,
+      },
     },
-    children: createElement(TemplateAdapter),
-  });
+    createElement(PlumixAdminBar, { hooks: ctx.hooks, request: ctx.request }),
+    createElement(TemplateAdapter),
+  );
   const rendered = renderToString(templateTree);
   const { hoisted, body } = splitHoistedMetadata(rendered);
 


### PR DESCRIPTION
Admin-bar slice 2. Declares the bar's single extension point and renders a working empty shell on every authenticated public-route render. Slice 3 will register the first contributors (site / edit-this / account).

**`admin_bar:nodes` filter**

Sync filter declared on `FilterRegistry` via module augmentation. Signature `(nodes: AdminBarNode[], ctx: BarRenderContext) => AdminBarNode[]`. `AdminBarNode`, `BarRenderContext`, and the `ADMIN_BAR_GROUPS` constant ship from `@plumix/core` and re-export through `plumix/plugin`.

**Per-handler error isolation**

The collect primitive drives its own iteration via a new `hooks.getFilterHandlers(name)` accessor on `HookExecutor` instead of `applyFilterSync` — each handler runs in its own try/catch, so one plugin's bug can't blank the whole chrome. Throws are logged with plugin id and discarded (chain continues with prior good state); non-array returns (string/null/undefined/number/object) are also logged and discarded. Post-collect dedupe by id keeps the first-seen position and last-seen value, with `console.warn` per collision (cross-handler and within-handler).

**`<PlumixAdminBar />`**

Server-rendered React component in `@plumix/core`. Returns null when `useUser()` is null. Otherwise renders the empty `<header data-testid="plumix-admin-bar" />` shell. Mounted as a sibling of the template tree in `renderThroughTheme()` so it appears on every authenticated public-route render. `BarRenderContext.queriedEntry` is wired live from `useQueriedEntry()` so later slices' filter handlers see the resolver-populated current entity, not a hardcoded null.

**Scope notes**

The bar carries no `role` attribute — `<header>` at top of `<body>` has implicit `role="banner"`. CSS, mobile breakpoint, a11y polish, multi-script font stack, i18n, RTL all land in slice 5 / #668 (amended scope from earlier in this work stream).

Reviews pre-commit: sentry-skills:senpai + sentry-skills:code-simplifier. Senpai caught the contract lie where `BarRenderContext.queriedEntry` was hardcoded null (now wired through `useQueriedEntry()`) and asked for a direct `getFilterHandlers` registry test. Simplifier trimmed verbose comments, normalized error-message shape, dropped redundant `role="banner"`, dropped a redundant type cast.

Verification:
- `pnpm exec turbo run typecheck test lint format --filter @plumix/core --filter @plumix/blocks --filter @plumix/admin`: 15 tasks green
- `pnpm exec turbo run typecheck test --filter "@plumix/plugin-*"`: 30 tasks green

Closes #665