### PR TITLE
feat(admin): copy preview link from the editor

### DIFF
--- a/packages/admin/e2e/editor-actions.spec.ts
+++ b/packages/admin/e2e/editor-actions.spec.ts
@@ -374,6 +374,28 @@ test.describe("editor actions: pattern authoring", () => {
     expect(clipboard).toContain('text: "Seeded heading"');
     expect(clipboard).toContain('block("core/rich-text"');
   });
+
+  test("copy preview link writes the absolute preview url to the clipboard", async ({
+    page,
+  }) => {
+    await installEditorMocks(page, {
+      handlers: {
+        "/entry/createPreviewLink": {
+          token: "tok123",
+          url: "/post/hello?preview=tok123",
+        },
+      },
+    });
+    await page.goto("entries/posts/1/edit");
+    await dismissStarterModal(page);
+
+    await page.getByTestId("editor-copy-preview-link").click();
+    await expect(page.getByTestId("toast-success")).toBeVisible();
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain("/post/hello?preview=tok123");
+    expect(clipboard).toMatch(/^https?:\/\//);
+  });
 });
 
 test.describe("editor actions: draft of a published entry", () => {

--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -965,6 +965,11 @@ msgid "blockActions.copyJson"
 msgstr "نسخ JSON"
 
 #. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copy"
+msgstr "نسخ رابط المعاينة"
+
+#. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.secret.description"
 msgstr "انسخ السرّ الآن. لن نعرضه مرة أخرى — فقدانه يعني إلغاءه وإصدار رمز "
@@ -1002,6 +1007,11 @@ msgstr "تعذّر إكمال الطلب. حاول مرة أخرى."
 #: src/lib/email-change-errors.ts
 msgid "emailChange.error.fallback"
 msgstr "تعذّر تأكيد تغيير البريد. حاول مرة أخرى."
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.failed"
+msgstr "تعذّر إنشاء رابط المعاينة"
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/create.tsx
@@ -2630,6 +2640,11 @@ msgstr "فشل عرض صفحة الإضافة"
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.col.prefix"
 msgstr "البادئة"
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copied"
+msgstr "تم نسخ رابط المعاينة إلى الحافظة"
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -962,6 +962,11 @@ msgid "blockActions.copyJson"
 msgstr "JSON kopieren"
 
 #. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copy"
+msgstr "Vorschaulink kopieren"
+
+#. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.secret.description"
 msgstr "Kopieren Sie das Geheimnis jetzt. Wir zeigen es nicht erneut an — wenn "
@@ -999,6 +1004,11 @@ msgstr "Anfrage konnte nicht abgeschlossen werden. Bitte erneut versuchen."
 #: src/lib/email-change-errors.ts
 msgid "emailChange.error.fallback"
 msgstr "E-Mail-Änderung konnte nicht bestätigt werden. Bitte erneut versuchen."
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.failed"
+msgstr "Vorschaulink konnte nicht erstellt werden"
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/create.tsx
@@ -2654,6 +2664,11 @@ msgstr "Plugin-Seite konnte nicht gerendert werden"
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.col.prefix"
 msgstr "Präfix"
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copied"
+msgstr "Vorschaulink in die Zwischenablage kopiert"
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -952,6 +952,11 @@ msgid "blockActions.copyJson"
 msgstr "Copy JSON"
 
 #. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copy"
+msgstr "Copy preview link"
+
+#. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.secret.description"
 msgstr "Copy the secret now. We won't show it again — losing it means revoking "
@@ -989,6 +994,11 @@ msgstr "Couldn't complete the request. Try again."
 #: src/lib/email-change-errors.ts
 msgid "emailChange.error.fallback"
 msgstr "Couldn't confirm the email change. Try again."
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.failed"
+msgstr "Couldn't create a preview link"
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/create.tsx
@@ -2620,6 +2630,11 @@ msgstr "Plugin page failed to render"
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.col.prefix"
 msgstr "Prefix"
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copied"
+msgstr "Preview link copied to clipboard"
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -968,6 +968,11 @@ msgid "blockActions.copyJson"
 msgstr "Копіювати JSON"
 
 #. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copy"
+msgstr "Скопіювати посилання для попереднього перегляду"
+
+#. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.secret.description"
 msgstr "Скопіюйте секрет зараз. Ми не покажемо його знову — втратите доведеться "
@@ -1005,6 +1010,11 @@ msgstr "Не вдалося виконати запит. Спробуйте зн
 #: src/lib/email-change-errors.ts
 msgid "emailChange.error.fallback"
 msgstr "Не вдалося підтвердити зміну email. Спробуйте знову."
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.failed"
+msgstr "Не вдалося створити посилання для попереднього перегляду"
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/create.tsx
@@ -2644,6 +2654,11 @@ msgstr "Не вдалося відобразити сторінку плагін
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.col.prefix"
 msgstr "Префікс"
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copied"
+msgstr "Посилання для попереднього перегляду скопійовано"
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -938,6 +938,11 @@ msgid "blockActions.copyJson"
 msgstr "复制 JSON"
 
 #. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copy"
+msgstr "复制预览链接"
+
+#. js-lingui-explicit-id
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.secret.description"
 msgstr "立即复制密钥。我们不会再次显示 — 如果遗失，您必须撤销并重新创建。"
@@ -972,6 +977,11 @@ msgstr "无法完成请求。请重试。"
 #: src/lib/email-change-errors.ts
 msgid "emailChange.error.fallback"
 msgstr "无法确认电子邮箱更改。请重试。"
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.failed"
+msgstr "无法创建预览链接"
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/create.tsx
@@ -2587,6 +2597,11 @@ msgstr "插件页面渲染失败"
 #: src/components/profile/api-tokens-card.tsx
 msgid "apiTokens.col.prefix"
 msgstr "前缀"
+
+#. js-lingui-explicit-id
+#: src/editor/CopyPreviewLinkButton.tsx
+msgid "editor.previewLink.copied"
+msgstr "预览链接已复制到剪贴板"
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/PreviewBanner.tsx

--- a/packages/admin/src/components/editor/plain-form-layout.tsx
+++ b/packages/admin/src/components/editor/plain-form-layout.tsx
@@ -63,6 +63,9 @@ interface PlainFormLayoutProps {
   // `<RevisionsSheet />` with RPC fetchers + onRestore and passes it
   // here when the entry type declares `supports: ['revisions']`.
   readonly revisionsTrigger?: ReactNode;
+  // Optional "Copy preview link" action slot — route layer wires the
+  // entry.createPreviewLink RPC and passes the button here.
+  readonly previewLinkAction?: ReactNode;
   // Debounce window for autosave. When > 0, value edits trigger
   // `onSubmit` after the window elapses with no new edits. 0 (default)
   // disables autosave entirely so the layout keeps its explicit-save
@@ -93,6 +96,7 @@ export function PlainFormLayout({
   serverError,
   onSubmit,
   revisionsTrigger,
+  previewLinkAction,
   autosaveMs = 0,
 }: PlainFormLayoutProps): ReactElement {
   const renderLabel = useLabel();
@@ -160,6 +164,7 @@ export function PlainFormLayout({
           >
             {renderLabel(LABEL[saveStatus])}
           </span>
+          {previewLinkAction}
           {revisionsTrigger}
           <Button
             type="submit"

--- a/packages/admin/src/editor/CopyPreviewLinkButton.test.tsx
+++ b/packages/admin/src/editor/CopyPreviewLinkButton.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderWithI18n } from "../../test/render-with-i18n.js";
+import { toastError, toastSuccess } from "../lib/toast.js";
+import { CopyPreviewLinkButton } from "./CopyPreviewLinkButton.js";
+
+vi.mock("../lib/toast.js", () => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  vi.stubGlobal("navigator", {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+describe("CopyPreviewLinkButton", () => {
+  test("mints a link, copies the absolute url, and toasts success", async () => {
+    const mintPreviewLink = vi
+      .fn()
+      .mockResolvedValue({ url: "/post/secret?preview=tok123" });
+    renderWithI18n(<CopyPreviewLinkButton mintPreviewLink={mintPreviewLink} />);
+
+    await userEvent.click(screen.getByTestId("editor-copy-preview-link"));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/post/secret?preview=tok123`,
+      );
+    });
+    expect(mintPreviewLink).toHaveBeenCalledOnce();
+    expect(toastSuccess).toHaveBeenCalledOnce();
+  });
+
+  test("toasts an error when minting fails", async () => {
+    const mintPreviewLink = vi.fn().mockRejectedValue(new Error("nope"));
+    renderWithI18n(<CopyPreviewLinkButton mintPreviewLink={mintPreviewLink} />);
+
+    await userEvent.click(screen.getByTestId("editor-copy-preview-link"));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledOnce();
+    });
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  test("toasts an error when the clipboard write fails", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error("denied")),
+      },
+    });
+    const mintPreviewLink = vi
+      .fn()
+      .mockResolvedValue({ url: "/post/secret?preview=tok" });
+    renderWithI18n(<CopyPreviewLinkButton mintPreviewLink={mintPreviewLink} />);
+
+    await userEvent.click(screen.getByTestId("editor-copy-preview-link"));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledOnce();
+    });
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/editor/CopyPreviewLinkButton.tsx
+++ b/packages/admin/src/editor/CopyPreviewLinkButton.tsx
@@ -1,0 +1,84 @@
+import type { MessageDescriptor } from "@lingui/core";
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button.js";
+import { toastError, toastSuccess } from "@/lib/toast.js";
+import { useLabel } from "@/lib/use-label.js";
+import { defineMessage } from "@lingui/core/macro";
+import { Link2 } from "lucide-react";
+
+const M = {
+  copy: defineMessage({
+    id: "editor.previewLink.copy",
+    message: "Copy preview link",
+  }),
+  copied: defineMessage({
+    id: "editor.previewLink.copied",
+    message: "Preview link copied to clipboard",
+  }),
+  failed: defineMessage({
+    id: "editor.previewLink.failed",
+    message: "Couldn't create a preview link",
+  }),
+} satisfies Record<string, MessageDescriptor>;
+
+// Safari only honors a clipboard write inside the originating user gesture,
+// and the `await` on minting consumes that activation. Handing `ClipboardItem`
+// a pending Blob registers the write synchronously within the gesture and lets
+// the text resolve afterward. Engines without `ClipboardItem` fall back to the
+// (gesture-sensitive) writeText.
+async function copyText(textPromise: Promise<string>): Promise<void> {
+  if (typeof ClipboardItem === "function") {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        "text/plain": textPromise.then(
+          (text) => new Blob([text], { type: "text/plain" }),
+        ),
+      }),
+    ]);
+    return;
+  }
+  await navigator.clipboard.writeText(await textPromise);
+}
+
+// Mints a shareable draft preview link and copies the absolute URL to the
+// clipboard. The route injects `mintPreviewLink` (wired to
+// entry.createPreviewLink) so this stays RPC-agnostic and unit-testable —
+// same DI shape as the revisions trigger.
+export function CopyPreviewLinkButton({
+  mintPreviewLink,
+}: {
+  readonly mintPreviewLink: () => Promise<{ readonly url: string }>;
+}): ReactElement {
+  const renderLabel = useLabel();
+  const [pending, setPending] = useState(false);
+
+  async function onClick(): Promise<void> {
+    setPending(true);
+    // url is a site-relative path; resolve against the current origin.
+    const hrefPromise = mintPreviewLink().then(
+      ({ url }) => new URL(url, window.location.origin).href,
+    );
+    try {
+      await copyText(hrefPromise);
+      toastSuccess(renderLabel(M.copied));
+    } catch {
+      toastError(renderLabel(M.failed));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      data-testid="editor-copy-preview-link"
+      onClick={() => void onClick()}
+      disabled={pending}
+      aria-label={renderLabel(M.copy)}
+    >
+      <Link2 className="size-4" aria-hidden />
+    </Button>
+  );
+}

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -101,6 +101,10 @@ export interface PlumixEditorLayoutProps {
   // Route layer owns RPC wiring and feeds a fully-wired <RevisionsSheet />
   // here; the layout only allocates space and doesn't know the contract.
   readonly revisionsTrigger?: ReactNode;
+  // Optional "Copy preview link" action rendered in the header. Route layer
+  // owns the entry.createPreviewLink RPC + clipboard write; the layout only
+  // allocates space.
+  readonly previewLinkAction?: ReactNode;
   // Optional co-author indicator (avatar group + last-seen labels)
   // surfaced next to the autosave pill. Route layer owns the
   // `entry.activity.list` polling; the layout just allocates space.
@@ -521,6 +525,7 @@ export function PlumixEditorLayout({
   isPublishing = false,
   isPublished = false,
   revisionsTrigger,
+  previewLinkAction,
   coAuthorIndicator,
   documentPanel,
   previewBanner,
@@ -602,6 +607,7 @@ export function PlumixEditorLayout({
           {isPreview ? null : <AutosaveStatusPill />}
           {isPreview ? null : coAuthorIndicator}
           {revisionsTrigger}
+          {isPreview ? null : previewLinkAction}
           {isPreview ? null : isDraftMode ? (
             <DraftActions draftMode={draftMode} />
           ) : (

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -19,6 +19,7 @@ import { buildAdminPatternRegistry } from "@/editor/admin-pattern-registry.js";
 import { AutosaveStatusContext } from "@/editor/AutosaveStatus.js";
 import { blockSpecsToPuckComponents } from "@/editor/block-adapter.js";
 import { CoAuthorIndicator } from "@/editor/CoAuthorIndicator.js";
+import { CopyPreviewLinkButton } from "@/editor/CopyPreviewLinkButton.js";
 import { createDebouncer } from "@/editor/debounce.js";
 import { detectStaleAutosave } from "@/editor/detect-stale-autosave.js";
 import { PlumixEditorLayout } from "@/editor/EditorLayout.js";
@@ -933,6 +934,14 @@ function PuckSpikeRouteInner({
       isPublishing: publish.isPending,
       isPublished,
       revisionsTrigger,
+      // Only public types have a public URL to preview; non-public types
+      // would always 409 on mint, so don't offer the action.
+      previewLinkAction:
+        entryType?.isPublic === false ? undefined : (
+          <CopyPreviewLinkButton
+            mintPreviewLink={() => orpc.entry.createPreviewLink.call({ id })}
+          />
+        ),
       coAuthorIndicator:
         coAuthors.length > 0 ? (
           <CoAuthorIndicator users={coAuthors} relativeTime={formatRelative} />
@@ -941,6 +950,8 @@ function PuckSpikeRouteInner({
       draftMode: draftModeProp,
     }),
     [
+      id,
+      entryType,
       title,
       handleTitleChange,
       backHref,
@@ -1257,6 +1268,13 @@ function PlainFormRouteInner({
       serverError={renderedError}
       autosaveMs={500}
       revisionsTrigger={revisionsTrigger}
+      previewLinkAction={
+        entryType.isPublic === false ? undefined : (
+          <CopyPreviewLinkButton
+            mintPreviewLink={() => orpc.entry.createPreviewLink.call({ id })}
+          />
+        )
+      }
       onSubmit={(values) =>
         updateMutation.mutate({
           title: values.title,


### PR DESCRIPTION
Completes shareable draft preview links (#872) — the admin half on top of the core RPC/resolver merged in #896.

A **Copy preview link** action now sits in the editor header (both the visual editor and the plain-form layout). It mints a link via `entry.createPreviewLink`, resolves the returned site-relative URL against the current origin, and copies the absolute link to the clipboard with a success/error toast.

**Offered only for public entry types**

Non-public types have no public URL, so the mint would always 409 — the button is gated on the entry type being public rather than relying on a post-click error.

**Clipboard write stays inside the user gesture**

Safari rejects a `clipboard.writeText` issued after the `await` on minting (the gesture activation is already consumed). The write registers a `ClipboardItem` with a *pending* `Blob` so it's queued synchronously within the gesture and resolves once the token arrives, falling back to `writeText` where `ClipboardItem` is unavailable.

The button is wired through an optional `previewLinkAction` ReactNode slot on both layouts (same DI shape as `revisionsTrigger`), keeping the layout RPC-agnostic. It's hidden in revision-preview mode. On already-published entries it still shows (a preview link there is harmless, just redundant).

Fixes #872