### PR TITLE
feat(plugin-media): add media/embed block

### DIFF
--- a/packages/plugins/media/src/blocks/embed/index.test.tsx
+++ b/packages/plugins/media/src/blocks/embed/index.test.tsx
@@ -1,0 +1,54 @@
+import { renderBlockSpecToHtml } from "plumix/blocks/test";
+import { describe, expect, test } from "vitest";
+
+import { embedBlock } from "./index.js";
+
+describe("media/embed", () => {
+  test("renders a lazy iframe for a safelisted provider", () => {
+    const html = renderBlockSpecToHtml(embedBlock, {
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(html).toContain('data-plumix-block="media/embed"');
+    expect(html).toContain(
+      'src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"',
+    );
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('data-provider="youtube"');
+  });
+
+  test("strict-sandboxes a non-safelist URL without same-origin", () => {
+    const html = renderBlockSpecToHtml(embedBlock, {
+      url: "https://example.com/widget",
+    });
+    expect(html).toContain('data-provider="generic"');
+    expect(html).toContain('sandbox="allow-scripts"');
+    expect(html).not.toContain("allow-same-origin");
+    // Untrusted host must not learn our origin.
+    expect(html).toMatch(/referrerpolicy="no-referrer"/i);
+  });
+
+  test("does not sandbox a safelisted provider", () => {
+    const html = renderBlockSpecToHtml(embedBlock, {
+      url: "https://vimeo.com/123456789",
+    });
+    expect(html).not.toContain("sandbox=");
+    expect(html).toMatch(/referrerpolicy="strict-origin-when-cross-origin"/i);
+  });
+
+  test("renders nothing for an empty or unframeable URL", () => {
+    expect(renderBlockSpecToHtml(embedBlock, { url: "" })).not.toContain(
+      "<iframe",
+    );
+    expect(
+      renderBlockSpecToHtml(embedBlock, { url: "javascript:alert(1)" }),
+    ).not.toContain("<iframe");
+  });
+
+  test("renders a caption when provided", () => {
+    const html = renderBlockSpecToHtml(embedBlock, {
+      url: "https://youtu.be/dQw4w9WgXcQ",
+      caption: "Never gonna give you up",
+    });
+    expect(html).toContain("<figcaption>Never gonna give you up</figcaption>");
+  });
+});

--- a/packages/plugins/media/src/blocks/embed/index.tsx
+++ b/packages/plugins/media/src/blocks/embed/index.tsx
@@ -1,0 +1,67 @@
+import type { CSSProperties, ReactElement } from "react";
+import { defineBlock } from "plumix/blocks";
+
+import { resolveEmbed } from "./resolve.js";
+
+export const embedBlock = defineBlock({
+  name: "media/embed",
+  title: "Embed",
+  category: "media",
+  description:
+    "Embed a YouTube, Vimeo, Loom, Spotify, or CodePen URL — or any other " +
+    "page in a sandboxed iframe.",
+  keywords: ["iframe", "video", "youtube", "vimeo", "media"],
+  inputs: [
+    { name: "url", type: "url", label: "URL" },
+    { name: "title", type: "text", label: "Accessible title" },
+    { name: "caption", type: "text", label: "Caption" },
+  ],
+  defaults: { url: "", title: "", caption: "" },
+  render: ({ attrs }): ReactElement | null => {
+    const url = typeof attrs.url === "string" ? attrs.url : "";
+    const resolved = resolveEmbed(url);
+    if (!resolved) return null;
+
+    const title =
+      typeof attrs.title === "string" && attrs.title.length > 0
+        ? attrs.title
+        : "Embedded content";
+    const caption = typeof attrs.caption === "string" ? attrs.caption : "";
+
+    // Iframes have no intrinsic size, so the wrapper carries the box
+    // (aspect ratio for video, fixed height for audio/code) and the
+    // iframe fills it. Inlined so the block is self-contained without
+    // requiring theme CSS.
+    const wrapperStyle: CSSProperties = {
+      width: "100%",
+      ...(resolved.aspect
+        ? { aspectRatio: resolved.aspect }
+        : { height: resolved.height }),
+    };
+
+    return (
+      <figure data-provider={resolved.provider}>
+        <div className="plumix-embed" style={wrapperStyle}>
+          <iframe
+            src={resolved.src}
+            title={title}
+            loading="lazy"
+            // Untrusted (non-safelist) URLs get a strict sandbox — notably
+            // WITHOUT `allow-same-origin`, which combined with allow-scripts
+            // lets a frame served from our origin strip its own sandbox — and
+            // `no-referrer` so an author-chosen host never learns our origin.
+            referrerPolicy={
+              resolved.sandboxed
+                ? "no-referrer"
+                : "strict-origin-when-cross-origin"
+            }
+            allowFullScreen={resolved.allowFullscreen === true}
+            style={{ width: "100%", height: "100%", border: 0 }}
+            {...(resolved.sandboxed && { sandbox: "allow-scripts" })}
+          />
+        </div>
+        {caption.length > 0 ? <figcaption>{caption}</figcaption> : null}
+      </figure>
+    );
+  },
+});

--- a/packages/plugins/media/src/blocks/embed/resolve.test.ts
+++ b/packages/plugins/media/src/blocks/embed/resolve.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveEmbed } from "./resolve.js";
+
+describe("resolveEmbed", () => {
+  test("maps a YouTube watch URL to a nocookie embed", () => {
+    const r = resolveEmbed("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    expect(r?.provider).toBe("youtube");
+    expect(r?.src).toBe("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ");
+    expect(r?.sandboxed).toBe(false);
+  });
+
+  test("maps youtu.be short links and /shorts/ paths", () => {
+    expect(resolveEmbed("https://youtu.be/dQw4w9WgXcQ")?.src).toBe(
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+    );
+    expect(
+      resolveEmbed("https://www.youtube.com/shorts/dQw4w9WgXcQ")?.src,
+    ).toBe("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ");
+  });
+
+  test("maps a Vimeo URL to the player embed", () => {
+    const r = resolveEmbed("https://vimeo.com/123456789");
+    expect(r?.provider).toBe("vimeo");
+    expect(r?.src).toBe("https://player.vimeo.com/video/123456789");
+    expect(r?.sandboxed).toBe(false);
+  });
+
+  test("video providers carry a 16/9 aspect and allow fullscreen", () => {
+    const yt = resolveEmbed("https://youtu.be/dQw4w9WgXcQ");
+    expect(yt?.aspect).toBe("16 / 9");
+    expect(yt?.allowFullscreen).toBe(true);
+    expect(yt?.height).toBeUndefined();
+  });
+
+  test("maps a Loom share URL to the embed path", () => {
+    const r = resolveEmbed("https://www.loom.com/share/abc123");
+    expect(r?.provider).toBe("loom");
+    expect(r?.src).toBe("https://www.loom.com/embed/abc123");
+  });
+
+  test("maps Spotify entities to fixed-height embeds", () => {
+    const r = resolveEmbed("https://open.spotify.com/track/abc123");
+    expect(r?.provider).toBe("spotify");
+    expect(r?.src).toBe("https://open.spotify.com/embed/track/abc123");
+    expect(r?.height).toBe(352);
+    expect(r?.aspect).toBeUndefined();
+  });
+
+  test("maps a CodePen pen to its embed path", () => {
+    const r = resolveEmbed("https://codepen.io/team/pen/xyz789");
+    expect(r?.provider).toBe("codepen");
+    expect(r?.src).toBe("https://codepen.io/team/embed/xyz789");
+    expect(r?.height).toBe(400);
+  });
+
+  test("falls back to a sandboxed generic iframe for non-safelist https URLs", () => {
+    const r = resolveEmbed("https://example.com/widget");
+    expect(r?.provider).toBe("generic");
+    expect(r?.src).toBe("https://example.com/widget");
+    expect(r?.sandboxed).toBe(true);
+  });
+
+  test("rejects crafted provider paths instead of emitting a malformed src", () => {
+    // A non-11-char / path-bearing YouTube id falls through to the
+    // sandboxed generic path rather than producing a broken embed src.
+    const traversal = resolveEmbed(
+      "https://www.youtube.com/watch?v=../../@evil.com/x",
+    );
+    expect(traversal?.provider).toBe("generic");
+    expect(traversal?.sandboxed).toBe(true);
+    // A Spotify id with a disallowed character is rejected too.
+    expect(
+      resolveEmbed("https://open.spotify.com/track/has.dot")?.provider,
+    ).toBe("generic");
+  });
+
+  test("rejects non-http(s) and unparseable URLs", () => {
+    expect(resolveEmbed("javascript:alert(1)")).toBeNull();
+    expect(resolveEmbed("data:text/html,<script>x</script>")).toBeNull();
+    expect(resolveEmbed("ftp://example.com/file")).toBeNull();
+    expect(resolveEmbed("not a url")).toBeNull();
+    expect(resolveEmbed("")).toBeNull();
+  });
+});

--- a/packages/plugins/media/src/blocks/embed/resolve.ts
+++ b/packages/plugins/media/src/blocks/embed/resolve.ts
@@ -1,0 +1,153 @@
+interface ResolvedEmbed {
+  readonly provider: string;
+  readonly src: string;
+  // Safelisted providers render with provider-appropriate `allow`
+  // permissions; everything else is framed under a strict sandbox.
+  readonly sandboxed: boolean;
+  // Responsive aspect-ratio container (e.g. "16 / 9") for video; mutually
+  // exclusive with `height`, which fixed-height audio/code embeds use.
+  readonly aspect?: string;
+  readonly height?: number;
+  readonly allowFullscreen?: boolean;
+}
+
+interface Provider {
+  readonly id: string;
+  // Hostname already stripped of a leading `www.`.
+  readonly host: (host: string) => boolean;
+  // Returns the embed `src`, or null when the path doesn't name a resource.
+  readonly toSrc: (url: URL) => string | null;
+  readonly aspect?: string;
+  readonly height?: number;
+  readonly allowFullscreen?: boolean;
+}
+
+function firstSegment(url: URL): string | undefined {
+  return url.pathname.split("/").find(Boolean);
+}
+
+// Provider ids/handles only ever contain url-safe word chars and
+// hyphens. Validating before interpolation keeps a crafted path
+// (traversal, extra segments) from producing a malformed embed `src`
+// instead of relying on the iframe origin staying fixed as the backstop.
+const SAFE_SEGMENT = /^[\w-]+$/;
+const YOUTUBE_ID = /^[\w-]{11}$/;
+
+const PROVIDERS: readonly Provider[] = [
+  {
+    id: "youtube",
+    host: (h) => h === "youtube.com" || h === "youtu.be",
+    toSrc: (url) => {
+      const host = url.hostname.replace(/^www\./, "");
+      const id =
+        host === "youtu.be"
+          ? firstSegment(url)
+          : (url.searchParams.get("v") ??
+            (url.pathname.startsWith("/shorts/")
+              ? url.pathname.split("/").filter(Boolean)[1]
+              : undefined));
+      return id && YOUTUBE_ID.test(id)
+        ? `https://www.youtube-nocookie.com/embed/${id}`
+        : null;
+    },
+    aspect: "16 / 9",
+    allowFullscreen: true,
+  },
+  {
+    id: "vimeo",
+    host: (h) => h === "vimeo.com",
+    toSrc: (url) => {
+      const id = firstSegment(url);
+      return id && /^\d+$/.test(id)
+        ? `https://player.vimeo.com/video/${id}`
+        : null;
+    },
+    aspect: "16 / 9",
+    allowFullscreen: true,
+  },
+  {
+    id: "loom",
+    host: (h) => h === "loom.com",
+    toSrc: (url) => {
+      const segments = url.pathname.split("/").filter(Boolean);
+      const id = segments[0] === "share" ? segments[1] : undefined;
+      return id && SAFE_SEGMENT.test(id)
+        ? `https://www.loom.com/embed/${id}`
+        : null;
+    },
+    aspect: "16 / 9",
+    allowFullscreen: true,
+  },
+  {
+    id: "spotify",
+    host: (h) => h === "open.spotify.com",
+    toSrc: (url) => {
+      const segments = url.pathname.split("/").filter(Boolean);
+      const [type, id] = segments;
+      const TYPES = new Set([
+        "track",
+        "album",
+        "playlist",
+        "episode",
+        "show",
+        "artist",
+      ]);
+      return type && id && TYPES.has(type) && SAFE_SEGMENT.test(id)
+        ? `https://open.spotify.com/embed/${type}/${id}`
+        : null;
+    },
+    height: 352,
+  },
+  {
+    id: "codepen",
+    host: (h) => h === "codepen.io",
+    toSrc: (url) => {
+      const segments = url.pathname.split("/").filter(Boolean);
+      const [user, kind, id] = segments;
+      return user &&
+        kind === "pen" &&
+        id &&
+        SAFE_SEGMENT.test(user) &&
+        SAFE_SEGMENT.test(id)
+        ? `https://codepen.io/${user}/embed/${id}`
+        : null;
+    },
+    height: 400,
+  },
+];
+
+export function resolveEmbed(rawUrl: string): ResolvedEmbed | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  // Only ever frame http(s) — keeps `javascript:`, `data:`, and other
+  // schemes out of the iframe `src`.
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return null;
+  }
+  const host = url.hostname.replace(/^www\./, "");
+
+  for (const provider of PROVIDERS) {
+    if (!provider.host(host)) continue;
+    const src = provider.toSrc(url);
+    if (!src) continue;
+    return {
+      provider: provider.id,
+      src,
+      sandboxed: false,
+      ...(provider.aspect && { aspect: provider.aspect }),
+      ...(provider.height && { height: provider.height }),
+      ...(provider.allowFullscreen && { allowFullscreen: true }),
+    };
+  }
+
+  return {
+    provider: "generic",
+    src: url.toString(),
+    sandboxed: true,
+    aspect: "16 / 9",
+  };
+}

