### PR TITLE
test(core): seed sessions/passkey tests through the user factory

### DIFF
--- a/packages/core/src/auth/passkey/register.test.ts
+++ b/packages/core/src/auth/passkey/register.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { users } from "../../db/schema/users.js";
+import { userFactory } from "../../test/factories.js";
 import {
   buildAttestation,
   generatePasskeyKeyPair,
@@ -19,21 +19,12 @@ const config = resolvePasskeyConfig({
   origin: "https://cms.example.com",
 });
 
-async function seedUserId(
-  db: Awaited<ReturnType<typeof createTestDb>>,
-): Promise<number> {
-  const [user] = await db
-    .insert(users)
-    .values({ email: "u@example.com", role: "admin" })
-    .returning({ id: users.id });
-  if (!user) throw new Error("seed");
-  return user.id;
-}
-
 describe("finishRegistration (positive ceremony with ES256)", () => {
   test("verifies origin, RP-ID, attestation=none, and extracts the SEC1 public key", async () => {
     const db = await createTestDb();
-    const userId = await seedUserId(db);
+    const userId = (
+      await userFactory.transient({ db }).create({ role: "admin" })
+    ).id;
     const { challenge } = await issueChallenge(db, 60_000, userId);
     const keyPair = generatePasskeyKeyPair();
     const credentialId = randomCredentialId();
@@ -65,7 +56,9 @@ describe("finishRegistration (positive ceremony with ES256)", () => {
     // a fixed-offset encoder then left-shifts Y, silently storing a
     // corrupted key that bricks the credential at every future login.
     const db = await createTestDb();
-    const userId = await seedUserId(db);
+    const userId = (
+      await userFactory.transient({ db }).create({ role: "admin" })
+    ).id;
     const { challenge } = await issueChallenge(db, 60_000, userId);
     const keyPair = leadingZeroYKeyPair();
     const credentialId = randomCredentialId();
@@ -96,7 +89,9 @@ describe("finishRegistration (positive ceremony with ES256)", () => {
 describe("finishRegistration (security checks)", () => {
   test("rejects a response whose origin does not match the configured origin", async () => {
     const db = await createTestDb();
-    const userId = await seedUserId(db);
+    const userId = (
+      await userFactory.transient({ db }).create({ role: "admin" })
+    ).id;
     const { challenge } = await issueChallenge(db, 60_000, userId);
     const keyPair = generatePasskeyKeyPair();
     const credentialId = randomCredentialId();
@@ -155,7 +150,9 @@ describe("finishRegistration (security checks)", () => {
 describe("persistCredential", () => {
   test("rejects a duplicate credential id (would silently re-bind otherwise)", async () => {
     const db = await createTestDb();
-    const userId = await seedUserId(db);
+    const userId = (
+      await userFactory.transient({ db }).create({ role: "admin" })
+    ).id;
     const verified = {
       credentialId: "dup",
       publicKey: new Uint8Array([0x04, ...new Uint8Array(64)]),
@@ -179,7 +176,9 @@ describe("persistCredential", () => {
 
   test("enforces the per-user credential limit", async () => {
     const db = await createTestDb();
-    const userId = await seedUserId(db);
+    const userId = (
+      await userFactory.transient({ db }).create({ role: "admin" })
+    ).id;
     await persistCredential(db, {
       userId,
       verified: {

--- a/packages/core/src/auth/sessions.test.ts
+++ b/packages/core/src/auth/sessions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 
 import type { SessionPolicy } from "./sessions.js";
 import { users } from "../db/schema/users.js";
+import { userFactory } from "../test/factories.js";
 import { createTestDb } from "../test/harness.js";
 import {
   createSession,
@@ -12,19 +13,10 @@ import {
 } from "./sessions.js";
 import { hashToken } from "./tokens.js";
 
-async function seedUser(db: Awaited<ReturnType<typeof createTestDb>>) {
-  const [user] = await db
-    .insert(users)
-    .values({ email: "alice@example.com", role: "admin" })
-    .returning();
-  if (!user) throw new Error("seed failed");
-  return user;
-}
-
 describe("session lifecycle", () => {
   test("round-trips a token while storing only its SHA-256 hash in the DB", async () => {
     const db = await createTestDb();
-    const user = await seedUser(db);
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
     const { token, session } = await createSession(db, { userId: user.id });
 
     expect(session.id).not.toBe(token);
@@ -36,7 +28,7 @@ describe("session lifecycle", () => {
 
   test("rejects a tampered token (hash miss → no row found)", async () => {
     const db = await createTestDb();
-    const user = await seedUser(db);
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
     const { token } = await createSession(db, { userId: user.id });
     const tampered = token.slice(0, -1) + (token.endsWith("a") ? "b" : "a");
     expect(await validateSession(db, tampered)).toBeNull();
@@ -44,7 +36,7 @@ describe("session lifecycle", () => {
 
   test("expired session is rejected and the row is purged", async () => {
     const db = await createTestDb();
-    const user = await seedUser(db);
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
     const policy: SessionPolicy = {
       ...DEFAULT_SESSION_POLICY,
       maxAgeSeconds: -10,
@@ -56,7 +48,7 @@ describe("session lifecycle", () => {
 
   test("sliding window extends expiresAt past the threshold", async () => {
     const db = await createTestDb();
-    const user = await seedUser(db);
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
     const policy: SessionPolicy = {
       maxAgeSeconds: 60,
       absoluteMaxAgeSeconds: 3600,
@@ -79,7 +71,7 @@ describe("session lifecycle", () => {
 
   test("absolute cap forbids extending past createdAt + absoluteMaxAge", async () => {
     const db = await createTestDb();
-    const user = await seedUser(db);
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
     const policy: SessionPolicy = {
       maxAgeSeconds: 60,
       absoluteMaxAgeSeconds: 1,
@@ -92,7 +84,7 @@ describe("session lifecycle", () => {
 
   test("disabled user can no longer validate — session is purged", async () => {
     const db = await createTestDb();
-    const user = await seedUser(db);
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
     const { token } = await createSession(db, { userId: user.id });
     await db
       .update(users)
@@ -103,7 +95,7 @@ describe("session lifecycle", () => {
 
   test("invalidateSession deletes by hash so the token stops working", async () => {
     const db = await createTestDb();
-    const user = await seedUser(db);
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
     const { token } = await createSession(db, { userId: user.id });
     await invalidateSession(db, token);
     expect(await validateSession(db, token)).toBeNull();


### PR DESCRIPTION
Batch of #943 (no raw `db` in tests). Replaces the `seedUser` / `seedUserId` helpers (direct `db.insert` into `users`) in the sessions and passkey-register suites with inline `userFactory.transient({ db }).create(...)`.

The mid-test `db.update(users).set({ disabledAt })` in the sessions "disabled user" test stays — it's the action under test (disabling an active session-holder), not seeding.

Behavior-preserving (the dropped fixed emails weren't asserted anywhere): sessions 7, passkey-register 6; full core suite 1971.

Refs #943