### PR TITLE
feat: thread the queried entry into body shortcode context

### DIFF
--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -68,6 +68,8 @@ export interface RenderBlockTreeOptions {
   readonly locale?: string;
   /** Registered shortcodes for authored-content body expansion. */
   readonly shortcodes?: ShortcodeRegistry;
+  /** Queried entry, exposed to shortcodes via `BlockContext.entry`. */
+  readonly entry?: Readonly<Record<string, unknown>> | null;
 }
 
 export interface BlockNodeRenderProps<
@@ -290,6 +292,7 @@ export function renderBlockTree(
   };
   const rootContext: BlockContext = {
     ...DEFAULT_BLOCK_CONTEXT,
+    entry: options?.entry ?? DEFAULT_BLOCK_CONTEXT.entry,
     locale: options?.locale ?? DEFAULT_BLOCK_CONTEXT.locale,
     shortcodes: options?.shortcodes ?? null,
   };

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -33,6 +33,8 @@ export interface PlumixContextValue {
   readonly locale?: string;
   /** Registered shortcodes for rich-text body expansion. */
   readonly shortcodes?: ShortcodeRegistry;
+  /** Queried entry, exposed to body shortcodes via `BlockContext.entry`. */
+  readonly entry?: Readonly<Record<string, unknown>> | null;
 }
 
 const PlumixContext = createContext<PlumixContextValue | null>(null);
@@ -68,6 +70,7 @@ export function BlockRenderer({
     loaderData: ctx.loaderData,
     locale: ctx.locale,
     shortcodes: ctx.shortcodes,
+    entry: ctx.entry,
   });
 }
 

--- a/packages/blocks/src/renderer/renderer.test.tsx
+++ b/packages/blocks/src/renderer/renderer.test.tsx
@@ -38,6 +38,37 @@ describe("BlockRenderer", () => {
     expect(html).toContain("Hello");
   });
 
+  test("threads the queried entry from the provider into body shortcode context", () => {
+    const authorShortcode: ShortcodeSpec = {
+      name: "author",
+      render: ({ context }) => {
+        const author = context.entry?.author;
+        return typeof author === "string" ? author : "anon";
+      },
+    };
+    const registry = createBlockRegistry([richTextBlock]);
+    const content = {
+      version: "plumix.v2" as const,
+      blocks: [
+        { id: "r", name: "core/rich-text", attrs: { body: "<p>[author]</p>" } },
+      ],
+    };
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider
+        value={{
+          registry,
+          entry: { author: "Ada" },
+          shortcodes: new Map([[authorShortcode.name, authorShortcode]]),
+        }}
+      >
+        <BlockRenderer content={content} />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("Ada");
+  });
+
   test("threads shortcodes + locale from the provider into rich-text body expansion", () => {
     const yearShortcode: ShortcodeSpec = {
       name: "year",

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -283,6 +283,12 @@ function renderTree({
     "entry" in data
       ? { type: data.entry.type, authorId: data.entry.authorId }
       : undefined;
+  // Body shortcodes get the post-expansion entry — its `title` is already
+  // rendered, not the raw `[year]` source the title pass itself expands.
+  const entry =
+    "entry" in data
+      ? (data.entry as unknown as Readonly<Record<string, unknown>>)
+      : null;
   const templateTree: ReactNode = createElement(
     PlumixProvider,
     {
@@ -294,6 +300,7 @@ function renderTree({
         queriedEntry: ctx.resolvedEntity,
         locale: ctx.locale.code,
         shortcodes: ctx.shortcodes,
+        entry,
       },
     },
     createElement(PlumixAdminBar, {


### PR DESCRIPTION
Follow-up from PRD #976. Body shortcodes ran with `entry: null` because nothing seeded `BlockContext.entry` on the public render path, while title expansion already passed the real entry — the asymmetry the `ShortcodeContext` "identical at every call site" contract promised not to have.

**Threading**

The entry now flows exactly like `locale`/`shortcodes` do: a new `entry` field on `RenderBlockTreeOptions` seeds the walker's root context, `PlumixContextValue` carries it, `BlockRenderer` forwards it, and core's `renderTree` sets it from `data.entry` for single entries (`null` for archive/search/front-page — the same `"entry" in data` guard the adjacent `queriedEntryDetails` uses). `core/rich-text` already passed `context.entry` into its `ShortcodeContext`, so an entry-aware body shortcode now resolves identically to the title path.

**Intentional one-field divergence**

Body shortcodes receive the *post-expansion* entry — its `title` is already rendered, not the raw `[year]` source the title pass itself expands. That's the rendered title an author-facing macro wants; feeding the pre-expansion title would re-expose unexpanded macro syntax. Documented inline so it isn't "fixed" into a circular bug later.

No behavior change when no entry is threaded (admin preview, block-only content, tests) — the option defaults to `null`.

Closes #983