### PR TITLE
fix(admin): surface the pending-draft banner without a reload

### DIFF
--- a/packages/admin/e2e/editor-actions.spec.ts
+++ b/packages/admin/e2e/editor-actions.spec.ts
@@ -382,16 +382,9 @@ test.describe("editor actions: pattern authoring", () => {
 });
 
 test.describe("editor actions: draft of a published entry", () => {
-  // KNOWN BROKEN: the autosave that creates the pending-draft row never
-  // refetches entry.get in-session, so the banner stays hidden and
-  // Discard / Publish stay disabled until a full reload — the user gets
-  // no signal that their edits diverged from the live row. The mock
-  // faithfully serves the WITH-autosave shape on every entry.get after
-  // the first update; the client simply never asks again.
   test("editing a published entry surfaces the banner without a reload", async ({
     page,
   }) => {
-    test.fail();
     const pristine = editorEntry({
       status: "published",
       content: SEEDED_CONTENT,
@@ -404,6 +397,9 @@ test.describe("editor actions: draft of a published entry", () => {
         liveUpdatedAt: null,
       },
     };
+    // Server contract: an autosave-routed save responds with the
+    // per-user autosave row, whose `type` is the reserved "autosave".
+    const autosaveRow = { ...pristine, type: "autosave" };
     let saved = false;
     await page.route("**/_plumix/rpc/**", (route) => {
       const url = route.request().url();
@@ -412,7 +408,7 @@ test.describe("editor actions: draft of a published entry", () => {
         return route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify({ json: pristine, meta: [] }),
+          body: JSON.stringify({ json: autosaveRow, meta: [] }),
         });
       }
       const map: Record<string, unknown> = {
@@ -440,6 +436,72 @@ test.describe("editor actions: draft of a published entry", () => {
     await expect(page.getByTestId("unpublished-changes-banner")).toBeVisible({
       timeout: 5_000,
     });
+    await expect(page.getByTestId("editor-draft-discard")).toBeEnabled();
+    await expect(page.getByTestId("editor-draft-publish")).toBeEnabled();
+  });
+
+  // KNOWN BROKEN: discarding a draft created in the SAME session leaves
+  // the edited title and canvas on screen — the dispatcher's remount
+  // key (`draftKey:previewSource`) never flips because the cached
+  // preview source stays "live" throughout (the in-session banner works
+  // off a local flag, not a refetch). Server state is correct (the
+  // autosave row is deleted; reload shows live content) — the editor
+  // just keeps rendering the discarded edits. Reachable only since the
+  // in-session banner fix enabled Discard without a reload.
+  test("in-session discard restores the live title and canvas", async ({
+    page,
+  }) => {
+    test.fail();
+    const pristine = editorEntry({
+      status: "published",
+      content: SEEDED_CONTENT,
+      title: "Live title",
+    });
+    const autosaveRow = { ...pristine, type: "autosave" };
+    await page.route("**/_plumix/rpc/**", (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/entry/update")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: autosaveRow, meta: [] }),
+        });
+      }
+      if (url.endsWith("/entry/discardDraft")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ json: { discarded: true }, meta: [] }),
+        });
+      }
+      const map: Record<string, unknown> = {
+        "/auth/session": AUTHED_ADMIN,
+        "/entry/get": pristine,
+        "/entry/activity/list": { users: [] },
+      };
+      for (const [suffix, body] of Object.entries(map)) {
+        if (url.endsWith(suffix)) {
+          return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({ json: body, meta: [] }),
+          });
+        }
+      }
+      return route.fulfill({ status: 404, body: "not-mocked" });
+    });
+
+    await page.goto("entries/posts/1/edit");
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+    await page.getByTestId("plumix-editor-title-input").fill("Edited title");
+    await expect(page.getByTestId("editor-draft-discard")).toBeEnabled();
+
+    await page.getByTestId("editor-draft-discard").click();
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeHidden();
+    await expect(page.getByTestId("plumix-editor-title-input")).toHaveValue(
+      "Live title",
+      { timeout: 5_000 },
+    );
   });
 });
 

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -311,6 +311,7 @@ function PuckSpikeRouteInner({
   );
   const [title, setTitle] = useState<string>(entry.title);
   const [status, setStatus] = useState<AutosaveStatus>("saved");
+  const [hasLocalDraft, setHasLocalDraft] = useState(false);
   // Optimistic-concurrency token; trailing-response wins on overlap.
   const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
   const queryClient = useQueryClient();
@@ -372,6 +373,14 @@ function PuckSpikeRouteInner({
           // publish (the canonical bug this guard prevents).
           if (updated.type === entry.type) {
             liveUpdatedAtRef.current = updated.updatedAt;
+          } else {
+            // The save landed on the per-user autosave row (reserved
+            // type) — a pending draft now exists server-side. Surface
+            // it locally: the preview query is never refetched
+            // in-session (a refetch would flip the dispatcher's
+            // remount key mid-keystroke), so without this flag the
+            // banner and Discard/Publish stay dead until a reload.
+            setHasLocalDraft(true);
           }
           if (titleChanged) lastSavedTitleRef.current = trimmedTitle;
           if (contentChanged) lastSavedContentRef.current = serializedBlocks;
@@ -479,7 +488,10 @@ function PuckSpikeRouteInner({
     capabilities: capabilitySet,
   });
   const isEditWithDraft = editorMode === "edit-with-draft";
-  const hasPendingDraft = entry._preview?.source === "autosave";
+  // Server truth at load time, OR-ed with the in-session signal from
+  // the autosave path above — see the debouncer's setHasLocalDraft.
+  const hasPendingDraft =
+    entry._preview?.source === "autosave" || hasLocalDraft;
 
   // Stale-draft state: pending autosave was anchored against an older
   // live row than what the server has now. Show the resolver dialog
@@ -512,6 +524,7 @@ function PuckSpikeRouteInner({
       }),
     onSuccess: async (updated) => {
       liveUpdatedAtRef.current = updated.updatedAt;
+      setHasLocalDraft(false);
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: orpc.entry.get.queryOptions({ input: { id } }).queryKey,
@@ -539,6 +552,7 @@ function PuckSpikeRouteInner({
   const discardDraft = useMutation({
     mutationFn: () => orpc.entry.discardDraft.call({ id }),
     onSuccess: async () => {
+      setHasLocalDraft(false);
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: orpc.entry.get.queryOptions({


### PR DESCRIPTION
Fixes the draft-banner staleness pin from #831: editing a published entry gave zero in-session signal that a pending draft now existed — the unpublished-changes banner stayed hidden and Discard/Publish stayed disabled until a full page reload.

**Why no refetch**

The preview query is deliberately never refetched mid-session: a refetch flips `_preview.source` and with it the dispatcher's remount key, which would remount the editor mid-keystroke (the disease #832 cured). The autosave **response** already carries the answer instead — draft-routed saves return the per-user autosave row with the reserved type, which the debouncer's existing live-token guard inspects. A local pending-draft flag set on that branch ORs into `hasPendingDraft`; publish-draft and discard clear it. Banner + header buttons now react in-session through the chrome context — no refetch, no remount.

**Verified live** against a real worker: banner appears on the first autosave after editing, Discard enables, discarding clears the banner. Mock contract updated to mirror the server's autosave-row response shape. Full admin e2e 122 green, 521 unit green.

**New pin (next slice)**

Making in-session Discard reachable exposed an adjacent gap that was previously unreachable: discarding keeps the *edited* title/canvas on screen (the remount key never flips since the cached source stays `live`; server state is correct — reload shows live content). Pinned as a `test.fail()` regression test.

Stack: #831 ← #832 ← #833 ← this.

Refs #831