### PR TITLE
test(core): seed core auth/term/settings tests through factories

### DIFF
--- a/packages/core/src/auth/email-change/email-change.test.ts
+++ b/packages/core/src/auth/email-change/email-change.test.ts
@@ -4,7 +4,7 @@ import { and, eq } from "../../db/index.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
 import { sessions } from "../../db/schema/sessions.js";
 import { users } from "../../db/schema/users.js";
-import { userFactory } from "../../test/factories.js";
+import { authTokenFactory, userFactory } from "../../test/factories.js";
 import { createTestDb } from "../../test/harness.js";
 import { makeMailer } from "../../test/mailer.js";
 import { hashToken } from "../tokens.js";
@@ -231,14 +231,13 @@ describe("verifyEmailChange", () => {
   test("returns token_expired past the TTL", async () => {
     const db = await createTestDb();
     const user = await userFactory.transient({ db }).create({});
-    const { token } = await requestEmailChange(db, {
+    // request always mints a live token; seed the expired state directly.
+    const { token } = await authTokenFactory.transient({ db }).create({
+      type: "email_verification",
       userId: user.id,
-      newEmail: "alice@new.example",
-      origin: ORIGIN,
-      mailer: makeMailer(),
-      siteName: SITE_NAME,
+      email: "alice@new.example",
+      expiresAt: new Date(Date.now() - 1000),
     });
-    await db.update(authTokens).set({ expiresAt: new Date(Date.now() - 1000) });
 
     await expect(verifyEmailChange(db, token)).rejects.toMatchObject({
       code: "token_expired",

--- a/packages/core/src/auth/hooks.test.ts
+++ b/packages/core/src/auth/hooks.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, test } from "vitest";
 
 import { eq } from "../db/index.js";
-import { allowedDomains } from "../db/schema/allowed_domains.js";
-import { authTokens } from "../db/schema/auth_tokens.js";
 import { credentials } from "../db/schema/credentials.js";
 import { createDispatcherHarness, plumixRequest } from "../test/dispatcher.js";
 import { makeMailer } from "../test/mailer.js";
 import { createRpcHarness } from "../test/rpc.js";
-import { generateToken, hashToken } from "./tokens.js";
 
 // Pins hook emissions across the auth surface so an audit-log plugin
 // can subscribe and capture every state-change without us touching
@@ -261,14 +258,10 @@ describe("auth hooks — passkey signed_in / signed_out / credential:created", (
     const spy = h.spyAction("user:signed_in");
 
     // Seed a magic-link token bound to the existing user.
-    const token = generateToken();
-    const hash = await hashToken(token);
-    await h.db.insert(authTokens).values({
-      hash,
+    const { token } = await h.factory.authToken.create({
+      type: "magic_link",
       userId: seeded.id,
       email: seeded.email,
-      type: "magic_link",
-      expiresAt: new Date(Date.now() + 15 * 60 * 1000),
     });
 
     const response = await h.dispatch(
@@ -295,20 +288,17 @@ describe("auth hooks — passkey signed_in / signed_out / credential:created", (
       mailer,
     });
     await h.factory.user.create({ email: "existing@allowed.test" });
-    await h.db
-      .insert(allowedDomains)
-      .values({ domain: "allowed.test", defaultRole: "subscriber" });
+    await h.factory.allowedDomain.create({
+      domain: "allowed.test",
+      defaultRole: "subscriber",
+    });
 
     const spy = h.spyAction("user:signed_in");
-    const token = generateToken();
-    const hash = await hashToken(token);
-    await h.db.insert(authTokens).values({
-      hash,
+    const { token } = await h.factory.authToken.create({
+      type: "magic_link",
       // Signup row: userId is null until verify provisions one.
       userId: null,
       email: "newcomer@allowed.test",
-      type: "magic_link",
-      expiresAt: new Date(Date.now() + 15 * 60 * 1000),
     });
 
     const response = await h.dispatch(

--- a/packages/core/src/auth/oauth/signup.test.ts
+++ b/packages/core/src/auth/oauth/signup.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
 
 import { eq, sql } from "../../db/index.js";
-import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { oauthAccounts } from "../../db/schema/oauth_accounts.js";
 import { users } from "../../db/schema/users.js";
 import {
@@ -166,7 +165,7 @@ describe("resolveOAuthUser — domain-gated signup", () => {
   test("disabled domain row rejects with domain_not_allowed", async () => {
     const db = await createTestDb();
     await userFactory.transient({ db }).create({ role: "admin" });
-    await db.insert(allowedDomains).values({
+    await allowedDomainFactory.transient({ db }).create({
       domain: "example.com",
       defaultRole: "contributor",
       isEnabled: false,

--- a/packages/core/src/rpc/procedures/settings/settings.test.ts
+++ b/packages/core/src/rpc/procedures/settings/settings.test.ts
@@ -13,20 +13,32 @@ describe("settings.get", () => {
 
   test("admin reads saved keys back", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
-    await h.context.db.insert(settings).values([
-      { group: "general", key: "site_title", value: "Example" },
-      { group: "general", key: "tagline", value: "A site" },
-    ]);
+    await h.factory.setting.create({
+      group: "general",
+      key: "site_title",
+      value: "Example",
+    });
+    await h.factory.setting.create({
+      group: "general",
+      key: "tagline",
+      value: "A site",
+    });
     const bag = await h.client.settings.get({ group: "general" });
     expect(bag).toEqual({ site_title: "Example", tagline: "A site" });
   });
 
   test("group scoping: only the requested group is returned", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
-    await h.context.db.insert(settings).values([
-      { group: "general", key: "site_title", value: "G" },
-      { group: "reading", key: "per_page", value: "10" },
-    ]);
+    await h.factory.setting.create({
+      group: "general",
+      key: "site_title",
+      value: "G",
+    });
+    await h.factory.setting.create({
+      group: "reading",
+      key: "per_page",
+      value: "10",
+    });
     expect(await h.client.settings.get({ group: "general" })).toEqual({
       site_title: "G",
     });
@@ -184,9 +196,11 @@ describe("settings.upsert", () => {
 
   test("empty values bag is a silent no-op and round-trips the stored bag", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
-    await h.context.db
-      .insert(settings)
-      .values([{ group: "general", key: "site_title", value: "Example" }]);
+    await h.factory.setting.create({
+      group: "general",
+      key: "site_title",
+      value: "Example",
+    });
     const spy = h.spyAction("settings:group_changed");
     const bag = await h.client.settings.upsert({
       group: "general",

--- a/packages/core/src/rpc/procedures/term/term.test.ts
+++ b/packages/core/src/rpc/procedures/term/term.test.ts
@@ -6,12 +6,6 @@ import { terms } from "../../../db/schema/terms.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
-function first<T>(rows: T[]): T {
-  const [row] = rows;
-  if (!row) throw new Error("expected at least one row from the db");
-  return row;
-}
-
 // "category" is the canonical hierarchical taxonomy in WP; used here as the
 // fixture because term RPC requires a registered taxonomy to operate.
 function taxonomyRegistry() {
@@ -38,10 +32,16 @@ describe("term.list", () => {
   test("returns terms in the requested taxonomy", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "subscriber", plugins });
-    await h.context.db.insert(terms).values([
-      { taxonomy: "category", name: "Alpha", slug: "alpha" },
-      { taxonomy: "category", name: "Beta", slug: "beta" },
-    ]);
+    await h.factory.term.create({
+      taxonomy: "category",
+      name: "Alpha",
+      slug: "alpha",
+    });
+    await h.factory.term.create({
+      taxonomy: "category",
+      name: "Beta",
+      slug: "beta",
+    });
 
     const rows = await h.client.term.list({ taxonomy: "category" });
     expect(rows.map((r) => r.slug).sort()).toEqual(["alpha", "beta"]);
@@ -61,13 +61,12 @@ describe("term.list", () => {
   test("parentId=null returns only top-level terms", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "subscriber", plugins });
-    const root = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "Root", slug: "root" })
-        .returning(),
-    );
-    await h.context.db.insert(terms).values({
+    const root = await h.factory.term.create({
+      taxonomy: "category",
+      name: "Root",
+      slug: "root",
+    });
+    await h.factory.term.create({
       taxonomy: "category",
       name: "Child",
       slug: "child",
@@ -85,12 +84,11 @@ describe("term.get", () => {
   test("returns the term", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "subscriber", plugins });
-    const row = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "Got", slug: "got" })
-        .returning(),
-    );
+    const row = await h.factory.term.create({
+      taxonomy: "category",
+      name: "Got",
+      slug: "got",
+    });
 
     const got = await h.client.term.get({ id: row.id });
     expect(got.slug).toBe("got");
@@ -166,12 +164,11 @@ describe("term.create", () => {
       registeredBy: "test",
     });
     const h = await createRpcHarness({ authAs: "editor", plugins });
-    const otherTaxRow = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "post_tag", name: "Tag", slug: "tag-1" })
-        .returning(),
-    );
+    const otherTaxRow = await h.factory.term.create({
+      taxonomy: "post_tag",
+      name: "Tag",
+      slug: "tag-1",
+    });
     await expect(
       h.client.term.create({
         taxonomy: "category",
@@ -190,12 +187,11 @@ describe("term.update", () => {
   test("editor can rename a term", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
-    const row = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "Old", slug: "old" })
-        .returning(),
-    );
+    const row = await h.factory.term.create({
+      taxonomy: "category",
+      name: "Old",
+      slug: "old",
+    });
     const updated = await h.client.term.update({
       id: row.id,
       name: "New Name",
@@ -206,12 +202,11 @@ describe("term.update", () => {
   test("subscriber cannot update", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "subscriber", plugins });
-    const row = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "Name", slug: "name" })
-        .returning(),
-    );
+    const row = await h.factory.term.create({
+      taxonomy: "category",
+      name: "Name",
+      slug: "name",
+    });
     await expect(
       h.client.term.update({ id: row.id, name: "Hax" }),
     ).rejects.toMatchObject({
@@ -223,12 +218,11 @@ describe("term.update", () => {
   test("setting parent = self → CONFLICT (parent_is_self)", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
-    const row = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "Self", slug: "self" })
-        .returning(),
-    );
+    const row = await h.factory.term.create({
+      taxonomy: "category",
+      name: "Self",
+      slug: "self",
+    });
     await expect(
       h.client.term.update({ id: row.id, parentId: row.id }),
     ).rejects.toMatchObject({
@@ -241,34 +235,23 @@ describe("term.update", () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
     // A -> B -> C (B's parent is A; C's parent is B).
-    const a = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "A", slug: "a" })
-        .returning(),
-    );
-    const b = first(
-      await h.context.db
-        .insert(terms)
-        .values({
-          taxonomy: "category",
-          name: "B",
-          slug: "b",
-          parentId: a.id,
-        })
-        .returning(),
-    );
-    const c = first(
-      await h.context.db
-        .insert(terms)
-        .values({
-          taxonomy: "category",
-          name: "C",
-          slug: "c",
-          parentId: b.id,
-        })
-        .returning(),
-    );
+    const a = await h.factory.term.create({
+      taxonomy: "category",
+      name: "A",
+      slug: "a",
+    });
+    const b = await h.factory.term.create({
+      taxonomy: "category",
+      name: "B",
+      slug: "b",
+      parentId: a.id,
+    });
+    const c = await h.factory.term.create({
+      taxonomy: "category",
+      name: "C",
+      slug: "c",
+      parentId: b.id,
+    });
     // Attempting A.parent = C would form a cycle A -> C -> B -> A.
     await expect(
       h.client.term.update({ id: a.id, parentId: c.id }),
@@ -281,15 +264,16 @@ describe("term.update", () => {
   test("slug collision on update → CONFLICT", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
-    const a = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "A", slug: "a-slug" })
-        .returning(),
-    );
-    await h.context.db
-      .insert(terms)
-      .values({ taxonomy: "category", name: "B", slug: "b-slug" });
+    const a = await h.factory.term.create({
+      taxonomy: "category",
+      name: "A",
+      slug: "a-slug",
+    });
+    await h.factory.term.create({
+      taxonomy: "category",
+      name: "B",
+      slug: "b-slug",
+    });
     await expect(
       h.client.term.update({ id: a.id, slug: "b-slug" }),
     ).rejects.toMatchObject({
@@ -303,23 +287,17 @@ describe("term.delete", () => {
   test("editor can delete a term; children have parentId nulled", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "editor", plugins });
-    const parent = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "P", slug: "p" })
-        .returning(),
-    );
-    const child = first(
-      await h.context.db
-        .insert(terms)
-        .values({
-          taxonomy: "category",
-          name: "C",
-          slug: "c",
-          parentId: parent.id,
-        })
-        .returning(),
-    );
+    const parent = await h.factory.term.create({
+      taxonomy: "category",
+      name: "P",
+      slug: "p",
+    });
+    const child = await h.factory.term.create({
+      taxonomy: "category",
+      name: "C",
+      slug: "c",
+      parentId: parent.id,
+    });
 
     await h.client.term.delete({ id: parent.id });
 
@@ -332,12 +310,11 @@ describe("term.delete", () => {
   test("author cannot delete", async () => {
     const plugins = taxonomyRegistry();
     const h = await createRpcHarness({ authAs: "author", plugins });
-    const row = first(
-      await h.context.db
-        .insert(terms)
-        .values({ taxonomy: "category", name: "X", slug: "x" })
-        .returning(),
-    );
+    const row = await h.factory.term.create({
+      taxonomy: "category",
+      name: "X",
+      slug: "x",
+    });
     await expect(h.client.term.delete({ id: row.id })).rejects.toMatchObject({
       code: "FORBIDDEN",
       data: { capability: "term:category:delete" },


### PR DESCRIPTION
Continues the #943 cleanup: the remaining raw `db.insert(...)` seeding in core test files now goes through the shared fishery factories — the same uniform, type-reusing construction path the rest of the suite already uses.

- `settings.get`/`upsert` tests → `h.factory.setting`
- term RPC tests → `h.factory.term` (drops the now-unused `first()` array-unwrap helper)
- auth-hooks magic-link + allowlist seeds → `h.factory.authToken` / `h.factory.allowedDomain`
- oauth signup disabled-domain seed → `allowedDomainFactory`

**Fixes a latent unscoped update**

The `email-change` `token_expired` test previously minted a live token and then ran `db.update(authTokens).set({ expiresAt })` with **no `.where()`** — expiring every token row in the db (harmless only because the test seeds exactly one). It now seeds an already-expired `email_verification` token directly via `authTokenFactory`, reproducing the exact row shape `requestEmailChange` writes.

Behaviour-preserving: full core suite **1975 passed**, unchanged from baseline.

Refs #943