### PR TITLE
feat(core): add render:document seam + canonical URL + canonical tag

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -19,6 +19,88 @@ const blogPlugin = definePlugin("blog", (ctx) => {
   });
 });
 
+function headOf(body: string): string {
+  return body.slice(body.indexOf("<head>"), body.indexOf("</head>"));
+}
+
+async function dispatchHead(
+  h: Awaited<ReturnType<typeof createDispatcherHarness>>,
+  url: string,
+): Promise<string> {
+  const res = await h.dispatch(new Request(url));
+  return headOf(await res.text());
+}
+
+async function seedPost(
+  h: Awaited<ReturnType<typeof createDispatcherHarness>>,
+  slug = "hello",
+): Promise<void> {
+  const author = await h.seedUser("admin");
+  await h.factory.entry.create({
+    type: "post",
+    slug,
+    title: "Hello",
+    content: null,
+    status: "published",
+    authorId: author.id,
+    publishedAt: new Date(),
+  });
+}
+
+describe("SEO — canonical + render:document seam", () => {
+  test("a public page renders exactly one canonical with the slash-less absolute URL", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await seedPost(h);
+
+    const head = await dispatchHead(h, "https://cms.example/post/hello");
+
+    expect(head.match(/rel="canonical"/g)).toHaveLength(1);
+    expect(head).toContain(
+      '<link rel="canonical" href="https://cms.example/post/hello"/>',
+    );
+  });
+
+  test("a render:document subscriber can override the canonical (gap-filler skips)", async () => {
+    const seoPlugin = definePlugin("seo-test", (ctx) => {
+      ctx.addFilter("render:document", (manifest) => ({
+        ...manifest,
+        link: [
+          ...(manifest.link ?? []),
+          { rel: "canonical", href: "https://cms.example/override" },
+        ],
+      }));
+    });
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, seoPlugin],
+      theme,
+    });
+    await seedPost(h);
+
+    const head = await dispatchHead(h, "https://cms.example/post/hello");
+
+    expect(head.match(/rel="canonical"/g)).toHaveLength(1);
+    expect(head).toContain('href="https://cms.example/override"');
+  });
+
+  test("a template-set canonical is not duplicated by the gap-filler", async () => {
+    const theme = defineTheme({
+      templates: { index: () => null },
+      document: {
+        link: [{ rel: "canonical", href: "https://cms.example/from-theme" }],
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await seedPost(h);
+
+    const head = await dispatchHead(h, "https://cms.example/post/hello");
+
+    expect(head.match(/rel="canonical"/g)).toHaveLength(1);
+    expect(head).toContain('href="https://cms.example/from-theme"');
+  });
+});
+
 describe("resolvePublicRoute — single entry through theme", () => {
   test("renders the entry title via the matched `single` template", async () => {
     const theme = defineTheme({

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -28,6 +28,7 @@ import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
 import { PlumixAdminBar } from "../../admin-bar/component.js";
 import { mergeDocumentManifest } from "../../document-merge.js";
+import { applyCanonical } from "../../seo/canonical.js";
 import {
   loadTemplateDeps,
   mergeTemplateDepDeclarations,
@@ -37,6 +38,24 @@ import { validateDocumentManifest } from "../../theme.js";
 import { bundledCssTags } from "./asset-manifest.js";
 import { injectIslandsBootstrap } from "./inject-islands-bootstrap.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
+
+declare module "../../hooks/types.js" {
+  interface FilterRegistry {
+    /**
+     * Per-request head transform — the entry point for `@plumix/plugin-seo` and
+     * any plugin to inject, override, or remove document head fields with the
+     * resolved `{data, ctx}` in hand. Fires on the assembled (theme + template)
+     * document and before core's SEO gap-fillers, so a subscriber can override
+     * any already-set field while core only backfills keys no one set. Real
+     * renders only — error pages don't fire it.
+     */
+    "render:document": (
+      manifest: DocumentManifest,
+      data: TemplateData,
+      ctx: AppContext,
+    ) => DocumentManifest | Promise<DocumentManifest>;
+  }
+}
 
 interface RenderArgs {
   readonly ctx: AppContext;
@@ -71,7 +90,7 @@ export async function renderThroughTheme({
     templateDeps,
     ctx,
   );
-  const renderDocument = resolveRenderDocument({
+  const merged = resolveRenderDocument({
     template,
     slot,
     document,
@@ -80,6 +99,13 @@ export async function renderThroughTheme({
     ctx,
     deps,
   });
+  const filtered = await ctx.hooks.applyFilter(
+    "render:document",
+    merged,
+    data,
+    ctx,
+  );
+  const renderDocument = applyCanonical(filtered, ctx);
   const loaderData = await prefetchEntryLoaders(ctx, data, template);
   return renderTree({
     ctx,

--- a/packages/core/src/seo/canonical.test.ts
+++ b/packages/core/src/seo/canonical.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import { canonicalUrl } from "./canonical.js";
+
+function ctxFor(url: string): AppContext {
+  return {
+    request: new Request(url),
+    origin: "https://cms.example",
+  } as unknown as AppContext;
+}
+
+describe("canonicalUrl", () => {
+  test.each([
+    [
+      "single entry",
+      "https://cms.example/post/hello",
+      "https://cms.example/post/hello",
+    ],
+    ["archive", "https://cms.example/post", "https://cms.example/post"],
+    [
+      "taxonomy term",
+      "https://cms.example/category/tech",
+      "https://cms.example/category/tech",
+    ],
+    ["front page", "https://cms.example/", "https://cms.example/"],
+    [
+      "trailing slash normalized away",
+      "https://cms.example/post/hello/",
+      "https://cms.example/post/hello",
+    ],
+    [
+      "query string dropped",
+      "https://cms.example/post/hello?utm=x",
+      "https://cms.example/post/hello",
+    ],
+    [
+      "page 1 collapses to the bare listing",
+      "https://cms.example/shop/page/1",
+      "https://cms.example/shop",
+    ],
+    [
+      "page 2+ is kept",
+      "https://cms.example/shop/page/2",
+      "https://cms.example/shop/page/2",
+    ],
+  ])("%s → slash-less absolute URL", (_label, requestUrl, expected) => {
+    expect(canonicalUrl(ctxFor(requestUrl))).toBe(expected);
+  });
+
+  test("uses the configured origin, not the request host", () => {
+    // A request served by an internal/edge host still canonicalizes to the
+    // configured site origin.
+    expect(canonicalUrl(ctxFor("https://edge.internal/post/hello"))).toBe(
+      "https://cms.example/post/hello",
+    );
+  });
+});

--- a/packages/core/src/seo/canonical.ts
+++ b/packages/core/src/seo/canonical.ts
@@ -1,0 +1,41 @@
+import type { AppContext } from "../context/app.js";
+import type { DocumentManifest } from "../theme.js";
+
+/**
+ * The single source of truth for a request's canonical URL: the configured
+ * site origin + the request path normalized to the fixed slash-less shape
+ * (query and fragment dropped so URL variants consolidate). Drives the
+ * `<link rel="canonical">` tag now and the 301 normalizer + sitemap/og:url
+ * in later slices, so they can never disagree.
+ */
+export function canonicalUrl(ctx: AppContext): string {
+  const { pathname } = new URL(ctx.request.url);
+  const slashless = pathname === "/" ? "/" : pathname.replace(/\/+$/, "");
+  // `/page/1` is the same content as the bare listing, so it canonicalizes to
+  // the listing — `/shop/page/1` → `/shop`, `/page/1` → `/`.
+  const normalized = slashless.replace(/\/page\/1$/, "");
+  return `${ctx.origin}${normalized || "/"}`;
+}
+
+function hasCanonical(manifest: DocumentManifest): boolean {
+  return manifest.link?.some((link) => link.rel === "canonical") ?? false;
+}
+
+/**
+ * Gap-filler: emit `<link rel="canonical">` only when neither the template nor
+ * a `render:document` subscriber already set one — so a higher layer's canonical
+ * always wins and the tag never duplicates.
+ */
+export function applyCanonical(
+  manifest: DocumentManifest,
+  ctx: AppContext,
+): DocumentManifest {
+  if (hasCanonical(manifest)) return manifest;
+  return {
+    ...manifest,
+    link: [
+      ...(manifest.link ?? []),
+      { rel: "canonical", href: canonicalUrl(ctx) },
+    ],
+  };
+}


### PR DESCRIPTION
First slice of core SEO out-of-the-box (PRD #986).

**`render:document` per-request seam**

A new filter fired on the assembled head manifest with the resolved `{data, ctx}` — the entry point a future `@plumix/plugin-seo` (or any plugin/theme) uses to inject, override, or remove head fields per page. Plugins subscribe via `ctx.addFilter("render:document", (manifest, data, ctx) => …)`.

**`canonicalUrl(ctx)` + canonical tag**

`canonicalUrl(ctx)` is the single source of truth (drives the tag now; the 301 normalizer, sitemap URLs, and `og:url` in later slices, so they can't disagree): site origin + request path normalized to the fixed slash-less shape, query/fragment dropped, and a redundant `/page/1` collapsed to the bare listing (paginated page 1 and the listing share one canonical).

A gap-filler emits `<link rel="canonical">` only when neither the template nor a `render:document` subscriber already set one — higher layers win, the tag never duplicates. Error pages don't claim a canonical.

**Notes for reviewers / follow-ups (out of slice-1 scope)**
- The filter fires on the merged (theme + template) document, so a `render:document` subscriber can override template-set fields. Given the additive document merge, strict "template-wins" isn't cleanly expressible; the gap-filler guarantees core is the lowest layer (the slice-1 contract). Comments describe the actual behavior.
- The `/page/1` collapse is a path-string rule; a content slug literally named `page` with a numeric child would be over-collapsed (deferred — would key off resolved route state).

Closes #987