### PR TITLE
refactor(create-plumix-app): resolve catalog refs from pnpm-workspace.yaml

### DIFF
--- a/packages/create-plumix-app/package.json
+++ b/packages/create-plumix-app/package.json
@@ -38,7 +38,7 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules templates",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
-    "prepack": "node scripts/sync-template.mjs",
+    "prepack": "tsc && node scripts/sync-template.mjs",
     "publint": "publint",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"

--- a/packages/create-plumix-app/scripts/sync-template.mjs
+++ b/packages/create-plumix-app/scripts/sync-template.mjs
@@ -1,46 +1,25 @@
 #!/usr/bin/env node
 /**
  * Snapshot `examples/minimal` into the package's `templates/starter`
- * directory so the published tarball carries a self-contained copy.
+ * directory so the published tarball carries a self-contained copy with
+ * pnpm's `workspace:`/`catalog:` protocols already resolved.
  *
- * Wired as `prepack` — pnpm runs it before `pnpm pack` / `pnpm
- * publish`. Skipped at dev/test time: the scaffolder resolves
- * `examples/minimal` directly from the workspace via a relative path
- * (see `src/scaffold.ts`), so the snapshot is only needed once the
- * package is detached from its monorepo.
- *
- * Dep rewriting (`workspace:*` / `catalog:` → SemVer) lives in
- * `scaffold.ts`, not here. Keeping rewriting in one place means the
- * snapshot stays byte-identical to the workspace example.
+ * Wired as `prepack` (after `build`, so `dist/` exists). The resolution
+ * logic lives in `src/sync-template.ts` — shared with the scaffolder and
+ * unit-tested — and is imported here from the freshly built `dist/`.
  */
