### PR TITLE
feat(admin): add a Recent group to the command palette

### DIFF
--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -2757,6 +2757,11 @@ msgid "userEdit.delete.reassign.label"
 msgstr "إعادة تعيين المنشورات إلى"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.recent"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.recent.title"
 msgstr "النشاط الأخير"
@@ -3162,11 +3167,6 @@ msgid "auth.acceptInvite.submit.pending"
 msgstr "جارٍ الإعداد…"
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.command.settings"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.title"
 msgstr "الإعدادات"
@@ -3180,6 +3180,11 @@ msgstr "الإعدادات"
 #: src/lib/core-nav-i18n.ts
 msgid "core.adminNav.item.settings"
 msgstr "الإعدادات"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/shell/user-menu.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -2781,6 +2781,11 @@ msgid "userEdit.delete.reassign.label"
 msgstr "Beiträge neu zuweisen an"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.recent"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.recent.title"
 msgstr "Letzte Aktivität"
@@ -3192,11 +3197,6 @@ msgid "auth.acceptInvite.submit.pending"
 msgstr "Wird eingerichtet…"
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.command.settings"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.title"
 msgstr "Einstellungen"
@@ -3210,6 +3210,11 @@ msgstr "Einstellungen"
 #: src/lib/core-nav-i18n.ts
 msgid "core.adminNav.item.settings"
 msgstr "Einstellungen"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/shell/user-menu.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -2747,6 +2747,11 @@ msgid "userEdit.delete.reassign.label"
 msgstr "Reassign entries to"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.recent"
+msgstr "Recent"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.recent.title"
 msgstr "Recent activity"
@@ -3155,11 +3160,6 @@ msgid "auth.acceptInvite.submit.pending"
 msgstr "Setting up…"
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.command.settings"
-msgstr "Settings"
-
-#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.title"
 msgstr "Settings"
@@ -3172,6 +3172,11 @@ msgstr "Settings"
 #. js-lingui-explicit-id
 #: src/lib/core-nav-i18n.ts
 msgid "core.adminNav.item.settings"
+msgstr "Settings"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
 msgstr "Settings"
 
 #. js-lingui-explicit-id

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -2771,6 +2771,11 @@ msgid "userEdit.delete.reassign.label"
 msgstr "Переназначити записи на"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.recent"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.recent.title"
 msgstr "Нещодавня активність"
@@ -3181,11 +3186,6 @@ msgid "auth.acceptInvite.submit.pending"
 msgstr "Налаштування…"
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.command.settings"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.title"
 msgstr "Налаштування"
@@ -3199,6 +3199,11 @@ msgstr "Налаштування"
 #: src/lib/core-nav-i18n.ts
 msgid "core.adminNav.item.settings"
 msgstr "Налаштування"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/shell/user-menu.tsx

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -2714,6 +2714,11 @@ msgid "userEdit.delete.reassign.label"
 msgstr "将文章重新分配给"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.group.recent"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/index.tsx
 msgid "dashboard.recent.title"
 msgstr "最近活动"
@@ -3116,11 +3121,6 @@ msgid "auth.acceptInvite.submit.pending"
 msgstr "设置中…"
 
 #. js-lingui-explicit-id
-#: src/components/shell/command-palette.tsx
-msgid "palette.command.settings"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_authenticated/settings/index.tsx
 msgid "settings.title"
 msgstr "设置"
@@ -3134,6 +3134,11 @@ msgstr "设置"
 #: src/lib/core-nav-i18n.ts
 msgid "core.adminNav.item.settings"
 msgstr "设置"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.command.settings"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/shell/user-menu.tsx

--- a/packages/admin/src/components/shell/command-palette.test.tsx
+++ b/packages/admin/src/components/shell/command-palette.test.tsx
@@ -3,6 +3,7 @@ import {
   _resetPaletteCommands,
   registerPaletteCommand,
 } from "@/lib/palette-commands.js";
