### PR TITLE
feat(plugin-menu): declare menu locations via plugin config

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -161,6 +161,7 @@ const config: KnipConfig = {
     // so knip auto-discovery doesn't miss the subdir-index layout.
     "packages/plugins/menu": {
       entry: [
+        "src/index.ts",
         "src/admin/index.tsx",
         "src/server/index.ts",
         "e2e/globalSetup.ts",

--- a/packages/plugins/menu/e2e/menu.spec.ts
+++ b/packages/plugins/menu/e2e/menu.spec.ts
@@ -97,12 +97,7 @@ test.describe.serial("@plumix/plugin-menu — worker-driven happy path", () => {
     await expect(reloadedRows.last()).toContainText("Home");
   });
 
-  // Skipped pending a new menu-location registration path (#846).
-  // theme.setup was removed in the theming-foundation slice (#493 /
-  // PR #500), which means the playground no longer registers a
-  // "primary" location; this test is the canary that unskips when the
-  // registration path lands.
-  test.skip("locations tab — assign the menu to Primary Nav, reload, assignment persists", async ({
+  test("locations tab — assign the menu to Primary Nav, reload, assignment persists", async ({
     page,
   }) => {
     await page.goto("pages/menus");

--- a/packages/plugins/menu/playground/plumix.config.ts
+++ b/packages/plugins/menu/playground/plumix.config.ts
@@ -34,6 +34,15 @@ export default plumix({
       origin,
     },
   }),
-  plugins: [menu],
+  // Locations are nav slots the theme renders; the e2e locations-tab
+  // canary assigns the Primary menu into "primary".
+  plugins: [
+    menu({
+      locations: {
+        primary: { label: "Primary Nav" },
+        footer: { label: "Footer" },
+      },
+    }),
+  ],
   theme: defineTheme({ templates: { index: () => null } }),
 });

--- a/packages/plugins/menu/src/hooks.test.ts
+++ b/packages/plugins/menu/src/hooks.test.ts
@@ -55,7 +55,7 @@ async function setup(): Promise<Bundle> {
   const hooks = new HookRegistry();
   const registry = createPluginRegistry();
   registerCoreLookupAdapters(registry);
-  await installPlugins({ hooks, plugins: [menu], registry });
+  await installPlugins({ hooks, plugins: [menu()], registry });
   const user = await adminUser
     .transient({ db })
     .create({ email: "hooks@example.test" });

--- a/packages/plugins/menu/src/index.test.ts
+++ b/packages/plugins/menu/src/index.test.ts
@@ -1,15 +1,66 @@
 import { HookRegistry, installPlugins } from "plumix/plugin";
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 
 import { menu } from "./index.js";
+import {
+  clearRegisteredLocations,
+  getRegisteredLocations,
+} from "./server/locations.js";
 
 const ADMIN_ENTRY_PATH = "node_modules/@plumix/plugin-menu/dist/admin/index.js";
 
 async function install() {
-  return installPlugins({ hooks: new HookRegistry(), plugins: [menu] });
+  return installPlugins({ hooks: new HookRegistry(), plugins: [menu()] });
 }
 
 describe("@plumix/plugin-menu", () => {
+  beforeEach(() => {
+    clearRegisteredLocations();
+  });
+
+  test("registers configured menu locations at setup", async () => {
+    await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [
+        menu({
+          locations: {
+            primary: { label: "Primary Nav" },
+            footer: { label: "Footer", description: "Below the fold" },
+          },
+        }),
+      ],
+    });
+    expect(getRegisteredLocations().get("primary")).toEqual({
+      id: "primary",
+      label: "Primary Nav",
+      description: undefined,
+    });
+    expect(getRegisteredLocations().get("footer")?.description).toBe(
+      "Below the fold",
+    );
+  });
+
+  test("each build owns the registry: a rebuild drops removed locations", async () => {
+    // Dev rebuilds re-run setup in the same module lifetime — the
+    // registry must reflect the latest config, not an additive union.
+    await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [
+        menu({
+          locations: {
+            primary: { label: "Primary Nav" },
+            footer: { label: "Footer" },
+          },
+        }),
+      ],
+    });
+    await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [menu({ locations: { primary: { label: "Primary Nav" } } })],
+    });
+    expect([...getRegisteredLocations().keys()]).toEqual(["primary"]);
+  });
+
   test("registers the menu_item entry type as private hierarchical", async () => {
     const { registry } = await install();
     const menuItem = registry.entryTypes.get("menu_item");
@@ -59,6 +110,6 @@ describe("@plumix/plugin-menu", () => {
   });
 
   test("declares the adminEntry chunk path the plumix vite plugin loads", () => {
-    expect(menu.adminEntry).toBe(ADMIN_ENTRY_PATH);
+    expect(menu().adminEntry).toBe(ADMIN_ENTRY_PATH);
   });
 });

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -1,10 +1,22 @@
 import type { Label } from "plumix/i18n";
-import type { EntryTypeLabels, TermTaxonomyLabels } from "plumix/plugin";
+import type {
+  EntryTypeLabels,
+  PluginDescriptor,
+  TermTaxonomyLabels,
+} from "plumix/plugin";
 import { definePlugin } from "plumix/plugin";
 
-import type { ResolvedMenu, ResolvedMenuItem } from "./server/types.js";
+import type {
+  MenuLocationOptions,
+  ResolvedMenu,
+  ResolvedMenuItem,
+} from "./server/types.js";
 import { createMenuRouter } from "./rpc.js";
 import { getMenuByName } from "./server/getMenuByName.js";
+import {
+  clearRegisteredLocations,
+  recordLocation,
+} from "./server/locations.js";
 
 // Plain descriptor literals — plugin source runs server-side without
 // the Babel macro pipeline. Per-entity tables (`MENU_ITEM_LABELS` /
@@ -153,6 +165,16 @@ declare module "plumix/plugin" {
 
 const ADMIN_ENTRY_PATH = "node_modules/@plumix/plugin-menu/dist/admin/index.js";
 
+export interface MenuPluginOptions {
+  /**
+   * Navigation slots the site's theme renders, keyed by location id;
+   * the label shows in the admin Locations tab. Replaces the
+   * registration path lost when `theme.setup` went away — the theme
+   * renders the slots, but the consumer config declares them.
+   */
+  readonly locations?: Readonly<Record<string, MenuLocationOptions>>;
+}
+
 /**
  * `@plumix/plugin-menu` — menus reuse the entries/terms/entry_term substrate
  * rather than adding tables: a menu is a `terms` row (`taxonomy = 'menu'`),
@@ -160,57 +182,69 @@ const ADMIN_ENTRY_PATH = "node_modules/@plumix/plugin-menu/dist/admin/index.js";
  * lives in `entry_term`. Both types are `isPublic: false` so they hide from
  * the generic Entries/Terms admin; the plugin owns its own admin (slices 7+).
  */
-export const menu = definePlugin("menu", {
-  adminEntry: ADMIN_ENTRY_PATH,
-  i18n: {
-    sourceLocale: "en",
-    locales: ["en"],
-    catalogPath: "./locales",
-  },
-  setup: (ctx) => {
-    ctx.registerEntryType("menu_item", {
-      label: MENU_ITEM_LABELS.plural,
-      labels: MENU_ITEM_LABELS,
-      description: "Items belonging to a navigation menu",
-      supports: ["title"],
-      termTaxonomies: ["menu"],
-      isHierarchical: true,
-      isPublic: false,
-      capabilityType: "menu_item",
-    });
+export function menu(
+  options: MenuPluginOptions = {},
+): PluginDescriptor<undefined> {
+  return definePlugin("menu", {
+    adminEntry: ADMIN_ENTRY_PATH,
+    i18n: {
+      sourceLocale: "en",
+      locales: ["en"],
+      catalogPath: "./locales",
+    },
+    setup: (ctx) => {
+      // Reset-then-populate: setup re-runs across dev rebuilds within
+      // one module lifetime, and each build must own the full location
+      // set — a removed config entry has to actually disappear.
+      clearRegisteredLocations();
+      for (const [id, location] of Object.entries(options.locations ?? {})) {
+        recordLocation(id, location);
+      }
 
-    ctx.registerTermTaxonomy("menu", {
-      label: MENU_LABELS.plural,
-      labels: MENU_LABELS,
-      isHierarchical: false,
-      entryTypes: ["menu_item"],
-      isPublic: false,
-    });
+      ctx.registerEntryType("menu_item", {
+        label: MENU_ITEM_LABELS.plural,
+        labels: MENU_ITEM_LABELS,
+        description: "Items belonging to a navigation menu",
+        supports: ["title"],
+        termTaxonomies: ["menu"],
+        isHierarchical: true,
+        isPublic: false,
+        capabilityType: "menu_item",
+      });
 
-    ctx.registerTemplateDep("menus", {
-      load: async (slugs, appCtx) => {
-        const result: Record<string, ResolvedMenu | null> = {};
-        await Promise.all(
-          slugs.map(async (slug) => {
-            result[slug] = await getMenuByName(appCtx, slug);
-          }),
-        );
-        return result;
-      },
-    });
-
-    ctx.registerRpcRouter(createMenuRouter());
-
-    ctx.registerAdminPage({
-      path: "/menus",
-      title: MENU_LABELS.plural,
-      capability: "term:menu:manage",
-      nav: {
-        group: { id: "appearance", label: APPEARANCE_LABEL, priority: 175 },
+      ctx.registerTermTaxonomy("menu", {
         label: MENU_LABELS.plural,
-        order: 10,
-      },
-      component: "MenusShell",
-    });
-  },
-});
+        labels: MENU_LABELS,
+        isHierarchical: false,
+        entryTypes: ["menu_item"],
+        isPublic: false,
+      });
+
+      ctx.registerTemplateDep("menus", {
+        load: async (slugs, appCtx) => {
+          const result: Record<string, ResolvedMenu | null> = {};
+          await Promise.all(
+            slugs.map(async (slug) => {
+              result[slug] = await getMenuByName(appCtx, slug);
+            }),
+          );
+          return result;
+        },
+      });
+
+      ctx.registerRpcRouter(createMenuRouter());
+
+      ctx.registerAdminPage({
+        path: "/menus",
+        title: MENU_LABELS.plural,
+        capability: "term:menu:manage",
+        nav: {
+          group: { id: "appearance", label: APPEARANCE_LABEL, priority: 175 },
+          label: MENU_LABELS.plural,
+          order: 10,
+        },
+        component: "MenusShell",
+      });
+    },
+  });
+}

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -81,7 +81,7 @@ async function buildHarness(role: UserRole = "editor"): Promise<Harness> {
   const hooks = new HookRegistry();
   const registry = createPluginRegistry();
   registerCoreLookupAdapters(registry);
-  await installPlugins({ hooks, plugins: [menu], registry });
+  await installPlugins({ hooks, plugins: [menu()], registry });
 
   const user =
     role === "admin"

--- a/packages/plugins/menu/src/server/getMenuForLocation.test.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.test.ts
@@ -28,7 +28,7 @@ async function buildTestRegistry(): Promise<TestRegistryBundle> {
   const hooks = new HookRegistry();
   const registry = createPluginRegistry();
   registerCoreLookupAdapters(registry);
-  await installPlugins({ hooks, plugins: [menu], registry });
+  await installPlugins({ hooks, plugins: [menu()], registry });
   return { registry, hooks };
 }
 

--- a/packages/plugins/menu/src/server/locations.ts
+++ b/packages/plugins/menu/src/server/locations.ts
@@ -2,12 +2,13 @@ import type { MenuLocationOptions, RegisteredMenuLocation } from "./types.js";
 import { MenuPluginError } from "../errors.js";
 
 /**
- * Module-scoped registry of menu locations populated at boot. The
- * menu RPC's `locations.list` + `locations.assign` procedures read it
- * to validate which location slots a theme has declared. Tests reset
- * state between cases via `clearRegisteredLocations`. A re-registration
- * path for themes (lost when `theme.setup` went away) is a separate
- * follow-up.
+ * Module-scoped registry of menu locations. Populated by the menu
+ * plugin's `setup` from `menu({ locations })`, which resets it first —
+ * setup re-runs within one module lifetime (dev rebuilds boot the app
+ * more than once), so the registry must reflect the latest build's
+ * declarations, not an additive union of every boot. The menu RPC's
+ * `locations.list` + `locations.assign` procedures read it to validate
+ * which location slots the consumer has declared.
  */
 const locations = new Map<string, RegisteredMenuLocation>();
 
@@ -47,7 +48,12 @@ export function getRegisteredLocations(): ReadonlyMap<
   return locations;
 }
 
-/** Test-only: reset state between cases. Production never calls this. */
+/**
+ * Reset the registry. The plugin's `setup` calls this before
+ * re-populating so each build declaratively owns the full location
+ * set — a removed config entry actually disappears. Tests use it to
+ * isolate cases.
+ */
 export function clearRegisteredLocations(): void {
   locations.clear();
 }

--- a/packages/plugins/menu/src/template-deps.test.tsx
+++ b/packages/plugins/menu/src/template-deps.test.tsx
@@ -42,7 +42,7 @@ async function bundle(): Promise<TestBundle> {
       definePlugin("menu-host", (ctx) => {
         ctx.registerEntryType("post", { label: "Posts", isPublic: true });
       }),
-      menu,
+      menu(),
     ],
     registry,
   });
@@ -167,7 +167,7 @@ describe("@plumix/plugin-menu — end-to-end SSR", () => {
       },
     });
     const h = await createDispatcherHarness({
-      plugins: [blogPlugin, menu],
+      plugins: [blogPlugin, menu()],
       theme,
     });
     const author = await h.seedUser("admin");


