### PR TITLE
feat(core): serve /robots.txt and add the site indexing gate

### DIFF
--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -569,6 +569,11 @@ msgid "users.list.roleFilter.all"
 msgstr "كل الأدوار"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.public"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.title"
 msgstr "النطاقات المسموح بها"

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -558,6 +558,11 @@ msgid "users.list.roleFilter.all"
 msgstr "Alle Rollen"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.public"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.title"
 msgstr "Erlaubte Domains"

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -554,6 +554,11 @@ msgid "users.list.roleFilter.all"
 msgstr "All roles"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.public"
+msgstr "Allow search engines to index this site"
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.title"
 msgstr "Allowed domains"

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -566,6 +566,11 @@ msgid "users.list.roleFilter.all"
 msgstr "Усі ролі"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.public"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.title"
 msgstr "Дозволені домени"

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -543,6 +543,11 @@ msgid "users.list.roleFilter.all"
 msgstr "所有角色"
 
 #. js-lingui-explicit-id
+#: src/lib/core-settings-i18n.ts
+msgid "core.settings.site.public"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
 msgid "allowedDomains.title"
 msgstr "允许的域名"

--- a/packages/admin/src/lib/core-settings-i18n.ts
+++ b/packages/admin/src/lib/core-settings-i18n.ts
@@ -40,6 +40,10 @@ export const CORE_SETTINGS_DESCRIPTORS = {
     id: "core.settings.site.default_og_image",
     message: "Default social image URL",
   }),
+  publicSite: defineMessage({
+    id: "core.settings.site.public",
+    message: "Allow search engines to index this site",
+  }),
   pageLabel: defineMessage({
     id: "core.settings.general.label",
     message: "General",

--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -206,6 +206,68 @@ describe("SEO — default head meta", () => {
   });
 });
 
