### PR TITLE
feat(blocks): add shortcode primitive and [year] expansion in rich-text

### DIFF
--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -162,6 +162,19 @@ export {
 export { coreMarks, coreMarkExtensions } from "./marks/core/index.js";
 export type { MarkSpec } from "./marks/types.js";
 
+// ─── Shortcodes ─────────────────────────────────────────────────────────────
+// `expandShortcodes` is the single integration point a future
+// `@plumix/plugin-seo` reuses to expand macros in meta descriptions.
+export { coreShortcodes } from "./shortcodes/core/index.js";
+export { expandShortcodes } from "./shortcodes/expand.js";
+export { defineShortcode } from "./shortcodes/types.js";
+export type {
+  ShortcodeContext,
+  ShortcodeRegistry,
+  ShortcodeRenderProps,
+  ShortcodeSpec,
+} from "./shortcodes/types.js";
+
 // ─── Islands authoring ──────────────────────────────────────────────────────
 export type {
   IslandProps,

--- a/packages/blocks/src/public-surface.test.ts
+++ b/packages/blocks/src/public-surface.test.ts
@@ -16,4 +16,12 @@ describe("@plumix/blocks public API — post-CSS-cleanup", () => {
     );
     expect(cssEmitterNames).toEqual([]);
   });
+
+  // The future `@plumix/plugin-seo` reuses this import to expand macros in
+  // meta descriptions; locking it keeps that integration point published.
+  test("publishes the shortcode primitive", () => {
+    expect(typeof blocksApi.expandShortcodes).toBe("function");
+    expect(typeof blocksApi.defineShortcode).toBe("function");
+    expect(Array.isArray(blocksApi.coreShortcodes)).toBe(true);
+  });
 });

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -8,6 +8,7 @@ import type {
   ResolvedLoaders,
 } from "./loaders.js";
 import type { PatternRegistry } from "./pattern-registry.js";
+import type { ShortcodeRegistry } from "./shortcodes/types.js";
 import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
 import type { ThemeTokens } from "./styles/types.js";
 import { emitBlockStyleCss } from "./styles/style-emitter.js";