### PR DESCRIPTION
Restores the menu-location registration path lost when `theme.setup` was removed in the theming reshape (#500). Since then `recordLocation` had zero production callers — the admin Locations tab, the `locations.list`/`locations.assign` RPCs, and `getMenuForLocation` were all dead code for consumers.

**The menu export becomes callable**, mirroring the `auditLog()`/`media()` options pattern:

```ts
plugins: [
  menu({
    locations: {
      primary: { label: "Primary Nav" },
      footer: { label: "Footer" },
    },
  }),
],
```

Locations are nav slots the theme renders, but the consumer config declares them — no core changes needed.

**Reset-then-populate registry semantics**

Setup clears the module-scoped registry before re-populating, so each build declaratively owns the full location set: dev rebuilds re-run setup within one module lifetime, and a location removed from config actually disappears instead of leaking from the previous boot (senpai's HIGH finding — the first cut used an additive idempotency check that would have kept stale slots assignable). The duplicate-id throw remains for genuine same-build double-claims.

Breaking pre-1.0: consumers must call `menu()`. All in-repo call sites updated (4 test files + playground); examples and the scaffolder never shipped menu, verified clean.

**This unskips the last skipped test in the entire e2e estate** — the menu locations-tab canary now assigns Primary Nav, reloads, and reads the assignment back from the real worker. Unit pins: configured locations register; a rebuild drops removed locations. 238/238 menu tests, knip/lint/typecheck/format/i18n green.

Fixes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)