### PR TITLE
feat(plugin-comments): paginate root comments newest-first with load-more

### DIFF
--- a/packages/plugins/comments/playground/theme.ts
+++ b/packages/plugins/comments/playground/theme.ts
@@ -40,6 +40,59 @@ function commentItem(comment: ThreadComment): ReactNode {
   );
 }
 
+// Progressive-enhancement "load more": fetches the next root page from
+// the plugin's public GET route and appends it, building the same markup
+// `commentItem` renders server-side so appended nodes match. Shipped
+// inline because the playground has no client bundler; a real theme would
+// author this in its own client entry. `bodyHtml` is sanitized
+// server-side (markdown-it `html:false`), so the `innerHTML` sink carries
+// the same trust boundary as the SSR `dangerouslySetInnerHTML` — never
+// feed this raw `bodyMd`.
+const LOAD_MORE_SCRIPT = `
+(function () {
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    Object.keys(attrs || {}).forEach(function (k) { node.setAttribute(k, attrs[k]); });
+    (children || []).forEach(function (c) { if (c) node.appendChild(c); });
+    return node;
+  }
+  function item(c) {
+    var li = el("li", { "data-testid": "comment-item-" + c.id });
+    li.appendChild(el("img", { "data-testid": "comment-avatar", src: c.avatarUrl, alt: "", width: "48", height: "48" }));
+    li.appendChild(el("span", { "data-testid": "comment-author" }, [document.createTextNode(c.authorName)]));
+    var body = el("div", { "data-testid": "comment-body" });
+    body.innerHTML = c.bodyHtml;
+    li.appendChild(body);
+    if (c.replies && c.replies.length) {
+      li.appendChild(el("ul", { "data-testid": "comment-replies" }, c.replies.map(item)));
+    }
+    return li;
+  }
+  document.addEventListener("click", function (e) {
+    var btn = e.target.closest && e.target.closest("[data-testid='comments-load-more']");
+    if (!btn) return;
+    btn.disabled = true;
+    var entryId = btn.getAttribute("data-entry-id");
+    var cursor = btn.getAttribute("data-cursor");
+    var url = "/_plumix/comments/list?entryId=" + encodeURIComponent(entryId) +
+      (cursor ? "&cursor=" + encodeURIComponent(cursor) : "");
+    fetch(url, { headers: { accept: "application/json" } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r); })
+      .then(function (page) {
+        var list = document.querySelector("[data-testid='comments-list']");
+        page.comments.forEach(function (c) { list.appendChild(item(c)); });
+        if (page.hasMore && page.nextCursor) {
+          btn.setAttribute("data-cursor", page.nextCursor);
+          btn.disabled = false;
+        } else {
+          btn.remove();
+        }
+      })
+      .catch(function () { btn.disabled = false; });
+  });
+})();
+`;
+
 const single = defineTemplate<SingleData>({
   comments: ["current"],
   render: ({ data, comments }): ReactNode => {
@@ -61,6 +114,22 @@ const single = defineTemplate<SingleData>({
           { "data-testid": "comments-list" },
           (thread?.comments ?? []).map(commentItem),
         ),
+        thread?.hasMore
+          ? h(
+              "button",
+              {
+                "data-testid": "comments-load-more",
+                "data-entry-id": String(thread.entryId),
+                "data-cursor": thread.nextCursor ?? "",
+              },
+              "Load more comments",
+            )
+          : null,
+        thread?.hasMore
+          ? h("script", {
+              dangerouslySetInnerHTML: { __html: LOAD_MORE_SCRIPT },
+            })
+          : null,
       ),
     );
   },

--- a/packages/plugins/comments/src/config.ts
+++ b/packages/plugins/comments/src/config.ts
@@ -9,6 +9,7 @@ export interface ResolvedCommentsConfig {
   readonly entryTypes: readonly string[];
   readonly mode: ModerationMode;
   readonly maxDepth: number;
+  readonly rootsPerPage: number;
   readonly requireEmail: boolean;
   readonly closeAfterDays: number | null;
   readonly rateLimit: RateLimitConfig;
@@ -20,6 +21,7 @@ export function resolveConfig(options: CommentsConfig): ResolvedCommentsConfig {
     entryTypes: options.entryTypes ?? [],
     mode: options.mode ?? "first_time",
     maxDepth: options.maxDepth ?? 3,
+    rootsPerPage: options.rootsPerPage ?? 20,
     requireEmail: options.requireEmail ?? true,
     closeAfterDays: options.closeAfterDays ?? null,
     rateLimit: options.rateLimit ?? { max: 5, windowMin: 10 },

--- a/packages/plugins/comments/src/index.ts
+++ b/packages/plugins/comments/src/index.ts
@@ -5,6 +5,7 @@ import type { CommentsConfig } from "./types.js";
 import { resolveConfig } from "./config.js";
 import * as schema from "./db/schema.js";
 import { COMMENT_MODERATE_CAPABILITY, createCommentsRouter } from "./rpc.js";
+import { createListHandler } from "./server/list.js";
 import { notifyModeratorOfPending } from "./server/notify.js";
 import { createSubmitHandler } from "./server/submit.js";
 import { createCommentsThreadLoader } from "./server/template-dep.js";
@@ -81,6 +82,12 @@ export function comments(options: CommentsConfig = {}) {
         path: "/submit",
         auth: "public",
         handler: createSubmitHandler(config),
+      });
+      ctx.registerRoute({
+        method: "GET",
+        path: "/list",
+        auth: "public",
+        handler: createListHandler(config),
       });
 
       if (config.notifyEmail) {

--- a/packages/plugins/comments/src/render.test.ts
+++ b/packages/plugins/comments/src/render.test.ts
@@ -52,6 +52,16 @@ const single = defineTemplate<SingleData>({
       el("h1", { "data-testid": "post-title" }, data.entry.title),
       el("p", { "data-testid": "comments-count" }, String(thread?.count ?? 0)),
       el("ul", null, ...(thread?.comments ?? []).map(renderComment)),
+      thread?.hasMore
+        ? el(
+            "button",
+            {
+              "data-testid": "load-more",
+              "data-cursor": thread.nextCursor ?? "",
+            },
+            "Load more",
+          )
+        : null,
     );
   },
 });
@@ -151,5 +161,50 @@ describe("comments read path through the dispatcher", () => {
     const repliesIdx = html.indexOf('data-testid="replies"');
     expect(repliesIdx).toBeGreaterThan(-1);
     expect(html.indexOf("the reply")).toBeGreaterThan(repliesIdx);
+  });
+
+  // Public content can't render under `plumix dev` (it serves the admin
+  // SPA), so the load-more flow is exercised here through the in-process
+  // dispatcher: the SSR page shows only the first root page plus the
+  // affordance, and the public list route reveals the next page.
+  test("shows a load-more affordance and reveals the next root page", async () => {
+    const harness = await createDispatcherHarness({
+      plugins: [testBlog, comments({ entryTypes: ["post"], rootsPerPage: 2 })],
+      theme,
+    });
+    await applyCommentsSchema(harness.db);
+    const entry = await seedPost(harness, "busy");
+    const seed = commentFactory.transient({ db: harness.db });
+    for (let i = 1; i <= 3; i++) {
+      await seed.create({
+        entryId: entry.id,
+        status: "approved",
+        authorName: `Root ${String(i)}`,
+        bodyMd: `root ${String(i)}`,
+        createdAt: new Date(`2026-06-0${String(i)}T00:00:00Z`),
+      });
+    }
+
+    const html = await (await harness.fetch("/posts/busy")).text();
+    // First page: the two newest roots and the load-more button; the
+    // oldest root is held back. Total count still reflects all three.
+    expect(html).toContain('data-testid="comments-count">3<');
+    expect(html).toContain("root 3");
+    expect(html).toContain("root 2");
+    expect(html).not.toContain("root 1");
+    expect(html).toContain('data-testid="load-more"');
+
+    const cursor = /data-cursor="([^"]+)"/.exec(html)?.[1];
+    expect(cursor).toBeTruthy();
+    const next = await (
+      await harness.fetch(
+        `/_plumix/comments/list?entryId=${String(entry.id)}&cursor=${String(
+          cursor,
+        )}`,
+      )
+    ).json<{ comments: { bodyHtml: string }[]; hasMore: boolean }>();
+    expect(next.comments).toHaveLength(1);
+    expect(next.comments[0]?.bodyHtml).toContain("root 1");
+    expect(next.hasMore).toBe(false);
   });
 });

