### PR TITLE
feat(core): expose term resources and embed terms on REST entries

### DIFF
--- a/packages/core/src/rest/dispatch.test.ts
+++ b/packages/core/src/rest/dispatch.test.ts
@@ -13,6 +13,23 @@ const blog = definePlugin("test-blog", (ctx) => {
     isPublic: true,
     isHierarchical: false,
     supports: ["title", "editor", "excerpt"],
+    termTaxonomies: ["category", "tag"],
+  });
+  ctx.registerTermTaxonomy("category", {
+    label: "Categories",
+    isHierarchical: true,
+    entryTypes: ["post"],
+  });
+  ctx.registerTermTaxonomy("tag", {
+    label: "Tags",
+    isHierarchical: false,
+    entryTypes: ["post"],
+  });
+  ctx.registerTermTaxonomy("secret_tax", {
+    label: "Secret",
+    isPublic: false,
+    isHierarchical: false,
+    entryTypes: ["post"],
   });
 });
 
@@ -310,8 +327,180 @@ describe("REST API — OpenAPI spec", () => {
       paths: Record<string, unknown>;
     };
     expect(doc.openapi).toMatch(/^3\.1/);
-    expect(doc.paths).toHaveProperty("/{type}");
-    expect(doc.paths).toHaveProperty("/{type}/{id}");
+    expect(doc.paths).toHaveProperty("/{collection}");
+    expect(doc.paths).toHaveProperty("/{collection}/{id}");
+  });
+
+  test("the spec documents term resources and the entry term-embed", async () => {
+    const h = await restHarness();
+
+    const res = await h.dispatch(apiGet("/_plumix/api/v1/openapi.json"));
+    const doc = (await res.json()) as Record<string, unknown>;
+    const json = JSON.stringify(doc);
+
+    // The entry schema's grouped term-embed field is documented...
+    expect(json).toContain('"terms"');
+    // ...and the collection responses are a union of the entry and term shapes.
+    expect(json).toMatch(/"(anyOf|oneOf)"/);
+  });
+});
+
+describe("REST API — term resources", () => {
+  test("GET /{taxonomy} returns a paginated envelope of terms", async () => {
+    const h = await restHarness();
+    await h.factory.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+
+    const res = await h.dispatch(apiGet("/_plumix/api/v1/categories"));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ListEnvelope;
+    expect(body.data).toHaveLength(1);
+    const term = body.data[0] as { id: number; name: string; slug: string };
+    expect(typeof term.id).toBe("number");
+    expect(term).toMatchObject({ name: "News", slug: "news" });
+    expect(body.meta).toMatchObject({ page: 1 });
+  });
+
+  test("a non-public taxonomy is not exposed (404)", async () => {
+    const h = await restHarness();
+
+    const res = await h.dispatch(apiGet("/_plumix/api/v1/secret_taxes"));
+
+    expect(res.status).toBe(404);
+  });
+
+  test("GET /{taxonomy}/{id} returns one term", async () => {
+    const h = await restHarness();
+    const term = await h.factory.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+
+    const res = await h.dispatch(
+      apiGet(`/_plumix/api/v1/categories/${term.id}`),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({ id: term.id, name: "News", slug: "news" });
+  });
+
+  test("a term requested under the wrong taxonomy is 404", async () => {
+    const h = await restHarness();
+    const term = await h.factory.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+
+    // The term exists, but under `category` — requesting it under `tags`
+    // (also public) must hide it rather than reveal a cross-taxonomy item.
+    const res = await h.dispatch(apiGet(`/_plumix/api/v1/tags/${term.id}`));
+
+    expect(res.status).toBe(404);
+  });
+
+  test("a missing term id is 404", async () => {
+    const h = await restHarness();
+
+    const res = await h.dispatch(apiGet("/_plumix/api/v1/categories/999999"));
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("REST API — entry term embed", () => {
+  test("an entry embeds its terms grouped by taxonomy", async () => {
+    const h = await restHarness();
+    const author = await h.factory.user.create({ role: "author" });
+    const entry = await h.factory.entry.create({
+      type: "post",
+      status: "published",
+      authorId: author.id,
+    });
+    const term = await h.factory.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+    await h.factory.entryTerm.create({ entryId: entry.id, termId: term.id });
+
+    const res = await h.dispatch(apiGet(`/_plumix/api/v1/posts/${entry.id}`));
+
+    const body = (await res.json()) as { terms: Record<string, unknown> };
+    expect(body.terms).toEqual({
+      category: [{ id: term.id, name: "News", slug: "news" }],
+    });
+  });
+
+  test("the list embeds terms and excludes non-public taxonomies", async () => {
+    const h = await restHarness();
+    const author = await h.factory.user.create({ role: "author" });
+    const entry = await h.factory.entry.create({
+      type: "post",
+      status: "published",
+      authorId: author.id,
+    });
+    const cat = await h.factory.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+    const secret = await h.factory.term.create({
+      taxonomy: "secret_tax",
+      name: "Hush",
+      slug: "hush",
+    });
+    await h.factory.entryTerm.create({ entryId: entry.id, termId: cat.id });
+    await h.factory.entryTerm.create({ entryId: entry.id, termId: secret.id });
+
+    const res = await h.dispatch(apiGet("/_plumix/api/v1/posts"));
+
+    const body = (await res.json()) as {
+      data: { terms: Record<string, unknown> }[];
+    };
+    expect(body.data[0]?.terms).toEqual({
+      category: [{ id: cat.id, name: "News", slug: "news" }],
+    });
+  });
+});
+
+describe("REST API — entry term filter", () => {
+  test("filters entries by a taxonomy query param", async () => {
+    const h = await restHarness();
+    const author = await h.factory.user.create({ role: "author" });
+    const matched = await h.factory.entry.create({
+      type: "post",
+      status: "published",
+      authorId: author.id,
+      title: "Matched",
+    });
+    await h.factory.entry.create({
+      type: "post",
+      status: "published",
+      authorId: author.id,
+      title: "Other",
+    });
+    const news = await h.factory.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+    await h.factory.entryTerm.create({
+      entryId: matched.id,
+      termId: news.id,
+    });
+
+    const res = await h.dispatch(apiGet("/_plumix/api/v1/posts?category=news"));
+
+    const body = (await res.json()) as { data: { title: string }[] };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]?.title).toBe("Matched");
   });
 });
 

--- a/packages/core/src/rest/entries-resource.ts
+++ b/packages/core/src/rest/entries-resource.ts
@@ -1,0 +1,114 @@
+import type { AppContext } from "../context/app.js";
+import type { RegisteredEntryType } from "../plugin/manifest.js";
+import type { RestErrors } from "./errors.js";
+import type { PublicEntry } from "./schemas.js";
+import { EntryReadError } from "../entries/errors.js";
+import { getEntry, listEntries } from "../entries/read-service.js";
+import { listEnvelope } from "./envelope.js";
+import {
+  loadEntriesTerms,
+  loadPublicAuthors,
+  projectEntry,
+} from "./projection.js";
+import { readPagination } from "./schemas.js";
+
+// Every entry-read failure mode (missing, reserved-type, forbidden, an
+// unpublished status the public principal can't see) collapses to 404 so the
+// existence of unreadable content stays hidden. A non-EntryReadError is
+// unexpected and rethrown for the dispatcher to surface as a 500.
+function entryNotFound(error: unknown, errors: RestErrors): unknown {
+  if (error instanceof EntryReadError) {
+    return errors.NOT_FOUND({ data: { kind: "entry" } });
+  }
+  return error;
+}
+
+// Pagination params own these query keys; a taxonomy that happens to share a
+// name with one is skipped as a filter so `?page=2` can't double as a term query.
+const RESERVED_QUERY_PARAMS = new Set(["page", "per_page"]);
+
+// Map `?<taxonomy>=slug,slug` query params onto the service's term filter. Only
+// registered public taxonomies are honored, so any other query key is ignored.
+function readTermFilters(
+  context: AppContext,
+  url: URL,
+): Record<string, string[]> | undefined {
+  const filters: Record<string, string[]> = {};
+  for (const taxonomy of context.plugins.termTaxonomies.values()) {
+    if (taxonomy.isPublic === false) continue;
+    if (RESERVED_QUERY_PARAMS.has(taxonomy.name)) continue;
+    const slugs = url.searchParams
+      .getAll(taxonomy.name)
+      .flatMap((value) => value.split(","))
+      .map((slug) => slug.trim())
+      .filter(Boolean);
+    if (slugs.length > 0) filters[taxonomy.name] = slugs;
+  }
+  return Object.keys(filters).length > 0 ? filters : undefined;
+}
+
+// A paginated envelope of published entries for a public content type.
+export async function listEntriesEnvelope(
+  context: AppContext,
+  entryType: RegisteredEntryType,
+  url: URL,
+) {
+  const { page, perPage, offset } = readPagination(url);
+
+  // Over-fetch one row to detect a next page without a separate COUNT — an
+  // exact-multiple last page then reports no next link.
+  const fetched = await listEntries(context, {
+    type: entryType.name,
+    orderBy: "published_at",
+    order: "desc",
+    termTaxonomies: readTermFilters(context, url),
+    limit: perPage + 1,
+    offset,
+  });
+  const hasNext = fetched.length > perPage;
+  const rows = hasNext ? fetched.slice(0, perPage) : fetched;
+
+  const ids = rows.map((row) => row.id);
+  const authors = await loadPublicAuthors(
+    context,
+    rows.map((row) => row.authorId),
+  );
+  const termsByEntry = await loadEntriesTerms(context, ids);
+  const data = rows.map((row) =>
+    projectEntry(
+      row,
+      authors.get(row.authorId) ?? null,
+      termsByEntry.get(row.id) ?? {},
+    ),
+  );
+
+  return listEnvelope(data, { url, page, perPage, hasNext });
+}
+
+// One published entry. Unviewable or missing content is 404, never 403.
+export async function getEntryItem(
+  context: AppContext,
+  entryType: RegisteredEntryType,
+  id: number,
+  errors: RestErrors,
+): Promise<PublicEntry> {
+  let entry: Awaited<ReturnType<typeof getEntry>>;
+  try {
+    entry = await getEntry(context, { id });
+  } catch (error) {
+    throw entryNotFound(error, errors);
+  }
+
+  // The id resolved to an entry of a different collection — hide that it
+  // exists rather than redirecting or 400ing.
+  if (entry.type !== entryType.name) {
+    throw errors.NOT_FOUND({ data: { kind: "entry" } });
+  }
+  const authors = await loadPublicAuthors(context, [entry.authorId]);
+  const termsByEntry = await loadEntriesTerms(context, [entry.id]);
+  return projectEntry(
+    entry,
+    authors.get(entry.authorId) ?? null,
+    termsByEntry.get(entry.id) ?? {},
+  );
+}

--- a/packages/core/src/rest/errors.ts
+++ b/packages/core/src/rest/errors.ts
@@ -1,11 +1,14 @@
+import type { ORPCErrorConstructorMap } from "@orpc/server";
 import * as v from "valibot";
 
 // Typed errors for the REST surface. Forbidden reads collapse to NOT_FOUND
-// upstream (in the entry services) to preserve hide-existence, so the public
-// read surface only ever needs NOT_FOUND today.
+// upstream (in the entry/term services) to preserve hide-existence, so the
+// public read surface only ever needs NOT_FOUND today.
 export const REST_ERRORS = {
   NOT_FOUND: {
     message: "Resource not found",
     data: v.object({ kind: v.string() }),
   },
 } as const;
+
+export type RestErrors = ORPCErrorConstructorMap<typeof REST_ERRORS>;

--- a/packages/core/src/rest/projection.ts
+++ b/packages/core/src/rest/projection.ts
@@ -1,8 +1,17 @@
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
-import type { PublicAuthor, PublicEntry } from "./schemas.js";
-import { inArray } from "../db/index.js";
+import type { Term } from "../db/schema/terms.js";
+import type { PublicAuthor, PublicEntry, PublicTerm } from "./schemas.js";
+import { eq, inArray } from "../db/index.js";
+import { entryTerm } from "../db/schema/entry_term.js";
+import { terms } from "../db/schema/terms.js";
 import { users } from "../db/schema/users.js";
+
+export function projectTerm(
+  term: Pick<Term, "id" | "name" | "slug">,
+): PublicTerm {
+  return { id: term.id, name: term.name, slug: term.slug };
+}
 
 /**
  * Explicit allowlist — default-deny. Privileged columns (authorId, sortOrder,
@@ -13,6 +22,7 @@ import { users } from "../db/schema/users.js";
 export function projectEntry(
   entry: Entry,
   author: PublicAuthor | null,
+  termsByTaxonomy: Record<string, PublicTerm[]>,
 ): PublicEntry {
   return {
     id: entry.id,
@@ -26,6 +36,7 @@ export function projectEntry(
     createdAt: entry.createdAt,
     updatedAt: entry.updatedAt,
     author,
+    terms: termsByTaxonomy,
   };
 }
 
@@ -42,4 +53,42 @@ export async function loadPublicAuthors(
     .from(users)
     .where(inArray(users.id, ids));
   return new Map(rows.map((row) => [row.id, row]));
+}
+
+/**
+ * Batched term embed for a page of entries — one join over `entry_term`, never
+ * a per-entry query. Terms in non-public taxonomies are dropped (default-deny);
+ * within a taxonomy they keep their `entry_term.sortOrder`.
+ */
+export async function loadEntriesTerms(
+  ctx: AppContext,
+  entryIds: readonly number[],
+): Promise<Map<number, Record<string, PublicTerm[]>>> {
+  const result = new Map<number, Record<string, PublicTerm[]>>();
+  if (entryIds.length === 0) return result;
+
+  const rows = await ctx.db
+    .select({
+      entryId: entryTerm.entryId,
+      id: terms.id,
+      name: terms.name,
+      slug: terms.slug,
+      taxonomy: terms.taxonomy,
+      sortOrder: entryTerm.sortOrder,
+    })
+    .from(entryTerm)
+    .innerJoin(terms, eq(entryTerm.termId, terms.id))
+    .where(inArray(entryTerm.entryId, [...new Set(entryIds)]))
+    // `id` tiebreaks the default-0 sortOrder so embed order is deterministic.
+    .orderBy(entryTerm.sortOrder, terms.id);
+
+  for (const row of rows) {
+    if (ctx.plugins.termTaxonomies.get(row.taxonomy)?.isPublic === false) {
+      continue;
+    }
+    const grouped = result.get(row.entryId) ?? {};
+    (grouped[row.taxonomy] ??= []).push(projectTerm(row));
+    result.set(row.entryId, grouped);
+  }
+  return result;
 }

--- a/packages/core/src/rest/rest-base.ts
+++ b/packages/core/src/rest/rest-base.ts
@@ -1,6 +1,7 @@
 import type {
   PluginRegistry,
   RegisteredEntryType,
+  RegisteredTermTaxonomy,
 } from "../plugin/manifest.js";
 
 // Naive pluralization; an explicit per-type rest_base override is a later concern.
@@ -10,10 +11,6 @@ function pluralize(name: string): string {
   }
   if (/(?:s|x|z|ch|sh)$/.test(name)) return `${name}es`;
   return `${name}s`;
-}
-
-function restBaseForEntryType(type: RegisteredEntryType): string {
-  return pluralize(type.name);
 }
 
 /**
@@ -26,8 +23,25 @@ export function resolvePublicEntryType(
   restBase: string,
 ): RegisteredEntryType | null {
   for (const type of registry.entryTypes.values()) {
-    if (type.isPublic !== false && restBaseForEntryType(type) === restBase) {
+    if (type.isPublic !== false && pluralize(type.name) === restBase) {
       return type;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a collection rest_base (e.g. `categories`) to its registered public
+ * taxonomy. Entry types and taxonomies share the top-level rest_base namespace
+ * (siblings, as in WordPress), so the dispatcher tries this after entry types.
+ */
+export function resolvePublicTaxonomy(
+  registry: PluginRegistry,
+  restBase: string,
+): RegisteredTermTaxonomy | null {
+  for (const taxonomy of registry.termTaxonomies.values()) {
+    if (taxonomy.isPublic !== false && pluralize(taxonomy.name) === restBase) {
+      return taxonomy;
     }
   }
   return null;

--- a/packages/core/src/rest/router.ts
+++ b/packages/core/src/rest/router.ts
@@ -1,102 +1,54 @@
-import type { ORPCErrorConstructorMap } from "@orpc/server";
+import * as v from "valibot";
 
-import type { REST_ERRORS } from "./errors.js";
-import { EntryReadError } from "../entries/errors.js";
-import { getEntry, listEntries } from "../entries/read-service.js";
 import { base } from "./base.js";
-import { listEnvelope } from "./envelope.js";
-import { loadPublicAuthors, projectEntry } from "./projection.js";
-import { resolvePublicEntryType } from "./rest-base.js";
+import { getEntryItem, listEntriesEnvelope } from "./entries-resource.js";
+import { resolvePublicEntryType, resolvePublicTaxonomy } from "./rest-base.js";
 import {
+  collectionItemParamsSchema,
+  collectionParamsSchema,
   entriesListEnvelopeSchema,
-  entryCollectionParamsSchema,
-  entryItemParamsSchema,
   publicEntrySchema,
-  readPagination,
+  publicTermSchema,
+  termsListEnvelopeSchema,
 } from "./schemas.js";
+import { getTermItem, listTermsEnvelope } from "./terms-resource.js";
 
-type RestErrors = ORPCErrorConstructorMap<typeof REST_ERRORS>;
+// Entry types and taxonomies are siblings in the top-level `{collection}`
+// rest_base namespace (as in WordPress), so a single pair of routes resolves
+// the rest_base to whichever registry owns it; an unowned base is 404.
 
-// Every entry-read failure mode (missing, reserved-type, forbidden, an
-// unpublished status the public principal can't see) collapses to 404 so the
-// existence of unreadable content stays hidden. A non-EntryReadError is
-// unexpected and rethrown for the dispatcher to surface as a 500.
-function entryNotFound(error: unknown, errors: RestErrors): unknown {
-  if (error instanceof EntryReadError) {
-    return errors.NOT_FOUND({ data: { kind: "entry" } });
-  }
-  return error;
-}
-
-// GET /{type} — a paginated envelope of published entries for any public
-// content type, resolved from the registry at request time so custom types
-// light up automatically.
-const listEntriesResource = base
-  .route({ method: "GET", path: "/{type}" })
-  .input(entryCollectionParamsSchema)
-  .output(entriesListEnvelopeSchema)
+// GET /{collection} — a paginated envelope of a public entry type or taxonomy.
+const collectionList = base
+  .route({ method: "GET", path: "/{collection}" })
+  .input(collectionParamsSchema)
+  .output(v.union([entriesListEnvelopeSchema, termsListEnvelopeSchema]))
   .handler(async ({ input, context, errors }) => {
-    const entryType = resolvePublicEntryType(context.plugins, input.type);
-    if (!entryType) throw errors.NOT_FOUND({ data: { kind: "collection" } });
-
     const url = new URL(context.request.url);
-    const { page, perPage, offset } = readPagination(url);
-
-    // Over-fetch one row to detect a next page without a separate COUNT — an
-    // exact-multiple last page then reports no next link.
-    const fetched = await listEntries(context, {
-      type: entryType.name,
-      orderBy: "published_at",
-      order: "desc",
-      limit: perPage + 1,
-      offset,
-    });
-    const hasNext = fetched.length > perPage;
-    const rows = hasNext ? fetched.slice(0, perPage) : fetched;
-
-    const authors = await loadPublicAuthors(
-      context,
-      rows.map((row) => row.authorId),
-    );
-    const data = rows.map((row) =>
-      projectEntry(row, authors.get(row.authorId) ?? null),
-    );
-
-    return listEnvelope(data, { url, page, perPage, hasNext });
+    const entryType = resolvePublicEntryType(context.plugins, input.collection);
+    if (entryType) return listEntriesEnvelope(context, entryType, url);
+    const taxonomy = resolvePublicTaxonomy(context.plugins, input.collection);
+    if (taxonomy) return listTermsEnvelope(context, taxonomy, url);
+    throw errors.NOT_FOUND({ data: { kind: "collection" } });
   });
 
-// GET /{type}/{id} — one published entry. Unviewable or missing content is
-// 404, never 403.
-const getEntryResource = base
-  .route({ method: "GET", path: "/{type}/{id}" })
-  .input(entryItemParamsSchema)
-  .output(publicEntrySchema)
+// GET /{collection}/{id} — one entry or term. Missing/unviewable items 404.
+const collectionGet = base
+  .route({ method: "GET", path: "/{collection}/{id}" })
+  .input(collectionItemParamsSchema)
+  .output(v.union([publicEntrySchema, publicTermSchema]))
   .handler(async ({ input, context, errors }) => {
-    const entryType = resolvePublicEntryType(context.plugins, input.type);
-    if (!entryType) throw errors.NOT_FOUND({ data: { kind: "collection" } });
-
     const id = Number(input.id);
     if (!Number.isInteger(id) || id < 1) {
-      throw errors.NOT_FOUND({ data: { kind: "entry" } });
+      throw errors.NOT_FOUND({ data: { kind: "item" } });
     }
-
-    let entry: Awaited<ReturnType<typeof getEntry>>;
-    try {
-      entry = await getEntry(context, { id });
-    } catch (error) {
-      throw entryNotFound(error, errors);
-    }
-
-    // The id resolved to an entry of a different collection — hide that it
-    // exists rather than redirecting or 400ing.
-    if (entry.type !== entryType.name) {
-      throw errors.NOT_FOUND({ data: { kind: "entry" } });
-    }
-    const authors = await loadPublicAuthors(context, [entry.authorId]);
-    return projectEntry(entry, authors.get(entry.authorId) ?? null);
+    const entryType = resolvePublicEntryType(context.plugins, input.collection);
+    if (entryType) return getEntryItem(context, entryType, id, errors);
+    const taxonomy = resolvePublicTaxonomy(context.plugins, input.collection);
+    if (taxonomy) return getTermItem(context, taxonomy, id, errors);
+    throw errors.NOT_FOUND({ data: { kind: "collection" } });
   });
 
 export const restRouter = {
-  entriesList: listEntriesResource,
-  entriesGet: getEntryResource,
+  collectionList,
+  collectionGet,
 };

--- a/packages/core/src/rest/schemas.ts
+++ b/packages/core/src/rest/schemas.ts
@@ -3,11 +3,13 @@ import * as v from "valibot";
 const MAX_PER_PAGE = 100;
 const DEFAULT_PER_PAGE = 20;
 
-// Path param only. Pagination is read from the query string directly (see
-// `readPagination`) so the surface doesn't depend on per-adapter query coercion.
-export const entryCollectionParamsSchema = v.object({ type: v.string() });
-export const entryItemParamsSchema = v.object({
-  type: v.string(),
+// Path params only. Entry types and taxonomies share the top-level
+// `{collection}` rest_base namespace. Pagination is read from the query string
+// directly (see `readPagination`) so the surface doesn't depend on per-adapter
+// query coercion.
+export const collectionParamsSchema = v.object({ collection: v.string() });
+export const collectionItemParamsSchema = v.object({
+  collection: v.string(),
   id: v.string(),
 });
 
@@ -18,6 +20,13 @@ export const publicAuthorSchema = v.object({
   id: v.number(),
   name: v.nullable(v.string()),
   avatarUrl: v.nullable(v.string()),
+});
+
+// Compact term shape, used both as a top-level resource and embedded on entries.
+export const publicTermSchema = v.object({
+  id: v.number(),
+  name: v.string(),
+  slug: v.string(),
 });
 
 export const publicEntrySchema = v.object({
@@ -32,20 +41,28 @@ export const publicEntrySchema = v.object({
   createdAt: v.date(),
   updatedAt: v.date(),
   author: v.nullable(publicAuthorSchema),
+  // Associations are embedded, never nested as their own sub-resource.
+  terms: v.record(v.string(), v.array(publicTermSchema)),
 });
 
-export const entriesListEnvelopeSchema = v.object({
-  data: v.array(publicEntrySchema),
-  meta: v.object({ page: v.number(), per_page: v.number() }),
-  links: v.object({
-    self: v.string(),
-    next: v.optional(v.string()),
-    prev: v.optional(v.string()),
-  }),
-});
+function listEnvelopeSchema<TItem extends v.GenericSchema>(item: TItem) {
+  return v.object({
+    data: v.array(item),
+    meta: v.object({ page: v.number(), per_page: v.number() }),
+    links: v.object({
+      self: v.string(),
+      next: v.optional(v.string()),
+      prev: v.optional(v.string()),
+    }),
+  });
+}
+
+export const entriesListEnvelopeSchema = listEnvelopeSchema(publicEntrySchema);
+export const termsListEnvelopeSchema = listEnvelopeSchema(publicTermSchema);
 
 export type PublicAuthor = v.InferOutput<typeof publicAuthorSchema>;
 export type PublicEntry = v.InferOutput<typeof publicEntrySchema>;
+export type PublicTerm = v.InferOutput<typeof publicTermSchema>;
 
 interface Pagination {
   readonly page: number;

--- a/packages/core/src/rest/terms-resource.ts
+++ b/packages/core/src/rest/terms-resource.ts
@@ -1,0 +1,60 @@
+import type { AppContext } from "../context/app.js";
+import type { RegisteredTermTaxonomy } from "../plugin/manifest.js";
+import type { RestErrors } from "./errors.js";
+import type { PublicTerm } from "./schemas.js";
+import { TermReadError } from "../terms/errors.js";
+import { getTerm, listTerms } from "../terms/read-service.js";
+import { listEnvelope } from "./envelope.js";
+import { projectTerm } from "./projection.js";
+import { readPagination } from "./schemas.js";
+
+// The public gate lives in `resolvePublicTaxonomy` (the dispatcher), not in the
+// term service — `term:<taxonomy>:read` is granted to subscriber for every
+// taxonomy, public or not. Only route public taxonomies here.
+//
+// Term reads hide existence the same way entry reads do: a missing term, an
+// unreadable taxonomy, or a wrong-taxonomy lookup all collapse to 404.
+function termNotFound(error: unknown, errors: RestErrors): unknown {
+  if (error instanceof TermReadError) {
+    return errors.NOT_FOUND({ data: { kind: "term" } });
+  }
+  return error;
+}
+
+// A paginated envelope of a public taxonomy's terms.
+export async function listTermsEnvelope(
+  context: AppContext,
+  taxonomy: RegisteredTermTaxonomy,
+  url: URL,
+) {
+  const { page, perPage, offset } = readPagination(url);
+  const fetched = await listTerms(context, {
+    taxonomy: taxonomy.name,
+    limit: perPage + 1,
+    offset,
+  });
+  const hasNext = fetched.length > perPage;
+  const rows = hasNext ? fetched.slice(0, perPage) : fetched;
+
+  return listEnvelope(rows.map(projectTerm), { url, page, perPage, hasNext });
+}
+
+// One term. A term in another taxonomy is hidden (404) rather than revealed.
+export async function getTermItem(
+  context: AppContext,
+  taxonomy: RegisteredTermTaxonomy,
+  id: number,
+  errors: RestErrors,
+): Promise<PublicTerm> {
+  let term: Awaited<ReturnType<typeof getTerm>>;
+  try {
+    term = await getTerm(context, { id });
+  } catch (error) {
+    throw termNotFound(error, errors);
+  }
+
+  if (term.taxonomy !== taxonomy.name) {
+    throw errors.NOT_FOUND({ data: { kind: "term" } });
+  }
+  return projectTerm(term);
+}


### PR DESCRIPTION
Extend the public REST API (PRD #995, building on #997/#998) with terms, following the association-not-composition rule.

**Unified collection namespace**

Entry types and taxonomies are siblings under the top-level rest_base namespace (as in WordPress), so a single resolver maps `/{collection}` to whichever registry owns it:

- `GET /categories`, `GET /categories/{id}` read a public taxonomy's terms in the same `{ data, meta, links }` envelope.
- Custom public taxonomies light up automatically; unowned or non-public bases 404.

**Terms embedded on entries**

Entry responses now embed their terms grouped by taxonomy, loaded with one batched join per page (no N+1) and **dropping non-public taxonomies by default**:

```json
{ "id": 42, "title": "…", "terms": { "category": [{ "id": 1, "name": "News", "slug": "news" }] } }
```

**Filter entries by term**

```
GET /posts?category=news,features&tag=cloud
```

Taxonomy query params map onto the existing `termTaxonomies` service filter (AND across taxonomies, OR within). Only registered public taxonomies are honored, and pagination keys (`page`/`per_page`) can't double as filters.

**Security**

Term reads reuse the read-only public principal and hide existence (404, never 403) like entries — including a term requested under the wrong taxonomy. The entry/term router split into `entries-resource`/`terms-resource` modules; term resources and the entry term-embed appear in `openapi.json` via valibot output schemas.

Closes #999