-import { cp, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { syncTemplate } from "../dist/sync-template.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = path.resolve(HERE, "..");
 const REPO_ROOT = path.resolve(PACKAGE_ROOT, "..", "..");
 
-const SOURCE = path.join(REPO_ROOT, "examples", "minimal");
-const DEST = path.join(PACKAGE_ROOT, "templates", "starter");
+const source = path.join(REPO_ROOT, "examples", "minimal");
+const dest = path.join(PACKAGE_ROOT, "templates", "starter");
 
-const EXCLUDED_SEGMENTS = new Set([
-  "node_modules",
-  ".cache",
-  ".turbo",
-  ".wrangler",
-  ".plumix",
-  "dist",
-]);
+await syncTemplate({ source, dest, repoRoot: REPO_ROOT });
 
-function shouldCopy(srcPath) {
-  const rel = path.relative(SOURCE, srcPath);
-  if (rel === "") return true;
-  return !rel.split(path.sep).some((segment) => EXCLUDED_SEGMENTS.has(segment));
-}
-
-await rm(DEST, { recursive: true, force: true });
-await mkdir(DEST, { recursive: true });
-await cp(SOURCE, DEST, { recursive: true, filter: shouldCopy });
-
-console.log(`[sync-template] snapshotted ${SOURCE} → ${DEST}`);
+console.log(`[sync-template] snapshotted ${source} → ${dest}`);

--- a/packages/create-plumix-app/src/catalog.test.ts
+++ b/packages/create-plumix-app/src/catalog.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import {
+  EMPTY_CATALOG_CONTEXT,
+  loadCatalogContext,
+  parseWorkspaceCatalog,
+  resolveDeps,
+} from "./catalog.js";
+import { packageVersion, REPO_ROOT } from "./test-support.js";
+
+describe("resolveDeps", () => {
+  test("passes concrete SemVer ranges through unchanged", () => {
+    expect(
+      resolveDeps(
+        { "drizzle-orm": "^0.45.2", valibot: "1.3.1" },
+        EMPTY_CATALOG_CONTEXT,
+      ),
+    ).toEqual({ "drizzle-orm": "^0.45.2", valibot: "1.3.1" });
+  });
+
+  test("resolves `catalog:` deps to the catalog range", () => {
+    expect(
+      resolveDeps(
+        { typescript: "catalog:", wrangler: "catalog:" },
+        {
+          catalog: { typescript: "^6.0.3", wrangler: "^4.98.0" },
+          workspaceVersions: {},
+        },
+      ),
+    ).toEqual({ typescript: "^6.0.3", wrangler: "^4.98.0" });
+  });
+
+  test("resolves `workspace:` deps to a caret range on the package version", () => {
+    expect(
+      resolveDeps(
+        { plumix: "workspace:*", "@plumix/runtime-cloudflare": "workspace:^" },
+        {
+          catalog: {},
+          workspaceVersions: {
+            plumix: "0.1.0",
+            "@plumix/runtime-cloudflare": "0.1.0",
+          },
+        },
+      ),
+    ).toEqual({ plumix: "^0.1.0", "@plumix/runtime-cloudflare": "^0.1.0" });
+  });
+
+  test("drops @plumix/typescript-config, a private dev-only package", () => {
+    const result = resolveDeps(
+      { "@plumix/typescript-config": "workspace:*", typescript: "catalog:" },
+      { catalog: { typescript: "^6.0.3" }, workspaceVersions: {} },
+    );
+    expect(result).not.toHaveProperty("@plumix/typescript-config");
+    expect(result?.typescript).toBe("^6.0.3");
+  });
+
+  test("throws on a `catalog:` dep absent from the catalog", () => {
+    expect(() =>
+      resolveDeps({ "future-dep": "catalog:" }, EMPTY_CATALOG_CONTEXT),
+    ).toThrow(/future-dep/);
+  });
+
+  test("throws on a `workspace:` dep whose version can't be found", () => {
+    expect(() =>
+      resolveDeps({ "@plumix/ghost": "workspace:*" }, EMPTY_CATALOG_CONTEXT),
+    ).toThrow(/@plumix\/ghost/);
+  });
+
+  test("returns undefined when given undefined", () => {
+    expect(resolveDeps(undefined, EMPTY_CATALOG_CONTEXT)).toBeUndefined();
+  });
+});
+
+describe("parseWorkspaceCatalog", () => {
+  test("reads the default catalog block, stopping at the next top-level key", () => {
+    const yaml = [
+      "packages:",
+      '  - "packages/*"',
+      "",
+      "catalog:",
+      '  "@types/node": ^24.13.1',
+      "  typescript: ^6.0.3",
+      "  wrangler: ^4.98.0",
+      "",
+      "onlyBuiltDependencies:",
+      "  - esbuild",
+    ].join("\n");
+
+    expect(parseWorkspaceCatalog(yaml)).toEqual({
+      "@types/node": "^24.13.1",
+      typescript: "^6.0.3",
+      wrangler: "^4.98.0",
+    });
+  });
+});
+
+describe("loadCatalogContext", () => {
+  test("reads the catalog and workspace package versions from the monorepo", async () => {
+    const ctx = await loadCatalogContext(REPO_ROOT);
+
+    // The catalog mirrors pnpm-workspace.yaml — no hand-kept copy.
+    const catalog = parseWorkspaceCatalog(
+      readFileSync(join(REPO_ROOT, "pnpm-workspace.yaml"), "utf8"),
+    );
+    expect(ctx.catalog).toEqual(catalog);
+    expect(ctx.catalog.typescript).toBe(catalog.typescript);
+
+    // Versions come straight from each package's own package.json.
+    expect(ctx.workspaceVersions.plumix).toBe(
+      packageVersion("packages/plumix"),
+    );
+    expect(ctx.workspaceVersions["@plumix/runtime-cloudflare"]).toBeDefined();
+  });
+});

--- a/packages/create-plumix-app/src/catalog.ts
+++ b/packages/create-plumix-app/src/catalog.ts
@@ -1,0 +1,148 @@
+import { glob, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ScaffoldError } from "./errors.js";
+
+interface PackageJson {
+  name?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+// `@plumix/typescript-config` is a private dev-only workspace package,
+// never published to npm. Scaffolded projects get a self-contained
+// tsconfig instead, so the dependency is dropped entirely.
+const PRIVATE_DEV_PACKAGE = "@plumix/typescript-config";
+
+export interface CatalogContext {
+  /** Default `catalog:` table from pnpm-workspace.yaml (name → range). */
+  readonly catalog: Record<string, string>;
+  /** Every workspace package's own version (name → version). */
+  readonly workspaceVersions: Record<string, string>;
+}
+
+export const EMPTY_CATALOG_CONTEXT: CatalogContext = {
+  catalog: {},
+  workspaceVersions: {},
+};
+
+export function resolveDeps(
+  deps: Record<string, string> | undefined,
+  ctx: CatalogContext,
+): Record<string, string> | undefined {
+  if (!deps) return deps;
+  const out: Record<string, string> = {};
+  for (const [name, range] of Object.entries(deps)) {
+    if (name === PRIVATE_DEV_PACKAGE) continue;
+    if (range.startsWith("workspace:")) {
+      const version = ctx.workspaceVersions[name];
+      if (!version) {
+        throw ScaffoldError.workspaceVersionMissing({ packageName: name });
+      }
+      out[name] = `^${version}`;
+      continue;
+    }
+    if (range.startsWith("catalog:")) {
+      const resolved = ctx.catalog[name];
+      if (!resolved) {
+        throw ScaffoldError.catalogResolutionMissing({ catalogName: name });
+      }
+      out[name] = resolved;
+      continue;
+    }
+    out[name] = range;
+  }
+  return out;
+}
+
+/**
+ * Resolve a `package.json` file's dependency protocols in place,
+ * applying an optional `patch` (e.g. renaming the package) first. The
+ * 2-space indent + trailing newline matches the template's other JSON;
+ * `JSON.stringify` rewrites the whole file, which is fine because these
+ * are plain JSON we control — no comments or key ordering to preserve.
+ */
+export async function rewritePackageJsonFile(
+  pkgPath: string,
+  ctx: CatalogContext,
+  patch?: (pkg: PackageJson) => void,
+): Promise<void> {
+  const pkg = JSON.parse(await readFile(pkgPath, "utf8")) as PackageJson;
+  patch?.(pkg);
+  const deps = resolveDeps(pkg.dependencies, ctx);
+  const devDeps = resolveDeps(pkg.devDependencies, ctx);
+  if (deps) pkg.dependencies = deps;
+  if (devDeps) pkg.devDependencies = devDeps;
+  await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+}
+
+/**
+ * Read the default catalog and every workspace package's version from
+ * the monorepo at `repoRoot`. Used at scaffold time (dev path) and at
+ * `prepack` time to bake concrete versions into the published snapshot.
+ */
+export async function loadCatalogContext(
+  repoRoot: string,
+): Promise<CatalogContext> {
+  const yaml = await readFile(join(repoRoot, "pnpm-workspace.yaml"), "utf8");
+  return {
+    catalog: parseWorkspaceCatalog(yaml),
+    workspaceVersions: await collectWorkspaceVersions(repoRoot, yaml),
+  };
+}
+
+async function collectWorkspaceVersions(
+  repoRoot: string,
+  yaml: string,
+): Promise<Record<string, string>> {
+  const patterns = parseWorkspacePackages(yaml).map((p) => `${p}/package.json`);
+  const out: Record<string, string> = {};
+  for await (const rel of glob(patterns, { cwd: repoRoot })) {
+    const raw = await readFile(join(repoRoot, rel), "utf8");
+    const pkg = JSON.parse(raw) as { name?: string; version?: string };
+    if (pkg.name && pkg.version) out[pkg.name] = pkg.version;
+  }
+  return out;
+}
+
+/** Parse the `packages:` glob list out of pnpm-workspace.yaml. */
+function parseWorkspacePackages(yaml: string): string[] {
+  const out: string[] = [];
+  for (const line of blockLines(yaml, "packages:")) {
+    const match = /^\s+-\s*"?([^"\s]+)"?\s*$/.exec(line);
+    if (match?.[1]) out.push(match[1]);
+  }
+  return out;
+}
+
+/**
+ * Parse the top-level `catalog:` map out of pnpm-workspace.yaml. The
+ * format is stable (we control it) so a tiny line-scanner is enough,
+ * keeping a YAML parser out of the scaffolder's dependency surface.
+ */
+export function parseWorkspaceCatalog(yaml: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of blockLines(yaml, "catalog:")) {
+    const match = /^\s+"?([^":\s]+)"?\s*:\s*(\S+)\s*$/.exec(line);
+    const [, name, version] = match ?? [];
+    if (name && version) out[name] = version;
+  }
+  return out;
+}
+
+// The block ends at the next top-level key (a non-indented line);
+// comments and blank lines inside it are left for the caller's regex.
+function* blockLines(yaml: string, key: string): Generator<string> {
+  let inBlock = false;
+  for (const line of yaml.split("\n")) {
+    if (line === key) {
+      inBlock = true;
+      continue;
+    }
+    if (!inBlock) continue;
+    if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("#"))
+      break;
+    yield line;
+  }
+}