--- a/packages/plugins/comments/src/server/list.test.ts
+++ b/packages/plugins/comments/src/server/list.test.ts
@@ -1,0 +1,142 @@
+import { definePlugin } from "plumix/plugin";
+import { createDispatcherHarness } from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+import type { CommentsConfig } from "../types.js";
+import { comments } from "../index.js";
+import { applyCommentsSchema } from "../test/db.js";
+import { commentFactory } from "../test/factories.js";
+
+const testBlog = definePlugin("test_blog", {
+  setup: (ctx) => {
+    ctx.registerEntryType("post", {
+      label: "Posts",
+      isPublic: true,
+      rewrite: { slug: "posts" },
+    });
+  },
+});
+
+type Harness = Awaited<ReturnType<typeof createDispatcherHarness>>;
+
+async function harnessWith(config: CommentsConfig): Promise<Harness> {
+  const harness = await createDispatcherHarness({
+    plugins: [testBlog, comments(config)],
+  });
+  await applyCommentsSchema(harness.db);
+  return harness;
+}
+
+async function seedPost(harness: Harness, overrides = {}) {
+  const user = await harness.factory.user.create({});
+  return harness.factory.entry.create({
+    type: "post",
+    title: "Post",
+    authorId: user.id,
+    status: "published",
+    ...overrides,
+  });
+}
+
+async function seedRoots(harness: Harness, entryId: number, n: number) {
+  const f = commentFactory.transient({ db: harness.db });
+  const made = [];
+  for (let i = 1; i <= n; i++) {
+    made.push(
+      await f.create({
+        entryId,
+        status: "approved",
+        bodyMd: `root ${String(i)}`,
+        createdAt: new Date(`2026-06-${String(i).padStart(2, "0")}T00:00:00Z`),
+      }),
+    );
+  }
+  return made;
+}
+
+interface ListPage {
+  comments: { id: number; bodyHtml: string; replies: { bodyHtml: string }[] }[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+describe("GET /_plumix/comments/list", () => {
+  test("rejects a missing or invalid entryId", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"] });
+    (await harness.fetch("/_plumix/comments/list")).assertStatus(400);
+    (await harness.fetch("/_plumix/comments/list?entryId=0")).assertStatus(400);
+  });
+
+  test("404s for a non-published entry", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"] });
+    const draft = await seedPost(harness, { status: "draft" });
+    (
+      await harness.fetch(`/_plumix/comments/list?entryId=${String(draft.id)}`)
+    ).assertStatus(404);
+  });
+
+  test("403s when the entry type has comments disabled", async () => {
+    const harness = await harnessWith({});
+    const entry = await seedPost(harness);
+    (
+      await harness.fetch(`/_plumix/comments/list?entryId=${String(entry.id)}`)
+    ).assertStatus(403);
+  });
+
+  test("returns the next, older page of roots with their descendants", async () => {
+    const harness = await harnessWith({
+      entryTypes: ["post"],
+      rootsPerPage: 2,
+    });
+    const entry = await seedPost(harness);
+    const [oldest] = await seedRoots(harness, entry.id, 3);
+    await commentFactory.transient({ db: harness.db }).create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: oldest?.id,
+      bodyMd: "reply to oldest",
+    });
+
+    const firstRes = await harness.fetch(
+      `/_plumix/comments/list?entryId=${String(entry.id)}`,
+    );
+    firstRes.assertStatus(200);
+    const first = await firstRes.json<ListPage>();
+    expect(first.comments).toHaveLength(2);
+    expect(first.comments[0]?.bodyHtml).toContain("root 3");
+    expect(first.hasMore).toBe(true);
+    expect(first.nextCursor).not.toBeNull();
+
+    const secondRes = await harness.fetch(
+      `/_plumix/comments/list?entryId=${String(entry.id)}&cursor=${String(
+        first.nextCursor,
+      )}`,
+    );
+    const second = await secondRes.json<ListPage>();
+    expect(second.comments).toHaveLength(1);
+    expect(second.comments[0]?.bodyHtml).toContain("root 1");
+    expect(second.comments[0]?.replies[0]?.bodyHtml).toContain(
+      "reply to oldest",
+    );
+    expect(second.hasMore).toBe(false);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  test("never leaks author email or ip hash in the payload", async () => {
+    const harness = await harnessWith({ entryTypes: ["post"] });
+    const entry = await seedPost(harness);
+    await commentFactory.transient({ db: harness.db }).create({
+      entryId: entry.id,
+      status: "approved",
+      authorEmail: "secret@example.test",
+      ipHash: "deadbeef",
+    });
+
+    const res = await harness.fetch(
+      `/_plumix/comments/list?entryId=${String(entry.id)}`,
+    );
+    const body = await res.text();
+    expect(body).not.toContain("secret@example.test");
+    expect(body).not.toContain("deadbeef");
+  });
+});

