### PR TITLE
build(create-plumix-app): keep test files out of the published dist

### DIFF
--- a/packages/create-plumix-app/package.json
+++ b/packages/create-plumix-app/package.json
@@ -34,11 +34,11 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules templates",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
-    "prepack": "tsc && node scripts/sync-template.mjs",
+    "prepack": "tsc -p tsconfig.build.json && node scripts/sync-template.mjs",
     "publint": "publint",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"

--- a/packages/create-plumix-app/tsconfig.build.json
+++ b/packages/create-plumix-app/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/test-support.ts"]
+}


### PR DESCRIPTION
`create-plumix-app` compiled every `src` file — including `*.test.ts` and
`test-support.ts` — into `dist` via a bare `tsc`, so the published tarball shipped
compiled tests that `import` vitest (a devDep absent from a consumer's install).

Add `tsconfig.build.json` (extends the base, excludes the test files) and point
`build` + `prepack` at it. `typecheck` still runs the full `tsconfig.json`, so tests
are type-checked but never emitted. Mirrors the build/typecheck split `core` and
`blocks` already use.

`dist/` now contains only the six source modules; `publint` passes (it packs via
`prepack`). 50 tests, lint, typecheck, knip, format all green.

Follow-up to the scaffolder work in #909/#910 (the deferred item noted there).