--- a/packages/create-plumix-app/src/errors.test.ts
+++ b/packages/create-plumix-app/src/errors.test.ts
@@ -48,7 +48,19 @@ describe("ScaffoldError.catalogResolutionMissing", () => {
     });
     expect(err.code).toBe("catalog_resolution_missing");
     expect(err.catalogName).toBe("react-dom");
-    expect(err.message).toContain('No catalog resolution for "react-dom"');
-    expect(err.message).toContain("CATALOG_RESOLUTIONS in scaffold.ts");
+    expect(err.message).toContain('No catalog entry for "react-dom"');
+    expect(err.message).toContain("pnpm-workspace.yaml");
+  });
+});
+
+describe("ScaffoldError.workspaceVersionMissing", () => {
+  test("class identity, code, exposed packageName, and message", () => {
+    const err = ScaffoldError.workspaceVersionMissing({
+      packageName: "@plumix/ghost",
+    });
+    expect(err.code).toBe("workspace_version_missing");
+    expect(err.packageName).toBe("@plumix/ghost");
+    expect(err.message).toContain('No workspace version for "@plumix/ghost"');
+    expect(err.message).toContain("workspace:");
   });
 });

--- a/packages/create-plumix-app/src/errors.ts
+++ b/packages/create-plumix-app/src/errors.ts
@@ -2,12 +2,14 @@ type ScaffoldErrorCode =
   | "target_parent_missing"
   | "target_not_directory"
   | "target_directory_not_empty"
