### PR TITLE
feat(core): generate sitemap index + paginated sub-sitemaps

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -206,6 +206,130 @@ describe("SEO — default head meta", () => {
   });
 });
 
+const taxonomyPlugin = definePlugin("taxo", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+  ctx.registerTermTaxonomy("category", {
+    label: "Categories",
+    isHierarchical: false,
+    entryTypes: ["post"],
+  });
+});
+
+describe("SEO — sitemap", () => {
+  async function sitemapText(
+    h: Awaited<ReturnType<typeof createDispatcherHarness>>,
+    path: string,
+  ): Promise<{ res: Response; body: string }> {
+    const res = await h.dispatch(new Request(`https://cms.example${path}`));
+    return { res, body: await res.text() };
+  }
+
+  test("the index lists a sub-sitemap for a type with published content", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await seedPost(h);
+
+    const { res, body } = await sitemapText(h, "/sitemap.xml");
+
+    expect(res.headers.get("content-type")).toContain("application/xml");
+    expect(body).toContain("<sitemapindex");
+    expect(body).toContain("<loc>https://cms.example/sitemap-post-1.xml</loc>");
+  });
+
+  test("a sub-sitemap lists published entry URLs with lastmod, excluding drafts", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "live",
+      title: "Live",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "draft",
+      title: "Draft",
+      content: null,
+      status: "draft",
+      authorId: author.id,
+    });
+
+    const { body } = await sitemapText(h, "/sitemap-post-1.xml");
+
+    expect(body).toContain("<loc>https://cms.example/post/live</loc>");
+    expect(body).toContain("<lastmod>");
+    expect(body).not.toContain("/post/draft");
+  });
+
+  test("a page past the end is an empty url-set", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await seedPost(h);
+
+    const { body } = await sitemapText(h, "/sitemap-post-2.xml");
+
+    expect(body).toContain("<urlset");
+    expect(body).not.toContain("<url>");
+  });
+
+  test("the seo:sitemap:urls filter can drop URLs", async () => {
+    const dropAll = definePlugin("sitemap-test", (ctx) => {
+      ctx.addFilter("seo:sitemap:urls", () => []);
+    });
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, dropAll],
+      theme,
+    });
+    await seedPost(h);
+
+    const { body } = await sitemapText(h, "/sitemap-post-1.xml");
+
+    expect(body).not.toContain("<url>");
+  });
+
+  test("a taxonomy sub-sitemap lists term URLs", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({
+      plugins: [taxonomyPlugin],
+      theme,
+    });
+    await h.factory.term.create({
+      taxonomy: "category",
+      name: "News",
+      slug: "news",
+    });
+
+    const { body } = await sitemapText(h, "/sitemap-category-1.xml");
+
+    expect(body).toContain("<loc>https://cms.example/category/news</loc>");
+  });
+
+  test("a private site suppresses the sitemap", async () => {
+    const theme = defineTheme({ templates: { index: () => null } });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    await h.factory.setting.create({
+      group: "site",
+      key: "public",
+      value: false,
+    });
+    await seedPost(h);
+
+    const { body } = await sitemapText(h, "/sitemap.xml");
+
+    expect(body).toContain("<sitemapindex");
+    expect(body).not.toContain("<sitemap>");
+  });
+});
+
 describe("SEO — robots.txt + public gate", () => {
   test("GET /robots.txt is text/plain and allows crawling by default", async () => {
     const theme = defineTheme({ templates: { index: () => null } });

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -13,6 +13,7 @@ import { matchRoute } from "../route/match.js";
 import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
 import { handleRobotsTxt } from "../seo/robots.js";
+import { handleSitemapIndex, handleSubSitemap } from "../seo/sitemap.js";
 import { rewriteAdminShellLangDir } from "./admin-shell.js";
 import { forbidden, jsonResponse, methodNotAllowed, notFound } from "./http.js";
 import { loadUserForPublicRequest } from "./load-user-for-public-request.js";
@@ -24,6 +25,10 @@ const PLUMIX_PREFIX = "/_plumix/";
 const MCP_PATH = "/_plumix/mcp";
 const API_PREFIX = "/_plumix/api";
 const ROBOTS_PATH = "/robots.txt";
+const SITEMAP_INDEX_PATH = "/sitemap.xml";
+// `/sitemap-<scope>-<page>.xml` — greedy scope so a hyphenated name keeps its
+// hyphens and only the trailing `-<digits>` is the page.
+const SUB_SITEMAP_PATTERN = /^\/sitemap-(.+)-(\d+)\.xml$/;
 
 // MCP is cold-path-exclusive (an agent endpoint, never the public render path).
 // Dynamic-import its handler so the tool registry and the MCP SDK it pulls in
@@ -245,6 +250,13 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   // rewrite rule can't shadow them.
   if (pathname === ROBOTS_PATH) {
     return handleRobotsTxt(ctx);
+  }
+  if (pathname === SITEMAP_INDEX_PATH) {
+    return handleSitemapIndex(ctx);
+  }
+  const subSitemap = SUB_SITEMAP_PATTERN.exec(pathname);
+  if (subSitemap) {
+    return handleSubSitemap(ctx, subSitemap[1] ?? "", Number(subSitemap[2]));
   }
 
   return dispatchPublicRoute(app, ctx, url);

--- a/packages/core/src/seo/sitemap.test.ts
+++ b/packages/core/src/seo/sitemap.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+
+import type { SitemapUrl } from "./sitemap.js";
+import { renderSitemapIndex, renderSubSitemap } from "./sitemap.js";
+
+describe("renderSitemapIndex", () => {
+  test("wraps each loc in a <sitemap> entry", () => {
+    const xml = renderSitemapIndex([
+      "https://cms.example/sitemap-post-1.xml",
+      "https://cms.example/sitemap-category-1.xml",
+    ]);
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain(
+      '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(xml).toContain(
+      "<sitemap><loc>https://cms.example/sitemap-post-1.xml</loc></sitemap>",
+    );
+    expect(xml.match(/<sitemap>/g)).toHaveLength(2);
+  });
+
+  test("empty index is still valid XML", () => {
+    expect(renderSitemapIndex([])).toContain("<sitemapindex");
+    expect(renderSitemapIndex([])).not.toContain("<sitemap>");
+  });
+});
+
+describe("renderSubSitemap", () => {
+  test("emits a <url> per entry, with lastmod when present", () => {
+    const urls: SitemapUrl[] = [
+      {
+        loc: "https://cms.example/post/a",
+        lastmod: "2026-06-14T00:00:00.000Z",
+      },
+      { loc: "https://cms.example/category/news" },
+    ];
+    const xml = renderSubSitemap(urls);
+    expect(xml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(xml).toContain(
+      "<url><loc>https://cms.example/post/a</loc><lastmod>2026-06-14T00:00:00.000Z</lastmod></url>",
+    );
+    expect(xml).toContain(
+      "<url><loc>https://cms.example/category/news</loc></url>",
+    );
+  });
+
+  test("escapes XML metacharacters in loc", () => {
+    const xml = renderSubSitemap([
+      { loc: "https://cms.example/post/a?x=1&y=2" },
+    ]);
+    expect(xml).toContain("a?x=1&amp;y=2");
+    expect(xml).not.toContain("x=1&y=2");
+  });
+});

--- a/packages/core/src/seo/sitemap.ts
+++ b/packages/core/src/seo/sitemap.ts
@@ -1,0 +1,204 @@
+import type { AppContext } from "../context/app.js";
+import { and, eq, sql } from "../db/index.js";
+import { entries } from "../db/schema/entries.js";
+import { terms } from "../db/schema/terms.js";
+import {
+  buildEntryPermalink,
+  buildTermArchiveUrl,
+} from "../route/permalink.js";
+import { loadSiteSettings } from "./site-settings.js";
+
+// Well under the sitemaps.org 50k cap, and small enough to build + hold in
+// Worker memory per request.
+export const SITEMAP_PAGE_SIZE = 1000;
+
+export interface SitemapUrl {
+  readonly loc: string;
+  readonly lastmod?: string;
+}
+
+declare module "../hooks/types.js" {
+  interface FilterRegistry {
+    /**
+     * Adjust a sub-sitemap's URL set before it's serialized — add, drop, or
+     * re-`lastmod` entries. Receives the scope (entry-type or taxonomy name).
+     */
+    "seo:sitemap:urls": (
+      urls: readonly SitemapUrl[],
+      scope: string,
+    ) => readonly SitemapUrl[] | Promise<readonly SitemapUrl[]>;
+  }
+}
+
+const XML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+function xmlEscape(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => XML_ESCAPES[char] ?? char);
+}
+
+export function renderSitemapIndex(locs: readonly string[]): string {
+  const body = locs
+    .map((loc) => `<sitemap><loc>${xmlEscape(loc)}</loc></sitemap>`)
+    .join("");
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${body}</sitemapindex>`
+  );
+}
+
+export function renderSubSitemap(urls: readonly SitemapUrl[]): string {
+  const body = urls
+    .map(({ loc, lastmod }) => {
+      const mod = lastmod ? `<lastmod>${xmlEscape(lastmod)}</lastmod>` : "";
+      return `<url><loc>${xmlEscape(loc)}</loc>${mod}</url>`;
+    })
+    .join("");
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${body}</urlset>`
+  );
+}
+
+function offsetFor(page: number): number {
+  return (page - 1) * SITEMAP_PAGE_SIZE;
+}
+
+async function entryUrls(
+  ctx: AppContext,
+  type: string,
+  page: number,
+): Promise<SitemapUrl[]> {
+  const rows = await ctx.db
+    .select({
+      slug: entries.slug,
+      type: entries.type,
+      parentId: entries.parentId,
+      updatedAt: entries.updatedAt,
+    })
+    .from(entries)
+    .where(and(eq(entries.type, type), eq(entries.status, "published")))
+    .orderBy(entries.id)
+    .limit(SITEMAP_PAGE_SIZE)
+    .offset(offsetFor(page));
+
+  const urls: SitemapUrl[] = [];
+  for (const row of rows) {
+    const path = await buildEntryPermalink(ctx, row);
+    if (path === null) continue;
+    urls.push({
+      loc: `${ctx.origin}${path}`,
+      lastmod: row.updatedAt.toISOString(),
+    });
+  }
+  return urls;
+}
+
+async function termUrls(
+  ctx: AppContext,
+  taxonomy: string,
+  page: number,
+): Promise<SitemapUrl[]> {
+  const rows = await ctx.db
+    .select({
+      slug: terms.slug,
+      taxonomy: terms.taxonomy,
+      parentId: terms.parentId,
+    })
+    .from(terms)
+    .where(eq(terms.taxonomy, taxonomy))
+    .orderBy(terms.id)
+    .limit(SITEMAP_PAGE_SIZE)
+    .offset(offsetFor(page));
+
+  const urls: SitemapUrl[] = [];
+  for (const row of rows) {
+    const path = await buildTermArchiveUrl(ctx, row);
+    if (path !== null) urls.push({ loc: `${ctx.origin}${path}` });
+  }
+  return urls;
+}
+
+/**
+ * The published, public-type URLs for one sub-sitemap scope + page, passed
+ * through the `seo:sitemap:urls` filter. Returns null for an unknown / non-public
+ * scope so the caller can 404.
+ */
+export async function collectSitemapUrls(
+  ctx: AppContext,
+  scope: string,
+  page: number,
+): Promise<readonly SitemapUrl[] | null> {
+  const entryType = ctx.plugins.entryTypes.get(scope);
+  let urls: SitemapUrl[] | null = null;
+  if (entryType && entryType.isPublic !== false) {
+    urls = await entryUrls(ctx, scope, page);
+  } else {
+    const taxonomy = ctx.plugins.termTaxonomies.get(scope);
+    if (taxonomy && taxonomy.isPublic !== false) {
+      urls = await termUrls(ctx, scope, page);
+    }
+  }
+  if (urls === null) return null;
+  return ctx.hooks.applyFilter("seo:sitemap:urls", urls, scope);
+}
+
+async function sitemapIndexLocs(ctx: AppContext): Promise<string[]> {
+  const locs: string[] = [];
+  const pushScope = (name: string, total: number): void => {
+    const pages = Math.max(1, Math.ceil(total / SITEMAP_PAGE_SIZE));
+    for (let page = 1; total > 0 && page <= pages; page++) {
+      locs.push(`${ctx.origin}/sitemap-${name}-${String(page)}.xml`);
+    }
+  };
+
+  for (const type of ctx.plugins.entryTypes.values()) {
+    if (type.isPublic === false) continue;
+    const [row] = await ctx.db
+      .select({ n: sql<number>`count(*)` })
+      .from(entries)
+      .where(and(eq(entries.type, type.name), eq(entries.status, "published")));
+    pushScope(type.name, Number(row?.n ?? 0));
+  }
+  for (const taxonomy of ctx.plugins.termTaxonomies.values()) {
+    if (taxonomy.isPublic === false) continue;
+    const [row] = await ctx.db
+      .select({ n: sql<number>`count(*)` })
+      .from(terms)
+      .where(eq(terms.taxonomy, taxonomy.name));
+    pushScope(taxonomy.name, Number(row?.n ?? 0));
+  }
+  return locs;
+}
+
+function xmlResponse(body: string): Response {
+  return new Response(body, {
+    headers: { "content-type": "application/xml; charset=utf-8" },
+  });
+}
+
+async function isPrivate(ctx: AppContext): Promise<boolean> {
+  return (await loadSiteSettings(ctx)).public === false;
+}
+
+export async function handleSitemapIndex(ctx: AppContext): Promise<Response> {
+  // A private site is held out of search: emit an empty index.
+  const locs = (await isPrivate(ctx)) ? [] : await sitemapIndexLocs(ctx);
+  return xmlResponse(renderSitemapIndex(locs));
+}
+
+export async function handleSubSitemap(
+  ctx: AppContext,
+  scope: string,
+  page: number,
+): Promise<Response> {
+  if (await isPrivate(ctx)) return xmlResponse(renderSubSitemap([]));
+  const urls = await collectSitemapUrls(ctx, scope, page);
+  if (urls === null) return xmlResponse(renderSubSitemap([]));
+  return xmlResponse(renderSubSitemap(urls));
+}


### PR DESCRIPTION
Fourth slice of core SEO out-of-the-box (PRD #986).

**Routes** (served in the dispatcher ahead of the public route map, so a plugin rewrite can't shadow them):
- `GET /sitemap.xml` — an index listing per-entry-type and per-taxonomy sub-sitemaps.
- `GET /sitemap-<scope>-<n>.xml` — paginated url-sets, built per request from D1 (caching is the next slice).

**Content**

`collectSitemapUrls` returns published, public-type entry URLs (and public taxonomy term URLs) at `SITEMAP_PAGE_SIZE` (1000) per file — absolute + slash-less via the permalink builders, `lastmod` from `updatedAt`, through the `seo:sitemap:urls` value filter. Only public types/taxonomies are listed; `buildEntryPermalink` returning null for non-public types is a backstop. A private site (`site.public` off) suppresses both the index and the sub-sitemaps.

**Notes for reviewers**
- Pure serializers (`renderSitemapIndex`/`renderSubSitemap`) are unit-tested; routing/filter/private-gate via dispatcher-harness integration.
- Known follow-up for the caching slice: hierarchical types resolve one ancestor CTE per row when building permalinks (flat types are O(1)); bounded by page size and amortized once the response is cached.
- `page=0`/negative URLs are benign (SQLite clamps a negative OFFSET to 0 with the LIMIT present; no crawler-reachable path generates them).

Closes #990