### PR TITLE
refactor(core): extract transport-neutral entries read service

### DIFF
--- a/packages/core/src/entries/errors.ts
+++ b/packages/core/src/entries/errors.ts
@@ -1,0 +1,42 @@
+/**
+ * Domain error the entries read service throws. The `data` discriminant carries
+ * exactly what each transport needs to render it — oRPC maps it to a typed error
+ * via {@link toRpcEntryReadError}. Mirrors the per-domain error pattern in
+ * `src/revisions/errors.ts`.
+ */
+export class EntryReadError extends Error {
+  static {
+    EntryReadError.prototype.name = "EntryReadError";
+  }
+
+  readonly data:
+    | { readonly code: "not_found"; readonly entryId: number }
+    | { readonly code: "forbidden"; readonly capability: string }
+    | { readonly code: "reserved_type" };
+
+  private constructor(data: EntryReadError["data"], message: string) {
+    super(message);
+    this.data = data;
+  }
+
+  static notFound(entryId: number): EntryReadError {
+    return new EntryReadError(
+      { code: "not_found", entryId },
+      `entry ${entryId} not found`,
+    );
+  }
+
+  static forbidden(capability: string): EntryReadError {
+    return new EntryReadError(
+      { code: "forbidden", capability },
+      `missing capability: ${capability}`,
+    );
+  }
+
+  static reservedType(type: string): EntryReadError {
+    return new EntryReadError(
+      { code: "reserved_type" },
+      `reserved entry type: ${type}`,
+    );
+  }
+}

