### PR TITLE
feat(plugin-comments): threaded replies with depth clamp

### DIFF
--- a/packages/plugins/comments/playground/theme.ts
+++ b/packages/plugins/comments/playground/theme.ts
@@ -8,9 +8,38 @@ import { defineTemplate, defineTheme } from "plumix";
 import type { ResolvedThread } from "@plumix/plugin-comments/server";
 
 // Minimal single-post template that renders the approved comment thread
-// the `comments` template dep resolves for the current entry. Authored
-// with `createElement` (no JSX) so the first real plumix theme stays
-// transform-agnostic across jiti config load + the vite worker bundle.
+// the `comments` template dep resolves for the current entry, recursing
+// into nested replies. Authored with `createElement` (no JSX) so the
+// first real plumix theme stays transform-agnostic across jiti config
+// load + the vite worker bundle.
+type ThreadComment = ResolvedThread["comments"][number];
+
+function commentItem(comment: ThreadComment): ReactNode {
+  return h(
+    "li",
+    { key: comment.id, "data-testid": `comment-item-${String(comment.id)}` },
+    h("img", {
+      "data-testid": "comment-avatar",
+      src: comment.avatarUrl,
+      alt: "",
+      width: 48,
+      height: 48,
+    }),
+    h("span", { "data-testid": "comment-author" }, comment.authorName),
+    h("div", {
+      "data-testid": "comment-body",
+      dangerouslySetInnerHTML: { __html: comment.bodyHtml },
+    }),
+    comment.replies.length > 0
+      ? h(
+          "ul",
+          { "data-testid": "comment-replies" },
+          comment.replies.map(commentItem),
+        )
+      : null,
+  );
+}
+
 const single = defineTemplate<SingleData>({
   comments: ["current"],
   render: ({ data, comments }): ReactNode => {
@@ -30,31 +59,7 @@ const single = defineTemplate<SingleData>({
         h(
           "ul",
           { "data-testid": "comments-list" },
-          (thread?.comments ?? []).map((comment) =>
-            h(
-              "li",
-              {
-                key: comment.id,
-                "data-testid": `comment-item-${String(comment.id)}`,
-              },
-              h("img", {
-                "data-testid": "comment-avatar",
-                src: comment.avatarUrl,
-                alt: "",
-                width: 48,
-                height: 48,
-              }),
-              h(
-                "span",
-                { "data-testid": "comment-author" },
-                comment.authorName,
-              ),
-              h("div", {
-                "data-testid": "comment-body",
-                dangerouslySetInnerHTML: { __html: comment.bodyHtml },
-              }),
-            ),
-          ),
+          (thread?.comments ?? []).map(commentItem),
         ),
       ),
     );

--- a/packages/plugins/comments/src/config.ts
+++ b/packages/plugins/comments/src/config.ts
@@ -8,6 +8,7 @@ import type {
 export interface ResolvedCommentsConfig {
   readonly entryTypes: readonly string[];
   readonly mode: ModerationMode;
+  readonly maxDepth: number;
   readonly requireEmail: boolean;
   readonly closeAfterDays: number | null;
   readonly rateLimit: RateLimitConfig;
@@ -17,6 +18,7 @@ export function resolveConfig(options: CommentsConfig): ResolvedCommentsConfig {
   return {
     entryTypes: options.entryTypes ?? [],
     mode: options.mode ?? "first_time",
+    maxDepth: options.maxDepth ?? 3,
     requireEmail: options.requireEmail ?? true,
     closeAfterDays: options.closeAfterDays ?? null,
     rateLimit: options.rateLimit ?? { max: 5, windowMin: 10 },

--- a/packages/plugins/comments/src/index.test.ts
+++ b/packages/plugins/comments/src/index.test.ts
@@ -2,6 +2,7 @@ import type { AppContext } from "plumix/plugin";
 import { describe, expect, test } from "vitest";
 
 import type { CommentsTestDb } from "./test/db.js";
+import { resolveConfig } from "./config.js";
 import { comments } from "./index.js";
 import { createCommentsThreadLoader } from "./server/template-dep.js";
 import { createCommentsTestDb, seedPublishedPost } from "./test/db.js";
@@ -51,7 +52,9 @@ describe("createCommentsThreadLoader", () => {
   test("loads the current entry's approved thread when enabled", async () => {
     const db = await createCommentsTestDb();
     const entry = await seedApprovedPost(db);
-    const load = createCommentsThreadLoader({ entryTypes: ["post"] });
+    const load = createCommentsThreadLoader(
+      resolveConfig({ entryTypes: ["post"] }),
+    );
 
     const result = await load(
       ["current"],
@@ -65,7 +68,7 @@ describe("createCommentsThreadLoader", () => {
   test("yields nothing for a comment-disabled entry type", async () => {
     const db = await createCommentsTestDb();
     const entry = await seedApprovedPost(db);
-    const load = createCommentsThreadLoader({});
+    const load = createCommentsThreadLoader(resolveConfig({}));
 
     const result = await load(
       ["current"],
@@ -78,7 +81,9 @@ describe("createCommentsThreadLoader", () => {
   test("yields nothing when there is no resolved entry", async () => {
     const db = await createCommentsTestDb();
     await seedApprovedPost(db);
-    const load = createCommentsThreadLoader({ entryTypes: ["post"] });
+    const load = createCommentsThreadLoader(
+      resolveConfig({ entryTypes: ["post"] }),
+    );
 
     const result = await load(["current"], ctxWith(db, null));
 

--- a/packages/plugins/comments/src/render.test.ts
+++ b/packages/plugins/comments/src/render.test.ts
@@ -22,7 +22,26 @@ const testBlog = definePlugin("test_blog", {
   },
 });
 
-// Theme that renders the approved thread the `comments` dep resolves.
+// Theme that renders the approved thread the `comments` dep resolves,
+// recursing into nested replies.
+function renderComment(
+  comment: ResolvedThread["comments"][number],
+): ReturnType<typeof el> {
+  return el(
+    "li",
+    { key: comment.id, "data-testid": "comment" },
+    el("span", { "data-testid": "comment-author" }, comment.authorName),
+    el("div", { dangerouslySetInnerHTML: { __html: comment.bodyHtml } }),
+    comment.replies.length > 0
+      ? el(
+          "ul",
+          { "data-testid": "replies" },
+          ...comment.replies.map(renderComment),
+        )
+      : null,
+  );
+}
+
 const single = defineTemplate<SingleData>({
   comments: ["current"],
   render: ({ data, comments: threadDep }) => {
@@ -32,14 +51,7 @@ const single = defineTemplate<SingleData>({
       null,
       el("h1", { "data-testid": "post-title" }, data.entry.title),
       el("p", { "data-testid": "comments-count" }, String(thread?.count ?? 0)),
-      ...(thread?.comments ?? []).map((comment) =>
-        el(
-          "article",
-          { key: comment.id, "data-testid": "comment" },
-          el("span", { "data-testid": "comment-author" }, comment.authorName),
-          el("div", { dangerouslySetInnerHTML: { __html: comment.bodyHtml } }),
-        ),
-      ),
+      el("ul", null, ...(thread?.comments ?? []).map(renderComment)),
     );
   },
 });
@@ -110,5 +122,34 @@ describe("comments read path through the dispatcher", () => {
     expect(html).toContain("Hello World");
     expect(html).toContain('data-testid="comments-count">0<');
     expect(html).not.toContain("Unheard");
+  });
+
+  test("renders a reply nested under its parent", async () => {
+    const harness = await createDispatcherHarness({
+      plugins: [testBlog, comments({ entryTypes: ["post"] })],
+      theme,
+    });
+    await applyCommentsSchema(harness.db);
+    const entry = await seedPost(harness, "threaded");
+    const seed = commentFactory.transient({ db: harness.db });
+    const root = await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      bodyMd: "the root",
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: root.id,
+      bodyMd: "the reply",
+    });
+
+    const html = await (await harness.fetch("/posts/threaded")).text();
+
+    expect(html).toContain('data-testid="comments-count">2<');
+    // The reply renders inside the parent's nested replies list.
+    const repliesIdx = html.indexOf('data-testid="replies"');
+    expect(repliesIdx).toBeGreaterThan(-1);
+    expect(html.indexOf("the reply")).toBeGreaterThan(repliesIdx);
   });
 });

--- a/packages/plugins/comments/src/server/load-thread.test.ts
+++ b/packages/plugins/comments/src/server/load-thread.test.ts
@@ -20,7 +20,7 @@ describe("loadThread", () => {
     await f.create({ entryId: entry.id, status: "spam" });
     await f.create({ entryId: entry.id, status: "trash" });
 
-    const thread = await loadThread(ctxFor(db), entry.id);
+    const thread = await loadThread(ctxFor(db), entry.id, 3);
 
     expect(thread.count).toBe(1);
     expect(thread.comments).toHaveLength(1);
@@ -51,7 +51,7 @@ describe("loadThread", () => {
       authorUserId: null,
     });
 
-    const thread = await loadThread(ctxFor(db), entry.id);
+    const thread = await loadThread(ctxFor(db), entry.id, 3);
     expect(thread.comments.map((c) => c.isRegistered).sort()).toEqual([
       false,
       true,
@@ -67,8 +67,8 @@ describe("loadThread", () => {
     await f.create({ entryId: b.id, status: "approved" });
     await f.create({ entryId: b.id, status: "approved" });
 
-    expect((await loadThread(ctxFor(db), a.id)).count).toBe(1);
-    expect((await loadThread(ctxFor(db), b.id)).count).toBe(2);
+    expect((await loadThread(ctxFor(db), a.id, 3)).count).toBe(1);
+    expect((await loadThread(ctxFor(db), b.id, 3)).count).toBe(2);
   });
 
   test("returns an empty thread when nothing is approved", async () => {
@@ -78,8 +78,84 @@ describe("loadThread", () => {
       .transient({ db })
       .create({ entryId: entry.id, status: "pending" });
 
-    const thread = await loadThread(ctxFor(db), entry.id);
+    const thread = await loadThread(ctxFor(db), entry.id, 3);
     expect(thread.count).toBe(0);
     expect(thread.comments).toEqual([]);
+  });
+});
+
+describe("loadThread — nesting", () => {
+  test("nests an approved reply under its parent, replies chronological", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    const root = await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      bodyMd: "root",
+      createdAt: new Date("2026-06-01T00:00:00Z"),
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: root.id,
+      bodyMd: "second",
+      createdAt: new Date("2026-06-03T00:00:00Z"),
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: root.id,
+      bodyMd: "first",
+      createdAt: new Date("2026-06-02T00:00:00Z"),
+    });
+
+    const thread = await loadThread(ctxFor(db), entry.id, 3);
+    expect(thread.count).toBe(3);
+    expect(thread.comments).toHaveLength(1);
+    const replies = thread.comments[0]?.replies ?? [];
+    expect(replies.map((r) => r.bodyHtml.includes("first"))).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  test("excludes a reply whose parent isn't approved", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    const hiddenParent = await seed.create({
+      entryId: entry.id,
+      status: "pending",
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: hiddenParent.id,
+    });
+
+    const thread = await loadThread(ctxFor(db), entry.id, 3);
+    expect(thread.count).toBe(0);
+  });
+
+  test("the maxDepth bound stops the recursion", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    const root = await seed.create({ entryId: entry.id, status: "approved" });
+    const reply = await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: root.id,
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: reply.id,
+    });
+
+    // maxDepth 1 → root (0) + its direct reply (1); the depth-2 reply is cut.
+    const thread = await loadThread(ctxFor(db), entry.id, 1);
+    expect(thread.count).toBe(2);
   });
 });

--- a/packages/plugins/comments/src/server/load-thread.ts
+++ b/packages/plugins/comments/src/server/load-thread.ts
@@ -1,15 +1,14 @@
 import type { AppContext } from "plumix/plugin";
-import { and, asc, eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 
-import { comments } from "../db/schema.js";
+import type { ThreadNode } from "./thread.js";
 import { gravatarUrl } from "./gravatar.js";
 import { renderCommentBody } from "./render-body.js";
+import { assembleThread } from "./thread.js";
 
 /**
- * A comment as exposed to the public theme. Deliberately omits
- * `authorEmail` and `ipHash` — those stay server-side. `isRegistered`
- * is the only signal of the author's account status (a verified badge);
- * `bodyHtml` is the rendered, sanitized markdown.
+ * A comment as exposed to the public theme — deliberately omits
+ * `authorEmail` and `ipHash`, which stay server-side.
  */
 export interface ResolvedComment {
   readonly id: number;
@@ -18,15 +17,21 @@ export interface ResolvedComment {
   readonly avatarUrl: string;
   readonly bodyHtml: string;
   readonly createdAt: Date;
+  readonly replies: readonly ResolvedComment[];
 }
 
-/** The assembled comment thread for one entry. */
+/** The assembled comment thread for one entry. `count` is every approved
+ * comment in the tree; `comments` are the roots (each with nested replies). */
 export interface ResolvedThread {
   readonly entryId: number;
   readonly comments: readonly ResolvedComment[];
   readonly count: number;
 }
 
+// Augment the template-dep registry so themes can declare
+// `defineTemplate({ comments: ["current"], render })` and receive a
+// `ResolvedThread` for the entry being rendered.
+//
 // Lives alongside the exported `ResolvedThread` (not the plugin entry) so
 // a theme importing the type from `./server` pulls the `comments` dep kind
 // into its `TemplateDepRegistry` too.
@@ -36,34 +41,75 @@ declare module "plumix/plugin" {
   }
 }
 
+type CommentValue = Omit<ResolvedComment, "replies">;
+
+interface CommentRow {
+  readonly id: number;
+  readonly parent_id: number | null;
+  readonly author_user_id: number | null;
+  readonly author_name: string;
+  readonly author_email: string;
+  readonly body_md: string;
+  // Unix seconds: the raw CTE bypasses drizzle's timestamp codec, so this
+  // is the stored integer — hence the `* 1000` when building the Date.
+  readonly created_at: number;
+}
+
+function toResolved(node: ThreadNode<CommentValue>): ResolvedComment {
+  return { ...node.value, replies: node.replies.map(toResolved) };
+}
+
 /**
- * Load the approved comments for an entry, rendered for display. Flat
- * and chronological for the read-path slice; threading (#962) and root
- * pagination (#967) build on this. One indexed query, then per-comment
- * markdown render + avatar hashing in parallel — no N+1.
+ * Load the approved thread for an entry, rendered for display. One
+ * recursive CTE walks roots → descendants down to `maxDepth` (the depth
+ * bound is a safety net; the submit path already clamps stored depth);
+ * the rows render in parallel (no N+1) and `assembleThread` nests them.
+ * A reply whose parent isn't approved is excluded (the CTE only descends
+ * through approved rows), not promoted. Chronological within each sibling
+ * group; root pagination + ordering are a later slice.
  */
 export async function loadThread(
   ctx: AppContext,
   entryId: number,
+  maxDepth: number,
 ): Promise<ResolvedThread> {
-  const rows = await ctx.db
-    .select()
-    .from(comments)
-    .where(and(eq(comments.entryId, entryId), eq(comments.status, "approved")))
-    .orderBy(asc(comments.createdAt), asc(comments.id));
+  const rows = await ctx.db.all<CommentRow>(sql`
+    WITH RECURSIVE thread AS (
+      SELECT id, parent_id, author_user_id, author_name, author_email,
+             body_md, created_at, 0 AS depth
+      FROM comments
+      WHERE entry_id = ${entryId} AND status = 'approved' AND parent_id IS NULL
+      UNION ALL
+      SELECT c.id, c.parent_id, c.author_user_id, c.author_name,
+             c.author_email, c.body_md, c.created_at, t.depth + 1
+      FROM comments c
+      JOIN thread t ON c.parent_id = t.id
+      WHERE c.status = 'approved' AND t.depth + 1 <= ${maxDepth}
+    )
+    SELECT id, parent_id, author_user_id, author_name, author_email,
+           body_md, created_at
+    FROM thread
+    ORDER BY created_at ASC, id ASC
+  `);
 
-  const resolved = await Promise.all(
-    rows.map(
-      async (row): Promise<ResolvedComment> => ({
+  const inputs = await Promise.all(
+    rows.map(async (row) => ({
+      id: row.id,
+      parentId: row.parent_id,
+      value: {
         id: row.id,
-        authorName: row.authorName,
-        isRegistered: row.authorUserId !== null,
-        avatarUrl: await gravatarUrl(row.authorEmail),
-        bodyHtml: renderCommentBody(row.bodyMd),
-        createdAt: row.createdAt,
-      }),
-    ),
+        authorName: row.author_name,
+        isRegistered: row.author_user_id !== null,
+        avatarUrl: await gravatarUrl(row.author_email),
+        bodyHtml: renderCommentBody(row.body_md),
+        createdAt: new Date(row.created_at * 1000),
+      } satisfies CommentValue,
+    })),
   );
 
-  return { entryId, comments: resolved, count: resolved.length };
+  return {
+    entryId,
+    comments: assembleThread(inputs).map(toResolved),
+    count: rows.length,
+  };
 }

--- a/packages/plugins/comments/src/server/repository.test.ts
+++ b/packages/plugins/comments/src/server/repository.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "vitest";
 
 import { createCommentsTestDb, ctxFor, seedPublishedPost } from "../test/db.js";
 import { commentFactory } from "../test/factories.js";
-import { countPriorApproved, insertComment } from "./repository.js";
+import {
+  clampParent,
+  countPriorApproved,
+  insertComment,
+} from "./repository.js";
 
 describe("countPriorApproved", () => {
   test("counts only approved comments for the given email", async () => {
@@ -51,5 +55,65 @@ describe("insertComment", () => {
     expect(row.id).toBeGreaterThan(0);
     expect(row.status).toBe("pending");
     expect(row.entryId).toBe(entry.id);
+  });
+});
+
+describe("clampParent", () => {
+  async function seedChain(
+    db: Awaited<ReturnType<typeof createCommentsTestDb>>,
+  ) {
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    const root = await seed.create({ entryId: entry.id, status: "approved" });
+    const c1 = await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: root.id,
+    });
+    const c2 = await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: c1.id,
+    });
+    const c3 = await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: c2.id,
+    });
+    return { entry, root, c1, c2, c3 };
+  }
+
+  test("returns null for a root comment (no parent)", async () => {
+    const db = await createCommentsTestDb();
+    const { entry } = await seedChain(db);
+    expect(await clampParent(ctxFor(db), null, entry.id, 3)).toBeNull();
+  });
+
+  test("keeps the parent when within the depth cap", async () => {
+    const db = await createCommentsTestDb();
+    const { entry, root, c1 } = await seedChain(db);
+    expect(await clampParent(ctxFor(db), root.id, entry.id, 3)).toBe(root.id);
+    expect(await clampParent(ctxFor(db), c1.id, entry.id, 3)).toBe(c1.id);
+  });
+
+  test("clamps a reply past the cap to the deepest allowed ancestor", async () => {
+    const db = await createCommentsTestDb();
+    const { entry, c2, c3 } = await seedChain(db);
+    // cap 3: replying to the depth-3 comment (c3) clamps to the depth-2
+    // ancestor (c2) so the new comment lands at depth 3, not 4.
+    expect(await clampParent(ctxFor(db), c3.id, entry.id, 3)).toBe(c2.id);
+  });
+
+  test("rejects a parent from a different entry", async () => {
+    const db = await createCommentsTestDb();
+    const { root } = await seedChain(db);
+    const other = await seedPublishedPost(db);
+    expect(await clampParent(ctxFor(db), root.id, other.id, 3)).toBeNull();
+  });
+
+  test("rejects a non-existent parent", async () => {
+    const db = await createCommentsTestDb();
+    const { entry } = await seedChain(db);
+    expect(await clampParent(ctxFor(db), 999_999, entry.id, 3)).toBeNull();
   });
 });

--- a/packages/plugins/comments/src/server/repository.ts
+++ b/packages/plugins/comments/src/server/repository.ts
@@ -4,6 +4,57 @@ import { and, count, eq } from "drizzle-orm";
 import type { Comment, NewComment } from "../db/schema.js";
 import { comments } from "../db/schema.js";
 
+// Absolute walk ceiling, independent of maxDepth, so the true depth is
+// measured even if maxDepth was lowered after deep rows were written
+// (otherwise the clamp could under-count and let a reply escape the cap).
+// Doubles as a cycle guard against (impossible-but-cheap-to-defend) loops.
+const MAX_ANCESTOR_WALK = 1000;
+
+/**
+ * Resolve the parent a new reply should actually attach to, clamped so the
+ * reply never lands deeper than `maxDepth` (root = 0). Replying to a
+ * comment already at the cap re-parents to its deepest in-cap ancestor.
+ * Returns null (a root comment) when there's no parent, the parent is
+ * missing, or it belongs to another entry.
+ */
+export async function clampParent(
+  ctx: AppContext,
+  requestedParentId: number | null,
+  entryId: number,
+  maxDepth: number,
+): Promise<number | null> {
+  if (requestedParentId === null) return null;
+
+  // Ancestor ids, child-first: [requestedParent, …, root].
+  const chain: number[] = [];
+  let cursor: number | null = requestedParentId;
+  while (cursor !== null && chain.length < MAX_ANCESTOR_WALK) {
+    const [row] = await ctx.db
+      .select({
+        id: comments.id,
+        parentId: comments.parentId,
+        entryId: comments.entryId,
+      })
+      .from(comments)
+      .where(eq(comments.id, cursor));
+    if (!row) break;
+    // The requested parent must belong to this entry; ancestors follow.
+    if (chain.length === 0 && row.entryId !== entryId) return null;
+    chain.push(row.id);
+    cursor = row.parentId;
+  }
+  if (chain.length === 0) return null;
+
+  // The requested parent sits at depth chain.length - 1 (root = 0). Cap the
+  // new comment at maxDepth by attaching to the ancestor at maxDepth - 1
+  // (or the parent itself when it's already shallower). chain is child-first,
+  // so that ancestor is this many entries from the end:
+  const requestedDepth = chain.length - 1;
+  const targetDepth = Math.min(requestedDepth, maxDepth - 1);
+  const indexFromRoot = chain.length - 1 - targetDepth;
+  return chain[indexFromRoot] ?? null;
+}
+
 /**
  * How many approved comments an email already has — the trust-policy
  * lookup that lets `first_time` moderation auto-approve a returning,

--- a/packages/plugins/comments/src/server/submit.test.ts
+++ b/packages/plugins/comments/src/server/submit.test.ts
@@ -172,4 +172,38 @@ describe("POST /_plumix/comments/submit", () => {
     expect(stored[0]?.ipHash).toMatch(/^[0-9a-f]{64}$/);
     expect(stored[0]?.ipHash).not.toContain("203.0.113.7");
   });
+
+  test("stores a reply under its parent", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"], mode: "none" });
+    const entry = await seedPost(harness);
+    await submit(harness, entry.id, { body: "root" });
+    const root = (await rows(harness)).find((c) => c.bodyMd === "root");
+
+    const res = await submit(harness, entry.id, {
+      body: "reply",
+      parentId: root?.id,
+    });
+
+    res.assertStatus(200);
+    const reply = (await rows(harness)).find((c) => c.bodyMd === "reply");
+    expect(reply?.parentId).toBe(root?.id);
+  });
+
+  test("clamps a reply that would exceed maxDepth", async () => {
+    const harness = await harnessWith({
+      entryTypes: ["post"],
+      mode: "none",
+      maxDepth: 1,
+    });
+    const entry = await seedPost(harness);
+    await submit(harness, entry.id, { body: "root" });
+    const root = (await rows(harness)).find((c) => c.bodyMd === "root");
+    await submit(harness, entry.id, { body: "d1", parentId: root?.id });
+    const d1 = (await rows(harness)).find((c) => c.bodyMd === "d1");
+
+    // depth-1 cap: a reply to the depth-1 comment clamps back to the root.
+    await submit(harness, entry.id, { body: "d2", parentId: d1?.id });
+    const d2 = (await rows(harness)).find((c) => c.bodyMd === "d2");
+    expect(d2?.parentId).toBe(root?.id);
+  });
 });

--- a/packages/plugins/comments/src/server/submit.ts
+++ b/packages/plugins/comments/src/server/submit.ts
@@ -8,7 +8,11 @@ import type { CommentModerationCandidate } from "./hooks.js";
 import { isCommentingEnabled } from "./enablement.js";
 import { hashIp } from "./ip-hash.js";
 import { applyModerationVerdict, decideBaselineStatus } from "./moderation.js";
-import { countPriorApproved, insertComment } from "./repository.js";
+import {
+  clampParent,
+  countPriorApproved,
+  insertComment,
+} from "./repository.js";
 import { getOrCreateIpSalt } from "./salt.js";
 import { checkRateLimit, isHoneypotTripped } from "./spam.js";
 
@@ -16,6 +20,10 @@ const MAX_UA_LENGTH = 1024;
 
 const submitInputSchema = v.object({
   entryId: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  parentId: v.optional(
+    v.nullable(v.pipe(v.number(), v.integer(), v.minValue(1))),
+    null,
+  ),
   name: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(120)),
   email: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(254)), ""),
   body: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(10_000)),
@@ -135,8 +143,16 @@ export function createSubmitHandler(config: ResolvedCommentsConfig) {
     );
     const status = applyModerationVerdict(baseline, verdict);
 
+    const parentId = await clampParent(
+      ctx,
+      input.parentId,
+      entry.id,
+      config.maxDepth,
+    );
+
     const row = await insertComment(ctx, {
       entryId: entry.id,
+      parentId,
       status,
       authorUserId: authUser?.id ?? null,
       // Display name is commenter-supplied even when logged in; the real

--- a/packages/plugins/comments/src/server/template-dep.ts
+++ b/packages/plugins/comments/src/server/template-dep.ts
@@ -2,7 +2,7 @@ import type { AppContext } from "plumix/plugin";
 import { eq } from "drizzle-orm";
 import { entries } from "plumix/schema";
 
-import type { CommentsConfig } from "../types.js";
+import type { ResolvedCommentsConfig } from "../config.js";
 import type { ResolvedThread } from "./load-thread.js";
 import { isCommentingEnabled } from "./enablement.js";
 import { loadThread } from "./load-thread.js";
@@ -15,7 +15,7 @@ import { loadThread } from "./load-thread.js";
  * thread keyed by each declared slug. Returns `{}` (→ `null` per slug)
  * for non-entry routes or comment-disabled types.
  */
-export function createCommentsThreadLoader(config: CommentsConfig) {
+export function createCommentsThreadLoader(config: ResolvedCommentsConfig) {
   return async (
     slugs: readonly string[],
     ctx: AppContext,
@@ -32,7 +32,7 @@ export function createCommentsThreadLoader(config: CommentsConfig) {
     const supports = ctx.plugins.entryTypes.get(row.type)?.supports;
     if (!isCommentingEnabled(row.type, supports, config)) return {};
 
-    const thread = await loadThread(ctx, resolved.id);
+    const thread = await loadThread(ctx, resolved.id, config.maxDepth);
     return Object.fromEntries(slugs.map((slug) => [slug, thread]));
   };
 }

--- a/packages/plugins/comments/src/server/thread.test.ts
+++ b/packages/plugins/comments/src/server/thread.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import { assembleThread } from "./thread.js";
+
+describe("assembleThread", () => {
+  test("returns an empty list for no input", () => {
+    expect(assembleThread([])).toEqual([]);
+  });
+
+  test("top-level comments become roots in input order", () => {
+    const tree = assembleThread([
+      { id: 1, parentId: null, value: "a" },
+      { id: 2, parentId: null, value: "b" },
+    ]);
+    expect(tree.map((n) => n.value)).toEqual(["a", "b"]);
+    expect(tree.every((n) => n.replies.length === 0)).toBe(true);
+  });
+
+  test("nests a reply under its parent", () => {
+    const tree = assembleThread([
+      { id: 1, parentId: null, value: "root" },
+      { id: 2, parentId: 1, value: "reply" },
+    ]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.value).toBe("root");
+    expect(tree[0]?.replies.map((n) => n.value)).toEqual(["reply"]);
+  });
+
+  test("nests multiple levels", () => {
+    const tree = assembleThread([
+      { id: 1, parentId: null, value: "r" },
+      { id: 2, parentId: 1, value: "c1" },
+      { id: 3, parentId: 2, value: "c2" },
+    ]);
+    expect(tree[0]?.replies[0]?.replies[0]?.value).toBe("c2");
+  });
+
+  test("preserves sibling order within a parent", () => {
+    const tree = assembleThread([
+      { id: 1, parentId: null, value: "r" },
+      { id: 2, parentId: 1, value: "first" },
+      { id: 3, parentId: 1, value: "second" },
+    ]);
+    expect(tree[0]?.replies.map((n) => n.value)).toEqual(["first", "second"]);
+  });
+
+  test("promotes an orphan (parent absent) to a root", () => {
+    // Parent is hidden (e.g. pending/spam) so it isn't in the set; the
+    // approved reply still surfaces rather than vanishing.
+    const tree = assembleThread([{ id: 2, parentId: 1, value: "orphan" }]);
+    expect(tree.map((n) => n.value)).toEqual(["orphan"]);
+  });
+});

--- a/packages/plugins/comments/src/server/thread.ts
+++ b/packages/plugins/comments/src/server/thread.ts
@@ -1,0 +1,45 @@
+interface ThreadInput<T> {
+  readonly id: number;
+  readonly parentId: number | null;
+  readonly value: T;
+}
+
+export interface ThreadNode<T> {
+  readonly value: T;
+  readonly replies: readonly ThreadNode<T>[];
+}
+
+interface MutableNode<T> {
+  readonly value: T;
+  readonly replies: ThreadNode<T>[];
+}
+
+/**
+ * Build a reply tree from a flat list, preserving input order within each
+ * sibling group. A node whose `parentId` isn't present in the set is
+ * promoted to a root. (Callers that pre-filter rows decide whether orphans
+ * can occur — `loadThread` excludes replies-to-unapproved at the query, so
+ * it never feeds an orphan here.)
+ */
+export function assembleThread<T>(
+  items: readonly ThreadInput<T>[],
+): ThreadNode<T>[] {
+  const nodes = new Map<number, MutableNode<T>>();
+  for (const item of items) {
+    nodes.set(item.id, { value: item.value, replies: [] });
+  }
+
+  const roots: ThreadNode<T>[] = [];
+  for (const item of items) {
+    const node = nodes.get(item.id);
+    if (!node) continue;
+    const parent =
+      item.parentId !== null ? nodes.get(item.parentId) : undefined;
+    if (parent) {
+      parent.replies.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  return roots;
+}

--- a/packages/plugins/comments/src/types.ts
+++ b/packages/plugins/comments/src/types.ts
@@ -37,6 +37,8 @@ export interface CommentsConfig {
   readonly entryTypes?: readonly string[];
   /** Trust policy. Defaults to `"first_time"`. */
   readonly mode?: ModerationMode;
+  /** Maximum reply nesting depth (root = 0). Defaults to `3`. */
+  readonly maxDepth?: number;
   /** Require a non-empty author email. Defaults to `true`. */
   readonly requireEmail?: boolean;
   /** Reject comments on posts older than this many days. `null` = never. */


### PR DESCRIPTION
Slice 3 of 8 for the comments plugin (PRD #959). Adds reply threading on top of the read + submit paths.

**Write-time depth clamp**

Submissions now accept a `parentId`, clamped so a reply never lands deeper than `maxDepth` (config, default 3; root = 0). Replying to a comment already at the cap re-parents to its deepest in-cap ancestor; a parent from another entry or a missing one falls back to a root. The clamp walks to the true root rather than stopping at `maxDepth`, so lowering `maxDepth` after deep rows exist still measures depth correctly (a review catch).

**Recursive-CTE read path**

`loadThread` is now a single `WITH RECURSIVE` query that walks approved roots → approved descendants down to `maxDepth`, renders the rows in parallel (no N+1), and nests them with a pure `assembleThread`. A reply whose parent isn't approved is excluded at the query (not promoted), so hidden parents don't leak structure. `ResolvedComment` carries a `replies` array and the theme renders it recursively.

### Testing

80 tests. New coverage: `assembleThread` (pure tree build, sibling order, orphan handling), the recursive CTE (nesting, the `maxDepth` bound, exclusion of replies-to-unapproved), `clampParent` (within-cap passthrough, past-cap re-parenting, cross-entry/missing rejection), the submit `parentId` path (stores under parent, clamps past-cap), and nested render through the dispatcher harness. Required gates — lint, typecheck, knip, format, commitlint — all green.

### Notes

- Root pagination + ordering (newest-first) are deferred to #967; this slice loads the whole approved tree per render.
- The clamp's ancestor walk is bounded by an absolute ceiling (cycle guard) independent of `maxDepth`.

### Out of scope (later slices)

Admin moderation queue (#963), bulk/search (#964), moderator email (#965), i18n (#966), root pagination (#967).

Closes #962
Refs #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)