### PR TITLE
feat: build admin-bar tree + register site/edit-this/account contributors

### DIFF
--- a/packages/core/src/admin-bar/build-tree.test.ts
+++ b/packages/core/src/admin-bar/build-tree.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+
+import type { AdminBarNode } from "./types.js";
+import { buildAdminBarTree } from "./build-tree.js";
+
+function node(id: string, fields: Partial<AdminBarNode> = {}): AdminBarNode {
+  return {
+    id,
+    title: id,
+    group: "primary",
+    ...fields,
+  };
+}
+
+describe("buildAdminBarTree", () => {
+  test("returns empty array for empty input", () => {
+    expect(buildAdminBarTree([])).toEqual([]);
+  });
+
+  test("sorts siblings by position ascending (lower first)", () => {
+    const tree = buildAdminBarTree([
+      node("b", { position: 20 }),
+      node("a", { position: 10 }),
+      node("c", { position: 30 }),
+    ]);
+
+    expect(tree.map((n) => n.id)).toEqual(["a", "b", "c"]);
+  });
+
+  test("stable tie-break on equal positions follows insertion order", () => {
+    const tree = buildAdminBarTree([
+      node("a", { position: 10 }),
+      node("b", { position: 10 }),
+      node("c", { position: 10 }),
+    ]);
+
+    expect(tree.map((n) => n.id)).toEqual(["a", "b", "c"]);
+  });
+
+  test("nodes without position sort after positioned nodes", () => {
+    const tree = buildAdminBarTree([node("z"), node("a", { position: 10 })]);
+
+    expect(tree.map((n) => n.id)).toEqual(["a", "z"]);
+  });
+
+  test("groups children under their parent", () => {
+    const tree = buildAdminBarTree([
+      node("root1", { position: 10 }),
+      node("child1", { parent: "root1", position: 10 }),
+      node("child2", { parent: "root1", position: 20 }),
+      node("root2", { position: 20 }),
+    ]);
+
+    const [root1, root2] = tree;
+    if (!root1 || !root2) throw new Error("expected two root nodes");
+
+    expect(tree.map((n) => n.id)).toEqual(["root1", "root2"]);
+    expect(root1.children.map((n) => n.id)).toEqual(["child1", "child2"]);
+    expect(root2.children).toEqual([]);
+  });
+
+  test("re-parents orphan nodes (parent id unknown) to root", () => {
+    const tree = buildAdminBarTree([
+      node("root", { position: 10 }),
+      node("orphan", { parent: "missing", position: 20 }),
+    ]);
+
+    expect(tree.map((n) => n.id)).toEqual(["root", "orphan"]);
+  });
+});

--- a/packages/core/src/admin-bar/build-tree.ts
+++ b/packages/core/src/admin-bar/build-tree.ts
@@ -1,0 +1,40 @@
+import type { AdminBarNode, AdminBarTreeNode } from "./types.js";
+
+export function buildAdminBarTree(
+  nodes: readonly AdminBarNode[],
+): readonly AdminBarTreeNode[] {
+  // Position-sort with stable insertion-order tie-break; nodes without a
+  // position sort after positioned ones (treated as +Infinity).
+  const indexed = nodes.map((node, insertOrder) => ({ node, insertOrder }));
+  indexed.sort((a, b) => {
+    const pa = a.node.position ?? Number.POSITIVE_INFINITY;
+    const pb = b.node.position ?? Number.POSITIVE_INFINITY;
+    if (pa !== pb) return pa - pb;
+    return a.insertOrder - b.insertOrder;
+  });
+
+  const ids = new Set(nodes.map((n) => n.id));
+  const childrenByParent = new Map<string, AdminBarTreeNode[]>();
+  const roots: AdminBarTreeNode[] = [];
+
+  for (const { node } of indexed) {
+    const tree: AdminBarTreeNode = { ...node, children: [] };
+    const parent = node.parent;
+    if (parent !== undefined && ids.has(parent)) {
+      const bucket = childrenByParent.get(parent) ?? [];
+      bucket.push(tree);
+      childrenByParent.set(parent, bucket);
+    } else {
+      roots.push(tree);
+    }
+  }
+
+  // Rebuild each tree node so children get filled in. The `children` we
+  // pushed above are the same object references as what's in the map.
+  const finalize = (tree: AdminBarTreeNode): AdminBarTreeNode => {
+    const kids = childrenByParent.get(tree.id) ?? [];
+    return { ...tree, children: kids.map(finalize) };
+  };
+
+  return roots.map(finalize);
+}