--- a/packages/plugins/comments/src/server/list.ts
+++ b/packages/plugins/comments/src/server/list.ts
@@ -1,0 +1,56 @@
+import type { AppContext } from "plumix/plugin";
+import { eq } from "drizzle-orm";
+import { entries, jsonResponse } from "plumix/plugin";
+
+import type { ResolvedCommentsConfig } from "../config.js";
+import { isCommentingEnabled } from "./enablement.js";
+import { loadThread } from "./load-thread.js";
+
+/**
+ * The public "load more roots" handler, mounted at
+ * `GET /_plumix/comments/list?entryId=<n>&cursor=<token>`
+ * (`auth: "public"`). Returns the next page of root comments — each with
+ * its descendants — in the same email/IP-private shape the SSR thread
+ * uses, so the client can append them. `cursor` is the opaque
+ * `nextCursor` from the prior page (or the SSR thread for page two);
+ * omit it to re-fetch the first page. Gates the entry the same way the
+ * submit route does: must be a published, comment-enabled entry.
+ */
+export function createListHandler(config: ResolvedCommentsConfig) {
+  return async (request: Request, ctx: AppContext): Promise<Response> => {
+    const url = new URL(request.url);
+    const entryIdRaw = url.searchParams.get("entryId");
+    const entryId = Number(entryIdRaw);
+    if (entryIdRaw === null || !Number.isInteger(entryId) || entryId < 1) {
+      return jsonResponse({ error: "invalid_input" }, { status: 400 });
+    }
+
+    const [entry] = await ctx.db
+      .select({ type: entries.type, status: entries.status })
+      .from(entries)
+      .where(eq(entries.id, entryId));
+    if (entry?.status !== "published") {
+      return jsonResponse({ error: "entry_not_found" }, { status: 404 });
+    }
+
+    const supports = ctx.plugins.entryTypes.get(entry.type)?.supports;
+    if (!isCommentingEnabled(entry.type, supports, config)) {
+      return jsonResponse({ error: "comments_disabled" }, { status: 403 });
+    }
+    // Mirrors the submit route's published + enablement gates, but
+    // deliberately omits its `closeAfterDays` check: a closed thread is
+    // read-only, not invisible — you can still page through old comments
+    // you can no longer reply to.
+
+    const thread = await loadThread(ctx, entryId, {
+      maxDepth: config.maxDepth,
+      rootsPerPage: config.rootsPerPage,
+      cursor: url.searchParams.get("cursor"),
+    });
+    return jsonResponse({
+      comments: thread.comments,
+      hasMore: thread.hasMore,
+      nextCursor: thread.nextCursor,
+    });
+  };
+}

