### PR TITLE
test(plugin-blog): verify the SSR admin bar renders localized on the theme front page

### DIFF
--- a/packages/plugins/blog/e2e/blog.spec.ts
+++ b/packages/plugins/blog/e2e/blog.spec.ts
@@ -86,4 +86,28 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
     await page.goto("entries/posts?status=published");
     await expect(page.locator(CONTENT_ROWS)).toHaveCount(1);
   });
+
+  test("the public theme page serves the admin bar in the user's locale", async ({
+    page,
+  }) => {
+    // Switch the seeded admin's locale via the profile card; the
+    // setLocale RPC persists user.meta.locale in real D1.
+    await page.goto("profile");
+    await page.getByTestId("locale-switcher-trigger").click();
+    const saved = page.waitForResponse(
+      (r) => r.url().endsWith("/user/setLocale") && r.status() === 200,
+    );
+    await page.getByTestId("locale-switcher-option-uk").click();
+    await saved;
+
+    // The front page is the theme's SSR surface, not the admin SPA —
+    // the worker resolves the session, reads meta.locale, and renders
+    // the bar chrome from core's compiled po catalogs. "/" resolves to
+    // the public root (baseURL's origin), not the admin base path.
+    await page.goto("/");
+    const bar = page.getByTestId("plumix-admin-bar");
+    await expect(bar).toBeVisible();
+    // The "+ New" group label comes from core's compiled uk catalog.
+    await expect(bar).toContainText("+ Новий");
+  });
 });

--- a/packages/plugins/blog/playground/plumix.config.ts
+++ b/packages/plugins/blog/playground/plumix.config.ts
@@ -35,5 +35,8 @@ export default plumix({
     },
   }),
   plugins: [blog],
+  // Ukrainian alongside the default so the e2e can exercise the
+  // locale switcher + the SSR admin bar translation end-to-end.
+  i18n: { defaultLocale: "en", locales: ["en", "uk"] },
   theme: defineTheme({ templates: { index: () => null } }),
 });


### PR DESCRIPTION
Answers the two questions about #854's admin-bar po migration with a real-worker test rather than assertion: **does it render through the theme on the front end, and does an authenticated user see the translation there?** Yes to both.

The test switches the seeded admin's locale via the profile card (the `setLocale` RPC persists `user.meta.locale` in real D1), then loads the theme's public front page — the worker's SSR surface, not the admin SPA — and asserts the admin bar chrome (`+ Новий`) comes back from core's compiled Ukrainian po catalog. The blog playground gains `uk` alongside `en` so the switcher has a target.

Confirmed along the way (no test needed — already covered): the bar is correctly gated on the session — a cookieless `curl /` returns no bar, and `render-template.test.ts` already pins the anonymous case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)