### PR TITLE
feat(core): add config-driven CORS by auth mode to the REST API

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,0 +1,77 @@
+# REST API
+
+Plumix can expose a read-only public REST API with a generated OpenAPI 3.1 spec.
+It is **off by default** — enable it explicitly:
+
+```ts
+plumix({
+  // …
+  api: { enabled: true },
+});
+```
+
+Once enabled:
+
+- `GET /_plumix/api/v1/{collection}` — paginated published entries or taxonomy
+  terms (`/posts`, `/categories`, …).
+- `GET /_plumix/api/v1/{collection}/{id}` — one entry or term.
+- `GET /_plumix/api/v1/{type}/{id}/comments` — when `@plumix/plugin-comments`
+  is installed.
+- `GET /_plumix/api/v1/openapi.json` — the generated spec.
+
+Anonymous requests see published content only; unviewable content is `404`
+(never `403`), so existence stays hidden. An `Authorization: Bearer <pat>` token
+reads as its user, gated by scope ∩ role.
+
+## CORS
+
+CORS is **closed by default**, even when the API is enabled. Open anonymous
+reads to specific browser origins (or all):
+
+```ts
+api: {
+  enabled: true,
+  cors: { origins: ["https://app.example.com"] }, // or origins: "*"
+}
+```
+
+PAT-authed responses are never CORS-exposed and never use
+`Access-Control-Allow-Credentials`, so a token embedded in browser JS can't be
+abused cross-origin — PATs are for server-to-server use.
+
+## Rate limiting
+
+Core ships no in-app rate limiter; the REST surface is a stable path prefix
+(`/_plumix/api/`) so you can throttle it at the edge:
+
+- **Cloudflare** — add a WAF rate-limiting rule scoped to
+  `http.request.uri.path starts_with "/_plumix/api/"`.
+- **Custom** — wrap the generated worker's `fetch` and short-circuit before
+  delegating, keying on `request.url` / client IP.
+
+## Docs UI (Scalar / Swagger)
+
+Core serves only the spec. Add a browsable reference as a userland plugin that
+serves an HTML page pointing at `/openapi.json`:
+
+```ts
+definePlugin("api-docs", {
+  setup: (ctx) => {
+    ctx.registerRoute({
+      method: "GET",
+      path: "/docs",
+      auth: "public",
+      handler: () =>
+        new Response(
+          `<!doctype html><html><head><meta charset="utf-8" /></head><body>
+            <script id="api-reference" data-url="/_plumix/api/v1/openapi.json"></script>
+            <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+          </body></html>`,
+          { headers: { "content-type": "text/html; charset=utf-8" } },
+        ),
+    });
+  },
+});
+```
+
+This mounts at `/_plumix/api-docs/docs`. Swap in Swagger UI the same way.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -42,6 +42,21 @@ export function interfaceEnabled(toggle: InterfaceToggle | undefined): boolean {
   return toggle?.enabled === true;
 }
 
