### PR TITLE
test(admin): add worker-driven editor e2e suite with regression pins

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -20,6 +20,11 @@ const config: KnipConfig = {
     "examples/minimal": {
       entry: ["plumix.config.ts"],
     },
+    // Admin's worker-driven e2e playground — same shape as the plugin
+    // playgrounds below.
+    "packages/admin/playground": {
+      entry: ["plumix.config.ts"],
+    },
     // Plugin playground — same shape as examples/*: `plumix.config.ts`
     // is the consumer entry, not visible to knip without an explicit
     // hint.
@@ -101,11 +106,13 @@ const config: KnipConfig = {
         // .tsx extension swap; list explicitly.
         "e2e/fixtures/runtime-proof-plugin/src/MediaLibrary.tsx",
         // With knip's playwright plugin disabled below, list the
-        // playwright config + spec/support files explicitly so they
+        // playwright configs + spec/support files explicitly so they
         // aren't flagged as unused.
         "playwright.config.ts",
         "e2e/*.spec.ts",
         "e2e/support/*.ts",
+        "e2e-live/globalSetup.ts",
+        "e2e-live/specs/**/*.ts",
         // Lingui CLI config + compiled catalogs. `lingui.config.ts` is
         // loaded by the `@lingui/cli` binary (extract/compile) — never
         // imported. Compiled `.mjs` catalogs are loaded by `i18n-boot`

--- a/packages/admin/e2e-live/globalSetup.ts
+++ b/packages/admin/e2e-live/globalSetup.ts
@@ -1,0 +1,32 @@
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { actingAs, openPlaygroundDb } from "@plumix/core/test/playwright";
+
+// Runs once after the baked webServer is ready, before the spec
+// suite. Seeds an admin user into the migrated D1, mints a session,
+// and writes the storageState.json that playwright's
+// `use.storageState` reads per-context. Anchors on `process.cwd()`
+// (the package root, where the pnpm script runs) because that's what
+// playwright's node:fs-based storageState reader resolves against —
+// NOT the config directory. See menu/e2e/globalSetup.ts for the same
+// rationale.
+//
+// Re-runs against a still-warm worker (`reuseExistingServer` skips the
+// state wipe baked into the webServer command) reuse the admin row from
+// the previous run instead of tripping the users.email UNIQUE
+// constraint — `actingAs` mints a fresh session either way.
+export default async function globalSetup(): Promise<void> {
+  const db = await openPlaygroundDb({
+    cwd: resolve(process.cwd(), "playground"),
+  });
+  const existingAdmin = await db.query.users.findFirst({
+    where: (users, { eq }) => eq(users.role, "admin"),
+  });
+  const { storageState } = await actingAs(db, existingAdmin ?? "admin");
+  await writeFile(
+    resolve(process.cwd(), "storageState.json"),
+    JSON.stringify(storageState, null, 2),
+    "utf8",
+  );
+}

--- a/packages/admin/e2e-live/playwright.config.ts
+++ b/packages/admin/e2e-live/playwright.config.ts
@@ -1,0 +1,22 @@
+import { definePlumixE2EConfig } from "@plumix/core/test/playwright";
+
+// Worker-driven editor e2e. The mock-based suite in `../e2e` stubs every
+// RPC, so the autosave round-trip (entry.update → refetch →
+// `_preview.source` flip) structurally cannot occur there — and that loop
+// is exactly where the editor regressions live. This config boots the
+// playground at `../playground` via `plumix dev` against real D1 and
+// drives the editor the way an author does: pointer drags, sustained
+// typing, pattern inserts, publish lifecycle.
+//
+// Build ordering: the playground's `plumix dev` needs plumix's dist, but
+// admin can't depend on plumix (plumix devDeps admin for copy-admin — a
+// cycle). turbo.json pins `@plumix/admin#test:e2e` to `plumix#build`
+// instead.
+export default definePlumixE2EConfig({
+  // Ports follow the worker-driven suite convention (HTTP ↔ inspector):
+  // 3010/audit-log, 3020/blog, 3030/media, 3040/menu, 3050/pages.
+  port: 3060,
+  inspectorPort: 9360,
+  playground: "../playground",
+  testDir: "./specs",
+});

--- a/packages/admin/e2e-live/specs/editor-blocks.spec.ts
+++ b/packages/admin/e2e-live/specs/editor-blocks.spec.ts
@@ -1,0 +1,105 @@
+// Block CRUD against the real worker: insert via palette click and slash
+// menu; reorder by dragging on the canvas; duplicate and delete through
+// the block actions panel. Every mutation asserts the autosave envelope
+// lands (entry/update 200) and — where it guards a regression — that the
+// content survives a reload.
+
+import { expect, test } from "@playwright/test";
+
+import {
+  canvasBlocks,
+  canvasOrder,
+  createPost,
+  dragBelow,
+  insertHeroPattern,
+  slashInsert,
+  withAutosave,
+} from "./support/editor.js";
+
+test.describe("editor blocks: insert", () => {
+  test("palette click inserts a block and autosaves it", async ({ page }) => {
+    const id = await createPost(page);
+
+    await withAutosave(page, async () => {
+      await page.getByTestId("plumix-blocks-tab-item-core/heading").click();
+    });
+    await expect(canvasBlocks(page, "core/heading")).toHaveCount(1);
+
+    // Round-trip: the block must come back from the real D1 row.
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(canvasBlocks(page, "core/heading")).toHaveCount(1);
+  });
+
+  // Palette rows are plain click-to-insert buttons today
+  // (InsertableEntryRow has no drag source wiring). This pins the gap:
+  // when drag-from-palette ships, replace the fixme with a real drag
+  // using `dragBelow`-style pointer steps onto the root drop zone.
+  test.fixme("palette item drags onto the canvas drop zone", async ({
+    page,
+  }) => {
+    await createPost(page);
+    const source = page.getByTestId("plumix-blocks-tab-item-core/separator");
+    const dropZone = page.getByTestId("dropzone:root:default-zone");
+    await dragBelow(page, source, dropZone);
+    await expect(canvasBlocks(page, "core/separator")).toHaveCount(1);
+  });
+
+  test("slash menu filters and inserts the matching block", async ({
+    page,
+  }) => {
+    await createPost(page);
+
+    await withAutosave(page, async () => {
+      await slashInsert(page, "quote");
+    });
+    await expect(canvasBlocks(page, "core/quote")).toHaveCount(1);
+  });
+});
+
+test.describe("editor blocks: arrange", () => {
+  test("dragging a block below its sibling reorders the tree", async ({
+    page,
+  }) => {
+    const id = await createPost(page);
+
+    // The e2e/hero pattern gives two visible blocks (heading + rich
+    // text) without depending on typing, which has its own spec.
+    await insertHeroPattern(page);
+    const heading = canvasBlocks(page, "core/heading").first();
+    const richText = canvasBlocks(page, "core/rich-text").first();
+    await expect(richText).toBeVisible();
+
+    await withAutosave(page, async () => {
+      await dragBelow(page, heading, richText);
+    });
+    // `canvasOrder` reads the DOM without auto-waiting — poll it.
+    await expect
+      .poll(() => canvasOrder(page))
+      .toEqual(["rich-text", "heading"]);
+
+    // Reload: the reorder must have reached the row, not just the store.
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect
+      .poll(() => canvasOrder(page))
+      .toEqual(["rich-text", "heading"]);
+  });
+
+  test("duplicate and delete via the block actions panel", async ({ page }) => {
+    await createPost(page);
+
+    await insertHeroPattern(page);
+    await canvasBlocks(page, "core/heading").first().click();
+    await expect(page.getByTestId("block-actions-panel")).toBeVisible();
+
+    await withAutosave(page, async () => {
+      await page.getByTestId("block-action-duplicate").click();
+    });
+    await expect(canvasBlocks(page, "core/heading")).toHaveCount(2);
+
+    await canvasBlocks(page, "core/heading").first().click();
+    await withAutosave(page, async () => {
+      await page.getByTestId("block-action-delete").click();
+    });
+    await expect(canvasBlocks(page, "core/heading")).toHaveCount(1);
+  });
+});

--- a/packages/admin/e2e-live/specs/editor-lifecycle.spec.ts
+++ b/packages/admin/e2e-live/specs/editor-lifecycle.spec.ts
@@ -1,0 +1,189 @@
+// Entry lifecycle through the real worker: publish, the
+// draft-of-published banner with save/discard/publish-draft, the
+// revisions sheet, and the silent hang when entry.create fails.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import {
+  createPost,
+  insertHeroPattern,
+  withAutosave,
+} from "./support/editor.js";
+
+// Publishing a live draft flips status through entry/update;
+// `entry.publish` only serves the draft-of-published header.
+async function publishEntry(page: Page) {
+  await withAutosave(page, async () => {
+    await page.getByTestId("plumix-editor-publish-button").click();
+  });
+  // Publishing swaps the header to the draft-of-published actions.
+  await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+}
+
+test.describe("editor lifecycle: publish", () => {
+  test("publish flips the entry to published in the list", async ({ page }) => {
+    const id = await createPost(page);
+    await insertHeroPattern(page);
+    // The title must reach the live row before publish snapshots it.
+    await withAutosave(page, async () => {
+      await page
+        .getByTestId("plumix-editor-title-input")
+        .fill(`Lifecycle ${String(id)}`);
+    });
+    await publishEntry(page);
+
+    // The status badge has no testid — anchor on the table row that
+    // contains this entry's title link.
+    await page.goto("entries/posts");
+    const row = page
+      .locator("tr")
+      .filter({ has: page.getByTestId(`content-list-row-${String(id)}`) });
+    // Status renders lowercase ("published") and is capitalized by CSS.
+    await expect(row).toContainText(/published/i);
+  });
+
+  test("published entry records a revision in the sheet", async ({ page }) => {
+    await createPost(page);
+    await insertHeroPattern(page);
+    await publishEntry(page);
+
+    await page.getByTestId("revisions-sheet-trigger").click();
+    await expect(page.getByTestId("revisions-sheet-list")).toBeVisible();
+    await expect(
+      page.locator("[data-testid^='revisions-sheet-item-']").first(),
+    ).toBeVisible();
+  });
+});
+
+test.describe("editor lifecycle: draft of a published entry", () => {
+  // KNOWN BROKEN: the autosave that creates the pending-draft row never
+  // refetches `entry.get` in-session, so the banner stays hidden and
+  // Discard / Publish stay disabled until a full reload — the user gets
+  // no signal that their edits diverged from the live row.
+  test("editing a published entry surfaces the banner without a reload", async ({
+    page,
+  }) => {
+    test.fail();
+    const id = await createPost(page);
+    await insertHeroPattern(page);
+    await publishEntry(page);
+
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+    await withAutosave(page, async () => {
+      await page
+        .getByTestId("plumix-editor-title-input")
+        .fill(`In-session ${String(id)}`);
+    });
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("pending draft shows the banner after reload; discard reverts", async ({
+    page,
+  }) => {
+    const id = await createPost(page);
+    await insertHeroPattern(page);
+    await withAutosave(page, async () => {
+      await page
+        .getByTestId("plumix-editor-title-input")
+        .fill(`Banner ${String(id)}`);
+    });
+    await publishEntry(page);
+
+    // Re-enter the editor in draft-of-published mode and stage a draft.
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+    await withAutosave(page, async () => {
+      await page
+        .getByTestId("plumix-editor-title-input")
+        .fill(`Banner edited ${String(id)}`);
+    });
+
+    // The reload works around the in-session staleness pinned above.
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeVisible();
+
+    const discarded = page.waitForResponse(
+      (r) => r.url().endsWith("/entry/discardDraft") && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.getByTestId("editor-draft-discard").click();
+    await discarded;
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeHidden();
+    await expect(page.getByTestId("plumix-editor-title-input")).toHaveValue(
+      `Banner ${String(id)}`,
+    );
+  });
+
+  test("publish-draft pushes pending changes live", async ({ page }) => {
+    const id = await createPost(page);
+    await insertHeroPattern(page);
+    await publishEntry(page);
+
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+    await withAutosave(page, async () => {
+      await page
+        .getByTestId("plumix-editor-title-input")
+        .fill(`Draft push ${String(id)}`);
+    });
+
+    // The reload works around the in-session staleness pinned above.
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeVisible();
+
+    const published = page.waitForResponse(
+      (r) => r.url().endsWith("/entry/publish") && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.getByTestId("editor-draft-publish").click();
+    await published;
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeHidden();
+
+    await page.goto("entries/posts");
+    const row = page
+      .locator("tr")
+      .filter({ has: page.getByTestId(`content-list-row-${String(id)}`) });
+    await expect(row).toContainText(`Draft push ${String(id)}`);
+    await expect(row).toContainText(/published/i);
+  });
+});
+
+test.describe("editor lifecycle: create failure", () => {
+  // KNOWN BROKEN: create.tsx has no onError — any entry.create failure
+  // (e.g. the 409 slug collision two same-millisecond creates produce,
+  // since the slug derives from Date.now()) leaves "Creating…" up
+  // forever with no feedback and no retry.
+  test("a failed create surfaces feedback instead of hanging", async ({
+    page,
+  }) => {
+    test.fail();
+    await page.route("**/_plumix/rpc/entry/create", (route) =>
+      route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          json: {
+            defined: true,
+            code: "CONFLICT",
+            status: 409,
+            message: "Resource conflict",
+            data: { reason: "slug_taken" },
+          },
+        }),
+      }),
+    );
+
+    await page.goto("entries/posts");
+    await page.getByTestId("content-list-new-button").click();
+    await expect(page.getByTestId("create-entry-pending")).toBeVisible();
+    // The pending indicator must resolve into something — an error
+    // surface or a navigation — within a generous window.
+    await expect(page.getByTestId("create-entry-pending")).toBeHidden({
+      timeout: 8_000,
+    });
+  });
+});

--- a/packages/admin/e2e-live/specs/editor-patterns.spec.ts
+++ b/packages/admin/e2e-live/specs/editor-patterns.spec.ts
@@ -1,0 +1,174 @@
+// Pattern flows against the real worker: insert from the Blocks-tab
+// patterns section and the slash menu (copy mode), insert + detach a
+// reference-mode pattern, author a new pattern via "Copy as pattern
+// source", and walk the starter modal that pattern registration
+// switches on.
+
+import { expect, test } from "@playwright/test";
+
+import {
+  canvasBlocks,
+  canvasOrder,
+  createPost,
+  dismissStarterModal,
+  openSlashMenu,
+  withAutosave,
+} from "./support/editor.js";
+
+test.describe("editor patterns: copy-mode insert", () => {
+  test("patterns section click splices the pattern body", async ({ page }) => {
+    const id = await createPost(page);
+
+    await withAutosave(page, async () => {
+      await page.getByTestId("plumix-patterns-row-e2e/hero").click();
+    });
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h2"),
+    ).toHaveText("Pattern heading");
+    await expect(
+      canvasBlocks(page, "core/rich-text").first().locator("p"),
+    ).toHaveText("Pattern body copy");
+
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect
+      .poll(() => canvasOrder(page))
+      .toEqual(["heading", "rich-text"]);
+  });
+
+  test("slash menu surfaces the pattern as a card and inserts it", async ({
+    page,
+  }) => {
+    await createPost(page);
+
+    await openSlashMenu(page, "hero");
+    const card = page.getByTestId("slash-menu-pattern-card-e2e/hero");
+    await expect(card).toBeVisible();
+    await withAutosave(page, async () => {
+      await card.click();
+    });
+    await expect(page.getByTestId("slash-menu-dialog")).toBeHidden();
+    await expect(canvasBlocks(page, "core/heading")).toHaveCount(1);
+    await expect(canvasBlocks(page, "core/rich-text")).toHaveCount(1);
+  });
+});
+
+test.describe("editor patterns: reference mode", () => {
+  test("reference pattern inserts a ref node that persists as a ref", async ({
+    page,
+  }) => {
+    const id = await createPost(page);
+
+    await withAutosave(page, async () => {
+      await page.getByTestId("plumix-patterns-row-e2e/promo").click();
+    });
+    await expect(
+      page.getByTestId("plumix-pattern-ref-e2e/promo"),
+    ).toBeVisible();
+
+    // The ref node — not an expanded copy — must be what persists.
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(
+      page.getByTestId("plumix-pattern-ref-e2e/promo"),
+    ).toBeVisible();
+  });
+
+  // KNOWN BROKEN: Puck's [data-puck-dnd] draggable wrapper intercepts
+  // pointer events over the whole block — even when it's selected — so
+  // the Detach / Open source buttons inside PatternRefPreview can never
+  // receive a real mouse click. Rich-text escapes through Puck's
+  // overlay portal; the ref preview doesn't.
+  test("detach button is reachable with the mouse", async ({ page }) => {
+    test.fail();
+    await createPost(page);
+
+    await withAutosave(page, async () => {
+      await page.getByTestId("plumix-patterns-row-e2e/promo").click();
+    });
+    const ref = page.getByTestId("plumix-pattern-ref-e2e/promo");
+    await ref.click();
+    await page
+      .getByTestId("plumix-pattern-ref-detach")
+      .click({ timeout: 5_000 });
+    await expect(ref).toBeHidden();
+  });
+
+  // KNOWN BROKEN: even a dispatched DOM click (which sidesteps the
+  // hit-testing bug above and verifiably fires on the button) never
+  // mutates Puck data — the ref stays put. The pure detachPatternRef
+  // helper is unit-covered, so the break sits in the wiring between
+  // the overlay-portal render and the usePuck dispatch.
+  test("detach action converts the ref into an editable copy", async ({
+    page,
+  }) => {
+    test.fail();
+    await createPost(page);
+
+    await withAutosave(page, async () => {
+      await page.getByTestId("plumix-patterns-row-e2e/promo").click();
+    });
+    await expect(
+      page.getByTestId("plumix-pattern-ref-e2e/promo"),
+    ).toBeVisible();
+
+    await page.getByTestId("plumix-pattern-ref-detach").dispatchEvent("click");
+    await expect(page.getByTestId("plumix-pattern-ref-e2e/promo")).toBeHidden({
+      timeout: 5_000,
+    });
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h3"),
+    ).toHaveText("Promo heading");
+  });
+});
+
+test.describe("editor patterns: authoring", () => {
+  test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+  test("copy as pattern source serializes the canvas to the clipboard", async ({
+    page,
+  }) => {
+    await createPost(page);
+    await withAutosave(page, async () => {
+      await page.getByTestId("plumix-patterns-row-e2e/hero").click();
+    });
+
+    await page.getByTestId("plumix-editor-copy-as-pattern-source").click();
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain("definePattern({");
+    expect(clipboard).toContain('block("core/heading"');
+    expect(clipboard).toContain('text: "Pattern heading"');
+    expect(clipboard).toContain('block("core/rich-text"');
+  });
+});
+
+test.describe("editor patterns: starter modal", () => {
+  test("fresh entry offers starter patterns; picking one seeds the canvas", async ({
+    page,
+  }) => {
+    await page.goto("entries/posts");
+    const navigated = page.waitForURL(/\/entries\/posts\/\d+\/edit/);
+    await page.getByTestId("content-list-new-button").click();
+    await navigated;
+
+    const modal = page.getByTestId("plumix-starter-modal");
+    await expect(modal).toBeVisible();
+    await withAutosave(page, async () => {
+      await page.getByTestId("plumix-starter-modal-card-e2e/hero").click();
+    });
+    await expect(modal).toBeHidden();
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h2"),
+    ).toHaveText("Pattern heading");
+  });
+
+  test("start blank leaves the canvas empty", async ({ page }) => {
+    await page.goto("entries/posts");
+    const navigated = page.waitForURL(/\/entries\/posts\/\d+\/edit/);
+    await page.getByTestId("content-list-new-button").click();
+    await navigated;
+
+    await dismissStarterModal(page);
+    await expect(
+      page.getByTestId("plumix-editor-canvas").locator("[data-puck-component]"),
+    ).toHaveCount(0);
+  });
+});

