### PR TITLE
feat(plugin-comments): bulk moderation, search, and per-entry filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,10 +43,11 @@ yarn-error.log*
 # fresh on every e2e run, never committed.
 drizzle/
 
-# worker-driven plugin e2e: storageState.json is written by globalSetup
-# at the package root; playwright traces / reports land in test-results/
-# + playwright-report/ (already covered above).
+# worker-driven plugin e2e: storageState.json + e2e-fixtures.json are
+# written by globalSetup at the package root; playwright traces / reports
+# land in test-results/ + playwright-report/ (already covered above).
 storageState.json
+e2e-fixtures.json
 
 # plumix generated
 .plumix/

--- a/packages/plugins/comments/e2e/comments-admin.spec.ts
+++ b/packages/plugins/comments/e2e/comments-admin.spec.ts
@@ -1,54 +1,61 @@
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { expect, test } from "@playwright/test";
-import { factoriesFor } from "plumix/test";
-import { openPlaygroundDb } from "plumix/test/playwright";
 
-import { commentFactory } from "../src/test/factories.js";
+// Seeded by globalSetup (see e2e/globalSetup.ts). The specs are read-only
+// against the database — they only drive the admin UI.
+interface Fixtures {
+  readonly pendingId: number;
+  readonly bulkEntryId: number;
+  readonly bulkIds: number[];
+}
+const fixtures = JSON.parse(
+  readFileSync(resolve(process.cwd(), "e2e-fixtures.json"), "utf8"),
+) as Fixtures;
 
-// The public-facing render of an approved comment is covered in-process by
-// the dispatcher-harness render tests (plumix dev serves the admin SPA for
-// public routes). This suite exercises the admin moderation queue, which
-// runs under plumix dev like the other plugin admin e2es.
-let pendingId = 0;
-
-test.beforeAll(async () => {
-  const db = await openPlaygroundDb({
-    cwd: resolve(process.cwd(), "playground"),
-  });
-  const factories = factoriesFor(db);
-  const author = await factories.user.create({ email: "author@example.test" });
-  const entry = await factories.entry.create({
-    type: "post",
-    slug: "moderate-me",
-    title: "Moderate me",
-    authorId: author.id,
-    status: "published",
-  });
-  const comment = await commentFactory.transient({ db }).create({
-    entryId: entry.id,
-    status: "pending",
-    authorName: "Pending Pat",
-    bodyMd: "please review me",
-  });
-  pendingId = comment.id;
-});
-
+// The public render of an approved comment is covered in-process by the
+// dispatcher-harness render tests (plumix dev serves the admin SPA for
+// public routes). This suite exercises the admin moderation queue.
 test("moderator approves a pending comment from the queue", async ({
   page,
 }) => {
   await page.goto("pages/comments");
   await expect(page.getByTestId("comments-shell")).toBeVisible();
 
-  // Pending is the default tab; the seeded comment is listed.
-  const row = page.getByTestId(`comment-row-${String(pendingId)}`);
+  const row = page.getByTestId(`comment-row-${String(fixtures.pendingId)}`);
   await expect(row).toBeVisible();
 
-  await page.getByTestId(`comment-approve-${String(pendingId)}`).click();
+  await page
+    .getByTestId(`comment-approve-${String(fixtures.pendingId)}`)
+    .click();
 
   // It leaves the pending queue and shows under Approved.
   await expect(row).toBeHidden();
   await page.getByTestId("comments-tab-approved").click();
   await expect(
-    page.getByTestId(`comment-row-${String(pendingId)}`),
+    page.getByTestId(`comment-row-${String(fixtures.pendingId)}`),
   ).toBeVisible();
+});
+
+test("moderator bulk-approves selected comments", async ({ page }) => {
+  await page.goto("pages/comments");
+  // Isolate this test's comments via the per-entry filter.
+  await page
+    .getByTestId("comments-entry-filter")
+    .fill(String(fixtures.bulkEntryId));
+
+  const [firstId, secondId] = fixtures.bulkIds;
+  await expect(
+    page.getByTestId(`comment-row-${String(firstId)}`),
+  ).toBeVisible();
+
+  await page.getByTestId(`comment-select-${String(firstId)}`).check();
+  await page.getByTestId(`comment-select-${String(secondId)}`).check();
+  await expect(page.getByTestId("comments-bulk-count")).toHaveText("2");
+
+  await page.getByTestId("comments-bulk-approve").click();
+  await expect(page.getByTestId(`comment-row-${String(firstId)}`)).toBeHidden();
+  await expect(
+    page.getByTestId(`comment-row-${String(secondId)}`),
+  ).toBeHidden();
 });

