### PR TITLE
feat(core): authenticate REST reads with bearer PATs

### DIFF
--- a/packages/core/src/auth/bearer.ts
+++ b/packages/core/src/auth/bearer.ts
@@ -1,0 +1,33 @@
+import type { AppContext } from "../context/app.js";
+import { withUser } from "../context/app.js";
+import { apiTokenAuthenticator } from "./authenticator.js";
+
+// Bearer PAT only — shared by the CSRF-exempt external surfaces (MCP, REST).
+// Deliberately NOT the request's configured authenticator (cookie/custom
+// guard): cookie auth must never resolve on an endpoint mounted ahead of the
+// CSRF gate, since only bearer auth is inherently CSRF-immune.
+const bearerAuthenticator = apiTokenAuthenticator();
+
+// Must stay a superset of what `apiTokenAuthenticator` actually parses, so the
+// "bearer present?" check never reports false while the token still fails to
+// authenticate — the gap (e.g. a multi-token header) fails closed to 401, never
+// to silent anonymous access.
+const BEARER = /^bearer\s+\S/i;
+
+export function hasBearerToken(request: Request): boolean {
+  return BEARER.test(request.headers.get("authorization") ?? "");
+}
+
+/**
+ * Resolve a bearer PAT to an authenticated context (user + token scopes), or
+ * null when the token is absent, malformed, expired, revoked, or its user is
+ * disabled. Callers decide whether a null means 401 or anonymous access.
+ */
+export async function authenticateBearer(
+  ctx: AppContext,
+): Promise<AppContext | null> {
+  const result = await bearerAuthenticator.authenticate(ctx.request, ctx.db);
+  if (!result) return null;
+  const { id, email, role, meta } = result.user;
+  return withUser(ctx, { id, email, role, meta }, result.tokenScopes ?? null);
+}

--- a/packages/core/src/mcp/dispatch.ts
+++ b/packages/core/src/mcp/dispatch.ts
@@ -1,14 +1,7 @@
 import type { AppContext } from "../context/app.js";
-import { apiTokenAuthenticator } from "../auth/authenticator.js";
-import { withUser } from "../context/app.js";
-import { jsonResponse, methodNotAllowed } from "../runtime/http.js";
+import { authenticateBearer } from "../auth/bearer.js";
+import { methodNotAllowed, unauthorized } from "../runtime/http.js";
 import { buildMcpToolRegistry } from "./registry.js";
