### PR TITLE
feat(core): emit default head meta (description, robots, OG, Twitter)

### DIFF
--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -1309,6 +1309,11 @@ msgid "allowedDomains.add.defaultRole.label"
 msgstr "الدور الافتراضي"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.default_og_image"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.delete"
 msgstr "حذف"

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -1314,6 +1314,11 @@ msgid "allowedDomains.add.defaultRole.label"
 msgstr "Standardrolle"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.default_og_image"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.delete"
 msgstr "Löschen"

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -1296,6 +1296,11 @@ msgid "allowedDomains.add.defaultRole.label"
 msgstr "Default role"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.default_og_image"
+msgstr "Default social image URL"
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.delete"
 msgstr "Delete"

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -1313,6 +1313,11 @@ msgid "allowedDomains.add.defaultRole.label"
 msgstr "Роль за замовчуванням"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.default_og_image"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.delete"
 msgstr "Видалити"

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -1279,6 +1279,11 @@ msgid "allowedDomains.add.defaultRole.label"
 msgstr "默认角色"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.default_og_image"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor/BlockActionsPanel.tsx
 msgid "blockActions.delete"
 msgstr "删除"

--- a/packages/admin/src/lib/core-settings-i18n.ts
+++ b/packages/admin/src/lib/core-settings-i18n.ts
@@ -36,6 +36,10 @@ export const CORE_SETTINGS_DESCRIPTORS = {
     id: "core.settings.site.mastodon",
     message: "Mastodon URL",
   }),
+  ogImage: defineMessage({
+    id: "core.settings.site.default_og_image",
+    message: "Default social image URL",
+  }),
   pageLabel: defineMessage({
     id: "core.settings.general.label",
     message: "General",

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -101,6 +101,111 @@ describe("SEO — canonical + render:document seam", () => {
   });
 });
 
