### PR TITLE
perf(core): lazy-evaluate the MCP dispatcher branch on Workers

### DIFF
--- a/packages/core/src/mcp/dispatch.ts
+++ b/packages/core/src/mcp/dispatch.ts
@@ -4,8 +4,6 @@ import { withUser } from "../context/app.js";
 import { jsonResponse, methodNotAllowed } from "../runtime/http.js";
 import { buildMcpToolRegistry } from "./registry.js";
 
-export const MCP_PATH = "/_plumix/mcp";
-
 // Bearer PAT only — NOT the request's configured authenticator (which defaults
 // to a cookie+bearer chain, or an operator's custom guard). Cookie/session auth
 // must not reach this endpoint: it's mounted ahead of the CSRF gate, and only

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -1,4 +1,5 @@
 import type { AppContext } from "../context/app.js";
+import type * as McpDispatch from "../mcp/dispatch.js";
 import type { RegisteredRawRoute } from "../plugin/manifest.js";
 import type { PlumixApp } from "./app.js";
 import { readSessionCookie } from "../auth/cookies.js";
@@ -28,7 +29,6 @@ import {
 } from "../auth/passkey/routes.js";
 import { withUser } from "../context/app.js";
 import { resolveLocale } from "../i18n/resolve-locale.js";
-import { handleMcpRequest, MCP_PATH } from "../mcp/dispatch.js";
 import { matchRoute } from "../route/match.js";
 import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
@@ -40,6 +40,13 @@ const RPC_PREFIX = "/_plumix/rpc";
 const ADMIN_PREFIX = "/_plumix/admin";
 const AUTH_PREFIX = "/_plumix/auth/";
 const PLUMIX_PREFIX = "/_plumix/";
+const MCP_PATH = "/_plumix/mcp";
+
+// MCP is cold-path-exclusive (an agent endpoint, never the public render path).
+// Dynamic-import its handler so the tool registry and the MCP SDK it pulls in
+// stay off the public render and cold-start paths, evaluating only on the first
+// MCP request per isolate.
+let mcpModule: Promise<typeof McpDispatch> | undefined;
 
 // Filenames look like `index.html`, `chunk-abc.js`, `fonts/g.woff2` — paths
 // with a dot-suffix after the last slash. Deep-link SPA routes never match.
@@ -129,6 +136,8 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   // header cross-site without a CORS grant Plumix never gives). The gate keeps
   // protecting the cookie-authed RPC/auth endpoints below it unchanged.
   if (pathname === MCP_PATH) {
+    const { handleMcpRequest } = await (mcpModule ??=
+      import("../mcp/dispatch.js"));
     return handleMcpRequest(ctx);
   }
 


### PR DESCRIPTION
The dispatcher statically imported `handleMcpRequest`, which pulled the MCP tool registry (`schema_describe`, `content_list`, the term/taxonomy tools) into the eager module graph every isolate evaluates at cold start. The MCP endpoint is an agent-only cold path — never the public render path — so public-only isolates were paying that evaluation cost for nothing. It now loads via a memoized dynamic import, evaluating only on the first MCP request per isolate.

**Deferred chunk**

`route()` dynamic-imports `../mcp/dispatch.js` through a module-level memoized promise (`mcpModule ??= import(...)`), so the tool registry and the MCP SDK it pulls in stay off the public-render and cold-start paths. The SDK itself was already behind a second-level dynamic import inside `handleMcpRequest`; this change additionally defers the tool registry + dispatch module — the part that was still eager.

**`MCP_PATH` relocation**

The path constant moves to a local `const` in the dispatcher (its only consumer), and `mcp/dispatch.ts` drops the now-unused `export`.

Pure perf refactor — no endpoint behavior change. The existing `mcp/dispatch.test.ts` suite (driving the real endpoint) guards against regression.

**Verification**

Full core suite (1976 tests) green; typecheck / lint / format / knip clean. Per the PRD (#929) decision the build-verification acceptance was done manually rather than as a new automated test: a Vite build of the dispatcher confirms `buildMcpToolRegistry` / `schema_describe` / `content_list` moved out of the eager entry chunk into a deferred `chunk-dispatch.js`.

```
Before:  [EAGER] entry.js        registry=true  schema_describe=true  content_list=true
After:   [EAGER] entry.js        registry=false schema_describe=false content_list=false
         [lazy]  chunk-dispatch  registry=true  schema_describe=true  content_list=true
```

The broader cold-path lazy-load effort (admin RPC, admin shell, media) remains tracked separately in #930.

Closes #936