### PR TITLE
feat: contribute media_list + media_get MCP tools via the plugin seam

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export * from "./db/index.js";
 export * from "./db/schema/index.js";
 export * from "./hooks/index.js";
 export * from "./i18n/index.js";
+export * from "./mcp/index.js";
 export * from "./plugin/index.js";
 export { isCurrentSource } from "./route/current.js";
 export type { CurrentSource, ResolvedEntity } from "./route/current.js";

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,0 +1,2 @@
+export type { McpTool } from "./tool.js";
+export { McpToolError } from "./errors.js";

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -28,6 +28,8 @@ export type { Factories } from "./factories.js";
 
 export { createTestDb } from "./harness.js";
 
+export { createApiToken } from "../auth/api-tokens.js";
+
 export { createDispatcherHarness, plumixRequest } from "./dispatcher.js";
 export type {
   DispatcherHarness,

--- a/packages/plugins/media/src/index.ts
+++ b/packages/plugins/media/src/index.ts
@@ -9,6 +9,7 @@ import { galleryBlock } from "./blocks/gallery/index.js";
 import { imageBlock } from "./blocks/image/index.js";
 import { videoBlock } from "./blocks/video/index.js";
 import { mediaLookupAdapter } from "./lookup.js";
+import { mediaGetTool, mediaListTool } from "./mcp-tools.js";
 import { DEFAULT_ACCEPTED_TYPES } from "./mime.js";
 import { createMediaRouter } from "./rpc.js";
 import { handleMediaServe } from "./serve-route.js";
@@ -186,6 +187,11 @@ export function media(
       ctx.registerRpcRouter(
         createMediaRouter({ acceptedTypes, maxUploadSize }),
       );
+
+      // Media's own MCP read tools, contributed through the plugin seam —
+      // they ship from the plugin that owns media, not core.
+      ctx.registerMcpTool(mediaListTool);
+      ctx.registerMcpTool(mediaGetTool);
 
       // Reference-field surface: any `media({ ... })` field calls
       // through `lookup.list({ kind: "media", ids })` for write

--- a/packages/plugins/media/src/mcp-tools.test.ts
+++ b/packages/plugins/media/src/mcp-tools.test.ts
@@ -1,0 +1,166 @@
+import { memoryStorage } from "plumix/plugin";
+import { createApiToken, createDispatcherHarness } from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+import { media } from "./index.js";
+
+type Harness = Awaited<ReturnType<typeof createDispatcherHarness>>;
+
+async function setup(): Promise<Harness> {
+  const storage = memoryStorage().connect({});
+  return createDispatcherHarness({ plugins: [media()], storage });
+}
+
+async function seedMedia(
+  h: Harness,
+  authorId: number,
+  slug: string,
+  status: "published" | "draft" = "published",
+): Promise<number> {
+  const entry = await h.factory.entry.create({
+    type: "media",
+    status,
+    title: `${slug}.png`,
+    slug,
+    authorId,
+    meta: {
+      mime: "image/png",
+      size: 100,
+      storageKey: `key-${slug}`,
+      originalName: `${slug}.png`,
+      alt: null,
+    },
+  });
+  return entry.id;
+}
+
+async function mintPat(
+  h: Harness,
+  scopes: string[] | null = null,
+): Promise<{ secret: string; userId: number }> {
+  const user = await h.seedUser("editor");
+  const { secret } = await createApiToken(h.db, {
+    userId: user.id,
+    name: "mcp",
+    expiresAt: null,
+    scopes,
+  });
+  return { secret, userId: user.id };
+}
+
+interface ToolCallResult {
+  readonly content: readonly { readonly text: string }[];
+  readonly isError?: boolean;
+}
+
+async function rpc<T>(
+  h: Harness,
+  secret: string,
+  body: unknown,
+): Promise<{ result: T }> {
+  const res = await h.dispatch(
+    new Request("https://cms.example/_plumix/mcp", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${secret}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+  return (await res.json()) as { result: T };
+}
+
+function callTool(
+  h: Harness,
+  secret: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ result: ToolCallResult }> {
+  return rpc(h, secret, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  });
+}
+
+describe("@plumix/plugin-media — MCP tools", () => {
+  test("registers media_list + media_get via the plugin seam", async () => {
+    const h = await setup();
+    const { secret } = await mintPat(h);
+
+    const { result } = await rpc<{
+      tools: {
+        name: string;
+        inputSchema: { type: string };
+        annotations?: { readOnlyHint?: boolean };
+      }[];
+    }>(h, secret, { jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+    const names = result.tools.map((t) => t.name);
+    expect(names).toContain("media_list");
+    expect(names).toContain("media_get");
+    const mediaList = result.tools.find((t) => t.name === "media_list");
+    expect(mediaList?.annotations?.readOnlyHint).toBe(true);
+    expect(mediaList?.inputSchema.type).toBe("object");
+  });
+
+  test("media_list returns published media for an authorized PAT", async () => {
+    const h = await setup();
+    const { secret, userId } = await mintPat(h);
+    await seedMedia(h, userId, "photo");
+
+    const { result } = await callTool(h, secret, "media_list", {});
+
+    const payload = JSON.parse(result.content[0]?.text ?? "null") as {
+      items: { title: string }[];
+    };
+    expect(payload.items.map((i) => i.title)).toContain("photo.png");
+  });
+
+  test("media_get returns a single item by id", async () => {
+    const h = await setup();
+    const { secret, userId } = await mintPat(h);
+    const id = await seedMedia(h, userId, "photo");
+
+    const { result } = await callTool(h, secret, "media_get", { id });
+
+    const item = JSON.parse(result.content[0]?.text ?? "null") as {
+      title: string;
+    };
+    expect(item.title).toBe("photo.png");
+  });
+
+  test("media_get on a missing id is a not_found envelope", async () => {
+    const h = await setup();
+    const { secret } = await mintPat(h);
+
+    const { result } = await callTool(h, secret, "media_get", { id: 9999 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("not_found");
+  });
+
+  test("media_get hides an unpublished (draft) item as not_found", async () => {
+    const h = await setup();
+    const { secret, userId } = await mintPat(h);
+    const draftId = await seedMedia(h, userId, "wip", "draft");
+
+    const { result } = await callTool(h, secret, "media_get", { id: draftId });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("not_found");
+  });
+
+  test("a token without media read capability is forbidden", async () => {
+    const h = await setup();
+    const { secret } = await mintPat(h, ["entry:post:read"]);
+
+    const { result } = await callTool(h, secret, "media_list", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("forbidden");
+  });
+});

--- a/packages/plugins/media/src/mcp-tools.ts
+++ b/packages/plugins/media/src/mcp-tools.ts
@@ -1,0 +1,51 @@
+import type { McpTool } from "plumix/plugin";
+import { McpToolError } from "plumix/plugin";
+import * as v from "valibot";
+
+import {
+  getMedia,
+  listMedia,
+  mediaListInputSchema,
+  MediaReadError,
+} from "./read-service.js";
+
+const mediaGetInputSchema = v.object({
+  id: v.pipe(v.number(), v.integer(), v.minValue(1)),
+});
+
+function asMcpToolError(error: unknown): McpToolError {
+  if (!(error instanceof MediaReadError)) throw error;
+  switch (error.data.code) {
+    case "not_found":
+      return McpToolError.notFound(error.message);
+    case "forbidden":
+      return McpToolError.forbidden(error.message);
+  }
+}
+
+export const mediaListTool: McpTool<typeof mediaListInputSchema> = {
+  name: "media_list",
+  description:
+    "List published media (images, files) with optional MIME and filename filters, paginated. Clamped to what your token may read.",
+  inputSchema: mediaListInputSchema,
+  async run(ctx, input) {
+    try {
+      return await listMedia(ctx, input);
+    } catch (error) {
+      throw asMcpToolError(error);
+    }
+  },
+};
+
+export const mediaGetTool: McpTool<typeof mediaGetInputSchema> = {
+  name: "media_get",
+  description: "Read a single published media item in full by its id.",
+  inputSchema: mediaGetInputSchema,
+  async run(ctx, input) {
+    try {
+      return await getMedia(ctx, input);
+    } catch (error) {
+      throw asMcpToolError(error);
+    }
+  },
+};

--- a/packages/plugins/media/src/read-service.ts
+++ b/packages/plugins/media/src/read-service.ts
@@ -1,0 +1,229 @@
+import type { AppContext, SQL } from "plumix/plugin";
+import {
+  and,
+  desc,
+  entries,
+  eq,
+  escapeLikePattern,
+  inArray,
+  like,
+  sql,
+} from "plumix/plugin";
+import * as v from "valibot";
+
+import { parseMediaMeta } from "./meta.js";
+
+export const MEDIA_ENTRY_TYPE = "media";
+const MEDIA_READ_CAPABILITY = "entry:media:read";
+
+const DEFAULT_PAGE_SIZE = 24;
+const MAX_PAGE_SIZE = 100;
+
+// 320px-wide auto-format thumbnail — enough for the 160px admin card at 2× DPI.
+const THUMBNAIL_OPTS = { width: 320, format: "auto", fit: "cover" } as const;
+
+export const mediaListInputSchema = v.object({
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(MAX_PAGE_SIZE)),
+    DEFAULT_PAGE_SIZE,
+  ),
+  offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
+  // MIME filter: string form (`"image/"`) does a `LIKE 'image/%'` prefix match;
+  // array form matches the listed MIMEs exactly. Pushed into SQL so `limit`
+  // counts only matching rows.
+  accept: v.optional(
+    v.union([
+      v.pipe(v.string(), v.maxLength(64)),
+      v.pipe(v.array(v.pipe(v.string(), v.maxLength(64))), v.maxLength(32)),
+    ]),
+  ),
+  search: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200))),
+});
+
+type MediaListInput = v.InferOutput<typeof mediaListInputSchema>;
+
+interface MediaItem {
+  readonly id: number;
+  readonly title: string;
+  readonly mime: string;
+  readonly size: number;
+  readonly storageKey: string;
+  readonly alt: string | null;
+  readonly url: string;
+  readonly thumbnailUrl: string;
+  readonly uploadedAt: string;
+  readonly uploadedById: number;
+}
+
+interface MediaListResult {
+  readonly items: readonly MediaItem[];
+  readonly hasMore: boolean;
+}
+
+/**
+ * Domain error the media read path throws. Each transport maps it to its own
+ * shape (oRPC typed error / MCP envelope), keeping the service transport-neutral.
+ */
+export class MediaReadError extends Error {
+  static {
+    MediaReadError.prototype.name = "MediaReadError";
+  }
+
+  readonly data:
+    | { readonly code: "forbidden"; readonly capability: string }
+    | { readonly code: "not_found"; readonly id: number };
+
+  private constructor(data: MediaReadError["data"], message: string) {
+    super(message);
+    this.data = data;
+  }
+
+  static forbidden(capability: string): MediaReadError {
+    return new MediaReadError(
+      { code: "forbidden", capability },
+      `missing capability: ${capability}`,
+    );
+  }
+
+  static notFound(id: number): MediaReadError {
+    return new MediaReadError(
+      { code: "not_found", id },
+      `media ${id} not found`,
+    );
+  }
+}
+
+/**
+ * List published media the caller may read, with MIME / filename filters and
+ * offset pagination. Fetches one extra row to report `hasMore` without a
+ * second COUNT query. Throws {@link MediaReadError}.
+ */
+export async function listMedia(
+  ctx: AppContext,
+  input: MediaListInput,
+): Promise<MediaListResult> {
+  if (!ctx.auth.can(MEDIA_READ_CAPABILITY)) {
+    throw MediaReadError.forbidden(MEDIA_READ_CAPABILITY);
+  }
+
+  const conditions: SQL[] = [
+    eq(entries.type, MEDIA_ENTRY_TYPE),
+    eq(entries.status, "published"),
+  ];
+  const acceptCondition = buildAcceptCondition(input.accept);
+  if (acceptCondition) conditions.push(acceptCondition);
+  if (input.search) {
+    const pattern = `%${escapeLikePattern(input.search)}%`;
+    conditions.push(sql`(
+      ${entries.title} LIKE ${pattern} ESCAPE '\\'
+      OR COALESCE(json_extract(${entries.meta}, '$.alt'), '') LIKE ${pattern} ESCAPE '\\'
+    )`);
+  }
+
+  const rows = await ctx.db
+    .select()
+    .from(entries)
+    .where(and(...conditions))
+    .orderBy(desc(entries.updatedAt), desc(entries.id))
+    .limit(input.limit + 1)
+    .offset(input.offset);
+  const hasMore = rows.length > input.limit;
+  const visibleRows = hasMore ? rows.slice(0, input.limit) : rows;
+
+  const items: MediaItem[] = [];
+  for (const row of visibleRows) {
+    const meta = parseMediaMeta(row.meta);
+    if (!meta) continue;
+    items.push(await buildMediaItem(ctx, row, meta));
+  }
+  return { items, hasMore };
+}
+
+/**
+ * Read a single published media item by id. A missing row, a non-media row, a
+ * draft, or corrupt meta all collapse to `not_found` so existence stays hidden.
+ */
+export async function getMedia(
+  ctx: AppContext,
+  input: { readonly id: number },
+): Promise<MediaItem> {
+  if (!ctx.auth.can(MEDIA_READ_CAPABILITY)) {
+    throw MediaReadError.forbidden(MEDIA_READ_CAPABILITY);
+  }
+
+  const row = await ctx.db.query.entries.findFirst({
+    where: eq(entries.id, input.id),
+  });
+  const meta = row ? parseMediaMeta(row.meta) : null;
+  if (row?.type !== MEDIA_ENTRY_TYPE || row.status !== "published" || !meta) {
+    throw MediaReadError.notFound(input.id);
+  }
+  return buildMediaItem(ctx, row, meta);
+}
+
+async function buildMediaItem(
+  ctx: AppContext,
+  row: typeof entries.$inferSelect,
+  meta: NonNullable<ReturnType<typeof parseMediaMeta>>,
+): Promise<MediaItem> {
+  const url = ctx.storage
+    ? await resolveMediaUrl(ctx.storage, meta.storageKey, row.id)
+    : meta.storageKey;
+  // `publishedAt` is the "uploaded on" source of truth; fall back to createdAt.
+  const uploadedAt = (row.publishedAt ?? row.createdAt).toISOString();
+  return {
+    id: row.id,
+    title: row.title,
+    mime: meta.mime,
+    size: meta.size,
+    storageKey: meta.storageKey,
+    alt: meta.alt,
+    url,
+    thumbnailUrl: thumbnailFor(ctx, url, meta.mime),
+    uploadedAt,
+    uploadedById: row.authorId,
+  };
+}
+
+export function thumbnailFor(
+  ctx: AppContext,
+  url: string,
+  mime: string,
+): string {
+  // imageDelivery transforms need an absolute, publicly-reachable source — the
+  // transform CDN fetches it itself. The worker-proxied serve fallback is
+  // relative, so skip transforms there.
+  if (!mime.startsWith("image/") || !ctx.imageDelivery) return url;
+  if (!url.startsWith("http://") && !url.startsWith("https://")) return url;
+  return ctx.imageDelivery.url(url, THUMBNAIL_OPTS);
+}
+
+/**
+ * Resolve a publicly-fetchable URL for a media row. Prefers the storage
+ * adapter's native URL; falls back to the worker-proxied serve route keyed on
+ * the entry id (not the storageKey — the serve route enforces `published`).
+ */
+export async function resolveMediaUrl(
+  storage: NonNullable<AppContext["storage"]>,
+  storageKey: string,
+  entryId: number,
+): Promise<string> {
+  const direct = await storage.url(storageKey);
+  return direct ?? `/_plumix/media/serve/${String(entryId)}`;
+}
+
+// Translate `accept` into a SQL predicate against the JSON `mime` field. Real
+// MIME strings don't contain LIKE wildcards and the input is plugin/agent
+// supplied, so no escaping is needed.
+function buildAcceptCondition(
+  accept: string | readonly string[] | undefined,
+): SQL | undefined {
+  if (accept === undefined) return undefined;
+  const mimeExpr = sql<string>`json_extract(${entries.meta}, '$.mime')`;
+  if (typeof accept === "string") {
+    if (accept === "") return undefined;
+    return like(mimeExpr, `${accept}%`);
+  }
+  if (accept.length === 0) return undefined;
+  return inArray(mimeExpr, accept as string[]);
+}

--- a/packages/plugins/media/src/rpc.ts
+++ b/packages/plugins/media/src/rpc.ts
@@ -1,23 +1,18 @@
-import type { AppContext, AuthenticatedAppContext, SQL } from "plumix/plugin";
-import {
-  and,
-  authenticated,
-  base,
-  desc,
-  entries,
-  eq,
-  escapeLikePattern,
-  inArray,
-  like,
-  sql,
-} from "plumix/plugin";
+import type { AuthenticatedAppContext } from "plumix/plugin";
+import { and, authenticated, base, entries, eq } from "plumix/plugin";
 import * as v from "valibot";
 
 import { looksLikeMime, MAGIC_BYTE_SAMPLE_SIZE } from "./magic-bytes.js";
 import { parseMediaMeta } from "./meta.js";
 import { extensionForMime } from "./mime.js";
-
-const MEDIA_ENTRY_TYPE = "media";
+import {
+  listMedia,
+  MEDIA_ENTRY_TYPE,
+  mediaListInputSchema,
+  MediaReadError,
+  resolveMediaUrl,
+  thumbnailFor,
+} from "./read-service.js";
 
 interface MediaRpcOptions {
   readonly acceptedTypes: readonly string[];
@@ -42,28 +37,6 @@ interface ConfirmResponse {
   readonly size: number;
 }
 
-interface MediaListItem {
-  readonly id: number;
-  readonly title: string;
-  readonly mime: string;
-  readonly size: number;
-  readonly storageKey: string;
-  readonly alt: string | null;
-  readonly url: string;
-  readonly thumbnailUrl: string;
-  // ISO-8601 timestamp — surfaces in the drawer's "Uploaded" line.
-  readonly uploadedAt: string;
-  // Author display info for the "Uploaded by" line. Populated when the
-  // join lands; left undefined when the row's authorId no longer
-  // resolves (deleted user).
-  readonly uploadedById: number;
-}
-
-interface MediaListResponse {
-  readonly items: readonly MediaListItem[];
-  readonly hasMore: boolean;
-}
-
 interface DeleteResponse {
   readonly id: number;
 }
@@ -78,18 +51,6 @@ interface UpdateResponse {
 // `Content-Type: image/png` (no space, no parameters) when uploading
 // a File via XHR; anything else here is a sign of a malformed client.
 const CONTENT_TYPE_RE = /^[\x21-\x7E]+$/;
-
-const DEFAULT_PAGE_SIZE = 24;
-const MAX_PAGE_SIZE = 100;
-
-// Default thumbnail variant the admin grid renders. 320px-wide AVIF/WebP
-// is enough for the 160px card under 2× DPI; format=auto lets Cloudflare
-// negotiate via `Accept`.
-const THUMBNAIL_OPTS = {
-  width: 320,
-  format: "auto",
-  fit: "cover",
-} as const;
 
 interface MediaRowGuards {
   readonly NOT_FOUND: (opts: {
@@ -342,95 +303,13 @@ export function createMediaRouter(
 
   const list = base
     .use(authenticated)
-    .input(
-      v.object({
-        limit: v.optional(
-          v.pipe(
-            v.number(),
-            v.integer(),
-            v.minValue(1),
-            v.maxValue(MAX_PAGE_SIZE),
-          ),
-          DEFAULT_PAGE_SIZE,
-        ),
-        offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
-        // MIME filter for picker mode. String form (`"image/"`) does
-        // a `LIKE 'image/%'` prefix match; array form does an exact
-        // match against the supplied MIMEs. Pushed into SQL so the
-        // `limit` clause counts only matching rows — JS post-filter
-        // would silently under-fill the picker grid for a field whose
-        // accept rejects a chunk of recent uploads.
-        accept: v.optional(
-          v.union([
-            v.pipe(v.string(), v.maxLength(64)),
-            v.pipe(
-              v.array(v.pipe(v.string(), v.maxLength(64))),
-              v.maxLength(32),
-            ),
-          ]),
-        ),
-        // Filename substring match. Empty string coerces to "no filter"
-        // client-side; cap mirrors the entries-list search bound.
-        search: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200))),
-      }),
-    )
-    .handler(async ({ input, context, errors }): Promise<MediaListResponse> => {
-      if (!context.auth.can("entry:media:read")) {
-        throw errors.FORBIDDEN({ data: { capability: "entry:media:read" } });
+    .input(mediaListInputSchema)
+    .handler(async ({ input, context, errors }) => {
+      try {
+        return await listMedia(context, input);
+      } catch (error) {
+        throw mapMediaReadError(error, errors);
       }
-      const conditions: SQL[] = [
-        eq(entries.type, MEDIA_ENTRY_TYPE),
-        eq(entries.status, "published"),
-      ];
-      const acceptCondition = buildAcceptCondition(input.accept);
-      if (acceptCondition) conditions.push(acceptCondition);
-      if (input.search) {
-        const pattern = `%${escapeLikePattern(input.search)}%`;
-        // Alt lives inside the meta JSON; COALESCE because rows without
-        // an alt yield NULL from json_extract, and `LIKE` on NULL is
-        // NULL — which would poison the OR for title-only matches.
-        conditions.push(sql`(
-          ${entries.title} LIKE ${pattern} ESCAPE '\\'
-          OR COALESCE(json_extract(${entries.meta}, '$.alt'), '') LIKE ${pattern} ESCAPE '\\'
-        )`);
-      }
-      // Fetch one extra row so we can report `hasMore` without a
-      // separate COUNT(*) query.
-      const rows = await context.db
-        .select()
-        .from(entries)
-        .where(and(...conditions))
-        .orderBy(desc(entries.updatedAt), desc(entries.id))
-        .limit(input.limit + 1)
-        .offset(input.offset);
-      const hasMore = rows.length > input.limit;
-      const visibleRows = hasMore ? rows.slice(0, input.limit) : rows;
-
-      const items: MediaListItem[] = [];
-      for (const row of visibleRows) {
-        const meta = parseMediaMeta(row.meta);
-        if (!meta) continue;
-        const url = context.storage
-          ? await resolveMediaUrl(context.storage, meta.storageKey, row.id)
-          : meta.storageKey;
-        // `publishedAt` is the source of truth for "uploaded on"
-        // (set by `confirm`'s CAS); fall back to createdAt for the
-        // edge case where publishedAt is somehow null.
-        const uploadedAt = (row.publishedAt ?? row.createdAt).toISOString();
-        items.push({
-          id: row.id,
-          title: row.title,
-          mime: meta.mime,
-          size: meta.size,
-          storageKey: meta.storageKey,
-          alt: meta.alt,
-          url,
-          thumbnailUrl: thumbnailFor(context, url, meta.mime),
-          uploadedAt,
-          uploadedById: row.authorId,
-        });
-      }
-      return { items, hasMore };
     });
 
   const update = base
@@ -520,40 +399,16 @@ export function createMediaRouter(
   return { createUploadUrl, confirm, list, update, delete: remove };
 }
 
-function thumbnailFor(
-  context: AppContext | AuthenticatedAppContext,
-  url: string,
-  mime: string,
-): string {
-  // imageDelivery transforms (e.g. Cloudflare Image Transformations)
-  // need an absolute, publicly-reachable source URL — the transform
-  // CDN fetches the source itself. When `storage.url()` falls back to
-  // the worker-proxied `/_plumix/media/serve/<id>` (binding-only mode,
-  // no publicUrlBase), the transform CDN can't fetch it: relative URL,
-  // no public origin to dereference. Apply transforms only to absolute
-  // URLs.
-  if (!mime.startsWith("image/") || !context.imageDelivery) return url;
-  if (!url.startsWith("http://") && !url.startsWith("https://")) return url;
-  return context.imageDelivery.url(url, THUMBNAIL_OPTS);
-}
-
-/**
- * Resolve a publicly-fetchable URL for a media row. Prefers the
- * storage adapter's native URL (presigned R2 / public bucket via
- * `publicUrlBase`); falls back to the worker-proxied serve route
- * keyed on the entry id when the bucket isn't publicly addressable.
- *
- * The id-based fallback is critical: keying on storageKey would
- * mean anyone with a key could fetch bytes (incl. drafts). Keying
- * on id lets the serve route enforce `status='published'`.
- */
-async function resolveMediaUrl(
-  storage: NonNullable<AppContext["storage"]>,
-  storageKey: string,
-  entryId: number,
-): Promise<string> {
-  const direct = await storage.url(storageKey);
-  return direct ?? `/_plumix/media/serve/${String(entryId)}`;
+// Map a media-read domain error to the oRPC typed error to throw; non-domain
+// errors pass through for the caller to rethrow.
+function mapMediaReadError(error: unknown, errors: MediaRowGuards): unknown {
+  if (!(error instanceof MediaReadError)) return error;
+  switch (error.data.code) {
+    case "forbidden":
+      return errors.FORBIDDEN({ data: { capability: error.data.capability } });
+    case "not_found":
+      return errors.NOT_FOUND({ data: { kind: "media", id: error.data.id } });
+  }
 }
 
 function normalizeMime(raw: string): string {
@@ -573,23 +428,4 @@ function sanitizeExtension(filename: string): string | undefined {
   if (ext.length > MAX_EXT_LEN) return undefined;
   if (!SAFE_EXT_RE.test(ext)) return undefined;
   return ext;
-}
-
-// Translate the `accept` input into a SQL predicate against the
-// extracted JSON `mime` field. Mirrors the `mediaLookupAdapter`'s
-// approach (see lookup.ts) so the picker grid and the lookup adapter
-// apply identical filtering. Real MIME strings don't contain `%`/`_`
-// and the accept input is plugin-supplied (or omitted), so no LIKE
-// escaping is needed.
-function buildAcceptCondition(
-  accept: string | readonly string[] | undefined,
-): SQL | undefined {
-  if (accept === undefined) return undefined;
-  const mimeExpr = sql<string>`json_extract(${entries.meta}, '$.mime')`;
-  if (typeof accept === "string") {
-    if (accept === "") return undefined;
-    return like(mimeExpr, `${accept}%`);
-  }
-  if (accept.length === 0) return undefined;
-  return inArray(mimeExpr, accept as string[]);
 }


### PR DESCRIPTION
Proves MCP plugin extensibility: `@plumix/plugin-media` contributes `media_list` and `media_get` through `registerMcpTool` from its own setup — these tools ship from the plugin that owns media, with no per-tool change to core.

**Plugin seam, completed**

Core now exports `McpTool` / `McpToolError` from its root and `createApiToken` from its test barrel, so any plugin (and its tests) can author tools and mint PATs. The media plugin registers its two tools in setup alongside its RPC router; the core endpoint discovers and serves them through the registry merge.

**Shared media read path**

`listMedia` / `getMedia` are extracted into a transport-neutral `read-service.ts` (with a `MediaReadError` taxonomy and the URL-enrichment helpers). The RPC `list` becomes a thin adapter over `listMedia`, so there's one read path — the existing 49-test media suite stays green as the equivalence net. The MCP tools delegate to the same service.

**Capability + existence hiding inherited**

The tools forward the bearer-authed `ctx`, so a token without `entry:media:read` gets a `forbidden` envelope. `getMedia` collapses a missing id, a non-media row, a draft, or corrupt meta into `not_found` — a draft or cross-type id can't be read or probed. (`forbidden`-on-cap is no oracle here: media read is a global capability checked before the row loads, unlike the per-type entry read cap.)

Closes #935