### PR TITLE
test: add an apiToken factory and use it for PAT seeding

### DIFF
--- a/packages/core/src/auth/api-tokens.ts
+++ b/packages/core/src/auth/api-tokens.ts
@@ -21,14 +21,14 @@ const API_TOKEN_BODY_BYTES = 32;
 // enough to disambiguate users' own tokens at a glance.
 const PREFIX_DISPLAY_BODY_CHARS = 4;
 
-interface MintedApiToken {
+export interface MintedApiToken {
   /** Raw token to ship to the client exactly once. Never persisted. */
   readonly secret: string;
   /** The persisted row, sans the secret (already in DB at return time). */
   readonly row: ApiToken;
 }
 
-interface CreateApiTokenInput {
+export interface CreateApiTokenInput {
   readonly userId: number;
   readonly name: string;
   /**

--- a/packages/core/src/entries/read-service.test.ts
+++ b/packages/core/src/entries/read-service.test.ts
@@ -140,7 +140,7 @@ describe("getEntry", () => {
       authorId: h.user.id,
       slug: "pub",
     });
-    const term = await h.factory.category.create({
+    const term = await h.factory.term.create({
       name: "News",
       slug: "news",
     });

--- a/packages/core/src/mcp/dispatch.test.ts
+++ b/packages/core/src/mcp/dispatch.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 
 import type { UserRole } from "../db/schema/users.js";
 import type { DispatcherHarness } from "../test/dispatcher.js";
-import { createApiToken } from "../auth/api-tokens.js";
 import { definePlugin } from "../plugin/define.js";
 import { createDispatcherHarness } from "../test/dispatcher.js";
 
@@ -52,10 +51,8 @@ async function mintPat(
   }: { role?: UserRole; scopes?: string[] | null } = {},
 ): Promise<string> {
   const user = await h.factory.user.create({ role });
-  const { secret } = await createApiToken(h.db, {
+  const { secret } = await h.factory.apiToken.create({
     userId: user.id,
-    name: "mcp-test",
-    expiresAt: null,
     scopes,
   });
   return secret;

--- a/packages/core/src/terms/read-service.test.ts
+++ b/packages/core/src/terms/read-service.test.ts
@@ -44,8 +44,8 @@ const getInput = (partial: Record<string, unknown>) =>
 describe("listTerms", () => {
   test("returns terms in the taxonomy ordered by name", async () => {
     const h = await harness("editor");
-    await h.factory.category.create({ name: "News", slug: "news" });
-    await h.factory.category.create({ name: "Apples", slug: "apples" });
+    await h.factory.term.create({ name: "News", slug: "news" });
+    await h.factory.term.create({ name: "Apples", slug: "apples" });
 
     const rows = await listTerms(
       authedCtx(h),
@@ -57,8 +57,8 @@ describe("listTerms", () => {
 
   test("filters by name search", async () => {
     const h = await harness("editor");
-    await h.factory.category.create({ name: "News", slug: "news" });
-    await h.factory.category.create({ name: "Sports", slug: "sports" });
+    await h.factory.term.create({ name: "News", slug: "news" });
+    await h.factory.term.create({ name: "Sports", slug: "sports" });
 
     const rows = await listTerms(
       authedCtx(h),
@@ -100,7 +100,7 @@ describe("listTerms", () => {
 describe("getTerm", () => {
   test("returns a term hydrated with decoded meta", async () => {
     const h = await harness("editor");
-    const seeded = await h.factory.category.create({
+    const seeded = await h.factory.term.create({
       name: "News",
       slug: "news",
     });
@@ -125,7 +125,7 @@ describe("getTerm", () => {
 
   test("hides a term in an unreadable taxonomy as term_not_found", async () => {
     const h = await harness("editor");
-    const seeded = await h.factory.category.create({
+    const seeded = await h.factory.term.create({
       name: "News",
       slug: "news",
     });

--- a/packages/core/src/test/factories.ts
+++ b/packages/core/src/test/factories.ts
@@ -1,5 +1,9 @@
 import { Factory } from "fishery";
 
+import type {
+  CreateApiTokenInput,
+  MintedApiToken,
+} from "../auth/api-tokens.js";
 import type { Db } from "../context/app.js";
 import type {
   AllowedDomain,
@@ -17,6 +21,7 @@ import type { NewSession, Session } from "../db/schema/sessions.js";
 import type { NewSetting, Setting } from "../db/schema/settings.js";
 import type { NewTerm, Term } from "../db/schema/terms.js";
 import type { NewUser, User } from "../db/schema/users.js";
+import { createApiToken } from "../auth/api-tokens.js";
 import { allowedDomains } from "../db/schema/allowed_domains.js";
 import { authTokens } from "../db/schema/auth_tokens.js";
 import { credentials } from "../db/schema/credentials.js";
@@ -275,6 +280,29 @@ export const credentialFactory = Factory.define<
   };
 });
 
+// Mints a real PAT through createApiToken (hashes the secret, inserts the row).
+// `.create()` returns the minted token — `.secret` is the one-time plaintext.
+export const apiTokenFactory = Factory.define<
+  CreateApiTokenInput,
+  DbTransient,
+  MintedApiToken
+>(({ sequence, transientParams, onCreate, params }) => {
+  onCreate((attrs) => createApiToken(requireDb(transientParams), attrs));
+
+  const userId = params.userId;
+  if (userId === undefined) {
+    throw new Error("apiTokenFactory: userId is required");
+  }
+  return {
+    userId,
+    name: params.name ?? `token-${sequence}`,
+    expiresAt: params.expiresAt ?? null,
+    // fishery's DeepPartial widens array elements to `T | undefined`; the
+    // caller passes a real scope list (or null), so narrow it back.
+    scopes: (params.scopes ?? null) as readonly string[] | null,
+  };
+});
+
 export interface Factories {
   readonly user: typeof userFactory;
   readonly admin: typeof adminUser;
@@ -295,6 +323,7 @@ export interface Factories {
   readonly setting: typeof settingFactory;
   readonly entryTerm: typeof entryTermFactory;
   readonly allowedDomain: typeof allowedDomainFactory;
+  readonly apiToken: typeof apiTokenFactory;
 }
 
 export function factoriesFor(db: Db): Factories {
@@ -318,5 +347,6 @@ export function factoriesFor(db: Db): Factories {
     setting: settingFactory.transient({ db }),
     entryTerm: entryTermFactory.transient({ db }),
     allowedDomain: allowedDomainFactory.transient({ db }),
+    apiToken: apiTokenFactory.transient({ db }),
   };
 }

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -22,13 +22,12 @@ export {
   settingFactory,
   entryTermFactory,
   allowedDomainFactory,
+  apiTokenFactory,
   factoriesFor,
 } from "./factories.js";
 export type { Factories } from "./factories.js";
 
 export { createTestDb } from "./harness.js";
-
-export { createApiToken } from "../auth/api-tokens.js";
 
 export { createDispatcherHarness, plumixRequest } from "./dispatcher.js";
 export type {

--- a/packages/plugins/media/src/mcp-tools.test.ts
+++ b/packages/plugins/media/src/mcp-tools.test.ts
@@ -1,5 +1,5 @@
 import { memoryStorage } from "plumix/plugin";
-import { createApiToken, createDispatcherHarness } from "plumix/test";
+import { createDispatcherHarness } from "plumix/test";
 import { describe, expect, test } from "vitest";
 
 import { media } from "./index.js";
@@ -39,10 +39,8 @@ async function mintPat(
   scopes: string[] | null = null,
 ): Promise<{ secret: string; userId: number }> {
   const user = await h.seedUser("editor");
-  const { secret } = await createApiToken(h.db, {
+  const { secret } = await h.factory.apiToken.create({
     userId: user.id,
-    name: "mcp",
-    expiresAt: null,
     scopes,
   });
   return { secret, userId: user.id };


### PR DESCRIPTION
First batch of the test-seeding cleanup (#943): seed PATs through a shared factory instead of calling `createApiToken` directly.

**`apiTokenFactory`**

Wraps `createApiToken` (which hashes the secret and inserts the `api_tokens` row) and returns the minted `{ secret, row }` — so it goes through the exact production mint path, not a parallel raw insert. Registered on the `Factories` map / `factoriesFor`, so the MCP tests mint via `h.factory.apiToken.create({ userId, scopes })`.

**`category` → `term`**

The two read-service tests used `h.factory.category`, which is just `termFactory` pinned to `taxonomy: "category"` — and `termFactory` already defaults to that taxonomy. Switched to the general `h.factory.term`.

Also exports `CreateApiTokenInput` / `MintedApiToken` (so the factory's typed declaration can name them) and drops the now-unused `createApiToken` re-export from the test barrel.

Test-only; no behavior change. Full suites green (core 1971, media 139).

Refs #943