+async function seedSiteSettings(
+  h: Awaited<ReturnType<typeof createDispatcherHarness>>,
+  values: Record<string, string>,
+): Promise<void> {
+  for (const [key, value] of Object.entries(values)) {
+    await h.factory.setting.create({ group: "site", key, value });
+  }
+}
+
+describe("SEO — default head meta", () => {
+  test("an entry page emits the singular default meta set", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await seedSiteSettings(h, {
+      title: "Demo",
+      tagline: "A tagline",
+      default_og_image: "https://cms.example/og.png",
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hello",
+      title: "Hello",
+      excerpt: "My excerpt",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const head = await dispatchHead(h, "https://cms.example/post/hello");
+
+    expect(head.match(/name="description"/g)).toHaveLength(1);
+    expect(head).toContain('<meta name="description" content="My excerpt"/>');
+    expect(head).toContain(
+      '<meta name="robots" content="index,follow,max-image-preview:large"/>',
+    );
+    expect(head).toContain('<meta property="og:title" content="Hello"/>');
+    expect(head).toContain('<meta property="og:type" content="article"/>');
+    expect(head).toContain(
+      '<meta property="og:url" content="https://cms.example/post/hello"/>',
+    );
+    expect(head).toContain('<meta property="og:site_name" content="Demo"/>');
+    expect(head).toContain('<meta property="og:locale" content="en"/>');
+    expect(head).toContain(
+      '<meta property="og:image" content="https://cms.example/og.png"/>',
+    );
+    expect(head).toContain(
+      '<meta name="twitter:card" content="summary_large_image"/>',
+    );
+  });
+
+  test("description falls back to the site tagline when the entry has no excerpt", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await seedSiteSettings(h, { tagline: "Fallback tagline" });
+    await seedPost(h);
+
+    const head = await dispatchHead(h, "https://cms.example/post/hello");
+
+    expect(head).toContain(
+      '<meta name="description" content="Fallback tagline"/>',
+    );
+  });
+
+  test("og:image is absent and the card downgrades when no default image is set", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await seedPost(h);
+
+    const head = await dispatchHead(h, "https://cms.example/post/hello");
+
+    expect(head).not.toContain('property="og:image"');
+    expect(head).toContain('<meta name="twitter:card" content="summary"/>');
+  });
+
+  test("a search-results route emits noindex", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+
+    const head = await dispatchHead(h, "https://cms.example/search/anything");
+
+    expect(head).toContain('<meta name="robots" content="noindex,follow"/>');
+  });
+
+  test("a template-set head field is not duplicated by the defaults", async () => {
+    const theme = defineTheme({
+      templates: { index: () => null },
+      document: {
+        meta: [{ property: "og:site_name", content: "From Theme" }],
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await seedSiteSettings(h, { title: "Demo" });
+    await seedPost(h);
+
+    const head = await dispatchHead(h, "https://cms.example/post/hello");
+
+    expect(head.match(/property="og:site_name"/g)).toHaveLength(1);
+    expect(head).toContain(
+      '<meta property="og:site_name" content="From Theme"/>',
+    );
+  });
+});
+
 describe("resolvePublicRoute — single entry through theme", () => {
   test("renders the entry title via the matched `single` template", async () => {
     const theme = defineTheme({

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -29,6 +29,7 @@ import type { ResolvedNode } from "./template-hierarchy.js";
 import { PlumixAdminBar } from "../../admin-bar/component.js";
 import { mergeDocumentManifest } from "../../document-merge.js";
 import { applyCanonical } from "../../seo/canonical.js";
+import { applyHeadMeta } from "../../seo/head-defaults.js";
 import {
   loadTemplateDeps,
   mergeTemplateDepDeclarations,
@@ -105,7 +106,12 @@ export async function renderThroughTheme({
     data,
     ctx,
   );
-  const renderDocument = applyCanonical(filtered, ctx);
+  const renderDocument = await applyHeadMeta(
+    applyCanonical(filtered, ctx),
+    data,
+    ctx,
+    title,
+  );
   const loaderData = await prefetchEntryLoaders(ctx, data, template);
   return renderTree({
     ctx,

--- a/packages/core/src/seo/head-defaults.test.ts
+++ b/packages/core/src/seo/head-defaults.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+
+import type { DocumentManifest, DocumentMeta } from "../theme.js";
+import { seoHeadDefaults } from "./head-defaults.js";
+
+const baseInputs = {
+  canonical: "https://cms.example/post/hello",
+  title: "Hello",
+  description: "An excerpt",
+  ogType: "article" as const,
+  ogImage: null,
+  siteName: "Demo",
+  ogLocale: "en",
+  noindex: false,
+};
+
+const meta = (m: DocumentManifest): readonly DocumentMeta[] => m.meta ?? [];
+const byName = (m: DocumentManifest, name: string): DocumentMeta | undefined =>
+  meta(m).find((entry) => entry.name === name);
+const byProperty = (
+  m: DocumentManifest,
+  property: string,
+): DocumentMeta | undefined =>
+  meta(m).find((entry) => entry.property === property);
+
+describe("seoHeadDefaults", () => {
+  test("emits the full default meta set", () => {
+    const out = seoHeadDefaults({}, baseInputs);
+    expect(
+      meta(out)
+        .map((e) => e.name)
+        .filter(Boolean),
+    ).toEqual(
+      expect.arrayContaining(["description", "robots", "twitter:card"]),
+    );
+    expect(
+      meta(out)
+        .map((e) => e.property)
+        .filter(Boolean),
+    ).toEqual(
+      expect.arrayContaining([
+        "og:title",
+        "og:type",
+        "og:url",
+        "og:site_name",
+        "og:description",
+        "og:locale",
+      ]),
+    );
+    expect(byProperty(out, "og:type")?.content).toBe("article");
+    expect(byProperty(out, "og:url")?.content).toBe(baseInputs.canonical);
+  });
+
+  test("indexable robots by default; noindex when flagged", () => {
+    expect(byName(seoHeadDefaults({}, baseInputs), "robots")?.content).toBe(
+      "index,follow,max-image-preview:large",
+    );
+    expect(
+      byName(seoHeadDefaults({}, { ...baseInputs, noindex: true }), "robots")
+        ?.content,
+    ).toBe("noindex,follow");
+  });
+
+  test("og:image omitted when none; summary card downgrades", () => {
+    const out = seoHeadDefaults({}, baseInputs);
+    expect(byProperty(out, "og:image")).toBeUndefined();
+    expect(byName(out, "twitter:card")?.content).toBe("summary");
+  });
+
+  test("og:image present upgrades the twitter card", () => {
+    const out = seoHeadDefaults(
+      {},
+      { ...baseInputs, ogImage: "https://cms.example/og.png" },
+    );
+    expect(byProperty(out, "og:image")?.content).toBe(
+      "https://cms.example/og.png",
+    );
+    expect(byName(out, "twitter:card")?.content).toBe("summary_large_image");
+  });
+
+  test("description omitted when null", () => {
+    const out = seoHeadDefaults({}, { ...baseInputs, description: null });
+    expect(byName(out, "description")).toBeUndefined();
+    expect(byProperty(out, "og:description")).toBeUndefined();
+  });
+
+  test("an already-set key is never duplicated", () => {
+    const out = seoHeadDefaults(
+      { meta: [{ name: "description", content: "theme" }] },
+      baseInputs,
+    );
+    const descriptions = meta(out).filter((e) => e.name === "description");
+    expect(descriptions).toHaveLength(1);
+    expect(descriptions[0]?.content).toBe("theme");
+  });
+});

--- a/packages/core/src/seo/head-defaults.ts
+++ b/packages/core/src/seo/head-defaults.ts
@@ -1,0 +1,110 @@
+import type { AppContext } from "../context/app.js";
+import type { DocumentManifest, DocumentMeta, TemplateData } from "../theme.js";
+import { settingsLoader } from "../template-deps-core.js";
+import { canonicalUrl } from "./canonical.js";
+
+const ROBOTS_INDEX = "index,follow,max-image-preview:large";
+const ROBOTS_NOINDEX = "noindex,follow";
+
+interface SeoInputs {
+  readonly canonical: string;
+  readonly title: string | undefined;
+  readonly description: string | null;
+  readonly ogType: "article" | "website";
+  readonly ogImage: string | null;
+  readonly siteName: string | null;
+  readonly ogLocale: string;
+  readonly noindex: boolean;
+}
+
+function hasName(
+  meta: readonly DocumentMeta[] | undefined,
+  name: string,
+): boolean {
+  return meta?.some((entry) => entry.name === name) ?? false;
+}
+
+function hasProperty(
+  meta: readonly DocumentMeta[] | undefined,
+  property: string,
+): boolean {
+  return meta?.some((entry) => entry.property === property) ?? false;
+}
+
+/**
+ * Pure gap-filler for the default head meta set: appends a `<meta>` only when
+ * its `name`/`property` key is absent, so a template- or plugin-set value always
+ * wins and nothing duplicates.
+ */
+export function seoHeadDefaults(
+  manifest: DocumentManifest,
+  inputs: SeoInputs,
+): DocumentManifest {
+  const existing = manifest.meta;
+  const additions: DocumentMeta[] = [];
+  const addName = (name: string, content: string | null): void => {
+    if (content && !hasName(existing, name)) additions.push({ name, content });
+  };
+  const addProperty = (property: string, content: string | null): void => {
+    if (content && !hasProperty(existing, property)) {
+      additions.push({ property, content });
+    }
+  };
+
+  addName("description", inputs.description);
+  addName("robots", inputs.noindex ? ROBOTS_NOINDEX : ROBOTS_INDEX);
+  addName("twitter:card", inputs.ogImage ? "summary_large_image" : "summary");
+  addProperty("og:title", inputs.title ?? null);
+  addProperty("og:type", inputs.ogType);
+  addProperty("og:url", inputs.canonical);
+  addProperty("og:site_name", inputs.siteName);
+  addProperty("og:description", inputs.description);
+  addProperty("og:locale", inputs.ogLocale);
+  addProperty("og:image", inputs.ogImage);
+
+  if (additions.length === 0) return manifest;
+  return { ...manifest, meta: [...(existing ?? []), ...additions] };
+}
+
+function nonEmpty(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+async function loadSiteSettings(
+  ctx: AppContext,
+): Promise<Record<string, unknown>> {
+  const groups = await settingsLoader(["site"], ctx);
+  return groups.site ?? {};
+}
+
+// `og:locale` wants `lang_TERRITORY`; the active locale code is `lang-TERRITORY`.
+function toOgLocale(localeCode: string): string {
+  return localeCode.replace("-", "_");
+}
+
+/**
+ * Fill the default head meta for a request. Reads the site settings (title,
+ * tagline, default OG image) for the values it can't derive from the page, then
+ * gap-fills via {@link seoHeadDefaults}.
+ */
+export async function applyHeadMeta(
+  manifest: DocumentManifest,
+  data: TemplateData,
+  ctx: AppContext,
+  title: string | undefined,
+): Promise<DocumentManifest> {
+  const site = await loadSiteSettings(ctx);
+  const excerpt = "entry" in data ? nonEmpty(data.entry.excerpt) : null;
+  const description = excerpt ?? nonEmpty(site.tagline);
+  return seoHeadDefaults(manifest, {
+    canonical: canonicalUrl(ctx),
+    title,
+    description,
+    ogType: "entry" in data ? "article" : "website",
+    ogImage: nonEmpty(site.default_og_image),
+    siteName: nonEmpty(site.title),
+    ogLocale: toOgLocale(ctx.locale.code),
+    // Search-results pages are thin; keep them out of the index.
+    noindex: "query" in data,
+  });
+}

--- a/packages/core/src/settings-core.ts
+++ b/packages/core/src/settings-core.ts
@@ -20,6 +20,10 @@ export const SITE_SETTINGS_DESCRIPTORS = {
   twitter: { id: "core.settings.site.twitter", message: "X (Twitter) URL" },
   github: { id: "core.settings.site.github", message: "GitHub URL" },
   mastodon: { id: "core.settings.site.mastodon", message: "Mastodon URL" },
+  ogImage: {
+    id: "core.settings.site.default_og_image",
+    message: "Default social image URL",
+  },
   pageLabel: { id: "core.settings.general.label", message: "General" },
   pageDescription: {
     id: "core.settings.general.description",
@@ -78,6 +82,15 @@ export function registerCoreSettings(registry: MutablePluginRegistry): void {
         inputType: "url",
         label: D.mastodon,
         maxLength: 300,
+      },
+      // Fallback Open Graph image for pages without their own; SEO defaults
+      // read it for `og:image`.
+      {
+        key: "default_og_image",
+        type: "string",
+        inputType: "url",
+        label: D.ogImage,
+        maxLength: 500,
       },
     ],
   });

--- a/packages/core/src/template-deps-core.ts
+++ b/packages/core/src/template-deps-core.ts
@@ -29,7 +29,7 @@ export function registerCoreTemplateDeps(
   });
 }
 
-async function settingsLoader(
+export async function settingsLoader(
   groups: readonly string[],
   ctx: AppContext,
 ): Promise<Record<string, Record<string, unknown>>> {


### PR DESCRIPTION
Second slice of core SEO out-of-the-box (PRD #986). Per page, core gap-fills the full default `<head>` meta set via the slice-1 mechanism — only keys no template or `render:document` subscriber already set, so nothing duplicates.

**Defaults**
- `description` — entry excerpt → site tagline fallback.
- `robots` — `index,follow,max-image-preview:large`; `noindex,follow` on search-results routes.
- Open Graph — `og:title/type/url/site_name/description/locale` (`og:url` reuses `canonicalUrl`; `og:type` is `article` for single entries, `website` otherwise; `og:locale` from the active locale).
- Twitter — `summary` card, upgraded to `summary_large_image` when an image is present.

**`default_og_image` setting**
Adds a `default_og_image` field to the `site` settings group (+ its i18n lockstep mirror and extracted catalogs). `og:image` is emitted from it and omitted when unset.

**Notes**
- The pure `seoHeadDefaults` gap-filler is unit-tested; the wiring (settings → derived inputs → tags) is covered by dispatcher-harness integration tests.
- `applyHeadMeta` reads the `site` settings once per render (a single covered lookup, deduped via the existing `settingsLoader`); the gap-filler guarantees no higher-layer field is duplicated (PRD AC #24). A strict skip-the-read-when-everything-preset early-out was left out as it'd rarely fire.
- New `core.settings.site.default_og_image` label is English-only in the non-source catalogs (normal post-extraction state; community translations per project policy).

Closes #988