### PR TITLE
feat(core): add per-taxonomy term feeds

### DIFF
--- a/packages/core/src/route/permalink.ts
+++ b/packages/core/src/route/permalink.ts
@@ -96,7 +96,7 @@ function entryTypeBaseSlug(entryType: RegisteredEntryType): string {
   return entryType.rewrite?.slug ?? entryType.name;
 }
 
-function termTaxonomyBaseSlug(taxonomy: RegisteredTermTaxonomy): string {
+export function termTaxonomyBaseSlug(taxonomy: RegisteredTermTaxonomy): string {
   return taxonomy.rewrite?.slug ?? taxonomy.name;
 }
 

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -12,7 +12,11 @@ import { resolveLocale } from "../i18n/resolve-locale.js";
 import { matchRoute } from "../route/match.js";
 import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
-import { handleFeed, isPublicEntryType } from "../seo/feed.js";
+import {
+  handleFeed,
+  isPublicEntryType,
+  publicTaxonomyByBaseSlug,
+} from "../seo/feed.js";
 import { handleRobotsTxt } from "../seo/robots.js";
 import { handleSitemapIndex, handleSubSitemap } from "../seo/sitemap.js";
 import { rewriteAdminShellLangDir } from "./admin-shell.js";
@@ -34,6 +38,8 @@ const SUB_SITEMAP_PATTERN = /^\/sitemap-(.+)-(\d+)\.xml$/;
 // leading segment is the entry-type scope; `/feed*` reserves these paths the
 // way WordPress does, so a page slugged "feed" can't shadow them.
 const FEED_PATTERN = /^\/(?:([^/]+)\/)?feed(\/atom)?$/;
+// `/<taxonomy>/<term>/feed` (+ `/atom`) — the term-scoped feed.
+const TERM_FEED_PATTERN = /^\/([^/]+)\/([^/]+)\/feed(\/atom)?$/;
 
 // MCP is cold-path-exclusive (an agent endpoint, never the public render path).
 // Dynamic-import its handler so the tool registry and the MCP SDK it pulls in
@@ -267,9 +273,25 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   if (feed) {
     // A scoped `/<x>/feed` is a feed only when `<x>` is a public entry type;
     // otherwise it's a real path (e.g. a page slugged "feed") — fall through.
-    const scope = feed[1] ?? null;
-    if (scope === null || isPublicEntryType(ctx, scope)) {
-      return handleFeed(ctx, scope, feed[2] ? "atom" : "rss2");
+    const type = feed[1];
+    if (type === undefined) {
+      return handleFeed(ctx, { kind: "site" }, feed[2] ? "atom" : "rss2");
+    }
+    if (isPublicEntryType(ctx, type)) {
+      return handleFeed(ctx, { kind: "type", type }, feed[2] ? "atom" : "rss2");
+    }
+  }
+  const termFeed = TERM_FEED_PATTERN.exec(pathname);
+  if (termFeed) {
+    // Only a public taxonomy's archive space owns `/<taxonomy>/<term>/feed`;
+    // anything else (e.g. a nested page) falls through to the public router.
+    const taxonomy = publicTaxonomyByBaseSlug(ctx, termFeed[1] ?? "");
+    if (taxonomy) {
+      return handleFeed(
+        ctx,
+        { kind: "term", taxonomy: taxonomy.name, term: termFeed[2] ?? "" },
+        termFeed[3] ? "atom" : "rss2",
+      );
     }
   }
 

--- a/packages/core/src/seo/feed-routes.test.ts
+++ b/packages/core/src/seo/feed-routes.test.ts
@@ -11,6 +11,18 @@ const blogPlugin = definePlugin("blog", (ctx) => {
   });
 });
 
