### PR TITLE
feat: polish admin bar with i18n, RTL, inline CSS and a11y

### DIFF
--- a/packages/core/src/admin-bar/collect.test.ts
+++ b/packages/core/src/admin-bar/collect.test.ts
@@ -11,6 +11,8 @@ const baseCtx: BarRenderContext = {
   siteName: "Site",
   auth: { can: () => true },
   entryTypes: new Map(),
+  locale: "en",
+  direction: "ltr",
 };
 
 describe("collectAdminBarNodes", () => {

--- a/packages/core/src/admin-bar/component.test.tsx
+++ b/packages/core/src/admin-bar/component.test.tsx
@@ -59,6 +59,204 @@ describe("PlumixAdminBar", () => {
     expect(html).toContain('data-testid="plumix-admin-bar"');
   });
 
+  test("right-anchors the account node via a dedicated class + margin-inline-start rule", () => {
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    // Account <li> carries the right-anchor class.
+    expect(html).toMatch(
+      /<li[^>]*data-testid="plumix-admin-bar-node-account"[^>]*class="[^"]*plumix-admin-bar__end/,
+    );
+    // CSS for that class pushes it to the row's end.
+    expect(html).toMatch(
+      /\.plumix-admin-bar__end[^{]*\{[^}]*margin-inline-start:\s*auto/,
+    );
+  });
+
+  test("emits the inline CSS style block once and applies the .plumix-admin-bar class", () => {
+    const hooks = new HookRegistry();
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain('data-testid="plumix-admin-bar-style"');
+    expect(html).toContain(".plumix-admin-bar");
+    expect(html).toContain('class="plumix-admin-bar"');
+    expect(html).toContain("system-ui");
+    expect(html).toContain("Noto Sans Arabic");
+    expect(html).toContain("Noto Sans SC");
+    expect(html).toMatch(/@media\s*\(max-width:\s*639px\)/);
+    expect(html).toMatch(/text-overflow:\s*ellipsis/);
+  });
+
+  test("renders nav with the localized aria-label", () => {
+    const hooks = new HookRegistry();
+
+    const enHtml = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+    expect(enHtml).toContain('aria-label="Admin"');
+
+    const deUser = { ...user, meta: { locale: "de" } };
+    const deHtml = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user: deUser }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="Meine Seite"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+    expect(deHtml).toContain('aria-label="Administration"');
+  });
+
+  test("translates chrome strings to Ukrainian when user locale is uk (Cyrillic snapshot)", () => {
+    const ukUser = { ...user, meta: { locale: "uk" } };
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+    const types = new Map([["post", { name: "post" } as never]]);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user: ukUser }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="Мій сайт"
+          auth={auth}
+          entryTypes={types}
+          queriedEntryDetails={{ type: "post", authorId: 7 }}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain('lang="uk"');
+    expect(html).toContain('aria-label="Адміністрування"');
+    expect(html).toContain("+ Новий");
+    expect(html).toContain('aria-label="Створити"');
+    expect(html).toContain("Мій сайт");
+  });
+
+  test("translates chrome strings to Simplified Chinese when user locale is zh-CN", () => {
+    const zhUser = { ...user, meta: { locale: "zh-CN" } };
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+    const types = new Map([["post", { name: "post" } as never]]);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user: zhUser }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="我的站点"
+          auth={auth}
+          entryTypes={types}
+          queriedEntryDetails={{ type: "post", authorId: 7 }}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain('lang="zh-CN"');
+    expect(html).toContain('aria-label="管理"');
+    expect(html).toContain("+ 新建");
+    expect(html).toContain('aria-label="新建内容"');
+    expect(html).toContain("我的站点");
+  });
+
+  test("applies dir='rtl' and lang='ar' when the user locale is Arabic", () => {
+    const arUser = { ...user, meta: { locale: "ar" } };
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user: arUser }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="موقعي"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain('dir="rtl"');
+    expect(html).toContain('lang="ar"');
+    expect(html).toContain('aria-label="الإدارة"');
+    // Site name passed in is Arabic — localized chrome surrounds it.
+    expect(html).toContain("موقعي");
+  });
+
+  test("wraps the user's account email in <bdi> so RTL chrome doesn't flip it", () => {
+    const arUser = { ...user, meta: { locale: "ar" } };
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user: arUser }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="موقعي"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("<bdi>editor@cms.example</bdi>");
+  });
+
+  test("emits a localized +New summary aria-label for screen readers", () => {
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+    const types = new Map([["post", { name: "post" } as never]]);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={types}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain('aria-label="Create new"');
+  });
+
   test("renders the +new group as a <details>/<summary> with one child per entry type", () => {
     const hooks = new HookRegistry();
     registerCoreAdminBarContributors(hooks);
@@ -80,7 +278,7 @@ describe("PlumixAdminBar", () => {
     );
 
     expect(html).toContain("<details>");
-    expect(html).toContain("<summary>+ New</summary>");
+    expect(html).toContain("+ New");
     expect(html).toContain('data-testid="plumix-admin-bar-node-+new:post"');
     expect(html).toContain('data-testid="plumix-admin-bar-node-+new:page"');
     expect(html).toContain('href="/_plumix/admin/entries/post/create"');

--- a/packages/core/src/admin-bar/component.tsx
+++ b/packages/core/src/admin-bar/component.tsx
@@ -4,9 +4,12 @@ import { useQueriedEntry, useUser } from "@plumix/blocks/renderer";
 
 import type { AuthenticatedUser, AuthNamespace } from "../context/app.js";
 import type { HookExecutor } from "../hooks/registry.js";
+import type { BarStrings } from "./i18n.js";
 import type { AdminBarTreeNode, BarRenderContext } from "./types.js";
 import { buildAdminBarTree } from "./build-tree.js";
 import { collectAdminBarNodes } from "./collect.js";
+import { barDirection, barMessages, resolveBarLocale } from "./i18n.js";
+import { ADMIN_BAR_BODY_OFFSET_CSS, ADMIN_BAR_CSS } from "./styles.js";
 
 interface PlumixAdminBarProps {
   readonly hooks: HookExecutor;
@@ -28,6 +31,9 @@ export function PlumixAdminBar({
   const user = useUser();
   const queriedEntry = useQueriedEntry();
   if (user === null) return null;
+  const locale = resolveBarLocale(user);
+  const direction = barDirection(locale);
+  const strings = barMessages(locale);
   // Renderer types widen these structurally to keep blocks free of core.
   const tree = buildAdminBarTree(
     collectAdminBarNodes(hooks, {
@@ -38,28 +44,55 @@ export function PlumixAdminBar({
       siteName,
       auth,
       entryTypes,
+      locale,
+      direction,
     }),
   );
   return (
-    <header data-testid="plumix-admin-bar">
-      <ul>
-        {tree.map((node) => (
-          <BarItem key={node.id} node={node} />
-        ))}
-      </ul>
-    </header>
+    <>
+      <style data-testid="plumix-admin-bar-style">{ADMIN_BAR_CSS}</style>
+      <style data-testid="plumix-admin-bar-body-offset">
+        {ADMIN_BAR_BODY_OFFSET_CSS}
+      </style>
+      <header
+        className="plumix-admin-bar"
+        data-testid="plumix-admin-bar"
+        dir={direction}
+        lang={locale}
+      >
+        <nav aria-label={strings.navAria}>
+          <ul>
+            {tree.map((node) => (
+              <BarItem key={node.id} node={node} strings={strings} />
+            ))}
+          </ul>
+        </nav>
+      </header>
+    </>
   );
 }
 
-function BarItem({ node }: { readonly node: AdminBarTreeNode }): ReactNode {
+function BarItem({
+  node,
+  strings,
+}: {
+  readonly node: AdminBarTreeNode;
+  readonly strings: BarStrings;
+}): ReactNode {
   if (node.children.length > 0) {
+    // `+new` group gets an explicit aria-label so screen readers announce
+    // the action ("Create new") instead of the visual "+ New" glyph soup.
+    const summaryAria = node.id === "+new" ? strings.newGroupAria : undefined;
     return (
-      <li data-testid={`plumix-admin-bar-node-${node.id}`}>
+      <li
+        data-testid={`plumix-admin-bar-node-${node.id}`}
+        className={node.id === "account" ? "plumix-admin-bar__end" : undefined}
+      >
         <details>
-          <summary>{node.title}</summary>
+          <summary aria-label={summaryAria}>{node.title}</summary>
           <ul>
             {node.children.map((child) => (
-              <BarItem key={child.id} node={child} />
+              <BarItem key={child.id} node={child} strings={strings} />
             ))}
           </ul>
         </details>
@@ -67,12 +100,29 @@ function BarItem({ node }: { readonly node: AdminBarTreeNode }): ReactNode {
     );
   }
   return (
-    <li data-testid={`plumix-admin-bar-node-${node.id}`}>
+    <li
+      data-testid={`plumix-admin-bar-node-${node.id}`}
+      className={node.id === "account" ? "plumix-admin-bar__end" : undefined}
+    >
       {node.href ? (
-        <a href={node.href}>{node.title}</a>
+        <a href={node.href}>
+          <BarLabel node={node} />
+        </a>
       ) : (
-        <span>{node.title}</span>
+        <span>
+          <BarLabel node={node} />
+        </span>
       )}
     </li>
   );
+}
+
+// User-supplied strings (account email, queried entry title once contributors
+// pass it through) get `<bdi>` wrapping so their script direction can't
+// invert the surrounding chrome layout.
+function BarLabel({ node }: { readonly node: AdminBarTreeNode }): ReactNode {
+  if (node.id === "account" || node.id.startsWith("+new:")) {
+    return <bdi>{node.title}</bdi>;
+  }
+  return <>{node.title}</>;
 }

--- a/packages/core/src/admin-bar/core-contributors.test.ts
+++ b/packages/core/src/admin-bar/core-contributors.test.ts
@@ -21,6 +21,8 @@ function ctx(overrides: Partial<BarRenderContext> = {}): BarRenderContext {
     siteName: "My Site",
     auth: { can: allow },
     entryTypes: new Map(),
+    locale: "en",
+    direction: "ltr",
     ...overrides,
   };
 }
@@ -123,6 +125,20 @@ describe("registerCoreAdminBarContributors — edit-this link", () => {
       ctx({ queriedEntry: { kind: "entry", id: 42 } }),
     );
     expect(nodes.find((n) => n.id === "edit-this")).toBeUndefined();
+  });
+
+  test("translates the title via the bar catalog for the active locale", () => {
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({
+        locale: "de",
+        direction: "ltr",
+        queriedEntry: { kind: "entry", id: 1 },
+        queriedEntryDetails: { type: "post", authorId: 1 },
+      }),
+    );
+
+    expect(nodes.find((n) => n.id === "edit-this")?.title).toBe("Bearbeiten");
   });
 
   test("appears for a non-author when auth allows edit_any", () => {

--- a/packages/core/src/admin-bar/core-contributors.ts
+++ b/packages/core/src/admin-bar/core-contributors.ts
@@ -1,5 +1,6 @@
 import type { HookRegistry } from "../hooks/registry.js";
 import type { AdminBarNode, BarRenderContext } from "./types.js";
+import { barMessages } from "./i18n.js";
 
 const SITE_POSITION = 10;
 const EDIT_THIS_POSITION = 20;
@@ -7,10 +8,13 @@ const NEW_GROUP_POSITION = 15;
 const ACCOUNT_POSITION = 10;
 
 /**
- * Registers the three contributors that ship with core: `site`, `edit-this`,
- * and `account`. Wired at `buildApp` time so they run before any plugin
- * filter handler (priority 10/20/30 — well under the
- * `DEFAULT_HOOK_PRIORITY` of 100 plugins land at).
+ * Registers the four core contributors (`site`, `edit-this`, `+new`,
+ * `account`). Wired at `buildApp` time so they run before any plugin
+ * filter handler.
+ *
+ * Filter priority levels (10/15/20/25/30) stay well under the
+ * `DEFAULT_HOOK_PRIORITY` of 100 plugins land at — plugins see core's
+ * contributions in their input.
  */
 export function registerCoreAdminBarContributors(hooks: HookRegistry): void {
   hooks.addFilter("admin_bar:nodes", siteContributor, {
@@ -35,11 +39,12 @@ function siteContributor(
   nodes: readonly AdminBarNode[],
   ctx: BarRenderContext,
 ): readonly AdminBarNode[] {
+  const fallback = barMessages(ctx.locale).siteFallback;
   return [
     ...nodes,
     {
       id: "site",
-      title: ctx.siteName,
+      title: ctx.siteName || fallback,
       href: "/_plumix/admin",
       group: "root",
       position: SITE_POSITION,
@@ -61,7 +66,7 @@ function editThisContributor(
     ...nodes,
     {
       id: "edit-this",
-      title: "Edit",
+      title: barMessages(ctx.locale).edit,
       href: `/_plumix/admin/entries/${details.type}/${ctx.queriedEntry.id}/edit`,
       group: "primary",
       position: EDIT_THIS_POSITION,
@@ -73,10 +78,11 @@ function newGroupContributor(
   nodes: readonly AdminBarNode[],
   ctx: BarRenderContext,
 ): readonly AdminBarNode[] {
+  const strings = barMessages(ctx.locale);
   const additions: AdminBarNode[] = [
     {
       id: "+new",
-      title: "+ New",
+      title: strings.newGroup,
       group: "+new",
       position: NEW_GROUP_POSITION,
     },

--- a/packages/core/src/admin-bar/i18n.ts
+++ b/packages/core/src/admin-bar/i18n.ts
@@ -1,0 +1,81 @@
+// Inline catalog — 9 strings, SSR-only, fixed locale set; not worth a
+// Lingui pipeline. Wider set ships when `pnpm i18n:check` moves into core.
+
+export type BarLocale = "en" | "de" | "uk" | "ar" | "zh-CN";
+
+export interface BarStrings {
+  readonly siteFallback: string;
+  readonly newGroup: string;
+  readonly newGroupAria: string;
+  readonly edit: string;
+  readonly account: string;
+  readonly navAria: string;
+}
+
+const CATALOGS: Readonly<Record<BarLocale, BarStrings>> = {
+  en: {
+    siteFallback: "Site",
+    newGroup: "+ New",
+    newGroupAria: "Create new",
+    edit: "Edit",
+    account: "Account",
+    navAria: "Admin",
+  },
+  de: {
+    siteFallback: "Website",
+    newGroup: "+ Neu",
+    newGroupAria: "Neu erstellen",
+    edit: "Bearbeiten",
+    account: "Konto",
+    navAria: "Administration",
+  },
+  uk: {
+    siteFallback: "Сайт",
+    newGroup: "+ Новий",
+    newGroupAria: "Створити",
+    edit: "Редагувати",
+    account: "Обліковий запис",
+    navAria: "Адміністрування",
+  },
+  ar: {
+    siteFallback: "الموقع",
+    newGroup: "+ جديد",
+    newGroupAria: "إنشاء جديد",
+    edit: "تعديل",
+    account: "الحساب",
+    navAria: "الإدارة",
+  },
+  "zh-CN": {
+    siteFallback: "站点",
+    newGroup: "+ 新建",
+    newGroupAria: "新建内容",
+    edit: "编辑",
+    account: "账户",
+    navAria: "管理",
+  },
+};
+
+const KNOWN: ReadonlySet<string> = new Set(Object.keys(CATALOGS));
+
+/**
+ * Resolves the admin user's bar locale from `meta.locale` (per WP semantics —
+ * `get_user_locale()`, not `get_locale()`). Falls back to English when the
+ * user has no stored locale or stored a locale we don't ship strings for.
+ */
+export function resolveBarLocale(user: {
+  readonly meta: Record<string, unknown>;
+}): BarLocale {
+  const stored = user.meta.locale;
+  if (typeof stored === "string" && KNOWN.has(stored)) {
+    return stored as BarLocale;
+  }
+  return "en";
+}
+
+export function barMessages(locale: BarLocale): BarStrings {
+  return CATALOGS[locale];
+}
+
+export function barDirection(locale: BarLocale): "ltr" | "rtl" {
+  return locale === "ar" ? "rtl" : "ltr";
+}

--- a/packages/core/src/admin-bar/styles.ts
+++ b/packages/core/src/admin-bar/styles.ts
@@ -1,0 +1,154 @@
+// Inline CSS for the admin bar — emitted once per page render via a
+// `<style>` tag inside the bar. All selectors scoped under a single stable
+// `.plumix-admin-bar` class so the theme's own CSS is untouchable. Font
+// stack covers Latin / Cyrillic / Arabic / CJK without a webfont request
+// (see [[plumix-admin-bar/issue-668]] for rationale). Multi-script glyph
+// rendering falls through `system-ui` to the OS UI font; missing-glyph
+// fallback is the browser's responsibility.
+
+// No-op tag — the tooling marker that lets vscode-styled-components +
+// stylelint syntax-highlight + lint the CSS source. CSS Modules don't fit
+// because the bar is built with tsc-only and emits its CSS inline in the
+// SSR response, not as a separate stylesheet request.
+function css(
+  strings: TemplateStringsArray,
+  ...values: readonly string[]
+): string {
+  let out = strings[0] ?? "";
+  for (let i = 0; i < values.length; i++) {
+    out += values[i] + (strings[i + 1] ?? "");
+  }
+  return out;
+}
+
+export const ADMIN_BAR_CSS = css`
+  .plumix-admin-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: var(--plumix-admin-bar-z-index, 99999);
+    height: 36px;
+    background: #1d2327;
+    color: #fff;
+    font-family:
+      system-ui,
+      -apple-system,
+      "Segoe UI",
+      Roboto,
+      "Noto Sans",
+      "Noto Sans Arabic",
+      "Noto Sans SC",
+      "Helvetica Neue",
+      Arial,
+      sans-serif;
+    font-size: 13px;
+    line-height: 36px;
+    box-sizing: border-box;
+  }
+  .plumix-admin-bar *,
+  .plumix-admin-bar *::before,
+  .plumix-admin-bar *::after {
+    box-sizing: inherit;
+  }
+  .plumix-admin-bar nav {
+    display: flex;
+    align-items: stretch;
+    height: 100%;
+    padding: 0 12px;
+  }
+  .plumix-admin-bar nav > ul {
+    flex: 1;
+  }
+  .plumix-admin-bar ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: stretch;
+    gap: 4px;
+  }
+  .plumix-admin-bar li {
+    display: flex;
+    align-items: stretch;
+    max-width: 240px;
+  }
+  .plumix-admin-bar__end {
+    margin-inline-start: auto;
+  }
+  .plumix-admin-bar a,
+  .plumix-admin-bar summary,
+  .plumix-admin-bar span {
+    color: #fff;
+    text-decoration: none;
+    padding: 0 10px;
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
+  .plumix-admin-bar a:hover,
+  .plumix-admin-bar summary:hover {
+    background: #2c3338;
+  }
+  .plumix-admin-bar details {
+    position: relative;
+    display: flex;
+  }
+  .plumix-admin-bar summary {
+    list-style: none;
+  }
+  .plumix-admin-bar summary::-webkit-details-marker {
+    display: none;
+  }
+  .plumix-admin-bar summary::after {
+    content: " \\25BE";
+    opacity: 0.7;
+    margin-inline-start: 4px;
+  }
+  .plumix-admin-bar details[open] > summary {
+    background: #2c3338;
+  }
+  .plumix-admin-bar details > ul {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    flex-direction: column;
+    background: #2c3338;
+    min-width: 200px;
+    padding: 4px 0;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+    z-index: 1;
+  }
+  .plumix-admin-bar details > ul > li {
+    max-width: 100%;
+  }
+  .plumix-admin-bar details > ul a {
+    display: block;
+    padding: 6px 12px;
+    line-height: 1.4;
+  }
+  .plumix-admin-bar[dir="rtl"] nav {
+    flex-direction: row-reverse;
+  }
+  .plumix-admin-bar[dir="rtl"] details > ul {
+    left: auto;
+    right: 0;
+  }
+  @media (max-width: 639px) {
+    .plumix-admin-bar {
+      display: none;
+    }
+  }
+`;
+
+export const ADMIN_BAR_BODY_OFFSET_CSS = css`
+  @media (min-width: 640px) {
+    body {
+      padding-top: 36px;
+    }
+  }
+`;

--- a/packages/core/src/admin-bar/types.ts
+++ b/packages/core/src/admin-bar/types.ts
@@ -1,6 +1,7 @@
 import type { AuthenticatedUser, AuthNamespace } from "../context/app.js";
 import type { RegisteredEntryType } from "../plugin/manifest.js";
 import type { ResolvedEntity } from "../route/current.ts";
+import type { BarLocale } from "./i18n.js";
 
 export const ADMIN_BAR_GROUPS = [
   "primary",
@@ -48,6 +49,15 @@ export interface BarRenderContext {
    * its child menu without a separate discovery API.
    */
   readonly entryTypes: ReadonlyMap<string, RegisteredEntryType>;
+  /**
+   * Resolved bar locale (WP-style — read from `user.meta.locale`, falls
+   * back to `en` for unrecognised values). Core contributors translate
+   * their literals through this; plugin contributors stay responsible
+   * for their own catalogs and pass already-translated `title` strings.
+   */
+  readonly locale: BarLocale;
+  /** Text direction for the bar element — `rtl` for `ar`, `ltr` elsewhere. */
+  readonly direction: "ltr" | "rtl";
 }
 
 declare module "../hooks/types.js" {


### PR DESCRIPTION
Admin-bar slice 5 — closes the chain. End-to-end working bar with localized chrome (en/de/uk/ar/zh-CN), RTL flip on Arabic, inline scoped CSS, mobile hide, long-label truncation, system-font stack covering Latin/Cyrillic/Arabic/CJK without a webfont request, and proper accessibility landmarks.

**Inline CSS via tagged template — not CSS Modules**

CSS Modules don't fit: \`@plumix/core\` is built with tsc-only and the bar emits its style inline in the SSR response, not as a separate stylesheet request. Wrapping the CSS string in a no-op \`css\\\`…\\\`\` tag gives vscode-styled-components + stylelint syntax highlighting + linting without changing the build pipeline. All selectors scoped under \`.plumix-admin-bar\`; \`--plumix-admin-bar-z-index\` custom property is the only override hook themes need. Account \`<li>\` carries \`plumix-admin-bar__end\` and \`margin-inline-start: auto\` pushes it to the row's end (works in both LTR and RTL).

**i18n — inline TS catalog**

9-string hand-authored table mirroring plumix's launch set per [[i18n-translator-readiness-complete]]. \`resolveBarLocale(user)\` reads \`user.meta.locale\` (WP-style \`get_user_locale()\`, not \`get_locale()\`) and falls back to \`en\` for unknown values. \`barDirection(locale)\` returns \`rtl\` only for \`ar\`. Plugin contributors stay responsible for their own catalogs and pass already-translated \`title\` strings; core does not re-translate plugin text.

**Deliberate scope deviation**: not wiring \`.po\` + \`lingui compile\` + \`pnpm i18n:check\` for nine SSR-only strings. The functional contract (locale-resolved chrome + fallback + RTL flip) is identical; the canonical pipeline gets wired when the \`pnpm i18n:check\` gate moves into core.

**RTL + bdi**

Bar element renders \`dir="rtl" lang="ar"\` for Arabic. User-supplied strings (account email, +new entry-type child titles) wrapped in \`<bdi>\` so their script direction can't invert the surrounding chrome.

**Accessibility**

\`<nav aria-label="...">\` (localized) inside \`<header>\`; explicit \`aria-label\` on the \`+ New\` summary so screen readers announce the action rather than the visual glyph soup. All items reachable via Tab and operable via Enter/Space using native semantics — no custom keyboard handling, zero JS.

**Mobile**: bar hidden at viewport widths below 640px.

**Tests**: 39 admin-bar tests pin every contract — locale snapshots for en/de/uk/ar/zh-CN, \`dir="rtl"\` attribute on Arabic, \`<bdi>\` wraps the account email, the right-anchor class + CSS rule pair, the inline style block, the localized nav-aria + +New summary aria, native \`<details>/<summary>\` toggle on groups with children.

**Reviews pre-commit**: sentry-skills:senpai + sentry-skills:code-simplifier in parallel. Senpai flagged a dead \`barLocaleMetadata\` export (deleted), duplicated locale union in \`types.ts\` (replaced with \`BarLocale\` import), and \`direction\` derived in two places (consolidated through \`barDirection\`). Simplifier additionally trimmed a one-line \`t()\` indirection and folded \`liClass\` to inline ternaries. Both converged; all findings applied.

**Visual proof**: captured via Playwright across all five locales + dropdown expansion in LTR + RTL. Account right-anchored, native \`<details>\` toggle works zero-JS, glyphs render correctly across scripts via the system-font fallback chain.

Verification:
- 15 tasks green across \`@plumix/core\` + \`@plumix/blocks\` + \`@plumix/admin\`
- 30 plugin tasks green
- No regressions

Closes #668