+/**
+ * Cross-origin policy for the REST API's anonymous reads. Default-closed: with
+ * no `cors`, no `Access-Control-Allow-Origin` is ever emitted. `origins: "*"`
+ * opens anonymous reads to any origin; an array allows only those. PAT-authed
+ * responses are never CORS-exposed regardless, so a token can't be abused from
+ * browser JS cross-origin.
+ */
+export interface ApiCorsConfig {
+  readonly origins?: readonly string[] | "*";
+}
+
+export interface ApiConfig extends InterfaceToggle {
+  readonly cors?: ApiCorsConfig;
+}
+
 export interface PlumixConfigInput {
   readonly runtime: RuntimeAdapter;
   readonly database: AnyDatabaseAdapter;
@@ -71,7 +86,7 @@ export interface PlumixConfigInput {
    * Public REST API + OpenAPI spec at `/_plumix/api/v1/`. Default-off; set
    * `{ enabled: true }` to mount it.
    */
-  readonly api?: InterfaceToggle;
+  readonly api?: ApiConfig;
   /**
    * Block-system configuration. Today only exposes the operator-
    * configurable `core/html` allowlist override; future block-level
@@ -99,7 +114,7 @@ export interface PlumixConfig {
   readonly plugins: readonly AnyPluginDescriptor[];
   readonly i18n: ResolvedI18n;
   readonly mcp?: InterfaceToggle;
-  readonly api?: InterfaceToggle;
+  readonly api?: ApiConfig;
   readonly blocks?: {
     readonly htmlAllowlist?: HtmlAllowlistOverride;
   };

--- a/packages/core/src/rest/build-handler.ts
+++ b/packages/core/src/rest/build-handler.ts
@@ -1,11 +1,23 @@
 import type { OpenAPI } from "@orpc/openapi";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 
+import type { ApiCorsConfig } from "../config.js";
 import type { AppContext } from "../context/app.js";
 import type { PluginRegistry } from "../plugin/manifest.js";
 import type { RestContext } from "./base.js";
 import type { RestPrincipal } from "./principal.js";
-import { jsonResponse, notFound, unauthorized } from "../runtime/http.js";
+import {
+  jsonResponse,
+  notFound,
+  unauthorized,
+  withHeaders,
+} from "../runtime/http.js";
+import {
+  isOriginDependent,
+  preflightResponse,
+  resolveAllowedOrigin,
+  withCors,
+} from "./cors.js";
 import { generateOpenApiDocument } from "./openapi.js";
 import { buildPluginRestRouter } from "./plugin-resources.js";
 import { resolveRestPrincipal } from "./principal.js";
@@ -21,7 +33,10 @@ export type RestDispatch = (ctx: AppContext) => Promise<Response>;
 const API_V1_PREFIX = "/_plumix/api/v1";
 const SPEC_PATH = `${API_V1_PREFIX}/openapi.json`;
 
-export function buildRestDispatcher(registry: PluginRegistry): RestDispatch {
+export function buildRestDispatcher(
+  registry: PluginRegistry,
+  cors?: ApiCorsConfig,
+): RestDispatch {
   // Core resources + plugin-contributed resources share one router, so plugin
   // endpoints route and appear in the spec automatically.
   const router = {
@@ -29,12 +44,24 @@ export function buildRestDispatcher(registry: PluginRegistry): RestDispatch {
     ...buildPluginRestRouter(registry.restResources),
   };
   const handler = new OpenAPIHandler(router);
+  const varyByOrigin = isOriginDependent(cors);
   // Generated once per isolate, on first request for the spec.
   let spec: Promise<OpenAPI.Document> | undefined;
   return async (ctx) => {
     const url = new URL(ctx.request.url);
+    const allowOrigin = resolveAllowedOrigin(
+      cors,
+      ctx.request.headers.get("origin"),
+    );
+    if (ctx.request.method === "OPTIONS") {
+      return preflightResponse(ctx.request, allowOrigin);
+    }
+
     if (url.pathname === SPEC_PATH) {
-      return jsonResponse(await (spec ??= generateOpenApiDocument(router)));
+      const doc = jsonResponse(
+        await (spec ??= generateOpenApiDocument(router)),
+      );
+      return withCors(doc, allowOrigin, varyByOrigin);
     }
 
     const principal: RestPrincipal = await resolveRestPrincipal(ctx);
@@ -52,17 +79,13 @@ export function buildRestDispatcher(registry: PluginRegistry): RestDispatch {
       ? result.response
       : notFound("rest-route-not-found");
 
-    // PAT-authed reads may include non-public content: never cache them.
-    return principal.kind === "authed" ? markNonCacheable(response) : response;
+    // PAT-authed reads may include non-public content: never cache them, and
+    // never CORS-expose them — a token in browser JS can't be used cross-origin.
+    if (principal.kind === "authed") {
+      return withHeaders(response, (h) =>
+        h.set("cache-control", "private, no-store"),
+      );
+    }
+    return withCors(response, allowOrigin, varyByOrigin);
   };
-}
-
-function markNonCacheable(response: Response): Response {
-  const headers = new Headers(response.headers);
-  headers.set("cache-control", "private, no-store");
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
 }

--- a/packages/core/src/rest/cors.ts
+++ b/packages/core/src/rest/cors.ts
@@ -1,0 +1,70 @@
+import type { ApiCorsConfig } from "../config.js";
+import { withHeaders } from "../runtime/http.js";
+
+/**
+ * Resolve the `Access-Control-Allow-Origin` value for a request, or null when
+ * the request must not be CORS-exposed. Default-closed: no config → null.
+ * `"*"` allows any origin; an array echoes the request's origin only if listed.
+ */
+export function resolveAllowedOrigin(
+  cors: ApiCorsConfig | undefined,
+  requestOrigin: string | null,
+): string | null {
+  if (!cors?.origins) return null;
+  if (cors.origins === "*") return "*";
+  if (requestOrigin && cors.origins.includes(requestOrigin)) {
+    return requestOrigin;
+  }
+  return null;
+}
+
+// True when the allowed origin is computed from the request's Origin (an
+// allowlist), so the response must `Vary: origin` even when this request's
+// origin didn't match — otherwise a shared cache could serve a no-CORS entry to
+// an allowed origin. A `"*"` (or closed) policy is origin-independent.
+export function isOriginDependent(cors: ApiCorsConfig | undefined): boolean {
+  return Array.isArray(cors?.origins);
+}
+
+// CORS for anonymous reads only. No `Access-Control-Allow-Credentials` is ever
+// set — the surface is bearer/anonymous, never cookie-authed, so credentialed
+// CORS would only invite a PAT-in-browser-JS footgun.
+function corsHeaders(allowOrigin: string): Headers {
+  const headers = new Headers({ "access-control-allow-origin": allowOrigin });
+  if (allowOrigin !== "*") headers.append("vary", "origin");
+  return headers;
+}
+
+export function withCors(
+  response: Response,
+  allowOrigin: string | null,
+  varyByOrigin: boolean,
+): Response {
+  if (!allowOrigin && !varyByOrigin) return response;
+  return withHeaders(response, (headers) => {
+    if (allowOrigin) {
+      headers.append("access-control-allow-origin", allowOrigin);
+    }
+    if (varyByOrigin) headers.append("vary", "origin");
+  });
+}
+
+// Preflight is principal-less (the browser sends no credentials), so it's
+// gated purely on the configured origins. The actual PAT-authed response still
+// carries no CORS, so a cross-origin credentialed read fails at the response —
+// PATs stay server-to-server by design.
+export function preflightResponse(
+  request: Request,
+  allowOrigin: string | null,
+): Response {
+  if (allowOrigin === null) return new Response(null, { status: 403 });
+  const headers = corsHeaders(allowOrigin);
+  headers.set("access-control-allow-methods", "GET, OPTIONS");
+  headers.set(
+    "access-control-allow-headers",
+    request.headers.get("access-control-request-headers") ??
+      "authorization, content-type",
+  );
+  headers.set("access-control-max-age", "600");
+  return new Response(null, { status: 204, headers });
+}

--- a/packages/core/src/rest/dispatch.test.ts
+++ b/packages/core/src/rest/dispatch.test.ts
@@ -438,6 +438,104 @@ describe("REST API — plugin resource collisions", () => {
   });
 });
 