+const blogWithTaxonomyPlugin = definePlugin("blog-tax", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+  ctx.registerTermTaxonomy("category", {
+    label: "Categories",
+    entryTypes: ["post"],
+  });
+});
+
 async function seedPost(
   h: Awaited<ReturnType<typeof createDispatcherHarness>>,
   slug: string,
@@ -107,6 +119,110 @@ describe("feed routes", () => {
     );
     expect(body).toContain(
       '<link rel="alternate" type="application/atom+xml" href="https://cms.example/feed/atom"',
+    );
+  });
+});
+
+describe("term feed routes", () => {
+  async function seedTermFeed(): Promise<
+    Awaited<ReturnType<typeof createDispatcherHarness>>
+  > {
+    const h = await createDispatcherHarness({
+      plugins: [blogWithTaxonomyPlugin],
+    });
+    const author = await h.seedUser("admin");
+    const term = await h.factory.category.create({
+      slug: "news",
+      name: "News",
+    });
+    const tagged = await h.factory.entry.create({
+      type: "post",
+      slug: "tagged",
+      title: "Tagged Post",
+      content: null,
+      status: "published",
+      authorId: author.id,
+    });
+    await h.factory.entry.create({
+      type: "post",
+      slug: "untagged",
+      title: "Untagged Post",
+      content: null,
+      status: "published",
+      authorId: author.id,
+    });
+    await h.factory.entryTerm.create({ entryId: tagged.id, termId: term.id });
+    return h;
+  }
+
+  test("GET /<taxonomy>/<term>/feed returns only entries tagged with the term", async () => {
+    const h = await seedTermFeed();
+    const res = await h.fetch("/category/news/feed");
+    res.assertStatus(200);
+    expect(res.headers.get("content-type")).toContain("application/rss+xml");
+    const body = await res.text();
+    expect(body).toContain("Tagged Post");
+    expect(body).not.toContain("Untagged Post");
+    expect(body).toContain(
+      '<atom:link href="https://cms.example/category/news/feed" rel="self"',
+    );
+  });
+
+  test("GET /<taxonomy>/<term>/feed/atom returns the Atom variant", async () => {
+    const h = await seedTermFeed();
+    const res = await h.fetch("/category/news/feed/atom");
+    res.assertStatus(200);
+    expect(res.headers.get("content-type")).toContain("application/atom+xml");
+    expect(await res.text()).toContain(
+      "<id>https://cms.example/category/news/feed/atom</id>",
+    );
+  });
+
+  test("a missing term 404s", async () => {
+    const h = await seedTermFeed();
+    const res = await h.fetch("/category/ghost/feed");
+    res.assertStatus(404);
+  });
+
+  test("a nested (child) term has no feed — top-level terms only", async () => {
+    const h = await createDispatcherHarness({
+      plugins: [blogWithTaxonomyPlugin],
+    });
+    const parent = await h.factory.category.create({
+      slug: "news",
+      name: "News",
+    });
+    await h.factory.category.create({
+      slug: "local",
+      name: "Local",
+      parentId: parent.id,
+    });
+    const res = await h.fetch("/category/local/feed");
+    res.assertStatus(404);
+  });
+
+  test("a non-taxonomy /<x>/<y>/feed path falls through to public routing", async () => {
+    const h = await seedTermFeed();
+    // "post" is an entry type, not a taxonomy base slug → not a term feed.
+    const res = await h.fetch("/post/tagged/feed");
+    res.assertStatus(404);
+  });
+
+  test("the seo:feed:items filter applies to the term-scoped list", async () => {
+    const h = await seedTermFeed();
+    h.spyFilter("seo:feed:items").override(() => []);
+    const body = await (await h.fetch("/category/news/feed")).text();
+    expect(body).not.toContain("<item>");
+  });
+
+  test("term-archive pages emit the matching feed-discovery tags", async () => {
+    const h = await seedTermFeed();
+    const body = await (await h.fetch("/category/news")).text();
+    expect(body).toContain(
+      '<link rel="alternate" type="application/rss+xml" href="https://cms.example/category/news/feed"',
+    );
+    expect(body).toContain(
+      '<link rel="alternate" type="application/atom+xml" href="https://cms.example/category/news/feed/atom"',
     );
   });
 });