--- a/packages/plugins/comments/e2e/globalSetup.ts
+++ b/packages/plugins/comments/e2e/globalSetup.ts
@@ -1,17 +1,61 @@
 import { writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { factoriesFor } from "plumix/test";
 import { actingAs, openPlaygroundDb } from "plumix/test/playwright";
 
-// Seeds an admin user into the migrated D1 and writes the storageState
-// playwright's `use.storageState` reads, so the moderation queue specs
-// run authenticated.
+import { commentFactory } from "../src/test/factories.js";
+
+// All e2e seeding happens here — once, in the quiet window after the worker
+// boots but before any spec drives it. Seeding from a spec (or a retry's
+// beforeAll) races the live worker for the D1 write lock (SQLITE_BUSY) and
+// re-collides on unique indexes. The specs read the seeded ids back from
+// e2e-fixtures.json and never touch the database.
 export default async function globalSetup(): Promise<void> {
-  const playgroundCwd = resolve(process.cwd(), "playground");
-  const db = await openPlaygroundDb({ cwd: playgroundCwd });
+  const db = await openPlaygroundDb({
+    cwd: resolve(process.cwd(), "playground"),
+  });
   const { storageState } = await actingAs(db, "admin");
   await writeFile(
     resolve(process.cwd(), "storageState.json"),
     JSON.stringify(storageState, null, 2),
+    "utf8",
+  );
+
+  const factories = factoriesFor(db);
+  const author = await factories.user.create({});
+  const single = await factories.entry.create({
+    type: "post",
+    title: "Moderate me",
+    authorId: author.id,
+    status: "published",
+  });
+  const pending = await commentFactory.transient({ db }).create({
+    entryId: single.id,
+    status: "pending",
+    authorName: "Pending Pat",
+    bodyMd: "please review me",
+  });
+
+  const bulkEntry = await factories.entry.create({
+    type: "post",
+    title: "Bulk target",
+    authorId: author.id,
+    status: "published",
+  });
+  const seed = commentFactory.transient({ db });
+  const first = await seed.create({ entryId: bulkEntry.id, status: "pending" });
+  const second = await seed.create({
+    entryId: bulkEntry.id,
+    status: "pending",
+  });
+
+  await writeFile(
+    resolve(process.cwd(), "e2e-fixtures.json"),
+    JSON.stringify({
+      pendingId: pending.id,
+      bulkEntryId: bulkEntry.id,
+      bulkIds: [first.id, second.id],
+    }),
     "utf8",
   );
 }

--- a/packages/plugins/comments/src/admin/CommentsShell.test.tsx
+++ b/packages/plugins/comments/src/admin/CommentsShell.test.tsx
@@ -13,7 +13,16 @@ import { CommentsShell } from "./CommentsShell.js";
 
 interface CapturedCall {
   readonly proc: string;
-  readonly body: { json?: { id?: number } } | undefined;
+  readonly body:
+    | {
+        json?: {
+          id?: number;
+          ids?: number[];
+          action?: string;
+          search?: string;
+        };
+      }
+    | undefined;
 }
 
 let calls: CapturedCall[];
@@ -141,6 +150,49 @@ describe("CommentsShell", () => {
     renderShell();
     await waitFor(() => {
       expect(screen.getByTestId("comments-empty")).toBeInTheDocument();
+    });
+  });
+
+  test("selecting rows reveals the bulk bar and bulk-approves", async () => {
+    const row2 = { ...ROW, id: 2, authorName: "Bob" };
+    mockRpc({
+      counts: { pending: 2, approved: 0, spam: 0, trash: 0 },
+      list: [ROW, row2],
+      bulk: { changed: 2 },
+    });
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("comment-select-1")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("comment-select-1"));
+    fireEvent.click(screen.getByTestId("comment-select-2"));
+    expect(screen.getByTestId("comments-bulk-count")).toHaveTextContent("2");
+
+    fireEvent.click(screen.getByTestId("comments-bulk-approve"));
+    await waitFor(() => {
+      expect(calls.some((c) => c.proc === "bulk")).toBe(true);
+    });
+    const bulkCall = calls.find((c) => c.proc === "bulk");
+    expect(bulkCall?.body?.json?.ids).toEqual([1, 2]);
+    expect(bulkCall?.body?.json?.action).toBe("approve");
+  });
+
+  test("typing in the search box refetches with the term", async () => {
+    mockRpc({
+      counts: { pending: 0, approved: 0, spam: 0, trash: 0 },
+      list: [],
+    });
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("comments-search")).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTestId("comments-search"), {
+      target: { value: "ada" },
+    });
+    await waitFor(() => {
+      expect(
+        calls.some((c) => c.proc === "list" && c.body?.json?.search === "ada"),
+      ).toBe(true);
     });
   });
 });

