### PR TITLE
fix: allow vite dev origin in example CSRF allowlists

### DIFF
--- a/examples/blog/plumix.config.ts
+++ b/examples/blog/plumix.config.ts
@@ -13,11 +13,15 @@ import { auth, consoleMailer, defineTheme, plumix } from "plumix";
 // Derives `rpId` + `origin` from the Workers Builds env (`WORKERS_CI`,
 // `WORKERS_CI_BRANCH`): production deploys → `<worker>.<account>.workers.dev`,
 // preview deploys → `<branch>-<worker>.<account>.workers.dev`,
-// local `pnpm dev` → `http://localhost:8787`. Swap to a hardcoded
-// `{ rpId, origin }` once you wire a custom domain.
+// local `pnpm dev` → `localOrigin`. The CSRF origin-allowlist must
+// match what the browser sends: `plumix dev` serves on vite's port
+// (5173 by default), NOT wrangler's 8787 — without the override every
+// /_plumix POST 403s and the admin can't even log in. Swap to a
+// hardcoded `{ rpId, origin }` once you wire a custom domain.
 const { rpId, origin } = cloudflareDeployOrigin({
   workerName: "plumix-blog",
   accountSubdomain: "enasyrov",
+  localOrigin: "http://localhost:5173",
 });
 
 // Media R2 + image-delivery wiring is opt-in via env. With S3

--- a/examples/minimal/plumix.config.ts
+++ b/examples/minimal/plumix.config.ts
@@ -8,11 +8,15 @@ import {
 // Derives `rpId` + `origin` from the Workers Builds env (`WORKERS_CI`,
 // `WORKERS_CI_BRANCH`): production deploys → `<worker>.<account>.workers.dev`,
 // preview deploys → `<branch>-<worker>.<account>.workers.dev`,
-// local `pnpm dev` → `http://localhost:8787`. Swap to a hardcoded
-// `{ rpId, origin }` once you wire a custom domain.
+// local `pnpm dev` → `localOrigin`. The CSRF origin-allowlist must
+// match what the browser sends: `plumix dev` serves on vite's port
+// (5173 by default), NOT wrangler's 8787 — without the override every
+// /_plumix POST 403s and the admin can't even log in. Swap to a
+// hardcoded `{ rpId, origin }` once you wire a custom domain.
 const { rpId, origin } = cloudflareDeployOrigin({
   workerName: "plumix-minimal",
   accountSubdomain: "enasyrov",
+  localOrigin: "http://localhost:5173",
 });
 
 export default plumix({


### PR DESCRIPTION
Found during the live editor verification that kicked off #831: a fresh `pnpm dev` in either example serves a **dead admin** — every `/_plumix/*` POST 403s with `csrf_origin_mismatch` and the login screen error-boundaries before rendering anything.

`cloudflareDeployOrigin` defaults `localOrigin` to wrangler's `:8787`, but `plumix dev` serves through vite on `:5173`, so the dispatcher's CSRF origin allowlist never matches what the browser sends. The plugin playgrounds already carry the `localOrigin` override (with a comment explaining exactly this); the examples never got it.

**Launch-relevant**: `create-plumix-app` copies `examples/minimal`'s config verbatim, so every scaffolded app inherited the broken default — a new user's first `pnpm dev` admin was dead on arrival. Both examples now set `localOrigin` to the vite port, and the stale comment claiming dev runs on `:8787` is corrected.

Verified live throughout the #831–#837 sessions (the entire editor verification ran on exactly this override).

Refs #831