### PR TITLE
feat: add +New admin-bar contributor with entry-type children

### DIFF
--- a/packages/core/src/admin-bar/collect.test.ts
+++ b/packages/core/src/admin-bar/collect.test.ts
@@ -10,6 +10,7 @@ const baseCtx: BarRenderContext = {
   request: new Request("https://cms.example/"),
   siteName: "Site",
   auth: { can: () => true },
+  entryTypes: new Map(),
 };
 
 describe("collectAdminBarNodes", () => {

--- a/packages/core/src/admin-bar/component.test.tsx
+++ b/packages/core/src/admin-bar/component.test.tsx
@@ -20,6 +20,7 @@ const user = {
 
 const request = new Request("https://cms.example/");
 const auth: AuthNamespace = { can: () => true };
+const entryTypes = new Map();
 
 describe("PlumixAdminBar", () => {
   test("renders nothing when user is null", () => {
@@ -32,6 +33,7 @@ describe("PlumixAdminBar", () => {
           request={request}
           siteName="My Site"
           auth={auth}
+          entryTypes={entryTypes}
         />
       </PlumixProvider>,
     );
@@ -49,11 +51,40 @@ describe("PlumixAdminBar", () => {
           request={request}
           siteName="My Site"
           auth={auth}
+          entryTypes={entryTypes}
         />
       </PlumixProvider>,
     );
 
     expect(html).toContain('data-testid="plumix-admin-bar"');
+  });
+
+  test("renders the +new group as a <details>/<summary> with one child per entry type", () => {
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+    const types = new Map([
+      ["post", { name: "post" } as never],
+      ["page", { name: "page" } as never],
+    ]);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={types}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("<details>");
+    expect(html).toContain("<summary>+ New</summary>");
+    expect(html).toContain('data-testid="plumix-admin-bar-node-+new:post"');
+    expect(html).toContain('data-testid="plumix-admin-bar-node-+new:page"');
+    expect(html).toContain('href="/_plumix/admin/entries/post/create"');
+    expect(html).toContain('href="/_plumix/admin/entries/page/create"');
   });
 
   test("renders core contributor nodes as anchors with stable testids", () => {
@@ -67,6 +98,7 @@ describe("PlumixAdminBar", () => {
           request={request}
           siteName="My Site"
           auth={auth}
+          entryTypes={entryTypes}
         />
       </PlumixProvider>,
     );

--- a/packages/core/src/admin-bar/component.tsx
+++ b/packages/core/src/admin-bar/component.tsx
@@ -14,6 +14,7 @@ interface PlumixAdminBarProps {
   readonly siteName: string;
   readonly auth: AuthNamespace;
   readonly queriedEntryDetails?: BarRenderContext["queriedEntryDetails"];
+  readonly entryTypes: BarRenderContext["entryTypes"];
 }
 
 export function PlumixAdminBar({
@@ -22,6 +23,7 @@ export function PlumixAdminBar({
   siteName,
   auth,
   queriedEntryDetails,
+  entryTypes,
 }: PlumixAdminBarProps): ReactNode {
   const user = useUser();
   const queriedEntry = useQueriedEntry();
@@ -35,6 +37,7 @@ export function PlumixAdminBar({
       request,
       siteName,
       auth,
+      entryTypes,
     }),
   );
   return (
@@ -49,19 +52,26 @@ export function PlumixAdminBar({
 }
 
 function BarItem({ node }: { readonly node: AdminBarTreeNode }): ReactNode {
+  if (node.children.length > 0) {
+    return (
+      <li data-testid={`plumix-admin-bar-node-${node.id}`}>
+        <details>
+          <summary>{node.title}</summary>
+          <ul>
+            {node.children.map((child) => (
+              <BarItem key={child.id} node={child} />
+            ))}
+          </ul>
+        </details>
+      </li>
+    );
+  }
   return (
     <li data-testid={`plumix-admin-bar-node-${node.id}`}>
       {node.href ? (
         <a href={node.href}>{node.title}</a>
       ) : (
         <span>{node.title}</span>
-      )}
-      {node.children.length > 0 && (
-        <ul>
-          {node.children.map((child) => (
-            <BarItem key={child.id} node={child} />
-          ))}
-        </ul>
       )}
     </li>
   );

--- a/packages/core/src/admin-bar/core-contributors.test.ts
+++ b/packages/core/src/admin-bar/core-contributors.test.ts
@@ -20,8 +20,13 @@ function ctx(overrides: Partial<BarRenderContext> = {}): BarRenderContext {
     request: new Request("https://cms.example/"),
     siteName: "My Site",
     auth: { can: allow },
+    entryTypes: new Map(),
     ...overrides,
   };
+}
+
+function typesMap(...slugs: readonly string[]): BarRenderContext["entryTypes"] {
+  return new Map(slugs.map((slug) => [slug, { name: slug } as never]));
 }
 
 function withCore(): HookRegistry {
@@ -42,6 +47,52 @@ describe("registerCoreAdminBarContributors — site link", () => {
       group: "root",
       position: 10,
     });
+  });
+});
+
+describe("registerCoreAdminBarContributors — +New group", () => {
+  test("emits a parent group with no children when no entry types are registered", () => {
+    const nodes = collectAdminBarNodes(withCore(), ctx());
+
+    const newGroup = nodes.find((n) => n.id === "+new");
+    expect(newGroup).toBeDefined();
+    expect(nodes.filter((n) => n.parent === "+new")).toEqual([]);
+  });
+
+  test("adds one child per registered entry type, in registration order", () => {
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({ entryTypes: typesMap("post", "page", "media") }),
+    );
+
+    const children = nodes.filter((n) => n.parent === "+new");
+    expect(children.map((n) => n.id)).toEqual([
+      "+new:post",
+      "+new:page",
+      "+new:media",
+    ]);
+    expect(children.map((n) => n.href)).toEqual([
+      "/_plumix/admin/entries/post/create",
+      "/_plumix/admin/entries/page/create",
+      "/_plumix/admin/entries/media/create",
+    ]);
+  });
+
+  test("plugin can suppress its own entry type from the menu via the filter", () => {
+    const hooks = withCore();
+    hooks.addFilter(
+      "admin_bar:nodes",
+      (nodes) => nodes.filter((n) => n.id !== "+new:media"),
+      { plugin: "media", priority: 100 },
+    );
+
+    const nodes = collectAdminBarNodes(
+      hooks,
+      ctx({ entryTypes: typesMap("post", "page", "media") }),
+    );
+
+    const children = nodes.filter((n) => n.parent === "+new");
+    expect(children.map((n) => n.id)).toEqual(["+new:post", "+new:page"]);
   });
 });
 

--- a/packages/core/src/admin-bar/core-contributors.ts
+++ b/packages/core/src/admin-bar/core-contributors.ts
@@ -3,6 +3,7 @@ import type { AdminBarNode, BarRenderContext } from "./types.js";
 
 const SITE_POSITION = 10;
 const EDIT_THIS_POSITION = 20;
+const NEW_GROUP_POSITION = 15;
 const ACCOUNT_POSITION = 10;
 
 /**
@@ -19,6 +20,10 @@ export function registerCoreAdminBarContributors(hooks: HookRegistry): void {
   hooks.addFilter("admin_bar:nodes", editThisContributor, {
     plugin: "core",
     priority: 20,
+  });
+  hooks.addFilter("admin_bar:nodes", newGroupContributor, {
+    plugin: "core",
+    priority: 25,
   });
   hooks.addFilter("admin_bar:nodes", accountContributor, {
     plugin: "core",
@@ -62,6 +67,33 @@ function editThisContributor(
       position: EDIT_THIS_POSITION,
     },
   ];
+}
+
+function newGroupContributor(
+  nodes: readonly AdminBarNode[],
+  ctx: BarRenderContext,
+): readonly AdminBarNode[] {
+  const additions: AdminBarNode[] = [
+    {
+      id: "+new",
+      title: "+ New",
+      group: "+new",
+      position: NEW_GROUP_POSITION,
+    },
+  ];
+  let childPosition = 10;
+  for (const [slug] of ctx.entryTypes) {
+    additions.push({
+      id: `+new:${slug}`,
+      title: slug,
+      href: `/_plumix/admin/entries/${slug}/create`,
+      group: "+new",
+      parent: "+new",
+      position: childPosition,
+    });
+    childPosition += 10;
+  }
+  return [...nodes, ...additions];
 }
 
 function accountContributor(

--- a/packages/core/src/admin-bar/types.ts
+++ b/packages/core/src/admin-bar/types.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedUser, AuthNamespace } from "../context/app.js";
+import type { RegisteredEntryType } from "../plugin/manifest.js";
 import type { ResolvedEntity } from "../route/current.ts";
 
 export const ADMIN_BAR_GROUPS = [
@@ -41,6 +42,12 @@ export interface BarRenderContext {
   readonly request: Request;
   readonly siteName: string;
   readonly auth: AuthNamespace;
+  /**
+   * Registered entry types in registration order — supplied by the renderer
+   * from `app.plugins.entryTypes` so the `+ New` contributor can populate
+   * its child menu without a separate discovery API.
+   */
+  readonly entryTypes: ReadonlyMap<string, RegisteredEntryType>;
 }
 
 declare module "../hooks/types.js" {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -300,6 +300,7 @@ function renderTree({
       siteName: ctx.siteName ?? "Site",
       auth: ctx.auth,
       queriedEntryDetails,
+      entryTypes: ctx.plugins.entryTypes,
     }),
     createElement(TemplateAdapter),
   );


### PR DESCRIPTION
Admin-bar slice 4. Fourth core contributor: the \`+ New\` dropdown that lists registered entry types as child nodes, rendered with native \`<details>/<summary>\` (zero JS).

**\`+ New\` group + per-type children**

The contributor reads \`ctx.entryTypes\` (threaded from \`app.plugins.entryTypes\` via \`renderThroughTheme\`) and emits one parent \`+new\` node plus one child per registered type:

```
{ id: "+new", title: "+ New", group: "+new", position: 15 }
{ id: "+new:post", parent: "+new", href: "/_plumix/admin/entries/post/create", ... }
{ id: "+new:page", parent: "+new", href: "/_plumix/admin/entries/page/create", ... }
```

Children appear in registration order. \`BarRenderContext\` widens with \`entryTypes: ReadonlyMap<string, RegisteredEntryType>\`.

**Plugin suppression contract**

Plugins suppress their own entry type from the menu by filtering \`+new:{slug}\` out of the returned array — no declarative sugar field on \`defineEntryType\`. Covered by an integration-style test that registers a downstream filter handler dropping a type and asserts the menu reflects it.

**\`<details>/<summary>\` rendering**

\`PlumixAdminBar\` now renders any tree node with children as a \`<details><summary>title</summary><ul>...</ul></details>\` block. Leaf nodes stay as anchors. Zero JavaScript — open/close is native browser semantics.

Verification:
- 30 admin-bar tests pass (5 +New scenarios: empty registry, N types, registration order, plugin suppression, details rendering)
- 15 tasks green across @plumix/core + @plumix/blocks + @plumix/admin
- 30 plugin tasks green

Closes #667