### PR TITLE
fix(core): encode passkey public keys with fixed-width SEC1 coordinates

### DIFF
--- a/packages/core/src/auth/passkey/register.test.ts
+++ b/packages/core/src/auth/passkey/register.test.ts
@@ -4,6 +4,7 @@ import { users } from "../../db/schema/users.js";
 import {
   buildAttestation,
   generatePasskeyKeyPair,
+  leadingZeroYKeyPair,
   randomCredentialId,
 } from "../../test/fixtures/webauthn.js";
 import { createTestDb } from "../../test/harness.js";
@@ -57,6 +58,38 @@ describe("finishRegistration (positive ceremony with ES256)", () => {
 
     expect(verified.publicKey).toEqual(keyPair.publicKeySec1);
     expect(verified.signatureCounter).toBe(0);
+  });
+
+  test("a Y coordinate with a leading zero byte still round-trips to a well-formed SEC1 key", async () => {
+    // ~1/256 of P-256 keys; a bigint round-trip drops the 0x00 lead and
+    // a fixed-offset encoder then left-shifts Y, silently storing a
+    // corrupted key that bricks the credential at every future login.
+    const db = await createTestDb();
+    const userId = await seedUserId(db);
+    const { challenge } = await issueChallenge(db, 60_000, userId);
+    const keyPair = leadingZeroYKeyPair();
+    const credentialId = randomCredentialId();
+
+    const att = buildAttestation({
+      keyPair,
+      rpId: config.rpId,
+      origin: config.origin,
+      challenge,
+      credentialId,
+    });
+
+    const verified = await finishRegistration(db, config, {
+      id: att.credentialIdBase64Url,
+      rawId: att.credentialIdBase64Url,
+      type: "public-key",
+      response: {
+        clientDataJSON: att.clientDataJSON,
+        attestationObject: att.attestationObject,
+      },
+    });
+
+    expect(verified.publicKey).toEqual(keyPair.publicKeySec1);
+    expect(verified.publicKey[33]).toBe(0);
   });
 });
 

--- a/packages/core/src/auth/passkey/register.ts
+++ b/packages/core/src/auth/passkey/register.ts
@@ -1,4 +1,3 @@
-import { ECDSAPublicKey, p256 } from "@oslojs/crypto/ecdsa";
 import {
   decodeBase64urlIgnorePadding,
   encodeBase64urlNoPadding,
@@ -164,11 +163,7 @@ export async function finishRegistration(
       reason: "Expected P-256 curve",
     });
   }