-  | "catalog_resolution_missing";
+  | "catalog_resolution_missing"
+  | "workspace_version_missing";
 
 interface ScaffoldErrorFields {
   parent?: string;
   targetDir?: string;
   catalogName?: string;
+  packageName?: string;
 }
 
 export class ScaffoldError extends Error {
@@ -19,6 +21,7 @@ export class ScaffoldError extends Error {
   readonly parent: string | undefined;
   readonly targetDir: string | undefined;
   readonly catalogName: string | undefined;
+  readonly packageName: string | undefined;
 
   private constructor(
     code: ScaffoldErrorCode,
@@ -30,6 +33,7 @@ export class ScaffoldError extends Error {
     this.parent = fields.parent;
     this.targetDir = fields.targetDir;
     this.catalogName = fields.catalogName;
+    this.packageName = fields.packageName;
   }
 
   static targetParentMissing(ctx: { parent: string }): ScaffoldError {
@@ -59,7 +63,15 @@ export class ScaffoldError extends Error {
   static catalogResolutionMissing(ctx: { catalogName: string }): ScaffoldError {
     return new ScaffoldError(
       "catalog_resolution_missing",
-      `No catalog resolution for "${ctx.catalogName}" — add it to CATALOG_RESOLUTIONS in scaffold.ts.`,
+      `No catalog entry for "${ctx.catalogName}" in pnpm-workspace.yaml — the template references it via \`catalog:\` but the workspace catalog has no such key.`,
+      ctx,
+    );
+  }
+
+  static workspaceVersionMissing(ctx: { packageName: string }): ScaffoldError {
+    return new ScaffoldError(
+      "workspace_version_missing",
+      `No workspace version for "${ctx.packageName}" — the template references it via \`workspace:\` but no workspace package publishes that name.`,
       ctx,
     );
   }

--- a/packages/create-plumix-app/src/scaffold.test.ts
+++ b/packages/create-plumix-app/src/scaffold.test.ts
@@ -10,12 +10,11 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
-  CATALOG_RESOLUTIONS,
   resolveTemplateRoot,
-  rewriteDeps,
   scaffold,
   shouldCopyTemplateEntry,
 } from "./scaffold.js";
+import { packageVersion } from "./test-support.js";
 
 describe("scaffold", () => {
   let tmp: string;
@@ -84,8 +83,14 @@ describe("scaffold", () => {
         /^catalog:/,
       );
     }
-    expect(pkg.dependencies?.plumix).toBe("^0.1.0");
-    expect(pkg.dependencies?.["@plumix/runtime-cloudflare"]).toBe("^0.1.0");
+    // `workspace:*` resolves to a caret range on each package's own
+    // version, read live from the monorepo — no hand-pinned constant.
+    expect(pkg.dependencies?.plumix).toBe(
+      `^${packageVersion("packages/plumix")}`,
+    );
+    expect(pkg.dependencies?.["@plumix/runtime-cloudflare"]).toBe(
+      `^${packageVersion("packages/runtimes/cloudflare")}`,
+    );
   });
 
   test("drops @plumix/typescript-config from devDependencies", async () => {
@@ -167,63 +172,6 @@ describe("resolveTemplateRoot", () => {
   });
 });
 
-describe("rewriteDeps", () => {
-  test("returns undefined when given undefined", () => {
-    expect(rewriteDeps(undefined)).toBeUndefined();
-  });
-
-  test("passes through concrete SemVer ranges unchanged", () => {
-    expect(
-      rewriteDeps({
-        "drizzle-orm": "^0.45.2",
-        valibot: "1.3.1",
-      }),
-    ).toEqual({
-      "drizzle-orm": "^0.45.2",
-      valibot: "1.3.1",
-    });
-  });
-
-  test("rewrites workspace: protocol to the pinned plumix range", () => {
-    expect(
-      rewriteDeps({
-        plumix: "workspace:*",
-        "@plumix/runtime-cloudflare": "workspace:^",
-      }),
-    ).toEqual({
-      plumix: "^0.1.0",
-      "@plumix/runtime-cloudflare": "^0.1.0",
-    });
-  });
-
-  test("rewrites catalog: protocol to the resolved version", () => {
-    expect(
-      rewriteDeps({
-        typescript: "catalog:",
-        wrangler: "catalog:",
-      }),
-    ).toEqual({
-      typescript: CATALOG_RESOLUTIONS.typescript,
-      wrangler: CATALOG_RESOLUTIONS.wrangler,
-    });
-  });
-
-  test("drops @plumix/typescript-config entirely", () => {
-    const result = rewriteDeps({
-      "@plumix/typescript-config": "workspace:*",
-      typescript: "catalog:",
-    });
-    expect(result).not.toHaveProperty("@plumix/typescript-config");
-    expect(result?.typescript).toBe("^6.0.3");
-  });
-
-  test("throws on an unknown catalog: dep so a forgotten table entry fails loudly", () => {
-    expect(() => rewriteDeps({ "some-future-dep": "catalog:" })).toThrow(
-      /No catalog resolution for "some-future-dep"/,
-    );
-  });
-});
-
 describe("shouldCopyTemplateEntry", () => {
   const root = "/template";
 
@@ -265,96 +213,3 @@ describe("shouldCopyTemplateEntry", () => {
     ).toBe(true);
   });
 });
-
-describe("CATALOG_RESOLUTIONS drift gate", () => {
-  // Resolve the workspace root from the package's known position:
-  // packages/create-plumix-app/src/scaffold.test.ts → ../../..
-  const here = new URL(".", import.meta.url).pathname;
-  const repoRoot = join(here, "..", "..", "..");
-
-  const minimalPkg = JSON.parse(
-    readFileSync(join(repoRoot, "examples", "minimal", "package.json"), "utf8"),
-  ) as {
-    readonly dependencies?: Record<string, string>;
-    readonly devDependencies?: Record<string, string>;
-  };
-
-  const workspaceCatalog = parseWorkspaceCatalog(
-    readFileSync(join(repoRoot, "pnpm-workspace.yaml"), "utf8"),
-  );
-
-  const minimalCatalogDeps = collectCatalogDeps(minimalPkg);
-
-  test("every `catalog:` dep in examples/minimal has a CATALOG_RESOLUTIONS entry", () => {
-    const missing = [...minimalCatalogDeps].filter(
-      (name) => !(name in CATALOG_RESOLUTIONS),
-    );
-    expect(missing).toEqual([]);
-  });
-
-  test("CATALOG_RESOLUTIONS has no orphan entries unused by the minimal template", () => {
-    const orphans = Object.keys(CATALOG_RESOLUTIONS).filter(
-      (name) => !minimalCatalogDeps.has(name),
-    );
-    expect(orphans).toEqual([]);
-  });
-
-  test("each CATALOG_RESOLUTIONS entry used by minimal matches pnpm-workspace.yaml", () => {
-    const drift: { name: string; scaffolder: string; workspace: string }[] = [];
-    for (const name of minimalCatalogDeps) {
-      const scaffolder = CATALOG_RESOLUTIONS[name];
-      const workspace = workspaceCatalog[name];
-      if (scaffolder !== workspace) {
-        drift.push({
-          name,
-          scaffolder: scaffolder ?? "<missing>",
-          workspace: workspace ?? "<missing>",
-        });
-      }
-    }
-    expect(drift).toEqual([]);
-  });
-});
-
-function collectCatalogDeps(pkg: {
-  readonly dependencies?: Record<string, string>;
-  readonly devDependencies?: Record<string, string>;
-}): Set<string> {
-  const out = new Set<string>();
-  for (const block of [pkg.dependencies ?? {}, pkg.devDependencies ?? {}]) {
-    for (const [name, range] of Object.entries(block)) {
-      if (typeof range === "string" && range.startsWith("catalog:")) {
-        out.add(name);
-      }
-    }
-  }
-  return out;
-}
-
-// Parses the top-level `catalog:` map out of pnpm-workspace.yaml. The
-// format is stable (we control it) so a tiny line-scanner is enough —
-// avoids pulling a YAML parser into the scaffolder tests.
-function parseWorkspaceCatalog(yaml: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  const lines = yaml.split("\n");
-  let inCatalog = false;
-  for (const line of lines) {
-    if (line === "catalog:") {
-      inCatalog = true;
-      continue;
-    }
-    if (inCatalog) {
-      // The catalog block ends at the next top-level key (no leading space).
-      if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("#")) {
-        inCatalog = false;
-        continue;
-      }
-      const match = /^\s+"?([^":\s]+)"?\s*:\s*(\S+)\s*$/.exec(line);
-      const [, name, version] = match ?? [];
-      if (name && version) {
-        out[name] = version;
-      }
-    }
-  }
-  return out;
-}

