### PR TITLE
feat(plugin-comments): expose approved comments over the REST API

### DIFF
--- a/packages/plugins/comments/src/index.test.ts
+++ b/packages/plugins/comments/src/index.test.ts
@@ -39,6 +39,7 @@ describe("comments() plugin", () => {
   interface CapturedSetup {
     readonly kinds: string[];
     readonly routes: string[];
+    readonly restResources: string[];
     readonly capabilities: string[];
     readonly adminPaths: string[];
     readonly actions: string[];
@@ -49,6 +50,7 @@ describe("comments() plugin", () => {
     const captured: CapturedSetup = {
       kinds: [],
       routes: [],
+      restResources: [],
       capabilities: [],
       adminPaths: [],
       actions: [],
@@ -58,6 +60,8 @@ describe("comments() plugin", () => {
       registerTemplateDep: (kind: string) => captured.kinds.push(kind),
       registerRoute: (opts: { path: string }) =>
         captured.routes.push(opts.path),
+      registerRestResource: (opts: { path: string }) =>
+        captured.restResources.push(opts.path),
       registerCapability: (name: string) => captured.capabilities.push(name),
       registerRpcRouter: () => {
         captured.rpcRouter = true;
@@ -74,6 +78,7 @@ describe("comments() plugin", () => {
     const s = captureSetup({});
     expect(s.kinds).toContain("comments");
     expect(s.routes).toContain("/submit");
+    expect(s.restResources).toContain("/{type}/{id}/comments");
     expect(s.capabilities).toContain("comment:moderate");
     expect(s.adminPaths).toContain("/comments");
     expect(s.rpcRouter).toBe(true);

--- a/packages/plugins/comments/src/index.ts
+++ b/packages/plugins/comments/src/index.ts
@@ -7,6 +7,11 @@ import * as schema from "./db/schema.js";
 import { COMMENT_MODERATE_CAPABILITY, createCommentsRouter } from "./rpc.js";
 import { createListHandler } from "./server/list.js";
 import { notifyModeratorOfPending } from "./server/notify.js";
+import {
+  commentCollectionParamsSchema,
+  commentsEnvelopeSchema,
+  createCommentsRestHandler,
+} from "./server/rest.js";
 import { createSubmitHandler } from "./server/submit.js";
 import { createCommentsThreadLoader } from "./server/template-dep.js";
 
@@ -88,6 +93,13 @@ export function comments(options: CommentsConfig = {}) {
         path: "/list",
         auth: "public",
         handler: createListHandler(config),
+      });
+      ctx.registerRestResource({
+        path: "/{type}/{id}/comments",
+        auth: "public",
+        input: commentCollectionParamsSchema,
+        output: commentsEnvelopeSchema,
+        handler: createCommentsRestHandler(config),
       });
 
       if (config.notifyEmail) {

--- a/packages/plugins/comments/src/server/rest.test.ts
+++ b/packages/plugins/comments/src/server/rest.test.ts
@@ -1,0 +1,170 @@
+import { definePlugin } from "plumix/plugin";
+import { createDispatcherHarness } from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+import { comments } from "../index.js";
+import { applyCommentsSchema } from "../test/db.js";
+import { commentFactory } from "../test/factories.js";
+
+const testBlog = definePlugin("test_blog", {
+  setup: (ctx) => {
+    ctx.registerEntryType("post", {
+      label: "Posts",
+      isPublic: true,
+      rewrite: { slug: "posts" },
+    });
+  },
+});
+
+type Harness = Awaited<ReturnType<typeof createDispatcherHarness>>;
+
+async function restHarness(): Promise<Harness> {
+  const harness = await createDispatcherHarness({
+    api: { enabled: true },
+    plugins: [testBlog, comments({ entryTypes: ["post"] })],
+  });
+  await applyCommentsSchema(harness.db);
+  return harness;
+}
+
+async function seedPost(harness: Harness, overrides = {}): Promise<number> {
+  const user = await harness.factory.user.create({});
+  const entry = await harness.factory.entry.create({
+    type: "post",
+    title: "Post",
+    authorId: user.id,
+    status: "published",
+    ...overrides,
+  });
+  return entry.id;
+}
+
+interface PublicComment {
+  readonly id: number;
+  readonly parentId: number | null;
+  readonly authorName: string;
+  readonly bodyHtml: string;
+}
+
+interface Envelope {
+  readonly data: PublicComment[];
+  readonly meta: { page: number; per_page: number };
+  readonly links: { self: string; next?: string; prev?: string };
+}
+
+function commentsUrl(entryId: number, query = ""): string {
+  return `https://cms.example/_plumix/api/v1/posts/${entryId}/comments${query}`;
+}
+
+describe("comments REST resource", () => {
+  test("returns approved comments flat, each with parentId, in the envelope", async () => {
+    const h = await restHarness();
+    const entryId = await seedPost(h);
+    const f = commentFactory.transient({ db: h.db });
+    const root = await f.create({
+      entryId,
+      status: "approved",
+      bodyMd: "root",
+    });
+    await f.create({
+      entryId,
+      status: "approved",
+      parentId: root.id,
+      bodyMd: "reply",
+    });
+
+    const res = await h.dispatch(new Request(commentsUrl(entryId)));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Envelope;
+    expect(body.data).toHaveLength(2);
+    const reply = body.data.find((c) => c.parentId !== null);
+    expect(reply?.parentId).toBe(root.id);
+    expect(reply?.bodyHtml).toContain("reply");
+    expect(body.meta).toMatchObject({ page: 1, per_page: 20 });
+  });
+
+  test("strips comment PII and moderation fields", async () => {
+    const h = await restHarness();
+    const entryId = await seedPost(h);
+    await commentFactory.transient({ db: h.db }).create({
+      entryId,
+      status: "approved",
+      authorEmail: "secret@example.test",
+      ipHash: "deadbeef",
+      userAgent: "Mozilla/5.0",
+    });
+
+    const res = await h.dispatch(new Request(commentsUrl(entryId)));
+
+    const body = (await res.json()) as { data: Record<string, unknown>[] };
+    const comment = body.data[0] ?? {};
+    expect(comment).not.toHaveProperty("authorEmail");
+    expect(comment).not.toHaveProperty("ipHash");
+    expect(comment).not.toHaveProperty("userAgent");
+    expect(comment).not.toHaveProperty("status");
+    expect(comment).not.toHaveProperty("bodyMd");
+  });
+
+  test("returns only approved comments", async () => {
+    const h = await restHarness();
+    const entryId = await seedPost(h);
+    const f = commentFactory.transient({ db: h.db });
+    await f.create({ entryId, status: "approved", bodyMd: "shown" });
+    await f.create({ entryId, status: "pending", bodyMd: "hidden-pending" });
+    await f.create({ entryId, status: "spam", bodyMd: "hidden-spam" });
+
+    const res = await h.dispatch(new Request(commentsUrl(entryId)));
+
+    const body = (await res.json()) as Envelope;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]?.bodyHtml).toContain("shown");
+  });
+
+  test("paginates with page/per_page and links", async () => {
+    const h = await restHarness();
+    const entryId = await seedPost(h);
+    const f = commentFactory.transient({ db: h.db });
+    for (let i = 1; i <= 3; i++) {
+      await f.create({ entryId, status: "approved", bodyMd: `c${String(i)}` });
+    }
+
+    const page1 = (await (
+      await h.dispatch(new Request(commentsUrl(entryId, "?per_page=2&page=1")))
+    ).json()) as Envelope;
+    expect(page1.data).toHaveLength(2);
+    expect(page1.links.next).toBeDefined();
+    expect(page1.links.prev).toBeUndefined();
+
+    const page2 = (await (
+      await h.dispatch(new Request(commentsUrl(entryId, "?per_page=2&page=2")))
+    ).json()) as Envelope;
+    expect(page2.data).toHaveLength(1);
+    expect(page2.links.prev).toBeDefined();
+    expect(page2.links.next).toBeUndefined();
+  });
+
+  test("comments of an unpublished entry resolve to an empty page", async () => {
+    const h = await restHarness();
+    const entryId = await seedPost(h, { status: "draft" });
+    await commentFactory
+      .transient({ db: h.db })
+      .create({ entryId, status: "approved", bodyMd: "hidden" });
+
+    const res = await h.dispatch(new Request(commentsUrl(entryId)));
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Envelope).data).toEqual([]);
+  });
+
+  test("the resource appears in the generated openapi.json", async () => {
+    const h = await restHarness();
+
+    const res = await h.dispatch(
+      new Request("https://cms.example/_plumix/api/v1/openapi.json"),
+    );
+
+    const doc = (await res.json()) as { paths: Record<string, unknown> };
+    expect(doc.paths).toHaveProperty("/{type}/{id}/comments");
+  });
+});

--- a/packages/plugins/comments/src/server/rest.ts
+++ b/packages/plugins/comments/src/server/rest.ts
@@ -1,0 +1,155 @@
+import type { AppContext } from "plumix/plugin";
+import { and, asc, eq } from "drizzle-orm";
+import { entries } from "plumix/schema";
+import * as v from "valibot";
+
+import type { ResolvedCommentsConfig } from "../config.js";
+import { comments } from "../db/schema.js";
+import { isCommentingEnabled } from "./enablement.js";
+import { gravatarUrl } from "./gravatar.js";
+import { renderCommentBody } from "./render-body.js";
+
+// Mirrors core's private rest/{schemas,envelope} pagination helpers. Kept local
+// while comments is the only plugin REST consumer; promote to a shared
+// `@plumix/core/rest` export when a second plugin needs offset pagination.
+const MAX_PER_PAGE = 100;
+const DEFAULT_PER_PAGE = 20;
+
+export const commentCollectionParamsSchema = v.object({
+  type: v.string(),
+  id: v.string(),
+});
+
+// Output schema = the public allowlist. Author email, IP, user-agent, the
+// moderation status, and meta never appear — only these fields leave.
+const publicCommentSchema = v.object({
+  id: v.number(),
+  parentId: v.nullable(v.number()),
+  authorName: v.string(),
+  isRegistered: v.boolean(),
+  avatarUrl: v.string(),
+  bodyHtml: v.string(),
+  createdAt: v.date(),
+});
+
+export const commentsEnvelopeSchema = v.object({
+  data: v.array(publicCommentSchema),
+  meta: v.object({ page: v.number(), per_page: v.number() }),
+  links: v.object({
+    self: v.string(),
+    next: v.optional(v.string()),
+    prev: v.optional(v.string()),
+  }),
+});
+
+type CommentsEnvelope = v.InferOutput<typeof commentsEnvelopeSchema>;
+
+function clampInt(
+  raw: string | null,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (raw === null) return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+// Relative path + query so links don't pin the response to an internal origin;
+// clients resolve them against the request base.
+function pageUrl(url: URL, page: number): string {
+  const next = new URL(url);
+  next.searchParams.set("page", String(page));
+  return `${next.pathname}${next.search}`;
+}
+
+/**
+ * `GET /_plumix/api/v1/{type}/{id}/comments` — a flat, offset-paginated list of
+ * approved comments for an entry, each carrying `parentId` so clients build the
+ * thread. Comments of an entry that isn't a published, comment-enabled one
+ * resolve to an empty page (existence stays hidden, no 403/404 to probe).
+ */
+export function createCommentsRestHandler(config: ResolvedCommentsConfig) {
+  return async ({
+    input,
+    context,
+  }: {
+    input: v.InferOutput<typeof commentCollectionParamsSchema>;
+    context: AppContext;
+  }): Promise<CommentsEnvelope> => {
+    const url = new URL(context.request.url);
+    const page = clampInt(
+      url.searchParams.get("page"),
+      1,
+      1,
+      Number.MAX_SAFE_INTEGER,
+    );
+    const perPage = clampInt(
+      url.searchParams.get("per_page"),
+      DEFAULT_PER_PAGE,
+      1,
+      MAX_PER_PAGE,
+    );
+    const envelope = (
+      data: CommentsEnvelope["data"],
+      hasNext: boolean,
+    ): CommentsEnvelope => ({
+      data,
+      meta: { page, per_page: perPage },
+      links: {
+        self: pageUrl(url, page),
+        ...(hasNext ? { next: pageUrl(url, page + 1) } : {}),
+        ...(page > 1 ? { prev: pageUrl(url, page - 1) } : {}),
+      },
+    });
+
+    const entryId = Number(input.id);
+    if (!Number.isInteger(entryId) || entryId < 1) return envelope([], false);
+
+    const [entry] = await context.db
+      .select({ type: entries.type, status: entries.status })
+      .from(entries)
+      .where(eq(entries.id, entryId));
+    if (entry?.status !== "published") return envelope([], false);
+    const supports = context.plugins.entryTypes.get(entry.type)?.supports;
+    if (!isCommentingEnabled(entry.type, supports, config)) {
+      return envelope([], false);
+    }
+
+    // Over-fetch one to detect a next page without a separate COUNT.
+    const rows = await context.db
+      .select({
+        id: comments.id,
+        parentId: comments.parentId,
+        authorUserId: comments.authorUserId,
+        authorName: comments.authorName,
+        authorEmail: comments.authorEmail,
+        bodyMd: comments.bodyMd,
+        createdAt: comments.createdAt,
+      })
+      .from(comments)
+      .where(
+        and(eq(comments.entryId, entryId), eq(comments.status, "approved")),
+      )
+      .orderBy(asc(comments.createdAt), asc(comments.id))
+      .limit(perPage + 1)
+      .offset((page - 1) * perPage);
+
+    const hasNext = rows.length > perPage;
+    const pageRows = hasNext ? rows.slice(0, perPage) : rows;
+    const data = await Promise.all(
+      pageRows.map(async (row) => ({
+        id: row.id,
+        parentId: row.parentId,
+        authorName: row.authorName,
+        isRegistered: row.authorUserId !== null,
+        avatarUrl: await gravatarUrl(row.authorEmail),
+        bodyHtml: renderCommentBody(row.bodyMd),
+        createdAt: row.createdAt,
+      })),
+    );
+
+    return envelope(data, hasNext);
+  };
+}


### PR DESCRIPTION
Register `GET /_plumix/api/v1/{type}/{id}/comments` via the core REST seam (PRD #995) — a flat, offset-paginated list of an entry's approved comments, each carrying `parentId` so clients assemble the thread.

```
GET /_plumix/api/v1/posts/42/comments?page=1&per_page=20
→ { data: [{ id, parentId, authorName, isRegistered, avatarUrl, bodyHtml, createdAt }], meta, links }
```

- **Flat + offset paginated** — no recursive tree resolution; clients build threads from `parentId`. No bare `/comments` collection or `/comments/{id}` in v1.
- **Default-deny projection** — the valibot output schema plus a hand-picked projection expose only the public fields; **author email, IP hash, user-agent, moderation status, and meta never leave** (the email is read only to derive the Gravatar hash).
- **Approved-only** — only `status = approved` rows are returned, across the over-fetch pagination boundary.
- **Hide-existence** — comments of an entry that isn't published + comment-enabled resolve to an empty page (no 403/404 to probe).
- Appears in `openapi.json` via the merged spec.

This is the first plugin consumer of the #1001 registration seam. The pagination/envelope helpers are kept local (mirroring core's internal ones) per catalog-hygiene — promote to a shared `@plumix/core/rest` export when a second plugin needs them.

Closes #1002