### PR TITLE
test(admin): cover editor actions in e2e with regression pins for live bugs

### DIFF
--- a/packages/admin/e2e/editor-actions.spec.ts
+++ b/packages/admin/e2e/editor-actions.spec.ts
@@ -1,0 +1,485 @@
+// Editor action coverage: every authoring interaction the canvas
+// offers, in one spec — insert (palette / slash / patterns), arrange
+// (drag reorder, duplicate, delete), edit (inspector fields, sustained
+// typing), pattern authoring (starter modal, refs, copy-as-source),
+// and the draft/create surfaces around them.
+//
+// The mock harness can't prove server persistence, so specs assert the
+// two client contracts instead: what the canvas renders, and what
+// envelope entry.update receives.
+//
+// Several tests are test.fail() regression pins for live-verified bugs
+// (2026-06-05). They keep the suite green today and flip to
+// "unexpectedly passed" when the fix lands — remove the annotation in
+// the same PR that fixes the bug.
+
+import { expect, test } from "@playwright/test";
+
+import {
+  canvasBlocks,
+  canvasOrder,
+  dismissStarterModal,
+  dragBelow,
+  editorEntry,
+  installEditorMocks,
+  lastUpdate,
+  SEEDED_CONTENT,
+} from "./support/editor.js";
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_EDITOR_PATTERNS,
+  mockManifest,
+  rpcErrorBody,
+} from "./support/rpc-mock.js";
+
+const SENTENCE = "The quick brown fox jumps over the lazy dog";
+
+test.use({ viewport: { width: 1280, height: 800 } });
+
+test.beforeEach(async ({ page }) => {
+  await mockManifest(page, MANIFEST_WITH_EDITOR_PATTERNS);
+});
+
+test.describe("editor actions: insert", () => {
+  test("palette click inserts a block and autosaves it", async ({ page }) => {
+    const updates = await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+    await dismissStarterModal(page);
+
+    await page.getByTestId("plumix-blocks-tab-item-core/quote").click();
+    await expect(canvasBlocks(page, "core/quote")).toHaveCount(1);
+
+    await expect.poll(() => updates.length).toBeGreaterThan(0);
+    const blocks = lastUpdate(updates)?.content?.blocks ?? [];
+    expect(blocks.map((b) => b.name)).toEqual(["core/quote"]);
+  });
+
+  // Palette rows are plain click-to-insert buttons today
+  // (InsertableEntryRow has no drag source wiring). This pins the gap:
+  // when drag-from-palette ships, flip the fixme into a real drag.
+  test.fixme("palette item drags onto the canvas drop zone", async ({
+    page,
+  }) => {
+    await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+    await dismissStarterModal(page);
+    await dragBelow(
+      page,
+      page.getByTestId("plumix-blocks-tab-item-core/separator"),
+      page.getByTestId("dropzone:root:default-zone"),
+    );
+    await expect(canvasBlocks(page, "core/separator")).toHaveCount(1);
+  });
+});
+
+test.describe("editor actions: arrange", () => {
+  test("dragging a block below its sibling reorders tree and envelope", async ({
+    page,
+  }) => {
+    const updates = await installEditorMocks(page, {
+      entry: editorEntry({ content: SEEDED_CONTENT }),
+    });
+    await page.goto("entries/posts/1/edit");
+
+    const heading = canvasBlocks(page, "core/heading").first();
+    const richText = canvasBlocks(page, "core/rich-text").first();
+    await expect(richText).toBeVisible();
+
+    await dragBelow(page, heading, richText);
+    await expect
+      .poll(() => canvasOrder(page))
+      .toEqual(["rich-text", "heading"]);
+
+    // The reorder must reach the autosave envelope, not just the DOM.
+    await expect.poll(() => updates.length).toBeGreaterThan(0);
+    const blocks = lastUpdate(updates)?.content?.blocks ?? [];
+    expect(blocks.map((b) => b.name)).toEqual([
+      "core/rich-text",
+      "core/heading",
+    ]);
+  });
+
+  test("duplicate and delete via the block actions panel", async ({ page }) => {
+    const updates = await installEditorMocks(page, {
+      entry: editorEntry({ content: SEEDED_CONTENT }),
+    });
+    await page.goto("entries/posts/1/edit");
+
+    await canvasBlocks(page, "core/heading").first().click();
+    await expect(page.getByTestId("block-actions-panel")).toBeVisible();
+
+    await page.getByTestId("block-action-duplicate").click();
+    await expect(canvasBlocks(page, "core/heading")).toHaveCount(2);
+
+    await canvasBlocks(page, "core/heading").first().click();
+    await page.getByTestId("block-action-delete").click();
+    await expect(canvasBlocks(page, "core/heading")).toHaveCount(1);
+
+    // Poll the final envelope shape, not the capture count — if the two
+    // clicks straddle the 1 s autosave debounce, an intermediate
+    // [heading, heading, rich-text] save lands first and a count-based
+    // poll would read it.
+    await expect
+      .poll(() =>
+        (lastUpdate(updates)?.content?.blocks ?? []).map((b) => b.name),
+      )
+      .toEqual(["core/heading", "core/rich-text"]);
+  });
+});
+
+test.describe("editor actions: edit fields", () => {
+  test("heading text edits through the inspector and reaches the canvas", async ({
+    page,
+  }) => {
+    const updates = await installEditorMocks(page, {
+      entry: editorEntry({ content: SEEDED_CONTENT }),
+    });
+    await page.goto("entries/posts/1/edit");
+
+    await canvasBlocks(page, "core/heading").first().click();
+    await expect(page.getByTestId("block-actions-panel")).toBeVisible();
+    // Puck renders the field without a testid — first text input of the
+    // inspector column is the heading's Text field.
+    const textField = page
+      .getByTestId("plumix-editor-right")
+      .locator("input")
+      .first();
+    await textField.fill("Inspector heading");
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h2"),
+    ).toHaveText("Inspector heading");
+
+    await expect
+      .poll(() => {
+        const blocks = lastUpdate(updates)?.content?.blocks ?? [];
+        return blocks[0]?.attrs?.text;
+      })
+      .toBe("Inspector heading");
+  });
+
+  test("inspector heading field keeps focus across a typing burst", async ({
+    page,
+  }) => {
+    await installEditorMocks(page, {
+      entry: editorEntry({ content: SEEDED_CONTENT }),
+    });
+    await page.goto("entries/posts/1/edit");
+
+    await canvasBlocks(page, "core/heading").first().click();
+    const textField = page
+      .getByTestId("plumix-editor-right")
+      .locator("input")
+      .first();
+    await textField.click();
+    await textField.clear();
+    await textField.pressSequentially(SENTENCE, { delay: 50 });
+    await expect(textField).toHaveValue(SENTENCE);
+    // The full value alone could survive a focus bounce (the locator
+    // re-targets per key) — pin that focus actually stayed put.
+    await expect(textField).toBeFocused();
+  });
+
+  // KNOWN BROKEN: the first keystroke's state update remounts the
+  // canvas Tiptap instance and ejects focus to <body>; every keystroke
+  // after the remount is dropped (and can land in global hotkey
+  // handlers). Verified live and under this mock harness — 0 of 44
+  // slow-typed chars persist.
+  test("inline rich-text typing on the canvas survives a burst", async ({
+    page,
+  }) => {
+    test.fail();
+    const updates = await installEditorMocks(page, {
+      entry: editorEntry({ content: SEEDED_CONTENT }),
+    });
+    await page.goto("entries/posts/1/edit");
+
+    const inline = canvasBlocks(page, "core/rich-text")
+      .first()
+      .locator('[contenteditable="true"]');
+    await inline.click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await inline.pressSequentially(SENTENCE, { delay: 80 });
+    await expect(inline.locator("p")).toHaveText(SENTENCE);
+
+    await expect
+      .poll(() => {
+        const blocks = lastUpdate(updates)?.content?.blocks ?? [];
+        return blocks[1]?.attrs?.body;
+      })
+      .toBe(`<p>${SENTENCE}</p>`);
+  });
+
+  // KNOWN BROKEN: same remount loop through the sidebar Body field.
+  test("sidebar Body field typing survives a burst", async ({ page }) => {
+    test.fail();
+    await installEditorMocks(page, {
+      entry: editorEntry({ content: SEEDED_CONTENT }),
+    });
+    await page.goto("entries/posts/1/edit");
+
+    await canvasBlocks(page, "core/rich-text").first().click();
+    await expect(page.getByTestId("block-actions-panel")).toBeVisible();
+    const body = page
+      .getByTestId("plumix-editor-right")
+      .locator('[contenteditable="true"]')
+      .first();
+    await body.click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await body.pressSequentially(SENTENCE, { delay: 80 });
+    await expect(body.locator("p")).toHaveText(SENTENCE);
+  });
+});
+
+test.describe("editor actions: patterns", () => {
+  test("patterns section click splices the pattern body", async ({ page }) => {
+    const updates = await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+    await dismissStarterModal(page);
+
+    await page.getByTestId("plumix-patterns-row-e2e/hero").click();
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h2"),
+    ).toHaveText("Pattern heading");
+    await expect(
+      canvasBlocks(page, "core/rich-text").first().locator("p"),
+    ).toHaveText("Pattern body copy");
+
+    await expect.poll(() => updates.length).toBeGreaterThan(0);
+    const blocks = lastUpdate(updates)?.content?.blocks ?? [];
+    expect(blocks.map((b) => b.name)).toEqual([
+      "core/heading",
+      "core/rich-text",
+    ]);
+  });
+
+  test("slash menu surfaces the pattern as a card and inserts it", async ({
+    page,
+  }) => {
+    await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+    await dismissStarterModal(page);
+
+    await page.getByTestId("plumix-editor-canvas").focus();
+    await page.keyboard.press("/");
+    await expect(page.getByTestId("slash-menu-dialog")).toBeVisible();
+    await page.keyboard.type("hero");
+    const card = page.getByTestId("slash-menu-pattern-card-e2e/hero");
+    await expect(card).toBeVisible();
+    await card.click();
+    await expect(page.getByTestId("slash-menu-dialog")).toBeHidden();
+    await expect(canvasBlocks(page, "core/heading")).toHaveCount(1);
+    await expect(canvasBlocks(page, "core/rich-text")).toHaveCount(1);
+  });
+
+  test("fresh empty entry offers starter patterns; picking one seeds the canvas", async ({
+    page,
+  }) => {
+    await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+
+    const modal = page.getByTestId("plumix-starter-modal");
+    await expect(modal).toBeVisible();
+    await page.getByTestId("plumix-starter-modal-card-e2e/hero").click();
+    await expect(modal).toBeHidden();
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h2"),
+    ).toHaveText("Pattern heading");
+  });
+
+  test("start blank leaves the canvas empty", async ({ page }) => {
+    await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+
+    await dismissStarterModal(page);
+    await expect(
+      page.getByTestId("plumix-editor-canvas").locator("[data-puck-component]"),
+    ).toHaveCount(0);
+  });
+
+  test("reference pattern inserts a ref node, not an expanded copy", async ({
+    page,
+  }) => {
+    const updates = await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+    await dismissStarterModal(page);
+
+    await page.getByTestId("plumix-patterns-row-e2e/promo").click();
+    await expect(
+      page.getByTestId("plumix-pattern-ref-e2e/promo"),
+    ).toBeVisible();
+
+    await expect.poll(() => updates.length).toBeGreaterThan(0);
+    const blocks = lastUpdate(updates)?.content?.blocks ?? [];
+    expect(blocks.map((b) => b.name)).toEqual(["core/pattern-ref"]);
+    expect(blocks[0]?.attrs?.slug).toBe("e2e/promo");
+  });
+
+  // KNOWN BROKEN: Puck's [data-puck-dnd] draggable wrapper intercepts
+  // pointer events over the whole block — even when it's selected — so
+  // the Detach / Open source buttons inside PatternRefPreview can never
+  // receive a real mouse click. Rich-text escapes through Puck's
+  // overlay portal; the ref preview doesn't.
+  test("pattern-ref detach button is reachable with the mouse", async ({
+    page,
+  }) => {
+    test.fail();
+    await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+    await dismissStarterModal(page);
+
+    await page.getByTestId("plumix-patterns-row-e2e/promo").click();
+    const ref = page.getByTestId("plumix-pattern-ref-e2e/promo");
+    await ref.click();
+    await page
+      .getByTestId("plumix-pattern-ref-detach")
+      .click({ timeout: 5_000 });
+    await expect(ref).toBeHidden();
+  });
+
+  // KNOWN BROKEN: even a dispatched DOM click (which sidesteps the
+  // hit-testing bug above and verifiably fires on the button) never
+  // mutates Puck data — the ref stays put. The pure detachPatternRef
+  // helper is unit-covered, so the break sits in the wiring between
+  // the overlay-portal render and the usePuck dispatch.
+  test("pattern-ref detach converts the ref into an editable copy", async ({
+    page,
+  }) => {
+    test.fail();
+    await installEditorMocks(page);
+    await page.goto("entries/posts/1/edit");
+    await dismissStarterModal(page);
+
+    await page.getByTestId("plumix-patterns-row-e2e/promo").click();
+    await expect(
+      page.getByTestId("plumix-pattern-ref-e2e/promo"),
+    ).toBeVisible();
+
+    await page.getByTestId("plumix-pattern-ref-detach").dispatchEvent("click");
+    await expect(page.getByTestId("plumix-pattern-ref-e2e/promo")).toBeHidden({
+      timeout: 5_000,
+    });
+    await expect(
+      canvasBlocks(page, "core/heading").first().locator("h3"),
+    ).toHaveText("Promo heading");
+  });
+});
+
+test.describe("editor actions: pattern authoring", () => {
+  test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+  test("copy as pattern source serializes the canvas to the clipboard", async ({
+    page,
+  }) => {
+    await installEditorMocks(page, {
+      entry: editorEntry({ content: SEEDED_CONTENT }),
+    });
+    await page.goto("entries/posts/1/edit");
+
+    await page.getByTestId("plumix-editor-copy-as-pattern-source").click();
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain("definePattern({");
+    expect(clipboard).toContain('block("core/heading"');
+    expect(clipboard).toContain('text: "Seeded heading"');
+    expect(clipboard).toContain('block("core/rich-text"');
+  });
+});
+
+test.describe("editor actions: draft of a published entry", () => {
+  // KNOWN BROKEN: the autosave that creates the pending-draft row never
+  // refetches entry.get in-session, so the banner stays hidden and
+  // Discard / Publish stay disabled until a full reload — the user gets
+  // no signal that their edits diverged from the live row. The mock
+  // faithfully serves the WITH-autosave shape on every entry.get after
+  // the first update; the client simply never asks again.
+  test("editing a published entry surfaces the banner without a reload", async ({
+    page,
+  }) => {
+    test.fail();
+    const pristine = editorEntry({
+      status: "published",
+      content: SEEDED_CONTENT,
+    });
+    const withAutosave = {
+      ...pristine,
+      _preview: {
+        source: "autosave",
+        autosaveUpdatedAt: null,
+        liveUpdatedAt: null,
+      },
+    };
+    let saved = false;
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/entry/update")) {
+        saved = true;
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: pristine, meta: [] }),
+        });
+      }
+      const map: Record<string, unknown> = {
+        "/auth/session": AUTHED_ADMIN,
+        "/entry/get": saved ? withAutosave : pristine,
+        "/entry/activity/list": { users: [] },
+      };
+      for (const [suffix, body] of Object.entries(map)) {
+        if (url.endsWith(suffix)) {
+          return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({ json: body, meta: [] }),
+          });
+        }
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+
+    await page.getByTestId("plumix-editor-title-input").fill("Edited live");
+    await expect.poll(() => saved, { timeout: 10_000 }).toBe(true);
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});
+
+test.describe("editor actions: create failure", () => {
+  // KNOWN BROKEN: create.tsx has no onError — any entry.create failure
+  // (e.g. the 409 slug collision two same-millisecond creates produce,
+  // since the slug derives from Date.now()) leaves "Creating…" up
+  // forever with no feedback and no retry.
+  test("a failed create surfaces feedback instead of hanging", async ({
+    page,
+  }) => {
+    test.fail();
+    await installEditorMocks(page, {
+      handlers: {
+        "/auth/session": AUTHED_ADMIN,
+        "/entry/list": [],
+      },
+    });
+    await page.route("**/_plumix/rpc/entry/create", (route) =>
+      route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: rpcErrorBody({
+          code: "CONFLICT",
+          message: "Resource conflict",
+          data: { reason: "slug_taken" },
+        }),
+      }),
+    );
+
+    await page.goto("entries/posts");
+    await page.getByTestId("content-list-new-button").click();
+    await expect(page.getByTestId("create-entry-pending")).toBeVisible();
+    // The pending indicator must resolve into something — an error
+    // surface or a navigation — within a generous window.
+    await expect(page.getByTestId("create-entry-pending")).toBeHidden({
+      timeout: 8_000,
+    });
+  });
+});

