### PR TITLE
feat: polish the command palette — new tab, loading, footer

### DIFF
--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -875,6 +875,11 @@ msgid "editor.layout.draftBanner.body"
 msgstr "اضغط «نشر» لإطلاقها، أو «تجاهل» للتراجع."
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.close"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.lookup.error.notFound"
 msgstr "الرمز غير موجود. تحقق من تطابقه مع ما طبعه CLI."
@@ -2280,6 +2285,11 @@ msgstr "يجب أن يكون الاسم ≤ 64 حرفاً."
 
 #. js-lingui-explicit-id
 #: src/components/shell/command-palette.tsx
+msgid "palette.hint.navigate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
 msgid "palette.group.navigation"
 msgstr ""
 
@@ -3060,9 +3070,19 @@ msgid "form.multiSelect.search"
 msgstr "بحث…"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.loading"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.transport.securityKey"
 msgstr "مفتاح أمان"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.select"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -871,6 +871,11 @@ msgstr "Klicken Sie auf «Veröffentlichen», um sie live zu schalten, oder auf 
 "«Verwerfen», um zurückzusetzen."
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.close"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.lookup.error.notFound"
 msgstr "Code nicht gefunden. Prüfen Sie, ob er mit dem von Ihrer CLI "
@@ -2294,6 +2299,11 @@ msgstr "Name muss ≤ 64 Zeichen lang sein."
 
 #. js-lingui-explicit-id
 #: src/components/shell/command-palette.tsx
+msgid "palette.hint.navigate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
 msgid "palette.group.navigation"
 msgstr ""
 
@@ -3085,9 +3095,19 @@ msgid "form.multiSelect.search"
 msgstr "Suchen…"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.loading"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.transport.securityKey"
 msgstr "Sicherheitsschlüssel"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.select"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -862,6 +862,11 @@ msgid "editor.layout.draftBanner.body"
 msgstr "Click Publish to push them live, or Discard to revert."
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.close"
+msgstr "Close"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.lookup.error.notFound"
 msgstr "Code not found. Check it matches what your CLI printed."
@@ -2267,6 +2272,11 @@ msgstr "Name must be ≤ 64 characters."
 
 #. js-lingui-explicit-id
 #: src/components/shell/command-palette.tsx
+msgid "palette.hint.navigate"
+msgstr "Navigate"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
 msgid "palette.group.navigation"
 msgstr "Navigation"
 
@@ -3051,9 +3061,19 @@ msgid "form.multiSelect.search"
 msgstr "Search…"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.loading"
+msgstr "Searching…"
+
+#. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.transport.securityKey"
 msgstr "Security key"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.select"
+msgstr "Select"
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -878,6 +878,11 @@ msgstr "Натисніть «Опублікувати», щоб запустит
 "щоб скасувати."
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.close"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.lookup.error.notFound"
 msgstr "Код не знайдено. Перевірте, що він збігається з виведеним у CLI."
@@ -2286,6 +2291,11 @@ msgstr "Назва має бути ≤ 64 символів."
 
 #. js-lingui-explicit-id
 #: src/components/shell/command-palette.tsx
+msgid "palette.hint.navigate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
 msgid "palette.group.navigation"
 msgstr ""
 
@@ -3075,9 +3085,19 @@ msgid "form.multiSelect.search"
 msgstr "Пошук…"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.loading"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.transport.securityKey"
 msgstr "Ключ безпеки"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.select"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -849,6 +849,11 @@ msgid "editor.layout.draftBanner.body"
 msgstr "点击「发布」使其上线，或点击「丢弃」恢复。"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.close"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/auth/device.tsx
 msgid "auth.device.lookup.error.notFound"
 msgstr "未找到代码。请检查它是否与您的 CLI 打印的相符。"
@@ -2240,6 +2245,11 @@ msgstr "名称不能超过 64 个字符。"
 
 #. js-lingui-explicit-id
 #: src/components/shell/command-palette.tsx
+msgid "palette.hint.navigate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
 msgid "palette.group.navigation"
 msgstr ""
 
@@ -3015,9 +3025,19 @@ msgid "form.multiSelect.search"
 msgstr "搜索…"
 
 #. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.loading"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.transport.securityKey"
 msgstr "安全密钥"
