### PR TITLE
feat(plugin-comments): read path — schema, render, thread template dep

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -32,6 +32,9 @@ const config: KnipConfig = {
     "packages/plugins/audit-log/playground": {
       entry: ["plumix.config.ts"],
     },
+    "packages/plugins/comments/playground": {
+      entry: ["plumix.config.ts"],
+    },
     "packages/plugins/blog/playground": {
       entry: ["plumix.config.ts"],
     },
@@ -222,6 +225,15 @@ const config: KnipConfig = {
       ignoreDependencies: ["@plumix/runtime-cloudflare"],
       // See packages/admin above for why the playwright plugin is off.
       playwright: false,
+    },
+    // The read-path slice (#960) ships the plugin entry + the server
+    // subpath; the read path is verified in-process via the dispatcher
+    // harness (public content can't render under `plumix dev`, which
+    // serves the admin SPA). The admin chunk + playwright e2e arrive
+    // with the moderation queue (#963).
+    "packages/plugins/comments": {
+      entry: ["src/index.ts", "src/server/index.ts"],
+      ignoreDependencies: ["@plumix/runtime-cloudflare"],
     },
   },
 };

--- a/packages/plugins/comments/eslint.config.ts
+++ b/packages/plugins/comments/eslint.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "eslint/config";
+
+import { pluginConfig } from "@plumix/eslint-config/plugin";
+
+export default defineConfig(...pluginConfig());

--- a/packages/plugins/comments/package.json
+++ b/packages/plugins/comments/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "@plumix/plugin-comments",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Comments plugin for Plumix — threaded, moderated discussion on entries with a tested playground.",
+  "license": "MIT",
+  "author": "Plumix Contributors",
+  "homepage": "https://github.com/withplumix/plumix#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/withplumix/plumix.git",
+    "directory": "packages/plugins/comments"
+  },
+  "bugs": {
+    "url": "https://github.com/withplumix/plumix/issues"
+  },
+  "keywords": [
+    "plumix",
+    "plugin",
+    "comments",
+    "discussion",
+    "moderation"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "default": "./dist/server/index.js"
+    },
+    "./schema": {
+      "types": "./dist/db/schema.d.ts",
+      "default": "./dist/db/schema.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "attw": "attw --pack . --profile esm-only",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "format": "prettier --check . --ignore-path ../../../.gitignore",
+    "lint": "eslint",
+    "publint": "publint",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "drizzle-orm": "catalog:",
+    "markdown-it": "^14.1.0"
+  },
+  "peerDependencies": {
+    "plumix": "workspace:*"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "catalog:",
+    "@plumix/eslint-config": "workspace:*",
+    "@plumix/prettier-config": "workspace:*",
+    "@plumix/runtime-cloudflare": "workspace:*",
+    "@plumix/typescript-config": "workspace:*",
+    "@plumix/vitest-config": "workspace:*",
+    "@types/markdown-it": "^14.1.2",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "drizzle-kit": "catalog:",
+    "eslint": "catalog:",
+    "fishery": "catalog:",
+    "plumix": "workspace:*",
+    "prettier": "catalog:",
+    "publint": "catalog:",
+    "react": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "prettier": "@plumix/prettier-config"
+}

--- a/packages/plugins/comments/playground/package.json
+++ b/packages/plugins/comments/playground/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@plumix/plugin-comments-playground",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Plumix consumer that wires @plumix/plugin-comments (+ blog) — for worker-driven e2e + manual dogfooding",
+  "license": "MIT",
+  "scripts": {
+    "build": "plumix build",
+    "clean": "git clean -xdf .plumix .wrangler dist node_modules",
+    "dev": "plumix dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@plumix/plugin-blog": "workspace:*",
+    "@plumix/plugin-comments": "workspace:*",
+    "@plumix/runtime-cloudflare": "workspace:*",
+    "plumix": "workspace:*",
+    "react": "catalog:"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
+    "@plumix/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "typescript": "catalog:",
+    "wrangler": "catalog:"
+  }
+}

--- a/packages/plugins/comments/playground/plumix.config.ts
+++ b/packages/plugins/comments/playground/plumix.config.ts
@@ -1,0 +1,38 @@
+import { auth, plumix } from "plumix";
+
+import { blog } from "@plumix/plugin-blog";
+import { comments } from "@plumix/plugin-comments";
+import {
+  cloudflare,
+  cloudflareDeployOrigin,
+  d1,
+} from "@plumix/runtime-cloudflare";
+
+import { theme } from "./theme.js";
+
+// Plumix consumer wiring the comments plugin on top of blog (for the
+// `post` entry type + its public permalink) — the smallest config that
+// dogfoods `@plumix/plugin-comments`'s read path, and the boot target for
+// the admin-queue e2e landing with #963. The read path itself is verified
+// in-process via the dispatcher harness (src/render.test.ts), since public
+// content renders through the worker, not the admin SPA `plumix dev` serves.
+
+const { rpId, origin } = cloudflareDeployOrigin({
+  workerName: "plumix-comments-playground",
+  accountSubdomain: "local",
+  localOrigin: "http://localhost:3060",
+});
+
+export default plumix({
+  runtime: cloudflare(),
+  database: d1({ binding: "DB", session: "auto" }),
+  auth: auth({
+    passkey: {
+      rpName: "Plumix — Comments playground",
+      rpId,
+      origin,
+    },
+  }),
+  plugins: [blog, comments({ entryTypes: ["post"] })],
+  theme,
+});

