### PR TITLE
refactor(core): move admin-bar strings into po catalogs

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -159,6 +159,12 @@ const config: KnipConfig = {
     // imports knip can follow. The `./server` subpath is consumer-
     // facing (themes import server-only helpers from there); listed
     // so knip auto-discovery doesn't miss the subdir-index layout.
+    // Core's lingui config + compiled catalogs are loaded by the i18n
+    // pipeline and the self-referencing `./locales/*` subpath — knip
+    // can't see either consumer.
+    "packages/core": {
+      entry: ["lingui.config.ts", "locales/*.mjs"],
+    },
     "packages/plugins/menu": {
       entry: [
         "src/index.ts",

--- a/packages/core/lingui.config.ts
+++ b/packages/core/lingui.config.ts
@@ -1,0 +1,3 @@
+import { defineLinguiConfig } from "@plumix/lingui-config";
+
+export default defineLinguiConfig();

--- a/packages/core/locales/ar.d.mts
+++ b/packages/core/locales/ar.d.mts
@@ -1,0 +1,1 @@
+export declare const messages: Record<string, string | readonly string[]>;

--- a/packages/core/locales/ar.mjs
+++ b/packages/core/locales/ar.mjs
@@ -1,0 +1,3 @@
+/*eslint-disable*/ export const messages = JSON.parse(
+  '{"core.adminBar.account":["الحساب"],"core.adminBar.edit":["تعديل"],"core.adminBar.navAria":["الإدارة"],"core.adminBar.newGroup":["+ جديد"],"core.adminBar.newGroupAria":["إنشاء جديد"],"core.adminBar.siteFallback":["الموقع"]}',
+);

--- a/packages/core/locales/ar.po
+++ b/packages/core/locales/ar.po
@@ -1,0 +1,39 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-07\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (admin bar renders server-side, no Babel pass)\n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.siteFallback"
+msgstr "الموقع"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroup"
+msgstr "+ جديد"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroupAria"
+msgstr "إنشاء جديد"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.edit"
+msgstr "تعديل"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.account"
+msgstr "الحساب"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.navAria"
+msgstr "الإدارة"

--- a/packages/core/locales/de.d.mts
+++ b/packages/core/locales/de.d.mts
@@ -1,0 +1,1 @@
+export declare const messages: Record<string, string | readonly string[]>;

--- a/packages/core/locales/de.mjs
+++ b/packages/core/locales/de.mjs
@@ -1,0 +1,3 @@
+/*eslint-disable*/ export const messages = JSON.parse(
+  '{"core.adminBar.account":["Konto"],"core.adminBar.edit":["Bearbeiten"],"core.adminBar.navAria":["Administration"],"core.adminBar.newGroup":["+ Neu"],"core.adminBar.newGroupAria":["Neu erstellen"],"core.adminBar.siteFallback":["Website"]}',
+);

--- a/packages/core/locales/de.po
+++ b/packages/core/locales/de.po
@@ -1,0 +1,39 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-07\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (admin bar renders server-side, no Babel pass)\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.siteFallback"
+msgstr "Website"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroup"
+msgstr "+ Neu"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroupAria"
+msgstr "Neu erstellen"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.edit"
+msgstr "Bearbeiten"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.account"
+msgstr "Konto"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.navAria"
+msgstr "Administration"

--- a/packages/core/locales/en.d.mts
+++ b/packages/core/locales/en.d.mts
@@ -1,0 +1,1 @@
+export declare const messages: Record<string, string | readonly string[]>;

--- a/packages/core/locales/en.mjs
+++ b/packages/core/locales/en.mjs
@@ -1,0 +1,3 @@
+/*eslint-disable*/ export const messages = JSON.parse(
+  '{"core.adminBar.account":["Account"],"core.adminBar.edit":["Edit"],"core.adminBar.navAria":["Admin"],"core.adminBar.newGroup":["+ New"],"core.adminBar.newGroupAria":["Create new"],"core.adminBar.siteFallback":["Site"]}',
+);

--- a/packages/core/locales/en.po
+++ b/packages/core/locales/en.po
@@ -1,0 +1,39 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-07\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (admin bar renders server-side, no Babel pass)\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.siteFallback"
+msgstr "Site"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroup"
+msgstr "+ New"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroupAria"
+msgstr "Create new"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.edit"
+msgstr "Edit"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.account"
+msgstr "Account"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.navAria"
+msgstr "Admin"

--- a/packages/core/locales/uk.d.mts
+++ b/packages/core/locales/uk.d.mts
@@ -1,0 +1,1 @@
+export declare const messages: Record<string, string | readonly string[]>;

--- a/packages/core/locales/uk.mjs
+++ b/packages/core/locales/uk.mjs
@@ -1,0 +1,3 @@
+/*eslint-disable*/ export const messages = JSON.parse(
+  '{"core.adminBar.account":["Обліковий запис"],"core.adminBar.edit":["Редагувати"],"core.adminBar.navAria":["Адміністрування"],"core.adminBar.newGroup":["+ Новий"],"core.adminBar.newGroupAria":["Створити"],"core.adminBar.siteFallback":["Сайт"]}',
+);

--- a/packages/core/locales/uk.po
+++ b/packages/core/locales/uk.po
@@ -1,0 +1,39 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-07\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (admin bar renders server-side, no Babel pass)\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.siteFallback"
+msgstr "Сайт"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroup"
+msgstr "+ Новий"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroupAria"
+msgstr "Створити"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.edit"
+msgstr "Редагувати"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.account"
+msgstr "Обліковий запис"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.navAria"
+msgstr "Адміністрування"

--- a/packages/core/locales/zh-CN.d.mts
+++ b/packages/core/locales/zh-CN.d.mts
@@ -1,0 +1,1 @@
+export declare const messages: Record<string, string | readonly string[]>;

--- a/packages/core/locales/zh-CN.mjs
+++ b/packages/core/locales/zh-CN.mjs
@@ -1,0 +1,3 @@
+/*eslint-disable*/ export const messages = JSON.parse(
+  '{"core.adminBar.account":["账户"],"core.adminBar.edit":["编辑"],"core.adminBar.navAria":["管理"],"core.adminBar.newGroup":["+ 新建"],"core.adminBar.newGroupAria":["新建内容"],"core.adminBar.siteFallback":["站点"]}',
+);

--- a/packages/core/locales/zh-CN.po
+++ b/packages/core/locales/zh-CN.po
@@ -1,0 +1,39 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-07\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (admin bar renders server-side, no Babel pass)\n"
+"Language: zh-CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.siteFallback"
+msgstr "站点"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroup"
+msgstr "+ 新建"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.newGroupAria"
+msgstr "新建内容"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.edit"
+msgstr "编辑"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.account"
+msgstr "账户"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.navAria"
+msgstr "管理"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/i18n/index.d.ts",
       "default": "./dist/i18n/index.js"
     },
+    "./locales/*": {
+      "types": "./locales/*.d.mts",
+      "default": "./locales/*.mjs"
+    },
     "./slugify": {
       "types": "./dist/slugify.d.ts",
       "default": "./dist/slugify.js"
@@ -51,6 +55,8 @@
     "clean": "git clean -xdf .cache .drizzle .turbo dist node_modules",
     "db:generate": "drizzle-kit generate",
     "format": "prettier --check . --ignore-path ../../.gitignore",
+    "i18n:check": "node ../plumix/bin/plumix.mjs i18n verify --src src/admin-bar",
+    "i18n:compile": "lingui compile --namespace es",
     "lint": "eslint",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
@@ -83,8 +89,10 @@
     }
   },
   "devDependencies": {
+    "@lingui/cli": "catalog:lingui",
     "@playwright/test": "catalog:",
     "@plumix/eslint-config": "workspace:*",
+    "@plumix/lingui-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
     "@plumix/vitest-config": "workspace:*",

--- a/packages/core/src/admin-bar/i18n.test.ts
+++ b/packages/core/src/admin-bar/i18n.test.ts
@@ -1,0 +1,35 @@
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+import { PLUMIX_LOCALES } from "@plumix/lingui-config";
+
+import { barMessages, resolveBarLocale } from "./i18n.js";
+
+const LOCALES_DIR = fileURLToPath(new URL("../../locales", import.meta.url));
+
+describe("admin-bar catalogs", () => {
+  test("the bar's locale set stays in lockstep with PLUMIX_LOCALES", () => {
+    // Adding a locale to the shared lingui config without shipping a
+    // bar catalog would silently fall back to English — fail loud here.
+    const poLocales = readdirSync(LOCALES_DIR)
+      .filter((f) => f.endsWith(".po"))
+      .map((f) => f.replace(/\.po$/, ""))
+      .sort();
+    expect(poLocales).toEqual([...PLUMIX_LOCALES].sort());
+    for (const locale of PLUMIX_LOCALES) {
+      expect(resolveBarLocale({ meta: { locale } })).toBe(locale);
+    }
+  });
+
+  test("every locale resolves translated strings, not the English fallback", () => {
+    for (const locale of ["de", "uk", "ar", "zh-CN"] as const) {
+      const strings = barMessages(locale);
+      // `edit` differs from English in every shipped locale — if the
+      // compiled catalog went missing the fallback would leak through.
+      expect(strings.edit).not.toBe("Edit");
+      expect(strings.navAria.length).toBeGreaterThan(0);
+    }
+    expect(barMessages("en").edit).toBe("Edit");
+  });
+});

--- a/packages/core/src/admin-bar/i18n.ts
+++ b/packages/core/src/admin-bar/i18n.ts
@@ -1,7 +1,39 @@
-// Inline catalog — 9 strings, SSR-only, fixed locale set; not worth a
-// Lingui pipeline. Wider set ships when `pnpm i18n:check` moves into core.
+// Admin-bar strings live in `locales/*.po` like every other plumix
+// surface — `plumix i18n verify` gates the descriptor↔catalog drift
+// and translators never have to find a second system. Catalogs are
+// compiled to static modules (worker-safe, no fs) and imported via
+// the package's own `./locales/*` subpath; the SSR render does a
+// direct per-request lookup, never a shared-singleton `activate()`.
+
+import { messages as arMessages } from "@plumix/core/locales/ar";
+import { messages as deMessages } from "@plumix/core/locales/de";
+import { messages as enMessages } from "@plumix/core/locales/en";
+import { messages as ukMessages } from "@plumix/core/locales/uk";
+import { messages as zhCnMessages } from "@plumix/core/locales/zh-CN";
 
 export type BarLocale = "en" | "de" | "uk" | "ar" | "zh-CN";
+
+type CompiledCatalog = Record<string, string | readonly string[]>;
+
+const CATALOGS: Readonly<Record<BarLocale, CompiledCatalog>> = {
+  en: enMessages,
+  de: deMessages,
+  uk: ukMessages,
+  ar: arMessages,
+  "zh-CN": zhCnMessages,
+};
+
+// Source descriptors — `plumix i18n verify` matches these against the
+// po catalogs; `message` is the English source and the runtime
+// fallback for locales missing an entry.
+const M = {
+  siteFallback: { id: "core.adminBar.siteFallback", message: "Site" },
+  newGroup: { id: "core.adminBar.newGroup", message: "+ New" },
+  newGroupAria: { id: "core.adminBar.newGroupAria", message: "Create new" },
+  edit: { id: "core.adminBar.edit", message: "Edit" },
+  account: { id: "core.adminBar.account", message: "Account" },
+  navAria: { id: "core.adminBar.navAria", message: "Admin" },
+} as const;
 
 export interface BarStrings {
   readonly siteFallback: string;
@@ -11,49 +43,6 @@ export interface BarStrings {
   readonly account: string;
   readonly navAria: string;
 }
-
-const CATALOGS: Readonly<Record<BarLocale, BarStrings>> = {
-  en: {
-    siteFallback: "Site",
-    newGroup: "+ New",
-    newGroupAria: "Create new",
-    edit: "Edit",
-    account: "Account",
-    navAria: "Admin",
-  },
-  de: {
-    siteFallback: "Website",
-    newGroup: "+ Neu",
-    newGroupAria: "Neu erstellen",
-    edit: "Bearbeiten",
-    account: "Konto",
-    navAria: "Administration",
-  },
-  uk: {
-    siteFallback: "Сайт",
-    newGroup: "+ Новий",
-    newGroupAria: "Створити",
-    edit: "Редагувати",
-    account: "Обліковий запис",
-    navAria: "Адміністрування",
-  },
-  ar: {
-    siteFallback: "الموقع",
-    newGroup: "+ جديد",
-    newGroupAria: "إنشاء جديد",
-    edit: "تعديل",
-    account: "الحساب",
-    navAria: "الإدارة",
-  },
-  "zh-CN": {
-    siteFallback: "站点",
-    newGroup: "+ 新建",
-    newGroupAria: "新建内容",
-    edit: "编辑",
-    account: "账户",
-    navAria: "管理",
-  },
-};
 
 const KNOWN: ReadonlySet<string> = new Set(Object.keys(CATALOGS));
 
@@ -72,8 +61,30 @@ export function resolveBarLocale(user: {
   return "en";
 }
 
+// Compiled lingui entries are token arrays (a lone string for plain
+// messages); the bar has no ICU placeholders, so anything else falls
+// back to the English source.
+function resolveMessage(
+  catalog: CompiledCatalog,
+  descriptor: { readonly id: string; readonly message: string },
+): string {
+  const value = catalog[descriptor.id];
+  const text = typeof value === "string" ? value : value?.[0];
+  return typeof text === "string" && text.length > 0
+    ? text
+    : descriptor.message;
+}
+
 export function barMessages(locale: BarLocale): BarStrings {
-  return CATALOGS[locale];
+  const catalog = CATALOGS[locale];
+  return {
+    siteFallback: resolveMessage(catalog, M.siteFallback),
+    newGroup: resolveMessage(catalog, M.newGroup),
+    newGroupAria: resolveMessage(catalog, M.newGroupAria),
+    edit: resolveMessage(catalog, M.edit),
+    account: resolveMessage(catalog, M.account),
+    navAria: resolveMessage(catalog, M.navAria),
+  };
 }
 
 export function barDirection(locale: BarLocale): "ltr" | "rtl" {

--- a/packages/plumix/src/cli/commands/i18n.test.ts
+++ b/packages/plumix/src/cli/commands/i18n.test.ts
@@ -246,6 +246,37 @@ describe("i18nCommand", () => {
         i18nCommand.run(ctx({ cwd: dir, argv: ["verify"] })),
       ).rejects.toThrow(/plugin\.x\.dead/);
     });
+
+    test("--src narrows the scan so descriptors outside the dir don't count as drift", async () => {
+      // Mirrors core: the bar's strings live in src/bar and own the
+      // catalog; descriptors elsewhere are translated by another
+      // package and must not be reported as missing.
+      seedPlugin({
+        sourceIds: ["pkg.elsewhere.label"],
+        catalogIds: ["pkg.bar.edit"],
+      });
+      mkdirSync(join(dir, "src", "bar"), { recursive: true });
+      writeFileSync(
+        join(dir, "src", "bar", "i18n.ts"),
+        `const edit = { id: "pkg.bar.edit", message: "Edit" };`,
+      );
+      await expect(
+        i18nCommand.run(
+          ctx({ cwd: dir, argv: ["verify", "--src", "src/bar"] }),
+        ),
+      ).resolves.toBeUndefined();
+      // Unscoped, the same tree drifts in both directions.
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["verify"] })),
+      ).rejects.toThrow(/pkg\.elsewhere\.label/);
+    });
+
+    test("--src without a directory argument throws", async () => {
+      seedPlugin({ sourceIds: [], catalogIds: [] });
+      await expect(
+        i18nCommand.run(ctx({ cwd: dir, argv: ["verify", "--src"] })),
+      ).rejects.toThrow(/missing directory/);
+    });
   });
 
   describe("extract --check", () => {

--- a/packages/plumix/src/cli/commands/i18n.ts
+++ b/packages/plumix/src/cli/commands/i18n.ts
@@ -290,14 +290,21 @@ async function runExtractCheck(
  *  scans source for any `{ id, message }`-shape literal — so descriptors
  *  wrapped in `withContext(...)` or declared as plain manifest fields
  *  count too. Exits non-zero with a sorted drift report when source and
- *  `locales/en.po` disagree. */
+ *  `locales/en.po` disagree.
+ *
+ *  `--src <dir>` (repeatable) narrows the scan to specific directories
+ *  for packages whose catalogs own only part of their source tree —
+ *  core's po carries the SSR admin-bar strings, while its adminNav
+ *  descriptors are translated by admin's catalogs. */
 function runVerify(ctx: CommandContext): void {
   const localesDir = resolve(ctx.cwd, "locales");
-  const srcDir = resolve(ctx.cwd, "src");
+  const srcDirs = verifySrcDirs(ctx);
   const sourceIds = new Set<string>();
-  for (const file of listSourceFiles(srcDir)) {
-    for (const id of sourceDescriptorIds(readFileSync(file, "utf8"))) {
-      sourceIds.add(id);
+  for (const srcDir of srcDirs) {
+    for (const file of listSourceFiles(srcDir)) {
+      for (const id of sourceDescriptorIds(readFileSync(file, "utf8"))) {
+        sourceIds.add(id);
+      }
     }
   }
   const catalogIds: string[] = [];
@@ -310,6 +317,26 @@ function runVerify(ctx: CommandContext): void {
   if (drift.missingInCatalog.length > 0 || drift.orphanedInCatalog.length > 0) {
     throw CliError.i18nVerifyDrift(drift);
   }
+}
+
+function verifySrcDirs(ctx: CommandContext): readonly string[] {
+  const dirs: string[] = [];
+  const rest = ctx.argv.slice(1);
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === "--src") {
+      const dir = rest[i + 1];
+      if (dir === undefined || dir.startsWith("--")) {
+        throw CliError.unknownSubcommand({
+          command: "i18n",
+          subcommand: "verify --src (missing directory)",
+          supported: [...SUPPORTED],
+        });
+      }
+      dirs.push(resolve(ctx.cwd, dir));
+      i++;
+    }
+  }
+  return dirs.length > 0 ? dirs : [resolve(ctx.cwd, "src")];
 }
 
 function listSourceFiles(dir: string): readonly string[] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,12 +529,18 @@ importers:
         specifier: 'catalog:'
         version: 1.4.1(typescript@6.0.3)
     devDependencies:
+      '@lingui/cli':
+        specifier: catalog:lingui
+        version: 6.2.0
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.59.1
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
+      '@plumix/lingui-config':
+        specifier: workspace:*
+        version: link:../../tooling/lingui
       '@plumix/prettier-config':
         specifier: workspace:*
         version: link:../../tooling/prettier
@@ -10223,7 +10229,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@24.12.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.8':
     dependencies:


### PR DESCRIPTION
The admin bar's inline string catalog was a second translation system — invisible to translators and community locale PRs, and guaranteed to drift the moment a locale gets added to `PLUMIX_LOCALES`. Core now speaks the same `.po` workflow as every other package.

**Core gets the standard pipeline**

`lingui.config.ts` via `@plumix/lingui-config`, hand-authored `{ id, message }` descriptors, `locales/*.po` carrying the existing de/uk/ar/zh-CN translations verbatim, and compiled catalogs imported through a self-referencing `./locales/*` subpath — static modules, worker-safe, no `fs`. The SSR render keeps a per-request lookup with the English source as fallback (never a shared-singleton `activate()`, which would race across concurrent worker requests).

**`plumix i18n verify` learns `--src`**

Core's catalogs own only what core renders (the bar); its `core.adminNav.*` descriptors are correctly translated by admin's catalogs. The new repeatable `--src` flag scopes the drift scan (`verify --src src/admin-bar`); unscoped behaviour is unchanged. Core's `i18n:check` invokes the built CLI by path — core can't depend on `plumix` (circular), and the turbo task already declares `dependsOn: plumix#build`.

**The "lost at some point" failure mode is now structural**

A lockstep test pins the bar's locale set and po files against `PLUMIX_LOCALES`, and root `pnpm i18n:check` covers core automatically — adding a locale without a bar catalog fails CI instead of silently shipping English.

Bonus: the first run of `verify` against core enumerated the audit's untranslated-core-strings blocker precisely (37 `type.generic.*` + 5 `validate.*` ids translated nowhere) — filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)