### PR TITLE
feat(core): add content_list + content_get MCP tools

### DIFF
--- a/packages/core/src/mcp/content-tools.ts
+++ b/packages/core/src/mcp/content-tools.ts
@@ -1,0 +1,71 @@
+import * as v from "valibot";
+
+import type { McpTool } from "./tool.js";
+import { EntryReadError } from "../entries/errors.js";
+import { getEntry, listEntries } from "../entries/read-service.js";
+import { entryListInputSchema } from "../rpc/procedures/entry/schemas.js";
+import { idParam } from "../rpc/validation.js";
+import { McpToolError } from "./errors.js";
+
+// Curated read surface: the entries list shape minus the admin-shaped filters
+// (author / parent / taxonomy). Picked from the canonical schema so validation
+// and the advertised JSON Schema can't drift from it.
+const contentListInputSchema = v.pick(entryListInputSchema, [
+  "type",
+  "status",
+  "search",
+  "orderBy",
+  "order",
+  "limit",
+  "offset",
+]);
+
+const contentGetInputSchema = v.object({
+  type: v.pipe(v.string(), v.description("Entry type the id must belong to.")),
+  id: idParam,
+});
+
+function asMcpToolError(error: unknown): McpToolError {
+  if (!(error instanceof EntryReadError)) throw error;
+  switch (error.data.code) {
+    case "not_found":
+      return McpToolError.notFound(error.message);
+    case "forbidden":
+      return McpToolError.forbidden(error.message);
+    case "reserved_type":
+      return McpToolError.badInput(error.message);
+  }
+}
+
+export const contentListTool: McpTool<typeof contentListInputSchema> = {
+  name: "content_list",
+  description:
+    "List entries of a type, filtered by status/search and ordered/paginated. Results are clamped to what your token may read.",
+  inputSchema: contentListInputSchema,
+  async run(ctx, input) {
+    try {
+      return await listEntries(ctx, input);
+    } catch (error) {
+      throw asMcpToolError(error);
+    }
+  },
+};
+
+export const contentGetTool: McpTool<typeof contentGetInputSchema> = {
+  name: "content_get",
+  description: "Read a single entry in full by its type and id.",
+  inputSchema: contentGetInputSchema,
+  async run(ctx, input) {
+    try {
+      const entry = await getEntry(ctx, { id: input.id });
+      // Scope the lookup to the requested type — a mismatch stays hidden as
+      // not-found rather than leaking that an id exists under another type.
+      if (entry.type !== input.type) {
+        throw EntryReadError.notFound(input.id);
+      }
+      return entry;
+    } catch (error) {
+      throw asMcpToolError(error);
+    }
+  },
+};

--- a/packages/core/src/mcp/dispatch.test.ts
+++ b/packages/core/src/mcp/dispatch.test.ts
@@ -237,3 +237,106 @@ describe("MCP endpoint — transport guards", () => {
     expect(res.status).toBe(401);
   });
 });
+
+interface ContentRow {
+  readonly slug: string;
+  readonly status: string;
+}
+
+describe("MCP endpoint — content_list", () => {
+  test("returns the entries the caller may see", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const author = await h.factory.user.create({ role: "editor" });
+    await h.factory.published.create({ authorId: author.id, slug: "pub" });
+    await h.factory.draft.create({ authorId: author.id, slug: "draft" });
+    const secret = await mintPat(h, { role: "editor" });
+
+    const { json } = await callTool(h, secret, 1, "content_list", {
+      type: "post",
+    });
+
+    const rows = parseToolResult<ContentRow[]>(json);
+    expect(rows.map((r) => r.slug).sort()).toEqual(["draft", "pub"]);
+  });
+
+  test("a read-scoped token cannot see drafts (capability clamp)", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const author = await h.factory.user.create({ role: "editor" });
+    await h.factory.published.create({ authorId: author.id, slug: "pub" });
+    await h.factory.draft.create({ authorId: author.id, slug: "secret" });
+    const secret = await mintPat(h, {
+      role: "editor",
+      scopes: ["entry:post:read"],
+    });
+
+    const { json } = await callTool(h, secret, 1, "content_list", {
+      type: "post",
+    });
+
+    const rows = parseToolResult<ContentRow[]>(json);
+    expect(rows.map((r) => r.slug)).toEqual(["pub"]);
+  });
+
+  test("content_list appears in tools/list with a projected JSON Schema", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const secret = await mintPat(h);
+
+    const { json } = await callMcp<{
+      tools: { name: string; inputSchema: { properties?: object } }[];
+    }>(h, secret, { jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+    const tool = json.result.tools.find((t) => t.name === "content_list");
+    expect(tool).toBeDefined();
+    expect(tool?.inputSchema.properties).toHaveProperty("status");
+  });
+});
+
+describe("MCP endpoint — content_get", () => {
+  test("returns a single entry by type + id", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const author = await h.factory.user.create({ role: "editor" });
+    const entry = await h.factory.published.create({
+      authorId: author.id,
+      slug: "pub",
+    });
+    const secret = await mintPat(h, { role: "editor" });
+
+    const { json } = await callTool(h, secret, 1, "content_get", {
+      type: "post",
+      id: entry.id,
+    });
+
+    expect(parseToolResult<ContentRow>(json).slug).toBe("pub");
+  });
+
+  test("a missing entry comes back as a not_found envelope", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const secret = await mintPat(h, { role: "editor" });
+
+    const { json } = await callTool(h, secret, 1, "content_get", {
+      type: "post",
+      id: 9999,
+    });
+
+    expect(json.result.isError).toBe(true);
+    expect(json.result.content[0]?.text).toContain("not_found");
+  });
+
+  test("a type that doesn't match the entry is hidden as not_found", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const author = await h.factory.user.create({ role: "editor" });
+    const entry = await h.factory.published.create({
+      authorId: author.id,
+      slug: "pub",
+    });
+    const secret = await mintPat(h, { role: "editor" });
+
+    const { json } = await callTool(h, secret, 1, "content_get", {
+      type: "page",
+      id: entry.id,
+    });
+
+    expect(json.result.isError).toBe(true);
+    expect(json.result.content[0]?.text).toContain("not_found");
+  });
+});

