### PR TITLE
fix(core): allow loopback origins for CSRF under plumix dev

### DIFF
--- a/packages/core/src/cli/worker-codegen.test.ts
+++ b/packages/core/src/cli/worker-codegen.test.ts
@@ -19,6 +19,12 @@ describe("generateWorkerSource", () => {
     );
   });
 
+  test("opts into localhost CSRF only under vite dev (import.meta.env.DEV)", () => {
+    const source = generateWorkerSource({ configModule: "../plumix.config" });
+    expect(source).toContain("buildApp(config, {");
+    expect(source).toContain("devCsrfLocalhost: import.meta.env.DEV");
+  });
+
   test("exports a fetch handler default export", () => {
     const source = generateWorkerSource({ configModule: "./config.ts" });
     expect(source).toContain("export default");
@@ -47,7 +53,7 @@ describe("generateWorkerSource", () => {
     expect(source).toContain(
       'import assetManifest from "virtual:plumix/asset-manifest";',
     );
-    expect(source).toContain("buildApp(config, { assetManifest })");
+    expect(source).toContain("buildApp(config, {");
   });
 
   test("no-ops cleanly when the runtime omits buildScheduledHandler", () => {

--- a/packages/core/src/cli/worker-codegen.ts
+++ b/packages/core/src/cli/worker-codegen.ts
@@ -17,7 +17,14 @@ export function generateWorkerSource({
     'import assetManifest from "virtual:plumix/asset-manifest";',
     `import config from ${JSON.stringify(configModule)};`,
     "",
-    "const appPromise = buildApp(config, { assetManifest });",
+    // vite statically replaces `import.meta.env.DEV` (true under dev,
+    // false in production builds) — see RuntimeContext.devCsrfLocalhost.
+    // Fail-closed: a bundler that leaves `import.meta.env` intact yields
+    // undefined, which buildApp coerces to false.
+    "const appPromise = buildApp(config, {",
+    "  assetManifest,",
+    "  devCsrfLocalhost: import.meta.env.DEV,",
+    "});",
     "let fetchHandler;",
     "let scheduledHandler;",
     "",

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -66,6 +66,8 @@ export interface PlumixApp {
    * features don't have to reach into `passkey.*` to learn it.
    */
   readonly origin: string;
+  /** See RuntimeContext.devCsrfLocalhost — false in production builds. */
+  readonly devCsrfLocalhost: boolean;
   readonly passkey: ResolvedPasskeyConfig;
   readonly sessionPolicy: SessionPolicy;
   /**
@@ -162,6 +164,14 @@ export interface PlumixApp {
 // inline object literal that structurally satisfies the type.
 interface RuntimeContext {
   readonly assetManifest?: AssetManifest;
+  /**
+   * Dev-server opt-in: treat any localhost origin as same-origin for
+   * CSRF. `plumix dev` serves through vite on a port the user's config
+   * cannot reliably predict (5173 by default, auto-incremented when
+   * taken), so the generated worker passes `import.meta.env.DEV` here —
+   * statically false in production builds.
+   */
+  readonly devCsrfLocalhost?: boolean;
 }
 
 export async function buildApp(
@@ -269,6 +279,7 @@ export async function buildApp(
       plugins: [new ResponseHeadersPlugin()],
     }),
     origin: passkey.origin,
+    devCsrfLocalhost: runtime.devCsrfLocalhost ?? false,
     passkey,
     sessionPolicy: config.auth.sessions ?? DEFAULT_SESSION_POLICY,
     authenticator,

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -287,6 +287,74 @@ describe("dispatcher — CSRF", () => {
     expect(body.reason).toBe("csrf_origin_mismatch");
   });
 
+  test("dev localhost CSRF: any loopback origin is allowed when the app opts in", async () => {
+    const h = await createDispatcherHarness({ devCsrfLocalhost: true });
+    for (const origin of [
+      "http://localhost:5174",
+      "http://127.0.0.1:8787",
+      "http://127.0.0.2:8787",
+      "http://[::1]:5173",
+    ]) {
+      const response = await h.dispatch(
+        plumixRequest("/_plumix/rpc/entry/list", {
+          method: "POST",
+          headers: { "content-type": "application/json", origin },
+          body: JSON.stringify({ json: {} }),
+        }),
+      );
+      expect(response.status, origin).not.toBe(403);
+    }
+  });
+
+  test("dev localhost CSRF: the relaxation cannot bypass the header gate", async () => {
+    const h = await createDispatcherHarness({ devCsrfLocalhost: true });
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/rpc/entry/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:5174",
+        },
+        body: JSON.stringify({ json: {} }),
+      }),
+    );
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { reason?: string };
+    expect(body.reason).toBe("csrf_header_missing");
+  });
+
+  test("dev localhost CSRF: non-localhost origins still mismatch", async () => {
+    const h = await createDispatcherHarness({ devCsrfLocalhost: true });
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/rpc/entry/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "https://attacker.example",
+        },
+        body: JSON.stringify({ json: {} }),
+      }),
+    );
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { reason?: string };
+    expect(body.reason).toBe("csrf_origin_mismatch");
+  });
+
+  test("without the dev opt-in, a localhost origin still mismatches", async () => {
+    const h = await createDispatcherHarness();
+    const response = await h.dispatch(
+      plumixRequest("/_plumix/rpc/entry/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:5174",
+        },
+        body: JSON.stringify({ json: {} }),
+      }),
+    );
+    expect(response.status).toBe(403);
+  });
+
   test("POST with a matching Origin header passes through to the RPC layer", async () => {
     const h = await createDispatcherHarness();
     const response = await h.dispatch(

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -92,9 +92,31 @@ function enforcePlumixCsrf(app: PlumixApp, ctx: AppContext): Response | null {
     ctx.request.headers.has("origin") &&
     !hasMatchingOrigin(ctx.request, { allowed: [app.origin] })
   ) {
+    // devCsrfLocalhost is statically false in production builds; see its
+    // declaration on RuntimeContext for why dev needs the relaxation.
+    if (app.devCsrfLocalhost && hasLocalhostOrigin(ctx.request)) {
+      return null;
+    }
     return forbidden("csrf_origin_mismatch");
   }
   return null;
+}
+
+function hasLocalhostOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+  try {
+    const { hostname } = new URL(origin);
+    // The whole 127.0.0.0/8 block is loopback, not just 127.0.0.1.
+    // WHATWG URL always compresses IPv6 loopback to `[::1]`.
+    return (
+      hostname === "localhost" ||
+      hostname === "[::1]" ||
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)
+    );
+  } catch {
+    return false;
+  }
 }
 
 async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -51,6 +51,7 @@ const stubDatabase = {
 };
 
 export interface CreateDispatcherHarnessOptions {
+  readonly devCsrfLocalhost?: boolean;
   /**
    * Runtime environment bindings (KV, R2, Durable Objects, etc.). Exposed
    * on `h.env` so tests can assert on or interact with bindings directly —
@@ -229,6 +230,7 @@ export async function createDispatcherHarness(
   });
   const app = await buildApp(config, {
     assetManifest: options.assetManifest,
+    devCsrfLocalhost: options.devCsrfLocalhost,
   });
   const dispatcher = createPlumixDispatcher(app);
   const { assets, storage } = options;


### PR DESCRIPTION
The deeper fix behind #838: `plumix dev` serves through vite on a port the user's config can't reliably predict (5173 default, auto-incremented when taken), so the CSRF origin allowlist drifts and every `/_plumix` POST 403s — a fresh scaffold whose port drifted shipped a dead dev admin. `localOrigin` mitigated this per-app; this makes the platform handle it.

**Mechanism**

`buildApp` gains an internal `devCsrfLocalhost` option; the generated worker wires it to `import.meta.env.DEV` — statically `true` under `plumix dev`, statically `false` in production builds (verified in a compiled bundle: `devCsrfLocalhost: false`), and **fail-closed** under any bundler path that leaves `import.meta.env` intact (`undefined` → `false`).

**Security posture** (senpai-reviewed, findings folded in)

The relaxation accepts loopback origins only — `localhost`, the whole `127.0.0.0/8` block, IPv6 loopback — and sits strictly *behind* the `X-Plumix-Request` header gate, firing only where the strict origin match already failed. A regression test pins the gate ordering; non-loopback origins still 403 in dev; nothing changes without the opt-in.

**Verified live**: blog example with `localOrigin` deleted — vite origin 200, other loopback ports 200, `attacker.example` 403. The `localOrigin` knob stays for non-loopback dev setups (e.g. LAN-exposed `--host`).

1846 core unit tests green.

Refs #831