### PR TITLE
feat(plugin-comments): admin moderation queue

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -226,14 +226,19 @@ const config: KnipConfig = {
       // See packages/admin above for why the playwright plugin is off.
       playwright: false,
     },
-    // The read-path slice (#960) ships the plugin entry + the server
-    // subpath; the read path is verified in-process via the dispatcher
-    // harness (public content can't render under `plumix dev`, which
-    // serves the admin SPA). The admin chunk + playwright e2e arrive
-    // with the moderation queue (#963).
+    // Admin chunk loaded via `adminEntry` at consumer build time; the
+    // playwright rig (globalSetup + spec) runs under plumix dev. None are
+    // static imports knip can follow.
     "packages/plugins/comments": {
-      entry: ["src/index.ts", "src/server/index.ts"],
+      entry: [
+        "src/index.ts",
+        "src/admin/index.tsx",
+        "src/server/index.ts",
+        "e2e/globalSetup.ts",
+        "e2e/*.spec.ts",
+      ],
       ignoreDependencies: ["@plumix/runtime-cloudflare"],
+      playwright: false,
     },
   },
 };

--- a/packages/plugins/comments/e2e/comments-admin.spec.ts
+++ b/packages/plugins/comments/e2e/comments-admin.spec.ts
@@ -1,0 +1,54 @@
+import { resolve } from "node:path";
+import { expect, test } from "@playwright/test";
+import { factoriesFor } from "plumix/test";
+import { openPlaygroundDb } from "plumix/test/playwright";
+
+import { commentFactory } from "../src/test/factories.js";
+
+// The public-facing render of an approved comment is covered in-process by
+// the dispatcher-harness render tests (plumix dev serves the admin SPA for
+// public routes). This suite exercises the admin moderation queue, which
+// runs under plumix dev like the other plugin admin e2es.
+let pendingId = 0;
+
+test.beforeAll(async () => {
+  const db = await openPlaygroundDb({
+    cwd: resolve(process.cwd(), "playground"),
+  });
+  const factories = factoriesFor(db);
+  const author = await factories.user.create({ email: "author@example.test" });
+  const entry = await factories.entry.create({
+    type: "post",
+    slug: "moderate-me",
+    title: "Moderate me",
+    authorId: author.id,
+    status: "published",
+  });
+  const comment = await commentFactory.transient({ db }).create({
+    entryId: entry.id,
+    status: "pending",
+    authorName: "Pending Pat",
+    bodyMd: "please review me",
+  });
+  pendingId = comment.id;
+});
+
+test("moderator approves a pending comment from the queue", async ({
+  page,
+}) => {
+  await page.goto("pages/comments");
+  await expect(page.getByTestId("comments-shell")).toBeVisible();
+
+  // Pending is the default tab; the seeded comment is listed.
+  const row = page.getByTestId(`comment-row-${String(pendingId)}`);
+  await expect(row).toBeVisible();
+
+  await page.getByTestId(`comment-approve-${String(pendingId)}`).click();
+
+  // It leaves the pending queue and shows under Approved.
+  await expect(row).toBeHidden();
+  await page.getByTestId("comments-tab-approved").click();
+  await expect(
+    page.getByTestId(`comment-row-${String(pendingId)}`),
+  ).toBeVisible();
+});

--- a/packages/plugins/comments/e2e/globalSetup.ts
+++ b/packages/plugins/comments/e2e/globalSetup.ts
@@ -1,0 +1,17 @@
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { actingAs, openPlaygroundDb } from "plumix/test/playwright";
+
+// Seeds an admin user into the migrated D1 and writes the storageState
+// playwright's `use.storageState` reads, so the moderation queue specs
+// run authenticated.
+export default async function globalSetup(): Promise<void> {
+  const playgroundCwd = resolve(process.cwd(), "playground");
+  const db = await openPlaygroundDb({ cwd: playgroundCwd });
+  const { storageState } = await actingAs(db, "admin");
+  await writeFile(
+    resolve(process.cwd(), "storageState.json"),
+    JSON.stringify(storageState, null, 2),
+    "utf8",
+  );
+}

--- a/packages/plugins/comments/e2e/playwright.config.ts
+++ b/packages/plugins/comments/e2e/playwright.config.ts
@@ -1,0 +1,9 @@
+import { definePlumixE2EConfig } from "plumix/test/playwright";
+
+export default definePlumixE2EConfig({
+  // Per-plugin HTTP + workerd inspector ports (convention: 30N0 ↔ 93N0).
+  // 3010 audit-log, 3020 blog, 3030 media, 3040 menu, 3050 pages, 3060 here.
+  port: 3060,
+  inspectorPort: 9360,
+  playground: "../playground",
+});

--- a/packages/plugins/comments/package.json
+++ b/packages/plugins/comments/package.json
@@ -54,6 +54,7 @@
     "lint": "eslint",
     "publint": "publint",
     "test": "vitest run",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