--- a/packages/core/src/mcp/errors.ts
+++ b/packages/core/src/mcp/errors.ts
@@ -1,6 +1,4 @@
-// The service-layer slices (#932/#933) extend this taxonomy as tools start
-// throwing the other conditions; #931 only needs not_found for schema_describe.
-type McpToolErrorCode = "not_found";
+type McpToolErrorCode = "not_found" | "forbidden" | "bad_input";
 
 /**
  * Domain error a tool's `run` throws to signal a caller-facing condition. The
@@ -21,6 +19,14 @@ export class McpToolError extends Error {
 
   static notFound(message: string): McpToolError {
     return new McpToolError("not_found", message);
+  }
+
+  static forbidden(message: string): McpToolError {
+    return new McpToolError("forbidden", message);
+  }
+
+  static badInput(message: string): McpToolError {
+    return new McpToolError("bad_input", message);
   }
 }
 

--- a/packages/core/src/mcp/registry.ts
+++ b/packages/core/src/mcp/registry.ts
@@ -1,5 +1,6 @@
 import type { PluginRegistry } from "../plugin/manifest.js";
 import type { McpTool } from "./tool.js";
+import { contentGetTool, contentListTool } from "./content-tools.js";
 import { schemaDescribeTool } from "./schema-describe.js";
 
 /**
@@ -7,7 +8,11 @@ import { schemaDescribeTool } from "./schema-describe.js";
  * Plugins add their own through `registerMcpTool`; the two merge in
  * {@link buildMcpToolRegistry}.
  */
-export const coreMcpTools: readonly McpTool[] = [schemaDescribeTool];
+export const coreMcpTools: readonly McpTool[] = [
+  schemaDescribeTool,
+  contentListTool,
+  contentGetTool,
+];
 
 export const CORE_MCP_TOOL_NAMES: ReadonlySet<string> = new Set(
   coreMcpTools.map((tool) => tool.name),


### PR DESCRIPTION
Add the first service-backed MCP read tools so an agent can enumerate and inspect a site's content over `/_plumix/mcp`. Both delegate to the transport-neutral entries read service from #932 — MCP never calls oRPC — so there's one capability/clamp policy behind both transports.

**Capability clamp is inherited, not re-implemented**

`content_list` and `content_get` forward the bearer-authed `ctx` to `listEntries` / `getEntry`, whose status clamping keys off `ctx.auth.can`. A read-scoped PAT (`scopes: ["entry:post:read"]`) gets `canSeeAnyStatus = false`, so drafts never surface through either tool. The tools add no DB access and no second code path — they can't weaken a clamp they never touch.

**Curated input, no smuggling**

`content_list` advertises only the read surface — `type, status, search, orderBy, order, limit, offset` — via `v.pick` from the canonical `entryListInputSchema`, so validation and the projected JSON Schema can't drift, the admin-shaped filters (author/parent/taxonomy) aren't exposed, and a caller passing them gets them silently dropped. Defaults (limit/offset/orderBy/order) are preserved by the pick.

**Errors become envelopes; cross-type lookups stay hidden**

`EntryReadError` (not_found / forbidden / reserved_type) maps to `McpToolError` so the call-tool handler renders an `isError` envelope rather than crashing the client. `content_get` scopes the lookup to the requested `type` *after* the access check — `{type: "page", id: <a post id>}` is indistinguishable from a missing id, so it can't probe cross-type existence. Extends the MCP tool-error taxonomy with `forbidden` + `bad_input`.

Closes #933