### PR TITLE
feat(admin): command palette search — terms domain

### DIFF
--- a/packages/admin/src/components/shell/command-palette.test.tsx
+++ b/packages/admin/src/components/shell/command-palette.test.tsx
@@ -42,6 +42,12 @@ vi.mock("@/lib/orpc.js", () => ({
               priority: 10,
               items: [{ id: "1", title: "Hello World" }],
             },
+            {
+              key: "term:category",
+              label: { id: "g.category", message: "Categories" },
+              priority: 100,
+              items: [{ id: "7", title: "News" }],
+            },
           ],
           enabled: opts.enabled,
         }),
@@ -129,6 +135,23 @@ describe("CommandPalette", () => {
     expect(navigate).toHaveBeenCalledWith({
       to: "/entries/$slug/$id/edit",
       params: { slug: "posts", id: 1 },
+    });
+  });
+
+  test("opens the term editor when a term result is selected", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    fireEvent.change(await screen.findByTestId("command-palette-input"), {
+      target: { value: "news" },
+    });
+
+    fireEvent.click(
+      await screen.findByTestId("command-palette-result-term:category:7"),
+    );
+
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/terms/$name/$id/edit",
+      params: { name: "category", id: 7 },
     });
   });
 

--- a/packages/admin/src/components/shell/command-palette.tsx
+++ b/packages/admin/src/components/shell/command-palette.tsx
@@ -112,14 +112,29 @@ export function CommandPalette({
     setQuery("");
   }
 
-  function openEntry(groupKey: string, id: string): void {
-    const type = groupKey.slice("entry:".length);
-    const slug = findEntryTypeByName(type)?.adminSlug ?? type;
+  // Routes a result to its editor from the group key + id. Each domain
+  // owns its route (the server stays admin-route-agnostic).
+  function openResult(groupKey: string, id: string): void {
     dismiss();
-    void navigate({
-      to: "/entries/$slug/$id/edit",
-      params: { slug, id: Number(id) },
-    });
+    const sep = groupKey.indexOf(":");
+    const domain = groupKey.slice(0, sep);
+    const name = groupKey.slice(sep + 1);
+    switch (domain) {
+      case "entry": {
+        const slug = findEntryTypeByName(name)?.adminSlug ?? name;
+        void navigate({
+          to: "/entries/$slug/$id/edit",
+          params: { slug, id: Number(id) },
+        });
+        return;
+      }
+      case "term":
+        void navigate({
+          to: "/terms/$name/$id/edit",
+          params: { name, id: Number(id) },
+        });
+        return;
+    }
   }
 
   return (
@@ -170,7 +185,7 @@ export function CommandPalette({
                     value={`${group.key}:${item.id}`}
                     data-testid={`command-palette-result-${group.key}:${item.id}`}
                     onSelect={() => {
-                      openEntry(group.key, item.id);
+                      openResult(group.key, item.id);
                     }}
                   >
                     <span>{item.title}</span>

--- a/packages/core/src/rpc/procedures/search/index.test.ts
+++ b/packages/core/src/rpc/procedures/search/index.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, test } from "vitest";
 
+import { deriveTermTaxonomyCapabilities } from "../../../auth/rbac.js";
 import { entries } from "../../../db/schema/entries.js";
+import { terms } from "../../../db/schema/terms.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { registerCoreSearchHandlers } from "../../../search/register-core-handlers.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
 type Harness = Awaited<ReturnType<typeof createRpcHarness>>;
 
-// Spin up a harness with a `post` entry type + the core search handler
-// wired on (the harness boots neither). Mirrors `createPlumixApp` boot.
+// Spin up a harness with a `post` entry type + a `category` taxonomy +
+// the core search handlers wired on (the harness boots none). `post` caps
+// are core; the taxonomy's are derived at registration, so we populate
+// them the way `registerTermTaxonomy` would. Mirrors `createPlumixApp`.
 async function searchHarness(authAs: "editor" | "author"): Promise<Harness> {
   const plugins = createPluginRegistry();
   plugins.entryTypes.set("post", {
@@ -16,9 +20,22 @@ async function searchHarness(authAs: "editor" | "author"): Promise<Harness> {
     labels: { plural: { id: "et.post.plural", message: "Posts" } },
     registeredBy: null,
   } as never);
+  const categorySpec = {
+    label: { id: "tt.category", message: "Categories" },
+    labels: { plural: { id: "tt.category.plural", message: "Categories" } },
+    registeredBy: null,
+  };
+  plugins.termTaxonomies.set("category", categorySpec as never);
+  for (const cap of deriveTermTaxonomyCapabilities("category", categorySpec)) {
+    plugins.capabilities.set(cap.name, { ...cap, registeredBy: null });
+  }
   const h = await createRpcHarness({ authAs, plugins });
   registerCoreSearchHandlers(h.hooks);
   return h;
+}
+
+async function seedTerm(h: Harness, name: string, slug: string): Promise<void> {
+  await h.context.db.insert(terms).values({ taxonomy: "category", name, slug });
 }
 
 async function seed(
@@ -86,5 +103,20 @@ describe("search.query", () => {
     await seed(h, { title: "Hello", slug: "h", status: "published" });
 
     expect(await h.client.search.query({ query: "  " })).toEqual([]);
+  });
+
+  test("groups matching terms by taxonomy", async () => {
+    const h = await searchHarness("editor");
+    await seedTerm(h, "News", "news");
+    await seedTerm(h, "Unrelated", "unrelated");
+
+    const groups = await h.client.search.query({ query: "news" });
+
+    expect(groups).toEqual([
+      expect.objectContaining({
+        key: "term:category",
+        items: [expect.objectContaining({ title: "News" })],
+      }),
+    ]);
   });
 });

--- a/packages/core/src/search/entries-handler.ts
+++ b/packages/core/src/search/entries-handler.ts
@@ -18,6 +18,8 @@ import {
 // no relevance ranking, so we take the most recently updated matches and
 // bucket them; a search plugin replaces this handler with real ranking.
 const SCAN_LIMIT = 50;
+// Group priority base; terms (100..) and later domains sort after Content.
+const PRIORITY_BASE = 10;
 
 /**
  * `admin:search:results` handler for the `entries` domain. Matches
@@ -74,7 +76,7 @@ export async function entriesSearchHandler(
   }
 
   const groups: SearchGroup[] = [];
-  let priority = 10;
+  let priority = PRIORITY_BASE;
   for (const [type, spec] of readable) {
     const items = byType.get(type);
     if (!items || items.length === 0) continue;

--- a/packages/core/src/search/register-core-handlers.ts
+++ b/packages/core/src/search/register-core-handlers.ts
@@ -1,5 +1,6 @@
 import type { HookRegistry } from "../hooks/registry.js";
 import { entriesSearchHandler } from "./entries-handler.js";
+import { termsSearchHandler } from "./terms-handler.js";
 
 /**
  * Register core's built-in `admin:search:results` domains. Called at app
@@ -9,5 +10,8 @@ import { entriesSearchHandler } from "./entries-handler.js";
 export function registerCoreSearchHandlers(hooks: HookRegistry): void {
   hooks.addFilter("admin:search:results", entriesSearchHandler, {
     priority: 10,
+  });
+  hooks.addFilter("admin:search:results", termsSearchHandler, {
+    priority: 20,
   });
 }

--- a/packages/core/src/search/terms-handler.test.ts
+++ b/packages/core/src/search/terms-handler.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import { termsSearchHandler } from "./terms-handler.js";
+
+// The handler skips taxonomies the caller can't read before touching the
+// db, so a denying `auth.can` short-circuits to no groups (no db needed).
+describe("termsSearchHandler", () => {
+  test("omits taxonomies the caller cannot read", async () => {
+    const ctx = {
+      auth: { can: () => false },
+      plugins: {
+        termTaxonomies: new Map([
+          ["category", { label: { id: "c", message: "Categories" } }],
+        ]),
+      },
+    } as unknown as AppContext;
+
+    expect(await termsSearchHandler({ query: "x", limit: 5 }, ctx)).toEqual([]);
+  });
+});

--- a/packages/core/src/search/terms-handler.ts
+++ b/packages/core/src/search/terms-handler.ts
@@ -1,0 +1,87 @@
+import type { AppContext } from "../context/app.js";
+import type { SQL } from "../db/index.js";
+import type { SearchTerm } from "../rpc/procedures/entry/search-terms.js";
+import type {
+  AdminSearchInput,
+  SearchGroup,
+  SearchResultItem,
+} from "./admin-search.js";
+import { and, asc, inArray, not, sql } from "../db/index.js";
+import { terms } from "../db/schema/terms.js";
+import {
+  escapeLikePattern,
+  tokenizeSearchQuery,
+} from "../rpc/procedures/entry/search-terms.js";
+import { taxonomyCapability } from "../rpc/procedures/term/helpers.js";
+
+// Max rows scanned across all taxonomies for one query; bucketed per
+// group afterward. Terms carry no draft/trash status — visibility is
+// just the per-taxonomy read capability.
+const SCAN_LIMIT = 50;
+// Group priority base, after the entries domain (10..) so Content sorts
+// above Terms in the palette.
+const PRIORITY_BASE = 100;
+
+/**
+ * `admin:search:results` handler for the `terms` domain. Matches
+ * name+slug (LIKE) across every taxonomy the caller can read, in a single
+ * query, and returns one group per taxonomy.
+ */
+export async function termsSearchHandler(
+  input: AdminSearchInput,
+  ctx: AppContext,
+): Promise<readonly SearchGroup[]> {
+  const tokens = tokenizeSearchQuery(input.query);
+  if (tokens.length === 0) return [];
+
+  const readable = [...ctx.plugins.termTaxonomies.entries()].filter(([name]) =>
+    ctx.auth.can(taxonomyCapability(name, "read")),
+  );
+  if (readable.length === 0) return [];
+
+  const rows = await ctx.db
+    .select({ id: terms.id, taxonomy: terms.taxonomy, name: terms.name })
+    .from(terms)
+    .where(
+      and(
+        inArray(
+          terms.taxonomy,
+          readable.map(([name]) => name),
+        ),
+        ...tokens.map(nameSlugCondition),
+      ),
+    )
+    .orderBy(asc(terms.name))
+    .limit(SCAN_LIMIT);
+
+  const byTaxonomy = new Map<string, SearchResultItem[]>();
+  for (const row of rows) {
+    const items = byTaxonomy.get(row.taxonomy) ?? [];
+    if (items.length >= input.limit) continue;
+    items.push({ id: String(row.id), title: row.name });
+    byTaxonomy.set(row.taxonomy, items);
+  }
+
+  const groups: SearchGroup[] = [];
+  let priority = PRIORITY_BASE;
+  for (const [name, spec] of readable) {
+    const items = byTaxonomy.get(name);
+    if (!items || items.length === 0) continue;
+    groups.push({
+      key: `term:${name}`,
+      label: spec.labels?.plural ?? spec.label,
+      priority: priority++,
+      items,
+    });
+  }
+  return groups;
+}
+
+function nameSlugCondition(term: SearchTerm): SQL {
+  const pattern = `%${escapeLikePattern(term.value)}%`;
+  const match = sql`(
+    ${terms.name} LIKE ${pattern} ESCAPE '\\'
+    OR ${terms.slug} LIKE ${pattern} ESCAPE '\\'
+  )`;
+  return term.exclude ? not(match) : match;
+}


### PR DESCRIPTION
Closes #915. Slice 3 of the command palette (#864).

Adds the **terms** domain to the `admin:search:results` seam built in #914 — a thin handler,
no new seam.

- **Terms handler** — matches term `name`+`slug` (LIKE, reusing the shared tokenize/escape
  helpers) across every taxonomy the caller can read (`taxonomyCapability(tax,"read")`), in
  one query, grouped by taxonomy. Terms have no draft/trash status, so visibility is just the
  per-taxonomy read cap, enforced server-side. Registered after entries (groups sort
  Content → Terms).
- **Palette** — a term result opens its taxonomy editor (`/terms/$name/$id/edit`); result
  routing now switches on the group-key domain so #916 (users) drops in as one `case`.

Built test-first: terms grouping via the RPC, the capability gate as a focused unit test
(`term:*:read` is subscriber-level, so no role can deny it through the RPC — the handler is
tested directly), and the palette term-result navigation. lint, typecheck, test, build,
knip, format all green.

Both reviewers passed it; applied the symmetry cleanups (switch-based result routing, named
priority base, `nameSlugCondition`). Deliberately did **not** extract a shared entries/terms
handler core yet — revisiting once #916 (users) shows whether all three converge.

Users (#916) is the last search domain; commands (#917) is independent.