--- a/packages/plugins/comments/src/server/load-thread.test.ts
+++ b/packages/plugins/comments/src/server/load-thread.test.ts
@@ -20,7 +20,10 @@ describe("loadThread", () => {
     await f.create({ entryId: entry.id, status: "spam" });
     await f.create({ entryId: entry.id, status: "trash" });
 
-    const thread = await loadThread(ctxFor(db), entry.id, 3);
+    const thread = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 100,
+    });
 
     expect(thread.count).toBe(1);
     expect(thread.comments).toHaveLength(1);
@@ -51,7 +54,10 @@ describe("loadThread", () => {
       authorUserId: null,
     });
 
-    const thread = await loadThread(ctxFor(db), entry.id, 3);
+    const thread = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 100,
+    });
     expect(thread.comments.map((c) => c.isRegistered).sort()).toEqual([
       false,
       true,
@@ -67,8 +73,14 @@ describe("loadThread", () => {
     await f.create({ entryId: b.id, status: "approved" });
     await f.create({ entryId: b.id, status: "approved" });
 
-    expect((await loadThread(ctxFor(db), a.id, 3)).count).toBe(1);
-    expect((await loadThread(ctxFor(db), b.id, 3)).count).toBe(2);
+    expect(
+      (await loadThread(ctxFor(db), a.id, { maxDepth: 3, rootsPerPage: 100 }))
+        .count,
+    ).toBe(1);
+    expect(
+      (await loadThread(ctxFor(db), b.id, { maxDepth: 3, rootsPerPage: 100 }))
+        .count,
+    ).toBe(2);
   });
 
   test("returns an empty thread when nothing is approved", async () => {
@@ -78,7 +90,10 @@ describe("loadThread", () => {
       .transient({ db })
       .create({ entryId: entry.id, status: "pending" });
 
-    const thread = await loadThread(ctxFor(db), entry.id, 3);
+    const thread = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 100,
+    });
     expect(thread.count).toBe(0);
     expect(thread.comments).toEqual([]);
   });
@@ -110,7 +125,10 @@ describe("loadThread — nesting", () => {
       createdAt: new Date("2026-06-02T00:00:00Z"),
     });
 
-    const thread = await loadThread(ctxFor(db), entry.id, 3);
+    const thread = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 100,
+    });
     expect(thread.count).toBe(3);
     expect(thread.comments).toHaveLength(1);
     const replies = thread.comments[0]?.replies ?? [];
