### PR TITLE
test(admin): restore entries-list e2e coverage

### DIFF
--- a/packages/admin/e2e/entries.spec.ts
+++ b/packages/admin/e2e/entries.spec.ts
@@ -1,0 +1,387 @@
+// /entries/$slug list coverage: filters, search, sort, pagination,
+// trash, capability gates, and the loading/empty/error/not-found
+// states. The list mock always returns fixtures — tests assert the
+// captured `entry.list` input (the server contract) plus the rendered
+// rows, never persistence.
+
+import { expect, test } from "@playwright/test";
+
+import type { PlumixManifest } from "@plumix/core/manifest";
+import type { Entry, Term } from "@plumix/core/schema";
+import { emptyManifest } from "@plumix/core/manifest";
+
+import { expectNoAxeViolations } from "./support/axe.js";
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  mockRpc,
+  mockRpcWithCapture,
+  rpcErrorBody,
+  rpcOkBody,
+} from "./support/rpc-mock.js";
+
+const T0 = new Date("2026-04-19T12:00:00Z");
+
+function entry(
+  overrides: Partial<Entry> & { id: number; title: string },
+): Entry {
+  return {
+    type: "post",
+    parentId: null,
+    slug: overrides.title.toLowerCase().replaceAll(" ", "-"),
+    content: null,
+    excerpt: null,
+    status: "published",
+    authorId: 1,
+    sortOrder: 0,
+    publishedAt: T0,
+    createdAt: T0,
+    updatedAt: T0,
+    meta: {},
+    ...overrides,
+  };
+}
+
+const TWO_ROWS = [
+  entry({ id: 1, title: "Hello world" }),
+  entry({ id: 2, title: "Draft in progress", status: "draft" }),
+];
+
+test.describe("/entries/$slug (list)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+  });
+
+  test("renders skeleton rows while loading, with zero WCAG 2.1 AA violations", async ({
+    page,
+  }) => {
+    // Deferred promise: we control when /entry/list resolves, letting the
+    // page sit in its loading state while axe runs, then releasing it so
+    // Playwright's teardown isn't waiting on a pending request.
+    let release: (() => void) | undefined;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", async (route) => {
+      await pending;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody([]),
+      });
+    });
+
+    await page.goto("entries/posts");
+    await expect(page.getByTestId("content-list-heading")).toBeVisible();
+    await expect(page.getByTestId("data-table-loading")).toBeVisible();
+    await expectNoAxeViolations(page);
+
+    release?.();
+  });
+
+  test("renders rows with zero WCAG 2.1 AA violations", async ({ page }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/list": TWO_ROWS,
+    });
+    await page.goto("entries/posts");
+
+    const helloRow = page.getByTestId("content-list-row-1");
+    await expect(helloRow).toBeVisible();
+    await expect(helloRow).toContainText("Hello world");
+    await expect(page.getByTestId("content-list-row-2")).toBeVisible();
+    await expectNoAxeViolations(page);
+  });
+
+  test("renders empty state with zero WCAG 2.1 AA violations", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/list": [],
+    });
+    await page.goto("entries/posts");
+    await expect(page.getByTestId("content-list-empty-state")).toBeVisible();
+    await expectNoAxeViolations(page);
+  });
+
+  test("renders the router's not-found state when the slug isn't registered", async ({
+    page,
+  }) => {
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.goto("entries/unknown-type");
+    await expect(page.getByTestId("not-found-page")).toBeVisible();
+  });
+
+  test("surfaces the load-error alert when entry.list rejects", async ({
+    page,
+  }) => {
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: rpcErrorBody({ code: "INTERNAL_SERVER_ERROR", message: "boom" }),
+      }),
+    );
+    await page.goto("entries/posts");
+    await expect(page.getByTestId("content-list-load-error")).toBeVisible();
+  });
+
+  test("search box URL-syncs ?q= and ships `search` in the refetch input", async ({
+    page,
+  }) => {
+    const inputs = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/list",
+      captureResponse: [],
+      handlers: { "/auth/session": AUTHED_ADMIN },
+    });
+
+    await page.goto("entries/posts");
+    await page.getByTestId("content-list-search-input").fill("quantum");
+    await expect(page).toHaveURL(/q=quantum/);
+    await expect
+      .poll(
+        () =>
+          (inputs.at(-1) as { search?: string } | undefined)?.search ?? null,
+      )
+      .toBe("quantum");
+  });
+
+  test("status pill URL-syncs and ships `status` in the refetch input", async ({
+    page,
+  }) => {
+    const inputs = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/list",
+      captureResponse: [],
+      handlers: { "/auth/session": AUTHED_ADMIN },
+    });
+
+    await page.goto("entries/posts?page=3");
+    await expect.poll(() => inputs.length).toBeGreaterThan(0);
+    // First call is deterministic — `at(-1)` could race a refetch.
+    expect(inputs[0]).not.toHaveProperty("status");
+
+    await page.getByTestId("status-view-published").click();
+    await expect(page).toHaveURL(/status=published/);
+    // Filter changes reset pagination.
+    await expect(page).toHaveURL(/page=1/);
+    await expect
+      .poll(
+        () =>
+          (inputs.at(-1) as { status?: string } | undefined)?.status ?? null,
+      )
+      .toBe("published");
+  });
+
+  test("Mine filter URL-syncs author=mine and sends session.user.id as authorId", async ({
+    page,
+  }) => {
+    const inputs = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/list",
+      captureResponse: [],
+      handlers: { "/auth/session": AUTHED_ADMIN },
+    });
+
+    await page.goto("entries/posts");
+    await page.getByTestId("author-filter").click();
+    await page.getByTestId("author-filter-mine").click();
+    await expect(page).toHaveURL(/author=mine/);
+    await expect
+      .poll(
+        () =>
+          (inputs.at(-1) as { authorId?: number } | undefined)?.authorId ??
+          null,
+      )
+      .toBe(AUTHED_ADMIN.user?.id);
+  });
+
+  test("column sort: Title defaults to asc, second click flips to desc", async ({
+    page,
+  }) => {
+    const inputs = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/list",
+      captureResponse: [],
+      handlers: { "/auth/session": AUTHED_ADMIN },
+    });
+
+    const lastSort = (): string | null => {
+      const last = inputs.at(-1) as
+        | { orderBy?: string; order?: string }
+        | undefined;
+      return last ? `${last.orderBy ?? ""}:${last.order ?? ""}` : null;
+    };
+
+    await page.goto("entries/posts");
+    await page.getByTestId("content-list-sort-title").click();
+    await expect(page).toHaveURL(/orderBy=title/);
+    await expect(page).toHaveURL(/order=asc/);
+    await expect.poll(lastSort).toBe("title:asc");
+
+    await page.getByTestId("content-list-sort-title").click();
+    await expect(page).toHaveURL(/order=desc/);
+    await expect.poll(lastSort).toBe("title:desc");
+  });
+
+  test("pagination: a full page enables Next; clicking it ships the next offset", async ({
+    page,
+  }) => {
+    const fullPage = Array.from({ length: 20 }, (_, i) =>
+      entry({ id: i + 1, title: `Post ${String(i + 1)}` }),
+    );
+    const inputs = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/list",
+      captureResponse: fullPage,
+      handlers: { "/auth/session": AUTHED_ADMIN },
+    });
+
+    await page.goto("entries/posts");
+    await expect(page.getByTestId("content-list-row-1")).toBeVisible();
+    await expect(page.getByTestId("list-pagination-prev")).toBeDisabled();
+    // Pin page 1's offset so the (page - 1) * PAGE_SIZE multiplier
+    // itself is load-bearing, not just the page-2 delta.
+    expect((inputs[0] as { offset?: number } | undefined)?.offset).toBe(0);
+
+    await page.getByTestId("list-pagination-next").click();
+    await expect(page).toHaveURL(/page=2/);
+    await expect
+      .poll(
+        () => (inputs.at(-1) as { offset?: number } | undefined)?.offset ?? -1,
+      )
+      .toBe(20);
+    await expect(page.getByTestId("list-pagination-prev")).toBeEnabled();
+  });
+
+  test("trash flow: row action → confirm dialog → entry.trash payload → refetched list drops the row", async ({
+    page,
+  }) => {
+    const trashed: unknown[] = [];
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(trashed.length === 0 ? TWO_ROWS : [TWO_ROWS[1]]),
+      }),
+    );
+    await page.route("**/_plumix/rpc/entry/trash", (route) => {
+      const body = route.request().postDataJSON() as { json?: unknown };
+      trashed.push(body.json);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody({ ...TWO_ROWS[0], status: "trash" }),
+      });
+    });
+
+    await page.goto("entries/posts");
+    // Row actions are hover-revealed; hover the row to surface them.
+    await page.getByTestId("content-list-row-1").hover();
+    await page.getByTestId("content-list-row-trash-1").click();
+    await page.getByTestId("content-list-trash-confirm").click();
+
+    expect(trashed[0]).toMatchObject({ id: 1 });
+    // Successful trash invalidates the list query — the row disappears.
+    await expect(page.getByTestId("content-list-row-1")).toHaveCount(0);
+    await expect(page.getByTestId("content-list-row-2")).toBeVisible();
+  });
+
+  test("without create/delete caps: New button and Trash row action are absent", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": {
+        user: {
+          id: 5,
+          email: "viewer@example.test",
+          name: "Viewer",
+          avatarUrl: null,
+          role: "subscriber",
+          // Read-only: no entry:post:create / entry:post:delete.
+          capabilities: ["entry:post:read"],
+        },
+        needsBootstrap: false,
+      },
+      "/entry/list": TWO_ROWS,
+    });
+
+    await page.goto("entries/posts");
+    await expect(page.getByTestId("content-list-row-1")).toBeVisible();
+    await expect(page.getByTestId("content-list-new-button")).toHaveCount(0);
+    await page.getByTestId("content-list-row-1").hover();
+    await expect(page.getByTestId("content-list-row-trash-1")).toHaveCount(0);
+  });
+});
+
+test.describe("/entries/$slug (list) — taxonomy filters", () => {
+  // Entry type wired to one hierarchical taxonomy so the filter
+  // dropdown renders; single consumer, so the manifest stays local.
+  const MANIFEST_WITH_FILTERABLE_TAXONOMY: PlumixManifest = {
+    ...emptyManifest(),
+    entryTypes: [
+      {
+        name: "post",
+        adminSlug: "posts",
+        label: "Posts",
+        labels: { singular: "Post", plural: "Posts" },
+        termTaxonomies: ["category"],
+      },
+    ],
+    termTaxonomies: [
+      {
+        name: "category",
+        label: "Categories",
+        labels: { singular: "Category" },
+        isHierarchical: true,
+      },
+    ],
+  };
+
+  function term(overrides: Partial<Term> & { id: number; name: string }): Term {
+    return {
+      taxonomy: "category",
+      slug: overrides.name.toLowerCase().replaceAll(" ", "-"),
+      description: null,
+      parentId: null,
+      meta: {},
+      version: 0,
+      ...overrides,
+    };
+  }
+
+  test("picking a term URL-syncs ?category= and ships termTaxonomies in the input", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_FILTERABLE_TAXONOMY);
+    const inputs = await mockRpcWithCapture(page, {
+      captureSuffix: "/entry/list",
+      captureResponse: [],
+      handlers: {
+        "/auth/session": AUTHED_ADMIN,
+        "/term/list": [
+          term({ id: 1, name: "News" }),
+          term({ id: 2, name: "Guides" }),
+        ],
+      },
+    });
+
+    await page.goto("entries/posts");
+    await page.getByTestId("taxonomy-filter-category").click();
+    await page.getByTestId("taxonomy-filter-category-option-news").click();
+
+    await expect(page).toHaveURL(/category=news/);
+    await expect
+      .poll(
+        () =>
+          (
+            inputs.at(-1) as
+              | { termTaxonomies?: Record<string, string[]> }
+              | undefined
+          )?.termTaxonomies ?? null,
+      )
+      .toEqual({ category: ["news"] });
+  });
+});

