### PR TITLE
feat(blocks): add shortcode attributes and the [month] built-in

### DIFF
--- a/packages/blocks/src/shortcodes/core/index.ts
+++ b/packages/blocks/src/shortcodes/core/index.ts
@@ -1,10 +1,12 @@
 import type { ShortcodeSpec } from "../types.js";
+import { monthShortcode } from "./month.js";
 import { yearShortcode } from "./year.js";
 
 /**
  * The built-in shortcodes shipped by `@plumix/blocks`, lowest precedence in
- * the assembled registry (core < plugin < theme). Bare tags only for now.
+ * the assembled registry (core < plugin < theme).
  */
 export const coreShortcodes: readonly ShortcodeSpec[] = Object.freeze([
   yearShortcode,
+  monthShortcode,
 ]);

--- a/packages/blocks/src/shortcodes/core/month.test.ts
+++ b/packages/blocks/src/shortcodes/core/month.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { ShortcodeContext } from "../types.js";
+import { expandShortcodes } from "../expand.js";
+import { monthShortcode } from "./month.js";
+
+function contextFor(locale: string): ShortcodeContext {
+  return { siteSettings: {}, locale, entry: null };
+}
+
+function render(locale: string, format?: string): string {
+  return monthShortcode.render({
+    atts: format === undefined ? {} : { format },
+    context: contextFor(locale),
+  });
+}
+
+describe("[month] built-in", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-12T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("renders the full month name by default", () => {
+    expect(render("en")).toBe("June");
+  });
+
+  test("format=short renders the abbreviated month", () => {
+    expect(render("en", "short")).toBe("Jun");
+  });
+
+  test("format=numeric renders the month number", () => {
+    expect(render("en", "numeric")).toBe("6");
+  });
+
+  test("localizes the month name to the context locale", () => {
+    expect(render("fr")).toBe("juin");
+  });
+
+  test("an unrecognized format falls back to the full name", () => {
+    expect(render("en", "2-digit")).toBe("June");
+  });
+
+  test("the format attribute flows through the expander to the built-in", () => {
+    const reg = new Map([[monthShortcode.name, monthShortcode]]);
+    expect(
+      expandShortcodes('[month format="short"]', reg, contextFor("en")),
+    ).toBe("Jun");
+  });
+});

--- a/packages/blocks/src/shortcodes/core/month.ts
+++ b/packages/blocks/src/shortcodes/core/month.ts
@@ -1,0 +1,24 @@
+import { defineShortcode } from "../types.js";
+
+const MONTH_FORMATS = ["long", "short", "numeric"] as const;
+type MonthFormat = (typeof MONTH_FORMATS)[number];
+
+function isMonthFormat(value: string): value is MonthFormat {
+  return (MONTH_FORMATS as readonly string[]).includes(value);
+}
+
+function resolveFormat(value: string | undefined): MonthFormat {
+  return value !== undefined && isMonthFormat(value) ? value : "long";
+}
+
+/**
+ * `[month format="long|short|numeric"]` → the current month in the site's
+ * locale, default `long`. Reads `new Date()` directly (fresh per request).
+ */
+export const monthShortcode = defineShortcode({
+  name: "month",
+  render: ({ atts, context }) =>
+    new Intl.DateTimeFormat(context.locale, {
+      month: resolveFormat(atts.format),
+    }).format(new Date()),
+});

--- a/packages/blocks/src/shortcodes/expand.test.ts
+++ b/packages/blocks/src/shortcodes/expand.test.ts
@@ -40,6 +40,13 @@ describe("expandShortcodes", () => {
     expect(expandShortcodes("[[notreg]]", reg, ctx)).toBe("[notreg]");
   });
 