--- a/packages/admin/e2e/editor-typing.spec.ts
+++ b/packages/admin/e2e/editor-typing.spec.ts
@@ -1,9 +1,8 @@
-// The CI-green cutover landed an editor whose canvas had no real typing
-// coverage — slash-menu insert + sidebar styling passed, but no test
-// actually typed into a richtext field on the canvas. This spec closes
-// that hole: insert a paragraph, type into it, assert the autosave
-// envelope reaches entry.update with the typed text and the server
-// answers OK (no 500, no INVALID_BLOCK_CONTENT).
+// Autosave envelope contracts around the editor: block insert and
+// title edits must reach entry.update with a valid plumix.v2 payload.
+// Despite the original intent, nothing here types into a richtext
+// field — sustained-typing coverage (which caught the Tiptap remount
+// keystroke loss) lives in editor-actions.spec.ts under "edit fields".
 
 import { expect, test } from "@playwright/test";
 

--- a/packages/admin/e2e/support/editor.ts
+++ b/packages/admin/e2e/support/editor.ts
@@ -1,0 +1,186 @@
+// Shared fixtures + interaction helpers for editor-actions.spec.ts.
+// The mock harness can't prove server persistence, so specs assert the
+// two client contracts instead: what the canvas renders, and what
+// envelope entry.update receives.
+
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+import { AUTHED_ADMIN, mockRpcWithCapture } from "./rpc-mock.js";
+
+export const T0 = new Date("2026-05-20T00:00:00Z");
+
+export interface EditorEntryOptions {
+  readonly id?: number;
+  readonly status?: "draft" | "published";
+  readonly content?: unknown;
+  readonly title?: string;
+}
+
+export function editorEntry(
+  options: EditorEntryOptions = {},
+): Record<string, unknown> {
+  const id = options.id ?? 1;
+  const status = options.status ?? "draft";
+  return {
+    id,
+    type: "post",
+    parentId: null,
+    title: options.title ?? "Untitled",
+    slug: `entry-${String(id)}`,
+    content: options.content ?? null,
+    excerpt: null,
+    status,
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: status === "published" ? T0 : null,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: {},
+  };
+}
+
+// Two visible blocks (heading text + rich-text body) so drag, select,
+// duplicate, and delete specs start from a canvas with real geometry —
+// empty blocks render zero-height and can't be clicked.
+export const SEEDED_CONTENT = {
+  version: "plumix.v2",
+  blocks: [
+    {
+      id: "b1",
+      name: "core/heading",
+      attrs: { level: 2, text: "Seeded heading" },
+    },
+    {
+      id: "b2",
+      name: "core/rich-text",
+      attrs: { body: "<p>Seeded body</p>" },
+    },
+  ],
+};
+
+export interface InstallEditorMocksOptions {
+  readonly entry?: Record<string, unknown>;
+  /** Extra suffix → body handlers, overriding the defaults on collision. */
+  readonly handlers?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Standard editor route mocks: session, entry/get, activity (empty),
+ * list (empty), and a captured entry/update echoing the entry back.
+ * Returns the captured update envelopes for contract assertions.
+ */
+export function installEditorMocks(
+  page: Page,
+  options: InstallEditorMocksOptions = {},
+): Promise<readonly unknown[]> {
+  const entry = options.entry ?? editorEntry();
+  return mockRpcWithCapture(page, {
+    captureSuffix: "/entry/update",
+    captureResponse: entry,
+    handlers: {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/get": entry,
+      "/entry/activity/list": { users: [] },
+      "/entry/list": [],
+      ...options.handlers,
+    },
+  });
+}
+
+// The starter modal opens whenever the manifest carries a starter-
+// eligible pattern and the entry content is empty. Specs that aren't
+// about the modal start blank.
+export async function dismissStarterModal(page: Page): Promise<void> {
+  const modal = page.getByTestId("plumix-starter-modal");
+  await modal.waitFor({ state: "visible" });
+  await page.getByTestId("plumix-starter-modal-start-blank").click();
+  await expect(modal).toBeHidden();
+}
+
+// Puck exposes only the item id on `data-puck-component` (pattern
+// inserts mint bare random ids), so block type is asserted through the
+// semantic element each core block renders — which doubles as checking
+// the block actually renders its markup.
+const BLOCK_DOM: Record<string, string> = {
+  "core/heading": "h1, h2, h3, h4, h5, h6",
+  "core/rich-text": ".rich-text",
+  "core/quote": "blockquote",
+  "core/separator": "hr",
+};
+
+/** Canvas-rendered block wrappers for a given block name. */
+export function canvasBlocks(page: Page, name: string): Locator {
+  const selector = BLOCK_DOM[name];
+  if (!selector) throw new Error(`canvasBlocks: no DOM mapping for ${name}`);
+  return page
+    .getByTestId("plumix-editor-canvas")
+    .locator("[data-puck-component]")
+    .filter({ has: page.locator(selector) });
+}
+
+/** Top-level canvas block order as semantic names, for reorder asserts. */
+export async function canvasOrder(page: Page): Promise<readonly string[]> {
+  return page
+    .getByTestId("plumix-editor-canvas")
+    .locator("[data-puck-component]")
+    .evaluateAll((nodes) =>
+      nodes.map((node) => {
+        if (node.querySelector("h1, h2, h3, h4, h5, h6")) return "heading";
+        if (node.querySelector(".rich-text")) return "rich-text";
+        if (node.querySelector("blockquote")) return "quote";
+        if (node.querySelector("hr")) return "separator";
+        return "unknown";
+      }),
+    );
+}
+
+/**
+ * Reorder drag for Puck's canvas (@dnd-kit/react, mouse sensor with a
+ * 5 px distance activation). HTML5 dragTo() doesn't fire pointer
+ * events, so this walks the cursor: down on the source, a short
+ * vertical move to clear the activation distance, a settle pause for
+ * the drag to engage, a stepped glide deep past the target's bottom
+ * edge (near-edge drops resolve back to the source's original slot — a
+ * silent no-op — while the collision detector clamps an overshoot to
+ * "after the last item"), another settle, then up. Meant for dropping
+ * after the zone's trailing block.
+ */
+export async function dragBelow(
+  page: Page,
+  source: Locator,
+  target: Locator,
+): Promise<void> {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+  if (!sourceBox || !targetBox) {
+    throw new Error("dragBelow: source or target has no bounding box");
+  }
+  const x = sourceBox.x + Math.min(40, sourceBox.width / 2);
+  const startY = sourceBox.y + sourceBox.height / 2;
+  await page.mouse.move(x, startY);
+  await page.mouse.down();
+  await page.mouse.move(x, startY + 10, { steps: 4 });
+  await page.waitForTimeout(300);
+  await page.mouse.move(x, targetBox.y + targetBox.height + 100, {
+    steps: 12,
+  });
+  await page.waitForTimeout(300);
+  await page.mouse.up();
+}
+
+/** Last captured entry.update envelope, typed for content asserts. */
+export function lastUpdate(updates: readonly unknown[]):
+  | {
+      readonly title?: string;
+      readonly content?: {
+        readonly version?: string;
+        readonly blocks?: readonly {
+          readonly name?: string;
+          readonly attrs?: Readonly<Record<string, unknown>>;
+        }[];
+      };
+    }
+  | undefined {
+  return updates.at(-1) as ReturnType<typeof lastUpdate>;
+}

--- a/packages/admin/e2e/support/rpc-mock.ts
+++ b/packages/admin/e2e/support/rpc-mock.ts
@@ -132,6 +132,60 @@ export const MANIFEST_WITH_POST: PlumixManifest = {
   ],
 };
 
