### PR TITLE
feat(admin): command palette search — users domain

### DIFF
--- a/packages/admin/src/components/shell/command-palette.test.tsx
+++ b/packages/admin/src/components/shell/command-palette.test.tsx
@@ -48,6 +48,14 @@ vi.mock("@/lib/orpc.js", () => ({
               priority: 100,
               items: [{ id: "7", title: "News" }],
             },
+            {
+              key: "users",
+              label: { id: "g.users", message: "Users" },
+              priority: 200,
+              items: [
+                { id: "9", title: "Alice", subtitle: "alice@example.com" },
+              ],
+            },
           ],
           enabled: opts.enabled,
         }),
@@ -152,6 +160,23 @@ describe("CommandPalette", () => {
     expect(navigate).toHaveBeenCalledWith({
       to: "/terms/$name/$id/edit",
       params: { name: "category", id: 7 },
+    });
+  });
+
+  test("opens the user editor when a user result is selected", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    fireEvent.change(await screen.findByTestId("command-palette-input"), {
+      target: { value: "alice" },
+    });
+
+    fireEvent.click(
+      await screen.findByTestId("command-palette-result-users:9"),
+    );
+
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/users/$id/edit",
+      params: { id: 9 },
     });
   });
 

--- a/packages/admin/src/components/shell/command-palette.tsx
+++ b/packages/admin/src/components/shell/command-palette.tsx
@@ -117,7 +117,7 @@ export function CommandPalette({
   function openResult(groupKey: string, id: string): void {
     dismiss();
     const sep = groupKey.indexOf(":");
-    const domain = groupKey.slice(0, sep);
+    const domain = sep === -1 ? groupKey : groupKey.slice(0, sep);
     const name = groupKey.slice(sep + 1);
     switch (domain) {
       case "entry": {
@@ -133,6 +133,9 @@ export function CommandPalette({
           to: "/terms/$name/$id/edit",
           params: { name, id: Number(id) },
         });
+        return;
+      case "users":
+        void navigate({ to: "/users/$id/edit", params: { id: Number(id) } });
         return;
     }
   }

--- a/packages/core/src/rpc/procedures/search/index.test.ts
+++ b/packages/core/src/rpc/procedures/search/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { deriveTermTaxonomyCapabilities } from "../../../auth/rbac.js";
 import { entries } from "../../../db/schema/entries.js";
 import { terms } from "../../../db/schema/terms.js";
+import { users } from "../../../db/schema/users.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { registerCoreSearchHandlers } from "../../../search/register-core-handlers.js";
 import { createRpcHarness } from "../../../test/rpc.js";
@@ -36,6 +37,14 @@ async function searchHarness(authAs: "editor" | "author"): Promise<Harness> {
 
 async function seedTerm(h: Harness, name: string, slug: string): Promise<void> {
   await h.context.db.insert(terms).values({ taxonomy: "category", name, slug });
+}
+
+async function seedUser(
+  h: Harness,
+  name: string,
+  email: string,
+): Promise<void> {
+  await h.context.db.insert(users).values({ name, email, role: "subscriber" });
 }
 
 async function seed(
@@ -118,5 +127,27 @@ describe("search.query", () => {
         items: [expect.objectContaining({ title: "News" })],
       }),
     ]);
+  });
+
+  test("returns a users group for a caller who can list users", async () => {
+    const h = await searchHarness("editor");
+    await seedUser(h, "Alice Smith", "alice@example.com");
+    await seedUser(h, "Bob Jones", "bob@example.com");
+
+    const groups = await h.client.search.query({ query: "alice" });
+
+    expect(groups).toEqual([
+      expect.objectContaining({
+        key: "users",
+        items: [expect.objectContaining({ title: "Alice Smith" })],
+      }),
+    ]);
+  });
+
+  test("omits the users group when the caller cannot list users", async () => {
+    const h = await searchHarness("author");
+    await seedUser(h, "Alice Smith", "alice@example.com");
+
+    expect(await h.client.search.query({ query: "alice" })).toEqual([]);
   });
 });

--- a/packages/core/src/search/register-core-handlers.ts
+++ b/packages/core/src/search/register-core-handlers.ts
@@ -1,6 +1,7 @@
 import type { HookRegistry } from "../hooks/registry.js";
 import { entriesSearchHandler } from "./entries-handler.js";
 import { termsSearchHandler } from "./terms-handler.js";