@@ -27,6 +28,13 @@ export interface BlockContext {
   readonly parent: string | null;
   /** 0 at root, incremented for each container traversal. */
   readonly depth: number;
+  /** Active render locale, threaded for shortcode/`Intl` localization. */
+  readonly locale: string;
+  /**
+   * Registry of registered shortcodes for authored-content expansion, or
+   * `null` when the host wired none (the body then renders verbatim).
+   */
+  readonly shortcodes: ShortcodeRegistry | null;
 }
 
 export interface BlockNode {
@@ -56,6 +64,10 @@ export interface RenderBlockTreeOptions {
   readonly hooks?: BlockRenderHooks;
   readonly loaderData?: ResolvedBlockLoaders;
   readonly patterns?: PatternRegistry;
+  /** Render locale for shortcode/`Intl` localization. Defaults to `"en"`. */
+  readonly locale?: string;
+  /** Registered shortcodes for authored-content body expansion. */
+  readonly shortcodes?: ShortcodeRegistry;
 }
 
 export interface BlockNodeRenderProps<
@@ -78,6 +90,8 @@ export const DEFAULT_BLOCK_CONTEXT: BlockContext = Object.freeze({
   theme: null,
   parent: null,
   depth: 0,
+  locale: "en",
+  shortcodes: null,
 });
 
 interface DevWarnState {
@@ -274,5 +288,10 @@ export function renderBlockTree(
     loaderData: options?.loaderData,
     patterns: options?.patterns,
   };
-  return renderNodes(nodes, env, DEFAULT_BLOCK_CONTEXT);
+  const rootContext: BlockContext = {
+    ...DEFAULT_BLOCK_CONTEXT,
+    locale: options?.locale ?? DEFAULT_BLOCK_CONTEXT.locale,
+    shortcodes: options?.shortcodes ?? null,
+  };
+  return renderNodes(nodes, env, rootContext);
 }

--- a/packages/blocks/src/rich-text/index.test.tsx
+++ b/packages/blocks/src/rich-text/index.test.tsx
@@ -1,7 +1,8 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { BlockNode } from "../render-block-tree.js";
+import type { ShortcodeSpec } from "../shortcodes/types.js";
 import { createBlockRegistry } from "../block-registry.js";
 import { renderBlockTree } from "../render-block-tree.js";
 import { richTextBlock } from "./index.js";
@@ -57,5 +58,59 @@ describe("core/rich-text walker render", () => {
     expect(html).toBe(
       `<div data-plumix-block="core/rich-text"><div>${body}</div></div>`,
     );
+  });
+
+  describe("shortcode body expansion", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-06-12T00:00:00Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const yearShortcode: ShortcodeSpec = {
+      name: "year",
+      render: ({ context }) =>
+        new Intl.DateTimeFormat(context.locale, { year: "numeric" }).format(
+          new Date(),
+        ),
+    };
+
+    test("expands a registered shortcode in the stored HTML body", () => {
+      const registry = createBlockRegistry([richTextBlock]);
+      const tree: readonly BlockNode[] = [
+        {
+          id: "r1",
+          name: "core/rich-text",
+          attrs: { body: "<p>Best Shoes for [year]</p>" },
+        },
+      ];
+
+      const html = renderToStaticMarkup(
+        renderBlockTree(tree, registry, {
+          shortcodes: new Map([[yearShortcode.name, yearShortcode]]),
+          locale: "en",
+        }),
+      );
+
+      expect(html).toContain("Best Shoes for 2026");
+    });
+
+    test("leaves the body untouched when no registry is threaded", () => {
+      const registry = createBlockRegistry([richTextBlock]);
+      const tree: readonly BlockNode[] = [
+        {
+          id: "r1",
+          name: "core/rich-text",
+          attrs: { body: "<p>Best Shoes for [year]</p>" },
+        },
+      ];
+
+      const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+      expect(html).toContain("Best Shoes for [year]");
+    });
   });
 });

--- a/packages/blocks/src/rich-text/index.tsx
+++ b/packages/blocks/src/rich-text/index.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { isValidElement } from "react";
 
 import { defineBlock } from "../block-registry.js";
