### PR TITLE
perf(core): defer the oRPC handler off the public render cold-start path

### DIFF
--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1254,15 +1254,6 @@ export interface RegisteredMcpTool {
   readonly registeredBy: string;
 }
 
-export const CORE_RPC_NAMESPACES: ReadonlySet<string> = new Set([
-  "auth",
-  "entry",
-  "term",
-  "user",
-  "lookup",
-  "settings",
-]);
-
 export interface RegisteredBlock {
   readonly spec: BlockSpec;
   readonly registeredBy: string;

--- a/packages/core/src/plugin/register.test.ts
+++ b/packages/core/src/plugin/register.test.ts
@@ -450,7 +450,7 @@ describe("registerRpcRouter", () => {
     );
   });
 
-  test.each(["auth", "entry", "term", "user", "settings"])(
+  test.each(["auth", "entry", "term", "user", "lookup", "search", "settings"])(
     "rejects plugin id `%s` that collides with a core RPC namespace",
     async (pluginId) => {
       const hooks = new HookRegistry();

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -48,9 +48,9 @@ import {
 } from "../auth/rbac.js";
 import { CORE_MCP_TOOL_NAMES } from "../mcp/registry.js";
 import { DEFAULT_REWRITE_RULE_PRIORITY } from "../route/compile.js";
+import { CORE_RPC_NAMESPACES } from "../rpc/namespaces.js";
 import { RESERVED_DEP_KIND_NAMES } from "../template-deps.js";
 import { DuplicateRegistrationError, PluginContextError } from "./errors.js";
-import { CORE_RPC_NAMESPACES } from "./manifest.js";
 import {
   assertComponentRef,
   assertMetaBoxFields,

--- a/packages/core/src/rpc/build-handler.ts
+++ b/packages/core/src/rpc/build-handler.ts
@@ -1,0 +1,25 @@
+import { RPCHandler } from "@orpc/server/fetch";
+import { ResponseHeadersPlugin } from "@orpc/server/plugins";
+
+import type { AppContext } from "../context/app.js";
+import type { PluginRpcRouter } from "../plugin/manifest.js";
+import { appRouter } from "./router.js";
+
+/**
+ * Build the merged oRPC handler — core `appRouter` plus the plugin routers.
+ * Split out of `buildApp` and loaded via dynamic import so the heavy procedure
+ * graph + oRPC runtime evaluate on the first RPC request per isolate, never on
+ * the public render cold-start path. Plugin-id collisions are already rejected
+ * eagerly in `buildApp`, so the merge here is a plain assign.
+ */
+export function buildRpcHandler(
+  pluginRouters: ReadonlyMap<string, PluginRpcRouter>,
+): RPCHandler<AppContext> {
+  const mergedRouter = { ...appRouter } as Record<string, unknown>;
+  for (const [pluginId, pluginRouter] of pluginRouters) {
+    mergedRouter[pluginId] = pluginRouter;
+  }
+  return new RPCHandler(mergedRouter as unknown as typeof appRouter, {
+    plugins: [new ResponseHeadersPlugin()],
+  });
+}

--- a/packages/core/src/rpc/namespaces.ts
+++ b/packages/core/src/rpc/namespaces.ts
@@ -1,0 +1,20 @@
+import type { AppRouter } from "./router.js";
+
+// The core RPC namespaces (the top-level keys of `appRouter`) as a light,
+// value-level set, so `buildApp` and plugin registration can reject plugin-id
+// collisions without importing the heavy procedure graph `appRouter` pulls in.
+// The `Record<keyof AppRouter, …>` source fails the build if it drifts from
+// `appRouter`'s keys in either direction.
+const NAMESPACE_FLAGS: Record<keyof AppRouter, true> = {
+  auth: true,
+  entry: true,
+  term: true,
+  user: true,
+  lookup: true,
+  search: true,
+  settings: true,
+};
+
+export const CORE_RPC_NAMESPACES: ReadonlySet<string> = new Set(
+  Object.keys(NAMESPACE_FLAGS),
+);

--- a/packages/core/src/runtime/app-rpc-collision.test.ts
+++ b/packages/core/src/runtime/app-rpc-collision.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+
+import { auth } from "../auth/config.js";
+import { plumix } from "../config.js";
+import { definePlugin } from "../plugin/define.js";
+import { defineTheme } from "../theme.js";
+import { buildApp } from "./app.js";
+
+const stubAdapter = {
+  name: "test" as const,
+  buildFetchHandler: () => () => new Response("stub"),
+};
+const stubDatabase = { kind: "test", connect: () => ({ db: {} }) } as const;
+const stubAuth = auth({
+  passkey: { rpName: "t", rpId: "t", origin: "https://t" },
+});
+const stubTheme = defineTheme({ templates: { index: () => null } });
+
+describe("buildApp — RPC plugin-id collisions", () => {
+  // `constructor` passes registration (it's not a core namespace) but would
+  // shadow a member of the merged router object, so buildApp must reject it —
+  // the boot-time guard that replaced the old `pluginId in appRouter` check.
+  test("rejects plugin id `constructor`, which would shadow the merged router", async () => {
+    const plugin = definePlugin("constructor", (ctx) => {
+      ctx.registerRpcRouter({});
+    });
+    await expect(
+      buildApp(
+        plumix({
+          runtime: stubAdapter,
+          database: stubDatabase,
+          auth: stubAuth,
+          theme: stubTheme,
+          plugins: [plugin],
+        }),
+      ),
+    ).rejects.toThrow(
+      /Plugin id "constructor" collides with a core RPC namespace at buildApp/,
+    );
+  });
+});

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -1,5 +1,4 @@
-import { RPCHandler } from "@orpc/server/fetch";
-import { ResponseHeadersPlugin } from "@orpc/server/plugins";
+import type { RPCHandler } from "@orpc/server/fetch";
 
 import type { BlockRegistry, HtmlAllowlist, MarkSpec } from "@plumix/blocks";
 import {
@@ -33,14 +32,11 @@ import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
 import * as coreSchema from "../db/schema/index.js";
 import { mergeDocumentManifest } from "../document-merge.js";
 import { HookRegistry } from "../hooks/registry.js";
-import {
-  CORE_RPC_NAMESPACES,
-  createPluginRegistry,
-} from "../plugin/manifest.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
 import { installPlugins } from "../plugin/register.js";
 import { compileRouteMap } from "../route/compile.js";
+import { CORE_RPC_NAMESPACES } from "../rpc/namespaces.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
-import { appRouter } from "../rpc/router.js";
 import { registerCoreSearchHandlers } from "../search/register-core-handlers.js";
 import { registerCoreSettings } from "../settings-core.js";
 import { registerCoreTemplateDeps } from "../template-deps-core.js";
@@ -60,7 +56,13 @@ export interface PlumixApp {
   readonly config: PlumixConfig;
   readonly hooks: HookRegistry;
   readonly plugins: PluginRegistry;
-  readonly rpcHandler: RPCHandler<AppContext>;
+  /**
+   * Lazily builds (and memoizes) the merged oRPC handler on first call. Cold-
+   * path-only — deferred so the heavy procedure graph + oRPC runtime never
+   * evaluate on the public render cold-start path. The dispatcher awaits this
+   * on an RPC request; nothing on the public path touches it.
+   */
+  readonly loadRpcHandler: () => Promise<RPCHandler<AppContext>>;
   /**
    * Canonical site origin (e.g. `https://cms.example.com`). Sourced from
    * the passkey config for now since that's the only place it lives in
@@ -223,17 +225,18 @@ export async function buildApp(
     }
   }
 
-  // The cast matches oRPC's runtime dispatch model: routers are opaque
-  // property-key lookups, so plugin sub-routers don't need static typing.
-  const mergedRouter = { ...appRouter } as Record<string, unknown>;
-  for (const [pluginId, pluginRouter] of registry.rpcRouters) {
-    if (CORE_RPC_NAMESPACES.has(pluginId)) {
+  // Reject plugin ids that collide with a core RPC namespace at boot, against
+  // the light name set — so validation stays eager while the merge + heavy
+  // router graph defer to `loadRpcHandler`. The `Object.hasOwn` arm also rejects
+  // "constructor" (the one Object.prototype key matching the plugin-id pattern),
+  // which would otherwise shadow a member of the merged router object.
+  for (const pluginId of registry.rpcRouters.keys()) {
+    if (
+      CORE_RPC_NAMESPACES.has(pluginId) ||
+      Object.hasOwn(Object.prototype, pluginId)
+    ) {
       throw AppBootError.pluginIdCollidesWithCoreRpcNamespace({ pluginId });
     }
-    if (pluginId in appRouter) {
-      throw AppBootError.pluginIdCollidesWithCoreRpcRouter({ pluginId });
-    }
-    mergedRouter[pluginId] = pluginRouter;
   }
 
   const passkey = resolvePasskeyConfig(config.auth.passkey);
@@ -275,13 +278,19 @@ export async function buildApp(
     document,
   );
 
+  // Memoized so the heavy router module + handler construction happen once per
+  // isolate, on the first RPC request — never on the public render cold path.
+  let rpcHandler: Promise<RPCHandler<AppContext>> | undefined;
+  const loadRpcHandler = (): Promise<RPCHandler<AppContext>> =>
+    (rpcHandler ??= import("../rpc/build-handler.js").then((m) =>
+      m.buildRpcHandler(registry.rpcRouters),
+    ));
+
   return {
     config,
     hooks,
     plugins: registry,
-    rpcHandler: new RPCHandler(mergedRouter as unknown as typeof appRouter, {
-      plugins: [new ResponseHeadersPlugin()],
-    }),
+    loadRpcHandler,
     origin: passkey.origin,
     devCsrfLocalhost: runtime.devCsrfLocalhost ?? false,
     passkey,

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -151,7 +151,8 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   }
 
   if (pathname === RPC_PREFIX || pathname.startsWith(`${RPC_PREFIX}/`)) {
-    const result = await app.rpcHandler.handle(ctx.request, {
+    const rpcHandler = await app.loadRpcHandler();
+    const result = await rpcHandler.handle(ctx.request, {
       prefix: RPC_PREFIX,
       context: ctx,
     });

--- a/packages/core/src/runtime/errors.test.ts
+++ b/packages/core/src/runtime/errors.test.ts
@@ -51,25 +51,3 @@ describe("AppBootError.pluginIdCollidesWithCoreRpcNamespace", () => {
     expect(err.message).toContain("rename the plugin");
   });
 });
-
-describe("AppBootError.pluginIdCollidesWithCoreRpcRouter", () => {
-  test("class identity, code, and exposed pluginId", () => {
-    const err = AppBootError.pluginIdCollidesWithCoreRpcRouter({
-      pluginId: "posts",
-    });
-    expect(err).toBeInstanceOf(AppBootError);
-    expect(err.name).toBe("AppBootError");
-    expect(err.code).toBe("plugin_id_collides_with_core_rpc_router");
-    expect(err.pluginId).toBe("posts");
-  });
-
-  test("message names the plugin id and the core RPC router key", () => {
-    const err = AppBootError.pluginIdCollidesWithCoreRpcRouter({
-      pluginId: "posts",
-    });
-    expect(err.message).toContain(
-      'Plugin id "posts" collides with the core RPC router key',
-    );
-    expect(err.message).toContain("rename the plugin");
-  });
-});

--- a/packages/core/src/runtime/errors.ts
+++ b/packages/core/src/runtime/errors.ts
@@ -1,7 +1,6 @@
 type AppBootErrorCode =
   | "schema_export_conflict"
-  | "plugin_id_collides_with_core_rpc_namespace"
-  | "plugin_id_collides_with_core_rpc_router";
+  | "plugin_id_collides_with_core_rpc_namespace";
 
 export class AppBootError extends Error {
   static {
@@ -47,17 +46,6 @@ export class AppBootError extends Error {
     return new AppBootError(
       "plugin_id_collides_with_core_rpc_namespace",
       `Plugin id "${ctx.pluginId}" collides with a core RPC namespace ` +
-        `at buildApp; rename the plugin.`,
-      ctx,
-    );
-  }
-
-  static pluginIdCollidesWithCoreRpcRouter(ctx: {
-    pluginId: string;
-  }): AppBootError {
-    return new AppBootError(
-      "plugin_id_collides_with_core_rpc_router",
-      `Plugin id "${ctx.pluginId}" collides with the core RPC router key ` +
         `at buildApp; rename the plugin.`,
       ctx,
     );


### PR DESCRIPTION
For a content-heavy site the public render path is the hot path; admin RPC is its cold path. `buildApp` statically imported `appRouter`, so every isolate — including public-render-only ones — evaluated the whole oRPC graph (~100 procedure modules + their valibot schemas + the oRPC runtime) at cold start. It was the single largest admin-only chunk still on the eager graph. It now builds on the first RPC request per isolate.

**Lazy `loadRpcHandler`**

`PlumixApp.rpcHandler` (an eagerly-built `RPCHandler`) becomes `loadRpcHandler(): Promise<RPCHandler>` — a memoized closure that dynamic-imports a new `rpc/build-handler.ts` and constructs the merged handler on first call. One production consumer (the dispatcher's RPC branch) now awaits it; the RPC test harness builds its own client from `appRouter` directly and is unaffected.

**Collision validation stays at boot**

A new light, type-guarded `rpc/namespaces.ts` holds `CORE_RPC_NAMESPACES` — sourced from a `Record<keyof AppRouter, true>` so the build fails if it drifts from `appRouter`'s keys in either direction. `buildApp` validates plugin-id collisions against it eagerly, without importing the heavy router. This also reconciles a latent inconsistency: the old set was **missing `search`**, so a plugin id `search` was only caught at `buildApp`, not at registration — now it's rejected consistently at both. The two boot-time checks collapse into one; an `Object.hasOwn(Object.prototype, …)` arm preserves the prior rejection of `constructor` (the one prototype key that would otherwise shadow the merged router), and the now-redundant `pluginIdCollidesWithCoreRpcRouter` error is removed.

**Behaviour-preserving**

Regression tests added: the registration collision `test.each` now covers all seven namespaces (it was missing `lookup` and `search`), and a new `buildApp` test asserts `constructor` is rejected at boot. A Vite build confirms the procedure graph (`entryRouter`/`termRouter`/`searchRouter`/`authRouter`) + `RPCHandler` construction leave the eager worker chunk for a deferred `chunk-build-handler`:

```
EAGER entry.js contains any RPC-graph symbol?
  ResponseHeadersPlugin  no (deferred)
  entryRouter            no (deferred)
  termRouter             no (deferred)
  searchRouter           no (deferred)
  authRouter             no (deferred)
buildRpcHandler lives in: chunk-build-handler.js
```

Full core suite (1977) green; typecheck / lint / knip / format clean. Removes ~40–54ms of admin-only eval from the public render cold-start path (measured on #930).

This completes the admin-surface deferral on #930 (MCP #936, auth-flow #957, oRPC here). admin-shell eval is a trivial string rewrite and media is plugin-loaded — neither warrants a lazy boundary.

Refs #930