@@ -134,7 +152,10 @@ describe("loadThread — nesting", () => {
       parentId: hiddenParent.id,
     });
 
-    const thread = await loadThread(ctxFor(db), entry.id, 3);
+    const thread = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 100,
+    });
     expect(thread.count).toBe(0);
   });
 
@@ -155,7 +176,154 @@ describe("loadThread — nesting", () => {
     });
 
     // maxDepth 1 → root (0) + its direct reply (1); the depth-2 reply is cut.
-    const thread = await loadThread(ctxFor(db), entry.id, 1);
+    const thread = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 1,
+      rootsPerPage: 100,
+    });
     expect(thread.count).toBe(2);
+  });
+});
+
+describe("loadThread — root pagination", () => {
+  // Seeds `n` approved roots dated 2026-06-01 .. 2026-06-0n so newest-first
+  // ordering is deterministic; returns them oldest-first.
+  async function seedRoots(
+    db: Awaited<ReturnType<typeof createCommentsTestDb>>,
+    entryId: number,
+    n: number,
+  ) {
+    const f = commentFactory.transient({ db });
+    const made = [];
+    for (let i = 1; i <= n; i++) {
+      made.push(
+        await f.create({
+          entryId,
+          status: "approved",
+          bodyMd: `root ${String(i)}`,
+          createdAt: new Date(
+            `2026-06-${String(i).padStart(2, "0")}T00:00:00Z`,
+          ),
+        }),
+      );
+    }
+    return made;
+  }
+
+  test("returns the newest rootsPerPage roots first, with a cursor for more", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    await seedRoots(db, entry.id, 3);
+
+    const page = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 2,
+    });
+
+    expect(page.comments).toHaveLength(2);
+    expect(page.comments[0]?.bodyHtml).toContain("root 3");
+    expect(page.comments[1]?.bodyHtml).toContain("root 2");
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).not.toBeNull();
+    expect(page.count).toBe(3);
+  });
+
+  test("the cursor loads the next, older page without overlap", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    await seedRoots(db, entry.id, 3);
+
+    const first = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 2,
+    });
+    const second = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 2,
+      cursor: first.nextCursor,
+    });
+
+    expect(second.comments).toHaveLength(1);
+    expect(second.comments[0]?.bodyHtml).toContain("root 1");
+    expect(second.hasMore).toBe(false);
+    expect(second.nextCursor).toBeNull();
+    const firstIds = new Set(first.comments.map((c) => c.id));
+    expect(second.comments.every((c) => !firstIds.has(c.id))).toBe(true);
+  });
+
+  test("a root's descendants load with that root's page", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const [oldest] = await seedRoots(db, entry.id, 3);
+    await commentFactory.transient({ db }).create({
+      entryId: entry.id,
+      status: "approved",
+      parentId: oldest?.id,
+      bodyMd: "reply to oldest",
+    });
+
+    const first = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 2,
+    });
+    expect(JSON.stringify(first.comments)).not.toContain("reply to oldest");
+    expect(first.count).toBe(4);
+
+    const second = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 2,
+      cursor: first.nextCursor,
+    });
+    expect(second.comments[0]?.replies[0]?.bodyHtml).toContain(
+      "reply to oldest",
+    );
+    // Load-more pages skip the count walk; the client kept page one's total.
+    expect(second.count).toBe(0);
+  });
+
+  test("breaks ties on id when roots share a timestamp — no dupe or skip", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    const createdAt = new Date("2026-06-01T00:00:00Z");
+    const f = commentFactory.transient({ db });
+    const a = await f.create({
+      entryId: entry.id,
+      status: "approved",
+      createdAt,
+    });
+    const b = await f.create({
+      entryId: entry.id,
+      status: "approved",
+      createdAt,
+    });
+
+    const first = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 1,
+    });
+    const second = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 1,
+      cursor: first.nextCursor,
+    });
+
+    // Higher id wins the DESC tie-break, so the later insert is page one.
+    expect(first.comments.map((c) => c.id)).toEqual([b.id]);
+    expect(second.comments.map((c) => c.id)).toEqual([a.id]);
+    expect(second.hasMore).toBe(false);
+  });
+
+  test("an unparseable cursor falls back to the first page", async () => {
+    const db = await createCommentsTestDb();
+    const entry = await seedPublishedPost(db);
+    await seedRoots(db, entry.id, 2);
+
+    const page = await loadThread(ctxFor(db), entry.id, {
+      maxDepth: 3,
+      rootsPerPage: 2,
+      cursor: "garbage",
+    });
+
+    expect(page.comments).toHaveLength(2);
+    expect(page.comments[0]?.bodyHtml).toContain("root 2");
   });
 });