-
-// Bearer PAT only — NOT the request's configured authenticator (which defaults
-// to a cookie+bearer chain, or an operator's custom guard). Cookie/session auth
-// must not reach this endpoint: it's mounted ahead of the CSRF gate, and only
-// bearer auth is inherently CSRF-immune.
-const bearerAuthenticator = apiTokenAuthenticator();
 
 /**
  * Serve the first-party MCP endpoint. Mounted ahead of the `/_plumix/` CSRF
@@ -22,15 +15,9 @@ const bearerAuthenticator = apiTokenAuthenticator();
 export async function handleMcpRequest(ctx: AppContext): Promise<Response> {
   if (ctx.request.method !== "POST") return methodNotAllowed(["POST"]);
 
-  const result = await bearerAuthenticator.authenticate(ctx.request, ctx.db);
-  if (!result) return jsonResponse({ error: "unauthorized" }, { status: 401 });
+  const authedCtx = await authenticateBearer(ctx);
+  if (!authedCtx) return unauthorized();
 
-  const { id, email, role, meta } = result.user;
-  const authedCtx = withUser(
-    ctx,
-    { id, email, role, meta },
-    result.tokenScopes ?? null,
-  );
   const tools = buildMcpToolRegistry(authedCtx.plugins);
 
   const { buildMcpServer } = await import("./server.js");

--- a/packages/core/src/rest/build-handler.ts
+++ b/packages/core/src/rest/build-handler.ts
@@ -2,9 +2,10 @@ import type { OpenAPI } from "@orpc/openapi";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 
 import type { AppContext } from "../context/app.js";
-import { jsonResponse, notFound } from "../runtime/http.js";
+import type { RestPrincipal } from "./principal.js";
+import { jsonResponse, notFound, unauthorized } from "../runtime/http.js";
 import { generateOpenApiDocument } from "./openapi.js";
-import { withPublicPrincipal } from "./principal.js";
+import { resolveRestPrincipal } from "./principal.js";
 import { restRouter } from "./router.js";
 
 /**
@@ -26,14 +27,29 @@ export function buildRestDispatcher(): RestDispatch {
     if (url.pathname === SPEC_PATH) {
       return jsonResponse(await (spec ??= generateOpenApiDocument()));
     }
-    // Anonymous reads resolve to a read-only public principal; the entry
-    // services then clamp to published + hide-existence with no REST-specific
-    // status logic.
-    const publicCtx = withPublicPrincipal(ctx);
+
+    const principal: RestPrincipal = await resolveRestPrincipal(ctx);
+    if (principal.kind === "unauthorized") return unauthorized();
+
     const result = await handler.handle(ctx.request, {
       prefix: API_V1_PREFIX,
-      context: publicCtx,
+      context: principal.ctx,
     });
-    return result.matched ? result.response : notFound("rest-route-not-found");
+    const response = result.matched
+      ? result.response
+      : notFound("rest-route-not-found");
+
+    // PAT-authed reads may include non-public content: never cache them.
+    return principal.kind === "authed" ? markNonCacheable(response) : response;
   };
+}
+
+function markNonCacheable(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set("cache-control", "private, no-store");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }

--- a/packages/core/src/rest/dispatch.test.ts
+++ b/packages/core/src/rest/dispatch.test.ts
@@ -62,6 +62,43 @@ function apiGet(path: string): Request {
   return new Request(`https://cms.example${path}`);
 }
 
+function bearerGet(path: string, secret: string): Request {
+  return new Request(`https://cms.example${path}`, {
+    headers: { authorization: `Bearer ${secret}` },
+  });
+}
+
+async function mintPat(
+  h: DispatcherHarness,
+  {
+    role = "editor",
+    scopes = null,
+    expiresAt,
+  }: {
+    role?: "subscriber" | "editor" | "admin";
+    scopes?: string[] | null;
+    expiresAt?: Date;
+  } = {},
+): Promise<{ userId: number; secret: string }> {
+  const user = await h.factory.user.create({ role });
+  const { secret } = await h.factory.apiToken.create({
+    userId: user.id,
+    scopes,
+    expiresAt: expiresAt ?? null,
+  });
+  return { userId: user.id, secret };
+}
+
+async function seedDraft(h: DispatcherHarness): Promise<number> {
+  const author = await h.factory.user.create({ role: "author" });
+  const entry = await h.factory.entry.create({
+    type: "post",
+    status: "draft",
+    authorId: author.id,
+  });
+  return entry.id;
+}
+
 interface ListEnvelope {
   readonly data: readonly Record<string, unknown>[];
   readonly meta: Record<string, unknown>;
@@ -275,5 +312,73 @@ describe("REST API — OpenAPI spec", () => {
     expect(doc.openapi).toMatch(/^3\.1/);
     expect(doc.paths).toHaveProperty("/{type}");
     expect(doc.paths).toHaveProperty("/{type}/{id}");
+  });
+});
+
+describe("REST API — bearer PAT auth", () => {
+  test("a valid PAT reads non-published content its user may see", async () => {
+    const h = await restHarness();
+    const draftId = await seedDraft(h);
+    const { secret } = await mintPat(h, { role: "editor" });
+
+    // Anonymous can't see the draft...
+    const anon = await h.dispatch(apiGet(`/_plumix/api/v1/posts/${draftId}`));
+    expect(anon.status).toBe(404);
+
+    // ...but an editor's PAT can.
+    const authed = await h.dispatch(
+      bearerGet(`/_plumix/api/v1/posts/${draftId}`, secret),
+    );
+    expect(authed.status).toBe(200);
+    const body = (await authed.json()) as Record<string, unknown>;
+    expect(body.id).toBe(draftId);
+    expect(body.status).toBe("draft");
+  });
+
+  test("a scoped token is gated by scope ∩ role", async () => {
+    const h = await restHarness();
+    const draftId = await seedDraft(h);
+    // Editor role could see drafts, but the token's scopes exclude edit_any.
+    const { secret } = await mintPat(h, {
+      role: "editor",
+      scopes: ["entry:post:read"],
+    });
+
+    const res = await h.dispatch(
+      bearerGet(`/_plumix/api/v1/posts/${draftId}`, secret),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  test("an expired token is rejected with 401", async () => {
+    const h = await restHarness();
+    const { secret } = await mintPat(h, {
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const res = await h.dispatch(bearerGet("/_plumix/api/v1/posts", secret));
+
+    expect(res.status).toBe(401);
+  });
+
+  test("a malformed bearer token is rejected with 401", async () => {
+    const h = await restHarness();
+
+    const res = await h.dispatch(
+      bearerGet("/_plumix/api/v1/posts", "pl_pat_not-a-real-token"),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  test("a PAT-authed response is non-cacheable", async () => {
+    const h = await restHarness();
+    const { secret } = await mintPat(h, { role: "editor" });
+
+    const res = await h.dispatch(bearerGet("/_plumix/api/v1/posts", secret));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("no-store");
   });
 });

--- a/packages/core/src/rest/principal.ts
+++ b/packages/core/src/rest/principal.ts
@@ -1,4 +1,5 @@
 import type { AppContext, AuthenticatedUser } from "../context/app.js";
+import { authenticateBearer, hasBearerToken } from "../auth/bearer.js";
 import { withUser } from "../context/app.js";
 
 // The lowest role: reads published content, holds no edit/admin capability.
@@ -12,6 +13,24 @@ const PUBLIC_PRINCIPAL: AuthenticatedUser = {
   meta: {},
 };
 
-export function withPublicPrincipal(ctx: AppContext): AppContext {
-  return withUser(ctx, PUBLIC_PRINCIPAL);
+export type RestPrincipal =
+  | { readonly kind: "authed"; readonly ctx: AppContext }
+  | { readonly kind: "anonymous"; readonly ctx: AppContext }
+  | { readonly kind: "unauthorized" };
+
+/**
+ * Resolve the principal for a REST request. No bearer token → anonymous
+ * read-only public principal. A bearer token must be valid: an expired /
+ * revoked / disabled-user / malformed token is rejected outright (`unauthorized`)
+ * rather than silently downgraded to anonymous, so a caller learns its
+ * credential failed.
+ */
+export async function resolveRestPrincipal(
+  ctx: AppContext,
+): Promise<RestPrincipal> {
+  if (!hasBearerToken(ctx.request)) {
+    return { kind: "anonymous", ctx: withUser(ctx, PUBLIC_PRINCIPAL) };
+  }
+  const authed = await authenticateBearer(ctx);
+  return authed ? { kind: "authed", ctx: authed } : { kind: "unauthorized" };
 }