+// Full editor fixture: an autosave-capable post type plus two registered
+// patterns — one copy-mode (also starter-eligible via `target`), one
+// reference-mode. Drives the patterns section, slash-menu cards, starter
+// modal, and the pattern-ref / detach surfaces, none of which render
+// without manifest patterns.
+export const MANIFEST_WITH_EDITOR_PATTERNS: PlumixManifest = {
+  ...emptyManifest(),
+  entryTypes: [
+    {
+      name: "post",
+      adminSlug: "posts",
+      label: "Posts",
+      labels: { singular: "Post", plural: "Posts" },
+      supports: ["title", "editor", "excerpt", "revisions", "autosave"],
+    },
+  ],
+  patterns: [
+    {
+      name: "e2e/hero",
+      title: "E2E Hero",
+      category: "hero",
+      insert: "copy",
+      target: "post-content",
+      entryTypes: ["post"],
+      priority: 1,
+      content: [
+        {
+          id: "p1",
+          name: "core/heading",
+          attrs: { level: 2, text: "Pattern heading" },
+        },
+        {
+          id: "p2",
+          name: "core/rich-text",
+          attrs: { body: "<p>Pattern body copy</p>" },
+        },
+      ],
+    },
+    {
+      name: "e2e/promo",
+      title: "E2E Promo",
+      category: "cta",
+      insert: "reference",
+      content: [
+        {
+          id: "p1",
+          name: "core/heading",
+          attrs: { level: 3, text: "Promo heading" },
+        },
+      ],
+    },
+  ],
+};
+
 // Manifest with two termTaxonomies — one hierarchical (category), one flat
 // (tag) — shared by the taxonomy e2e specs so both code paths can be
 // exercised from a single fixture.


