### PR TITLE
feat(core): add term_list, term_get, taxonomy_list MCP tools

### DIFF
--- a/packages/core/src/mcp/dispatch.test.ts
+++ b/packages/core/src/mcp/dispatch.test.ts
@@ -340,3 +340,79 @@ describe("MCP endpoint — content_get", () => {
     expect(json.result.content[0]?.text).toContain("not_found");
   });
 });
+
+describe("MCP endpoint — term tools", () => {
+  test("term_list returns terms in a taxonomy", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    await h.factory.category.create({ name: "News", slug: "news" });
+    const secret = await mintPat(h, { role: "editor" });
+
+    const { json } = await callTool(h, secret, 1, "term_list", {
+      taxonomy: "category",
+    });
+
+    const rows = parseToolResult<{ slug: string }[]>(json);
+    expect(rows.map((r) => r.slug)).toEqual(["news"]);
+  });
+
+  test("term_list maps a forbidden read to an envelope", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const secret = await mintPat(h, {
+      role: "editor",
+      scopes: ["entry:post:read"],
+    });
+
+    const { json } = await callTool(h, secret, 1, "term_list", {
+      taxonomy: "category",
+    });
+
+    expect(json.result.isError).toBe(true);
+    expect(json.result.content[0]?.text).toContain("forbidden");
+  });
+
+  test("term_get returns a term by taxonomy + id", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const term = await h.factory.category.create({
+      name: "News",
+      slug: "news",
+    });
+    const secret = await mintPat(h, { role: "editor" });
+
+    const { json } = await callTool(h, secret, 1, "term_get", {
+      taxonomy: "category",
+      id: term.id,
+    });
+
+    expect(parseToolResult<{ slug: string }>(json).slug).toBe("news");
+  });
+
+  test("term_get hides a taxonomy mismatch as not_found", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const term = await h.factory.category.create({
+      name: "News",
+      slug: "news",
+    });
+    const secret = await mintPat(h, { role: "editor" });
+
+    const { json } = await callTool(h, secret, 1, "term_get", {
+      taxonomy: "post_tag",
+      id: term.id,
+    });
+
+    expect(json.result.isError).toBe(true);
+    expect(json.result.content[0]?.text).toContain("not_found");
+  });
+
+  test("taxonomy_list enumerates registered taxonomies", async () => {
+    const h = await createDispatcherHarness({ plugins: [blog] });
+    const secret = await mintPat(h, { role: "editor" });
+
+    const { json } = await callTool(h, secret, 1, "taxonomy_list", {});
+
+    const rows =
+      parseToolResult<{ name: string; isHierarchical: boolean }[]>(json);
+    expect(rows).toContainEqual(
+      expect.objectContaining({ name: "category", isHierarchical: true }),
+    );
+  });
+});

--- a/packages/core/src/mcp/registry.ts
+++ b/packages/core/src/mcp/registry.ts
@@ -2,6 +2,7 @@ import type { PluginRegistry } from "../plugin/manifest.js";
 import type { McpTool } from "./tool.js";
 import { contentGetTool, contentListTool } from "./content-tools.js";
 import { schemaDescribeTool } from "./schema-describe.js";