--- a/packages/plugins/comments/src/admin/CommentsShell.tsx
+++ b/packages/plugins/comments/src/admin/CommentsShell.tsx
@@ -1,11 +1,18 @@
 import { useState } from "react";
 
 import type {
+  BulkAction,
   CommentStatus,
   ModerationAction,
   ModerationCommentDTO,
 } from "./rpc.js";
-import { useCommentCounts, useCommentList, useModeration } from "./rpc.js";
+import {
+  BULK_ACTIONS,
+  useBulkModeration,
+  useCommentCounts,
+  useCommentList,
+  useModeration,
+} from "./rpc.js";
 
 const TABS: readonly CommentStatus[] = ["pending", "approved", "spam", "trash"];
 
@@ -21,9 +28,39 @@ const ACTIONS: Record<CommentStatus, readonly ModerationAction[]> = {
 export function CommentsShell(): React.ReactElement {
   const [tab, setTab] = useState<CommentStatus>("pending");
   const [selected, setSelected] = useState<ModerationCommentDTO | null>(null);
+  const [search, setSearch] = useState("");
+  const [entryFilter, setEntryFilter] = useState("");
+  const [picked, setPicked] = useState<ReadonlySet<number>>(new Set());
   const counts = useCommentCounts();
-  const list = useCommentList(tab);
+  const entryId = Number.parseInt(entryFilter, 10);
+  const list = useCommentList(tab, {
+    search: search.trim() || undefined,
+    entryId: Number.isFinite(entryId) ? entryId : undefined,
+  });
   const moderation = useModeration();
+  const bulk = useBulkModeration();
+
+  function reset(next: CommentStatus): void {
+    setTab(next);
+    setSelected(null);
+    setPicked(new Set());
+  }
+
+  function togglePicked(id: number): void {
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function runBulk(action: BulkAction): void {
+    bulk.mutate(
+      { action, ids: [...picked] },
+      { onSuccess: () => setPicked(new Set()) },
+    );
+  }
 
   return (
     <div data-testid="comments-shell">
@@ -35,8 +72,7 @@ export function CommentsShell(): React.ReactElement {
             data-testid={`comments-tab-${status}`}
             aria-pressed={tab === status}
             onClick={() => {
-              setTab(status);
-              setSelected(null);
+              reset(status);
             }}
           >
             {status}{" "}
@@ -46,6 +82,40 @@ export function CommentsShell(): React.ReactElement {
           </button>
         ))}
       </div>
+
+      <div data-testid="comments-filters">
+        <input
+          type="search"
+          data-testid="comments-search"
+          aria-label="Search comments"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+        <input
+          type="number"
+          data-testid="comments-entry-filter"
+          aria-label="Filter by entry id"
+          value={entryFilter}
+          onChange={(event) => setEntryFilter(event.target.value)}
+        />
+      </div>
+
+      {picked.size > 0 ? (
+        <div data-testid="comments-bulk-bar">
+          <span data-testid="comments-bulk-count">{picked.size}</span>
+          {BULK_ACTIONS.map((action) => (
+            <button
+              key={action}
+              type="button"
+              data-testid={`comments-bulk-${action}`}
+              disabled={bulk.isPending}
+              onClick={() => runBulk(action)}
+            >
+              {action}
+            </button>
+          ))}
+        </div>
+      ) : null}
 
       {list.isLoading ? (
         <div data-testid="comments-loading" />
@@ -58,6 +128,15 @@ export function CommentsShell(): React.ReactElement {
           <tbody>
             {(list.data ?? []).map((comment) => (
               <tr key={comment.id} data-testid={`comment-row-${comment.id}`}>
+                <td>
+                  <input
+                    type="checkbox"
+                    data-testid={`comment-select-${comment.id}`}
+                    aria-label={`Select comment ${String(comment.id)}`}
+                    checked={picked.has(comment.id)}
+                    onChange={() => togglePicked(comment.id)}
+                  />
+                </td>
                 <td>
                   <button
                     type="button"

--- a/packages/plugins/comments/src/admin/rpc.ts
+++ b/packages/plugins/comments/src/admin/rpc.ts
@@ -57,12 +57,34 @@ export function useCommentCounts(): UseQueryResult<StatusCounts> {
   });
 }
 
+interface QueueFilters {
+  readonly search?: string;
+  readonly entryId?: number;
+}
+
 export function useCommentList(
   status: CommentStatus,
+  filters: QueueFilters = {},
 ): UseQueryResult<ModerationCommentDTO[]> {
   return useQuery({
-    queryKey: [...COMMENTS_KEY, "list", status],
-    queryFn: () => rpcCall<ModerationCommentDTO[]>("comments/list", { status }),
+    queryKey: [...COMMENTS_KEY, "list", status, filters],
+    queryFn: () =>
+      rpcCall<ModerationCommentDTO[]>("comments/list", { status, ...filters }),
+  });
+}
+
+export const BULK_ACTIONS = ["approve", "spam", "trash"] as const;
+export type BulkAction = (typeof BULK_ACTIONS)[number];
+
+export function useBulkModeration(): UseMutationResult<
+  unknown,
+  Error,
+  { action: BulkAction; ids: number[] }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ action, ids }) => rpcCall("comments/bulk", { action, ids }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: COMMENTS_KEY }),
   });
 }
 

--- a/packages/plugins/comments/src/rpc.test.ts
+++ b/packages/plugins/comments/src/rpc.test.ts
@@ -21,6 +21,8 @@ interface Client {
       status: CommentStatus;
       limit?: number;
       offset?: number;
+      entryId?: number;
+      search?: string;
     }) => Promise<ModerationCommentDTO[]>;
     readonly counts: () => Promise<Record<CommentStatus, number>>;
     readonly approve: (input: { id: number }) => Promise<{ status: string }>;
