### PR TITLE
feat: add plugin dashboard-widget surface

### DIFF
--- a/packages/admin/e2e/dashboard.spec.ts
+++ b/packages/admin/e2e/dashboard.spec.ts
@@ -52,6 +52,8 @@ test.describe("/ (dashboard)", () => {
     await expect(page.getByTestId("dashboard-recent-activity")).toContainText(
       "Latest post",
     );
+    // No plugin dashboard widgets registered → no widget grid.
+    await expect(page.getByTestId("dashboard-widgets")).toHaveCount(0);
     await expectNoAxeViolations(page);
   });
 

--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -237,7 +237,8 @@ msgstr "{characters, plural, zero {# حرف} one {حرف واحد} two {حرفا
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.count.draft"
-msgstr "{count, plural, zero {# مسودة} one {# مسودة} two {مسودتان} few {# مسودات} many {# مسودة} other {# مسودة}}"
+msgstr "{count, plural, zero {# مسودة} one {# مسودة} two {مسودتان} few {# "
+"مسودات} many {# مسودة} other {# مسودة}}"
 
 #. count: number of selected entries
 #. js-lingui-explicit-id
@@ -258,7 +259,8 @@ msgstr "{count, plural, zero {لا توجد مجموعات} one {مجموعة و
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.count.published"
-msgstr "{count, plural, zero {# منشور} one {# منشور} two {منشوران} few {# منشورات} many {# منشورًا} other {# منشور}}"
+msgstr "{count, plural, zero {# منشور} one {# منشور} two {منشوران} few {# "
+"منشورات} many {# منشورًا} other {# منشور}}"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -328,6 +330,12 @@ msgstr "{display} · آخر ظهور {lastSeen}"
 #: src/lib/plugin-error-boundary.tsx
 msgid "plugin.errorBoundary.inlineStub"
 msgstr "فشل {label} {kind}"
+
+#. label: a plugin-author-provided name (e.g. 'SEO meta')
+#. js-lingui-explicit-id
+#: src/lib/plugin-error-boundary.tsx
+msgid "plugin.errorBoundary.widgetBody"
+msgstr "فشل عرض {label}."
 
 #. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')
 #. js-lingui-explicit-id

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -318,6 +318,12 @@ msgstr "{display} · zuletzt gesehen {lastSeen}"
 msgid "plugin.errorBoundary.inlineStub"
 msgstr "{label} {kind} fehlgeschlagen"
 
+#. label: a plugin-author-provided name (e.g. 'SEO meta')
+#. js-lingui-explicit-id
+#: src/lib/plugin-error-boundary.tsx
+msgid "plugin.errorBoundary.widgetBody"
+msgstr "{label} konnte nicht gerendert werden."
+
 #. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -316,6 +316,12 @@ msgstr "{display} · last seen {lastSeen}"
 msgid "plugin.errorBoundary.inlineStub"
 msgstr "{label} {kind} failed"
 
+#. label: a plugin-author-provided name (e.g. 'SEO meta')
+#. js-lingui-explicit-id
+#: src/lib/plugin-error-boundary.tsx
+msgid "plugin.errorBoundary.widgetBody"
+msgstr "{label} failed to render."
+
 #. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -237,7 +237,8 @@ msgstr "{characters, plural, one {# символ} few {# символи} many {#
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.count.draft"
-msgstr "{count, plural, one {# чернетка} few {# чернетки} many {# чернеток} other {# чернетки}}"
+msgstr "{count, plural, one {# чернетка} few {# чернетки} many {# чернеток} "
+"other {# чернетки}}"
 
 #. count: number of selected entries
 #. js-lingui-explicit-id
@@ -257,7 +258,8 @@ msgstr "{count, plural, one {# група} few {# групи} many {# груп} 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.count.published"
-msgstr "{count, plural, one {# опубліковано} few {# опубліковано} many {# опубліковано} other {# опубліковано}}"
+msgstr "{count, plural, one {# опубліковано} few {# опубліковано} many {# "
+"опубліковано} other {# опубліковано}}"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/entries-bulk-bar.tsx
@@ -323,6 +325,12 @@ msgstr "{display} · востаннє {lastSeen}"
 #: src/lib/plugin-error-boundary.tsx
 msgid "plugin.errorBoundary.inlineStub"
 msgstr "{label} {kind}: помилка"
