### PR TITLE
test: add auditLogFactory and seed the audit-log tests through it

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "drizzle-kit": "catalog:",
     "drizzle-orm": "catalog:",
     "drizzle-valibot": "catalog:",
-    "fishery": "^2.4.0",
+    "fishery": "catalog:",
     "valibot": "catalog:"
   },
   "peerDependencies": {

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -89,6 +89,7 @@
     "@vitest/coverage-v8": "catalog:",
     "drizzle-kit": "catalog:",
     "eslint": "catalog:",
+    "fishery": "catalog:",
     "jsdom": "catalog:",
     "plumix": "workspace:*",
     "prettier": "catalog:",

--- a/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
+++ b/packages/plugins/audit-log/src/server/storage-sqlite.test.ts
@@ -1,123 +1,68 @@
 import type { AppContext } from "plumix/plugin";
-import { createClient } from "@libsql/client";
-import {
-  generateSQLiteDrizzleJson,
-  generateSQLiteMigration,
-} from "drizzle-kit/api";
-import { sql } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/libsql";
 import { beforeEach, describe, expect, test } from "vitest";
 
-import type { NewAuditLogRow } from "../db/schema.js";
-import * as schema from "../db/schema.js";
-import { auditLog } from "../db/schema.js";
+import type { TestDb } from "../test-support.js";
+import { auditLogFactory, createDb, ctxFor } from "../test-support.js";
 import { encodeCursor } from "./cursor.js";
 import { sqlite } from "./storage-sqlite.js";
-
-type TestDb = ReturnType<typeof drizzle<typeof schema>>;
-
-const schemaImports = schema as unknown as Record<string, unknown>;
-
-let cachedStatements: string[] | null = null;
-
-// drizzle-kit's `api` surface is loosely typed (`SQLiteSchema` is opaque);
-// we treat it as a black-box snapshot blob and only read its `id` field.
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
-async function compileSchemaSql(): Promise<string[]> {
-  if (cachedStatements) return cachedStatements;
-  const empty = await generateSQLiteDrizzleJson({}, undefined, "snake_case");
-  const current = await generateSQLiteDrizzleJson(
-    schemaImports,
-    empty.id,
-    "snake_case",
-  );
-  cachedStatements = await generateSQLiteMigration(empty, current);
-  return cachedStatements;
-}
-/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
-
-async function createDb(): Promise<TestDb> {
-  const client = createClient({ url: ":memory:" });
-  const db = drizzle(client, { schema, casing: "snake_case" });
-  const statements = await compileSchemaSql();
-  for (const stmt of statements) await db.run(sql.raw(stmt));
-  return db;
-}
-
-function row(
-  overrides: Partial<NewAuditLogRow> & {
-    readonly occurredAt: Date;
-  },
-): NewAuditLogRow {
-  return {
-    event: "entry:updated",
-    subjectType: "entry",
-    subjectId: "1",
-    subjectLabel: "Hello",
-    actorId: 1,
-    actorLabel: "alice@example.com",
-    properties: {},
-    ...overrides,
-  };
-}
-
-function ctxFor(db: TestDb): AppContext {
-  return { db } as unknown as AppContext;
-}
 
 describe("sqlite() storage adapter — filter + cursor pagination", () => {
   let db: TestDb;
   let ctx: AppContext;
+  let factory: typeof auditLogFactory;
 
   beforeEach(async () => {
     db = await createDb();
     ctx = ctxFor(db);
+    factory = auditLogFactory.transient({ db });
   });
 
   test("no filter returns rows latest-first by (occurred_at desc, id desc)", async () => {
-    await db
-      .insert(auditLog)
-      .values([
-        row({ occurredAt: new Date("2026-05-01T00:00:00Z"), id: 1 }),
-        row({ occurredAt: new Date("2026-05-03T00:00:00Z"), id: 2 }),
-        row({ occurredAt: new Date("2026-05-02T00:00:00Z"), id: 3 }),
-      ]);
+    for (const o of [
+      { occurredAt: new Date("2026-05-01T00:00:00Z"), id: 1 },
+      { occurredAt: new Date("2026-05-03T00:00:00Z"), id: 2 },
+      { occurredAt: new Date("2026-05-02T00:00:00Z"), id: 3 },
+    ]) {
+      await factory.create(o);
+    }
     const result = await sqlite().query(ctx, {});
     expect(result.rows.map((r) => r.id)).toEqual([2, 3, 1]);
     expect(result.nextCursor).toBeNull();
   });
 
   test("actorId filter restricts to that actor's rows", async () => {
-    await db
-      .insert(auditLog)
-      .values([
-        row({ occurredAt: new Date("2026-05-01T00:00:00Z"), actorId: 1 }),
-        row({ occurredAt: new Date("2026-05-02T00:00:00Z"), actorId: 2 }),
-        row({ occurredAt: new Date("2026-05-03T00:00:00Z"), actorId: 1 }),
-      ]);
+    for (const o of [
+      { occurredAt: new Date("2026-05-01T00:00:00Z"), actorId: 1 },
+      { occurredAt: new Date("2026-05-02T00:00:00Z"), actorId: 2 },
+      { occurredAt: new Date("2026-05-03T00:00:00Z"), actorId: 1 },
+    ]) {
+      await factory.create(o);
+    }
     const result = await sqlite().query(ctx, { actorId: 1 });
     expect(result.rows).toHaveLength(2);
     expect(result.rows.every((r) => r.actorId === 1)).toBe(true);
   });
 
   test("subjectType + subjectId restrict together", async () => {
-    await db.insert(auditLog).values([
-      row({
+    for (const o of [
+      {
         occurredAt: new Date("2026-05-01T00:00:00Z"),
         subjectType: "entry",
         subjectId: "1",
-      }),
-      row({
+      },
+      {
         occurredAt: new Date("2026-05-02T00:00:00Z"),
         subjectType: "entry",
         subjectId: "2",
-      }),
-      row({
+      },
+      {
         occurredAt: new Date("2026-05-03T00:00:00Z"),
         subjectType: "user",
         subjectId: "1",
-      }),
-    ]);
+      },
+    ]) {
+      await factory.create(o);
+    }
     const both = await sqlite().query(ctx, {
       subjectType: "entry",
       subjectId: "1",
@@ -130,20 +75,22 @@ describe("sqlite() storage adapter — filter + cursor pagination", () => {
   });
 
   test("eventPrefix does an indexed prefix range scan", async () => {
-    await db.insert(auditLog).values([
-      row({
+    for (const o of [
+      {
         occurredAt: new Date("2026-05-01T00:00:00Z"),
         event: "entry:published",
-      }),
-      row({
+      },
+      {
         occurredAt: new Date("2026-05-02T00:00:00Z"),
         event: "entry:trashed",
-      }),
-      row({
+      },
+      {
         occurredAt: new Date("2026-05-03T00:00:00Z"),
         event: "user:signed_in",
-      }),
-    ]);
+      },
+    ]) {
+      await factory.create(o);
+    }
     const result = await sqlite().query(ctx, { eventPrefix: "entry:" });
     expect(result.rows.map((r) => r.event).sort()).toEqual([
       "entry:published",
@@ -152,13 +99,13 @@ describe("sqlite() storage adapter — filter + cursor pagination", () => {
   });
 
   test("occurredAfter / occurredBefore form an inclusive window", async () => {
-    await db
-      .insert(auditLog)
-      .values([
-        row({ occurredAt: new Date("2026-05-01T00:00:00Z") }),
-        row({ occurredAt: new Date("2026-05-03T00:00:00Z") }),
-        row({ occurredAt: new Date("2026-05-05T00:00:00Z") }),
-      ]);
+    for (const o of [
+      { occurredAt: new Date("2026-05-01T00:00:00Z") },
+      { occurredAt: new Date("2026-05-03T00:00:00Z") },
+      { occurredAt: new Date("2026-05-05T00:00:00Z") },
+    ]) {
+      await factory.create(o);
+    }
     const result = await sqlite().query(ctx, {
       occurredAfter: Math.floor(
         new Date("2026-05-02T00:00:00Z").getTime() / 1000,
@@ -174,15 +121,14 @@ describe("sqlite() storage adapter — filter + cursor pagination", () => {
   });
 
   test("limit + cursor paginate without skipping or repeating rows", async () => {
-    const values = Array.from({ length: 7 }, (_, i) =>
-      row({
+    for (let i = 0; i < 7; i += 1) {
+      await factory.create({
         occurredAt: new Date(
           `2026-05-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
         ),
         subjectId: String(i + 1),
-      }),
-    );
-    await db.insert(auditLog).values(values);
+      });
+    }
 
     const page1 = await sqlite().query(ctx, { limit: 3 });
     expect(page1.rows.map((r) => r.subjectId)).toEqual(["7", "6", "5"]);
@@ -204,26 +150,22 @@ describe("sqlite() storage adapter — filter + cursor pagination", () => {
   });
 
   test("a row inserted between page fetches at an older timestamp is included in the next page (no skip)", async () => {
-    await db.insert(auditLog).values(
-      Array.from({ length: 4 }, (_, i) =>
-        row({
-          occurredAt: new Date(
-            `2026-05-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
-          ),
-          subjectId: String(i + 1),
-        }),
-      ),
-    );
+    for (let i = 0; i < 4; i += 1) {
+      await factory.create({
+        occurredAt: new Date(
+          `2026-05-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+        ),
+        subjectId: String(i + 1),
+      });
+    }
     const page1 = await sqlite().query(ctx, { limit: 2 });
     expect(page1.rows.map((r) => r.subjectId)).toEqual(["4", "3"]);
 
     // A concurrent insert at an OLDER occurredAt lands behind the cursor.
-    await db.insert(auditLog).values(
-      row({
-        occurredAt: new Date("2026-05-01T12:00:00Z"),
-        subjectId: "concurrent",
-      }),
-    );
+    await factory.create({
+      occurredAt: new Date("2026-05-01T12:00:00Z"),
+      subjectId: "concurrent",
+    });
 
     const page2 = await sqlite().query(ctx, {
       limit: 10,
@@ -241,58 +183,48 @@ describe("sqlite() storage adapter — filter + cursor pagination", () => {
   });
 
   test("limit defaults to 50 when omitted", async () => {
-    const values = Array.from({ length: 75 }, (_, i) =>
-      row({
-        occurredAt: new Date(2026, 4, 1, 0, 0, i),
-        subjectId: String(i + 1),
-      }),
-    );
-    await db.insert(auditLog).values(values);
+    await factory.createList(75);
     const result = await sqlite().query(ctx, {});
     expect(result.rows).toHaveLength(50);
   });
 
   test("limit > 500 clamps to 500 (storage-side ceiling)", async () => {
-    const values = Array.from({ length: 600 }, (_, i) =>
-      row({
-        occurredAt: new Date(2026, 4, 1, 0, 0, i),
-        subjectId: String(i + 1),
-      }),
-    );
-    await db.insert(auditLog).values(values);
+    await factory.createList(600);
     const result = await sqlite().query(ctx, { limit: 10_000 });
     expect(result.rows).toHaveLength(500);
   });
 
   test("nextCursor is null when the page returns fewer rows than the limit", async () => {
-    await db
-      .insert(auditLog)
-      .values([
-        row({ occurredAt: new Date("2026-05-01T00:00:00Z") }),
-        row({ occurredAt: new Date("2026-05-02T00:00:00Z") }),
-      ]);
+    for (const o of [
+      { occurredAt: new Date("2026-05-01T00:00:00Z") },
+      { occurredAt: new Date("2026-05-02T00:00:00Z") },
+    ]) {
+      await factory.create(o);
+    }
     const result = await sqlite().query(ctx, { limit: 50 });
     expect(result.nextCursor).toBeNull();
   });
 
   test("an explicit cursor still respects filters", async () => {
-    await db.insert(auditLog).values([
-      row({
+    for (const o of [
+      {
         occurredAt: new Date("2026-05-01T00:00:00Z"),
         event: "entry:published",
         subjectId: "a",
-      }),
-      row({
+      },
+      {
         occurredAt: new Date("2026-05-02T00:00:00Z"),
         event: "user:signed_in",
         subjectId: "b",
-      }),
-      row({
+      },
+      {
         occurredAt: new Date("2026-05-03T00:00:00Z"),
         event: "entry:trashed",
         subjectId: "c",
-      }),
-    ]);
+      },
+    ]) {
+      await factory.create(o);
+    }
     const cursor = encodeCursor({
       occurredAt: Math.floor(new Date("2026-05-04T00:00:00Z").getTime() / 1000),
       id: 1,
@@ -309,11 +241,13 @@ describe("sqlite() storage adapter — purge", () => {
   let db: TestDb;
   let ctx: AppContext;
   let adapter: ReturnType<typeof sqlite>;
+  let factory: typeof auditLogFactory;
 
   beforeEach(async () => {
     db = await createDb();
     ctx = ctxFor(db);
     adapter = sqlite();
+    factory = auditLogFactory.transient({ db });
   });
 
   async function runPurge(cutoff: Date) {
@@ -324,22 +258,15 @@ describe("sqlite() storage adapter — purge", () => {
   }
 
   test("deletes rows strictly older than the cutoff and reports the count", async () => {
-    await db.insert(auditLog).values([
-      row({ occurredAt: new Date("2026-01-01T00:00:00Z"), subjectId: "old-1" }),
-      row({ occurredAt: new Date("2026-02-01T00:00:00Z"), subjectId: "old-2" }),
-      row({
-        occurredAt: new Date("2026-04-11T00:00:00Z"),
-        subjectId: "boundary",
-      }),
-      row({
-        occurredAt: new Date("2026-04-15T00:00:00Z"),
-        subjectId: "kept-1",
-      }),
-      row({
-        occurredAt: new Date("2026-05-11T00:00:00Z"),
-        subjectId: "kept-2",
-      }),
-    ]);
+    for (const o of [
+      { occurredAt: new Date("2026-01-01T00:00:00Z"), subjectId: "old-1" },
+      { occurredAt: new Date("2026-02-01T00:00:00Z"), subjectId: "old-2" },
+      { occurredAt: new Date("2026-04-11T00:00:00Z"), subjectId: "boundary" },
+      { occurredAt: new Date("2026-04-15T00:00:00Z"), subjectId: "kept-1" },
+      { occurredAt: new Date("2026-05-11T00:00:00Z"), subjectId: "kept-2" },
+    ]) {
+      await factory.create(o);
+    }
 
     const result = await runPurge(new Date("2026-04-11T00:00:00Z"));
 
@@ -354,9 +281,9 @@ describe("sqlite() storage adapter — purge", () => {
   });
 
   test("returns deleted: 0 when no rows match the cutoff", async () => {
-    await db
-      .insert(auditLog)
-      .values([row({ occurredAt: new Date("2026-05-11T00:00:00Z") })]);
+    await auditLogFactory
+      .transient({ db })
+      .create({ occurredAt: new Date("2026-05-11T00:00:00Z") });
 
     const result = await runPurge(new Date("2026-01-01T00:00:00Z"));
 

--- a/packages/plugins/audit-log/src/test-support.test.ts
+++ b/packages/plugins/audit-log/src/test-support.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { auditLogFactory, createDb } from "./test-support.js";
+
+describe("auditLogFactory", () => {
+  test("inserts a row with defaults and honours overrides", async () => {
+    const db = await createDb();
+    const occurredAt = new Date("2026-05-11T00:00:00Z");
+
+    const row = await auditLogFactory
+      .transient({ db })
+      .create({ event: "entry:published", occurredAt });
+
+    expect(row.id).toBeGreaterThan(0);
+    expect(row.event).toBe("entry:published");
+    expect(row.subjectType).toBe("entry");
+    expect(row.actorLabel).toBe("alice@example.com");
+    expect(row.occurredAt.getTime()).toBe(occurredAt.getTime());
+  });
+
+  test("createList seeds N rows", async () => {
+    const db = await createDb();
+    const rows = await auditLogFactory.transient({ db }).createList(5);
+    expect(rows).toHaveLength(5);
+  });
+});

--- a/packages/plugins/audit-log/src/test-support.ts
+++ b/packages/plugins/audit-log/src/test-support.ts
@@ -1,0 +1,84 @@
+import type { AppContext } from "plumix/plugin";
+import { createClient } from "@libsql/client";
+import {
+  generateSQLiteDrizzleJson,
+  generateSQLiteMigration,
+} from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/libsql";
+import { Factory } from "fishery";
+
+import type { NewAuditLogRow } from "./db/schema.js";
+import * as schema from "./db/schema.js";
+import { auditLog } from "./db/schema.js";
+
+export type TestDb = ReturnType<typeof drizzle<typeof schema>>;
+
+const schemaImports = schema as unknown as Record<string, unknown>;
+let cachedStatements: string[] | null = null;
+
+// drizzle-kit's `api` surface is loosely typed (`SQLiteSchema` is opaque);
+// we treat it as a black-box snapshot blob and only read its `id` field.
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+async function compileSchemaSql(): Promise<string[]> {
+  if (cachedStatements) return cachedStatements;
+  const empty = await generateSQLiteDrizzleJson({}, undefined, "snake_case");
+  const current = await generateSQLiteDrizzleJson(
+    schemaImports,
+    empty.id,
+    "snake_case",
+  );
+  cachedStatements = await generateSQLiteMigration(empty, current);
+  return cachedStatements;
+}
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+
+export async function createDb(): Promise<TestDb> {
+  const client = createClient({ url: ":memory:" });
+  const db = drizzle(client, { schema, casing: "snake_case" });
+  for (const stmt of await compileSchemaSql()) await db.run(sql.raw(stmt));
+  return db;
+}
+
+export function ctxFor(db: TestDb): AppContext {
+  return { db } as unknown as AppContext;
+}
+
+interface DbTransient {
+  db: TestDb;
+}
+
+function requireDb(transient: Partial<DbTransient>): TestDb {
+  if (!transient.db) {
+    // eslint-disable-next-line no-restricted-syntax -- test-support guard
+    throw new Error("auditLogFactory requires a db via .transient({ db })");
+  }
+  return transient.db;
+}
+
+type AuditLogRow = typeof auditLog.$inferSelect;
+
+export const auditLogFactory = Factory.define<
+  NewAuditLogRow,
+  DbTransient,
+  AuditLogRow
+>(({ transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(auditLog).values(attrs).returning();
+    // eslint-disable-next-line no-restricted-syntax -- test-support guard
+    if (!row) throw new Error("auditLogFactory: insert returned no row");
+    return row;
+  });
+
+  return {
+    event: params.event ?? "entry:updated",
+    subjectType: params.subjectType ?? "entry",
+    subjectId: params.subjectId ?? "1",
+    subjectLabel: params.subjectLabel ?? "Hello",
+    actorId: params.actorId ?? 1,
+    actorLabel: params.actorLabel ?? "alice@example.com",
+    properties: params.properties ?? {},
+    occurredAt: params.occurredAt ?? new Date(),
+  };
+});

--- a/packages/plugins/audit-log/tsconfig.build.json
+++ b/packages/plugins/audit-log/tsconfig.build.json
@@ -5,5 +5,5 @@
     "stripInternal": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-support.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ catalogs:
     eslint:
       specifier: ^10.4.1
       version: 10.4.1
+    fishery:
+      specifier: ^2.4.0
+      version: 2.4.0
     jsdom:
       specifier: ^29.1.1
       version: 29.1.1
@@ -532,7 +535,7 @@ importers:
         specifier: 'catalog:'
         version: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260526.1)(@libsql/client@0.17.3))(valibot@1.4.1(typescript@6.0.3))
       fishery:
-        specifier: ^2.4.0
+        specifier: 'catalog:'
         version: 2.4.0
       valibot:
         specifier: 'catalog:'
@@ -698,6 +701,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.4.1(jiti@2.7.0)
+      fishery:
+        specifier: 'catalog:'
+        version: 2.4.0
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1
@@ -10484,7 +10490,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.8':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ catalog:
   drizzle-valibot: ^0.4.2
   esbuild: ^0.27.7
   eslint: ^10.4.1
+  fishery: ^2.4.0
   jsdom: ^29.1.1
   prettier: ^3.8.3
   publint: ^0.3.21


### PR DESCRIPTION
Batch of #943 (no raw `db` in tests) — a new plugin-local factory, done `/tdd`-style (red→green in `test-support.test.ts`).

**`auditLogFactory`**

The `audit_log` table lives in `@plumix/plugin-audit-log`, so the factory lives in the plugin's `src/test-support.ts` (excluded from the published build via `tsconfig.build.json` — it imports `fishery`, a dev-only dep, and the plugin's runtime entry never touches it). The plugin's `createDb` / `ctxFor` / schema-compile helpers move there too. Defaults match the old `row()` builder exactly, plus an `occurredAt` default for the bulk path.

**Conversion**

The 14 raw `db.insert(auditLog)` calls in `storage-sqlite.test.ts` are gone. The factory is bound once per `beforeEach` (`factory = auditLogFactory.transient({ db })`); multi-row inserts become inline `for (const o of [...]) await factory.create(o)` (sequential, so auto-increment ids follow insertion order where assertions depend on it), and the two bulk limit/clamp tests (75 / 600 rows, count-only assertions) use `factory.createList(n)`.

**Catalog**

`fishery` now has two consumers (core + audit-log), so it moves to the workspace catalog; core re-sources it via `catalog:` (still a runtime `dependency`, since `plumix/test` uses it).

Behaviour-preserving: audit-log 140, core 1974.

Refs #943