@@ -28,6 +30,10 @@ interface Client {
     readonly trash: (input: { id: number }) => Promise<{ status: string }>;
     readonly restore: (input: { id: number }) => Promise<{ status: string }>;
     readonly purge: (input: { id: number }) => Promise<{ result: string }>;
+    readonly bulk: (input: {
+      ids: number[];
+      action: "approve" | "spam" | "trash";
+    }) => Promise<{ changed: number }>;
   };
 }
 
@@ -149,6 +155,50 @@ describe("comments moderation RPC", () => {
     );
   });
 
+  test("list supports search and per-entry filtering", async () => {
+    const h = await buildHarness();
+    const a = await seedPublishedPost(h.db);
+    const b = await seedPublishedPost(h.db);
+    const seed = commentFactory.transient({ db: h.db });
+    await seed.create({
+      entryId: a.id,
+      status: "pending",
+      authorName: "Ada",
+    });
+    await seed.create({
+      entryId: b.id,
+      status: "pending",
+      authorName: "Bob",
+    });
+
+    expect(
+      await h.client.comments.list({ status: "pending", search: "ada" }),
+    ).toHaveLength(1);
+    expect(
+      await h.client.comments.list({ status: "pending", entryId: b.id }),
+    ).toHaveLength(1);
+  });
+
+  test("bulk approves many comments and fires the action per row", async () => {
+    const h = await buildHarness();
+    const entry = await seedPublishedPost(h.db);
+    const seed = commentFactory.transient({ db: h.db });
+    const a = await seed.create({ entryId: entry.id, status: "pending" });
+    const b = await seed.create({ entryId: entry.id, status: "pending" });
+    let fired = 0;
+    h.hooks.addAction("comment:approved", () => {
+      fired += 1;
+    });
+
+    const res = await h.client.comments.bulk({
+      ids: [a.id, b.id],
+      action: "approve",
+    });
+    expect(res.changed).toBe(2);
+    expect(fired).toBe(2);
+    expect((await h.client.comments.counts()).approved).toBe(2);
+  });
+
   test("a non-moderator is forbidden from every procedure", async () => {
     const h = await buildHarness("subscriber");
     // list/counts return the PII-bearing payload; the capability gate is
@@ -158,5 +208,8 @@ describe("comments moderation RPC", () => {
       h.client.comments.list({ status: "pending" }),
     ).rejects.toThrow();
     await expect(h.client.comments.purge({ id: 1 })).rejects.toThrow();
+    await expect(
+      h.client.comments.bulk({ ids: [1], action: "approve" }),
+    ).rejects.toThrow();
   });
 });

