### PR TITLE
feat: match command palette navigation on keyword aliases

### DIFF
--- a/packages/admin/src/components/shell/command-palette.test.tsx
+++ b/packages/admin/src/components/shell/command-palette.test.tsx
@@ -19,9 +19,14 @@ vi.mock("@tanstack/react-router", async (importOriginal) => ({
   useNavigate: () => navigate,
 }));
 
-vi.mock("@/lib/palette-nav.js", () => ({
+vi.mock("@/lib/palette-nav.js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   paletteNavItems: () => [
-    { to: "/entries/posts", label: { id: "i.posts", message: "Posts" } },
+    {
+      to: "/entries/posts",
+      label: { id: "i.posts", message: "Posts" },
+      keywords: [{ id: "k.articles", message: "articles" }],
+    },
     { to: "/users", label: { id: "i.users", message: "Users" } },
   ],
 }));
@@ -131,6 +136,17 @@ describe("CommandPalette", () => {
       ).toBeNull(),
     );
     screen.getByTestId("command-palette-nav-/users");
+  });
+
+  test("surfaces a navigation item by a keyword synonym, not just its label", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    const input = await screen.findByTestId("command-palette-input");
+
+    fireEvent.change(input, { target: { value: "articles" } });
+
+    await screen.findByTestId("command-palette-nav-/entries/posts");
+    expect(screen.queryByTestId("command-palette-nav-/users")).toBeNull();
   });
 
   test("shows server content results and opens the editor on select", async () => {

--- a/packages/admin/src/components/shell/command-palette.tsx
+++ b/packages/admin/src/components/shell/command-palette.tsx
@@ -23,7 +23,7 @@ import {
   getRegisteredPaletteCommands,
   selectCommands,
 } from "@/lib/palette-commands.js";
-import { paletteNavItems } from "@/lib/palette-nav.js";
+import { paletteNavItems, selectNavItems } from "@/lib/palette-nav.js";
 import { useLabel } from "@/lib/use-label.js";
 import { defineMessage } from "@lingui/core/macro";
 import { useQuery } from "@tanstack/react-query";
@@ -133,17 +133,16 @@ export function CommandPalette({
     }),
   );
 
-  const lower = trimmed.toLowerCase();
   const commands = selectCommands(
     [...CORE_COMMANDS, ...getRegisteredPaletteCommands()],
     capabilities,
     trimmed,
     renderLabel,
   );
-  const navItems = paletteNavItems(capabilities).filter(
-    (item) =>
-      lower.length === 0 ||
-      renderLabel(item.label).toLowerCase().includes(lower),
+  const navItems = selectNavItems(
+    paletteNavItems(capabilities),
+    trimmed,
+    renderLabel,
   );
   const groups = trimmed.length >= MIN_QUERY_LENGTH ? (search.data ?? []) : [];
 

--- a/packages/admin/src/lib/palette-commands.test.ts
+++ b/packages/admin/src/lib/palette-commands.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 
-import type { Label } from "@plumix/core/i18n";
-
 import type { PaletteCommand } from "./palette-commands.js";
+import { labelText as text } from "../../test/label-text.js";
 import {
   _resetPaletteCommands,
   getRegisteredPaletteCommands,
@@ -11,8 +10,6 @@ import {
 } from "./palette-commands.js";
 
 const noop = (): void => undefined;
-const text = (label: Label): string =>
-  typeof label === "string" ? label : (label.message ?? label.id);
 
 function cmd(
   id: string,

--- a/packages/admin/src/lib/palette-nav.test.ts
+++ b/packages/admin/src/lib/palette-nav.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vitest";
 
+import type { Label } from "@plumix/core/i18n";
 import type { PlumixManifest } from "@plumix/core/manifest";
 
-import { paletteNavItems } from "./palette-nav.js";
+import { labelText as text } from "../../test/label-text.js";
+import { paletteNavItems, selectNavItems } from "./palette-nav.js";
 
 const SOURCE: PlumixManifest = {
   adminNav: [
@@ -46,5 +48,41 @@ describe("paletteNavItems", () => {
   test("drops items whose capability the user lacks, reusing the sidebar filter", () => {
     const items = paletteNavItems([], SOURCE);
     expect(items.map((item) => item.to)).toEqual(["/entries/posts"]);
+  });
+});
+
+describe("selectNavItems", () => {
+  const items = [
+    {
+      to: "/media",
+      label: { id: "i.media", message: "Media Library" } as Label,
+      keywords: [
+        { id: "k.uploads", message: "uploads" },
+        { id: "k.images", message: "images" },
+      ] as readonly Label[],
+    },
+    {
+      to: "/settings",
+      label: { id: "i.settings", message: "Settings" } as Label,
+    },
+  ];
+
+  test("returns all items for an empty query", () => {
+    expect(selectNavItems(items, "", text).map((i) => i.to)).toEqual([
+      "/media",
+      "/settings",
+    ]);
+  });
+
+  test("matches a synonym against keywords, not just the visible label", () => {
+    expect(selectNavItems(items, "uploads", text).map((i) => i.to)).toEqual([
+      "/media",
+    ]);
+  });
+
+  test("matches against the label too", () => {
+    expect(selectNavItems(items, "settings", text).map((i) => i.to)).toEqual([
+      "/settings",
+    ]);
   });
 });

--- a/packages/admin/src/lib/palette-nav.ts
+++ b/packages/admin/src/lib/palette-nav.ts
@@ -7,6 +7,7 @@ interface PaletteNavItem {
   readonly to: string;
   readonly label: Label;
   readonly coreIcon?: CoreIconName;
+  readonly keywords?: readonly Label[];
 }
 
 // Reuses `visibleAdminNav` verbatim so palette navigation can never drift
@@ -20,6 +21,24 @@ export function paletteNavItems(
       to: item.to,
       label: item.label,
       ...(item.coreIcon ? { coreIcon: item.coreIcon } : {}),
+      ...(item.keywords ? { keywords: item.keywords } : {}),
     })),
   );
+}
+
+/** `toText` is the caller's i18n-bound `Label` resolver; mirrors
+ *  `selectCommands`. */
+export function selectNavItems(
+  items: readonly PaletteNavItem[],
+  query: string,
+  toText: (label: Label) => string,
+): readonly PaletteNavItem[] {
+  const needle = query.trim().toLowerCase();
+  if (needle.length === 0) return items;
+  return items.filter((item) => {
+    const haystack = [item.label, ...(item.keywords ?? [])]
+      .map(toText)
+      .join(" ");
+    return haystack.toLowerCase().includes(needle);
+  });
 }

--- a/packages/admin/test/label-text.ts
+++ b/packages/admin/test/label-text.ts
@@ -1,0 +1,6 @@
+import type { Label } from "@plumix/core/i18n";
+
+/** Stand-in `Label` resolver for unit tests of `selectX(items, query, toText)`
+ *  helpers — no Lingui instance needed. */
+export const labelText = (label: Label): string =>
+  typeof label === "string" ? label : (label.message ?? label.id);

--- a/packages/core/src/plugin/manifest.test.ts
+++ b/packages/core/src/plugin/manifest.test.ts
@@ -173,6 +173,69 @@ describe("buildManifest", () => {
     ]);
   });
 