--- a/packages/core/src/entries/read-service.test.ts
+++ b/packages/core/src/entries/read-service.test.ts
@@ -1,0 +1,219 @@
+import * as v from "valibot";
+import { describe, expect, test } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import type { AuthenticatedRpcHarness } from "../test/rpc.js";
+import { withUser } from "../context/app.js";
+import { entryTerm } from "../db/schema/entry_term.js";
+import { terms } from "../db/schema/terms.js";
+import {
+  entryGetInputSchema,
+  entryListInputSchema,
+} from "../rpc/procedures/entry/schemas.js";
+import { createRpcHarness } from "../test/rpc.js";
+import { EntryReadError } from "./errors.js";
+import { getEntry, listEntries } from "./read-service.js";
+
+function authedCtx(h: AuthenticatedRpcHarness): AppContext {
+  return withUser(h.context, h.user, null);
+}
+
+const listInput = (partial: Record<string, unknown> = {}) =>
+  v.parse(entryListInputSchema, partial);
+const getInput = (partial: Record<string, unknown>) =>
+  v.parse(entryGetInputSchema, partial);
+
+describe("listEntries", () => {
+  test("clamps a subscriber to published entries by default", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "pub" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "draft" });
+
+    const rows = await listEntries(authedCtx(h), listInput());
+
+    expect(rows.map((r) => r.slug)).toEqual(["pub"]);
+  });
+
+  test("lets an editor filter to drafts", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "pub" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "draft" });
+
+    const rows = await listEntries(
+      authedCtx(h),
+      listInput({ status: "draft" }),
+    );
+
+    expect(rows.map((r) => r.slug)).toEqual(["draft"]);
+  });
+
+  test("excludes trash from an editor's default view", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({ authorId: h.user.id, slug: "pub" });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      slug: "gone",
+      status: "trash",
+    });
+
+    const rows = await listEntries(authedCtx(h), listInput());
+
+    expect(rows.map((r) => r.slug)).toEqual(["pub"]);
+  });
+
+  test("silently clamps — a subscriber asking for drafts gets an empty list", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    await h.factory.draft.create({ authorId: h.user.id, slug: "secret" });
+
+    const rows = await listEntries(
+      authedCtx(h),
+      listInput({ status: "draft" }),
+    );
+
+    expect(rows).toEqual([]);
+  });
+
+  test("narrows by free-text search across title", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "a",
+      title: "Hello world",
+    });
+    await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "b",
+      title: "Something else",
+    });
+
+    const rows = await listEntries(
+      authedCtx(h),
+      listInput({ search: "hello" }),
+    );
+
+    expect(rows.map((r) => r.slug)).toEqual(["a"]);
+  });
+
+  test("paginates with limit + offset on a stable order", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    for (const slug of ["a", "b", "c"]) {
+      await h.factory.published.create({ authorId: h.user.id, slug });
+    }
+
+    const page = await listEntries(
+      authedCtx(h),
+      listInput({ orderBy: "title", order: "asc", limit: 1, offset: 1 }),
+    );
+
+    expect(page).toHaveLength(1);
+  });
+
+  test("throws forbidden when the caller can't read the type", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+
+    const error = await listEntries(
+      authedCtx(h),
+      listInput({ type: "secret" }),
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(EntryReadError);
+    expect(error).toMatchObject({
+      data: { code: "forbidden", capability: "entry:secret:read" },
+    });
+  });
+
+  test("throws reserved_type for revision/autosave rows", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+
+    const error = await listEntries(
+      authedCtx(h),
+      listInput({ type: "revision" }),
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(EntryReadError);
+    expect(error).toMatchObject({ data: { code: "reserved_type" } });
+  });
+});
+
+describe("getEntry", () => {
+  test("returns a published entry hydrated with meta + terms", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const entry = await h.factory.published.create({
+      authorId: h.user.id,
+      slug: "pub",
+    });
+    const [term] = await h.context.db
+      .insert(terms)
+      .values({ taxonomy: "category", name: "News", slug: "news" })
+      .returning();
+    if (!term) throw new Error("seed: term insert returned no row");
+    await h.context.db
+      .insert(entryTerm)
+      .values({ entryId: entry.id, termId: term.id });
+
+    const result = await getEntry(authedCtx(h), getInput({ id: entry.id }));
+
+    expect(result.slug).toBe("pub");
+    expect(result.meta).toEqual({});
+    expect(result.terms).toEqual({ category: [term.id] });
+  });
+
+  test("throws not_found for a missing id", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+
+    const error = await getEntry(authedCtx(h), getInput({ id: 9999 })).catch(
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(EntryReadError);
+    expect(error).toMatchObject({ data: { code: "not_found", entryId: 9999 } });
+  });
+
+  test("hides a draft from a subscriber as not_found, not forbidden", async () => {
+    const h = await createRpcHarness({ authAs: "subscriber" });
+    const draft = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "secret",
+    });
+
+    const error = await getEntry(
+      authedCtx(h),
+      getInput({ id: draft.id }),
+    ).catch((e: unknown) => e);
+
+    expect(error).toMatchObject({ data: { code: "not_found" } });
+  });
+
+  test("lets an editor read any draft", async () => {
+    const h = await createRpcHarness({ authAs: "editor" });
+    const draft = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "wip",
+    });
+
+    const result = await getEntry(authedCtx(h), getInput({ id: draft.id }));
+
+    expect(result.slug).toBe("wip");
+  });
+
+  test("lets an author read their own draft but hides others'", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const other = await h.factory.user.create({ role: "author" });
+    const mine = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "mine",
+    });
+    const theirs = await h.factory.draft.create({
+      authorId: other.id,
+      slug: "theirs",
+    });
+
+    const ctx = authedCtx(h);
+    await expect(
+      getEntry(ctx, getInput({ id: mine.id })),
+    ).resolves.toMatchObject({ slug: "mine" });
+    await expect(
+      getEntry(ctx, getInput({ id: theirs.id })),
+    ).rejects.toMatchObject({ data: { code: "not_found" } });
+  });
+});