--- a/packages/plugins/comments/src/rpc.ts
+++ b/packages/plugins/comments/src/rpc.ts
@@ -9,6 +9,7 @@ import {
   listForModeration,
   purgeComment,
   setStatus,
+  setStatusMany,
 } from "./server/repository.js";
 import { COMMENT_STATUSES } from "./types.js";
 
@@ -37,6 +38,20 @@ function requireModerator(ctx: AppContext, errors: ForbiddenErrors): void {
 
 type TransitionAction = "comment:approved" | "comment:spam" | "comment:trashed";
 
+// Single source for the status transitions a moderator can drive (single
+// or bulk): each maps to its target status + the lifecycle action it fires.
+// `restore` reuses the approved entry; `purge` is separate (it removes).
+const BULK_ACTIONS = ["approve", "spam", "trash"] as const;
+type BulkAction = (typeof BULK_ACTIONS)[number];
+const TRANSITIONS: Record<
+  BulkAction,
+  { target: CommentStatus; action: TransitionAction }
+> = {
+  approve: { target: "approved", action: "comment:approved" },
+  spam: { target: "spam", action: "comment:spam" },
+  trash: { target: "trash", action: "comment:trashed" },
+};
+
 const idInput = v.object({
   id: v.pipe(v.number(), v.integer(), v.minValue(1)),
 });
@@ -49,6 +64,8 @@ export function createCommentsRouter() {
         status: v.picklist(COMMENT_STATUSES),
         limit: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
         offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+        entryId: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+        search: v.optional(v.pipe(v.string(), v.maxLength(200))),
       }),
     )
     .handler(
@@ -58,6 +75,8 @@ export function createCommentsRouter() {
           status: input.status,
           limit: Math.min(input.limit ?? DEFAULT_LIMIT, MAX_LIMIT),
           offset: input.offset ?? 0,
+          entryId: input.entryId,
+          search: input.search,
         });
         return rows.map((row) => ({
           ...row,
@@ -114,13 +133,36 @@ export function createCommentsRouter() {
       },
     );
 
+  // Bulk transitions fire the lifecycle action per affected comment.
+  const bulk = base
+    .use(authenticated)
+    .input(
+      v.object({
+        ids: v.pipe(
+          v.array(v.pipe(v.number(), v.integer(), v.minValue(1))),
+          v.maxLength(200),
+        ),
+        action: v.picklist(BULK_ACTIONS),
+      }),
+    )
+    .handler(
+      async ({ input, context, errors }): Promise<{ changed: number }> => {
+        requireModerator(context, errors);
+        const { target, action } = TRANSITIONS[input.action];
+        const rows = await setStatusMany(context, input.ids, target);
+        for (const row of rows) await context.hooks.doAction(action, row);
+        return { changed: rows.length };
+      },
+    );
+
   return {
     list,
     counts,
-    approve: transition("approved", "comment:approved"),
-    spam: transition("spam", "comment:spam"),
-    trash: transition("trash", "comment:trashed"),
-    restore: transition("approved", "comment:approved"),
+    approve: transition(TRANSITIONS.approve.target, TRANSITIONS.approve.action),
+    spam: transition(TRANSITIONS.spam.target, TRANSITIONS.spam.action),
+    trash: transition(TRANSITIONS.trash.target, TRANSITIONS.trash.action),
+    restore: transition(TRANSITIONS.approve.target, TRANSITIONS.approve.action),
     purge,
+    bulk,
   };
 }

--- a/packages/plugins/comments/src/server/repository.test.ts
+++ b/packages/plugins/comments/src/server/repository.test.ts
@@ -10,6 +10,7 @@ import {
   listForModeration,
   purgeComment,
   setStatus,
+  setStatusMany,
 } from "./repository.js";
 
 describe("countPriorApproved", () => {
@@ -231,5 +232,106 @@ describe("moderation repository ops", () => {
     expect(tombstone?.bodyMd).toBe("");
     expect(tombstone?.authorEmail).toBe("");
     expect(kept).toBeDefined();
+  });
+});
+
+describe("moderation list filters + bulk", () => {
+  test("search matches author name, email, or body (escaped)", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      authorName: "Ada Lovelace",
+      bodyMd: "nothing",
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      authorName: "Bob",
+      authorEmail: "ada@example.test",
+      bodyMd: "nothing",
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      authorName: "Carol",
+      bodyMd: "mentions ada in the body",
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      authorName: "Dave",
+      bodyMd: "unrelated",
+    });
+
+    const hits = await listForModeration(ctxFor(db), {
+      status: "pending",
+      limit: 50,
+      offset: 0,
+      search: "ada",
+    });
+    expect(hits).toHaveLength(3);
+  });
+
+  test("a literal % in the search is not a wildcard", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      bodyMd: "100% sure",
+    });
+    await seed.create({
+      entryId: entry.id,
+      status: "pending",
+      bodyMd: "anything",
+    });
+
+    const hits = await listForModeration(ctxFor(db), {
+      status: "pending",
+      limit: 50,
+      offset: 0,
+      search: "100%",
+    });
+    expect(hits).toHaveLength(1);
+  });
+
+  test("entryId narrows the queue to one entry", async () => {
+    const db = await createCommentsTestDb();
+    const a = await seedPublishedPost(db);
+    const b = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    await seed.create({ entryId: a.id, status: "pending" });
+    await seed.create({ entryId: b.id, status: "pending" });
+    await seed.create({ entryId: b.id, status: "pending" });
+
+    const hits = await listForModeration(ctxFor(db), {
+      status: "pending",
+      limit: 50,
+      offset: 0,
+      entryId: b.id,
+    });
+    expect(hits).toHaveLength(2);
+  });
+
+  test("setStatusMany transitions many comments and returns the count", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const seed = commentFactory.transient({ db });
+    const a = await seed.create({ entryId: entry.id, status: "pending" });
+    const b = await seed.create({ entryId: entry.id, status: "pending" });
+    await seed.create({ entryId: entry.id, status: "pending" });
+
+    const changed = await setStatusMany(ctxFor(db), [a.id, b.id], "approved");
+    expect(changed).toHaveLength(2);
+    expect((await countByStatus(ctxFor(db))).approved).toBe(2);
+  });
+
+  test("setStatusMany with no ids is a no-op", async () => {
+    const db = await createCommentsTestDb();
+    expect(await setStatusMany(ctxFor(db), [], "approved")).toHaveLength(0);
   });
 });

