### PR TITLE
feat(admin): drag blocks from the palette onto the canvas

### DIFF
--- a/packages/admin/e2e/editor-actions.spec.ts
+++ b/packages/admin/e2e/editor-actions.spec.ts
@@ -20,6 +20,7 @@ import {
   canvasOrder,
   dismissStarterModal,
   dragBelow,
+  dragOnto,
   editorEntry,
   installEditorMocks,
   lastUpdate,
@@ -46,7 +47,12 @@ test.describe("editor actions: insert", () => {
     await page.goto("entries/posts/1/edit");
     await dismissStarterModal(page);
 
-    await page.getByTestId("plumix-blocks-tab-item-core/quote").click();
+    // The Drawer renders a drag-preview twin of each row — scope the
+    // click through Puck's item wrapper.
+    await page
+      .getByTestId("drawer-item:core/quote")
+      .getByTestId("plumix-blocks-tab-item-core/quote")
+      .click();
     await expect(canvasBlocks(page, "core/quote")).toHaveCount(1);
 
     await expect.poll(() => updates.length).toBeGreaterThan(0);
@@ -54,21 +60,25 @@ test.describe("editor actions: insert", () => {
     expect(blocks.map((b) => b.name)).toEqual(["core/quote"]);
   });
 
-  // Palette rows are plain click-to-insert buttons today
-  // (InsertableEntryRow has no drag source wiring). This pins the gap:
-  // when drag-from-palette ships, flip the fixme into a real drag.
-  test.fixme("palette item drags onto the canvas drop zone", async ({
-    page,
-  }) => {
-    await installEditorMocks(page);
+  test("palette item drags onto the canvas drop zone", async ({ page }) => {
+    const updates = await installEditorMocks(page);
     await page.goto("entries/posts/1/edit");
     await dismissStarterModal(page);
-    await dragBelow(
+
+    // Puck's Drawer renders a hidden drag-preview twin of each row, so
+    // the row testid resolves twice — drag from Puck's item wrapper.
+    await dragOnto(
       page,
-      page.getByTestId("plumix-blocks-tab-item-core/separator"),
-      page.getByTestId("dropzone:root:default-zone"),
+      page.getByTestId("drawer-item:core/separator"),
+      page.getByTestId("plumix-editor-canvas-frame"),
     );
     await expect(canvasBlocks(page, "core/separator")).toHaveCount(1);
+
+    await expect
+      .poll(() =>
+        (lastUpdate(updates)?.content?.blocks ?? []).map((b) => b.name),
+      )
+      .toEqual(["core/separator"]);
   });
 });
 

--- a/packages/admin/e2e/editor-plugin-block-registration.spec.ts
+++ b/packages/admin/e2e/editor-plugin-block-registration.spec.ts
@@ -99,8 +99,12 @@ test.describe("plugin block registered via window.plumix bridge", () => {
     // The block is wired in two places — the inserter sidebar list and
     // the slash menu. Asserting both proves the runtime registry feeds
     // every consumer that the hardcoded `coreBlocks` import used to.
+    // The Drawer renders a drag-preview twin of each row — scope
+    // through Puck's item wrapper.
     await expect(
-      page.getByTestId("plumix-blocks-tab-item-test/fake"),
+      page
+        .getByTestId("drawer-item:test/fake")
+        .getByTestId("plumix-blocks-tab-item-test/fake"),
     ).toBeVisible();
 
     const canvas = page.getByTestId("plumix-editor-canvas");

--- a/packages/admin/e2e/support/editor.ts
+++ b/packages/admin/e2e/support/editor.ts
@@ -98,6 +98,56 @@ export async function dismissStarterModal(page: Page): Promise<void> {
   await expect(modal).toBeHidden();
 }
 
+type BoundingBox = NonNullable<Awaited<ReturnType<Locator["boundingBox"]>>>;
+
+/** Resolves both drag endpoints' boxes, throwing if either is off-screen. */
+async function dragBoxes(
+  label: string,
+  source: Locator,
+  target: Locator,
+): Promise<{ source: BoundingBox; target: BoundingBox }> {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+  if (!sourceBox || !targetBox) {
+    throw new Error(`${label}: source or target has no bounding box`);
+  }
+  return { source: sourceBox, target: targetBox };
+}
+
+/**
+ * Palette → canvas drag (@dnd-kit/react, 5 px mouse activation). Walks
+ * the cursor from the source's center onto the target's center with a
+ * settle pause for the drag to engage and one for the collision
+ * detector before release. Assumes the target's center is droppable —
+ * i.e. an empty canvas; on a populated one, prefer dragBelow.
+ */
+export async function dragOnto(
+  page: Page,
+  source: Locator,
+  target: Locator,
+): Promise<void> {
+  const { source: sourceBox, target: targetBox } = await dragBoxes(
+    "dragOnto",
+    source,
+    target,
+  );
+  const from = {
+    x: sourceBox.x + sourceBox.width / 2,
+    y: sourceBox.y + sourceBox.height / 2,
+  };
+  const to = {
+    x: targetBox.x + targetBox.width / 2,
+    y: targetBox.y + targetBox.height / 2,
+  };
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  await page.mouse.move(from.x + 8, from.y + 8, { steps: 4 });
+  await page.waitForTimeout(300);
+  await page.mouse.move(to.x, to.y, { steps: 16 });
+  await page.waitForTimeout(300);
+  await page.mouse.up();
+}
+
 // Puck exposes only the item id on `data-puck-component` (pattern
 // inserts mint bare random ids), so block type is asserted through the
 // semantic element each core block renders — which doubles as checking
@@ -151,11 +201,11 @@ export async function dragBelow(
   source: Locator,
   target: Locator,
 ): Promise<void> {
-  const sourceBox = await source.boundingBox();
-  const targetBox = await target.boundingBox();
-  if (!sourceBox || !targetBox) {
-    throw new Error("dragBelow: source or target has no bounding box");
-  }
+  const { source: sourceBox, target: targetBox } = await dragBoxes(
+    "dragBelow",
+    source,
+    target,
+  );
   const x = sourceBox.x + Math.min(40, sourceBox.width / 2);
   const startY = sourceBox.y + sourceBox.height / 2;
   await page.mouse.move(x, startY);

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -32,7 +32,7 @@ import { useLabel } from "@/lib/use-label.js";
 import { cn } from "@/lib/utils.js";
 import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
-import { Puck, useGetPuck } from "@puckeditor/core";
+import { Drawer, Puck, useGetPuck } from "@puckeditor/core";
 import { Minus, Monitor, Plus, Smartphone, Tablet } from "lucide-react";
 
 import type {
@@ -832,18 +832,45 @@ function PlumixBlocksTab({
 
   return (
     <div className="flex flex-col">
-      <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
-        {entries.map((entry) => (
-          <li key={entryKey(entry)}>
-            <InsertableEntryRow
-              entry={entry}
-              blocks={registry}
-              patterns={patternRegistry}
-              onClick={() => handleInsert(entry)}
-            />
-          </li>
-        ))}
-      </ul>
+      {/* Drawer.Item turns a row into a drag source for the canvas drop
+          zones (Puck's palette mechanism), with dnd-kit's 5 px activation
+          distance leaving plain clicks for onClick. Only plain blocks
+          wrap — a Drawer.Item maps to a component TYPE and can't carry a
+          variation's preset attrs, so variations stay click-only. */}
+      <Drawer>
+        <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
+          {entries.map((entry) => {
+            const row = (
+              <InsertableEntryRow
+                entry={entry}
+                blocks={registry}
+                patterns={patternRegistry}
+                onClick={() => handleInsert(entry)}
+                interactive={isVariation(entry)}
+              />
+            );
+            // A drop inserts the bare component type, which would skip
+            // the BlockScopePicker the click path opens — disable drag
+            // for blocks that still have pickable block-scope
+            // variations so the two paths can't diverge.
+            const dragDisabled =
+              !isVariation(entry) &&
+              resolveBlockScopeVariations(registry, entry.name, capabilities)
+                .length > 0;
+            return (
+              <li key={entryKey(entry)}>
+                {isVariation(entry) ? (
+                  row
+                ) : (
+                  <Drawer.Item name={entry.name} isDragDisabled={dragDisabled}>
+                    {() => row}
+                  </Drawer.Item>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </Drawer>
       <PatternsSection
         patterns={patterns}
         onSelect={handlePatternInsert}

--- a/packages/admin/src/editor/InsertableEntryRow.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.tsx
@@ -18,6 +18,14 @@ interface InsertableEntryRowProps {
   readonly blocks: BlockRegistry;
   readonly patterns: PatternRegistry;
   readonly onClick: () => void;
+  /**
+   * Rows nested inside a Puck `Drawer.Item` wrapper must not be
+   * interactive themselves (axe `nested-interactive`) — dnd-kit's
+   * keyboard sensor makes the wrapper a focusable role=button whose
+   * action is keyboard DRAG, not insert. The plain row carries the
+   * pointer click; keyboard insertion lives in the slash menu.
+   */
+  readonly interactive?: boolean;
 }
 
 export function InsertableEntryRow({
@@ -25,18 +33,34 @@ export function InsertableEntryRow({
   blocks,
   patterns,
   onClick,
+  interactive = true,
 }: InsertableEntryRowProps): ReactElement {
   const renderLabel = useLabel();
   if (!isVariation(entry)) {
+    const className =
+      "hover:bg-muted flex w-full cursor-pointer items-center gap-2 rounded border px-3 py-2 text-start text-sm";
+    const testId = `plumix-blocks-tab-item-${entryKey(entry)}`;
+    const content = (
+      <>
+        <BlockIcon name={entry.icon} />
+        <span className="truncate">{renderLabel(entry.title)}</span>
+      </>
+    );
+    if (!interactive) {
+      return (
+        <div className={className} data-testid={testId} onClick={onClick}>
+          {content}
+        </div>
+      );
+    }
     return (
       <button
         type="button"
-        className="hover:bg-muted flex w-full items-center gap-2 rounded border px-3 py-2 text-start text-sm"
-        data-testid={`plumix-blocks-tab-item-${entryKey(entry)}`}
+        className={className}
+        data-testid={testId}
         onClick={onClick}
       >
-        <BlockIcon name={entry.icon} />
-        <span className="truncate">{renderLabel(entry.title)}</span>
+        {content}
       </button>
     );
   }


### PR DESCRIPTION
Closes the last annotation in `editor-actions.spec.ts`: the palette-drag `fixme` becomes a real passing drag test — the suite now runs **19/19 with zero annotations**.

**Drawer integration (Puck's own palette mechanism)**

Plain block rows wrap in `Drawer.Item` (the mechanism Puck's custom-ui demo uses); dnd-kit's 5 px activation keeps click-to-insert working unchanged. Variations stay click-only (`Drawer.Item` maps to a component *type* — it can't carry preset attrs), and drag is disabled for blocks with pickable block-scope variations so a drop can't silently skip the `BlockScopePicker` the click path opens (review finding).

**A11y, caught by the existing axe gate**

`Drawer.Item`'s wrapper is made a focusable `role=button` by dnd-kit's keyboard sensor — nesting our `<button>` rows inside tripped `nested-interactive`. In-drawer rows render as passive divs: the wrapper carries the keyboard-*drag* affordance, the row carries the pointer click, and keyboard *insertion* remains the slash menu (covered by `editor-keyboard-walkthrough`).

**Test notes**

New `dragOnto` helper (palette→canvas center, empty-canvas semantics documented); two specs scope row testids through Puck's `drawer-item:*` wrapper because the Drawer renders a hidden drag-preview twin of each row (Puck-internal coupling noted in comments for future version bumps).

Verified: 123/123 admin e2e (incl. both axe tests), 521 unit tests. senpai + simplifier reviewed; all findings folded in.

Refs #831