### PR TITLE
test(plugin-blog): wait for the locale-switch reload before leaving the admin zone

### DIFF
--- a/packages/plugins/blog/e2e/blog.spec.ts
+++ b/packages/plugins/blog/e2e/blog.spec.ts
@@ -103,14 +103,15 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
     page,
   }) => {
     // Switch the seeded admin's locale via the profile card; the
-    // setLocale RPC persists user.meta.locale in real D1.
+    // setLocale RPC persists user.meta.locale in real D1, then the card
+    // does `window.location.reload()` on success. Arm the reload's load
+    // event BEFORE selecting so the later navigation to the public page
+    // can't race that reload into net::ERR_ABORTED (the CI flake).
     await page.goto("profile");
     await page.getByTestId("locale-switcher-trigger").click();
-    const saved = page.waitForResponse(
-      (r) => r.url().endsWith("/user/setLocale") && r.status() === 200,
-    );
+    const reloaded = page.waitForEvent("load");
     await page.getByTestId("locale-switcher-option-uk").click();
-    await saved;
+    await reloaded;
 
     // The front page is the theme's SSR surface, not the admin SPA —
     // the worker resolves the session, reads meta.locale, and renders


### PR DESCRIPTION
Second half of turning main's e2e green (the pages count fix was #858; this is the blog admin-bar test I introduced in #856).

The language card does `onSuccess: () => window.location.reload()` after `setLocale`. The test awaited the setLocale *response* and then navigated to the public page — which collided with the SPA's in-flight reload and aborted (`net::ERR_ABORTED`) under CI timing. Locally the reload-vs-goto order happened to favor us.

Fix: arm the reload's `load` event before selecting the locale, await it, then navigate — so the cross-zone goto runs only after the reload settles. Awaiting the reload also confirms `setLocale` succeeded (the card reloads only on success), so the explicit response wait is dropped.

Verified green locally; the real proof is CI timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