--- a/packages/core/src/entries/read-service.ts
+++ b/packages/core/src/entries/read-service.ts
@@ -1,0 +1,202 @@
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
+
+import type { AppContext } from "../context/app.js";
+import type { SQL } from "../db/index.js";
+import type { Entry, EntryStatus } from "../db/schema/entries.js";
+import type {
+  EntryGetInput,
+  EntryListInput,
+  EntryListOrderColumn,
+} from "../rpc/procedures/entry/schemas.js";
+import type { SearchTerm } from "../rpc/procedures/entry/search-terms.js";
+import { and, asc, desc, eq, inArray, isNull, not, sql } from "../db/index.js";
+import { entries } from "../db/schema/entries.js";
+import { entryTerm } from "../db/schema/entry_term.js";
+import { terms } from "../db/schema/terms.js";
+import { isReservedType } from "../revisions/slug-codec.js";
+import { entryCapability } from "../rpc/procedures/entry/lifecycle.js";
+import { decodeMetaBag } from "../rpc/procedures/entry/meta.js";
+import {
+  escapeLikePattern,
+  tokenizeSearchQuery,
+} from "../rpc/procedures/entry/search-terms.js";
+import { loadEntryTerms } from "../rpc/procedures/entry/terms.js";
+import { EntryReadError } from "./errors.js";
+
+const PUBLIC_STATUS: EntryStatus = "published";
+const TRASH_STATUS: EntryStatus = "trash";
+
+type EntryRead = Omit<Entry, "meta"> & {
+  readonly meta: Record<string, unknown>;
+  readonly terms: Record<string, number[]>;
+};
+
+/**
+ * List entries of a type, clamped to what the caller may see. Capability checks
+ * and status clamping live here so every transport (oRPC, MCP) reads through
+ * the same policy. Throws {@link EntryReadError} for reserved types and missing
+ * read capability; an explicit request for statuses the caller can't see
+ * returns an empty list rather than erroring (matches WP's silent admin filter).
+ */
+export async function listEntries(
+  ctx: AppContext,
+  input: EntryListInput,
+): Promise<readonly Entry[]> {
+  const type = input.type ?? "post";
+  if (isReservedType(type)) throw EntryReadError.reservedType(type);
+  const readCapability = entryCapability(type, "read");
+  if (!ctx.auth.can(readCapability)) {
+    throw EntryReadError.forbidden(readCapability);
+  }
+
+  const canSeeAnyStatus = ctx.auth.can(entryCapability(type, "edit_any"));
+  const statusClause = resolveStatusClause(input.status, canSeeAnyStatus);
+  if (statusClause === "forbidden") return [];
+
+  const conditions: SQL[] = [eq(entries.type, type), statusClause];
+  if (input.authorId !== undefined) {
+    conditions.push(eq(entries.authorId, input.authorId));
+  }
+  if (input.parentId === null) {
+    conditions.push(isNull(entries.parentId));
+  } else if (input.parentId !== undefined) {
+    conditions.push(eq(entries.parentId, input.parentId));
+  }
+  if (input.search) {
+    for (const term of tokenizeSearchQuery(input.search)) {
+      conditions.push(searchTermCondition(term));
+    }
+  }
+  if (input.termTaxonomies) {
+    for (const [termTaxonomy, slugs] of Object.entries(input.termTaxonomies)) {
+      if (slugs.length === 0) continue;
+      // Correlated subquery: entries.id must appear in `entry_term` joined to
+      // `terms` filtered by this taxonomy + listed slugs. One clause per
+      // taxonomy; multiple clauses AND together — WP's default `tax_query`.
+      const matching = ctx.db
+        .select({ entryId: entryTerm.entryId })
+        .from(entryTerm)
+        .innerJoin(terms, eq(terms.id, entryTerm.termId))
+        .where(
+          and(
+            eq(terms.taxonomy, termTaxonomy),
+            inArray(terms.slug, [...slugs]),
+          ),
+        );
+      conditions.push(inArray(entries.id, matching));
+    }
+  }
+
+  const orderCol = ORDER_COLUMNS[input.orderBy];
+  const primary = input.order === "asc" ? asc(orderCol) : desc(orderCol);
+  // `entries.id` is always a desc tiebreaker — pagination must be stable
+  // across ties on the user-selected order column.
+  return ctx.db
+    .select()
+    .from(entries)
+    .where(and(...conditions))
+    .orderBy(primary, desc(entries.id))
+    .limit(input.limit)
+    .offset(input.offset);
+}
+
+/**
+ * Read a single entry by id, hydrated with meta + terms. Every condition that
+ * would reveal an entry the caller can't see — missing, reserved-type, no read
+ * capability, or an unpublished status they can't view — collapses to
+ * `not_found` so existence stays hidden. Preview/autosave overlay is an editor
+ * concern and lives in the oRPC adapter, not here.
+ */
+export async function getEntry(
+  ctx: AppContext,
+  input: EntryGetInput,
+): Promise<EntryRead> {
+  const row = await ctx.db.query.entries.findFirst({
+    where: eq(entries.id, input.id),
+  });
+  if (!row) throw EntryReadError.notFound(input.id);
+  if (isReservedType(row.type)) throw EntryReadError.notFound(input.id);
+  if (!ctx.auth.can(entryCapability(row.type, "read"))) {
+    throw EntryReadError.notFound(input.id);
+  }
+
+  if (row.status !== PUBLIC_STATUS) {
+    const canSeeAny = ctx.auth.can(entryCapability(row.type, "edit_any"));
+    const ownsAndCanEdit =
+      row.authorId === ctx.user?.id &&
+      ctx.auth.can(entryCapability(row.type, "edit_own"));
+    if (!canSeeAny && !ownsAndCanEdit) throw EntryReadError.notFound(input.id);
+  }
+
+  const meta = decodeMetaBag(ctx.plugins, row, row.meta);
+  const entryTerms = await loadEntryTerms(ctx, row.id);
+  return { ...row, meta, terms: entryTerms };
+}
+
+// Kept here, not in schemas.ts, so schemas.ts stays free of drizzle imports.
+const ORDER_COLUMNS: Record<EntryListOrderColumn, AnySQLiteColumn> = {
+  updated_at: entries.updatedAt,
+  published_at: entries.publishedAt,
+  title: entries.title,
+  sort_order: entries.sortOrder,
+};
+
+type StatusInput =
+  | EntryStatus
+  | readonly (EntryStatus | undefined)[]
+  | undefined;
+
+/**
+ * Resolve the caller's `status` input into a WHERE clause, honoring the
+ * capability check.
+ *
+ * - Can see any status + `undefined` → exclude trash (WP "All" tab).
+ * - Can see any status + explicit list/string → match as given.
+ * - Cannot see any status → pin to `published`; if they asked for anything
+ *   else, return "forbidden" so the caller yields an empty result (not a 403 —
+ *   WP's admin also silently filters).
+ */
+function resolveStatusClause(
+  input: StatusInput,
+  canSeeAnyStatus: boolean,
+): SQL | "forbidden" {
+  const normalized = normalizeStatusInput(input);
+
+  if (!canSeeAnyStatus) {
+    if (normalized === undefined) return eq(entries.status, PUBLIC_STATUS);
+    if (normalized.length === 1 && normalized[0] === PUBLIC_STATUS) {
+      return eq(entries.status, PUBLIC_STATUS);
+    }
+    return "forbidden";
+  }
+
+  if (normalized === undefined) return not(eq(entries.status, TRASH_STATUS));
+  const [only, ...rest] = normalized;
+  if (only !== undefined && rest.length === 0) return eq(entries.status, only);
+  return inArray(entries.status, normalized);
+}
+
+// Collapse the valibot-widened input into a non-empty list or `undefined`.
+function normalizeStatusInput(
+  input: StatusInput,
+): readonly EntryStatus[] | undefined {
+  if (input === undefined) return undefined;
+  const list = Array.isArray(input)
+    ? input.filter((s): s is EntryStatus => s !== undefined)
+    : [input as EntryStatus];
+  return list.length === 0 ? undefined : list;
+}
+
+// One search term → `(title LIKE ? OR content LIKE ? OR excerpt LIKE ?)`
+// against an explicit ESCAPE char so literal `%` / `_` in user input don't
+// match-all. Excluded (`-term`) wraps the OR in `NOT (…)`. COALESCE handles
+// nullable columns so null behaves as empty text across both clause polarities.
+function searchTermCondition(term: SearchTerm): SQL {
+  const pattern = `%${escapeLikePattern(term.value)}%`;
+  const match = sql`(
+    COALESCE(${entries.title}, '') LIKE ${pattern} ESCAPE '\\'
+    OR COALESCE(${entries.content}, '') LIKE ${pattern} ESCAPE '\\'
+    OR COALESCE(${entries.excerpt}, '') LIKE ${pattern} ESCAPE '\\'
+  )`;
+  return term.exclude ? not(match) : match;
+}