+import { expandShortcodes } from "../shortcodes/expand.js";
 
 export const richTextBlock = defineBlock({
   name: "core/rich-text",
@@ -20,10 +21,20 @@ export const richTextBlock = defineBlock({
   // the raw HTML string. TODO(#XXX): sanitize the HTML at the
   // entry.update ingest — the trust boundary is the stored bytes, not
   // the editor.
-  render: ({ attrs }): ReactNode => {
+  render: ({ attrs, context }): ReactNode => {
     if (isValidElement(attrs.body)) return attrs.body;
     if (typeof attrs.body === "string") {
-      return <div dangerouslySetInnerHTML={{ __html: attrs.body }} />;
+      // Expand `[year]`-style macros over the already-sanitized HTML string
+      // before output. Only registered tags expand; shortcode output is
+      // escaped, so no new sanitiser surface is introduced.
+      const body = context.shortcodes
+        ? expandShortcodes(attrs.body, context.shortcodes, {
+            siteSettings: context.siteSettings,
+            locale: context.locale,
+            entry: context.entry,
+          })
+        : attrs.body;
+      return <div dangerouslySetInnerHTML={{ __html: body }} />;
     }
     return <div />;
   },

--- a/packages/blocks/src/shortcodes/core/index.ts
+++ b/packages/blocks/src/shortcodes/core/index.ts
@@ -1,0 +1,10 @@
+import type { ShortcodeSpec } from "../types.js";
+import { yearShortcode } from "./year.js";
+
+/**
+ * The built-in shortcodes shipped by `@plumix/blocks`, lowest precedence in
+ * the assembled registry (core < plugin < theme). Bare tags only for now.
+ */
+export const coreShortcodes: readonly ShortcodeSpec[] = Object.freeze([
+  yearShortcode,
+]);

--- a/packages/blocks/src/shortcodes/core/year.test.ts
+++ b/packages/blocks/src/shortcodes/core/year.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { ShortcodeContext } from "../types.js";
+import { yearShortcode } from "./year.js";
+
+function contextFor(locale: string): ShortcodeContext {
+  return { siteSettings: {}, locale, entry: null };
+}
+
+describe("[year] built-in", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-12T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("renders the current year for an English locale", () => {
+    expect(yearShortcode.render({ atts: {}, context: contextFor("en") })).toBe(
+      "2026",
+    );
+  });
+
+  test("localizes the year to Arabic-Indic numerals", () => {
+    expect(
+      yearShortcode.render({ atts: {}, context: contextFor("ar-EG") }),
+    ).toBe("٢٠٢٦");
+  });
+});

--- a/packages/blocks/src/shortcodes/core/year.ts
+++ b/packages/blocks/src/shortcodes/core/year.ts
@@ -1,0 +1,14 @@
+import { defineShortcode } from "../types.js";
+
+/**
+ * `[year]` → the current year in the site's locale and numeral system
+ * (Arabic locale → ٢٠٢٦). Reads `new Date()` directly: public HTML renders
+ * fresh per request, so the year re-evaluates every render with no cache.
+ */
+export const yearShortcode = defineShortcode({
+  name: "year",
+  render: ({ context }) =>
+    new Intl.DateTimeFormat(context.locale, { year: "numeric" }).format(
+      new Date(),
+    ),
+});

--- a/packages/blocks/src/shortcodes/expand.test.ts
+++ b/packages/blocks/src/shortcodes/expand.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { ShortcodeContext, ShortcodeSpec } from "./types.js";
+import { expandShortcodes } from "./expand.js";
+
+const ctx: ShortcodeContext = { siteSettings: {}, locale: "en", entry: null };
+
+function registry(...specs: ShortcodeSpec[]): Map<string, ShortcodeSpec> {
+  return new Map(specs.map((spec) => [spec.name, spec]));
+}
+
+describe("expandShortcodes", () => {
+  test("expands a registered bare tag inline", () => {
+    const reg = registry({ name: "greet", render: () => "hi" });
+    expect(expandShortcodes("a [greet] b", reg, ctx)).toBe("a hi b");
+  });
+
+  test("passes unregistered bracket text through verbatim", () => {
+    const reg = registry({ name: "year", render: () => "2026" });
+    expect(expandShortcodes("[1] [citation needed] [TODO]", reg, ctx)).toBe(
+      "[1] [citation needed] [TODO]",
+    );
+  });
+
+  test("returns a string with no '[' unchanged via the fast path", () => {
+    const reg = registry({ name: "year", render: () => "2026" });
+    const input = "plain prose, no macros here";
+    expect(expandShortcodes(input, reg, ctx)).toBe(input);
+  });
+
+  test("renders the literal tag for the escaped form [[tag]]", () => {
+    const reg = registry({ name: "year", render: () => "2026" });
+    expect(expandShortcodes("Best Shoes for [[year]]", reg, ctx)).toBe(
+      "Best Shoes for [year]",
+    );
+  });
+
+  test("escaping is structural: [[tag]] unwraps even for an unregistered tag", () => {
+    const reg = registry({ name: "year", render: () => "2026" });
+    expect(expandShortcodes("[[notreg]]", reg, ctx)).toBe("[notreg]");
+  });
+
+  test("is single-pass: output containing a tag is not re-scanned", () => {
+    const reg = registry({ name: "echo", render: () => "[year]" });
+    expect(expandShortcodes("[echo]", reg, ctx)).toBe("[year]");
+  });
+
+  test("expands multiple shortcodes in one string", () => {
+    const reg = registry(
+      { name: "a", render: () => "1" },
+      { name: "b", render: () => "2" },
+    );
+    expect(expandShortcodes("[a] and [b]", reg, ctx)).toBe("1 and 2");
+  });
+
+  test("escapes shortcode output so HTML cannot be injected", () => {
+    const reg = registry({ name: "evil", render: () => '<b x="y">&\'' });
+    expect(expandShortcodes("[evil]", reg, ctx)).toBe(
+      "&lt;b x=&quot;y&quot;&gt;&amp;&#39;",
+    );
+  });
+
+  test("renders empty when a registered shortcode throws", () => {
+    const reg = registry({
+      name: "boom",
+      render: () => {
+        throw new Error("nope");
+      },
+    });
+    expect(expandShortcodes("x[boom]y", reg, ctx)).toBe("xy");
+  });
+
+  test("renders empty when a registered shortcode returns a non-string", () => {
+    const reg = registry({
+      name: "bad",
+      render: () => 42 as unknown as string,
+    });
+    expect(expandShortcodes("x[bad]y", reg, ctx)).toBe("xy");
+  });
+
+  test("warns in dev when a registered shortcode throws", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const reg = registry({
+      name: "boom",
+      render: () => {
+        throw new Error("nope");
+      },
+    });
+    expandShortcodes("[boom]", reg, ctx);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[boom]"),
+      expect.anything(),
+    );
+    warn.mockRestore();
+  });
+});

--- a/packages/blocks/src/shortcodes/expand.ts
+++ b/packages/blocks/src/shortcodes/expand.ts
@@ -1,0 +1,78 @@
+import type {
+  ShortcodeContext,
+  ShortcodeRegistry,
+  ShortcodeSpec,
+} from "./types.js";
+
+// Escaped form `[[tag]]` is matched first so it wins over the bare `[tag]`
+// at the same index. Bare tags only for now — no attributes.
+const TOKEN = /\[\[([a-z0-9-]+)\]\]|\[([a-z0-9-]+)\]/g;
+
+/**
+ * Expand registered `[tag]` macros in authored text to escaped text.
+ *
+ * Single pass: the global `replace` walks left-to-right and never re-scans
+ * its own output, so a shortcode returning `[year]` stays literal and
+ * infinite expansion is structurally impossible. Unknown tags pass through
+ * verbatim; `[[tag]]` renders the literal `[tag]`.
+ */
+export function expandShortcodes(
+  text: string,
+  registry: ShortcodeRegistry,
+  context: ShortcodeContext,
+): string {
+  // Common case — prose with no brackets never allocates a regex match.
+  if (!text.includes("[")) return text;
+
+  // Each match sets exactly one group, so both are `string | undefined`.
+  return text.replace(TOKEN, (match, escaped?: string, tag?: string) => {
+    if (escaped !== undefined) return `[${escaped}]`;
+    const spec = tag !== undefined ? registry.get(tag) : undefined;
+    if (!spec) return match;
+    return escapeText(runShortcode(spec, context));
+  });
+}
+
+function runShortcode(spec: ShortcodeSpec, context: ShortcodeContext): string {
+  try {
+    const result = spec.render({ atts: {}, context });
+    if (typeof result !== "string") {
+      warnDev(
+        `Shortcode [${spec.name}] returned a non-string; rendered empty.`,
+      );
+      return "";
+    }
+    return result;
+  } catch (error) {
+    warnDev(`Shortcode [${spec.name}] threw; rendered empty.`, error);
+    return "";
+  }
+}
+
+const ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeText(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => ESCAPES[char] ?? char);
+}
+
+function warnDev(message: string, error?: unknown): void {
+  if (!isDevMode()) return;
+  if (error !== undefined) {
+    console.warn(`[plumix:blocks] ${message}`, error);
+  } else {
+    console.warn(`[plumix:blocks] ${message}`);
+  }
+}
+
+// Mirrors `render-block-tree`'s in-package dev signal; kept inline so this
+// leaf module stays a pure dependency of a future `@plumix/plugin-seo`.
+function isDevMode(): boolean {
+  if (typeof process === "undefined") return false;
+  return process.env.NODE_ENV !== "production";
+}

--- a/packages/blocks/src/shortcodes/types.ts
+++ b/packages/blocks/src/shortcodes/types.ts
@@ -1,0 +1,42 @@
+/**
+ * The render-time context handed to every shortcode. It is the
+ * intersection of `AppContext` and `BlockContext` — the fields guaranteed
+ * identical at every call site (entry title, rich-text body, and a future
+ * meta description). No `db`/`request`: those aren't available inside the
+ * walker, and anything needing them belongs to the deferred async path.
+ */
+export interface ShortcodeContext {
+  readonly siteSettings: Readonly<Record<string, unknown>>;
+  readonly locale: string;
+  readonly entry: Readonly<Record<string, unknown>> | null;
+}
+
+export interface ShortcodeRenderProps {
+  /** Parsed named attributes, always strings. Empty for bare tags. */
+  readonly atts: Readonly<Record<string, string>>;
+  readonly context: ShortcodeContext;
+}
+
+/**
+ * An inline text macro authors type into authored content (`[year]`). The
+ * inline-text sibling of `MarkSpec`; deliberately text-only — markup is the
+ * job of blocks.
+ */
+export interface ShortcodeSpec {
+  readonly name: string;
+  readonly render: (props: ShortcodeRenderProps) => string;
+}
+
+/**
+ * The lookup `expandShortcodes` reads. A plain `Map<string, ShortcodeSpec>`
+ * satisfies it; `@plumix/core` builds the precedence-merged registry behind
+ * this same shape.
+ */
+export interface ShortcodeRegistry {
+  get(name: string): ShortcodeSpec | undefined;
+}
+
+/** Identity helper for inference parity with `defineBlock`. */
+export function defineShortcode(spec: ShortcodeSpec): ShortcodeSpec {
+  return Object.freeze(spec);
+}

--- a/packages/blocks/src/test/index.ts
+++ b/packages/blocks/src/test/index.ts
@@ -17,6 +17,8 @@ const EMPTY_CONTEXT: BlockContext = {
   theme: null,
   parent: null,
   depth: 0,
+  locale: "en",
+  shortcodes: null,
 };
 
 export { EMPTY_CONTEXT };


### PR DESCRIPTION
Introduce shortcodes — inline text macros authors type into authored content (`[year]`) that expand to escaped text at render time. They are the inline-text sibling of marks and are text-only by design; markup remains the job of blocks. A paragraph reading `Best Shoes for [year]` now renders `Best Shoes for 2026`, localized to the render locale.

This is slice 1 of #976, scoped to `@plumix/blocks`. Registry assembly, precedence (core < plugin < theme), the `registerShortcode` setup method, `ThemeDescriptor.shortcodes`, and title expansion at resolve follow in the `@plumix/core` slice.

**Single-pass expander, no new sanitiser surface**

`expandShortcodes(text, registry, ctx)` is a pure function. It scans left-to-right exactly once and never re-scans its own output, so a shortcode returning `[year]` stays literal and infinite expansion is structurally impossible. Only registered tags expand; unknown tags (`[1]`, `[citation needed]`, `[TODO]`) pass through verbatim; `[[year]]` renders the literal `[year]`; a string with no `[` skips parsing entirely. Output is HTML-escaped at insertion, so the rich-text `dangerouslySetInnerHTML` path gains no new allowlist.

**Render wiring**

`locale` and the shortcode registry are threaded through `RenderBlockTreeOptions` into `BlockContext`; the `core/rich-text` block expands its stored HTML body before output. When no registry is wired, the body renders verbatim.

**Published for plugin-seo**

`expandShortcodes` is exported from `@plumix/blocks` as the single integration point a future `@plumix/plugin-seo` reuses to expand macros in meta descriptions — no new core work needed when that surface exists.

The `[year]` built-in renders via `Intl.DateTimeFormat(locale, { year: "numeric" })`. Note: bare `ar` resolves to Latin digits in current CLDR; only region-tagged locales (`ar-EG`, `ar-SA`) yield Arabic-Indic numerals (٢٠٢٦). The primitive is correct — this is a locale-resolution concern for the core slice.

Fixes #977