### PR TITLE
feat(plugin-comments): moderator-on-pending email notification

### DIFF
--- a/packages/plugins/comments/src/config.ts
+++ b/packages/plugins/comments/src/config.ts
@@ -12,6 +12,7 @@ export interface ResolvedCommentsConfig {
   readonly requireEmail: boolean;
   readonly closeAfterDays: number | null;
   readonly rateLimit: RateLimitConfig;
+  readonly notifyEmail: string | null;
 }
 
 export function resolveConfig(options: CommentsConfig): ResolvedCommentsConfig {
@@ -22,5 +23,6 @@ export function resolveConfig(options: CommentsConfig): ResolvedCommentsConfig {
     requireEmail: options.requireEmail ?? true,
     closeAfterDays: options.closeAfterDays ?? null,
     rateLimit: options.rateLimit ?? { max: 5, windowMin: 10 },
+    notifyEmail: options.notifyEmail ?? null,
   };
 }

--- a/packages/plugins/comments/src/index.test.ts
+++ b/packages/plugins/comments/src/index.test.ts
@@ -2,6 +2,7 @@ import type { AppContext } from "plumix/plugin";
 import { describe, expect, test } from "vitest";
 
 import type { CommentsTestDb } from "./test/db.js";
+import type { CommentsConfig } from "./types.js";
 import { resolveConfig } from "./config.js";
 import { comments } from "./index.js";
 import { createCommentsThreadLoader } from "./server/template-dep.js";
@@ -35,27 +36,54 @@ describe("comments() plugin", () => {
     expect(plugin.schema).toBeDefined();
   });
 
-  test("setup registers the moderation surface", () => {
-    const kinds: string[] = [];
-    const routes: string[] = [];
-    const capabilities: string[] = [];
-    const adminPaths: string[] = [];
-    let rpcRouter = false;
+  interface CapturedSetup {
+    readonly kinds: string[];
+    readonly routes: string[];
+    readonly capabilities: string[];
+    readonly adminPaths: string[];
+    readonly actions: string[];
+    rpcRouter: boolean;
+  }
+
+  function captureSetup(config: CommentsConfig): CapturedSetup {
+    const captured: CapturedSetup = {
+      kinds: [],
+      routes: [],
+      capabilities: [],
+      adminPaths: [],
+      actions: [],
+      rpcRouter: false,
+    };
     const ctx = {
-      registerTemplateDep: (kind: string) => kinds.push(kind),
-      registerRoute: (opts: { path: string }) => routes.push(opts.path),
-      registerCapability: (name: string) => capabilities.push(name),
+      registerTemplateDep: (kind: string) => captured.kinds.push(kind),
+      registerRoute: (opts: { path: string }) =>
+        captured.routes.push(opts.path),
+      registerCapability: (name: string) => captured.capabilities.push(name),
       registerRpcRouter: () => {
-        rpcRouter = true;
+        captured.rpcRouter = true;
       },
-      registerAdminPage: (opts: { path: string }) => adminPaths.push(opts.path),
+      registerAdminPage: (opts: { path: string }) =>
+        captured.adminPaths.push(opts.path),
+      addAction: (name: string) => captured.actions.push(name),
     } as unknown as Parameters<ReturnType<typeof comments>["setup"]>[0];
-    void comments().setup(ctx, undefined);
-    expect(kinds).toContain("comments");
-    expect(routes).toContain("/submit");
-    expect(capabilities).toContain("comment:moderate");
-    expect(adminPaths).toContain("/comments");
-    expect(rpcRouter).toBe(true);
+    void comments(config).setup(ctx, undefined);
+    return captured;
+  }
+
+  test("setup registers the moderation surface", () => {
+    const s = captureSetup({});
+    expect(s.kinds).toContain("comments");
+    expect(s.routes).toContain("/submit");
+    expect(s.capabilities).toContain("comment:moderate");
+    expect(s.adminPaths).toContain("/comments");
+    expect(s.rpcRouter).toBe(true);
+  });
+
+  test("registers a comment:created listener only when notifyEmail is set", () => {
+    expect(captureSetup({}).actions).not.toContain("comment:created");
+    expect(captureSetup({ notifyEmail: "mod@example.test" }).actions).toContain(
+      "comment:created",
+    );
   });
 });
 