--- a/packages/admin/e2e-live/specs/editor-typing.spec.ts
+++ b/packages/admin/e2e-live/specs/editor-typing.spec.ts
@@ -1,0 +1,125 @@
+// Sustained typing against the real worker. The mock-based admin suite
+// can't catch the autosave→refetch→remount loop that ejects focus from
+// Tiptap mid-burst (verified live 2026-06-05: 44 slow-typed chars → 0
+// persisted), so these are the regression pins for it. The known-broken
+// paths carry test.fail() — when a fix lands they flip to "unexpectedly
+// passed" and the annotation comes off with it.
+
+import { expect, test } from "@playwright/test";
+
+import {
+  canvasBlocks,
+  createPost,
+  insertHeroPattern,
+  withAutosave,
+} from "./support/editor.js";
+
+const SENTENCE = "The quick brown fox jumps over the lazy dog";
+
+test.describe("editor typing: fields that commit in one shot", () => {
+  test("title input round-trips through autosave", async ({ page }) => {
+    const id = await createPost(page);
+
+    await withAutosave(page, async () => {
+      await page.getByTestId("plumix-editor-title-input").fill("Typed title");
+    });
+
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(page.getByTestId("plumix-editor-title-input")).toHaveValue(
+      "Typed title",
+    );
+  });
+
+  test("heading text edits through the inspector field", async ({ page }) => {
+    const id = await createPost(page);
+    await insertHeroPattern(page);
+
+    await canvasBlocks(page, "core/heading").first().click();
+    await expect(page.getByTestId("block-actions-panel")).toBeVisible();
+    // Puck renders the field without a testid — first text input of the
+    // inspector column is the heading's Text field.
+    const textField = page
+      .getByTestId("plumix-editor-right")
+      .locator("input")
+      .first();
+    await withAutosave(page, async () => {
+      await textField.fill("Inspector heading");
+    });
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h2"),
+    ).toHaveText("Inspector heading");
+
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h2"),
+    ).toHaveText("Inspector heading");
+  });
+});
+
+test.describe("editor typing: sustained keystrokes", () => {
+  test("inspector heading field keeps focus across a typing burst", async ({
+    page,
+  }) => {
+    await createPost(page);
+    await insertHeroPattern(page);
+
+    await canvasBlocks(page, "core/heading").first().click();
+    const textField = page
+      .getByTestId("plumix-editor-right")
+      .locator("input")
+      .first();
+    await textField.click();
+    await textField.clear();
+    await textField.pressSequentially(SENTENCE, { delay: 50 });
+    await expect(textField).toHaveValue(SENTENCE);
+    // The full value alone could survive a focus bounce (the locator
+    // re-targets per key) — pin that focus actually stayed put.
+    await expect(textField).toBeFocused();
+  });
+
+  // KNOWN BROKEN: the first autosave round-trip remounts the canvas
+  // Tiptap instance and ejects focus to <body>; every keystroke after
+  // the remount is dropped (and can land in global hotkey handlers).
+  test("inline rich-text typing on the canvas survives autosave", async ({
+    page,
+  }) => {
+    test.fail();
+    const id = await createPost(page);
+    await insertHeroPattern(page);
+
+    const inline = canvasBlocks(page, "core/rich-text")
+      .first()
+      .locator('[contenteditable="true"]');
+    await inline.click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await inline.pressSequentially(SENTENCE, { delay: 80 });
+    await expect(inline.locator("p")).toHaveText(SENTENCE);
+
+    // And the typed text must reach the row, not just the DOM.
+    await withAutosave(page, async () => {
+      await page.keyboard.press("End");
+    });
+    await page.goto(`entries/posts/${String(id)}/edit`);
+    await expect(
+      canvasBlocks(page, "core/rich-text").first().locator("p"),
+    ).toHaveText(SENTENCE);
+  });
+
+  // KNOWN BROKEN: same remount loop through the sidebar Body field.
+  test("sidebar Body field typing survives autosave", async ({ page }) => {
+    test.fail();
+    await createPost(page);
+    await insertHeroPattern(page);
+
+    await canvasBlocks(page, "core/rich-text").first().click();
+    await expect(page.getByTestId("block-actions-panel")).toBeVisible();
+    const body = page
+      .getByTestId("plumix-editor-right")
+      .locator('[contenteditable="true"]')
+      .first();
+    await body.click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await body.pressSequentially(SENTENCE, { delay: 80 });
+    await expect(body.locator("p")).toHaveText(SENTENCE);
+  });
+});

