### PR TITLE
test(core): add deviceCodeFactory and seed device-flow tests with it

### DIFF
--- a/packages/core/src/auth/device-flow-routes.test.ts
+++ b/packages/core/src/auth/device-flow-routes.test.ts
@@ -129,17 +129,11 @@ describe("POST /_plumix/auth/device/token", () => {
     const h = await createDispatcherHarness();
     const seeded = await h.factory.user.create({});
 
-    // Start a device-flow session, then directly approve the row in
-    // the DB to skip the browser-side approve UI.
-    const startResponse = await h.dispatch(
-      plumixRequest(DEVICE_CODE_PATH, { method: "POST" }),
-    );
-    const { device_code } = (await startResponse.json()) as {
-      device_code: string;
-    };
-    await h.db
-      .update(deviceCodes)
-      .set({ status: "approved", userId: seeded.id, tokenName: "ci" });
+    const { deviceCode: device_code } = await h.factory.deviceCode.create({
+      status: "approved",
+      userId: seeded.id,
+      tokenName: "ci",
+    });
 
     const response = await h.dispatch(
       plumixRequest(DEVICE_TOKEN_PATH, {
@@ -174,13 +168,9 @@ describe("POST /_plumix/auth/device/token", () => {
   test("returns access_denied + consumes the row for a denied session", async () => {
     const h = await createDispatcherHarness();
 
-    const startResponse = await h.dispatch(
-      plumixRequest(DEVICE_CODE_PATH, { method: "POST" }),
-    );
-    const { device_code } = (await startResponse.json()) as {
-      device_code: string;
-    };
-    await h.db.update(deviceCodes).set({ status: "denied" });
+    const { deviceCode: device_code } = await h.factory.deviceCode.create({
+      status: "denied",
+    });
 
     const response = await h.dispatch(
       plumixRequest(DEVICE_TOKEN_PATH, {
@@ -211,15 +201,9 @@ describe("POST /_plumix/auth/device/token", () => {
   test("returns expired_token + reaps the row past TTL", async () => {
     const h = await createDispatcherHarness();
 
-    const startResponse = await h.dispatch(
-      plumixRequest(DEVICE_CODE_PATH, { method: "POST" }),
-    );
-    const { device_code } = (await startResponse.json()) as {
-      device_code: string;
-    };
-    await h.db
-      .update(deviceCodes)
-      .set({ expiresAt: new Date(Date.now() - 1000) });
+    const { deviceCode: device_code } = await h.factory.deviceCode.create({
+      expiresAt: new Date(Date.now() - 1000),
+    });
 
     const response = await h.dispatch(
       plumixRequest(DEVICE_TOKEN_PATH, {

--- a/packages/core/src/auth/device-flow.test.ts
+++ b/packages/core/src/auth/device-flow.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import { eq } from "../db/index.js";
 import { apiTokens } from "../db/schema/api_tokens.js";
 import { deviceCodes } from "../db/schema/device_codes.js";
-import { userFactory } from "../test/factories.js";
+import { deviceCodeFactory, userFactory } from "../test/factories.js";
 import { createTestDb } from "../test/harness.js";
 import { API_TOKEN_PREFIX } from "./api-tokens.js";
 import {
@@ -65,10 +65,9 @@ describe("lookupDeviceCodeByUserCode", () => {
 
   test("returns expired for a row whose TTL has passed", async () => {
     const db = await createTestDb();
-    const { userCode } = await requestDeviceCode(db);
-    await db
-      .update(deviceCodes)
-      .set({ expiresAt: new Date(Date.now() - 1000) });
+    const { userCode } = await deviceCodeFactory.transient({ db }).create({
+      expiresAt: new Date(Date.now() - 1000),
+    });
 
     const result = await lookupDeviceCodeByUserCode(db, userCode);
     expect(result.outcome).toBe("expired");
@@ -179,10 +178,9 @@ describe("exchangeDeviceCode", () => {
 
   test("returns expired and reaps the row when the TTL has passed", async () => {
     const db = await createTestDb();
-    const { deviceCode } = await requestDeviceCode(db);
-    await db
-      .update(deviceCodes)
-      .set({ expiresAt: new Date(Date.now() - 1000) });
+    const { deviceCode } = await deviceCodeFactory.transient({ db }).create({
+      expiresAt: new Date(Date.now() - 1000),
+    });
 
     const result = await exchangeDeviceCode(db, deviceCode, "cli");
     expect(result.outcome).toBe("expired");

--- a/packages/core/src/rpc/procedures/auth/auth.test.ts
+++ b/packages/core/src/rpc/procedures/auth/auth.test.ts
@@ -1226,11 +1226,9 @@ describe("auth.deviceFlow", () => {
 
   test("approve on an expired row → CONFLICT/expired", async () => {
     const h = await createRpcHarness({ authAs: "editor" });
-    const { userCode } = await requestDeviceCode(h.db);
-    const { deviceCodes } = await import("../../../db/schema/device_codes.js");
-    await h.db
-      .update(deviceCodes)
-      .set({ expiresAt: new Date(Date.now() - 1000) });
+    const { userCode } = await h.factory.deviceCode.create({
+      expiresAt: new Date(Date.now() - 1000),
+    });
 
     await expect(
       h.client.auth.deviceFlow.approve({ userCode, tokenName: "x" }),
@@ -1242,11 +1240,9 @@ describe("auth.deviceFlow", () => {
 
   test("deny on an expired row → CONFLICT/expired", async () => {
     const h = await createRpcHarness({ authAs: "editor" });
-    const { userCode } = await requestDeviceCode(h.db);
-    const { deviceCodes } = await import("../../../db/schema/device_codes.js");
-    await h.db
-      .update(deviceCodes)
-      .set({ expiresAt: new Date(Date.now() - 1000) });
+    const { userCode } = await h.factory.deviceCode.create({
+      expiresAt: new Date(Date.now() - 1000),
+    });
 
     await expect(
       h.client.auth.deviceFlow.deny({ userCode }),

--- a/packages/core/src/test/factories.test.ts
+++ b/packages/core/src/test/factories.test.ts
@@ -5,6 +5,7 @@ import { hashToken } from "../auth/tokens.js";
 import {
   apiTokenFactory,
   authTokenFactory,
+  deviceCodeFactory,
   oauthAccountFactory,
   userFactory,
 } from "./factories.js";
@@ -24,6 +25,18 @@ describe("oauthAccountFactory", () => {
     expect(row.userId).toBe(user.id);
     expect(row.provider).toBe("github");
     expect(row.providerAccountId).toBe("gh-1");
+  });
+});
+
+describe("deviceCodeFactory", () => {
+  test("mints a device code whose secret hashes to the stored row id", async () => {
+    const db = await createTestDb();
+
+    const minted = await deviceCodeFactory.transient({ db }).create({});
+
+    expect(minted.row.id).toBe(await hashToken(minted.deviceCode));
+    expect(minted.row.status).toBe("pending");
+    expect(minted.row.userCode).toBe(minted.userCode);
   });
 });
 

--- a/packages/core/src/test/factories.ts
+++ b/packages/core/src/test/factories.ts
@@ -15,6 +15,7 @@ import type {
   CredentialTransport,
   NewCredential,
 } from "../db/schema/credentials.js";
+import type { DeviceCode, NewDeviceCode } from "../db/schema/device_codes.js";
 import type { Entry, NewEntry } from "../db/schema/entries.js";
 import type { EntryTerm, NewEntryTerm } from "../db/schema/entry_term.js";
 import type {
@@ -30,6 +31,7 @@ import { generateToken, hashToken } from "../auth/tokens.js";
 import { allowedDomains } from "../db/schema/allowed_domains.js";
 import { authTokens } from "../db/schema/auth_tokens.js";
 import { credentials } from "../db/schema/credentials.js";
+import { deviceCodes } from "../db/schema/device_codes.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
 import { oauthAccounts } from "../db/schema/oauth_accounts.js";
@@ -371,6 +373,49 @@ export const oauthAccountFactory = Factory.define<
   };
 });
 
+interface MintedDeviceCode {
+  /** Plaintext device_code the polling client exchanges with; never stored. */
+  readonly deviceCode: string;
+  /** Human-typed approval code; stored plaintext under a unique constraint. */
+  readonly userCode: string;
+  readonly row: DeviceCode;
+}
+
+// Mints a device-flow row (RFC 8628): generates the device_code, stores only
+// its SHA-256 under the PK, and returns the plaintext so a test can drive the
+// poll/exchange path. Pass `status` / `userId` to seed an approved or denied
+// terminal state directly. `id` is always derived, never passed.
+export const deviceCodeFactory = Factory.define<
+  Omit<NewDeviceCode, "id">,
+  DbTransient,
+  MintedDeviceCode
+>(({ sequence, transientParams, onCreate, params }) => {
+  onCreate(async (attrs) => {
+    const db = requireDb(transientParams);
+    const deviceCode = generateToken();
+    const id = await hashToken(deviceCode);
+    const [row] = await db
+      .insert(deviceCodes)
+      .values({ ...attrs, id })
+      .returning();
+    if (!row) throw new Error("deviceCodeFactory: insert returned no row");
+    return { deviceCode, userCode: row.userCode, row };
+  });
+
+  return {
+    // RFC 8628 "ABCD-EFGH" shape — the deviceFlow RPC validates this format.
+    userCode:
+      params.userCode ?? `TEST-${String(sequence).padStart(4, "0").slice(-4)}`,
+    userId: params.userId ?? null,
+    status: params.status ?? "pending",
+    tokenName: params.tokenName ?? null,
+    // fishery's DeepPartial widens array elements to `T | undefined`; the
+    // caller passes a real scope list (or null), so narrow it back.
+    scopes: (params.scopes ?? null) as readonly string[] | null,
+    expiresAt: params.expiresAt ?? new Date(Date.now() + 10 * 60 * 1000),
+  };
+});
+
 export interface Factories {
   readonly user: typeof userFactory;
   readonly admin: typeof adminUser;
@@ -394,6 +439,7 @@ export interface Factories {
   readonly apiToken: typeof apiTokenFactory;
   readonly authToken: typeof authTokenFactory;
   readonly oauthAccount: typeof oauthAccountFactory;
+  readonly deviceCode: typeof deviceCodeFactory;
 }
 
 export function factoriesFor(db: Db): Factories {
@@ -420,5 +466,6 @@ export function factoriesFor(db: Db): Factories {
     apiToken: apiTokenFactory.transient({ db }),
     authToken: authTokenFactory.transient({ db }),
     oauthAccount: oauthAccountFactory.transient({ db }),
+    deviceCode: deviceCodeFactory.transient({ db }),
   };
 }

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -25,6 +25,7 @@ export {
   apiTokenFactory,
   authTokenFactory,
   oauthAccountFactory,
+  deviceCodeFactory,
   factoriesFor,
 } from "./factories.js";
 export type { Factories } from "./factories.js";


### PR DESCRIPTION
Continues #943. Adds a `deviceCodeFactory` and converts the last remaining raw `db.update(deviceCodes)` state-transition seeds in the test suite.

The factory mirrors production `requestDeviceCode` (RFC 8628): it generates the `device_code`, stores only its SHA-256 under the row PK, and returns the plaintext so a test can drive the poll/exchange path. `status` / `userId` / `expiresAt` params seed an approved, denied, or expired terminal state directly.

**Seed terminal state instead of start-then-mutate**

Every converted site previously started a live device-flow session and then ran `db.update(deviceCodes).set(...)` to force it into a denied/approved/expired state. They now seed that terminal state through the factory in one call. The consumer under test (exchange reaping, lookup-expired, the approve/deny expiry guard) is unchanged — only the setup is — and the real `exchangeDeviceCode` still does a genuine `hashToken` PK lookup against the seeded plaintext.

Built via TDD (red factory test → impl). Behaviour-preserving: full core suite **1976 passed**.

Refs #943