+  test("entry-type keywords flow onto its admin-nav item", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("blog", (ctx) => {
+      ctx.registerEntryType("post", {
+        label: "Posts",
+        showInSidebar: true,
+        keywords: [{ id: "k.articles", message: "articles" }, "blog"],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    const content = manifest.adminNav.find((g) => g.id === "content");
+    const post = content?.items.find((i) => i.to === "/entries/posts");
+    expect(post?.keywords).toEqual([
+      { id: "k.articles", message: "articles" },
+      "blog",
+    ]);
+  });
+
+  test("admin-page nav keywords flow onto its admin-nav item", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("media", (ctx) => {
+      ctx.registerAdminPage({
+        path: "/media",
+        title: "Media Library",
+        nav: {
+          group: { id: "library", label: "Library" },
+          label: "Media Library",
+          keywords: [{ id: "k.uploads", message: "uploads" }, "images"],
+        },
+        component: "MediaLibrary",
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    const library = manifest.adminNav.find((g) => g.id === "library");
+    const media = library?.items.find((i) => i.to === "/pages/media");
+    expect(media?.keywords).toEqual([
+      { id: "k.uploads", message: "uploads" },
+      "images",
+    ]);
+  });
+
+  test("taxonomy keywords flow onto its admin-nav item", async () => {
+    const hooks = new HookRegistry();
+    const plugin = definePlugin("blog", (ctx) => {
+      ctx.registerTermTaxonomy("category", {
+        label: "Categories",
+        showInSidebar: true,
+        keywords: [{ id: "k.taxonomy", message: "taxonomy" }],
+      });
+    });
+    const { registry } = await installPlugins({ hooks, plugins: [plugin] });
+    const manifest = buildManifest(registry);
+    const taxonomies = manifest.adminNav.find(
+      (g) => g.id === "term-taxonomies",
+    );
+    const category = taxonomies?.items.find((i) => i.to === "/terms/category");
+    expect(category?.keywords).toEqual([
+      { id: "k.taxonomy", message: "taxonomy" },
+    ]);
+  });
+
   test("projects registered settings groups, fields use the shared MetaBoxField shape", async () => {
     const hooks = new HookRegistry();
     const corePlugin = definePlugin("core", (ctx) => {

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -144,6 +144,8 @@ export interface EntryTypeOptions {
   readonly capabilities?: EntryTypeCapabilityOverrides;
   readonly priority?: number;
   readonly menuIcon?: string;
+  /** Synonyms the command palette matches in addition to the sidebar label. */
+  readonly keywords?: readonly Label[];
   /**
    * Per-type versioning policy. Only honored when `supports` includes
    * `"revisions"`. `maxRevisions` caps how many revision rows are
@@ -231,6 +233,8 @@ export interface TermTaxonomyOptions {
   };
   readonly capabilities?: TermTaxonomyCapabilityOverrides;
   readonly menuIcon?: string;
+  /** Synonyms the command palette matches in addition to the sidebar label. */
+  readonly keywords?: readonly Label[];
   /** Page size for this taxonomy's term archives. Default 20. */
   readonly archivePerPage?: number;
 }
@@ -1020,6 +1024,8 @@ export interface AdminPageOptions {
     readonly label: Label;
     readonly icon?: PluginComponentRef;
     readonly order?: number;
+    /** Synonyms the command palette matches in addition to `label`. */
+    readonly keywords?: readonly Label[];
   };
   readonly capability?: string;
   readonly component: PluginComponentRef;
@@ -1432,6 +1438,8 @@ export interface EntryTypeManifestEntry {
   readonly capabilityType?: string;
   readonly priority?: number;
   readonly menuIcon?: string;
+  /** Synonyms the command palette matches in addition to the sidebar label. */
+  readonly keywords?: readonly Label[];
   /**
    * Per-type versioning policy. Populated when the entry type opts
    * into `supports: ['revisions']`. `maxRevisions` caps how many
@@ -1568,6 +1576,8 @@ export interface TermTaxonomyManifestEntry {
   readonly showUI?: boolean;
   readonly showInSidebar?: boolean;
   readonly menuIcon?: string;
+  /** Synonyms the command palette matches in addition to the sidebar label. */
+  readonly keywords?: readonly Label[];
 }
 
 /**
@@ -1618,6 +1628,8 @@ export interface AdminNavItem {
   readonly coreIcon?: CoreIconName;
   readonly component?: PluginComponentRef;
   readonly exact?: boolean;
+  /** Synonyms the command palette matches in addition to `label`. */
+  readonly keywords?: readonly Label[];
 }
 
 export interface AdminNavGroup {
@@ -1969,6 +1981,7 @@ const CORE_NAV_ITEMS: readonly { groupId: string; item: AdminNavItem }[] = [
       coreIcon: "dashboard",
       order: 0,
       exact: true,
+      keywords: ["home", "overview"],
     },
   },
   {
@@ -1979,6 +1992,7 @@ const CORE_NAV_ITEMS: readonly { groupId: string; item: AdminNavItem }[] = [
       coreIcon: "users",
       order: 100,
       capability: "user:list",
+      keywords: ["accounts", "team", "people"],
     },
   },
   {
@@ -1992,6 +2006,7 @@ const CORE_NAV_ITEMS: readonly { groupId: string; item: AdminNavItem }[] = [
       coreIcon: "users",
       order: 150,
       capability: "settings:manage",
+      keywords: ["domains", "email", "signups"],
     },
   },
   {
@@ -2002,6 +2017,7 @@ const CORE_NAV_ITEMS: readonly { groupId: string; item: AdminNavItem }[] = [
       coreIcon: "mail",
       order: 175,
       capability: "settings:manage",
+      keywords: ["email", "smtp"],
     },
   },
   {
@@ -2012,6 +2028,7 @@ const CORE_NAV_ITEMS: readonly { groupId: string; item: AdminNavItem }[] = [
       coreIcon: "settings",
       order: 200,
       capability: "settings:manage",
+      keywords: ["configuration", "preferences", "options"],
     },
   },
 ];
@@ -2059,6 +2076,7 @@ function addEntryNavItems(
       order: entry.priority,
       coreIcon: resolveEntryMenuIcon(entry.menuIcon),
       capability: `entry:${entry.capabilityType ?? entry.name}:edit_own`,
+      ...(entry.keywords ? { keywords: entry.keywords } : {}),
     });
   }
 }
@@ -2074,6 +2092,7 @@ function addTaxonomyNavItems(
       label: tax.label,
       coreIcon: resolveTaxonomyMenuIcon(tax.menuIcon, tax.isHierarchical),
       capability: `term:${tax.name}:read`,
+      ...(tax.keywords ? { keywords: tax.keywords } : {}),
     });
   }
 }
@@ -2112,6 +2131,7 @@ function addAdminPageNavItems(
       coreIcon: page.nav.icon ? undefined : "puzzle",
       component: page.component,
       capability: page.capability,
+      ...(page.nav.keywords ? { keywords: page.nav.keywords } : {}),
     });
   }
 }
