### PR TITLE
feat: restore and permanently delete trashed entries

### DIFF
--- a/packages/admin/e2e/entries.spec.ts
+++ b/packages/admin/e2e/entries.spec.ts
@@ -289,6 +289,85 @@ test.describe("/entries/$slug (list)", () => {
     await expect(page.getByTestId("content-list-row-2")).toBeVisible();
   });
 
+  test("trash view: Restore row action → entry.restore payload → refetched list drops the row", async ({
+    page,
+  }) => {
+    const TRASHED_ROW = entry({ id: 3, title: "Binned", status: "trash" });
+    const restored: unknown[] = [];
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(restored.length === 0 ? [TRASHED_ROW] : []),
+      }),
+    );
+    await page.route("**/_plumix/rpc/entry/restore", (route) => {
+      const body = route.request().postDataJSON() as { json?: unknown };
+      restored.push(body.json);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody({ ...TRASHED_ROW, status: "draft" }),
+      });
+    });
+
+    await page.goto("entries/posts?status=trash");
+    await page.getByTestId("content-list-row-3").hover();
+    await page.getByTestId("content-list-row-restore-3").click();
+
+    expect(restored[0]).toMatchObject({ id: 3 });
+    await expect(page.getByTestId("content-list-row-3")).toHaveCount(0);
+  });
+
+  test("trash view: Delete permanently → confirm dialog → entry.deletePermanent payload → row gone", async ({
+    page,
+  }) => {
+    const TRASHED_ROW = entry({ id: 3, title: "Binned", status: "trash" });
+    const deleted: unknown[] = [];
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(deleted.length === 0 ? [TRASHED_ROW] : []),
+      }),
+    );
+    await page.route("**/_plumix/rpc/entry/deletePermanent", (route) => {
+      const body = route.request().postDataJSON() as { json?: unknown };
+      deleted.push(body.json);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(TRASHED_ROW),
+      });
+    });
+
+    await page.goto("entries/posts?status=trash");
+    await page.getByTestId("content-list-row-3").hover();
+    await page.getByTestId("content-list-row-delete-3").click();
+    // Permanent delete is unrecoverable — it must go through a confirm
+    // dialog, unlike Restore which fires immediately.
+    await page.getByTestId("content-list-delete-confirm").click();
+
+    expect(deleted[0]).toMatchObject({ id: 3 });
+    await expect(page.getByTestId("content-list-row-3")).toHaveCount(0);
+  });
+
+  test("non-trash rows never surface Restore / Delete permanently", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/list": TWO_ROWS,
+    });
+    await page.goto("entries/posts");
+    await page.getByTestId("content-list-row-1").hover();
+    await expect(page.getByTestId("content-list-row-trash-1")).toBeVisible();
+    await expect(page.getByTestId("content-list-row-restore-1")).toHaveCount(0);
+    await expect(page.getByTestId("content-list-row-delete-1")).toHaveCount(0);
+  });
+
   test("without create/delete caps: New button and Trash row action are absent", async ({
     page,
   }) => {

--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -632,6 +632,11 @@ msgid "userEdit.error.reassignToSelf"
 msgstr "لا يمكن إعادة التعيين للمستخدم الذي يتم حذفه."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.cancel"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/users/create.tsx
 msgid "userInvite.cancel"
 msgstr "إلغاء"
@@ -1209,6 +1214,21 @@ msgid "profile.passkeys.delete.confirm"
 msgstr "حذف passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.deletePermanently"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.confirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.delete.cardTitle"
 msgstr "حذف المصطلح"
@@ -1232,6 +1252,11 @@ msgstr "حذف المستخدم"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.button"
 msgstr "حذف المستخدم"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.deleting"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
@@ -2546,9 +2571,20 @@ msgid "profile.passkeys.rename.label"
 msgstr "إعادة تسمية passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
+msgid "entries.list.row.restore"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
 msgid "editor.revisions.preview.restore"
 msgstr "استعادة هذه المراجعة"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.restoring"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
@@ -3369,6 +3405,11 @@ msgstr "هذا passkey غير قابل للاستخدام على هذا المو
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.notFound"
 msgstr "لم يعد هذا passkey موجوداً. حدّث القائمة."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.description"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -640,6 +640,11 @@ msgid "userEdit.error.reassignToSelf"
 msgstr "Eine Neuzuweisung an den zu löschenden Benutzer ist nicht möglich."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.cancel"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/users/create.tsx
 msgid "userInvite.cancel"
 msgstr "Abbrechen"
@@ -1227,6 +1232,21 @@ msgid "profile.passkeys.delete.confirm"
 msgstr "Passkey löschen"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.deletePermanently"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.confirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.delete.cardTitle"
 msgstr "Begriff löschen"
@@ -1250,6 +1270,11 @@ msgstr "Benutzer löschen"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.button"
 msgstr "Benutzer löschen"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.deleting"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
@@ -2584,9 +2609,20 @@ msgid "profile.passkeys.rename.label"
 msgstr "Passkey umbenennen"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
+msgid "entries.list.row.restore"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
 msgid "editor.revisions.preview.restore"
 msgstr "Diese Revision wiederherstellen"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.restoring"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
@@ -3433,6 +3469,11 @@ msgstr "Dieser Passkey ist auf dieser Website nicht verwendbar."
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.notFound"
 msgstr "Dieser Passkey existiert nicht mehr. Liste aktualisieren."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.description"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -634,6 +634,11 @@ msgid "userEdit.error.reassignToSelf"
 msgstr "Can't reassign to the user being deleted."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.cancel"
+msgstr "Cancel"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/users/create.tsx
 msgid "userInvite.cancel"
 msgstr "Cancel"
@@ -1211,6 +1216,21 @@ msgid "profile.passkeys.delete.confirm"
 msgstr "Delete passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.deletePermanently"
+msgstr "Delete permanently"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.confirm"
+msgstr "Delete permanently"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.title"
+msgstr "Delete permanently?"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.delete.cardTitle"
 msgstr "Delete term"
@@ -1234,6 +1254,11 @@ msgstr "Delete user"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.button"
 msgstr "Delete user"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.deleting"
+msgstr "Deleting…"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
@@ -2552,9 +2577,20 @@ msgid "profile.passkeys.rename.label"
 msgstr "Rename passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
+msgid "entries.list.row.restore"
+msgstr "Restore"
+
+#. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
 msgid "editor.revisions.preview.restore"
 msgstr "Restore this revision"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.restoring"
+msgstr "Restoring…"
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
@@ -3385,6 +3421,12 @@ msgstr "This passkey isn't usable on this site."
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.notFound"
 msgstr "This passkey no longer exists. Refresh the list."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.description"
+msgstr "This permanently deletes the entry and its revisions. It cannot be "
+"undone."
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -639,6 +639,11 @@ msgid "userEdit.error.reassignToSelf"
 msgstr "Не можна переназначити користувачу, якого видаляють."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.cancel"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/users/create.tsx
 msgid "userInvite.cancel"
 msgstr "Скасувати"
@@ -1218,6 +1223,21 @@ msgid "profile.passkeys.delete.confirm"
 msgstr "Видалити passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.deletePermanently"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.confirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.delete.cardTitle"
 msgstr "Видалити термін"
@@ -1241,6 +1261,11 @@ msgstr "Видалити користувача"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.button"
 msgstr "Видалити користувача"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.deleting"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
@@ -2566,9 +2591,20 @@ msgid "profile.passkeys.rename.label"
 msgstr "Перейменувати passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
+msgid "entries.list.row.restore"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
 msgid "editor.revisions.preview.restore"
 msgstr "Відновити цю ревізію"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.restoring"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
@@ -3404,6 +3440,11 @@ msgstr "Цей passkey непридатний для цього сайту."
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.notFound"
 msgstr "Цей passkey більше не існує. Оновіть список."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.description"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -624,6 +624,11 @@ msgid "userEdit.error.reassignToSelf"
 msgstr "无法将内容重新分配给正在删除的用户。"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.cancel"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/users/create.tsx
 msgid "userInvite.cancel"
 msgstr "取消"
@@ -1197,6 +1202,21 @@ msgid "profile.passkeys.delete.confirm"
 msgstr "删除 Passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.deletePermanently"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.confirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.delete.cardTitle"
 msgstr "删除术语"
@@ -1220,6 +1240,11 @@ msgstr "删除用户"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.button"
 msgstr "删除用户"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.deleting"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/users/$id/edit.tsx
@@ -2520,9 +2545,20 @@ msgid "profile.passkeys.rename.label"
 msgstr "重命名 Passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgctxt "action verb"
+msgid "entries.list.row.restore"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
 msgid "editor.revisions.preview.restore"
 msgstr "恢复此修订版本"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.restoring"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx
@@ -3330,6 +3366,11 @@ msgstr "此 Passkey 不能在此站点使用。"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.notFound"
 msgstr "此 Passkey 不再存在。请刷新列表。"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.deleteDialog.description"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -223,6 +223,31 @@ const M = {
     id: "entries.list.trashDialog.confirm",
     message: "Move to trash",
   }),
