### PR TITLE
feat(core): serve RSS2 + Atom feeds with discovery links

### DIFF
--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -12,6 +12,7 @@ import { resolveLocale } from "../i18n/resolve-locale.js";
 import { matchRoute } from "../route/match.js";
 import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
+import { handleFeed, isPublicEntryType } from "../seo/feed.js";
 import { handleRobotsTxt } from "../seo/robots.js";
 import { handleSitemapIndex, handleSubSitemap } from "../seo/sitemap.js";
 import { rewriteAdminShellLangDir } from "./admin-shell.js";
@@ -29,6 +30,10 @@ const SITEMAP_INDEX_PATH = "/sitemap.xml";
 // `/sitemap-<scope>-<page>.xml` — greedy scope so a hyphenated name keeps its
 // hyphens and only the trailing `-<digits>` is the page.
 const SUB_SITEMAP_PATTERN = /^\/sitemap-(.+)-(\d+)\.xml$/;
+// `/feed`, `/feed/atom`, `/<type>/feed`, `/<type>/feed/atom`. The optional
+// leading segment is the entry-type scope; `/feed*` reserves these paths the
+// way WordPress does, so a page slugged "feed" can't shadow them.
+const FEED_PATTERN = /^\/(?:([^/]+)\/)?feed(\/atom)?$/;
 
 // MCP is cold-path-exclusive (an agent endpoint, never the public render path).
 // Dynamic-import its handler so the tool registry and the MCP SDK it pulls in
@@ -257,6 +262,15 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   const subSitemap = SUB_SITEMAP_PATTERN.exec(pathname);
   if (subSitemap) {
     return handleSubSitemap(ctx, subSitemap[1] ?? "", Number(subSitemap[2]));
+  }
+  const feed = FEED_PATTERN.exec(pathname);
+  if (feed) {
+    // A scoped `/<x>/feed` is a feed only when `<x>` is a public entry type;
+    // otherwise it's a real path (e.g. a page slugged "feed") — fall through.
+    const scope = feed[1] ?? null;
+    if (scope === null || isPublicEntryType(ctx, scope)) {
+      return handleFeed(ctx, scope, feed[2] ? "atom" : "rss2");
+    }
   }
 
   return dispatchPublicRoute(app, ctx, url);

--- a/packages/core/src/seo/feed-routes.test.ts
+++ b/packages/core/src/seo/feed-routes.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+
+import { definePlugin } from "../plugin/define.js";
+import { createDispatcherHarness } from "../test/dispatcher.js";
+
+const blogPlugin = definePlugin("blog", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+});
+
+async function seedPost(
+  h: Awaited<ReturnType<typeof createDispatcherHarness>>,
+  slug: string,
+  title: string,
+  status: "published" | "draft" = "published",
+): Promise<void> {
+  const author = await h.seedUser("admin");
+  await h.factory.entry.create({
+    type: "post",
+    slug,
+    title,
+    content: null,
+    status,
+    authorId: author.id,
+  });
+}
+
+describe("feed routes", () => {
+  test("GET /feed returns RSS2 for recent published posts", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    await seedPost(h, "hello", "Hello World");
+
+    const res = await h.fetch("/feed");
+    res.assertStatus(200);
+    expect(res.headers.get("content-type")).toContain("application/rss+xml");
+    const body = await res.text();
+    expect(body).toContain('<rss version="2.0"');
+    expect(body).toContain("<title>Hello World</title>");
+    expect(body).toContain("<link>https://cms.example/post/hello</link>");
+  });
+
+  test("GET /feed/atom returns an Atom feed", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    await seedPost(h, "hello", "Hello World");
+
+    const res = await h.fetch("/feed/atom");
+    res.assertStatus(200);
+    expect(res.headers.get("content-type")).toContain("application/atom+xml");
+    const body = await res.text();
+    expect(body).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(body).toContain("<id>https://cms.example/feed/atom</id>");
+    expect(body).toContain("<title>Hello World</title>");
+  });
+
+  test("GET /<type>/feed returns the type-scoped feed", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    await seedPost(h, "hello", "Hello World");
+
+    const rss = await h.fetch("/post/feed");
+    rss.assertStatus(200);
+    expect(await rss.text()).toContain(
+      '<atom:link href="https://cms.example/post/feed" rel="self"',
+    );
+
+    const atom = await h.fetch("/post/feed/atom");
+    atom.assertStatus(200);
+    expect(await atom.text()).toContain(
+      "<id>https://cms.example/post/feed/atom</id>",
+    );
+  });
+
+  test("only published entries appear in the feed", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    await seedPost(h, "live", "Live Post", "published");
+    await seedPost(h, "wip", "Draft Post", "draft");
+
+    const body = await (await h.fetch("/feed")).text();
+    expect(body).toContain("Live Post");
+    expect(body).not.toContain("Draft Post");
+  });
+
+  test("an unknown entry type 404s", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    const res = await h.fetch("/widget/feed");
+    res.assertStatus(404);
+  });
+
+  test("the seo:feed:items filter can adjust the item list", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    await seedPost(h, "hello", "Hello World");
+    h.spyFilter("seo:feed:items").override(() => []);
+
+    const body = await (await h.fetch("/feed")).text();
+    expect(body).not.toContain("<item>");
+  });
+
+  test("feed discovery <link rel=alternate> tags appear in the head", async () => {
+    const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+    await seedPost(h, "hello", "Hello World");
+
+    const body = await (await h.fetch("/")).text();
+    expect(body).toContain(
+      '<link rel="alternate" type="application/rss+xml" href="https://cms.example/feed"',
+    );
+    expect(body).toContain(
+      '<link rel="alternate" type="application/atom+xml" href="https://cms.example/feed/atom"',
+    );
+  });
+});