+import { taxonomyListTool, termGetTool, termListTool } from "./term-tools.js";
 
 /**
  * Tools core contributes unconditionally — the MCP analogue of `appRouter`.
@@ -12,6 +13,9 @@ export const coreMcpTools: readonly McpTool[] = [
   schemaDescribeTool,
   contentListTool,
   contentGetTool,
+  termListTool,
+  termGetTool,
+  taxonomyListTool,
 ];
 
 export const CORE_MCP_TOOL_NAMES: ReadonlySet<string> = new Set(

--- a/packages/core/src/mcp/term-tools.ts
+++ b/packages/core/src/mcp/term-tools.ts
@@ -1,0 +1,87 @@
+import * as v from "valibot";
+
+import type { McpTool } from "./tool.js";
+import { labelSourceText } from "../i18n/label.js";
+import { termListInputSchema } from "../rpc/procedures/term/schemas.js";
+import { idParam } from "../rpc/validation.js";
+import { TermReadError } from "../terms/errors.js";
+import { getTerm, listTerms } from "../terms/read-service.js";
+import { McpToolError } from "./errors.js";
+
+// Curated read surface: taxonomy + search + pagination, picked from the
+// canonical schema so validation and the advertised JSON Schema can't drift.
+const termListInput = v.pick(termListInputSchema, [
+  "taxonomy",
+  "search",
+  "limit",
+  "offset",
+]);
+
+const termGetInput = v.object({
+  taxonomy: v.pipe(
+    v.string(),
+    v.description("Taxonomy the id must belong to."),
+  ),
+  id: idParam,
+});
+
+const emptyInput = v.object({});
+
+function asMcpToolError(error: unknown): McpToolError {
+  if (!(error instanceof TermReadError)) throw error;
+  switch (error.data.code) {
+    case "taxonomy_not_found":
+    case "term_not_found":
+      return McpToolError.notFound(error.message);
+    case "forbidden":
+      return McpToolError.forbidden(error.message);
+  }
+}
+
+export const termListTool: McpTool<typeof termListInput> = {
+  name: "term_list",
+  description:
+    "List terms (categories/tags) in a taxonomy, optionally filtered by search and paginated.",
+  inputSchema: termListInput,
+  async run(ctx, input) {
+    try {
+      return await listTerms(ctx, input);
+    } catch (error) {
+      throw asMcpToolError(error);
+    }
+  },
+};
+
+export const termGetTool: McpTool<typeof termGetInput> = {
+  name: "term_get",
+  description: "Read a single term in full by its taxonomy and id.",
+  inputSchema: termGetInput,
+  async run(ctx, input) {
+    try {
+      const term = await getTerm(ctx, { id: input.id });
+      // Scope the lookup to the requested taxonomy — a mismatch stays hidden
+      // as not-found rather than leaking that an id exists elsewhere.
+      if (term.taxonomy !== input.taxonomy) {
+        throw TermReadError.termNotFound(input.id);
+      }
+      return term;
+    } catch (error) {
+      throw asMcpToolError(error);
+    }
+  },
+};
+
+export const taxonomyListTool: McpTool<typeof emptyInput> = {
+  name: "taxonomy_list",
+  description:
+    "List the taxonomies in the content model — name, label, whether hierarchical, and the entry types they apply to.",
+  inputSchema: emptyInput,
+  run(ctx) {
+    return [...ctx.plugins.termTaxonomies.values()].map((taxonomy) => ({
+      name: taxonomy.name,
+      label: labelSourceText(taxonomy.label),
+      isHierarchical: taxonomy.isHierarchical ?? false,
+      entryTypes: taxonomy.entryTypes ?? [],
+    }));
+  },
+};

--- a/packages/core/src/rpc/procedures/term/get.ts
+++ b/packages/core/src/rpc/procedures/term/get.ts
@@ -1,31 +1,17 @@
-import { eq } from "../../../db/index.js";
-import { terms } from "../../../db/schema/terms.js";
+import { getTerm } from "../../../terms/read-service.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
-import { taxonomyCapability } from "./helpers.js";
-import { decodeMetaBag } from "./meta.js";
+import { toRpcTermReadError } from "./read-errors.js";
 import { termGetInputSchema } from "./schemas.js";
 
 export const get = base
   .use(authenticated)
   .input(termGetInputSchema)
   .handler(async ({ input, context, errors }) => {
-    const row = await context.db.query.terms.findFirst({
-      where: eq(terms.id, input.id),
-    });
-    if (!row) {
-      throw errors.NOT_FOUND({ data: { kind: "term", id: input.id } });
+    try {
+      const term = await getTerm(context, input);
+      return await context.hooks.applyFilter("rpc:term.get:output", term);
+    } catch (error) {
+      throw toRpcTermReadError(error, errors);
     }
-
-    const readCap = taxonomyCapability(row.taxonomy, "read");
-    if (!context.auth.can(readCap)) {
-      // Hide existence — mirror entry.get's "no oracle" rule.
-      throw errors.NOT_FOUND({ data: { kind: "term", id: input.id } });
-    }
-
-    const meta = decodeMetaBag(context.plugins, row.taxonomy, row.meta);
-    return context.hooks.applyFilter("rpc:term.get:output", {
-      ...row,
-      meta,
-    });
   });

--- a/packages/core/src/rpc/procedures/term/list.ts
+++ b/packages/core/src/rpc/procedures/term/list.ts
@@ -1,8 +1,7 @@
-import { and, asc, eq, isNull, like } from "../../../db/index.js";
-import { terms } from "../../../db/schema/terms.js";
+import { listTerms } from "../../../terms/read-service.js";
 import { authenticated } from "../../authenticated.js";
 import { base } from "../../base.js";
-import { taxonomyCapability } from "./helpers.js";
+import { toRpcTermReadError } from "./read-errors.js";
 import { termListInputSchema } from "./schemas.js";
 
 export const list = base
@@ -13,35 +12,10 @@ export const list = base
       "rpc:term.list:input",
       input,
     );
-
-    if (!context.plugins.termTaxonomies.has(filtered.taxonomy)) {
-      throw errors.NOT_FOUND({
-        data: { kind: "taxonomy", id: filtered.taxonomy },
-      });
+    try {
+      const rows = await listTerms(context, filtered);
+      return await context.hooks.applyFilter("rpc:term.list:output", rows);
+    } catch (error) {
+      throw toRpcTermReadError(error, errors);
     }
-
-    const readCap = taxonomyCapability(filtered.taxonomy, "read");
-    if (!context.auth.can(readCap)) {
-      throw errors.FORBIDDEN({ data: { capability: readCap } });
-    }
-
-    const conditions = [eq(terms.taxonomy, filtered.taxonomy)];
-    if (filtered.parentId === null) {
-      conditions.push(isNull(terms.parentId));
-    } else if (filtered.parentId !== undefined) {
-      conditions.push(eq(terms.parentId, filtered.parentId));
-    }
-    if (filtered.search && filtered.search.length > 0) {
-      conditions.push(like(terms.name, `%${filtered.search}%`));
-    }
-
-    const rows = await context.db
-      .select()
-      .from(terms)
-      .where(and(...conditions))
-      .orderBy(asc(terms.name), asc(terms.id))
-      .limit(filtered.limit)
-      .offset(filtered.offset);
-
-    return context.hooks.applyFilter("rpc:term.list:output", rows);
   });

--- a/packages/core/src/rpc/procedures/term/read-errors.test.ts
+++ b/packages/core/src/rpc/procedures/term/read-errors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import type { TermReadErrorConstructors } from "./read-errors.js";
+import { TermReadError } from "../../../terms/errors.js";
+import { toRpcTermReadError } from "./read-errors.js";
+
+function stubErrors(): TermReadErrorConstructors {
+  const make =
+    (mappedCode: string) =>
+    (opts: { data: Record<string, unknown> }): Error =>
+      Object.assign(new Error(mappedCode), { mappedCode, data: opts.data });
+  return { NOT_FOUND: make("NOT_FOUND"), FORBIDDEN: make("FORBIDDEN") };
+}
+
+describe("toRpcTermReadError", () => {
+  test("maps taxonomy_not_found to NOT_FOUND with the taxonomy", () => {
+    const mapped = toRpcTermReadError(
+      TermReadError.taxonomyNotFound("nope"),
+      stubErrors(),
+    );
+    expect(mapped).toMatchObject({
+      mappedCode: "NOT_FOUND",
+      data: { kind: "taxonomy", id: "nope" },
+    });
+  });
+
+  test("maps term_not_found to NOT_FOUND with the term id", () => {
+    const mapped = toRpcTermReadError(
+      TermReadError.termNotFound(7),
+      stubErrors(),
+    );
+    expect(mapped).toMatchObject({
+      mappedCode: "NOT_FOUND",
+      data: { kind: "term", id: 7 },
+    });
+  });
+
+  test("maps forbidden to FORBIDDEN with the capability", () => {
+    const mapped = toRpcTermReadError(
+      TermReadError.forbidden("term:category:read"),
+      stubErrors(),
+    );
+    expect(mapped).toMatchObject({
+      mappedCode: "FORBIDDEN",
+      data: { capability: "term:category:read" },
+    });
+  });
+
+  test("passes a non-domain error through unchanged", () => {
+    const original = new Error("boom");
+    expect(toRpcTermReadError(original, stubErrors())).toBe(original);
+  });
+});

--- a/packages/core/src/rpc/procedures/term/read-errors.ts
+++ b/packages/core/src/rpc/procedures/term/read-errors.ts
@@ -1,0 +1,35 @@
+import { TermReadError } from "../../../terms/errors.js";
+
+/**
+ * The subset of oRPC typed-error constructors the terms read path maps onto.
+ * Structural so the mapper is unit-testable with a plain stub — no oRPC runtime.
+ */
+export interface TermReadErrorConstructors {
+  NOT_FOUND(opts: { data: { kind: string; id: number | string } }): Error;
+  FORBIDDEN(opts: { data: { capability: string } }): Error;
+}
+
+/**
+ * Translate a terms-read domain error into the oRPC typed error to throw.
+ * Non-domain errors pass through unchanged for the caller to rethrow.
+ */
+export function toRpcTermReadError(
+  error: unknown,
+  errors: TermReadErrorConstructors,
+): unknown {
+  if (!(error instanceof TermReadError)) return error;
+  switch (error.data.code) {
+    case "taxonomy_not_found":
+      return errors.NOT_FOUND({
+        data: { kind: "taxonomy", id: error.data.taxonomy },
+      });
+    case "term_not_found":
+      return errors.NOT_FOUND({
+        data: { kind: "term", id: error.data.termId },
+      });
+    case "forbidden":
+      return errors.FORBIDDEN({
+        data: { capability: error.data.capability },
+      });
+  }
+}