+  rowRestore: defineMessage({
+    id: "entries.list.row.restore",
+    message: "Restore",
+    context: "action verb",
+  }),
+  rowRestoring: defineMessage({
+    id: "entries.list.row.restoring",
+    message: "Restoring…",
+  }),
+  rowDelete: defineMessage({
+    id: "entries.list.row.deletePermanently",
+    message: "Delete permanently",
+  }),
+  deleteDialogTitle: defineMessage({
+    id: "entries.list.deleteDialog.title",
+    message: "Delete permanently?",
+  }),
+  deleteDialogDeleting: defineMessage({
+    id: "entries.list.deleteDialog.deleting",
+    message: "Deleting…",
+  }),
+  deleteDialogConfirm: defineMessage({
+    id: "entries.list.deleteDialog.confirm",
+    message: "Delete permanently",
+  }),
 } satisfies Record<string, MessageDescriptor>;
 
 const STATUS_FILTER_OPTIONS: {
@@ -244,6 +269,9 @@ function buildColumns({
   canDelete,
   onTrash,
   trashingId,
+  onRestore,
+  restoringId,
+  onDeletePermanent,
   renderLabel,
   editLabel,
   formatDate,
@@ -255,6 +283,9 @@ function buildColumns({
   canDelete: boolean;
   onTrash: (id: number) => void;
   trashingId: number | null;
+  onRestore: (id: number) => void;
+  restoringId: number | null;
+  onDeletePermanent: (id: number) => void;
   renderLabel: (label: MessageDescriptor) => string;
   editLabel: string;
   formatDate: (value: Date, options?: Intl.DateTimeFormatOptions) => string;
@@ -279,6 +310,9 @@ function buildColumns({
           canDelete={canDelete}
           onTrash={onTrash}
           isTrashing={trashingId === row.original.id}
+          onRestore={onRestore}
+          isRestoring={restoringId === row.original.id}
+          onDeletePermanent={onDeletePermanent}
           editLabel={editLabel}
         />
       ),
@@ -487,14 +521,17 @@ function ContentListRoute(): ReactNode {
   const canDelete = hasCap(user.capabilities, deleteCapability);
 
   const queryClient = useQueryClient();
+  const invalidateList = useCallback(
+    () =>
+      queryClient.invalidateQueries({
+        queryKey: orpc.entry.list.key({ input: { type: entryType.name } }),
+      }),
+    [queryClient, entryType.name],
+  );
   const [pendingTrashId, setPendingTrashId] = useState<number | null>(null);
   const trash = useMutation({
     mutationFn: (id: number) => orpc.entry.trash.call({ id }),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: orpc.entry.list.key({ input: { type: entryType.name } }),
-      });
-    },
+    onSuccess: invalidateList,
     // Close the dialog regardless of outcome — keeping it open after a
     // server error left users stuck with no error surface and a still-
     // clickable Confirm button.
@@ -513,6 +550,40 @@ function ContentListRoute(): ReactNode {
       ? trash.variables
       : null;
 
+  // Restore fires immediately — it's recoverable (the row lands back in
+  // Drafts), so a confirm dialog would just add friction.
+  const restore = useMutation({
+    mutationFn: (id: number) => orpc.entry.restore.call({ id }),
+    onSuccess: invalidateList,
+  });
+  const onRestore = useCallback(
+    (id: number): void => {
+      restore.mutate(id);
+    },
+    [restore],
+  );
+  const restoringId =
+    restore.isPending && typeof restore.variables === "number"
+      ? restore.variables
+      : null;
+
+  // Permanent delete is unrecoverable, so it goes through a confirm
+  // dialog like trash does.
+  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
+  const deletePermanent = useMutation({
+    mutationFn: (id: number) => orpc.entry.deletePermanent.call({ id }),
+    onSuccess: invalidateList,
+    onSettled: () => {
+      setPendingDeleteId(null);
+    },
+  });
+  const onDeletePermanent = useCallback(
+    (id: number): void => {
+      setPendingDeleteId(id);
+    },
+    [setPendingDeleteId],
+  );
+
   const editLabel = renderLabel(entryTypeLabel(entryType, "editItem"));
   const { formatDate } = useFormatters();
   const columns = useMemo(
@@ -525,6 +596,9 @@ function ContentListRoute(): ReactNode {
         canDelete,
         onTrash,
         trashingId,
+        onRestore,
+        restoringId,
+        onDeletePermanent,
         renderLabel,
         editLabel,
         formatDate,
@@ -537,6 +611,9 @@ function ContentListRoute(): ReactNode {
       canDelete,
       onTrash,
       trashingId,
+      onRestore,
+      restoringId,
+      onDeletePermanent,
       renderLabel,
       editLabel,
       formatDate,
@@ -665,6 +742,45 @@ function ContentListRoute(): ReactNode {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <AlertDialog
+        open={pendingDeleteId !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDeleteId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {renderLabel(M.deleteDialogTitle)}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <Trans
+                id="entries.list.deleteDialog.description"
+                message="This permanently deletes the entry and its revisions. It cannot be undone."
+              />
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deletePermanent.isPending}>
+              <Trans id="entries.list.deleteDialog.cancel" message="Cancel" />
+            </AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="content-list-delete-confirm"
+              disabled={deletePermanent.isPending}
+              onClick={(e) => {
+                e.preventDefault();
+                if (pendingDeleteId !== null)
+                  deletePermanent.mutate(pendingDeleteId);
+              }}
+            >
+              {deletePermanent.isPending
+                ? renderLabel(M.deleteDialogDeleting)
+                : renderLabel(M.deleteDialogConfirm)}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -749,6 +865,9 @@ function TitleCell({
   canDelete,
   onTrash,
   isTrashing,
+  onRestore,
+  isRestoring,
+  onDeletePermanent,
   editLabel,
 }: {
   entry: Entry;
@@ -756,10 +875,15 @@ function TitleCell({
   canDelete: boolean;
   onTrash: (id: number) => void;
   isTrashing: boolean;
+  onRestore: (id: number) => void;
+  isRestoring: boolean;
+  onDeletePermanent: (id: number) => void;
   editLabel: string;
 }): ReactNode {
   const renderLabel = useLabel();
-  const showTrashAction = canDelete && entry.status !== "trash";
+  const isTrashed = entry.status === "trash";
+  const showTrashAction = canDelete && !isTrashed;
+  const showTrashedActions = canDelete && isTrashed;
   return (
     <div className="flex flex-col gap-0.5">
       <Link
@@ -806,6 +930,39 @@ function TitleCell({
               {isTrashing
                 ? renderLabel(M.rowTrashing)
                 : renderLabel(M.rowTrash)}
+            </button>
+          </>
+        ) : null}
+        {showTrashedActions ? (
+          <>
+            <span aria-hidden className="text-muted-foreground/50">
+              |
+            </span>
+            <button
+              type="button"
+              disabled={isRestoring}
+              onClick={() => {
+                onRestore(entry.id);
+              }}
+              className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+              data-testid={`content-list-row-restore-${String(entry.id)}`}
+            >
+              {isRestoring
+                ? renderLabel(M.rowRestoring)
+                : renderLabel(M.rowRestore)}
+            </button>
+            <span aria-hidden className="text-muted-foreground/50">
+              |
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                onDeletePermanent(entry.id);
+              }}
+              className="text-muted-foreground hover:text-destructive"
+              data-testid={`content-list-row-delete-${String(entry.id)}`}
+            >
+              {renderLabel(M.rowDelete)}
             </button>
           </>
         ) : null}

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -67,6 +67,12 @@ declare module "../hooks/types.js" {
     "rpc:entry.trash:input": (input: { id: number }) => typeof input;
     "rpc:entry.trash:output": (output: Entry) => Entry;
 
+    "rpc:entry.restore:input": (input: { id: number }) => typeof input;
+    "rpc:entry.restore:output": (output: Entry) => Entry;
+
+    "rpc:entry.deletePermanent:input": (input: { id: number }) => typeof input;
+    "rpc:entry.deletePermanent:output": (output: Entry) => Entry;
+
     "rpc:user.list:input": (input: UserListInput) => UserListInput;
     "rpc:user.list:output": (
       output: readonly UserListRow[],
@@ -151,6 +157,8 @@ declare module "../hooks/types.js" {
     "entry:published": (entry: Entry) => void | Promise<void>;
     "entry:updated": (entry: Entry, previous: Entry) => void | Promise<void>;
     "entry:trashed": (entry: Entry) => void | Promise<void>;
+    "entry:restored": (entry: Entry) => void | Promise<void>;
+    "entry:deleted": (entry: Entry) => void | Promise<void>;
     "entry:transition": (
       entry: Entry,
       oldStatus: EntryStatus,
@@ -161,6 +169,8 @@ declare module "../hooks/types.js" {
       previous: Entry,
     ) => void | Promise<void>;
     [K: `entry:${string}:trashed`]: (entry: Entry) => void | Promise<void>;
+    [K: `entry:${string}:restored`]: (entry: Entry) => void | Promise<void>;
+    [K: `entry:${string}:deleted`]: (entry: Entry) => void | Promise<void>;
     [K: `entry:${string}:transition`]: (
       entry: Entry,
       oldStatus: EntryStatus,

--- a/packages/core/src/rpc/procedures/entry/delete-permanent.test.ts
+++ b/packages/core/src/rpc/procedures/entry/delete-permanent.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Entry } from "../../../db/schema/entries.js";
+import { eq, like, or } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("entry.deletePermanent", () => {
+  test("editor permanently deletes a trashed entry: row, revisions, and autosaves are gone and deleted action fires", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const target = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "gone-for-good",
+    });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      type: "revision",
+      slug: `revision:${String(target.id)}:abcdefghijklmnopqrstu`,
+    });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      type: "autosave",
+      slug: `autosave:${String(target.id)}:${String(h.user.id)}`,
+    });
+
+    const onDelete = vi.fn<(post: Entry) => void>();
+    h.hooks.addAction("entry:deleted", onDelete);
+
+    const result = await h.client.entry.deletePermanent({ id: target.id });
+    expect(result.id).toBe(target.id);
+    expect(onDelete).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ id: target.id }),
+    );
+
+    const leftovers = await h.db.query.entries.findMany({
+      where: or(
+        eq(entries.id, target.id),
+        like(entries.slug, `revision:${String(target.id)}:%`),
+        like(entries.slug, `autosave:${String(target.id)}:%`),
+      ),
+    });
+    expect(leftovers).toEqual([]);
+  });
+
+  test("a live entry cannot be permanently deleted — it must be trashed first", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const live = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "still-live",
+    });
+    await expect(
+      h.client.entry.deletePermanent({ id: live.id }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "not_trashed" },
+    });
+  });
+
+  test("contributor cannot permanently delete (no post:delete cap)", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    const target = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "shielded",
+    });
+    await expect(
+      h.client.entry.deletePermanent({ id: target.id }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "entry:post:delete" },
+    });
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/delete-permanent.ts
+++ b/packages/core/src/rpc/procedures/entry/delete-permanent.ts
@@ -1,0 +1,56 @@
+import { and, eq, like, or } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { AUTOSAVE_TYPE, REVISION_TYPE } from "../../../revisions/slug-codec.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { fireEntryDeleted, loadDeletableEntry } from "./lifecycle.js";
+import { entryDeletePermanentInputSchema } from "./schemas.js";
+
+export const deletePermanent = base
+  .use(authenticated)
+  .input(entryDeletePermanentInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:entry.deletePermanent:input",
+      input,
+    );
+
+    const existing = await loadDeletableEntry(context, filtered.id, {
+      notFound: (id) => {
+        throw errors.NOT_FOUND({ data: { kind: "entry", id } });
+      },
+      forbidden: (capability) => {
+        throw errors.FORBIDDEN({ data: { capability } });
+      },
+    });
+
+    if (existing.status !== "trash") {
+      throw errors.CONFLICT({ data: { reason: "not_trashed" } });
+    }
+
+    // Revisions and autosaves are separate entry rows linked to the live
+    // entry only through their encoded slugs, so they need explicit
+    // cleanup — entry_term rows cascade via FK, children re-root via
+    // `ON DELETE SET NULL`.
+    await context.db
+      .delete(entries)
+      .where(
+        or(
+          and(
+            eq(entries.type, REVISION_TYPE),
+            like(entries.slug, `revision:${String(existing.id)}:%`),
+          ),
+          and(
+            eq(entries.type, AUTOSAVE_TYPE),
+            like(entries.slug, `autosave:${String(existing.id)}:%`),
+          ),
+        ),
+      );
+    await context.db.delete(entries).where(eq(entries.id, existing.id));
+
+    await fireEntryDeleted(context, existing);
+    return context.hooks.applyFilter(
+      "rpc:entry.deletePermanent:output",
+      existing,
+    );
+  });

--- a/packages/core/src/rpc/procedures/entry/index.ts
+++ b/packages/core/src/rpc/procedures/entry/index.ts
@@ -1,9 +1,11 @@
 import { list as activityList } from "./activity.js";
 import { create } from "./create.js";
+import { deletePermanent } from "./delete-permanent.js";
 import { discardDraft } from "./discard-draft.js";
 import { get } from "./get.js";
 import { list } from "./list.js";
 import { publish } from "./publish.js";
+import { restore } from "./restore.js";
 import { revisionsRouter } from "./revisions.js";
 import { trash } from "./trash.js";
 import { update } from "./update.js";
@@ -14,6 +16,8 @@ export const entryRouter = {
   create,
   update,
   trash,
+  restore,
+  deletePermanent,
   publish,
   discardDraft,
   revisions: revisionsRouter,

--- a/packages/core/src/rpc/procedures/entry/lifecycle.ts
+++ b/packages/core/src/rpc/procedures/entry/lifecycle.ts
@@ -67,6 +67,22 @@ export async function fireEntryTrashed(
   await ctx.hooks.doAction("entry:trashed", entry);
 }
 
+export async function fireEntryRestored(
+  ctx: AppContext,
+  entry: Entry,
+): Promise<void> {
+  await ctx.hooks.doAction(`entry:${entry.type}:restored`, entry);
+  await ctx.hooks.doAction("entry:restored", entry);
+}
+
+export async function fireEntryDeleted(
+  ctx: AppContext,
+  entry: Entry,
+): Promise<void> {
+  await ctx.hooks.doAction(`entry:${entry.type}:deleted`, entry);
+  await ctx.hooks.doAction("entry:deleted", entry);
+}
+
 // Type-specific event keys on the live entry's type — the autosave row
 // itself carries `type='autosave'`, but subscribers care about the
 // type of the entry being edited (e.g. `entry:post:autosave_saved`),
@@ -114,6 +130,35 @@ export async function fireEntryRevisionRestored(
 
 export function entryCapability(type: string, action: string): string {
   return `entry:${type}:${action}`;
+}
+
+/**
+ * Shared prelude for the trash-lifecycle procedures (trash / restore /
+ * deletePermanent): load-or-404, then gate on the `delete` capability
+ * plus author-or-`edit_any`. Deliberately distinct from the edit gate in
+ * `update.ts` (`(author AND edit_own) OR edit_any`, no `delete` cap) —
+ * don't unify them.
+ */
+export async function loadDeletableEntry(
+  ctx: AuthenticatedAppContext,
+  id: number,
+  guards: {
+    readonly notFound: (id: number) => never;
+    readonly forbidden: (capability: string) => never;
+  },
+): Promise<Entry> {
+  const existing = await ctx.db.query.entries.findFirst({
+    where: eq(entries.id, id),
+  });
+  if (!existing) guards.notFound(id);
+
+  const deleteCapability = entryCapability(existing.type, "delete");
+  if (!ctx.auth.can(deleteCapability)) guards.forbidden(deleteCapability);
+  if (existing.authorId !== ctx.user.id) {
+    const editAnyCapability = entryCapability(existing.type, "edit_any");
+    if (!ctx.auth.can(editAnyCapability)) guards.forbidden(editAnyCapability);
+  }
+  return existing;
 }
 
 // Mirrors the readability rules in `entry.get`: any type-level `read` cap,

--- a/packages/core/src/rpc/procedures/entry/restore.test.ts
+++ b/packages/core/src/rpc/procedures/entry/restore.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Entry } from "../../../db/schema/entries.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("entry.restore", () => {
+  test("editor restores a trashed entry: status returns to draft and restored action fires", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const target = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "binned",
+    });
+
+    const onRestore = vi.fn<(post: Entry) => void>();
+    h.hooks.addAction("entry:restored", onRestore);
+
+    const result = await h.client.entry.restore({ id: target.id });
+    expect(result.status).toBe("draft");
+    expect(onRestore).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ id: target.id, status: "draft" }),
+    );
+  });
+
+  test("contributor cannot restore (no post:delete cap)", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    const target = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "locked",
+    });
+    await expect(
+      h.client.entry.restore({ id: target.id }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "entry:post:delete" },
+    });
+  });
+
+  test("restoring an entry that is not in the trash is rejected", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const live = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "live",
+    });
+    await expect(h.client.entry.restore({ id: live.id })).rejects.toMatchObject(
+      {
+        code: "CONFLICT",
+        data: { reason: "not_trashed" },
+      },
+    );
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/restore.ts
+++ b/packages/core/src/rpc/procedures/entry/restore.ts
@@ -2,15 +2,15 @@ import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
-import { fireEntryTrashed, loadDeletableEntry } from "./lifecycle.js";
-import { entryTrashInputSchema } from "./schemas.js";
+import { fireEntryRestored, loadDeletableEntry } from "./lifecycle.js";
+import { entryRestoreInputSchema } from "./schemas.js";
 