-  const publicKey = new ECDSAPublicKey(
-    p256,
-    cose.x,
-    cose.y,
-  ).encodeSEC1Uncompressed();
+  const publicKey = encodeSec1Uncompressed(cose.x, cose.y);
 
   return {
     credentialId: encodeBase64urlNoPadding(credential.id),
@@ -233,4 +228,30 @@ export async function persistCredential(
   // eslint-disable-next-line no-restricted-syntax -- defensive driver-regression guard; migrate alongside auth errors in PR 2 (#234)
   if (!row) throw new Error("persistCredential: insert returned no row");
   return row;
+}
+
+// COSE delivers x/y as fixed 32-byte wire values, but oslojs's parser
+// hands them back as bigints, and its `encodeSEC1Uncompressed` places
+// a minimal-length Y at a fixed offset — a Y with a leading zero byte
+// (~1/256 of P-256 keys) comes out left-shifted, silently storing a
+// corrupted key that fails every future assertion. Encode with fixed
+// 32-byte big-endian slots instead (RFC 5480 §2.2).
+function encodeSec1Uncompressed(x: bigint, y: bigint): Uint8Array {
+  const out = new Uint8Array(65);
+  out[0] = 0x04;
+  writeFixedWidthBE(out, x, 1);
+  writeFixedWidthBE(out, y, 33);
+  return out;
+}
+
+function writeFixedWidthBE(
+  out: Uint8Array,
+  value: bigint,
+  offset: number,
+): void {
+  let v = value;
+  for (let i = 31; i >= 0; i--) {
+    out[offset + i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
 }

--- a/packages/core/src/test/fixtures/webauthn.ts
+++ b/packages/core/src/test/fixtures/webauthn.ts
@@ -7,8 +7,12 @@
 // Not part of the public surface; tests only. node:crypto is fine here
 // (tests run on Node).
 
-import { createHash, generateKeyPairSync, sign } from "node:crypto";
-import type { createPrivateKey } from "node:crypto";
+import {
+  createHash,
+  createPrivateKey,
+  generateKeyPairSync,
+  sign,
+} from "node:crypto";
 import { encodeBase64urlNoPadding } from "@oslojs/encoding";
 
 const ATTESTED_FLAG = 0x40;
@@ -35,13 +39,40 @@ export function generatePasskeyKeyPair(): PasskeyKeyPair {
   const { privateKey, publicKey } = generateKeyPairSync("ec", {
     namedCurve: "P-256",
   });
-  const jwk = publicKey.export({ format: "jwk" });
+  return keyPairFromJwk(privateKey, publicKey.export({ format: "jwk" }));
+}
+
+// Pinned P-256 key whose Y coordinate starts with 0x00 — the ~1/256
+// case where a bigint round-trip silently drops the leading byte.
+// Deterministic regression anchor for SEC1 fixed-width encoding; the
+// random generator above only hits it probabilistically.
+const LEADING_ZERO_Y_JWK = {
+  kty: "EC",
+  crv: "P-256",
+  x: "IjI5tWqb-qMp8P20g33a1x7ztHInOfhfDz1eSkBBYcM",
+  y: "ABjCsQ39-fwI1G2ruGlDlWf75p_c6i3IFAijztON-cw",
+  d: "QMyn7kVOVwyqbLPPNV6XEUnRSIKrRkUW3P4-9DUUuBo",
+};
+
+export function leadingZeroYKeyPair(): PasskeyKeyPair {
+  const privateKey = createPrivateKey({
+    key: LEADING_ZERO_Y_JWK,
+    format: "jwk",
+  });
+  return keyPairFromJwk(privateKey, LEADING_ZERO_Y_JWK);
+}
+
+function keyPairFromJwk(
+  privateKey: PasskeyKeyPair["privateKey"],
+  jwk: { x?: string; y?: string },
+): PasskeyKeyPair {
   if (typeof jwk.x !== "string" || typeof jwk.y !== "string") {
     throw new Error("EC keypair export missing x/y");
   }
-  // JWK drops leading zero bytes from EC coordinates (~1/256 probability
-  // per coord for P-256). Left-pad back to 32 bytes so publicKeySec1 is
-  // always a well-formed 65-byte uncompressed point.
+  // Left-pad to 32 bytes so publicKeySec1 is always a well-formed
+  // 65-byte uncompressed point even for JWK
+  // sources that trim leading zero bytes (Node keeps them; not all
+  // encoders do).
   const x = padLeft(base64urlToBytes(jwk.x), 32);
   const y = padLeft(base64urlToBytes(jwk.y), 32);
   return {


### PR DESCRIPTION
The "flaky" ES256 test in `register.test.ts` wasn't flake — it was a real bug rolling a 1/256 die.

**The bug** — `@oslojs/crypto@1.0.1` (latest) `encodeSEC1Uncompressed()` right-aligns X into its 32-byte slot but writes Y at a **fixed offset**:

```js
bytes.set(xBytes, 1 + size - xBytes.byteLength);  // X right-aligned ✓
bytes.set(yBytes, 1 + size);                      // Y left-aligned ✗
```

Any P-256 key whose Y has a leading zero byte (~1/256) comes out left-shifted. `finishRegistration` stored that corrupted key, and since the shift is unrecoverable, **every later assertion against the credential fails — a permanently bricked passkey**. The authenticator's COSE wire value was a valid fixed 32-byte Y; oslojs's parser converts to bigint, which is where the width is lost.

**The fix** — encode locally with fixed 32-byte big-endian slots for both coordinates (RFC 5480 §2.2), dropping the `ECDSAPublicKey` usage (its constructor performs no validation — all curve/type/algorithm checks happen upstream in the ceremony, which is unchanged).

**Deterministic regression** — a mined P-256 key whose Y starts `0x00` is pinned in the test fixture (`leadingZeroYKeyPair()`); the regression test runs the full registration ceremony and asserts the stored key is the well-formed 65-byte point with `byte[33] === 0`. Verified RED on the old encoder, GREEN on the new one. The throwaway private scalar in a test fixture grants nothing (origin-bound, never a real credential).

No migration needed: pre-1.0, no production data; an already-corrupted stored key is unrecoverable by construction.

Security-reviewed against the Copenhagen Book ceremony (order unchanged) — no high/medium findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)