### PR TITLE
feat(plugin-comments): public submission + moderation engine

### DIFF
--- a/packages/plugins/comments/package.json
+++ b/packages/plugins/comments/package.json
@@ -58,7 +58,8 @@
   },
   "dependencies": {
     "drizzle-orm": "catalog:",
-    "markdown-it": "^14.1.0"
+    "markdown-it": "^14.1.0",
+    "valibot": "catalog:"
   },
   "peerDependencies": {
     "plumix": "workspace:*"

--- a/packages/plugins/comments/src/config.ts
+++ b/packages/plugins/comments/src/config.ts
@@ -1,0 +1,24 @@
+import type {
+  CommentsConfig,
+  ModerationMode,
+  RateLimitConfig,
+} from "./types.js";
+
+/** `CommentsConfig` with every knob filled in from its default. */
+export interface ResolvedCommentsConfig {
+  readonly entryTypes: readonly string[];
+  readonly mode: ModerationMode;
+  readonly requireEmail: boolean;
+  readonly closeAfterDays: number | null;
+  readonly rateLimit: RateLimitConfig;
+}
+
+export function resolveConfig(options: CommentsConfig): ResolvedCommentsConfig {
+  return {
+    entryTypes: options.entryTypes ?? [],
+    mode: options.mode ?? "first_time",
+    requireEmail: options.requireEmail ?? true,
+    closeAfterDays: options.closeAfterDays ?? null,
+    rateLimit: options.rateLimit ?? { max: 5, windowMin: 10 },
+  };
+}

--- a/packages/plugins/comments/src/index.test.ts
+++ b/packages/plugins/comments/src/index.test.ts
@@ -34,13 +34,16 @@ describe("comments() plugin", () => {
     expect(plugin.schema).toBeDefined();
   });
 
-  test("setup registers a 'comments' template dep", () => {
+  test("setup registers a 'comments' template dep and a submit route", () => {
     const kinds: string[] = [];
+    const routes: string[] = [];
     const ctx = {
       registerTemplateDep: (kind: string) => kinds.push(kind),
+      registerRoute: (opts: { path: string }) => routes.push(opts.path),
     } as unknown as Parameters<ReturnType<typeof comments>["setup"]>[0];
     void comments().setup(ctx, undefined);
     expect(kinds).toContain("comments");
+    expect(routes).toContain("/submit");
   });
 });
 

--- a/packages/plugins/comments/src/index.ts
+++ b/packages/plugins/comments/src/index.ts
@@ -1,17 +1,19 @@
 import { definePlugin } from "plumix/plugin";
 
 import type { CommentsConfig } from "./types.js";
+import { resolveConfig } from "./config.js";
 import * as schema from "./db/schema.js";
+import { createSubmitHandler } from "./server/submit.js";
 import { createCommentsThreadLoader } from "./server/template-dep.js";
 
-export type { CommentsConfig, CommentStatus } from "./types.js";
+export type { CommentsConfig, CommentStatus, ModerationMode } from "./types.js";
 export { COMMENT_STATUSES } from "./types.js";
 
 /**
  * `@plumix/plugin-comments` — threaded, moderated discussion on entries.
  *
- * The read path (this slice) registers a `comments` template dep so a
- * theme can render the approved thread for the entry it's displaying:
+ * Registers a `comments` template dep so a theme can render the approved
+ * thread for the entry it's displaying:
  *
  *     defineTemplate({
  *       single: {
@@ -20,12 +22,16 @@ export { COMMENT_STATUSES } from "./types.js";
  *       },
  *     })
  *
+ * and a public `POST /_plumix/comments/submit` route that runs a new
+ * comment through honeypot + rate-limit + the trust policy and the
+ * `comment:moderate` filter chain before persisting it.
+ *
  * Commenting is enabled for an entry type when the type is listed in
  * `comments({ entryTypes })` or self-declares `supports: ['comments']`.
- * Submission, moderation, threading, and the admin queue arrive in
- * later slices; the `comments` table ships now so migrations include it.
+ * Threading depth and the admin moderation queue arrive in later slices.
  */
 export function comments(options: CommentsConfig = {}) {
+  const config = resolveConfig(options);
   return definePlugin("comments", {
     schema,
     // Module specifier `plumix migrate generate` uses to fold this
@@ -33,7 +39,13 @@ export function comments(options: CommentsConfig = {}) {
     schemaModule: "@plumix/plugin-comments/schema",
     setup: (ctx) => {
       ctx.registerTemplateDep("comments", {
-        load: createCommentsThreadLoader(options),
+        load: createCommentsThreadLoader(config),
+      });
+      ctx.registerRoute({
+        method: "POST",
+        path: "/submit",
+        auth: "public",
+        handler: createSubmitHandler(config),
       });
     },
   });

--- a/packages/plugins/comments/src/server/gravatar.ts
+++ b/packages/plugins/comments/src/server/gravatar.ts
@@ -1,11 +1,4 @@
-const ENCODER = new TextEncoder();
-
-async function sha256Hex(input: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", ENCODER.encode(input));
-  return [...new Uint8Array(digest)]
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
+import { sha256Hex } from "./hash.js";
 
 interface GravatarOptions {
   /** Pixel size of the requested avatar. Defaults to 80. */

--- a/packages/plugins/comments/src/server/hash.ts
+++ b/packages/plugins/comments/src/server/hash.ts
@@ -1,0 +1,12 @@
+const ENCODER = new TextEncoder();
+
+/** Lowercase-hex encoding of bytes. */
+export function toHex(bytes: Uint8Array): string {
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** Lowercase-hex SHA-256 of a string, via WebCrypto (Workers + Node). */
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", ENCODER.encode(input));
+  return toHex(new Uint8Array(digest));
+}

--- a/packages/plugins/comments/src/server/hooks.ts
+++ b/packages/plugins/comments/src/server/hooks.ts
@@ -1,0 +1,29 @@
+import type { Comment } from "../db/schema.js";
+import type { CommentStatus } from "../types.js";
+
+/**
+ * What a `comment:moderate` filter sees about an incoming comment. Spam,
+ * Akismet, or AI plugins read these signals and may only push the status
+ * toward the restrictive end (the submit handler clamps via
+ * `mostRestrictive`, so order between filters doesn't matter).
+ */
+export interface CommentModerationCandidate {
+  readonly entryId: number;
+  readonly authorName: string;
+  readonly authorEmail: string;
+  readonly bodyMd: string;
+  readonly ipHash: string;
+  readonly isAuthenticated: boolean;
+}
+
+declare module "plumix/plugin" {
+  interface FilterRegistry {
+    "comment:moderate": (
+      status: CommentStatus,
+      candidate: CommentModerationCandidate,
+    ) => CommentStatus | Promise<CommentStatus>;
+  }
+  interface ActionRegistry {
+    "comment:created": (comment: Comment) => void | Promise<void>;
+  }
+}

--- a/packages/plugins/comments/src/server/index.ts
+++ b/packages/plugins/comments/src/server/index.ts
@@ -4,3 +4,7 @@
 // alongside `ResolvedThread`.
 export type { ResolvedComment, ResolvedThread } from "./load-thread.js";
 export { loadThread } from "./load-thread.js";
+// Re-exported so a third-party moderation plugin can type its
+// `comment:moderate` filter; importing it also pulls the plugin's
+// FilterRegistry/ActionRegistry augmentation into scope.
+export type { CommentModerationCandidate } from "./hooks.js";

--- a/packages/plugins/comments/src/server/ip-hash.test.ts
+++ b/packages/plugins/comments/src/server/ip-hash.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import { hashIp } from "./ip-hash.js";
+
+describe("hashIp", () => {
+  test("produces a 64-char lowercase hex digest", async () => {
+    expect(await hashIp("203.0.113.5", "salt")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("is deterministic for the same ip + salt", async () => {
+    expect(await hashIp("203.0.113.5", "s")).toBe(
+      await hashIp("203.0.113.5", "s"),
+    );
+  });
+
+  test("changes with the ip", async () => {
+    expect(await hashIp("203.0.113.5", "s")).not.toBe(
+      await hashIp("203.0.113.6", "s"),
+    );
+  });
+
+  test("changes with the salt (so the hash is not a bare sha256 of the ip)", async () => {
+    expect(await hashIp("203.0.113.5", "s1")).not.toBe(
+      await hashIp("203.0.113.5", "s2"),
+    );
+  });
+});

--- a/packages/plugins/comments/src/server/ip-hash.ts
+++ b/packages/plugins/comments/src/server/ip-hash.ts
@@ -1,0 +1,11 @@
+import { sha256Hex } from "./hash.js";
+
+/**
+ * Salted SHA-256 of a visitor IP. The per-install salt (persisted in the
+ * settings table) means the stored hash isn't a bare digest an attacker
+ * could reverse with a rainbow table of the IPv4 space. Cleartext IPs are
+ * never stored.
+ */
+export function hashIp(ip: string, salt: string): Promise<string> {
+  return sha256Hex(`${salt}:${ip}`);
+}

--- a/packages/plugins/comments/src/server/moderation.test.ts
+++ b/packages/plugins/comments/src/server/moderation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+
+import { applyModerationVerdict, decideBaselineStatus } from "./moderation.js";
+
+describe("decideBaselineStatus", () => {
+  test("logged-in users are approved regardless of mode", () => {
+    expect(
+      decideBaselineStatus({
+        mode: "all",
+        priorApprovedCount: 0,
+        isAuthenticated: true,
+      }),
+    ).toBe("approved");
+  });
+
+  test("mode 'none' approves anonymous comments", () => {
+    expect(
+      decideBaselineStatus({
+        mode: "none",
+        priorApprovedCount: 0,
+        isAuthenticated: false,
+      }),
+    ).toBe("approved");
+  });
+
+  test("mode 'all' holds anonymous comments as pending", () => {
+    expect(
+      decideBaselineStatus({
+        mode: "all",
+        priorApprovedCount: 5,
+        isAuthenticated: false,
+      }),
+    ).toBe("pending");
+  });
+
+  test("mode 'first_time' holds a new email as pending", () => {
+    expect(
+      decideBaselineStatus({
+        mode: "first_time",
+        priorApprovedCount: 0,
+        isAuthenticated: false,
+      }),
+    ).toBe("pending");
+  });
+
+  test("mode 'first_time' approves an email with a prior approved comment", () => {
+    expect(
+      decideBaselineStatus({
+        mode: "first_time",
+        priorApprovedCount: 1,
+        isAuthenticated: false,
+      }),
+    ).toBe("approved");
+  });
+});
+
+describe("applyModerationVerdict", () => {
+  test("a filter may demote toward spam", () => {
+    expect(applyModerationVerdict("approved", "spam")).toBe("spam");
+    expect(applyModerationVerdict("pending", "trash")).toBe("trash");
+  });
+
+  test("a filter may not promote (most-restrictive wins)", () => {
+    expect(applyModerationVerdict("pending", "approved")).toBe("pending");
+    expect(applyModerationVerdict("spam", "approved")).toBe("spam");
+  });
+
+  test("keeps the baseline when the verdict matches it", () => {
+    expect(applyModerationVerdict("approved", "approved")).toBe("approved");
+  });
+
+  test("ignores a verdict that isn't a known status", () => {
+    expect(applyModerationVerdict("pending", "garbage")).toBe("pending");
+    expect(applyModerationVerdict("approved", undefined)).toBe("approved");
+    expect(applyModerationVerdict("pending", 42)).toBe("pending");
+  });
+});

--- a/packages/plugins/comments/src/server/moderation.ts
+++ b/packages/plugins/comments/src/server/moderation.ts
@@ -1,0 +1,60 @@
+import type { CommentStatus, ModerationMode } from "../types.js";
+import { COMMENT_STATUSES } from "../types.js";
+
+/**
+ * The trust-policy baseline status for a new comment, before any
+ * `comment:moderate` filters run. Logged-in commenters take a fast path
+ * to `approved`; otherwise the mode decides (see {@link ModerationMode}).
+ *
+ * `first_time` trusts the prior-approved count for an *unverified* email
+ * (WordPress's `comment_previously_approved` model): an anonymous author
+ * who supplies a known-good address gets auto-approved. The moderation
+ * queue and the `comment:moderate` chain (spam/AI plugins) are the
+ * backstop; email verification is a future hardening.
+ */
+export function decideBaselineStatus(input: {
+  readonly mode: ModerationMode;
+  readonly priorApprovedCount: number;
+  readonly isAuthenticated: boolean;
+}): CommentStatus {
+  if (input.isAuthenticated) return "approved";
+  if (input.mode === "none") return "approved";
+  if (input.mode === "all") return "pending";
+  return input.priorApprovedCount > 0 ? "approved" : "pending";
+}
+
+// Higher rank = more restrictive. The `comment:moderate` chain may only
+// push a comment toward the restrictive end, so detectors compose without
+// caring about order: spam > trash > pending > approved.
+const RANK: Record<CommentStatus, number> = {
+  approved: 0,
+  pending: 1,
+  trash: 2,
+  spam: 3,
+};
+
+function mostRestrictive(a: CommentStatus, b: CommentStatus): CommentStatus {
+  return RANK[a] >= RANK[b] ? a : b;
+}
+
+function isCommentStatus(value: unknown): value is CommentStatus {
+  return (
+    typeof value === "string" &&
+    (COMMENT_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Fold a `comment:moderate` filter's verdict into the baseline. Filters
+ * may only demote (most-restrictive wins, so order doesn't matter); a
+ * verdict that isn't a known status is ignored rather than persisted —
+ * a misbehaving filter can't corrupt the column or promote a comment.
+ */
+export function applyModerationVerdict(
+  baseline: CommentStatus,
+  verdict: unknown,
+): CommentStatus {
+  return isCommentStatus(verdict)
+    ? mostRestrictive(baseline, verdict)
+    : baseline;
+}

--- a/packages/plugins/comments/src/server/repository.test.ts
+++ b/packages/plugins/comments/src/server/repository.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+
+import { createCommentsTestDb, ctxFor, seedPublishedPost } from "../test/db.js";
+import { commentFactory } from "../test/factories.js";
+import { countPriorApproved, insertComment } from "./repository.js";
+
+describe("countPriorApproved", () => {
+  test("counts only approved comments for the given email", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    await seed.create({
+      entryId: entry.id,
+      authorEmail: "ada@example.test",
+      status: "approved",
+    });
+    await seed.create({
+      entryId: entry.id,
+      authorEmail: "ada@example.test",
+      status: "approved",
+    });
+    await seed.create({
+      entryId: entry.id,
+      authorEmail: "ada@example.test",
+      status: "pending",
+    });
+    await seed.create({
+      entryId: entry.id,
+      authorEmail: "bob@example.test",
+      status: "approved",
+    });
+
+    expect(await countPriorApproved(ctxFor(db), "ada@example.test")).toBe(2);
+    expect(await countPriorApproved(ctxFor(db), "new@example.test")).toBe(0);
+  });
+});
+
+describe("insertComment", () => {
+  test("persists a comment and returns the stored row", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+
+    const row = await insertComment(ctxFor(db), {
+      entryId: entry.id,
+      status: "pending",
+      authorName: "Ada",
+      authorEmail: "ada@example.test",
+      bodyMd: "hi",
+    });
+
+    expect(row.id).toBeGreaterThan(0);
+    expect(row.status).toBe("pending");
+    expect(row.entryId).toBe(entry.id);
+  });
+});

--- a/packages/plugins/comments/src/server/repository.ts
+++ b/packages/plugins/comments/src/server/repository.ts
@@ -1,0 +1,36 @@
+import type { AppContext } from "plumix/plugin";
+import { and, count, eq } from "drizzle-orm";
+
+import type { Comment, NewComment } from "../db/schema.js";
+import { comments } from "../db/schema.js";
+
+/**
+ * How many approved comments an email already has — the trust-policy
+ * lookup that lets `first_time` moderation auto-approve a returning,
+ * previously-approved commenter.
+ */
+export async function countPriorApproved(
+  ctx: AppContext,
+  email: string,
+): Promise<number> {
+  const [row] = await ctx.db
+    .select({ value: count() })
+    .from(comments)
+    .where(
+      and(eq(comments.authorEmail, email), eq(comments.status, "approved")),
+    );
+  return row?.value ?? 0;
+}
+
+/** Insert a comment and return the stored row. */
+export async function insertComment(
+  ctx: AppContext,
+  values: NewComment,
+): Promise<Comment> {
+  const [row] = await ctx.db.insert(comments).values(values).returning();
+  if (!row) {
+    // eslint-disable-next-line no-restricted-syntax -- unreachable: returning() yields the row
+    throw new Error("insertComment: insert returned no row");
+  }
+  return row;
+}

--- a/packages/plugins/comments/src/server/salt.test.ts
+++ b/packages/plugins/comments/src/server/salt.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+
+import { createCommentsTestDb, ctxFor } from "../test/db.js";
+import { getOrCreateIpSalt } from "./salt.js";
+
+describe("getOrCreateIpSalt", () => {
+  test("generates and persists a hex salt on first call", async () => {
+    const db = await createCommentsTestDb();
+    expect(await getOrCreateIpSalt(ctxFor(db))).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test("returns the same salt on subsequent calls", async () => {
+    const db = await createCommentsTestDb();
+    const ctx = ctxFor(db);
+    expect(await getOrCreateIpSalt(ctx)).toBe(await getOrCreateIpSalt(ctx));
+  });
+});

--- a/packages/plugins/comments/src/server/salt.ts
+++ b/packages/plugins/comments/src/server/salt.ts
@@ -1,0 +1,43 @@
+import type { AppContext } from "plumix/plugin";
+import { and, eq } from "drizzle-orm";
+import { settings } from "plumix/schema";
+
+import { toHex } from "./hash.js";
+
+// Its own settings group, not "comments": a future user-facing `comments`
+// settings group read via `settings.get` would otherwise surface this
+// secret in the admin UI.
+const GROUP = "comments_internal";
+const KEY = "ip_salt";
+
+function generateSalt(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return toHex(bytes);
+}
+
+async function readSalt(ctx: AppContext): Promise<string | null> {
+  const [row] = await ctx.db
+    .select({ value: settings.value })
+    .from(settings)
+    .where(and(eq(settings.group, GROUP), eq(settings.key, KEY)));
+  return typeof row?.value === "string" ? row.value : null;
+}
+
+/**
+ * The per-install salt for {@link import("./ip-hash.js").hashIp}. Lazily
+ * generated on first comment and persisted in the settings table, so no
+ * env var or KV binding is required. `onConflictDoNothing` + a re-read
+ * makes concurrent first-writes converge on one salt.
+ */
+export async function getOrCreateIpSalt(ctx: AppContext): Promise<string> {
+  const existing = await readSalt(ctx);
+  if (existing !== null) return existing;
+
+  const salt = generateSalt();
+  await ctx.db
+    .insert(settings)
+    .values({ group: GROUP, key: KEY, value: salt })
+    .onConflictDoNothing();
+  return (await readSalt(ctx)) ?? salt;
+}

--- a/packages/plugins/comments/src/server/spam.test.ts
+++ b/packages/plugins/comments/src/server/spam.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+
+import { createCommentsTestDb, ctxFor, seedPublishedPost } from "../test/db.js";
+import { commentFactory } from "../test/factories.js";
+import { checkRateLimit, isHoneypotTripped } from "./spam.js";
+
+describe("isHoneypotTripped", () => {
+  test("untripped for empty, whitespace, null, or undefined", () => {
+    expect(isHoneypotTripped(undefined)).toBe(false);
+    expect(isHoneypotTripped(null)).toBe(false);
+    expect(isHoneypotTripped("")).toBe(false);
+    expect(isHoneypotTripped("   ")).toBe(false);
+  });
+
+  test("tripped when a bot fills the hidden field", () => {
+    expect(isHoneypotTripped("http://spam.example")).toBe(true);
+  });
+});
+
+describe("checkRateLimit", () => {
+  const limit = { max: 3, windowMin: 10 };
+
+  test("allows submissions below the window limit", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    await seed.create({ entryId: entry.id, ipHash: "ip-a" });
+    await seed.create({ entryId: entry.id, ipHash: "ip-a" });
+
+    expect(await checkRateLimit(ctxFor(db), "ip-a", limit)).toBe(false);
+  });
+
+  test("blocks once the window limit is reached", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    for (let i = 0; i < 3; i++) {
+      await seed.create({ entryId: entry.id, ipHash: "ip-b" });
+    }
+
+    expect(await checkRateLimit(ctxFor(db), "ip-b", limit)).toBe(true);
+  });
+
+  test("counts only the same ip hash", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    for (let i = 0; i < 3; i++) {
+      await seed.create({ entryId: entry.id, ipHash: "other" });
+    }
+
+    expect(await checkRateLimit(ctxFor(db), "ip-c", limit)).toBe(false);
+  });
+
+  test("ignores comments older than the window", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    const old = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+    for (let i = 0; i < 5; i++) {
+      await seed.create({ entryId: entry.id, ipHash: "ip-d", createdAt: old });
+    }
+
+    expect(await checkRateLimit(ctxFor(db), "ip-d", limit)).toBe(false);
+  });
+});

--- a/packages/plugins/comments/src/server/spam.ts
+++ b/packages/plugins/comments/src/server/spam.ts
@@ -1,0 +1,32 @@
+import type { AppContext } from "plumix/plugin";
+import { and, count, eq, gte } from "drizzle-orm";
+
+import type { RateLimitConfig } from "../types.js";
+import { comments } from "../db/schema.js";
+
+/**
+ * A hidden form field bots tend to auto-fill. Real users never touch it,
+ * so any non-empty value means "drop this submission" — the caller fakes
+ * a success rather than revealing the trap.
+ */
+export function isHoneypotTripped(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Whether this ip hash has hit the submission limit within the window.
+ * Counts the plugin's own rows (no separate counter store) so the limiter
+ * works on any deployment without a KV binding.
+ */
+export async function checkRateLimit(
+  ctx: AppContext,
+  ipHash: string,
+  limit: RateLimitConfig,
+): Promise<boolean> {
+  const since = new Date(Date.now() - limit.windowMin * 60 * 1000);
+  const [row] = await ctx.db
+    .select({ value: count() })
+    .from(comments)
+    .where(and(eq(comments.ipHash, ipHash), gte(comments.createdAt, since)));
+  return (row?.value ?? 0) >= limit.max;
+}

--- a/packages/plugins/comments/src/server/submit.test.ts
+++ b/packages/plugins/comments/src/server/submit.test.ts
@@ -1,0 +1,175 @@
+import { definePlugin } from "plumix/plugin";
+import { createDispatcherHarness } from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+import type { CommentsConfig } from "../types.js";
+import { comments as commentsTable } from "../db/schema.js";
+import { comments } from "../index.js";
+import { applyCommentsSchema } from "../test/db.js";
+
+const testBlog = definePlugin("test_blog", {
+  setup: (ctx) => {
+    ctx.registerEntryType("post", {
+      label: "Posts",
+      isPublic: true,
+      rewrite: { slug: "posts" },
+    });
+  },
+});
+
+type Harness = Awaited<ReturnType<typeof createDispatcherHarness>>;
+
+async function harnessWith(config: CommentsConfig): Promise<Harness> {
+  const harness = await createDispatcherHarness({
+    plugins: [testBlog, comments(config)],
+  });
+  await applyCommentsSchema(harness.db);
+  return harness;
+}
+
+async function seedPost(harness: Harness, overrides = {}) {
+  const user = await harness.factory.user.create({});
+  return harness.factory.entry.create({
+    type: "post",
+    title: "Post",
+    authorId: user.id,
+    status: "published",
+    ...overrides,
+  });
+}
+
+function submit(
+  harness: Harness,
+  entryId: number,
+  body: Record<string, unknown> = {},
+) {
+  return harness.fetch("/_plumix/comments/submit", {
+    method: "POST",
+    json: {
+      entryId,
+      name: "Ada",
+      email: "ada@example.test",
+      body: "hello world",
+      ...body,
+    },
+  });
+}
+
+async function rows(harness: Harness) {
+  return harness.db.select().from(commentsTable);
+}
+
+describe("POST /_plumix/comments/submit", () => {
+  test("auto-approves under mode 'none' and persists the comment", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"], mode: "none" });
+    const entry = await seedPost(harness);
+
+    const res = await submit(harness, entry.id);
+
+    res.assertStatus(200);
+    expect(await res.json()).toEqual({ status: "approved" });
+    const stored = await rows(harness);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.status).toBe("approved");
+    expect(stored[0]?.bodyMd).toBe("hello world");
+  });
+
+  test("holds a new email as pending under 'first_time'", async () => {
+    const harness = await harnessWith({
+      entryTypes: ["post"],
+      mode: "first_time",
+    });
+    const entry = await seedPost(harness);
+
+    const res = await submit(harness, entry.id);
+
+    expect(await res.json()).toEqual({ status: "pending" });
+  });
+
+  test("honeypot submissions fake success and are not stored", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"], mode: "none" });
+    const entry = await seedPost(harness);
+
+    const res = await submit(harness, entry.id, {
+      website: "http://spam.example",
+    });
+
+    res.assertStatus(200);
+    expect(await rows(harness)).toHaveLength(0);
+  });
+
+  test("rejects comments on a non-enabled entry type", async () => {
+    const harness = await harnessWith({ mode: "none" }); // post not enabled
+    const entry = await seedPost(harness);
+
+    const res = await submit(harness, entry.id);
+
+    res.assertStatus(403);
+    expect(await rows(harness)).toHaveLength(0);
+  });
+
+  test("rejects a missing email when requireEmail is on", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"], mode: "none" });
+    const entry = await seedPost(harness);
+
+    const res = await submit(harness, entry.id, { email: "" });
+
+    res.assertStatus(400);
+  });
+
+  test("rate-limits a flood from one source", async () => {
+    const harness = await harnessWith({
+      entryTypes: ["post"],
+      mode: "none",
+      rateLimit: { max: 2, windowMin: 10 },
+    });
+    const entry = await seedPost(harness);
+
+    await submit(harness, entry.id);
+    await submit(harness, entry.id);
+    const third = await submit(harness, entry.id);
+
+    third.assertStatus(429);
+    expect(await rows(harness)).toHaveLength(2);
+  });
+
+  test("a comment:moderate filter can demote to spam", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"], mode: "none" });
+    harness.spyFilter("comment:moderate").override(() => "spam");
+    const entry = await seedPost(harness);
+
+    const res = await submit(harness, entry.id);
+
+    expect(await res.json()).toEqual({ status: "spam" });
+  });
+
+  test("fires comment:created with the stored row", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"], mode: "none" });
+    const spy = harness.spyAction("comment:created");
+    const entry = await seedPost(harness);
+
+    await submit(harness, entry.id);
+
+    spy.assertCalledOnce();
+  });
+
+  test("stores a salted ip hash, never the cleartext ip", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"], mode: "none" });
+    const entry = await seedPost(harness);
+
+    await harness.fetch("/_plumix/comments/submit", {
+      method: "POST",
+      headers: { "cf-connecting-ip": "203.0.113.7" },
+      json: {
+        entryId: entry.id,
+        name: "Ada",
+        email: "ada@example.test",
+        body: "hi",
+      },
+    });
+
+    const stored = await rows(harness);
+    expect(stored[0]?.ipHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(stored[0]?.ipHash).not.toContain("203.0.113.7");
+  });
+});

--- a/packages/plugins/comments/src/server/submit.ts
+++ b/packages/plugins/comments/src/server/submit.ts
@@ -1,0 +1,156 @@
+import type { AppContext } from "plumix/plugin";
+import { eq } from "drizzle-orm";
+import { entries, jsonResponse } from "plumix/plugin";
+import * as v from "valibot";
+
+import type { ResolvedCommentsConfig } from "../config.js";
+import type { CommentModerationCandidate } from "./hooks.js";
+import { isCommentingEnabled } from "./enablement.js";
+import { hashIp } from "./ip-hash.js";
+import { applyModerationVerdict, decideBaselineStatus } from "./moderation.js";
+import { countPriorApproved, insertComment } from "./repository.js";
+import { getOrCreateIpSalt } from "./salt.js";
+import { checkRateLimit, isHoneypotTripped } from "./spam.js";
+
+const MAX_UA_LENGTH = 1024;
+
+const submitInputSchema = v.object({
+  entryId: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  name: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(120)),
+  email: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(254)), ""),
+  body: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(10_000)),
+  // Honeypot — real users never fill it.
+  website: v.optional(v.string(), ""),
+});
+
+// IP is trustworthy only when a trusted edge sets it: `cf-connecting-ip`
+// on Cloudflare. The `x-forwarded-for` fallback is client-spoofable off
+// CF, so the rate limiter is best-effort there; `"unknown"` is a shared
+// bucket for visitors with no resolvable IP. Edge/WAF rules are the
+// real flood defense.
+function extractRequestMeta(request: Request): {
+  readonly ip: string;
+  readonly userAgent: string | null;
+} {
+  const cfIp = request.headers.get("cf-connecting-ip");
+  const xff = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const ua = request.headers.get("user-agent");
+  return {
+    ip: cfIp ?? (xff && xff.length > 0 ? xff : "unknown"),
+    userAgent: ua ? ua.slice(0, MAX_UA_LENGTH) : null,
+  };
+}
+
+function isClosed(
+  publishedAt: Date | null,
+  closeAfterDays: number | null,
+): boolean {
+  if (closeAfterDays === null || publishedAt === null) return false;
+  return Date.now() > publishedAt.getTime() + closeAfterDays * 86_400_000;
+}
+
+/**
+ * The public comment-submission handler. Mounted at
+ * `POST /_plumix/comments/submit` (`auth: "public"`); the dispatcher's
+ * CSRF header + same-origin guard runs upstream. Pipeline: validate →
+ * honeypot → resolve+gate the entry → identity (logged-in fast path) →
+ * salted ip hash + rate limit → trust baseline + `comment:moderate`
+ * chain → insert → fire `comment:created`.
+ */
+export function createSubmitHandler(config: ResolvedCommentsConfig) {
+  return async (request: Request, ctx: AppContext): Promise<Response> => {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return jsonResponse({ error: "invalid_json" }, { status: 400 });
+    }
+    const parsed = v.safeParse(submitInputSchema, raw);
+    if (!parsed.success) {
+      return jsonResponse({ error: "invalid_input" }, { status: 400 });
+    }
+    const input = parsed.output;
+
+    // Filled honeypot → fake success, never store, never reveal the trap.
+    if (isHoneypotTripped(input.website))
+      return jsonResponse({ status: "pending" });
+
+    const [entry] = await ctx.db
+      .select({
+        id: entries.id,
+        type: entries.type,
+        status: entries.status,
+        publishedAt: entries.publishedAt,
+      })
+      .from(entries)
+      .where(eq(entries.id, input.entryId));
+    if (entry?.status !== "published") {
+      return jsonResponse({ error: "entry_not_found" }, { status: 404 });
+    }
+
+    const supports = ctx.plugins.entryTypes.get(entry.type)?.supports;
+    if (!isCommentingEnabled(entry.type, supports, config)) {
+      return jsonResponse({ error: "comments_disabled" }, { status: 403 });
+    }
+    if (isClosed(entry.publishedAt, config.closeAfterDays)) {
+      return jsonResponse({ error: "comments_closed" }, { status: 403 });
+    }
+
+    // Public route — the dispatcher doesn't authenticate it, so check for a
+    // session here to give logged-in commenters the trust fast path.
+    const auth = await ctx.authenticator.authenticate(request, ctx.db);
+    const authUser = auth?.user ?? null;
+    const isAuthenticated = authUser !== null;
+    // Lowercase so the trust lookup and Gravatar agree on one identity.
+    const email = (authUser?.email ?? input.email).trim().toLowerCase();
+    if (config.requireEmail && email.length === 0) {
+      return jsonResponse({ error: "email_required" }, { status: 400 });
+    }
+
+    const { ip, userAgent } = extractRequestMeta(request);
+    const ipHash = await hashIp(ip, await getOrCreateIpSalt(ctx));
+    if (await checkRateLimit(ctx, ipHash, config.rateLimit)) {
+      return jsonResponse({ error: "rate_limited" }, { status: 429 });
+    }
+
+    const priorApprovedCount =
+      email.length > 0 ? await countPriorApproved(ctx, email) : 0;
+    const baseline = decideBaselineStatus({
+      mode: config.mode,
+      priorApprovedCount,
+      isAuthenticated,
+    });
+    const candidate: CommentModerationCandidate = {
+      entryId: entry.id,
+      authorName: input.name,
+      authorEmail: email,
+      bodyMd: input.body,
+      ipHash,
+      isAuthenticated,
+    };
+    const verdict = await ctx.hooks.applyFilter(
+      "comment:moderate",
+      baseline,
+      candidate,
+    );
+    const status = applyModerationVerdict(baseline, verdict);
+
+    const row = await insertComment(ctx, {
+      entryId: entry.id,
+      status,
+      authorUserId: authUser?.id ?? null,
+      // Display name is commenter-supplied even when logged in; the real
+      // account link lives in authorUserId. Sourcing it from the user
+      // record (WP-style snapshot) is a later refinement.
+      authorName: input.name,
+      authorEmail: email,
+      bodyMd: input.body,
+      ipHash,
+      userAgent,
+    });
+
+    await ctx.hooks.doAction("comment:created", row);
+
+    return jsonResponse({ status });
+  };
+}