--- a/packages/admin/e2e-live/specs/support/editor.ts
+++ b/packages/admin/e2e-live/specs/support/editor.ts
@@ -1,0 +1,165 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+// The playground registers a starter-eligible pattern (`e2e/hero`,
+// `target: "post-content"`), so every freshly created entry opens the
+// starter modal. Specs that aren't about the modal start blank.
+export async function dismissStarterModal(page: Page): Promise<void> {
+  const modal = page.getByTestId("plumix-starter-modal");
+  await modal.waitFor({ state: "visible" });
+  await page.getByTestId("plumix-starter-modal-start-blank").click();
+  await expect(modal).toBeHidden();
+}
+
+/**
+ * Create a fresh draft post through the real UI (list → New → editor
+ * redirect) and land in the editor with the starter modal dismissed.
+ * Returns the entry id parsed from the edit URL.
+ */
+export async function createPost(page: Page): Promise<number> {
+  // Retried because parallel workers can collide on entry.create:
+  // create.tsx derives the slug from Date.now(), so two same-millisecond
+  // creates 409 (`slug_taken`) — and the route has no onError, leaving
+  // "Creating…" up forever. The silent hang has its own regression test
+  // in editor-lifecycle.spec.ts; the retry here keeps unrelated specs
+  // from inheriting the flake.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.goto("entries/posts");
+    const navigated = page
+      .waitForURL(/\/entries\/posts\/\d+\/edit/, { timeout: 8_000 })
+      .then(() => true)
+      .catch(() => false);
+    await page.getByTestId("content-list-new-button").click();
+    if (await navigated) {
+      await dismissStarterModal(page);
+      const match = /\/entries\/posts\/(\d+)\/edit/.exec(page.url());
+      if (!match) throw new Error(`expected an edit URL, got ${page.url()}`);
+      return Number(match[1]);
+    }
+  }
+  throw new Error("createPost: entry.create kept failing after 3 attempts");
+}
+
+/**
+ * Arm an `entry/update` response waiter, run the action, and wait for
+ * the editor's keystroke-debounced autosave to land. Arming BEFORE the
+ * action means a fast RPC can't slip past the waiter.
+ *
+ * Contract: the action must actually dirty the title or content — the
+ * editor dedups no-op saves against its last-saved snapshot, so a
+ * non-mutating action never produces an `entry/update` and the waiter
+ * times out. With back-to-back calls the waiter can also match the
+ * previous call's trailing save; follow with a web-first assertion on
+ * the mutated state, never on the response alone.
+ */
+export async function withAutosave(
+  page: Page,
+  action: () => Promise<void>,
+): Promise<void> {
+  const updated = page.waitForResponse(
+    (r) => r.url().endsWith("/entry/update") && r.status() === 200,
+    { timeout: 15_000 },
+  );
+  await action();
+  await updated;
+}
+
+/**
+ * Reorder drag for Puck's canvas (@dnd-kit/react, mouse sensor with a
+ * 5 px distance activation). HTML5 dragTo() doesn't fire pointer
+ * events, so this walks the cursor: down on the source, a short
+ * vertical move to clear the activation distance, a settle pause for
+ * the drag to engage, a stepped glide past the target's far edge,
+ * another settle for the collision detector, then up.
+ */
+export async function dragBelow(
+  page: Page,
+  source: Locator,
+  target: Locator,
+): Promise<void> {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+  if (!sourceBox || !targetBox) {
+    throw new Error("dragBelow: source or target has no bounding box");
+  }
+  const x = sourceBox.x + Math.min(40, sourceBox.width / 2);
+  const startY = sourceBox.y + sourceBox.height / 2;
+  await page.mouse.move(x, startY);
+  await page.mouse.down();
+  await page.mouse.move(x, startY + 10, { steps: 4 });
+  await page.waitForTimeout(300);
+  // Overshoot deep past the target's bottom edge — zoomed-out canvas
+  // blocks can be ~15 px tall, and near-edge drops resolve back to the
+  // source's original slot (a silent no-op). The collision detector
+  // clamps an overshoot to "after the last item", so this helper is
+  // meant for dropping after the zone's trailing block.
+  await page.mouse.move(x, targetBox.y + targetBox.height + 100, {
+    steps: 12,
+  });
+  await page.waitForTimeout(300);
+  await page.mouse.up();
+}
+
+// Puck exposes only the item id on `data-puck-component` (pattern
+// inserts mint bare random ids), so block type is asserted through the
+// semantic element each core block renders — which doubles as checking
+// the block actually renders its markup.
+const BLOCK_DOM: Record<string, string> = {
+  "core/heading": "h1, h2, h3, h4, h5, h6",
+  "core/rich-text": ".rich-text",
+  "core/quote": "blockquote",
+  "core/separator": "hr",
+};
+
+/** Canvas-rendered block wrappers for a given block name. */
+export function canvasBlocks(page: Page, name: string): Locator {
+  const selector = BLOCK_DOM[name];
+  if (!selector) throw new Error(`canvasBlocks: no DOM mapping for ${name}`);
+  return page
+    .getByTestId("plumix-editor-canvas")
+    .locator("[data-puck-component]")
+    .filter({ has: page.locator(selector) });
+}
+
+/** Top-level canvas block order as semantic names, for reorder asserts. */
+export async function canvasOrder(page: Page): Promise<readonly string[]> {
+  return page
+    .getByTestId("plumix-editor-canvas")
+    .locator("[data-puck-component]")
+    .evaluateAll((nodes) =>
+      nodes.map((node) => {
+        if (node.querySelector("h1, h2, h3, h4, h5, h6")) return "heading";
+        if (node.querySelector(".rich-text")) return "rich-text";
+        if (node.querySelector("blockquote")) return "quote";
+        if (node.querySelector("hr")) return "separator";
+        return "unknown";
+      }),
+    );
+}
+
+/** Open the slash menu from the canvas and type a filter into it. */
+export async function openSlashMenu(page: Page, filter: string): Promise<void> {
+  await page.getByTestId("plumix-editor-canvas").focus();
+  await page.keyboard.press("/");
+  await expect(page.getByTestId("slash-menu-dialog")).toBeVisible();
+  await page.keyboard.type(filter);
+}
+
+/** Insert a block through the slash menu, the keyboard-first path. */
+export async function slashInsert(page: Page, filter: string): Promise<void> {
+  await openSlashMenu(page, filter);
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("slash-menu-dialog")).toBeHidden();
+}
+
+/** Insert the e2e/hero pattern (heading + rich text) and await autosave. */
+export async function insertHeroPattern(page: Page): Promise<void> {
+  await withAutosave(page, async () => {
+    await page.getByTestId("plumix-patterns-row-e2e/hero").click();
+  });
+  await expect(canvasBlocks(page, "core/heading")).toHaveCount(1);
+  // Let the autosave response's state echo settle — a canvas re-render
+  // mid-drag cancels @dnd-kit's drag, so callers that drag right after
+  // inserting would flake without this.
+  await page.waitForTimeout(800);
+}

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/i18n-compile-check.mjs && vite build",
-    "clean": "git clean -xdf .cache .turbo dist node_modules playwright-report test-results",
+    "clean": "git clean -xdf .cache .turbo dist node_modules playwright-report test-results e2e-live/playwright-report e2e-live/test-results storageState.json",
     "dev": "vite",
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "i18n:check": "node ../plumix/bin/plumix.mjs i18n extract --check",
@@ -14,7 +14,7 @@
     "i18n:compile": "lingui compile --namespace es",
     "lint": "eslint",
     "test": "vitest run",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test && playwright test --config=e2e-live/playwright.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -71,6 +71,7 @@
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@testing-library/user-event": "catalog:",
+    "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",