--- a/packages/core/src/rpc/procedures/entry/get.ts
+++ b/packages/core/src/rpc/procedures/entry/get.ts
@@ -1,13 +1,11 @@
-import { eq } from "../../../db/index.js";
-import { entries } from "../../../db/schema/entries.js";
+import { getEntry } from "../../../entries/read-service.js";
 import { getAutosave } from "../../../revisions/repository.js";
-import { isReservedType } from "../../../revisions/slug-codec.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
 import { entryCapability } from "./lifecycle.js";
 import { decodeMetaBag } from "./meta.js";
+import { toRpcEntryReadError } from "./read-errors.js";
 import { entryGetInputSchema } from "./schemas.js";
-import { loadEntryTerms } from "./terms.js";
 
 export const get = base
   .use(authenticated)
@@ -18,81 +16,49 @@ export const get = base
       input,
     );
 
-    const row = await context.db.query.entries.findFirst({
-      where: eq(entries.id, filtered.id),
-    });
-    if (!row) {
-      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
-    }
-    // Reserved-type rows (revisions, autosaves) surface through their
-    // dedicated endpoints only — their existence here shouldn't be
-    // observable, so 404 (not BAD_REQUEST).
-    if (isReservedType(row.type)) {
-      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
-    }
-
-    if (!context.auth.can(entryCapability(row.type, "read"))) {
-      throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
-    }
-
-    if (row.status !== "published") {
-      const canSeeAny = context.auth.can(entryCapability(row.type, "edit_any"));
-      const ownsAndCanEdit =
-        row.authorId === context.user.id &&
-        context.auth.can(entryCapability(row.type, "edit_own"));
-      if (!canSeeAny && !ownsAndCanEdit) {
-        throw errors.NOT_FOUND({ data: { kind: "entry", id: filtered.id } });
+    try {
+      const live = await getEntry(context, filtered);
+      if (!filtered.preview) {
+        return await context.hooks.applyFilter("rpc:entry.get:output", live);
       }
-    }
 
-    // Preview mode: overlay the caller's autosave (if any) onto the
-    // live row's read fields, leaving `id` / `slug` / `parentId` /
-    // `authorId` / `updatedAt` / `createdAt` etc. anchored to live.
-    // Gated by edit_own / edit_any because previewing a pending draft
-    // is an editor concern.
-    if (filtered.preview) {
-      const canSeeAny = context.auth.can(entryCapability(row.type, "edit_any"));
+      // Preview mode: overlay the caller's autosave (if any) onto the live
+      // row's read fields. Gated by edit_own / edit_any because previewing a
+      // pending draft is an editor concern.
+      const canSeeAny = context.auth.can(
+        entryCapability(live.type, "edit_any"),
+      );
       const ownsAndCanEdit =
-        row.authorId === context.user.id &&
-        context.auth.can(entryCapability(row.type, "edit_own"));
+        live.authorId === context.user.id &&
+        context.auth.can(entryCapability(live.type, "edit_own"));
       if (!canSeeAny && !ownsAndCanEdit) {
         throw errors.FORBIDDEN({
-          data: { capability: entryCapability(row.type, "edit_own") },
+          data: { capability: entryCapability(live.type, "edit_own") },
         });
       }
+
       const autosave = await getAutosave(context.db, {
-        entryId: row.id,
+        entryId: live.id,
         authorId: context.user.id,
       });
-      const source: "autosave" | "live" = autosave ? "autosave" : "live";
       const overlaid = autosave
         ? {
-            ...row,
+            ...live,
             title: autosave.title,
             content: autosave.content,
             excerpt: autosave.excerpt,
-            meta: autosave.meta,
+            meta: decodeMetaBag(context.plugins, live, autosave.meta),
           }
-        : row;
-      const meta = decodeMetaBag(context.plugins, overlaid, overlaid.meta);
-      const terms = await loadEntryTerms(context, row.id);
-      return context.hooks.applyFilter("rpc:entry.get:output", {
+        : live;
+      return await context.hooks.applyFilter("rpc:entry.get:output", {
         ...overlaid,
-        meta,
-        terms,
         _preview: {
-          source,
+          source: autosave ? ("autosave" as const) : ("live" as const),
           autosaveUpdatedAt: autosave?.updatedAt ?? null,
-          liveUpdatedAt: row.updatedAt,
+          liveUpdatedAt: live.updatedAt,
         },
       });
+    } catch (error) {
+      throw toRpcEntryReadError(error, errors);
     }
-
-    const meta = decodeMetaBag(context.plugins, row, row.meta);
-    const terms = await loadEntryTerms(context, row.id);
-    return context.hooks.applyFilter("rpc:entry.get:output", {
-      ...row,
-      meta,
-      terms,
-    });
   });

--- a/packages/core/src/rpc/procedures/entry/list.ts
+++ b/packages/core/src/rpc/procedures/entry/list.ts
@@ -1,30 +1,8 @@
-import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
-
-import type { SQL } from "../../../db/index.js";
-import type { Entry, EntryStatus } from "../../../db/schema/entries.js";
-import type { EntryListOrderColumn } from "./schemas.js";
-import type { SearchTerm } from "./search-terms.js";
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  inArray,
-  isNull,
-  not,
-  sql,
-} from "../../../db/index.js";
-import { entries } from "../../../db/schema/entries.js";
-import { entryTerm } from "../../../db/schema/entry_term.js";
-import { terms } from "../../../db/schema/terms.js";
-import { isReservedType } from "../../../revisions/slug-codec.js";
+import { listEntries } from "../../../entries/read-service.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
-import { entryCapability } from "./lifecycle.js";
+import { toRpcEntryReadError } from "./read-errors.js";
 import { entryListInputSchema } from "./schemas.js";
-import { escapeLikePattern, tokenizeSearchQuery } from "./search-terms.js";
-
-const PUBLIC_STATUS: EntryStatus = "published";
 
 export const list = base
   .use(authenticated)
@@ -34,159 +12,10 @@ export const list = base
       "rpc:entry.list:input",
       input,
     );