### PR DESCRIPTION
Adds editor action coverage to the existing mock-based admin e2e suite — one consolidated `editor-actions.spec.ts` with describe groups, plus a patterns manifest fixture and shared helpers. No new packages, no new harness: a live verification pass (2026-06-05) showed the editor is currently unusable for core authoring actions, and **every defect reproduces under the existing mock harness** — the suite just never drove the canvas. 18 tests: 17 green, 1 fixme; full admin suite stays green (121 passed).

**What was never tested before**

No spec clicked the palette, dragged a block, typed into a rich-text field (the old `editor-typing.spec.ts` header claimed it; the spec only slash-inserts — header corrected), or touched patterns: no manifest fixture even carried a `patterns` array, so the patterns section, slash-menu cards, starter modal, and pattern-ref surfaces had zero coverage. Mocks can't prove DB persistence, so tests assert the two client contracts: canvas DOM and the captured `entry.update` envelope.

**Six live defects pinned as `test.fail()` / `test.fixme()`**

The suite runs green today and flips loudly when each fix lands — remove the annotation in the same PR that fixes the bug:

1. Inline rich-text typing drops everything after the first keystroke — the keystroke's re-render remounts the Tiptap instance and ejects focus to `<body>` (0 of 44 slow-typed chars persist)
2. Sidebar Body field typing — same remount loop
3. Pattern-ref **Detach** unreachable by mouse — the `[data-puck-dnd]` wrapper intercepts pointer events even when the block is selected
4. Pattern-ref detach inert even to dispatched DOM clicks that verifiably fire on the button — wiring break between the overlay-portal render and the `usePuck` dispatch
5. Draft-of-published banner stays hidden (Discard/Publish disabled) until a full reload — the client never refetches `entry.get` after the autosave that creates the pending draft; the mock faithfully serves the WITH-autosave shape, the client just never asks
6. `entry.create` failures hang on "Creating…" forever — `create.tsx` has no `onError` (and the `Date.now()`-derived slug 409s on same-millisecond creates)

Plus a `test.fixme` pinning that palette rows have no drag-source wiring at all (click-to-insert only).

Contrast guard: the inspector's plain `<input>` survives the same typing burst — narrowing the keystroke loss to Tiptap field remounts specifically.

Also noted during verification (no test, follow-up candidate): "Copy as pattern source" emits `import { block, definePattern } from "plumix/blocks"`, but neither symbol is exported from that public surface — copied snippets don't compile.