--- a/packages/admin/playground/package.json
+++ b/packages/admin/playground/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@plumix/admin-e2e-playground",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Plumix consumer with an inline entry type + patterns — host app for the worker-driven editor e2e",
+  "license": "MIT",
+  "scripts": {
+    "build": "plumix build",
+    "clean": "git clean -xdf .plumix .wrangler dist node_modules",
+    "dev": "plumix dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@plumix/runtime-cloudflare": "workspace:*",
+    "plumix": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
+    "@plumix/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "wrangler": "catalog:"
+  }
+}

--- a/packages/admin/playground/plumix.config.ts
+++ b/packages/admin/playground/plumix.config.ts
@@ -1,0 +1,93 @@
+import { auth, defineTheme, plumix } from "plumix";
+import { definePlugin } from "plumix/plugin";
+
+import {
+  cloudflare,
+  cloudflareDeployOrigin,
+  d1,
+} from "@plumix/runtime-cloudflare";
+
+// Plumix consumer for the worker-driven editor e2e in
+// `packages/admin-e2e`. No published plugin — an inline plugin
+// registers the one editor-enabled entry type the specs drive, plus
+// two patterns (one copy-mode, one reference-mode) so the inserter,
+// slash menu, starter modal, and pattern-ref detach paths all have
+// real registrations to exercise.
+const { rpId, origin } = cloudflareDeployOrigin({
+  workerName: "plumix-admin-e2e-playground",
+  accountSubdomain: "local",
+  // CSRF origin-allowlist must match what the browser sends. The
+  // e2e harness boots `plumix dev --port 3060` (see
+  // `../playwright.config.ts`); override here if you boot the
+  // playground manually with a different `--port`.
+  localOrigin: "http://localhost:3060",
+});
+
+const editorE2E = definePlugin("editor-e2e", {
+  setup: (ctx) => {
+    ctx.registerEntryType("post", {
+      label: "Posts",
+      description: "Editor e2e target type",
+      supports: ["title", "editor", "excerpt", "revisions", "autosave"],
+      versioning: { maxRevisions: 25, autosaveIntervalSeconds: 60 },
+      isHierarchical: false,
+      isPublic: true,
+      rewrite: { slug: "posts" },
+      capabilityType: "post",
+      menuIcon: "file-text",
+    });
+
+    // Copy-mode pattern: the inserter splices a deep clone of the body.
+    // `target: "post-content"` also makes it a starter-modal candidate.
+    ctx.registerPattern({
+      name: "e2e/hero",
+      title: "E2E Hero",
+      category: "hero",
+      target: "post-content",
+      entryTypes: ["post"],
+      priority: 1,
+      content: [
+        {
+          id: "p1",
+          name: "core/heading",
+          attrs: { level: 2, text: "Pattern heading" },
+        },
+        {
+          id: "p2",
+          name: "core/rich-text",
+          attrs: { body: "<p>Pattern body copy</p>" },
+        },
+      ],
+    });
+
+    // Reference-mode pattern: inserts a single `core/pattern-ref` node,
+    // giving the specs a real detach / copy-slug surface.
+    ctx.registerPattern({
+      name: "e2e/promo",
+      title: "E2E Promo",
+      category: "cta",
+      insert: "reference",
+      content: [
+        {
+          id: "p1",
+          name: "core/heading",
+          attrs: { level: 3, text: "Promo heading" },
+        },
+      ],
+    });
+  },
+});
+
+export default plumix({
+  runtime: cloudflare(),
+  database: d1({ binding: "DB", session: "auto" }),
+  auth: auth({
+    passkey: {
+      rpName: "Plumix — Admin editor e2e playground",
+      rpId,
+      origin,
+    },
+  }),
+  plugins: [editorE2E],
+  theme: defineTheme({ templates: { index: () => null } }),
+});