+
+#. js-lingui-explicit-id
+#: src/components/shell/command-palette.tsx
+msgid "palette.hint.select"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/multi-reference-picker.tsx

--- a/packages/admin/src/components/shell/command-palette.test.tsx
+++ b/packages/admin/src/components/shell/command-palette.test.tsx
@@ -196,6 +196,17 @@ describe("CommandPalette", () => {
     });
   });
 
+  test("shows a loading indicator while the search query is in flight", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    fireEvent.change(await screen.findByTestId("command-palette-input"), {
+      target: { value: "hello" },
+    });
+
+    // Debounce hasn't elapsed yet — query !== debounced, so it's loading.
+    expect(screen.getByTestId("command-palette-loading")).not.toBeNull();
+  });
+
   test("opens the term editor when a term result is selected", async () => {
     renderPalette(<CommandPalette capabilities={[]} />);
     pressCmdK();
@@ -211,6 +222,28 @@ describe("CommandPalette", () => {
       to: "/terms/$name/$id/edit",
       params: { name: "category", id: 7 },
     });
+  });
+
+  test("opens a content result in a new tab on Cmd/Ctrl+click", async () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+    fireEvent.change(await screen.findByTestId("command-palette-input"), {
+      target: { value: "hello" },
+    });
+
+    fireEvent.click(
+      await screen.findByTestId("command-palette-result-entry:post:1"),
+      { metaKey: true },
+    );
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "/_plumix/admin/entries/posts/1/edit",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(navigate).not.toHaveBeenCalled();
+    openSpy.mockRestore();
   });
 
   test("opens the user editor when a user result is selected", async () => {
@@ -264,6 +297,13 @@ describe("CommandPalette", () => {
     expect(
       screen.queryByTestId("command-palette-command-plugin:secret"),
     ).toBeNull();
+  });
+
+  test("renders a footer with keyboard hints", async () => {
+    renderPalette(<CommandPalette capabilities={[]} />);
+    pressCmdK();
+
+    await screen.findByTestId("command-palette-footer");
   });
 
   test("Escape closes the palette", async () => {

--- a/packages/admin/src/components/shell/command-palette.tsx
+++ b/packages/admin/src/components/shell/command-palette.tsx
@@ -1,7 +1,7 @@
 import type { PaletteCommand } from "@/lib/palette-commands.js";
 import type { MessageDescriptor } from "@lingui/core";
-import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Command,
   CommandEmpty,
@@ -24,6 +24,11 @@ import {
   selectCommands,
 } from "@/lib/palette-commands.js";
 import { paletteNavItems, selectNavItems } from "@/lib/palette-nav.js";
+import {
+  parseGroupKey,
+  resultHref,
+  shouldOpenInNewTab,
+} from "@/lib/palette-result.js";
 import {
   readRecentNav,
   recordRecentNav,
@@ -57,6 +62,13 @@ const M = {
     id: "palette.group.commands",
     message: "Commands",
   }),
+  loading: defineMessage({ id: "palette.loading", message: "Searching…" }),
+  hintNavigate: defineMessage({
+    id: "palette.hint.navigate",
+    message: "Navigate",
+  }),
+  hintSelect: defineMessage({ id: "palette.hint.select", message: "Select" }),
+  hintClose: defineMessage({ id: "palette.hint.close", message: "Close" }),
 } satisfies Record<string, MessageDescriptor>;
 
 // Built-in commands. Distinct from the Navigation group: these are
@@ -115,6 +127,8 @@ export function CommandPalette({
   const [query, setQuery] = useState("");
   const navigate = useNavigate();
   const renderLabel = useLabel();
+  // cmdk's onSelect carries no event; capture the modifier separately.
+  const newTabRef = useRef(false);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
@@ -158,6 +172,11 @@ export function CommandPalette({
       ? selectRecentNavItems(navItems, readRecentNav(), RECENT_LIMIT)
       : [];
   const groups = trimmed.length >= MIN_QUERY_LENGTH ? (search.data ?? []) : [];
+  // Suppress the empty state while debouncing/in flight so "no results"
+  // doesn't flash before the first response lands.
+  const searching =
+    trimmed.length >= MIN_QUERY_LENGTH &&
+    (trimmed !== debounced || search.isFetching);
 
   function dismiss(): void {
     setOpen(false);
@@ -173,10 +192,21 @@ export function CommandPalette({
   // Routes a result to its editor from the group key + id. Each domain
   // owns its route (the server stays admin-route-agnostic).
   function openResult(groupKey: string, id: string): void {
+    // Every select pathway (click capture, Enter keydown) writes the ref
+    // first, so it's never stale here.
+    const newTab = newTabRef.current;
+    newTabRef.current = false;
     dismiss();
-    const sep = groupKey.indexOf(":");
-    const domain = sep === -1 ? groupKey : groupKey.slice(0, sep);
-    const name = groupKey.slice(sep + 1);
+    if (newTab) {
+      const url = resultHref(
+        groupKey,
+        id,
+        (name) => findEntryTypeByName(name)?.adminSlug ?? name,
+      );
+      if (url) window.open(url, "_blank", "noopener,noreferrer");
+      return;
+    }
+    const { domain, name } = parseGroupKey(groupKey);
     switch (domain) {
       case "entry": {
         const slug = findEntryTypeByName(name)?.adminSlug ?? name;
@@ -198,6 +228,12 @@ export function CommandPalette({
     }
   }
 
+  function captureNewTab(
+    event: ReactKeyboardEvent | { metaKey: boolean; ctrlKey: boolean },
+  ): void {
+    newTabRef.current = shouldOpenInNewTab(event);
+  }
+
   return (
     <Dialog
       open={open}
@@ -211,7 +247,13 @@ export function CommandPalette({
         <DialogDescription>{renderLabel(M.description)}</DialogDescription>
       </DialogHeader>
       <DialogContent className="overflow-hidden p-0">
-        <Command shouldFilter={false}>
+        <Command
+          shouldFilter={false}
+          onClickCapture={captureNewTab}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") captureNewTab(event);
+          }}
+        >
           <CommandInput
             value={query}
             onValueChange={setQuery}
@@ -219,7 +261,16 @@ export function CommandPalette({
             placeholder={renderLabel(M.placeholder)}
           />
           <CommandList>
-            <CommandEmpty>{renderLabel(M.empty)}</CommandEmpty>
+            {searching ? (
+              <div
+                data-testid="command-palette-loading"
+                className="text-muted-foreground px-3 py-2 text-sm"
+              >
+                {renderLabel(M.loading)}
+              </div>
+            ) : (
+              <CommandEmpty>{renderLabel(M.empty)}</CommandEmpty>
+            )}
             {recent.length > 0 ? (
               <CommandGroup heading={renderLabel(M.recent)}>
                 {recent.map((item) => (
@@ -291,6 +342,23 @@ export function CommandPalette({
               </CommandGroup>
             ))}
           </CommandList>
+          <div
+            data-testid="command-palette-footer"
+            className="text-muted-foreground flex items-center gap-4 border-t px-3 py-2 text-xs"
+          >
+            <span className="flex items-center gap-1">
+              <kbd>↑↓</kbd>
+              {renderLabel(M.hintNavigate)}
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd>↵</kbd>
+              {renderLabel(M.hintSelect)}
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd>⎋</kbd>
+              {renderLabel(M.hintClose)}
+            </span>
+          </div>
         </Command>
       </DialogContent>
     </Dialog>

--- a/packages/admin/src/lib/palette-result.test.ts
+++ b/packages/admin/src/lib/palette-result.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+
+import { resultHref, shouldOpenInNewTab } from "./palette-result.js";
+
+const slug = (name: string): string => (name === "post" ? "posts" : name);
+
+describe("resultHref", () => {
+  test("builds an entry editor URL using the resolved admin slug", () => {
+    expect(resultHref("entry:post", "1", slug)).toBe(
+      "/_plumix/admin/entries/posts/1/edit",
+    );
+  });
+
+  test("builds a term editor URL", () => {
+    expect(resultHref("term:category", "7", slug)).toBe(
+      "/_plumix/admin/terms/category/7/edit",
+    );
+  });
+
+  test("builds a user editor URL", () => {
+    expect(resultHref("users", "9", slug)).toBe("/_plumix/admin/users/9/edit");
+  });
+
+  test("returns null for an unknown domain", () => {
+    expect(resultHref("widget:thing", "1", slug)).toBeNull();
+  });
+});
+
+describe("shouldOpenInNewTab", () => {
+  test("true when meta or ctrl is held", () => {
+    expect(shouldOpenInNewTab({ metaKey: true, ctrlKey: false })).toBe(true);
+    expect(shouldOpenInNewTab({ metaKey: false, ctrlKey: true })).toBe(true);
+  });
+
+  test("false otherwise", () => {
+    expect(shouldOpenInNewTab({ metaKey: false, ctrlKey: false })).toBe(false);
+  });
+});

--- a/packages/admin/src/lib/palette-result.ts
+++ b/packages/admin/src/lib/palette-result.ts
@@ -1,0 +1,43 @@
+import { ADMIN_BASE_PATH } from "./constants.js";
+
+/** Split a search group key into its domain and remainder (`entry:post`
+ *  → `{ domain: "entry", name: "post" }`; `users` → `{ "users", "" }`). */
+export function parseGroupKey(groupKey: string): {
+  readonly domain: string;
+  readonly name: string;
+} {
+  const sep = groupKey.indexOf(":");
+  return sep === -1
+    ? { domain: groupKey, name: "" }
+    : { domain: groupKey.slice(0, sep), name: groupKey.slice(sep + 1) };
+}
+
+/** Full admin URL for a content result, for opening in a new tab. Mirrors
+ *  the in-app routes; `null` for an unroutable domain. `resolveSlug` maps
+ *  an entry-type name to its admin slug. Segments are encoded to match the
+ *  router's encoding on the SPA path. */
+export function resultHref(
+  groupKey: string,
+  id: string,
+  resolveSlug: (name: string) => string,
+): string | null {
+  const { domain, name } = parseGroupKey(groupKey);
+  const eid = encodeURIComponent(id);
+  switch (domain) {
+    case "entry":
+      return `${ADMIN_BASE_PATH}/entries/${encodeURIComponent(resolveSlug(name))}/${eid}/edit`;
+    case "term":
+      return `${ADMIN_BASE_PATH}/terms/${encodeURIComponent(name)}/${eid}/edit`;
+    case "users":
+      return `${ADMIN_BASE_PATH}/users/${eid}/edit`;
+    default:
+      return null;
+  }
+}
+
+export function shouldOpenInNewTab(event: {
+  readonly metaKey: boolean;
+  readonly ctrlKey: boolean;
+}): boolean {
+  return event.metaKey || event.ctrlKey;
+}

--- a/tooling/eslint/i18n.ts
+++ b/tooling/eslint/i18n.ts
@@ -357,6 +357,9 @@ export const i18nStrictOverrides: Linter.Config = {
           "URLSearchParams",
           "Symbol",
           "fetch",
+          // `window.open(url, target, features)` — all args are protocol
+          // values (URL, "_blank", "noopener"), never UI copy.
+          "window.open",
           // DOM queries — id / selector args, never user copy.
           "document.getElementById",
           "document.querySelectorAll",


### PR DESCRIPTION
Three refinements to the command palette, completing the
navigation-findability work (alongside nav keyword aliases and the
Recent group).

**Open in a new tab**

Content results (entries, terms, users) open in a new tab on
Cmd/Ctrl+click or Cmd/Ctrl+Enter. cmdk's `onSelect` carries no event and
it overrides item `onClick`, so the modifier is captured on the command
root (click-capture + Enter keydown) into a ref that `openResult` reads —
`window.open`-ing the built editor URL instead of navigating in place.
URLs are built from `ADMIN_BASE_PATH` and encoded to match the router.

**Loading indicator**

A loading row shows while the query is debouncing or the request is in
flight, and it suppresses the empty state so "no results" no longer
flashes before the first response lands.

**Footer hints**

A footer surfaces the universal keyboard hints — navigate / select /
close.

Closes GH-923