### PR TITLE
feat(admin): command palette content search (entries domain)

### DIFF
--- a/packages/admin/src/components/shell/command-palette.test.tsx
+++ b/packages/admin/src/components/shell/command-palette.test.tsx
@@ -1,4 +1,7 @@
+import type { ReactNode } from "react";
+import { createQueryClient } from "@/providers/query-client.js";
 import { DirectionProvider } from "@radix-ui/react-direction";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -14,18 +17,46 @@ vi.mock("@tanstack/react-router", async (importOriginal) => ({
 
 vi.mock("@/lib/palette-nav.js", () => ({
   paletteNavItems: () => [
-    {
-      to: "/entries/posts",
-      label: { id: "i.posts", message: "Posts" },
-      coreIcon: "file-text",
-    },
-    {
-      to: "/users",
-      label: { id: "i.users", message: "Users" },
-      coreIcon: "users",
-    },
+    { to: "/entries/posts", label: { id: "i.posts", message: "Posts" } },
+    { to: "/users", label: { id: "i.users", message: "Users" } },
   ],
 }));
+
+vi.mock("@/lib/manifest.js", () => ({
+  findEntryTypeByName: () => ({ adminSlug: "posts" }),
+}));
+
+vi.mock("@/lib/orpc.js", () => ({
+  orpc: {
+    search: {
+      query: {
+        queryOptions: (opts: {
+          input: { query: string };
+          enabled?: boolean;
+        }) => ({
+          queryKey: ["search", opts.input.query],
+          queryFn: () => [
+            {
+              key: "entry:post",
+              label: { id: "g.post", message: "Posts" },
+              priority: 10,
+              items: [{ id: "1", title: "Hello World" }],
+            },
+          ],
+          enabled: opts.enabled,
+        }),
+      },
+    },
+  },
+}));
+
+function renderPalette(node: ReactNode): void {
+  renderWithI18n(
+    <QueryClientProvider client={createQueryClient()}>
+      {node}
+    </QueryClientProvider>,
+  );
+}
 
 afterEach(() => {
   cleanup();
@@ -38,7 +69,7 @@ function pressCmdK(): void {
 
 describe("CommandPalette", () => {
   test("opens on Cmd+K and is closed before that", async () => {
-    renderWithI18n(<CommandPalette capabilities={[]} />);
+    renderPalette(<CommandPalette capabilities={[]} />);
     expect(screen.queryByTestId("command-palette-input")).toBeNull();
 
     pressCmdK();
@@ -47,23 +78,15 @@ describe("CommandPalette", () => {
   });
 
   test("opens on Ctrl+K for non-mac", async () => {
-    renderWithI18n(<CommandPalette capabilities={[]} />);
+    renderPalette(<CommandPalette capabilities={[]} />);
 
     fireEvent.keyDown(document, { key: "k", ctrlKey: true });
 
     await screen.findByTestId("command-palette-input");
   });
 
-  test("lists navigation items from the shared nav source", async () => {
-    renderWithI18n(<CommandPalette capabilities={[]} />);
-    pressCmdK();
-
-    await screen.findByTestId("command-palette-nav-/entries/posts");
-    screen.getByTestId("command-palette-nav-/users");
-  });
-
-  test("selecting a navigation item navigates and closes the palette", async () => {
-    renderWithI18n(<CommandPalette capabilities={[]} />);
+  test("lists navigation items and navigates on select", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
     pressCmdK();
 
     fireEvent.click(
@@ -76,8 +99,41 @@ describe("CommandPalette", () => {
     );
   });
 
+  test("filters navigation items by the typed query", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    const input = await screen.findByTestId("command-palette-input");
+
+    fireEvent.change(input, { target: { value: "users" } });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("command-palette-nav-/entries/posts"),
+      ).toBeNull(),
+    );
+    screen.getByTestId("command-palette-nav-/users");
+  });
+
+  test("shows server content results and opens the editor on select", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    fireEvent.change(await screen.findByTestId("command-palette-input"), {
+      target: { value: "hello" },
+    });
+
+    const result = await screen.findByTestId(
+      "command-palette-result-entry:post:1",
+    );
+    fireEvent.click(result);
+
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/entries/$slug/$id/edit",
+      params: { slug: "posts", id: 1 },
+    });
+  });
+
   test("Escape closes the palette", async () => {
-    renderWithI18n(<CommandPalette capabilities={[]} />);
+    renderPalette(<CommandPalette capabilities={[]} />);
     pressCmdK();
     const input = await screen.findByTestId("command-palette-input");
 
@@ -89,7 +145,7 @@ describe("CommandPalette", () => {
   });
 
   test("mounts under an RTL direction provider without crashing", async () => {
-    renderWithI18n(
+    renderPalette(
       <DirectionProvider dir="rtl">
         <CommandPalette capabilities={[]} />
       </DirectionProvider>,

--- a/packages/admin/src/components/shell/command-palette.tsx
+++ b/packages/admin/src/components/shell/command-palette.tsx
@@ -2,19 +2,32 @@ import type { MessageDescriptor } from "@lingui/core";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import {
-  CommandDialog,
+  Command,
   CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
 } from "@/components/ui/command.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
+import { findEntryTypeByName } from "@/lib/manifest.js";
+import { orpc } from "@/lib/orpc.js";
 import { paletteNavItems } from "@/lib/palette-nav.js";
 import { useLabel } from "@/lib/use-label.js";
 import { defineMessage } from "@lingui/core/macro";
+import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 
 import { CoreIcon } from "./core-icon.js";
+
+const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 250;
 
 const M = {
   title: defineMessage({ id: "palette.title", message: "Command palette" }),
@@ -30,11 +43,27 @@ const M = {
   }),
 } satisfies Record<string, MessageDescriptor>;
 
+function useDebounced(value: string, ms: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebounced(value);
+    }, ms);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, ms]);
+  return debounced;
+}
+
 /**
  * Global command palette. Opened with Cmd/Ctrl+K from anywhere in the
- * authenticated admin; lists capability-filtered navigation destinations
- * (the same source the sidebar renders) and navigates on select. RTL is
- * inherited from the app-root `DirectionProvider`.
+ * authenticated admin: filters the sidebar's navigation destinations
+ * client-side and shows debounced cross-domain content results from the
+ * server, grouped by type. `shouldFilter` is off because content results
+ * are already query-matched server-side (they may match on excerpt, not
+ * title); navigation is filtered explicitly. RTL is inherited from the
+ * app-root `DirectionProvider`.
  */
 export function CommandPalette({
   capabilities,
@@ -42,6 +71,7 @@ export function CommandPalette({
   readonly capabilities: readonly string[];
 }): ReactNode {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const navigate = useNavigate();
   const renderLabel = useLabel();
 
@@ -60,38 +90,97 @@ export function CommandPalette({
     };
   }, []);
 
-  const items = paletteNavItems(capabilities);
+  const trimmed = query.trim();
+  const debounced = useDebounced(trimmed, DEBOUNCE_MS);
+  const search = useQuery(
+    orpc.search.query.queryOptions({
+      input: { query: debounced },
+      enabled: open && debounced.length >= MIN_QUERY_LENGTH,
+    }),
+  );
+
+  const lower = trimmed.toLowerCase();
+  const navItems = paletteNavItems(capabilities).filter(
+    (item) =>
+      lower.length === 0 ||
+      renderLabel(item.label).toLowerCase().includes(lower),
+  );
+  const groups = trimmed.length >= MIN_QUERY_LENGTH ? (search.data ?? []) : [];
+
+  function dismiss(): void {
+    setOpen(false);
+    setQuery("");
+  }
+
+  function openEntry(groupKey: string, id: string): void {
+    const type = groupKey.slice("entry:".length);
+    const slug = findEntryTypeByName(type)?.adminSlug ?? type;
+    dismiss();
+    void navigate({
+      to: "/entries/$slug/$id/edit",
+      params: { slug, id: Number(id) },
+    });
+  }
 
   return (
-    <CommandDialog
+    <Dialog
       open={open}
-      onOpenChange={setOpen}
-      title={renderLabel(M.title)}
-      description={renderLabel(M.description)}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
     >
-      <CommandInput
-        data-testid="command-palette-input"
-        placeholder={renderLabel(M.placeholder)}
-      />
-      <CommandList>
-        <CommandEmpty>{renderLabel(M.empty)}</CommandEmpty>
-        <CommandGroup heading={renderLabel(M.navigation)}>
-          {items.map((item) => (
-            <CommandItem
-              key={item.to}
-              value={renderLabel(item.label)}
-              data-testid={`command-palette-nav-${item.to}`}
-              onSelect={() => {
-                setOpen(false);
-                void navigate({ to: item.to });
-              }}
-            >
-              <CoreIcon name={item.coreIcon} />
-              <span>{renderLabel(item.label)}</span>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </CommandDialog>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{renderLabel(M.title)}</DialogTitle>
+        <DialogDescription>{renderLabel(M.description)}</DialogDescription>
+      </DialogHeader>
+      <DialogContent className="overflow-hidden p-0">
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            data-testid="command-palette-input"
+            placeholder={renderLabel(M.placeholder)}
+          />
+          <CommandList>
+            <CommandEmpty>{renderLabel(M.empty)}</CommandEmpty>
+            {navItems.length > 0 ? (
+              <CommandGroup heading={renderLabel(M.navigation)}>
+                {navItems.map((item) => (
+                  <CommandItem
+                    key={item.to}
+                    value={item.to}
+                    data-testid={`command-palette-nav-${item.to}`}
+                    onSelect={() => {
+                      dismiss();
+                      void navigate({ to: item.to });
+                    }}
+                  >
+                    <CoreIcon name={item.coreIcon} />
+                    <span>{renderLabel(item.label)}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
+            {groups.map((group) => (
+              <CommandGroup key={group.key} heading={renderLabel(group.label)}>
+                {group.items.map((item) => (
+                  <CommandItem
+                    key={`${group.key}:${item.id}`}
+                    value={`${group.key}:${item.id}`}
+                    data-testid={`command-palette-result-${group.key}:${item.id}`}
+                    onSelect={() => {
+                      openEntry(group.key, item.id);
+                    }}
+                  >
+                    <span>{item.title}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/core/src/rpc/procedures/search/index.test.ts
+++ b/packages/core/src/rpc/procedures/search/index.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+
+import { entries } from "../../../db/schema/entries.js";
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { registerCoreSearchHandlers } from "../../../search/register-core-handlers.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+type Harness = Awaited<ReturnType<typeof createRpcHarness>>;
+
+// Spin up a harness with a `post` entry type + the core search handler
+// wired on (the harness boots neither). Mirrors `createPlumixApp` boot.
+async function searchHarness(authAs: "editor" | "author"): Promise<Harness> {
+  const plugins = createPluginRegistry();
+  plugins.entryTypes.set("post", {
+    label: { id: "et.post", message: "Posts" },
+    labels: { plural: { id: "et.post.plural", message: "Posts" } },
+    registeredBy: null,
+  } as never);
+  const h = await createRpcHarness({ authAs, plugins });
+  registerCoreSearchHandlers(h.hooks);
+  return h;
+}
+
+async function seed(
+  h: Harness,
+  values: {
+    title: string;
+    slug: string;
+    status: "published" | "draft" | "trash";
+  },
+): Promise<void> {
+  const author = h.user;
+  if (!author) throw new Error("harness has no authenticated user");
+  await h.context.db
+    .insert(entries)
+    .values({ type: "post", authorId: author.id, ...values });
+}
+
+describe("search.query", () => {
+  test("groups matching entries by type and matches title", async () => {
+    const h = await searchHarness("editor");
+    await seed(h, { title: "Hello World", slug: "hello", status: "published" });
+    await seed(h, { title: "Unrelated", slug: "other", status: "published" });
+
+    const groups = await h.client.search.query({ query: "hello" });
+
+    expect(groups).toEqual([
+      expect.objectContaining({
+        key: "entry:post",
+        items: [expect.objectContaining({ title: "Hello World" })],
+      }),
+    ]);
+  });
+
+  test("editor sees draft matches", async () => {
+    const h = await searchHarness("editor");
+    await seed(h, { title: "Hidden Draft", slug: "d1", status: "draft" });
+
+    const groups = await h.client.search.query({ query: "hidden" });
+
+    expect(groups[0]?.items).toEqual([
+      expect.objectContaining({ title: "Hidden Draft" }),
+    ]);
+  });
+
+  test("an author sees their own draft (mirrors entry read rules)", async () => {
+    const h = await searchHarness("author");
+    await seed(h, { title: "My Own Draft", slug: "d2", status: "draft" });
+
+    const groups = await h.client.search.query({ query: "own" });
+
+    expect(groups[0]?.items).toEqual([
+      expect.objectContaining({ title: "My Own Draft" }),
+    ]);
+  });
+
+  test("trash entries are excluded even for editors", async () => {
+    const h = await searchHarness("editor");
+    await seed(h, { title: "Trashed Item", slug: "t1", status: "trash" });
+
+    expect(await h.client.search.query({ query: "trashed" })).toEqual([]);
+  });
+
+  test("returns nothing for an empty query", async () => {
+    const h = await searchHarness("editor");
+    await seed(h, { title: "Hello", slug: "h", status: "published" });
+
+    expect(await h.client.search.query({ query: "  " })).toEqual([]);
+  });
+});

--- a/packages/core/src/rpc/procedures/search/index.ts
+++ b/packages/core/src/rpc/procedures/search/index.ts
@@ -1,0 +1,34 @@
+import * as v from "valibot";
+
+import { runAdminSearch } from "../../../search/admin-search.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+
+const DEFAULT_LIMIT = 5;
+
+const searchInputSchema = v.object({
+  query: v.pipe(v.string(), v.trim(), v.maxLength(200)),
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(20)),
+  ),
+});
+
+/**
+ * Cross-domain admin search for the command palette. Fans out across the
+ * registered `admin:search:results` domains (entries, terms, users, and
+ * plugin-contributed ones) and returns grouped results. Each domain
+ * enforces its own capabilities server-side.
+ */
+const query = base
+  .use(authenticated)
+  .input(searchInputSchema)
+  .handler(async ({ input, context }) => {
+    if (input.query.length === 0) return [];
+    return runAdminSearch(
+      context.hooks,
+      { query: input.query, limit: input.limit ?? DEFAULT_LIMIT },
+      context,
+    );
+  });
+
+export const searchRouter = { query } as const;

--- a/packages/core/src/rpc/router.ts
+++ b/packages/core/src/rpc/router.ts
@@ -3,6 +3,7 @@ import type { RouterClient } from "@orpc/server";
 import { authRouter } from "./procedures/auth/index.js";
 import { entryRouter } from "./procedures/entry/index.js";
 import { lookupRouter } from "./procedures/lookup/index.js";
+import { searchRouter } from "./procedures/search/index.js";
 import { settingsRouter } from "./procedures/settings/index.js";
 import { termRouter } from "./procedures/term/index.js";
 import { userRouter } from "./procedures/user/index.js";
@@ -13,6 +14,7 @@ export const appRouter = {
   term: termRouter,
   user: userRouter,
   lookup: lookupRouter,
+  search: searchRouter,
   settings: settingsRouter,
 } as const;
 

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -41,6 +41,7 @@ import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { appRouter } from "../rpc/router.js";
+import { registerCoreSearchHandlers } from "../search/register-core-handlers.js";
 import { registerCoreSettings } from "../settings-core.js";
 import { registerCoreTemplateDeps } from "../template-deps-core.js";
 import { isTemplate } from "../template.js";
@@ -181,6 +182,7 @@ export async function buildApp(
 ): Promise<PlumixApp> {
   const hooks = new HookRegistry();
   registerCoreAdminBarContributors(hooks);
+  registerCoreSearchHandlers(hooks);
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
   registerCoreTemplateDeps(seededRegistry);

--- a/packages/core/src/search/admin-search.test.ts
+++ b/packages/core/src/search/admin-search.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import type { HookExecutor } from "../hooks/registry.js";
+import type { SearchGroup } from "./admin-search.js";
+import { runAdminSearch } from "./admin-search.js";
+
+const ctx = {} as AppContext;
+const input = { query: "hello", limit: 5 };
+
+function group(key: string, priority: number, items = 1): SearchGroup {
+  return {
+    key,
+    label: { id: `g.${key}`, message: key },
+    priority,
+    items: Array.from({ length: items }, (_, i) => ({
+      id: `${key}-${i}`,
+      title: `${key} ${i}`,
+    })),
+  };
+}
+
+function hooksWith(
+  handlers: readonly ((input: unknown, ctx: unknown) => unknown)[],
+): Pick<HookExecutor, "getFilterHandlers"> {
+  return {
+    getFilterHandlers: () =>
+      handlers.map((fn) => ({ fn: fn as never, plugin: null })),
+  } as Pick<HookExecutor, "getFilterHandlers">;
+}
+
+describe("runAdminSearch", () => {
+  test("merges every handler's groups, ordered by priority", async () => {
+    const hooks = hooksWith([
+      () => [group("users", 30)],
+      () => [group("entry:post", 10), group("entry:page", 11)],
+    ]);
+
+    const groups = await runAdminSearch(hooks, input, ctx);
+
+    expect(groups.map((g) => g.key)).toEqual([
+      "entry:post",
+      "entry:page",
+      "users",
+    ]);
+  });
+
+  test("isolates a failing handler so the others still return", async () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const hooks = hooksWith([
+      () => {
+        throw new Error("boom");
+      },
+      () => [group("entry:post", 10)],
+    ]);
+
+    const groups = await runAdminSearch(hooks, input, ctx);
+
+    expect(groups.map((g) => g.key)).toEqual(["entry:post"]);
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  test("drops groups that have no items", async () => {
+    const hooks = hooksWith([
+      () => [group("entry:post", 10, 0)],
+      () => [group("users", 30, 1)],
+    ]);
+
+    const groups = await runAdminSearch(hooks, input, ctx);
+
+    expect(groups.map((g) => g.key)).toEqual(["users"]);
+  });
+});

--- a/packages/core/src/search/admin-search.ts
+++ b/packages/core/src/search/admin-search.ts
@@ -1,0 +1,70 @@
+import type { AppContext } from "../context/app.js";
+import type { HookExecutor } from "../hooks/registry.js";
+import type { Label } from "../i18n/label.js";
+
+export interface AdminSearchInput {
+  readonly query: string;
+  readonly limit: number;
+}
+
+export interface SearchResultItem {
+  readonly id: string;
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly url?: string;
+}
+
+/**
+ * One result group, e.g. "Posts", "Tags", "Users". `label` is a `Label`
+ * (string | descriptor) the client resolves with `useLabel`. `priority`
+ * orders groups in the palette (lower first).
+ */
+export interface SearchGroup {
+  readonly key: string;
+  readonly label: Label;
+  readonly priority: number;
+  readonly items: readonly SearchResultItem[];
+}
+
+declare module "../hooks/types.js" {
+  interface FilterRegistry {
+    // Producer set, run via `getFilterHandlers` — each handler is invoked
+    // with the same input and returns its own groups (not a pipeline).
+    "admin:search:results": (
+      input: AdminSearchInput,
+      ctx: AppContext,
+    ) => readonly SearchGroup[] | Promise<readonly SearchGroup[]>;
+  }
+}
+
+/**
+ * Run every `admin:search:results` handler concurrently and merge their
+ * groups. Each handler is isolated: a throwing or rejecting one degrades
+ * to no contribution instead of breaking the palette. Empty groups are
+ * dropped; the rest are ordered by `priority`.
+ */
+export async function runAdminSearch(
+  hooks: Pick<HookExecutor, "getFilterHandlers">,
+  input: AdminSearchInput,
+  ctx: AppContext,
+): Promise<readonly SearchGroup[]> {
+  const produced = await Promise.all(
+    hooks
+      .getFilterHandlers("admin:search:results")
+      .map(async ({ fn, plugin }) => {
+        try {
+          return await fn(input, ctx);
+        } catch (error) {
+          console.error(
+            `[plumix] admin:search:results handler failed plugin=${plugin ?? "core"}`,
+            error,
+          );
+          return [] as readonly SearchGroup[];
+        }
+      }),
+  );
+  return produced
+    .flat()
+    .filter((group) => group.items.length > 0)
+    .sort((a, b) => a.priority - b.priority);
+}

--- a/packages/core/src/search/entries-handler.ts
+++ b/packages/core/src/search/entries-handler.ts
@@ -1,0 +1,98 @@
+import type { AppContext } from "../context/app.js";
+import type { SQL } from "../db/index.js";
+import type { SearchTerm } from "../rpc/procedures/entry/search-terms.js";
+import type {
+  AdminSearchInput,
+  SearchGroup,
+  SearchResultItem,
+} from "./admin-search.js";
+import { and, desc, eq, not, or, sql } from "../db/index.js";
+import { entries } from "../db/schema/entries.js";
+import { entryCapability } from "../rpc/procedures/entry/lifecycle.js";
+import {
+  escapeLikePattern,
+  tokenizeSearchQuery,
+} from "../rpc/procedures/entry/search-terms.js";
+
+// Max rows scanned across all types for one query. Title+excerpt LIKE has
+// no relevance ranking, so we take the most recently updated matches and
+// bucket them; a search plugin replaces this handler with real ranking.
+const SCAN_LIMIT = 50;
+
+/**
+ * `admin:search:results` handler for the `entries` domain. Matches
+ * title+excerpt (LIKE) across every entry type the caller can read, in a
+ * single query, and returns one group per type. Drafts are included only
+ * for types the caller can edit-any; everything is capped per group.
+ */
+export async function entriesSearchHandler(
+  input: AdminSearchInput,
+  ctx: AppContext,
+): Promise<readonly SearchGroup[]> {
+  const tokens = tokenizeSearchQuery(input.query);
+  if (tokens.length === 0) return [];
+
+  const readable = [...ctx.plugins.entryTypes.entries()].filter(([type]) =>
+    ctx.auth.can(entryCapability(type, "read")),
+  );
+  if (readable.length === 0) return [];
+
+  // Mirror `canReadEntry`'s visibility, minus trash (a browse surface
+  // hides the bin, like the entries list default): published is always
+  // visible; `edit_any` sees any non-trash; `edit_own` additionally sees
+  // its own non-trash; everyone else sees published only.
+  const userId = ctx.user?.id ?? null;
+  const notTrash = not(eq(entries.status, "trash"));
+  const typeClauses = readable.map(([type]) => {
+    const ofType = eq(entries.type, type);
+    if (ctx.auth.can(entryCapability(type, "edit_any"))) {
+      return and(ofType, notTrash);
+    }
+    if (userId !== null && ctx.auth.can(entryCapability(type, "edit_own"))) {
+      return and(
+        ofType,
+        notTrash,
+        or(eq(entries.status, "published"), eq(entries.authorId, userId)),
+      );
+    }
+    return and(ofType, eq(entries.status, "published"));
+  });
+
+  const rows = await ctx.db
+    .select({ id: entries.id, type: entries.type, title: entries.title })
+    .from(entries)
+    .where(and(or(...typeClauses), ...tokens.map(titleExcerptCondition)))
+    .orderBy(desc(entries.updatedAt))
+    .limit(SCAN_LIMIT);
+
+  const byType = new Map<string, SearchResultItem[]>();
+  for (const row of rows) {
+    const items = byType.get(row.type) ?? [];
+    if (items.length >= input.limit) continue;
+    items.push({ id: String(row.id), title: row.title });
+    byType.set(row.type, items);
+  }
+
+  const groups: SearchGroup[] = [];
+  let priority = 10;
+  for (const [type, spec] of readable) {
+    const items = byType.get(type);
+    if (!items || items.length === 0) continue;
+    groups.push({
+      key: `entry:${type}`,
+      label: spec.labels?.plural ?? spec.label,
+      priority: priority++,
+      items,
+    });
+  }
+  return groups;
+}
+
+function titleExcerptCondition(term: SearchTerm): SQL {
+  const pattern = `%${escapeLikePattern(term.value)}%`;
+  const match = sql`(
+    COALESCE(${entries.title}, '') LIKE ${pattern} ESCAPE '\\'
+    OR COALESCE(${entries.excerpt}, '') LIKE ${pattern} ESCAPE '\\'
+  )`;
+  return term.exclude ? not(match) : match;
+}

--- a/packages/core/src/search/register-core-handlers.ts
+++ b/packages/core/src/search/register-core-handlers.ts
@@ -1,0 +1,13 @@
+import type { HookRegistry } from "../hooks/registry.js";
+import { entriesSearchHandler } from "./entries-handler.js";
+
+/**
+ * Register core's built-in `admin:search:results` domains. Called at app
+ * boot alongside the other core hook registrations. Plugins register
+ * their own domains (or replace these) via the same filter.
+ */
+export function registerCoreSearchHandlers(hooks: HookRegistry): void {
+  hooks.addFilter("admin:search:results", entriesSearchHandler, {
+    priority: 10,
+  });
+}


### PR DESCRIPTION
Closes #914. Slice 2 of the command palette (#864).

Wires cross-domain admin content search into the Cmd+K palette, starting with the
**entries** domain, behind a swappable seam.

**The seam** — `admin:search:results` (a hook filter). `runAdminSearch` fans out across
registered handlers via `getFilterHandlers`, **concurrently** and **isolated** (a throwing
handler contributes nothing instead of breaking the palette), drops empty groups, orders
by priority. Mirrors the admin-bar's `collect` pattern. A future search plugin (or any
plugin) adds/replaces a domain by registering a handler — extend = new key, replace =
higher priority.

**The entries domain** — one Drizzle query matching `title`+`excerpt` (LIKE, reusing the
shared tokenize/escape helpers) across every entry type the caller can read, grouped by
type. **Visibility mirrors `canReadEntry` minus trash** (a browse surface hides the bin
like the entries list): published always; `edit_any` sees any non-trash; `edit_own`
additionally sees its own drafts; everyone else published-only. Enforced server-side.

**The RPC** — `search.query({query, limit?})` fans out through the seam; each domain owns
its capabilities. **The palette** debounces the query and renders grouped results below
navigation; selecting an entry opens its editor. Composes shadcn Dialog+Command with
`shouldFilter={false}` (server results may match on excerpt, not title); nav is filtered
client-side; group labels resolve via `useLabel`.

Built test-first: aggregator (concurrency/isolation/ordering/empty-drop), the entries RPC
(grouping, caps, draft + trash visibility), and the palette UI (debounced results →
editor). lint, typecheck, test, build, knip, i18n, format all green.

Both reviewers passed it; applied their fixes — visibility now mirrors `canReadEntry`
(was leaking trash to editors and hiding authors' own drafts), plus test/comment cleanups.

Terms (#915) and users (#916) are thin adds on this seam.