--- a/packages/admin/playground/tsconfig.json
+++ b/packages/admin/playground/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@plumix/typescript-config/base.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/workers-types"],
+    // Resolve workspace packages from `src/` (not `dist/`) — see the
+    // comment in `packages/plugins/media/playground/tsconfig.json` for
+    // the full rationale.
+    "paths": {
+      "plumix": ["../../plumix/src/index.ts"],
+      "plumix/plugin": ["../../plumix/src/plugin.ts"],
+      "plumix/blocks": ["../../plumix/src/blocks/index.ts"],
+      "@plumix/runtime-cloudflare": ["../../runtimes/cloudflare/src/index.ts"]
+    }
+  },
+  "include": ["plumix.config.ts", ".plumix"]
+}

--- a/packages/admin/playground/wrangler.jsonc
+++ b/packages/admin/playground/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://unpkg.com/wrangler/config-schema.json",
+  "name": "plumix-admin-e2e-playground",
+  "main": ".plumix/worker.ts",
+  "compatibility_date": "2026-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "plumix_admin_e2e_playground",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "drizzle",
+    },
+  ],
+  "assets": {
+    "directory": ".plumix/public",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+  },
+}

--- a/packages/admin/tsconfig.json
+++ b/packages/admin/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "types": ["vite/client", "@testing-library/jest-dom"],
+    "types": ["vite/client", "@testing-library/jest-dom", "node"],
     "paths": {
       "@/*": ["./src/*"]
     }
