### PR TITLE
feat: support serving the site under a configurable basePath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     name: Commitlint
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:
@@ -34,6 +35,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -42,6 +44,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -50,6 +53,7 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -58,6 +62,7 @@ jobs:
   knip:
     name: Knip
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -69,6 +74,7 @@ jobs:
   i18n:
     name: i18n
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -77,6 +83,7 @@ jobs:
   i18n-ratchet:
     name: i18n ratchet
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -85,6 +92,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -93,6 +101,7 @@ jobs:
   test-e2e:
     name: Test (e2e)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -147,6 +156,7 @@ jobs:
   publint:
     name: Publint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -155,6 +165,7 @@ jobs:
   attw:
     name: Are The Types Wrong
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup

--- a/packages/admin/e2e/fixtures/build-runtime-proof-plugin.ts
+++ b/packages/admin/e2e/fixtures/build-runtime-proof-plugin.ts
@@ -1,3 +1,4 @@
+import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,3 +22,18 @@ await buildAdminPluginChunkForE2E({
   scriptMarker: "data-plumix-e2e",
   logTag: "[e2e/runtime-proof] fixture plugin",
 });
+
+// The admin builds with a relative base (`./`) so the precompiled bundle is
+// relocatable under a runtime basePath; production's `serveAdmin` injects a
+// `<base href>` to anchor the relative asset URLs. `vite preview` doesn't, so
+// SPA deep-link reloads (`/_plumix/admin/entries/posts/1/edit`) would resolve
+// `./assets/*` against the wrong path and 404. Inject the same `<base href>`
+// here so the preview mirrors the worker.
+const indexHtmlPath = resolve(ADMIN_ROOT, "dist/index.html");
+const indexHtml = readFileSync(indexHtmlPath, "utf8");
+if (!indexHtml.includes("<base ")) {
+  writeFileSync(
+    indexHtmlPath,
+    indexHtml.replace(/<head>/i, '<head><base href="/_plumix/admin/">'),
+  );
+}

--- a/packages/admin/src/lib/admin-base.test.ts
+++ b/packages/admin/src/lib/admin-base.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { adminBasePath } from "./admin-base.js";
+
+function setBaseHref(href: string | null): void {
+  document.head.innerHTML = href ? `<base href="${href}">` : "";
+}
+
+afterEach(() => {
+  document.head.innerHTML = "";
+});
+
+describe("adminBasePath", () => {
+  test("no <base> tag → root deployment", () => {
+    setBaseHref(null);
+    expect(adminBasePath()).toBe("");
+  });
+
+  test("root mount → empty base path", () => {
+    setBaseHref("/_plumix/admin/");
+    expect(adminBasePath()).toBe("");
+  });
+
+  test("subdirectory mount → the subdirectory prefix", () => {
+    setBaseHref("/custom-directory/_plumix/admin/");
+    expect(adminBasePath()).toBe("/custom-directory");
+  });
+
+  test("nested subdirectory mount", () => {
+    setBaseHref("/a/b/_plumix/admin/");
+    expect(adminBasePath()).toBe("/a/b");
+  });
+});

--- a/packages/admin/src/lib/admin-base.ts
+++ b/packages/admin/src/lib/admin-base.ts
@@ -1,0 +1,24 @@
+import { ADMIN_BASE_PATH } from "./constants.js";
+
+/**
+ * The subdirectory the admin is mounted under (`""` at the domain root,
+ * `/custom-directory` behind a subdirectory proxy), derived at runtime from the
+ * `<base href>` the worker injects into the admin shell. Lets the same
+ * precompiled admin bundle address the right router / RPC paths without a
+ * rebuild — the client-side half of plumix's `basePath` support.
+ */
+export function adminBasePath(): string {
+  if (typeof document === "undefined") return "";
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- DOM selector + attribute, not UI copy
+  const href = document.querySelector("base")?.getAttribute("href");
+  if (!href) return "";
+  // Resolve a possibly-relative href against a throwaway origin; only the
+  // pathname matters. Trim the `/_plumix/admin` mount suffix to leave the prefix.
+  const path = new URL(href, "http://plumix.invalid/").pathname.replace(
+    /\/$/,
+    "",
+  );
+  return path.endsWith(ADMIN_BASE_PATH)
+    ? path.slice(0, -ADMIN_BASE_PATH.length)
+    : "";
+}

--- a/packages/admin/src/lib/magic-link.ts
+++ b/packages/admin/src/lib/magic-link.ts
@@ -1,6 +1,7 @@
 import type { MessageDescriptor } from "@lingui/core";
 import { defineMessage } from "@lingui/core/macro";
 
+import { adminBasePath } from "./admin-base.js";
 import { createStrictErrorDescriptorRegistry } from "./error-descriptor-registry.js";
 
 // Client wrapper for the magic-link request endpoint. Not an oRPC
