### PR TITLE
perf(core): defer auth-flow route handlers off the public render path

### DIFF
--- a/packages/core/src/auth/flow-routes.ts
+++ b/packages/core/src/auth/flow-routes.ts
@@ -1,0 +1,28 @@
+/**
+ * Aggregates every auth-flow route handler (passkey, invite, magic-link,
+ * device-flow, OAuth, email-change) into one chunk the dispatcher loads via a
+ * single memoized dynamic import — see `loadAuthFlowRoutes` for why.
+ *
+ * `parseOAuthPath` is deliberately NOT re-exported here: the dispatcher matches
+ * OAuth paths eagerly from `./oauth/match.js`, and re-exporting it would drag
+ * the heavy handler graph back onto the eager path.
+ */
+export {
+  handleInviteRegisterOptions,
+  handleInviteRegisterVerify,
+  handlePasskeyLoginOptions,
+  handlePasskeyLoginVerify,
+  handlePasskeyRegisterOptions,
+  handlePasskeyRegisterVerify,
+  handleSignout,
+} from "./passkey/routes.js";
+export {
+  handleMagicLinkRequest,
+  handleMagicLinkVerify,
+} from "./magic-link/routes.js";
+export {
+  handleDeviceCodeRequest,
+  handleDeviceTokenExchange,
+} from "./device-flow-routes.js";
+export { handleOAuthCallback, handleOAuthStart } from "./oauth/routes.js";
+export { handleEmailChangeVerify } from "./email-change/routes.js";

--- a/packages/core/src/auth/oauth/match.ts
+++ b/packages/core/src/auth/oauth/match.ts
@@ -1,0 +1,30 @@
+import { OAUTH_PROVIDER_KEY_PATTERN } from "./types.js";
+
+interface OAuthRouteParams {
+  readonly providerKey: string;
+}
+
+/**
+ * Match `/_plumix/auth/oauth/<key>/(start|callback)`. The shape check
+ * (alphanum + `_-`) happens here; existence check ("is this a configured
+ * provider?") happens in the handler. A path that doesn't match the
+ * shape returns null → 404 from the dispatcher.
+ *
+ * Kept apart from the OAuth handlers so the dispatcher can match the path
+ * eagerly without pulling the (heavy) consumer/arctic graph onto the
+ * public render cold-start path; the handlers load on first OAuth request.
+ */
+export function parseOAuthPath(
+  pathname: string,
+): { params: OAuthRouteParams; tail: "start" | "callback" } | null {
+  const prefix = "/_plumix/auth/oauth/";
+  if (!pathname.startsWith(prefix)) return null;
+  const rest = pathname.slice(prefix.length);
+  const slash = rest.indexOf("/");
+  if (slash < 0) return null;
+  const providerKey = rest.slice(0, slash);
+  const tail = rest.slice(slash + 1);
+  if (!OAUTH_PROVIDER_KEY_PATTERN.test(providerKey)) return null;
+  if (tail !== "start" && tail !== "callback") return null;
+  return { params: { providerKey }, tail };
+}

--- a/packages/core/src/auth/oauth/routes.ts
+++ b/packages/core/src/auth/oauth/routes.ts
@@ -9,7 +9,6 @@ import { buildAuthorizeUrl, exchangeAndFetchProfile } from "./consumer.js";
 import { OAuthError } from "./errors.js";
 import { resolveOAuthUser } from "./signup.js";
 import { consumeOAuthState } from "./state.js";
-import { OAUTH_PROVIDER_KEY_PATTERN } from "./types.js";
 
 const ADMIN_PATH = "/_plumix/admin";
 const LOGIN_PATH = "/_plumix/admin/login";
@@ -20,31 +19,6 @@ const BOOTSTRAP_PATH = "/_plumix/admin/bootstrap";
 // current provider while bounding URL/body amplification on a malformed
 // callback.
 const MAX_CODE_LENGTH = 4096;