--- a/packages/core/src/seo/feed.test.ts
+++ b/packages/core/src/seo/feed.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import type { DocumentManifest, TemplateData } from "../theme.js";
+import type { FeedChannel, FeedItem } from "./feed.js";
+import { applyFeedDiscovery, renderAtom, renderRss2 } from "./feed.js";
+
+const CHANNEL: FeedChannel = {
+  title: "Acme Blog",
+  link: "https://cms.example",
+  feedUrl: "https://cms.example/feed",
+  description: "News & notes",
+  updated: "2026-06-14T10:00:00.000Z",
+};
+
+const ITEMS: readonly FeedItem[] = [
+  {
+    title: "Hello & welcome",
+    link: "https://cms.example/post/hello",
+    id: "https://cms.example/post/hello",
+    updated: "2026-06-14T10:00:00.000Z",
+    published: "2026-06-14T09:00:00.000Z",
+    summary: "First <post>",
+    author: "Ada",
+  },
+  {
+    title: "Second",
+    link: "https://cms.example/post/second",
+    id: "https://cms.example/post/second",
+    updated: "2026-06-13T10:00:00.000Z",
+  },
+];
+
+describe("renderRss2", () => {
+  test("emits a valid RSS2 channel with one <item> per entry", () => {
+    const xml = renderRss2(CHANNEL, ITEMS);
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<rss version="2.0"');
+    expect(xml).toContain("<title>Acme Blog</title>");
+    expect(xml).toContain("<link>https://cms.example</link>");
+    expect(xml).toContain(
+      '<atom:link href="https://cms.example/feed" rel="self" type="application/rss+xml"></atom:link>',
+    );
+    expect(xml.match(/<item>/g)).toHaveLength(2);
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://cms.example/post/hello</guid>',
+    );
+    // RSS2 dates are RFC-822.
+    expect(xml).toContain("<pubDate>Sun, 14 Jun 2026 09:00:00 GMT</pubDate>");
+  });
+
+  test("escapes XML metacharacters in titles and summaries", () => {
+    const xml = renderRss2(CHANNEL, ITEMS);
+    expect(xml).toContain("<title>Hello &amp; welcome</title>");
+    expect(xml).toContain("<description>First &lt;post&gt;</description>");
+    expect(xml).not.toContain("<post>");
+  });
+
+  test("emits dc:creator only when the item has an author", () => {
+    const xml = renderRss2(CHANNEL, ITEMS);
+    expect(xml).toContain("<dc:creator>Ada</dc:creator>");
+    expect(xml.match(/<dc:creator>/g)).toHaveLength(1);
+  });
+});
+
+describe("renderAtom", () => {
+  test("emits a valid Atom feed with one <entry> per item", () => {
+    const xml = renderAtom(CHANNEL, ITEMS);
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(xml).toContain("<id>https://cms.example/feed</id>");
+    expect(xml).toContain(
+      '<link href="https://cms.example/feed" rel="self"></link>',
+    );
+    expect(xml).toContain("<updated>2026-06-14T10:00:00.000Z</updated>");
+    expect(xml.match(/<entry>/g)).toHaveLength(2);
+    expect(xml).toContain(
+      '<link href="https://cms.example/post/hello"></link>',
+    );
+    expect(xml).toContain("<author><name>Ada</name></author>");
+  });
+
+  test("escapes XML metacharacters", () => {
+    const xml = renderAtom(CHANNEL, ITEMS);
+    expect(xml).toContain("<title>Hello &amp; welcome</title>");
+    expect(xml).not.toContain("<post>");
+  });
+});
+
+describe("applyFeedDiscovery", () => {
+  const ctx = {
+    origin: "https://cms.example",
+    plugins: {
+      entryTypes: new Map([["post", { name: "post", isPublic: true }]]),
+    },
+  } as unknown as AppContext;
+  const empty: DocumentManifest = {};
+  const alternates = (m: DocumentManifest): readonly string[] =>
+    (m.link ?? [])
+      .filter((l) => l.rel === "alternate")
+      .map((l) => `${String(l.type)} ${String(l.href)}`);
+
+  test("front-page data advertises the site feed (RSS + Atom)", () => {
+    const data = {
+      entries: [],
+      pagination: { page: 1, perPage: 10, total: 0, pageCount: 0 },
+    } as unknown as TemplateData;
+    expect(
+      alternates(
+        applyFeedDiscovery(empty, data, ctx, { siteIsPrivate: false }),
+      ),
+    ).toEqual([
+      "application/rss+xml https://cms.example/feed",
+      "application/atom+xml https://cms.example/feed/atom",
+    ]);
+  });
+
+  test("archive data advertises the type feed", () => {
+    const data = {
+      contentType: "post",
+      entries: [],
+      pagination: { page: 1, perPage: 10, total: 0, pageCount: 0 },
+    } as unknown as TemplateData;
+    expect(
+      alternates(
+        applyFeedDiscovery(empty, data, ctx, { siteIsPrivate: false }),
+      ),
+    ).toEqual([
+      "application/rss+xml https://cms.example/post/feed",
+      "application/atom+xml https://cms.example/post/feed/atom",
+    ]);
+  });
+
+  test("single-entry data advertises the site feed (not its type feed)", () => {
+    const data = { entry: { type: "post" } } as unknown as TemplateData;
+    expect(
+      alternates(
+        applyFeedDiscovery(empty, data, ctx, { siteIsPrivate: false }),
+      ),
+    ).toEqual([
+      "application/rss+xml https://cms.example/feed",
+      "application/atom+xml https://cms.example/feed/atom",
+    ]);
+  });
+
+  test("search and private pages advertise nothing", () => {
+    const search = {
+      query: "x",
+      entries: [],
+      pagination: {},
+    } as unknown as TemplateData;
+    expect(
+      applyFeedDiscovery(empty, search, ctx, { siteIsPrivate: false }).link,
+    ).toBeUndefined();
+
+    const front = { entries: [], pagination: {} } as unknown as TemplateData;
+    expect(
+      applyFeedDiscovery(empty, front, ctx, { siteIsPrivate: true }).link,
+    ).toBeUndefined();
+  });
+
+  test("does not duplicate an alternate the template already set", () => {
+    const front = { entries: [], pagination: {} } as unknown as TemplateData;
+    const seeded: DocumentManifest = {
+      link: [
+        {
+          rel: "alternate",
+          type: "application/rss+xml",
+          href: "https://cms.example/custom",
+        },
+      ],
+    };
+    const out = applyFeedDiscovery(seeded, front, ctx, {
+      siteIsPrivate: false,
+    });
+    expect(alternates(out)).toEqual([
+      "application/rss+xml https://cms.example/custom",
+      "application/atom+xml https://cms.example/feed/atom",
+    ]);
+  });
+});