--- a/packages/plugins/comments/playground/theme.ts
+++ b/packages/plugins/comments/playground/theme.ts
@@ -1,0 +1,69 @@
+import type { SingleData } from "plumix";
+import type { ReactNode } from "react";
+import { createElement as h } from "react";
+import { defineTemplate, defineTheme } from "plumix";
+
+// Importing the result type also pulls the plugin's `TemplateDepRegistry`
+// augmentation, so `comments` is typed on the render args below.
+import type { ResolvedThread } from "@plumix/plugin-comments/server";
+
+// Minimal single-post template that renders the approved comment thread
+// the `comments` template dep resolves for the current entry. Authored
+// with `createElement` (no JSX) so the first real plumix theme stays
+// transform-agnostic across jiti config load + the vite worker bundle.
+const single = defineTemplate<SingleData>({
+  comments: ["current"],
+  render: ({ data, comments }): ReactNode => {
+    const thread: ResolvedThread | null = comments?.current ?? null;
+    return h(
+      "main",
+      null,
+      h("h1", { "data-testid": "post-title" }, data.entry.title),
+      h(
+        "section",
+        { "data-testid": "comments" },
+        h(
+          "p",
+          { "data-testid": "comments-count" },
+          `${String(thread?.count ?? 0)} comments`,
+        ),
+        h(
+          "ul",
+          { "data-testid": "comments-list" },
+          (thread?.comments ?? []).map((comment) =>
+            h(
+              "li",
+              {
+                key: comment.id,
+                "data-testid": `comment-item-${String(comment.id)}`,
+              },
+              h("img", {
+                "data-testid": "comment-avatar",
+                src: comment.avatarUrl,
+                alt: "",
+                width: 48,
+                height: 48,
+              }),
+              h(
+                "span",
+                { "data-testid": "comment-author" },
+                comment.authorName,
+              ),
+              h("div", {
+                "data-testid": "comment-body",
+                dangerouslySetInnerHTML: { __html: comment.bodyHtml },
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+  },
+});
+
+export const theme = defineTheme({
+  templates: {
+    index: () => null,
+    single,
+  },
+});

--- a/packages/plugins/comments/playground/tsconfig.json
+++ b/packages/plugins/comments/playground/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@plumix/typescript-config/base.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/workers-types"],
+    "jsx": "react-jsx",
+    // Resolve workspace packages from `src/` (not `dist/`) so the
+    // playground typechecks against live source. See the comment in
+    // packages/plugins/media/playground/tsconfig.json for the rationale.
+    "paths": {
+      "plumix": ["../../../plumix/src/index.ts"],
+      "@plumix/plugin-comments": ["../src/index.ts"],
+      "@plumix/plugin-comments/server": ["../src/server/index.ts"],
+      "@plumix/plugin-blog": ["../../blog/src/index.ts"],
+      "@plumix/runtime-cloudflare": [
+        "../../../runtimes/cloudflare/src/index.ts"
+      ]
+    }
+  },
+  "include": ["plumix.config.ts", "theme.ts", ".plumix"]
+}

--- a/packages/plugins/comments/playground/wrangler.jsonc
+++ b/packages/plugins/comments/playground/wrangler.jsonc
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://unpkg.com/wrangler/config-schema.json",
+  "name": "plumix-comments-playground",
+  "main": ".plumix/worker.ts",
+  "compatibility_date": "2026-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "plumix_comments_playground",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "drizzle",
+    },
+  ],
+  // `none` (not the admin-only playgrounds' `single-page-application`) so
+  // the worker runs for every non-asset path and resolves public content
+  // routes itself — SPA mode would serve the admin index.html before the
+  // worker ever sees `/posts/:slug`. Matches examples/blog + minimal.
+  "assets": {
+    "directory": ".plumix/public",
+    "binding": "ASSETS",
+    "not_found_handling": "none",
+  },
+}

--- a/packages/plugins/comments/src/db/schema.ts
+++ b/packages/plugins/comments/src/db/schema.ts
@@ -1,0 +1,73 @@
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { index, sqliteTable } from "drizzle-orm/sqlite-core";
+import { entries, users } from "plumix/schema";
+
+import { COMMENT_STATUSES } from "../types.js";
+
+/**
+ * A comment on an entry. Author identity is snapshotted (name/email
+ * captured at write time) so the row survives a user rename or delete —
+ * `author_user_id` links a logged-in commenter but display never joins
+ * live user data. `author_email` is private: it drives trust lookups,
+ * Gravatar, and notifications but is never serialized into the public
+ * payload. `ip_hash` is a salted SHA-256, never a cleartext address.
+ */
+export const comments = sqliteTable(
+  "comments",
+  (t) => ({
+    id: t.integer().primaryKey({ autoIncrement: true }),
+    entryId: t
+      .integer()
+      .notNull()
+      .references(() => entries.id, { onDelete: "cascade" }),
+    // Threading parent. Clamped at write time so stored depth never
+    // exceeds the configured cap. Cascade is the entry-delete safety
+    // net; comment-level deletes go through the service (tombstone in
+    // #963), not raw cascade.
+    parentId: t
+      .integer()
+      .references((): AnySQLiteColumn => comments.id, { onDelete: "cascade" }),
+    status: t.text({ enum: COMMENT_STATUSES }).notNull().default("pending"),
+    authorUserId: t
+      .integer()
+      .references(() => users.id, { onDelete: "set null" }),
+    authorName: t.text().notNull(),
+    authorEmail: t.text().notNull(),
+    bodyMd: t.text().notNull(),
+    ipHash: t.text(),
+    userAgent: t.text(),
+    meta: t
+      .text({ mode: "json" })
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    createdAt: t
+      .integer({ mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: t
+      .integer({ mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`)
+      .$onUpdate(() => sql`(unixepoch())`),
+  }),
+  (table) => [
+    // The thread query: roots + status for one entry, newest-first.
+    index("comments_entry_status_created_idx").on(
+      table.entryId,
+      table.status,
+      table.createdAt,
+    ),
+    // Descendant walking in the recursive CTE.
+    index("comments_parent_id_idx").on(table.parentId),
+    // The moderation queue: one status tab, newest-first.
+    index("comments_status_created_idx").on(table.status, table.createdAt),
+    // Trust lookup ("has this email a prior approved comment?").
+    index("comments_author_email_idx").on(table.authorEmail),
+    index("comments_author_user_id_idx").on(table.authorUserId),
+  ],
+);
+
+export type Comment = typeof comments.$inferSelect;
+export type NewComment = typeof comments.$inferInsert;

--- a/packages/plugins/comments/src/index.test.ts
+++ b/packages/plugins/comments/src/index.test.ts
@@ -1,0 +1,84 @@
+import type { AppContext } from "plumix/plugin";
+import { describe, expect, test } from "vitest";
+
+import type { CommentsTestDb } from "./test/db.js";
+import { comments } from "./index.js";
+import { createCommentsThreadLoader } from "./server/template-dep.js";
+import { createCommentsTestDb, seedPublishedPost } from "./test/db.js";
+import { commentFactory } from "./test/factories.js";
+
+function ctxWith(
+  db: CommentsTestDb,
+  resolvedEntity: { kind: "entry"; id: number } | null,
+): AppContext {
+  return {
+    db,
+    resolvedEntity,
+    plugins: { entryTypes: new Map() },
+  } as unknown as AppContext;
+}
+
+async function seedApprovedPost(db: CommentsTestDb) {
+  const entry = await seedPublishedPost(db);
+  await commentFactory
+    .transient({ db })
+    .create({ entryId: entry.id, status: "approved", bodyMd: "hello" });
+  return entry;
+}
+
+describe("comments() plugin", () => {
+  test("descriptor exposes id, schema, and schemaModule", () => {
+    const plugin = comments();
+    expect(plugin.id).toBe("comments");
+    expect(plugin.schemaModule).toBe("@plumix/plugin-comments/schema");
+    expect(plugin.schema).toBeDefined();
+  });
+
+  test("setup registers a 'comments' template dep", () => {
+    const kinds: string[] = [];
+    const ctx = {
+      registerTemplateDep: (kind: string) => kinds.push(kind),
+    } as unknown as Parameters<ReturnType<typeof comments>["setup"]>[0];
+    void comments().setup(ctx, undefined);
+    expect(kinds).toContain("comments");
+  });
+});
+
+describe("createCommentsThreadLoader", () => {
+  test("loads the current entry's approved thread when enabled", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedApprovedPost(db);
+    const load = createCommentsThreadLoader({ entryTypes: ["post"] });
+
+    const result = await load(
+      ["current"],
+      ctxWith(db, { kind: "entry", id: entry.id }),
+    );
+
+    expect(result.current?.count).toBe(1);
+    expect(result.current?.comments[0]?.bodyHtml).toContain("hello");
+  });
+
+  test("yields nothing for a comment-disabled entry type", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedApprovedPost(db);
+    const load = createCommentsThreadLoader({});
+
+    const result = await load(
+      ["current"],
+      ctxWith(db, { kind: "entry", id: entry.id }),
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test("yields nothing when there is no resolved entry", async () => {
+    const db = await createCommentsTestDb();
+    await seedApprovedPost(db);
+    const load = createCommentsThreadLoader({ entryTypes: ["post"] });
+
+    const result = await load(["current"], ctxWith(db, null));
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/plugins/comments/src/index.ts
+++ b/packages/plugins/comments/src/index.ts
@@ -1,0 +1,40 @@
+import { definePlugin } from "plumix/plugin";
+
+import type { CommentsConfig } from "./types.js";
+import * as schema from "./db/schema.js";
+import { createCommentsThreadLoader } from "./server/template-dep.js";
+
+export type { CommentsConfig, CommentStatus } from "./types.js";
+export { COMMENT_STATUSES } from "./types.js";
+
+/**
+ * `@plumix/plugin-comments` — threaded, moderated discussion on entries.
+ *
+ * The read path (this slice) registers a `comments` template dep so a
+ * theme can render the approved thread for the entry it's displaying:
+ *
+ *     defineTemplate({
+ *       single: {
+ *         comments: ["current"],
+ *         render: ({ comments }) => <Thread data={comments?.current} />,
+ *       },
+ *     })
+ *
+ * Commenting is enabled for an entry type when the type is listed in
+ * `comments({ entryTypes })` or self-declares `supports: ['comments']`.
+ * Submission, moderation, threading, and the admin queue arrive in
+ * later slices; the `comments` table ships now so migrations include it.
+ */
+export function comments(options: CommentsConfig = {}) {
+  return definePlugin("comments", {
+    schema,
+    // Module specifier `plumix migrate generate` uses to fold this
+    // plugin's table into the host's drizzle-kit codegen.
+    schemaModule: "@plumix/plugin-comments/schema",
+    setup: (ctx) => {
+      ctx.registerTemplateDep("comments", {
+        load: createCommentsThreadLoader(options),
+      });
+    },
+  });
+}

--- a/packages/plugins/comments/src/render.test.ts
+++ b/packages/plugins/comments/src/render.test.ts
@@ -1,0 +1,114 @@
+import type { SingleData } from "plumix";
+import { createElement as el } from "react";
+import { defineTemplate, defineTheme } from "plumix";
+import { definePlugin } from "plumix/plugin";
+import { createDispatcherHarness } from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+import type { ResolvedThread } from "./server/load-thread.js";
+import { comments } from "./index.js";
+import { applyCommentsSchema } from "./test/db.js";
+import { commentFactory } from "./test/factories.js";
+
+// Minimal host plugin registering a public `post` type so the dispatcher
+// compiles a `/posts/:slug` single route.
+const testBlog = definePlugin("test_blog", {
+  setup: (ctx) => {
+    ctx.registerEntryType("post", {
+      label: "Posts",
+      isPublic: true,
+      rewrite: { slug: "posts" },
+    });
+  },
+});
+
+// Theme that renders the approved thread the `comments` dep resolves.
+const single = defineTemplate<SingleData>({
+  comments: ["current"],
+  render: ({ data, comments: threadDep }) => {
+    const thread: ResolvedThread | null = threadDep?.current ?? null;
+    return el(
+      "main",
+      null,
+      el("h1", { "data-testid": "post-title" }, data.entry.title),
+      el("p", { "data-testid": "comments-count" }, String(thread?.count ?? 0)),
+      ...(thread?.comments ?? []).map((comment) =>
+        el(
+          "article",
+          { key: comment.id, "data-testid": "comment" },
+          el("span", { "data-testid": "comment-author" }, comment.authorName),
+          el("div", { dangerouslySetInnerHTML: { __html: comment.bodyHtml } }),
+        ),
+      ),
+    );
+  },
+});
+
+const theme = defineTheme({ templates: { index: () => null, single } });
+
+async function seedPost(
+  harness: Awaited<ReturnType<typeof createDispatcherHarness>>,
+  slug: string,
+) {
+  const user = await harness.factory.user.create({});
+  return harness.factory.entry.create({
+    type: "post",
+    slug,
+    title: "Hello World",
+    authorId: user.id,
+    status: "published",
+  });
+}
+
+describe("comments read path through the dispatcher", () => {
+  test("renders approved comments on a single post and excludes pending", async () => {
+    const harness = await createDispatcherHarness({
+      plugins: [testBlog, comments({ entryTypes: ["post"] })],
+      theme,
+    });
+    await applyCommentsSchema(harness.db);
+    const entry = await seedPost(harness, "hello-world");
+    const seed = commentFactory.transient({ db: harness.db });
+    await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      authorName: "Ada Lovelace",
+      bodyMd: "**great** post",
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      authorName: "Pending Patty",
+      bodyMd: "hold me",
+    });
+
+    const html = await (await harness.fetch("/posts/hello-world")).text();
+
+    expect(html).toContain("Hello World");
+    expect(html).toContain("Ada Lovelace");
+    expect(html).toContain("<strong>great</strong>");
+    expect(html).toContain('data-testid="comments-count">1<');
+    expect(html).not.toContain("Pending Patty");
+  });
+
+  test("renders no thread for a comment-disabled entry type", async () => {
+    const harness = await createDispatcherHarness({
+      plugins: [testBlog, comments()],
+      theme,
+    });
+    await applyCommentsSchema(harness.db);
+    const entry = await seedPost(harness, "quiet");
+    await commentFactory.transient({ db: harness.db }).create({
+      entryId: entry.id,
+      status: "approved",
+      authorName: "Unheard",
+      bodyMd: "hi",
+    });
+
+    const html = await (await harness.fetch("/posts/quiet")).text();
+
+    expect(html).toContain("Hello World");
+    expect(html).toContain('data-testid="comments-count">0<');
+    expect(html).not.toContain("Unheard");
+  });
+});

--- a/packages/plugins/comments/src/server/enablement.test.ts
+++ b/packages/plugins/comments/src/server/enablement.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import { isCommentingEnabled } from "./enablement.js";
+
+describe("isCommentingEnabled", () => {
+  test("enabled when the type is listed in config.entryTypes", () => {
+    expect(
+      isCommentingEnabled("post", undefined, { entryTypes: ["post"] }),
+    ).toBe(true);
+  });
+
+  test("enabled when the entry type declares supports: ['comments']", () => {
+    expect(isCommentingEnabled("post", ["title", "comments"], {})).toBe(true);
+  });
+
+  test("config and supports union — either path enables", () => {
+    expect(
+      isCommentingEnabled("recipe", ["title"], { entryTypes: ["recipe"] }),
+    ).toBe(true);
+  });
+
+  test("disabled when neither config nor supports opt in", () => {
+    expect(
+      isCommentingEnabled("page", ["title", "editor"], {
+        entryTypes: ["post"],
+      }),
+    ).toBe(false);
+  });
+
+  test("disabled when supports is undefined and config is empty", () => {
+    expect(isCommentingEnabled("page", undefined, {})).toBe(false);
+  });
+});

--- a/packages/plugins/comments/src/server/enablement.ts
+++ b/packages/plugins/comments/src/server/enablement.ts
@@ -1,0 +1,26 @@
+import type { CommentsConfig } from "../types.js";
+
+/**
+ * The `supports` flag an entry type declares to opt into comments —
+ * the WordPress `post_type_supports($type, 'comments')` model. Lives in
+ * the entry type's open `supports: string[]` array.
+ */
+export const COMMENTS_SUPPORT = "comments";
+
+/**
+ * Whether commenting is enabled for an entry type. The effective set is
+ * the union of two sources: types the site lists in `config.entryTypes`,
+ * and types that self-declare `supports: ['comments']` at registration.
+ *
+ * @param typeName  the entry type (e.g. `"post"`).
+ * @param supports  the type's registered `supports` array, if any.
+ * @param config    the resolved plugin config.
+ */
+export function isCommentingEnabled(
+  typeName: string,
+  supports: readonly string[] | undefined,
+  config: CommentsConfig,
+): boolean {
+  if (config.entryTypes?.includes(typeName)) return true;
+  return supports?.includes(COMMENTS_SUPPORT) ?? false;
+}

--- a/packages/plugins/comments/src/server/gravatar.test.ts
+++ b/packages/plugins/comments/src/server/gravatar.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import { gravatarUrl } from "./gravatar.js";
+
+describe("gravatarUrl", () => {
+  test("builds a gravatar avatar URL with a 64-char sha256 hash", async () => {
+    const url = await gravatarUrl("person@example.com");
+    expect(url).toMatch(
+      /^https:\/\/www\.gravatar\.com\/avatar\/[0-9a-f]{64}\?/,
+    );
+  });
+
+  test("normalizes case and surrounding whitespace before hashing", async () => {
+    const a = await gravatarUrl("  Person@Example.COM ");
+    const b = await gravatarUrl("person@example.com");
+    expect(a).toBe(b);
+  });
+
+  test("different emails produce different hashes", async () => {
+    const a = await gravatarUrl("a@example.com");
+    const b = await gravatarUrl("b@example.com");
+    expect(a).not.toBe(b);
+  });
+
+  test("includes a default size and fallback image", async () => {
+    const url = await gravatarUrl("person@example.com");
+    expect(url).toContain("s=80");
+    expect(url).toContain("d=mp");
+  });
+
+  test("size is overridable", async () => {
+    const url = await gravatarUrl("person@example.com", { size: 48 });
+    expect(url).toContain("s=48");
+  });
+});

--- a/packages/plugins/comments/src/server/gravatar.ts
+++ b/packages/plugins/comments/src/server/gravatar.ts
@@ -1,0 +1,35 @@
+const ENCODER = new TextEncoder();
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", ENCODER.encode(input));
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+interface GravatarOptions {
+  /** Pixel size of the requested avatar. Defaults to 80. */
+  readonly size?: number;
+  /**
+   * Fallback when the email has no Gravatar. Defaults to `"mp"`
+   * (mystery-person), matching WordPress's default.
+   */
+  readonly default?: string;
+}
+
+/**
+ * Gravatar avatar URL for an email. Hashes the normalized (trimmed,
+ * lowercased) address with SHA-256 — Gravatar's recommended algorithm,
+ * and the one `crypto.subtle` supports on both Workers and Node (no md5
+ * dependency). The raw email never leaves the server; only its hash
+ * rides in the URL.
+ */
+export async function gravatarUrl(
+  email: string,
+  options: GravatarOptions = {},
+): Promise<string> {
+  const hash = await sha256Hex(email.trim().toLowerCase());
+  const size = options.size ?? 80;
+  const fallback = options.default ?? "mp";
+  return `https://www.gravatar.com/avatar/${hash}?s=${String(size)}&d=${fallback}`;
+}

--- a/packages/plugins/comments/src/server/index.ts
+++ b/packages/plugins/comments/src/server/index.ts
@@ -1,0 +1,6 @@
+// Consumer-facing server surface. Themes import the thread types from
+// here to type their `comments` template-dep render arg; importing this
+// barrel also pulls in the `TemplateDepRegistry` augmentation declared
+// alongside `ResolvedThread`.
+export type { ResolvedComment, ResolvedThread } from "./load-thread.js";
+export { loadThread } from "./load-thread.js";

--- a/packages/plugins/comments/src/server/load-thread.test.ts
+++ b/packages/plugins/comments/src/server/load-thread.test.ts
@@ -1,0 +1,85 @@
+import { factoriesFor } from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+import { createCommentsTestDb, ctxFor, seedPublishedPost } from "../test/db.js";
+import { commentFactory } from "../test/factories.js";
+import { loadThread } from "./load-thread.js";
+
+describe("loadThread", () => {
+  test("returns only approved comments, rendered, without leaking email", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const f = commentFactory.transient({ db });
+    await f.create({
+      entryId: entry.id,
+      status: "approved",
+      bodyMd: "**hi**",
+      authorEmail: "secret@example.test",
+    });
+    await f.create({ entryId: entry.id, status: "pending" });
+    await f.create({ entryId: entry.id, status: "spam" });
+    await f.create({ entryId: entry.id, status: "trash" });
+
+    const thread = await loadThread(ctxFor(db), entry.id);
+
+    expect(thread.count).toBe(1);
+    expect(thread.comments).toHaveLength(1);
+    const comment = thread.comments[0];
+    expect(comment?.bodyHtml).toContain("<strong>hi</strong>");
+    expect(comment?.avatarUrl).toContain("gravatar.com");
+    expect(JSON.stringify(thread)).not.toContain("secret@example.test");
+  });
+
+  test("flags registered vs anonymous authors", async () => {
+    const db = await createCommentsTestDb();
+    const f0 = factoriesFor(db);
+    const user = await f0.user.create({});
+    const entry = await f0.entry.create({
+      type: "post",
+      authorId: user.id,
+      status: "published",
+    });
+    const f = commentFactory.transient({ db });
+    await f.create({
+      entryId: entry.id,
+      status: "approved",
+      authorUserId: user.id,
+    });
+    await f.create({
+      entryId: entry.id,
+      status: "approved",
+      authorUserId: null,
+    });
+
+    const thread = await loadThread(ctxFor(db), entry.id);
+    expect(thread.comments.map((c) => c.isRegistered).sort()).toEqual([
+      false,
+      true,
+    ]);
+  });
+
+  test("scopes to the requested entry", async () => {
+    const db = await createCommentsTestDb();
+    const a = await seedPublishedPost(db);
+    const b = await seedPublishedPost(db);
+    const f = commentFactory.transient({ db });
+    await f.create({ entryId: a.id, status: "approved" });
+    await f.create({ entryId: b.id, status: "approved" });
+    await f.create({ entryId: b.id, status: "approved" });
+
+    expect((await loadThread(ctxFor(db), a.id)).count).toBe(1);
+    expect((await loadThread(ctxFor(db), b.id)).count).toBe(2);
+  });
+
+  test("returns an empty thread when nothing is approved", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    await commentFactory
+      .transient({ db })
+      .create({ entryId: entry.id, status: "pending" });
+
+    const thread = await loadThread(ctxFor(db), entry.id);
+    expect(thread.count).toBe(0);
+    expect(thread.comments).toEqual([]);
+  });
+});

--- a/packages/plugins/comments/src/server/load-thread.ts
+++ b/packages/plugins/comments/src/server/load-thread.ts
@@ -1,0 +1,69 @@
+import type { AppContext } from "plumix/plugin";
+import { and, asc, eq } from "drizzle-orm";
+
+import { comments } from "../db/schema.js";
+import { gravatarUrl } from "./gravatar.js";
+import { renderCommentBody } from "./render-body.js";
+
+/**
+ * A comment as exposed to the public theme. Deliberately omits
+ * `authorEmail` and `ipHash` — those stay server-side. `isRegistered`
+ * is the only signal of the author's account status (a verified badge);
+ * `bodyHtml` is the rendered, sanitized markdown.
+ */
+export interface ResolvedComment {
+  readonly id: number;
+  readonly authorName: string;
+  readonly isRegistered: boolean;
+  readonly avatarUrl: string;
+  readonly bodyHtml: string;
+  readonly createdAt: Date;
+}
+
+/** The assembled comment thread for one entry. */
+export interface ResolvedThread {
+  readonly entryId: number;
+  readonly comments: readonly ResolvedComment[];
+  readonly count: number;
+}
+
+// Lives alongside the exported `ResolvedThread` (not the plugin entry) so
+// a theme importing the type from `./server` pulls the `comments` dep kind
+// into its `TemplateDepRegistry` too.
+declare module "plumix/plugin" {
+  interface TemplateDepRegistry {
+    comments: { slug: string; result: ResolvedThread };
+  }
+}
+
+/**
+ * Load the approved comments for an entry, rendered for display. Flat
+ * and chronological for the read-path slice; threading (#962) and root
+ * pagination (#967) build on this. One indexed query, then per-comment
+ * markdown render + avatar hashing in parallel — no N+1.
+ */
+export async function loadThread(
+  ctx: AppContext,
+  entryId: number,
+): Promise<ResolvedThread> {
+  const rows = await ctx.db
+    .select()
+    .from(comments)
+    .where(and(eq(comments.entryId, entryId), eq(comments.status, "approved")))
+    .orderBy(asc(comments.createdAt), asc(comments.id));
+
+  const resolved = await Promise.all(
+    rows.map(
+      async (row): Promise<ResolvedComment> => ({
+        id: row.id,
+        authorName: row.authorName,
+        isRegistered: row.authorUserId !== null,
+        avatarUrl: await gravatarUrl(row.authorEmail),
+        bodyHtml: renderCommentBody(row.bodyMd),
+        createdAt: row.createdAt,
+      }),
+    ),
+  );
+
+  return { entryId, comments: resolved, count: resolved.length };
+}

--- a/packages/plugins/comments/src/server/render-body.test.ts
+++ b/packages/plugins/comments/src/server/render-body.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import { renderCommentBody } from "./render-body.js";
+
+describe("renderCommentBody", () => {
+  test("renders basic markdown formatting", () => {
+    const html = renderCommentBody("**bold** and _italic_ and `code`");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).toContain("<code>code</code>");
+  });
+
+  test("renders lists and blockquotes", () => {
+    const html = renderCommentBody("> quote\n\n- one\n- two");
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("<ul>");
+    expect(html).toContain("<li>one</li>");
+  });
+
+  test("links carry rel='nofollow ugc noopener'", () => {
+    const html = renderCommentBody("[plumix](https://plumix.dev)");
+    expect(html).toContain('href="https://plumix.dev"');
+    expect(html).toContain('rel="nofollow ugc noopener"');
+  });
+
+  test("raw HTML is escaped, never parsed", () => {
+    const html = renderCommentBody("<script>alert('xss')</script>");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  test("inline raw HTML does not produce live tags or attributes", () => {
+    const html = renderCommentBody('<img src=x onerror="alert(1)">');
+    // Escaped to inert text — no live <img> element, no real attribute.
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain('onerror="');
+    expect(html).toContain("&lt;img");
+  });
+
+  test("javascript: scheme links produce no active href", () => {
+    const html = renderCommentBody("[click](javascript:alert(1))");
+    expect(html.toLowerCase()).not.toContain('href="javascript:');
+    expect(html).not.toContain("<a ");
+  });
+
+  test("data: scheme links produce no active href", () => {
+    const html = renderCommentBody("[x](data:text/html;base64,PHNjcmlwdD4=)");
+    expect(html.toLowerCase()).not.toContain('href="data:');
+    expect(html).not.toContain("<a ");
+  });
+});

--- a/packages/plugins/comments/src/server/render-body.ts
+++ b/packages/plugins/comments/src/server/render-body.ts
@@ -1,0 +1,37 @@
+import MarkdownIt from "markdown-it";
+
+// `html: false` is the whole safety posture: raw HTML in the source is
+// escaped to text, never parsed into nodes, so the only elements emitted
+// are the ones markdown-it produces from markdown syntax — no separate
+// HTML sanitizer needed. markdown-it's default `validateLink` drops
+// `javascript:`/`vbscript:`/`file:` and non-raster `data:` link hrefs
+// (raster `data:` images are still allowed — tighten in the submission
+// slice if embedded images are unwanted).
+const md: MarkdownIt = new MarkdownIt({
+  html: false,
+  linkify: false,
+  breaks: true,
+});
+
+const renderToken: NonNullable<typeof md.renderer.rules.link_open> = (
+  tokens,
+  idx,
+  options,
+  _env,
+  self,
+) => self.renderToken(tokens, idx, options);
+
+const defaultLinkOpen = md.renderer.rules.link_open ?? renderToken;
+
+// Every rendered link is user-generated content pointing off-site:
+// `nofollow` (no SEO equity), `ugc` (user-generated content hint), and
+// `noopener` (sever the `window.opener` handle).
+md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+  tokens[idx]?.attrSet("rel", "nofollow ugc noopener");
+  return defaultLinkOpen(tokens, idx, options, env, self);
+};
+
+/** Render a raw markdown comment body to safe, allowlisted HTML. */
+export function renderCommentBody(markdown: string): string {
+  return md.render(markdown);
+}

--- a/packages/plugins/comments/src/server/template-dep.ts
+++ b/packages/plugins/comments/src/server/template-dep.ts
@@ -1,0 +1,38 @@
+import type { AppContext } from "plumix/plugin";
+import { eq } from "drizzle-orm";
+import { entries } from "plumix/schema";
+
+import type { CommentsConfig } from "../types.js";
+import type { ResolvedThread } from "./load-thread.js";
+import { isCommentingEnabled } from "./enablement.js";
+import { loadThread } from "./load-thread.js";
+
+/**
+ * Build the `comments` template-dep loader for a given plugin config.
+ * The loader reads the entry being rendered from `ctx.resolvedEntity`
+ * (set by the single-route resolver before deps load), confirms
+ * commenting is enabled for that entry's type, and returns the approved
+ * thread keyed by each declared slug. Returns `{}` (→ `null` per slug)
+ * for non-entry routes or comment-disabled types.
+ */
+export function createCommentsThreadLoader(config: CommentsConfig) {
+  return async (
+    slugs: readonly string[],
+    ctx: AppContext,
+  ): Promise<Record<string, ResolvedThread | null>> => {
+    const resolved = ctx.resolvedEntity;
+    if (resolved?.kind !== "entry") return {};
+
+    const [row] = await ctx.db
+      .select({ type: entries.type })
+      .from(entries)
+      .where(eq(entries.id, resolved.id));
+    if (!row) return {};
+
+    const supports = ctx.plugins.entryTypes.get(row.type)?.supports;
+    if (!isCommentingEnabled(row.type, supports, config)) return {};
+
+    const thread = await loadThread(ctx, resolved.id);
+    return Object.fromEntries(slugs.map((slug) => [slug, thread]));
+  };
+}

--- a/packages/plugins/comments/src/test/db.ts
+++ b/packages/plugins/comments/src/test/db.ts
@@ -1,0 +1,76 @@
+import type { AppContext } from "plumix/plugin";
+import type { Entry, NewEntry } from "plumix/schema";
+import {
+  generateSQLiteDrizzleJson,
+  generateSQLiteMigration,
+} from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { createTestDb, factoriesFor } from "plumix/test";
+
+import * as schema from "../db/schema.js";
+
+export type CommentsTestDb = Awaited<ReturnType<typeof createTestDb>>;
+
+/** Minimal AppContext stand-in carrying just the db, for server-module tests. */
+export function ctxFor(db: CommentsTestDb): AppContext {
+  return { db } as unknown as AppContext;
+}
+
+/**
+ * Seed a published `post` (with its author) — the comment target every
+ * read-path test needs. Slug defaults to the factory's unique value so
+ * repeated calls don't collide on the type+slug unique index.
+ */
+export async function seedPublishedPost(
+  db: CommentsTestDb,
+  overrides: Partial<NewEntry> = {},
+): Promise<Entry> {
+  const factories = factoriesFor(db);
+  const author = await factories.user.create({});
+  return factories.entry.create({
+    type: "post",
+    authorId: author.id,
+    status: "published",
+    ...overrides,
+  });
+}
+
+const schemaImports = schema as unknown as Record<string, unknown>;
+let cachedStatements: string[] | null = null;
+
+// drizzle-kit's `api` surface is loosely typed (`SQLiteSchema` is opaque);
+// treat it as a black-box snapshot blob and read only its `id`. Mirrors
+// the audit-log plugin's test-support compiler.
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+async function compileCommentsSql(): Promise<string[]> {
+  if (cachedStatements) return cachedStatements;
+  const empty = await generateSQLiteDrizzleJson({}, undefined, "snake_case");
+  const current = await generateSQLiteDrizzleJson(
+    schemaImports,
+    empty.id,
+    "snake_case",
+  );
+  cachedStatements = await generateSQLiteMigration(empty, current);
+  return cachedStatements;
+}
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+
+/**
+ * Layer the plugin's `comments` table onto an existing core test db
+ * (e.g. the one inside `createDispatcherHarness`). The FKs reference core
+ * `entries`/`users`, which the core schema already created.
+ */
+export async function applyCommentsSchema(db: CommentsTestDb): Promise<void> {
+  for (const stmt of await compileCommentsSql()) await db.run(sql.raw(stmt));
+}
+
+/**
+ * An in-memory test database with the core schema (via `createTestDb`)
+ * plus the plugin's `comments` table layered on top. Use with the core
+ * `factoriesFor(db)` and `commentFactory`.
+ */
+export async function createCommentsTestDb(): Promise<CommentsTestDb> {
+  const db = await createTestDb();
+  await applyCommentsSchema(db);
+  return db;
+}

--- a/packages/plugins/comments/src/test/factories.test.ts
+++ b/packages/plugins/comments/src/test/factories.test.ts
@@ -1,0 +1,46 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+import { comments } from "../db/schema.js";
+import { createCommentsTestDb, seedPublishedPost } from "./db.js";
+import { commentFactory } from "./factories.js";
+
+describe("commentFactory", () => {
+  test("seeds a comment row attached to an entry", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+
+    const comment = await commentFactory
+      .transient({ db })
+      .create({ entryId: entry.id, status: "approved" });
+
+    expect(comment.id).toBeGreaterThan(0);
+    expect(comment.entryId).toBe(entry.id);
+    expect(comment.status).toBe("approved");
+    expect(comment.authorName).toBeTruthy();
+    expect(comment.authorEmail).toContain("@");
+    expect(comment.bodyMd).toBeTruthy();
+
+    const rows = await db
+      .select()
+      .from(comments)
+      .where(eq(comments.entryId, entry.id));
+    expect(rows).toHaveLength(1);
+  });
+
+  test("defaults status to pending", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const comment = await commentFactory
+      .transient({ db })
+      .create({ entryId: entry.id });
+    expect(comment.status).toBe("pending");
+  });
+
+  test("requires entryId", async () => {
+    const db = await createCommentsTestDb();
+    await expect(commentFactory.transient({ db }).create({})).rejects.toThrow(
+      /entryId/,
+    );
+  });
+});

--- a/packages/plugins/comments/src/test/factories.ts
+++ b/packages/plugins/comments/src/test/factories.ts
@@ -1,0 +1,54 @@
+import { Factory } from "fishery";
+
+import type { Comment, NewComment } from "../db/schema.js";
+import type { CommentsTestDb } from "./db.js";
+import { comments } from "../db/schema.js";
+
+interface DbTransient {
+  db: CommentsTestDb;
+}
+
+function requireDb(transient: Partial<DbTransient>): CommentsTestDb {
+  if (!transient.db) {
+    // eslint-disable-next-line no-restricted-syntax -- test-support guard
+    throw new Error("commentFactory requires a db via .transient({ db })");
+  }
+  return transient.db;
+}
+
+/**
+ * Seeds a `comments` row. Requires `entryId` (a comment with no entry is
+ * meaningless); everything else has a sane default, with `status`
+ * defaulting to `pending` to mirror the table default. Pair with the
+ * core `factoriesFor(db)` to create the entry/user it points at.
+ */
+export const commentFactory = Factory.define<NewComment, DbTransient, Comment>(
+  ({ sequence, transientParams, onCreate, params }) => {
+    onCreate(async (attrs) => {
+      const db = requireDb(transientParams);
+      const [row] = await db.insert(comments).values(attrs).returning();
+      // eslint-disable-next-line no-restricted-syntax -- test-support guard
+      if (!row) throw new Error("commentFactory: insert returned no row");
+      return row;
+    });
+
+    const entryId = params.entryId;
+    if (entryId === undefined) {
+      // eslint-disable-next-line no-restricted-syntax -- test-support guard
+      throw new Error("commentFactory: entryId is required");
+    }
+
+    return {
+      entryId,
+      parentId: params.parentId ?? null,
+      status: params.status ?? "pending",
+      authorUserId: params.authorUserId ?? null,
+      authorName: params.authorName ?? `Commenter ${String(sequence)}`,
+      authorEmail:
+        params.authorEmail ?? `commenter-${String(sequence)}@example.test`,
+      bodyMd: params.bodyMd ?? `Comment body ${String(sequence)}`,
+      ipHash: params.ipHash ?? null,
+      userAgent: params.userAgent ?? null,
+    };
+  },
+);

--- a/packages/plugins/comments/src/types.ts
+++ b/packages/plugins/comments/src/types.ts
@@ -1,0 +1,23 @@
+/**
+ * The four-state moderation lifecycle. `trash` is a recoverable
+ * soft-delete; `spam` is retained for heuristics; hard removal is a
+ * separate purge action (slice #963).
+ */
+export const COMMENT_STATUSES = [
+  "pending",
+  "approved",
+  "spam",
+  "trash",
+] as const;
+
+export type CommentStatus = (typeof COMMENT_STATUSES)[number];
+
+/** Set-once configuration passed to `comments(options)` at include time. */
+export interface CommentsConfig {
+  /**
+   * Entry types to enable comments on, beyond any that self-declare
+   * `supports: ['comments']`. The WordPress `add_post_type_support`
+   * analog for types whose registration you don't own.
+   */
+  readonly entryTypes?: readonly string[];
+}

--- a/packages/plugins/comments/tsconfig.build.json
+++ b/packages/plugins/comments/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "stripInternal": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**"]
+}

--- a/packages/plugins/comments/tsconfig.json
+++ b/packages/plugins/comments/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@plumix/typescript-config/library.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/comments/vitest.config.ts
+++ b/packages/plugins/comments/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config";
+
+import { baseConfig } from "@plumix/vitest-config/base";
+
+export default defineConfig(baseConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,6 +839,110 @@ importers:
         specifier: 'catalog:'
         version: 4.98.0(@cloudflare/workers-types@4.20260526.1)
 
+  packages/plugins/comments:
+    dependencies:
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.2(@cloudflare/workers-types@4.20260526.1)(@libsql/client@0.17.3)
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.2.0
+    devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: 'catalog:'
+        version: 0.18.3
+      '@plumix/eslint-config':
+        specifier: workspace:*
+        version: link:../../../tooling/eslint
+      '@plumix/prettier-config':
+        specifier: workspace:*
+        version: link:../../../tooling/prettier
+      '@plumix/runtime-cloudflare':
+        specifier: workspace:*
+        version: link:../../runtimes/cloudflare
+      '@plumix/typescript-config':
+        specifier: workspace:*
+        version: link:../../../tooling/typescript
+      '@plumix/vitest-config':
+        specifier: workspace:*
+        version: link:../../../tooling/vitest
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.16
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
+      drizzle-kit:
+        specifier: 'catalog:'
+        version: 0.31.10
+      eslint:
+        specifier: 'catalog:'
+        version: 10.4.1(jiti@2.7.0)
+      fishery:
+        specifier: 'catalog:'
+        version: 2.4.0
+      plumix:
+        specifier: workspace:*
+        version: link:../../plumix
+      prettier:
+        specifier: 'catalog:'
+        version: 3.8.3
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.21
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/plugins/comments/playground:
+    dependencies:
+      '@plumix/plugin-blog':
+        specifier: workspace:*
+        version: link:../../blog
+      '@plumix/plugin-comments':
+        specifier: workspace:*
+        version: link:..
+      '@plumix/runtime-cloudflare':
+        specifier: workspace:*
+        version: link:../../../runtimes/cloudflare
+      plumix:
+        specifier: workspace:*
+        version: link:../../../plumix
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260526.1
+      '@plumix/typescript-config':
+        specifier: workspace:*
+        version: link:../../../../tooling/typescript
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.16
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.98.0(@cloudflare/workers-types@4.20260526.1)
+
   packages/plugins/media:
     dependencies:
       valibot:
@@ -4397,6 +4501,15 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
 
@@ -6119,6 +6232,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
@@ -6166,6 +6282,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
+    hasBin: true
+
   marked-terminal@7.3.0:
     resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
     engines: {node: '>=16.0.0'}
@@ -6183,6 +6303,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -6570,6 +6693,10 @@ packages:
     resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -7116,6 +7243,9 @@ packages:
   ua-parser-js@2.0.9:
     resolution: {integrity: sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   unbash@2.2.0:
     resolution: {integrity: sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==}
@@ -10232,6 +10362,15 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/node@24.13.1':
     dependencies:
       undici-types: 7.18.2
@@ -12060,6 +12199,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
+
   linkifyjs@4.3.3: {}
 
   locate-path@6.0.0:
@@ -12105,6 +12248,15 @@ snapshots:
     dependencies:
       semver: 7.8.1
 
+  markdown-it@14.2.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   marked-terminal@7.3.0(marked@9.1.6):
     dependencies:
       ansi-escapes: 7.3.0
@@ -12121,6 +12273,8 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
@@ -12525,6 +12679,8 @@ snapshots:
       package-manager-detector: 1.6.0
       picocolors: 1.1.1
       sade: 1.8.1
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -13209,6 +13365,8 @@ snapshots:
       detect-europe-js: 0.1.2
       is-standalone-pwa: 0.1.1
       ua-is-frozen: 0.1.2
+
+  uc.micro@2.1.0: {}
 
   unbash@2.2.0: {}
 


### PR DESCRIPTION
First-party `@plumix/plugin-comments`, read path only — slice 1 of 8 toward the comments subsystem (PRD #959). A theme can now render an entry's approved discussion; submission, moderation, and the admin queue follow in later slices.

The plugin ships the `comments` table plus the read-side pieces: an enablement resolver, a markdown renderer, a Gravatar URL builder, `loadThread`, a test factory, and a `comments` template dep that resolves the approved thread for the entry being rendered.

**Enablement follows WordPress's `post_type_supports` model**

Comments are on for an entry type when it is listed in `comments({ entryTypes })` or the type self-declares `supports: ['comments']` — the union of an explicit site allowlist and decoupled self-declaration. The blog plugin is untouched.

**Markdown rendering needs no separate sanitizer**

`renderCommentBody` runs markdown-it with `html: false`, so raw HTML in a comment is escaped to inert text rather than parsed — the only elements emitted are the ones markdown produces. Links get `rel="nofollow ugc noopener"` and dangerous-scheme hrefs are dropped. An XSS battery covers script tags, event-handler attributes, and `javascript:`/`data:` links.

**Email and IP never reach the public payload**

`ResolvedComment` is an explicit allowlist; `loadThread` reads the author email server-side only (to hash for Gravatar) and a regression test asserts the serialized thread never contains it. IPs are stored as a salted SHA-256, never cleartext.

### Testing

31 tests: pure-unit coverage per module (including the XSS battery and the email-leak guard), integration for `loadThread` and the factory over an in-memory db that layers the plugin table onto the core schema, and an in-process dispatcher-harness test driving the full route → template-dep → render pipeline. Required gates — lint, typecheck, knip, format, commitlint — all green.

### Notes / decisions

- **Read-path e2e is in-process, not Playwright.** Public content renders through the worker, but `plumix dev` serves the admin SPA for those paths (no existing plugin e2e renders public content), so the dispatcher harness verifies the full pipeline deterministically. The playground app ships now for dogfooding; the admin-queue Playwright e2e lands with #963.
- **Gravatar is the one deliberate privacy divergence** — the email hash, not the email, rides in the avatar URL.
- **Deferred:** i18n slot + locales (#966); admin chunk, RPC, and the moderation engine (#963).

### Out of scope (later slices)

Submission, moderation engine, threading depth, admin moderation queue, notifications, i18n, pagination.

Closes #960
Refs #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)