--- a/packages/admin/src/components/data-table/list-pagination.tsx
+++ b/packages/admin/src/components/data-table/list-pagination.tsx
@@ -56,6 +56,7 @@ export function ListPagination({
               onPageChange(page - 1);
             }}
             aria-label={label(M.prevAria)}
+            data-testid="list-pagination-prev"
           >
             <ChevronLeft className="rtl:rotate-180" />
             <span className="hidden sm:inline">
@@ -72,6 +73,7 @@ export function ListPagination({
               onPageChange(page + 1);
             }}
             aria-label={label(M.nextAria)}
+            data-testid="list-pagination-next"
           >
             <span className="hidden sm:inline">
               <Trans id="listPagination.next.label" message="Next" />

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -597,7 +597,7 @@ function ContentListRoute(): ReactNode {
       </div>
 
       {query.isError ? (
-        <Alert variant="destructive">
+        <Alert variant="destructive" data-testid="content-list-load-error">
           <AlertDescription>
             {query.error instanceof Error
               ? query.error.message


### PR DESCRIPTION
The `/entries/$slug` list page has had zero e2e coverage since the page-builder rearchitecture (#470) deleted `content.spec.ts` — the editor specs were rebuilt, the list never was. This restores it as `entries.spec.ts` (13 tests) under the conventions established in #841.

**Server-contract assertions, not just URL sync**

The capture-based tests pin the actual `entry.list` input the route builds: `status` omitted entirely for the "all" view, page-1 `offset: 0` so the `(page − 1) × PAGE_SIZE` multiplier itself is load-bearing, `orderBy`/`order` asserted together through the asc→desc flip, `authorId` from the session user, and `termTaxonomies` as a slug map (`{ category: ["news"] }`).

**Coverage**

Loading/empty/error/not-found states (with axe), search debounce, status pills (+ page reset on filter change), Mine author filter, column sort, pagination, the trash flow (confirm dialog → `entry.trash` payload → refetched list drops the row), taxonomy filters, and create/delete capability gating.

Test enablement: `data-testid` added to the pagination prev/next buttons and the list load-error alert.

Fixes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)