### PR TITLE
feat(core): cache sitemap sub-files via the Cache API with versioned keys

### DIFF
--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -47,6 +47,7 @@ import { compileRouteMap } from "../route/compile.js";
 import { CORE_RPC_NAMESPACES } from "../rpc/namespaces.js";
 import { registerCoreLookupAdapters } from "../rpc/procedures/lookup-adapters.js";
 import { registerCoreSearchHandlers } from "../search/register-core-handlers.js";
+import { registerCoreSitemapInvalidator } from "../seo/register-sitemap-invalidator.js";
 import { registerCoreSettings } from "../settings-core.js";
 import { registerCoreTemplateDeps } from "../template-deps-core.js";
 import { isTemplate } from "../template.js";
@@ -209,6 +210,7 @@ export async function buildApp(
   const hooks = new HookRegistry();
   registerCoreAdminBarContributors(hooks);
   registerCoreSearchHandlers(hooks);
+  registerCoreSitemapInvalidator(hooks);
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
   registerCoreTemplateDeps(seededRegistry);

--- a/packages/core/src/seo/register-sitemap-invalidator.test.ts
+++ b/packages/core/src/seo/register-sitemap-invalidator.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+
+import type { Entry } from "../db/schema/entries.js";
+import type { Term } from "../db/schema/terms.js";
+import { requestStore } from "../context/stores.js";
+import { createRpcHarness } from "../test/rpc.js";
+import { registerCoreSitemapInvalidator } from "./register-sitemap-invalidator.js";
+import { readSitemapVersion } from "./sitemap-cache.js";
+
+const ENTRY_EVENTS = [
+  "entry:published",
+  "entry:updated",
+  "entry:trashed",
+  "entry:restored",
+  "entry:deleted",
+] as const;
+
+const TERM_EVENTS = [
+  "term:created",
+  "term:updated",
+  "term:deleted",
+  "term:meta_changed",
+] as const;
+
+describe("registerCoreSitemapInvalidator", () => {
+  // Subscribers ignore the payload (a bump retires every key regardless), so a
+  // stub entity stands in for the real lifecycle argument.
+  const entry = { id: 1, type: "post" } as unknown as Entry;
+  const term = { id: 1, taxonomy: "category" } as unknown as Term;
+
+  test.each(ENTRY_EVENTS)("%s bumps the sitemap version", async (event) => {
+    const h = await createRpcHarness();
+    registerCoreSitemapInvalidator(h.hooks);
+
+    await requestStore.run(h.context, () =>
+      h.hooks.doAction(event as never, entry as never, entry as never),
+    );
+
+    expect(await readSitemapVersion(h.context)).toBe(1);
+  });
+
+  test.each(TERM_EVENTS)("%s bumps the sitemap version", async (event) => {
+    const h = await createRpcHarness();
+    registerCoreSitemapInvalidator(h.hooks);
+
+    await requestStore.run(h.context, () =>
+      h.hooks.doAction(
+        event as never,
+        term as never,
+        { set: {}, removed: [] } as never,
+      ),
+    );
+
+    expect(await readSitemapVersion(h.context)).toBe(1);
+  });
+
+  test("settings:group_changed bumps only for the site group", async () => {
+    const h = await createRpcHarness();
+    registerCoreSitemapInvalidator(h.hooks);
+
+    await requestStore.run(h.context, async () => {
+      // An unrelated group must not retire the sitemap cache.
+      await h.hooks.doAction("settings:group_changed", {
+        group: "mail",
+        set: { from: "x@y.z" },
+        removed: [],
+      });
+      expect(await readSitemapVersion(h.context)).toBe(0);
+
+      await h.hooks.doAction("settings:group_changed", {
+        group: "site",
+        set: { public: false },
+        removed: [],
+      });
+      expect(await readSitemapVersion(h.context)).toBe(1);
+    });
+  });
+
+  test("a fired action outside a request context is a no-op (no throw)", async () => {
+    const h = await createRpcHarness();
+    registerCoreSitemapInvalidator(h.hooks);
+
+    await h.hooks.doAction("entry:published", entry);
+
+    expect(await readSitemapVersion(h.context)).toBe(0);
+  });
+});

--- a/packages/core/src/seo/register-sitemap-invalidator.ts
+++ b/packages/core/src/seo/register-sitemap-invalidator.ts
@@ -1,0 +1,44 @@
+import type { HookRegistry } from "../hooks/registry.js";
+import { tryGetContext } from "../context/stores.js";
+import { bumpSitemapVersion } from "./sitemap-cache.js";
+
+// Lifecycle actions whose payloads can change which URLs belong in a sitemap.
+// Firing any of them retires every cached sub-sitemap by bumping the version.
+const ENTITY_ACTIONS = [
+  "entry:published",
+  "entry:updated",
+  "entry:trashed",
+  "entry:restored",
+  "entry:deleted",
+  "term:created",
+  "term:updated",
+  "term:deleted",
+  "term:meta_changed",
+] as const;
+
+// Subscribers get no context argument, so they resolve the per-request
+// `AppContext` from the request store; a fire outside a request frame is a
+// silent no-op.
+function bump(): Promise<void> | void {
+  const ctx = tryGetContext();
+  if (!ctx) return;
+  return bumpSitemapVersion(ctx);
+}
+
+/**
+ * Register core's sitemap cache-busting subscribers. Called at app boot
+ * alongside the other core hook registrations.
+ */
+export function registerCoreSitemapInvalidator(hooks: HookRegistry): void {
+  for (const action of ENTITY_ACTIONS) {
+    hooks.addAction(action as never, bump);
+  }
+  // A site-privacy toggle changes which URLs (if any) the sitemap may expose;
+  // the gate lives inside the cached generator, so the cache must be retired
+  // when the `site` group changes for it to take effect. Other settings groups
+  // don't affect sitemap output — skip them to avoid needless invalidation.
+  hooks.addAction("settings:group_changed", (changes) => {
+    if (changes.group !== "site") return;
+    return bump();
+  });
+}

--- a/packages/core/src/seo/sitemap-cache.test.ts
+++ b/packages/core/src/seo/sitemap-cache.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { Entry } from "../db/schema/entries.js";
+import { requestStore } from "../context/stores.js";
+import { eq } from "../db/index.js";
+import { entries } from "../db/schema/entries.js";
+import { createRpcHarness } from "../test/rpc.js";
+import { registerCoreSitemapInvalidator } from "./register-sitemap-invalidator.js";
+import {
+  bumpSitemapVersion,
+  cachedSubSitemap,
+  readSitemapVersion,
+} from "./sitemap-cache.js";
+import { handleSubSitemap, renderSubSitemap } from "./sitemap.js";
+
+// In-memory stand-in for the Cloudflare Cache API (`caches.default`). It
+// ignores `Cache-Control` TTLs — the tests drive invalidation through the
+// version bump (which deletes the pointer), never through clock expiry.
+class FakeCache {
+  readonly store = new Map<string, Response>();
+  putCount = 0;
+  private key(req: RequestInfo | URL): string {
+    return typeof req === "string" ? req : (req as Request).url;
+  }
+  match(req: RequestInfo | URL): Promise<Response | undefined> {
+    const hit = this.store.get(this.key(req));
+    return Promise.resolve(hit?.clone());
+  }
+  put(req: RequestInfo | URL, res: Response): Promise<void> {
+    this.putCount += 1;
+    this.store.set(this.key(req), res.clone());
+    return Promise.resolve();
+  }
+  delete(req: RequestInfo | URL): Promise<boolean> {
+    return Promise.resolve(this.store.delete(this.key(req)));
+  }
+}
+
+function stubCaches(): FakeCache {
+  const cache = new FakeCache();
+  vi.stubGlobal("caches", { default: cache });
+  return cache;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("readSitemapVersion / bumpSitemapVersion", () => {
+  test("version starts at 0 and bumps monotonically in D1", async () => {
+    const h = await createRpcHarness();
+    expect(await readSitemapVersion(h.context)).toBe(0);
+
+    await bumpSitemapVersion(h.context);
+    expect(await readSitemapVersion(h.context)).toBe(1);
+
+    await bumpSitemapVersion(h.context);
+    expect(await readSitemapVersion(h.context)).toBe(2);
+  });
+});
+
+describe("cachedSubSitemap", () => {
+  test("regenerates on every request when no Cache API is present", async () => {
+    const h = await createRpcHarness();
+    const generate = vi.fn(() =>
+      Promise.resolve(new Response(renderSubSitemap([]))),
+    );
+
+    await cachedSubSitemap(h.context, "post", 1, generate);
+    await cachedSubSitemap(h.context, "post", 1, generate);
+
+    expect(generate).toHaveBeenCalledTimes(2);
+  });
+
+  test("serves repeat requests from the cache (generates once)", async () => {
+    const h = await createRpcHarness();
+    stubCaches();
+    let calls = 0;
+    const generate = (): Promise<Response> => {
+      calls += 1;
+      return Promise.resolve(
+        new Response(renderSubSitemap([{ loc: `https://x/post/n${calls}` }])),
+      );
+    };
+
+    const first = await (
+      await cachedSubSitemap(h.context, "post", 1, generate)
+    ).text();
+    const second = await (
+      await cachedSubSitemap(h.context, "post", 1, generate)
+    ).text();
+
+    expect(calls).toBe(1);
+    expect(first).toContain("https://x/post/n1");
+    expect(second).toBe(first);
+  });
+
+  test("a cache hit issues no D1 query", async () => {
+    const h = await createRpcHarness();
+    stubCaches();
+    const generate = (): Promise<Response> =>
+      Promise.resolve(new Response(renderSubSitemap([])));
+
+    // Warm the cache (and the version pointer) on the first request.
+    await cachedSubSitemap(h.context, "post", 1, generate);
+
+    const select = vi.spyOn(h.context.db, "select");
+    await cachedSubSitemap(h.context, "post", 1, generate);
+
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  test("a version bump makes the next request regenerate", async () => {
+    const h = await createRpcHarness();
+    const cache = stubCaches();
+    let calls = 0;
+    const generate = (): Promise<Response> => {
+      calls += 1;
+      return Promise.resolve(
+        new Response(renderSubSitemap([{ loc: `https://x/post/n${calls}` }])),
+      );
+    };
+
+    const before = await (
+      await cachedSubSitemap(h.context, "post", 1, generate)
+    ).text();
+
+    await bumpSitemapVersion(h.context);
+
+    const after = await (
+      await cachedSubSitemap(h.context, "post", 1, generate)
+    ).text();
+
+    expect(calls).toBe(2);
+    expect(before).toContain("n1");
+    expect(after).toContain("n2");
+    // The stale v0 entry lingers (no per-key purge) — it's just unreachable.
+    expect(cache.store.size).toBeGreaterThan(1);
+  });
+});
+
+describe("handleSubSitemap", () => {
+  test("serves repeat requests from the cache without re-querying", async () => {
+    const h = await createRpcHarness();
+    const cache = stubCaches();
+
+    await handleSubSitemap(h.context, "post", 1);
+    const putsAfterMiss = cache.putCount;
+    await handleSubSitemap(h.context, "post", 1);
+
+    expect(putsAfterMiss).toBeGreaterThan(0);
+    expect(cache.putCount).toBe(putsAfterMiss);
+  });
+
+  test("publishing an entry retires the cache so the next sitemap reflects it", async () => {
+    const h = await createRpcHarness();
+    registerCoreSitemapInvalidator(h.hooks);
+    stubCaches();
+    const author = await h.factory.user.create();
+    const generate = async (): Promise<Response> => {
+      const rows = await h.context.db
+        .select({ slug: entries.slug })
+        .from(entries)
+        .where(eq(entries.status, "published"));
+      return new Response(
+        renderSubSitemap(
+          rows.map((r) => ({ loc: `https://x/post/${r.slug}` })),
+        ),
+      );
+    };
+
+    await h.factory.published.create({ authorId: author.id, slug: "first" });
+    const before = await (
+      await cachedSubSitemap(h.context, "post", 1, generate)
+    ).text();
+    expect(before).toContain("/post/first");
+    expect(before).not.toContain("/post/second");
+
+    await h.factory.published.create({ authorId: author.id, slug: "second" });
+    await requestStore.run(h.context, () =>
+      h.hooks.doAction("entry:published", { id: 2 } as unknown as Entry),
+    );
+
+    const after = await (
+      await cachedSubSitemap(h.context, "post", 1, generate)
+    ).text();
+    expect(after).toContain("/post/second");
+  });
+});

--- a/packages/core/src/seo/sitemap-cache.ts
+++ b/packages/core/src/seo/sitemap-cache.ts
@@ -1,0 +1,124 @@
+import { sql } from "drizzle-orm";
+
+import type { AppContext } from "../context/app.js";
+import { and, eq } from "../db/index.js";
+import { settings } from "../db/schema/settings.js";
+
+// The version token lives in a `settings` row — D1 is strongly consistent
+// and already on every `ctx`, so a bump is visible to every isolate on its
+// next read. The token is embedded in the Cache API key, so bumping it makes
+// every prior sub-sitemap unreachable without a per-key purge (which the
+// Cache API doesn't offer).
+const VERSION_GROUP = "seo";
+const VERSION_KEY = "sitemap_version";
+
+// Synthetic, never-routed cache keys. The version pointer carries a short TTL
+// so each colo re-reads D1 at most once per window (a bump also deletes it for
+// immediate convergence in the writing colo); sub-sitemap bodies are keyed by
+// version, so a bump retires them logically (an old-version body lingers,
+// unreachable, until the platform evicts it).
+const CACHE_ORIGIN = "https://sitemap.plumix.internal";
+const VERSION_POINTER = `${CACHE_ORIGIN}/version`;
+const VERSION_POINTER_TTL_SECONDS = 60;
+
+// Minimal shape of the Cloudflare Cache API (`caches.default`); typed locally
+// so core stays free of `@cloudflare/workers-types`.
+interface SitemapCache {
+  match(request: string): Promise<Response | undefined>;
+  put(request: string, response: Response): Promise<void>;
+  delete(request: string): Promise<boolean>;
+}
+
+function cacheStore(): SitemapCache | null {
+  const store = (globalThis as { caches?: { default?: SitemapCache } }).caches;
+  return store?.default ?? null;
+}
+
+function subSitemapKey(scope: string, page: number, version: number): string {
+  return `${CACHE_ORIGIN}/sitemap-${scope}-${String(page)}.xml?v=${String(version)}`;
+}
+
+/**
+ * Read the current sitemap version straight from D1. The source of truth;
+ * `currentSitemapVersion` layers a Cache-API pointer over this to keep the
+ * read off D1 on the hot path.
+ */
+export async function readSitemapVersion(ctx: AppContext): Promise<number> {
+  const [row] = await ctx.db
+    .select({ value: settings.value })
+    .from(settings)
+    .where(
+      and(eq(settings.group, VERSION_GROUP), eq(settings.key, VERSION_KEY)),
+    );
+  return typeof row?.value === "number" ? row.value : 0;
+}
+
+/**
+ * Increment the version so every cached sub-sitemap key goes stale. Fired by
+ * the lifecycle-action subscriber on entry/term mutations. The increment is a
+ * single SQL statement, so concurrent bumps can't lose an increment.
+ */
+export async function bumpSitemapVersion(ctx: AppContext): Promise<void> {
+  await ctx.db
+    .insert(settings)
+    .values({ group: VERSION_GROUP, key: VERSION_KEY, value: 1 })
+    .onConflictDoUpdate({
+      target: [settings.group, settings.key],
+      set: { value: sql`${settings.value} + 1` },
+    });
+  // Drop this colo's pointer so it re-reads the bumped version immediately;
+  // other colos converge when their pointer TTL lapses.
+  await cacheStore()?.delete(VERSION_POINTER);
+}
+
+/**
+ * The version to key cache entries by. Reads a Cache-API pointer first so the
+ * hot path stays off D1; falls back to D1 (and re-seeds the pointer) on a
+ * pointer miss, or straight to D1 when no Cache API is available.
+ */
+async function currentSitemapVersion(ctx: AppContext): Promise<number> {
+  const store = cacheStore();
+  if (!store) return readSitemapVersion(ctx);
+
+  const pointer = await store.match(VERSION_POINTER);
+  if (pointer) {
+    const parsed = Number(await pointer.text());
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  const version = await readSitemapVersion(ctx);
+  await store.put(
+    VERSION_POINTER,
+    new Response(String(version), {
+      headers: {
+        "cache-control": `max-age=${String(VERSION_POINTER_TTL_SECONDS)}`,
+      },
+    }),
+  );
+  return version;
+}
+
+/**
+ * Serve a sub-sitemap from the Cache API, keyed by `scope+page+version`, only
+ * regenerating on a miss. Falls back to per-request generation when no Cache
+ * API is present (tests, non-Workers runtimes).
+ */
+export async function cachedSubSitemap(
+  ctx: AppContext,
+  scope: string,
+  page: number,
+  generate: () => Promise<Response>,
+): Promise<Response> {
+  const store = cacheStore();
+  if (!store) return generate();
+
+  const version = await currentSitemapVersion(ctx);
+  const key = subSitemapKey(scope, page, version);
+
+  const hit = await store.match(key);
+  if (hit) return hit;
+
+  const fresh = await generate();
+  await store.put(key, fresh.clone());
+  return fresh;
+}

--- a/packages/core/src/seo/sitemap.ts
+++ b/packages/core/src/seo/sitemap.ts
@@ -7,6 +7,7 @@ import {
   buildTermArchiveUrl,
 } from "../route/permalink.js";
 import { loadSiteSettings } from "./site-settings.js";
+import { cachedSubSitemap } from "./sitemap-cache.js";
 
 // Well under the sitemaps.org 50k cap, and small enough to build + hold in
 // Worker memory per request.
@@ -127,7 +128,7 @@ async function termUrls(
 /**
  * The published, public-type URLs for one sub-sitemap scope + page, passed
  * through the `seo:sitemap:urls` filter. Returns null for an unknown / non-public
- * scope so the caller can 404.
+ * scope, which the caller renders as an empty `<urlset>`.
  */
 export async function collectSitemapUrls(
   ctx: AppContext,
@@ -192,13 +193,17 @@ export async function handleSitemapIndex(ctx: AppContext): Promise<Response> {
   return xmlResponse(renderSitemapIndex(locs));
 }
 
-export async function handleSubSitemap(
+export function handleSubSitemap(
   ctx: AppContext,
   scope: string,
   page: number,
 ): Promise<Response> {
-  if (await isPrivate(ctx)) return xmlResponse(renderSubSitemap([]));
-  const urls = await collectSitemapUrls(ctx, scope, page);
-  if (urls === null) return xmlResponse(renderSubSitemap([]));
-  return xmlResponse(renderSubSitemap(urls));
+  // The privacy gate and the URL scan both live inside the generator so a
+  // cache hit touches D1 zero times. A `settings:group_changed` bump retires
+  // the cache when the site flips private, keeping the gate honest.
+  return cachedSubSitemap(ctx, scope, page, async () => {
+    if (await isPrivate(ctx)) return xmlResponse(renderSubSitemap([]));
+    const urls = await collectSitemapUrls(ctx, scope, page);
+    return xmlResponse(renderSubSitemap(urls ?? []));
+  });
 }


### PR DESCRIPTION
Generated sub-sitemaps are now served from the Cloudflare Cache API, keyed by `scope+page+version`, so a repeat request never re-scans D1. The Cache API has no tag/wildcard purge, so invalidation rides a version token bumped by a boot-registered subscriber on entry/term lifecycle actions.

**Version-token storage decision (the slice's HITL point)**

The token lives in a D1 `settings` row (`group: "seo"`, `key: "sitemap_version"`), not KV. D1 is strongly consistent and already on every request context; the `kv` config slot is a never-connected descriptor, and KV writes lag up to ~60s globally — so KV would add infra for no consistency gain. To keep the requirement *"no per-request D1 query on a cache hit"*, the current version is mirrored in a short-TTL **Cache-API pointer** read before D1; a bump deletes the pointer in the writing colo, and other colos converge within the pointer TTL (60s). With no Cache API present (tests, non-Workers) the handler falls back to per-request generation.

**Convergence SLA**

A bump is immediate in the colo that handled the mutation; other colos reflect it within `VERSION_POINTER_TTL_SECONDS` (60s). This is well inside crawler re-fetch intervals.

**Privacy gate moved inside the generator**

`handleSubSitemap` now evaluates the private-site check inside the cached generator (so a cache hit reads zero D1). Because a privacy toggle isn't an entry/term mutation, the invalidator also bumps on a `settings:group_changed` for the `site` group — and only that group, to avoid retiring the cache on unrelated settings writes.

Closes #991