### PR TITLE
feat: register custom commands in the admin command palette

### DIFF
--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -885,6 +885,11 @@ msgid "palette.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.commands"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/StaleDraftDialog.tsx
 msgid "editor.staleDraft.compare"
 msgstr "مقارنة"
@@ -1567,6 +1572,11 @@ msgstr "تحرير"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.title.other"
 msgstr "تحرير {email}"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.profile"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
@@ -3030,14 +3040,14 @@ msgid "palette.description"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.placeholder"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.searchItems"
 msgstr "بحث…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.placeholder"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3150,6 +3160,11 @@ msgstr "اضبط موقعك — هذا البريد يصبح حساب المدي
 #: src/routes/_auth/accept-invite/$token.tsx
 msgid "auth.acceptInvite.submit.pending"
 msgstr "جارٍ الإعداد…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -882,6 +882,11 @@ msgid "palette.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.commands"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/StaleDraftDialog.tsx
 msgid "editor.staleDraft.compare"
 msgstr "Vergleichen"
@@ -1575,6 +1580,11 @@ msgstr "Bearbeiten"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.title.other"
 msgstr "{email} bearbeiten"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.profile"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
@@ -3055,14 +3065,14 @@ msgid "palette.description"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.placeholder"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.searchItems"
 msgstr "Suchen…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.placeholder"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3180,6 +3190,11 @@ msgstr "Richten Sie Ihre Website ein — diese E-Mail wird das "
 #: src/routes/_auth/accept-invite/$token.tsx
 msgid "auth.acceptInvite.submit.pending"
 msgstr "Wird eingerichtet…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -872,6 +872,11 @@ msgid "palette.title"
 msgstr "Command palette"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.commands"
+msgstr "Commands"
+
+#. js-lingui-explicit-id
 #: src/editor/StaleDraftDialog.tsx
 msgid "editor.staleDraft.compare"
 msgstr "Compare"
@@ -1554,6 +1559,11 @@ msgstr "Edit"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.title.other"
 msgstr "Edit {email}"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.profile"
+msgstr "Edit profile"
 
 #. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
@@ -3021,13 +3031,13 @@ msgid "palette.description"
 msgstr "Search to navigate the admin."
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.placeholder"
+#: src/lib/core-type-labels-i18n.ts
+msgid "type.generic.searchItems"
 msgstr "Search…"
 
 #. js-lingui-explicit-id
-#: src/lib/core-type-labels-i18n.ts
-msgid "type.generic.searchItems"
+#: src/components/shell/command-palette.tsx
+msgid "palette.placeholder"
 msgstr "Search…"
 
 #. js-lingui-explicit-id
@@ -3143,6 +3153,11 @@ msgstr "Set up your site — this email becomes the admin account."
 #: src/routes/_auth/accept-invite/$token.tsx
 msgid "auth.acceptInvite.submit.pending"
 msgstr "Setting up…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr "Settings"
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -888,6 +888,11 @@ msgid "palette.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.commands"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/StaleDraftDialog.tsx
 msgid "editor.staleDraft.compare"
 msgstr "Порівняти"
@@ -1572,6 +1577,11 @@ msgstr "Редагувати"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.title.other"
 msgstr "Редагувати {email}"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.profile"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
@@ -3045,14 +3055,14 @@ msgid "palette.description"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.placeholder"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.searchItems"
 msgstr "Пошук…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.placeholder"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3169,6 +3179,11 @@ msgstr "Налаштуйте свій сайт — цей email стане об�
 #: src/routes/_auth/accept-invite/$token.tsx
 msgid "auth.acceptInvite.submit.pending"
 msgstr "Налаштування…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -859,6 +859,11 @@ msgid "palette.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.commands"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/StaleDraftDialog.tsx
 msgid "editor.staleDraft.compare"
 msgstr "比较"
@@ -1533,6 +1538,11 @@ msgstr "编辑"
 #: src/routes/_authenticated/users/$id/edit.tsx
 msgid "userEdit.title.other"
 msgstr "编辑 {email}"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.profile"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/breadcrumbs.ts
@@ -2985,14 +2995,14 @@ msgid "palette.description"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.placeholder"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.searchItems"
 msgstr "搜索…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.placeholder"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/form/multi-select.tsx
