### PR TITLE
feat(core): let plugins register REST resources with boot collision checks

### DIFF
--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1194,6 +1194,31 @@ export interface RegisteredRawRoute {
   ) => Response | Promise<Response>;
 }
 
+export type RestResourceMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/**
+ * A REST resource a plugin contributes into the shared `/_plumix/api/v1/`
+ * namespace. `path` is relative to that prefix (e.g. `/{type}/{id}/comments`)
+ * and uses `{param}` segments. `auth` reuses the declarative route model; core
+ * enforces it before the handler runs. `input`/`output` are valibot schemas —
+ * the `output` schema is the public allowlist and feeds the generated spec.
+ */
+export interface RestResourceOptions {
+  readonly method?: RestResourceMethod;
+  readonly path: string;
+  readonly auth: PluginRouteAuth;
+  /* eslint-disable @typescript-eslint/no-explicit-any -- one registry slot holds every plugin's heterogeneous valibot schemas */
+  readonly input?: any;
+  readonly output: any;
+  readonly handler: (args: { input: any; context: AppContext }) => any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
+export interface RegisteredRestResource extends RestResourceOptions {
+  readonly pluginId: string;
+  readonly method: RestResourceMethod;
+}
+
 /**
  * Tiny `{ key, label, href }` blob a plugin attaches so the standard
  * login screen can render a button for the sign-in flow it ships. The
@@ -1294,6 +1319,7 @@ export interface PluginRegistry {
   readonly rpcRouters: ReadonlyMap<string, PluginRpcRouter>;
   readonly mcpTools: ReadonlyMap<string, RegisteredMcpTool>;
   readonly rawRoutes: readonly RegisteredRawRoute[];
+  readonly restResources: readonly RegisteredRestResource[];
   readonly loginLinks: readonly RegisteredLoginLink[];
   readonly adminPages: ReadonlyMap<string, RegisteredAdminPage>;
   readonly dashboardWidgets: ReadonlyMap<string, RegisteredDashboardWidget>;
@@ -1320,6 +1346,7 @@ export interface MutablePluginRegistry extends PluginRegistry {
   readonly rpcRouters: Map<string, PluginRpcRouter>;
   readonly mcpTools: Map<string, RegisteredMcpTool>;
   readonly rawRoutes: RegisteredRawRoute[];
+  readonly restResources: RegisteredRestResource[];
   readonly loginLinks: RegisteredLoginLink[];
   readonly adminPages: Map<string, RegisteredAdminPage>;
   readonly dashboardWidgets: Map<string, RegisteredDashboardWidget>;
@@ -1347,6 +1374,7 @@ export function createPluginRegistry(): MutablePluginRegistry {
     rpcRouters: new Map(),
     mcpTools: new Map(),
     rawRoutes: [],
+    restResources: [],
     loginLinks: [],
     adminPages: new Map(),
     dashboardWidgets: new Map(),

--- a/packages/core/src/plugin/setup-context.ts
+++ b/packages/core/src/plugin/setup-context.ts
@@ -39,6 +39,7 @@ import type {
   PluginRouteAuth,
   PluginRouteMethod,
   PluginRpcRouter,
+  RestResourceOptions,
   ScheduledTask,
   SettingsGroupOptions,
   SettingsPageOptions,
@@ -67,6 +68,7 @@ import {
   assertValidLookupAdapterKind,
   assertValidNavGroupId,
   assertValidPluginRoutePath,
+  assertValidRestResourcePath,
   assertValidScheduledTask,
 } from "./validation/index.js";
 
@@ -197,6 +199,16 @@ export interface PluginSetupContextBase {
       ctx: AppContext,
     ) => Response | Promise<Response>;
   }): void;
+
+  /**
+   * Contribute a REST resource into the shared `/_plumix/api/v1/` namespace.
+   * Unlike `registerRoute` (a raw Request handler under the plugin's own
+   * prefix), this is an oRPC resource that merges into the public REST router
+   * and appears automatically in `openapi.json`. `path` is relative to the API
+   * prefix; core enforces `auth` before the handler runs. Path collisions
+   * (plugin↔plugin or plugin↔core) are rejected at boot.
+   */
+  registerRestResource(options: RestResourceOptions): void;
 
   registerAdminPage(options: AdminPageOptions): void;
   /**
@@ -535,6 +547,17 @@ export function createPluginSetupContext({
         path,
         auth,
         handler,
+      });
+    },
+
+    registerRestResource: (options) => {
+      assertValidRestResourcePath(pluginId, options.path);
+      // Cross-resource path collisions are validated at boot (buildApp), where
+      // the full set across all plugins + core reserved paths is known.
+      registry.restResources.push({
+        ...options,
+        pluginId,
+        method: options.method ?? "GET",
       });
     },
 

--- a/packages/core/src/plugin/validation/paths.ts
+++ b/packages/core/src/plugin/validation/paths.ts
@@ -31,6 +31,15 @@ export function assertValidAdminPagePath(pluginId: string, path: string): void {
   }
 }
 
+export function assertValidRestResourcePath(
+  pluginId: string,
+  path: string,
+): void {
+  // REST resources use oRPC `{param}` segments (no `*` wildcards); the prefix
+  // rules (leading slash, no traversal/query) are the same.
+  assertValidPathPrefix(pluginId, path, "REST resource");
+}
+
 export function assertValidPluginRoutePath(
   pluginId: string,
   path: string,

--- a/packages/core/src/rest/base.ts
+++ b/packages/core/src/rest/base.ts
@@ -3,4 +3,13 @@ import { os } from "@orpc/server";
 import type { AppContext } from "../context/app.js";
 import { REST_ERRORS } from "./errors.js";
 
-export const base = os.$context<AppContext>().errors(REST_ERRORS);
+/**
+ * The REST request context: the resolved principal context plus whether it came
+ * from a real bearer token (vs the anonymous public principal). Plugin resource
+ * auth gates read `restAuthenticated` to enforce `authenticated`.
+ */
+export interface RestContext extends AppContext {
+  readonly restAuthenticated: boolean;
+}
+
+export const base = os.$context<RestContext>().errors(REST_ERRORS);

--- a/packages/core/src/rest/build-handler.ts
+++ b/packages/core/src/rest/build-handler.ts
@@ -2,9 +2,12 @@ import type { OpenAPI } from "@orpc/openapi";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 
 import type { AppContext } from "../context/app.js";
+import type { PluginRegistry } from "../plugin/manifest.js";
+import type { RestContext } from "./base.js";
 import type { RestPrincipal } from "./principal.js";
 import { jsonResponse, notFound, unauthorized } from "../runtime/http.js";
 import { generateOpenApiDocument } from "./openapi.js";
+import { buildPluginRestRouter } from "./plugin-resources.js";
 import { resolveRestPrincipal } from "./principal.js";
 import { restRouter } from "./router.js";
 
@@ -18,22 +21,32 @@ export type RestDispatch = (ctx: AppContext) => Promise<Response>;
 const API_V1_PREFIX = "/_plumix/api/v1";
 const SPEC_PATH = `${API_V1_PREFIX}/openapi.json`;
 
-export function buildRestDispatcher(): RestDispatch {
-  const handler = new OpenAPIHandler(restRouter);
+export function buildRestDispatcher(registry: PluginRegistry): RestDispatch {
+  // Core resources + plugin-contributed resources share one router, so plugin
+  // endpoints route and appear in the spec automatically.
+  const router = {
+    ...restRouter,
+    ...buildPluginRestRouter(registry.restResources),
+  };
+  const handler = new OpenAPIHandler(router);
   // Generated once per isolate, on first request for the spec.
   let spec: Promise<OpenAPI.Document> | undefined;
   return async (ctx) => {
     const url = new URL(ctx.request.url);
     if (url.pathname === SPEC_PATH) {
-      return jsonResponse(await (spec ??= generateOpenApiDocument()));
+      return jsonResponse(await (spec ??= generateOpenApiDocument(router)));
     }
 
     const principal: RestPrincipal = await resolveRestPrincipal(ctx);
     if (principal.kind === "unauthorized") return unauthorized();
 
+    const context: RestContext = {
+      ...principal.ctx,
+      restAuthenticated: principal.kind === "authed",
+    };
     const result = await handler.handle(ctx.request, {
       prefix: API_V1_PREFIX,
-      context: principal.ctx,
+      context,
     });
     const response = result.matched
       ? result.response

--- a/packages/core/src/rest/dispatch.test.ts
+++ b/packages/core/src/rest/dispatch.test.ts
@@ -1,3 +1,4 @@
+import * as v from "valibot";
 import { describe, expect, test } from "vitest";
 
 import type {
@@ -331,6 +332,109 @@ describe("REST API — type exposure", () => {
     const res = await h.dispatch(apiGet("/_plumix/api/v1/ledgers"));
 
     expect(res.status).toBe(404);
+  });
+});
+
+const OK_OUTPUT = v.object({ ok: v.boolean() });
+
+// Plugin that contributes resources at every auth level. Core owns the 1- and
+// 2-segment collection space, so plugin resources nest deeper.
+const apiPlugin = definePlugin("test-api-plugin", (ctx) => {
+  ctx.registerRestResource({
+    path: "/system/diag/ping",
+    auth: "public",
+    output: v.object({ pong: v.boolean() }),
+    handler: () => ({ pong: true }),
+  });
+  ctx.registerRestResource({
+    path: "/system/diag/whoami",
+    auth: "authenticated",
+    output: v.object({ id: v.number() }),
+    handler: ({ context }) => ({ id: context.user?.id ?? -1 }),
+  });
+  ctx.registerRestResource({
+    path: "/system/diag/privileged",
+    auth: { capability: "entry:post:edit_any" },
+    output: OK_OUTPUT,
+    handler: () => ({ ok: true }),
+  });
+});
+
+describe("REST API — plugin resource seam", () => {
+  test("a public plugin resource is reachable and in the spec", async () => {
+    const h = await restHarness({ plugins: [apiPlugin] });
+
+    const res = await h.dispatch(apiGet("/_plumix/api/v1/system/diag/ping"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ pong: true });
+
+    const spec = (await (
+      await h.dispatch(apiGet("/_plumix/api/v1/openapi.json"))
+    ).json()) as { paths: Record<string, unknown> };
+    expect(spec.paths).toHaveProperty("/system/diag/ping");
+  });
+
+  test("an `authenticated` resource is 401 anonymously, 200 with a PAT", async () => {
+    const h = await restHarness({ plugins: [apiPlugin] });
+    const { userId, secret } = await mintPat(h, { role: "editor" });
+
+    const anon = await h.dispatch(apiGet("/_plumix/api/v1/system/diag/whoami"));
+    expect(anon.status).toBe(401);
+
+    const authed = await h.dispatch(
+      bearerGet("/_plumix/api/v1/system/diag/whoami", secret),
+    );
+    expect(authed.status).toBe(200);
+    expect(await authed.json()).toEqual({ id: userId });
+  });
+
+  test("a capability resource is 403 without the grant, 200 with it", async () => {
+    const h = await restHarness({ plugins: [apiPlugin] });
+    const { secret } = await mintPat(h, { role: "admin" });
+
+    const forbidden = await h.dispatch(
+      apiGet("/_plumix/api/v1/system/diag/privileged"),
+    );
+    expect(forbidden.status).toBe(403);
+
+    const ok = await h.dispatch(
+      bearerGet("/_plumix/api/v1/system/diag/privileged", secret),
+    );
+    expect(ok.status).toBe(200);
+  });
+});
+
+describe("REST API — plugin resource collisions", () => {
+  function resourcePlugin(id: string, path: string) {
+    return definePlugin(id, (ctx) => {
+      ctx.registerRestResource({
+        path,
+        auth: "public",
+        output: OK_OUTPUT,
+        handler: () => ({ ok: true }),
+      });
+    });
+  }
+
+  test("two plugins claiming overlapping paths are rejected at boot", async () => {
+    await expect(
+      createDispatcherHarness({
+        api: { enabled: true },
+        plugins: [
+          resourcePlugin("dup-a", "/feed/{id}/dup"),
+          resourcePlugin("dup-b", "/feed/{slug}/dup"),
+        ],
+      }),
+    ).rejects.toThrow(/dup/i);
+  });
+
+  test("a plugin path that shadows a core route is rejected at boot", async () => {
+    await expect(
+      createDispatcherHarness({
+        api: { enabled: true },
+        plugins: [resourcePlugin("shadow", "/{anything}")],
+      }),
+    ).rejects.toThrow(/shadow|reserved|core/i);
   });
 });
 

--- a/packages/core/src/rest/errors.ts
+++ b/packages/core/src/rest/errors.ts
@@ -9,6 +9,11 @@ export const REST_ERRORS = {
     message: "Resource not found",
     data: v.object({ kind: v.string() }),
   },
+  UNAUTHORIZED: { message: "Authentication required" },
+  FORBIDDEN: {
+    message: "Permission denied",
+    data: v.object({ capability: v.string() }),
+  },
 } as const;
 
 export type RestErrors = ORPCErrorConstructorMap<typeof REST_ERRORS>;

--- a/packages/core/src/rest/openapi.ts
+++ b/packages/core/src/rest/openapi.ts
@@ -1,14 +1,17 @@
 import type { OpenAPI } from "@orpc/openapi";
+import type { AnyRouter } from "@orpc/server";
 import { OpenAPIGenerator } from "@orpc/openapi";
 import { experimental_ValibotToJsonSchemaConverter } from "@orpc/valibot";
 
-import { restRouter } from "./router.js";
-
-export function generateOpenApiDocument(): Promise<OpenAPI.Document> {
+// Generated from the merged router (core + plugin resources) so plugin
+// endpoints appear in the spec automatically.
+export function generateOpenApiDocument(
+  router: AnyRouter,
+): Promise<OpenAPI.Document> {
   const generator = new OpenAPIGenerator({
     schemaConverters: [new experimental_ValibotToJsonSchemaConverter()],
   });
-  return generator.generate(restRouter, {
+  return generator.generate(router, {
     info: { title: "Plumix REST API", version: "1.0.0" },
   });
 }

--- a/packages/core/src/rest/plugin-resources.ts
+++ b/packages/core/src/rest/plugin-resources.ts
@@ -1,0 +1,50 @@
+import * as v from "valibot";
+
+import type {
+  PluginRouteAuth,
+  RegisteredRestResource,
+} from "../plugin/manifest.js";
+import type { RestContext } from "./base.js";
+import type { RestErrors } from "./errors.js";
+import { base } from "./base.js";
+
+// Enforce the declarative route-auth model before a plugin handler runs:
+// `public` is open; `authenticated` requires a real bearer principal (not the
+// anonymous public one); a capability gate defers to the principal's grants.
+function enforceRestAuth(
+  auth: PluginRouteAuth,
+  context: RestContext,
+  errors: RestErrors,
+): void {
+  if (auth === "public") return;
+  if (auth === "authenticated") {
+    if (!context.restAuthenticated) throw errors.UNAUTHORIZED();
+    return;
+  }
+  if (!context.auth.can(auth.capability)) {
+    throw errors.FORBIDDEN({ data: { capability: auth.capability } });
+  }
+}
+
+const EMPTY_INPUT = v.object({});
+
+// Build oRPC procedures for plugin resources, keyed by index (OpenAPI routing
+// is driven by each procedure's `route`, not the object key).
+export function buildPluginRestRouter(
+  resources: readonly RegisteredRestResource[],
+): Record<string, unknown> {
+  const router: Record<string, unknown> = {};
+  resources.forEach((resource, index) => {
+    router[`pluginResource${index}`] = base
+      // oRPC types `path` as a `/${string}` literal; the leading slash is
+      // enforced by `assertValidRestResourcePath` at registration.
+      .route({ method: resource.method, path: resource.path as `/${string}` })
+      .input(resource.input ?? EMPTY_INPUT)
+      .output(resource.output)
+      .handler(({ input, context, errors }) => {
+        enforceRestAuth(resource.auth, context, errors);
+        return resource.handler({ input, context });
+      });
+  });
+  return router;
+}

--- a/packages/core/src/rest/rest-routes.ts
+++ b/packages/core/src/rest/rest-routes.ts
@@ -1,0 +1,37 @@
+// Pure route-overlap helpers — no oRPC imports, so the boot-time collision
+// check (buildApp) can use them without pulling the REST handler graph onto the
+// cold-start path.
+
+export interface RestRoute {
+  readonly method: string;
+  readonly path: string;
+}
+
+function isParam(segment: string): boolean {
+  return segment.startsWith("{") && segment.endsWith("}");
+}
+
+/**
+ * Two routes overlap when some URL would match both: same method, same segment
+ * count, and every position is either an exact literal match or a `{param}` on
+ * either side. The matcher ranks static segments above params, so a literal
+ * plugin path inside core's `/{collection}` space would silently shadow it —
+ * overlap (not string equality) is what makes "core paths reserved" real.
+ */
+export function routesOverlap(a: RestRoute, b: RestRoute): boolean {
+  if (a.method !== b.method) return false;
+  const aSegments = a.path.split("/");
+  const bSegments = b.path.split("/");
+  if (aSegments.length !== bSegments.length) return false;
+  return aSegments.every((segment, i) => {
+    const other = bSegments[i] ?? "";
+    return segment === other || isParam(segment) || isParam(other);
+  });
+}
+
+// Core's reserved routes. Core owns the entire 1- and 2-segment collection
+// space, so plugin resources must nest deeper (e.g. `/{type}/{id}/comments`).
+export const CORE_REST_ROUTES: readonly RestRoute[] = [
+  { method: "GET", path: "/{collection}" },
+  { method: "GET", path: "/{collection}/{id}" },
+];

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -28,6 +28,7 @@ import type {
 } from "../plugin/manifest.js";
 import type { ContextExtensionEntry } from "../plugin/provides-context.js";
 import type { RestDispatch } from "../rest/build-handler.js";
+import type { RestRoute } from "../rest/rest-routes.js";
 import type { RouteRule } from "../route/intent.js";
 import type { AssetManifest } from "../route/render/asset-manifest.js";
 import type { DocumentManifest } from "../theme.js";
@@ -41,6 +42,7 @@ import { mergeDocumentManifest } from "../document-merge.js";
 import { HookRegistry } from "../hooks/registry.js";
 import { createPluginRegistry } from "../plugin/manifest.js";
 import { installPlugins } from "../plugin/register.js";
+import { CORE_REST_ROUTES, routesOverlap } from "../rest/rest-routes.js";
 import { compileRouteMap } from "../route/compile.js";
 import { CORE_RPC_NAMESPACES } from "../rpc/namespaces.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
@@ -261,6 +263,34 @@ export async function buildApp(
     }
   }
 
+  // Plugin REST resources share the flat `/_plumix/api/v1/` namespace. Reject,
+  // at boot, any resource that overlaps a reserved core route or another
+  // plugin's resource (overlap, not string equality — the matcher prefers
+  // static segments, so a literal path could otherwise shadow a param route).
+  const seenRestRoutes: { pluginId: string; route: RestRoute }[] = [];
+  for (const resource of registry.restResources) {
+    const route = { method: resource.method, path: resource.path };
+    if (CORE_REST_ROUTES.some((core) => routesOverlap(route, core))) {
+      throw AppBootError.restResourceShadowsCore({
+        pluginId: resource.pluginId,
+        method: resource.method,
+        path: resource.path,
+      });
+    }
+    const clash = seenRestRoutes.find((seen) =>
+      routesOverlap(route, seen.route),
+    );
+    if (clash) {
+      throw AppBootError.restResourcePathConflict({
+        pluginId: resource.pluginId,
+        otherPluginId: clash.pluginId,
+        method: resource.method,
+        path: resource.path,
+      });
+    }
+    seenRestRoutes.push({ pluginId: resource.pluginId, route });
+  }
+
   const passkey = resolvePasskeyConfig(config.auth.passkey);
   const oauth = config.auth.oauth;
   const oauthProviders: OAuthProviderSummary[] = oauth
@@ -320,7 +350,7 @@ export async function buildApp(
   let restHandler: Promise<RestDispatch> | undefined;
   const loadRestHandler = (): Promise<RestDispatch> =>
     (restHandler ??= import("../rest/build-handler.js").then((m) =>
-      m.buildRestDispatcher(),
+      m.buildRestDispatcher(registry),
     ));
 
   return {

--- a/packages/core/src/runtime/errors.ts
+++ b/packages/core/src/runtime/errors.ts
@@ -1,6 +1,8 @@
 type AppBootErrorCode =
   | "schema_export_conflict"
-  | "plugin_id_collides_with_core_rpc_namespace";
+  | "plugin_id_collides_with_core_rpc_namespace"
+  | "rest_resource_path_conflict"
+  | "rest_resource_shadows_core";
 
 export class AppBootError extends Error {
   static {
@@ -48,6 +50,33 @@ export class AppBootError extends Error {
       `Plugin id "${ctx.pluginId}" collides with a core RPC namespace ` +
         `at buildApp; rename the plugin.`,
       ctx,
+    );
+  }
+
+  static restResourcePathConflict(ctx: {
+    pluginId: string;
+    otherPluginId: string;
+    method: string;
+    path: string;
+  }): AppBootError {
+    return new AppBootError(
+      "rest_resource_path_conflict",
+      `Plugin "${ctx.pluginId}" registers REST resource "${ctx.method} ${ctx.path}" ` +
+        `already registered by "${ctx.otherPluginId}".`,
+      { pluginId: ctx.pluginId, previousOwner: ctx.otherPluginId },
+    );
+  }
+
+  static restResourceShadowsCore(ctx: {
+    pluginId: string;
+    method: string;
+    path: string;
+  }): AppBootError {
+    return new AppBootError(
+      "rest_resource_shadows_core",
+      `Plugin "${ctx.pluginId}" REST resource "${ctx.method} ${ctx.path}" ` +
+        `shadows a reserved core path.`,
+      { pluginId: ctx.pluginId },
     );
   }
 }


### PR DESCRIPTION
A seam so plugins contribute resources into the shared `/_plumix/api/v1/` namespace (PRD #995), reusing the declarative route-auth model.

```ts
ctx.registerRestResource({
  path: "/{type}/{id}/comments",
  auth: "public",
  output: commentsEnvelopeSchema,
  handler: ({ input, context }) => listComments(context, input),
});
```

Core builds the oRPC procedure, enforces `auth` **before** the handler runs, and merges the resource into the REST router so it routes and appears in `openapi.json` automatically.

**Declarative auth, enforced by core**

- `public` — open.
- `authenticated` — requires a real bearer principal (the anonymous public principal is rejected), tracked via a `restAuthenticated` flag on the REST context.
- `{ capability }` — defers to the principal's grants (403 otherwise).

The resource `output` schema stays the public allowlist.

**Collisions rejected at boot**

Mirroring the RPC-namespace check, a resource that overlaps a reserved core route or another plugin's resource throws `AppBootError` at `buildApp`. Overlap is **structural** — a literal segment can shadow a param route (the matcher prefers static segments), so core fully owns the 1- and 2-segment collection space and plugins nest deeper. The pure overlap helpers live in an oRPC-free module, keeping the boot check off the cold-start path. Resource paths are validated at registration like sibling registrars.

Closes #1001