### PR TITLE
feat(core): 301-normalize non-canonical public URLs

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -3103,7 +3103,7 @@ describe("resolvePublicRoute — front-page through theme", () => {
     expect(body).not.toContain('data-testid="row-no-date"');
   });
 
-  test("/page/N renders the front-page on page N", async () => {
+  test("/page/1 canonical-redirects to the front page, which renders page 1", async () => {
     const theme = defineTheme({
       templates: {
         index: () => null,
@@ -3125,11 +3125,15 @@ describe("resolvePublicRoute — front-page through theme", () => {
       publishedAt: new Date(),
     });
 
-    const response = await h.dispatch(
+    const redirect = await h.dispatch(
       new Request("https://cms.example/page/1"),
     );
-    expect(response.status).toBe(200);
-    expect(await response.text()).toContain("page:1");
+    expect(redirect.status).toBe(301);
+    expect(redirect.headers.get("location")).toBe("https://cms.example/");
+
+    const home = await h.dispatch(new Request("https://cms.example/"));
+    expect(home.status).toBe(200);
+    expect(await home.text()).toContain("page:1");
   });
 
   test("/page/0 on the front-page is out-of-range 404", async () => {
@@ -3144,9 +3148,11 @@ describe("resolvePublicRoute — front-page through theme", () => {
     expect(response.status).toBe(404);
   });
 
-  test("/page/N is not shadowed by a plugin that grabs the `/page/:slug` auto-route", async () => {
+  test("/page/1 is canonical-redirected before the `/page/:slug` auto-route can shadow it", async () => {
     // The `page` entry type auto-generates `/page/:slug`, which would
-    // otherwise swallow `/page/1`.
+    // otherwise swallow `/page/1`. The canonical 301 fires ahead of routing,
+    // so `/page/1` redirects to the front page rather than resolving the
+    // page-entry single "1".
     const pagesPlugin = definePlugin("pages", (ctx) => {
       ctx.registerEntryType("page", { label: "Pages", isPublic: true });
     });
@@ -3174,11 +3180,14 @@ describe("resolvePublicRoute — front-page through theme", () => {
       publishedAt: new Date(),
     });
 
-    const response = await h.dispatch(
+    const redirect = await h.dispatch(
       new Request("https://cms.example/page/1"),
     );
-    expect(response.status).toBe(200);
-    expect(await response.text()).toContain("page:1");
+    expect(redirect.status).toBe(301);
+    expect(redirect.headers.get("location")).toBe("https://cms.example/");
+
+    const home = await h.dispatch(new Request("https://cms.example/"));
+    expect(await home.text()).toContain("page:1");
   });
 
   test("blog archive at /posts resolves even when a pages plugin's empty-slug catch-all registers first", async () => {

--- a/packages/core/src/route/resolve.test.ts
+++ b/packages/core/src/route/resolve.test.ts
@@ -534,37 +534,24 @@ describe("resolvePublicRoute — archive", () => {
     expect(response.status).toBe(404);
   });
 
-  test("explicit /page/1 resolves the same content as the bare archive", async () => {
+  test("explicit /page/1 canonical-redirects (301) to the bare archive", async () => {
     const h = await createDispatcherHarness({ plugins: [shopPlugin] });
-    const author = await h.seedUser("admin");
-    await h.factory.entry.create({
-      type: "product",
-      slug: "thing",
-      title: "Thing",
-      content: null,
-      status: "published",
-      authorId: author.id,
-      publishedAt: new Date(),
-    });
     const bare = await h.dispatch(new Request("https://cms.example/shop"));
     const paginated = await h.dispatch(
       new Request("https://cms.example/shop/page/1"),
     );
     expect(bare.status).toBe(200);
-    expect(paginated.status).toBe(200);
-    const bareBody = await bare.text();
-    const paginatedBody = await paginated.text();
-    expect(paginatedBody).toBe(bareBody);
+    expect(paginated.status).toBe(301);
+    expect(paginated.headers.get("location")).toBe("https://cms.example/shop");
   });
 
-  test("empty archive on page=1 still returns 200 (regression from #224)", async () => {
+  test("empty archive on /page/1 redirects, not 404s (regression from #224)", async () => {
     const h = await createDispatcherHarness({ plugins: [blogPlugin] });
     const response = await h.dispatch(
       new Request("https://cms.example/post/page/1"),
     );
-    expect(response.status).toBe(200);
-    const body = await response.text();
-    expect(body).toContain("No entries yet.");
+    expect(response.status).toBe(301);
+    expect(response.headers.get("location")).toBe("https://cms.example/post");
   });
 
   test("archive title falls back label → entryType when labels.plural is absent", async () => {
@@ -755,15 +742,16 @@ describe("resolvePublicRoute — taxonomy", () => {
     expect(response.status).toBe(404);
   });
 
-  test("empty term on page=1 still returns 200 (regression from #224)", async () => {
+  test("empty term on /page/1 redirects, not 404s (regression from #224)", async () => {
     const h = await createDispatcherHarness({ plugins: [taxonomyPlugin] });
     await h.factory.category.create({ slug: "empty", name: "Empty" });
     const response = await h.dispatch(
       new Request("https://cms.example/category/empty/page/1"),
     );
-    expect(response.status).toBe(200);
-    const body = await response.text();
-    expect(body).toContain("No entries yet.");
+    expect(response.status).toBe(301);
+    expect(response.headers.get("location")).toBe(
+      "https://cms.example/category/empty",
+    );
   });
 
   test("hierarchical taxonomy /<base>/parent/leaf resolves the nested term", async () => {

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -12,6 +12,7 @@ import { resolveLocale } from "../i18n/resolve-locale.js";
 import { matchRoute } from "../route/match.js";
 import { renderErrorThroughTheme } from "../route/render/render-template.js";
 import { resolvePublicRoute } from "../route/resolve.js";
+import { canonicalRedirectTarget } from "../seo/canonical.js";
 import {
   handleFeed,
   isPublicEntryType,
@@ -20,7 +21,13 @@ import {
 import { handleRobotsTxt } from "../seo/robots.js";
 import { handleSitemapIndex, handleSubSitemap } from "../seo/sitemap.js";
 import { rewriteAdminShellLangDir } from "./admin-shell.js";
-import { forbidden, jsonResponse, methodNotAllowed, notFound } from "./http.js";
+import {
+  forbidden,
+  jsonResponse,
+  methodNotAllowed,
+  notFound,
+  permanentRedirect,
+} from "./http.js";
 import { loadUserForPublicRequest } from "./load-user-for-public-request.js";
 
 const RPC_PREFIX = "/_plumix/rpc";
@@ -294,6 +301,11 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
       );
     }
   }
+
+  // Normalize a public page URL to its canonical (slash-less) shape before
+  // routing — the 301 target shares `canonicalUrl` with the rel=canonical tag.
+  const canonical = canonicalRedirectTarget(ctx);
+  if (canonical !== null) return permanentRedirect(canonical);
 
   return dispatchPublicRoute(app, ctx, url);
 }

--- a/packages/core/src/runtime/http.ts
+++ b/packages/core/src/runtime/http.ts
@@ -53,6 +53,10 @@ export function redirectTo(
   return new Response(null, { status: 302, headers });
 }
 
+export function permanentRedirect(location: string): Response {
+  return new Response(null, { status: 301, headers: { Location: location } });
+}
+
 export function loginErrorRedirect(
   loginPath: string,
   paramName: string,

--- a/packages/core/src/seo/canonical-redirect.test.ts
+++ b/packages/core/src/seo/canonical-redirect.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+
+import { definePlugin } from "../plugin/define.js";
+import { createDispatcherHarness } from "../test/dispatcher.js";
+
+const blogPlugin = definePlugin("blog", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+});
+
+async function harness(): Promise<
+  Awaited<ReturnType<typeof createDispatcherHarness>>
+> {
+  const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+  const author = await h.seedUser("admin");
+  await h.factory.entry.create({
+    type: "post",
+    slug: "hello",
+    title: "Hello World",
+    content: null,
+    status: "published",
+    authorId: author.id,
+  });
+  return h;
+}
+
+describe("canonical 301 normalization", () => {
+  test("a trailing-slash public URL 301s to the slash-less canonical", async () => {
+    const h = await harness();
+    const res = await h.fetch("/post/hello/");
+    res.assertStatus(301);
+    expect(res.headers.get("location")).toBe("https://cms.example/post/hello");
+  });
+
+  test("an already-canonical URL is served, not redirected", async () => {
+    const h = await harness();
+    const res = await h.fetch("/post/hello");
+    res.assertStatus(200);
+    expect(await res.text()).toContain("<h1>Hello World</h1>");
+  });
+
+  test("the query string is preserved on the redirect", async () => {
+    const h = await harness();
+    const res = await h.fetch("/post/hello/?utm=x&ref=y");
+    res.assertStatus(301);
+    expect(res.headers.get("location")).toBe(
+      "https://cms.example/post/hello?utm=x&ref=y",
+    );
+  });
+
+  test("/page/1 collapses to the bare listing", async () => {
+    const h = await harness();
+    const res = await h.fetch("/post/page/1");
+    res.assertStatus(301);
+    expect(res.headers.get("location")).toBe("https://cms.example/post");
+  });
+
+  test.each([
+    ["robots.txt", "/robots.txt"],
+    ["a feed endpoint", "/feed"],
+    ["the sitemap", "/sitemap.xml"],
+  ])("exempt route %s is not redirected", async (_label, path) => {
+    const h = await harness();
+    const res = await h.fetch(path);
+    expect(res.headers.get("location")).toBeNull();
+  });
+});

--- a/packages/core/src/seo/canonical.test.ts
+++ b/packages/core/src/seo/canonical.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import type { AppContext } from "../context/app.js";
-import { canonicalUrl } from "./canonical.js";
+import { canonicalRedirectTarget, canonicalUrl } from "./canonical.js";
 
 function ctxFor(url: string): AppContext {
   return {
@@ -54,5 +54,50 @@ describe("canonicalUrl", () => {
     expect(canonicalUrl(ctxFor("https://edge.internal/post/hello"))).toBe(
       "https://cms.example/post/hello",
     );
+  });
+});
+
+describe("canonicalRedirectTarget", () => {
+  test("trailing slash redirects to the slash-less canonical", () => {
+    expect(canonicalRedirectTarget(ctxFor("https://cms.example/about/"))).toBe(
+      "https://cms.example/about",
+    );
+  });
+
+  test("/page/1 redirects to the bare listing", () => {
+    expect(
+      canonicalRedirectTarget(ctxFor("https://cms.example/shop/page/1")),
+    ).toBe("https://cms.example/shop");
+  });
+
+  test("an already-canonical URL is not redirected (no loop)", () => {
+    expect(
+      canonicalRedirectTarget(ctxFor("https://cms.example/about")),
+    ).toBeNull();
+  });
+
+  test("the query string is preserved on the redirect", () => {
+    expect(
+      canonicalRedirectTarget(ctxFor("https://cms.example/about/?utm=x&p=2")),
+    ).toBe("https://cms.example/about?utm=x&p=2");
+  });
+
+  test.each([
+    ["root", "https://cms.example/"],
+    ["plumix surface", "https://cms.example/_plumix/admin/"],
+    ["robots", "https://cms.example/robots.txt"],
+    ["feed", "https://cms.example/feed/"],
+    ["sub-feed", "https://cms.example/feed/atom/"],
+    ["dotted asset", "https://cms.example/favicon.ico/"],
+    ["sitemap xml", "https://cms.example/sitemap.xml/"],
+  ])("exempt: %s is never redirected", (_label, url) => {
+    expect(canonicalRedirectTarget(ctxFor(url))).toBeNull();
+  });
+
+  test("a feed-prefixed real page is still canonicalized", () => {
+    // `/feedback` only shares a prefix with `/feed`; it's a normal page.
+    expect(
+      canonicalRedirectTarget(ctxFor("https://cms.example/feedback/")),
+    ).toBe("https://cms.example/feedback");
   });
 });

--- a/packages/core/src/seo/canonical.ts
+++ b/packages/core/src/seo/canonical.ts
@@ -2,19 +2,56 @@ import type { AppContext } from "../context/app.js";
 import type { DocumentManifest } from "../theme.js";
 
 /**
+ * Normalize a pathname to its canonical, slash-less shape. `/page/1` is the
+ * same content as the bare listing, so it collapses — `/shop/page/1` → `/shop`,
+ * `/page/1` → `/`. Shared by {@link canonicalUrl} and
+ * {@link canonicalRedirectTarget} so the tag and the 301 can never disagree.
+ */
+function canonicalPath(pathname: string): string {
+  const slashless = pathname === "/" ? "/" : pathname.replace(/\/+$/, "");
+  return slashless.replace(/\/page\/1$/, "") || "/";
+}
+
+/**
  * The single source of truth for a request's canonical URL: the configured
  * site origin + the request path normalized to the fixed slash-less shape
  * (query and fragment dropped so URL variants consolidate). Drives the
- * `<link rel="canonical">` tag now and the 301 normalizer + sitemap/og:url
- * in later slices, so they can never disagree.
+ * `<link rel="canonical">` tag and the 301 normalizer + sitemap/og:url, so
+ * they can never disagree.
  */
 export function canonicalUrl(ctx: AppContext): string {
-  const { pathname } = new URL(ctx.request.url);
-  const slashless = pathname === "/" ? "/" : pathname.replace(/\/+$/, "");
-  // `/page/1` is the same content as the bare listing, so it canonicalizes to
-  // the listing — `/shop/page/1` → `/shop`, `/page/1` → `/`.
-  const normalized = slashless.replace(/\/page\/1$/, "");
-  return `${ctx.origin}${normalized || "/"}`;
+  return `${ctx.origin}${canonicalPath(new URL(ctx.request.url).pathname)}`;
+}
+
+/**
+ * Paths the 301 normalizer must never touch: the root, the plumix surface, the
+ * SEO machine endpoints (robots, feeds), and asset/extension-like paths (a dot
+ * in the last segment — covers `sitemap*.xml`, `favicon.ico`, etc.). Everything
+ * else is a public page route whose shape we normalize.
+ */
+export function isCanonicalExempt(pathname: string): boolean {
+  if (pathname === "/") return true;
+  if (pathname === "/robots.txt") return true;
+  if (pathname.startsWith("/_plumix/")) return true;
+  // Feed endpoints own their exact routing; `/feedback` only shares a prefix.
+  if (pathname === "/feed" || pathname.startsWith("/feed/")) return true;
+  const trimmed = pathname.replace(/\/+$/, "");
+  const lastSegment = trimmed.slice(trimmed.lastIndexOf("/") + 1);
+  return lastSegment.includes(".");
+}
+
+/**
+ * The canonical URL to 301-redirect this request to, or null when it's already
+ * canonical or exempt. Shares {@link canonicalUrl} with the `<link rel=canonical>`
+ * tag so the redirect target and the tag can never disagree; the query string
+ * is preserved, and an already-canonical path returns null (loop-safe).
+ */
+export function canonicalRedirectTarget(ctx: AppContext): string | null {
+  const url = new URL(ctx.request.url);
+  if (isCanonicalExempt(url.pathname)) return null;
+  const target = canonicalPath(url.pathname);
+  if (url.pathname === target) return null;
+  return `${ctx.origin}${target}${url.search}`;
 }
 
 function hasCanonical(manifest: DocumentManifest): boolean {


### PR DESCRIPTION
Adds the final SEO slice: a dispatcher-level guard that 301-redirects non-canonical public page URLs to their canonical slash-less form, completing PRD #986.

**One normalizer, two consumers**

The redirect target and the `<link rel="canonical">` tag now both flow through a single `canonicalPath` helper, so they can never disagree (AC#5). A trailing-slash or `/page/1` URL 301s to the bare canonical; an already-canonical path is served unchanged (loop-safe); the query string is preserved on the redirect.

**Behavior change: `/page/1` now redirects**

Previously `/page/1` (and `/<scope>/page/1`) served the same content as the bare listing with a canonical tag; it now 301s to the bare listing — the stronger, duplicate-free signal, consistent with trailing-slash handling. The #224 regression (empty `/page/1` must not 404) stays prevented: it 301s to the bare listing, which serves 200. Five pre-existing tests that asserted the old 200 behavior were updated accordingly.

**Exemptions**

Root, `/_plumix/*`, `/robots.txt`, `/feed*`, and asset/extension-like (dotted-last-segment) paths are hard-exempt; robots/sitemap/feed resolve in their own branches ahead of the guard. Two known low-severity edges, both stemming from the AC's explicit exemption list, are left as follow-ups: a term slug containing a dot (e.g. `node.js`) is treated as asset-like so its trailing-slash variant isn't normalized; and the site feed's trailing-slash variant (`/feed/`) 404s rather than redirecting (scoped `/<type>/feed/` variants do redirect).

Closes #994