### PR TITLE
feat: bulk actions on the entries list

### DIFF
--- a/packages/admin/e2e/entries.spec.ts
+++ b/packages/admin/e2e/entries.spec.ts
@@ -290,6 +290,139 @@ test.describe("/entries/$slug (list)", () => {
     await expect(page.getByTestId("toast-success")).toBeVisible();
   });
 
+  test("bulk trash: select all → bar → confirm → entry.trashMany payload → rows drop", async ({
+    page,
+  }) => {
+    const trashed: unknown[] = [];
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(trashed.length === 0 ? TWO_ROWS : []),
+      }),
+    );
+    await page.route("**/_plumix/rpc/entry/trashMany", (route) => {
+      const body = route.request().postDataJSON() as {
+        json?: { ids: number[] };
+      };
+      trashed.push(body.json);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody({ ids: body.json?.ids ?? [] }),
+      });
+    });
+
+    await page.goto("entries/posts");
+    // No bar until something is selected.
+    await expect(page.getByTestId("content-list-bulk-bar")).toHaveCount(0);
+    await page.getByTestId("content-list-select-all").check();
+    await expect(page.getByTestId("content-list-bulk-bar")).toBeVisible();
+    await expect(page.getByTestId("content-list-bulk-count")).toContainText(
+      "2",
+    );
+
+    await page.getByTestId("content-list-bulk-trash").click();
+    await page.getByTestId("content-list-bulk-confirm").click();
+
+    expect(trashed[0]).toMatchObject({ ids: [1, 2] });
+    await expect(page.getByTestId("content-list-row-1")).toHaveCount(0);
+    await expect(page.getByTestId("toast-success")).toBeVisible();
+  });
+
+  test("bulk trash uses only the individually selected rows", async ({
+    page,
+  }) => {
+    const trashed: unknown[] = [];
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(trashed.length === 0 ? TWO_ROWS : [TWO_ROWS[1]]),
+      }),
+    );
+    await page.route("**/_plumix/rpc/entry/trashMany", (route) => {
+      const body = route.request().postDataJSON() as {
+        json?: { ids: number[] };
+      };
+      trashed.push(body.json);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody({ ids: body.json?.ids ?? [] }),
+      });
+    });
+
+    await page.goto("entries/posts");
+    await page.getByTestId("content-list-select-1").check();
+    await page.getByTestId("content-list-bulk-trash").click();
+    await page.getByTestId("content-list-bulk-confirm").click();
+
+    expect(trashed[0]).toMatchObject({ ids: [1] });
+  });
+
+  test("trash view: bulk bar offers Restore + Delete permanently, not Trash", async ({
+    page,
+  }) => {
+    const TRASHED = [
+      entry({ id: 7, title: "Binned A", status: "trash" }),
+      entry({ id: 8, title: "Binned B", status: "trash" }),
+    ];
+    const restored: unknown[] = [];
+    await mockRpc(page, { "/auth/session": AUTHED_ADMIN });
+    await page.route("**/_plumix/rpc/entry/list", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody(restored.length === 0 ? TRASHED : []),
+      }),
+    );
+    await page.route("**/_plumix/rpc/entry/restoreMany", (route) => {
+      const body = route.request().postDataJSON() as {
+        json?: { ids: number[] };
+      };
+      restored.push(body.json);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: rpcOkBody({ ids: body.json?.ids ?? [] }),
+      });
+    });
+
+    await page.goto("entries/posts?status=trash");
+    await page.getByTestId("content-list-select-all").check();
+    await expect(page.getByTestId("content-list-bulk-restore")).toBeVisible();
+    await expect(page.getByTestId("content-list-bulk-delete")).toBeVisible();
+    await expect(page.getByTestId("content-list-bulk-trash")).toHaveCount(0);
+
+    // Restore fires immediately (no confirm — it's recoverable).
+    await page.getByTestId("content-list-bulk-restore").click();
+    expect(restored[0]).toMatchObject({ ids: [7, 8] });
+    await expect(page.getByTestId("toast-success")).toBeVisible();
+  });
+
+  test("without delete cap: the select column is absent", async ({ page }) => {
+    await mockRpc(page, {
+      "/auth/session": {
+        user: {
+          id: 5,
+          email: "viewer@example.test",
+          name: "Viewer",
+          avatarUrl: null,
+          role: "subscriber",
+          capabilities: ["entry:post:read"],
+        },
+        needsBootstrap: false,
+      },
+      "/entry/list": TWO_ROWS,
+    });
+    await page.goto("entries/posts");
+    await expect(page.getByTestId("content-list-row-1")).toBeVisible();
+    await expect(page.getByTestId("content-list-select-all")).toHaveCount(0);
+  });
+
   test("duplicate flow: row action → entry.duplicate payload → toast + refetched list", async ({
     page,
   }) => {

--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -229,6 +229,13 @@ msgid "editor.layout.characterCount"
 msgstr "{characters, plural, zero {# حرف} one {حرف واحد} two {حرفان} few {# "
 "أحرف} many {# حرفًا} other {# حرف}}"
 
+#. count: number of selected entries
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.selected"
+msgstr "{count, plural, zero {# إدخال محدد} one {# إدخال محدد} two {تم تحديد إدخالين} few {# إدخالات محددة} many {# إدخالًا محددًا} other {# إدخال محدد}}"
+"many {# محددًا} other {# محدد}}"
+
 #. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
@@ -236,6 +243,43 @@ msgstr "{characters, plural, zero {# حرف} one {حرف واحد} two {حرفا
 msgid "settings.pageSummary"
 msgstr "{count, plural, zero {لا توجد مجموعات} one {مجموعة واحدة} two "
 "{مجموعتان} few {# مجموعات} many {# مجموعة} other {# مجموعة}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteTitle"
+msgstr "{count, plural, zero {حذف # إدخال نهائيًا؟} one {حذف # إدخال نهائيًا؟} "
+"two {حذف إدخالين نهائيًا؟} few {حذف # إدخالات نهائيًا؟} many {حذف # "
+"إدخالًا نهائيًا؟} other {حذف # إدخال نهائيًا؟}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastDeleted"
+msgstr "{count, plural, zero {تم حذف # إدخال.} one {تم حذف # إدخال.} two {تم "
+"حذف إدخالين.} few {تم حذف # إدخالات.} many {تم حذف # إدخالًا.} other "
+"{تم حذف # إدخال.}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trashTitle"
+msgstr "{count, plural, zero {نقل # إدخال إلى المهملات؟} one {نقل # إدخال إلى "
+"المهملات؟} two {نقل إدخالين إلى المهملات؟} few {نقل # إدخالات إلى "
+"المهملات؟} many {نقل # إدخالًا إلى المهملات؟} other {نقل # إدخال إلى "
+"المهملات؟}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastTrashed"
+msgstr "{count, plural, zero {تم نقل # إدخال إلى المهملات.} one {تم نقل # إدخال "
+"إلى المهملات.} two {تم نقل إدخالين إلى المهملات.} few {تم نقل # إدخالات "
+"إلى المهملات.} many {تم نقل # إدخالًا إلى المهملات.} other {تم نقل # "
+"إدخال إلى المهملات.}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastRestored"
+msgstr "{count, plural, zero {تمت استعادة # إدخال.} one {تمت استعادة # إدخال.} "
+"two {تمت استعادة إدخالين.} few {تمت استعادة # إدخالات.} many {تمت "
+"استعادة # إدخالًا.} other {تمت استعادة # إدخال.}}"
 
 #. count: number of selected options in the multi-select
 #. js-lingui-explicit-id
@@ -661,6 +705,11 @@ msgid "terms.edit.delete.cancel"
 msgstr "إلغاء"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.cancel"
+msgstr "إلغاء"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.cancel"
 msgstr "إلغاء"
@@ -815,6 +864,11 @@ msgstr "مقارنة"
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.list.title"
 msgstr "النطاقات المُكوَّنة"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.confirm"
+msgstr "تأكيد"
 
 #. userCode: the short device-flow code the CLI displayed (e.g. 'WDJB-MJHT'); pass through verbatim
 #. js-lingui-explicit-id
@@ -1241,6 +1295,11 @@ msgstr "حذف نهائي"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.delete.confirm"
 msgstr "حذف passkey"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.delete"
+msgstr "حذف نهائي"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2064,6 +2123,11 @@ msgid "editor.device.mobile"
 msgstr "الجوال"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trash"
+msgstr "نقل إلى المهملات"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.confirm"
 msgstr "نقل إلى المهملات"
@@ -2655,6 +2719,11 @@ msgid "profile.passkeys.rename.label"
 msgstr "إعادة تسمية passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.restore"
+msgstr "استعادة"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgctxt "action verb"
 msgid "entries.list.row.restore"
@@ -2925,6 +2994,16 @@ msgstr "اختر كتلة لرؤية الإجراءات."
 #: src/editor/StyleTab.tsx
 msgid "editor.styleTab.empty"
 msgstr "اختر كتلة لتنسيقها."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectAllAria"
+msgstr "تحديد كل الإدخالات في هذه الصفحة"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectRowAria"
+msgstr "تحديد الإدخال"
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3303,6 +3382,11 @@ msgid "entries.list.toast.failed"
 msgstr "لم ينجح ذلك — حاول مرة أخرى."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastFailed"
+msgstr "لم ينجح ذلك — حاول مرة أخرى."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.error.domainExists"
 msgstr "هذا النطاق مُكوَّن بالفعل."
@@ -3520,6 +3604,11 @@ msgstr "لم يعد هذا passkey موجوداً. حدّث القائمة."
 msgid "entries.list.deleteDialog.description"
 msgstr "سيؤدي هذا إلى حذف الإدخال ومراجعاته نهائيًا. لا يمكن التراجع عن هذا "
 "الإجراء."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteBody"
+msgstr "يؤدي هذا إلى حذف الإدخالات المحددة ومراجعاتها نهائيًا. لا يمكن التراجع."
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -228,12 +228,47 @@ msgstr "{browser} auf {os}"
 msgid "editor.layout.characterCount"
 msgstr "{characters, plural, one {# Zeichen} other {# Zeichen}}"
 
+#. count: number of selected entries
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.selected"
+msgstr "{count, plural, one {# Eintrag ausgewählt} other {# Einträge ausgewählt}}"
+
 #. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr "{count, plural, one {# Gruppe} other {# Gruppen}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteTitle"
+msgstr "{count, plural, one {# Eintrag endgültig löschen?} other {# Einträge "
+"endgültig löschen?}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastDeleted"
+msgstr "{count, plural, one {# Eintrag gelöscht.} other {# Einträge gelöscht.}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trashTitle"
+msgstr "{count, plural, one {# Eintrag in den Papierkorb verschieben?} other {# "
+"Einträge in den Papierkorb verschieben?}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastTrashed"
+msgstr "{count, plural, one {# Eintrag in den Papierkorb verschoben.} other {# "
+"Einträge in den Papierkorb verschoben.}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastRestored"
+msgstr "{count, plural, one {# Eintrag wiederhergestellt.} other {# Einträge "
+"wiederhergestellt.}}"
 
 #. count: number of selected options in the multi-select
 #. js-lingui-explicit-id
@@ -667,6 +702,11 @@ msgid "terms.edit.delete.cancel"
 msgstr "Abbrechen"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.cancel"
+msgstr "Abbrechen"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.cancel"
 msgstr "Abbrechen"
@@ -823,6 +863,11 @@ msgstr "Vergleichen"
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.list.title"
 msgstr "Konfigurierte Domains"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.confirm"
+msgstr "Bestätigen"
 
 #. userCode: the short device-flow code the CLI displayed (e.g. 'WDJB-MJHT'); pass through verbatim
 #. js-lingui-explicit-id
@@ -1257,6 +1302,11 @@ msgstr "Endgültig löschen"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.delete.confirm"
 msgstr "Passkey löschen"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.delete"
+msgstr "Endgültig löschen"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2089,6 +2139,11 @@ msgid "editor.device.mobile"
 msgstr "Mobil"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trash"
+msgstr "In den Papierkorb"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.confirm"
 msgstr "In den Papierkorb verschieben"
@@ -2691,6 +2746,11 @@ msgid "profile.passkeys.rename.label"
 msgstr "Passkey umbenennen"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.restore"
+msgstr "Wiederherstellen"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgctxt "action verb"
 msgid "entries.list.row.restore"
@@ -2961,6 +3021,16 @@ msgstr "Wählen Sie einen Block, um Aktionen anzuzeigen."
 #: src/editor/StyleTab.tsx
 msgid "editor.styleTab.empty"
 msgstr "Wählen Sie einen Block zum Stylen aus."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectAllAria"
+msgstr "Alle Einträge auf dieser Seite auswählen"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectRowAria"
+msgstr "Eintrag auswählen"
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3352,6 +3422,11 @@ msgid "entries.list.toast.failed"
 msgstr "Das hat nicht geklappt — bitte erneut versuchen."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastFailed"
+msgstr "Das hat nicht geklappt — bitte erneut versuchen."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.error.domainExists"
 msgstr "Diese Domain ist bereits konfiguriert."
@@ -3582,6 +3657,12 @@ msgstr "Dieser Passkey existiert nicht mehr. Liste aktualisieren."
 msgid "entries.list.deleteDialog.description"
 msgstr "Der Eintrag und seine Revisionen werden endgültig gelöscht. Das kann "
 "nicht rückgängig gemacht werden."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteBody"
+msgstr "Dies löscht die ausgewählten Einträge und ihre Revisionen endgültig. "
+"Das kann nicht rückgängig gemacht werden."
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -228,12 +228,46 @@ msgstr "{browser} on {os}"
 msgid "editor.layout.characterCount"
 msgstr "{characters, plural, one {# character} other {# characters}}"
 
+#. count: number of selected entries
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.selected"
+msgstr "{count, plural, one {# entry selected} other {# entries selected}}"
+
 #. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr "{count, plural, one {# group} other {# groups}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteTitle"
+msgstr "{count, plural, one {Delete # entry permanently?} other {Delete # "
+"entries permanently?}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastDeleted"
+msgstr "{count, plural, one {Deleted # entry.} other {Deleted # entries.}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trashTitle"
+msgstr "{count, plural, one {Move # entry to trash?} other {Move # entries to "
+"trash?}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastTrashed"
+msgstr "{count, plural, one {Moved # entry to trash.} other {Moved # entries to "
+"trash.}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastRestored"
+msgstr "{count, plural, one {Restored # entry.} other {Restored # entries.}}"
 
 #. count: number of selected options in the multi-select
 #. js-lingui-explicit-id
@@ -661,6 +695,11 @@ msgid "terms.edit.delete.cancel"
 msgstr "Cancel"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.cancel"
+msgstr "Cancel"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.cancel"
 msgstr "Cancel"
@@ -815,6 +854,11 @@ msgstr "Compare"
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.list.title"
 msgstr "Configured domains"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.confirm"
+msgstr "Confirm"
 
 #. userCode: the short device-flow code the CLI displayed (e.g. 'WDJB-MJHT'); pass through verbatim
 #. js-lingui-explicit-id
@@ -1241,6 +1285,11 @@ msgstr "Delete forever"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.delete.confirm"
 msgstr "Delete passkey"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.delete"
+msgstr "Delete permanently"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2064,6 +2113,11 @@ msgid "editor.device.mobile"
 msgstr "Mobile"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trash"
+msgstr "Move to trash"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.confirm"
 msgstr "Move to trash"
@@ -2659,6 +2713,11 @@ msgid "profile.passkeys.rename.label"
 msgstr "Rename passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.restore"
+msgstr "Restore"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgctxt "action verb"
 msgid "entries.list.row.restore"
@@ -2929,6 +2988,16 @@ msgstr "Select a block to see actions."
 #: src/editor/StyleTab.tsx
 msgid "editor.styleTab.empty"
 msgstr "Select a block to style."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectAllAria"
+msgstr "Select all entries on this page"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectRowAria"
+msgstr "Select entry"
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3311,6 +3380,11 @@ msgid "entries.list.toast.failed"
 msgstr "That didn't work — try again."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastFailed"
+msgstr "That didn't work — try again."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.error.domainExists"
 msgstr "That domain is already configured."
@@ -3534,6 +3608,12 @@ msgstr "This passkey no longer exists. Refresh the list."
 msgid "entries.list.deleteDialog.description"
 msgstr "This permanently deletes the entry and its revisions. It cannot be "
 "undone."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteBody"
+msgstr "This permanently deletes the selected entries and their revisions. It "
+"cannot be undone."
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -229,6 +229,13 @@ msgid "editor.layout.characterCount"
 msgstr "{characters, plural, one {# символ} few {# символи} many {# символів} "
 "other {# символа}}"
 
+#. count: number of selected entries
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.selected"
+msgstr "{count, plural, one {# запис вибрано} few {# записи вибрано} many {# записів вибрано} other {# запису вибрано}}"
+"{# вибрано}}"
+
 #. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
@@ -236,6 +243,39 @@ msgstr "{characters, plural, one {# символ} few {# символи} many {#
 msgid "settings.pageSummary"
 msgstr "{count, plural, one {# група} few {# групи} many {# груп} other {# "
 "груп}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteTitle"
+msgstr "{count, plural, one {Видалити # запис назавжди?} few {Видалити # записи "
+"назавжди?} many {Видалити # записів назавжди?} other {Видалити # запису "
+"назавжди?}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastDeleted"
+msgstr "{count, plural, one {Видалено # запис.} few {Видалено # записи.} many "
+"{Видалено # записів.} other {Видалено # запису.}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trashTitle"
+msgstr "{count, plural, one {Перемістити # запис до кошика?} few {Перемістити # "
+"записи до кошика?} many {Перемістити # записів до кошика?} other "
+"{Перемістити # запису до кошика?}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastTrashed"
+msgstr "{count, plural, one {Переміщено # запис до кошика.} few {Переміщено # "
+"записи до кошика.} many {Переміщено # записів до кошика.} other "
+"{Переміщено # запису до кошика.}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastRestored"
+msgstr "{count, plural, one {Відновлено # запис.} few {Відновлено # записи.} "
+"many {Відновлено # записів.} other {Відновлено # запису.}}"
 
 #. count: number of selected options in the multi-select
 #. js-lingui-explicit-id
@@ -668,6 +708,11 @@ msgid "terms.edit.delete.cancel"
 msgstr "Скасувати"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.cancel"
+msgstr "Скасувати"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.cancel"
 msgstr "Скасувати"
@@ -823,6 +868,11 @@ msgstr "Порівняти"
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.list.title"
 msgstr "Налаштовані домени"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.confirm"
+msgstr "Підтвердити"
 
 #. userCode: the short device-flow code the CLI displayed (e.g. 'WDJB-MJHT'); pass through verbatim
 #. js-lingui-explicit-id
@@ -1250,6 +1300,11 @@ msgstr "Видалити назавжди"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.delete.confirm"
 msgstr "Видалити passkey"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.delete"
+msgstr "Видалити назавжди"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2075,6 +2130,11 @@ msgid "editor.device.mobile"
 msgstr "Мобільний"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trash"
+msgstr "До кошика"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.confirm"
 msgstr "У кошик"
@@ -2675,6 +2735,11 @@ msgid "profile.passkeys.rename.label"
 msgstr "Перейменувати passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.restore"
+msgstr "Відновити"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgctxt "action verb"
 msgid "entries.list.row.restore"
@@ -2945,6 +3010,16 @@ msgstr "Виберіть блок, щоб побачити дії."
 #: src/editor/StyleTab.tsx
 msgid "editor.styleTab.empty"
 msgstr "Виберіть блок для стилізації."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectAllAria"
+msgstr "Вибрати всі записи на цій сторінці"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectRowAria"
+msgstr "Вибрати запис"
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3330,6 +3405,11 @@ msgid "entries.list.toast.failed"
 msgstr "Не вдалося — спробуйте ще раз."
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastFailed"
+msgstr "Не вдалося — спробуйте ще раз."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.error.domainExists"
 msgstr "Цей домен уже налаштовано."
@@ -3554,6 +3634,12 @@ msgstr "Цей passkey більше не існує. Оновіть список
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.deleteDialog.description"
 msgstr "Запис і всі його редакції буде видалено назавжди. Цю дію неможливо "
+"скасувати."
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteBody"
+msgstr "Це назавжди видалить вибрані записи та їхні редакції. Дію не можна "
 "скасувати."
 
 #. js-lingui-explicit-id

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -228,12 +228,43 @@ msgstr "{browser}（{os}）"
 msgid "editor.layout.characterCount"
 msgstr "{characters, plural, other {# 个字符}}"
 
+#. count: number of selected entries
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.selected"
+msgstr "{count, plural, other {已选择 # 个条目}}"
+
 #. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.test.tsx
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr "{count, plural, other {# 个分组}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteTitle"
+msgstr "{count, plural, other {永久删除 # 个条目？}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastDeleted"
+msgstr "{count, plural, other {已删除 # 个条目。}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trashTitle"
+msgstr "{count, plural, other {将 # 个条目移至回收站？}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastTrashed"
+msgstr "{count, plural, other {已将 # 个条目移至回收站。}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastRestored"
+msgstr "{count, plural, other {已恢复 # 个条目。}}"
 
 #. count: number of selected options in the multi-select
 #. js-lingui-explicit-id
@@ -651,6 +682,11 @@ msgid "terms.edit.delete.cancel"
 msgstr "取消"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.cancel"
+msgstr "取消"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.cancel"
 msgstr "取消"
@@ -805,6 +841,11 @@ msgstr "比较"
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.list.title"
 msgstr "已配置的域名"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.confirm"
+msgstr "确认"
 
 #. userCode: the short device-flow code the CLI displayed (e.g. 'WDJB-MJHT'); pass through verbatim
 #. js-lingui-explicit-id
@@ -1227,6 +1268,11 @@ msgstr "永久删除"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.delete.confirm"
 msgstr "删除 Passkey"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.delete"
+msgstr "永久删除"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2041,6 +2087,11 @@ msgid "editor.device.mobile"
 msgstr "移动设备"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.trash"
+msgstr "移至回收站"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.trashDialog.confirm"
 msgstr "移至回收站"
@@ -2627,6 +2678,11 @@ msgid "profile.passkeys.rename.label"
 msgstr "重命名 Passkey"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.restore"
+msgstr "恢复"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgctxt "action verb"
 msgid "entries.list.row.restore"
@@ -2896,6 +2952,16 @@ msgstr "选择一个区块以查看操作。"
 #: src/editor/StyleTab.tsx
 msgid "editor.styleTab.empty"
 msgstr "选择一个区块以应用样式。"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectAllAria"
+msgstr "选择本页所有条目"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.selectRowAria"
+msgstr "选择条目"
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3268,6 +3334,11 @@ msgid "entries.list.toast.failed"
 msgstr "操作失败，请重试。"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/index.tsx
+msgid "entries.list.bulk.toastFailed"
+msgstr "操作失败，请重试。"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.error.domainExists"
 msgstr "此域名已配置。"
@@ -3478,6 +3549,11 @@ msgstr "此 Passkey 不再存在。请刷新列表。"
 #: src/routes/_authenticated/entries/$slug/index.tsx
 msgid "entries.list.deleteDialog.description"
 msgstr "这将永久删除该条目及其所有修订版本，且无法撤销。"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+msgid "entries.list.bulk.deleteBody"
+msgstr "这将永久删除所选条目及其修订版本，且无法撤销。"
 
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/src/components/data-table/data-table.tsx
+++ b/packages/admin/src/components/data-table/data-table.tsx
@@ -6,7 +6,11 @@
 // unknown. The warning is informational, not an error.
 
 import type { MessageDescriptor } from "@lingui/core";
-import type { ColumnDef } from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  OnChangeFn,
+  RowSelectionState,
+} from "@tanstack/react-table";
 import type { ReactNode } from "react";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import {
@@ -51,6 +55,9 @@ export function DataTable<TData>({
   isLoading = false,
   emptyState,
   loadingLabel,
+  rowSelection,
+  onRowSelectionChange,
+  getRowId,
 }: {
   readonly columns: ColumnDef<TData>[];
   readonly data: readonly TData[];
@@ -59,9 +66,18 @@ export function DataTable<TData>({
   /** Screen-reader label for the loading region when `isLoading`.
    *  Defaults to the localized "Loading" descriptor. */
   readonly loadingLabel?: string;
+  /** Controlled row-selection state. When provided (with
+   *  `onRowSelectionChange`), selection is enabled and a selection column
+   *  can be added by the caller via `columns`. Keyed by `getRowId`. */
+  readonly rowSelection?: RowSelectionState;
+  readonly onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  /** Stable per-row id for selection keys (e.g. the entry id) — without
+   *  it, selection keys by row index and breaks across refetches. */
+  readonly getRowId?: (row: TData) => string;
 }): ReactNode {
   const label = useLabel();
   const resolvedLoadingLabel = loadingLabel ?? label(M.loading);
+  const selectable = rowSelection !== undefined;
   // `useReactTable` returns a non-stable table instance — React Compiler
   // can't memoize the surrounding render. The instance is the documented
   // contract (its methods and state are read by row/cell components)
@@ -71,6 +87,14 @@ export function DataTable<TData>({
     data: data as TData[],
     columns,
     getCoreRowModel: getCoreRowModel(),
+    ...(selectable
+      ? {
+          enableRowSelection: true,
+          state: { rowSelection },
+          onRowSelectionChange,
+          ...(getRowId ? { getRowId } : {}),
+        }
+      : {}),
   });
 
   const rows = table.getRowModel().rows;

--- a/packages/admin/src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -1,0 +1,176 @@
+import type { MessageDescriptor } from "@lingui/core";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog.js";
+import { Button } from "@/components/ui/button.js";
+import { defineMessage } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+
+// View-scoped bulk action bar (WordPress model): the Trash view offers
+// Restore + Delete permanently; every other view offers Trash. Keying off
+// the active view sidesteps mixed-status selections entirely. Rendered
+// only when at least one row is selected.
+const M = {
+  selected: defineMessage({
+    id: "entries.list.bulk.selected",
+    message:
+      "{count, plural, one {# entry selected} other {# entries selected}}",
+    comment: "count: number of selected entries",
+  }),
+  trash: defineMessage({
+    id: "entries.list.bulk.trash",
+    message: "Move to trash",
+  }),
+  restore: defineMessage({
+    id: "entries.list.bulk.restore",
+    message: "Restore",
+  }),
+  delete: defineMessage({
+    id: "entries.list.bulk.delete",
+    message: "Delete permanently",
+  }),
+  trashTitle: defineMessage({
+    id: "entries.list.bulk.trashTitle",
+    message:
+      "{count, plural, one {Move # entry to trash?} other {Move # entries to trash?}}",
+  }),
+  deleteTitle: defineMessage({
+    id: "entries.list.bulk.deleteTitle",
+    message:
+      "{count, plural, one {Delete # entry permanently?} other {Delete # entries permanently?}}",
+  }),
+  deleteBody: defineMessage({
+    id: "entries.list.bulk.deleteBody",
+    message:
+      "This permanently deletes the selected entries and their revisions. It cannot be undone.",
+  }),
+  confirm: defineMessage({
+    id: "entries.list.bulk.confirm",
+    message: "Confirm",
+  }),
+  cancel: defineMessage({ id: "entries.list.bulk.cancel", message: "Cancel" }),
+} satisfies Record<string, MessageDescriptor>;
+
+export function EntriesBulkBar({
+  count,
+  view,
+  busy,
+  onTrash,
+  onRestore,
+  onDeletePermanent,
+}: {
+  readonly count: number;
+  readonly view: "trash" | "active";
+  readonly busy: boolean;
+  readonly onTrash: () => void;
+  readonly onRestore: () => void;
+  readonly onDeletePermanent: () => void;
+}): ReactNode {
+  const { i18n } = useLingui();
+  const [dialog, setDialog] = useState<"trash" | "delete" | null>(null);
+
+  const plural = (m: MessageDescriptor): string =>
+    i18n._(m.id, { count }, { message: m.message });
+
+  return (
+    <div
+      data-testid="content-list-bulk-bar"
+      className="bg-muted/40 flex items-center gap-3 rounded-md border px-4 py-2"
+    >
+      <span
+        data-testid="content-list-bulk-count"
+        className="text-sm font-medium"
+      >
+        {plural(M.selected)}
+      </span>
+      <div className="ms-auto flex items-center gap-2">
+        {view === "trash" ? (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={onRestore}
+              data-testid="content-list-bulk-restore"
+            >
+              {i18n._(M.restore.id, {}, { message: M.restore.message })}
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={busy}
+              onClick={() => {
+                // eslint-disable-next-line lingui/no-unlocalized-strings -- dialog discriminant, not UI copy
+                setDialog("delete");
+              }}
+              data-testid="content-list-bulk-delete"
+            >
+              {i18n._(M.delete.id, {}, { message: M.delete.message })}
+            </Button>
+          </>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => {
+              setDialog("trash");
+            }}
+            data-testid="content-list-bulk-trash"
+          >
+            {i18n._(M.trash.id, {}, { message: M.trash.message })}
+          </Button>
+        )}
+      </div>
+
+      <AlertDialog
+        open={dialog !== null}
+        onOpenChange={(open) => {
+          if (!open) setDialog(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {dialog === "delete"
+                ? plural(M.deleteTitle)
+                : plural(M.trashTitle)}
+            </AlertDialogTitle>
+            {dialog === "delete" ? (
+              <AlertDialogDescription>
+                {i18n._(M.deleteBody.id, {}, { message: M.deleteBody.message })}
+              </AlertDialogDescription>
+            ) : null}
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy}>
+              {i18n._(M.cancel.id, {}, { message: M.cancel.message })}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="content-list-bulk-confirm"
+              disabled={busy}
+              onClick={(e) => {
+                e.preventDefault();
+                const action = dialog;
+                setDialog(null);
+                if (action === "delete") onDeletePermanent();
+                else if (action === "trash") onTrash();
+              }}
+            >
+              {i18n._(M.confirm.id, {}, { message: M.confirm.message })}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -1,5 +1,5 @@
 import type { MessageDescriptor } from "@lingui/core";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
 import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { DataTable } from "@/components/data-table/data-table.js";
@@ -53,6 +53,8 @@ import * as v from "valibot";
 
 import type { EntryTypeManifestEntry } from "@plumix/core/manifest";
 import type { Entry, EntryStatus, Term } from "@plumix/core/schema";
+
+import { EntriesBulkBar } from "./entries-bulk-bar.js";
 
 const PAGE_SIZE = 20;
 
@@ -277,6 +279,33 @@ const M = {
     id: "entries.list.row.duplicating",
     message: "Duplicating…",
   }),
+  selectAllAria: defineMessage({
+    id: "entries.list.selectAllAria",
+    message: "Select all entries on this page",
+  }),
+  selectRowAria: defineMessage({
+    id: "entries.list.selectRowAria",
+    message: "Select entry",
+  }),
+  bulkFailed: defineMessage({
+    id: "entries.list.bulk.toastFailed",
+    message: "That didn't work — try again.",
+  }),
+  bulkTrashed: defineMessage({
+    id: "entries.list.bulk.toastTrashed",
+    message:
+      "{count, plural, one {Moved # entry to trash.} other {Moved # entries to trash.}}",
+  }),
+  bulkRestored: defineMessage({
+    id: "entries.list.bulk.toastRestored",
+    message:
+      "{count, plural, one {Restored # entry.} other {Restored # entries.}}",
+  }),
+  bulkDeleted: defineMessage({
+    id: "entries.list.bulk.toastDeleted",
+    message:
+      "{count, plural, one {Deleted # entry.} other {Deleted # entries.}}",
+  }),
 } satisfies Record<string, MessageDescriptor>;
 
 const STATUS_FILTER_OPTIONS: {
@@ -304,6 +333,9 @@ function buildColumns({
   onRestore,
   restoringId,
   onDeletePermanent,
+  showSelect,
+  selectAllLabel,
+  selectRowLabel,
   renderLabel,
   editLabel,
   formatDate,
@@ -321,11 +353,41 @@ function buildColumns({
   onRestore: (id: number) => void;
   restoringId: number | null;
   onDeletePermanent: (id: number) => void;
+  showSelect: boolean;
+  selectAllLabel: string;
+  selectRowLabel: string;
   renderLabel: (label: MessageDescriptor) => string;
   editLabel: string;
   formatDate: (value: Date, options?: Intl.DateTimeFormatOptions) => string;
 }): ColumnDef<Entry>[] {
+  const selectColumn: ColumnDef<Entry> = {
+    id: "select",
+    meta: { className: "w-8" },
+    header: ({ table }) => (
+      <input
+        type="checkbox"
+        checked={table.getIsAllPageRowsSelected()}
+        ref={(el) => {
+          if (el) el.indeterminate = table.getIsSomePageRowsSelected();
+        }}
+        onChange={table.getToggleAllPageRowsSelectedHandler()}
+        aria-label={selectAllLabel}
+        data-testid="content-list-select-all"
+      />
+    ),
+    cell: ({ row }) => (
+      <input
+        type="checkbox"
+        checked={row.getIsSelected()}
+        disabled={!row.getCanSelect()}
+        onChange={row.getToggleSelectedHandler()}
+        aria-label={selectRowLabel}
+        data-testid={`content-list-select-${String(row.original.id)}`}
+      />
+    ),
+  };
   return [
+    ...(showSelect ? [selectColumn] : []),
     {
       accessorKey: "title",
       header: () => (
@@ -655,6 +717,58 @@ function ContentListRoute(): ReactNode {
     [setPendingDeleteId],
   );
 
+  // ── Bulk selection ──────────────────────────────────────────────
+  // Selection is page-scoped by construction: `selectedIds` intersects
+  // the row-selection map with the currently-visible rows, so a tick left
+  // over from a prior page / filter can never ride into a bulk action —
+  // no reset-on-change effect needed.
+  const { i18n } = useLingui();
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const selectedIds = useMemo(() => {
+    const visible = new Set(rows.map((row) => row.id));
+    return Object.keys(rowSelection)
+      .map(Number)
+      .filter((id) => rowSelection[String(id)] && visible.has(id));
+  }, [rowSelection, rows]);
+  const isTrashView = search.status === "trash";
+  // Bulk is gated on the same `delete` cap the per-row trash/restore/
+  // delete actions use; the select column only renders when available.
+  const showSelect = canDelete && rows.length > 0;
+
+  const bulkToast = useCallback(
+    (m: MessageDescriptor, count: number): void => {
+      toastSuccess(i18n._(m.id, { count }, { message: m.message }));
+    },
+    [i18n],
+  );
+  const onBulkSuccess = useCallback(
+    (m: MessageDescriptor) => (result: { readonly ids: readonly number[] }) => {
+      bulkToast(m, result.ids.length);
+      setRowSelection({});
+      return invalidateList();
+    },
+    [bulkToast, invalidateList],
+  );
+  const trashMany = useMutation({
+    mutationFn: (ids: number[]) => orpc.entry.trashMany.call({ ids }),
+    onSuccess: onBulkSuccess(M.bulkTrashed),
+    onError: onMutationError,
+  });
+  const restoreMany = useMutation({
+    mutationFn: (ids: number[]) => orpc.entry.restoreMany.call({ ids }),
+    onSuccess: onBulkSuccess(M.bulkRestored),
+    onError: onMutationError,
+  });
+  const deletePermanentMany = useMutation({
+    mutationFn: (ids: number[]) => orpc.entry.deletePermanentMany.call({ ids }),
+    onSuccess: onBulkSuccess(M.bulkDeleted),
+    onError: onMutationError,
+  });
+  const bulkBusy =
+    trashMany.isPending ||
+    restoreMany.isPending ||
+    deletePermanentMany.isPending;
+
   const editLabel = renderLabel(entryTypeLabel(entryType, "editItem"));
   const { formatDate } = useFormatters();
   const columns = useMemo(
@@ -673,6 +787,9 @@ function ContentListRoute(): ReactNode {
         onRestore,
         restoringId,
         onDeletePermanent,
+        showSelect,
+        selectAllLabel: renderLabel(M.selectAllAria),
+        selectRowLabel: renderLabel(M.selectRowAria),
         renderLabel,
         editLabel,
         formatDate,
@@ -691,6 +808,7 @@ function ContentListRoute(): ReactNode {
       onRestore,
       restoringId,
       onDeletePermanent,
+      showSelect,
       renderLabel,
       editLabel,
       formatDate,
@@ -750,6 +868,24 @@ function ContentListRoute(): ReactNode {
         </div>
       </div>
 
+      {showSelect && selectedIds.length > 0 ? (
+        <EntriesBulkBar
+          count={selectedIds.length}
+          // eslint-disable-next-line lingui/no-unlocalized-strings -- view discriminant, not UI copy
+          view={isTrashView ? "trash" : "active"}
+          busy={bulkBusy}
+          onTrash={() => {
+            trashMany.mutate(selectedIds);
+          }}
+          onRestore={() => {
+            restoreMany.mutate(selectedIds);
+          }}
+          onDeletePermanent={() => {
+            deletePermanentMany.mutate(selectedIds);
+          }}
+        />
+      ) : null}
+
       {query.isError ? (
         <Alert variant="destructive" data-testid="content-list-load-error">
           <AlertDescription>
@@ -764,6 +900,13 @@ function ContentListRoute(): ReactNode {
           data={rows}
           isLoading={query.isPending}
           loadingLabel={renderLabel(entryTypeLabel(entryType, "loadingItems"))}
+          {...(showSelect
+            ? {
+                rowSelection,
+                onRowSelectionChange: setRowSelection,
+                getRowId: (entry: Entry) => String(entry.id),
+              }
+            : {})}
           emptyState={
             <EmptyState
               entryType={entryType}

--- a/packages/core/src/rpc/procedures/entry/bulk.test.ts
+++ b/packages/core/src/rpc/procedures/entry/bulk.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Entry } from "../../../db/schema/entries.js";
+import { eq, inArray, like, or } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+describe("entry.trashMany", () => {
+  test("editor trashes several entries in one call; trashed fires per entry", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const a = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "a",
+    });
+    const b = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "b",
+    });
+
+    const onTrash = vi.fn<(post: Entry) => void>();
+    h.hooks.addAction("entry:trashed", onTrash);
+
+    const result = await h.client.entry.trashMany({ ids: [a.id, b.id] });
+    expect(new Set(result.ids)).toEqual(new Set([a.id, b.id]));
+    expect(onTrash).toHaveBeenCalledTimes(2);
+
+    const rows = await h.db.query.entries.findMany({
+      where: inArray(entries.id, [a.id, b.id]),
+    });
+    expect(rows.every((r) => r.status === "trash")).toBe(true);
+  });
+
+  test("already-trashed ids are skipped idempotently", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const live = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "live",
+    });
+    const gone = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "gone",
+    });
+    const result = await h.client.entry.trashMany({ ids: [live.id, gone.id] });
+    expect(result.ids).toEqual([live.id]);
+  });
+
+  test("fail-all: a forbidden row rejects the whole batch, nothing is trashed", async () => {
+    const h = await createRpcHarness({ authAs: "contributor" });
+    const mine = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "mine",
+    });
+    await expect(
+      h.client.entry.trashMany({ ids: [mine.id] }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    const row = await h.db.query.entries.findFirst({
+      where: eq(entries.id, mine.id),
+    });
+    expect(row?.status).toBe("published");
+  });
+
+  test("duplicate ids act once — no double-fire, no inflated result", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const target = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "dup",
+    });
+    const onTrash = vi.fn();
+    h.hooks.addAction("entry:trashed", onTrash);
+    const result = await h.client.entry.trashMany({
+      ids: [target.id, target.id],
+    });
+    expect(result.ids).toEqual([target.id]);
+    expect(onTrash).toHaveBeenCalledTimes(1);
+  });
+
+  test("404 when any id is missing", async () => {
+    const h = await createRpcHarness({ authAs: "admin" });
+    const real = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "real",
+    });
+    await expect(
+      h.client.entry.trashMany({ ids: [real.id, 9999] }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("entry.restoreMany", () => {
+  test("restores trashed entries to draft", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const a = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "ra",
+    });
+    const b = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "rb",
+    });
+    const result = await h.client.entry.restoreMany({ ids: [a.id, b.id] });
+    expect(new Set(result.ids)).toEqual(new Set([a.id, b.id]));
+    const rows = await h.db.query.entries.findMany({
+      where: inArray(entries.id, [a.id, b.id]),
+    });
+    expect(rows.every((r) => r.status === "draft")).toBe(true);
+  });
+
+  test("non-trashed ids are skipped", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const trashed = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "t",
+    });
+    const live = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "l",
+    });
+    const result = await h.client.entry.restoreMany({
+      ids: [trashed.id, live.id],
+    });
+    expect(result.ids).toEqual([trashed.id]);
+  });
+});
+
+describe("entry.deletePermanentMany", () => {
+  test("permanently deletes trashed entries plus their revision/autosave rows", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const a = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "da",
+    });
+    const b = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "db",
+    });
+    for (const t of [a, b]) {
+      await h.factory.entry.create({
+        authorId: h.user.id,
+        type: "revision",
+        slug: `revision:${String(t.id)}:abcdefghijklmnopqrstu`,
+      });
+    }
+
+    const result = await h.client.entry.deletePermanentMany({
+      ids: [a.id, b.id],
+    });
+    expect(new Set(result.ids)).toEqual(new Set([a.id, b.id]));
+
+    const leftovers = await h.db.query.entries.findMany({
+      where: or(
+        inArray(entries.id, [a.id, b.id]),
+        like(entries.slug, `revision:${String(a.id)}:%`),
+        like(entries.slug, `revision:${String(b.id)}:%`),
+      ),
+    });
+    expect(leftovers).toEqual([]);
+  });
+
+  test("rejects when any id is not trashed (fail-all)", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const trashed = await h.factory.trashed.create({
+      authorId: h.user.id,
+      slug: "tt",
+    });
+    const live = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "ll",
+    });
+    await expect(
+      h.client.entry.deletePermanentMany({ ids: [trashed.id, live.id] }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      data: { reason: "not_trashed" },
+    });
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/bulk.ts
+++ b/packages/core/src/rpc/procedures/entry/bulk.ts
@@ -1,0 +1,106 @@
+import { and, eq, inArray, like, or } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { AUTOSAVE_TYPE, REVISION_TYPE } from "../../../revisions/slug-codec.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import {
+  entryDeletableGuards,
+  fireEntryDeleted,
+  fireEntryRestored,
+  fireEntryTrashed,
+  loadDeletableEntries,
+} from "./lifecycle.js";
+import {
+  entryDeletePermanentManyInputSchema,
+  entryRestoreManyInputSchema,
+  entryTrashManyInputSchema,
+} from "./schemas.js";
+
+export const trashMany = base
+  .use(authenticated)
+  .input(entryTrashManyInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const rows = await loadDeletableEntries(
+      context,
+      input.ids,
+      entryDeletableGuards(errors),
+    );
+    // Skip rows already in the trash — bulk trash is idempotent, mirroring
+    // the single-row no-op.
+    const toTrash = rows.filter((row) => row.status !== "trash");
+    if (toTrash.length === 0) return { ids: [] };
+
+    const ids = toTrash.map((row) => row.id);
+    await context.db
+      .update(entries)
+      .set({ status: "trash" })
+      .where(inArray(entries.id, ids));
+
+    for (const row of toTrash) {
+      await fireEntryTrashed(context, { ...row, status: "trash" });
+    }
+    return { ids };
+  });
+
+export const restoreMany = base
+  .use(authenticated)
+  .input(entryRestoreManyInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const rows = await loadDeletableEntries(
+      context,
+      input.ids,
+      entryDeletableGuards(errors),
+    );
+    // Only trashed rows are restorable; others are skipped (the trash
+    // view never mixes statuses, this is the defensive backstop).
+    const toRestore = rows.filter((row) => row.status === "trash");
+    if (toRestore.length === 0) return { ids: [] };
+
+    const ids = toRestore.map((row) => row.id);
+    await context.db
+      .update(entries)
+      .set({ status: "draft" })
+      .where(inArray(entries.id, ids));
+
+    for (const row of toRestore) {
+      await fireEntryRestored(context, { ...row, status: "draft" });
+    }
+    return { ids };
+  });
+
+export const deletePermanentMany = base
+  .use(authenticated)
+  .input(entryDeletePermanentManyInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const rows = await loadDeletableEntries(
+      context,
+      input.ids,
+      entryDeletableGuards(errors),
+    );
+    // Permanent delete is unrecoverable — fail-all if any selected row
+    // isn't trashed, matching the single-row guard.
+    if (rows.some((row) => row.status !== "trash")) {
+      throw errors.CONFLICT({ data: { reason: "not_trashed" } });
+    }
+
+    const ids = rows.map((row) => row.id);
+    // Revision / autosave rows are linked by slug encoding, not FK, so
+    // clear them in one batched statement before the entries themselves.
+    const slugClauses = ids.flatMap((id) => [
+      and(
+        eq(entries.type, REVISION_TYPE),
+        like(entries.slug, `revision:${String(id)}:%`),
+      ),
+      and(
+        eq(entries.type, AUTOSAVE_TYPE),
+        like(entries.slug, `autosave:${String(id)}:%`),
+      ),
+    ]);
+    await context.db.delete(entries).where(or(...slugClauses));
+    await context.db.delete(entries).where(inArray(entries.id, ids));
+
+    for (const row of rows) {
+      await fireEntryDeleted(context, row);
+    }
+    return { ids };
+  });

