### PR TITLE
feat(core): gate REST meta exposure behind a per-field showInApi flag

### DIFF
--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -360,6 +360,12 @@ export interface MetaBoxFieldBase {
    * repeater field's gate). Defaults to no gating.
    */
   readonly capability?: string;
+  /**
+   * Expose this field's value on the public REST API. Default-deny: meta is
+   * hidden from REST responses unless a field opts in with `showInApi: true`,
+   * so internal fields never leak by default. Has no effect on the admin RPC.
+   */
+  readonly showInApi?: boolean;
 }
 
 /**

--- a/packages/core/src/rest/dispatch.test.ts
+++ b/packages/core/src/rest/dispatch.test.ts
@@ -31,6 +31,25 @@ const blog = definePlugin("test-blog", (ctx) => {
     isHierarchical: false,
     entryTypes: ["post"],
   });
+  ctx.registerEntryMetaBox("seo", {
+    label: "SEO",
+    entryTypes: ["post"],
+    fields: [
+      {
+        key: "featured",
+        label: "Featured",
+        inputType: "checkbox",
+        type: "boolean",
+        showInApi: true,
+      },
+      {
+        key: "internal_note",
+        label: "Internal",
+        inputType: "text",
+        type: "string",
+      },
+    ],
+  });
 });
 
 // A custom public type plus a non-public one, to prove custom types light up
@@ -239,12 +258,13 @@ describe("REST API — public projection (default-deny)", () => {
     const res = await h.dispatch(apiGet(`/_plumix/api/v1/posts/${entry.id}`));
 
     const body = (await res.json()) as Record<string, unknown>;
-    // The allowlist omits raw authorId, sortOrder, parentId, and meta — adding
-    // a column to the entries table cannot leak it through this surface.
+    // The allowlist omits raw authorId, sortOrder, and parentId — adding a
+    // column to the entries table cannot leak it through this surface. Meta is
+    // present but default-deny (empty until a field opts in via showInApi).
     expect(body).not.toHaveProperty("authorId");
     expect(body).not.toHaveProperty("sortOrder");
     expect(body).not.toHaveProperty("parentId");
-    expect(body).not.toHaveProperty("meta");
+    expect(body.meta).toEqual({});
   });
 });
 
@@ -411,6 +431,62 @@ describe("REST API — term resources", () => {
     const res = await h.dispatch(apiGet("/_plumix/api/v1/categories/999999"));
 
     expect(res.status).toBe(404);
+  });
+});
+
+describe("REST API — meta visibility (default-deny)", () => {
+  async function seedWithMeta(
+    h: DispatcherHarness,
+    meta: Record<string, unknown>,
+  ): Promise<number> {
+    const author = await h.factory.user.create({ role: "author" });
+    const entry = await h.factory.entry.create({
+      type: "post",
+      status: "published",
+      authorId: author.id,
+      meta,
+    });
+    return entry.id;
+  }
+
+  test("a whitelisted meta field appears; a non-whitelisted one does not", async () => {
+    const h = await restHarness();
+    const id = await seedWithMeta(h, {
+      featured: true,
+      internal_note: "secret",
+    });
+
+    const res = await h.dispatch(apiGet(`/_plumix/api/v1/posts/${id}`));
+
+    const body = (await res.json()) as { meta: Record<string, unknown> };
+    expect(body.meta).toEqual({ featured: true });
+    expect(body.meta).not.toHaveProperty("internal_note");
+  });
+
+  test("an unregistered meta key is never exposed (default-deny)", async () => {
+    const h = await restHarness();
+    const id = await seedWithMeta(h, { rogue: "leak" });
+
+    const res = await h.dispatch(apiGet(`/_plumix/api/v1/posts/${id}`));
+
+    const body = (await res.json()) as { meta: Record<string, unknown> };
+    expect(body.meta).toEqual({});
+  });
+
+  test("a PAT-authed read applies the same meta whitelist", async () => {
+    const h = await restHarness();
+    const id = await seedWithMeta(h, {
+      featured: true,
+      internal_note: "secret",
+    });
+    const { secret } = await mintPat(h, { role: "admin" });
+
+    const res = await h.dispatch(
+      bearerGet(`/_plumix/api/v1/posts/${id}`, secret),
+    );
+
+    const body = (await res.json()) as { meta: Record<string, unknown> };
+    expect(body.meta).toEqual({ featured: true });
   });
 });
 

--- a/packages/core/src/rest/entries-resource.ts
+++ b/packages/core/src/rest/entries-resource.ts
@@ -6,6 +6,7 @@ import { EntryReadError } from "../entries/errors.js";
 import { getEntry, listEntries } from "../entries/read-service.js";
 import { listEnvelope } from "./envelope.js";
 import {
+  apiVisibleMetaKeys,
   loadEntriesTerms,
   loadPublicAuthors,
   projectEntry,
@@ -74,11 +75,13 @@ export async function listEntriesEnvelope(
     rows.map((row) => row.authorId),
   );
   const termsByEntry = await loadEntriesTerms(context, ids);
+  const visibleMeta = apiVisibleMetaKeys(context.plugins, entryType.name);
   const data = rows.map((row) =>
     projectEntry(
       row,
       authors.get(row.authorId) ?? null,
       termsByEntry.get(row.id) ?? {},
+      visibleMeta,
     ),
   );
 
@@ -106,9 +109,11 @@ export async function getEntryItem(
   }
   const authors = await loadPublicAuthors(context, [entry.authorId]);
   const termsByEntry = await loadEntriesTerms(context, [entry.id]);
+  const visibleMeta = apiVisibleMetaKeys(context.plugins, entryType.name);
   return projectEntry(
     entry,
     authors.get(entry.authorId) ?? null,
     termsByEntry.get(entry.id) ?? {},
+    visibleMeta,
   );
 }

--- a/packages/core/src/rest/projection.ts
+++ b/packages/core/src/rest/projection.ts
@@ -1,6 +1,7 @@
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
 import type { Term } from "../db/schema/terms.js";
+import type { PluginRegistry } from "../plugin/manifest.js";
 import type { PublicAuthor, PublicEntry, PublicTerm } from "./schemas.js";
 import { eq, inArray } from "../db/index.js";
 import { entryTerm } from "../db/schema/entry_term.js";
@@ -13,6 +14,34 @@ export function projectTerm(
   return { id: term.id, name: term.name, slug: term.slug };
 }
 
+// The meta keys an entry type opts into exposing (`showInApi`). Default-deny:
+// a key absent from any registered field, or registered without the flag, is
+// never returned — adding a field can't leak it.
+export function apiVisibleMetaKeys(
+  registry: PluginRegistry,
+  entryType: string,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const box of registry.entryMetaBoxes.values()) {
+    if (!box.entryTypes.includes(entryType)) continue;
+    for (const field of box.fields) {
+      if (field.showInApi === true) keys.add(field.key);
+    }
+  }
+  return keys;
+}
+
+function projectMeta(
+  bag: Record<string, unknown>,
+  visibleKeys: Set<string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of visibleKeys) {
+    if (key in bag) out[key] = bag[key];
+  }
+  return out;
+}
+
 /**
  * Explicit allowlist — default-deny. Privileged columns (authorId, sortOrder,
  * parentId, meta) and the author's email/role never appear because they are
@@ -23,6 +52,7 @@ export function projectEntry(
   entry: Entry,
   author: PublicAuthor | null,
   termsByTaxonomy: Record<string, PublicTerm[]>,
+  visibleMetaKeys: Set<string>,
 ): PublicEntry {
   return {
     id: entry.id,
@@ -37,6 +67,7 @@ export function projectEntry(
     updatedAt: entry.updatedAt,
     author,
     terms: termsByTaxonomy,
+    meta: projectMeta(entry.meta, visibleMetaKeys),
   };
 }
 

--- a/packages/core/src/rest/schemas.ts
+++ b/packages/core/src/rest/schemas.ts
@@ -43,6 +43,8 @@ export const publicEntrySchema = v.object({
   author: v.nullable(publicAuthorSchema),
   // Associations are embedded, never nested as their own sub-resource.
   terms: v.record(v.string(), v.array(publicTermSchema)),
+  // Only meta fields whitelisted with `showInApi` reach this map (default-deny).
+  meta: v.record(v.string(), v.unknown()),
 });
 
 function listEnvelopeSchema<TItem extends v.GenericSchema>(item: TItem) {


### PR DESCRIPTION
Meta is now **default-deny** on the public REST API (PRD #995). A registered meta field is omitted from entry responses unless it explicitly opts in:

```ts
ctx.registerEntryMetaBox("seo", {
  entryTypes: ["post"],
  fields: [
    { key: "featured", label: "Featured", inputType: "checkbox", type: "boolean", showInApi: true },
    { key: "internal_note", label: "Internal", inputType: "text", type: "string" }, // hidden
  ],
});
```

The new `showInApi` flag lives on the shared meta-field model (alongside the existing per-field `capability` gate) and has **no effect on the admin RPC**, which keeps seeing the full meta bag.

**Default-deny, principal-independent**

Entry responses now carry a `meta` object containing only the entry type's whitelisted keys (scoped per entry type via its metaboxes). The projection iterates the allowlist (never the stored bag), so an unregistered key, an un-flagged field, or a newly added field can't leak. The same whitelist applies to list and single reads, and to anonymous and PAT-authed requests alike — even an admin PAT only sees whitelisted meta over REST. The `meta` field appears in the entry schema in `openapi.json`.

Closes #1000