### PR TITLE
feat(blocks): language combobox for the code block

### DIFF
--- a/packages/admin/src/editor/combobox-field.test.tsx
+++ b/packages/admin/src/editor/combobox-field.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { ComboboxField } from "./combobox-field.js";
+
+const OPTIONS = [
+  { label: "TypeScript", value: "typescript" },
+  { label: "Rust", value: "rust" },
+];
+
+afterEach(cleanup);
+
+describe("ComboboxField", () => {
+  test("displays a stored value even when it isn't in the suggestion list", () => {
+    render(
+      <ComboboxField
+        value="ts"
+        options={OPTIONS}
+        onChange={vi.fn()}
+        testId="combo"
+      />,
+    );
+    // The select this replaced would show blank for an out-of-list value;
+    // the combobox shows the real stored value.
+    expect(screen.getByTestId("combo")).toHaveValue("ts");
+  });
+
+  test("emits the raw typed value so any language is preserved", async () => {
+    const onChange = vi.fn();
+    render(
+      <ComboboxField
+        value=""
+        options={OPTIONS}
+        onChange={onChange}
+        testId="combo"
+      />,
+    );
+    // Controlled with a fixed empty value, so each keystroke emits that
+    // single char — enough to prove the raw string flows through onChange
+    // unfiltered (no option-list constraint).
+    await userEvent.type(screen.getByTestId("combo"), "x");
+    expect(onChange).toHaveBeenCalledWith("x");
+  });
+});

--- a/packages/admin/src/editor/combobox-field.tsx
+++ b/packages/admin/src/editor/combobox-field.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+import { useId } from "react";
+
+interface ComboboxOption {
+  readonly label: string;
+  readonly value: string;
+}
+
+// Free-text input backed by a <datalist> of suggestions. Unlike Puck's
+// native <select>, this preserves any stored string — including legacy
+// free-text values not in the suggestion list — so existing content is
+// never silently dropped (the reason the code block can't use a select).
+export function ComboboxField({
+  label,
+  value,
+  options,
+  onChange,
+  testId,
+}: {
+  readonly label?: string;
+  readonly value: unknown;
+  readonly options: readonly ComboboxOption[];
+  readonly onChange: (value: string) => void;
+  readonly testId?: string;
+}): ReactNode {
+  const listId = useId();
+  return (
+    <label className="flex flex-col gap-2 text-sm">
+      {label ? <span className="text-muted-foreground">{label}</span> : null}
+      <input
+        type="text"
+        value={typeof value === "string" ? value : ""}
+        onChange={(e) => {
+          onChange(e.target.value);
+        }}
+        list={listId}
+        data-testid={testId}
+        className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
+      />
+      <datalist id={listId}>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </datalist>
+    </label>
+  );
+}

--- a/packages/admin/src/editor/field-type-translator.test.ts
+++ b/packages/admin/src/editor/field-type-translator.test.ts
@@ -41,6 +41,23 @@ describe("translateField", () => {
     });
   });
 
+  test("maps combobox to a Puck custom field that renders ComboboxField", () => {
+    const out = translateField({
+      name: "language",
+      type: "combobox",
+      label: "Language",
+      options: [{ label: "TypeScript", value: "typescript" }],
+    });
+    expect(out).toMatchObject({ type: "custom", label: "Language" });
+    // The render fn must mount without throwing given Puck's render args.
+    const rendered = (
+      out as unknown as {
+        render: (p: { value: unknown; onChange: () => void }) => unknown;
+      }
+    ).render({ value: "ts", onChange: () => undefined });
+    expect(rendered).toBeTruthy();
+  });
+
   test("maps slot to Puck's slot field type", () => {
     expect(
       translateField({ name: "content", type: "slot", label: "Body" }),

--- a/packages/admin/src/editor/field-type-translator.tsx
+++ b/packages/admin/src/editor/field-type-translator.tsx
@@ -6,6 +6,8 @@ import { defineMessage } from "@lingui/core/macro";
 import type { BlockInput } from "@plumix/blocks";
 import { resolveLabel } from "@plumix/core/i18n";
 
+import { ComboboxField } from "./combobox-field.js";
+
 const YES_LABEL = defineMessage({
   id: "fieldTypes.boolean.yes",
   message: "Yes",
@@ -47,6 +49,32 @@ export function translateField(
           value: opt.value,
         })),
       };
+    case "combobox": {
+      // Free-text + suggestions. Native select would drop any stored
+      // value not in `options` (e.g. legacy free-text), so a custom
+      // field backs it with a <datalist> instead.
+      // String-coerce values (unlike select, which keeps raw
+      // string|number|boolean) — a datalist + text input is string-only.
+      const comboOptions = (input.options ?? []).map((opt) => ({
+        label: resolveLabel(opt.label, i18n),
+        value: String(opt.value),
+      }));
+      return {
+        type: "custom",
+        label,
+        render: ({ value, onChange }) => (
+          <ComboboxField
+            label={label}
+            value={value as unknown}
+            options={comboOptions}
+            onChange={(next: string) => {
+              onChange(next);
+            }}
+            testId={`block-combobox-${input.name}`}
+          />
+        ),
+      };
+    }
     case "slot":
       return { type: "slot", label };
     case "richtext":

--- a/packages/admin/src/editor/puck-to-block-tree.test.ts
+++ b/packages/admin/src/editor/puck-to-block-tree.test.ts
@@ -35,6 +35,22 @@ describe("puckDataToBlockTree", () => {
     ]);
   });
 