+import { usersSearchHandler } from "./users-handler.js";
 
 /**
  * Register core's built-in `admin:search:results` domains. Called at app
@@ -13,5 +14,8 @@ export function registerCoreSearchHandlers(hooks: HookRegistry): void {
   });
   hooks.addFilter("admin:search:results", termsSearchHandler, {
     priority: 20,
+  });
+  hooks.addFilter("admin:search:results", usersSearchHandler, {
+    priority: 30,
   });
 }

--- a/packages/core/src/search/users-handler.ts
+++ b/packages/core/src/search/users-handler.ts
@@ -1,0 +1,61 @@
+import type { AppContext } from "../context/app.js";
+import type { SQL } from "../db/index.js";
+import type { SearchTerm } from "../rpc/procedures/entry/search-terms.js";
+import type { AdminSearchInput, SearchGroup } from "./admin-search.js";
+import { and, asc, not, sql } from "../db/index.js";
+import { users } from "../db/schema/users.js";
+import {
+  escapeLikePattern,
+  tokenizeSearchQuery,
+} from "../rpc/procedures/entry/search-terms.js";
+
+// Group priority base, after entries (10..) and terms (100..).
+const PRIORITY_BASE = 200;
+
+// Reuses the existing nav label so the group localizes via the admin
+// catalog with no new message.
+const USERS_LABEL = { id: "core.adminNav.item.users", message: "Users" };
+
+/**
+ * `admin:search:results` handler for the `users` domain. Gated by the
+ * single `user:list` capability; matches name+email (LIKE) and returns one
+ * "Users" group. Names are optional, so the email is the fallback title.
+ */
+export async function usersSearchHandler(
+  input: AdminSearchInput,
+  ctx: AppContext,
+): Promise<readonly SearchGroup[]> {
+  const tokens = tokenizeSearchQuery(input.query);
+  if (tokens.length === 0) return [];
+  if (!ctx.auth.can("user:list")) return [];
+
+  const rows = await ctx.db
+    .select({ id: users.id, name: users.name, email: users.email })
+    .from(users)
+    .where(and(...tokens.map(nameEmailCondition)))
+    .orderBy(asc(users.email))
+    .limit(input.limit);
+  if (rows.length === 0) return [];
+
+  return [
+    {
+      key: "users",
+      label: USERS_LABEL,
+      priority: PRIORITY_BASE,
+      items: rows.map((row) => ({
+        id: String(row.id),
+        title: row.name ?? row.email,
+        ...(row.name ? { subtitle: row.email } : {}),
+      })),
+    },
+  ];
+}
+
+function nameEmailCondition(term: SearchTerm): SQL {
+  const pattern = `%${escapeLikePattern(term.value)}%`;
+  const match = sql`(
+    COALESCE(${users.name}, '') LIKE ${pattern} ESCAPE '\\'
+    OR ${users.email} LIKE ${pattern} ESCAPE '\\'
+  )`;
+  return term.exclude ? not(match) : match;
+}


### PR DESCRIPTION
Closes #916. Slice 4 (final search domain) of the command palette (#864).

Adds the **users** domain to the `admin:search:results` seam — a thin handler, gated by the
single `user:list` capability (returns nothing when the caller lacks it). It matches
name+email (LIKE, reusing the shared tokenize/escape helpers) and returns one "Users" group,
reusing the existing `core.adminNav.item.users` nav label so it localizes with no new message.
Selecting a user opens its editor.

**Two deliberate divergences from the `user.list` RPC**

Search matches **name in addition to email** (a name-driven palette surface, vs the RPC's
email-only filter), and **disabled users are included** (parity with `user.list`, which
surfaces them so the table can badge them). Both sit behind the same `user:list` gate, so
neither widens exposure beyond what listing users already allows.

**Result routing**

`openResult` now handles the colon-less `users` group key alongside `entry:`/`term:`,
routing to `/users/$id/edit`.

Built test-first: the cap gate is proven by role (editor sees the Users group, author —
lacking `user:list` — gets none), plus name/email matching and palette user-result
navigation. lint, typecheck, test, build, knip, i18n, format all green.

Both reviewers passed it. The deferred "extract a shared handler core" question (raised in
#915) is now resolved: **don't** — the users domain breaks the multi-group symmetry
(single group, single cap, no bucketing), confirming the three handlers should stay parallel.

This completes the search side of #864; only commands (#917) remains.