--- a/packages/core/src/seo/feed.ts
+++ b/packages/core/src/seo/feed.ts
@@ -1,0 +1,296 @@
+import type { AppContext } from "../context/app.js";
+import type { DocumentLink, DocumentManifest, TemplateData } from "../theme.js";
+import { and, desc, eq, inArray } from "../db/index.js";
+import { entries } from "../db/schema/entries.js";
+import { users } from "../db/schema/users.js";
+import { buildEntryPermalink } from "../route/permalink.js";
+import { loadSiteSettings, nonEmpty } from "./site-settings.js";
+import { xmlEscape } from "./xml.js";
+
+// Recent-items window. Generous enough for a reader's "what's new" without
+// turning the feed into a full archive (that's the sitemap's job).
+export const FEED_LIMIT = 20;
+
+type FeedFormat = "rss2" | "atom";
+
+declare module "../hooks/types.js" {
+  interface FilterRegistry {
+    /**
+     * Adjust a feed's item list before serialization — add, drop, or re-order.
+     * Receives the scope: `null` for the site feed, or the entry-type name.
+     */
+    "seo:feed:items": (
+      items: readonly FeedItem[],
+      scope: string | null,
+    ) => readonly FeedItem[] | Promise<readonly FeedItem[]>;
+  }
+}
+
+export interface FeedItem {
+  readonly title: string;
+  readonly link: string;
+  /** Stable identifier (Atom `<id>`); typically the permalink. */
+  readonly id: string;
+  /** Last-modified timestamp, ISO-8601. */
+  readonly updated: string;
+  /** First-published timestamp, ISO-8601. Falls back to `updated`. */
+  readonly published?: string;
+  readonly summary?: string;
+  readonly author?: string;
+}
+
+export interface FeedChannel {
+  readonly title: string;
+  /** The site home URL. */
+  readonly link: string;
+  /** This feed's own URL (`rel="self"`). */
+  readonly feedUrl: string;
+  readonly description: string;
+  /** Feed-level last-modified timestamp, ISO-8601. */
+  readonly updated: string;
+}
+
+// RSS2 timestamps are RFC-822; `toUTCString()` produces exactly that shape.
+function rfc822(iso: string): string {
+  return new Date(iso).toUTCString();
+}
+
+export function renderRss2(
+  channel: FeedChannel,
+  items: readonly FeedItem[],
+): string {
+  const body = items
+    .map((item) => {
+      const summary = item.summary
+        ? `<description>${xmlEscape(item.summary)}</description>`
+        : "";
+      const creator = item.author
+        ? `<dc:creator>${xmlEscape(item.author)}</dc:creator>`
+        : "";
+      return (
+        `<item>` +
+        `<title>${xmlEscape(item.title)}</title>` +
+        `<link>${xmlEscape(item.link)}</link>` +
+        `<guid isPermaLink="true">${xmlEscape(item.link)}</guid>` +
+        `<pubDate>${rfc822(item.published ?? item.updated)}</pubDate>` +
+        summary +
+        creator +
+        `</item>`
+      );
+    })
+    .join("");
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+    `<channel>` +
+    `<title>${xmlEscape(channel.title)}</title>` +
+    `<link>${xmlEscape(channel.link)}</link>` +
+    `<description>${xmlEscape(channel.description)}</description>` +
+    `<atom:link href="${xmlEscape(channel.feedUrl)}" rel="self" type="application/rss+xml"></atom:link>` +
+    `<lastBuildDate>${rfc822(channel.updated)}</lastBuildDate>` +
+    body +
+    `</channel></rss>`
+  );
+}
+
+export function renderAtom(
+  channel: FeedChannel,
+  items: readonly FeedItem[],
+): string {
+  const body = items
+    .map((item) => {
+      const published = item.published
+        ? `<published>${xmlEscape(item.published)}</published>`
+        : "";
+      const summary = item.summary
+        ? `<summary>${xmlEscape(item.summary)}</summary>`
+        : "";
+      const author = item.author
+        ? `<author><name>${xmlEscape(item.author)}</name></author>`
+        : "";
+      return (
+        `<entry>` +
+        `<title>${xmlEscape(item.title)}</title>` +
+        `<link href="${xmlEscape(item.link)}"></link>` +
+        `<id>${xmlEscape(item.id)}</id>` +
+        `<updated>${xmlEscape(item.updated)}</updated>` +
+        published +
+        summary +
+        author +
+        `</entry>`
+      );
+    })
+    .join("");
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<feed xmlns="http://www.w3.org/2005/Atom">` +
+    `<title>${xmlEscape(channel.title)}</title>` +
+    `<link href="${xmlEscape(channel.link)}"></link>` +
+    `<link href="${xmlEscape(channel.feedUrl)}" rel="self"></link>` +
+    `<id>${xmlEscape(channel.feedUrl)}</id>` +
+    `<updated>${xmlEscape(channel.updated)}</updated>` +
+    body +
+    `</feed>`
+  );
+}
+
+/** The path of a feed scope's RSS2 feed (`null` = the site feed). */
+export function feedBasePath(scope: string | null): string {
+  return scope === null ? "/feed" : `/${scope}/feed`;
+}
+
+/** Whether a scope names a registered, public entry type. */
+export function isPublicEntryType(ctx: AppContext, scope: string): boolean {
+  const type = ctx.plugins.entryTypes.get(scope);
+  return type !== undefined && type.isPublic !== false;
+}
+
+function publicEntryTypeNames(ctx: AppContext): string[] {
+  return [...ctx.plugins.entryTypes.values()]
+    .filter((type) => type.isPublic !== false)
+    .map((type) => type.name);
+}
+
+/**
+ * Recent published entries for a feed scope (`null` = every public entry type,
+ * else a single type), newest first, run through `seo:feed:items`. Returns null
+ * for an unknown / non-public type so the route can 404.
+ */
+export async function collectFeedItems(
+  ctx: AppContext,
+  scope: string | null,
+): Promise<readonly FeedItem[] | null> {
+  let typeNames: string[];
+  if (scope === null) {
+    typeNames = publicEntryTypeNames(ctx);
+  } else {
+    if (!isPublicEntryType(ctx, scope)) return null;
+    typeNames = [scope];
+  }
+
+  const rows =
+    typeNames.length === 0
+      ? []
+      : await ctx.db
+          .select({
+            title: entries.title,
+            slug: entries.slug,
+            type: entries.type,
+            parentId: entries.parentId,
+            excerpt: entries.excerpt,
+            updatedAt: entries.updatedAt,
+            publishedAt: entries.publishedAt,
+            authorName: users.name,
+          })
+          .from(entries)
+          .leftJoin(users, eq(entries.authorId, users.id))
+          .where(
+            and(
+              inArray(entries.type, typeNames),
+              eq(entries.status, "published"),
+            ),
+          )
+          .orderBy(desc(entries.publishedAt))
+          .limit(FEED_LIMIT);
+
+  const items: FeedItem[] = [];
+  for (const row of rows) {
+    const path = await buildEntryPermalink(ctx, row);
+    if (path === null) continue;
+    const link = `${ctx.origin}${path}`;
+    items.push({
+      title: row.title,
+      link,
+      id: link,
+      updated: row.updatedAt.toISOString(),
+      published: (row.publishedAt ?? row.updatedAt).toISOString(),
+      summary: row.excerpt ?? undefined,
+      author: row.authorName ?? undefined,
+    });
+  }
+  return ctx.hooks.applyFilter("seo:feed:items", items, scope);
+}
+
+const CONTENT_TYPE: Record<FeedFormat, string> = {
+  rss2: "application/rss+xml; charset=utf-8",
+  atom: "application/atom+xml; charset=utf-8",
+};
+
+export async function handleFeed(
+  ctx: AppContext,
+  scope: string | null,
+  format: FeedFormat,
+): Promise<Response> {
+  const site = await loadSiteSettings(ctx);
+  // A private site is held out of syndication. (The sitemap returns an empty
+  // 200 instead — there's no "valid but empty because private" feed idiom, so
+  // 404 is the honest answer here.)
+  if (site.public === false) return new Response(null, { status: 404 });
+
+  const items = await collectFeedItems(ctx, scope);
+  if (items === null) return new Response(null, { status: 404 });
+
+  const base = feedBasePath(scope);
+  const channel: FeedChannel = {
+    title: nonEmpty(site.title) ?? ctx.origin,
+    link: ctx.origin,
+    feedUrl: `${ctx.origin}${base}${format === "atom" ? "/atom" : ""}`,
+    description: nonEmpty(site.tagline) ?? "",
+    updated: items[0]?.updated ?? new Date().toISOString(),
+  };
+  const body =
+    format === "atom" ? renderAtom(channel, items) : renderRss2(channel, items);
+  return new Response(body, {
+    headers: { "content-type": CONTENT_TYPE[format] },
+  });
+}
+
+// The feed scope a page should advertise: the entry-type for a type archive,
+// `null` (the site feed) for a single entry / front page / taxonomy, or `false`
+// for pages with no feed (search, error). A single entry advertises the site
+// feed, not its type feed — a reader subscribing from a post wants "everything
+// new", which is the convention (WordPress et al.).
+function feedScope(data: TemplateData): string | null | false {
+  if ("contentType" in data) return data.contentType;
+  if ("query" in data) return false;
+  if ("request" in data) return false;
+  return null;
+}
+
+function hasAlternate(
+  links: readonly DocumentLink[] | undefined,
+  type: string,
+): boolean {
+  return links?.some((l) => l.rel === "alternate" && l.type === type) ?? false;
+}
+
+/**
+ * Gap-filler: append `<link rel="alternate">` feed-discovery tags for the
+ * page's scope, skipping any type already present so a template / plugin value
+ * wins. A private site advertises nothing (it 404s its feeds).
+ */
+export function applyFeedDiscovery(
+  manifest: DocumentManifest,
+  data: TemplateData,
+  ctx: AppContext,
+  opts: { readonly siteIsPrivate: boolean },
+): DocumentManifest {
+  if (opts.siteIsPrivate) return manifest;
+  const scope = feedScope(data);
+  if (scope === false) return manifest;
+  if (scope !== null && !isPublicEntryType(ctx, scope)) return manifest;
+
+  const base = feedBasePath(scope);
+  const existing = manifest.link;
+  const additions: DocumentLink[] = [];
+  const add = (type: string, href: string): void => {
+    if (!hasAlternate(existing, type)) {
+      additions.push({ rel: "alternate", type, href });
+    }
+  };
+  add("application/rss+xml", `${ctx.origin}${base}`);
+  add("application/atom+xml", `${ctx.origin}${base}/atom`);
+
+  if (additions.length === 0) return manifest;
+  return { ...manifest, link: [...(existing ?? []), ...additions] };
+}

--- a/packages/core/src/seo/head-defaults.ts
+++ b/packages/core/src/seo/head-defaults.ts
@@ -1,7 +1,8 @@
 import type { AppContext } from "../context/app.js";
 import type { DocumentManifest, DocumentMeta, TemplateData } from "../theme.js";
 import { canonicalUrl } from "./canonical.js";
-import { loadSiteSettings } from "./site-settings.js";
+import { applyFeedDiscovery } from "./feed.js";
+import { loadSiteSettings, nonEmpty } from "./site-settings.js";
 
 const ROBOTS_INDEX = "index,follow,max-image-preview:large";
 const ROBOTS_SEARCH = "noindex,follow";
@@ -84,10 +85,6 @@ export function seoHeadDefaults(
   return { ...manifest, meta: [...(existing ?? []), ...additions] };
 }
 
-function nonEmpty(value: unknown): string | null {
-  return typeof value === "string" && value.length > 0 ? value : null;
-}
-
 // `og:locale` wants `lang_TERRITORY`; the active locale code is `lang-TERRITORY`.
 function toOgLocale(localeCode: string): string {
   return localeCode.replace("-", "_");
@@ -105,9 +102,10 @@ export async function applyHeadMeta(
   title: string | undefined,
 ): Promise<DocumentManifest> {
   const site = await loadSiteSettings(ctx);
+  const siteIsPrivate = site.public === false;
   const excerpt = "entry" in data ? nonEmpty(data.entry.excerpt) : null;
   const description = excerpt ?? nonEmpty(site.tagline);
-  return seoHeadDefaults(manifest, {
+  const withMeta = seoHeadDefaults(manifest, {
     canonical: canonicalUrl(ctx),
     title,
     description,
@@ -117,6 +115,7 @@ export async function applyHeadMeta(
     ogLocale: toOgLocale(ctx.locale.code),
     // Search-results pages are thin; keep them out of the index.
     noindex: "query" in data,
-    siteIsPrivate: site.public === false,
+    siteIsPrivate,
   });
+  return applyFeedDiscovery(withMeta, data, ctx, { siteIsPrivate });
 }

--- a/packages/core/src/seo/site-settings.ts
+++ b/packages/core/src/seo/site-settings.ts
@@ -8,3 +8,8 @@ export async function loadSiteSettings(
   const groups = await settingsLoader(["site"], ctx);
   return groups.site ?? {};
 }
+
+/** A settings value coerced to a non-empty string, or null. */
+export function nonEmpty(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/packages/core/src/seo/sitemap.ts
+++ b/packages/core/src/seo/sitemap.ts
@@ -8,6 +8,7 @@ import {
 } from "../route/permalink.js";
 import { loadSiteSettings } from "./site-settings.js";
 import { cachedSubSitemap } from "./sitemap-cache.js";
+import { xmlEscape } from "./xml.js";
 
 // Well under the sitemaps.org 50k cap, and small enough to build + hold in
 // Worker memory per request.
@@ -29,18 +30,6 @@ declare module "../hooks/types.js" {
       scope: string,
     ) => readonly SitemapUrl[] | Promise<readonly SitemapUrl[]>;
   }
-}
-
-const XML_ESCAPES: Record<string, string> = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&apos;",
-};
-
-function xmlEscape(value: string): string {
-  return value.replace(/[&<>"']/g, (char) => XML_ESCAPES[char] ?? char);
 }
 
 export function renderSitemapIndex(locs: readonly string[]): string {

--- a/packages/core/src/seo/xml.ts
+++ b/packages/core/src/seo/xml.ts
@@ -1,0 +1,12 @@
+const XML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+/** Escape the five XML metacharacters for safe inclusion in element text. */
+export function xmlEscape(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => XML_ESCAPES[char] ?? char);
+}


### PR DESCRIPTION
Adds site and per-entry-type syndication feeds plus `<link rel="alternate">` discovery.

**Routes**

`GET /feed` and `/feed/atom` return the site feed (recent published entries across every public entry type); `GET /<type>/feed` and `/<type>/feed/atom` return the type-scoped feed. `collectFeedItems(ctx, scope)` gathers items (batched author join, no N+1 for flat types) through the new `seo:feed:items` filter; `renderRss2` / `renderAtom` serialize them (RSS2 dates RFC-822, Atom RFC-3339, all text + attributes XML-escaped).

**Path reservation, gated**

`/feed*` is reserved WordPress-style. A *scoped* `/<x>/feed` is only treated as a feed when `<x>` is a registered public entry type — otherwise it falls through to public routing, so a real page isn't shadowed by an unknown-type 404. A private site 404s its feeds (no "valid-but-empty-because-private" feed idiom; the sitemap's empty-200 is a crawler contract, feeds aren't).

**Discovery**

Feed-discovery `<link rel="alternate">` tags are gap-filled into the head alongside the other SEO meta: the type feed on a type archive, the site feed on the front page, taxonomy, and single entries. A single post advertises the *site* feed (the convention — a reader subscribing from a post wants everything new), not its type feed.

**Refactors**

Extracts the shared `xmlEscape` into `seo/xml.ts` (sitemap now imports it) and the `nonEmpty` site-settings coercion into `seo/site-settings.ts`.

Known follow-ups (shared with the sitemap, out of scope here): hierarchical-type permalink resolution is one CTE per row, and feeds are uncached.

Closes #992