--- a/packages/core/src/terms/errors.ts
+++ b/packages/core/src/terms/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Domain error the terms read service throws. The `data` discriminant carries
+ * what each transport needs — oRPC maps it via {@link toRpcTermReadError}.
+ * Mirrors `src/entries/errors.ts`.
+ */
+export class TermReadError extends Error {
+  static {
+    TermReadError.prototype.name = "TermReadError";
+  }
+
+  readonly data:
+    | { readonly code: "taxonomy_not_found"; readonly taxonomy: string }
+    | { readonly code: "term_not_found"; readonly termId: number }
+    | { readonly code: "forbidden"; readonly capability: string };
+
+  private constructor(data: TermReadError["data"], message: string) {
+    super(message);
+    this.data = data;
+  }
+
+  static taxonomyNotFound(taxonomy: string): TermReadError {
+    return new TermReadError(
+      { code: "taxonomy_not_found", taxonomy },
+      `unknown taxonomy: ${taxonomy}`,
+    );
+  }
+
+  static termNotFound(termId: number): TermReadError {
+    return new TermReadError(
+      { code: "term_not_found", termId },
+      `term ${termId} not found`,
+    );
+  }
+
+  static forbidden(capability: string): TermReadError {
+    return new TermReadError(
+      { code: "forbidden", capability },
+      `missing capability: ${capability}`,
+    );
+  }
+}