-export const trash = base
+export const restore = base
   .use(authenticated)
-  .input(entryTrashInputSchema)
+  .input(entryRestoreInputSchema)
   .handler(async ({ input, context, errors }) => {
     const filtered = await context.hooks.applyFilter(
-      "rpc:entry.trash:input",
+      "rpc:entry.restore:input",
       input,
     );
 
@@ -23,19 +23,19 @@ export const trash = base
       },
     });
 
-    if (existing.status === "trash") {
-      return context.hooks.applyFilter("rpc:entry.trash:output", existing);
+    if (existing.status !== "trash") {
+      throw errors.CONFLICT({ data: { reason: "not_trashed" } });
     }
 
-    const [trashed] = await context.db
+    const [restored] = await context.db
       .update(entries)
-      .set({ status: "trash" })
+      .set({ status: "draft" })
       .where(eq(entries.id, existing.id))
       .returning();
-    if (!trashed) {
-      throw errors.CONFLICT({ data: { reason: "trash_failed" } });
+    if (!restored) {
+      throw errors.CONFLICT({ data: { reason: "restore_failed" } });
     }
 
-    await fireEntryTrashed(context, trashed);
-    return context.hooks.applyFilter("rpc:entry.trash:output", trashed);
+    await fireEntryRestored(context, restored);
+    return context.hooks.applyFilter("rpc:entry.restore:output", restored);
   });

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -218,6 +218,8 @@ export const entryGetInputSchema = v.object({
   preview: v.optional(v.boolean()),
 });
 export const entryTrashInputSchema = v.object({ id: idParam });