--- a/packages/plugins/comments/src/server/load-thread.ts
+++ b/packages/plugins/comments/src/server/load-thread.ts
@@ -21,11 +21,48 @@ export interface ResolvedComment {
 }
 
 /** The assembled comment thread for one entry. `count` is every approved
- * comment in the tree; `comments` are the roots (each with nested replies). */
+ * comment in the displayed tree (depth-bounded, orphans excluded) — but
+ * only on the first page (no `cursor`); load-more pages return `0`, since
+ * the client already rendered the total and recounting the whole tree on
+ * every fetch is wasted work. `comments` are the roots for the requested
+ * page (newest first, each with nested replies). `hasMore` flags older
+ * roots beyond this page, reachable by passing `nextCursor` back to
+ * `GET /_plumix/comments/list`. */
 export interface ResolvedThread {
   readonly entryId: number;
   readonly comments: readonly ResolvedComment[];
   readonly count: number;
+  readonly hasMore: boolean;
+  readonly nextCursor: string | null;
+}
+
+/** One page of root comments to load. `cursor` is an opaque
+ * `GET /_plumix/comments/list` token from a prior `nextCursor`; omit it
+ * for the first (newest) page. */
+interface LoadThreadOptions {
+  readonly maxDepth: number;
+  readonly rootsPerPage: number;
+  readonly cursor?: string | null;
+}
+
+interface RootCursor {
+  readonly createdAt: number;
+  readonly id: number;
+}
+
+// Keyset cursor over the root ordering `(created_at DESC, id DESC)`,
+// encoded `"<unixSeconds>_<id>"`. Keyset (not offset) so newly approved
+// comments arriving between page loads can't shift the window and dupe or
+// skip a root. Unparseable input → null → treated as the first page.
+function encodeCursor(createdAt: number, id: number): string {
+  return `${String(createdAt)}_${String(id)}`;
+}
+
+function decodeCursor(cursor: string | null | undefined): RootCursor | null {
+  if (!cursor) return null;
+  const match = /^(\d+)_(\d+)$/.exec(cursor);
+  if (!match) return null;
+  return { createdAt: Number(match[1]), id: Number(match[2]) };
 }
 
 // Augment the template-dep registry so themes can declare