--- a/packages/core/src/terms/read-service.test.ts
+++ b/packages/core/src/terms/read-service.test.ts
@@ -1,0 +1,140 @@
+import * as v from "valibot";
+import { describe, expect, test } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import type { UserRole } from "../db/schema/users.js";
+import type { AuthenticatedRpcHarness } from "../test/rpc.js";
+import { withUser } from "../context/app.js";
+import { HookRegistry } from "../hooks/registry.js";
+import { definePlugin } from "../plugin/define.js";
+import { installPlugins } from "../plugin/register.js";
+import {
+  termGetInputSchema,
+  termListInputSchema,
+} from "../rpc/procedures/term/schemas.js";
+import { createRpcHarness } from "../test/rpc.js";
+import { TermReadError } from "./errors.js";
+import { getTerm, listTerms } from "./read-service.js";
+
+const taxonomies = definePlugin("test-tax", (ctx) => {
+  ctx.registerTermTaxonomy("category", {
+    label: "Categories",
+    isHierarchical: true,
+  });
+});
+
+async function harness(role: UserRole): Promise<AuthenticatedRpcHarness> {
+  const hooks = new HookRegistry();
+  const { registry } = await installPlugins({ hooks, plugins: [taxonomies] });
+  return createRpcHarness({ authAs: role, plugins: registry, hooks });
+}
+
+function authedCtx(
+  h: AuthenticatedRpcHarness,
+  tokenScopes: string[] | null = null,
+): AppContext {
+  return withUser(h.context, h.user, tokenScopes);
+}
+
+const listInput = (partial: Record<string, unknown>) =>
+  v.parse(termListInputSchema, partial);
+const getInput = (partial: Record<string, unknown>) =>
+  v.parse(termGetInputSchema, partial);
+
+describe("listTerms", () => {
+  test("returns terms in the taxonomy ordered by name", async () => {
+    const h = await harness("editor");
+    await h.factory.category.create({ name: "News", slug: "news" });
+    await h.factory.category.create({ name: "Apples", slug: "apples" });
+
+    const rows = await listTerms(
+      authedCtx(h),
+      listInput({ taxonomy: "category" }),
+    );
+
+    expect(rows.map((r) => r.name)).toEqual(["Apples", "News"]);
+  });
+
+  test("filters by name search", async () => {
+    const h = await harness("editor");
+    await h.factory.category.create({ name: "News", slug: "news" });
+    await h.factory.category.create({ name: "Sports", slug: "sports" });
+
+    const rows = await listTerms(
+      authedCtx(h),
+      listInput({ taxonomy: "category", search: "New" }),
+    );
+
+    expect(rows.map((r) => r.slug)).toEqual(["news"]);
+  });
+
+  test("throws taxonomy_not_found for an unregistered taxonomy", async () => {
+    const h = await harness("editor");
+
+    const error = await listTerms(
+      authedCtx(h),
+      listInput({ taxonomy: "nope" }),
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(TermReadError);
+    expect(error).toMatchObject({
+      data: { code: "taxonomy_not_found", taxonomy: "nope" },
+    });
+  });
+
+  test("throws forbidden when the token can't read the taxonomy", async () => {
+    const h = await harness("editor");
+
+    const error = await listTerms(
+      authedCtx(h, ["term:category:assign"]),
+      listInput({ taxonomy: "category" }),
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(TermReadError);
+    expect(error).toMatchObject({
+      data: { code: "forbidden", capability: "term:category:read" },
+    });
+  });
+});
+
+describe("getTerm", () => {
+  test("returns a term hydrated with decoded meta", async () => {
+    const h = await harness("editor");
+    const seeded = await h.factory.category.create({
+      name: "News",
+      slug: "news",
+    });
+
+    const term = await getTerm(authedCtx(h), getInput({ id: seeded.id }));
+
+    expect(term.name).toBe("News");
+    expect(term.meta).toEqual({});
+  });
+
+  test("throws term_not_found for a missing id", async () => {
+    const h = await harness("editor");
+
+    const error = await getTerm(authedCtx(h), getInput({ id: 9999 })).catch(
+      (e: unknown) => e,
+    );
+
+    expect(error).toMatchObject({
+      data: { code: "term_not_found", termId: 9999 },
+    });
+  });
+
+  test("hides a term in an unreadable taxonomy as term_not_found", async () => {
+    const h = await harness("editor");
+    const seeded = await h.factory.category.create({
+      name: "News",
+      slug: "news",
+    });
+
+    const error = await getTerm(
+      authedCtx(h, ["term:category:assign"]),
+      getInput({ id: seeded.id }),
+    ).catch((e: unknown) => e);
+
+    expect(error).toMatchObject({ data: { code: "term_not_found" } });
+  });
+});

--- a/packages/core/src/terms/read-service.ts
+++ b/packages/core/src/terms/read-service.ts
@@ -1,0 +1,68 @@
+import type { AppContext } from "../context/app.js";
+import type { Term } from "../db/schema/terms.js";
+import type {
+  TermGetInput,
+  TermListInput,
+} from "../rpc/procedures/term/schemas.js";
+import { and, asc, eq, isNull, like } from "../db/index.js";
+import { terms } from "../db/schema/terms.js";
+import { taxonomyCapability } from "../rpc/procedures/term/helpers.js";
+import { decodeMetaBag } from "../rpc/procedures/term/meta.js";
+import { TermReadError } from "./errors.js";
+
+type TermRead = Omit<Term, "meta"> & { readonly meta: Record<string, unknown> };
+
+/**
+ * List terms in a taxonomy the caller may read. The taxonomy must be
+ * registered and the caller must hold its read capability; both checks live
+ * here so every transport reads through one policy. Throws {@link TermReadError}.
+ */
+export async function listTerms(
+  ctx: AppContext,
+  input: TermListInput,
+): Promise<readonly Term[]> {
+  if (!ctx.plugins.termTaxonomies.has(input.taxonomy)) {
+    throw TermReadError.taxonomyNotFound(input.taxonomy);
+  }
+  const readCap = taxonomyCapability(input.taxonomy, "read");
+  if (!ctx.auth.can(readCap)) throw TermReadError.forbidden(readCap);
+
+  const conditions = [eq(terms.taxonomy, input.taxonomy)];
+  if (input.parentId === null) {
+    conditions.push(isNull(terms.parentId));
+  } else if (input.parentId !== undefined) {
+    conditions.push(eq(terms.parentId, input.parentId));
+  }
+  if (input.search && input.search.length > 0) {
+    conditions.push(like(terms.name, `%${input.search}%`));
+  }
+
+  return ctx.db
+    .select()
+    .from(terms)
+    .where(and(...conditions))
+    .orderBy(asc(terms.name), asc(terms.id))
+    .limit(input.limit)
+    .offset(input.offset);
+}
+
+/**
+ * Read a single term by id, hydrated with decoded meta. A missing term and one
+ * in a taxonomy the caller can't read both collapse to `term_not_found` so
+ * existence stays hidden.
+ */
+export async function getTerm(
+  ctx: AppContext,
+  input: TermGetInput,
+): Promise<TermRead> {
+  const row = await ctx.db.query.terms.findFirst({
+    where: eq(terms.id, input.id),
+  });
+  if (!row) throw TermReadError.termNotFound(input.id);
+  if (!ctx.auth.can(taxonomyCapability(row.taxonomy, "read"))) {
+    throw TermReadError.termNotFound(input.id);
+  }
+
+  const meta = decodeMetaBag(ctx.plugins, row.taxonomy, row.meta);
+  return { ...row, meta };
+}


### PR DESCRIPTION
Extend the MCP read surface to taxonomies and terms, following the entries read service (#932) + content tools (#933) pattern: a transport-neutral terms read service feeds both oRPC and three new MCP tools.

**Terms read service**

`listTerms` / `getTerm` (in `src/terms/`) own the per-taxonomy capability check and existence-hiding policy, throwing a `TermReadError` taxonomy. The oRPC `term.list` / `term.get` procedures become thin adapters that apply their filter hooks and map domain errors to typed errors — the existing 17-test term suite stays green, so behavior is unchanged. The service and the mapper are tested directly.

**Three MCP tools**

`term_list` (taxonomy + search + pagination, curated via `v.pick` from the canonical schema), `term_get` (taxonomy + id), and the manifest-backed `taxonomy_list`. All carry `readOnlyHint` and project JSON Schema for `tools/list`.

**Capability + existence hiding inherited**

The tools forward the bearer-authed `ctx`, so a token lacking `term:<taxonomy>:read` gets a forbidden envelope rather than data, and `term_get` scopes the lookup to the requested taxonomy *after* the access check — a `{taxonomy: "post_tag", id: <a category term id>}` request is indistinguishable from a missing id, with no cross-taxonomy existence oracle. `taxonomy_list` exposes only taxonomy names/labels (no term rows), consistent with `schema_describe`.

Closes #934