-
-    const type = filtered.type ?? "post";
-    if (isReservedType(type)) {
-      throw errors.BAD_REQUEST({ data: { reason: "reserved_type" } });
+    try {
+      const rows = await listEntries(context, filtered);
+      return await context.hooks.applyFilter("rpc:entry.list:output", rows);
+    } catch (error) {
+      throw toRpcEntryReadError(error, errors);
     }
-    const readCapability = entryCapability(type, "read");
-    if (!context.auth.can(readCapability)) {
-      throw errors.FORBIDDEN({ data: { capability: readCapability } });
-    }
-
-    const canSeeAnyStatus = context.auth.can(entryCapability(type, "edit_any"));
-    const statusClause = resolveStatusClause(filtered.status, canSeeAnyStatus);
-    if (statusClause === "forbidden") {
-      return context.hooks.applyFilter(
-        "rpc:entry.list:output",
-        [] as readonly Entry[],
-      );
-    }
-
-    const conditions: SQL[] = [eq(entries.type, type)];
-    conditions.push(statusClause);
-    if (filtered.authorId !== undefined) {
-      conditions.push(eq(entries.authorId, filtered.authorId));
-    }
-    if (filtered.parentId === null) {
-      conditions.push(isNull(entries.parentId));
-    } else if (filtered.parentId !== undefined) {
-      conditions.push(eq(entries.parentId, filtered.parentId));
-    }
-    if (filtered.search) {
-      for (const term of tokenizeSearchQuery(filtered.search)) {
-        conditions.push(searchTermCondition(term));
-      }
-    }
-    if (filtered.termTaxonomies) {
-      for (const [termTaxonomy, slugs] of Object.entries(
-        filtered.termTaxonomies,
-      )) {
-        if (slugs.length === 0) continue;
-        // Correlated subquery: entries.id must appear in `entry_term` joined
-        // to `terms` filtered by this termTaxonomy + listed slugs. One clause
-        // per termTaxonomy; multiple clauses AND together — matching WP's
-        // default `tax_query` relation.
-        const matching = context.db
-          .select({ entryId: entryTerm.entryId })
-          .from(entryTerm)
-          .innerJoin(terms, eq(terms.id, entryTerm.termId))
-          .where(
-            and(
-              eq(terms.taxonomy, termTaxonomy),
-              inArray(terms.slug, [...slugs]),
-            ),
-          );
-        conditions.push(inArray(entries.id, matching));
-      }
-    }
-
-    const orderCol = ORDER_COLUMNS[filtered.orderBy];
-    const primary = filtered.order === "asc" ? asc(orderCol) : desc(orderCol);
-    // `entries.id` is always a desc tiebreaker — pagination must be stable
-    // across ties on the user-selected order column.
-    const rows = await context.db
-      .select()
-      .from(entries)
-      .where(and(...conditions))
-      .orderBy(primary, desc(entries.id))
-      .limit(filtered.limit)
-      .offset(filtered.offset);
-
-    return context.hooks.applyFilter("rpc:entry.list:output", rows);
   });
