### PR TITLE
fix(admin): stop editor remount on keystroke by stabilizing puck override identity

### DIFF
--- a/packages/admin/e2e/editor-actions.spec.ts
+++ b/packages/admin/e2e/editor-actions.spec.ts
@@ -179,26 +179,35 @@ test.describe("editor actions: edit fields", () => {
     await expect(textField).toBeFocused();
   });
 
-  // KNOWN BROKEN: the first keystroke's state update remounts the
-  // canvas Tiptap instance and ejects focus to <body>; every keystroke
-  // after the remount is dropped (and can land in global hotkey
-  // handlers). Verified live and under this mock harness — 0 of 44
-  // slow-typed chars persist.
   test("inline rich-text typing on the canvas survives a burst", async ({
     page,
   }) => {
-    test.fail();
     const updates = await installEditorMocks(page, {
       entry: editorEntry({ content: SEEDED_CONTENT }),
     });
     await page.goto("entries/posts/1/edit");
 
+    // `.tiptap` skips Puck's Suspense fallback — a transient
+    // contenteditable that the real editor replaces ~300 ms after the
+    // field mounts, destroying whatever just got focus.
     const inline = canvasBlocks(page, "core/rich-text")
       .first()
-      .locator('[contenteditable="true"]');
+      .locator('.tiptap[contenteditable="true"]');
+    // Select-then-edit, Puck's intended canvas UX: the first click
+    // selects the block (the overlay swallows it), the second enters
+    // the Tiptap editor. The pause keeps the second click outside the
+    // browser's ~500 ms dblclick window — a coalesced dblclick never
+    // enters edit mode. keyboard.type (not pressSequentially) because
+    // the latter re-focuses the element per burst, resetting the
+    // Ctrl+A selection.
     await inline.click();
+    await expect(page.getByTestId("block-actions-panel")).toBeVisible();
+    await page.waitForTimeout(600);
+    await inline.click();
+    await expect(inline).toBeFocused();
+    await page.waitForTimeout(300);
     await page.keyboard.press("ControlOrMeta+a");
-    await inline.pressSequentially(SENTENCE, { delay: 80 });
+    await page.keyboard.type(SENTENCE, { delay: 80 });
     await expect(inline.locator("p")).toHaveText(SENTENCE);
 
     await expect
@@ -209,9 +218,7 @@ test.describe("editor actions: edit fields", () => {
       .toBe(`<p>${SENTENCE}</p>`);
   });
 
-  // KNOWN BROKEN: same remount loop through the sidebar Body field.
   test("sidebar Body field typing survives a burst", async ({ page }) => {
-    test.fail();
     await installEditorMocks(page, {
       entry: editorEntry({ content: SEEDED_CONTENT }),
     });
@@ -219,13 +226,15 @@ test.describe("editor actions: edit fields", () => {
 
     await canvasBlocks(page, "core/rich-text").first().click();
     await expect(page.getByTestId("block-actions-panel")).toBeVisible();
+    // `.tiptap` skips the Suspense fallback — see the inline test.
     const body = page
       .getByTestId("plumix-editor-right")
-      .locator('[contenteditable="true"]')
+      .locator('.tiptap[contenteditable="true"]')
       .first();
     await body.click();
+    await expect(body).toBeFocused();
     await page.keyboard.press("ControlOrMeta+a");
-    await body.pressSequentially(SENTENCE, { delay: 80 });
+    await page.keyboard.type(SENTENCE, { delay: 80 });
     await expect(body.locator("p")).toHaveText(SENTENCE);
   });
 });

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -32,7 +32,7 @@ import { useLabel } from "@/lib/use-label.js";
 import { cn } from "@/lib/utils.js";
 import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
-import { Puck, usePuck } from "@puckeditor/core";
+import { Puck, useGetPuck } from "@puckeditor/core";
 import { Minus, Monitor, Plus, Smartphone, Tablet } from "lucide-react";
 
 import type {
@@ -69,6 +69,7 @@ import { MobileSidebarSheet } from "./MobileSidebarSheet.js";
 import { patchStyleAtSelector } from "./patch-style.js";
 import { PatternRefProvider } from "./PatternRefPreview.js";
 import { PatternsSection } from "./PatternsSection.js";
+import { usePuckSelector } from "./puck-hooks.js";
 import { puckDataToBlockTree } from "./puck-to-block-tree.js";
 import { PUCK_ROOT_ZONE } from "./puck-zones.js";
 import { nextInsertPoint, resolveSlashMenuItems } from "./slash-menu-items.js";
@@ -281,11 +282,11 @@ function CanvasToolbar({
   onReopenStarter,
   onCopyAsPatternSource,
 }: CanvasToolbarProps): ReactElement {
-  const puck = usePuck();
   const renderLabel = useLabel();
-  const { viewports } = puck.appState.ui;
-  const currentWidth = viewports.current.width;
-  const dispatch = puck.dispatch;
+  const currentWidth = usePuckSelector(
+    (s) => s.appState.ui.viewports.current.width,
+  );
+  const dispatch = usePuckSelector((s) => s.dispatch);
   useEffect(() => {
     const target = VIEWPORT_PRESETS[DEFAULT_VIEWPORT_INDEX];
     if (!target) return;
@@ -414,12 +415,11 @@ function CanvasToolbar({
 }
 
 function PlumixAuditTab(): ReactElement {
-  const puck = usePuck();
-  const tree = useMemo(
-    () => puckDataToBlockTree(puck.appState.data),
-    [puck.appState.data],
-  );
+  const data = usePuckSelector((s) => s.appState.data);
+  const getPuck = useGetPuck();
+  const tree = useMemo(() => puckDataToBlockTree(data), [data]);
   const handleSelect = (nodeId: string): void => {
+    const puck = getPuck();
     const itemSelector = puck.getSelectorForId(nodeId);
     if (!itemSelector) return;
     puck.dispatch({ type: "setUi", ui: { itemSelector } });
@@ -743,7 +743,7 @@ function PlumixBlocksTab({
   capabilities,
   patterns,
 }: PlumixBlocksTabProps): ReactElement {
-  const puck = usePuck();
+  const getPuck = useGetPuck();
   const renderLabel = useLabel();
   const [pendingPick, setPendingPick] = useState<PendingPick | undefined>();
   const entries = useMemo(() => {
@@ -758,13 +758,14 @@ function PlumixBlocksTab({
 
   const insertEntry = useCallback(
     (entry: InsertableBlockEntry): void => {
+      const puck = getPuck();
       dispatchVariationInsert(
         puck.dispatch,
         entry,
         puck.appState.data.content.length,
       );
     },
-    [puck],
+    [getPuck],
   );
 
   const handleInsert = useCallback(
@@ -791,13 +792,13 @@ function PlumixBlocksTab({
 
   const handlePatternInsert = useCallback(
     (pattern: PatternManifestEntry): void => {
-      puck.dispatch({
+      getPuck().dispatch({
         type: "setData",
         data: (previous) =>
           insertPattern(previous, pattern, previous.content.length),
       });
     },
-    [puck],
+    [getPuck],
   );
 
   const handlePickerSelect = useCallback(
@@ -937,29 +938,30 @@ function PlumixCanvasWithSlashMenu({
   starterCandidates,
   entryTitle,
 }: PlumixCanvasWithSlashMenuProps): ReactElement {
-  const puck = usePuck();
+  const getPuck = useGetPuck();
+  const isCanvasEmpty = usePuckSelector(
+    (s) => s.appState.data.content.length === 0,
+  );
   const renderLabel = useLabel();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   // Captured once at mount: the modal's initial open state must reflect
   // the entry as it was loaded, not later state changes that follow a
   // pattern seed.
-  const [initiallyEmpty] = useState(
-    () => puck.appState.data.content.length === 0,
-  );
+  const [initiallyEmpty] = useState(() => isCanvasEmpty);
   const starterState = useStarterModalState({
     initiallyEmpty,
     candidates: starterCandidates,
   });
   const handleStarterSelect = useCallback(
     (pattern: PatternManifestEntry): void => {
-      puck.dispatch({
+      getPuck().dispatch({
         type: "setData",
         data: (previous) => insertPattern(previous, pattern, 0),
       });
       starterState.dismiss();
     },
-    [puck, starterState],
+    [getPuck, starterState],
   );
 
   const items = useMemo(
@@ -997,6 +999,7 @@ function PlumixCanvasWithSlashMenu({
 
   const handleSelect = useCallback(
     (item: SlashMenuItem): void => {
+      const puck = getPuck();
       const { itemSelector } = puck.appState.ui;
       const { zone, index } = nextInsertPoint(
         itemSelector,
@@ -1024,10 +1027,12 @@ function PlumixCanvasWithSlashMenu({
       }
       setOpen(false);
     },
-    [puck],
+    [getPuck],
   );
 
-  const currentViewportWidth = puck.appState.ui.viewports.current.width;
+  const currentViewportWidth = usePuckSelector(
+    (s) => s.appState.ui.viewports.current.width,
+  );
   const viewportPx =
     typeof currentViewportWidth === "number"
       ? currentViewportWidth
@@ -1060,6 +1065,7 @@ function PlumixCanvasWithSlashMenu({
   const zoom = manualZoom ?? fitZoom;
 
   const handleCopyAsPatternSource = useCallback((): void => {
+    const puck = getPuck();
     const source = buildCopyPatternSource({
       title: entryTitle,
       data: puck.appState.data,
@@ -1072,7 +1078,7 @@ function PlumixCanvasWithSlashMenu({
         error,
       );
     });
-  }, [puck, entryTitle, renderLabel]);
+  }, [getPuck, entryTitle, renderLabel]);
 
   return (
     <div
@@ -1082,10 +1088,7 @@ function PlumixCanvasWithSlashMenu({
       <CanvasToolbar
         zoom={zoom}
         onZoomChange={setManualZoom}
-        canReopenStarter={
-          puck.appState.data.content.length === 0 &&
-          starterCandidates.length > 0
-        }
+        canReopenStarter={isCanvasEmpty && starterCandidates.length > 0}
         onReopenStarter={starterState.reopen}
         onCopyAsPatternSource={handleCopyAsPatternSource}
       />
@@ -1153,14 +1156,16 @@ interface PlumixStyleTabProps {
 }
 
 function PlumixStyleTab({ tokens }: PlumixStyleTabProps): ReactElement {
-  const puck = usePuck();
-  const { selectedItem } = puck;
-  const bucket = viewportWidthToBucket(
-    puck.appState.ui.viewports.current.width,
+  const getPuck = useGetPuck();
+  const selectedItem = usePuckSelector((s) => s.selectedItem);
+  const currentWidth = usePuckSelector(
+    (s) => s.appState.ui.viewports.current.width,
   );
+  const bucket = viewportWidthToBucket(currentWidth);
 
   const handleStyleChange = useCallback(
     (nextStyle: ResponsiveStyleSlot | undefined): void => {
+      const puck = getPuck();
       const { itemSelector } = puck.appState.ui;
       if (!itemSelector) return;
       puck.dispatch({
@@ -1169,7 +1174,7 @@ function PlumixStyleTab({ tokens }: PlumixStyleTabProps): ReactElement {
           patchStyleAtSelector(previous, itemSelector, nextStyle),
       });
     },
-    [puck],
+    [getPuck],
   );
 
   return (
@@ -1189,11 +1194,12 @@ interface PlumixBlockActionsProps {
 function PlumixBlockActions({
   registry,
 }: PlumixBlockActionsProps): ReactElement {
-  const puck = usePuck();
-  const { selectedItem } = puck;
+  const getPuck = useGetPuck();
+  const selectedItem = usePuckSelector((s) => s.selectedItem);
 
   const handleTransform = useCallback(
     (option: TransformOption): void => {
+      const puck = getPuck();
       const { itemSelector } = puck.appState.ui;
       if (!itemSelector || !selectedItem) return;
       const currentAttrs = selectedItem.props as Record<string, unknown>;
@@ -1213,10 +1219,11 @@ function PlumixBlockActions({
         },
       });
     },
-    [puck, selectedItem, registry],
+    [getPuck, selectedItem, registry],
   );
 
   const handleDuplicate = useCallback((): void => {
+    const puck = getPuck();
     const { itemSelector } = puck.appState.ui;
     if (!itemSelector) return;
     puck.dispatch({
@@ -1224,9 +1231,10 @@ function PlumixBlockActions({
       sourceIndex: itemSelector.index,
       sourceZone: itemSelector.zone ?? PUCK_ROOT_ZONE,
     });
-  }, [puck]);
+  }, [getPuck]);
 
   const handleDelete = useCallback((): void => {
+    const puck = getPuck();
     const { itemSelector } = puck.appState.ui;
     if (!itemSelector) return;
     puck.dispatch({
@@ -1234,7 +1242,7 @@ function PlumixBlockActions({
       index: itemSelector.index,
       zone: itemSelector.zone ?? PUCK_ROOT_ZONE,
     });
-  }, [puck]);
+  }, [getPuck]);
 
   const handleCopyJson = useCallback((): void => {
     if (!selectedItem) return;

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -78,7 +78,7 @@ import { StyleTab } from "./StyleTab.js";
 import { useStarterModalState } from "./use-starter-modal-state.js";
 import { viewportWidthToBucket } from "./viewport-bucket.js";
 
-interface PlumixEditorLayoutProps {
+export interface PlumixEditorLayoutProps {
   readonly registry?: BlockRegistry;
   readonly patternRegistry?: PatternRegistry;
   // Pre-filtered starter patterns surfaced in the entry-create modal.

--- a/packages/admin/src/editor/PatternRefPreview.tsx
+++ b/packages/admin/src/editor/PatternRefPreview.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { createContext, useCallback, useContext, useMemo } from "react";
 import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
-import { usePuck } from "@puckeditor/core";
+import { useGetPuck } from "@puckeditor/core";
 import { Link, Unlink } from "lucide-react";
 
 import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
@@ -38,7 +38,7 @@ interface PatternRefPreviewProps {
 
 export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
   const ctx = useContext(PatternRefContext);
-  const puck = usePuck();
+  const getPuck = useGetPuck();
   const renderLabel = useLabel();
   const slug = props.slug ?? "";
   const pattern = ctx?.patterns.get(slug);
@@ -52,7 +52,7 @@ export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
 
   const handleDetach = useCallback(() => {
     if (!ctx) return;
-    puck.dispatch({
+    getPuck().dispatch({
       type: "setData",
       data: (previous) => {
         const idx = previous.content.findIndex(
@@ -64,7 +64,7 @@ export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
         return detachPatternRef(previous, idx, ctx.patterns);
       },
     });
-  }, [ctx, puck, props.id]);
+  }, [ctx, getPuck, props.id]);
 
   const handleCopySlug = useCallback(() => {
     void navigator.clipboard.writeText(slug);

--- a/packages/admin/src/editor/puck-hooks.ts
+++ b/packages/admin/src/editor/puck-hooks.ts
@@ -1,0 +1,8 @@
+import { createUsePuck } from "@puckeditor/core";
+
+// Single selector-hook instance shared by the editor chrome, following
+// upstream's custom-ui example. The legacy bare `usePuck()` re-renders
+// its caller on every Puck store change — per keystroke once typing
+// syncs — while a selector re-renders only when its slice does. Pair
+// with `useGetPuck` for click-time reads that need no subscription.
+export const usePuckSelector = createUsePuck();

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -1,8 +1,17 @@
 import type { AutosaveStatus } from "@/editor/AutosaveStatus.js";
+import type { PlumixEditorLayoutProps } from "@/editor/EditorLayout.js";
 import type { MessageDescriptor } from "@lingui/core";
 import type { Config, Data } from "@puckeditor/core";
 import type { ReactElement, ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { PlainFormLayout } from "@/components/editor/plain-form-layout.js";
 import { ErrorPlaceholder } from "@/components/error-placeholder.js";
 import { buildAdminPatternRegistry } from "@/editor/admin-pattern-registry.js";
@@ -107,6 +116,26 @@ const config: Config = {
     richtextExtensions: [...coreMarkExtensions],
   }),
 };
+const IFRAME_DISABLED = { enabled: false };
+const PREVIEW_NOOP = (): void => undefined;
+// Puck derives its layout component from the `overrides.puck` identity
+// (`CustomPuck = useMemo(..., [overrides])`), so a new component per
+// render remounts the entire editor UI — Tiptap included, which ejects
+// focus and drops every keystroke after the first. The override stays
+// module-stable; per-render chrome flows through this context instead.
+const EditorChromeContext = createContext<PlumixEditorLayoutProps | null>(null);
+
+function EditorLayoutOverride(): ReactElement {
+  const chrome = useContext(EditorChromeContext);
+  if (!chrome) {
+    // Provider always wraps <Puck> (same file); unreachable in practice.
+    // eslint-disable-next-line no-restricted-syntax -- impossible state
+    throw new Error("EditorChromeContext missing above <Puck>");
+  }
+  return <PlumixEditorLayout {...chrome} />;
+}
+
+const STABLE_OVERRIDES = { puck: EditorLayoutOverride };
 
 // `?revision=<id>` switches the route into preview mode: the editor
 // loads the chosen revision's content read-only and replaces the
@@ -601,32 +630,26 @@ function PuckSpikeRouteInner({
       discardDraft.isPending,
     ],
   );
-  const Layout = useCallback(
-    (): ReactElement => (
-      <PlumixEditorLayout
-        registry={registry}
-        patternRegistry={patternRegistry}
-        starterCandidates={starterCandidates}
-        capabilities={capabilitySet}
-        tokens={themeTokens}
-        title={title}
-        onTitleChange={handleTitleChange}
-        backHref={backHref}
-        onPublish={handlePublish}
-        isPublishing={publish.isPending}
-        isPublished={isPublished}
-        revisionsTrigger={revisionsTrigger}
-        coAuthorIndicator={
-          coAuthors.length > 0 ? (
-            <CoAuthorIndicator
-              users={coAuthors}
-              relativeTime={formatRelative}
-            />
-          ) : null
-        }
-        draftMode={draftModeProp}
-      />
-    ),
+  const chrome = useMemo<PlumixEditorLayoutProps>(
+    () => ({
+      registry,
+      patternRegistry,
+      starterCandidates,
+      capabilities: capabilitySet,
+      tokens: themeTokens,
+      title,
+      onTitleChange: handleTitleChange,
+      backHref,
+      onPublish: handlePublish,
+      isPublishing: publish.isPending,
+      isPublished,
+      revisionsTrigger,
+      coAuthorIndicator:
+        coAuthors.length > 0 ? (
+          <CoAuthorIndicator users={coAuthors} relativeTime={formatRelative} />
+        ) : null,
+      draftMode: draftModeProp,
+    }),
     [
       title,
       handleTitleChange,
@@ -645,13 +668,15 @@ function PuckSpikeRouteInner({
 
   return (
     <AutosaveStatusContext.Provider value={status}>
-      <Puck
-        config={config}
-        data={initialData}
-        onChange={handleChange}
-        iframe={{ enabled: false }}
-        overrides={{ puck: Layout }}
-      />
+      <EditorChromeContext.Provider value={chrome}>
+        <Puck
+          config={config}
+          data={initialData}
+          onChange={handleChange}
+          iframe={IFRAME_DISABLED}
+          overrides={STABLE_OVERRIDES}
+        />
+      </EditorChromeContext.Provider>
       {/*
         Stale-draft resolver: blocks the canvas until the user picks
         Use mine / Use theirs when their autosave was anchored against
@@ -789,34 +814,32 @@ function PuckPreviewRouteInner({
     restoreErrorLabel !== null ? renderLabel(restoreErrorLabel) : null;
   const revisionAuthor =
     revision.authorName ?? revision.authorEmail ?? `#${String(revisionId)}`;
-  const Layout = useCallback(
-    // Preview mode never opens the starter modal — the entry being
-    // previewed is always pre-populated.
-    (): ReactElement => (
-      <PlumixEditorLayout
-        registry={registry}
-        patternRegistry={patternRegistry}
-        capabilities={capabilitySet}
-        tokens={themeTokens}
-        title={revision.title}
-        onTitleChange={() => undefined}
-        backHref={backHref}
-        onPublish={() => undefined}
-        isPublishing={false}
-        isPublished={false}
-        previewBanner={
-          <PreviewBanner
-            revisionUpdatedAt={revision.updatedAt}
-            revisionAuthor={revisionAuthor}
-            relativeTime={formatRelative}
-            onBackToLive={handleBackToLive}
-            onRestore={handleRestore}
-            isRestoring={restore.isPending}
-            restoreError={restoreError}
-          />
-        }
-      />
-    ),
+  // Preview mode never opens the starter modal — the entry being
+  // previewed is always pre-populated.
+  const chrome = useMemo<PlumixEditorLayoutProps>(
+    () => ({
+      registry,
+      patternRegistry,
+      capabilities: capabilitySet,
+      tokens: themeTokens,
+      title: revision.title,
+      onTitleChange: PREVIEW_NOOP,
+      backHref,
+      onPublish: PREVIEW_NOOP,
+      isPublishing: false,
+      isPublished: false,
+      previewBanner: (
+        <PreviewBanner
+          revisionUpdatedAt={revision.updatedAt}
+          revisionAuthor={revisionAuthor}
+          relativeTime={formatRelative}
+          onBackToLive={handleBackToLive}
+          onRestore={handleRestore}
+          isRestoring={restore.isPending}
+          restoreError={restoreError}
+        />
+      ),
+    }),
     [
       revision.title,
       revision.updatedAt,
@@ -832,13 +855,15 @@ function PuckPreviewRouteInner({
   );
 
   return (
-    <Puck
-      config={config}
-      data={initialData}
-      iframe={{ enabled: false }}
-      permissions={READ_ONLY_PERMISSIONS}
-      overrides={{ puck: Layout }}
-    />
+    <EditorChromeContext.Provider value={chrome}>
+      <Puck
+        config={config}
+        data={initialData}
+        iframe={IFRAME_DISABLED}
+        permissions={READ_ONLY_PERMISSIONS}
+        overrides={STABLE_OVERRIDES}
+      />
+    </EditorChromeContext.Provider>
   );
 }
 


### PR DESCRIPTION
Fixes the editor's keystroke loss — the worst of the live defects pinned in #831. Typing into any rich-text surface dropped everything after the first character: the first keystroke flips the autosave pill `saved → saving`, the route re-renders, and `overrides={{ puck: Layout }}` (a per-render `useCallback` closure) handed Puck a **new component type** — `CustomPuck = useMemo(..., [overrides])` keys on override identity, so React unmounted and remounted the entire editor UI, Tiptap included, ejecting focus to `<body>`.

**The fix**

Both Puck mounts (live + revision preview) now pass a module-constant overrides object whose `puck` component never changes identity. The chrome values it renders (title, publish state, revisions trigger, draft mode, …) flow through a new `EditorChromeContext` instead of a closure — chrome updates re-render the layout in place rather than remounting it. The `iframe` prop is a module constant for the same reason (it feeds Puck's `generateAppStore` effect deps).

**Validated against upstream's own example**

Puck's repo (`apps/demo/app/custom-ui`) uses the same `overrides.puck` surface with an inline closure — which survives only because their host component holds no editor-coupled state and never re-renders mid-edit. Our host owns plumix state (title, autosave status, draft mode) and must re-render, so the stable-component + context indirection is the same architecture adapted to that constraint: stable chrome component, changing values delivered through a subscription.

**Selector-based puck hooks (second commit)**

The example's other pattern is adopted wholesale: all seven bare `usePuck()` callers (which re-render on *every* store change — per keystroke) are replaced with a shared `createUsePuck()` selector instance for live values (viewport width, `selectedItem`, canvas emptiness) and `useGetPuck()` imperative reads for click-time values. This also stabilizes the handler callbacks and fixes a latent staleness in copy-as-pattern-source, which now snapshots data/selection at click time.

**Both typing pins flip to real passing tests**

`test.fail()` removed from "inline rich-text typing survives a burst" and "sidebar Body field typing survives a burst". Diagnosing also surfaced the genuine interaction contract, now encoded in the tests:

- select-then-edit: the second click must land outside the browser's ~500 ms dblclick window or it coalesces and never enters edit mode
- `.tiptap` selector skips Puck's transient Suspense-fallback contenteditable (a lazy-loaded editor replaces it ~300 ms after field mount, destroying whatever held focus)
- `keyboard.type` over `pressSequentially` (the latter re-focuses per burst, resetting the select-all)

**Verified**: 17/17 editor-actions e2e, 121 full admin e2e, 521 unit tests — and live against a real worker: a 69-character burst lands fully, mirrors to the sidebar field, and autosaves to D1.

Stacked on #831 (the regression suite that pins the remaining bugs).

Refs #831