@@ -59,26 +96,84 @@ function toResolved(node: ThreadNode<CommentValue>): ResolvedComment {
   return { ...node.value, replies: node.replies.map(toResolved) };
 }
 
+/** Count every approved comment in the displayed tree — depth-bounded and
+ * orphan-excluded the same way `loadThread` renders it — so the count is
+ * stable across pages and matches what's actually shown. */
+async function countThread(
+  ctx: AppContext,
+  entryId: number,
+  maxDepth: number,
+): Promise<number> {
+  const [row] = await ctx.db.all<{ c: number }>(sql`
+    WITH RECURSIVE thread AS (
+      SELECT id, created_at, 0 AS depth
+      FROM comments
+      WHERE entry_id = ${entryId} AND status = 'approved' AND parent_id IS NULL
+      UNION ALL
+      SELECT c.id, c.created_at, t.depth + 1
+      FROM comments c
+      JOIN thread t ON c.parent_id = t.id
+      WHERE c.status = 'approved' AND t.depth + 1 <= ${maxDepth}
+    )
+    SELECT count(*) AS c FROM thread
+  `);
+  return row?.c ?? 0;
+}
+
 /**
- * Load the approved thread for an entry, rendered for display. One
- * recursive CTE walks roots → descendants down to `maxDepth` (the depth
- * bound is a safety net; the submit path already clamps stored depth);
- * the rows render in parallel (no N+1) and `assembleThread` nests them.
- * A reply whose parent isn't approved is excluded (the CTE only descends
- * through approved rows), not promoted. Chronological within each sibling
- * group; root pagination + ordering are a later slice.
+ * Load one page of the approved thread for an entry, rendered for display.
+ * Roots paginate newest-first at `rootsPerPage` via a keyset cursor; each
+ * root's descendants down to `maxDepth` come with it. Two indexed queries
+ * (the root page, then a recursive CTE descending the page's roots) plus a
+ * count — no N+1 regardless of page size. A reply whose parent isn't
+ * approved is excluded (the CTE only descends approved rows), not
+ * promoted; replies stay chronological within each sibling group.
  */
 export async function loadThread(
   ctx: AppContext,
   entryId: number,
-  maxDepth: number,
+  options: LoadThreadOptions,
 ): Promise<ResolvedThread> {
+  const { maxDepth, rootsPerPage } = options;
+  const before = decodeCursor(options.cursor);
+
+  // Fetch one extra root to detect a further page without a second count.
+  const beforeClause = before
+    ? sql`AND (created_at < ${before.createdAt}
+             OR (created_at = ${before.createdAt} AND id < ${before.id}))`
+    : sql``;
+  const rootRows = await ctx.db.all<{ id: number; created_at: number }>(sql`
+    SELECT id, created_at
+    FROM comments
+    WHERE entry_id = ${entryId} AND status = 'approved' AND parent_id IS NULL
+      ${beforeClause}
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${rootsPerPage + 1}
+  `);
+
+  const hasMore = rootRows.length > rootsPerPage;
+  const pageRoots = rootRows.slice(0, rootsPerPage);
+  const lastRoot = pageRoots.at(-1);
+  const nextCursor =
+    hasMore && lastRoot ? encodeCursor(lastRoot.created_at, lastRoot.id) : null;
+
+  // The total is only shown on the first SSR render; skip the full-tree
+  // count walk on load-more pages, which discard it.
+  const count = before ? 0 : await countThread(ctx, entryId, maxDepth);
+  if (pageRoots.length === 0) {
+    return { entryId, comments: [], count, hasMore: false, nextCursor: null };
+  }
+
+  const rootIds = pageRoots.map((r) => r.id);
   const rows = await ctx.db.all<CommentRow>(sql`
     WITH RECURSIVE thread AS (
       SELECT id, parent_id, author_user_id, author_name, author_email,
              body_md, created_at, 0 AS depth
       FROM comments
-      WHERE entry_id = ${entryId} AND status = 'approved' AND parent_id IS NULL
+      WHERE id IN (${sql.join(
+        rootIds.map((id) => sql`${id}`),
+        sql`, `,
+      )})
       UNION ALL
       SELECT c.id, c.parent_id, c.author_user_id, c.author_name,
              c.author_email, c.body_md, c.created_at, t.depth + 1
@@ -107,9 +202,14 @@ export async function loadThread(
     })),
   );
 
-  return {
-    entryId,
-    comments: assembleThread(inputs).map(toResolved),
-    count: rows.length,
-  };
+  // `assembleThread` nests in chronological input order; re-sort the roots
+  // (only) newest-first so the page matches the cursor ordering. Replies
+  // keep their chronological order.
+  const comments = assembleThread(inputs)
+    .map(toResolved)
+    .sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime() || b.id - a.id,
+    );
+
+  return { entryId, comments, count, hasMore, nextCursor };
 }

--- a/packages/plugins/comments/src/server/template-dep.ts
+++ b/packages/plugins/comments/src/server/template-dep.ts
@@ -32,7 +32,11 @@ export function createCommentsThreadLoader(config: ResolvedCommentsConfig) {
     const supports = ctx.plugins.entryTypes.get(row.type)?.supports;
     if (!isCommentingEnabled(row.type, supports, config)) return {};
 
-    const thread = await loadThread(ctx, resolved.id, config.maxDepth);
+    // First (newest) page; older roots load via GET /_plumix/comments/list.
+    const thread = await loadThread(ctx, resolved.id, {
+      maxDepth: config.maxDepth,
+      rootsPerPage: config.rootsPerPage,
+    });
     return Object.fromEntries(slugs.map((slug) => [slug, thread]));
   };
 }

--- a/packages/plugins/comments/src/types.ts
+++ b/packages/plugins/comments/src/types.ts
@@ -39,6 +39,11 @@ export interface CommentsConfig {
   readonly mode?: ModerationMode;
   /** Maximum reply nesting depth (root = 0). Defaults to `3`. */
   readonly maxDepth?: number;
+  /**
+   * Root comments rendered per page (newest-first); older roots load
+   * on demand via `GET /_plumix/comments/list`. Defaults to `20`.
+   */
+  readonly rootsPerPage?: number;
   /** Require a non-empty author email. Defaults to `true`. */
   readonly requireEmail?: boolean;
   /** Reject comments on posts older than this many days. `null` = never. */


### PR DESCRIPTION
Root comments now render newest-first, capped at `rootsPerPage` (default 20), with older roots loaded on demand. Each root page brings its full descendant subtree. This is the final slice of the comments plugin (PRD #959).

**Keyset pagination**

`loadThread` takes a page descriptor (`{ maxDepth, rootsPerPage, cursor }`) and returns `hasMore` plus an opaque `nextCursor`. Ordering keys on `(created_at, id)` rather than an offset, so a comment approved between page loads can't shift the window and cause a root to duplicate or be skipped. The first (SSR) page reports the full displayed-tree `count` (depth-bounded, orphan-excluded); load-more pages skip that count walk since the client already rendered the total.

**Public list route**

```
GET /_plumix/comments/list?entryId=<n>&cursor=<token>
```

Returns `{ comments, hasMore, nextCursor }` in the same email/IP-private shape as the SSR thread. Gated like the submit route (published + comment-enabled) but **without** the `closeAfterDays` check — a closed thread is read-only, not invisible, so you can still page through old comments you can no longer reply to.

**Theme affordance**

The playground theme renders a "load more" button plus an inline progressive-enhancement script that fetches the route and appends the next page, mirroring the SSR markup. It's shipped inline because the playground has no client bundler; a real theme would author this in its own client entry. `bodyHtml` is sanitized server-side (markdown-it `html:false`), so the client `innerHTML` carries the same trust boundary as the SSR render.

## Notes / decisions

- Public content can't render under `plumix dev` (it serves the admin SPA), so the load-more flow is verified in-process via the dispatcher harness rather than a real browser — same decision as slice #960. The inline theme script is dogfood and not auto-tested.
- `count` is first-page-only by design; load-more pages return `0` to avoid recomputing the whole tree on every fetch.
- Tie-breaking on equal timestamps is covered by a dedicated test (two roots sharing `created_at`, asserting no dupe/skip across the page boundary).

All five required gates pass (lint, typecheck, knip, format, commitlint); 121 unit tests green.

Closes #967
Refs #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)