@@ -2371,6 +2391,7 @@ function toEntryTypeManifest(pt: RegisteredEntryType): EntryTypeManifestEntry {
     capabilityType,
     priority,
     menuIcon,
+    keywords,
     versioning,
   } = pt as RegisteredEntryType & {
     readonly versioning?: EntryTypeManifestEntry["versioning"];
@@ -2395,6 +2416,7 @@ function toEntryTypeManifest(pt: RegisteredEntryType): EntryTypeManifestEntry {
     capabilityType,
     priority,
     menuIcon,
+    keywords,
     versioning: deriveVersioning(supports, versioning),
   };
 }
@@ -2429,6 +2451,7 @@ function toTermTaxonomyEntry(
     isHierarchical,
     entryTypes,
     menuIcon,
+    keywords,
   } = tax;
   const visibility = resolveTermTaxonomyVisibility(tax);
   return {
@@ -2442,6 +2465,7 @@ function toTermTaxonomyEntry(
     showUI: visibility.showUI,
     showInSidebar: visibility.showInSidebar,
     menuIcon,
+    keywords,
   };
 }
 

--- a/packages/plugins/audit-log/src/index.ts
+++ b/packages/plugins/audit-log/src/index.ts
@@ -161,6 +161,7 @@ export function auditLog(options: AuditLogPluginOptions = {}) {
           group: { id: "tools", label: AUDIT_LABELS.tools, priority: 600 },
           label: AUDIT_LABELS.auditLog,
           order: 10,
+          keywords: ["history", "activity", "events", "log", "security"],
         },
         component: "AuditLogShell",
       });

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -143,6 +143,7 @@ export const blog = definePlugin("blog", {
       rewrite: { slug: "posts" },
       capabilityType: "post",
       menuIcon: "file-text",
+      keywords: ["articles", "blog", "writing", "news"],
     });
 
     ctx.registerTermTaxonomy("category", {
@@ -153,6 +154,7 @@ export const blog = definePlugin("blog", {
       isPublic: true,
       hasAdminColumn: true,
       rewrite: { slug: "category", isHierarchical: true },
+      keywords: ["taxonomy", "categories"],
     });
 
     ctx.registerTermTaxonomy("tag", {
@@ -163,6 +165,7 @@ export const blog = definePlugin("blog", {
       isPublic: true,
       hasAdminColumn: true,
       rewrite: { slug: "tag" },
+      keywords: ["taxonomy", "tags"],
     });
   },
 });

--- a/packages/plugins/media/src/index.ts
+++ b/packages/plugins/media/src/index.ts
@@ -237,6 +237,7 @@ export function media(
           },
           label: MEDIA_LIBRARY_LABEL,
           order: 50,
+          keywords: ["images", "files", "uploads", "photos", "assets"],
         },
         component: "MediaLibrary",
       });