--- a/packages/plugins/comments/src/test/factories.ts
+++ b/packages/plugins/comments/src/test/factories.ts
@@ -49,6 +49,9 @@ export const commentFactory = Factory.define<NewComment, DbTransient, Comment>(
       bodyMd: params.bodyMd ?? `Comment body ${String(sequence)}`,
       ipHash: params.ipHash ?? null,
       userAgent: params.userAgent ?? null,
+      // Passed through (undefined → DB `unixepoch()` default) so tests can
+      // backdate a row to exercise the rate-limit window.
+      createdAt: params.createdAt,
     };
   },
 );

--- a/packages/plugins/comments/src/types.ts
+++ b/packages/plugins/comments/src/types.ts
@@ -12,6 +12,21 @@ export const COMMENT_STATUSES = [
 
 export type CommentStatus = (typeof COMMENT_STATUSES)[number];
 
+/**
+ * Trust policy for a new comment:
+ * - `all` — always hold for moderation.
+ * - `first_time` — hold a new email's first comment; auto-approve once it
+ *   has a prior approved comment (WordPress `comment_previously_approved`).
+ * - `none` — auto-approve everything.
+ */
+export type ModerationMode = "all" | "first_time" | "none";
+
+/** Per-source rate limit for public submissions. */
+export interface RateLimitConfig {
+  readonly max: number;
+  readonly windowMin: number;
+}
+
 /** Set-once configuration passed to `comments(options)` at include time. */
 export interface CommentsConfig {
   /**
@@ -20,4 +35,12 @@ export interface CommentsConfig {
    * analog for types whose registration you don't own.
    */
   readonly entryTypes?: readonly string[];
+  /** Trust policy. Defaults to `"first_time"`. */
+  readonly mode?: ModerationMode;
+  /** Require a non-empty author email. Defaults to `true`. */
+  readonly requireEmail?: boolean;
+  /** Reject comments on posts older than this many days. `null` = never. */
+  readonly closeAfterDays?: number | null;
+  /** Sliding-window rate limit. Defaults to `{ max: 5, windowMin: 10 }`. */
+  readonly rateLimit?: RateLimitConfig;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -847,6 +847,9 @@ importers:
       markdown-it:
         specifier: ^14.1.0
         version: 14.2.0
+      valibot:
+        specifier: 'catalog:'
+        version: 1.4.1(typescript@6.0.3)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'


### PR DESCRIPTION
Slice 2 of 8 for the comments plugin (PRD #959). Adds the public submission path on top of the read path: site visitors can now post a comment, which flows through a trust-based moderation pipeline before it appears.

The route is `POST /_plumix/comments/submit` (`auth: "public"`), behind the dispatcher's existing CSRF header + same-origin guard. The handler runs a deliberate pipeline with the cheap rejects first.

**Moderation is an extensible, fail-safe filter chain**

A trust baseline (`all` / `first_time` / `none`, default `first_time`; logged-in commenters fast-path to approved) is folded with the `comment:moderate` filter chain via a most-restrictive clamp — registered filters may only *demote* a comment, so spam/Akismet/AI detectors compose without caring about order, and a filter that returns a non-status is ignored rather than persisted. `comment:moderate` and the `comment:created` action ship with their registry augmentation, exported from `/server` for those future plugins.

**Spam + abuse defense without extra infrastructure**

A hidden honeypot field returns a fake success (indistinguishable from a held comment) and is never stored. A salted SHA-256 IP hash — per-install salt generated lazily and persisted in the settings table — feeds a sliding-window rate limit that counts the plugin's own rows, so no KV binding is required. Cleartext IPs are never stored.

**Identity & privacy**

The public route authenticates the session itself to grant logged-in users the trust fast-path. Email is lowercased so the trust lookup and Gravatar resolve one identity, and it stays server-side (never in the public payload).

### Testing

63 tests. The submit pipeline is covered end to end through the in-process dispatcher harness (auto-approve, first-time hold, honeypot drop, disabled-type/closed/require-email rejections, rate-limit 429, a `comment:moderate` filter demoting to spam, the `comment:created` action firing, and a salted-IP-hash-never-cleartext assertion), plus unit suites for the moderation engine (incl. the invalid-verdict guard), rate limiter, salt, IP hash, and repository. Required gates — lint, typecheck, knip, format, commitlint — all green.

### Notes / decisions

- **Trust-model caveat (documented in code):** `first_time` auto-approves an *unverified* prior-approved email — WordPress's `comment_previously_approved` model. The moderation queue (#963) and the `comment:moderate` chain are the backstop; email verification is a future hardening.
- **IP trust:** `cf-connecting-ip` is authoritative on Cloudflare; the `x-forwarded-for` fallback is best-effort off-CF (edge/WAF is the real flood layer). Noted in code.
- Display name is commenter-supplied even when logged in (the account link lives in `authorUserId`); WP-style snapshot-from-record is a later refinement.

### Out of scope (later slices)

Threading depth/clamp (#962), admin moderation queue (#963), bulk/search (#964), moderator email (#965), i18n (#966), pagination (#967).

Closes #961
Refs #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)