### PR TITLE
feat: duplicate an entry into a new draft

### DIFF
--- a/packages/admin/e2e/entries.spec.ts
+++ b/packages/admin/e2e/entries.spec.ts
@@ -290,6 +290,70 @@ test.describe("/entries/$slug (list)", () => {
     await expect(page.getByTestId("toast-success")).toBeVisible();
   });
 
+  test("duplicate flow: row action → entry.duplicate payload → toast + refetched list", async ({
+    page,
+  }) => {
+    const duplicated: unknown[] = [];
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(
+          duplicated.length === 0
+            ? TWO_ROWS
+            : [
+                ...TWO_ROWS,
+                entry({ id: 3, title: "Hello world (copy)", status: "draft" }),
+              ],
+        ),
+      }),
+    );
+    await page.route("**/_plumix/rpc/entry/duplicate", (route) => {
+      const body = route.request().postDataJSON() as { json?: unknown };
+      duplicated.push(body.json);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(
+          entry({ id: 3, title: "Hello world (copy)", status: "draft" }),
+        ),
+      });
+    });
+
+    await page.goto("entries/posts");
+    await page.getByTestId("content-list-row-1").hover();
+    await page.getByTestId("content-list-row-duplicate-1").click();
+
+    expect(duplicated[0]).toMatchObject({ id: 1 });
+    await expect(page.getByTestId("toast-success")).toBeVisible();
+    await expect(page.getByTestId("content-list-row-3")).toBeVisible();
+  });
+
+  test("without create cap: Duplicate row action is absent", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": {
+        user: {
+          id: 5,
+          email: "viewer@example.test",
+          name: "Viewer",
+          avatarUrl: null,
+          role: "subscriber",
+          capabilities: ["entry:post:read"],
+        },
+        needsBootstrap: false,
+      },
+      "/entry/list": TWO_ROWS,
+    });
+    await page.goto("entries/posts");
+    await page.getByTestId("content-list-row-1").hover();
+    await expect(page.getByTestId("content-list-row-duplicate-1")).toHaveCount(
+      0,
+    );
+  });
+
   test("trash view: Restore row action → entry.restore payload → refetched list drops the row", async ({
     page,
   }) => {

--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -1411,9 +1411,24 @@ msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "تم تجاهل المسودة."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicate"
+msgstr "تكرار"
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.duplicate"
 msgstr "تكرار"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.toast.duplicated"
+msgstr "تم التكرار كمسودة."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicating"
+msgstr "جارٍ التكرار…"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -3449,7 +3464,8 @@ msgstr "لم يعد هذا passkey موجوداً. حدّث القائمة."
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.deleteDialog.description"
-msgstr "سيؤدي هذا إلى حذف الإدخال ومراجعاته نهائيًا. لا يمكن التراجع عن هذا الإجراء."
+msgstr "سيؤدي هذا إلى حذف الإدخال ومراجعاته نهائيًا. لا يمكن التراجع عن هذا "
+"الإجراء."
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -1432,9 +1432,24 @@ msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "Entwurf verworfen."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicate"
+msgstr "Duplizieren"
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.duplicate"
 msgstr "Duplizieren"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.toast.duplicated"
+msgstr "Als Entwurf dupliziert."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicating"
+msgstr "Wird dupliziert…"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -3513,7 +3528,8 @@ msgstr "Dieser Passkey existiert nicht mehr. Liste aktualisieren."
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.deleteDialog.description"
-msgstr "Der Eintrag und seine Revisionen werden endgültig gelöscht. Das kann nicht rückgängig gemacht werden."
+msgstr "Der Eintrag und seine Revisionen werden endgültig gelöscht. Das kann "
+"nicht rückgängig gemacht werden."
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -1413,9 +1413,24 @@ msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "Draft discarded."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicate"
+msgstr "Duplicate"
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.duplicate"
 msgstr "Duplicate"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.toast.duplicated"
+msgstr "Duplicated as a draft."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicating"
+msgstr "Duplicating…"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -1421,9 +1421,24 @@ msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "Чернетку відхилено."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicate"
+msgstr "Дублювати"
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.duplicate"
 msgstr "Дублювати"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.toast.duplicated"
+msgstr "Дубльовано як чернетку."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicating"
+msgstr "Дублювання…"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -3484,7 +3499,8 @@ msgstr "Цей passkey більше не існує. Оновіть список
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.deleteDialog.description"
-msgstr "Запис і всі його редакції буде видалено назавжди. Цю дію неможливо скасувати."
+msgstr "Запис і всі його редакції буде видалено назавжди. Цю дію неможливо "
+"скасувати."
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -1395,9 +1395,24 @@ msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "已放弃草稿。"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicate"
+msgstr "复制"
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.duplicate"
 msgstr "复制"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.toast.duplicated"
+msgstr "已复制为草稿。"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.row.duplicating"
+msgstr "复制中…"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -265,6 +265,18 @@ const M = {
     id: "entries.list.toast.failed",
     message: "That didn't work — try again.",
   }),
+  toastDuplicated: defineMessage({
+    id: "entries.list.toast.duplicated",
+    message: "Duplicated as a draft.",
+  }),
+  rowDuplicate: defineMessage({
+    id: "entries.list.row.duplicate",
+    message: "Duplicate",
+  }),
+  rowDuplicating: defineMessage({
+    id: "entries.list.row.duplicating",
+    message: "Duplicating…",
+  }),
 } satisfies Record<string, MessageDescriptor>;
 
 const STATUS_FILTER_OPTIONS: {
@@ -284,8 +296,11 @@ function buildColumns({
   onSort,
   adminSlug,
   canDelete,
+  canCreate,
   onTrash,
   trashingId,
+  onDuplicate,
+  duplicatingId,
   onRestore,
   restoringId,
   onDeletePermanent,
@@ -298,8 +313,11 @@ function buildColumns({
   onSort: (column: OrderBy, defaultDirection: Order) => void;
   adminSlug: string;
   canDelete: boolean;
+  canCreate: boolean;
   onTrash: (id: number) => void;
   trashingId: number | null;
+  onDuplicate: (id: number) => void;
+  duplicatingId: number | null;
   onRestore: (id: number) => void;
   restoringId: number | null;
   onDeletePermanent: (id: number) => void;
@@ -325,8 +343,11 @@ function buildColumns({
           entry={row.original}
           adminSlug={adminSlug}
           canDelete={canDelete}
+          canCreate={canCreate}
           onTrash={onTrash}
           isTrashing={trashingId === row.original.id}
+          onDuplicate={onDuplicate}
+          isDuplicating={duplicatingId === row.original.id}
           onRestore={onRestore}
           isRestoring={restoringId === row.original.id}
           onDeletePermanent={onDeletePermanent}
@@ -580,6 +601,24 @@ function ContentListRoute(): ReactNode {
       ? trash.variables
       : null;
 
+  // Duplicate fires immediately — it creates a fresh draft, nothing
+  // destructive, so no confirm dialog.
+  const duplicate = useMutation({
+    mutationFn: (id: number) => orpc.entry.duplicate.call({ id }),
+    onSuccess: onListSuccess(M.toastDuplicated),
+    onError: onMutationError,
+  });
+  const onDuplicate = useCallback(
+    (id: number): void => {
+      duplicate.mutate(id);
+    },
+    [duplicate],
+  );
+  const duplicatingId =
+    duplicate.isPending && typeof duplicate.variables === "number"
+      ? duplicate.variables
+      : null;
+
   // Restore fires immediately — it's recoverable (the row lands back in
   // Drafts), so a confirm dialog would just add friction.
   const restore = useMutation({
@@ -626,8 +665,11 @@ function ContentListRoute(): ReactNode {
         onSort: setSort,
         adminSlug: entryType.adminSlug,
         canDelete,
+        canCreate,
         onTrash,
         trashingId,
+        onDuplicate,
+        duplicatingId,
         onRestore,
         restoringId,
         onDeletePermanent,
@@ -641,8 +683,11 @@ function ContentListRoute(): ReactNode {
       setSort,
       entryType.adminSlug,
       canDelete,
+      canCreate,
       onTrash,
       trashingId,
+      onDuplicate,
+      duplicatingId,
       onRestore,
       restoringId,
       onDeletePermanent,
@@ -895,8 +940,11 @@ function TitleCell({
   entry,
   adminSlug,
   canDelete,
+  canCreate,
   onTrash,
   isTrashing,
+  onDuplicate,
+  isDuplicating,
   onRestore,
   isRestoring,
   onDeletePermanent,
@@ -905,8 +953,11 @@ function TitleCell({
   entry: Entry;
   adminSlug: string;
   canDelete: boolean;
+  canCreate: boolean;
   onTrash: (id: number) => void;
   isTrashing: boolean;
+  onDuplicate: (id: number) => void;
+  isDuplicating: boolean;
   onRestore: (id: number) => void;
   isRestoring: boolean;
   onDeletePermanent: (id: number) => void;
@@ -915,6 +966,7 @@ function TitleCell({
   const renderLabel = useLabel();
   const isTrashed = entry.status === "trash";
   const showTrashAction = canDelete && !isTrashed;
+  const showDuplicateAction = canCreate && !isTrashed;
   const showTrashedActions = canDelete && isTrashed;
   return (
     <div className="flex flex-col gap-0.5">
@@ -962,6 +1014,26 @@ function TitleCell({
               {isTrashing
                 ? renderLabel(M.rowTrashing)
                 : renderLabel(M.rowTrash)}
+            </button>
+          </>
+        ) : null}
+        {showDuplicateAction ? (
+          <>
+            <span aria-hidden className="text-muted-foreground/50">
+              |
+            </span>
+            <button
+              type="button"
+              disabled={isDuplicating}
+              onClick={() => {
+                onDuplicate(entry.id);
+              }}
+              className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+              data-testid={`content-list-row-duplicate-${String(entry.id)}`}
+            >
+              {isDuplicating
+                ? renderLabel(M.rowDuplicating)
+                : renderLabel(M.rowDuplicate)}
             </button>
           </>
         ) : null}

--- a/packages/core/src/rpc/hooks.ts
+++ b/packages/core/src/rpc/hooks.ts
@@ -73,6 +73,9 @@ declare module "../hooks/types.js" {
     "rpc:entry.deletePermanent:input": (input: { id: number }) => typeof input;
     "rpc:entry.deletePermanent:output": (output: Entry) => Entry;
 
+    "rpc:entry.duplicate:input": (input: { id: number }) => typeof input;
+    "rpc:entry.duplicate:output": (output: Entry) => Entry;
+
     "rpc:user.list:input": (input: UserListInput) => UserListInput;
     "rpc:user.list:output": (
       output: readonly UserListRow[],

--- a/packages/core/src/rpc/procedures/entry/duplicate.test.ts
+++ b/packages/core/src/rpc/procedures/entry/duplicate.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "vitest";
+
+import type { UserRole } from "../../../db/schema/users.js";
+import { eq } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { terms } from "../../../db/schema/terms.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+// Minimal taxonomy registry so `entry.update` accepts a `category`
+// term patch — mirrors the scaffold in terms.test.ts.
+function categoryRegistry() {
+  const registry = createPluginRegistry();
+  const name = "category";
+  registry.termTaxonomies.set(name, {
+    name,
+    label: name,
+    registeredBy: "test",
+  });
+  for (const [action, minRole] of [
+    ["read", "subscriber"],
+    ["assign", "contributor"],
+    ["edit", "editor"],
+  ] as const satisfies readonly [string, UserRole][]) {
+    registry.capabilities.set(`term:${name}:${action}`, {
+      name: `term:${name}:${action}`,
+      minRole,
+      registeredBy: "test",
+    });
+  }
+  return registry;
+}
+
+describe("entry.duplicate", () => {
+  test("editor duplicates an entry: a new draft row copies the content, with a fresh id and slug", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const source = await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Original",
+      slug: "original",
+      excerpt: "the excerpt",
+      content: { type: "doc", content: [] },
+    });
+
+    const copy = await h.client.entry.duplicate({ id: source.id });
+
+    expect(copy.id).not.toBe(source.id);
+    expect(copy.status).toBe("draft");
+    expect(copy.slug).not.toBe(source.slug);
+    expect(copy.excerpt).toBe("the excerpt");
+    expect(copy.content).toEqual({ type: "doc", content: [] });
+    // Title carries a "copy" marker so the duplicate is distinguishable
+    // in the list.
+    expect(copy.title).toContain("Original");
+
+    // The copy is a real persisted row, not just an echo of the input.
+    const persisted = await h.db.query.entries.findFirst({
+      where: eq(entries.id, copy.id),
+    });
+    expect(persisted?.status).toBe("draft");
+    expect(persisted?.authorId).toBe(h.user.id);
+  });
+
+  test("duplicating the same source twice yields two distinct slugs", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const source = await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Twice",
+      slug: "twice",
+    });
+
+    const first = await h.client.entry.duplicate({ id: source.id });
+    const second = await h.client.entry.duplicate({ id: source.id });
+
+    expect(first.slug).not.toBe(second.slug);
+    expect(new Set([source.slug, first.slug, second.slug]).size).toBe(3);
+  });
+
+  test("copies term assignments from the source", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: categoryRegistry(),
+    });
+    const [category] = await h.context.db
+      .insert(terms)
+      .values({ taxonomy: "category", name: "news", slug: "news" })
+      .returning();
+    if (!category) throw new Error("seed: term insert returned no row");
+    const source = await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Tagged",
+      slug: "tagged",
+    });
+    await h.client.entry.update({
+      id: source.id,
+      terms: { category: [category.id] },
+    });
+
+    const copy = await h.client.entry.duplicate({ id: source.id });
+
+    const fetched = await h.client.entry.get({ id: copy.id });
+    expect(fetched.terms.category).toEqual([category.id]);
+  });
+
+  test("copies the raw meta column from the source", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const source = await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Has meta",
+      slug: "has-meta",
+      meta: { featured: true },
+    });
+
+    const copy = await h.client.entry.duplicate({ id: source.id });
+
+    const persisted = await h.db.query.entries.findFirst({
+      where: eq(entries.id, copy.id),
+    });
+    expect(persisted?.meta).toEqual({ featured: true });
+  });
+
+  test("a duplicate of a duplicate keeps producing fresh slugs", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const source = await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Chain",
+      slug: "chain",
+    });
+    const first = await h.client.entry.duplicate({ id: source.id });
+    const second = await h.client.entry.duplicate({ id: first.id });
+    expect(second.id).not.toBe(first.id);
+    expect(second.slug).not.toBe(first.slug);
+  });
+
+  test("contributor without the type's create cap is rejected", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const source = await h.factory.published.create({
+      authorId: h.user.id,
+      title: "Locked",
+      slug: "locked-dup",
+    });
+    await expect(
+      h.client.entry.duplicate({ id: source.id }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      data: { capability: "entry:post:create" },
+    });
+  });
+
+  test("404 for a missing source", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    await expect(h.client.entry.duplicate({ id: 9999 })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  test("cannot duplicate another author's unreadable draft (404, no content leak)", async () => {
+    // An author holds create + read, but a peer's *draft* isn't readable
+    // to them (read of non-published needs edit_any or author+edit_own).
+    // Duplicating it must 404 rather than hand back a copy of its content.
+    const h = await createRpcHarness({ authAs: "author" });
+    const peer = await h.factory.author.create();
+    const secret = await h.factory.draft.create({
+      authorId: peer.id,
+      title: "Peer secret",
+      slug: "peer-secret",
+    });
+    await expect(
+      h.client.entry.duplicate({ id: secret.id }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("cannot duplicate a reserved-type row (revision/autosave)", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const revision = await h.factory.entry.create({
+      authorId: h.user.id,
+      type: "revision",
+      slug: "revision:1:abcdefghijklmnopqrstu",
+      title: "snapshot",
+    });
+    await expect(
+      h.client.entry.duplicate({ id: revision.id }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/duplicate.ts
+++ b/packages/core/src/rpc/procedures/entry/duplicate.ts
@@ -1,0 +1,99 @@
+import type { NewEntry } from "../../../db/schema/entries.js";
+import { eq } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { canReadEntry, entryCapability } from "./lifecycle.js";
+import { decodeMetaBag } from "./meta.js";
+import { entryDuplicateInputSchema } from "./schemas.js";
+import { applyTermPatch, loadEntryTerms } from "./terms.js";
+
+// Bounded retry so two duplicates of the same source don't collide on
+// the `(type, slug)` unique index: "original-copy", "original-copy-2", …
+const MAX_SLUG_ATTEMPTS = 50;
+
+export const duplicate = base
+  .use(authenticated)
+  .input(entryDuplicateInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const filtered = await context.hooks.applyFilter(
+      "rpc:entry.duplicate:input",
+      input,
+    );
+
+    const source = await context.db.query.entries.findFirst({
+      where: eq(entries.id, filtered.id),
+    });
+    // Reserved internal rows (revision/autosave) aren't first-class
+    // entries — 404 them so duplicate can't smuggle a reserved-type row
+    // into the table or leak a snapshot's content. `canReadEntry` would
+    // also reject these (no read cap on reserved types), but the explicit
+    // guard mirrors `entry.create` / `entry.get`.
+    if (!source || isReservedType(source.type)) {
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
+    }
+
+    // The copy reads the source's content, so gate on readability first —
+    // a create cap alone would let a caller harvest a draft they can't
+    // see. 404 (not 403) to avoid leaking the row's existence, matching
+    // `entry.get`.
+    if (!canReadEntry(context, source)) {
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
+    }
+
+    // Duplicating is also a create on the source's type — gate on the same
+    // capability `entry.create` uses, not the source's delete/edit caps.
+    const createCapability = entryCapability(source.type, "create");
+    if (!context.auth.can(createCapability)) {
+      throw errors.FORBIDDEN({ data: { capability: createCapability } });
+    }
+
+    const candidate: NewEntry = {
+      type: source.type,
+      title: `${source.title} (copy)`,
+      slug: source.slug,
+      content: source.content,
+      excerpt: source.excerpt,
+      status: "draft",
+      // Keep the source's parent — the copy stays a sibling. A deleted
+      // parent already nulled this via the FK's ON DELETE SET NULL, so
+      // there's no dangling reference to revalidate.
+      parentId: source.parentId,
+      sortOrder: source.sortOrder,
+      authorId: context.user.id,
+      publishedAt: null,
+      // Copy the raw meta JSON verbatim — it was already sanitized on
+      // the source, so no decode/re-validate round trip is needed.
+      meta: source.meta,
+    };
+
+    let created: typeof entries.$inferSelect | undefined;
+    for (let attempt = 1; attempt <= MAX_SLUG_ATTEMPTS; attempt++) {
+      const slug =
+        attempt === 1
+          ? `${source.slug}-copy`
+          : `${source.slug}-copy-${String(attempt)}`;
+      [created] = await context.db
+        .insert(entries)
+        .values({ ...candidate, slug })
+        .onConflictDoNothing({ target: [entries.type, entries.slug] })
+        .returning();
+      if (created) break;
+    }
+    if (!created) {
+      throw errors.CONFLICT({ data: { reason: "slug_taken" } });
+    }
+
+    const sourceTerms = await loadEntryTerms(context, source.id);
+    if (Object.keys(sourceTerms).length > 0) {
+      await applyTermPatch(context, created.id, sourceTerms);
+    }
+
+    const meta = decodeMetaBag(context.plugins, created, created.meta);
+
+    return context.hooks.applyFilter("rpc:entry.duplicate:output", {
+      ...created,
+      meta,
+    });
+  });

--- a/packages/core/src/rpc/procedures/entry/index.ts
+++ b/packages/core/src/rpc/procedures/entry/index.ts
@@ -2,6 +2,7 @@ import { list as activityList } from "./activity.js";
 import { create } from "./create.js";
 import { deletePermanent } from "./delete-permanent.js";
 import { discardDraft } from "./discard-draft.js";
+import { duplicate } from "./duplicate.js";
 import { get } from "./get.js";
 import { list } from "./list.js";
 import { publish } from "./publish.js";
@@ -18,6 +19,7 @@ export const entryRouter = {
   trash,
   restore,
   deletePermanent,
+  duplicate,
   publish,
   discardDraft,
   revisions: revisionsRouter,

--- a/packages/core/src/rpc/procedures/entry/lifecycle.ts
+++ b/packages/core/src/rpc/procedures/entry/lifecycle.ts
@@ -163,9 +163,13 @@ export async function loadDeletableEntry(
 
 // Mirrors the readability rules in `entry.get`: any type-level `read` cap,
 // and for non-published entries also requires `edit_any` or (author +
-// `edit_own`). Kept local because this is the only call site — `entry.get`
-// inlines its own variant that also issues an errors.NOT_FOUND directly.
-function canReadEntry(ctx: AuthenticatedAppContext, entry: Entry): boolean {
+// `edit_own`). `entry.get` inlines its own variant that also issues an
+// errors.NOT_FOUND directly; `entry.duplicate` reuses this to gate the
+// source it copies (a create cap alone would leak unreadable drafts).
+export function canReadEntry(
+  ctx: AuthenticatedAppContext,
+  entry: Entry,
+): boolean {
   if (!ctx.auth.can(entryCapability(entry.type, "read"))) return false;
   if (entry.status === "published") return true;
   if (ctx.auth.can(entryCapability(entry.type, "edit_any"))) return true;

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -220,6 +220,7 @@ export const entryGetInputSchema = v.object({
 export const entryTrashInputSchema = v.object({ id: idParam });
 export const entryRestoreInputSchema = v.object({ id: idParam });
 export const entryDeletePermanentInputSchema = v.object({ id: idParam });
+export const entryDuplicateInputSchema = v.object({ id: idParam });
 
 export type EntryListInput = v.InferOutput<typeof entryListInputSchema>;
 export type EntryGetInput = v.InferOutput<typeof entryGetInputSchema>;


### PR DESCRIPTION
Authors had no way to clone an entry — recreating a near-identical post meant retyping it. Adds `entry.duplicate` and a Duplicate row action.

**What gets copied**

Title (suffixed `" (copy)"`), content, excerpt, the raw `meta` column, and term assignments → a fresh **draft** with a unique slug via bounded retry (`slug-copy`, `slug-copy-2`, … against the `(type, slug)` index).

**Authorization — two gates, not one**

A create cap alone would let a caller harvest a draft they can't see, so duplicate gates on **both** the source type's create cap **and** the source's readability (the same `canReadEntry` rules `entry.get` uses). Unreadable sources 404 rather than 403 to avoid leaking existence, and reserved-type rows (revision/autosave) 404 so an internal snapshot can't be cloned. (This read gate was added in response to review — the first cut gated on create only.)

**Admin**

The entries list grows a Duplicate row action on non-trashed rows, gated on the create cap, firing immediately with a success toast (it's a non-destructive create — no confirm dialog).

**No audit event** — a duplicated draft fires nothing, matching plain create-draft, since the `draft` lifecycle transition is a no-op when from == to. Noted so it's a conscious choice rather than a surprise for the audit-log plugin.

Fixes #867