### PR TITLE
feat(core): mint and resolve shareable draft preview links

### DIFF
--- a/packages/core/src/auth/preview-token.test.ts
+++ b/packages/core/src/auth/preview-token.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { eq } from "../db/index.js";
+import { authTokens } from "../db/schema/auth_tokens.js";
+import { factoriesFor } from "../test/factories.js";
+import { createTestDb } from "../test/harness.js";
+import { createPreviewToken, verifyPreviewToken } from "./preview-token.js";
+
+describe("preview tokens", () => {
+  test("a minted token verifies back to its entry id", async () => {
+    const db = await createTestDb();
+    const user = await factoriesFor(db).user.create();
+
+    const token = await createPreviewToken(db, {
+      entryId: 42,
+      userId: user.id,
+    });
+    expect(await verifyPreviewToken(db, token)).toBe(42);
+  });
+
+  test("only the hash is persisted, never the raw token", async () => {
+    const db = await createTestDb();
+    const user = await factoriesFor(db).user.create();
+    const token = await createPreviewToken(db, { entryId: 7, userId: user.id });
+
+    const rows = await db.query.authTokens.findMany({
+      where: eq(authTokens.type, "preview_link"),
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.hash).not.toBe(token);
+    expect(rows[0]?.payload).toEqual({ entryId: 7 });
+  });
+
+  test("an expired token does not verify", async () => {
+    const db = await createTestDb();
+    const user = await factoriesFor(db).user.create();
+    const token = await createPreviewToken(db, { entryId: 1, userId: user.id });
+    // Backdate the row past its expiry.
+    await db
+      .update(authTokens)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(authTokens.type, "preview_link"));
+    expect(await verifyPreviewToken(db, token)).toBeNull();
+  });
+
+  test("an unknown or non-preview token does not verify", async () => {
+    const db = await createTestDb();
+    expect(await verifyPreviewToken(db, "not-a-real-token")).toBeNull();
+  });
+});

--- a/packages/core/src/auth/preview-token.ts
+++ b/packages/core/src/auth/preview-token.ts
@@ -1,0 +1,49 @@
+import type { Db } from "../context/app.js";
+import { and, eq } from "../db/index.js";
+import { authTokens } from "../db/schema/auth_tokens.js";
+import { generateToken, hashToken } from "./tokens.js";
+
+// Preview links are meant to outlive a single review sitting but not
+// linger indefinitely; entry-scoped + expiring is the whole security
+// model. Reusable until expiry (unlike single-use magic links) so a
+// reviewer can refresh and re-share.
+const PREVIEW_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface PreviewPayload {
+  readonly entryId: number;
+}
+
+export async function createPreviewToken(
+  db: Db,
+  args: { readonly entryId: number; readonly userId: number },
+): Promise<string> {
+  const token = generateToken();
+  const hash = await hashToken(token);
+  await db.insert(authTokens).values({
+    hash,
+    userId: args.userId,
+    type: "preview_link",
+    payload: { entryId: args.entryId } satisfies PreviewPayload,
+    expiresAt: new Date(Date.now() + PREVIEW_TOKEN_TTL_MS),
+  });
+  return token;
+}
+
+/**
+ * Resolve a raw preview token to the entry id it grants draft visibility
+ * for, or null when the token is missing, the wrong type, expired, or
+ * malformed. Does not consume the token — preview links stay valid until
+ * they expire.
+ */
+export async function verifyPreviewToken(
+  db: Db,
+  rawToken: string,
+): Promise<number | null> {
+  const hash = await hashToken(rawToken);
+  const row = await db.query.authTokens.findFirst({
+    where: and(eq(authTokens.hash, hash), eq(authTokens.type, "preview_link")),
+  });
+  if (!row || row.expiresAt.getTime() < Date.now()) return null;
+  const entryId = (row.payload as PreviewPayload | null)?.entryId;
+  return typeof entryId === "number" ? entryId : null;
+}