+  test("escapes an attributed tag literally rather than expanding it", () => {
+    const reg = registry({ name: "month", render: () => "June" });
+    expect(expandShortcodes('[[month format="short"]]', reg, ctx)).toBe(
+      '[month format="short"]',
+    );
+  });
+
   test("is single-pass: output containing a tag is not re-scanned", () => {
     const reg = registry({ name: "echo", render: () => "[year]" });
     expect(expandShortcodes("[echo]", reg, ctx)).toBe("[year]");
@@ -92,5 +99,54 @@ describe("expandShortcodes", () => {
       expect.anything(),
     );
     warn.mockRestore();
+  });
+
+  describe("named attributes", () => {
+    const echoAtt = (key: string): ShortcodeSpec => ({
+      name: "echo",
+      render: ({ atts }) => atts[key] ?? "none",
+    });
+
+    test("parses a double-quoted attribute value into the atts map", () => {
+      const reg = registry(echoAtt("sku"));
+      expect(expandShortcodes('[echo sku="abc"]', reg, ctx)).toBe("abc");
+    });
+
+    test("parses a single-quoted attribute value", () => {
+      const reg = registry(echoAtt("sku"));
+      expect(expandShortcodes("[echo sku='abc']", reg, ctx)).toBe("abc");
+    });
+
+    test("parses a bare attribute value with no spaces", () => {
+      const reg = registry(echoAtt("sku"));
+      expect(expandShortcodes("[echo sku=abc]", reg, ctx)).toBe("abc");
+    });
+
+    test("a bare value with an embedded space is rejected (verbatim)", () => {
+      const reg = registry(echoAtt("sku"));
+      expect(expandShortcodes("[echo sku=a b]", reg, ctx)).toBe(
+        "[echo sku=a b]",
+      );
+    });
+
+    test("parses multiple mixed-quoting attributes", () => {
+      const reg = registry({
+        name: "echo",
+        render: ({ atts }) => `${atts.a}-${atts.b}-${atts.c}`,
+      });
+      expect(expandShortcodes(`[echo a="one" b='two' c=three]`, reg, ctx)).toBe(
+        "one-two-three",
+      );
+    });
+
+    test("a valueless attribute is not accepted (verbatim)", () => {
+      const reg = registry(echoAtt("sku"));
+      expect(expandShortcodes("[echo sku]", reg, ctx)).toBe("[echo sku]");
+    });
+
+    test("a quoted value preserves spaces", () => {
+      const reg = registry(echoAtt("label"));
+      expect(expandShortcodes('[echo label="a b c"]', reg, ctx)).toBe("a b c");
+    });
   });
 });

--- a/packages/blocks/src/shortcodes/expand.ts
+++ b/packages/blocks/src/shortcodes/expand.ts
@@ -4,9 +4,18 @@ import type {
   ShortcodeSpec,
 } from "./types.js";
 