@@ -3104,6 +3114,11 @@ msgstr "设置您的站点 — 此电子邮箱将成为管理员账户。"
 #: src/routes/_auth/accept-invite/$token.tsx
 msgid "auth.acceptInvite.submit.pending"
 msgstr "设置中…"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx

--- a/packages/admin/src/components/shell/command-palette.test.tsx
+++ b/packages/admin/src/components/shell/command-palette.test.tsx
@@ -1,4 +1,8 @@
 import type { ReactNode } from "react";
+import {
+  _resetPaletteCommands,
+  registerPaletteCommand,
+} from "@/lib/palette-commands.js";
 import { createQueryClient } from "@/providers/query-client.js";
 import { DirectionProvider } from "@radix-ui/react-direction";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -75,6 +79,7 @@ function renderPalette(node: ReactNode): void {
 afterEach(() => {
   cleanup();
   navigate.mockClear();
+  _resetPaletteCommands();
 });
 
 function pressCmdK(): void {
@@ -178,6 +183,42 @@ describe("CommandPalette", () => {
       to: "/users/$id/edit",
       params: { id: 9 },
     });
+  });
+
+  test("runs a registered command and closes the palette", async () => {
+    const run = vi.fn();
+    registerPaletteCommand({
+      id: "plugin:do-x",
+      title: { id: "cmd.x", message: "Do X" },
+      run,
+    });
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+
+    fireEvent.click(
+      await screen.findByTestId("command-palette-command-plugin:do-x"),
+    );
+
+    expect(run).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(screen.queryByTestId("command-palette-input")).toBeNull(),
+    );
+  });
+
+  test("hides a command whose capability the user lacks", async () => {
+    registerPaletteCommand({
+      id: "plugin:secret",
+      title: { id: "cmd.secret", message: "Secret" },
+      capability: "secret:do",
+      run: vi.fn(),
+    });
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    await screen.findByTestId("command-palette-input");
+
+    expect(
+      screen.queryByTestId("command-palette-command-plugin:secret"),
+    ).toBeNull();
   });
 
   test("Escape closes the palette", async () => {

--- a/packages/admin/src/components/shell/command-palette.tsx
+++ b/packages/admin/src/components/shell/command-palette.tsx
@@ -1,3 +1,4 @@
+import type { PaletteCommand } from "@/lib/palette-commands.js";
 import type { MessageDescriptor } from "@lingui/core";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -18,6 +19,10 @@ import {
 } from "@/components/ui/dialog.js";
 import { findEntryTypeByName } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
+import {
+  getRegisteredPaletteCommands,
+  selectCommands,
+} from "@/lib/palette-commands.js";
 import { paletteNavItems } from "@/lib/palette-nav.js";
 import { useLabel } from "@/lib/use-label.js";
 import { defineMessage } from "@lingui/core/macro";
@@ -41,7 +46,36 @@ const M = {
     id: "palette.group.navigation",
     message: "Navigation",
   }),
+  commands: defineMessage({
+    id: "palette.group.commands",
+    message: "Commands",
+  }),
 } satisfies Record<string, MessageDescriptor>;