+function originGet(path: string, origin: string): Request {
+  return new Request(`https://cms.example${path}`, { headers: { origin } });
+}
+
+describe("REST API — CORS by auth mode", () => {
+  test("CORS is closed by default even when the API is enabled", async () => {
+    const h = await restHarness();
+    await seedPublished(h, 1);
+
+    const res = await h.dispatch(
+      originGet("/_plumix/api/v1/posts", "https://app.example"),
+    );
+
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("a configured origin is echoed on anonymous reads; others are not", async () => {
+    const h = await restHarness({
+      api: { enabled: true, cors: { origins: ["https://app.example"] } },
+    });
+    await seedPublished(h, 1);
+
+    const allowed = await h.dispatch(
+      originGet("/_plumix/api/v1/posts", "https://app.example"),
+    );
+    expect(allowed.headers.get("access-control-allow-origin")).toBe(
+      "https://app.example",
+    );
+    expect(allowed.headers.get("vary")?.toLowerCase()).toContain("origin");
+
+    const denied = await h.dispatch(
+      originGet("/_plumix/api/v1/posts", "https://evil.example"),
+    );
+    expect(denied.headers.get("access-control-allow-origin")).toBeNull();
+    // Still varies by Origin so a shared cache can't serve this no-CORS entry
+    // to an allowed origin.
+    expect(denied.headers.get("vary")?.toLowerCase()).toContain("origin");
+  });
+
+  test("`*` opens anonymous reads to any origin", async () => {
+    const h = await restHarness({
+      api: { enabled: true, cors: { origins: "*" } },
+    });
+    await seedPublished(h, 1);
+
+    const res = await h.dispatch(
+      originGet("/_plumix/api/v1/posts", "https://anything.example"),
+    );
+
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  test("PAT-authed responses are never CORS-exposed", async () => {
+    const h = await restHarness({
+      api: { enabled: true, cors: { origins: "*" } },
+    });
+    const { secret } = await mintPat(h, { role: "editor" });
+
+    const res = await h.dispatch(
+      new Request("https://cms.example/_plumix/api/v1/posts", {
+        headers: {
+          origin: "https://app.example",
+          authorization: `Bearer ${secret}`,
+        },
+      }),
+    );
+
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+
+  test("preflight is answered for allowed origins and refused otherwise", async () => {
+    const h = await restHarness({
+      api: { enabled: true, cors: { origins: ["https://app.example"] } },
+    });
+
+    const ok = await h.dispatch(
+      new Request("https://cms.example/_plumix/api/v1/posts", {
+        method: "OPTIONS",
+        headers: { origin: "https://app.example" },
+      }),
+    );
+    expect(ok.status).toBe(204);
+    expect(ok.headers.get("access-control-allow-origin")).toBe(
+      "https://app.example",
+    );
+    expect(ok.headers.get("access-control-allow-methods")).toContain("GET");
+
+    const refused = await h.dispatch(
+      new Request("https://cms.example/_plumix/api/v1/posts", {
+        method: "OPTIONS",
+        headers: { origin: "https://evil.example" },
+      }),
+    );
+    expect(refused.status).toBe(403);
+  });
+});
+
 describe("REST API — OpenAPI spec", () => {
   test("GET /openapi.json returns an OpenAPI 3.1 doc with the entries resources", async () => {
     const h = await restHarness();
@@ -466,6 +564,19 @@ describe("REST API — OpenAPI spec", () => {
     expect(json).toContain('"terms"');
     // ...and the collection responses are a union of the entry and term shapes.
     expect(json).toMatch(/"(anyOf|oneOf)"/);
+  });
+
+  test("typed errors are documented with their status codes", async () => {
+    const h = await restHarness();
+
+    const res = await h.dispatch(apiGet("/_plumix/api/v1/openapi.json"));
+    const doc = (await res.json()) as {
+      paths: Record<string, { get?: { responses?: Record<string, unknown> } }>;
+    };
+
+    // The hide-existence 404 on the item route is part of the contract.
+    const itemResponses = doc.paths["/{collection}/{id}"]?.get?.responses ?? {};
+    expect(itemResponses).toHaveProperty("404");
   });
 });
 

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -350,7 +350,7 @@ export async function buildApp(
   let restHandler: Promise<RestDispatch> | undefined;
   const loadRestHandler = (): Promise<RestDispatch> =>
     (restHandler ??= import("../rest/build-handler.js").then((m) =>
-      m.buildRestDispatcher(registry),
+      m.buildRestDispatcher(registry, config.api?.cors),
     ));
 
   return {

--- a/packages/core/src/runtime/http.ts
+++ b/packages/core/src/runtime/http.ts
@@ -1,3 +1,18 @@
+// Clone a response, preserving its body/status, with mutated headers — for
+// adding headers to a response produced elsewhere (CORS, cache directives).
+export function withHeaders(
+  response: Response,
+  mutate: (headers: Headers) => void,
+): Response {
+  const headers = new Headers(response.headers);
+  mutate(headers);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   const headers = new Headers(init.headers);
   if (!headers.has("content-type")) {

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -2,7 +2,11 @@ import type { RequestAuthenticator } from "../auth/authenticator.js";
 import type { BootstrapVia, PlumixMagicLinkConfig } from "../auth/config.js";
 import type { Mailer } from "../auth/mailer/types.js";
 import type { OAuthProviderClient } from "../auth/oauth/types.js";
-import type { AnyPluginDescriptor, InterfaceToggle } from "../config.js";
+import type {
+  AnyPluginDescriptor,
+  ApiConfig,
+  InterfaceToggle,
+} from "../config.js";
 import type { AppContext } from "../context/app.js";
 import type { User, UserRole } from "../db/schema/users.js";
 import type {
@@ -114,7 +118,7 @@ export interface CreateDispatcherHarnessOptions {
   /** Mount the MCP endpoint. Default-off mirrors production. */
   readonly mcp?: InterfaceToggle;
   /** Mount the REST API. Default-off mirrors production. */
-  readonly api?: InterfaceToggle;
+  readonly api?: ApiConfig;
   /**
    * Vite-emitted asset manifest. Tests that exercise the renderer's
    * `<link rel="stylesheet">` auto-injection pass a stub manifest here;


### PR DESCRIPTION
Final slice of PRD #995: cross-origin support for the REST API, split by auth mode, plus spec/seam polish.

**CORS, default-closed**

```ts
api: { enabled: true, cors: { origins: ["https://app.example.com"] } } // or "*"
```

- No `cors` → no `Access-Control-Allow-Origin` is ever emitted, even with the API enabled.
- An allowlisted origin is echoed with `Vary: origin` (set on every response when an allowlist is configured, so a shared cache can't serve a no-CORS entry to an allowed origin); `"*"` is origin-independent.
- `OPTIONS` preflight is answered (`204`) for allowed origins and refused (`403`) otherwise.

**Authed responses are never CORS-exposed**

PAT-authed responses carry no `Access-Control-Allow-Origin` and never `Access-Control-Allow-Credentials`, so a token embedded in browser JS can't be used cross-origin — PATs stay server-to-server.

**Spec & seams**

Typed errors already surface in `openapi.json` with their status codes (the hide-existence `404` included). `docs/rest-api.md` documents enabling the API, CORS, the edge **rate-limiting seam**, and adding a userland **Scalar/Swagger docs UI** against `/openapi.json`. A shared `withHeaders` response-clone helper backs the CORS and cache-control paths.

Closes #1003