--- a/packages/core/src/admin-bar/collect.test.ts
+++ b/packages/core/src/admin-bar/collect.test.ts
@@ -8,6 +8,8 @@ const baseCtx: BarRenderContext = {
   user: { id: 1, email: "u@x", role: "admin", meta: {} },
   queriedEntry: null,
   request: new Request("https://cms.example/"),
+  siteName: "Site",
+  auth: { can: () => true },
 };
 
 describe("collectAdminBarNodes", () => {

--- a/packages/core/src/admin-bar/component.test.tsx
+++ b/packages/core/src/admin-bar/component.test.tsx
@@ -4,8 +4,10 @@ import { describe, expect, test } from "vitest";
 import { createBlockRegistry } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
+import type { AuthNamespace } from "../context/app.js";
 import { HookRegistry } from "../hooks/registry.js";
 import { PlumixAdminBar } from "./component.js";
+import { registerCoreAdminBarContributors } from "./core-contributors.js";
 
 const emptyRegistry = createBlockRegistry([]);
 
@@ -17,6 +19,7 @@ const user = {
 };
 
 const request = new Request("https://cms.example/");
+const auth: AuthNamespace = { can: () => true };
 
 describe("PlumixAdminBar", () => {
   test("renders nothing when user is null", () => {
@@ -24,22 +27,54 @@ describe("PlumixAdminBar", () => {
 
     const html = renderToStaticMarkup(
       <PlumixProvider value={{ registry: emptyRegistry, user: null }}>
-        <PlumixAdminBar hooks={hooks} request={request} />
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+        />
       </PlumixProvider>,
     );
 
     expect(html).toBe("");
   });
 
-  test("renders a <header data-testid='plumix-admin-bar'> when user is populated", () => {
+  test("renders the bar shell when user is populated", () => {
     const hooks = new HookRegistry();
 
     const html = renderToStaticMarkup(
       <PlumixProvider value={{ registry: emptyRegistry, user }}>
-        <PlumixAdminBar hooks={hooks} request={request} />
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+        />
       </PlumixProvider>,
     );
 
     expect(html).toContain('data-testid="plumix-admin-bar"');
+  });
+
+  test("renders core contributor nodes as anchors with stable testids", () => {
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain('data-testid="plumix-admin-bar-node-site"');
+    expect(html).toContain('href="/_plumix/admin"');
+    expect(html).toContain("My Site");
+    expect(html).toContain('data-testid="plumix-admin-bar-node-account"');
+    expect(html).toContain("editor@cms.example");
   });
 });

--- a/packages/core/src/admin-bar/component.tsx
+++ b/packages/core/src/admin-bar/component.tsx
@@ -2,27 +2,67 @@ import type { ReactNode } from "react";
 
 import { useQueriedEntry, useUser } from "@plumix/blocks/renderer";
 
-import type { AuthenticatedUser } from "../context/app.js";
+import type { AuthenticatedUser, AuthNamespace } from "../context/app.js";
 import type { HookExecutor } from "../hooks/registry.js";
+import type { AdminBarTreeNode, BarRenderContext } from "./types.js";
+import { buildAdminBarTree } from "./build-tree.js";
 import { collectAdminBarNodes } from "./collect.js";
 
 interface PlumixAdminBarProps {
   readonly hooks: HookExecutor;
   readonly request: Request;
+  readonly siteName: string;
+  readonly auth: AuthNamespace;
+  readonly queriedEntryDetails?: BarRenderContext["queriedEntryDetails"];
 }
 
 export function PlumixAdminBar({
   hooks,
   request,
+  siteName,
+  auth,
+  queriedEntryDetails,
 }: PlumixAdminBarProps): ReactNode {
   const user = useUser();
   const queriedEntry = useQueriedEntry();
   if (user === null) return null;
   // Renderer types widen these structurally to keep blocks free of core.
-  collectAdminBarNodes(hooks, {
-    user: user as AuthenticatedUser,
-    queriedEntry,
-    request,
-  });
-  return <header data-testid="plumix-admin-bar" />;
+  const tree = buildAdminBarTree(
+    collectAdminBarNodes(hooks, {
+      user: user as AuthenticatedUser,
+      queriedEntry,
+      queriedEntryDetails,
+      request,
+      siteName,
+      auth,
+    }),
+  );
+  return (
+    <header data-testid="plumix-admin-bar">
+      <ul>
+        {tree.map((node) => (
+          <BarItem key={node.id} node={node} />
+        ))}
+      </ul>
+    </header>
+  );
+}
+
+function BarItem({ node }: { readonly node: AdminBarTreeNode }): ReactNode {
+  return (
+    <li data-testid={`plumix-admin-bar-node-${node.id}`}>
+      {node.href ? (
+        <a href={node.href}>{node.title}</a>
+      ) : (
+        <span>{node.title}</span>
+      )}
+      {node.children.length > 0 && (
+        <ul>
+          {node.children.map((child) => (
+            <BarItem key={child.id} node={child} />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
 }

--- a/packages/core/src/admin-bar/core-contributors.test.ts
+++ b/packages/core/src/admin-bar/core-contributors.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+
+import type { BarRenderContext } from "./types.js";
+import { HookRegistry } from "../hooks/registry.js";
+import { collectAdminBarNodes } from "./collect.js";
+import { registerCoreAdminBarContributors } from "./core-contributors.js";
+
+const allow = (): boolean => true;
+const deny = (): boolean => false;
+
+function ctx(overrides: Partial<BarRenderContext> = {}): BarRenderContext {
+  return {
+    user: {
+      id: 1,
+      email: "editor@cms.example",
+      role: "editor",
+      meta: {},
+    },
+    queriedEntry: null,
+    request: new Request("https://cms.example/"),
+    siteName: "My Site",
+    auth: { can: allow },
+    ...overrides,
+  };
+}
+
+function withCore(): HookRegistry {
+  const hooks = new HookRegistry();
+  registerCoreAdminBarContributors(hooks);
+  return hooks;
+}
+
+describe("registerCoreAdminBarContributors — site link", () => {
+  test("adds a 'site' node pointing at the admin root with the resolved site name", () => {
+    const nodes = collectAdminBarNodes(withCore(), ctx());
+
+    const site = nodes.find((n) => n.id === "site");
+    expect(site).toEqual({
+      id: "site",
+      title: "My Site",
+      href: "/_plumix/admin",
+      group: "root",
+      position: 10,
+    });
+  });
+});
+
+describe("registerCoreAdminBarContributors — account link", () => {
+  test("adds an 'account' node titled with the user's email", () => {
+    const nodes = collectAdminBarNodes(withCore(), ctx());
+
+    const account = nodes.find((n) => n.id === "account");
+    expect(account).toEqual({
+      id: "account",
+      title: "editor@cms.example",
+      href: "/_plumix/admin/profile",
+      group: "account",
+      position: 10,
+    });
+  });
+});
+
+describe("registerCoreAdminBarContributors — edit-this link", () => {
+  test("does not appear when there is no queried entry", () => {
+    const nodes = collectAdminBarNodes(withCore(), ctx());
+    expect(nodes.find((n) => n.id === "edit-this")).toBeUndefined();
+  });
+
+  test("does not appear when queried entry lacks pre-resolved details", () => {
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({ queriedEntry: { kind: "entry", id: 42 } }),
+    );
+    expect(nodes.find((n) => n.id === "edit-this")).toBeUndefined();
+  });
+
+  test("appears for a non-author when auth allows edit_any", () => {
+    const seen: string[] = [];
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({
+        queriedEntry: { kind: "entry", id: 42 },
+        queriedEntryDetails: { type: "post", authorId: 999 },
+        auth: {
+          can: (cap: string) => {
+            seen.push(cap);
+            return cap === "entry:post:edit_any";
+          },
+        },
+      }),
+    );
+
+    expect(nodes.find((n) => n.id === "edit-this")).toEqual({
+      id: "edit-this",
+      title: "Edit",
+      href: "/_plumix/admin/entries/post/42/edit",
+      group: "primary",
+      position: 20,
+    });
+    expect(seen).toContain("entry:post:edit_any");
+  });
+
+  test("appears for the entry's author when auth allows edit_own", () => {
+    const seen: string[] = [];
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({
+        queriedEntry: { kind: "entry", id: 7 },
+        queriedEntryDetails: { type: "post", authorId: 1 },
+        auth: {
+          can: (cap: string) => {
+            seen.push(cap);
+            return cap === "entry:post:edit_own";
+          },
+        },
+      }),
+    );
+
+    expect(nodes.find((n) => n.id === "edit-this")).toBeDefined();
+    expect(seen).toContain("entry:post:edit_own");
+  });
+
+  test("does not appear when user lacks the capability for own or any", () => {
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({
+        queriedEntry: { kind: "entry", id: 7 },
+        queriedEntryDetails: { type: "post", authorId: 999 },
+        auth: { can: deny },
+      }),
+    );
+
+    expect(nodes.find((n) => n.id === "edit-this")).toBeUndefined();
+  });
+});

--- a/packages/core/src/admin-bar/core-contributors.ts
+++ b/packages/core/src/admin-bar/core-contributors.ts
@@ -1,0 +1,81 @@
+import type { HookRegistry } from "../hooks/registry.js";
+import type { AdminBarNode, BarRenderContext } from "./types.js";
+
+const SITE_POSITION = 10;
+const EDIT_THIS_POSITION = 20;
+const ACCOUNT_POSITION = 10;
+
+/**
+ * Registers the three contributors that ship with core: `site`, `edit-this`,
+ * and `account`. Wired at `buildApp` time so they run before any plugin
+ * filter handler (priority 10/20/30 — well under the
+ * `DEFAULT_HOOK_PRIORITY` of 100 plugins land at).
+ */
+export function registerCoreAdminBarContributors(hooks: HookRegistry): void {
+  hooks.addFilter("admin_bar:nodes", siteContributor, {
+    plugin: "core",
+    priority: 10,
+  });
+  hooks.addFilter("admin_bar:nodes", editThisContributor, {
+    plugin: "core",
+    priority: 20,
+  });
+  hooks.addFilter("admin_bar:nodes", accountContributor, {
+    plugin: "core",
+    priority: 30,
+  });
+}
+
+function siteContributor(
+  nodes: readonly AdminBarNode[],
+  ctx: BarRenderContext,
+): readonly AdminBarNode[] {
+  return [
+    ...nodes,
+    {
+      id: "site",
+      title: ctx.siteName,
+      href: "/_plumix/admin",
+      group: "root",
+      position: SITE_POSITION,
+    },
+  ];
+}
+
+function editThisContributor(
+  nodes: readonly AdminBarNode[],
+  ctx: BarRenderContext,
+): readonly AdminBarNode[] {
+  if (ctx.queriedEntry?.kind !== "entry") return nodes;
+  const details = ctx.queriedEntryDetails;
+  if (!details) return nodes;
+  const ownerScope = details.authorId === ctx.user.id ? "edit_own" : "edit_any";
+  const capability = `entry:${details.type}:${ownerScope}`;
+  if (!ctx.auth.can(capability)) return nodes;
+  return [
+    ...nodes,
+    {
+      id: "edit-this",
+      title: "Edit",
+      href: `/_plumix/admin/entries/${details.type}/${ctx.queriedEntry.id}/edit`,
+      group: "primary",
+      position: EDIT_THIS_POSITION,
+    },
+  ];
+}
+
+function accountContributor(
+  nodes: readonly AdminBarNode[],
+  ctx: BarRenderContext,
+): readonly AdminBarNode[] {
+  return [
+    ...nodes,
+    {
+      id: "account",
+      title: ctx.user.email,
+      href: "/_plumix/admin/profile",
+      group: "account",
+      position: ACCOUNT_POSITION,
+    },
+  ];
+}

--- a/packages/core/src/admin-bar/types.ts
+++ b/packages/core/src/admin-bar/types.ts
@@ -1,4 +1,4 @@
-import type { AuthenticatedUser } from "../context/app.js";
+import type { AuthenticatedUser, AuthNamespace } from "../context/app.js";
 import type { ResolvedEntity } from "../route/current.ts";
 
 export const ADMIN_BAR_GROUPS = [
@@ -17,12 +17,30 @@ export interface AdminBarNode {
   readonly href?: string;
   readonly group: AdminBarGroup;
   readonly parent?: string;
+  readonly position?: number;
+}
+
+export interface AdminBarTreeNode extends AdminBarNode {
+  readonly children: readonly AdminBarTreeNode[];
 }
 
 export interface BarRenderContext {
   readonly user: AuthenticatedUser;
   readonly queriedEntry: ResolvedEntity | null;
+  /**
+   * Pre-resolved details for `queriedEntry.kind === "entry"` — the
+   * entry's registered type and `authorId`. Populated by the renderer
+   * before the bar collects nodes so sync filter handlers (e.g. the
+   * core edit-this contributor) can check capabilities without async
+   * DB lookups.
+   */
+  readonly queriedEntryDetails?: {
+    readonly type: string;
+    readonly authorId: number;
+  };
   readonly request: Request;
+  readonly siteName: string;
+  readonly auth: AuthNamespace;
 }
 
 declare module "../hooks/types.js" {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -279,6 +279,10 @@ function renderTree({
   // silently clobber the canonical args.
   const TemplateAdapter = (): ReactNode =>
     template.render({ ...deps, data, ctx });
+  const queriedEntryDetails =
+    "entry" in data
+      ? { type: data.entry.type, authorId: data.entry.authorId }
+      : undefined;
   const templateTree: ReactNode = createElement(
     PlumixProvider,
     {
@@ -290,7 +294,13 @@ function renderTree({
         queriedEntry: ctx.resolvedEntity,
       },
     },
-    createElement(PlumixAdminBar, { hooks: ctx.hooks, request: ctx.request }),
+    createElement(PlumixAdminBar, {
+      hooks: ctx.hooks,
+      request: ctx.request,
+      siteName: ctx.siteName ?? "Site",
+      auth: ctx.auth,
+      queriedEntryDetails,
+    }),
     createElement(TemplateAdapter),
   );
   const rendered = renderToString(templateTree);

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -25,6 +25,7 @@ import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RouteRule } from "../route/intent.js";
 import type { AssetManifest } from "../route/render/asset-manifest.js";
 import type { DocumentManifest } from "../theme.js";
+import { registerCoreAdminBarContributors } from "../admin-bar/core-contributors.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
@@ -168,6 +169,7 @@ export async function buildApp(
   runtime: RuntimeContext = {},
 ): Promise<PlumixApp> {
   const hooks = new HookRegistry();
+  registerCoreAdminBarContributors(hooks);
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
   registerCoreTemplateDeps(seededRegistry);


### PR DESCRIPTION
Admin-bar slice 3. Three core contributors register via the \`admin_bar:nodes\` filter at \`buildApp\`; the bar component turns the collected flat list into a tree of anchors. End-to-end: any authenticated editor visiting a public page now sees a real bar with 2–3 working links depending on queried-entry + capability state.

**\`buildAdminBarTree(nodes)\`**

Pure function. Sorts siblings by \`position\` ascending with stable insertion-order tie-break; unpositioned nodes sort after positioned ones; nodes with an unknown \`parent\` id silently re-parent to root. Tree shape adds a \`children\` field to each node.

**\`BarRenderContext\` widening**

Now carries \`siteName\`, \`auth\` (the AuthNamespace), and optional \`queriedEntryDetails\` (\`{ type, authorId }\`). \`renderThroughTheme()\` pre-resolves the entry details from \`data.entry\` when present so sync filter handlers can do capability checks without async DB lookups.

**Core contributors**

| id | href | group | position | conditions |
|---|---|---|---|---|
| \`site\` | \`/_plumix/admin\` | root | 10 | always |
| \`edit-this\` | \`/_plumix/admin/entries/{type}/{id}/edit\` | primary | 20 | \`queriedEntry.kind === "entry"\` AND \`queriedEntryDetails\` resolved AND \`auth.can("entry:{type}:edit_own")\` (self-author) or \`...edit_any\` (otherwise) |
| \`account\` | \`/_plumix/admin/profile\` | account | 10 | always |

Wired in \`buildApp\` via \`registerCoreAdminBarContributors(hooks)\` at priorities 10/20/30 — well under the default-100 priorities plugin hooks land at, so plugin handlers see core's contributions in their input.

**Bar component**

\`PlumixAdminBar\` now renders \`<ul>\` of \`<li data-testid="plumix-admin-bar-node-{id}">\` carrying anchors. Nested children render recursively. Empty bar shell still emits when no contributor fires.

Reviews pre-commit: slice 2's senpai + simplifier findings already absorbed here (queriedEntry wired live, registry test pinned, redundant comments trimmed). Test coverage explicit per the issue's acceptance criteria: every edit-this scenario the spec enumerates has a colocated test.

Verification:
- 15 tasks green across @plumix/core + @plumix/blocks + @plumix/admin (typecheck, test, lint, format)
- 30 tasks green across plugins

Closes #666