--- a/packages/plugins/media/src/index.test.ts
+++ b/packages/plugins/media/src/index.test.ts
@@ -9,11 +9,12 @@ async function install() {
 }
 
 describe("@plumix/plugin-media — registration", () => {
-  test("contributes five media/* block specs", async () => {
+  test("contributes six media/* block specs", async () => {
     const { registry } = await install();
     const blockNames = Array.from(registry.blockSpecs.keys()).sort();
     expect(blockNames).toEqual([
       "media/audio",
+      "media/embed",
       "media/file",
       "media/gallery",
       "media/image",
@@ -29,6 +30,7 @@ describe("@plumix/plugin-media — registration", () => {
       "media/video",
       "media/audio",
       "media/file",
+      "media/embed",
     ]) {
       const entry = registry.blockSpecs.get(name);
       expect(entry?.registeredBy).toBe("media");

--- a/packages/plugins/media/src/index.ts
+++ b/packages/plugins/media/src/index.ts
@@ -3,6 +3,7 @@ import type { EntryTypeLabels, PluginDescriptor } from "plumix/plugin";
 import { definePlugin } from "plumix/plugin";
 
 import { audioBlock } from "./blocks/audio/index.js";
+import { embedBlock } from "./blocks/embed/index.js";
 import { fileBlock } from "./blocks/file/index.js";
 import { galleryBlock } from "./blocks/gallery/index.js";
 import { imageBlock } from "./blocks/image/index.js";
@@ -157,13 +158,14 @@ export function media(
   return definePlugin(
     "media",
     (ctx) => {
-      // Six media blocks contributed under the `media/` namespace.
-      // Order is just for readability; the registry is keyed by name.
+      // Media blocks contributed under the `media/` namespace. Order is
+      // just for readability; the registry is keyed by name.
       ctx.registerBlock(imageBlock);
       ctx.registerBlock(galleryBlock);
       ctx.registerBlock(videoBlock);
       ctx.registerBlock(audioBlock);
       ctx.registerBlock(fileBlock);
+      ctx.registerBlock(embedBlock);
 
       ctx.registerEntryType("media", {
         label: MEDIA_LABELS.plural,

--- a/packages/plugins/media/src/media-blocks.ts
+++ b/packages/plugins/media/src/media-blocks.ts
@@ -1,6 +1,7 @@
 import type { BlockSpec } from "plumix/blocks";
 
 import { audioBlock } from "./blocks/audio/index.js";
+import { embedBlock } from "./blocks/embed/index.js";
 import { fileBlock } from "./blocks/file/index.js";
 import { galleryBlock } from "./blocks/gallery/index.js";
 import { imageBlock } from "./blocks/image/index.js";
@@ -15,4 +16,5 @@ export const mediaBlocks: readonly BlockSpec[] = Object.freeze([
   videoBlock,
   audioBlock,
   fileBlock,
+  embedBlock,
 ]);


### PR DESCRIPTION
Restores the `media/embed` block that was in #313's scope but never landed (the media plugin shipped image/gallery/video/audio/file only). Authors can now embed a share URL and get a responsive, lazy-loaded iframe.

A pure resolver maps URLs from a provider safelist — YouTube (nocookie), Vimeo, Loom, Spotify, CodePen — to their embed `src`; anything else falls back to a strict-sandboxed generic iframe.

**Security posture for author-supplied URLs framed on the public site**

- Non-`http(s)` schemes (`javascript:`, `data:`, …) are rejected outright.
- Provider ids are validated (`/^[\w-]{11}$/` for YouTube, `/^[\w-]+$/` for the rest) before interpolation, so a crafted path falls through to the sandboxed generic path instead of emitting a malformed `src`.
- The generic fallback sandboxes **without** `allow-same-origin` — combined with `allow-scripts` it would let a frame served from our origin remove its own `sandbox` and reload unsandboxed — and sends `referrerpolicy="no-referrer"` so an author-chosen host never learns our origin. Safelisted providers render unsandboxed with `strict-origin-when-cross-origin`.

**Deferred**

Document-level paste-to-convert (needs block-paste infrastructure that doesn't exist yet) and a click-to-load facade island (tracked as a separate hardening follow-up — it's the real mitigation for clickjacking/connection-leak on untrusted frames).

Fixes #871