+
+// Built-in commands. Distinct from the Navigation group: these are
+// actions/destinations the sidebar doesn't surface (e.g. the current
+// user's own profile, reached via the user menu).
+const CORE_COMMANDS: readonly PaletteCommand[] = [
+  {
+    id: "core:profile",
+    title: defineMessage({
+      id: "palette.command.profile",
+      message: "Edit profile",
+    }),
+    coreIcon: "users",
+    run: ({ navigate }) => void navigate({ to: "/profile" }),
+  },
+  {
+    id: "core:settings",
+    title: defineMessage({
+      id: "palette.command.settings",
+      message: "Settings",
+    }),
+    coreIcon: "settings",
+    capability: "settings:manage",
+    run: ({ navigate }) => void navigate({ to: "/settings" }),
+  },
+];
 
 function useDebounced(value: string, ms: number): string {
   const [debounced, setDebounced] = useState(value);
@@ -100,6 +134,12 @@ export function CommandPalette({
   );
 
   const lower = trimmed.toLowerCase();
+  const commands = selectCommands(
+    [...CORE_COMMANDS, ...getRegisteredPaletteCommands()],
+    capabilities,
+    trimmed,
+    renderLabel,
+  );
   const navItems = paletteNavItems(capabilities).filter(
     (item) =>
       lower.length === 0 ||
@@ -162,6 +202,26 @@ export function CommandPalette({
           />
           <CommandList>
             <CommandEmpty>{renderLabel(M.empty)}</CommandEmpty>
+            {commands.length > 0 ? (
+              <CommandGroup heading={renderLabel(M.commands)}>
+                {commands.map((command) => (
+                  <CommandItem
+                    key={command.id}
+                    value={command.id}
+                    data-testid={`command-palette-command-${command.id}`}
+                    onSelect={() => {
+                      dismiss();
+                      command.run({ navigate });
+                    }}
+                  >
+                    {command.coreIcon ? (
+                      <CoreIcon name={command.coreIcon} />
+                    ) : null}
+                    <span>{renderLabel(command.title)}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
             {navItems.length > 0 ? (
               <CommandGroup heading={renderLabel(M.navigation)}>
                 {navItems.map((item) => (

--- a/packages/admin/src/lib/palette-commands.test.ts
+++ b/packages/admin/src/lib/palette-commands.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import type { Label } from "@plumix/core/i18n";
+
+import type { PaletteCommand } from "./palette-commands.js";
+import {
+  _resetPaletteCommands,
+  getRegisteredPaletteCommands,
+  registerPaletteCommand,
+  selectCommands,
+} from "./palette-commands.js";
+
+const noop = (): void => undefined;
+const text = (label: Label): string =>
+  typeof label === "string" ? label : (label.message ?? label.id);
+
+function cmd(
+  id: string,
+  message: string,
+  extra: Partial<PaletteCommand> = {},
+): PaletteCommand {
+  return { id, title: { id, message }, run: noop, ...extra };
+}
+
+afterEach(() => {
+  _resetPaletteCommands();
+});
+
+describe("selectCommands", () => {
+  const commands = [
+    cmd("a", "Create post"),
+    cmd("b", "Settings", { capability: "settings:manage" }),
+  ];
+
+  test("hides commands whose capability the user lacks", () => {
+    expect(selectCommands(commands, [], "", text).map((c) => c.id)).toEqual([
+      "a",
+    ]);
+  });
+
+  test("shows capability-gated commands once the user has the cap", () => {
+    const ids = selectCommands(commands, ["settings:manage"], "", text).map(
+      (c) => c.id,
+    );
+    expect(ids).toEqual(["a", "b"]);
+  });
+
+  test("filters by query against the resolved title", () => {
+    const ids = selectCommands(commands, ["settings:manage"], "set", text).map(
+      (c) => c.id,
+    );
+    expect(ids).toEqual(["b"]);
+  });
+
+  test("matches query against keywords too", () => {
+    const withKeyword = [cmd("a", "Create post", { keywords: ["new", "add"] })];
+    expect(
+      selectCommands(withKeyword, [], "add", text).map((c) => c.id),
+    ).toEqual(["a"]);
+  });
+});
+
+describe("palette command registry", () => {
+  test("registers a command and exposes it", () => {
+    registerPaletteCommand(cmd("plugin:x", "Do X"));
+    expect(getRegisteredPaletteCommands().map((c) => c.id)).toEqual([
+      "plugin:x",
+    ]);
+  });
+
+  test("rejects a duplicate id", () => {
+    registerPaletteCommand(cmd("plugin:x", "Do X"));
+    expect(() => registerPaletteCommand(cmd("plugin:x", "Again"))).toThrow();
+  });
+});

--- a/packages/admin/src/lib/palette-commands.ts
+++ b/packages/admin/src/lib/palette-commands.ts
@@ -1,0 +1,66 @@
+import type { useNavigate } from "@tanstack/react-router";
+
+import type { Label } from "@plumix/core/i18n";
+import type { CoreIconName } from "@plumix/core/manifest";
+
+import { hasCap } from "./caps.js";
+import { AdminPluginRegistryError } from "./errors.js";
+
+export interface PaletteCommandContext {
+  readonly navigate: ReturnType<typeof useNavigate>;
+}
+
+/** An executable command-palette entry (distinct from search results and
+ *  manifest navigation). `capability` gates client-side visibility only. */
+export interface PaletteCommand {
+  readonly id: string;
+  readonly title: Label;
+  readonly keywords?: readonly string[];
+  readonly coreIcon?: CoreIconName;
+  readonly capability?: string;
+  readonly run: (ctx: PaletteCommandContext) => void;
+}
+
+const registered = new Map<string, PaletteCommand>();
+
+/** Register a command. Plugins call this from their admin chunk via
+ *  `window.plumix.registerPaletteCommand`. */
+export function registerPaletteCommand(command: PaletteCommand): void {
+  if (registered.has(command.id)) {
+    throw AdminPluginRegistryError.duplicateKey({
+      registerName: "registerPaletteCommand",
+      key: command.id,
+    });
+  }
+  registered.set(command.id, command);
+}
+
+export function getRegisteredPaletteCommands(): readonly PaletteCommand[] {
+  return [...registered.values()];
+}
+
+/** @internal Test-only. */
+export function _resetPaletteCommands(): void {
+  registered.clear();
+}
+
+/** `toText` is the caller's i18n-bound `Label` resolver; capability
+ *  gating mirrors the sidebar's. */
+export function selectCommands(
+  commands: readonly PaletteCommand[],
+  capabilities: readonly string[],
+  query: string,
+  toText: (label: Label) => string,
+): readonly PaletteCommand[] {
+  const needle = query.trim().toLowerCase();
+  return commands.filter((command) => {
+    if (command.capability && !hasCap(capabilities, command.capability)) {
+      return false;
+    }
+    if (needle.length === 0) return true;
+    const haystack = [toText(command.title), ...(command.keywords ?? [])].join(
+      " ",
+    );
+    return haystack.toLowerCase().includes(needle);
+  });
+}

--- a/packages/admin/src/lib/plumix-globals.ts
+++ b/packages/admin/src/lib/plumix-globals.ts
@@ -11,6 +11,7 @@ import * as ReactDomNs from "react-dom";
 import * as ReactDomClientNs from "react-dom/client";
 
 import { pluginCatalogLoaderRef } from "./i18n-boot.js";
+import { registerPaletteCommand } from "./palette-commands.js";
 import {
   registerPluginBlock,
   registerPluginBlockEditor,
@@ -58,6 +59,7 @@ declare global {
       readonly registerPluginBlockEditor: typeof registerPluginBlockEditor;
       readonly registerPluginBlock: typeof registerPluginBlock;
       readonly registerPluginMarkSchema: typeof registerPluginMarkSchema;
+      readonly registerPaletteCommand: typeof registerPaletteCommand;
       readonly runtime: typeof runtime;
       readonly i18n: PlumixI18nGlobal;
     };
@@ -75,6 +77,7 @@ export function bootPlumixGlobals(): void {
     registerPluginBlockEditor,
     registerPluginBlock,
     registerPluginMarkSchema,
+    registerPaletteCommand,
     runtime,
     // Indirection through the ref so the manifest-bound loader
     // installed by `bootI18n` is reachable from plugin chunks that

--- a/tooling/eslint/i18n.ts
+++ b/tooling/eslint/i18n.ts
@@ -261,6 +261,9 @@ export const i18nStrictOverrides: Linter.Config = {
           // StyleTab section dispatcher — `property="background"`
           // selects which CSS prop the section edits.
           "property",
+          // `coreIcon` selects a built-in admin glyph (`CoreIconName`
+          // discriminator on nav items / palette commands), never copy.
+          "coreIcon",
           "fill",
           "stroke",
           "viewBox",


### PR DESCRIPTION
The Cmd+K command palette now has a registerable command layer. Plugins
can contribute executable actions that appear in a dedicated "Commands"
group alongside navigation destinations and server-backed search results.

**Registration surface**

Plugin admin chunks register commands at runtime via
`window.plumix.registerPaletteCommand`. A `PaletteCommand` carries an id,
a `Label` title, optional keywords and `coreIcon`, an optional capability,
and a `run({ navigate })` handler invoked on select.

**Client-side capability gating**

Commands are static client-side data, so visibility is gated with the same
`hasCap` helper the sidebar uses — not a server round-trip. `capability`
hides the row only; it is not an authorization boundary, so a command's
`run` must still rely on the route/RPC it triggers to enforce access. This
mirrors the locked decision that search *results* are filtered server-side
while static nav/commands filter on the client.

Two built-in commands ship: edit profile and settings. The `coreIcon`
discriminator is added to the `no-unlocalized-strings` allowlist since it
names a built-in glyph, never user copy.

Closes GH-917
Closes GH-864