+
+#. label: a plugin-author-provided name (e.g. 'SEO meta')
+#. js-lingui-explicit-id
+#: src/lib/plugin-error-boundary.tsx
+msgid "plugin.errorBoundary.widgetBody"
+msgstr "{label} не вдалося відобразити."
 
 #. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')
 #. js-lingui-explicit-id

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -311,6 +311,12 @@ msgstr "{display} · 最近活跃 {lastSeen}"
 msgid "plugin.errorBoundary.inlineStub"
 msgstr "{label} {kind} 失败"
 
+#. label: a plugin-author-provided name (e.g. 'SEO meta')
+#. js-lingui-explicit-id
+#: src/lib/plugin-error-boundary.tsx
+msgid "plugin.errorBoundary.widgetBody"
+msgstr "{label} 渲染失败。"
+
 #. label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')
 #. js-lingui-explicit-id
 #: src/lib/plugin-error-boundary.tsx

--- a/packages/admin/src/lib/manifest.test.ts
+++ b/packages/admin/src/lib/manifest.test.ts
@@ -16,6 +16,7 @@ import {
   getPatterns,
   groupsForSettingsPage,
   readManifest,
+  visibleDashboardWidgets,
   visibleEntryTypes,
   visibleSettingsPages,
   visibleTermTaxonomies,
@@ -516,6 +517,32 @@ describe("findSettingsPageByName + visibleSettingsPages + findSettingsGroupByNam
     };
     expect(groupsForSettingsPage(orphan, source).map((g) => g.name)).toEqual([
       "identity",
+    ]);
+  });
+});
+
+describe("visibleDashboardWidgets", () => {
+  const source: PlumixManifest = {
+    dashboardWidgets: [
+      { id: "a:open", title: "Open", component: "Open" },
+      {
+        id: "a:gated",
+        title: "Gated",
+        capability: "secret:read",
+        component: "Gated",
+      },
+    ],
+  };
+
+  test("returns ungated widgets plus gated ones the caller can access", () => {
+    expect(
+      visibleDashboardWidgets(["secret:read"], source).map((w) => w.id),
+    ).toEqual(["a:open", "a:gated"]);
+  });
+
+  test("hides a gated widget when the caller lacks its capability", () => {
+    expect(visibleDashboardWidgets([], source).map((w) => w.id)).toEqual([
+      "a:open",
     ]);
   });
 });

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -2,6 +2,7 @@ import type { ThemeTokens } from "@plumix/blocks";
 import type {
   AdminNavGroup,
   AdminNavItem,
+  DashboardWidgetManifestEntry,
   EntryMetaBoxManifestEntry,
   EntryTypeManifestEntry,
   PatternManifestEntry,
@@ -143,6 +144,16 @@ export function visibleSettingsPages(
 ): readonly SettingsPageManifestEntry[] {
   if (!capabilities.includes("settings:manage")) return [];
   return source.settingsPages ?? [];
+}
+
+export function visibleDashboardWidgets(
+  capabilities: readonly string[],
+  source: PlumixManifest = manifest,
+): readonly DashboardWidgetManifestEntry[] {
+  const caps = new Set(capabilities);
+  return (source.dashboardWidgets ?? []).filter(
+    (w) => !w.capability || caps.has(w.capability),
+  );
 }
 
 // Three meta-box visibility filters (entry/term/user) share the same

--- a/packages/admin/src/lib/plugin-error-boundary.tsx
+++ b/packages/admin/src/lib/plugin-error-boundary.tsx
@@ -6,7 +6,7 @@ import { i18n } from "@lingui/core";
 import { defineMessage } from "@lingui/core/macro";
 import { AlertTriangle } from "lucide-react";
 
-type Kind = "page" | "icon" | "block" | "field";
+type Kind = "page" | "widget" | "icon" | "block" | "field";
 
 interface Props {
   readonly kind: Kind;
@@ -37,6 +37,13 @@ const M = {
     comment:
       "label: a plugin-author-provided name (e.g. 'SEO meta', 'Hero block')",
   }),
+  // Card-body alert for a dashboard widget — the host already supplies
+  // the card chrome and title, so this fills just the body.
+  widgetBody: defineMessage({
+    id: "plugin.errorBoundary.widgetBody",
+    message: "{label} failed to render.",
+    comment: "label: a plugin-author-provided name (e.g. 'SEO meta')",
+  }),
   // Inline stub for blocks / field renderers — `{kind}` is the
   // protocol discriminator (block / field) verbatim. Localizing it
   // would require a kind→noun map; keep raw for now (same policy
@@ -58,8 +65,8 @@ const M = {
  * Catch render errors in plugin-supplied components so a third-party
  * bug doesn't take down the surrounding admin shell. Each kind picks
  * a fallback shape that fits its host context: pages get a full-card
- * alert, icons get a tiny warning glyph, blocks/fields get inline
- * stubs.
+ * alert, widgets get a card-body alert, icons get a tiny warning glyph,
+ * blocks/fields get inline stubs.
  *
  * Class component because React error boundaries still require it
  * (no hook equivalent for `componentDidCatch` as of React 19). Label
@@ -118,6 +125,21 @@ export class PluginErrorBoundary extends Component<Props, State> {
             </AlertDescription>
           </Alert>
         </div>
+      );
+    }
+
+    if (kind === "widget") {
+      return (
+        <Alert variant="destructive" data-testid="plugin-widget__error">
+          <AlertTriangle className="size-4" />
+          <AlertDescription>
+            {i18n._(
+              M.widgetBody.id,
+              { label },
+              { message: M.widgetBody.message },
+            )}
+          </AlertDescription>
+        </Alert>
       );
     }
 

--- a/packages/admin/src/lib/plugin-registry.ts
+++ b/packages/admin/src/lib/plugin-registry.ts
@@ -41,6 +41,9 @@ function makeRegistry<TComponent>(
 }
 
 const pages = makeRegistry<ComponentType>("registerPluginPage");
+const dashboardWidgets = makeRegistry<ComponentType>(
+  "registerPluginDashboardWidget",
+);
 const fieldTypes = makeRegistry<PluginFieldComponent>(
   "registerPluginFieldType",
 );
@@ -74,6 +77,19 @@ export function registerPluginPage(
 
 export function getPluginPage(path: string): ComponentType | undefined {
   return pages.map.get(path);
+}
+
+export function registerPluginDashboardWidget(
+  id: string,
+  component: ComponentType,
+): void {
+  register(dashboardWidgets, id, component);
+}
+
+export function getPluginDashboardWidget(
+  id: string,
+): ComponentType | undefined {
+  return dashboardWidgets.map.get(id);
 }
 
 // Built-in `inputType` names handled by the host's meta-box-field
@@ -176,6 +192,7 @@ export function getRegisteredBlocks(): readonly BlockSpec[] {
 /** @internal Test-only. */
 export function _resetPluginRegistry(): void {
   pages.map.clear();
+  dashboardWidgets.map.clear();
   fieldTypes.map.clear();
   blockSchemas.map.clear();
   blockEditors.map.clear();

--- a/packages/admin/src/lib/plumix-globals.ts
+++ b/packages/admin/src/lib/plumix-globals.ts
@@ -15,6 +15,7 @@ import {
   registerPluginBlock,
   registerPluginBlockEditor,
   registerPluginBlockSchema,
+  registerPluginDashboardWidget,
   registerPluginFieldType,
   registerPluginMarkSchema,
   registerPluginPage,
@@ -51,6 +52,7 @@ declare global {
   interface Window {
     plumix?: {
       readonly registerPluginPage: typeof registerPluginPage;
+      readonly registerPluginDashboardWidget: typeof registerPluginDashboardWidget;
       readonly registerPluginFieldType: typeof registerPluginFieldType;
       readonly registerPluginBlockSchema: typeof registerPluginBlockSchema;
       readonly registerPluginBlockEditor: typeof registerPluginBlockEditor;
@@ -67,6 +69,7 @@ export function bootPlumixGlobals(): void {
   if (window.plumix) return;
   window.plumix = {
     registerPluginPage,
+    registerPluginDashboardWidget,
     registerPluginFieldType,
     registerPluginBlockSchema,
     registerPluginBlockEditor,

--- a/packages/admin/src/routes/_authenticated/-dashboard-widgets.test.tsx
+++ b/packages/admin/src/routes/_authenticated/-dashboard-widgets.test.tsx
@@ -1,0 +1,69 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+
+import type { DashboardWidgetManifestEntry } from "@plumix/core/manifest";
+
+import { messages as enMessages } from "../../../locales/en.mjs";
+import {
+  _resetPluginRegistry,
+  registerPluginDashboardWidget,
+} from "../../lib/plugin-registry.js";
+import { DashboardWidgets } from "./-dashboard-widgets.js";
+
+beforeAll(() => {
+  i18n.load("en", enMessages);
+  i18n.activate("en");
+});
+
+afterEach(() => {
+  cleanup();
+  _resetPluginRegistry();
+});
+
+const WIDGETS: readonly DashboardWidgetManifestEntry[] = [
+  { id: "demo:hello", title: "Hello widget", component: "Hello" },
+  { id: "demo:missing", title: "Not loaded", component: "Missing" },
+];
+
+function renderWidgets(widgets: readonly DashboardWidgetManifestEntry[]): void {
+  render(
+    <I18nProvider i18n={i18n}>
+      <DashboardWidgets widgets={widgets} />
+    </I18nProvider>,
+  );
+}
+
+describe("DashboardWidgets", () => {
+  test("renders a registered widget's component and title", () => {
+    registerPluginDashboardWidget("demo:hello", () => <p>hi there</p>);
+    renderWidgets(WIDGETS);
+    const card = screen.getByTestId("dashboard-widget-demo:hello");
+    expect(card).toHaveTextContent("Hello widget");
+    expect(card).toHaveTextContent("hi there");
+  });
+
+  test("skips a widget whose component isn't registered", () => {
+    registerPluginDashboardWidget("demo:hello", () => <p>hi</p>);
+    renderWidgets(WIDGETS);
+    expect(screen.queryByTestId("dashboard-widget-demo:missing")).toBeNull();
+  });
+
+  test("renders nothing when no widgets have a registered component", () => {
+    renderWidgets(WIDGETS);
+    expect(screen.queryByTestId("dashboard-widgets")).toBeNull();
+  });
+
+  test("shows a widget-scoped fallback when a widget throws", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    registerPluginDashboardWidget("demo:hello", () => {
+      throw new Error("boom");
+    });
+    renderWidgets(WIDGETS);
+    expect(screen.getByTestId("plugin-widget__error")).toBeVisible();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/admin/src/routes/_authenticated/-dashboard-widgets.tsx
+++ b/packages/admin/src/routes/_authenticated/-dashboard-widgets.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import { Suspense } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Skeleton } from "@/components/ui/skeleton.js";
+import { PluginErrorBoundary } from "@/lib/plugin-error-boundary.js";
+import { getPluginDashboardWidget } from "@/lib/plugin-registry.js";
+import { useLabel } from "@/lib/use-label.js";
+
+import type { DashboardWidgetManifestEntry } from "@plumix/core/manifest";
+
+// Renders the given (already capability-filtered) dashboard widgets. A
+// widget whose admin chunk hasn't registered a component yet is skipped
+// silently — a missing widget shouldn't break the dashboard the way a
+// missing full-page route would.
+export function DashboardWidgets({
+  widgets,
+}: {
+  readonly widgets: readonly DashboardWidgetManifestEntry[];
+}): ReactNode {
+  const renderLabel = useLabel();
+  const mounted = widgets.flatMap((widget) => {
+    const Component = getPluginDashboardWidget(widget.id);
+    return Component ? [{ widget, Component }] : [];
+  });
+  if (mounted.length === 0) return null;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2" data-testid="dashboard-widgets">
+      {mounted.map(({ widget, Component }) => (
+        <Card key={widget.id} data-testid={`dashboard-widget-${widget.id}`}>
+          <CardHeader>
+            <CardTitle>{renderLabel(widget.title)}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <PluginErrorBoundary
+              kind="widget"
+              pluginLabel={renderLabel(widget.title)}
+            >
+              <Suspense fallback={<Skeleton className="h-16 w-full" />}>
+                <Component />
+              </Suspense>
+            </PluginErrorBoundary>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/empty.js";
 import { toDate } from "@/lib/dates.js";
 import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
-import { visibleEntryTypes } from "@/lib/manifest.js";
+import { visibleDashboardWidgets, visibleEntryTypes } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { useFormatters } from "@/lib/use-formatters.js";
 import { useLabel } from "@/lib/use-label.js";
@@ -27,6 +27,8 @@ import { Trans, useLingui } from "@lingui/react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, FileText, Puzzle } from "lucide-react";
+
+import { DashboardWidgets } from "./-dashboard-widgets.js";
 
 const M = {
   countPublished: defineMessage({
@@ -207,6 +209,8 @@ function DashboardIndex(): ReactNode {
           </CardContent>
         </Card>
       ) : null}
+
+      <DashboardWidgets widgets={visibleDashboardWidgets(user.capabilities)} />
     </div>
   );
 }

--- a/packages/core/src/plugin/dashboard-widgets.test.ts
+++ b/packages/core/src/plugin/dashboard-widgets.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+
+import { HookRegistry } from "../hooks/registry.js";
+import { definePlugin } from "./define.js";
+import { DuplicateRegistrationError } from "./errors.js";
+import { buildManifest } from "./manifest.js";
+import { installPlugins } from "./register.js";
+
+describe("registerDashboardWidget", () => {
+  test("registers a widget and projects it into the manifest", async () => {
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [
+        definePlugin("widget-plugin", (ctx) => {
+          ctx.registerDashboardWidget({
+            id: "widget-plugin:hello",
+            title: { id: "x", message: "Hello" },
+            component: "HelloWidget",
+            priority: 20,
+          });
+        }),
+      ],
+    });
+    const widget = registry.dashboardWidgets.get("widget-plugin:hello");
+    expect(widget?.component).toBe("HelloWidget");
+    expect(widget?.registeredBy).toBe("widget-plugin");
+
+    const manifest = buildManifest(registry, { tokens: {} });
+    expect(manifest.dashboardWidgets[0]?.id).toBe("widget-plugin:hello");
+  });
+
+  test("widgets project in priority order", async () => {
+    const { registry } = await installPlugins({
+      hooks: new HookRegistry(),
+      plugins: [
+        definePlugin("widget-plugin", (ctx) => {
+          ctx.registerDashboardWidget({
+            id: "widget-plugin:b",
+            title: { id: "b", message: "B" },
+            component: "B",
+            priority: 30,
+          });
+          ctx.registerDashboardWidget({
+            id: "widget-plugin:a",
+            title: { id: "a", message: "A" },
+            component: "A",
+            priority: 10,
+          });
+        }),
+      ],
+    });
+    const manifest = buildManifest(registry, { tokens: {} });
+    expect(manifest.dashboardWidgets.map((w) => w.id)).toEqual([
+      "widget-plugin:a",
+      "widget-plugin:b",
+    ]);
+  });
+
+  test("rejects a duplicate widget id", async () => {
+    await expect(
+      installPlugins({
+        hooks: new HookRegistry(),
+        plugins: [
+          definePlugin("widget-plugin", (ctx) => {
+            const opts = {
+              id: "widget-plugin:dup",
+              title: { id: "d", message: "D" },
+              component: "Dup",
+            };
+            ctx.registerDashboardWidget(opts);
+            ctx.registerDashboardWidget(opts);
+          }),
+        ],
+      }),
+    ).rejects.toBeInstanceOf(DuplicateRegistrationError);
+  });
+
+  test("rejects a non-namespaced widget id", async () => {
+    await expect(
+      installPlugins({
+        hooks: new HookRegistry(),
+        plugins: [
+          definePlugin("widget-plugin", (ctx) => {
+            ctx.registerDashboardWidget({
+              id: "nocolon",
+              title: { id: "n", message: "N" },
+              component: "N",
+            });
+          }),
+        ],
+      }),
+    ).rejects.toBeTruthy();
+  });
+
+  test("rejects a widget whose namespace isn't the registering plugin", async () => {
+    await expect(
+      installPlugins({
+        hooks: new HookRegistry(),
+        plugins: [
+          definePlugin("widget-plugin", (ctx) => {
+            ctx.registerDashboardWidget({
+              id: "other-plugin:thing",
+              title: { id: "o", message: "O" },
+              component: "O",
+            });
+          }),
+        ],
+      }),
+    ).rejects.toBeTruthy();
+  });
+});

--- a/packages/core/src/plugin/errors.ts
+++ b/packages/core/src/plugin/errors.ts
@@ -27,6 +27,7 @@ type PluginContextErrorCode =
   | "route_path_wildcard_not_after_slash"
   | "identifier_too_long"
   | "identifier_shape_invalid"
+  | "identifier_namespace_mismatch"
   | "meta_box_too_many_fields"
   | "meta_box_field_invalid_key"
   | "meta_box_field_duplicate_key"
@@ -491,6 +492,24 @@ export class PluginContextError extends Error {
         kind: ctx.kind,
         identifierName: ctx.name,
         pattern: ctx.pattern,
+      },
+    );
+  }
+
+  static identifierNamespaceMismatch(ctx: {
+    kind: string;
+    name: string;
+    pluginId: string;
+  }): PluginContextError {
+    return new PluginContextError(
+      "identifier_namespace_mismatch",
+      `Invalid ${ctx.kind} "${ctx.name}" — the namespace before ":" must be ` +
+        `the registering plugin's id ("${ctx.pluginId}") so one plugin can't ` +
+        `squat another's ids.`,
+      {
+        kind: ctx.kind,
+        identifierName: ctx.name,
+        pluginId: ctx.pluginId,
       },
     );
   }

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1029,6 +1029,34 @@ export interface RegisteredAdminPage extends AdminPageOptions {
   readonly registeredBy: string | null;
 }
 
+export interface DashboardWidgetOptions {
+  /** Unique widget id, conventionally `<pluginId>:<name>`. */
+  readonly id: string;
+  readonly title: Label;
+  /** Hidden unless the viewer holds this capability (when set). */
+  readonly capability?: string;
+  /** Export name in the plugin's admin chunk, resolved at render. */
+  readonly component: PluginComponentRef;
+  /** Lower sorts first on the dashboard; unset sorts last. */
+  readonly priority?: number;
+}
+
+export interface RegisteredDashboardWidget extends DashboardWidgetOptions {
+  readonly registeredBy: string | null;
+}
+
+// Wire shape intentionally equals DashboardWidgetOptions (minus
+// registeredBy) — unlike e.g. FieldTypeManifestEntry, a widget's options
+// carry nothing server-only to drop, so the manifest entry just mirrors
+// them as the admin-facing boundary.
+export interface DashboardWidgetManifestEntry {
+  readonly id: string;
+  readonly title: Label;
+  readonly capability?: string;
+  readonly component: PluginComponentRef;
+  readonly priority?: number;
+}
+
 /**
  * Built-in nav-icon names that core nav items reference. The admin maps
  * each value to a lucide component at render time — keeps the wire
@@ -1252,6 +1280,7 @@ export interface PluginRegistry {
   readonly rawRoutes: readonly RegisteredRawRoute[];
   readonly loginLinks: readonly RegisteredLoginLink[];
   readonly adminPages: ReadonlyMap<string, RegisteredAdminPage>;
+  readonly dashboardWidgets: ReadonlyMap<string, RegisteredDashboardWidget>;
   readonly fieldTypes: ReadonlyMap<string, RegisteredFieldType>;
   readonly blockSpecs: ReadonlyMap<string, RegisteredBlock>;
   readonly markSpecs: ReadonlyMap<string, RegisteredMark>;
@@ -1275,6 +1304,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly rawRoutes: RegisteredRawRoute[];
   readonly loginLinks: RegisteredLoginLink[];
   readonly adminPages: Map<string, RegisteredAdminPage>;
+  readonly dashboardWidgets: Map<string, RegisteredDashboardWidget>;
   readonly fieldTypes: Map<string, RegisteredFieldType>;
   readonly blockSpecs: Map<string, RegisteredBlock>;
   readonly markSpecs: Map<string, RegisteredMark>;
@@ -1299,6 +1329,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     rawRoutes: [],
     loginLinks: [],
     adminPages: new Map(),
+    dashboardWidgets: new Map(),
     fieldTypes: new Map(),
     blockSpecs: new Map(),
     markSpecs: new Map(),
@@ -1656,6 +1687,7 @@ export interface PlumixManifest {
   readonly settingsGroups?: readonly SettingsGroupManifestEntry[];
   readonly settingsPages?: readonly SettingsPageManifestEntry[];
   readonly adminNav?: readonly AdminNavGroup[];
+  readonly dashboardWidgets?: readonly DashboardWidgetManifestEntry[];
   readonly fieldTypes?: readonly FieldTypeManifestEntry[];
   readonly blocks?: readonly BlockManifestEntry[];
   readonly marks?: readonly MarkManifestEntry[];
@@ -1741,6 +1773,7 @@ export function emptyManifest(): PlumixManifest {
     settingsGroups: [],
     settingsPages: [],
     adminNav: [],
+    dashboardWidgets: [],
     fieldTypes: [],
     blocks: [],
     marks: [],
@@ -1834,6 +1867,9 @@ export function buildManifest(
     .sort(byPriorityThen((p) => p.name));
   assertSettingsPageGroupsExist(settingsPages, registry.settingsGroups);
   const adminNav = projectAdminNav(registry, entries, termTaxonomies);
+  const dashboardWidgets = Array.from(registry.dashboardWidgets.values())
+    .map(toDashboardWidgetEntry)
+    .sort(byPriorityThen((w) => w.id));
   const fieldTypes = Array.from(registry.fieldTypes.values())
     .map(toFieldTypeEntry)
     .sort((a, b) => a.type.localeCompare(b.type));
@@ -1855,6 +1891,7 @@ export function buildManifest(
     settingsGroups,
     settingsPages,
     adminNav,
+    dashboardWidgets,
     fieldTypes,
     blocks,
     marks,
@@ -2532,6 +2569,13 @@ function toFieldTypeEntry(
 ): FieldTypeManifestEntry {
   const { type, component } = fieldType;
   return { type, component };
+}
+
+function toDashboardWidgetEntry(
+  widget: RegisteredDashboardWidget,
+): DashboardWidgetManifestEntry {
+  const { id, title, capability, component, priority } = widget;
+  return { id, title, capability, component, priority };
 }
 
 function toBlockEntry(block: RegisteredBlock): BlockManifestEntry {

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -23,6 +23,7 @@ import type { TemplateDepRegistry } from "../template.js";
 import type { LookupAdapterOptions } from "./lookup.js";
 import type {
   AdminPageOptions,
+  DashboardWidgetOptions,
   EntryMetaBoxOptions,
   EntryTypeOptions,
   FieldTypeOptions,
@@ -51,6 +52,7 @@ import { CORE_RPC_NAMESPACES } from "./manifest.js";
 import {
   assertComponentRef,
   assertMetaBoxFields,
+  assertNamespacedId,
   assertValidAdminPagePath,
   assertValidFieldTypeName,
   assertValidIdentifier,
@@ -182,6 +184,13 @@ export interface PluginSetupContextBase {
   }): void;
 
   registerAdminPage(options: AdminPageOptions): void;
+  /**
+   * Register a widget rendered on the admin dashboard. The component is
+   * resolved from the plugin's admin chunk at render; gate visibility
+   * with `capability`. Mirrors `registerAdminPage` but targets the
+   * dashboard grid instead of a route.
+   */
+  registerDashboardWidget(options: DashboardWidgetOptions): void;
   registerFieldType(options: FieldTypeOptions): void;
   /**
    * Register a `BlockSpec` produced by `defineBlock` from `plumix/blocks`.
@@ -514,6 +523,25 @@ export function createPluginSetupContext({
         assertValidNavGroupId(pluginId, groupId);
       }
       registry.adminPages.set(options.path, {
+        ...options,
+        registeredBy: pluginId,
+      });
+    },
+
+    registerDashboardWidget: (options) => {
+      assertNamespacedId("dashboard widget id", options.id, pluginId);
+      if (registry.dashboardWidgets.has(options.id)) {
+        throw DuplicateRegistrationError.alreadyRegistered({
+          kind: "dashboard widget",
+          identifier: options.id,
+        });
+      }
+      assertComponentRef(
+        pluginId,
+        `dashboard widget "${options.id}"`,
+        options.component,
+      );
+      registry.dashboardWidgets.set(options.id, {
         ...options,
         registeredBy: pluginId,
       });

--- a/packages/core/src/plugin/validation/identifiers.ts
+++ b/packages/core/src/plugin/validation/identifiers.ts
@@ -55,6 +55,39 @@ export function assertValidIdentifier(kind: string, name: string): void {
   }
 }
 
+// Namespaced `<plugin>:<name>` shape. Both segments allow the hyphen
+// plugin ids use. The namespace must be the registering plugin's id so
+// one plugin can't squat another's ids in the shared, id-keyed registry.
+const NAMESPACED_ID_RE = /^[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$/;
+
+export function assertNamespacedId(
+  kind: string,
+  id: string,
+  pluginId: string,
+): void {
+  if (id.length > MAX_SETTINGS_IDENTIFIER_LENGTH) {
+    throw PluginContextError.identifierTooLong({
+      kind,
+      name: id,
+      maxLength: MAX_SETTINGS_IDENTIFIER_LENGTH,
+    });
+  }
+  if (!NAMESPACED_ID_RE.test(id)) {
+    throw PluginContextError.identifierShapeInvalid({
+      kind,
+      name: id,
+      pattern: NAMESPACED_ID_RE.source,
+    });
+  }
+  if (id.slice(0, id.indexOf(":")) !== pluginId) {
+    throw PluginContextError.identifierNamespaceMismatch({
+      kind,
+      name: id,
+      pluginId,
+    });
+  }
+}
+
 export function assertValidNavGroupId(pluginId: string, id: string): void {
   if (id.length === 0 || id.length > MAX_PLUGIN_ID_LENGTH) {
     throw PluginContextError.invalidNavGroupIdLength({


### PR DESCRIPTION
Plugins can now register dashboard widgets via `ctx.registerDashboardWidget`. The core
projects them into the manifest (priority-ordered, capability-gated) and the admin renders
the registered components in a grid on the dashboard, below the recent-activity panel.

**Crash isolation**

Each widget mounts behind a Suspense boundary and a new `"widget"` error-boundary kind, so a
third-party render error degrades to a card-body alert instead of taking down the dashboard.
The widget fallback shows only `{label} failed to render.` — it deliberately omits the raw
error message that the page kind dumps in a `<pre>`, to limit leak surface in a shared grid.

**Missing components are skipped, not fatal**

A widget whose admin chunk hasn't registered a component yet is dropped silently — a missing
widget shouldn't break the page the way a missing route would.

**Namespace ownership**

Widget ids must be `<plugin>:<name>` and the namespace must equal the registering plugin's id.
The registry is global and id-keyed, so without this one plugin could squat or shadow another's
ids; `assertNamespacedId` now enforces the binding.

Capability gating is client-side (consistent with entry types, settings pages, and meta-boxes):
it hides UI, not data. A widget rendering sensitive data must still authorize in its own RPC.

Fixes #892
Refs #866