-
-// Whitelist map from wire-level column names to drizzle column refs.
-// Keeping it here (not in schemas.ts) lets schemas.ts stay runtime-free of
-// drizzle imports.
-const ORDER_COLUMNS: Record<EntryListOrderColumn, AnySQLiteColumn> = {
-  updated_at: entries.updatedAt,
-  published_at: entries.publishedAt,
-  title: entries.title,
-  sort_order: entries.sortOrder,
-};
-
-const TRASH_STATUS: EntryStatus = "trash";
-
-/**
- * Resolve the caller's `status` input into a WHERE clause, honoring the
- * capability check.
- *
- * - User can see any status + `undefined` → exclude trash (WP "All" tab).
- * - User can see any status + explicit list/string → match as given.
- * - User cannot see any status → pin to `published`; if they asked for
- *   anything else, short-circuit with "forbidden" so the caller returns
- *   an empty result (not a 403 — WP's admin also silently filters).
- *
- * Input type is what valibot's `v.union([picklist, v.array(picklist)])`
- * produces — the array inner type widens to `EntryStatus | undefined`
- * through valibot's pipe, so we filter at the boundary.
- */
-type StatusInput =
-  | EntryStatus
-  | readonly (EntryStatus | undefined)[]
-  | undefined;
-
-function resolveStatusClause(
-  input: StatusInput,
-  canSeeAnyStatus: boolean,
-): SQL | "forbidden" {
-  const normalized = normalizeStatusInput(input);
-
-  if (!canSeeAnyStatus) {
-    if (normalized === undefined) return eq(entries.status, PUBLIC_STATUS);
-    if (normalized.length === 1 && normalized[0] === PUBLIC_STATUS) {
-      return eq(entries.status, PUBLIC_STATUS);
-    }
-    return "forbidden";
-  }
-
-  if (normalized === undefined) return not(eq(entries.status, TRASH_STATUS));
-  const [only, ...rest] = normalized;
-  if (only !== undefined && rest.length === 0) return eq(entries.status, only);
-  return inArray(entries.status, normalized);
-}
-
-// Collapse the valibot-widened input into a non-empty list or `undefined`.
-// `v.minLength(1)` on the array schema blocks empty-array input at the
-// boundary, but defend here too so the resolver's contract is explicit.
-function normalizeStatusInput(
-  input: StatusInput,
-): readonly EntryStatus[] | undefined {
-  if (input === undefined) return undefined;
-  const list = Array.isArray(input)
-    ? input.filter((s): s is EntryStatus => s !== undefined)
-    : [input as EntryStatus];
-  return list.length === 0 ? undefined : list;
-}
-
-// One search term → `(title LIKE ? OR content LIKE ? OR excerpt LIKE ?)`
-// against an explicit ESCAPE char so literal `%` / `_` in user input don't
-// match-all. Excluded (`-term`) wraps the OR in `NOT (…)`.
-//
-// `content` and `excerpt` are nullable; `LIKE` on NULL yields NULL, which
-// is falsy for inclusion matches but becomes `NOT NULL` → still NULL → a
-// false-negative for exclusion. COALESCE to empty string so null columns
-// behave as empty text across both positive and negative clauses.
-function searchTermCondition(term: SearchTerm): SQL {
-  const pattern = `%${escapeLikePattern(term.value)}%`;
-  // Build the column OR via the raw `sql` tag — `or(...)` returns
-  // `SQL | undefined`, which fights both lint rules on non-null assertion
-  // style. The sql-tag form has the same parameterization guarantees.
-  const match = sql`(
-    COALESCE(${entries.title}, '') LIKE ${pattern} ESCAPE '\\'
-    OR COALESCE(${entries.content}, '') LIKE ${pattern} ESCAPE '\\'
-    OR COALESCE(${entries.excerpt}, '') LIKE ${pattern} ESCAPE '\\'
-  )`;
-  return term.exclude ? not(match) : match;
-}