--- a/packages/core/src/seo/feed.test.ts
+++ b/packages/core/src/seo/feed.test.ts
@@ -92,6 +92,9 @@ describe("applyFeedDiscovery", () => {
     origin: "https://cms.example",
     plugins: {
       entryTypes: new Map([["post", { name: "post", isPublic: true }]]),
+      termTaxonomies: new Map([
+        ["category", { name: "category", isPublic: true }],
+      ]),
     },
   } as unknown as AppContext;
   const empty: DocumentManifest = {};
@@ -141,6 +144,35 @@ describe("applyFeedDiscovery", () => {
       "application/rss+xml https://cms.example/feed",
       "application/atom+xml https://cms.example/feed/atom",
     ]);
+  });
+
+  test("top-level taxonomy-term data advertises the term feed", () => {
+    const data = {
+      taxonomy: "category",
+      term: { slug: "news", parentId: null },
+      entries: [],
+      pagination: {},
+    } as unknown as TemplateData;
+    expect(
+      alternates(
+        applyFeedDiscovery(empty, data, ctx, { siteIsPrivate: false }),
+      ),
+    ).toEqual([
+      "application/rss+xml https://cms.example/category/news/feed",
+      "application/atom+xml https://cms.example/category/news/feed/atom",
+    ]);
+  });
+
+  test("a nested term advertises no feed (top-level only)", () => {
+    const data = {
+      taxonomy: "category",
+      term: { slug: "local", parentId: 1 },
+      entries: [],
+      pagination: {},
+    } as unknown as TemplateData;
+    expect(
+      applyFeedDiscovery(empty, data, ctx, { siteIsPrivate: false }).link,
+    ).toBeUndefined();
   });
 
   test("search and private pages advertise nothing", () => {

--- a/packages/core/src/seo/feed.ts
+++ b/packages/core/src/seo/feed.ts
@@ -1,9 +1,17 @@
+import type { SQL } from "drizzle-orm";
+
 import type { AppContext } from "../context/app.js";
+import type { RegisteredTermTaxonomy } from "../plugin/manifest.js";
 import type { DocumentLink, DocumentManifest, TemplateData } from "../theme.js";
 import { and, desc, eq, inArray } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
+import { entryTerm } from "../db/schema/entry_term.js";
+import { terms } from "../db/schema/terms.js";
 import { users } from "../db/schema/users.js";
-import { buildEntryPermalink } from "../route/permalink.js";
+import {
+  buildEntryPermalink,
+  termTaxonomyBaseSlug,
+} from "../route/permalink.js";
 import { loadSiteSettings, nonEmpty } from "./site-settings.js";
 import { xmlEscape } from "./xml.js";
 
@@ -13,15 +21,24 @@ export const FEED_LIMIT = 20;
 
 type FeedFormat = "rss2" | "atom";
 
+/**
+ * What a feed covers: the whole site, one entry type, or one taxonomy term.
+ * `taxonomy`/`term` are the registered taxonomy name + term slug.
+ */
+type FeedScope =
+  | { readonly kind: "site" }
+  | { readonly kind: "type"; readonly type: string }
+  | { readonly kind: "term"; readonly taxonomy: string; readonly term: string };
+
 declare module "../hooks/types.js" {
   interface FilterRegistry {
     /**
      * Adjust a feed's item list before serialization — add, drop, or re-order.
-     * Receives the scope: `null` for the site feed, or the entry-type name.
+     * Receives the {@link FeedScope} the items were collected for.
      */
     "seo:feed:items": (
       items: readonly FeedItem[],
-      scope: string | null,
+      scope: FeedScope,
     ) => readonly FeedItem[] | Promise<readonly FeedItem[]>;
   }
 }
@@ -134,15 +151,26 @@ export function renderAtom(
   );
 }
 
-/** The path of a feed scope's RSS2 feed (`null` = the site feed). */
-export function feedBasePath(scope: string | null): string {
-  return scope === null ? "/feed" : `/${scope}/feed`;
+/** Whether a scope names a registered, public entry type. */
+export function isPublicEntryType(ctx: AppContext, type: string): boolean {
+  const entryType = ctx.plugins.entryTypes.get(type);
+  return entryType !== undefined && entryType.isPublic !== false;
 }
 
-/** Whether a scope names a registered, public entry type. */
-export function isPublicEntryType(ctx: AppContext, scope: string): boolean {
-  const type = ctx.plugins.entryTypes.get(scope);
-  return type !== undefined && type.isPublic !== false;
+/** The public taxonomy whose archive base slug matches `slug`, if any. */
+export function publicTaxonomyByBaseSlug(
+  ctx: AppContext,
+  slug: string,
+): RegisteredTermTaxonomy | undefined {
+  for (const taxonomy of ctx.plugins.termTaxonomies.values()) {
+    if (
+      taxonomy.isPublic !== false &&
+      termTaxonomyBaseSlug(taxonomy) === slug
+    ) {
+      return taxonomy;
+    }
+  }
+  return undefined;
 }
 
 function publicEntryTypeNames(ctx: AppContext): string[] {
@@ -151,47 +179,68 @@ function publicEntryTypeNames(ctx: AppContext): string[] {
     .map((type) => type.name);
 }
 
+// SQL row filter for a scope; `null` means the scope can't yield a feed
+// (unknown type/term, nested term, or no public types) so the caller 404s.
+async function feedFilter(
+  ctx: AppContext,
+  scope: FeedScope,
+): Promise<SQL | undefined | null> {
+  const published = eq(entries.status, "published");
+  if (scope.kind === "type") {
+    if (!isPublicEntryType(ctx, scope.type)) return null;
+    return and(eq(entries.type, scope.type), published);
+  }
+
+  const typeNames = publicEntryTypeNames(ctx);
+  const publicTypes = inArray(entries.type, typeNames);
+  if (scope.kind === "site") {
+    return typeNames.length === 0 ? null : and(publicTypes, published);
+  }
+
+  // term: only entries attached to the term, and still of a public type. Only
+  // top-level terms have the flat `/base/slug/feed` URL the route addresses —
+  // nested terms have no feed route yet, so they 404.
+  const [term] = await ctx.db
+    .select({ id: terms.id, parentId: terms.parentId })
+    .from(terms)
+    .where(and(eq(terms.taxonomy, scope.taxonomy), eq(terms.slug, scope.term)));
+  if (!term) return null;
+  if (term.parentId !== null || typeNames.length === 0) return null;
+  const attached = ctx.db
+    .select({ id: entryTerm.entryId })
+    .from(entryTerm)
+    .where(eq(entryTerm.termId, term.id));
+  return and(publicTypes, published, inArray(entries.id, attached));
+}
+
 /**
- * Recent published entries for a feed scope (`null` = every public entry type,
- * else a single type), newest first, run through `seo:feed:items`. Returns null
- * for an unknown / non-public type so the route can 404.
+ * Recent published, public-type entries for a feed scope, newest first, run
+ * through `seo:feed:items`. Returns null for an unknown scope (non-public type,
+ * missing term) so the route can 404.
  */
 export async function collectFeedItems(
   ctx: AppContext,
-  scope: string | null,
+  scope: FeedScope,
 ): Promise<readonly FeedItem[] | null> {
-  let typeNames: string[];
-  if (scope === null) {
-    typeNames = publicEntryTypeNames(ctx);
-  } else {
-    if (!isPublicEntryType(ctx, scope)) return null;
-    typeNames = [scope];
-  }
+  const where = await feedFilter(ctx, scope);
+  if (where === null) return null;
 
-  const rows =
-    typeNames.length === 0
-      ? []
-      : await ctx.db
-          .select({
-            title: entries.title,
-            slug: entries.slug,
-            type: entries.type,
-            parentId: entries.parentId,
-            excerpt: entries.excerpt,
-            updatedAt: entries.updatedAt,
-            publishedAt: entries.publishedAt,
-            authorName: users.name,
-          })
-          .from(entries)
-          .leftJoin(users, eq(entries.authorId, users.id))
-          .where(
-            and(
-              inArray(entries.type, typeNames),
-              eq(entries.status, "published"),
-            ),
-          )
-          .orderBy(desc(entries.publishedAt))
-          .limit(FEED_LIMIT);
+  const rows = await ctx.db
+    .select({
+      title: entries.title,
+      slug: entries.slug,
+      type: entries.type,
+      parentId: entries.parentId,
+      excerpt: entries.excerpt,
+      updatedAt: entries.updatedAt,
+      publishedAt: entries.publishedAt,
+      authorName: users.name,
+    })
+    .from(entries)
+    .leftJoin(users, eq(entries.authorId, users.id))
+    .where(where)
+    .orderBy(desc(entries.publishedAt))
+    .limit(FEED_LIMIT);
 
   const items: FeedItem[] = [];
   for (const row of rows) {
@@ -218,7 +267,7 @@ const CONTENT_TYPE: Record<FeedFormat, string> = {
 
 export async function handleFeed(
   ctx: AppContext,
-  scope: string | null,
+  scope: FeedScope,
   format: FeedFormat,
 ): Promise<Response> {
   const site = await loadSiteSettings(ctx);
@@ -230,11 +279,11 @@ export async function handleFeed(
   const items = await collectFeedItems(ctx, scope);
   if (items === null) return new Response(null, { status: 404 });
 
-  const base = feedBasePath(scope);
   const channel: FeedChannel = {
     title: nonEmpty(site.title) ?? ctx.origin,
     link: ctx.origin,
-    feedUrl: `${ctx.origin}${base}${format === "atom" ? "/atom" : ""}`,
+    // The feed's self URL is just this request's path.
+    feedUrl: `${ctx.origin}${new URL(ctx.request.url).pathname}`,
     description: nonEmpty(site.tagline) ?? "",
     updated: items[0]?.updated ?? new Date().toISOString(),
   };
@@ -245,16 +294,29 @@ export async function handleFeed(
   });
 }
 
-// The feed scope a page should advertise: the entry-type for a type archive,
-// `null` (the site feed) for a single entry / front page / taxonomy, or `false`
-// for pages with no feed (search, error). A single entry advertises the site
-// feed, not its type feed — a reader subscribing from a post wants "everything
-// new", which is the convention (WordPress et al.).
-function feedScope(data: TemplateData): string | null | false {
-  if ("contentType" in data) return data.contentType;
+// The feed base path a page should advertise, or `false` when it has none
+// (search, error, or a non-public type/taxonomy). A single entry advertises the
+// site feed, not its type feed — a reader subscribing from a post wants
+// "everything new", which is the convention (WordPress et al.).
+function discoveryFeedBase(
+  data: TemplateData,
+  ctx: AppContext,
+): string | false {
+  if ("contentType" in data) {
+    return isPublicEntryType(ctx, data.contentType)
+      ? `/${data.contentType}/feed`
+      : false;
+  }
+  if ("taxonomy" in data) {
+    const taxonomy = ctx.plugins.termTaxonomies.get(data.taxonomy);
+    if (!taxonomy || taxonomy.isPublic === false) return false;
+    // Only top-level terms have the flat URL the feed route can address.
+    if (data.term.parentId !== null) return false;
+    return `/${termTaxonomyBaseSlug(taxonomy)}/${data.term.slug}/feed`;
+  }
   if ("query" in data) return false;
   if ("request" in data) return false;
-  return null;
+  return "/feed";
 }
 
 function hasAlternate(
@@ -276,11 +338,9 @@ export function applyFeedDiscovery(
   opts: { readonly siteIsPrivate: boolean },
 ): DocumentManifest {
   if (opts.siteIsPrivate) return manifest;
-  const scope = feedScope(data);
-  if (scope === false) return manifest;
-  if (scope !== null && !isPublicEntryType(ctx, scope)) return manifest;
+  const base = discoveryFeedBase(data, ctx);
+  if (base === false) return manifest;
 
-  const base = feedBasePath(scope);
   const existing = manifest.link;
   const additions: DocumentLink[] = [];
   const add = (type: string, href: string): void => {


### PR DESCRIPTION
Extends the feed surface to taxonomy terms: `GET /<taxonomy>/<term>/feed` (and `/atom`) returns the RSS2/Atom feed of entries attached to that term, and term-archive pages advertise it via `<link rel="alternate">`.

**Scope model**

The feed scope is now a discriminated union — `{kind:"site"} | {kind:"type"} | {kind:"term"}` — threaded through `collectFeedItems` and the `seo:feed:items` filter (whose signature changed from the prior, just-merged slice; no external consumers). The term branch resolves the term, then filters entries with a batched `entries.id IN (SELECT entryId FROM entry_term WHERE termId = ?)`, still constrained to published + public-type entries.

**Top-level terms only**

The 2-segment route can address only the flat `/base/slug/feed` URL, so this slice deliberately covers **top-level terms**. A nested (child) term 404s, and its archive page advertises no feed — keeping the route, the discovery tag, and the term archive's own canonical URL (`buildTermArchiveUrl`) consistent rather than advertising a flat URL that disagrees with the nested archive. Nested-term feeds are a clean follow-up (widen the route + derive the discovery path from `buildTermArchiveUrl`).

Also dedups the taxonomy base-slug logic (exports the existing `termTaxonomyBaseSlug` instead of a third copy).

Closes #993