--- a/packages/plugins/menu/src/index.ts
+++ b/packages/plugins/menu/src/index.ts
@@ -242,6 +242,7 @@ export function menu(
           group: { id: "appearance", label: APPEARANCE_LABEL, priority: 175 },
           label: MENU_LABELS.plural,
           order: 10,
+          keywords: ["navigation", "nav", "appearance", "header", "footer"],
         },
         component: "MenusShell",
       });

--- a/packages/plugins/pages/src/index.ts
+++ b/packages/plugins/pages/src/index.ts
@@ -67,6 +67,7 @@ export const pages = definePlugin("pages", {
       rewrite: { slug: "" },
       capabilityType: "page",
       menuIcon: "layout",
+      keywords: ["static", "page"],
     });
   },
 });


### PR DESCRIPTION
The command palette now finds navigation entries by synonym, not just
their visible label. Typing "uploads" finds **Media**, "navigation"
finds **Menus**, "articles" finds **Posts** — the parity gap with
emdash's palette, where every nav item carries keyword aliases.

**Declarable at registration — all surfaces covered**

Each nav-contributing registration (`registerEntryType`,
`registerTermTaxonomy`, `registerAdminPage`'s `nav`) plus core's
built-in nav items accept an optional `keywords` list, threaded through
the manifest onto the admin-nav item. Because keywords are declared at
registration, third-party plugins participate with no central map.

Core (Dashboard / Users / Settings / Mailer / Allowed domains) and all
five bundled plugins (blog, pages, media, menu, audit-log) declare their
own aliases.

**Matching mirrors commands**

A new pure `selectNavItems(items, query, toText)` matches the query
against the resolved label OR any keyword — the same shape the existing
`selectCommands` uses. Capability gating is unchanged: `visibleAdminNav`
still filters nav upstream; `selectNavItems` only does query matching.

Keywords are plain strings for now. The field type is `Label`
(`string | MessageDescriptor`), so localized aliases are a later add
with no interface change.

Refs GH-923