### PR TITLE
fix(admin): make pattern-ref header buttons clickable via overlay portal

### DIFF
--- a/packages/admin/e2e/editor-actions.spec.ts
+++ b/packages/admin/e2e/editor-actions.spec.ts
@@ -323,15 +323,9 @@ test.describe("editor actions: patterns", () => {
     expect(blocks[0]?.attrs?.slug).toBe("e2e/promo");
   });
 
-  // KNOWN BROKEN: Puck's [data-puck-dnd] draggable wrapper intercepts
-  // pointer events over the whole block — even when it's selected — so
-  // the Detach / Open source buttons inside PatternRefPreview can never
-  // receive a real mouse click. Rich-text escapes through Puck's
-  // overlay portal; the ref preview doesn't.
   test("pattern-ref detach button is reachable with the mouse", async ({
     page,
   }) => {
-    test.fail();
     await installEditorMocks(page);
     await page.goto("entries/posts/1/edit");
     await dismissStarterModal(page);
@@ -345,15 +339,9 @@ test.describe("editor actions: patterns", () => {
     await expect(ref).toBeHidden();
   });
 
-  // KNOWN BROKEN: even a dispatched DOM click (which sidesteps the
-  // hit-testing bug above and verifiably fires on the button) never
-  // mutates Puck data — the ref stays put. The pure detachPatternRef
-  // helper is unit-covered, so the break sits in the wiring between
-  // the overlay-portal render and the usePuck dispatch.
   test("pattern-ref detach converts the ref into an editable copy", async ({
     page,
   }) => {
-    test.fail();
     await installEditorMocks(page);
     await page.goto("entries/posts/1/edit");
     await dismissStarterModal(page);

--- a/packages/admin/src/editor/PatternRefPreview.tsx
+++ b/packages/admin/src/editor/PatternRefPreview.tsx
@@ -1,8 +1,15 @@
 import type { ReactElement } from "react";
-import { createContext, useCallback, useContext, useMemo } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
-import { useGetPuck } from "@puckeditor/core";
+import { registerOverlayPortal, useGetPuck } from "@puckeditor/core";
 import { Link, Unlink } from "lucide-react";
 
 import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
@@ -42,6 +49,17 @@ export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
   const renderLabel = useLabel();
   const slug = props.slug ?? "";
   const pattern = ctx?.patterns.get(slug);
+
+  // Puck's component overlay intercepts pointer events over the whole
+  // block, so the header's Open source / Detach buttons would never
+  // receive a click. Registering the header as an overlay portal is
+  // the sanctioned escape hatch — the same mechanism Puck's inline
+  // rich-text editor uses to stay interactive on the canvas.
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const cleanup = registerOverlayPortal(headerRef.current);
+    return () => cleanup?.();
+  }, [pattern]);
 
   const body = useMemo(() => {
     if (!pattern || !ctx) return null;
@@ -96,7 +114,10 @@ export function PatternRefPreview(props: PatternRefPreviewProps): ReactElement {
       data-pattern-ref-state="resolved"
       data-testid={`plumix-pattern-ref-${slug}`}
     >
-      <div className="text-foreground flex items-center gap-2 bg-blue-500/10 px-3 py-1 text-xs">
+      <div
+        ref={headerRef}
+        className="text-foreground flex items-center gap-2 bg-blue-500/10 px-3 py-1 text-xs"
+      >
         <Link className="h-3 w-3" aria-hidden />
         <span className="flex-1">{renderLabel(pattern.title)}</span>
         <button


### PR DESCRIPTION
Fixes the dead pattern-ref **Detach** / **Open source** buttons — two more pins from #831. Puck's component overlay intercepts pointer events across the whole block, so the header buttons never received a real mouse click; before #832's override-identity fix, even dispatched clicks died to the remount race.

**The fix (one effect)**

Register the header strip with Puck's public `registerOverlayPortal` — the exact escape hatch Puck's own inline rich-text editor uses to stay interactive on the canvas (capture-phase pass-through; drag suppressed only while a header button holds focus). The block body keeps its `pointer-events-none` preview semantics, and the wrapper still drags and selects normally.

**Both detach pins flip to real passing tests**

- "detach button is reachable with the mouse" — a true `.click()` now reaches Detach (the hit-testing guard)
- "detach converts the ref into an editable copy" — the dispatch→detach→copy data-flow guard

Verified: full admin e2e 121 green, 272 editor unit tests green. `patterns.get()` reference stability confirmed (Map-backed) for the registration effect's `[pattern]` dep.

Stacked on #832 → #831.

Refs #831