### PR TITLE
feat(plugin-media): filename search in the media library

### DIFF
--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -23,6 +23,7 @@ export {
 } from "./procedures/entry/lifecycle.js";
 export { entryRouter } from "./procedures/entry/index.js";
 export type { EntryRouter } from "./procedures/entry/index.js";
+export { escapeLikePattern } from "./procedures/entry/search-terms.js";
 export {
   entryCreateInputSchema,
   entryGetInputSchema,

--- a/packages/plugins/media/e2e/media.spec.ts
+++ b/packages/plugins/media/e2e/media.spec.ts
@@ -11,6 +11,17 @@
 
 import { expect, test } from "@playwright/test";
 
+// Minimal valid 1×1 transparent PNG — real signature + IHDR + IDAT +
+// IEND so the plugin's magic-byte confirm step doesn't 409.
+const PNG_1X1 = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06,
+  0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44,
+  0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d,
+  0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
 test.describe.serial("@plumix/plugin-media — worker-driven happy path", () => {
   test("empty state → upload → card visible → delete → empty again", async ({
     page,
@@ -34,14 +45,6 @@ test.describe.serial("@plumix/plugin-media — worker-driven happy path", () => 
     //    confirm doesn't 409. The worker handles createUploadUrl →
     //    worker-routed PUT → confirm in a single round-trip; on
     //    success the list query invalidates and a card appears.
-    const PNG_1X1 = Buffer.from([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
-      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
-      0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
-      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
-      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
-    ]);
     const fileInput = page.locator(
       '[data-testid="media-library-upload"] input[type="file"]',
     );
@@ -62,7 +65,7 @@ test.describe.serial("@plumix/plugin-media — worker-driven happy path", () => 
     // `:not(...)` filter excludes the per-card title/delete inner
     // elements that share the testid prefix.
     const cards = page.locator(
-      "[data-testid^='media-card-']:not([data-testid$='-title']):not([data-testid$='-delete']):not([data-testid$='-thumb'])",
+      "[data-testid='media-library-grid'] > [data-testid^='media-card-']",
     );
     await expect(cards).toHaveCount(1);
     await expect(cards.first()).toContainText("smoke.png");
@@ -82,5 +85,42 @@ test.describe.serial("@plumix/plugin-media — worker-driven happy path", () => 
 
     await expect(cards).toHaveCount(0);
     await expect(page.getByTestId("media-library-dropzone")).toBeVisible();
+  });
+
+  test("filename search narrows the grid and clearing restores it", async ({
+    page,
+  }) => {
+    await page.goto("pages/media");
+    const fileInput = page.locator(
+      '[data-testid="media-library-upload"] input[type="file"]',
+    );
+    const cards = page.locator(
+      "[data-testid='media-library-grid'] > [data-testid^='media-card-']",
+    );
+    // Two uploads with distinct names so the filter has something to
+    // separate. Serial suite: the previous test left the library empty.
+    for (const name of ["sunset-beach.png", "invoice-q3.png"]) {
+      const confirmed = page.waitForResponse(
+        (r) => r.url().endsWith("/media/confirm") && r.status() === 200,
+      );
+      await fileInput.setInputFiles({
+        name,
+        mimeType: "image/png",
+        buffer: PNG_1X1,
+      });
+      await confirmed;
+    }
+    await expect(cards).toHaveCount(2);
+
+    await page.getByTestId("media-library-search").fill("sunset");
+    await expect(cards).toHaveCount(1);
+    await expect(cards.first()).toContainText("sunset-beach.png");
+
+    await page.getByTestId("media-library-search").fill("zzz-no-such-file");
+    await expect(page.getByTestId("media-library-no-matches")).toBeVisible();
+    await expect(page.getByTestId("media-library-dropzone")).toHaveCount(0);
+
+    await page.getByTestId("media-library-search").fill("");
+    await expect(cards).toHaveCount(2);
   });
 });

--- a/packages/plugins/media/locales/ar.po
+++ b/packages/plugins/media/locales/ar.po
@@ -366,3 +366,13 @@ msgstr "إزالة {name}"
 #: src/admin/MediaListPickerField.tsx
 msgid "plugin.media.listField.modalAria"
 msgstr "إضافة وسائط"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.searchPlaceholder"
+msgstr "البحث باسم الملف…"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.noMatches"
+msgstr "لا توجد ملفات مطابقة لبحثك."

--- a/packages/plugins/media/locales/de.po
+++ b/packages/plugins/media/locales/de.po
@@ -366,3 +366,13 @@ msgstr "{name} entfernen"
 #: src/admin/MediaListPickerField.tsx
 msgid "plugin.media.listField.modalAria"
 msgstr "Medien hinzufügen"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.searchPlaceholder"
+msgstr "Nach Dateiname suchen…"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.noMatches"
+msgstr "Keine passenden Dateien gefunden."

--- a/packages/plugins/media/locales/en.po
+++ b/packages/plugins/media/locales/en.po
@@ -366,3 +366,13 @@ msgstr "Remove {name}"
 #: src/admin/MediaListPickerField.tsx
 msgid "plugin.media.listField.modalAria"
 msgstr "Add media"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.searchPlaceholder"
+msgstr "Search by filename…"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.noMatches"
+msgstr "No files match your search."

--- a/packages/plugins/media/locales/uk.po
+++ b/packages/plugins/media/locales/uk.po
@@ -366,3 +366,13 @@ msgstr "Видалити {name}"
 #: src/admin/MediaListPickerField.tsx
 msgid "plugin.media.listField.modalAria"
 msgstr "Додати медіа"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.searchPlaceholder"
+msgstr "Пошук за назвою файлу…"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.noMatches"
+msgstr "Жодного файлу не знайдено за вашим запитом."

--- a/packages/plugins/media/locales/zh-CN.po
+++ b/packages/plugins/media/locales/zh-CN.po
@@ -366,3 +366,13 @@ msgstr "移除 {name}"
 #: src/admin/MediaListPickerField.tsx
 msgid "plugin.media.listField.modalAria"
 msgstr "添加媒体"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.searchPlaceholder"
+msgstr "按文件名搜索…"
+
+#. js-lingui-explicit-id
+#: src/admin/MediaLibrary.tsx
+msgid "plugin.media.library.noMatches"
+msgstr "没有符合搜索条件的文件。"

--- a/packages/plugins/media/src/admin/MediaLibrary.tsx
+++ b/packages/plugins/media/src/admin/MediaLibrary.tsx
@@ -53,6 +53,10 @@ const M = {
     message: "Uploading {count, plural, one {# file} other {# files}}…",
     comment: "count: number of files currently uploading",
   },
+  searchPlaceholder: {
+    id: "plugin.media.library.searchPlaceholder",
+    message: "Search by filename…",
+  },
 } satisfies Record<string, MessageDescriptor>;
 
 const PAGE_SIZE = 24;
@@ -63,8 +67,27 @@ const UPLOAD_CONCURRENCY = 4;
 // scoped to `accept: "image/"` never poison each other's data.
 function mediaListKey(
   accept: string | readonly string[] | undefined,
+  search: string,
 ): readonly unknown[] {
-  return ["media", "list", accept ?? null] as const;
+  return ["media", "list", accept ?? null, search] as const;
+}
+
+// Matches the admin's DebouncedSearchInput interval for list-screen parity.
+const SEARCH_DEBOUNCE_MS = 250;
+
+// Local debounce — the admin shell's DebouncedSearchInput lives behind
+// the `@/` alias and isn't part of the plugin-facing surface.
+function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebounced(value);
+    }, delayMs);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delayMs]);
+  return debounced;
 }
 
 // Resolve a media URL to absolute form for copy/display. The plugin
