### PR TITLE
feat(admin): live counts and recent activity on the dashboard

### DIFF
--- a/packages/admin/e2e/dashboard.spec.ts
+++ b/packages/admin/e2e/dashboard.spec.ts
@@ -5,28 +5,82 @@ import {
   AUTHED_ADMIN,
   MANIFEST_WITH_POST,
   mockManifest,
+  mockRpc,
   mockSession,
+  rpcOkBody,
 } from "./support/rpc-mock.js";
 
+const STATS = [
+  { type: "post", status: "published", count: 4 },
+  { type: "post", status: "draft", count: 2 },
+];
+
+const T0 = new Date("2026-04-19T12:00:00Z").toISOString();
+const RECENT = [
+  {
+    id: 1,
+    type: "post",
+    title: "Latest post",
+    slug: "latest-post",
+    status: "published",
+    updatedAt: T0,
+  },
+];
+
 test.describe("/ (dashboard)", () => {
-  test("renders content tiles from the manifest with zero WCAG 2.1 AA violations", async ({
+  test("renders tiles, live counts and recent activity, zero WCAG 2.1 AA violations", async ({
     page,
   }) => {
     await mockManifest(page, MANIFEST_WITH_POST);
-    await mockSession(page, AUTHED_ADMIN);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/stats": STATS,
+      "/entry/recentActivity": RECENT,
+    });
     await page.goto("");
+
     await expect(page.getByTestId("dashboard-welcome-heading")).toBeVisible();
     await expect(page.getByTestId("dashboard-tile-post-link")).toHaveAttribute(
       "href",
       /\/entries\/posts/,
     );
+    // Live counts from entry.stats.
+    const counts = page.getByTestId("dashboard-tile-post-counts");
+    await expect(counts).toContainText("4");
+    await expect(counts).toContainText("2");
+    // Recent activity from entry.recentActivity.
+    await expect(page.getByTestId("dashboard-recent-activity")).toContainText(
+      "Latest post",
+    );
     await expectNoAxeViolations(page);
+  });
+
+  test("recent-activity panel shows an empty state when there's no activity", async ({
+    page,
+  }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/stats": [],
+      "/entry/recentActivity": [],
+    });
+    await page.goto("");
+    await expect(page.getByTestId("dashboard-recent-activity")).toBeVisible();
+    // Zero-count tiles still render.
+    await expect(page.getByTestId("dashboard-tile-post-counts")).toContainText(
+      "0",
+    );
   });
 
   test("renders the empty-state card when no post types are registered", async ({
     page,
   }) => {
     await mockSession(page, AUTHED_ADMIN);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/stats": [],
+      "/entry/recentActivity": [],
+    });
     await page.goto("");
     await expect(page.getByTestId("dashboard-empty-state")).toBeVisible();
     await expectNoAxeViolations(page);

--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -164,6 +164,11 @@ msgstr ""
 #~ msgstr "Edit"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+#~ msgid "dashboard.tile.description.generic"
+#~ msgstr "اكتب، حرّر، انشر."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.descendantsHint"
 msgstr " — لا يمكن اختيار الأبناء كأب."
@@ -229,12 +234,18 @@ msgid "editor.layout.characterCount"
 msgstr "{characters, plural, zero {# حرف} one {حرف واحد} two {حرفان} few {# "
 "أحرف} many {# حرفًا} other {# حرف}}"
 
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.draft"
+msgstr "{count, plural, zero {# مسودة} one {# مسودة} two {مسودتان} few {# مسودات} many {# مسودة} other {# مسودة}}"
+
 #. count: number of selected entries
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
 msgid "entries.list.bulk.selected"
-msgstr "{count, plural, zero {# إدخال محدد} one {# إدخال محدد} two {تم تحديد إدخالين} few {# إدخالات محددة} many {# إدخالًا محددًا} other {# إدخال محدد}}"
-"many {# محددًا} other {# محدد}}"
+msgstr "{count, plural, zero {# إدخال محدد} one {# إدخال محدد} two {تم تحديد "
+"إدخالين} few {# إدخالات محددة} many {# إدخالًا محددًا} other {# إدخال "
+"محدد}}many {# محددًا} other {# محدد}}"
 
 #. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
@@ -243,6 +254,11 @@ msgstr "{count, plural, zero {# إدخال محدد} one {# إدخال محدد}
 msgid "settings.pageSummary"
 msgstr "{count, plural, zero {لا توجد مجموعات} one {مجموعة واحدة} two "
 "{مجموعتان} few {# مجموعات} many {# مجموعة} other {# مجموعة}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.published"
+msgstr "{count, plural, zero {# منشور} one {# منشور} two {منشوران} few {# منشورات} many {# منشورًا} other {# منشور}}"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -2437,6 +2453,11 @@ msgid "type.generic.notFound"
 msgstr "لا شيء بعد"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.empty"
+msgstr "لا شيء بعد."
+
+#. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
 msgid "oauth.error.registrationClosed"
 msgstr "تسجيل OAuth غير متاح حتى ينتهي المدير من الإعداد."
@@ -2686,6 +2707,11 @@ msgstr "إعادة تفعيل المستخدم"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.reassign.label"
 msgstr "إعادة تعيين المنشورات إلى"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.title"
+msgstr "النشاط الأخير"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -3858,11 +3884,6 @@ msgstr "مرحباً، {greeting}"
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.tagline"
 msgstr "ما الذي تريد العمل عليه اليوم؟"
-
-#. js-lingui-explicit-id
-#: src/routes/_authenticated/index.tsx
-msgid "dashboard.tile.description.generic"
-msgstr "اكتب، حرّر، انشر."
 
 #. js-lingui-explicit-id
 #: src/lib/core-settings-i18n.ts

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -164,6 +164,11 @@ msgstr ""
 #~ msgstr "Edit"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+#~ msgid "dashboard.tile.description.generic"
+#~ msgstr "Schreiben, bearbeiten und veröffentlichen."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.descendantsHint"
 msgstr " — Untergeordnete können nicht als übergeordnet ausgewählt werden."
@@ -228,11 +233,17 @@ msgstr "{browser} auf {os}"
 msgid "editor.layout.characterCount"
 msgstr "{characters, plural, one {# Zeichen} other {# Zeichen}}"
 
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.draft"
+msgstr "{count, plural, one {# Entwurf} other {# Entwürfe}}"
+
 #. count: number of selected entries
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
 msgid "entries.list.bulk.selected"
-msgstr "{count, plural, one {# Eintrag ausgewählt} other {# Einträge ausgewählt}}"
+msgstr "{count, plural, one {# Eintrag ausgewählt} other {# Einträge "
+"ausgewählt}}"
 
 #. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
@@ -240,6 +251,11 @@ msgstr "{count, plural, one {# Eintrag ausgewählt} other {# Einträge ausgewäh
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr "{count, plural, one {# Gruppe} other {# Gruppen}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.published"
+msgstr "{count, plural, one {# veröffentlicht} other {# veröffentlicht}}"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -2457,6 +2473,11 @@ msgid "type.generic.notFound"
 msgstr "Noch nichts"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.empty"
+msgstr "Noch nichts."
+
+#. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
 msgid "oauth.error.registrationClosed"
 msgstr "OAuth-Registrierung ist nicht verfügbar, bis ein Administrator die "
@@ -2712,6 +2733,11 @@ msgstr "Benutzer reaktivieren"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.reassign.label"
 msgstr "Beiträge neu zuweisen an"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.title"
+msgstr "Letzte Aktivität"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -3918,11 +3944,6 @@ msgstr "Willkommen, {greeting}"
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.tagline"
 msgstr "Woran möchten Sie heute arbeiten?"
-
-#. js-lingui-explicit-id
-#: src/routes/_authenticated/index.tsx
-msgid "dashboard.tile.description.generic"
-msgstr "Schreiben, bearbeiten und veröffentlichen."
 
 #. js-lingui-explicit-id
 #: src/lib/core-settings-i18n.ts

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -164,6 +164,11 @@ msgstr ""
 #~ msgstr "Edit"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+#~ msgid "dashboard.tile.description.generic"
+#~ msgstr "Write, edit, and publish."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.descendantsHint"
 msgstr " — descendants can't be picked as parent."
@@ -228,6 +233,11 @@ msgstr "{browser} on {os}"
 msgid "editor.layout.characterCount"
 msgstr "{characters, plural, one {# character} other {# characters}}"
 
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.draft"
+msgstr "{count, plural, one {# draft} other {# drafts}}"
+
 #. count: number of selected entries
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -240,6 +250,11 @@ msgstr "{count, plural, one {# entry selected} other {# entries selected}}"
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr "{count, plural, one {# group} other {# groups}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.published"
+msgstr "{count, plural, one {# published} other {# published}}"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -2429,6 +2444,11 @@ msgid "type.generic.notFound"
 msgstr "Nothing yet"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.empty"
+msgstr "Nothing yet."
+
+#. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
 msgid "oauth.error.registrationClosed"
 msgstr "OAuth signup is unavailable until an admin has finished setup."
@@ -2679,6 +2699,11 @@ msgstr "Re-enable user"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.reassign.label"
 msgstr "Reassign entries to"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.title"
+msgstr "Recent activity"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -3865,11 +3890,6 @@ msgstr "Welcome, {greeting}"
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.tagline"
 msgstr "What would you like to work on today?"
-
-#. js-lingui-explicit-id
-#: src/routes/_authenticated/index.tsx
-msgid "dashboard.tile.description.generic"
-msgstr "Write, edit, and publish."
 
 #. js-lingui-explicit-id
 #: src/lib/core-settings-i18n.ts

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -164,6 +164,11 @@ msgstr ""
 #~ msgstr "Edit"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+#~ msgid "dashboard.tile.description.generic"
+#~ msgstr "Пишіть, редагуйте та публікуйте."
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.descendantsHint"
 msgstr " — нащадків не можна вибрати як батьківський елемент."
@@ -229,12 +234,17 @@ msgid "editor.layout.characterCount"
 msgstr "{characters, plural, one {# символ} few {# символи} many {# символів} "
 "other {# символа}}"
 
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.draft"
+msgstr "{count, plural, one {# чернетка} few {# чернетки} many {# чернеток} other {# чернетки}}"
+
 #. count: number of selected entries
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
 msgid "entries.list.bulk.selected"
-msgstr "{count, plural, one {# запис вибрано} few {# записи вибрано} many {# записів вибрано} other {# запису вибрано}}"
-"{# вибрано}}"
+msgstr "{count, plural, one {# запис вибрано} few {# записи вибрано} many {# "
+"записів вибрано} other {# запису вибрано}}{# вибрано}}"
 
 #. count: number of settings groups this page surfaces
 #. js-lingui-explicit-id
@@ -243,6 +253,11 @@ msgstr "{count, plural, one {# запис вибрано} few {# записи в
 msgid "settings.pageSummary"
 msgstr "{count, plural, one {# група} few {# групи} many {# груп} other {# "
 "груп}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.published"
+msgstr "{count, plural, one {# опубліковано} few {# опубліковано} many {# опубліковано} other {# опубліковано}}"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -2447,6 +2462,11 @@ msgid "type.generic.notFound"
 msgstr "Поки нічого"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.empty"
+msgstr "Поки нічого."
+
+#. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
 msgid "oauth.error.registrationClosed"
 msgstr "Реєстрація через OAuth недоступна, доки адміністратор не завершив "
@@ -2701,6 +2721,11 @@ msgstr "Повторно ввімкнути користувача"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.reassign.label"
 msgstr "Переназначити записи на"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.title"
+msgstr "Нещодавня активність"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -3894,11 +3919,6 @@ msgstr "Вітаємо, {greeting}"
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.tagline"
 msgstr "Над чим хочете попрацювати сьогодні?"
-
-#. js-lingui-explicit-id
-#: src/routes/_authenticated/index.tsx
-msgid "dashboard.tile.description.generic"
-msgstr "Пишіть, редагуйте та публікуйте."
 
 #. js-lingui-explicit-id
 #: src/lib/core-settings-i18n.ts

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -164,6 +164,11 @@ msgstr ""
 #~ msgstr "Edit"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+#~ msgid "dashboard.tile.description.generic"
+#~ msgstr "写作、编辑和发布。"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/terms/$name/$id/edit.tsx
 msgid "terms.edit.descendantsHint"
 msgstr " — 子项无法被选为父项。"
@@ -228,6 +233,11 @@ msgstr "{browser}（{os}）"
 msgid "editor.layout.characterCount"
 msgstr "{characters, plural, other {# 个字符}}"
 
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.draft"
+msgstr "{count, plural, other {草稿 #}}"
+
 #. count: number of selected entries
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -240,6 +250,11 @@ msgstr "{count, plural, other {已选择 # 个条目}}"
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.pageSummary"
 msgstr "{count, plural, other {# 个分组}}"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.count.published"
+msgstr "{count, plural, other {已发布 #}}"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -2399,6 +2414,11 @@ msgid "type.generic.notFound"
 msgstr "暂无内容"
 
 #. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.empty"
+msgstr "暂无内容。"
+
+#. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
 msgid "oauth.error.registrationClosed"
 msgstr "OAuth 注册在管理员完成设置之前不可用。"
@@ -2646,6 +2666,11 @@ msgstr "重新激活用户"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.delete.reassign.label"
 msgstr "将文章重新分配给"
+
+#. js-lingui-explicit-id
+#: src/routes/_authenticated/index.tsx
+msgid "dashboard.recent.title"
+msgstr "最近活动"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/mailer/index.tsx
@@ -3799,11 +3824,6 @@ msgstr "欢迎,{greeting}"
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.tagline"
 msgstr "今天想做些什么？"
-
-#. js-lingui-explicit-id
-#: src/routes/_authenticated/index.tsx
-msgid "dashboard.tile.description.generic"
-msgstr "写作、编辑和发布。"
 
 #. js-lingui-explicit-id
 #: src/lib/core-settings-i18n.ts

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -1,4 +1,6 @@
+import type { MessageDescriptor } from "@lingui/core";
 import type { ReactNode } from "react";
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button.js";
 import {
   Card,
@@ -14,12 +16,28 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty.js";
+import { toDate } from "@/lib/dates.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import { visibleEntryTypes } from "@/lib/manifest.js";
+import { orpc } from "@/lib/orpc.js";
+import { useFormatters } from "@/lib/use-formatters.js";
 import { useLabel } from "@/lib/use-label.js";
-import { Trans } from "@lingui/react";
+import { defineMessage } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, FileText, Puzzle } from "lucide-react";
+
+const M = {
+  countPublished: defineMessage({
+    id: "dashboard.count.published",
+    message: "{count, plural, one {# published} other {# published}}",
+  }),
+  countDraft: defineMessage({
+    id: "dashboard.count.draft",
+    message: "{count, plural, one {# draft} other {# drafts}}",
+  }),
+} satisfies Record<string, MessageDescriptor>;
 
 export const Route = createFileRoute("/_authenticated/")({
   component: DashboardIndex,
@@ -30,6 +48,22 @@ function DashboardIndex(): ReactNode {
   const greeting = user.name ?? user.email;
   const tiles = visibleEntryTypes(user.capabilities);
   const renderLabel = useLabel();
+  const { i18n } = useLingui();
+  const { formatRelative } = useFormatters();
+
+  const statsQuery = useQuery(orpc.entry.stats.queryOptions({ input: {} }));
+  const recentQuery = useQuery(
+    orpc.entry.recentActivity.queryOptions({ input: { limit: 8 } }),
+  );
+
+  // type → { status → count } for O(1) tile lookups.
+  const countsByType = useMemo(() => {
+    const map: Record<string, Record<string, number>> = {};
+    for (const row of statsQuery.data ?? []) {
+      (map[row.type] ??= {})[row.status] = row.count;
+    }
+    return map;
+  }, [statsQuery.data]);
 
   return (
     <div className="flex flex-col gap-6">
@@ -57,10 +91,7 @@ function DashboardIndex(): ReactNode {
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {tiles.map((pt) => {
             const label = renderLabel(pt.labels?.plural ?? pt.label);
-            // Tile description + browse-button copy stay noun-less so
-            // the lowercase-the-plural substitution can't reach DE/RU/
-            // PL/UK/AR users. The tile title already carries the type's
-            // plural label up top.
+            const counts = countsByType[pt.name] ?? {};
             return (
               <Card key={pt.name} data-testid={`dashboard-tile-${pt.name}`}>
                 <CardHeader>
@@ -68,12 +99,19 @@ function DashboardIndex(): ReactNode {
                     <FileText className="size-5" aria-hidden />
                   </div>
                   <CardTitle>{label}</CardTitle>
-                  <CardDescription>
-                    {pt.description ?? (
-                      <Trans
-                        id="dashboard.tile.description.generic"
-                        message="Write, edit, and publish."
-                      />
+                  <CardDescription
+                    data-testid={`dashboard-tile-${pt.name}-counts`}
+                  >
+                    {i18n._(
+                      M.countPublished.id,
+                      { count: counts.published ?? 0 },
+                      { message: M.countPublished.message },
+                    )}
+                    {" · "}
+                    {i18n._(
+                      M.countDraft.id,
+                      { count: counts.draft ?? 0 },
+                      { message: M.countDraft.message },
                     )}
                   </CardDescription>
                 </CardHeader>
@@ -121,6 +159,54 @@ function DashboardIndex(): ReactNode {
           </Empty>
         </Card>
       )}
+
+      {tiles.length > 0 ? (
+        <Card data-testid="dashboard-recent-activity">
+          <CardHeader>
+            <CardTitle>
+              <Trans id="dashboard.recent.title" message="Recent activity" />
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {(recentQuery.data ?? []).length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                <Trans id="dashboard.recent.empty" message="Nothing yet." />
+              </p>
+            ) : (
+              <ul className="flex flex-col divide-y">
+                {(recentQuery.data ?? []).map((row) => {
+                  const tile = tiles.find((t) => t.name === row.type);
+                  const inner = (
+                    <>
+                      <span className="truncate">{row.title}</span>
+                      <span className="text-muted-foreground ms-auto shrink-0 text-xs">
+                        {formatRelative(toDate(row.updatedAt))}
+                      </span>
+                    </>
+                  );
+                  return (
+                    <li key={row.id} data-testid={`dashboard-recent-${row.id}`}>
+                      {tile ? (
+                        <Link
+                          to="/entries/$slug/$id/edit"
+                          params={{ slug: tile.adminSlug, id: row.id }}
+                          className="hover:text-primary flex items-center gap-2 py-2 text-sm"
+                        >
+                          {inner}
+                        </Link>
+                      ) : (
+                        <div className="flex items-center gap-2 py-2 text-sm">
+                          {inner}
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      ) : null}
     </div>
   );
 }

--- a/packages/core/src/rpc/procedures/entry/dashboard.test.ts
+++ b/packages/core/src/rpc/procedures/entry/dashboard.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+// Stats/activity scope to *registered* entry types, so the harness needs
+// a `post` type registered (the default empty registry has none).
+function postRegistry() {
+  const registry = createPluginRegistry();
+  registry.entryTypes.set("post", {
+    name: "post",
+    registeredBy: "test",
+    label: "Posts",
+    capabilityType: "post",
+  });
+  return registry;
+}
+
+describe("entry.stats", () => {
+  test("returns per-type counts grouped by status", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: postRegistry(),
+    });
+    await h.factory.published.create({ authorId: h.user.id, slug: "p1" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "p2" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "d1" });
+    await h.factory.trashed.create({ authorId: h.user.id, slug: "t1" });
+
+    const stats = await h.client.entry.stats();
+    const post = stats.filter((s) => s.type === "post");
+    const byStatus = Object.fromEntries(post.map((s) => [s.status, s.count]));
+    expect(byStatus.published).toBe(2);
+    expect(byStatus.draft).toBe(1);
+    expect(byStatus.trash).toBe(1);
+  });
+
+  test("never counts reserved (revision/autosave) rows", async () => {
+    const h = await createRpcHarness({
+      authAs: "admin",
+      plugins: postRegistry(),
+    });
+    await h.factory.published.create({ authorId: h.user.id, slug: "vis" });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      type: "revision",
+      slug: "revision:1:abcdefghijklmnopqrstu",
+    });
+    const stats = await h.client.entry.stats();
+    expect(stats.some((s) => s.type === "revision")).toBe(false);
+  });
+
+  test("a read-only caller sees published counts but not drafts or trash", async () => {
+    // Subscriber has entry:post:read but not edit_any — draft/trash counts
+    // must stay hidden, matching entry.list / entry.get visibility.
+    const h = await createRpcHarness({
+      authAs: "subscriber",
+      plugins: postRegistry(),
+    });
+    await h.factory.published.create({ authorId: h.user.id, slug: "pub" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "dr" });
+    await h.factory.trashed.create({ authorId: h.user.id, slug: "tr" });
+
+    const stats = await h.client.entry.stats();
+    const byStatus = Object.fromEntries(
+      stats.filter((s) => s.type === "post").map((s) => [s.status, s.count]),
+    );
+    expect(byStatus.published).toBe(1);
+    expect(byStatus.draft).toBeUndefined();
+    expect(byStatus.trash).toBeUndefined();
+  });
+});
+
+describe("entry.recentActivity", () => {
+  test("returns recent non-trashed entries newest-first, capped by limit", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: postRegistry(),
+    });
+    await h.factory.published.create({ authorId: h.user.id, slug: "old" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "new" });
+    await h.factory.trashed.create({ authorId: h.user.id, slug: "binned" });
+
+    const recent = await h.client.entry.recentActivity({ limit: 10 });
+    expect(recent.some((r) => r.slug === "binned")).toBe(false);
+    expect(recent.length).toBe(2);
+    // Newest-first: the later-created row sorts ahead.
+    expect(recent[0]?.slug).toBe("new");
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/dashboard.ts
+++ b/packages/core/src/rpc/procedures/entry/dashboard.ts
@@ -1,0 +1,100 @@
+import type { SQL } from "drizzle-orm";
+
+import type { AuthenticatedAppContext } from "../../../context/app.js";
+import { and, desc, eq, inArray, ne, or, sql } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { entryCapability } from "./lifecycle.js";
+import { entryRecentActivityInputSchema } from "./schemas.js";
+
+interface ScopedTypes {
+  // Types the caller can edit_any — count/list every status.
+  readonly full: string[];
+  // Types the caller can only read — restricted to published, matching
+  // `entry.list` / `entry.get` (read alone never exposes drafts).
+  readonly publishedOnly: string[];
+}
+
+// Partition registered entry types by the caller's visibility. Reserved
+// rows (revision/autosave) aren't registered types, so they're excluded
+// for free. A `read`-only caller must not see draft/trash counts or
+// titles — only `edit_any` widens the scope to all statuses.
+function scopeTypes(context: AuthenticatedAppContext): ScopedTypes {
+  const full: string[] = [];
+  const publishedOnly: string[] = [];
+  for (const type of context.plugins.entryTypes.values()) {
+    const ns = type.capabilityType ?? type.name;
+    if (!context.auth.can(entryCapability(ns, "read"))) continue;
+    if (context.auth.can(entryCapability(ns, "edit_any"))) {
+      full.push(type.name);
+    } else {
+      publishedOnly.push(type.name);
+    }
+  }
+  return { full, publishedOnly };
+}
+
+// Visibility predicate: every status for `full` types, published-only for
+// `publishedOnly` types. `extra` further constrains the full set (e.g.
+// "not trash" for the activity feed). Returns undefined when nothing is
+// visible so callers can short-circuit.
+function visibilityClause(scope: ScopedTypes, extra?: SQL): SQL | undefined {
+  // `and`/`or` drop undefined operands, so undefined branches fall away
+  // and a single live branch returns itself — no assertions needed.
+  const fullClause =
+    scope.full.length > 0
+      ? and(inArray(entries.type, scope.full), extra)
+      : undefined;
+  const publishedClause =
+    scope.publishedOnly.length > 0
+      ? and(
+          inArray(entries.type, scope.publishedOnly),
+          eq(entries.status, "published"),
+        )
+      : undefined;
+  return or(fullClause, publishedClause);
+}
+
+export const stats = base.use(authenticated).handler(async ({ context }) => {
+  const where = visibilityClause(scopeTypes(context));
+  if (!where) return [];
+  const rows = await context.db
+    .select({
+      type: entries.type,
+      status: entries.status,
+      count: sql<number>`count(*)`.as("count"),
+    })
+    .from(entries)
+    .where(where)
+    .groupBy(entries.type, entries.status);
+  return rows.map((row) => ({
+    type: row.type,
+    status: row.status,
+    count: Number(row.count),
+  }));
+});
+
+export const recentActivity = base
+  .use(authenticated)
+  .input(entryRecentActivityInputSchema)
+  .handler(async ({ input, context }) => {
+    const where = visibilityClause(
+      scopeTypes(context),
+      ne(entries.status, "trash"),
+    );
+    if (!where) return [];
+    return context.db
+      .select({
+        id: entries.id,
+        type: entries.type,
+        title: entries.title,
+        slug: entries.slug,
+        status: entries.status,
+        updatedAt: entries.updatedAt,
+      })
+      .from(entries)
+      .where(where)
+      .orderBy(desc(entries.updatedAt), desc(entries.id))
+      .limit(input.limit);
+  });

--- a/packages/core/src/rpc/procedures/entry/index.ts
+++ b/packages/core/src/rpc/procedures/entry/index.ts
@@ -1,6 +1,7 @@
 import { list as activityList } from "./activity.js";
 import { deletePermanentMany, restoreMany, trashMany } from "./bulk.js";
 import { create } from "./create.js";
+import { recentActivity, stats } from "./dashboard.js";
 import { deletePermanent } from "./delete-permanent.js";
 import { discardDraft } from "./discard-draft.js";
 import { duplicate } from "./duplicate.js";
@@ -26,6 +27,8 @@ export const entryRouter = {
   duplicate,
   publish,
   discardDraft,
+  stats,
+  recentActivity,
   revisions: revisionsRouter,
   activity: { list: activityList },
 } as const;

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -231,6 +231,13 @@ export const entryTrashManyInputSchema = bulkIdsSchema;
 export const entryRestoreManyInputSchema = bulkIdsSchema;
 export const entryDeletePermanentManyInputSchema = bulkIdsSchema;
 
+export const entryRecentActivityInputSchema = v.object({
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(50)),
+    10,
+  ),
+});
+
 export type EntryListInput = v.InferOutput<typeof entryListInputSchema>;
 export type EntryGetInput = v.InferOutput<typeof entryGetInputSchema>;
 export type EntryCreateInput = v.InferOutput<typeof entryCreateInputSchema>;


### PR DESCRIPTION
The dashboard was a static tile grid with no signal about what's in the site. Tiles now carry per-type published/draft counts, and a recent-activity panel lists the latest entries across types.

**Two visibility-scoped RPCs**

`entry.stats` returns counts grouped by type + status in a single `GROUP BY` query; `entry.recentActivity` returns the newest non-trashed entries. Both scope to the caller's visibility exactly as `entry.list` / `entry.get` do — `edit_any` sees every status, a `read`-only caller sees published only. This was the key review finding: gating on `read` alone would have leaked draft counts and titles to a subscriber. Reserved revision/autosave rows are excluded structurally (not registered entry types).

**Graceful UI**

Counts default to 0 until stats loads; recent rows deep-link to the editor only when the type's tile is visible to the user, else plain text.

**Scope note**

This PR delivers the **live-data** half of #866. The **plugin dashboard-widget surface** (a new `registerDashboardWidget` extension API) is a focused follow-up PR — splitting keeps each reviewable rather than one 1500-line change. Hence `Refs`, not `Fixes`.

uk/ar/de/zh-CN translated for the new count/activity strings.

Refs #866