--- a/packages/core/src/rpc/procedures/entry/delete-permanent.ts
+++ b/packages/core/src/rpc/procedures/entry/delete-permanent.ts
@@ -3,7 +3,11 @@ import { entries } from "../../../db/schema/entries.js";
 import { AUTOSAVE_TYPE, REVISION_TYPE } from "../../../revisions/slug-codec.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
-import { fireEntryDeleted, loadDeletableEntry } from "./lifecycle.js";
+import {
+  entryDeletableGuards,
+  fireEntryDeleted,
+  loadDeletableEntry,
+} from "./lifecycle.js";
 import { entryDeletePermanentInputSchema } from "./schemas.js";
 
 export const deletePermanent = base
@@ -15,14 +19,11 @@ export const deletePermanent = base
       input,
     );
 
-    const existing = await loadDeletableEntry(context, filtered.id, {
-      notFound: (id) => {
-        throw errors.NOT_FOUND({ data: { kind: "entry", id } });
-      },
-      forbidden: (capability) => {
-        throw errors.FORBIDDEN({ data: { capability } });
-      },
-    });
+    const existing = await loadDeletableEntry(
+      context,
+      filtered.id,
+      entryDeletableGuards(errors),
+    );
 
     if (existing.status !== "trash") {
       throw errors.CONFLICT({ data: { reason: "not_trashed" } });

--- a/packages/core/src/rpc/procedures/entry/index.ts
+++ b/packages/core/src/rpc/procedures/entry/index.ts
@@ -1,4 +1,5 @@
 import { list as activityList } from "./activity.js";
+import { deletePermanentMany, restoreMany, trashMany } from "./bulk.js";
 import { create } from "./create.js";
 import { deletePermanent } from "./delete-permanent.js";
 import { discardDraft } from "./discard-draft.js";
@@ -19,6 +20,9 @@ export const entryRouter = {
   trash,
   restore,
   deletePermanent,
+  trashMany,
+  restoreMany,
+  deletePermanentMany,
   duplicate,
   publish,
   discardDraft,

--- a/packages/core/src/rpc/procedures/entry/lifecycle.ts
+++ b/packages/core/src/rpc/procedures/entry/lifecycle.ts
@@ -7,7 +7,7 @@ import type {
   EntryStatus,
   NewEntry,
 } from "../../../db/schema/entries.js";
-import { eq } from "../../../db/index.js";
+import { eq, inArray } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
 import {
   pruneOldRevisions,
@@ -139,26 +139,82 @@ export function entryCapability(type: string, action: string): string {
  * `update.ts` (`(author AND edit_own) OR edit_any`, no `delete` cap) —
  * don't unify them.
  */
+interface DeletableGuards {
+  readonly notFound: (id: number) => never;
+  readonly forbidden: (capability: string) => never;
+}
+
+// The trash-lifecycle procedures (single + bulk) all translate a missing
+// row into NOT_FOUND and a failed cap into FORBIDDEN. `errors` is the
+// per-handler oRPC builder, so this is a thin shared adapter.
+export function entryDeletableGuards(errors: {
+  NOT_FOUND: (opts: { data: { kind: string; id: number } }) => Error;
+  FORBIDDEN: (opts: { data: { capability: string } }) => Error;
+}): DeletableGuards {
+  return {
+    notFound: (id) => {
+      throw errors.NOT_FOUND({ data: { kind: "entry", id } });
+    },
+    forbidden: (capability) => {
+      throw errors.FORBIDDEN({ data: { capability } });
+    },
+  };
+}
+
+// Pure (no query) gate: `delete` cap plus author-or-`edit_any`. Shared by
+// the single-row and batched loaders.
+function assertDeletable(
+  ctx: AuthenticatedAppContext,
+  entry: Entry,
+  guards: DeletableGuards,
+): void {
+  const deleteCapability = entryCapability(entry.type, "delete");
+  if (!ctx.auth.can(deleteCapability)) guards.forbidden(deleteCapability);
+  if (entry.authorId !== ctx.user.id) {
+    const editAnyCapability = entryCapability(entry.type, "edit_any");
+    if (!ctx.auth.can(editAnyCapability)) guards.forbidden(editAnyCapability);
+  }
+}
+
 export async function loadDeletableEntry(
   ctx: AuthenticatedAppContext,
   id: number,
-  guards: {
-    readonly notFound: (id: number) => never;
-    readonly forbidden: (capability: string) => never;
-  },
+  guards: DeletableGuards,
 ): Promise<Entry> {
   const existing = await ctx.db.query.entries.findFirst({
     where: eq(entries.id, id),
   });
   if (!existing) guards.notFound(id);
-
-  const deleteCapability = entryCapability(existing.type, "delete");
-  if (!ctx.auth.can(deleteCapability)) guards.forbidden(deleteCapability);
-  if (existing.authorId !== ctx.user.id) {
-    const editAnyCapability = entryCapability(existing.type, "edit_any");
-    if (!ctx.auth.can(editAnyCapability)) guards.forbidden(editAnyCapability);
-  }
+  assertDeletable(ctx, existing, guards);
   return existing;
+}
+
+/**
+ * Batched sibling of `loadDeletableEntry` for the bulk procedures: one
+ * `WHERE id IN (…)` read (no N+1), then per-row gating in memory.
+ * Fail-all — any missing id or any forbidden row throws, so a bulk op
+ * never half-applies across a mix of permitted and forbidden entries.
+ */
+export async function loadDeletableEntries(
+  ctx: AuthenticatedAppContext,
+  ids: readonly number[],
+  guards: DeletableGuards,
+): Promise<Entry[]> {
+  // Dedupe so a repeated id can't double-fire lifecycle hooks or inflate
+  // the result count — bulk ops act on each entry once.
+  const uniqueIds = [...new Set(ids)];
+  const rows = await ctx.db.query.entries.findMany({
+    where: inArray(entries.id, uniqueIds),
+  });
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const ordered: Entry[] = [];
+  for (const id of uniqueIds) {
+    const row = byId.get(id);
+    if (!row) guards.notFound(id);
+    assertDeletable(ctx, row, guards);
+    ordered.push(row);
+  }
+  return ordered;
 }
 
 // Mirrors the readability rules in `entry.get`: any type-level `read` cap,

--- a/packages/core/src/rpc/procedures/entry/restore.ts
+++ b/packages/core/src/rpc/procedures/entry/restore.ts
@@ -2,7 +2,11 @@ import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
-import { fireEntryRestored, loadDeletableEntry } from "./lifecycle.js";
+import {
+  entryDeletableGuards,
+  fireEntryRestored,
+  loadDeletableEntry,
+} from "./lifecycle.js";
 import { entryRestoreInputSchema } from "./schemas.js";
 
 export const restore = base
@@ -14,14 +18,11 @@ export const restore = base
       input,
     );
 
-    const existing = await loadDeletableEntry(context, filtered.id, {
-      notFound: (id) => {
-        throw errors.NOT_FOUND({ data: { kind: "entry", id } });
-      },
-      forbidden: (capability) => {
-        throw errors.FORBIDDEN({ data: { capability } });
-      },
-    });
+    const existing = await loadDeletableEntry(
+      context,
+      filtered.id,
+      entryDeletableGuards(errors),
+    );
 
     if (existing.status !== "trash") {
       throw errors.CONFLICT({ data: { reason: "not_trashed" } });

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -222,6 +222,15 @@ export const entryRestoreInputSchema = v.object({ id: idParam });
 export const entryDeletePermanentInputSchema = v.object({ id: idParam });
 export const entryDuplicateInputSchema = v.object({ id: idParam });
 
+// Bulk action input. Capped at 100 ids per call so a single batched
+// `WHERE id IN (…)` stays bounded; the admin selects a page at a time.
+const bulkIdsSchema = v.object({
+  ids: v.pipe(v.array(idParam), v.minLength(1), v.maxLength(100)),
+});
+export const entryTrashManyInputSchema = bulkIdsSchema;
+export const entryRestoreManyInputSchema = bulkIdsSchema;
+export const entryDeletePermanentManyInputSchema = bulkIdsSchema;
+
 export type EntryListInput = v.InferOutput<typeof entryListInputSchema>;
 export type EntryGetInput = v.InferOutput<typeof entryGetInputSchema>;
 export type EntryCreateInput = v.InferOutput<typeof entryCreateInputSchema>;

--- a/packages/core/src/rpc/procedures/entry/trash.ts
+++ b/packages/core/src/rpc/procedures/entry/trash.ts
@@ -2,7 +2,11 @@ import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
-import { fireEntryTrashed, loadDeletableEntry } from "./lifecycle.js";
+import {
+  entryDeletableGuards,
+  fireEntryTrashed,
+  loadDeletableEntry,
+} from "./lifecycle.js";
 import { entryTrashInputSchema } from "./schemas.js";
 
 export const trash = base
@@ -14,14 +18,11 @@ export const trash = base
       input,
     );
 
-    const existing = await loadDeletableEntry(context, filtered.id, {
-      notFound: (id) => {
-        throw errors.NOT_FOUND({ data: { kind: "entry", id } });
-      },
-      forbidden: (capability) => {
-        throw errors.FORBIDDEN({ data: { capability } });
-      },
-    });
+    const existing = await loadDeletableEntry(
+      context,
+      filtered.id,
+      entryDeletableGuards(errors),
+    );
 
     if (existing.status === "trash") {
       return context.hooks.applyFilter("rpc:entry.trash:output", existing);


### PR DESCRIPTION
Managing more than a handful of entries meant repeating the same single-row action over and over. The list now supports row selection plus batched trash / restore / delete-permanently.

**Batched, fail-all RPC**

`entry.trashMany` / `restoreMany` / `deletePermanentMany` each load all targets in one `WHERE id IN` read, gate per row in memory, dedupe ids, then write in a single batched statement — no N+1. Capability is **fail-all**: any missing or forbidden id rejects the whole batch (never a partial apply, no half-leak). Status handling mirrors the single-row guards — trashMany skips already-trashed and restoreMany skips non-trashed idempotently; deletePermanentMany conflicts if any selected row isn't trashed. The shared load+gate prelude (`loadDeletableEntries` / `assertDeletable` / `entryDeletableGuards`) is now used by the single-row procedures too, so there's one capability gate, not six copies.

**View-scoped bulk bar**

A select column + a bar that follows the WordPress model: the Trash view offers Restore + Delete permanently; every other view offers Trash. This sidesteps mixed-status selections entirely. Restore fires immediately (recoverable); trash and permanent-delete go through confirm dialogs.

**Page-scoped selection by construction**

`selectedIds` intersects the selection map with the currently-visible rows, so a tick left over from a prior page or filter can never enter a bulk payload — no reset-on-change effect needed.

Review fixes folded in: deduped batch ids (a repeated id was double-firing lifecycle hooks), extracted the guards helper across all six procedures, and made the selection-count plural meaningful (entry/entries). uk/ar/de/zh-CN translated.

Fixes #868