--- a/packages/plugins/comments/src/server/repository.ts
+++ b/packages/plugins/comments/src/server/repository.ts
@@ -1,5 +1,8 @@
+import type { SQL } from "drizzle-orm";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 import type { AppContext } from "plumix/plugin";
-import { and, count, desc, eq } from "drizzle-orm";
+import { and, count, desc, eq, inArray, or, sql } from "drizzle-orm";
+import { escapeLikePattern } from "plumix/plugin";
 
 import type { Comment, NewComment } from "../db/schema.js";
 import type { CommentStatus } from "../types.js";
@@ -121,19 +124,64 @@ function toModeration(row: Comment): ModerationComment {
   };
 }
 
-/** One status tab of the moderation queue, newest-first, paginated. */
+// LIKE pattern matching `term` anywhere, with the SQL wildcards escaped so
+// a literal `%` or `_` in the search box isn't treated as a wildcard.
+function likeContains(column: AnySQLiteColumn, term: string): SQL {
+  return sql`${column} LIKE ${`%${escapeLikePattern(term)}%`} ESCAPE '\\'`;
+}
+
+/**
+ * One status tab of the moderation queue, newest-first, paginated.
+ * Optionally narrowed to one entry and/or a free-text search over the
+ * author name, email, and body.
+ */
 export async function listForModeration(
   ctx: AppContext,
-  opts: { status: CommentStatus; limit: number; offset: number },
+  opts: {
+    status: CommentStatus;
+    limit: number;
+    offset: number;
+    entryId?: number;
+    search?: string;
+  },
 ): Promise<ModerationComment[]> {
+  const conditions: SQL[] = [eq(comments.status, opts.status)];
+  if (opts.entryId !== undefined) {
+    conditions.push(eq(comments.entryId, opts.entryId));
+  }
+  const term = opts.search?.trim();
+  if (term) {
+    const match = or(
+      likeContains(comments.authorName, term),
+      likeContains(comments.authorEmail, term),
+      likeContains(comments.bodyMd, term),
+    );
+    if (match) conditions.push(match);
+  }
+
   const rows = await ctx.db
     .select()
     .from(comments)
-    .where(eq(comments.status, opts.status))
+    .where(and(...conditions))
     .orderBy(desc(comments.createdAt), desc(comments.id))
     .limit(opts.limit)
     .offset(opts.offset);
   return rows.map(toModeration);
+}
+
+/** Apply a status to many comments at once (bulk moderation). Returns the
+ * updated rows so the caller can fire per-comment lifecycle actions. */
+export async function setStatusMany(
+  ctx: AppContext,
+  ids: readonly number[],
+  status: CommentStatus,
+): Promise<Comment[]> {
+  if (ids.length === 0) return [];
+  return ctx.db
+    .update(comments)
+    .set({ status })
+    .where(inArray(comments.id, [...ids]))
+    .returning();
 }
 
 /** Comment counts per status, for the queue's tab badges. */