+describe("SEO — robots.txt + public gate", () => {
+  test("GET /robots.txt is text/plain and allows crawling by default", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+
+    const res = await h.dispatch(new Request("https://cms.example/robots.txt"));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    expect(await res.text()).toBe("User-agent: *\nDisallow:\n");
+  });
+
+  test("a private site disallows all crawling", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await h.factory.setting.create({
+      group: "site",
+      key: "public",
+      value: false,
+    });
+
+    const res = await h.dispatch(new Request("https://cms.example/robots.txt"));
+
+    expect(await res.text()).toBe("User-agent: *\nDisallow: /\n");
+  });
+
+  test("the seo:robots-txt filter can modify the body", async () => {
+    const seoPlugin = definePlugin("robots-test", (ctx) => {
+      ctx.addFilter(
+        "seo:robots-txt",
+        (body) => `${body}Sitemap: https://cms.example/sitemap.xml\n`,
+      );
+    });
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, seoPlugin],
+      theme,
+    });
+
+    const body = await (
+      await h.dispatch(new Request("https://cms.example/robots.txt"))
+    ).text();
+
+    expect(body).toContain("Sitemap: https://cms.example/sitemap.xml");
+  });
+
+  test("a private site cascades to noindex,nofollow on rendered pages", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await h.factory.setting.create({
+      group: "site",
+      key: "public",
+      value: false,
+    });
+    await seedPost(h);
+
+    const head = await dispatchHead(h, "https://cms.example/post/hello");
+
+    expect(head).toContain('<meta name="robots" content="noindex,nofollow"/>');
+  });
+});
+
 describe("resolvePublicRoute — single entry through theme", () => {
   test("renders the entry title via the matched `single` template", async () => {
     const theme = defineTheme({

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -12,6 +12,7 @@ import { resolveLocale } from "../i18n/resolve-locale.js";
 import { matchRoute } from "../route/match.js";
 import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
+import { handleRobotsTxt } from "../seo/robots.js";
 import { rewriteAdminShellLangDir } from "./admin-shell.js";
 import { forbidden, jsonResponse, methodNotAllowed, notFound } from "./http.js";
 import { loadUserForPublicRequest } from "./load-user-for-public-request.js";
@@ -22,6 +23,7 @@ const AUTH_PREFIX = "/_plumix/auth/";
 const PLUMIX_PREFIX = "/_plumix/";
 const MCP_PATH = "/_plumix/mcp";
 const API_PREFIX = "/_plumix/api";
+const ROBOTS_PATH = "/robots.txt";
 
 // MCP is cold-path-exclusive (an agent endpoint, never the public render path).
 // Dynamic-import its handler so the tool registry and the MCP SDK it pulls in
@@ -237,6 +239,12 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
 
   if (ctx.request.method !== "GET" && ctx.request.method !== "HEAD") {
     return methodNotAllowed(["GET", "HEAD"]);
+  }
+
+  // Core SEO asset routes resolve ahead of the public route map so a plugin
+  // rewrite rule can't shadow them.
+  if (pathname === ROBOTS_PATH) {
+    return handleRobotsTxt(ctx);
   }
 
   return dispatchPublicRoute(app, ctx, url);

--- a/packages/core/src/seo/head-defaults.test.ts
+++ b/packages/core/src/seo/head-defaults.test.ts
@@ -12,6 +12,7 @@ const baseInputs = {
   siteName: "Demo",
   ogLocale: "en",
   noindex: false,
+  siteIsPrivate: false,
 };
 
 const meta = (m: DocumentManifest): readonly DocumentMeta[] => m.meta ?? [];
@@ -51,7 +52,7 @@ describe("seoHeadDefaults", () => {
     expect(byProperty(out, "og:url")?.content).toBe(baseInputs.canonical);
   });
 
-  test("indexable robots by default; noindex when flagged", () => {
+  test("robots reflects index / search / private", () => {
     expect(byName(seoHeadDefaults({}, baseInputs), "robots")?.content).toBe(
       "index,follow,max-image-preview:large",
     );
@@ -59,6 +60,12 @@ describe("seoHeadDefaults", () => {
       byName(seoHeadDefaults({}, { ...baseInputs, noindex: true }), "robots")
         ?.content,
     ).toBe("noindex,follow");
+    expect(
+      byName(
+        seoHeadDefaults({}, { ...baseInputs, siteIsPrivate: true }),
+        "robots",
+      )?.content,
+    ).toBe("noindex,nofollow");
   });
 
   test("og:image omitted when none; summary card downgrades", () => {

--- a/packages/core/src/seo/head-defaults.ts
+++ b/packages/core/src/seo/head-defaults.ts
@@ -1,10 +1,21 @@
 import type { AppContext } from "../context/app.js";
 import type { DocumentManifest, DocumentMeta, TemplateData } from "../theme.js";
-import { settingsLoader } from "../template-deps-core.js";
 import { canonicalUrl } from "./canonical.js";
+import { loadSiteSettings } from "./site-settings.js";
 
 const ROBOTS_INDEX = "index,follow,max-image-preview:large";
-const ROBOTS_NOINDEX = "noindex,follow";
+const ROBOTS_SEARCH = "noindex,follow";
+const ROBOTS_PRIVATE = "noindex,nofollow";
+
+// A private site is held out entirely; a thin search-results page is kept out
+// of the index but its links are still followed.
+function robotsDirective(input: {
+  readonly siteIsPrivate: boolean;
+  readonly noindex: boolean;
+}): string {
+  if (input.siteIsPrivate) return ROBOTS_PRIVATE;
+  return input.noindex ? ROBOTS_SEARCH : ROBOTS_INDEX;
+}
 
 interface SeoInputs {
   readonly canonical: string;
@@ -15,6 +26,7 @@ interface SeoInputs {
   readonly siteName: string | null;
   readonly ogLocale: string;
   readonly noindex: boolean;
+  readonly siteIsPrivate: boolean;
 }
 
 function hasName(
@@ -52,7 +64,13 @@ export function seoHeadDefaults(
   };
 
   addName("description", inputs.description);
-  addName("robots", inputs.noindex ? ROBOTS_NOINDEX : ROBOTS_INDEX);
+  addName(
+    "robots",
+    robotsDirective({
+      siteIsPrivate: inputs.siteIsPrivate,
+      noindex: inputs.noindex,
+    }),
+  );
   addName("twitter:card", inputs.ogImage ? "summary_large_image" : "summary");
   addProperty("og:title", inputs.title ?? null);
   addProperty("og:type", inputs.ogType);
@@ -68,13 +86,6 @@ export function seoHeadDefaults(
 
 function nonEmpty(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
-}
-
-async function loadSiteSettings(
-  ctx: AppContext,
-): Promise<Record<string, unknown>> {
-  const groups = await settingsLoader(["site"], ctx);
-  return groups.site ?? {};
 }
 
 // `og:locale` wants `lang_TERRITORY`; the active locale code is `lang-TERRITORY`.
@@ -106,5 +117,6 @@ export async function applyHeadMeta(
     ogLocale: toOgLocale(ctx.locale.code),
     // Search-results pages are thin; keep them out of the index.
     noindex: "query" in data,
+    siteIsPrivate: site.public === false,
   });
 }

--- a/packages/core/src/seo/robots.test.ts
+++ b/packages/core/src/seo/robots.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+
+import { buildRobotsTxt } from "./robots.js";
+
+describe("buildRobotsTxt", () => {
+  test("a public site allows all crawling", () => {
+    expect(buildRobotsTxt({ isPublic: true })).toBe(
+      "User-agent: *\nDisallow:\n",
+    );
+  });
+
+  test("a private site disallows everything", () => {
+    expect(buildRobotsTxt({ isPublic: false })).toBe(
+      "User-agent: *\nDisallow: /\n",
+    );
+  });
+});

--- a/packages/core/src/seo/robots.ts
+++ b/packages/core/src/seo/robots.ts
@@ -1,0 +1,36 @@
+import type { AppContext } from "../context/app.js";
+import { loadSiteSettings } from "./site-settings.js";
+
+declare module "../hooks/types.js" {
+  interface FilterRegistry {
+    /**
+     * Adjust the generated `/robots.txt` body. The value filter for plugins
+     * (e.g. `@plumix/plugin-seo`) to add `Sitemap:` lines, crawl-delay, or
+     * per-agent rules without owning the route.
+     */
+    "seo:robots-txt": (body: string) => string | Promise<string>;
+  }
+}
+
+/**
+ * The `robots.txt` body. Default-public allows all crawling; a private site
+ * (the `site.public` setting off) disallows everything.
+ */
+export function buildRobotsTxt(options: {
+  readonly isPublic: boolean;
+}): string {
+  const rule = options.isPublic ? "Disallow:" : "Disallow: /";
+  return `User-agent: *\n${rule}\n`;
+}
+
+export async function handleRobotsTxt(ctx: AppContext): Promise<Response> {
+  const site = await loadSiteSettings(ctx);
+  const isPublic = site.public !== false;
+  const body = await ctx.hooks.applyFilter(
+    "seo:robots-txt",
+    buildRobotsTxt({ isPublic }),
+  );
+  return new Response(body, {
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}

--- a/packages/core/src/seo/site-settings.ts
+++ b/packages/core/src/seo/site-settings.ts
@@ -1,0 +1,10 @@
+import type { AppContext } from "../context/app.js";
+import { settingsLoader } from "../template-deps-core.js";
+
+/** The `site` settings group as a flat `key → value` bag (empty when unset). */
+export async function loadSiteSettings(
+  ctx: AppContext,
+): Promise<Record<string, unknown>> {
+  const groups = await settingsLoader(["site"], ctx);
+  return groups.site ?? {};
+}

--- a/packages/core/src/settings-core.ts
+++ b/packages/core/src/settings-core.ts
@@ -24,6 +24,10 @@ export const SITE_SETTINGS_DESCRIPTORS = {
     id: "core.settings.site.default_og_image",
     message: "Default social image URL",
   },
+  publicSite: {
+    id: "core.settings.site.public",
+    message: "Allow search engines to index this site",
+  },
   pageLabel: { id: "core.settings.general.label", message: "General" },
   pageDescription: {
     id: "core.settings.general.description",
@@ -91,6 +95,15 @@ export function registerCoreSettings(registry: MutablePluginRegistry): void {
         inputType: "url",
         label: D.ogImage,
         maxLength: 500,
+      },
+      // Site-wide indexing gate. Default-true; when off, SEO emits
+      // `noindex,nofollow` and `robots.txt` disallows all crawling.
+      {
+        key: "public",
+        type: "boolean",
+        inputType: "checkbox",
+        label: D.publicSite,
+        default: true,
       },
     ],
   });


### PR DESCRIPTION
Third slice of core SEO out-of-the-box (PRD #986).

**`GET /robots.txt`**

Served from the dispatcher ahead of the public route map, so a plugin rewrite rule can't shadow it. The body comes from `buildRobotsTxt` and passes through a new `seo:robots-txt` value filter (where `@plumix/plugin-seo` can add `Sitemap:` lines, crawl-delay, per-agent rules).

**`public` indexing gate**

Adds a `public` boolean (default true) to the `site` settings group (+ i18n mirror + catalogs). When off, the site is held out of search:

- `robots.txt` → `User-agent: *\nDisallow: /`
- per-page robots meta → `noindex,nofollow` (overriding the slice-2 default)

The robots route and the head meta read the same `site.public` value through one shared `loadSiteSettings` helper, so they can never disagree. (Per the PRD's accepted caveat, `Disallow: /` + `noindex` together won't fully de-index an already-public site — correct/strongest for the never-public staging case. Sitemap suppression lands with the sitemap slice.)

Closes #989