### PR TITLE
test(core): add oauthAccountFactory and seed the oauth signup tests with it

### DIFF
--- a/packages/core/src/auth/oauth/signup.test.ts
+++ b/packages/core/src/auth/oauth/signup.test.ts
@@ -4,7 +4,11 @@ import { eq, sql } from "../../db/index.js";
 import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
 import { users } from "../../db/schema/users.js";
-import { allowedDomainFactory, userFactory } from "../../test/factories.js";
+import {
+  allowedDomainFactory,
+  oauthAccountFactory,
+  userFactory,
+} from "../../test/factories.js";
 import { createTestDb } from "../../test/harness.js";
 import { OAuthError } from "./errors.js";
 import { resolveOAuthUser } from "./signup.js";
@@ -25,7 +29,7 @@ describe("resolveOAuthUser — dangling oauth_accounts row", () => {
     // to a userId that doesn't exist. Mirrors the production-data shape we
     // care about: a row that the cascade should have deleted but didn't.
     await db.run(sql`PRAGMA foreign_keys = OFF`);
-    await db.insert(oauthAccounts).values({
+    await oauthAccountFactory.transient({ db }).create({
       provider: "github",
       providerAccountId: "ghost-1",
       userId: 9999,
@@ -48,7 +52,7 @@ describe("resolveOAuthUser — link existing oauth account", () => {
       email: PROFILE.email,
       role: "editor",
     });
-    await db.insert(oauthAccounts).values({
+    await oauthAccountFactory.transient({ db }).create({
       provider: "github",
       providerAccountId: PROFILE.providerAccountId,
       userId: seeded.id,
@@ -70,7 +74,7 @@ describe("resolveOAuthUser — link existing oauth account", () => {
       role: "editor",
       disabledAt: new Date(),
     });
-    await db.insert(oauthAccounts).values({
+    await oauthAccountFactory.transient({ db }).create({
       provider: "github",
       providerAccountId: PROFILE.providerAccountId,
       userId: seeded.id,

--- a/packages/core/src/test/factories.test.ts
+++ b/packages/core/src/test/factories.test.ts
@@ -2,8 +2,30 @@ import { describe, expect, test } from "vitest";
 
 import { validateApiToken } from "../auth/api-tokens.js";
 import { hashToken } from "../auth/tokens.js";
-import { apiTokenFactory, authTokenFactory, userFactory } from "./factories.js";
+import {
+  apiTokenFactory,
+  authTokenFactory,
+  oauthAccountFactory,
+  userFactory,
+} from "./factories.js";
 import { createTestDb } from "./harness.js";
+
+describe("oauthAccountFactory", () => {
+  test("links an oauth account to a user", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({});
+
+    const row = await oauthAccountFactory.transient({ db }).create({
+      userId: user.id,
+      provider: "github",
+      providerAccountId: "gh-1",
+    });
+
+    expect(row.userId).toBe(user.id);
+    expect(row.provider).toBe("github");
+    expect(row.providerAccountId).toBe("gh-1");
+  });
+});
 
 describe("apiTokenFactory", () => {
   test("mints a PAT whose secret validates against the stored hash", async () => {

--- a/packages/core/src/test/factories.ts
+++ b/packages/core/src/test/factories.ts
@@ -17,6 +17,10 @@ import type {
 } from "../db/schema/credentials.js";
 import type { Entry, NewEntry } from "../db/schema/entries.js";
 import type { EntryTerm, NewEntryTerm } from "../db/schema/entry_term.js";
+import type {
+  NewOAuthAccount,
+  OAuthAccount,
+} from "../db/schema/oauth_accounts.js";
 import type { NewSession, Session } from "../db/schema/sessions.js";
 import type { NewSetting, Setting } from "../db/schema/settings.js";
 import type { NewTerm, Term } from "../db/schema/terms.js";
@@ -28,6 +32,7 @@ import { authTokens } from "../db/schema/auth_tokens.js";
 import { credentials } from "../db/schema/credentials.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
+import { oauthAccounts } from "../db/schema/oauth_accounts.js";
 import { sessions } from "../db/schema/sessions.js";
 import { settings } from "../db/schema/settings.js";
 import { terms } from "../db/schema/terms.js";
@@ -341,6 +346,31 @@ export const authTokenFactory = Factory.define<
   };
 });
 
+// Links a user to an external provider. Caller supplies `userId`; provider +
+// account id default to a github account.
+export const oauthAccountFactory = Factory.define<
+  NewOAuthAccount,
+  DbTransient,
+  OAuthAccount
+>(({ sequence, transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const [row] = await db.insert(oauthAccounts).values(attrs).returning();
+    if (!row) throw new Error("oauthAccountFactory: insert returned no row");
+    return row;
+  });
+
+  const userId = params.userId;
+  if (userId === undefined) {
+    throw new Error("oauthAccountFactory: userId is required");
+  }
+  return {
+    provider: params.provider ?? "github",
+    providerAccountId: params.providerAccountId ?? `account-${sequence}`,
+    userId,
+  };
+});
+
 export interface Factories {
   readonly user: typeof userFactory;
   readonly admin: typeof adminUser;
@@ -363,6 +393,7 @@ export interface Factories {
   readonly allowedDomain: typeof allowedDomainFactory;
   readonly apiToken: typeof apiTokenFactory;
   readonly authToken: typeof authTokenFactory;
+  readonly oauthAccount: typeof oauthAccountFactory;
 }
 
 export function factoriesFor(db: Db): Factories {
@@ -388,5 +419,6 @@ export function factoriesFor(db: Db): Factories {
     allowedDomain: allowedDomainFactory.transient({ db }),
     apiToken: apiTokenFactory.transient({ db }),
     authToken: authTokenFactory.transient({ db }),
+    oauthAccount: oauthAccountFactory.transient({ db }),
   };
 }

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -24,6 +24,7 @@ export {
   allowedDomainFactory,
   apiTokenFactory,
   authTokenFactory,
+  oauthAccountFactory,
   factoriesFor,
 } from "./factories.js";
 export type { Factories } from "./factories.js";


### PR DESCRIPTION
Batch of #943 (no raw `db` in tests) with a new factory, done `/tdd`-style (red→green in `factories.test.ts`).

Adds `oauthAccountFactory` (the `oauth_accounts` core table) and converts the three `db.insert(oauthAccounts)` calls in `oauth/signup.test.ts` to `oauthAccountFactory.transient({ db }).create(...)`. The `link_broken` test keeps its `PRAGMA foreign_keys = OFF` wrapper around the factory `create` so it can still seed a row referencing a non-existent user (the cascade-should-have-deleted case).

Behaviour-preserving: signup 11, full core suite 1975.

Refs #943