--- a/packages/core/src/runtime/http.ts
+++ b/packages/core/src/runtime/http.ts
@@ -22,6 +22,10 @@ export function methodNotAllowed(allowed: readonly string[]): Response {
   });
 }
 
+export function unauthorized(): Response {
+  return jsonResponse({ error: "unauthorized" }, { status: 401 });
+}
+
 export function forbidden(reason: string): Response {
   return jsonResponse({ error: "forbidden", reason }, { status: 403 });
 }


### PR DESCRIPTION
Add bearer-PAT authentication to the public REST API (PRD #995, building on #997). A request carrying `Authorization: Bearer <pat>` resolves to the token's principal via the existing PAT authenticator, with reads gated by **scope ∩ role** — unlocking privileged reads (non-published content the token's user may see) over the same endpoints. A request with no bearer stays anonymous (published-only, hide-existence 404).

**Bearer must be valid — fail closed**

Expired, revoked, disabled-user, and malformed tokens are rejected with **401**, never silently downgraded to anonymous, so a caller learns its credential failed.

```
no Authorization header   → anonymous (published-only)
valid Bearer <pat>        → authed   (scope ∩ role)
invalid/expired Bearer    → 401
```

**Privileged responses are not cacheable or cross-origin**

PAT-authed responses are marked `Cache-Control: private, no-store` and carry no CORS, so non-public content is never cached or exposed cross-origin. Bearer auth is CSRF-immune (the surface mounts ahead of the CSRF gate).

**Shared bearer helper**

The bearer-to-context resolution (`authenticateBearer` + `hasBearerToken`) is extracted into `auth/bearer.ts`, now shared by both the REST surface and MCP (refactored onto it — pure refactor, covered by existing MCP tests). Adds an `unauthorized()` http helper alongside `notFound`/`methodNotAllowed`.

Scope ∩ role is enforced through the existing `auth.can` intersection (`tokenScopes` threaded via `withUser`); no new authorization logic.

Closes #998