-
-interface OAuthRouteParams {
-  readonly providerKey: string;
-}
-
-/**
- * Match `/_plumix/auth/oauth/<key>/(start|callback)`. The shape check
- * (alphanum + `_-`) happens here; existence check ("is this a configured
- * provider?") happens in the handler. A path that doesn't match the
- * shape returns null → 404 from the dispatcher.
- */
-export function parseOAuthPath(
-  pathname: string,
-): { params: OAuthRouteParams; tail: "start" | "callback" } | null {
-  const prefix = "/_plumix/auth/oauth/";
-  if (!pathname.startsWith(prefix)) return null;
-  const rest = pathname.slice(prefix.length);
-  const slash = rest.indexOf("/");
-  if (slash < 0) return null;
-  const providerKey = rest.slice(0, slash);
-  const tail = rest.slice(slash + 1);
-  if (!OAUTH_PROVIDER_KEY_PATTERN.test(providerKey)) return null;
-  if (tail !== "start" && tail !== "callback") return null;
-  return { params: { providerKey }, tail };
-}
 
 export async function handleOAuthStart(
   ctx: AppContext,

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -1,32 +1,11 @@
+import type * as AuthFlowRoutes from "../auth/flow-routes.js";
 import type { AppContext } from "../context/app.js";
 import type * as McpDispatch from "../mcp/dispatch.js";
 import type { RegisteredRawRoute } from "../plugin/manifest.js";
 import type { PlumixApp } from "./app.js";
 import { readSessionCookie } from "../auth/cookies.js";
 import { hasCsrfHeader, hasMatchingOrigin } from "../auth/csrf.js";
-import {
-  handleDeviceCodeRequest,
-  handleDeviceTokenExchange,
-} from "../auth/device-flow-routes.js";
-import { handleEmailChangeVerify } from "../auth/email-change/routes.js";
-import {
-  handleMagicLinkRequest,
-  handleMagicLinkVerify,
-} from "../auth/magic-link/routes.js";
-import {
-  handleOAuthCallback,
-  handleOAuthStart,
-  parseOAuthPath,
-} from "../auth/oauth/routes.js";
-import {
-  handleInviteRegisterOptions,
-  handleInviteRegisterVerify,
-  handlePasskeyLoginOptions,
-  handlePasskeyLoginVerify,
-  handlePasskeyRegisterOptions,
-  handlePasskeyRegisterVerify,
-  handleSignout,
-} from "../auth/passkey/routes.js";
+import { parseOAuthPath } from "../auth/oauth/match.js";
 import { withUser } from "../context/app.js";
 import { resolveLocale } from "../i18n/resolve-locale.js";
 import { matchRoute } from "../route/match.js";
@@ -48,23 +27,48 @@ const MCP_PATH = "/_plumix/mcp";
 // MCP request per isolate.
 let mcpModule: Promise<typeof McpDispatch> | undefined;
 
+// Auth-flow handlers (passkey/oauth/magic-link/device/email-change) are
+// admin-login cold paths — never the public render path. Load them via one
+// memoized dynamic import on the first auth-flow request per isolate so their
+// heavy graph (webauthn/oslo, arctic) stays off the public render cold-start
+// path; the lightweight path matchers below stay eager.
+let authFlowRoutes: Promise<typeof AuthFlowRoutes> | undefined;
+function loadAuthFlowRoutes(): Promise<typeof AuthFlowRoutes> {
+  return (authFlowRoutes ??= import("../auth/flow-routes.js"));
+}
+
 // Filenames look like `index.html`, `chunk-abc.js`, `fonts/g.woff2` — paths
 // with a dot-suffix after the last slash. Deep-link SPA routes never match.
 const ASSET_LIKE = /\.[^/]+$/;
 
 type RouteHandler = (ctx: AppContext, app: PlumixApp) => Promise<Response>;
+// Maps a path to its handler accessor on the lazily-loaded module, so the map
+// itself pulls no handler code into the eager graph — only the matching paths.
+type AuthFlowRoute = (handlers: typeof AuthFlowRoutes) => RouteHandler;
 
-const POST_AUTH_ROUTES = new Map<string, RouteHandler>([
-  ["/_plumix/auth/passkey/register/options", handlePasskeyRegisterOptions],
-  ["/_plumix/auth/passkey/register/verify", handlePasskeyRegisterVerify],
-  ["/_plumix/auth/passkey/login/options", handlePasskeyLoginOptions],
-  ["/_plumix/auth/passkey/login/verify", handlePasskeyLoginVerify],
-  ["/_plumix/auth/invite/register/options", handleInviteRegisterOptions],
-  ["/_plumix/auth/invite/register/verify", handleInviteRegisterVerify],
-  ["/_plumix/auth/magic-link/request", handleMagicLinkRequest],
-  ["/_plumix/auth/device/code", handleDeviceCodeRequest],
-  ["/_plumix/auth/device/token", (ctx) => handleDeviceTokenExchange(ctx)],
-  ["/_plumix/auth/signout", (ctx) => handleSignout(ctx)],
+const POST_AUTH_ROUTES = new Map<string, AuthFlowRoute>([
+  [
+    "/_plumix/auth/passkey/register/options",
+    (h) => h.handlePasskeyRegisterOptions,
+  ],
+  [
+    "/_plumix/auth/passkey/register/verify",
+    (h) => h.handlePasskeyRegisterVerify,
+  ],
+  ["/_plumix/auth/passkey/login/options", (h) => h.handlePasskeyLoginOptions],
+  ["/_plumix/auth/passkey/login/verify", (h) => h.handlePasskeyLoginVerify],
+  [
+    "/_plumix/auth/invite/register/options",
+    (h) => h.handleInviteRegisterOptions,
+  ],
+  ["/_plumix/auth/invite/register/verify", (h) => h.handleInviteRegisterVerify],
+  ["/_plumix/auth/magic-link/request", (h) => h.handleMagicLinkRequest],
+  ["/_plumix/auth/device/code", (h) => h.handleDeviceCodeRequest],
+  [
+    "/_plumix/auth/device/token",
+    (h) => (ctx) => h.handleDeviceTokenExchange(ctx),
+  ],
+  ["/_plumix/auth/signout", (h) => (ctx) => h.handleSignout(ctx)],
 ]);
 
 const MAGIC_LINK_VERIFY_PATH = "/_plumix/auth/magic-link/verify";
@@ -156,10 +160,11 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
       : notFound("rpc-procedure-not-found");
   }
 
-  const authHandler = POST_AUTH_ROUTES.get(pathname);
-  if (authHandler) {
+  const authRoute = POST_AUTH_ROUTES.get(pathname);
+  if (authRoute) {
     if (ctx.request.method !== "POST") return methodNotAllowed(["POST"]);
-    return authHandler(ctx, app);
+    const handlers = await loadAuthFlowRoutes();
+    return authRoute(handlers)(ctx, app);
   }
 
   // OAuth endpoints are top-level GET navigations from the browser, so they
@@ -169,9 +174,10 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   const oauth = parseOAuthPath(pathname);
   if (oauth) {
     if (ctx.request.method !== "GET") return methodNotAllowed(["GET"]);
+    const handlers = await loadAuthFlowRoutes();
     return oauth.tail === "start"
-      ? handleOAuthStart(ctx, app, oauth.params.providerKey)
-      : handleOAuthCallback(ctx, app, oauth.params.providerKey);
+      ? handlers.handleOAuthStart(ctx, app, oauth.params.providerKey)
+      : handlers.handleOAuthCallback(ctx, app, oauth.params.providerKey);
   }
 
   // Magic-link verify is the same shape — top-level GET from the user's
@@ -179,7 +185,7 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   // per-request CSRF anchor.
   if (pathname === MAGIC_LINK_VERIFY_PATH) {
     if (ctx.request.method !== "GET") return methodNotAllowed(["GET"]);
-    return handleMagicLinkVerify(ctx, app);
+    return (await loadAuthFlowRoutes()).handleMagicLinkVerify(ctx, app);
   }
 
   // Email-change verify — same anchor model. The link goes to the
@@ -187,7 +193,7 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   // change atomically + invalidates every session for that user.
   if (pathname === EMAIL_CHANGE_VERIFY_PATH) {
     if (ctx.request.method !== "GET") return methodNotAllowed(["GET"]);
-    return handleEmailChangeVerify(ctx, app);
+    return (await loadAuthFlowRoutes()).handleEmailChangeVerify(ctx, app);
   }
 
   if (pathname === ADMIN_PREFIX || pathname.startsWith(`${ADMIN_PREFIX}/`)) {


### PR DESCRIPTION
For a content-heavy site the public render path is the hot path; admin-only code should not tax its cold start. The dispatcher statically imported the passkey / invite / magic-link / device-flow / OAuth / email-change handlers, so every isolate — including public-render-only ones — evaluated their heavy graph (webauthn/oslo, arctic) at cold start even though a content reader never hits those routes. They now load via one memoized dynamic import on the first auth-flow request per isolate.

**Eager path-matching, deferred handler bodies**

`parseOAuthPath` moves to a new `auth/oauth/match.ts` (it only needs the provider-key regex), so OAuth paths still match eagerly without pulling the arctic-backed handler graph. `POST_AUTH_ROUTES` changes from `Map<path, RouteHandler>` to `Map<path, (handlers) => RouteHandler>` — the map carries only path strings and tiny accessor closures, no handler code. A new `auth/flow-routes.ts` aggregates the handlers into the single deferred chunk.

**Behaviour-preserving**

Handlers run identically; the CSRF/PAT boundaries, method gates, and CSRF-anchor ordering are unchanged (the method check still 405s before the dynamic import fires). This changes *when* the auth code loads, not *what* runs.

**Verification**

Full core suite (1976 tests) + dispatcher/auth suites (415) green; typecheck / lint / knip / format clean. A Vite build of the dispatcher confirms every auth-impl symbol leaves the eager entry chunk for a deferred `chunk-flow-routes`:

```
EAGER entry.js contains any auth-impl symbol?
  beginAuthentication      no (deferred)
  buildAuthorizeUrl        no (deferred)
  exchangeAndFetchProfile  no (deferred)
  resolveOAuthUser         no (deferred)
  consumeOAuthState        no (deferred)
  provisionUser            no (deferred)
```

Removes ~38ms of admin-only eval from the public render cold-start path (measured on #930). Part of the broader effort there to keep the content render path lean; the oRPC `app.rpcHandler` deferral is the next slice.

Refs #930