--- a/packages/plugins/comments/src/index.ts
+++ b/packages/plugins/comments/src/index.ts
@@ -1,9 +1,10 @@
-import { definePlugin } from "plumix/plugin";
+import { definePlugin, tryGetContext } from "plumix/plugin";
 
 import type { CommentsConfig } from "./types.js";
 import { resolveConfig } from "./config.js";
 import * as schema from "./db/schema.js";
 import { COMMENT_MODERATE_CAPABILITY, createCommentsRouter } from "./rpc.js";
+import { notifyModeratorOfPending } from "./server/notify.js";
 import { createSubmitHandler } from "./server/submit.js";
 import { createCommentsThreadLoader } from "./server/template-dep.js";
 
@@ -66,6 +67,18 @@ export function comments(options: CommentsConfig = {}) {
         auth: "public",
         handler: createSubmitHandler(config),
       });
+
+      if (config.notifyEmail) {
+        const recipient = config.notifyEmail;
+        // The action carries only the comment, so the mailer-bearing
+        // AppContext comes from the request store; skip if it's absent
+        // (the action fired outside a request).
+        ctx.addAction("comment:created", async (comment) => {
+          const appCtx = tryGetContext();
+          if (appCtx)
+            await notifyModeratorOfPending(appCtx, comment, recipient);
+        });
+      }
     },
   });
 }