+import { recordRecentNav } from "@/lib/recent-nav.js";
 import { createQueryClient } from "@/providers/query-client.js";
 import { DirectionProvider } from "@radix-ui/react-direction";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -85,6 +86,7 @@ afterEach(() => {
   cleanup();
   navigate.mockClear();
   _resetPaletteCommands();
+  localStorage.clear();
 });
 
 function pressCmdK(): void {
@@ -147,6 +149,33 @@ describe("CommandPalette", () => {
 
     await screen.findByTestId("command-palette-nav-/entries/posts");
     expect(screen.queryByTestId("command-palette-nav-/users")).toBeNull();
+  });
+
+  test("shows a Recent group of previously visited destinations on empty query", async () => {
+    recordRecentNav("/users");
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+
+    await screen.findByTestId("command-palette-recent-/users");
+  });
+
+  test("renders a recent destination and its nav entry side by side", async () => {
+    recordRecentNav("/users");
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+
+    await screen.findByTestId("command-palette-recent-/users");
+    screen.getByTestId("command-palette-nav-/users");
+  });
+
+  test("records a visited destination so it surfaces under Recent next time", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    fireEvent.click(await screen.findByTestId("command-palette-nav-/users"));
+
+    pressCmdK();
+
+    await screen.findByTestId("command-palette-recent-/users");
   });
 
   test("shows server content results and opens the editor on select", async () => {

--- a/packages/admin/src/components/shell/command-palette.tsx
+++ b/packages/admin/src/components/shell/command-palette.tsx
@@ -24,6 +24,11 @@ import {
   selectCommands,
 } from "@/lib/palette-commands.js";
 import { paletteNavItems, selectNavItems } from "@/lib/palette-nav.js";
+import {
+  readRecentNav,
+  recordRecentNav,
+  selectRecentNavItems,
+} from "@/lib/recent-nav.js";
 import { useLabel } from "@/lib/use-label.js";
 import { defineMessage } from "@lingui/core/macro";
 import { useQuery } from "@tanstack/react-query";
@@ -33,6 +38,7 @@ import { CoreIcon } from "./core-icon.js";
 
 const MIN_QUERY_LENGTH = 2;
 const DEBOUNCE_MS = 250;
+const RECENT_LIMIT = 5;
 
 const M = {
   title: defineMessage({ id: "palette.title", message: "Command palette" }),
@@ -46,6 +52,7 @@ const M = {
     id: "palette.group.navigation",
     message: "Navigation",
   }),
+  recent: defineMessage({ id: "palette.group.recent", message: "Recent" }),
   commands: defineMessage({
     id: "palette.group.commands",
     message: "Commands",
@@ -144,11 +151,23 @@ export function CommandPalette({
     trimmed,
     renderLabel,
   );
+  // Drop Recent once typing — the filtered nav group then covers the
+  // same destinations.
+  const recent =
+    open && trimmed.length === 0
+      ? selectRecentNavItems(navItems, readRecentNav(), RECENT_LIMIT)
+      : [];
   const groups = trimmed.length >= MIN_QUERY_LENGTH ? (search.data ?? []) : [];
 
   function dismiss(): void {
     setOpen(false);
     setQuery("");
+  }
+
+  function goToNav(to: string): void {
+    recordRecentNav(to);
+    dismiss();
+    void navigate({ to });
   }
 
   // Routes a result to its editor from the group key + id. Each domain
@@ -201,6 +220,23 @@ export function CommandPalette({
           />
           <CommandList>
             <CommandEmpty>{renderLabel(M.empty)}</CommandEmpty>
+            {recent.length > 0 ? (
+              <CommandGroup heading={renderLabel(M.recent)}>
+                {recent.map((item) => (
+                  <CommandItem
+                    key={`recent:${item.to}`}
+                    value={`recent:${item.to}`}
+                    data-testid={`command-palette-recent-${item.to}`}
+                    onSelect={() => {
+                      goToNav(item.to);
+                    }}
+                  >
+                    <CoreIcon name={item.coreIcon} />
+                    <span>{renderLabel(item.label)}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
             {commands.length > 0 ? (
               <CommandGroup heading={renderLabel(M.commands)}>
                 {commands.map((command) => (
@@ -229,8 +265,7 @@ export function CommandPalette({
                     value={item.to}
                     data-testid={`command-palette-nav-${item.to}`}
                     onSelect={() => {
-                      dismiss();
-                      void navigate({ to: item.to });
+                      goToNav(item.to);
                     }}
                   >
                     <CoreIcon name={item.coreIcon} />

--- a/packages/admin/src/lib/recent-nav.test.ts
+++ b/packages/admin/src/lib/recent-nav.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  readRecentNav,
+  recordRecentNav,
+  selectRecentNavItems,
+} from "./recent-nav.js";
+
+const NAV = [{ to: "/media" }, { to: "/users" }, { to: "/settings" }];
+
+describe("selectRecentNavItems", () => {
+  test("returns nav items in recency order", () => {
+    const recent = selectRecentNavItems(NAV, ["/settings", "/media"], 5);
+    expect(recent.map((i) => i.to)).toEqual(["/settings", "/media"]);
+  });
+
+  test("caps to the limit", () => {
+    const recent = selectRecentNavItems(
+      NAV,
+      ["/settings", "/media", "/users"],
+      2,
+    );
+    expect(recent.map((i) => i.to)).toEqual(["/settings", "/media"]);
+  });
+
+  test("drops recents that are no longer visible nav items", () => {
+    const recent = selectRecentNavItems(NAV, ["/gone", "/users"], 5);
+    expect(recent.map((i) => i.to)).toEqual(["/users"]);
+  });
+});
+
+describe("recordRecentNav / readRecentNav", () => {
+  test("records most-recent-first", () => {
+    recordRecentNav("/media");
+    recordRecentNav("/users");
+    expect(readRecentNav()).toEqual(["/users", "/media"]);
+  });
+
+  test("re-recording moves an entry to the front without duplicating", () => {
+    recordRecentNav("/media");
+    recordRecentNav("/users");
+    recordRecentNav("/media");
+    expect(readRecentNav()).toEqual(["/media", "/users"]);
+  });
+
+  test("caps the stored list", () => {
+    for (let i = 0; i < 12; i++) recordRecentNav(`/p${String(i)}`);
+    expect(readRecentNav()).toHaveLength(8);
+    expect(readRecentNav()[0]).toBe("/p11");
+  });
+});
+
+afterEach(() => {
+  localStorage.clear();
+});

--- a/packages/admin/src/lib/recent-nav.ts
+++ b/packages/admin/src/lib/recent-nav.ts
@@ -1,0 +1,48 @@
+const RECENT_KEY = "plumix.v2.palette.recent";
+const MAX_STORED = 8;
+
+/** Push a destination to the front of the recently-visited list
+ *  (deduped, capped). Silent on failure — recents are a convenience,
+ *  not worth surfacing a quota/private-mode error per navigation. */
+export function recordRecentNav(to: string): void {
+  try {
+    const next = [to, ...readRecentNav().filter((t) => t !== to)].slice(
+      0,
+      MAX_STORED,
+    );
+    localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  } catch {
+    /* empty */
+  }
+}
+
+export function readRecentNav(): readonly string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    if (raw === null) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((x): x is string => typeof x === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Recents absent from `navItems` (uninstalled plugin, lost capability)
+ *  drop out, so capability filtering and dead-route pruning come for free
+ *  from the already-filtered nav list. */
+export function selectRecentNavItems<T extends { readonly to: string }>(
+  navItems: readonly T[],
+  recents: readonly string[],
+  limit: number,
+): readonly T[] {
+  const byTo = new Map(navItems.map((item) => [item.to, item]));
+  const out: T[] = [];
+  for (const to of recents) {
+    const item = byTo.get(to);
+    if (item) out.push(item);
+    if (out.length >= limit) break;
+  }
+  return out;
+}


### PR DESCRIPTION
Opening the command palette on an empty query now leads with a **Recent**
group — the last few admin destinations you visited — so the most common
jumps need no typing (the Linear/Raycast pattern). Selecting a
destination from either Recent or Navigation records it for next time.

**Capability-safe by construction**

Recents are stored as bare route keys in localStorage (`plumix.v2.palette.recent`,
deduped, capped) and projected onto the live, capability-filtered nav
list at render time. A destination the user can no longer reach — lost
capability or an uninstalled plugin — isn't in the nav list, so it drops
out of Recent automatically. Storage never holds a label/route snapshot,
only the `to` key.

**Scope**

Recent shows only while the palette is open on an empty query; the full
Navigation group still renders below it (an intentional shortcut subset).
Recent items use `recent:`-prefixed cmdk values so they don't collide
with the nav group's selection state. Stores 8, shows 5 — so dropping a
now-hidden entry still leaves a full list.

Refs GH-923