--- a/packages/create-plumix-app/src/scaffold.ts
+++ b/packages/create-plumix-app/src/scaffold.ts
@@ -1,8 +1,14 @@
 import { existsSync, statSync } from "node:fs";
-import { cp, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { cp, mkdir, readdir, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { CatalogContext } from "./catalog.js";
+import {
+  EMPTY_CATALOG_CONTEXT,
+  loadCatalogContext,
+  rewritePackageJsonFile,
+} from "./catalog.js";
 import { ScaffoldError } from "./errors.js";
 
 const EXCLUDED_SEGMENTS: ReadonlySet<string> = new Set([
@@ -48,42 +54,32 @@ const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 // never drift from the canonical example. Published builds carry a
 // snapshot under `templates/starter/` (written at `prepack` time)
 // that's used when the workspace example isn't reachable.
-const WORKSPACE_TEMPLATE = join(
-  PACKAGE_ROOT,
-  "..",
-  "..",
-  "examples",
-  "minimal",
-);
+const REPO_ROOT = join(PACKAGE_ROOT, "..", "..");
+const WORKSPACE_TEMPLATE = join(REPO_ROOT, "examples", "minimal");
 const PUBLISHED_TEMPLATE = join(PACKAGE_ROOT, "templates", "starter");
 
+// Use the workspace example only when we're actually inside the plumix
+// monorepo — both the example and the catalog it resolves against must
+// be present. Keying off the example alone would misfire if a published
+// install happened to sit next to an unrelated `examples/minimal`.
 export function resolveTemplateRoot(): string {
-  return existsSync(WORKSPACE_TEMPLATE)
+  return existsSync(WORKSPACE_TEMPLATE) &&
+    existsSync(join(REPO_ROOT, "pnpm-workspace.yaml"))
     ? WORKSPACE_TEMPLATE
     : PUBLISHED_TEMPLATE;
 }
 
-// The example's `package.json` uses pnpm's `workspace:*` and `catalog:`
-// protocols, which only resolve inside the plumix monorepo. End-user
-// projects need concrete SemVer ranges, so we rewrite at copy time.
-// Bump these together with the corresponding workspace catalog
-// (`pnpm-workspace.yaml`) and the next plumix release.
-const PLUMIX_PACKAGE_VERSION = "^0.1.0";
-// Mirrors `pnpm-workspace.yaml`'s `catalog:` for every package that
-// `examples/minimal/package.json` references via `catalog:`. The
-// drift-gate test in `scaffold.test.ts` keeps these locked in step.
-// Bump together with the workspace catalog and the next plumix release.
-export const CATALOG_RESOLUTIONS: Record<string, string> = {
-  "@cloudflare/workers-types": "^4.20260526.1",
-  "@types/node": "^24.13.1",
-  typescript: "^6.0.3",
-  wrangler: "^4.98.0",
-};
-
-// `@plumix/typescript-config` is a private dev-only workspace package,
-// not published to npm. The example's tsconfig `extends` it; the
-// scaffolded project gets a self-contained equivalent instead.
-const TYPESCRIPT_CONFIG_PKG = "@plumix/typescript-config";
+// The workspace example's `package.json` uses pnpm's `workspace:*` and
+// `catalog:` protocols, which only resolve inside the plumix monorepo —
+// so we resolve them against the live catalog and sibling package
+// versions at copy time. The published snapshot under `templates/starter`
+// is already resolved at `prepack`, so it needs no catalog (empty
+// context, no protocols left to rewrite).
+function catalogContextFor(templateRoot: string): Promise<CatalogContext> {
+  return templateRoot === WORKSPACE_TEMPLATE
+    ? loadCatalogContext(REPO_ROOT)
+    : Promise.resolve(EMPTY_CATALOG_CONTEXT);
+}
 
 const SCAFFOLDED_TSCONFIG = {
   $schema: "https://json.schemastore.org/tsconfig",
@@ -137,57 +133,16 @@ export async function scaffold(
   });
 
   const name = basename(targetDir);
-  await rewritePackageJson(targetDir, name);
+  await rewritePackageJsonFile(
+    join(targetDir, "package.json"),
+    await catalogContextFor(source),
+    (pkg) => {
+      pkg.name = name;
+    },
+  );
   await writeScaffoldedTsconfig(targetDir);
 
   return { targetDir, name };
-}
-
-interface PackageJsonShape {
-  name: string;
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  [key: string]: unknown;
-}
-
-export function rewriteDeps(
-  deps: Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  if (!deps) return deps;
-  const out: Record<string, string> = {};
-  for (const [name, range] of Object.entries(deps)) {
-    if (name === TYPESCRIPT_CONFIG_PKG) continue;
-    if (range.startsWith("workspace:")) {
-      out[name] = PLUMIX_PACKAGE_VERSION;
-      continue;
-    }
-    if (range.startsWith("catalog:")) {
-      const resolved = CATALOG_RESOLUTIONS[name];
-      if (!resolved) {
-        throw ScaffoldError.catalogResolutionMissing({ catalogName: name });
-      }
-      out[name] = resolved;
-      continue;
-    }
-    out[name] = range;
-  }
-  return out;
-}
-
-async function rewritePackageJson(dir: string, name: string): Promise<void> {
-  const pkgPath = join(dir, "package.json");
-  const raw = await readFile(pkgPath, "utf-8");
-  const pkg = JSON.parse(raw) as PackageJsonShape;
-  pkg.name = name;
-  const deps = rewriteDeps(pkg.dependencies);
-  const devDeps = rewriteDeps(pkg.devDependencies);
-  if (deps) pkg.dependencies = deps;
-  if (devDeps) pkg.devDependencies = devDeps;
-  // 2-space indent + trailing newline matches the rest of the
-  // template's JSON files. JSON.stringify rewrites the whole file —
-  // fine because the template's package.json is plain JSON we control,
-  // no comments or custom key ordering to lose.
-  await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
 }
 
 async function writeScaffoldedTsconfig(dir: string): Promise<void> {

--- a/packages/create-plumix-app/src/sync-template.test.ts
+++ b/packages/create-plumix-app/src/sync-template.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { syncTemplate } from "./sync-template.js";
+import { packageVersion, REPO_ROOT } from "./test-support.js";
+
+const SOURCE = join(REPO_ROOT, "examples", "minimal");
+
+describe("syncTemplate", () => {
+  let dest: string;
+
+  beforeEach(() => {
+    dest = mkdtempSync(join(tmpdir(), "plumix-sync-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dest, { recursive: true, force: true });
+  });
+
+  test("bakes a snapshot whose package.json carries no pnpm protocols", async () => {
+    await syncTemplate({ source: SOURCE, dest, repoRoot: REPO_ROOT });
+
+    const pkg = JSON.parse(
+      readFileSync(join(dest, "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+    for (const [name, range] of Object.entries(allDeps)) {
+      expect(range, `dep ${name}`).not.toMatch(/^(workspace|catalog):/);
+    }
+    expect(pkg.dependencies?.plumix).toBe(
+      `^${packageVersion("packages/plumix")}`,
+    );
+    expect(pkg.devDependencies?.["@plumix/typescript-config"]).toBeUndefined();
+  });
+});

--- a/packages/create-plumix-app/src/sync-template.ts
+++ b/packages/create-plumix-app/src/sync-template.ts
@@ -1,0 +1,37 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { loadCatalogContext, rewritePackageJsonFile } from "./catalog.js";
+import { shouldCopyTemplateEntry } from "./scaffold.js";
+
+interface SyncTemplateOptions {
+  /** The workspace example to snapshot (e.g. `examples/minimal`). */
+  readonly source: string;
+  /** Where the self-contained snapshot is written. */
+  readonly dest: string;
+  /** Monorepo root, used to resolve the catalog and package versions. */
+  readonly repoRoot: string;
+}
+
+/**
+ * Snapshot the workspace example into a self-contained template with
+ * pnpm's `workspace:`/`catalog:` protocols already resolved to concrete
+ * SemVer — the same rewrite pnpm performs at publish. Baking it here, at
+ * `prepack`, means the published tarball needs no monorepo context when
+ * the scaffolder runs on an end user's machine.
+ */
+export async function syncTemplate({
+  source,
+  dest,
+  repoRoot,
+}: SyncTemplateOptions): Promise<void> {
+  await rm(dest, { recursive: true, force: true });
+  await mkdir(dest, { recursive: true });
+  await cp(source, dest, {
+    recursive: true,
+    filter: (srcPath) => shouldCopyTemplateEntry(srcPath, source),
+  });
+
+  const ctx = await loadCatalogContext(repoRoot);
+  await rewritePackageJsonFile(join(dest, "package.json"), ctx);
+}

--- a/packages/create-plumix-app/src/test-support.ts
+++ b/packages/create-plumix-app/src/test-support.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// packages/create-plumix-app/src → repo root is three levels up.
+export const REPO_ROOT = join(
+  new URL(".", import.meta.url).pathname,
+  "..",
+  "..",
+  "..",
+);
+
+/** Read a workspace package's declared version (relative to the repo root). */
+export function packageVersion(relDir: string): string {
+  const pkg = JSON.parse(
+    readFileSync(join(REPO_ROOT, relDir, "package.json"), "utf8"),
+  ) as { version: string };
+  return pkg.version;
+}


### PR DESCRIPTION
The scaffolder turned the `examples/minimal` template's pnpm `catalog:` and
`workspace:*` references into concrete versions using a **hand-maintained
`CATALOG_RESOLUTIONS` map** and a `PLUMIX_PACKAGE_VERSION` constant, kept honest
by a drift test. Every dependency bump had to be copied into `scaffold.ts` by
hand — exactly the friction #908 hit when bumping `@types/node` and `wrangler`.

This resolves the protocols **dynamically** by reading the catalog and each
workspace package's own version straight from `pnpm-workspace.yaml` — the same
rewrite pnpm itself performs at publish, and the approach emdash-cms uses. The
hand-kept map, the version constant, and the drift gate are gone (net −160 lines).

**Two-path resolution**

- **Published tarball** — `prepack` bakes concrete versions into the
  `templates/starter` snapshot, so an end user's machine needs no monorepo context.
- **In-workspace dev** — resolves at runtime against the live `pnpm-workspace.yaml`.

**`workspace:*` now tracks the live package version**

It resolves to `^<version>` read from each `@plumix/*` package's own `package.json`,
making the package version the single source of truth. Whatever bumps the packages
to `0.1.0` at release time flows through automatically — no constant to bump.

**`@types/node` answer (carried over from #908)**

There is no published `@types/node@24.15.x`; `24.13.1` is the newest in the 24 major
line, which matches our Node 24 target (`.nvmrc` / `engines`). The dynamic resolver
just reads whatever the catalog holds, so this is now self-correcting either way.

Built test-first (red→green per behavior). 40 tests pass; lint, typecheck, knip,
and format are green.

**Out of scope (noted from review):** the package already compiles `*.test.ts`
into the shipped `dist/` (pre-existing) — splitting build vs. typecheck tsconfig is
a separate cleanup. Named pnpm `catalogs:` aren't resolved (the template only uses
the default `catalog:`); an unresolved ref fails closed with a clear error.