@@ -16,15 +17,18 @@ interface MagicLinkRequestResponse {
 export async function requestMagicLink(
   email: string,
 ): Promise<MagicLinkRequestResponse> {
-  const response = await fetch("/_plumix/auth/magic-link/request", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-plumix-request": "1",
+  const response = await fetch(
+    `${adminBasePath()}/_plumix/auth/magic-link/request`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-plumix-request": "1",
+      },
+      body: JSON.stringify({ email }),
+      credentials: "same-origin",
     },
-    body: JSON.stringify({ email }),
-    credentials: "same-origin",
-  });
+  );
 
   if (response.status === 503) {
     throw MagicLinkRequestError.notConfigured();

--- a/packages/admin/src/lib/orpc.ts
+++ b/packages/admin/src/lib/orpc.ts
@@ -4,14 +4,17 @@ import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 
 import type { AppRouterClient } from "@plumix/core";
 
+import { adminBasePath } from "./admin-base.js";
+
 // Admin and the plumix backend are same-origin in production; prefixing the
 // path with `window.location.origin` keeps things same-origin while giving
 // `RPCLink` the absolute URL its `new URL(...)` constructor needs — a bare
 // path like "/_plumix/rpc" throws "Invalid URL" at `URL` construction time.
+// `adminBasePath()` adds the subdirectory prefix under a subdirectory proxy.
 // Resolved lazily per call so SSR / prerender contexts (no `window`) can
 // import this module without crashing; every actual call runs in the browser.
 const link = new RPCLink({
-  url: () => `${window.location.origin}/_plumix/rpc`,
+  url: () => `${window.location.origin}${adminBasePath()}/_plumix/rpc`,
   headers: () => ({
     // Dispatcher rejects any non-safe /_plumix/* method missing this header.
     "x-plumix-request": "1",

--- a/packages/admin/src/lib/passkey.ts
+++ b/packages/admin/src/lib/passkey.ts
@@ -1,4 +1,5 @@
 import type { PasskeyErrorCode } from "./passkey-errors.js";
+import { adminBasePath } from "./admin-base.js";
 import { base64urlToBuffer, bufferToBase64url } from "./base64url.js";
 import { PasskeyError } from "./passkey-errors.js";
 
@@ -47,7 +48,7 @@ interface VerifySuccess {
 async function postJson<T>(path: string, body: unknown): Promise<T> {
   let response: Response;
   try {
-    response = await fetch(path, {
+    response = await fetch(`${adminBasePath()}${path}`, {
       method: "POST",
       credentials: "same-origin",
       headers: { "content-type": "application/json", ...PLUMIX_CSRF_HEADER },
@@ -74,7 +75,7 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
 async function postJsonNoBody<T>(path: string): Promise<T> {
   let response: Response;
   try {
-    response = await fetch(path, {
+    response = await fetch(`${adminBasePath()}${path}`, {
       method: "POST",
       credentials: "same-origin",
       headers: PLUMIX_CSRF_HEADER,

--- a/packages/admin/src/lib/plumix-globals.ts
+++ b/packages/admin/src/lib/plumix-globals.ts
@@ -10,6 +10,7 @@ import * as ReactRouterNs from "@tanstack/react-router";
 import * as ReactDomNs from "react-dom";
 import * as ReactDomClientNs from "react-dom/client";
 
+import { adminBasePath } from "./admin-base.js";
 import { pluginCatalogLoaderRef } from "./i18n-boot.js";
 import { registerPaletteCommand } from "./palette-commands.js";
 import {
@@ -62,6 +63,9 @@ declare global {
       readonly registerPaletteCommand: typeof registerPaletteCommand;
       readonly runtime: typeof runtime;
       readonly i18n: PlumixI18nGlobal;
+      /** Subdirectory mount for plugin chunks to prefix their `/_plumix/...`
+       *  fetches with; derived from the `<base href>` (see {@link adminBasePath}). */
+      readonly basePath: string;
     };
   }
 }
@@ -79,6 +83,7 @@ export function bootPlumixGlobals(): void {
     registerPluginMarkSchema,
     registerPaletteCommand,
     runtime,
+    basePath: adminBasePath(),
     // Indirection through the ref so the manifest-bound loader
     // installed by `bootI18n` is reachable from plugin chunks that
     // load post-boot. Pre-boot callers hit the no-op default; the

--- a/packages/admin/src/providers/router.ts
+++ b/packages/admin/src/providers/router.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { createRouter as createTanstackRouter } from "@tanstack/react-router";
 
 import { ErrorBoundaryFallback } from "../components/error-boundary-fallback.js";
+import { adminBasePath } from "../lib/admin-base.js";
 import { ADMIN_BASE_PATH } from "../lib/constants.js";
 import { routeTree } from "../routeTree.gen.js";
 
@@ -10,7 +11,9 @@ import { routeTree } from "../routeTree.gen.js";
 export function createRouter(queryClient: QueryClient) {
   return createTanstackRouter({
     routeTree,
-    basepath: ADMIN_BASE_PATH,
+    // Prefix the admin mount with the deployment's subdirectory (if any) so
+    // deep links and navigation resolve under a subdirectory proxy.
+    basepath: `${adminBasePath()}${ADMIN_BASE_PATH}`,
     defaultPreload: "intent",
     // Defer freshness to Query's own cache — avoids two competing
     // SWR policies fighting over the same data.

--- a/packages/admin/src/routes/_auth/-locale-param.ts
+++ b/packages/admin/src/routes/_auth/-locale-param.ts
@@ -3,6 +3,8 @@
 // pick are byte-identical and the unified `resolveLocale` reads either.
 import { buildLocaleCookie } from "@plumix/core/i18n";
 
+import { adminBasePath } from "../../lib/admin-base.js";
+
 /** Builds the next search-param object when the login locale dropdown
  *  changes. Always sets `?lang=`, even when the chosen code matches
  *  the site default, because the admin shell's Accept-Language fallback
@@ -41,5 +43,5 @@ export function writeLocaleCookie(
   const secure =
     options.secure ??
     (typeof location !== "undefined" && location.protocol === "https:");
-  document.cookie = buildLocaleCookie(code, secure);
+  document.cookie = buildLocaleCookie(code, secure, adminBasePath());
 }

--- a/packages/admin/vite.config.ts
+++ b/packages/admin/vite.config.ts
@@ -20,8 +20,12 @@ const BACKEND_URL = process.env.PLUMIX_BACKEND_URL ?? "http://localhost:5173";
 // (knip) still find `packages/admin/lingui.config.ts`.
 const PACKAGE_DIR = fileURLToPath(new URL(".", import.meta.url));
 
-export default defineConfig({
-  base: `${ADMIN_BASE_PATH}/`,
+export default defineConfig(({ command }) => ({
+  // A relative base makes the built bundle relocatable: the worker injects a
+  // `<base href>` into the shell, so the same precompiled admin resolves its
+  // assets at the root or under any subdirectory proxy without a rebuild. Dev
+  // is served standalone, so it keeps the absolute mount path.
+  base: command === "build" ? "./" : `${ADMIN_BASE_PATH}/`,
   // tanstackRouter must run before @vitejs/plugin-react. quoteStyle +
   // semicolons keep routeTree.gen.ts prettier-clean across builds.
   plugins: [
@@ -51,4 +55,4 @@ export default defineConfig({
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
-});
+}));

--- a/packages/core/src/auth/device-flow-routes.ts
+++ b/packages/core/src/auth/device-flow-routes.ts
@@ -2,6 +2,7 @@ import * as v from "valibot";
 
 import type { AppContext } from "../context/app.js";
 import type { PlumixApp } from "../runtime/app.js";
+import { withBasePath } from "../base-path.js";
 import { jsonResponse } from "../runtime/http.js";
 import { exchangeDeviceCode, requestDeviceCode } from "./device-flow.js";
 
@@ -47,7 +48,10 @@ export async function handleDeviceCodeRequest(
     ctx.db,
   );
 
-  const verificationUri = new URL(VERIFICATION_PATH, app.origin).toString();
+  const verificationUri = new URL(
+    withBasePath(VERIFICATION_PATH, app.basePath),
+    app.origin,
+  ).toString();
   const verificationUriComplete = `${verificationUri}?user_code=${encodeURIComponent(userCode)}`;
 
   return jsonResponse({

--- a/packages/core/src/auth/email-change/routes.ts
+++ b/packages/core/src/auth/email-change/routes.ts
@@ -1,6 +1,7 @@
 import type { AppContext } from "../../context/app.js";
 import type { PlumixApp } from "../../runtime/app.js";
 import type { EmailChangeErrorCode } from "./errors.js";
+import { withBasePath } from "../../base-path.js";
 import { loginErrorRedirect, redirectTo } from "../../runtime/http.js";
 import { EmailChangeError } from "./errors.js";
 import { verifyEmailChange } from "./verify.js";
@@ -31,8 +32,9 @@ export async function handleEmailChangeVerify(
 ): Promise<Response> {
   const url = new URL(ctx.request.url);
   const token = url.searchParams.get("token");
-  if (!token) return loginError("missing_token");
-  if (token.length > MAX_TOKEN_LENGTH) return loginError("token_invalid");
+  if (!token) return loginError(ctx.basePath, "missing_token");
+  if (token.length > MAX_TOKEN_LENGTH)
+    return loginError(ctx.basePath, "token_invalid");
 
   let result: Awaited<ReturnType<typeof verifyEmailChange>>;
   try {
@@ -40,10 +42,10 @@ export async function handleEmailChangeVerify(
   } catch (error) {
     if (error instanceof EmailChangeError) {
       ctx.logger.warn("email_change_verify_rejected", { code: error.code });
-      return loginError(error.code);
+      return loginError(ctx.basePath, error.code);
     }
     ctx.logger.error("email_change_verify_failed", { error });
-    return loginError("token_invalid");
+    return loginError(ctx.basePath, "token_invalid");
   }
 
   // The change is COMMITTED at this point — email + emailVerifiedAt
@@ -61,9 +63,15 @@ export async function handleEmailChangeVerify(
   } catch (error) {
     ctx.logger.error("email_change_hook_failed", { error });
   }
-  return redirectTo(`${LOGIN_PATH}?email_change_success=1`);
+  return redirectTo(
+    `${withBasePath(LOGIN_PATH, ctx.basePath)}?email_change_success=1`,
+  );
 }
 
-function loginError(code: EmailChangeErrorCode): Response {
-  return loginErrorRedirect(LOGIN_PATH, "email_change_error", code);
+function loginError(basePath: string, code: EmailChangeErrorCode): Response {
+  return loginErrorRedirect(
+    withBasePath(LOGIN_PATH, basePath),
+    "email_change_error",
+    code,
+  );
 }

--- a/packages/core/src/auth/magic-link/request.test.ts
+++ b/packages/core/src/auth/magic-link/request.test.ts
@@ -40,6 +40,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "alice@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test Site",
     });
@@ -76,6 +77,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "stranger@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test",
     });
@@ -97,6 +99,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "blocked@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test",
     });
@@ -115,6 +118,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "  Alice@Example.com  ",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test",
     });
@@ -136,6 +140,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "newcomer@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test",
     });
@@ -166,6 +171,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "newcomer@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test",
     });
@@ -183,6 +189,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "stranger@unknown.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test",
     });
@@ -202,6 +209,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "first@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test",
     });
@@ -223,6 +231,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "first@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test",
       bootstrapAllowed: true,
@@ -249,6 +258,7 @@ describe("requestMagicLink", () => {
       requestMagicLink(db, {
         email: "alice@example.com",
         origin: "https://cms.example",
+        basePath: "",
         mailer,
         siteName: "Test",
       }),
@@ -268,6 +278,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "klaus@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test Site",
       locale: "de",
@@ -289,6 +300,7 @@ describe("requestMagicLink", () => {
     await requestMagicLink(db, {
       email: "fallback@example.com",
       origin: "https://cms.example",
+      basePath: "",
       mailer,
       siteName: "Test Site",
       locale: "xx-INVALID",

--- a/packages/core/src/auth/magic-link/request.ts
+++ b/packages/core/src/auth/magic-link/request.ts
@@ -1,5 +1,6 @@
 import type { Db, Logger } from "../../context/app.js";
 import type { Mailer } from "../mailer/types.js";
+import { withBasePath } from "../../base-path.js";
 import { eq } from "../../db/index.js";
 import { allowedDomains } from "../../db/schema/allowed_domains.js";
 import { authTokens } from "../../db/schema/auth_tokens.js";
@@ -25,6 +26,8 @@ interface RequestMagicLinkInput {
   readonly email: string;
   /** `${origin}/_plumix/admin/magic-link?token=…` will be sent to the user. */
   readonly origin: string;
+  /** Subdirectory prefix the verify link must carry (`""` at the root). */
+  readonly basePath: string;
   readonly mailer: Mailer;
   readonly siteName: string;
   readonly ttlSeconds?: number;
@@ -146,7 +149,10 @@ async function issueAndSend(
     expiresAt,
   });
 
-  const verifyUrl = new URL("/_plumix/auth/magic-link/verify", input.origin);
+  const verifyUrl = new URL(
+    withBasePath("/_plumix/auth/magic-link/verify", input.basePath),
+    input.origin,
+  );
   verifyUrl.searchParams.set("token", token);
 
   try {

--- a/packages/core/src/auth/magic-link/routes.test.ts
+++ b/packages/core/src/auth/magic-link/routes.test.ts
@@ -78,6 +78,29 @@ describe("magic-link request route", () => {
     );
   });
 
+  test("the verify link in the email carries the configured basePath", async () => {
+    const { mailer, sent } = captureMailer();
+    const h = await createDispatcherHarness({
+      basePath: "/custom-directory",
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
+    });
+    await h.factory.user.create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+
+    const response = await h.dispatch(
+      postRequest("/custom-directory/_plumix/auth/magic-link/request", {
+        email: "alice@example.com",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(sent[0]?.text).toContain(
+      "https://cms.example/custom-directory/_plumix/auth/magic-link/verify?token=",
+    );
+  });
+
   test("returns the same shape when user does not exist (no enumeration)", async () => {
     const { mailer, sent } = captureMailer();
     const h = await createDispatcherHarness({
@@ -173,6 +196,38 @@ describe("magic-link verify route", () => {
     const sessionRows = await h.db.select().from(sessions);
     expect(sessionRows).toHaveLength(1);
     expect(sessionRows[0]?.userId).toBe(user.id);
+  });
+
+  test("under a basePath the post-verify redirect and cookie are base-scoped", async () => {
+    const { mailer } = captureMailer();
+    const h = await createDispatcherHarness({
+      basePath: "/custom-directory",
+      magicLink: { siteName: "Plumix Test" },
+      mailer,
+    });
+    const user = await h.factory.user.create({
+      email: "alice@example.com",
+      role: "editor",
+    });
+    const token = (
+      await h.factory.authToken.create({
+        userId: user.id,
+        email: "alice@example.com",
+      })
+    ).token;
+
+    const response = await h.dispatch(
+      getRequest(
+        `/custom-directory/_plumix/auth/magic-link/verify?token=${token}`,
+      ),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "/custom-directory/_plumix/admin",
+    );
+    expect(response.headers.get("set-cookie")).toContain(
+      "Path=/custom-directory",
+    );
   });
 
   test("rejects an unknown token with token_invalid", async () => {

--- a/packages/core/src/auth/magic-link/routes.ts
+++ b/packages/core/src/auth/magic-link/routes.ts
@@ -3,6 +3,7 @@ import * as v from "valibot";
 import type { AppContext } from "../../context/app.js";
 import type { PlumixApp } from "../../runtime/app.js";
 import type { MagicLinkErrorCode } from "./errors.js";
+import { withBasePath } from "../../base-path.js";
 import {
   jsonResponse,
   loginErrorRedirect,
@@ -69,6 +70,7 @@ export async function handleMagicLinkRequest(
     await requestMagicLink(ctx.db, {
       email: parsed.output.email,
       origin: app.origin,
+      basePath: app.basePath,
       mailer: ctx.mailer,
       siteName: app.config.auth.magicLink.siteName,
       ttlSeconds: app.config.auth.magicLink.ttlSeconds,
@@ -108,13 +110,14 @@ export async function handleMagicLinkVerify(
   app: PlumixApp,
 ): Promise<Response> {
   if (!app.config.auth.magicLink) {
-    return loginError("token_invalid");
+    return loginError(app.basePath, "token_invalid");
   }
 
   const url = new URL(ctx.request.url);
   const token = url.searchParams.get("token");
-  if (!token) return loginError("missing_token");
-  if (token.length > MAX_TOKEN_LENGTH) return loginError("token_invalid");
+  if (!token) return loginError(app.basePath, "missing_token");
+  if (token.length > MAX_TOKEN_LENGTH)
+    return loginError(app.basePath, "token_invalid");
 
   try {
     const { user, created } = await verifyMagicLink(ctx.db, token, {
@@ -125,14 +128,16 @@ export async function handleMagicLinkVerify(
       method: "magic_link",
       firstSignIn: created,
     });
-    return redirectTo(ADMIN_PATH, { "set-cookie": cookieHeader });
+    return redirectTo(withBasePath(ADMIN_PATH, app.basePath), {
+      "set-cookie": cookieHeader,
+    });
   } catch (error) {
     if (error instanceof MagicLinkError) {
       ctx.logger.warn("magic_link_verify_rejected", { code: error.code });
-      return loginError(error.code);
+      return loginError(app.basePath, error.code);
     }
     ctx.logger.error("magic_link_verify_failed", { error });
-    return loginError("token_invalid");
+    return loginError(app.basePath, "token_invalid");
   }
 }
 
@@ -140,6 +145,10 @@ function invalidInput(): Response {
   return jsonResponse({ error: "invalid_input" }, { status: 400 });
 }
 
-function loginError(code: MagicLinkErrorCode): Response {
-  return loginErrorRedirect(LOGIN_PATH, "magic_link_error", code);
+function loginError(basePath: string, code: MagicLinkErrorCode): Response {
+  return loginErrorRedirect(
+    withBasePath(LOGIN_PATH, basePath),
+    "magic_link_error",
+    code,
+  );
 }

--- a/packages/core/src/auth/oauth/routes.test.ts
+++ b/packages/core/src/auth/oauth/routes.test.ts
@@ -74,6 +74,28 @@ describe("oauth start route", () => {
     expect(response.headers.get("location")).toBe("/_plumix/admin/bootstrap");
   });
 
+  test("under a basePath the redirect_uri and post-auth redirects carry the prefix", async () => {
+    const h = await createDispatcherHarness({
+      basePath: "/custom-directory",
+      oauth: TEST_OAUTH,
+    });
+    await h.seedUser("admin");
+
+    const response = await h.dispatch(
+      new Request(
+        "https://cms.example/custom-directory/_plumix/auth/oauth/github/start",
+      ),
+    );
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    if (!location) throw new Error("missing location header");
+    // The redirect_uri the IdP will bounce back to must include the base, or
+    // the callback 404s as outside-the-base.
+    expect(new URL(location).searchParams.get("redirect_uri")).toBe(
+      "https://cms.example/custom-directory/_plumix/auth/oauth/github/callback",
+    );
+  });
+
   test("bootstrapVia=first-method-wins lets the OAuth flow start with zero users", async () => {
     const h = await createDispatcherHarness({
       oauth: TEST_OAUTH,

--- a/packages/core/src/auth/oauth/routes.ts
+++ b/packages/core/src/auth/oauth/routes.ts
@@ -2,6 +2,7 @@ import type { AppContext } from "../../context/app.js";
 import type { PlumixApp } from "../../runtime/app.js";
 import type { OAuthErrorCode } from "./errors.js";
 import type { OAuthProviderClient } from "./types.js";
+import { withBasePath } from "../../base-path.js";
 import { users } from "../../db/schema/users.js";
 import { loginErrorRedirect, redirectTo } from "../../runtime/http.js";
 import { mintSessionAndCookie } from "../sign-in.js";
@@ -26,7 +27,7 @@ export async function handleOAuthStart(
   providerKey: string,
 ): Promise<Response> {
   const provider = pickProvider(app, providerKey);
-  if (!provider) return loginError("provider_not_configured");
+  if (!provider) return loginError(app.basePath, "provider_not_configured");
 
   // Block OAuth on a fresh deploy when the operator left bootstrap on
   // the passkey rail. An OAuth signup before any user exists would
@@ -37,7 +38,7 @@ export async function handleOAuthStart(
   if (!ctx.bootstrapAllowed) {
     const userCount = await ctx.db.$count(users);
     if (userCount === 0) {
-      return redirectTo(BOOTSTRAP_PATH);
+      return redirectTo(withBasePath(BOOTSTRAP_PATH, app.basePath));
     }
   }
 
@@ -53,7 +54,7 @@ export async function handleOAuthStart(
     return redirectTo(url);
   } catch (error) {
     ctx.logger.error("oauth_start_failed", { error, provider: providerKey });
-    return loginError("code_exchange_failed");
+    return loginError(app.basePath, "code_exchange_failed");
   }
 }
 
@@ -63,7 +64,7 @@ export async function handleOAuthCallback(
   providerKey: string,
 ): Promise<Response> {
   const provider = pickProvider(app, providerKey);
-  if (!provider) return loginError("provider_not_configured");
+  if (!provider) return loginError(app.basePath, "provider_not_configured");
 
   const url = new URL(ctx.request.url);
   const state = url.searchParams.get("state");
@@ -73,16 +74,18 @@ export async function handleOAuthCallback(
   // TTL; consume it here so the slot is freed immediately.
   if (url.searchParams.has("error")) {
     if (state) await consumeOAuthState(ctx.db, state);
-    return loginError("state_invalid");
+    return loginError(app.basePath, "state_invalid");
   }
 
   const code = url.searchParams.get("code");
-  if (!code || !state) return loginError("state_invalid");
-  if (code.length > MAX_CODE_LENGTH) return loginError("state_invalid");
+  if (!code || !state) return loginError(app.basePath, "state_invalid");
+  if (code.length > MAX_CODE_LENGTH)
+    return loginError(app.basePath, "state_invalid");
 
   const stored = await consumeOAuthState(ctx.db, state);
-  if (!stored) return loginError("state_expired");
-  if (stored.provider !== providerKey) return loginError("state_invalid");
+  if (!stored) return loginError(app.basePath, "state_expired");
+  if (stored.provider !== providerKey)
+    return loginError(app.basePath, "state_invalid");
 
   const redirectUri = oauthCallbackUrl(app, providerKey);
 
@@ -108,17 +111,19 @@ export async function handleOAuthCallback(
       firstSignIn: created,
     });
 
-    return redirectTo(ADMIN_PATH, { "set-cookie": cookieHeader });
+    return redirectTo(withBasePath(ADMIN_PATH, app.basePath), {
+      "set-cookie": cookieHeader,
+    });
   } catch (error) {
     if (error instanceof OAuthError) {
       ctx.logger.warn("oauth_callback_rejected", {
         provider: providerKey,
         code: error.code,
       });
-      return loginError(error.code);
+      return loginError(app.basePath, error.code);
     }
     ctx.logger.error("oauth_callback_failed", { error, provider: providerKey });
-    return loginError("code_exchange_failed");
+    return loginError(app.basePath, "code_exchange_failed");
   }
 }
 
@@ -139,11 +144,16 @@ function pickProvider(app: PlumixApp, key: string): OAuthProviderClient | null {
 // custom adapter rewrites Host on the way in. (Cloudflare Workers binds
 // `request.url` to the connection hostname, but other adapters may not.)
 function oauthCallbackUrl(app: PlumixApp, providerKey: string): string {
-  return `${app.origin}/_plumix/auth/oauth/${providerKey}/callback`;
+  const path = `/_plumix/auth/oauth/${providerKey}/callback`;
+  return `${app.origin}${withBasePath(path, app.basePath)}`;
 }
 
-function loginError(code: OAuthErrorCode): Response {
+function loginError(basePath: string, code: OAuthErrorCode): Response {
   // Relative location — keeps the same scheme/host/port the browser
   // already used to reach us, no need to know the canonical origin.
-  return loginErrorRedirect(LOGIN_PATH, "oauth_error", code);
+  return loginErrorRedirect(
+    withBasePath(LOGIN_PATH, basePath),
+    "oauth_error",
+    code,
+  );
 }

--- a/packages/core/src/auth/passkey/routes.ts
+++ b/packages/core/src/auth/passkey/routes.ts
@@ -5,6 +5,7 @@ import type { User } from "../../db/schema/users.js";
 import type { PlumixApp } from "../../runtime/app.js";
 import type { ValidInvite } from "../invite.js";
 import type { AuthenticationResponse } from "./types.js";
+import { withBasePath } from "../../base-path.js";
 import { eq, isUniqueConstraintError } from "../../db/index.js";
 import { credentials } from "../../db/schema/credentials.js";
 import { users } from "../../db/schema/users.js";
@@ -383,6 +384,9 @@ export async function handleSignout(ctx: AppContext): Promise<Response> {
   const cookie = buildSessionDeletionCookie({
     secure: isSecureRequest(ctx.request),
     sameSite: "Lax",
+    // Must match the Path the session was minted with (see mintSessionAndCookie)
+    // or the browser won't clear it.
+    path: withBasePath("/", ctx.basePath),
   });
   // If the configured authenticator runs an external session (CF
   // Access, SAML), surface the IdP logout URL so the admin client can

--- a/packages/core/src/auth/sign-in.ts
+++ b/packages/core/src/auth/sign-in.ts
@@ -1,5 +1,6 @@
 import type { AppContext } from "../context/app.js";
 import type { PlumixApp } from "../runtime/app.js";
+import { withBasePath } from "../base-path.js";
 import { buildSessionCookie, isSecureRequest } from "./cookies.js";
 import { createSession, readRequestMeta } from "./sessions.js";
 
@@ -34,6 +35,9 @@ export async function mintSessionAndCookie(
     maxAgeSeconds: app.sessionPolicy.maxAgeSeconds,
     secure: isSecureRequest(ctx.request),
     sameSite: "Lax",
+    // Scope the session to the subdirectory so it isn't sent to a sibling
+    // app on the same host (`""` → `/`, the host-wide default).
+    path: withBasePath("/", app.basePath),
   });
   return { token, cookieHeader };
 }

--- a/packages/core/src/base-path.test.ts
+++ b/packages/core/src/base-path.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+
+import { normalizeBasePath, stripBasePath, withBasePath } from "./base-path.js";
+
+describe("normalizeBasePath", () => {
+  test.each([
+    ["undefined → root", undefined, ""],
+    ["empty → root", "", ""],
+    ["bare slash → root", "/", ""],
+    ["already canonical", "/docs", "/docs"],
+    ["adds the leading slash", "docs", "/docs"],
+    ["strips the trailing slash", "/docs/", "/docs"],
+    ["strips repeated trailing slashes", "/docs///", "/docs"],
+    ["collapses internal duplicate slashes", "/a//b", "/a/b"],
+    ["nested path", "/a/b/c", "/a/b/c"],
+    ["trims surrounding whitespace", "  /docs  ", "/docs"],
+  ])("%s", (_label, input, expected) => {
+    expect(normalizeBasePath(input)).toBe(expected);
+  });
+});
+
+describe("stripBasePath", () => {
+  test("root base is a pure pass-through (byte-identical to no base path)", () => {
+    expect(stripBasePath("/post/hello", "")).toBe("/post/hello");
+    expect(stripBasePath("/_plumix/admin", "")).toBe("/_plumix/admin");
+    expect(stripBasePath("/", "")).toBe("/");
+  });
+
+  test("the exact base maps to the site root", () => {
+    expect(stripBasePath("/docs", "/docs")).toBe("/");
+    expect(stripBasePath("/docs/", "/docs")).toBe("/");
+  });
+
+  test("a path under the base is returned with the prefix removed", () => {
+    expect(stripBasePath("/docs/post/hello", "/docs")).toBe("/post/hello");
+    expect(stripBasePath("/docs/_plumix/admin", "/docs")).toBe(
+      "/_plumix/admin",
+    );
+  });
+
+  test("a path that merely shares the base's stem is not under the base", () => {
+    expect(stripBasePath("/docsss", "/docs")).toBeNull();
+  });
+
+  test("a path outside the base returns null (caller 404s)", () => {
+    expect(stripBasePath("/post/hello", "/docs")).toBeNull();
+    expect(stripBasePath("/", "/docs")).toBeNull();
+  });
+
+  test("duplicate leading slashes can't smuggle a path past the base gate", () => {
+    // `//docs/admin` must not be treated as outside-the-base and slip through;
+    // it collapses to `/docs/admin` before matching.
+    expect(stripBasePath("//docs/admin", "/docs")).toBe("/admin");
+  });
+
+  test("strip and prefix round-trip back to the original path", () => {
+    const stripped = stripBasePath("/docs/post/hello", "/docs");
+    expect(stripped).not.toBeNull();
+    expect(withBasePath(stripped ?? "", "/docs")).toBe("/docs/post/hello");
+  });
+});
+
+describe("withBasePath", () => {
+  test("root base is a pure pass-through", () => {
+    expect(withBasePath("/post/hello", "")).toBe("/post/hello");
+    expect(withBasePath("/", "")).toBe("/");
+  });
+
+  test("prepends the base to a root-relative path", () => {
+    expect(withBasePath("/post/hello", "/docs")).toBe("/docs/post/hello");
+  });
+
+  test("the site root under a base is the bare base (no trailing slash)", () => {
+    expect(withBasePath("/", "/docs")).toBe("/docs");
+  });
+});

--- a/packages/core/src/base-path.ts
+++ b/packages/core/src/base-path.ts
@@ -1,0 +1,57 @@
+/**
+ * Base-path algebra for serving a plumix site under a subdirectory
+ * (`example.com/custom-directory/*`). Three pure helpers mirror the model
+ * the major frameworks settled on: normalize once at config load, strip once
+ * on the inbound request before routing, prepend on every outbound URL.
+ *
+ * The empty string is the root deployment (today's behavior) and every helper
+ * treats it as a no-op, so an unconfigured site is byte-for-byte unchanged.
+ */
+
+/**
+ * Canonicalize an operator-supplied base path: `""` for a root deployment,
+ * otherwise a leading-slash, no-trailing-slash, single-slash-separated prefix.
+ * Lenient by design (`docs`, `/docs/`, `/a//b` all normalize) so a small
+ * config typo doesn't 404 the whole site.
+ */
+export function normalizeBasePath(input: string | undefined): string {
+  if (input === undefined) return "";
+  const segments = input.split("/").filter((part) => part.trim().length > 0);
+  if (segments.length === 0) return "";
+  return "/" + segments.map((part) => part.trim()).join("/");
+}
+
+/**
+ * Remove the base prefix from an inbound pathname so the rest of the router
+ * matches against root-relative paths unchanged. Returns the remainder (always
+ * leading-slash; the bare base maps to `/`) or `null` when the request isn't
+ * under the base, which the caller turns into a 404.
+ *
+ * A root base (`""`) is a pure pass-through — the path is returned verbatim so
+ * an unconfigured deployment behaves exactly as before. When a base IS set,
+ * duplicate leading slashes are collapsed first so `//docs/admin` can't dodge
+ * the prefix gate (matching the hardening the SSR frameworks apply).
+ */
+export function stripBasePath(
+  pathname: string,
+  basePath: string,
+): string | null {
+  if (basePath === "") return pathname;
+  const collapsed = pathname.replace(/^\/+/, "/");
+  if (collapsed === basePath) return "/";
+  if (collapsed.startsWith(`${basePath}/`)) {
+    return collapsed.slice(basePath.length);
+  }
+  return null;
+}
+
+/**
+ * Prepend the base to a root-relative path for an outbound URL (canonical tag,
+ * sitemap `<loc>`, feed link, permalink, cookie `Path`). Inverse of
+ * {@link stripBasePath}: the site root (`/`) maps back to the bare base, and a
+ * root base (`""`) returns the path untouched.
+ */
+export function withBasePath(path: string, basePath: string): string {
+  if (basePath === "") return path;
+  return path === "/" ? basePath : `${basePath}${path}`;
+}

--- a/packages/core/src/cli/schema-codegen.test.ts
+++ b/packages/core/src/cli/schema-codegen.test.ts
@@ -16,6 +16,7 @@ const baseConfig: PlumixConfig = {
   theme: defineTheme({ templates: { index: () => null } }),
   plugins: [],
   i18n: resolveLocales({ defaultLocale: "en", locales: ["en"] }),
+  basePath: "",
 };
 
 function pluginWithSchemaModule(

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -118,6 +118,22 @@ test("plumix() preserves top-level vite passthrough for the Vite layer to consum
   expect(config.vite?.optimizeDeps).toEqual({ exclude: ["x"] });
 });
 
+test("plumix() defaults basePath to the empty string (root deployment)", () => {
+  const config = plumix({ runtime, database, auth: authConfig, theme });
+  expect(config.basePath).toBe("");
+});
+
+test("plumix() normalizes a configured basePath to its canonical form", () => {
+  const config = plumix({
+    runtime,
+    database,
+    auth: authConfig,
+    theme,
+    basePath: "custom-directory/",
+  });
+  expect(config.basePath).toBe("/custom-directory");
+});
+
 test("plumix() accepts auth.magicLink when paired with a top-level mailer", () => {
   const authWithMagicLink = auth({
     passkey: {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -12,6 +12,7 @@ import type {
   ObjectStorage,
 } from "./runtime/slots.js";
 import type { ThemeDescriptor } from "./theme.js";
+import { normalizeBasePath } from "./base-path.js";
 import { resolveLocales } from "./i18n/locale-registry.js";
 
 /**
@@ -78,6 +79,15 @@ export interface PlumixConfigInput {
   readonly plugins?: readonly AnyPluginDescriptor[];
   readonly i18n?: I18nInput;
   /**
+   * Serve the whole site under a subdirectory (`example.com/custom-directory/*`)
+   * — set this when a reverse proxy mounts plumix below the domain root.
+   * Mirrors Next's `basePath` / Nuxt's `app.baseURL`: a leading-slash prefix
+   * with no trailing slash. Normalized leniently (`docs`, `/docs/` both work);
+   * the default `""` is a root deployment. Path-only — it never touches
+   * `auth.passkey.origin`, which stays scheme+host for WebAuthn.
+   */
+  readonly basePath?: string;
+  /**
    * Model Context Protocol endpoint at `/_plumix/mcp`. Default-off; set
    * `{ enabled: true }` to mount it.
    */
@@ -113,6 +123,8 @@ export interface PlumixConfig {
   readonly theme: ThemeDescriptor;
   readonly plugins: readonly AnyPluginDescriptor[];
   readonly i18n: ResolvedI18n;
+  /** Normalized subdirectory prefix (`""` for a root deployment). */
+  readonly basePath: string;
   readonly mcp?: InterfaceToggle;
   readonly api?: ApiConfig;
   readonly blocks?: {
@@ -145,6 +157,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
     i18n: resolveLocales(
       config.i18n ?? { defaultLocale: "en", locales: ["en"] },
     ),
+    basePath: normalizeBasePath(config.basePath),
     mcp: config.mcp,
     api: config.api,
     blocks: config.blocks,

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -196,6 +196,14 @@ export interface AppContextBase<
    */
   readonly origin: string;
   /**
+   * Normalized subdirectory prefix the site is served under (`""` for a root
+   * deployment, `/custom-directory` otherwise). Sourced from `config.basePath`.
+   * The dispatcher strips it from the inbound path before routing; outbound URL
+   * builders (canonical, sitemap, feeds, permalinks, cookie `Path`) prepend it
+   * via `withBasePath` so links resolve under the subdirectory.
+   */
+  readonly basePath: string;
+  /**
    * Operator-set site name from `auth.magicLink.siteName`, used as
    * the human-friendly label in mailer subjects ("Confirm your email
    * for {siteName}"). Undefined when magic-link isn't configured —
@@ -250,6 +258,7 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly user?: AuthenticatedUser | null;
   readonly tokenScopes?: readonly string[] | null;
   readonly origin?: string;
+  readonly basePath?: string;
   readonly siteName?: string;
   readonly logger?: Logger;
   readonly defer?: DeferFn;
@@ -370,6 +379,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     // always passes the canonical operator-set origin so URLs in
     // outgoing email are stable across worker geos.
     origin: args.origin ?? new URL(args.request.url).origin,
+    basePath: args.basePath ?? "",
     siteName: args.siteName,
   };
   // Spread plugin-contributed entries onto the base. The cast is the

--- a/packages/core/src/i18n/cookie.ts
+++ b/packages/core/src/i18n/cookie.ts
@@ -1,3 +1,5 @@
+import { withBasePath } from "../base-path.js";
+
 // Underscore-cased to match `plumix_session` prior art in `auth/cookies.ts`.
 // `Path=/_plumix/` keeps the browser from sending the cookie on public-route
 // requests (public HTML stays identical across visitors so cache layers
@@ -10,11 +12,17 @@ const ONE_YEAR_SECONDS = 31_536_000;
 
 /** `code` is written raw — caller is the validation seam (only
  *  registry-matched codes should reach here). `Secure` is appended only
- *  over HTTPS; jsdom tests pass `false` to bypass. */
-export function buildLocaleCookie(code: string, secure: boolean): string {
+ *  over HTTPS; jsdom tests pass `false` to bypass. `basePath` scopes the
+ *  cookie under a subdirectory mount so the browser actually sends it back
+ *  (and it matches the session cookie's scope); `""` keeps `Path=/_plumix/`. */
+export function buildLocaleCookie(
+  code: string,
+  secure: boolean,
+  basePath = "",
+): string {
   const parts = [
     `${ADMIN_LOCALE_COOKIE}=${code}`,
-    `Path=${ADMIN_LOCALE_COOKIE_PATH}`,
+    `Path=${withBasePath(ADMIN_LOCALE_COOKIE_PATH, basePath)}`,
     `Max-Age=${ONE_YEAR_SECONDS}`,
     "SameSite=Lax",
   ];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ import "./template-deps-core.js";
 
 export * from "./admin/index.js";
 export * from "./auth/index.js";
+export { withBasePath } from "./base-path.js";
 export * from "./cli/index.js";
 export * from "./config.js";
 export * from "./context/index.js";

--- a/packages/core/src/route/permalink.test.ts
+++ b/packages/core/src/route/permalink.test.ts
@@ -25,8 +25,9 @@ async function buildRegistry(
 function ctxFor(
   db: Awaited<ReturnType<typeof createTestDb>>,
   registry: PluginRegistry,
+  basePath = "",
 ): AppContext {
-  return { db, plugins: registry } as unknown as AppContext;
+  return { db, plugins: registry, basePath } as unknown as AppContext;
 }
 
 describe("buildEntryPermalink", () => {
@@ -44,6 +45,20 @@ describe("buildEntryPermalink", () => {
       slug: "hello-world",
     });
     expect(url).toBe("/post/hello-world");
+  });
+
+  test("prepends the configured basePath so links resolve under the subdirectory", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry, "/custom-directory");
+
+    expect(
+      await buildEntryPermalink(ctx, { type: "post", slug: "hello-world" }),
+    ).toBe("/custom-directory/post/hello-world");
   });
 
   test("honors rewrite.slug as the base segment", async () => {

--- a/packages/core/src/route/permalink.ts
+++ b/packages/core/src/route/permalink.ts
@@ -5,6 +5,7 @@ import type {
   RegisteredEntryType,
   RegisteredTermTaxonomy,
 } from "../plugin/manifest.js";
+import { withBasePath } from "../base-path.js";
 
 /**
  * Reverse of `compileRouteMap` — given an entry, produce its public URL.
@@ -40,7 +41,10 @@ export async function buildEntryPermalink(
   if (!shouldNestUnderEntryParent(entryType, parentId)) return null;
   const ancestors =
     options?.ancestorSlugs ?? (await loadAncestorSlugs(ctx, parentId));
-  return joinSegments([entryTypeBaseSlug(entryType), ...ancestors, entry.slug]);
+  return withBasePath(
+    joinSegments([entryTypeBaseSlug(entryType), ...ancestors, entry.slug]),
+    ctx.basePath,
+  );
 }
 
 /**
@@ -64,12 +68,15 @@ export async function buildTermArchiveUrl(
   const parentId = term.parentId ?? null;
 
   if (!shouldNestUnderTermParent(taxonomy, parentId)) {
-    return joinSegments([baseSlug, term.slug]);
+    return withBasePath(joinSegments([baseSlug, term.slug]), ctx.basePath);
   }
 
   const ancestors =
     options?.ancestorSlugs ?? (await loadTermAncestorSlugs(ctx, parentId));
-  return joinSegments([baseSlug, ...ancestors, term.slug]);
+  return withBasePath(
+    joinSegments([baseSlug, ...ancestors, term.slug]),
+    ctx.basePath,
+  );
 }
 
 /**
@@ -89,7 +96,10 @@ export function buildEntryPermalinkSync(
   if (!entryType || entryType.isPublic === false) return null;
   if (shouldNestUnderEntryParent(entryType, entry.parentId ?? null))
     return null;
-  return joinSegments([entryTypeBaseSlug(entryType), entry.slug]);
+  return withBasePath(
+    joinSegments([entryTypeBaseSlug(entryType), entry.slug]),
+    ctx.basePath,
+  );
 }
 
 function entryTypeBaseSlug(entryType: RegisteredEntryType): string {

--- a/packages/core/src/route/render/asset-manifest.test.ts
+++ b/packages/core/src/route/render/asset-manifest.test.ts
@@ -17,6 +17,19 @@ describe("bundledCssTags", () => {
     );
   });
 
+  test("prefixes the configured basePath so theme CSS loads under a subdirectory", () => {
+    const manifest: AssetManifest = {
+      "src/theme/index.ts": {
+        file: "assets/theme-abc123.js",
+        isEntry: true,
+        css: ["assets/theme-def456.css"],
+      },
+    };
+    expect(bundledCssTags(manifest, "/custom-directory")).toBe(
+      '<link rel="stylesheet" href="/custom-directory/assets/theme-def456.css" />',
+    );
+  });
+
   test("emits nothing when no entry chunk references CSS", () => {
     const manifest: AssetManifest = {
       "src/theme/index.ts": {

--- a/packages/core/src/route/render/asset-manifest.ts
+++ b/packages/core/src/route/render/asset-manifest.ts
@@ -1,3 +1,5 @@
+import { withBasePath } from "../../base-path.js";
+
 /**
  * The Vite-emitted manifest shape (subset). Vite writes this to
  * `<outDir>/.vite/manifest.json` when `build.manifest: true`; plumix's
@@ -27,7 +29,7 @@ export type AssetManifest = Readonly<Record<string, AssetManifestEntry>>;
 // controllable. Themes that need a specific cascade should declare
 // CSS via `document.link[]` (emits before bundled CSS) and rely on
 // CSS specificity for the rest.
-export function bundledCssTags(manifest: AssetManifest): string {
+export function bundledCssTags(manifest: AssetManifest, basePath = ""): string {
   const css = new Set<string>();
   const visited = new Set<string>();
   for (const [key, entry] of Object.entries(manifest)) {
@@ -35,7 +37,10 @@ export function bundledCssTags(manifest: AssetManifest): string {
   }
   if (css.size === 0) return "";
   return Array.from(css)
-    .map((href) => `<link rel="stylesheet" href="/${href}" />`)
+    .map(
+      (href) =>
+        `<link rel="stylesheet" href="${withBasePath(`/${href}`, basePath)}" />`,
+    )
     .join("");
 }
 

--- a/packages/core/src/route/render/inject-islands-bootstrap.test.ts
+++ b/packages/core/src/route/render/inject-islands-bootstrap.test.ts
@@ -49,6 +49,32 @@ describe("injectIslandsBootstrap", () => {
     );
   });
 
+  test("build mode prefixes the basePath so islands hydrate under a subdirectory", () => {
+    const body = '<plumix-island chunk-url="/x"></plumix-island>';
+    const manifest = {
+      ".plumix/islands-entry.ts": {
+        file: "assets/plumix-islands-runtime-abc123.js",
+        isEntry: true,
+      },
+      ".plumix/islands-renderer-entry.ts": {
+        file: "assets/plumix-islands-renderer-def456.js",
+        isEntry: true,
+      },
+    };
+    const out = injectIslandsBootstrap(
+      body,
+      manifest,
+      "build",
+      "/custom-directory",
+    );
+    expect(out).toContain(
+      'src="/custom-directory/assets/plumix-islands-runtime-abc123.js"',
+    );
+    expect(out).toContain(
+      'data-plumix-renderer-url="/custom-directory/assets/plumix-islands-renderer-def456.js"',
+    );
+  });
+
   test("build mode falls back to the dev paths when manifest entries are missing", () => {
     // First-build edge: manifest exists but doesn't have the entries yet
     // (the cold-build ordering @cloudflare/vite-plugin produces). Don't

--- a/packages/core/src/route/render/inject-islands-bootstrap.ts
+++ b/packages/core/src/route/render/inject-islands-bootstrap.ts
@@ -15,6 +15,7 @@
 // `rollupOptions.input`). Read from Vite's `.vite/manifest.json`.
 
 import type { AssetManifest } from "./asset-manifest.js";
+import { withBasePath } from "../../base-path.js";
 
 const DEV_ENTRY_PATH = "/.plumix/islands-entry.ts";
 const RUNTIME_MANIFEST_KEY = ".plumix/islands-entry.ts";
@@ -30,6 +31,7 @@ export function injectIslandsBootstrap(
   body: string,
   manifest: AssetManifest,
   command: "serve" | "build",
+  basePath = "",
 ): string {
   if (!body.includes("<plumix-island")) return body;
   const src = resolveEntryUrl(
@@ -37,12 +39,14 @@ export function injectIslandsBootstrap(
     command,
     RUNTIME_MANIFEST_KEY,
     DEV_ENTRY_PATH,
+    basePath,
   );
   const rendererUrl = resolveEntryUrl(
     manifest,
     command,
     RENDERER_MANIFEST_KEY,
     DEV_RENDERER_PATH,
+    basePath,
   );
   return (
     body +
@@ -58,10 +62,11 @@ function resolveEntryUrl(
   command: "serve" | "build",
   key: string,
   devPath: string,
+  basePath: string,
 ): string {
   if (command === "build") {
     const entry = manifest[key];
-    if (entry?.file) return "/" + entry.file;
+    if (entry?.file) return withBasePath("/" + entry.file, basePath);
   }
   return devPath;
 }

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -374,7 +374,7 @@ function renderTree({
     hoisted +
     titleFallback +
     voidTagsToHtml("link", document.link) +
-    bundledCssTags(assetManifest) +
+    bundledCssTags(assetManifest, ctx.basePath) +
     voidTagsToHtml("meta", document.meta) +
     scripts.headEnd.map(scriptToHtml).join("");
 
@@ -387,6 +387,7 @@ function renderTree({
       // — non-empty in `plumix dev`, empty in `plumix build`. The
       // plumix Vite plugin's `define` populates the literal.
       process.env.PLUMIX_DEV ? "serve" : "build",
+      ctx.basePath,
     ) +
     scripts.bodyEnd.map(scriptToHtml).join("") +
     HYDRATION_SLOT;

--- a/packages/core/src/route/resolve.test.ts
+++ b/packages/core/src/route/resolve.test.ts
@@ -163,7 +163,11 @@ describe("resolvePublicRoute — hierarchical single", () => {
       parentId: team.id,
     });
 
-    const ctx = { db: h.db, plugins: h.app.plugins } as unknown as AppContext;
+    const ctx = {
+      db: h.db,
+      plugins: h.app.plugins,
+      basePath: "",
+    } as unknown as AppContext;
     const url = await buildEntryPermalink(ctx, {
       type: "page",
       slug: leadership.slug,
@@ -826,7 +830,11 @@ describe("resolvePublicRoute — taxonomy", () => {
       parentId: europe.id,
     });
 
-    const ctx = { db: h.db, plugins: h.app.plugins } as unknown as AppContext;
+    const ctx = {
+      db: h.db,
+      plugins: h.app.plugins,
+      basePath: "",
+    } as unknown as AppContext;
     const url = await buildTermArchiveUrl(ctx, {
       taxonomy: "region",
       slug: france.slug,

--- a/packages/core/src/rpc/procedures/user/set-locale.ts
+++ b/packages/core/src/rpc/procedures/user/set-locale.ts
@@ -36,6 +36,10 @@ export const setLocale = base
     );
     context.resHeaders?.append(
       "set-cookie",
-      buildLocaleCookie(match.code, isSecureRequest(context.request)),
+      buildLocaleCookie(
+        match.code,
+        isSecureRequest(context.request),
+        context.basePath,
+      ),
     );
   });

--- a/packages/core/src/runtime/admin-shell.test.ts
+++ b/packages/core/src/runtime/admin-shell.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "vitest";
 
 import type { ResolvedLocale } from "../i18n/locale-registry.js";
-import { rewriteAdminShellLangDir } from "./admin-shell.js";
+import {
+  injectAdminBaseHref,
+  rewriteAdminShellLangDir,
+} from "./admin-shell.js";
 
 const arabic: ResolvedLocale = {
   code: "ar",
@@ -19,5 +22,26 @@ describe("rewriteAdminShellLangDir", () => {
 
     expect(rewritten).toContain('<html lang="ar" dir="rtl">');
     expect(rewritten).not.toContain('<html lang="en">');
+  });
+});
+
+describe("injectAdminBaseHref", () => {
+  test("inserts a <base href> at the top of <head> so relative assets resolve under the mount", () => {
+    const html =
+      '<!doctype html><html lang="en"><head><title>Plumix Admin</title></head><body></body></html>';
+
+    const rewritten = injectAdminBaseHref(
+      html,
+      "/custom-directory/_plumix/admin/",
+    );
+
+    expect(rewritten).toContain(
+      '<head><base href="/custom-directory/_plumix/admin/">',
+    );
+  });
+
+  test("is a no-op when the shell has no <head> to anchor against", () => {
+    const html = "<!doctype html><title>admin</title>";
+    expect(injectAdminBaseHref(html, "/_plumix/admin/")).toBe(html);
   });
 });

--- a/packages/core/src/runtime/admin-shell.ts
+++ b/packages/core/src/runtime/admin-shell.ts
@@ -9,3 +9,17 @@ export function rewriteAdminShellLangDir(
     `<html lang="${locale.code}" dir="${locale.direction}">`,
   );
 }
+
+/**
+ * Insert a `<base href>` at the top of the admin shell's `<head>` so the
+ * relative-based client bundle resolves its assets — and the client router /
+ * RPC base — against the directory the admin is actually mounted under
+ * (`/custom-directory/_plumix/admin/` behind a subdirectory proxy, plain
+ * `/_plumix/admin/` at the root). No-op when there's no `<head>` to anchor to.
+ */
+export function injectAdminBaseHref(html: string, href: string): string {
+  return html.replace(
+    /<head\b[^>]*>/i,
+    (head) => `${head}<base href="${href}">`,
+  );
+}

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -88,6 +88,13 @@ export interface PlumixApp {
    * features don't have to reach into `passkey.*` to learn it.
    */
   readonly origin: string;
+  /**
+   * Normalized subdirectory prefix from `config.basePath` (`""` for a root
+   * deployment). Hoisted alongside `origin` so the dispatcher and runtime
+   * adapters thread it onto each per-request `AppContext` without reaching
+   * into `config`.
+   */
+  readonly basePath: string;
   /** See RuntimeContext.devCsrfLocalhost — false in production builds. */
   readonly devCsrfLocalhost: boolean;
   readonly passkey: ResolvedPasskeyConfig;
@@ -362,6 +369,7 @@ export async function buildApp(
     loadRpcHandler,
     loadRestHandler,
     origin: passkey.origin,
+    basePath: config.basePath,
     devCsrfLocalhost: runtime.devCsrfLocalhost ?? false,
     passkey,
     sessionPolicy: config.auth.sessions ?? DEFAULT_SESSION_POLICY,

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -838,6 +838,174 @@ describe("dispatcher — plugin raw routes", () => {
   });
 });
 
+describe("dispatcher — basePath (served under a subdirectory)", () => {
+  const blog = definePlugin("test-blog", (ctx) => {
+    ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+  });
+
+  test("a public route under the base path renders; the bare path 404s", async () => {
+    const h = await createDispatcherHarness({
+      basePath: "/custom-directory",
+      plugins: [blog],
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hello-world",
+      title: "Hello World",
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const underBase = await h.dispatch(
+      new Request("https://cms.example/custom-directory/post/hello-world"),
+    );
+    expect(underBase.status).toBe(200);
+    expect(await underBase.text()).toContain("<h1>Hello World</h1>");
+
+    // The same path WITHOUT the prefix isn't part of the mounted site.
+    const bare = await h.dispatch(
+      new Request("https://cms.example/post/hello-world"),
+    );
+    expect(bare.status).toBe(404);
+  });
+
+  test("the front page is served at the bare base prefix", async () => {
+    const h = await createDispatcherHarness({ basePath: "/custom-directory" });
+    const response = await h.dispatch(
+      new Request("https://cms.example/custom-directory/"),
+    );
+    expect(response.status).toBe(200);
+  });
+
+  test("the sitemap index lists base-prefixed sub-sitemap URLs", async () => {
+    const h = await createDispatcherHarness({
+      basePath: "/custom-directory",
+      plugins: [blog],
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hello-world",
+      title: "Hello World",
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/custom-directory/sitemap.xml"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain(
+      "https://cms.example/custom-directory/sitemap-post-1.xml",
+    );
+  });
+
+  test("the feed advertises base-prefixed entry links and a base-prefixed self URL", async () => {
+    const h = await createDispatcherHarness({
+      basePath: "/custom-directory",
+      plugins: [blog],
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "hello-world",
+      title: "Hello World",
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/custom-directory/feed"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain(
+      "https://cms.example/custom-directory/post/hello-world",
+    );
+    expect(body).toContain("https://cms.example/custom-directory/feed");
+  });
+
+  test("admin/RPC surfaces stay reachable under the base prefix", async () => {
+    const h = await createDispatcherHarness({ basePath: "/custom-directory" });
+    const response = await h.dispatch(
+      plumixRequest("/custom-directory/_plumix/rpc/entry/list", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: {} }),
+      }),
+    );
+    // 401 (not 404): the strip exposed the RPC route, then auth rejected it.
+    expect(response.status).toBe(401);
+  });
+
+  test("the admin shell injects a base-prefixed <base href> so the SPA resolves assets under the mount", async () => {
+    const assets = htmlAssets(
+      '<!doctype html><html lang="en"><head></head><body></body></html>',
+    );
+    const h = await createDispatcherHarness({
+      basePath: "/custom-directory",
+      assets,
+    });
+
+    const response = await h.dispatch(
+      plumixRequest("/custom-directory/_plumix/admin/", { method: "GET" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain(
+      '<base href="/custom-directory/_plumix/admin/">',
+    );
+  });
+
+  test("admin asset requests under the base are served from the binding at the stripped path", async () => {
+    const calls: string[] = [];
+    const assets = {
+      fetch(request: Request): Promise<Response> {
+        calls.push(new URL(request.url).pathname);
+        return Promise.resolve(
+          new Response("console.log(1)", {
+            status: 200,
+            headers: { "content-type": "text/javascript" },
+          }),
+        );
+      },
+    };
+    const h = await createDispatcherHarness({
+      basePath: "/custom-directory",
+      assets,
+    });
+
+    const response = await h.dispatch(
+      plumixRequest("/custom-directory/_plumix/admin/assets/index-abc.js", {
+        method: "GET",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("console.log(1)");
+    // The binding is hit at the root-relative asset path, not the prefixed one.
+    expect(calls).toContain("/_plumix/admin/assets/index-abc.js");
+  });
+
+  test("the session cookie is scoped to the base so it isn't sent to sibling apps", async () => {
+    const h = await createDispatcherHarness({ basePath: "/custom-directory" });
+    const response = await h.dispatch(
+      plumixRequest("/custom-directory/_plumix/auth/signout", {
+        method: "POST",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain(
+      "Path=/custom-directory",
+    );
+  });
+});
+
 describe("dispatcher — imageDelivery slot wiring", () => {
   test("ctx.imageDelivery is exposed to plugin route handlers when configured", async () => {
     const plugin = definePlugin("media", (ctx) => {

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -6,6 +6,7 @@ import type { PlumixApp } from "./app.js";
 import { readSessionCookie } from "../auth/cookies.js";
 import { hasCsrfHeader, hasMatchingOrigin } from "../auth/csrf.js";
 import { parseOAuthPath } from "../auth/oauth/match.js";
+import { stripBasePath, withBasePath } from "../base-path.js";
 import { interfaceEnabled } from "../config.js";
 import { withUser } from "../context/app.js";
 import { resolveLocale } from "../i18n/resolve-locale.js";
@@ -20,7 +21,10 @@ import {
 } from "../seo/feed.js";
 import { handleRobotsTxt } from "../seo/robots.js";
 import { handleSitemapIndex, handleSubSitemap } from "../seo/sitemap.js";
-import { rewriteAdminShellLangDir } from "./admin-shell.js";
+import {
+  injectAdminBaseHref,
+  rewriteAdminShellLangDir,
+} from "./admin-shell.js";
 import {
   forbidden,
   jsonResponse,
@@ -159,6 +163,22 @@ function hasLocalhostOrigin(request: Request): boolean {
 }
 
 async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
+  // Strip the configured subdirectory prefix once, at the edge, by rewriting
+  // the request URL to its root-relative form. Every downstream branch and
+  // sub-handler (RPC, MCP, REST, auth flows, plugin routes, the public router,
+  // the admin shell) then matches root-relative paths with no base awareness
+  // of its own; outbound URL builders re-add the prefix via `withBasePath`. A
+  // request that isn't under the base (e.g. the bare domain root when mounted
+  // at `/custom-directory`) isn't part of the mounted site — 404 it. A root
+  // deployment (`basePath === ""`) leaves the request untouched.
+  if (app.basePath !== "") {
+    const rawUrl = new URL(ctx.request.url);
+    const stripped = stripBasePath(rawUrl.pathname, app.basePath);
+    if (stripped === null) return notFound("outside-base-path");
+    rawUrl.pathname = stripped;
+    ctx = { ...ctx, request: new Request(rawUrl, ctx.request) };
+  }
+
   const url = new URL(ctx.request.url);
   const { pathname } = url;
 
@@ -494,6 +514,15 @@ async function serveAdmin(ctx: AppContext): Promise<Response> {
   // asset layer before the worker or represent a real 404. Don't mask a
   // missing asset by returning HTML — the browser loader would choke.
   if (ASSET_LIKE.test(pathname)) {
+    // Under a subdirectory mount the platform asset layer never matched this
+    // request — its bucket paths omit the prefix, so the (already base-stripped)
+    // request fell through to the worker. Serve it from the binding here. At
+    // the root the platform had its chance, so a miss is a genuine 404.
+    if (ctx.basePath !== "") {
+      return ctx.assets.fetch(
+        new Request(new URL(ctx.request.url), ctx.request),
+      );
+    }
     return notFound("admin-asset-not-found");
   }
   // SPA deep link: admin's client router owns routing past /_plumix/admin/.
@@ -533,8 +562,17 @@ async function serveAdmin(ctx: AppContext): Promise<Response> {
   headers.set("cache-control", "private, no-cache");
   headers.append("vary", "cookie, accept-language");
 
+  // `<base href>` anchors the relative-based client bundle (assets, the client
+  // router's basepath, and the RPC URL) to wherever the admin is mounted, so
+  // the same precompiled admin serves correctly at the root or under any
+  // subdirectory without a rebuild.
+  const baseHref = withBasePath(`${ADMIN_PREFIX}/`, ctx.basePath);
   const html = await upstream.text();
-  return new Response(rewriteAdminShellLangDir(html, locale), {
+  const shell = injectAdminBaseHref(
+    rewriteAdminShellLangDir(html, locale),
+    baseHref,
+  );
+  return new Response(shell, {
     status: upstream.status,
     statusText: upstream.statusText,
     headers,

--- a/packages/core/src/seo/canonical.test.ts
+++ b/packages/core/src/seo/canonical.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, test } from "vitest";
 import type { AppContext } from "../context/app.js";
 import { canonicalRedirectTarget, canonicalUrl } from "./canonical.js";
 
-function ctxFor(url: string): AppContext {
+function ctxFor(url: string, basePath = ""): AppContext {
   return {
     request: new Request(url),
     origin: "https://cms.example",
+    basePath,
   } as unknown as AppContext;
 }
 

--- a/packages/core/src/seo/canonical.ts
+++ b/packages/core/src/seo/canonical.ts
@@ -1,5 +1,6 @@
 import type { AppContext } from "../context/app.js";
 import type { DocumentManifest } from "../theme.js";
+import { withBasePath } from "../base-path.js";
 
 /**
  * Normalize a pathname to its canonical, slash-less shape. `/page/1` is the
@@ -20,7 +21,10 @@ function canonicalPath(pathname: string): string {
  * they can never disagree.
  */
 export function canonicalUrl(ctx: AppContext): string {
-  return `${ctx.origin}${canonicalPath(new URL(ctx.request.url).pathname)}`;
+  // The dispatcher already stripped any base prefix from the request, so the
+  // pathname is root-relative; re-add the prefix on the way out.
+  const canonical = canonicalPath(new URL(ctx.request.url).pathname);
+  return `${ctx.origin}${withBasePath(canonical, ctx.basePath)}`;
 }
 
 /**
@@ -47,11 +51,13 @@ export function isCanonicalExempt(pathname: string): boolean {
  * is preserved, and an already-canonical path returns null (loop-safe).
  */
 export function canonicalRedirectTarget(ctx: AppContext): string | null {
+  // Request path is already root-relative (base stripped at the dispatcher
+  // edge), so `/` — the base prefix's own front page — is exempt as usual.
   const url = new URL(ctx.request.url);
   if (isCanonicalExempt(url.pathname)) return null;
   const target = canonicalPath(url.pathname);
   if (url.pathname === target) return null;
-  return `${ctx.origin}${target}${url.search}`;
+  return `${ctx.origin}${withBasePath(target, ctx.basePath)}${url.search}`;
 }
 
 function hasCanonical(manifest: DocumentManifest): boolean {

--- a/packages/core/src/seo/feed.test.ts
+++ b/packages/core/src/seo/feed.test.ts
@@ -90,6 +90,7 @@ describe("renderAtom", () => {
 describe("applyFeedDiscovery", () => {
   const ctx = {
     origin: "https://cms.example",
+    basePath: "",
     plugins: {
       entryTypes: new Map([["post", { name: "post", isPublic: true }]]),
       termTaxonomies: new Map([
@@ -115,6 +116,22 @@ describe("applyFeedDiscovery", () => {
     ).toEqual([
       "application/rss+xml https://cms.example/feed",
       "application/atom+xml https://cms.example/feed/atom",
+    ]);
+  });
+
+  test("discovery links carry the configured basePath", () => {
+    const basedCtx = { ...ctx, basePath: "/custom-directory" } as AppContext;
+    const data = {
+      entries: [],
+      pagination: { page: 1, perPage: 10, total: 0, pageCount: 0 },
+    } as unknown as TemplateData;
+    expect(
+      alternates(
+        applyFeedDiscovery(empty, data, basedCtx, { siteIsPrivate: false }),
+      ),
+    ).toEqual([
+      "application/rss+xml https://cms.example/custom-directory/feed",
+      "application/atom+xml https://cms.example/custom-directory/feed/atom",
     ]);
   });
 

--- a/packages/core/src/seo/feed.ts
+++ b/packages/core/src/seo/feed.ts
@@ -3,6 +3,7 @@ import type { SQL } from "drizzle-orm";
 import type { AppContext } from "../context/app.js";
 import type { RegisteredTermTaxonomy } from "../plugin/manifest.js";
 import type { DocumentLink, DocumentManifest, TemplateData } from "../theme.js";
+import { withBasePath } from "../base-path.js";
 import { and, desc, eq, inArray } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
@@ -281,9 +282,10 @@ export async function handleFeed(
 
   const channel: FeedChannel = {
     title: nonEmpty(site.title) ?? ctx.origin,
-    link: ctx.origin,
-    // The feed's self URL is just this request's path.
-    feedUrl: `${ctx.origin}${new URL(ctx.request.url).pathname}`,
+    link: `${ctx.origin}${withBasePath("/", ctx.basePath)}`,
+    // The feed's self URL is this request's path. The dispatcher already
+    // stripped the base prefix, so re-add it for the externally-visible URL.
+    feedUrl: `${ctx.origin}${withBasePath(new URL(ctx.request.url).pathname, ctx.basePath)}`,
     description: nonEmpty(site.tagline) ?? "",
     updated: items[0]?.updated ?? new Date().toISOString(),
   };
@@ -348,8 +350,14 @@ export function applyFeedDiscovery(
       additions.push({ rel: "alternate", type, href });
     }
   };
-  add("application/rss+xml", `${ctx.origin}${base}`);
-  add("application/atom+xml", `${ctx.origin}${base}/atom`);
+  add(
+    "application/rss+xml",
+    `${ctx.origin}${withBasePath(base, ctx.basePath)}`,
+  );
+  add(
+    "application/atom+xml",
+    `${ctx.origin}${withBasePath(`${base}/atom`, ctx.basePath)}`,
+  );
 
   if (additions.length === 0) return manifest;
   return { ...manifest, link: [...(existing ?? []), ...additions] };

--- a/packages/core/src/seo/sitemap.ts
+++ b/packages/core/src/seo/sitemap.ts
@@ -1,4 +1,5 @@
 import type { AppContext } from "../context/app.js";
+import { withBasePath } from "../base-path.js";
 import { and, eq, sql } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { terms } from "../db/schema/terms.js";
@@ -143,7 +144,8 @@ async function sitemapIndexLocs(ctx: AppContext): Promise<string[]> {
   const pushScope = (name: string, total: number): void => {
     const pages = Math.max(1, Math.ceil(total / SITEMAP_PAGE_SIZE));
     for (let page = 1; total > 0 && page <= pages; page++) {
-      locs.push(`${ctx.origin}/sitemap-${name}-${String(page)}.xml`);
+      const path = `/sitemap-${name}-${String(page)}.xml`;
+      locs.push(`${ctx.origin}${withBasePath(path, ctx.basePath)}`);
     }
   };
 

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -115,6 +115,12 @@ export interface CreateDispatcherHarnessOptions {
   readonly bootstrapVia?: BootstrapVia;
   readonly theme?: ThemeDescriptor;
   readonly i18n?: I18nInput;
+  /**
+   * Serve the harness app under a subdirectory. Tests that exercise the
+   * inbound strip / outbound prefixing pass e.g. `"/custom-directory"`; the
+   * default `""` mirrors a root deployment.
+   */
+  readonly basePath?: string;
   /** Mount the MCP endpoint. Default-off mirrors production. */
   readonly mcp?: InterfaceToggle;
   /** Mount the REST API. Default-off mirrors production. */
@@ -208,6 +214,7 @@ function withRequest(
     authenticator: app.authenticator,
     bootstrapAllowed: app.bootstrapAllowed,
     origin: app.origin,
+    basePath: app.basePath,
     siteName: app.config.auth.magicLink?.siteName,
   });
 }
@@ -235,6 +242,7 @@ export async function createDispatcherHarness(
     imageDelivery: options.imageDelivery,
     mailer: options.mailer,
     i18n: options.i18n,
+    basePath: options.basePath,
     mcp: options.mcp,
     api: options.api,
     theme: options.theme ?? defaultTestTheme,

--- a/packages/plugins/audit-log/src/admin/rpc.ts
+++ b/packages/plugins/audit-log/src/admin/rpc.ts
@@ -38,7 +38,9 @@ async function rpcCall<TOutput>(
   procedure: string,
   input: unknown = {},
 ): Promise<TOutput> {
-  const res = await fetch(`/_plumix/rpc/${procedure}`, {
+  const base =
+    (globalThis as { plumix?: { basePath?: string } }).plumix?.basePath ?? "";
+  const res = await fetch(`${base}/_plumix/rpc/${procedure}`, {
     method: "POST",
     headers: {
       "content-type": "application/json",

--- a/packages/plugins/comments/src/admin/rpc.ts
+++ b/packages/plugins/comments/src/admin/rpc.ts
@@ -30,7 +30,9 @@ async function rpcCall<TOutput>(
   procedure: string,
   input: unknown = {},
 ): Promise<TOutput> {
-  const res = await fetch(`/_plumix/rpc/${procedure}`, {
+  const base =
+    (globalThis as { plumix?: { basePath?: string } }).plumix?.basePath ?? "";
+  const res = await fetch(`${base}/_plumix/rpc/${procedure}`, {
     method: "POST",
     headers: { "content-type": "application/json", "x-plumix-request": "1" },
     body: JSON.stringify({ json: input, meta: [] }),

--- a/packages/plugins/media/src/admin/MediaLibrary.tsx
+++ b/packages/plugins/media/src/admin/MediaLibrary.tsx
@@ -160,11 +160,19 @@ interface ConfirmResponse {
 // Hand-rolled oRPC POST. Plugin `media/*` procedures don't surface in the
 // admin's typed client (`AppRouterClient` covers core only), so we speak
 // the StandardRPC envelope `{ json, meta: [] }` directly.
+// The subdirectory mount the host exposes (see plumix-globals), used to prefix
+// the worker-routed `/_plumix/...` URLs this file builds in two scopes.
+function pluginBasePath(): string {
+  return (
+    (globalThis as { plumix?: { basePath?: string } }).plumix?.basePath ?? ""
+  );
+}
+
 async function rpcCall<TOutput>(
   procedure: string,
   input: Record<string, unknown>,
 ): Promise<TOutput> {
-  const res = await fetch(`/_plumix/rpc/${procedure}`, {
+  const res = await fetch(`${pluginBasePath()}/_plumix/rpc/${procedure}`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -1240,7 +1248,7 @@ function MediaDetailDrawer({
             // but the route always sends `Content-Disposition:
             // attachment` for this query param, so downloads work
             // regardless of which mode `item.url` is in.
-            href={`/_plumix/media/serve/${String(item.id)}?attachment=1`}
+            href={`${pluginBasePath()}/_plumix/media/serve/${String(item.id)}?attachment=1`}
             download={item.title}
             data-testid="media-detail-download"
             className="bg-card hover:bg-muted flex-1 rounded border px-3 py-2 text-center text-xs no-underline"

--- a/packages/plugins/media/src/admin/index.test.ts
+++ b/packages/plugins/media/src/admin/index.test.ts
@@ -1,40 +1,36 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
-afterEach(() => {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  delete (globalThis as { window?: unknown }).window;
-});
+import { mediaBlocks } from "../media-blocks.js";
+import { registerMediaAdmin } from "./index.js";
 
-describe("media admin entry side effects", () => {
-  test("registers every mediaBlocks spec via window.plumix.registerPluginBlock on load", async () => {
+describe("registerMediaAdmin", () => {
+  test("registers every mediaBlocks spec and both field types with the host", () => {
     const registerPluginBlock = vi.fn();
     const registerPluginFieldType = vi.fn();
-    (globalThis as { window?: unknown }).window = {
-      plumix: { registerPluginBlock, registerPluginFieldType },
-    };
 
-    vi.resetModules();
-    // Import after resetModules so admin entry + mediaBlocks share the
-    // same fresh module instance (object identity matters for the
-    // toHaveBeenNthCalledWith spec assertions).
-    await import("./index.js");
-    const { mediaBlocks } = await import("../media-blocks.js");
+    registerMediaAdmin({ registerPluginBlock, registerPluginFieldType });
 
     expect(registerPluginBlock).toHaveBeenCalledTimes(mediaBlocks.length);
     mediaBlocks.forEach((spec, i) => {
       expect(registerPluginBlock).toHaveBeenNthCalledWith(i + 1, spec);
     });
+    expect(registerPluginFieldType).toHaveBeenCalledWith(
+      "media",
+      expect.anything(),
+    );
+    expect(registerPluginFieldType).toHaveBeenCalledWith(
+      "mediaList",
+      expect.anything(),
+    );
   });
 
-  test("warns and does not throw when window.plumix is missing", async () => {
-    (globalThis as { window?: unknown }).window = {};
+  test("warns and does not throw when the host global is missing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
-    vi.resetModules();
-    await expect(import("./index.js")).resolves.toBeDefined();
+    expect(() => registerMediaAdmin(undefined)).not.toThrow();
 
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0]?.[0]).toMatch(/window\.plumix not initialized/);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("window.plumix not initialized"),
+    );
   });
 });

--- a/packages/plugins/media/src/admin/index.tsx
+++ b/packages/plugins/media/src/admin/index.tsx
@@ -35,31 +35,40 @@ declare const window:
     }
   | undefined;
 
-if (typeof window !== "undefined") {
-  if (window.plumix) {
-    window.plumix.registerPluginFieldType(
+// Exported so the behaviour is testable without re-evaluating the module's
+// load-time side effect (which `vi.resetModules()` + dynamic import can run
+// more than once under load — the source of a prior flaky test).
+export function registerMediaAdmin(
+  plumix: PlumixWindowGlobal | undefined,
+): void {
+  if (plumix) {
+    plumix.registerPluginFieldType(
       "media",
       MediaPickerField as ComponentType<never>,
     );
-    window.plumix.registerPluginFieldType(
+    plumix.registerPluginFieldType(
       "mediaList",
       MediaListPickerField as ComponentType<never>,
     );
     for (const spec of mediaBlocks) {
-      window.plumix.registerPluginBlock(spec);
+      plumix.registerPluginBlock(spec);
     }
-  } else {
-    // Silent no-op would leave the `media`/`mediaList` field renderers
-    // unregistered for the whole session — every media field would fall
-    // through to the legacy text-input fallback with no error visible.
-    // Surface the misconfiguration so a deployment with a broken
-    // load-order is diagnosable instead of silently degraded.
-    console.warn(
-      "[plumix-plugin-media] window.plumix not initialized — media " +
-        "field renderers and blocks not registered. Verify the host admin " +
-        "has booted plumix-globals before the plugin chunk loads.",
-    );
+    return;
   }
+  // Silent no-op would leave the `media`/`mediaList` field renderers
+  // unregistered for the whole session — every media field would fall
+  // through to the legacy text-input fallback with no error visible.
+  // Surface the misconfiguration so a deployment with a broken
+  // load-order is diagnosable instead of silently degraded.
+  console.warn(
+    "[plumix-plugin-media] window.plumix not initialized — media " +
+      "field renderers and blocks not registered. Verify the host admin " +
+      "has booted plumix-globals before the plugin chunk loads.",
+  );
+}
+
+if (typeof window !== "undefined") {
+  registerMediaAdmin(window.plumix);
 }
 
 export { MediaLibrary } from "./MediaLibrary.js";

--- a/packages/plugins/media/src/read-service.ts
+++ b/packages/plugins/media/src/read-service.ts
@@ -8,6 +8,7 @@ import {
   inArray,
   like,
   sql,
+  withBasePath,
 } from "plumix/plugin";
 import * as v from "valibot";
 
@@ -167,7 +168,7 @@ async function buildMediaItem(
   meta: NonNullable<ReturnType<typeof parseMediaMeta>>,
 ): Promise<MediaItem> {
   const url = ctx.storage
-    ? await resolveMediaUrl(ctx.storage, meta.storageKey, row.id)
+    ? await resolveMediaUrl(ctx.storage, meta.storageKey, row.id, ctx.basePath)
     : meta.storageKey;
   // `publishedAt` is the "uploaded on" source of truth; fall back to createdAt.
   const uploadedAt = (row.publishedAt ?? row.createdAt).toISOString();
@@ -207,9 +208,12 @@ export async function resolveMediaUrl(
   storage: NonNullable<AppContext["storage"]>,
   storageKey: string,
   entryId: number,
+  basePath = "",
 ): Promise<string> {
   const direct = await storage.url(storageKey);
-  return direct ?? `/_plumix/media/serve/${String(entryId)}`;
+  return (
+    direct ?? withBasePath(`/_plumix/media/serve/${String(entryId)}`, basePath)
+  );
 }
 
 // Translate `accept` into a SQL predicate against the JSON `mime` field. Real

--- a/packages/plugins/media/src/rpc.ts
+++ b/packages/plugins/media/src/rpc.ts
@@ -1,5 +1,12 @@
 import type { AuthenticatedAppContext } from "plumix/plugin";
-import { and, authenticated, base, entries, eq } from "plumix/plugin";
+import {
+  and,
+  authenticated,
+  base,
+  entries,
+  eq,
+  withBasePath,
+} from "plumix/plugin";
 import * as v from "valibot";
 
 import { looksLikeMime, MAGIC_BYTE_SAMPLE_SIZE } from "./magic-bytes.js";
@@ -203,7 +210,10 @@ export function createMediaRouter(
         // and the upload-route enforces the size cap on the actual
         // stream, not just the Content-Length header.
         return {
-          uploadUrl: `/_plumix/media/upload/${String(created.id)}`,
+          uploadUrl: withBasePath(
+            `/_plumix/media/upload/${String(created.id)}`,
+            context.basePath,
+          ),
           method: "PUT",
           headers: { "content-type": normalizedMime },
           mediaId: created.id,
@@ -290,7 +300,12 @@ export function createMediaRouter(
         throw errors.CONFLICT({ data: { reason: "already_confirmed" } });
       }
 
-      const url = await resolveMediaUrl(storage, meta.storageKey, published.id);
+      const url = await resolveMediaUrl(
+        storage,
+        meta.storageKey,
+        published.id,
+        context.basePath,
+      );
       return {
         id: published.id,
         url,

--- a/packages/plugins/menu/src/admin/rpc.ts
+++ b/packages/plugins/menu/src/admin/rpc.ts
@@ -58,7 +58,9 @@ export async function rpcCall<TOutput>(
   procedure: string,
   input: unknown = {},
 ): Promise<TOutput> {
-  const res = await fetch(`/_plumix/rpc/${procedure}`, {
+  const base =
+    (globalThis as { plumix?: { basePath?: string } }).plumix?.basePath ?? "";
+  const res = await fetch(`${base}/_plumix/rpc/${procedure}`, {
     method: "POST",
     headers: {
       "content-type": "application/json",

--- a/packages/plugins/menu/src/server/getMenuByName.test.ts
+++ b/packages/plugins/menu/src/server/getMenuByName.test.ts
@@ -47,6 +47,7 @@ function ctxFor(
     hooks: bundle.hooks,
     request: new Request("https://test.example/"),
     resolvedEntity: null,
+    basePath: "",
   } as unknown as AppContext;
 }
 
@@ -402,6 +403,7 @@ describe("getMenuByName", () => {
         hooks: ctx.hooks,
         request: new Request(url),
         resolvedEntity: resolved,
+        basePath: "",
       } as unknown as AppContext;
     }
 

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -206,6 +206,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
         authenticator: app.authenticator,
         bootstrapAllowed: app.bootstrapAllowed,
         origin: app.origin,
+        basePath: app.basePath,
         siteName: app.config.auth.magicLink?.siteName,
         appContextExtensions: app.appContextExtensions,
       });
@@ -281,6 +282,7 @@ function buildScheduled(app: PlumixApp): ScheduledHandler {
       authenticator: app.authenticator,
       bootstrapAllowed: app.bootstrapAllowed,
       origin: app.origin,
+      basePath: app.basePath,
       siteName: app.config.auth.magicLink?.siteName,
       appContextExtensions: app.appContextExtensions,
     });


### PR DESCRIPTION
Adds a `plumix({ basePath })` option so a plumix site can be served under a subdirectory (e.g. `example.com/custom-directory/*`) behind a reverse proxy. The design follows the model the major frameworks converged on (Next.js `basePath`, Nuxt `app.baseURL`, Astro `base`): normalize once at config load, strip the prefix once on the inbound request, and re-add it on every outbound URL. A root deployment (`basePath: ""`, the default) is a no-op throughout — existing behavior is byte-for-byte identical.

```ts
plumix({ basePath: "/custom-directory" }) // "" | "/seg"; path-only, never touches auth.passkey.origin
```

**Strip once at the edge.** The dispatcher rewrites the inbound request to its root-relative form before any routing, so every downstream surface — RPC, MCP, REST, auth flows, plugin routes, the public router, the admin shell — matches root-relative paths with no base awareness of its own. A request that isn't under the base 404s as `outside-base-path`. Leading-slash collapse keeps `//base/...` from dodging the gate.

**Outbound re-prefixing via `withBasePath`.** Canonical tags, sitemap (index + sub), RSS/Atom feeds, permalinks, and the session + locale cookie `Path` all carry the prefix. The OAuth `redirect_uri` / magic-link email + post-auth redirects are base-scoped too, so those flows complete under a subdirectory instead of bouncing to a base-less 404. Passkey was already correct (JSON + base-aware admin client).

**Admin: relocatable precompiled bundle.** The admin ships precompiled, so it can't bake a per-deploy base. Instead it's built with a relative Vite base and the worker injects `<base href="${basePath}/_plumix/admin/">` into the shell; the client derives its mount from that tag (`adminBasePath()`) for the TanStack Router basepath and the oRPC URL. Admin asset requests that reach the worker under the base are served from the assets binding at the stripped path.

**Validation.** Server-side (config → strip → outbound), the admin build, and all unit/integration layers are green: core 2167 + admin 562 + cloudflare 149 tests, typecheck/lint/knip/format clean, and the admin builds cleanly with the relative base (relative asset URLs, no absolute `/_plumix/admin/` refs). The one remaining manual gate is an **e2e run of the admin SPA behind a real subdirectory proxy** — asset loading + deep-link reloads under a base can only be fully proven in a browser, not by unit/integration tests.