### PR TITLE
test(core): add authTokenFactory and seed magic-link/invite tokens with it

### DIFF
--- a/packages/core/src/auth/invite.test.ts
+++ b/packages/core/src/auth/invite.test.ts
@@ -2,37 +2,14 @@ import { describe, expect, test } from "vitest";
 
 import { eq } from "../db/index.js";
 import { authTokens } from "../db/schema/auth_tokens.js";
-import { userFactory } from "../test/factories.js";
+import { authTokenFactory, userFactory } from "../test/factories.js";
 import { createTestDb } from "../test/harness.js";
 import {
   consumeInviteToken,
   InviteError,
   validateInviteToken,
 } from "./invite.js";
-import { generateToken, hashToken } from "./tokens.js";
-
-async function seedInvite(
-  db: Awaited<ReturnType<typeof createTestDb>>,
-  overrides: {
-    readonly userId?: number | null;
-    readonly email?: string | null;
-    readonly role?: "admin" | "editor" | "author" | null;
-    readonly expiresInMs?: number;
-    readonly type?: "invite" | "magic_link";
-  } = {},
-): Promise<{ token: string; tokenHash: string }> {
-  const token = generateToken();
-  const tokenHash = await hashToken(token);
-  await db.insert(authTokens).values({
-    hash: tokenHash,
-    userId: overrides.userId ?? null,
-    email: overrides.email ?? null,
-    role: overrides.role ?? null,
-    type: overrides.type ?? "invite",
-    expiresAt: new Date(Date.now() + (overrides.expiresInMs ?? 60_000)),
-  });
-  return { token, tokenHash };
-}
+import { generateToken } from "./tokens.js";
 
 describe("validateInviteToken", () => {
   test("returns the invite when the token is valid and fields are present", async () => {
@@ -40,14 +17,15 @@ describe("validateInviteToken", () => {
     const user = await userFactory
       .transient({ db })
       .create({ email: "invitee@example.test", role: "author" });
-    const { token, tokenHash } = await seedInvite(db, {
+    const { token, row } = await authTokenFactory.transient({ db }).create({
+      type: "invite",
       userId: user.id,
       email: user.email,
       role: "author",
     });
 
     const invite = await validateInviteToken(db, token);
-    expect(invite.tokenHash).toBe(tokenHash);
+    expect(invite.tokenHash).toBe(row.hash);
     expect(invite.userId).toBe(user.id);
     expect(invite.email).toBe("invitee@example.test");
     expect(invite.role).toBe("author");
@@ -63,11 +41,11 @@ describe("validateInviteToken", () => {
   test("throws invalid_token for a non-invite token type", async () => {
     const db = await createTestDb();
     const user = await userFactory.transient({ db }).create();
-    const { token } = await seedInvite(db, {
+    const { token } = await authTokenFactory.transient({ db }).create({
+      type: "magic_link",
       userId: user.id,
       email: user.email,
       role: "author",
-      type: "magic_link",
     });
     await expect(validateInviteToken(db, token)).rejects.toMatchObject({
       code: "invalid_token",
@@ -76,7 +54,8 @@ describe("validateInviteToken", () => {
 
   test("throws invalid_token when required fields are null", async () => {
     const db = await createTestDb();
-    const { token } = await seedInvite(db, {
+    const { token } = await authTokenFactory.transient({ db }).create({
+      type: "invite",
       userId: null,
       email: "x@example.test",
       role: "author",
@@ -89,11 +68,12 @@ describe("validateInviteToken", () => {
   test("throws token_expired when expiresAt is in the past", async () => {
     const db = await createTestDb();
     const user = await userFactory.transient({ db }).create();
-    const { token } = await seedInvite(db, {
+    const { token } = await authTokenFactory.transient({ db }).create({
+      type: "invite",
       userId: user.id,
       email: user.email,
       role: "author",
-      expiresInMs: -60_000,
+      expiresAt: new Date(Date.now() - 60_000),
     });
     await expect(validateInviteToken(db, token)).rejects.toMatchObject({
       code: "token_expired",
@@ -103,7 +83,8 @@ describe("validateInviteToken", () => {
   test("is idempotent — does not consume the token on success", async () => {
     const db = await createTestDb();
     const user = await userFactory.transient({ db }).create();
-    const { token, tokenHash } = await seedInvite(db, {
+    const { token, row } = await authTokenFactory.transient({ db }).create({
+      type: "invite",
       userId: user.id,
       email: user.email,
       role: "author",
@@ -112,10 +93,10 @@ describe("validateInviteToken", () => {
     await validateInviteToken(db, token);
     await validateInviteToken(db, token);
 
-    const row = await db.query.authTokens.findFirst({
-      where: eq(authTokens.hash, tokenHash),
+    const stored = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, row.hash),
     });
-    expect(row).toBeDefined();
+    expect(stored).toBeDefined();
   });
 });
 
@@ -123,18 +104,19 @@ describe("consumeInviteToken", () => {
   test("deletes the token row", async () => {
     const db = await createTestDb();
     const user = await userFactory.transient({ db }).create();
-    const { token, tokenHash } = await seedInvite(db, {
+    const { token, row } = await authTokenFactory.transient({ db }).create({
+      type: "invite",
       userId: user.id,
       email: user.email,
       role: "author",
     });
 
-    await consumeInviteToken(db, tokenHash);
+    await consumeInviteToken(db, row.hash);
 
-    const row = await db.query.authTokens.findFirst({
-      where: eq(authTokens.hash, tokenHash),
+    const found = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, row.hash),
     });
-    expect(row).toBeUndefined();
+    expect(found).toBeUndefined();
     await expect(validateInviteToken(db, token)).rejects.toMatchObject({
       code: "invalid_token",
     });

--- a/packages/core/src/auth/magic-link/routes.test.ts
+++ b/packages/core/src/auth/magic-link/routes.test.ts
@@ -7,7 +7,6 @@ import { authTokens } from "../../db/schema/auth_tokens.js";
 import { sessions } from "../../db/schema/sessions.js";
 import { users } from "../../db/schema/users.js";
 import { createDispatcherHarness } from "../../test/dispatcher.js";
-import { generateToken, hashToken } from "../tokens.js";
 
 interface CapturedSend {
   readonly to: string;
@@ -132,24 +131,6 @@ describe("magic-link request route", () => {
 });
 
 describe("magic-link verify route", () => {
-  async function seedToken(
-    h: Awaited<ReturnType<typeof createDispatcherHarness>>,
-    userId: number,
-    email: string,
-    ttlSeconds: number = 15 * 60,
-  ): Promise<string> {
-    const token = generateToken();
-    const hash = await hashToken(token);
-    await h.db.insert(authTokens).values({
-      hash,
-      userId,
-      email,
-      type: "magic_link",
-      expiresAt: new Date(Date.now() + ttlSeconds * 1000),
-    });
-    return token;
-  }
-
   test("missing token redirects with magic_link_error=missing_token", async () => {
     const { mailer } = captureMailer();
     const h = await createDispatcherHarness({
@@ -175,7 +156,12 @@ describe("magic-link verify route", () => {
       email: "alice@example.com",
       role: "editor",
     });
-    const token = await seedToken(h, user.id, "alice@example.com");
+    const token = (
+      await h.factory.authToken.create({
+        userId: user.id,
+        email: "alice@example.com",
+      })
+    ).token;
 
     const response = await h.dispatch(
       getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
@@ -212,7 +198,13 @@ describe("magic-link verify route", () => {
       mailer,
     });
     const user = await h.factory.user.create({ role: "editor" });
-    const token = await seedToken(h, user.id, user.email, -1);
+    const token = (
+      await h.factory.authToken.create({
+        userId: user.id,
+        email: user.email,
+        expiresAt: new Date(Date.now() - 1000),
+      })
+    ).token;
 
     const response = await h.dispatch(
       getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
@@ -232,7 +224,9 @@ describe("magic-link verify route", () => {
       role: "editor",
       disabledAt: new Date(),
     });
-    const token = await seedToken(h, user.id, user.email);
+    const token = (
+      await h.factory.authToken.create({ userId: user.id, email: user.email })
+    ).token;
 
     const response = await h.dispatch(
       getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
@@ -268,7 +262,12 @@ describe("magic-link verify route", () => {
       email: "alice@example.com",
       role: "editor",
     });
-    const token = await seedToken(h, user.id, "alice@example.com");
+    const token = (
+      await h.factory.authToken.create({
+        userId: user.id,
+        email: "alice@example.com",
+      })
+    ).token;
 
     const first = await h.dispatch(
       getRequest(`/_plumix/auth/magic-link/verify?token=${token}`),
@@ -305,7 +304,12 @@ describe("magic-link verify route", () => {
     const beforeCount = (await h.db.select().from(sessions)).length;
     expect(beforeCount).toBe(1);
 
-    const token = await seedToken(h, user.id, "alice@example.com");
+    const token = (
+      await h.factory.authToken.create({
+        userId: user.id,
+        email: "alice@example.com",
+      })
+    ).token;
     const cookie = existingSessioned.headers.get("cookie");
     const response = await h.dispatch(
       new Request(

--- a/packages/core/src/auth/magic-link/verify.test.ts
+++ b/packages/core/src/auth/magic-link/verify.test.ts
@@ -3,29 +3,14 @@ import { describe, expect, test } from "vitest";
 import { eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { users } from "../../db/schema/users.js";
-import { allowedDomainFactory, userFactory } from "../../test/factories.js";
+import {
+  allowedDomainFactory,
+  authTokenFactory,
+  userFactory,
+} from "../../test/factories.js";
 import { createTestDb } from "../../test/harness.js";
-import { generateToken, hashToken } from "../tokens.js";
 import { MagicLinkError } from "./errors.js";
 import { verifyMagicLink } from "./verify.js";
-
-async function seedToken(
-  db: Awaited<ReturnType<typeof createTestDb>>,
-  userId: number | null,
-  email: string,
-  ttlSeconds: number = 15 * 60,
-): Promise<string> {
-  const token = generateToken();
-  const hash = await hashToken(token);
-  await db.insert(authTokens).values({
-    hash,
-    userId,
-    email,
-    type: "magic_link",
-    expiresAt: new Date(Date.now() + ttlSeconds * 1000),
-  });
-  return token;
-}
 
 describe("verifyMagicLink", () => {
   test("returns the user and deletes the row on success", async () => {
@@ -34,7 +19,11 @@ describe("verifyMagicLink", () => {
       email: "alice@example.com",
       role: "editor",
     });
-    const token = await seedToken(db, user.id, "alice@example.com");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: user.id, email: "alice@example.com" })
+    ).token;
 
     const result = await verifyMagicLink(db, token);
     expect(result.user.id).toBe(user.id);
@@ -58,7 +47,13 @@ describe("verifyMagicLink", () => {
       role: "editor",
       email: "x@y.z",
     });
-    const token = await seedToken(db, user.id, "x@y.z", -1);
+    const token = (
+      await authTokenFactory.transient({ db }).create({
+        userId: user.id,
+        email: "x@y.z",
+        expiresAt: new Date(Date.now() - 1000),
+      })
+    ).token;
 
     await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
       code: "token_expired",
@@ -75,7 +70,11 @@ describe("verifyMagicLink", () => {
       email: "x@y.z",
       disabledAt: new Date(),
     });
-    const token = await seedToken(db, user.id, "x@y.z");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: user.id, email: "x@y.z" })
+    ).token;
 
     await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
       code: "account_disabled",
@@ -85,29 +84,26 @@ describe("verifyMagicLink", () => {
   test("ignores tokens of a different type stored under the same hash", async () => {
     const db = await createTestDb();
     const user = await userFactory.transient({ db }).create({ role: "admin" });
-    // Insert an invite-typed row whose hash matches what verifyMagicLink
-    // would compute for a chosen raw token. Verify that we don't accept
-    // it as a magic-link.
-    const raw = generateToken();
-    const hash = await hashToken(raw);
-    await db.insert(authTokens).values({
-      hash,
-      userId: user.id,
-      email: user.email,
-      type: "invite",
-      role: "subscriber",
-      expiresAt: new Date(Date.now() + 60_000),
-    });
+    // An invite-typed token must not be accepted as a magic-link, even though
+    // both live in auth_tokens under the same hash scheme.
+    const { token: raw, row } = await authTokenFactory
+      .transient({ db })
+      .create({
+        type: "invite",
+        userId: user.id,
+        email: user.email,
+        role: "subscriber",
+      });
 
     await expect(verifyMagicLink(db, raw)).rejects.toMatchObject({
       code: "token_invalid",
     });
 
     // The invite row is untouched.
-    const row = await db.query.authTokens.findFirst({
-      where: eq(authTokens.hash, hash),
+    const found = await db.query.authTokens.findFirst({
+      where: eq(authTokens.hash, row.hash),
     });
-    expect(row?.type).toBe("invite");
+    expect(found?.type).toBe("invite");
   });
 
   test("throws MagicLinkError instances for all reject paths", async () => {
@@ -127,7 +123,11 @@ describe("verifyMagicLink — signup branch (userId null)", () => {
       defaultRole: "author",
       isEnabled: true,
     });
-    const token = await seedToken(db, null, "newcomer@example.com");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: null, email: "newcomer@example.com" })
+    ).token;
 
     const result = await verifyMagicLink(db, token);
     expect(result.user.email).toBe("newcomer@example.com");
@@ -151,7 +151,11 @@ describe("verifyMagicLink — signup branch (userId null)", () => {
       defaultRole: "author",
       isEnabled: false,
     });
-    const token = await seedToken(db, null, "newcomer@example.com");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: null, email: "newcomer@example.com" })
+    ).token;
 
     await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
       code: "domain_not_allowed",
@@ -166,7 +170,11 @@ describe("verifyMagicLink — signup branch (userId null)", () => {
   test("rejects with domain_not_allowed when the allowed-domains row was removed mid-flight", async () => {
     const db = await createTestDb();
     await userFactory.transient({ db }).create({ role: "admin" });
-    const token = await seedToken(db, null, "newcomer@example.com");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: null, email: "newcomer@example.com" })
+    ).token;
     // No allowed_domains row at all — domain was deleted between request
     // and verify, or the row never existed (defensive: token was hand-
     // rolled).
@@ -186,7 +194,11 @@ describe("verifyMagicLink — signup branch (userId null)", () => {
     // Hand-rolled signup token — the request path would refuse to
     // issue this when zero users exist, but a hand-rolled DB state or
     // a now-deleted-admin race could surface it.
-    const token = await seedToken(db, null, "newcomer@example.com");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: null, email: "newcomer@example.com" })
+    ).token;
 
     await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
       code: "registration_closed",
@@ -200,7 +212,11 @@ describe("verifyMagicLink — signup branch (userId null)", () => {
       defaultRole: "subscriber",
       isEnabled: true,
     });
-    const token = await seedToken(db, null, "first@example.com");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: null, email: "first@example.com" })
+    ).token;
 
     const result = await verifyMagicLink(db, token, {
       bootstrapAllowed: true,
@@ -222,7 +238,11 @@ describe("verifyMagicLink — signup branch (userId null)", () => {
       email: "newcomer@example.com",
       role: "subscriber",
     });
-    const token = await seedToken(db, null, "newcomer@example.com");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: null, email: "newcomer@example.com" })
+    ).token;
 
     const result = await verifyMagicLink(db, token);
     expect(result.user.id).toBe(raced.id);
@@ -239,7 +259,11 @@ describe("verifyMagicLink — signup branch (userId null)", () => {
       role: "subscriber",
       disabledAt: new Date(),
     });
-    const token = await seedToken(db, null, "newcomer@example.com");
+    const token = (
+      await authTokenFactory
+        .transient({ db })
+        .create({ userId: null, email: "newcomer@example.com" })
+    ).token;
 
     await expect(verifyMagicLink(db, token)).rejects.toMatchObject({
       code: "account_disabled",

--- a/packages/core/src/test/factories.test.ts
+++ b/packages/core/src/test/factories.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+
+import { validateApiToken } from "../auth/api-tokens.js";
+import { hashToken } from "../auth/tokens.js";
+import { apiTokenFactory, authTokenFactory, userFactory } from "./factories.js";
+import { createTestDb } from "./harness.js";
+
+describe("apiTokenFactory", () => {
+  test("mints a PAT whose secret validates against the stored hash", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({ role: "editor" });
+
+    const minted = await apiTokenFactory
+      .transient({ db })
+      .create({ userId: user.id, scopes: ["entry:post:read"] });
+
+    expect(minted.secret).toMatch(/^pl_pat_/);
+    const validated = await validateApiToken(db, minted.secret);
+    expect(validated?.user.id).toBe(user.id);
+    expect(validated?.token.scopes).toEqual(["entry:post:read"]);
+  });
+});
+
+describe("authTokenFactory", () => {
+  test("mints a real token whose stored hash matches", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({});
+
+    const minted = await authTokenFactory.transient({ db }).create({
+      type: "magic_link",
+      userId: user.id,
+      email: user.email,
+    });
+
+    expect(minted.token).toMatch(/^[\w-]+$/);
+    expect(minted.row.hash).toBe(await hashToken(minted.token));
+    expect(minted.row.type).toBe("magic_link");
+    expect(minted.row.userId).toBe(user.id);
+  });
+
+  test("honours an explicit type and expiry", async () => {
+    const db = await createTestDb();
+    const expiresAt = new Date(Date.now() + 1000);
+
+    const minted = await authTokenFactory
+      .transient({ db })
+      .create({ type: "invite", role: "editor", expiresAt });
+
+    expect(minted.row.type).toBe("invite");
+    expect(minted.row.role).toBe("editor");
+    // auth_tokens.expiresAt stores Unix seconds, so compare at that precision.
+    expect(Math.floor(minted.row.expiresAt.getTime() / 1000)).toBe(
+      Math.floor(expiresAt.getTime() / 1000),
+    );
+  });
+});

--- a/packages/core/src/test/factories.ts
+++ b/packages/core/src/test/factories.ts
@@ -22,6 +22,7 @@ import type { NewSetting, Setting } from "../db/schema/settings.js";
 import type { NewTerm, Term } from "../db/schema/terms.js";
 import type { NewUser, User } from "../db/schema/users.js";
 import { createApiToken } from "../auth/api-tokens.js";
+import { generateToken, hashToken } from "../auth/tokens.js";
 import { allowedDomains } from "../db/schema/allowed_domains.js";
 import { authTokens } from "../db/schema/auth_tokens.js";
 import { credentials } from "../db/schema/credentials.js";
@@ -303,6 +304,43 @@ export const apiTokenFactory = Factory.define<
   };
 });
 
+interface MintedAuthToken {
+  /** Plaintext token to hand to the client once; never persisted. */
+  readonly token: string;
+  readonly row: AuthToken;
+}
+
+// Mints a real auth-token (magic-link / invite / email-verification / …):
+// generates the token, stores only its hash, and returns the plaintext so a
+// test can drive the verify path. `hash` is always derived, never passed.
+export const authTokenFactory = Factory.define<
+  Omit<NewAuthToken, "hash">,
+  DbTransient,
+  MintedAuthToken
+>(({ transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const token = generateToken();
+    const hash = await hashToken(token);
+    const [row] = await db
+      .insert(authTokens)
+      .values({ ...attrs, hash })
+      .returning();
+    if (!row) throw new Error("authTokenFactory: insert returned no row");
+    return { token, row };
+  });
+
+  return {
+    type: params.type ?? "magic_link",
+    userId: params.userId ?? null,
+    email: params.email ?? null,
+    role: params.role ?? null,
+    invitedBy: params.invitedBy ?? null,
+    payload: params.payload ?? null,
+    expiresAt: params.expiresAt ?? new Date(Date.now() + 15 * 60 * 1000),
+  };
+});
+
 export interface Factories {
   readonly user: typeof userFactory;
   readonly admin: typeof adminUser;
@@ -324,6 +362,7 @@ export interface Factories {
   readonly entryTerm: typeof entryTermFactory;
   readonly allowedDomain: typeof allowedDomainFactory;
   readonly apiToken: typeof apiTokenFactory;
+  readonly authToken: typeof authTokenFactory;
 }
 
 export function factoriesFor(db: Db): Factories {
@@ -348,5 +387,6 @@ export function factoriesFor(db: Db): Factories {
     entryTerm: entryTermFactory.transient({ db }),
     allowedDomain: allowedDomainFactory.transient({ db }),
     apiToken: apiTokenFactory.transient({ db }),
+    authToken: authTokenFactory.transient({ db }),
   };
 }

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -23,6 +23,7 @@ export {
   entryTermFactory,
   allowedDomainFactory,
   apiTokenFactory,
+  authTokenFactory,
   factoriesFor,
 } from "./factories.js";
 export type { Factories } from "./factories.js";


### PR DESCRIPTION
Batch of #943 (no raw `db` in tests), and the first to add a *new* factory — done `/tdd`-style (red→green in `factories.test.ts` before wiring call-sites).

**`authTokenFactory`**

Mints a real auth-token the way production does — `generateToken` → `hashToken`, store only the hash — and returns `{ token, row }` so a test can drive the verify path. Input is `Omit<NewAuthToken, "hash">` and the hash is always derived in `onCreate`, so a caller can't smuggle one in. Defaults (`magic_link`, 15-min expiry) match the deleted `seedToken` helpers and production issuance. Also backfills a characterization test for the existing `apiTokenFactory`.

**Conversions**

The `seedToken` / `seedInvite` helpers (raw `db.insert` into `auth_tokens`) in `magic-link/{verify,routes}.test.ts` and `invite.test.ts` are gone; call-sites use `authTokenFactory.transient({ db })` / `h.factory.authToken`. The old `{ token, tokenHash }` return maps to `{ token, row.hash }` (query-result vars renamed `stored`/`found` to avoid shadowing the factory `row`). Magic-link calls rely on the `magic_link` default; invite calls pass `type:"invite"` explicitly.

Behavior-preserving — the minted rows match the old inserts column-for-column (the expired `ttl=-1` cases become `expiresAt: now - 1000ms`, the same instant). Suites green: verify 13, routes 17, invite; full core suite 1974.

Refs #943