@@ -12,9 +12,10 @@
     "src",
     "test",
     "e2e",
+    "e2e-live",
     "vite.config.ts",
     "vitest.config.ts",
     "playwright.config.ts"
   ],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "playground"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,7 +332,7 @@ importers:
         version: 6.2.0
       '@lingui/vite-plugin':
         specifier: ^6.2.0
-        version: 6.2.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.2.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.59.1
@@ -356,10 +356,10 @@ importers:
         version: link:../../tooling/vitest
       '@rolldown/plugin-babel':
         specifier: ^0.2.0
-        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tailwindcss/vite':
         specifier: catalog:tailwind
-        version: 4.3.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.3.0(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-query-devtools':
         specifier: ^5.100.9
         version: 5.100.9(@tanstack/react-query@5.100.14(react@19.2.7))(react@19.2.7)
@@ -368,7 +368,7 @@ importers:
         version: 1.166.13(@tanstack/react-router@1.169.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.169.2)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-plugin':
         specifier: ^1.167.35
-        version: 1.167.35(@tanstack/react-router@1.169.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.167.35(@tanstack/react-router@1.169.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -378,6 +378,9 @@ importers:
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.16
@@ -386,7 +389,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(vitest@4.1.8)
@@ -416,10 +419,35 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.8(@types/node@24.12.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/admin/playground:
+    dependencies:
+      '@plumix/runtime-cloudflare':
+        specifier: workspace:*
+        version: link:../../runtimes/cloudflare
+      plumix:
+        specifier: workspace:*
+        version: link:../../plumix
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260526.1
+      '@plumix/typescript-config':
+        specifier: workspace:*
+        version: link:../../../tooling/typescript
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.94.0(@cloudflare/workers-types@4.20260526.1)
 
   packages/blocks:
     dependencies:
@@ -8415,15 +8443,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@lingui/vite-plugin@6.2.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@lingui/vite-plugin@6.2.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@lingui/cli': 6.2.0
       '@lingui/conf': 6.2.0
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       '@babel/core': 7.29.7
       '@lingui/babel-plugin-lingui-macro': 6.2.0
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       rolldown: 1.0.0-rc.16
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -9627,14 +9655,14 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.16
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@rolldown/pluginutils@1.0.0-rc.16': {}
 
@@ -9726,12 +9754,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/history@1.161.6': {}
 
@@ -9824,7 +9852,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.35(@tanstack/react-router@1.169.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/router-plugin@1.167.35(@tanstack/react-router@1.169.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
@@ -9841,7 +9869,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.169.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10260,12 +10288,12 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
@@ -10279,7 +10307,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@24.12.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -10297,14 +10325,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@vitest/mocker@4.1.8(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -12930,21 +12950,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.16
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.6.0
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.21.0
-      yaml: 2.8.3
-
   vitest@4.1.8(@types/node@24.12.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.8
@@ -12969,36 +12974,6 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
-      happy-dom: 20.9.0
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.6.0
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       happy-dom: 20.9.0
       jsdom: 29.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "packages/admin"
+  - "packages/admin/playground"
   - "packages/blocks"
   - "packages/core"
   - "packages/create-plumix-app"

--- a/turbo.json
+++ b/turbo.json
@@ -33,6 +33,14 @@
       "dependsOn": ["build", "^build"],
       "cache": false
     },
+    // The e2e-live config boots `packages/admin/playground` via
+    // `plumix dev`, which needs plumix's dist. Admin can't declare the
+    // dependency (plumix devDeps admin for copy-admin — a cycle), so
+    // the ordering is pinned at the task level instead.
+    "@plumix/admin#test:e2e": {
+      "dependsOn": ["build", "^build", "plumix#build"],
+      "cache": false
+    },
     "clean": {
       "cache": false
     },


### PR DESCRIPTION
Adds a worker-driven Playwright suite for the admin editor at `packages/admin/e2e-live`, chained behind the existing mock suite in admin's `test:e2e`. The mock suite stubs every RPC, so the autosave round-trip (entry/update → refetch → preview-source flip) can never occur in CI — and a live verification pass showed that loop is exactly where the editor breaks today. The new config boots a dedicated playground (`plumix dev`, port 3060, real D1) and drives the editor through real pointer drags, sustained keystrokes, pattern inserts, and the publish lifecycle. 24 tests: 23 green on a cold run, 1 fixme.

**Six live defects pinned as `test.fail()` / `test.fixme()`**

The suite runs green today and flips loudly when each fix lands — remove the annotation in the same PR that fixes the bug:

1. Tiptap keystroke loss after the first autosave round-trip (inline canvas + sidebar Body field) — plain `<input>` fields survive bursts, narrowing the bug to Tiptap field remounts
2. Pattern-ref **Detach** unreachable by mouse — the `[data-puck-dnd]` wrapper intercepts pointer events even when the block is selected
3. Pattern-ref detach inert even to dispatched DOM clicks that verifiably fire on the button — wiring break between the overlay-portal render and the `usePuck` dispatch (the pure `detachPatternRef` helper is unit-covered)
4. Draft-of-published banner stays hidden and Discard/Publish stay disabled until a full reload — the autosave that creates the pending-draft row never refetches `entry.get` in-session
5. `entry.create` failures hang on "Creating…" forever — `create.tsx` has no `onError`, and the `Date.now()`-derived slug 409s when two creates land in the same millisecond
6. Palette rows are click-only — no drag-from-palette wiring exists (`InsertableEntryRow`)

**Build ordering without a dependency cycle**

`plumix` devDeps on `@plumix/admin` (copy-admin), so admin can't depend back on `plumix` for the playground's dist. The suite reaches the shared harness through `@plumix/core/test/playwright` (already an admin dependency), and `turbo.json` pins `@plumix/admin#test:e2e` to `plumix#build` — the same package-task pattern `i18n:check` already uses.

**Playground as a nested workspace package**

`packages/admin/playground` mirrors the plugin playgrounds: a private consumer app registering an inline plugin (one editor-enabled entry type plus copy-mode and reference-mode patterns) so the inserter, slash menu, starter modal, and pattern-ref paths all exercise real registrations without depending on any published plugin.

Also noted during verification (no test, follow-up candidate): "Copy as pattern source" emits `import { block, definePattern } from "plumix/blocks"`, but neither symbol is exported from that public surface — copied snippets don't compile.