+export const entryRestoreInputSchema = v.object({ id: idParam });
+export const entryDeletePermanentInputSchema = v.object({ id: idParam });
 
 export type EntryListInput = v.InferOutput<typeof entryListInputSchema>;
 export type EntryGetInput = v.InferOutput<typeof entryGetInputSchema>;

--- a/packages/plugins/audit-log/src/server/auditEvents.test.ts
+++ b/packages/plugins/audit-log/src/server/auditEvents.test.ts
@@ -464,6 +464,28 @@ describe("registerAuditEvents — entry backfill", () => {
     });
   });
 
+  test("entry:restored produces a row keyed on the entry", async () => {
+    const h = harness();
+    await h.fire("entry:restored", subjectEntry);
+    expect(h.state.rows[0]).toMatchObject({
+      event: "entry:restored",
+      subjectType: "entry",
+      subjectId: "11",
+      subjectLabel: "Some Post",
+    });
+  });
+
+  test("entry:deleted produces a row keyed on the entry", async () => {
+    const h = harness();
+    await h.fire("entry:deleted", subjectEntry);
+    expect(h.state.rows[0]).toMatchObject({
+      event: "entry:deleted",
+      subjectType: "entry",
+      subjectId: "11",
+      subjectLabel: "Some Post",
+    });
+  });
+
   test("entry:meta_changed records set/removed key names only", async () => {
     const h = harness();
     await h.fire(
@@ -697,8 +719,10 @@ describe("auditEvents table", () => {
       "credential:revoked",
       "device_code:approved",
       "device_code:denied",
+      "entry:deleted",
       "entry:meta_changed",
       "entry:published",
+      "entry:restored",
       "entry:transition",
       "entry:trashed",
       "entry:updated",

--- a/packages/plugins/audit-log/src/server/auditEvents.ts
+++ b/packages/plugins/audit-log/src/server/auditEvents.ts
@@ -283,6 +283,16 @@ export const auditEvents: readonly AuditEventDef[] = [
     actor: { kind: "ctx" },
   },
   {
+    event: "entry:restored",
+    subject: { kind: "extract", type: "entry" },
+    actor: { kind: "ctx" },
+  },
+  {
+    event: "entry:deleted",
+    subject: { kind: "extract", type: "entry" },
+    actor: { kind: "ctx" },
+  },
+  {
     event: "entry:meta_changed",
     subject: {
       kind: "inline",


### PR DESCRIPTION
The trash dialog promised "You can restore it from the Trash view later", but the trash view offered no way back — no restore procedure existed, and trashed entries accumulated forever. Trashed rows now offer Restore and Delete permanently.

**New RPC contract**

`entry.restore` moves trash → draft; `entry.deletePermanent` hard-deletes a trashed row plus its slug-linked revision and autosave rows (`entry_term` cascades via FK, children re-root via `ON DELETE SET NULL`). Both reject non-trashed entries with `CONFLICT { reason: "not_trashed" }` and reuse the trash gate (`delete` cap + author-or-`edit_any`), now extracted into `loadDeletableEntry` — three verbatim copies of a security gate invite drift.

**Restore is immediate, permanent delete is not**

Restore fires without confirmation (the result is recoverable from Drafts); Delete permanently goes through a confirm dialog. Both new lifecycle events (`entry:restored`, `entry:deleted`) are recorded by the audit-log plugin, matching `entry:trashed`.

**Known follow-ups (flagged in review, deliberately out of scope)**

The test harness doesn't enable SQLite FK enforcement, so the cascade behavior the delete relies on is asserted only by schema, not by test; the two delete statements aren't wrapped in a transaction (consistent with the repo's existing norm); restore doesn't fire `entry:transition`, mirroring `trash`'s existing asymmetry.

Fixes #862