### PR TITLE
fix(create-plumix-app): unstick CATALOG_RESOLUTIONS from workspace drift

### DIFF
--- a/packages/create-plumix-app/src/scaffold.test.ts
+++ b/packages/create-plumix-app/src/scaffold.test.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
+  CATALOG_RESOLUTIONS,
   resolveTemplateRoot,
   rewriteDeps,
   scaffold,
@@ -202,8 +203,8 @@ describe("rewriteDeps", () => {
         wrangler: "catalog:",
       }),
     ).toEqual({
-      typescript: "^6.0.3",
-      wrangler: "^4.86.0",
+      typescript: CATALOG_RESOLUTIONS.typescript,
+      wrangler: CATALOG_RESOLUTIONS.wrangler,
     });
   });
 
@@ -264,3 +265,96 @@ describe("shouldCopyTemplateEntry", () => {
     ).toBe(true);
   });
 });
+
+describe("CATALOG_RESOLUTIONS drift gate", () => {
+  // Resolve the workspace root from the package's known position:
+  // packages/create-plumix-app/src/scaffold.test.ts → ../../..
+  const here = new URL(".", import.meta.url).pathname;
+  const repoRoot = join(here, "..", "..", "..");
+
+  const minimalPkg = JSON.parse(
+    readFileSync(join(repoRoot, "examples", "minimal", "package.json"), "utf8"),
+  ) as {
+    readonly dependencies?: Record<string, string>;
+    readonly devDependencies?: Record<string, string>;
+  };
+
+  const workspaceCatalog = parseWorkspaceCatalog(
+    readFileSync(join(repoRoot, "pnpm-workspace.yaml"), "utf8"),
+  );
+
+  const minimalCatalogDeps = collectCatalogDeps(minimalPkg);
+
+  test("every `catalog:` dep in examples/minimal has a CATALOG_RESOLUTIONS entry", () => {
+    const missing = [...minimalCatalogDeps].filter(
+      (name) => !(name in CATALOG_RESOLUTIONS),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  test("CATALOG_RESOLUTIONS has no orphan entries unused by the minimal template", () => {
+    const orphans = Object.keys(CATALOG_RESOLUTIONS).filter(
+      (name) => !minimalCatalogDeps.has(name),
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("each CATALOG_RESOLUTIONS entry used by minimal matches pnpm-workspace.yaml", () => {
+    const drift: { name: string; scaffolder: string; workspace: string }[] = [];
+    for (const name of minimalCatalogDeps) {
+      const scaffolder = CATALOG_RESOLUTIONS[name];
+      const workspace = workspaceCatalog[name];
+      if (scaffolder !== workspace) {
+        drift.push({
+          name,
+          scaffolder: scaffolder ?? "<missing>",
+          workspace: workspace ?? "<missing>",
+        });
+      }
+    }
+    expect(drift).toEqual([]);
+  });
+});
+
+function collectCatalogDeps(pkg: {
+  readonly dependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
+}): Set<string> {
+  const out = new Set<string>();
+  for (const block of [pkg.dependencies ?? {}, pkg.devDependencies ?? {}]) {
+    for (const [name, range] of Object.entries(block)) {
+      if (typeof range === "string" && range.startsWith("catalog:")) {
+        out.add(name);
+      }
+    }
+  }
+  return out;
+}
+
+// Parses the top-level `catalog:` map out of pnpm-workspace.yaml. The
+// format is stable (we control it) so a tiny line-scanner is enough —
+// avoids pulling a YAML parser into the scaffolder tests.
+function parseWorkspaceCatalog(yaml: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const lines = yaml.split("\n");
+  let inCatalog = false;
+  for (const line of lines) {
+    if (line === "catalog:") {
+      inCatalog = true;
+      continue;
+    }
+    if (inCatalog) {
+      // The catalog block ends at the next top-level key (no leading space).
+      if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("#")) {
+        inCatalog = false;
+        continue;
+      }
+      const match = /^\s+"?([^":\s]+)"?\s*:\s*(\S+)\s*$/.exec(line);
+      const [, name, version] = match ?? [];
+      if (name && version) {
+        out[name] = version;
+      }
+    }
+  }
+  return out;
+}

--- a/packages/create-plumix-app/src/scaffold.ts
+++ b/packages/create-plumix-app/src/scaffold.ts
@@ -69,15 +69,15 @@ export function resolveTemplateRoot(): string {
 // Bump these together with the corresponding workspace catalog
 // (`pnpm-workspace.yaml`) and the next plumix release.
 const PLUMIX_PACKAGE_VERSION = "^0.1.0";
-const CATALOG_RESOLUTIONS: Record<string, string> = {
-  "@cloudflare/workers-types": "^4.20260421.1",
+// Mirrors `pnpm-workspace.yaml`'s `catalog:` for every package that
+// `examples/minimal/package.json` references via `catalog:`. The
+// drift-gate test in `scaffold.test.ts` keeps these locked in step.
+// Bump together with the workspace catalog and the next plumix release.
+export const CATALOG_RESOLUTIONS: Record<string, string> = {
+  "@cloudflare/workers-types": "^4.20260526.1",
   "@types/node": "^24.12.2",
-  "@types/react": "^19.2.14",
-  "@types/react-dom": "^19.2.3",
-  react: "^19.2.6",
-  "react-dom": "^19.2.6",
   typescript: "^6.0.3",
-  wrangler: "^4.86.0",
+  wrangler: "^4.94.0",
 };
 
 // `@plumix/typescript-config` is a private dev-only workspace package,


### PR DESCRIPTION
First gauntlet item before the manual 0.1.0 publish. The scaffolder's \`CATALOG_RESOLUTIONS\` table had drifted from \`pnpm-workspace.yaml\`'s \`catalog:\` — five of eight entries pointed at older versions than the rest of plumix builds and tests against. A scaffolded project would have installed wrangler \`^4.86\` while every other workspace package uses \`^4.94\`.

**Drift gate**

Three new tests load \`examples/minimal/package.json\` and \`pnpm-workspace.yaml\` at test time:

- every \`catalog:\` dep in the template has a \`CATALOG_RESOLUTIONS\` entry
- no \`CATALOG_RESOLUTIONS\` entry is an orphan unused by the template
- every \`CATALOG_RESOLUTIONS\` entry used by the template matches the workspace catalog verbatim

The existing \`"rewrites catalog: protocol to the resolved version"\` test now references \`CATALOG_RESOLUTIONS.typescript\` / \`.wrangler\` instead of hardcoded version strings, so future catalog bumps don't break it.

**Cleanup**

Deleted the four dead \`react\` / \`@types/react\` / \`@types/react-dom\` / \`react-dom\` entries. \`examples/minimal\` doesn't reference them via \`catalog:\` today, and the new orphan assertion mechanically catches anyone who re-introduces dead entries.

**Verification**

\`pnpm pack\` produces a self-contained tarball with the \`templates/starter/\` snapshot. \`npm install <tarball>\` followed by \`create-plumix-app /tmp/foo\` produces a target whose \`package.json\` carries:

- \`wrangler\` \`^4.94.0\` (was \`^4.86.0\`)
- \`@cloudflare/workers-types\` \`^4.20260526.1\` (was \`^4.20260421.1\`)
- \`@plumix/typescript-config\` correctly stripped
- \`plumix\` and \`@plumix/runtime-cloudflare\` pinned to \`^0.1.0\` for the publish gauntlet

Reviewed by sentry-skills:senpai pre-commit; the orphan assertion was the inline suggestion and is included.

Refs the phase-8 scaffolder + 0.1.0 publish gauntlet.