--- a/packages/core/src/db/schema/auth_tokens.ts
+++ b/packages/core/src/db/schema/auth_tokens.ts
@@ -11,6 +11,7 @@ export const AUTH_TOKEN_TYPES = [
   "password_reset",
   "invite",
   "oauth_state",
+  "preview_link",
 ] as const;
 
 export type AuthTokenType = (typeof AUTH_TOKEN_TYPES)[number];

--- a/packages/core/src/route/path-chain.ts
+++ b/packages/core/src/route/path-chain.ts
@@ -22,6 +22,7 @@ import { and, eq } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { terms } from "../db/schema/terms.js";
 import { loadAncestorSlugs, loadTermAncestorSlugs } from "./permalink.js";
+import { previewTokenGrantsEntry } from "./preview.js";
 
 export async function findEntryByPath(
   ctx: AppContext,
@@ -38,13 +39,17 @@ export async function findEntryByPath(
   if (leafSlug === undefined) return null;
 
   const leaf = await ctx.db.query.entries.findFirst({
-    where: and(
-      eq(entries.type, entryType),
-      eq(entries.slug, leafSlug),
-      eq(entries.status, "published"),
-    ),
+    where: and(eq(entries.type, entryType), eq(entries.slug, leafSlug)),
   });
   if (!leaf) return null;
+  // Visible if published, or if a `?preview=` token grants this draft.
+  // Checked before the ancestor walk so an ordinary draft 404s without the
+  // extra CTE query.
+  if (
+    leaf.status !== "published" &&
+    !(await previewTokenGrantsEntry(ctx, leaf))
+  )
+    return null;
 
   const expected = segments.slice(0, -1);
   const actual =

--- a/packages/core/src/route/preview.ts
+++ b/packages/core/src/route/preview.ts
@@ -1,0 +1,24 @@
+import type { AppContext } from "../context/app.js";
+import type { Entry } from "../db/schema/entries.js";
+import { verifyPreviewToken } from "../auth/preview-token.js";
+
+export function readPreviewToken(ctx: AppContext): string | null {
+  return new URL(ctx.request.url).searchParams.get("preview");
+}
+
+/**
+ * True when a `?preview=<token>` token on the request grants public
+ * visibility to this exact entry. Entry-scoped: the token must have been
+ * minted for `entry.id`. Trash is never previewable. Shared by the flat
+ * (`findEntryForSingle`) and hierarchical (`findEntryByPath`) resolvers so
+ * the one draft-visibility rule lives in a single place.
+ */
+export async function previewTokenGrantsEntry(
+  ctx: AppContext,
+  entry: Entry,
+): Promise<boolean> {
+  if (entry.status === "trash") return false;
+  const token = readPreviewToken(ctx);
+  if (token === null) return false;
+  return (await verifyPreviewToken(ctx.db, token)) === entry.id;
+}

--- a/packages/core/src/route/resolve.test.ts
+++ b/packages/core/src/route/resolve.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import type { AppContext } from "../context/app.js";
+import { createPreviewToken } from "../auth/preview-token.js";
 import { definePlugin } from "../plugin/define.js";
 import { createDispatcherHarness } from "../test/dispatcher.js";
 import { buildEntryPermalink, buildTermArchiveUrl } from "./permalink.js";
@@ -258,6 +259,140 @@ describe("resolvePublicRoute — single", () => {
       new Request("https://cms.example/post/gone"),
     );
     expect(response.status).toBe(404);
+  });
+
+  test("a valid preview token reveals a draft at its URL", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    const draft = await h.factory.entry.create({
+      type: "post",
+      slug: "secret",
+      title: "Secret Draft",
+      content: TIPTAP_BODY,
+      status: "draft",
+      authorId: author.id,
+    });
+    const token = await createPreviewToken(h.db, {
+      entryId: draft.id,
+      userId: author.id,
+    });
+
+    const response = await h.dispatch(
+      new Request(`https://cms.example/post/secret?preview=${token}`),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("<h1>Secret Draft</h1>");
+  });
+
+  test("an invalid preview token still 404s the draft", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "secret",
+      title: "Secret",
+      content: null,
+      status: "draft",
+      authorId: author.id,
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/post/secret?preview=bogus-token"),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("a preview token does not reveal a different draft's URL", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    const a = await h.factory.entry.create({
+      type: "post",
+      slug: "draft-a",
+      title: "Draft A",
+      content: null,
+      status: "draft",
+      authorId: author.id,
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "draft-b",
+      title: "Draft B",
+      content: null,
+      status: "draft",
+      authorId: author.id,
+    });
+    const tokenForA = await createPreviewToken(h.db, {
+      entryId: a.id,
+      userId: author.id,
+    });
+
+    // A's token on B's URL must not reveal B.
+    const response = await h.dispatch(
+      new Request(`https://cms.example/post/draft-b?preview=${tokenForA}`),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("a preview token never reveals a trashed entry", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const author = await h.seedUser("admin");
+    const gone = await h.factory.entry.create({
+      type: "post",
+      slug: "binned",
+      title: "Binned",
+      content: null,
+      status: "trash",
+      authorId: author.id,
+    });
+    const token = await createPreviewToken(h.db, {
+      entryId: gone.id,
+      userId: author.id,
+    });
+
+    const response = await h.dispatch(
+      new Request(`https://cms.example/post/binned?preview=${token}`),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("a preview token reveals a nested draft page under a published parent", async () => {
+    const h = await createDispatcherHarness({
+      plugins: [hierarchicalPagesPlugin],
+    });
+    const author = await h.seedUser("admin");
+    const parent = await h.factory.entry.create({
+      type: "page",
+      slug: "docs",
+      title: "Docs",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: null,
+    });
+    const child = await h.factory.entry.create({
+      type: "page",
+      slug: "unreleased",
+      title: "Unreleased Page",
+      content: TIPTAP_BODY,
+      status: "draft",
+      authorId: author.id,
+      parentId: parent.id,
+    });
+    const token = await createPreviewToken(h.db, {
+      entryId: child.id,
+      userId: author.id,
+    });
+
+    const without = await h.dispatch(
+      new Request("https://cms.example/page/docs/unreleased"),
+    );
+    expect(without.status).toBe(404);
+
+    const withToken = await h.dispatch(
+      new Request(`https://cms.example/page/docs/unreleased?preview=${token}`),
+    );
+    expect(withToken.status).toBe(200);
+    expect(await withToken.text()).toContain("<h1>Unreleased Page</h1>");
   });
 });
 

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -29,6 +29,7 @@ import { notFound } from "../runtime/http.js";
 import { paginate } from "./paginate.js";
 import { findEntryByPath, findTermByPath } from "./path-chain.js";
 import { buildEntryPermalinkSync } from "./permalink.js";
+import { previewTokenGrantsEntry, readPreviewToken } from "./preview.js";
 import { renderThroughTheme } from "./render/render-template.js";
 
 declare module "../hooks/types.js" {
@@ -509,15 +510,22 @@ async function findEntryForSingle(
   }
   const slug = params.slug;
   if (typeof slug !== "string" || slug === "") return null;
-  return (
-    (await ctx.db.query.entries.findFirst({
-      where: and(
-        eq(entries.type, entryType),
-        eq(entries.slug, slug),
-        eq(entries.status, "published"),
-      ),
-    })) ?? null
-  );
+  const published = await ctx.db.query.entries.findFirst({
+    where: and(
+      eq(entries.type, entryType),
+      eq(entries.slug, slug),
+      eq(entries.status, "published"),
+    ),
+  });
+  if (published) return published;
+  // A valid `?preview=` token can reveal the matching draft. Skip the extra
+  // query entirely on the common no-token 404.
+  if (readPreviewToken(ctx) === null) return null;
+  const candidate = await ctx.db.query.entries.findFirst({
+    where: and(eq(entries.type, entryType), eq(entries.slug, slug)),
+  });
+  if (!candidate) return null;
+  return (await previewTokenGrantsEntry(ctx, candidate)) ? candidate : null;
 }
 
 async function findTermForTaxonomy(

--- a/packages/core/src/rpc/procedures/entry/create-preview-link.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create-preview-link.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vitest";
+
+import { verifyPreviewToken } from "../../../auth/preview-token.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+// buildEntryPermalinkSync needs the type registered + public to form a URL.
+function postRegistry() {
+  const registry = createPluginRegistry();
+  registry.entryTypes.set("post", {
+    name: "post",
+    registeredBy: "test",
+    label: "Posts",
+    capabilityType: "post",
+    isPublic: true,
+  });
+  return registry;
+}
+
+describe("entry.createPreviewLink", () => {
+  test("mints a token-bearing preview url for a draft the caller can edit", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: postRegistry(),
+    });
+    const draft = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "secret-draft",
+    });
+
+    const result = await h.client.entry.createPreviewLink({ id: draft.id });
+
+    expect(result.url).toBe(`/post/secret-draft?preview=${result.token}`);
+    expect(await verifyPreviewToken(h.db, result.token)).toBe(draft.id);
+  });
+
+  test("mints an ancestor-walked url for a nested page of a hierarchical type", async () => {
+    const registry = createPluginRegistry();
+    registry.entryTypes.set("page", {
+      name: "page",
+      registeredBy: "test",
+      label: "Pages",
+      capabilityType: "page",
+      isPublic: true,
+      isHierarchical: true,
+    });
+    // entry:page:* aren't builtin (only entry:post:* are), so register the
+    // caps canReadEntry consults — `registry.entryTypes.set` skips the
+    // derivation `ctx.registerEntryType` does in the real flow.
+    for (const [action, minRole] of [
+      ["read", "subscriber"],
+      ["edit_own", "contributor"],
+      ["edit_any", "editor"],
+    ] as const) {
+      registry.capabilities.set(`entry:page:${action}`, {
+        name: `entry:page:${action}`,
+        minRole,
+        registeredBy: "test",
+      });
+    }
+    const h = await createRpcHarness({ authAs: "editor", plugins: registry });
+    const parent = await h.factory.published.create({
+      authorId: h.user.id,
+      type: "page",
+      slug: "docs",
+    });
+    const child = await h.factory.draft.create({
+      authorId: h.user.id,
+      type: "page",
+      slug: "unreleased",
+      parentId: parent.id,
+    });
+
+    const result = await h.client.entry.createPreviewLink({ id: child.id });
+    expect(result.url).toBe(`/page/docs/unreleased?preview=${result.token}`);
+  });
+
+  test("404s a draft the caller can't read (no link-minting for others' drafts)", async () => {
+    const h = await createRpcHarness({
+      authAs: "contributor",
+      plugins: postRegistry(),
+    });
+    // A draft authored by someone else — a contributor has neither
+    // edit_any nor authorship, so canReadEntry is false.
+    const other = await h.factory.user.create();
+    const draft = await h.factory.draft.create({
+      authorId: other.id,
+      slug: "not-mine",
+    });
+
+    await expect(
+      h.client.entry.createPreviewLink({ id: draft.id }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("404s a non-existent entry", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: postRegistry(),
+    });
+    await expect(
+      h.client.entry.createPreviewLink({ id: 9999 }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/create-preview-link.ts
+++ b/packages/core/src/rpc/procedures/entry/create-preview-link.ts
@@ -1,0 +1,40 @@
+import { createPreviewToken } from "../../../auth/preview-token.js";
+import { eq } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
+import { buildEntryPermalink } from "../../../route/permalink.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { canReadEntry } from "./lifecycle.js";
+import { entryCreatePreviewLinkInputSchema } from "./schemas.js";
+
+// Mint a shareable, entry-scoped, expiring preview link so a draft can be
+// shown to someone without an account. Gated by `canReadEntry` — the same
+// rule `entry.get`/`entry.duplicate` use — so only someone who can already
+// see the draft (its author with `edit_own`, or an `edit_any` editor) can
+// hand it out. 404 (not 403) on an unreadable or missing entry to avoid
+// leaking which rows exist.
+export const createPreviewLink = base
+  .use(authenticated)
+  .input(entryCreatePreviewLinkInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const entry = await context.db.query.entries.findFirst({
+      where: eq(entries.id, input.id),
+    });
+    if (!entry || isReservedType(entry.type) || !canReadEntry(context, entry)) {
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: input.id } });
+    }
+
+    // Async variant so a nested entry of a hierarchical type (e.g. a page
+    // under a parent) gets its full ancestor-walked URL instead of null.
+    const path = await buildEntryPermalink(context, entry);
+    if (path === null) {
+      throw errors.CONFLICT({ data: { reason: "no_public_url" } });
+    }
+
+    const token = await createPreviewToken(context.db, {
+      entryId: entry.id,
+      userId: context.user.id,
+    });
+    return { token, url: `${path}?preview=${token}` };
+  });

--- a/packages/core/src/rpc/procedures/entry/index.ts
+++ b/packages/core/src/rpc/procedures/entry/index.ts
@@ -1,5 +1,6 @@
 import { list as activityList } from "./activity.js";
 import { deletePermanentMany, restoreMany, trashMany } from "./bulk.js";
+import { createPreviewLink } from "./create-preview-link.js";
 import { create } from "./create.js";
 import { recentActivity, stats } from "./dashboard.js";
 import { deletePermanent } from "./delete-permanent.js";
@@ -25,6 +26,7 @@ export const entryRouter = {
   restoreMany,
   deletePermanentMany,
   duplicate,
+  createPreviewLink,
   publish,
   discardDraft,
   stats,

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -221,6 +221,7 @@ export const entryTrashInputSchema = v.object({ id: idParam });
 export const entryRestoreInputSchema = v.object({ id: idParam });
 export const entryDeletePermanentInputSchema = v.object({ id: idParam });
 export const entryDuplicateInputSchema = v.object({ id: idParam });
+export const entryCreatePreviewLinkInputSchema = v.object({ id: idParam });
 
 // Bulk action input. Capped at 100 ids per call so a single batched
 // `WHERE id IN (…)` stays bounded; the admin selects a page at a time.


### PR DESCRIPTION
The core half of shareable draft preview links (#872). A draft can now be shown to someone without an account via an entry-scoped, expiring link.

**Minting** — `entry.createPreviewLink({ id })` is gated by `canReadEntry` (the same rule `entry.get`/`entry.duplicate` use), so only someone who can already see the draft — its author with `edit_own`, or an `edit_any` editor — can hand one out. It 404s (not 403) on a missing/unreadable/reserved entry so row existence isn't leaked. It returns the entry's public permalink with the token attached:

\`\`\`
{ token, url: "/post/my-draft?preview=<token>" }
\`\`\`

**Token model** — reuses the random-token-hashed-at-rest pattern already used for magic-link/invite tokens: a 192-bit random token, only its SHA-256 hash stored in the existing `auth_tokens` table (new `preview_link` type, payload `{ entryId }`, 7-day TTL, reusable until expiry). No new signing secret is introduced.

**Resolution** — the public single-entry resolver, both flat (`/post/slug`) and hierarchical (`/page/parent/child`), honours a valid `?preview=` token to reveal that one draft. It's scoped to the exact entry id, requires the URL's type+slug (and ancestor chain) to match, and never reveals a trashed row. Archive, search, front-page, and taxonomy keep their published-only gate untouched — `single` is the only widened surface.

**Deferred** (follow-ups, not blockers): a `Referrer-Policy: no-referrer` on preview responses so a draft's outbound assets can't leak the token, and an expiry sweep for dead `preview_link` rows. The admin "Copy preview link" button lands in a follow-up PR that closes #872.

Refs #872