-// Escaped form `[[tag]]` is matched first so it wins over the bare `[tag]`
-// at the same index. Bare tags only for now — no attributes.
-const TOKEN = /\[\[([a-z0-9-]+)\]\]|\[([a-z0-9-]+)\]/g;
+// A tag plus its optional attribute run, shared by both token branches.
+// Positional/valueless/space-in-bare attrs deliberately don't match, so the
+// whole tag falls through verbatim rather than half-parsing.
+const ATTR_SRC = `[a-z0-9-]+=(?:"[^"]*"|'[^']*'|[^\\s\\]'"]+)`;
+const TAG_SRC = `[a-z0-9-]+(?:\\s+${ATTR_SRC})*`;
+// Escaped `[[tag …]]` is matched first so it wins over `[tag …]` at the same
+// index; it re-emits its inner text literally, attributes and all.
+const TOKEN = new RegExp(
+  `\\[\\[(${TAG_SRC})\\s*\\]\\]|\\[([a-z0-9-]+)((?:\\s+${ATTR_SRC})*)\\s*\\]`,
+  "g",
+);
+const ATTR = /([a-z0-9-]+)=(?:"([^"]*)"|'([^']*)'|([^\s\]'"]+))/g;
 
 /**
  * Expand registered `[tag]` macros in authored text to escaped text.
@@ -14,7 +23,7 @@ const TOKEN = /\[\[([a-z0-9-]+)\]\]|\[([a-z0-9-]+)\]/g;
  * Single pass: the global `replace` walks left-to-right and never re-scans
  * its own output, so a shortcode returning `[year]` stays literal and
  * infinite expansion is structurally impossible. Unknown tags pass through
- * verbatim; `[[tag]]` renders the literal `[tag]`.
+ * verbatim; `[[tag …]]` renders the literal `[tag …]`.
  */
 export function expandShortcodes(
   text: string,
@@ -24,18 +33,36 @@ export function expandShortcodes(
   // Common case — prose with no brackets never allocates a regex match.
   if (!text.includes("[")) return text;
 
-  // Each match sets exactly one group, so both are `string | undefined`.
-  return text.replace(TOKEN, (match, escaped?: string, tag?: string) => {
-    if (escaped !== undefined) return `[${escaped}]`;
-    const spec = tag !== undefined ? registry.get(tag) : undefined;
-    if (!spec) return match;
-    return escapeText(runShortcode(spec, context));
-  });
+  // `escaped` is set by the first branch; `tag`/`rawAtts` by the second.
+  return text.replace(
+    TOKEN,
+    (match, escaped?: string, tag?: string, rawAtts?: string) => {
+      if (escaped !== undefined) return `[${escaped}]`;
+      const spec = tag !== undefined ? registry.get(tag) : undefined;
+      if (!spec) return match;
+      return escapeText(runShortcode(spec, parseAtts(rawAtts), context));
+    },
+  );
 }
 
-function runShortcode(spec: ShortcodeSpec, context: ShortcodeContext): string {
+function parseAtts(raw: string | undefined): Record<string, string> {
+  const atts: Record<string, string> = {};
+  if (!raw) return atts;
+  for (const m of raw.matchAll(ATTR)) {
+    const key = m[1];
+    if (key === undefined) continue;
+    atts[key] = m[2] ?? m[3] ?? m[4] ?? "";
+  }
+  return atts;
+}
+
+function runShortcode(
+  spec: ShortcodeSpec,
+  atts: Readonly<Record<string, string>>,
+  context: ShortcodeContext,
+): string {
   try {
-    const result = spec.render({ atts: {}, context });
+    const result = spec.render({ atts, context });
     if (typeof result !== "string") {
       warnDev(
         `Shortcode [${spec.name}] returned a non-string; rendered empty.`,


### PR DESCRIPTION
Extend the shortcode expander with named attributes and ship `[month]` as the first consumer of the attribute path. This is the final slice of PRD #976.

**Attribute grammar**

Attributes are `key="value"`, `key='value'`, or bare `key=value` (bare only when the value has no spaces); keys are `[a-z0-9-]+`; positional and valueless attributes are not accepted. The grammar is baked into the token regex, so a malformed run makes the whole tag fall through verbatim rather than half-parsing. Parsed values reach `render` as a string map:

```
[product sku="abc"]   →   render({ atts: { sku: "abc" }, … })
```

**`[month]` built-in**

`[month]` renders the current month localized via `Intl.DateTimeFormat(locale, { month })`:

```
[month]                  →  June   (default long, localized: fr → juin)
[month format="short"]   →  Jun
[month format="numeric"] →  6
```

An unrecognized `format` falls back to `long`.

**Escape contract kept whole**

The `[[…]]` escape now swallows an attribute run, so `[[month format="short"]]` renders the literal `[month format="short"]` instead of expanding the inner tag and leaving stray brackets — a regression the attribute support would otherwise have introduced (caught in review, fixed with a test).

The single-pass, fast-path, output-escaping, and verbatim-passthrough invariants from the earlier slices all still hold with attributes present (verified). Reviewer note: `[month]`/`[year]` format in the runtime timezone — there's no site-timezone setting to anchor to yet, so it's unchanged from the prior slices.

Closes #978