### PR TITLE
test: unskip the plugin e2e orphaned by the editor rearchitecture

### DIFF
--- a/packages/plugins/blog/e2e/blog.spec.ts
+++ b/packages/plugins/blog/e2e/blog.spec.ts
@@ -7,6 +7,11 @@
 
 import { expect, test } from "@playwright/test";
 
+// Title links carry `content-list-row-<id>`; the actions strip and
+// trash button reuse the prefix, so exclude them when counting rows.
+const CONTENT_ROWS =
+  "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])";
+
 test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
   test("posts list mounts against the real worker", async ({ page }) => {
     await page.goto("entries/posts");
@@ -16,27 +21,21 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
     // block on any failure, so a strict empty-state check here would
     // cascade-fail once a later test had created a post — turning one
     // real failure into three reported ones. Admin's mock-based
-    // content.spec.ts covers the empty-state UI exhaustively.
-    const rows = page.locator(
-      "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])",
-    );
+    // entries.spec.ts covers the empty-state UI exhaustively.
+    const rows = page.locator(CONTENT_ROWS);
     if ((await rows.count()) === 0) {
       await expect(page.getByTestId("content-list-empty-state")).toBeVisible();
     }
   });
 
   test("create a draft post → row appears in the list", async ({ page }) => {
-    // v2 flow: click New takes the user through /entries/posts/create
-    // (the redirect-on-mount route that calls entry.create + navigates
-    // to the edit URL), then we land in the Puck editor. Title is
-    // bound to the title input; autosave fires on change.
+    // Arm the URL waiter before clicking New — the create route
+    // redirects to the edit URL as soon as entry.create resolves.
     await page.goto("entries/posts");
     const navigated = page.waitForURL(/\/entries\/posts\/\d+\/edit/);
     await page.getByTestId("content-list-new-button").click();
     await navigated;
 
-    // The Puck editor mounts; title input is wired through to
-    // entry.update. Wait for autosave to confirm via response.
     await expect(page.getByTestId("plumix-editor-title-input")).toBeVisible();
     const updated = page.waitForResponse(
       (r) => r.url().endsWith("/entry/update") && r.status() === 200,
@@ -44,32 +43,24 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
     await page.getByTestId("plumix-editor-title-input").fill("Hello world");
     await updated;
 
-    // Back to the list — the new row carries the typed title.
     await page.goto("entries/posts");
-    const rows = page.locator(
-      "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])",
-    );
+    const rows = page.locator(CONTENT_ROWS);
     await expect(rows).toHaveCount(1);
     await expect(rows.first()).toContainText("Hello world");
   });
 
-  test.skip("edit the draft → publish → status persists across reload", async ({
+  test("edit the draft → publish → status persists across reload", async ({
     page,
   }) => {
     await page.goto("entries/posts");
-    const rows = page.locator(
-      "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])",
-    );
+    const rows = page.locator(CONTENT_ROWS);
     const rowTestid = await rows.first().getAttribute("data-testid");
     if (!rowTestid) throw new Error("expected post row to have a data-testid");
     const id = rowTestid.replace("content-list-row-", "");
 
     await page.goto(`entries/posts/${id}/edit`);
-    await expect(page.getByTestId("post-editor-form")).toBeVisible();
+    await expect(page.getByTestId("plumix-editor-layout")).toBeVisible();
 
-    await page
-      .getByTestId("post-editor-status-select")
-      .selectOption("published");
     // Arm the response waiter BEFORE the click so we never miss a fast
     // update RPC — `waitForResponse` only matches responses that arrive
     // after it's armed, and the update can resolve in <10ms against a
@@ -77,23 +68,22 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
     const updated = page.waitForResponse(
       (r) => r.url().endsWith("/entry/update") && r.status() === 200,
     );
-    await page.getByTestId("post-editor-submit").click();
+    await page.getByTestId("plumix-editor-publish-button").click();
     await updated;
 
-    await page.reload();
-    await expect(page.getByTestId("post-editor-form")).toBeVisible();
-    await expect(page.getByTestId("post-editor-status-select")).toHaveValue(
-      "published",
-    );
+    // Publishing refetches entry.get; on an autosave-capable type the
+    // header flips into the three-button draft-mode chrome once the
+    // entry is published — that flip is the visible publish receipt.
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
 
-    // Back to the list — the row is still there and now in published
-    // state. The list defaults to "all" so a published post stays
-    // visible.
-    await page.goto("entries/posts");
-    await expect(
-      page.locator(
-        "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])",
-      ),
-    ).toHaveCount(1);
+    await page.reload();
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+    // Nothing pending right after a publish.
+    await expect(page.getByTestId("editor-draft-publish")).toBeDisabled();
+
+    // The server-side status filter is the persistence proof: the row
+    // comes back under ?status=published from real D1.
+    await page.goto("entries/posts?status=published");
+    await expect(page.locator(CONTENT_ROWS)).toHaveCount(1);
   });
 });

--- a/packages/plugins/menu/e2e/menu.spec.ts
+++ b/packages/plugins/menu/e2e/menu.spec.ts
@@ -97,11 +97,11 @@ test.describe.serial("@plumix/plugin-menu — worker-driven happy path", () => {
     await expect(reloadedRows.last()).toContainText("Home");
   });
 
-  // Skipped pending a new menu-location registration path. theme.setup was
-  // removed in the theming-foundation slice (#493 / PR #500), which means
-  // the playground no longer registers a "primary" location. A follow-up
-  // will reintroduce registration via plugin config or admin-defined
-  // locations; this test is the canary that unskips when that lands.
+  // Skipped pending a new menu-location registration path (#846).
+  // theme.setup was removed in the theming-foundation slice (#493 /
+  // PR #500), which means the playground no longer registers a
+  // "primary" location; this test is the canary that unskips when the
+  // registration path lands.
   test.skip("locations tab — assign the menu to Primary Nav, reload, assignment persists", async ({
     page,
   }) => {

--- a/packages/plugins/pages/e2e/pages.spec.ts
+++ b/packages/plugins/pages/e2e/pages.spec.ts
@@ -3,11 +3,14 @@
 // by globalSetup with an admin user + storageState carrying the
 // session cookie. No RPC mocking — the spec exercises pages'
 // declarative registration (hierarchical `page` entry type) end-to-
-// end through core admin's CRUD against real D1, including the
-// hierarchical parent picker that's only mounted when
-// `isHierarchical: true`.
+// end through core admin's CRUD against real D1.
 
 import { expect, test } from "@playwright/test";
+
+// Title links carry `content-list-row-<id>`; the actions strip and
+// trash button reuse the prefix, so exclude them when counting rows.
+const CONTENT_ROWS =
+  "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])";
 
 test.describe.serial("@plumix/plugin-pages — worker-driven happy path", () => {
   test("pages list mounts against the real worker", async ({ page }) => {
@@ -16,38 +19,38 @@ test.describe.serial("@plumix/plugin-pages — worker-driven happy path", () => 
     // Soft empty-state assertion: only enforce when the list actually
     // has no rows. See `packages/plugins/blog/e2e/blog.spec.ts` for
     // the cascade-failure rationale.
-    const rows = page.locator(
-      "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])",
-    );
+    const rows = page.locator(CONTENT_ROWS);
     if ((await rows.count()) === 0) {
       await expect(page.getByTestId("content-list-empty-state")).toBeVisible();
     }
   });
 
-  test.skip("create a draft page → row appears in the list", async ({
-    page,
-  }) => {
+  test("create a draft page → row appears in the list", async ({ page }) => {
+    // Arm the URL waiter before clicking New — the create route
+    // redirects to the edit URL as soon as entry.create resolves.
     await page.goto("entries/pages");
+    const navigated = page.waitForURL(/\/entries\/pages\/\d+\/edit/);
     await page.getByTestId("content-list-new-button").click();
+    await navigated;
 
-    await expect(page.getByTestId("post-editor-form")).toBeVisible();
-    await page.getByTestId("post-editor-title-input").fill("About");
-    await page.getByTestId("post-editor-submit").click();
-
-    // On successful create the editor navigates from
-    // `/entries/pages/create` to `/entries/pages/<id>/edit` — wait
-    // for that URL change before navigating away so we don't race
-    // the create RPC.
-    await page.waitForURL(/\/entries\/pages\/\d+\/edit/);
+    await expect(page.getByTestId("plumix-editor-title-input")).toBeVisible();
+    const updated = page.waitForResponse(
+      (r) => r.url().endsWith("/entry/update") && r.status() === 200,
+    );
+    await page.getByTestId("plumix-editor-title-input").fill("About");
+    await updated;
 
     await page.goto("entries/pages");
-    const rows = page.locator(
-      "[data-testid^='content-list-row-']:not([data-testid*='-actions-']):not([data-testid*='-trash-'])",
-    );
+    const rows = page.locator(CONTENT_ROWS);
     await expect(rows).toHaveCount(1);
     await expect(rows.first()).toContainText("About");
   });
 
+  // Skipped pending an entry-parent surface in the v2 editor (#845).
+  // The rearchitecture (#470) dropped the v1 form's parent select and
+  // the Puck editor exposes no document-settings panel yet — `parentId`
+  // never reaches `entry.update` from the UI. This test is the canary
+  // that unskips when the parent picker lands.
   test.skip("set a parent on a second page → hierarchy persists across reload", async ({
     page,
   }) => {
@@ -55,30 +58,28 @@ test.describe.serial("@plumix/plugin-pages — worker-driven happy path", () => 
     // intended parent — the parent picker exposes every existing
     // page (minus self/descendants) as an option.
     await page.goto("entries/pages/create");
-    await expect(page.getByTestId("post-editor-form")).toBeVisible();
-    await page.getByTestId("post-editor-title-input").fill("Team");
-    await page.getByTestId("post-editor-submit").click();
     await page.waitForURL(/\/entries\/pages\/\d+\/edit/);
-
-    // The hierarchical parent select is only rendered when the
-    // entry-type's `isHierarchical: true`. Setting it to the
-    // pre-existing "About" page should persist after a reload.
-    await page
-      .getByTestId("post-editor-parent-select")
-      .selectOption({ label: "About" });
-    await page.getByTestId("post-editor-submit").click();
-
-    await page.waitForResponse(
+    await expect(page.getByTestId("plumix-editor-title-input")).toBeVisible();
+    const titleSaved = page.waitForResponse(
       (r) => r.url().endsWith("/entry/update") && r.status() === 200,
     );
+    await page.getByTestId("plumix-editor-title-input").fill("Team");
+    await titleSaved;
+
+    const parentSaved = page.waitForResponse(
+      (r) => r.url().endsWith("/entry/update") && r.status() === 200,
+    );
+    await page
+      .getByTestId("entry-parent-select")
+      .selectOption({ label: "About" });
+    await parentSaved;
 
     await page.reload();
-    await expect(page.getByTestId("post-editor-form")).toBeVisible();
     // `option:checked` reads the currently-selected option's text
     // — avoids pulling DOM lib into the plugin's typecheck for one
     // line of `HTMLSelectElement`.
     await expect(
-      page.getByTestId("post-editor-parent-select").locator("option:checked"),
+      page.getByTestId("entry-parent-select").locator("option:checked"),
     ).toHaveText("About");
   });
 });


### PR DESCRIPTION
Two of the four skipped worker-driven plugin tests come back to life against the v2 editor; the other two get accurate skip reasons pointing at the product gaps that block them.

**Blog: publish-persistence is tested again**

The only real-stack publish test rewritten for the v2 surface: click the editor's Publish button, take the header flipping into the three-button draft-mode chrome as the publish receipt, reload, then prove persistence by fetching the row back under `?status=published` from real D1. (The per-user autosave row can't pollute that count — publishing a draft writes the live row in place, and autosave rows live under a reserved type that `entry.list` filters out.)

**Pages: create-draft flow restored**

Mirrors blog's working v2 create flow — New → redirect-on-mount create route → Puck editor → title autosave confirmed by response → row in the list.

**The two remaining skips are product gaps, not test gaps**

- pages hierarchy: the editor has no entry-parent surface — `parentId` never reaches `entry.update` from any UI (Refs #845)
- menu locations: `recordLocation()` has zero production callers since `theme.setup` was removed in #500 (Refs #846)

Both skipped bodies are updated to the expected future surface so they fail loudly (not error) the day the features land.

Refs #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)