### PR TITLE
test(core): seed entries/terms/search tests through factories

### DIFF
--- a/packages/core/src/rpc/procedures/entry/read.test.ts
+++ b/packages/core/src/rpc/procedures/entry/read.test.ts
@@ -2,31 +2,8 @@ import { describe, expect, test } from "vitest";
 
 import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
-import { entryTerm } from "../../../db/schema/entry_term.js";
-import { terms } from "../../../db/schema/terms.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
-
-async function seedTerm(
-  h: Awaited<ReturnType<typeof createRpcHarness>>,
-  termTaxonomy: string,
-  slug: string,
-): Promise<number> {
-  const [row] = await h.context.db
-    .insert(terms)
-    .values({ taxonomy: termTaxonomy, name: slug, slug })
-    .returning();
-  if (!row) throw new Error("seedTerm: insert returned no row");
-  return row.id;
-}
-
-async function attachTerm(
-  h: Awaited<ReturnType<typeof createRpcHarness>>,
-  entryId: number,
-  termId: number,
-): Promise<void> {
-  await h.context.db.insert(entryTerm).values({ entryId, termId });
-}
 
 describe("entry.list", () => {
   test("returns published entries by default for subscriber", async () => {
@@ -264,8 +241,16 @@ describe("entry.list", () => {
 
   test("termTaxonomy filter: single termTaxonomy, IN across term slugs", async () => {
     const h = await createRpcHarness({ authAs: "editor" });
-    const news = await seedTerm(h, "category", "news");
-    const tutorials = await seedTerm(h, "category", "tutorials");
+    const news = await h.factory.term.create({
+      taxonomy: "category",
+      name: "news",
+      slug: "news",
+    });
+    const tutorials = await h.factory.term.create({
+      taxonomy: "category",
+      name: "tutorials",
+      slug: "tutorials",
+    });
     const p1 = await h.factory.published.create({
       authorId: h.user.id,
       slug: "news-post",
@@ -278,8 +263,8 @@ describe("entry.list", () => {
       authorId: h.user.id,
       slug: "untagged",
     });
-    await attachTerm(h, p1.id, news);
-    await attachTerm(h, p2.id, tutorials);
+    await h.factory.entryTerm.create({ entryId: p1.id, termId: news.id });
+    await h.factory.entryTerm.create({ entryId: p2.id, termId: tutorials.id });
 
     const rows = await h.client.entry.list({
       termTaxonomies: { category: ["news", "tutorials"] },
@@ -289,8 +274,16 @@ describe("entry.list", () => {
 
   test("termTaxonomy filter: AND across termTaxonomies (post must match each)", async () => {
     const h = await createRpcHarness({ authAs: "editor" });
-    const news = await seedTerm(h, "category", "news");
-    const urgent = await seedTerm(h, "tag", "urgent");
+    const news = await h.factory.term.create({
+      taxonomy: "category",
+      name: "news",
+      slug: "news",
+    });
+    const urgent = await h.factory.term.create({
+      taxonomy: "tag",
+      name: "urgent",
+      slug: "urgent",
+    });
     const both = await h.factory.published.create({
       authorId: h.user.id,
       slug: "both",
@@ -303,10 +296,13 @@ describe("entry.list", () => {
       authorId: h.user.id,
       slug: "urgent-only",
     });
-    await attachTerm(h, both.id, news);
-    await attachTerm(h, both.id, urgent);
-    await attachTerm(h, newsOnly.id, news);
-    await attachTerm(h, urgentOnly.id, urgent);
+    await h.factory.entryTerm.create({ entryId: both.id, termId: news.id });
+    await h.factory.entryTerm.create({ entryId: both.id, termId: urgent.id });
+    await h.factory.entryTerm.create({ entryId: newsOnly.id, termId: news.id });
+    await h.factory.entryTerm.create({
+      entryId: urgentOnly.id,
+      termId: urgent.id,
+    });
 
     const rows = await h.client.entry.list({
       termTaxonomies: { category: ["news"], tag: ["urgent"] },
@@ -330,8 +326,16 @@ describe("entry.list", () => {
     // Same slug in two termTaxonomies — filter must only match within the
     // specified termTaxonomy. `{ category: ["news"] }` should NOT match a
     // post tagged `tag:news`.
-    const catNews = await seedTerm(h, "category", "news");
-    const tagNews = await seedTerm(h, "tag", "news");
+    const catNews = await h.factory.term.create({
+      taxonomy: "category",
+      name: "news",
+      slug: "news",
+    });
+    const tagNews = await h.factory.term.create({
+      taxonomy: "tag",
+      name: "news",
+      slug: "news",
+    });
     const catPost = await h.factory.published.create({
       authorId: h.user.id,
       slug: "in-category",
@@ -340,8 +344,14 @@ describe("entry.list", () => {
       authorId: h.user.id,
       slug: "in-tag",
     });
-    await attachTerm(h, catPost.id, catNews);
-    await attachTerm(h, tagPost.id, tagNews);
+    await h.factory.entryTerm.create({
+      entryId: catPost.id,
+      termId: catNews.id,
+    });
+    await h.factory.entryTerm.create({
+      entryId: tagPost.id,
+      termId: tagNews.id,
+    });
 
     const rows = await h.client.entry.list({
       termTaxonomies: { category: ["news"] },
@@ -351,7 +361,11 @@ describe("entry.list", () => {
 
   test("termTaxonomy filter composes with search", async () => {
     const h = await createRpcHarness({ authAs: "editor" });
-    const news = await seedTerm(h, "category", "news");
+    const news = await h.factory.term.create({
+      taxonomy: "category",
+      name: "news",
+      slug: "news",
+    });
     const matches = await h.factory.published.create({
       authorId: h.user.id,
       title: "Quantum breakthrough",
@@ -362,7 +376,7 @@ describe("entry.list", () => {
       title: "Quantum breakthrough elsewhere",
       slug: "qbn-2",
     });
-    await attachTerm(h, matches.id, news);
+    await h.factory.entryTerm.create({ entryId: matches.id, termId: news.id });
     // `notTagged` has the same title but no term — termTaxonomy filter excludes it
 
     const rows = await h.client.entry.list({

--- a/packages/core/src/rpc/procedures/entry/terms.test.ts
+++ b/packages/core/src/rpc/procedures/entry/terms.test.ts
@@ -39,19 +39,6 @@ function taxonomyRegistry(
   return registry;
 }
 
-async function seedTerm(
-  h: Awaited<ReturnType<typeof createRpcHarness>>,
-  termTaxonomy: string,
-  slug: string,
-): Promise<number> {
-  const [row] = await h.context.db
-    .insert(terms)
-    .values({ taxonomy: termTaxonomy, name: slug, slug })
-    .returning();
-  if (!row) throw new Error("seedTerm: insert returned no row");
-  return row.id;
-}
-
 // Both replacement-semantics and sortOrder tests need the same shape:
 // an editor-authed harness, an empty post, and three pre-seeded
 // "category" terms. Centralized so a future tweak to the scaffold
@@ -70,9 +57,15 @@ async function setupEditorWithThreeCategoryTerms(): Promise<{
   const plugins = taxonomyRegistry();
   const h = await createRpcHarness({ authAs: "editor", plugins });
   const post = await h.factory.draft.create({ authorId: h.user.id });
-  const a = await seedTerm(h, "category", "a");
-  const b = await seedTerm(h, "category", "b");
-  const c = await seedTerm(h, "category", "c");
+  const a = (
+    await h.factory.term.create({ taxonomy: "category", name: "a", slug: "a" })
+  ).id;
+  const b = (
+    await h.factory.term.create({ taxonomy: "category", name: "b", slug: "b" })
+  ).id;
+  const c = (
+    await h.factory.term.create({ taxonomy: "category", name: "c", slug: "c" })
+  ).id;
   return { h, post, a, b, c };
 }
 
@@ -97,8 +90,20 @@ describe("entry.update — terms", () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "author", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
-    const catA = await seedTerm(h, "category", "news");
-    const catB = await seedTerm(h, "category", "reviews");
+    const catA = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "news",
+        slug: "news",
+      })
+    ).id;
+    const catB = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "reviews",
+        slug: "reviews",
+      })
+    ).id;
 
     await h.client.entry.update({
       id: post.id,
@@ -121,7 +126,13 @@ describe("entry.update — terms", () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
-    const a = await seedTerm(h, "category", "a");
+    const a = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "a",
+        slug: "a",
+      })
+    ).id;
 
     await h.client.entry.update({ id: post.id, terms: { category: [a] } });
     await h.client.entry.update({ id: post.id, terms: { category: [] } });
@@ -133,8 +144,20 @@ describe("entry.update — terms", () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
-    const cat = await seedTerm(h, "category", "cat-1");
-    const tag = await seedTerm(h, "post_tag", "tag-1");
+    const cat = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "cat-1",
+        slug: "cat-1",
+      })
+    ).id;
+    const tag = (
+      await h.factory.term.create({
+        taxonomy: "post_tag",
+        name: "tag-1",
+        slug: "tag-1",
+      })
+    ).id;
 
     await h.client.entry.update({
       id: post.id,
@@ -154,7 +177,13 @@ describe("entry.update — terms", () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
-    const a = await seedTerm(h, "category", "a");
+    const a = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "a",
+        slug: "a",
+      })
+    ).id;
 
     await h.client.entry.update({
       id: post.id,
@@ -167,7 +196,13 @@ describe("entry.update — terms", () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
-    const cat = await seedTerm(h, "category", "cat");
+    const cat = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "cat",
+        slug: "cat",
+      })
+    ).id;
 
     await expect(
       h.client.entry.update({
@@ -187,7 +222,13 @@ describe("entry.update — terms", () => {
     const plugins = taxonomyRegistry({ assignRole: "admin" });
     const h = await createRpcHarness({ authAs: "editor", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
-    const cat = await seedTerm(h, "category", "cat");
+    const cat = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "cat",
+        slug: "cat",
+      })
+    ).id;
 
     await expect(
       h.client.entry.update({ id: post.id, terms: { category: [cat] } }),
@@ -201,7 +242,13 @@ describe("entry.update — terms", () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
-    const tag = await seedTerm(h, "post_tag", "misplaced");
+    const tag = (
+      await h.factory.term.create({
+        taxonomy: "post_tag",
+        name: "misplaced",
+        slug: "misplaced",
+      })
+    ).id;
 
     await expect(
       h.client.entry.update({
@@ -235,7 +282,13 @@ describe("entry.update — terms", () => {
     const h = await createRpcHarness({ authAs: "editor", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
     const originalTitle = post.title;
-    const cat = await seedTerm(h, "category", "only-terms");
+    const cat = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "only-terms",
+        slug: "only-terms",
+      })
+    ).id;
 
     const updated = await h.client.entry.update({
       id: post.id,
@@ -272,7 +325,13 @@ describe("entry.update — terms", () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
     const post = await h.factory.draft.create({ authorId: h.user.id });
-    const cat = await seedTerm(h, "category", "stable");
+    const cat = (
+      await h.factory.term.create({
+        taxonomy: "category",
+        name: "stable",
+        slug: "stable",
+      })
+    ).id;
 
     await h.client.entry.update({ id: post.id, terms: { category: [cat] } });
     // Second call with the same set — without onConflictDoNothing the

--- a/packages/core/src/rpc/procedures/search/index.test.ts
+++ b/packages/core/src/rpc/procedures/search/index.test.ts
@@ -1,20 +1,18 @@
 import { describe, expect, test } from "vitest";
 
+import type { AuthenticatedRpcHarness } from "../../../test/rpc.js";
 import { deriveTermTaxonomyCapabilities } from "../../../auth/rbac.js";
-import { entries } from "../../../db/schema/entries.js";
-import { terms } from "../../../db/schema/terms.js";
-import { users } from "../../../db/schema/users.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { registerCoreSearchHandlers } from "../../../search/register-core-handlers.js";
 import { createRpcHarness } from "../../../test/rpc.js";
-
-type Harness = Awaited<ReturnType<typeof createRpcHarness>>;
 
 // Spin up a harness with a `post` entry type + a `category` taxonomy +
 // the core search handlers wired on (the harness boots none). `post` caps
 // are core; the taxonomy's are derived at registration, so we populate
 // them the way `registerTermTaxonomy` would. Mirrors `createPlumixApp`.
-async function searchHarness(authAs: "editor" | "author"): Promise<Harness> {
+async function searchHarness(
+  authAs: "editor" | "author",
+): Promise<AuthenticatedRpcHarness> {
   const plugins = createPluginRegistry();
   plugins.entryTypes.set("post", {
     label: { id: "et.post", message: "Posts" },
@@ -35,38 +33,21 @@ async function searchHarness(authAs: "editor" | "author"): Promise<Harness> {
   return h;
 }
 
-async function seedTerm(h: Harness, name: string, slug: string): Promise<void> {
-  await h.context.db.insert(terms).values({ taxonomy: "category", name, slug });
-}
-
-async function seedUser(
-  h: Harness,
-  name: string,
-  email: string,
-): Promise<void> {
-  await h.context.db.insert(users).values({ name, email, role: "subscriber" });
-}
-
-async function seed(
-  h: Harness,
-  values: {
-    title: string;
-    slug: string;
-    status: "published" | "draft" | "trash";
-  },
-): Promise<void> {
-  const author = h.user;
-  if (!author) throw new Error("harness has no authenticated user");
-  await h.context.db
-    .insert(entries)
-    .values({ type: "post", authorId: author.id, ...values });
-}
-
 describe("search.query", () => {
   test("groups matching entries by type and matches title", async () => {
     const h = await searchHarness("editor");
-    await seed(h, { title: "Hello World", slug: "hello", status: "published" });
-    await seed(h, { title: "Unrelated", slug: "other", status: "published" });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      title: "Hello World",
+      slug: "hello",
+      status: "published",
+    });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      title: "Unrelated",
+      slug: "other",
+      status: "published",
+    });
 
     const groups = await h.client.search.query({ query: "hello" });
 
@@ -80,7 +61,12 @@ describe("search.query", () => {
 
   test("editor sees draft matches", async () => {
     const h = await searchHarness("editor");
-    await seed(h, { title: "Hidden Draft", slug: "d1", status: "draft" });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      title: "Hidden Draft",
+      slug: "d1",
+      status: "draft",
+    });
 
     const groups = await h.client.search.query({ query: "hidden" });
 
@@ -91,7 +77,12 @@ describe("search.query", () => {
 
   test("an author sees their own draft (mirrors entry read rules)", async () => {
     const h = await searchHarness("author");
-    await seed(h, { title: "My Own Draft", slug: "d2", status: "draft" });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      title: "My Own Draft",
+      slug: "d2",
+      status: "draft",
+    });
 
     const groups = await h.client.search.query({ query: "own" });
 
@@ -102,22 +93,40 @@ describe("search.query", () => {
 
   test("trash entries are excluded even for editors", async () => {
     const h = await searchHarness("editor");
-    await seed(h, { title: "Trashed Item", slug: "t1", status: "trash" });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      title: "Trashed Item",
+      slug: "t1",
+      status: "trash",
+    });
 
     expect(await h.client.search.query({ query: "trashed" })).toEqual([]);
   });
 
   test("returns nothing for an empty query", async () => {
     const h = await searchHarness("editor");
-    await seed(h, { title: "Hello", slug: "h", status: "published" });
+    await h.factory.entry.create({
+      authorId: h.user.id,
+      title: "Hello",
+      slug: "h",
+      status: "published",
+    });
 
     expect(await h.client.search.query({ query: "  " })).toEqual([]);
   });
 
   test("groups matching terms by taxonomy", async () => {
     const h = await searchHarness("editor");
-    await seedTerm(h, "News", "news");
-    await seedTerm(h, "Unrelated", "unrelated");
+    await h.factory.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+    await h.factory.term.create({
+      taxonomy: "category",
+      name: "Unrelated",
+      slug: "unrelated",
+    });
 
     const groups = await h.client.search.query({ query: "news" });
 
@@ -131,8 +140,14 @@ describe("search.query", () => {
 
   test("returns a users group for a caller who can list users", async () => {
     const h = await searchHarness("editor");
-    await seedUser(h, "Alice Smith", "alice@example.com");
-    await seedUser(h, "Bob Jones", "bob@example.com");
+    await h.factory.user.create({
+      name: "Alice Smith",
+      email: "alice@example.com",
+    });
+    await h.factory.user.create({
+      name: "Bob Jones",
+      email: "bob@example.com",
+    });
 
     const groups = await h.client.search.query({ query: "alice" });
 
@@ -146,7 +161,10 @@ describe("search.query", () => {
 
   test("omits the users group when the caller cannot list users", async () => {
     const h = await searchHarness("author");
-    await seedUser(h, "Alice Smith", "alice@example.com");
+    await h.factory.user.create({
+      name: "Alice Smith",
+      email: "alice@example.com",
+    });
 
     expect(await h.client.search.query({ query: "alice" })).toEqual([]);
   });


### PR DESCRIPTION
Batch 2 of #943 (no raw `db` calls in tests). Replaces the hand-rolled `seedTerm` / `attachTerm` / `seedUser` / `seed` helpers (direct `db.insert`) in the entry-read, entry-terms, and search test suites with inline factory calls (`h.factory.term` / `entryTerm` / `user` / `entry`).

The pure seed-wrapper functions are gone; the genuine scaffolds (`setupEditorWithThreeCategoryTerms`, `taxonomyRegistry`, `searchHarness`) stay. `searchHarness` now returns an `AuthenticatedRpcHarness`, so the seeded entries reference `h.user.id` directly (dropping the old null-guard).

Behavior-preserving: the factory rows match the old inserts column-for-column (the one nominal difference — `entryFactory` setting `publishedAt` for published entries vs the old `NULL` — is invisible to every search assertion, which order by `updatedAt` and assert on `title`). Suites green: read 34, terms 13, search 8; full core suite 1971.

Refs #943