@@ -62,26 +63,37 @@
     "valibot": "catalog:"
   },
   "peerDependencies": {
-    "plumix": "workspace:*"
+    "@tanstack/react-query": "^5.100.14",
+    "plumix": "workspace:*",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@libsql/client": "catalog:",
+    "@orpc/server": "catalog:",
+    "@playwright/test": "catalog:",
     "@plumix/eslint-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/runtime-cloudflare": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
     "@plumix/vitest-config": "workspace:*",
+    "@tanstack/react-query": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "drizzle-kit": "catalog:",
     "eslint": "catalog:",
     "fishery": "catalog:",
+    "jsdom": "catalog:",
     "plumix": "workspace:*",
     "prettier": "catalog:",
     "publint": "catalog:",
     "react": "catalog:",
+    "react-dom": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/plugins/comments/src/admin/CommentsShell.test.tsx
+++ b/packages/plugins/comments/src/admin/CommentsShell.test.tsx
@@ -1,0 +1,146 @@
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { CommentsShell } from "./CommentsShell.js";
+
+interface CapturedCall {
+  readonly proc: string;
+  readonly body: { json?: { id?: number } } | undefined;
+}
+
+let calls: CapturedCall[];
+
+function mockRpc(handlers: Record<string, unknown>): void {
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const proc = url.replace("/_plumix/rpc/comments/", "");
+    const bodyStr = typeof init?.body === "string" ? init.body : null;
+    calls.push({
+      proc,
+      body: bodyStr ? (JSON.parse(bodyStr) as CapturedCall["body"]) : undefined,
+    });
+    return Promise.resolve(
+      new Response(JSON.stringify({ json: handlers[proc] ?? {}, meta: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+function renderShell(): ReactElement {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <CommentsShell />
+    </QueryClientProvider>,
+  ).container as unknown as ReactElement;
+}
+
+const ROW = {
+  id: 1,
+  entryId: 7,
+  parentId: null,
+  status: "pending",
+  authorName: "Ada Lovelace",
+  authorEmail: "ada@example.test",
+  bodyMd: "hello world",
+  ipHash: "abc123",
+  userAgent: null,
+  createdAt: "2026-06-01T00:00:00Z",
+};
+
+beforeEach(() => {
+  calls = [];
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("CommentsShell", () => {
+  test("renders status tabs with counts", async () => {
+    mockRpc({
+      counts: { pending: 3, approved: 8, spam: 1, trash: 0 },
+      list: [],
+    });
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("comments-count-pending")).toHaveTextContent(
+        "3",
+      );
+    });
+    expect(screen.getByTestId("comments-count-approved")).toHaveTextContent(
+      "8",
+    );
+  });
+
+  test("renders the pending queue rows", async () => {
+    mockRpc({
+      counts: { pending: 1, approved: 0, spam: 0, trash: 0 },
+      list: [ROW],
+    });
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("comment-row-1")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("comment-excerpt-1")).toHaveTextContent(
+      "hello world",
+    );
+  });
+
+  test("approving a row posts to the approve procedure", async () => {
+    mockRpc({
+      counts: { pending: 1, approved: 0, spam: 0, trash: 0 },
+      list: [ROW],
+      approve: { status: "approved" },
+    });
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("comment-approve-1")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("comment-approve-1"));
+    await waitFor(() => {
+      expect(calls.some((c) => c.proc === "approve")).toBe(true);
+    });
+    expect(calls.find((c) => c.proc === "approve")?.body?.json?.id).toBe(1);
+  });
+
+  test("opening a row reveals the detail panel with private context", async () => {
+    mockRpc({
+      counts: { pending: 1, approved: 0, spam: 0, trash: 0 },
+      list: [ROW],
+    });
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("comment-open-1")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("comment-open-1"));
+    expect(screen.getByTestId("comment-detail-email")).toHaveTextContent(
+      "ada@example.test",
+    );
+    expect(screen.getByTestId("comment-detail-ip")).toHaveTextContent("abc123");
+  });
+
+  test("shows an empty state when a tab has no comments", async () => {
+    mockRpc({
+      counts: { pending: 0, approved: 0, spam: 0, trash: 0 },
+      list: [],
+    });
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("comments-empty")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/plugins/comments/src/admin/CommentsShell.tsx
+++ b/packages/plugins/comments/src/admin/CommentsShell.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+
+import type {
+  CommentStatus,
+  ModerationAction,
+  ModerationCommentDTO,
+} from "./rpc.js";
+import { useCommentCounts, useCommentList, useModeration } from "./rpc.js";
+
+const TABS: readonly CommentStatus[] = ["pending", "approved", "spam", "trash"];
+
+// Which actions each status tab offers. `purge` (hard remove) is always
+// available; the rest move the comment between queues.
+const ACTIONS: Record<CommentStatus, readonly ModerationAction[]> = {
+  pending: ["approve", "spam", "trash", "purge"],
+  approved: ["spam", "trash", "purge"],
+  spam: ["approve", "trash", "purge"],
+  trash: ["restore", "purge"],
+};
+
+export function CommentsShell(): React.ReactElement {
+  const [tab, setTab] = useState<CommentStatus>("pending");
+  const [selected, setSelected] = useState<ModerationCommentDTO | null>(null);
+  const counts = useCommentCounts();
+  const list = useCommentList(tab);
+  const moderation = useModeration();
+
+  return (
+    <div data-testid="comments-shell">
+      <div data-testid="comments-tabs" role="tablist">
+        {TABS.map((status) => (
+          <button
+            key={status}
+            type="button"
+            data-testid={`comments-tab-${status}`}
+            aria-pressed={tab === status}
+            onClick={() => {
+              setTab(status);
+              setSelected(null);
+            }}
+          >
+            {status}{" "}
+            <span data-testid={`comments-count-${status}`}>
+              {counts.data?.[status] ?? 0}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {list.isLoading ? (
+        <div data-testid="comments-loading" />
+      ) : list.isError ? (
+        <div data-testid="comments-error">Failed to load comments</div>
+      ) : (list.data ?? []).length === 0 ? (
+        <p data-testid="comments-empty">No {tab} comments</p>
+      ) : (
+        <table data-testid="comments-table">
+          <tbody>
+            {(list.data ?? []).map((comment) => (
+              <tr key={comment.id} data-testid={`comment-row-${comment.id}`}>
+                <td>
+                  <button
+                    type="button"
+                    data-testid={`comment-open-${comment.id}`}
+                    onClick={() => setSelected(comment)}
+                  >
+                    {comment.authorName}
+                  </button>
+                </td>
+                <td data-testid={`comment-excerpt-${comment.id}`}>
+                  {comment.bodyMd.slice(0, 80)}
+                </td>
+                <td>
+                  {ACTIONS[tab].map((action) => (
+                    <button
+                      key={action}
+                      type="button"
+                      data-testid={`comment-${action}-${comment.id}`}
+                      disabled={moderation.isPending}
+                      onClick={() =>
+                        moderation.mutate({ action, id: comment.id })
+                      }
+                    >
+                      {action}
+                    </button>
+                  ))}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {selected ? (
+        <aside data-testid="comment-detail">
+          {/* Moderator sees the raw markdown source as text, not rendered HTML. */}
+          <div data-testid="comment-detail-body">{selected.bodyMd}</div>
+          <dl>
+            <dt>Author</dt>
+            <dd data-testid="comment-detail-author">{selected.authorName}</dd>
+            <dt>Email</dt>
+            <dd data-testid="comment-detail-email">{selected.authorEmail}</dd>
+            <dt>Entry</dt>
+            <dd data-testid="comment-detail-entry">{selected.entryId}</dd>
+            <dt>IP hash</dt>
+            <dd data-testid="comment-detail-ip">{selected.ipHash ?? "—"}</dd>
+            <dt>Submitted</dt>
+            <dd data-testid="comment-detail-date">{selected.createdAt}</dd>
+          </dl>
+        </aside>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/plugins/comments/src/admin/index.tsx
+++ b/packages/plugins/comments/src/admin/index.tsx
@@ -1,0 +1,19 @@
+import type { ComponentType } from "react";
+
+import { CommentsShell } from "./CommentsShell.js";
+
+interface PlumixWindowGlobal {
+  readonly registerPluginPage: (path: string, component: ComponentType) => void;
+}
+
+declare const window:
+  | {
+      readonly plumix?: PlumixWindowGlobal;
+    }
+  | undefined;
+
+if (typeof window !== "undefined") {
+  window.plumix?.registerPluginPage("/comments", CommentsShell);
+}
+
+export { CommentsShell };

--- a/packages/plugins/comments/src/admin/rpc.ts
+++ b/packages/plugins/comments/src/admin/rpc.ts
@@ -1,0 +1,79 @@
+import type { UseMutationResult, UseQueryResult } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export type CommentStatus = "pending" | "approved" | "spam" | "trash";
+
+export interface ModerationCommentDTO {
+  readonly id: number;
+  readonly entryId: number;
+  readonly parentId: number | null;
+  readonly status: CommentStatus;
+  readonly authorName: string;
+  readonly authorEmail: string;
+  readonly bodyMd: string;
+  readonly ipHash: string | null;
+  readonly userAgent: string | null;
+  readonly createdAt: string;
+}
+
+type StatusCounts = Record<CommentStatus, number>;
+export type ModerationAction =
+  | "approve"
+  | "spam"
+  | "trash"
+  | "restore"
+  | "purge";
+
+const COMMENTS_KEY = ["comments"] as const;
+
+async function rpcCall<TOutput>(
+  procedure: string,
+  input: unknown = {},
+): Promise<TOutput> {
+  const res = await fetch(`/_plumix/rpc/${procedure}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-plumix-request": "1" },
+    body: JSON.stringify({ json: input, meta: [] }),
+  });
+  const envelope = (await res.json().catch(() => null)) as {
+    json?: unknown;
+  } | null;
+  if (!res.ok) {
+    const error = envelope?.json as
+      | { message?: string; data?: { reason?: string } }
+      | undefined;
+    // eslint-disable-next-line no-restricted-syntax -- rethrow server-derived rpc error
+    throw new Error(
+      error?.data?.reason ?? error?.message ?? `rpc_${String(res.status)}`,
+    );
+  }
+  return envelope?.json as TOutput;
+}
+
+export function useCommentCounts(): UseQueryResult<StatusCounts> {
+  return useQuery({
+    queryKey: [...COMMENTS_KEY, "counts"],
+    queryFn: () => rpcCall<StatusCounts>("comments/counts"),
+  });
+}
+
+export function useCommentList(
+  status: CommentStatus,
+): UseQueryResult<ModerationCommentDTO[]> {
+  return useQuery({
+    queryKey: [...COMMENTS_KEY, "list", status],
+    queryFn: () => rpcCall<ModerationCommentDTO[]>("comments/list", { status }),
+  });
+}
+
+export function useModeration(): UseMutationResult<
+  unknown,
+  Error,
+  { action: ModerationAction; id: number }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ action, id }) => rpcCall(`comments/${action}`, { id }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: COMMENTS_KEY }),
+  });
+}

--- a/packages/plugins/comments/src/index.test.ts
+++ b/packages/plugins/comments/src/index.test.ts
@@ -35,16 +35,27 @@ describe("comments() plugin", () => {
     expect(plugin.schema).toBeDefined();
   });
 
-  test("setup registers a 'comments' template dep and a submit route", () => {
+  test("setup registers the moderation surface", () => {
     const kinds: string[] = [];
     const routes: string[] = [];
+    const capabilities: string[] = [];
+    const adminPaths: string[] = [];
+    let rpcRouter = false;
     const ctx = {
       registerTemplateDep: (kind: string) => kinds.push(kind),
       registerRoute: (opts: { path: string }) => routes.push(opts.path),
+      registerCapability: (name: string) => capabilities.push(name),
+      registerRpcRouter: () => {
+        rpcRouter = true;
+      },
+      registerAdminPage: (opts: { path: string }) => adminPaths.push(opts.path),
     } as unknown as Parameters<ReturnType<typeof comments>["setup"]>[0];
     void comments().setup(ctx, undefined);
     expect(kinds).toContain("comments");
     expect(routes).toContain("/submit");
+    expect(capabilities).toContain("comment:moderate");
+    expect(adminPaths).toContain("/comments");
+    expect(rpcRouter).toBe(true);
   });
 });
 

--- a/packages/plugins/comments/src/index.ts
+++ b/packages/plugins/comments/src/index.ts
@@ -3,11 +3,15 @@ import { definePlugin } from "plumix/plugin";
 import type { CommentsConfig } from "./types.js";
 import { resolveConfig } from "./config.js";
 import * as schema from "./db/schema.js";
+import { COMMENT_MODERATE_CAPABILITY, createCommentsRouter } from "./rpc.js";
 import { createSubmitHandler } from "./server/submit.js";
 import { createCommentsThreadLoader } from "./server/template-dep.js";
 
 export type { CommentsConfig, CommentStatus, ModerationMode } from "./types.js";
 export { COMMENT_STATUSES } from "./types.js";
+
+const ADMIN_ENTRY_PATH =
+  "node_modules/@plumix/plugin-comments/dist/admin/index.js";
 
 /**
  * `@plumix/plugin-comments` — threaded, moderated discussion on entries.
@@ -37,7 +41,22 @@ export function comments(options: CommentsConfig = {}) {
     // Module specifier `plumix migrate generate` uses to fold this
     // plugin's table into the host's drizzle-kit codegen.
     schemaModule: "@plumix/plugin-comments/schema",
+    adminEntry: ADMIN_ENTRY_PATH,
     setup: (ctx) => {
+      ctx.registerCapability(COMMENT_MODERATE_CAPABILITY, "editor");
+      ctx.registerRpcRouter(createCommentsRouter());
+      ctx.registerAdminPage({
+        path: "/comments",
+        title: "Comments",
+        capability: COMMENT_MODERATE_CAPABILITY,
+        nav: {
+          group: { id: "content", label: "Content", priority: 200 },
+          label: "Comments",
+          order: 30,
+          keywords: ["moderation", "discussion", "replies", "spam"],
+        },
+        component: "CommentsShell",
+      });
       ctx.registerTemplateDep("comments", {
         load: createCommentsThreadLoader(config),
       });

--- a/packages/plugins/comments/src/rpc.test.ts
+++ b/packages/plugins/comments/src/rpc.test.ts
@@ -1,0 +1,162 @@
+import type { RequestAuthenticator, User, UserRole } from "plumix/plugin";
+import { createRouterClient } from "@orpc/server";
+import {
+  createAppContext,
+  createPluginRegistry,
+  HookRegistry,
+  installPlugins,
+} from "plumix/plugin";
+import { editorUser, factoriesFor } from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+import type { ModerationCommentDTO } from "./rpc.js";
+import type { CommentStatus } from "./types.js";
+import { comments } from "./index.js";
+import { createCommentsTestDb, seedPublishedPost } from "./test/db.js";
+import { commentFactory } from "./test/factories.js";
+
+interface Client {
+  readonly comments: {
+    readonly list: (input: {
+      status: CommentStatus;
+      limit?: number;
+      offset?: number;
+    }) => Promise<ModerationCommentDTO[]>;
+    readonly counts: () => Promise<Record<CommentStatus, number>>;
+    readonly approve: (input: { id: number }) => Promise<{ status: string }>;
+    readonly spam: (input: { id: number }) => Promise<{ status: string }>;
+    readonly trash: (input: { id: number }) => Promise<{ status: string }>;
+    readonly restore: (input: { id: number }) => Promise<{ status: string }>;
+    readonly purge: (input: { id: number }) => Promise<{ result: string }>;
+  };
+}
+
+function stubAuthenticator(user: User): RequestAuthenticator {
+  return { authenticate: () => Promise.resolve({ user, tokenScopes: null }) };
+}
+
+async function buildHarness(role: UserRole = "editor") {
+  const db = await createCommentsTestDb();
+  const hooks = new HookRegistry();
+  const registry = createPluginRegistry();
+  await installPlugins({ hooks, plugins: [comments()], registry });
+
+  const user =
+    role === "editor"
+      ? await editorUser.transient({ db }).create({})
+      : await factoriesFor(db).user.create({ role });
+
+  const ctx = createAppContext({
+    db,
+    env: {},
+    request: new Request("https://cms.example/_plumix/rpc", { method: "POST" }),
+    hooks,
+    plugins: registry,
+    user: { id: user.id, email: user.email, role: user.role, meta: {} },
+    authenticator: stubAuthenticator(user),
+    origin: "https://cms.example",
+  });
+
+  const router = registry.rpcRouters.get("comments");
+  if (!router) throw new Error("comments router not registered");
+  const client = createRouterClient(
+    { comments: router },
+    { context: ctx },
+  ) as unknown as Client;
+  return { db, hooks, user, client };
+}
+
+describe("comments moderation RPC", () => {
+  test("list returns one status tab, newest-first", async () => {
+    const h = await buildHarness();
+    const entry = await seedPublishedPost(h.db);
+    const seed = commentFactory.transient({ db: h.db });
+    await seed.create({ entryId: entry.id, status: "pending", bodyMd: "p1" });
+    await seed.create({ entryId: entry.id, status: "approved", bodyMd: "a1" });
+
+    const rows = await h.client.comments.list({ status: "pending" });
+    expect(rows.map((r) => r.bodyMd)).toEqual(["p1"]);
+    expect(typeof rows[0]?.createdAt).toBe("string");
+  });
+
+  test("counts returns a tally per status", async () => {
+    const h = await buildHarness();
+    const entry = await seedPublishedPost(h.db);
+    const seed = commentFactory.transient({ db: h.db });
+    await seed.create({ entryId: entry.id, status: "pending" });
+    await seed.create({ entryId: entry.id, status: "pending" });
+
+    expect((await h.client.comments.counts()).pending).toBe(2);
+  });
+
+  test("approve transitions the comment and fires comment:approved", async () => {
+    const h = await buildHarness();
+    const entry = await seedPublishedPost(h.db);
+    const c = await commentFactory
+      .transient({ db: h.db })
+      .create({ entryId: entry.id, status: "pending" });
+    let fired = 0;
+    h.hooks.addAction("comment:approved", () => {
+      fired += 1;
+    });
+
+    const res = await h.client.comments.approve({ id: c.id });
+    expect(res.status).toBe("approved");
+    expect(fired).toBe(1);
+    expect((await h.client.comments.counts()).approved).toBe(1);
+  });
+
+  test("spam and trash fire their actions", async () => {
+    const h = await buildHarness();
+    const entry = await seedPublishedPost(h.db);
+    const seed = commentFactory.transient({ db: h.db });
+    const a = await seed.create({ entryId: entry.id, status: "pending" });
+    const b = await seed.create({ entryId: entry.id, status: "pending" });
+    let spam = 0;
+    let trashed = 0;
+    h.hooks.addAction("comment:spam", () => {
+      spam += 1;
+    });
+    h.hooks.addAction("comment:trashed", () => {
+      trashed += 1;
+    });
+
+    await h.client.comments.spam({ id: a.id });
+    await h.client.comments.trash({ id: b.id });
+    expect([spam, trashed]).toEqual([1, 1]);
+  });
+
+  test("restore returns a comment to the approved queue", async () => {
+    const h = await buildHarness();
+    const entry = await seedPublishedPost(h.db);
+    const c = await commentFactory
+      .transient({ db: h.db })
+      .create({ entryId: entry.id, status: "trash" });
+
+    const res = await h.client.comments.restore({ id: c.id });
+    expect(res.status).toBe("approved");
+  });
+
+  test("purge deletes a leaf comment", async () => {
+    const h = await buildHarness();
+    const entry = await seedPublishedPost(h.db);
+    const c = await commentFactory
+      .transient({ db: h.db })
+      .create({ entryId: entry.id, status: "spam" });
+
+    expect((await h.client.comments.purge({ id: c.id })).result).toBe(
+      "deleted",
+    );
+  });
+
+  test("a non-moderator is forbidden from every procedure", async () => {
+    const h = await buildHarness("subscriber");
+    // list/counts return the PII-bearing payload; the capability gate is
+    // the only thing protecting it, so assert the read + a mutation deny.
+    await expect(h.client.comments.counts()).rejects.toThrow();
+    await expect(
+      h.client.comments.list({ status: "pending" }),
+    ).rejects.toThrow();
+    await expect(h.client.comments.purge({ id: 1 })).rejects.toThrow();
+  });
+});

--- a/packages/plugins/comments/src/rpc.ts
+++ b/packages/plugins/comments/src/rpc.ts
@@ -1,0 +1,126 @@
+import type { AppContext } from "plumix/plugin";
+import { authenticated, base } from "plumix/plugin";
+import * as v from "valibot";
+
+import type { ModerationComment } from "./server/repository.js";
+import type { CommentStatus } from "./types.js";
+import {
+  countByStatus,
+  listForModeration,
+  purgeComment,
+  setStatus,
+} from "./server/repository.js";
+import { COMMENT_STATUSES } from "./types.js";
+
+export const COMMENT_MODERATE_CAPABILITY = "comment:moderate";
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+/** A queue row over the wire — the repository shape with `createdAt`
+ * serialized to an ISO string. */
+export type ModerationCommentDTO = Omit<ModerationComment, "createdAt"> & {
+  readonly createdAt: string;
+};
+
+interface ForbiddenErrors {
+  readonly FORBIDDEN: (opts: { data: { capability: string } }) => Error;
+}
+
+function requireModerator(ctx: AppContext, errors: ForbiddenErrors): void {
+  if (!ctx.auth.can(COMMENT_MODERATE_CAPABILITY)) {
+    throw errors.FORBIDDEN({
+      data: { capability: COMMENT_MODERATE_CAPABILITY },
+    });
+  }
+}
+
+type TransitionAction = "comment:approved" | "comment:spam" | "comment:trashed";
+
+const idInput = v.object({
+  id: v.pipe(v.number(), v.integer(), v.minValue(1)),
+});
+
+export function createCommentsRouter() {
+  const list = base
+    .use(authenticated)
+    .input(
+      v.object({
+        status: v.picklist(COMMENT_STATUSES),
+        limit: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+        offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+      }),
+    )
+    .handler(
+      async ({ input, context, errors }): Promise<ModerationCommentDTO[]> => {
+        requireModerator(context, errors);
+        const rows = await listForModeration(context, {
+          status: input.status,
+          limit: Math.min(input.limit ?? DEFAULT_LIMIT, MAX_LIMIT),
+          offset: input.offset ?? 0,
+        });
+        return rows.map((row) => ({
+          ...row,
+          createdAt: row.createdAt.toISOString(),
+        }));
+      },
+    );
+
+  const counts = base
+    .use(authenticated)
+    .handler(
+      async ({ context, errors }): Promise<Record<CommentStatus, number>> => {
+        requireModerator(context, errors);
+        return countByStatus(context);
+      },
+    );
+
+  // `restore` reuses the approved action — returning a comment to the queue
+  // is re-approving it (no separate comment:restored action in v1).
+  function transition(target: CommentStatus, action: TransitionAction) {
+    return base
+      .use(authenticated)
+      .input(idInput)
+      .handler(
+        async ({
+          input,
+          context,
+          errors,
+        }): Promise<{ status: CommentStatus }> => {
+          requireModerator(context, errors);
+          const row = await setStatus(context, input.id, target);
+          if (!row) {
+            throw errors.NOT_FOUND({
+              data: { kind: "comment", id: input.id },
+            });
+          }
+          await context.hooks.doAction(action, row);
+          return { status: row.status };
+        },
+      );
+  }
+
+  const purge = base
+    .use(authenticated)
+    .input(idInput)
+    .handler(
+      async ({
+        input,
+        context,
+        errors,
+      }): Promise<{ result: "tombstoned" | "deleted" | "missing" }> => {
+        requireModerator(context, errors);
+        return { result: await purgeComment(context, input.id) };
+      },
+    );
+
+  return {
+    list,
+    counts,
+    approve: transition("approved", "comment:approved"),
+    spam: transition("spam", "comment:spam"),
+    trash: transition("trash", "comment:trashed"),
+    restore: transition("approved", "comment:approved"),
+    purge,
+  };
+}

--- a/packages/plugins/comments/src/server/hooks.ts
+++ b/packages/plugins/comments/src/server/hooks.ts
@@ -25,5 +25,8 @@ declare module "plumix/plugin" {
   }
   interface ActionRegistry {
     "comment:created": (comment: Comment) => void | Promise<void>;
+    "comment:approved": (comment: Comment) => void | Promise<void>;
+    "comment:spam": (comment: Comment) => void | Promise<void>;
+    "comment:trashed": (comment: Comment) => void | Promise<void>;
   }
 }

--- a/packages/plugins/comments/src/server/repository.test.ts
+++ b/packages/plugins/comments/src/server/repository.test.ts
@@ -4,8 +4,12 @@ import { createCommentsTestDb, ctxFor, seedPublishedPost } from "../test/db.js";
 import { commentFactory } from "../test/factories.js";
 import {
   clampParent,
+  countByStatus,
   countPriorApproved,
   insertComment,
+  listForModeration,
+  purgeComment,
+  setStatus,
 } from "./repository.js";
 
 describe("countPriorApproved", () => {
@@ -115,5 +119,117 @@ describe("clampParent", () => {
     const db = await createCommentsTestDb();
     const { entry } = await seedChain(db);
     expect(await clampParent(ctxFor(db), 999_999, entry.id, 3)).toBeNull();
+  });
+});
+
+describe("moderation repository ops", () => {
+  test("listForModeration returns one status newest-first, paginated", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      bodyMd: "older",
+      createdAt: new Date("2026-06-01T00:00:00Z"),
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      bodyMd: "newer",
+      createdAt: new Date("2026-06-02T00:00:00Z"),
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      bodyMd: "appr",
+    });
+
+    const page = await listForModeration(ctxFor(db), {
+      status: "pending",
+      limit: 10,
+      offset: 0,
+    });
+    expect(page.map((c) => c.bodyMd)).toEqual(["newer", "older"]);
+    expect(page[0]?.authorEmail).toContain("@"); // admin payload keeps email
+  });
+
+  test("countByStatus tallies every status", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    await seed.create({ entryId: entry.id, status: "pending" });
+    await seed.create({ entryId: entry.id, status: "pending" });
+    await seed.create({ entryId: entry.id, status: "approved" });
+    await seed.create({ entryId: entry.id, status: "spam" });
+
+    const counts = await countByStatus(ctxFor(db));
+    expect(counts).toEqual({ pending: 2, approved: 1, spam: 1, trash: 0 });
+  });
+
+  test("setStatus transitions a comment", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const c = await commentFactory
+      .transient({ db })
+      .create({ entryId: entry.id, status: "pending" });
+
+    const updated = await setStatus(ctxFor(db), c.id, "approved");
+    expect(updated?.status).toBe("approved");
+  });
+
+  test("purgeComment deletes a leaf", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const c = await commentFactory
+      .transient({ db })
+      .create({ entryId: entry.id, status: "spam" });
+
+    expect(await purgeComment(ctxFor(db), c.id)).toBe("deleted");
+    expect(
+      (
+        await listForModeration(ctxFor(db), {
+          status: "spam",
+          limit: 10,
+          offset: 0,
+        })
+      ).length,
+    ).toBe(0);
+  });
+
+  test("purgeComment tombstones a comment that has replies", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    const parent = await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      authorName: "Real Name",
+      authorEmail: "real@example.test",
+      bodyMd: "to remove",
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: parent.id,
+    });
+
+    expect(await purgeComment(ctxFor(db), parent.id)).toBe("tombstoned");
+    const [kept] = await listForModeration(ctxFor(db), {
+      status: "approved",
+      limit: 10,
+      offset: 0,
+    });
+    // The reply (newest) is first; the tombstoned parent is blanked.
+    const tombstone = (
+      await listForModeration(ctxFor(db), {
+        status: "approved",
+        limit: 10,
+        offset: 0,
+      })
+    ).find((c) => c.id === parent.id);
+    expect(tombstone?.bodyMd).toBe("");
+    expect(tombstone?.authorEmail).toBe("");
+    expect(kept).toBeDefined();
   });
 });

--- a/packages/plugins/comments/src/server/repository.ts
+++ b/packages/plugins/comments/src/server/repository.ts
@@ -1,8 +1,10 @@
 import type { AppContext } from "plumix/plugin";
-import { and, count, eq } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 
 import type { Comment, NewComment } from "../db/schema.js";
+import type { CommentStatus } from "../types.js";
 import { comments } from "../db/schema.js";
+import { COMMENT_STATUSES } from "../types.js";
 
 // Absolute walk ceiling, independent of maxDepth, so the true depth is
 // measured even if maxDepth was lowered after deep rows were written
@@ -84,4 +86,118 @@ export async function insertComment(
     throw new Error("insertComment: insert returned no row");
   }
   return row;
+}
+
+/**
+ * A comment as the moderation queue sees it — unlike the public payload
+ * this keeps `authorEmail`, `ipHash`, and `userAgent`, the context a
+ * moderator needs.
+ */
+export interface ModerationComment {
+  readonly id: number;
+  readonly entryId: number;
+  readonly parentId: number | null;
+  readonly status: CommentStatus;
+  readonly authorName: string;
+  readonly authorEmail: string;
+  readonly bodyMd: string;
+  readonly ipHash: string | null;
+  readonly userAgent: string | null;
+  readonly createdAt: Date;
+}
+
+function toModeration(row: Comment): ModerationComment {
+  return {
+    id: row.id,
+    entryId: row.entryId,
+    parentId: row.parentId,
+    status: row.status,
+    authorName: row.authorName,
+    authorEmail: row.authorEmail,
+    bodyMd: row.bodyMd,
+    ipHash: row.ipHash,
+    userAgent: row.userAgent,
+    createdAt: row.createdAt,
+  };
+}
+
+/** One status tab of the moderation queue, newest-first, paginated. */
+export async function listForModeration(
+  ctx: AppContext,
+  opts: { status: CommentStatus; limit: number; offset: number },
+): Promise<ModerationComment[]> {
+  const rows = await ctx.db
+    .select()
+    .from(comments)
+    .where(eq(comments.status, opts.status))
+    .orderBy(desc(comments.createdAt), desc(comments.id))
+    .limit(opts.limit)
+    .offset(opts.offset);
+  return rows.map(toModeration);
+}
+
+/** Comment counts per status, for the queue's tab badges. */
+export async function countByStatus(
+  ctx: AppContext,
+): Promise<Record<CommentStatus, number>> {
+  const rows = await ctx.db
+    .select({ status: comments.status, value: count() })
+    .from(comments)
+    .groupBy(comments.status);
+  const tally = Object.fromEntries(
+    COMMENT_STATUSES.map((status) => [status, 0]),
+  ) as Record<CommentStatus, number>;
+  for (const row of rows) tally[row.status] = row.value;
+  return tally;
+}
+
+/** Transition a comment to a new status. */
+export async function setStatus(
+  ctx: AppContext,
+  id: number,
+  status: CommentStatus,
+): Promise<Comment | null> {
+  const [row] = await ctx.db
+    .update(comments)
+    .set({ status })
+    .where(eq(comments.id, id))
+    .returning();
+  return row ?? null;
+}
+
+/**
+ * Hard-remove a comment. A comment with replies is tombstoned (body and
+ * author identity blanked, node kept) so the thread structure survives; a
+ * leaf is deleted outright.
+ */
+export async function purgeComment(
+  ctx: AppContext,
+  id: number,
+): Promise<"tombstoned" | "deleted" | "missing"> {
+  const [child] = await ctx.db
+    .select({ id: comments.id })
+    .from(comments)
+    .where(eq(comments.parentId, id))
+    .limit(1);
+
+  if (child) {
+    const [row] = await ctx.db
+      .update(comments)
+      .set({
+        bodyMd: "",
+        authorName: "[deleted]",
+        authorEmail: "",
+        ipHash: null,
+        userAgent: null,
+      })
+      .where(eq(comments.id, id))
+      .returning({ id: comments.id });
+    return row ? "tombstoned" : "missing";
+  }
+
+  const deleted = await ctx.db
+    .delete(comments)
+    .where(eq(comments.id, id))
+    .returning({ id: comments.id });
+  return deleted.length > 0 ? "deleted" : "missing";
 }

--- a/packages/plugins/comments/test/setup.ts
+++ b/packages/plugins/comments/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/plugins/comments/tsconfig.json
+++ b/packages/plugins/comments/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "rootDir": ".",
-    "types": ["node"]
+    "jsx": "react-jsx",
+    "types": ["node", "@testing-library/jest-dom"]
   },
-  "include": ["src"]
+  "include": ["src", "e2e", "test"]
 }

--- a/packages/plugins/comments/vitest.config.ts
+++ b/packages/plugins/comments/vitest.config.ts
@@ -1,5 +1,15 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 import { baseConfig } from "@plumix/vitest-config/base";
 
-export default defineConfig(baseConfig);
+// jsdom for the admin component suites (`src/admin/*.test.tsx`); the
+// server suites are environment-agnostic and run fine under it too.
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      setupFiles: ["./test/setup.ts"],
+    },
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,6 +854,15 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.3
+      '@libsql/client':
+        specifier: 'catalog:'
+        version: 0.17.3
+      '@orpc/server':
+        specifier: 'catalog:'
+        version: 1.14.5(ws@8.20.1)
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../../tooling/eslint
@@ -869,6 +878,15 @@ importers:
       '@plumix/vitest-config':
         specifier: workspace:*
         version: link:../../../tooling/vitest
+      '@tanstack/react-query':
+        specifier: 'catalog:'
+        version: 5.101.0(react@19.2.7)
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
@@ -878,6 +896,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.16
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.16)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(vitest@4.1.8)
@@ -890,6 +911,9 @@ importers:
       fishery:
         specifier: 'catalog:'
         version: 2.4.0
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1
       plumix:
         specifier: workspace:*
         version: link:../../plumix
@@ -902,6 +926,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3


### PR DESCRIPTION
Slice 4 of 8 for the comments plugin (PRD #959). Adds the moderation surface — a precompiled `CommentsShell` admin chunk plus the oRPC router behind it.

**Authorization is the whole story here**

The admin payload exposes the moderator-only context the public payload withholds (author email, IP hash, user agent), so the `comment:moderate` capability (registered at `editor`) is the sole guard on that PII. Every one of the seven procedures — `list`, `counts`, `approve`, `spam`, `trash`, `restore`, `purge` — enforces it before any read or mutation; the transitions route through one `requireModerator`-gated factory. A regression test asserts a subscriber is denied the PII read (`list`) and a mutation (`purge`), not just `counts`.

**The queue**

`CommentsShell` is a status-tabbed queue (Pending/Approved/Spam/Trash) with live badge counts, per-status row actions, and a detail panel. Status transitions fire `comment:approved` / `comment:spam` / `comment:trashed` lifecycle actions. `purge` tombstones a comment that has replies (blanks body + author identity, keeps the node so the thread survives) and deletes a leaf outright. The moderator view renders the **raw markdown source as text** — never `dangerouslySetInnerHTML` — so a stored payload can't execute in the admin.

### Testing

97 unit tests: repository moderation ops (list/counts/setStatus/tombstone-vs-delete), the RPC router (each transition + action firing + authorization on the read and a mutation), and the `CommentsShell` component (tabs, counts, row actions post to the right procedure, detail panel reveals the private context). Plus a worker-driven Playwright e2e that approves a pending comment from the live queue. Required gates — lint, typecheck, knip, format, commitlint — green.

### Notes / deferred

- **i18n** of the admin strings lands with the i18n slice (#966); strings are plain English for now (the action/tab labels are the protocol identifiers).
- Forwarding the new lifecycle actions to audit-log, surfacing the `purge` result (tombstoned vs deleted) in the UI, and bulk/search are follow-ups (#964+).

### Out of scope (later slices)

Bulk actions + search (#964), moderator-on-pending email (#965), i18n (#966), root pagination (#967).

Closes #963
Refs #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)