--- a/packages/plugins/comments/src/server/enablement.ts
+++ b/packages/plugins/comments/src/server/enablement.ts
@@ -1,5 +1,3 @@
-import type { CommentsConfig } from "../types.js";
-
 /**
  * The `supports` flag an entry type declares to opt into comments —
  * the WordPress `post_type_supports($type, 'comments')` model. Lives in
@@ -9,17 +7,17 @@ export const COMMENTS_SUPPORT = "comments";
 
 /**
  * Whether commenting is enabled for an entry type. The effective set is
- * the union of two sources: types the site lists in `config.entryTypes`,
- * and types that self-declare `supports: ['comments']` at registration.
+ * the union of two sources: types the site lists in `entryTypes`, and
+ * types that self-declare `supports: ['comments']` at registration.
  *
  * @param typeName  the entry type (e.g. `"post"`).
  * @param supports  the type's registered `supports` array, if any.
- * @param config    the resolved plugin config.
+ * @param config    the plugin config's entry-type allowlist.
  */
 export function isCommentingEnabled(
   typeName: string,
   supports: readonly string[] | undefined,
-  config: CommentsConfig,
+  config: { readonly entryTypes?: readonly string[] },
 ): boolean {
   if (config.entryTypes?.includes(typeName)) return true;
   return supports?.includes(COMMENTS_SUPPORT) ?? false;

--- a/packages/plugins/comments/src/server/notify.test.ts
+++ b/packages/plugins/comments/src/server/notify.test.ts
@@ -1,0 +1,51 @@
+import type { AppContext } from "plumix/plugin";
+import { describe, expect, test, vi } from "vitest";
+
+import type { Comment } from "../db/schema.js";
+import { notifyModeratorOfPending } from "./notify.js";
+
+function comment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    status: "pending",
+    authorName: "Ada",
+    bodyMd: "please review",
+    ...overrides,
+  } as Comment;
+}
+
+function ctxWith(send?: ReturnType<typeof vi.fn>): AppContext {
+  return { mailer: send ? { send } : undefined } as unknown as AppContext;
+}
+
+describe("notifyModeratorOfPending", () => {
+  test("emails the moderator for a pending comment", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await notifyModeratorOfPending(
+      ctxWith(send),
+      comment(),
+      "mod@example.test",
+    );
+    expect(send).toHaveBeenCalledOnce();
+    expect(send.mock.calls[0]?.[0]).toMatchObject({ to: "mod@example.test" });
+  });
+
+  test("does not email for an approved comment", async () => {
+    const send = vi.fn();
+    await notifyModeratorOfPending(
+      ctxWith(send),
+      comment({ status: "approved" }),
+      "mod@example.test",
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test("is a no-op when no mailer is configured", async () => {
+    await expect(
+      notifyModeratorOfPending(
+        ctxWith(undefined),
+        comment(),
+        "mod@example.test",
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/plugins/comments/src/server/notify.ts
+++ b/packages/plugins/comments/src/server/notify.ts
@@ -1,0 +1,20 @@
+import type { AppContext } from "plumix/plugin";
+
+import type { Comment } from "../db/schema.js";
+
+/**
+ * A no-op unless the comment is `pending` and a mailer is configured, so
+ * callers can fire it unconditionally on every new comment.
+ */
+export async function notifyModeratorOfPending(
+  ctx: AppContext,
+  comment: Comment,
+  recipient: string,
+): Promise<void> {
+  if (comment.status !== "pending" || !ctx.mailer) return;
+  await ctx.mailer.send({
+    to: recipient,
+    subject: "A comment is awaiting moderation",
+    text: `${comment.authorName} left a comment that's held for review:\n\n${comment.bodyMd}`,
+  });
+}

--- a/packages/plugins/comments/src/types.ts
+++ b/packages/plugins/comments/src/types.ts
@@ -43,6 +43,12 @@ export interface CommentsConfig {
   readonly requireEmail?: boolean;
   /** Reject comments on posts older than this many days. `null` = never. */
   readonly closeAfterDays?: number | null;
+  /**
+   * Email a moderator when a comment is held for review. Requires a
+   * configured `ctx.mailer`; with no address, no email is sent (the
+   * in-app queue is the always-on surface).
+   */
+  readonly notifyEmail?: string;
   /** Sliding-window rate limit. Defaults to `{ max: 5, windowMin: 10 }`. */
   readonly rateLimit?: RateLimitConfig;
 }


### PR DESCRIPTION
Slice 6 of 8 for the comments plugin (PRD #959). Emails a moderator when a comment is held for review, so the queue gets attended without polling.

Opt-in via `comments({ notifyEmail })`. When a comment lands `pending`, the plugin emails that address via `ctx.mailer`. It's wired as a **`comment:created` action listener** (decoupled and swappable — a future plugin can replace it) rather than an inline mailer call. The listener pulls the mailer-bearing `AppContext` from the request store, since the action signature carries only the comment.

`notifyModeratorOfPending` is a no-op unless the comment is pending **and** a mailer is configured, so it's safe to fire on every new comment: an auto-approved comment never triggers it, and a deploy without a mailer just skips silently (the in-app queue is the always-on surface). The listener is registered only when `notifyEmail` is set.

### Testing

110 tests. The delivery rides the request-store context the **cloudflare adapter** establishes (`requestStore.run`), which the dispatcher/RPC harnesses don't — so rather than a fragile through-harness test, the chain is covered by: the `notifyModeratorOfPending` unit tests (pending→sends, approved→skips, no-mailer→no-op), a wiring test (the `comment:created` listener is registered iff `notifyEmail` is set), and the existing coverage that submit fires `comment:created`. Required gates — lint, typecheck, knip, format, commitlint — green.

### Notes

- Email copy is plain English; i18n + the descriptor pattern (matching core's `auth/email/messages.ts`) land with #966.
- Also relaxes `isCommentingEnabled` to take just the entry-type allowlist (decouples it from the full config shape).
- Deferred (follow-ups): author-on-approval and reply-to-commenter notifications.

### Out of scope (later slices)

i18n (#966), root pagination (#967).

Closes #965
Refs #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)