@@ -339,7 +362,10 @@ export function MediaLibrary({
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const isPicker = mode === "picker";
 
-  const queryKey = mediaListKey(accept);
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search.trim(), SEARCH_DEBOUNCE_MS);
+
+  const queryKey = mediaListKey(accept, debouncedSearch);
   const list = useInfiniteQuery({
     queryKey,
     initialPageParam: 0,
@@ -350,6 +376,7 @@ export function MediaLibrary({
         // `accept` only flows through in picker mode. Page mode shows
         // the full library regardless.
         ...(isPicker && accept !== undefined ? { accept } : {}),
+        ...(debouncedSearch ? { search: debouncedSearch } : {}),
       }),
     getNextPageParam: (last, allPages) =>
       last.hasMore ? allPages.length * PAGE_SIZE : undefined,
@@ -490,7 +517,27 @@ export function MediaLibrary({
           >
             {isPicker ? i18n._(M.titlePicker) : i18n._(M.titleLibrary)}
           </h1>
-          <UploadButton onSelect={(files) => void startUpload(files)} />
+          <div className="flex items-center gap-2">
+            <input
+              type="search"
+              role="searchbox"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+              }}
+              placeholder={i18n._(M.searchPlaceholder)}
+              // Placeholder is not an accessible name (it clears on
+              // input); name the field explicitly. maxLength mirrors the
+              // server's 200-char cap on media.list's search input.
+              aria-label={i18n._(M.searchPlaceholder)}
+              maxLength={200}
+              data-testid="media-library-search"
+              // Classes mirror the admin's vendored Input (components/ui/
+              // input) — unreachable from plugin code behind the @/ alias.
+              className="border-input bg-background focus-visible:ring-ring h-9 w-56 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
+            />
+            <UploadButton onSelect={(files) => void startUpload(files)} />
+          </div>
         </header>
 
         {pending.length > 0 && <UploadProgressBar pending={pending} />}
@@ -509,12 +556,26 @@ export function MediaLibrary({
           </div>
         )}
 
-        {list.status === "success" && items.length === 0 && (
-          <Dropzone
-            onSelect={(files) => void startUpload(files)}
-            highlight={dragging}
-          />
-        )}
+        {list.status === "success" &&
+          items.length === 0 &&
+          (debouncedSearch ? (
+            // A no-match search must not show the "library is empty"
+            // dropzone — the library isn't empty, the filter is.
+            <p
+              data-testid="media-library-no-matches"
+              className="text-muted-foreground text-sm"
+            >
+              <Trans
+                id="plugin.media.library.noMatches"
+                message="No files match your search."
+              />
+            </p>
+          ) : (
+            <Dropzone
+              onSelect={(files) => void startUpload(files)}
+              highlight={dragging}
+            />
+          ))}
 
         {list.status === "success" && items.length > 0 && (
           <div

--- a/packages/plugins/media/src/index.test.ts
+++ b/packages/plugins/media/src/index.test.ts
@@ -598,6 +598,63 @@ describe("@plumix/plugin-media — media.list", () => {
     expect(status).toBe(401);
   });
 
+  test("search filters by filename, case-insensitively", async () => {
+    const storage = memoryStorage().connect({});
+    const h = await createDispatcherHarness({ plugins: [media()], storage });
+    const user = await h.seedUser("contributor");
+    await seedPublishedMedia(h, storage, user.id, "Sunset-Beach.png");
+    await seedPublishedMedia(h, storage, user.id, "invoice.png");
+
+    const result = await rpcDispatch<MediaListOutput>(
+      h,
+      "media/list",
+      { limit: 10, offset: 0, search: "sunset" },
+      user.id,
+    );
+    expect(result.output?.items.length).toBe(1);
+    expect(result.output?.items[0]?.title).toBe("Sunset-Beach.png");
+  });
+
+  test("search also matches alt text", async () => {
+    const storage = memoryStorage().connect({});
+    const h = await createDispatcherHarness({ plugins: [media()], storage });
+    const user = await h.seedUser("contributor");
+    const seeded = await seedPublishedMedia(h, storage, user.id, "img-001.png");
+    await seedPublishedMedia(h, storage, user.id, "img-002.png");
+    await rpcDispatch(
+      h,
+      "media/update",
+      { id: seeded.id, alt: "golden retriever puppy" },
+      user.id,
+    );
+
+    const result = await rpcDispatch<MediaListOutput>(
+      h,
+      "media/list",
+      { limit: 10, offset: 0, search: "retriever" },
+      user.id,
+    );
+    expect(result.output?.items.length).toBe(1);
+    expect(result.output?.items[0]?.title).toBe("img-001.png");
+  });
+
+  test("search escapes LIKE wildcards — a literal % matches only itself", async () => {
+    const storage = memoryStorage().connect({});
+    const h = await createDispatcherHarness({ plugins: [media()], storage });
+    const user = await h.seedUser("contributor");
+    await seedPublishedMedia(h, storage, user.id, "discount-50%.png");
+    await seedPublishedMedia(h, storage, user.id, "discount-flat.png");
+
+    const result = await rpcDispatch<MediaListOutput>(
+      h,
+      "media/list",
+      { limit: 10, offset: 0, search: "50%" },
+      user.id,
+    );
+    expect(result.output?.items.length).toBe(1);
+    expect(result.output?.items[0]?.title).toBe("discount-50%.png");
+  });
+
   test("hasMore flag fires when there are more rows than the page", async () => {
     const storage = memoryStorage().connect({});
     const h = await createDispatcherHarness({ plugins: [media()], storage });

--- a/packages/plugins/media/src/rpc.ts
+++ b/packages/plugins/media/src/rpc.ts
@@ -6,6 +6,7 @@ import {
   desc,
   entries,
   eq,
+  escapeLikePattern,
   inArray,
   like,
   sql,
@@ -368,6 +369,9 @@ export function createMediaRouter(
             ),
           ]),
         ),
+        // Filename substring match. Empty string coerces to "no filter"
+        // client-side; cap mirrors the entries-list search bound.
+        search: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200))),
       }),
     )
     .handler(async ({ input, context, errors }): Promise<MediaListResponse> => {
@@ -380,6 +384,16 @@ export function createMediaRouter(
       ];
       const acceptCondition = buildAcceptCondition(input.accept);
       if (acceptCondition) conditions.push(acceptCondition);
+      if (input.search) {
+        const pattern = `%${escapeLikePattern(input.search)}%`;
+        // Alt lives inside the meta JSON; COALESCE because rows without
+        // an alt yield NULL from json_extract, and `LIKE` on NULL is
+        // NULL — which would poison the OR for title-only matches.
+        conditions.push(sql`(
+          ${entries.title} LIKE ${pattern} ESCAPE '\\'
+          OR COALESCE(json_extract(${entries.meta}, '$.alt'), '') LIKE ${pattern} ESCAPE '\\'
+        )`);
+      }
       // Fetch one extra row so we can report `hasMore` without a
       // separate COUNT(*) query.
       const rows = await context.db


### PR DESCRIPTION
The media library had MIME filtering and infinite scroll but no way to find a file by name. A debounced search box now filters the grid server-side.

**Search matches filename and alt text**

`media.list` gains a `search` input that LIKE-matches `title` and the `meta.alt` JSON field. The alt clause is COALESCE-guarded (a null alt would otherwise NULL-poison the OR and drop title-only matches), and the pattern is escaped + paired with `ESCAPE '\'` so a literal `%` matches only itself rather than every row.

**No-matches state is distinct from empty-library**

A filtered grid with zero results shows "No files match your search" — not the "library is empty" dropzone, which would wrongly invite an upload.

**New core export**

`escapeLikePattern` is now exported from `@plumix/core` so plugins can build safe LIKE patterns instead of hand-rolling wildcard escaping (the media search is the first consumer).

Review fixes applied: `aria-label` + `role=searchbox` on the input (placeholder isn't an accessible name), client `maxLength={200}` mirroring the server cap, debounce aligned to the admin's 250ms, and the e2e card selector tightened to grid-direct-children.

Fixes #869