### PR DESCRIPTION
Slice 5 of 8 for the comments plugin (PRD #959). Extends the moderation queue with the throughput tools.

**Search + per-entry filter**

The `list` RPC gains a free-text search over author name, email, and body — an escaped `LIKE` that reuses core's `escapeLikePattern`, so a literal `%` or `_` in the search box isn't a wildcard (and the term is a bound parameter, never concatenated). A per-entry filter narrows the queue to one entry.

**Bulk moderation**

A new `bulk` procedure applies approve/spam/trash to up to 200 selected comments in one call — gated by `comment:moderate` like every other procedure, and firing the lifecycle action per affected row. The single and bulk transitions now share one `target/action` mapping (a review catch — the two copies are collapsed). `CommentsShell` grows a search box, an entry-id filter, per-row select checkboxes, and a bulk action bar.

**e2e seeding hardening**

All e2e seeding moved into `globalSetup` (writing ids to `e2e-fixtures.json` the specs read), so specs never write to the D1 the live worker holds. A spec/retry write was racing the worker for the write lock (`SQLITE_BUSY`) and re-colliding on unique indexes; specs are now read-only against the database.

### Testing

106 unit tests: repository filters + bulk (`setStatusMany`, escaped search incl. a literal-`%` case, entry filter), the RPC (search/filter/bulk + the authorization gate asserted on **every** procedure including `bulk`), and `CommentsShell` (select → bulk-approve, search-refetch). Two worker-driven e2es (single approve + bulk-approve isolated via the entry filter). Required gates — lint, typecheck, knip, format, commitlint — green.

### Out of scope (later slices)

Moderator-on-pending email (#965), i18n (#966), root pagination (#967).

Closes #964
Refs #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)