### PR TITLE
test(plugin-menu): seed menu location settings through settingFactory

### DIFF
--- a/packages/plugins/menu/src/hooks.test.ts
+++ b/packages/plugins/menu/src/hooks.test.ts
@@ -11,7 +11,6 @@ import {
   HookRegistry,
   installPlugins,
   registerCoreLookupAdapters,
-  settings,
 } from "plumix/plugin";
 import {
   adminUser,
@@ -243,7 +242,7 @@ describe("menu hook surface", () => {
       recordLocation("primary", { label: "Primary" });
       const termId = await seedMenuTerm(b, "primary");
       await seedItem(b, termId, "Home", "/");
-      await b.db.insert(settings).values({
+      await b.factories.setting.create({
         group: "menu_locations",
         key: "primary",
         value: "primary",

--- a/packages/plugins/menu/src/rpc.test.ts
+++ b/packages/plugins/menu/src/rpc.test.ts
@@ -515,7 +515,7 @@ describe("menu RPC", () => {
     test("sweeps any settings binding pointing at the deleted menu", async () => {
       const h = await buildHarness();
       const m = await seedMenu(h.db, h.factories, "ghost");
-      await h.db.insert(settings).values({
+      await h.factories.setting.create({
         group: "menu_locations",
         key: "primary",
         value: m.slug,
@@ -682,7 +682,7 @@ describe("menu RPC", () => {
       const h = await buildHarness();
       recordLocation("primary", { label: "Primary" });
       await seedMenu(h.db, h.factories, "main");
-      await h.db.insert(settings).values({
+      await h.factories.setting.create({
         group: "menu_locations",
         key: "ghost",
         value: "main",

--- a/packages/plugins/menu/src/server/getMenuForLocation.test.ts
+++ b/packages/plugins/menu/src/server/getMenuForLocation.test.ts
@@ -91,7 +91,7 @@ describe("getMenuForLocation", () => {
   }
 
   async function bind(location: string, termSlug: string): Promise<void> {
-    await db.insert(settings).values({
+    await factories.setting.create({
       group: "menu_locations",
       key: location,
       value: termSlug,
@@ -126,6 +126,8 @@ describe("getMenuForLocation", () => {
     "returns null when the binding value shape is invalid: %s",
     async (name, value) => {
       void name;
+      // Raw insert: settingFactory's `value ?? ""` default would coerce the
+      // deliberately-malformed shapes here (notably null) into "".
       await db.insert(settings).values({
         group: "menu_locations",
         key: "primary",


### PR DESCRIPTION
Continues the #943 cleanup in the menu plugin: raw `db.insert(settings)` seeds in the tests now go through the shared `settingFactory`, reached via the already-bound `factories` object on each test harness (`b.factories` / `h.factories` / `factories`).

**One insert stays raw, on purpose**

`getMenuForLocation`'s `test.each` for invalid binding-value shapes feeds deliberately-malformed values (`null`, `""`, `42`, an array, an object). `settingFactory` defaults `value` via `value ?? ""`, which would coerce the `null` case into `""` and collapse it into the empty-string case — silently dropping coverage. That call site keeps its raw insert with a comment explaining why.

Behaviour-preserving: **238 menu tests pass**, unchanged.

Refs #943