### PR TITLE
feat(core)!: gate mcp behind mcp.enabled (default off)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -28,6 +28,20 @@ export type AnyPluginDescriptor = PluginDescriptor<any>;
 export type AnyDatabaseAdapter = DatabaseAdapter<any>;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
+/**
+ * Shared on/off switch for an external interface surface (MCP today, the
+ * REST API next). Default-off: a surface is mounted only when its config
+ * sets `enabled: true`, so the dispatcher can 404 before importing the
+ * surface's handler graph at all.
+ */
+export interface InterfaceToggle {
+  readonly enabled?: boolean;
+}
+
+export function interfaceEnabled(toggle: InterfaceToggle | undefined): boolean {
+  return toggle?.enabled === true;
+}
+
 export interface PlumixConfigInput {
   readonly runtime: RuntimeAdapter;
   readonly database: AnyDatabaseAdapter;
@@ -48,6 +62,11 @@ export interface PlumixConfigInput {
   readonly theme: ThemeDescriptor;
   readonly plugins?: readonly AnyPluginDescriptor[];
   readonly i18n?: I18nInput;
+  /**
+   * Model Context Protocol endpoint at `/_plumix/mcp`. Default-off; set
+   * `{ enabled: true }` to mount it.
+   */
+  readonly mcp?: InterfaceToggle;
   /**
    * Block-system configuration. Today only exposes the operator-
    * configurable `core/html` allowlist override; future block-level
@@ -74,6 +93,7 @@ export interface PlumixConfig {
   readonly theme: ThemeDescriptor;
   readonly plugins: readonly AnyPluginDescriptor[];
   readonly i18n: ResolvedI18n;
+  readonly mcp?: InterfaceToggle;
   readonly blocks?: {
     readonly htmlAllowlist?: HtmlAllowlistOverride;
   };
@@ -104,6 +124,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
     i18n: resolveLocales(
       config.i18n ?? { defaultLocale: "en", locales: ["en"] },
     ),
+    mcp: config.mcp,
     blocks: config.blocks,
     vite: config.vite,
   };

--- a/packages/core/src/mcp/dispatch.test.ts
+++ b/packages/core/src/mcp/dispatch.test.ts
@@ -5,6 +5,14 @@ import type { DispatcherHarness } from "../test/dispatcher.js";
 import { definePlugin } from "../plugin/define.js";
 import { createDispatcherHarness } from "../test/dispatcher.js";
 
+// MCP is default-off; every test in this suite exercises the live endpoint,
+// so opt it in here rather than repeating `mcp: { enabled: true }` per call.
+function mcpHarness(
+  options: Parameters<typeof createDispatcherHarness>[0] = {},
+): Promise<DispatcherHarness> {
+  return createDispatcherHarness({ mcp: { enabled: true }, ...options });
+}
+
 const blog = definePlugin("test-blog", (ctx) => {
   ctx.registerEntryType("post", {
     label: "Posts",
@@ -106,7 +114,7 @@ function parseToolResult<T>(json: JsonRpcEnvelope<ToolCallResult>): T {
 
 describe("MCP endpoint — tools/list", () => {
   test("a PAT-authenticated client sees schema_describe with JSON Schema + readOnlyHint", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const secret = await mintPat(h);
 
     const { res, json } = await callMcp<{ tools: ToolDescriptor[] }>(
@@ -129,7 +137,7 @@ describe("MCP endpoint — tools/list", () => {
 
 describe("MCP endpoint — schema_describe", () => {
   test("with no argument it lists entry types and taxonomies", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const secret = await mintPat(h);
 
     const { res, json } = await callTool(h, secret, 2, "schema_describe", {});
@@ -151,7 +159,7 @@ describe("MCP endpoint — schema_describe", () => {
   });
 
   test("with a type it returns that type's statuses, supports, and taxonomies", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const secret = await mintPat(h);
 
     const { res, json } = await callTool(h, secret, 3, "schema_describe", {
@@ -170,7 +178,7 @@ describe("MCP endpoint — schema_describe", () => {
   });
 
   test("an unknown type comes back as an MCP error envelope, not a crash", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const secret = await mintPat(h);
 
     const { res, json } = await callTool(h, secret, 4, "schema_describe", {
@@ -188,7 +196,7 @@ describe("MCP endpoint — transport guards", () => {
   test.each(["GET", "DELETE"])(
     "%s is rejected with 405 (the endpoint is POST-only)",
     async (method) => {
-      const h = await createDispatcherHarness({ plugins: [blog] });
+      const h = await mcpHarness({ plugins: [blog] });
       const secret = await mintPat(h);
 
       const res = await h.dispatch(mcpRequest({}, { secret, method }));
@@ -199,7 +207,7 @@ describe("MCP endpoint — transport guards", () => {
   );
 
   test("a request without a bearer token is rejected with 401", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
 
     const res = await h.dispatch(
       mcpRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
@@ -209,7 +217,7 @@ describe("MCP endpoint — transport guards", () => {
   });
 
   test("an invalid bearer token is rejected with 401", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
 
     const res = await h.dispatch(
       mcpRequest(
@@ -222,7 +230,7 @@ describe("MCP endpoint — transport guards", () => {
   });
 
   test("a session-cookie request is rejected — MCP authenticates by bearer PAT only", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const user = await h.factory.user.create({ role: "editor" });
     const cookieReq = await h.authenticateRequest(
       mcpRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
@@ -242,7 +250,7 @@ interface ContentRow {
 
 describe("MCP endpoint — content_list", () => {
   test("returns the entries the caller may see", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const author = await h.factory.user.create({ role: "editor" });
     await h.factory.published.create({ authorId: author.id, slug: "pub" });
     await h.factory.draft.create({ authorId: author.id, slug: "draft" });
@@ -257,7 +265,7 @@ describe("MCP endpoint — content_list", () => {
   });
 
   test("a read-scoped token cannot see drafts (capability clamp)", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const author = await h.factory.user.create({ role: "editor" });
     await h.factory.published.create({ authorId: author.id, slug: "pub" });
     await h.factory.draft.create({ authorId: author.id, slug: "secret" });
@@ -275,7 +283,7 @@ describe("MCP endpoint — content_list", () => {
   });
 
   test("content_list appears in tools/list with a projected JSON Schema", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const secret = await mintPat(h);
 
     const { json } = await callMcp<{
@@ -290,7 +298,7 @@ describe("MCP endpoint — content_list", () => {
 
 describe("MCP endpoint — content_get", () => {
   test("returns a single entry by type + id", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const author = await h.factory.user.create({ role: "editor" });
     const entry = await h.factory.published.create({
       authorId: author.id,
@@ -307,7 +315,7 @@ describe("MCP endpoint — content_get", () => {
   });
 
   test("a missing entry comes back as a not_found envelope", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const secret = await mintPat(h, { role: "editor" });
 
     const { json } = await callTool(h, secret, 1, "content_get", {
@@ -320,7 +328,7 @@ describe("MCP endpoint — content_get", () => {
   });
 
   test("a type that doesn't match the entry is hidden as not_found", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const author = await h.factory.user.create({ role: "editor" });
     const entry = await h.factory.published.create({
       authorId: author.id,
@@ -340,7 +348,7 @@ describe("MCP endpoint — content_get", () => {
 
 describe("MCP endpoint — term tools", () => {
   test("term_list returns terms in a taxonomy", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     await h.factory.category.create({ name: "News", slug: "news" });
     const secret = await mintPat(h, { role: "editor" });
 
@@ -353,7 +361,7 @@ describe("MCP endpoint — term tools", () => {
   });
 
   test("term_list maps a forbidden read to an envelope", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const secret = await mintPat(h, {
       role: "editor",
       scopes: ["entry:post:read"],
@@ -368,7 +376,7 @@ describe("MCP endpoint — term tools", () => {
   });
 
   test("term_get returns a term by taxonomy + id", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const term = await h.factory.category.create({
       name: "News",
       slug: "news",
@@ -384,7 +392,7 @@ describe("MCP endpoint — term tools", () => {
   });
 
   test("term_get hides a taxonomy mismatch as not_found", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const term = await h.factory.category.create({
       name: "News",
       slug: "news",
@@ -401,7 +409,7 @@ describe("MCP endpoint — term tools", () => {
   });
 
   test("taxonomy_list enumerates registered taxonomies", async () => {
-    const h = await createDispatcherHarness({ plugins: [blog] });
+    const h = await mcpHarness({ plugins: [blog] });
     const secret = await mintPat(h, { role: "editor" });
 
     const { json } = await callTool(h, secret, 1, "taxonomy_list", {});

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -1,9 +1,54 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import type { RegisteredRawRoute } from "../plugin/manifest.js";
 import { definePlugin } from "../plugin/define.js";
 import { createDispatcherHarness, plumixRequest } from "../test/dispatcher.js";
 import { matchPluginRawRoute } from "./dispatcher.js";
+
+// Track when the dispatcher dynamic-imports the MCP module: the factory runs
+// once on first import, so `loadCount` is the no-load assertion for the
+// disabled path. Nothing else in this file imports the module — so the
+// disabled test must run before the enabled one for `loadCount === 0` to hold.
+const mcpMock = vi.hoisted(() => ({
+  loadCount: 0,
+  handleMcpRequest: vi.fn(() => new Response("mcp-ok", { status: 200 })),
+}));
+vi.mock("../mcp/dispatch.js", () => {
+  mcpMock.loadCount += 1;
+  return { handleMcpRequest: mcpMock.handleMcpRequest };
+});
+
+function mcpRequest(): Request {
+  return new Request("https://cms.example/_plumix/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
+  });
+}
+
+describe("dispatcher — MCP enablement gate", () => {
+  test("MCP is disabled by default: POST /_plumix/mcp returns 404 without loading the MCP module", async () => {
+    const h = await createDispatcherHarness();
+
+    const response = await h.dispatch(mcpRequest());
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-plumix-hint")).toBe("mcp-disabled");
+    expect(mcpMock.loadCount).toBe(0);
+    expect(mcpMock.handleMcpRequest).not.toHaveBeenCalled();
+  });
+
+  test("mcp.enabled imports the MCP module once and delegates to its handler", async () => {
+    const h = await createDispatcherHarness({ mcp: { enabled: true } });
+
+    const response = await h.dispatch(mcpRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("mcp-ok");
+    expect(mcpMock.loadCount).toBe(1);
+    expect(mcpMock.handleMcpRequest).toHaveBeenCalledOnce();
+  });
+});
 
 describe("dispatcher — routing", () => {
   test("/_plumix/admin returns 404 with admin-not-available when no assets binding is configured", async () => {

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -6,6 +6,7 @@ import type { PlumixApp } from "./app.js";
 import { readSessionCookie } from "../auth/cookies.js";
 import { hasCsrfHeader, hasMatchingOrigin } from "../auth/csrf.js";
 import { parseOAuthPath } from "../auth/oauth/match.js";
+import { interfaceEnabled } from "../config.js";
 import { withUser } from "../context/app.js";
 import { resolveLocale } from "../i18n/resolve-locale.js";
 import { matchRoute } from "../route/match.js";
@@ -140,6 +141,9 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   // header cross-site without a CORS grant Plumix never gives). The gate keeps
   // protecting the cookie-authed RPC/auth endpoints below it unchanged.
   if (pathname === MCP_PATH) {
+    // Default-off: 404 before the dynamic import so a disabled deployment
+    // never pulls the MCP SDK + tool registry onto the cold-start path.
+    if (!interfaceEnabled(app.config.mcp)) return notFound("mcp-disabled");
     const { handleMcpRequest } = await (mcpModule ??=
       import("../mcp/dispatch.js"));
     return handleMcpRequest(ctx);

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -2,7 +2,7 @@ import type { RequestAuthenticator } from "../auth/authenticator.js";
 import type { BootstrapVia, PlumixMagicLinkConfig } from "../auth/config.js";
 import type { Mailer } from "../auth/mailer/types.js";
 import type { OAuthProviderClient } from "../auth/oauth/types.js";
-import type { AnyPluginDescriptor } from "../config.js";
+import type { AnyPluginDescriptor, InterfaceToggle } from "../config.js";
 import type { AppContext } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
 import type {
@@ -111,6 +111,8 @@ export interface CreateDispatcherHarnessOptions {
   readonly bootstrapVia?: BootstrapVia;
   readonly theme?: ThemeDescriptor;
   readonly i18n?: I18nInput;
+  /** Mount the MCP endpoint. Default-off mirrors production. */
+  readonly mcp?: InterfaceToggle;
   /**
    * Vite-emitted asset manifest. Tests that exercise the renderer's
    * `<link rel="stylesheet">` auto-injection pass a stub manifest here;
@@ -227,6 +229,7 @@ export async function createDispatcherHarness(
     imageDelivery: options.imageDelivery,
     mailer: options.mailer,
     i18n: options.i18n,
+    mcp: options.mcp,
     theme: options.theme ?? defaultTestTheme,
   });
   const app = await buildApp(config, {

--- a/packages/plugins/media/src/mcp-tools.test.ts
+++ b/packages/plugins/media/src/mcp-tools.test.ts
@@ -8,7 +8,11 @@ type Harness = Awaited<ReturnType<typeof createDispatcherHarness>>;
 
 async function setup(): Promise<Harness> {
   const storage = memoryStorage().connect({});
-  return createDispatcherHarness({ plugins: [media()], storage });
+  return createDispatcherHarness({
+    plugins: [media()],
+    storage,
+    mcp: { enabled: true },
+  });
 }
 
 async function seedMedia(


### PR DESCRIPTION
Introduce a shared dispatcher enablement model that gates external interface surfaces by config, and apply it to MCP first. MCP is now **default-off**: `/_plumix/mcp` only mounts when config opts in.

**Breaking change (pre-1.0)**

MCP was previously always-mounted. It is now gated behind config and disabled by default — enable it explicitly:

```ts
plumix({
  // …
  mcp: { enabled: true },
})
```

**Shared enablement gate**

The gate is a reusable primitive — an `InterfaceToggle` (`{ enabled?: boolean }`) plus an `interfaceEnabled` helper — not MCP-specific. The REST surface (Slice 2 of PRD #995) reuses it verbatim via `api.enabled`.

**404 before the import**

When MCP is disabled the dispatcher returns 404 *before* the dynamic `import("../mcp/dispatch.js")`, so a disabled deployment never pulls the MCP SDK and tool registry onto the cold-start path. When enabled, bearer auth and tools are unchanged.

Tests cover disabled → 404 with the MCP module never loaded (asserted via a file-scoped import counter) and enabled → delegates to the handler, loading the module once. The existing MCP dispatch suite opts in through a local `mcpHarness` helper.

Closes #996