+  test("preserves an arbitrary string attr verbatim (e.g. a legacy code-block language)", () => {
+    // #881: the code block's language is a free-text combobox, so a
+    // value authored before the picker ("ts", or an unknown language)
+    // must survive the Puck round-trip rather than being dropped/snapped.
+    const result = puckDataToBlockTree(
+      data([
+        {
+          type: "core/code",
+          props: { id: "c1", text: "const x = 1;", language: "ts" },
+        },
+      ]),
+    );
+
+    expect(result[0]?.attrs?.language).toBe("ts");
+  });
+
   test("uses a fallback id when props.id is missing or empty", () => {
     const result = puckDataToBlockTree(
       data([

--- a/packages/blocks/src/code/index.test.tsx
+++ b/packages/blocks/src/code/index.test.tsx
@@ -33,4 +33,23 @@ describe("core/code", () => {
     expect(html).not.toContain("<code");
     expect(html).not.toContain("data-language");
   });
+
+  test("normalizes an alias to its canonical id at render", () => {
+    const html = renderBlockSpecToHtml(codeBlock, {
+      text: "const x = 1;",
+      language: "ts",
+    });
+
+    expect(html).toContain('data-language="typescript"');
+  });
+
+  test("exposes the language input as a combobox suggesting common languages", () => {
+    const languageInput = codeBlock.inputs?.find((i) => i.name === "language");
+    // Combobox (free text + datalist), not select — a select would drop
+    // stored values outside the suggestion list.
+    expect(languageInput?.type).toBe("combobox");
+    const values = languageInput?.options?.map((o) => o.value);
+    expect(values).toContain("typescript");
+    expect(values).toContain("rust");
+  });
 });

--- a/packages/blocks/src/code/index.tsx
+++ b/packages/blocks/src/code/index.tsx
@@ -1,6 +1,17 @@
 import type { ReactNode } from "react";
 
 import { defineBlock } from "../block-registry.js";
+import { CODE_LANGUAGES, normalizeLanguage } from "./languages.js";
+
+// Suggestions for the language combobox — the curated common-language
+// list. A combobox (free text + datalist), not a select: the stored
+// value stays a plain string, so content authored with the old
+// free-text field (alias or unknown language) is preserved and
+// normalized at render rather than dropped.
+const LANGUAGE_OPTIONS = CODE_LANGUAGES.map((lang) => ({
+  label: lang.label,
+  value: lang.id,
+}));
 
 export const codeBlock = defineBlock({
   name: "core/code",
@@ -9,7 +20,12 @@ export const codeBlock = defineBlock({
   category: "text",
   inputs: [
     { name: "text", type: "textarea", label: "Code" },
-    { name: "language", type: "text", label: "Language" },
+    {
+      name: "language",
+      type: "combobox",
+      label: "Language",
+      options: LANGUAGE_OPTIONS,
+    },
   ],
   defaults: { text: "", language: "" },
   render: ({ attrs }): ReactNode => {
@@ -17,7 +33,7 @@ export const codeBlock = defineBlock({
       readonly text?: string;
       readonly language?: string;
     };
-    const lang = language.trim() || undefined;
+    const lang = normalizeLanguage(language);
     return (
       <pre data-language={lang}>
         {lang ? <code data-language={lang}>{text}</code> : text}

--- a/packages/blocks/src/code/languages.test.ts
+++ b/packages/blocks/src/code/languages.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  CODE_LANGUAGES,
+  LANGUAGE_ALIASES,
+  normalizeLanguage,
+} from "./languages.js";
+
+describe("normalizeLanguage", () => {
+  test("returns undefined for empty or whitespace-only input", () => {
+    expect(normalizeLanguage("")).toBeUndefined();
+    expect(normalizeLanguage("   ")).toBeUndefined();
+    expect(normalizeLanguage(undefined)).toBeUndefined();
+  });
+
+  test("passes a canonical language through unchanged", () => {
+    expect(normalizeLanguage("typescript")).toBe("typescript");
+    expect(normalizeLanguage("rust")).toBe("rust");
+  });
+
+  test("maps common aliases to their canonical id", () => {
+    expect(normalizeLanguage("ts")).toBe("typescript");
+    expect(normalizeLanguage("py")).toBe("python");
+    expect(normalizeLanguage("js")).toBe("javascript");
+    expect(normalizeLanguage("sh")).toBe("shell");
+  });
+
+  test("is case- and whitespace-insensitive", () => {
+    expect(normalizeLanguage("  TypeScript  ")).toBe("typescript");
+    expect(normalizeLanguage("RUST")).toBe("rust");
+  });
+
+  test("preserves an unknown language verbatim (lowercased) so existing content is untouched", () => {
+    expect(normalizeLanguage("brainfuck")).toBe("brainfuck");
+  });
+
+  test("every canonical language is a stable, lowercase id", () => {
+    for (const lang of CODE_LANGUAGES) {
+      expect(lang.id).toBe(lang.id.toLowerCase());
+      expect(normalizeLanguage(lang.id)).toBe(lang.id);
+    }
+  });
+
+  test("every alias resolves to a canonical language id (no typo'd targets)", () => {
+    const ids = new Set(CODE_LANGUAGES.map((l) => l.id));
+    for (const target of Object.values(LANGUAGE_ALIASES)) {
+      expect(ids.has(target)).toBe(true);
+    }
+  });
+});

--- a/packages/blocks/src/code/languages.ts
+++ b/packages/blocks/src/code/languages.ts
@@ -1,0 +1,72 @@
+import type { Label } from "../i18n-label.js";
+
+interface CodeLanguage {
+  // Stable, lowercase id stored on the block and emitted as
+  // `data-language` — highlighters key off these.
+  readonly id: string;
+  readonly label: Label;
+}
+
+// Curated common-language list for the code block's picker. Labels stay
+// plain English (proper nouns / not worth translating); ids are the
+// canonical highlighter slugs.
+export const CODE_LANGUAGES: readonly CodeLanguage[] = [
+  { id: "bash", label: "Bash" },
+  { id: "c", label: "C" },
+  { id: "cpp", label: "C++" },
+  { id: "csharp", label: "C#" },
+  { id: "css", label: "CSS" },
+  { id: "diff", label: "Diff" },
+  { id: "go", label: "Go" },
+  { id: "graphql", label: "GraphQL" },
+  { id: "html", label: "HTML" },
+  { id: "java", label: "Java" },
+  { id: "javascript", label: "JavaScript" },
+  { id: "jsx", label: "JSX" },
+  { id: "json", label: "JSON" },
+  { id: "kotlin", label: "Kotlin" },
+  { id: "markdown", label: "Markdown" },
+  { id: "php", label: "PHP" },
+  { id: "python", label: "Python" },
+  { id: "ruby", label: "Ruby" },
+  { id: "rust", label: "Rust" },
+  { id: "shell", label: "Shell" },
+  { id: "sql", label: "SQL" },
+  { id: "swift", label: "Swift" },
+  { id: "toml", label: "TOML" },
+  { id: "tsx", label: "TSX" },
+  { id: "typescript", label: "TypeScript" },
+  { id: "yaml", label: "YAML" },
+];
+
+// Short forms / fence names that map onto a canonical id. Anything not
+// listed falls through unchanged (lowercased) so an unknown language
+// already stored on a block is preserved rather than dropped. Every
+// value here must be an id in CODE_LANGUAGES — guarded by a test.
+export const LANGUAGE_ALIASES: Readonly<Record<string, string>> = {
+  ts: "typescript",
+  js: "javascript",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  kt: "kotlin",
+  sh: "shell",
+  zsh: "shell",
+  yml: "yaml",
+  md: "markdown",
+  "c++": "cpp",
+  "c#": "csharp",
+  cs: "csharp",
+  golang: "go",
+};
+
+/**
+ * Normalize a raw language string to a canonical id: trim + lowercase,
+ * map known aliases, otherwise return the lowercased value verbatim.
+ * Empty / whitespace-only / undefined → undefined (no language).
+ */
+export function normalizeLanguage(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim().toLowerCase();
+  if (!trimmed) return undefined;
+  return LANGUAGE_ALIASES[trimmed] ?? trimmed;
+}


### PR DESCRIPTION
The code block's language was a bare free-text field — no discovery of what languages highlighters support, and no normalization, so `ts` and `typescript` produced different `data-language` output. It's now a combobox over a curated list, with alias normalization at render.

**Alias normalization at render**

`normalizeLanguage` (trim/lowercase, map `ts`→`typescript`, `py`→`python`, … and pass unknown languages through) runs in the block's render, so a stored alias or legacy free-text value emits a consistent canonical `data-language`. The stored attribute is never rewritten.

**Combobox, not select — to avoid silent data loss**

The first attempt used a Puck native `<select>`. Review caught, and a round-trip test confirmed, that a select drops any stored value outside the option list — exactly the legacy free-text / unknown-language values this feature must preserve. The fix adds a generic `combobox` block input backed by a Puck custom field: a free-text `<input>` + `<datalist>` of suggestions. It preserves and displays every stored string while still offering the curated list.

Preservation is guarded at each layer: a `puckDataToBlockTree` round-trip test (an out-of-list `language` survives), a `ComboboxField` component test (an out-of-list value renders; typed input flows through unfiltered), and an alias-integrity test (every alias resolves to a real canonical id).

Fixes #881