### PR TITLE
test(core): seed precondition state at creation, not post-insert mutation

### DIFF
--- a/packages/core/src/auth/email-change/email-change.test.ts
+++ b/packages/core/src/auth/email-change/email-change.test.ts
@@ -100,11 +100,8 @@ describe("requestEmailChange", () => {
     const db = await createTestDb();
     const user = await userFactory.transient({ db }).create({
       email: "alice@example.test",
+      disabledAt: new Date(),
     });
-    await db
-      .update(users)
-      .set({ disabledAt: new Date() })
-      .where(eq(users.id, user.id));
     const mailer = makeMailer();
 
     await expect(
@@ -174,15 +171,12 @@ describe("requestEmailChange", () => {
 describe("verifyEmailChange", () => {
   test("commits the new email + resets emailVerifiedAt + invalidates sessions", async () => {
     const db = await createTestDb();
-    const user = await userFactory.transient({ db }).create({
-      email: "alice@old.example",
-    });
     // Pre-existing verified state + a session — both should be reset
     // by the email change to require re-auth + re-verification.
-    await db
-      .update(users)
-      .set({ emailVerifiedAt: new Date("2026-01-01") })
-      .where(eq(users.id, user.id));
+    const user = await userFactory.transient({ db }).create({
+      email: "alice@old.example",
+      emailVerifiedAt: new Date("2026-01-01"),
+    });
     const { createSession } = await import("../sessions.js");
     await createSession(db, { userId: user.id });
     await createSession(db, { userId: user.id });

--- a/packages/core/src/auth/oauth/routes.test.ts
+++ b/packages/core/src/auth/oauth/routes.test.ts
@@ -296,12 +296,11 @@ describe("oauth callback route", () => {
 
   test("happy path — links to existing user, mints session, sets cookie, redirects to admin", async () => {
     const h = await createDispatcherHarness({ oauth: TEST_OAUTH });
-    const seeded = await h.seedUser("editor");
-    // Force the email so the verified-email link path is exercised.
-    await h.db
-      .update(users)
-      .set({ email: "alice@example.com" })
-      .where(eq(users.id, seeded.id));
+    // Email forced so the verified-email link path is exercised.
+    const seeded = await h.factory.user.create({
+      role: "editor",
+      email: "alice@example.com",
+    });
 
     const state = await seedState(h, "github", "v-1");
 

--- a/packages/core/src/auth/passkey/authenticate.test.ts
+++ b/packages/core/src/auth/passkey/authenticate.test.ts
@@ -3,8 +3,7 @@ import { describe, expect, test } from "vitest";
 
 import type { PasskeyKeyPair } from "../../test/fixtures/webauthn.js";
 import { credentials } from "../../db/schema/credentials.js";
-import { users } from "../../db/schema/users.js";
-import { credentialFactory } from "../../test/factories.js";
+import { credentialFactory, userFactory } from "../../test/factories.js";
 import {
   buildAssertion,
   buildAttestation,
@@ -33,11 +32,9 @@ interface RegisteredFixture {
 
 async function registerFixtureCredential(): Promise<RegisteredFixture> {
   const db = await createTestDb();
-  const [user] = await db
-    .insert(users)
-    .values({ email: "u@example.com", role: "admin" })
-    .returning({ id: users.id });
-  if (!user) throw new Error("seed");
+  const user = await userFactory
+    .transient({ db })
+    .create({ email: "u@example.com", role: "admin" });
 
   const { challenge } = await issueChallenge(db, 60_000, user.id);
   const keyPair = generatePasskeyKeyPair();

--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -198,17 +198,11 @@ describe("entry.create", () => {
     const h = await createRpcHarness({ authAs: "contributor" });
     // Another author's draft — contributor lacks post:edit_any, doesn't own it.
     const other = await h.factory.admin.create({ email: "a@example.test" });
-    const [secret] = await h.db
-      .insert(entries)
-      .values({
-        type: "post",
-        title: "hidden",
-        slug: "hidden",
-        status: "draft",
-        authorId: other.id,
-      })
-      .returning();
-    if (!secret) throw new Error("seed");
+    const secret = await h.factory.draft.create({
+      title: "hidden",
+      slug: "hidden",
+      authorId: other.id,
+    });
 
     await expect(
       h.client.entry.create({
@@ -224,18 +218,12 @@ describe("entry.create", () => {
 
   test("rejects a parentId of a different post type", async () => {
     const h = await createRpcHarness({ authAs: "admin" });
-    const [page] = await h.db
-      .insert(entries)
-      .values({
-        type: "page",
-        title: "p",
-        slug: "p",
-        status: "published",
-        authorId: h.user.id,
-        publishedAt: new Date(),
-      })
-      .returning();
-    if (!page) throw new Error("seed");
+    const page = await h.factory.published.create({
+      type: "page",
+      title: "p",
+      slug: "p",
+      authorId: h.user.id,
+    });
 
     await expect(
       h.client.entry.create({

--- a/packages/core/src/rpc/procedures/entry/duplicate.test.ts
+++ b/packages/core/src/rpc/procedures/entry/duplicate.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from "vitest";
 import type { UserRole } from "../../../db/schema/users.js";
 import { eq } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
-import { terms } from "../../../db/schema/terms.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
@@ -81,11 +80,11 @@ describe("entry.duplicate", () => {
       authAs: "editor",
       plugins: categoryRegistry(),
     });
-    const [category] = await h.context.db
-      .insert(terms)
-      .values({ taxonomy: "category", name: "news", slug: "news" })
-      .returning();
-    if (!category) throw new Error("seed: term insert returned no row");
+    const category = await h.factory.term.create({
+      taxonomy: "category",
+      name: "news",
+      slug: "news",
+    });
     const source = await h.factory.published.create({
       authorId: h.user.id,
       title: "Tagged",

--- a/packages/core/src/rpc/procedures/entry/meta.test.ts
+++ b/packages/core/src/rpc/procedures/entry/meta.test.ts
@@ -281,11 +281,8 @@ describe("applyMetaPatch + loadEntryMeta", () => {
     const post = await h.factory.draft.create({
       authorId: h.user.id,
       slug: "target",
+      meta: { untouched: "keep" },
     });
-    await h.context.db
-      .update(entries)
-      .set({ meta: { untouched: "keep" } })
-      .where(eq(entries.id, post.id));
 
     const patch = sanitizeMetaInput(findField(plugins, post.type), {
       title: "Written",

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 
-import { entries } from "../../../db/schema/entries.js";
 import { createPluginRegistry } from "../../../plugin/manifest.js";
 import { createRpcHarness } from "../../../test/rpc.js";
 
@@ -203,32 +202,20 @@ describe("entry.update", () => {
 
   test("rejects reparenting under a post the caller cannot read", async () => {
     const h = await createRpcHarness({ authAs: "contributor" });
-    const [own] = await h.db
-      .insert(entries)
-      .values({
-        type: "post",
-        title: "mine",
-        slug: "mine",
-        status: "draft",
-        authorId: h.user.id,
-      })
-      .returning();
-    if (!own) throw new Error("seed");
+    const own = await h.factory.draft.create({
+      title: "mine",
+      slug: "mine",
+      authorId: h.user.id,
+    });
 
     const other = await h.factory.admin.create({
       email: "hidden@example.test",
     });
-    const [secret] = await h.db
-      .insert(entries)
-      .values({
-        type: "post",
-        title: "secret",
-        slug: "secret",
-        status: "draft",
-        authorId: other.id,
-      })
-      .returning();
-    if (!secret) throw new Error("seed");
+    const secret = await h.factory.draft.create({
+      title: "secret",
+      slug: "secret",
+      authorId: other.id,
+    });
 
     await expect(
       h.client.entry.update({ id: own.id, parentId: secret.id }),

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -92,13 +92,10 @@ describe("dispatcher — routing", () => {
       assets,
       i18n: { defaultLocale: "en", locales: ["en", "ar"] },
     });
-    const admin = await h.seedUser("admin");
-    const { users } = await import("../db/schema/users.js");
-    const { eq } = await import("drizzle-orm");
-    await h.db
-      .update(users)
-      .set({ meta: { locale: "ar" } })
-      .where(eq(users.id, admin.id));
+    const admin = await h.factory.user.create({
+      role: "admin",
+      meta: { locale: "ar" },
+    });
 
     const request = await h.authenticateRequest(
       plumixRequest("/_plumix/admin/", { method: "GET" }),


### PR DESCRIPTION
Continues #943. Replaces the remaining create-then-mutate test setups with a single factory call that seeds the terminal state up front. fishery deep-merges the override object over the generator output, so a column the generator doesn't list (`disabledAt`, `emailVerifiedAt`, `meta`) is still written by `.create({...})`.

- **email-change**: disabled / pre-verified users seeded via `userFactory` params instead of `db.update(users)` after creation
- **oauth routes + dispatcher**: `seedUser` + `db.update(users)` → `h.factory.user.create({...})` with the email / `meta.locale` set at creation
- **passkey authenticate** fixture: raw `insert(users)` → `userFactory`
- **entry create/update/duplicate**: raw `insert(entries|terms)` → `draft`/`published`/`term` factory (drops the array-destructure + `"seed"` throw guards)
- **entry meta** merge test: the pre-existing meta bag is seeded via `draft.create({ meta })`

Drops the now-unused `entries`/`terms`/`users` schema imports those raw inserts required.

Behaviour-preserving: full core suite **1976 passed**. The `emailVerifiedAt`/`disabledAt` assertions actively confirm the deep-merge persists — they'd fail if it didn't.

Refs #943