--- a/packages/core/src/rpc/procedures/entry/read-errors.test.ts
+++ b/packages/core/src/rpc/procedures/entry/read-errors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+
+import type { EntryReadErrorConstructors } from "./read-errors.js";
+import { EntryReadError } from "../../../entries/errors.js";
+import { toRpcEntryReadError } from "./read-errors.js";
+
+// Stub the oRPC typed-error constructors: each records the code it stands for
+// plus the data it was handed, so the test asserts the mapping without oRPC.
+function stubErrors(): EntryReadErrorConstructors {
+  const make =
+    (mappedCode: string) =>
+    (opts: { data: Record<string, unknown> }): Error =>
+      Object.assign(new Error(mappedCode), { mappedCode, data: opts.data });
+  return {
+    NOT_FOUND: make("NOT_FOUND"),
+    FORBIDDEN: make("FORBIDDEN"),
+    BAD_REQUEST: make("BAD_REQUEST"),
+  };
+}
+
+describe("toRpcEntryReadError", () => {
+  test("maps not_found to NOT_FOUND carrying the entry id", () => {
+    const mapped = toRpcEntryReadError(
+      EntryReadError.notFound(42),
+      stubErrors(),
+    );
+    expect(mapped).toMatchObject({
+      mappedCode: "NOT_FOUND",
+      data: { kind: "entry", id: 42 },
+    });
+  });
+
+  test("maps forbidden to FORBIDDEN carrying the capability", () => {
+    const mapped = toRpcEntryReadError(
+      EntryReadError.forbidden("entry:post:read"),
+      stubErrors(),
+    );
+    expect(mapped).toMatchObject({
+      mappedCode: "FORBIDDEN",
+      data: { capability: "entry:post:read" },
+    });
+  });
+
+  test("maps reserved_type to BAD_REQUEST", () => {
+    const mapped = toRpcEntryReadError(
+      EntryReadError.reservedType("revision"),
+      stubErrors(),
+    );
+    expect(mapped).toMatchObject({
+      mappedCode: "BAD_REQUEST",
+      data: { reason: "reserved_type" },
+    });
+  });
+
+  test("passes a non-domain error through unchanged", () => {
+    const original = new Error("boom");
+    expect(toRpcEntryReadError(original, stubErrors())).toBe(original);
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/read-errors.ts
+++ b/packages/core/src/rpc/procedures/entry/read-errors.ts
@@ -1,0 +1,35 @@
+import { EntryReadError } from "../../../entries/errors.js";
+
+/**
+ * The subset of oRPC typed-error constructors the entries read path maps onto.
+ * Structural so the mapper is unit-testable with a plain stub — no oRPC runtime.
+ */
+export interface EntryReadErrorConstructors {
+  NOT_FOUND(opts: { data: { kind: string; id: number | string } }): Error;
+  FORBIDDEN(opts: { data: { capability: string } }): Error;
+  BAD_REQUEST(opts: { data: { reason: string } }): Error;
+}
+
+/**
+ * Translate an entries-read domain error into the oRPC typed error to throw,
+ * preserving the wire contract the SPA already handles. Non-domain errors pass
+ * through unchanged for the caller to rethrow.
+ */
+export function toRpcEntryReadError(
+  error: unknown,
+  errors: EntryReadErrorConstructors,
+): unknown {
+  if (!(error instanceof EntryReadError)) return error;
+  switch (error.data.code) {
+    case "not_found":
+      return errors.NOT_FOUND({
+        data: { kind: "entry", id: error.data.entryId },
+      });
+    case "forbidden":
+      return errors.FORBIDDEN({
+        data: { capability: error.data.capability },
+      });
+    case "reserved_type":
+      return errors.BAD_REQUEST({ data: { reason: "reserved_type" } });
+  }
+}


### PR DESCRIPTION
Extract the `entry.list` / `entry.get` read logic out of the fat oRPC procedures into a transport-neutral service so oRPC and the upcoming MCP read tools call one tested unit instead of duplicating policy. This is the keystone refactor the MCP content tools (#933) build on.

**One read policy, two transports**

`listEntries` / `getEntry` live in a new `src/entries/` module and own the capability checks and status clamping. They throw an `EntryReadError` domain-error taxonomy; each transport maps it to its own shape. The oRPC procedures become thin adapters — apply their input/output filter hooks, call the service, and translate domain errors to oRPC typed errors through a pure mapper (`toRpcEntryReadError`). The autosave/preview overlay stays in the `get` adapter since it's an editor concern, not a read primitive.

**Behavior is unchanged**

The existing 34-test integration suite (`entry/read.test.ts`) passes untouched — it's the equivalence net proving the extraction changed nothing observable, including the preview path's NOT_FOUND-vs-FORBIDDEN split and the autosave-overlay shape.

**Tested at the right seams**

The service has direct unit tests (capability clamp, silent-empty filtering, `not_found` vs `forbidden`, own-vs-others drafts) and the error mapper is unit-tested in isolation against a stub `errors` object. Because the service is the tested source of truth, #933's MCP tools can mock it and only test their own envelope wiring.

Refs #932