### PR TITLE
feat: add libsql database adapter exposed via plumix/db/libsql

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -76,6 +76,10 @@ const config: KnipConfig = {
         "src/blocks/island-runtime.ts",
         "src/blocks/island-renderer.ts",
         "src/cli/index.ts",
+        // `plumix/db/libsql` re-exports the core libSQL adapter on its own
+        // subpath; not reachable from `src/index.ts` (kept off the root
+        // barrel so the driver stays out of unrelated bundles).
+        "src/db/libsql.ts",
         "src/fields/index.ts",
         "src/i18n/index.ts",
         "src/schema/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/db/schema/index.d.ts",
       "default": "./dist/db/schema/index.js"
     },
+    "./db/libsql": {
+      "types": "./dist/db/libsql.d.ts",
+      "default": "./dist/db/libsql.js"
+    },
     "./test": {
       "types": "./dist/test/index.d.ts",
       "default": "./dist/test/index.js"

--- a/packages/core/src/db/libsql.test.ts
+++ b/packages/core/src/db/libsql.test.ts
@@ -1,0 +1,78 @@
+import type { LibSQLDatabase } from "drizzle-orm/libsql";
+import { sql } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+import { libsql } from "./libsql.js";
+
+describe("libsql() adapter", () => {
+  test("connect() returns a working drizzle db bound to the url", async () => {
+    const adapter = libsql({ url: ":memory:" });
+    const { db } = adapter.connect({}, new Request("https://x/"), {});
+    const rows = await (db as LibSQLDatabase).all<{ one: number }>(
+      sql`select 1 as one`,
+    );
+    expect(rows).toEqual([{ one: 1 }]);
+  });
+
+  test("identifies as 'libsql' and exposes its config", () => {
+    const adapter = libsql({ url: "libsql://db.turso.io", authToken: "tok" });
+    expect(adapter.kind).toBe("libsql");
+    expect(adapter.config).toEqual({
+      url: "libsql://db.turso.io",
+      authToken: "tok",
+    });
+  });
+
+  test("has no connectRequest hook (single endpoint, strong consistency)", () => {
+    expect(libsql({ url: ":memory:" }).connectRequest).toBeUndefined();
+  });
+
+  test("declares no required env bindings (connection comes from config)", () => {
+    expect(libsql({ url: ":memory:" }).requiredBindings).toBeUndefined();
+  });
+
+  test("resolves connection config from the runtime env (resolver form)", async () => {
+    const adapter = libsql((env) => ({
+      url: (env as { DB_URL: string }).DB_URL,
+    }));
+    const { db } = adapter.connect(
+      { DB_URL: ":memory:" },
+      new Request("https://x/"),
+      {},
+    );
+    const rows = await (db as LibSQLDatabase).all<{ one: number }>(
+      sql`select 1 as one`,
+    );
+    expect(rows).toEqual([{ one: 1 }]);
+  });
+
+  test("does not call the resolver until connect() (env is request-time)", () => {
+    let called = false;
+    libsql(() => {
+      called = true;
+      return { url: ":memory:" };
+    });
+    expect(called).toBe(false);
+  });
+
+  test("memoizes the client — the resolver runs once across requests", () => {
+    let calls = 0;
+    const adapter = libsql(() => {
+      calls += 1;
+      return { url: ":memory:" };
+    });
+    adapter.connect({}, new Request("https://x/"), {});
+    adapter.connect({}, new Request("https://x/"), {});
+    expect(calls).toBe(1);
+  });
+
+  test("connect() applies snake_case column casing", async () => {
+    const adapter = libsql({ url: ":memory:" });
+    const { db } = adapter.connect({}, new Request("https://x/"), {});
+    const lib = db as LibSQLDatabase;
+    await lib.run(sql`create table t (first_name text)`);
+    await lib.run(sql`insert into t (first_name) values ('ada')`);
+    const rows = await lib.all<{ first_name: string }>(sql`select * from t`);
+    expect(rows).toEqual([{ first_name: "ada" }]);
+  });
+});

--- a/packages/core/src/db/libsql.ts
+++ b/packages/core/src/db/libsql.ts
@@ -1,0 +1,57 @@
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+
+import type { DatabaseAdapter } from "../runtime/slots.js";
+
+export interface LibsqlConfig {
+  /**
+   * libSQL connection URL — `file:./data.db`, `:memory:`, or a remote
+   * `libsql://` / `https://` endpoint (Turso, self-hosted sqld, …).
+   */
+  readonly url: string;
+  readonly authToken?: string;
+}
+
+/**
+ * Either literal connection config, or a resolver that derives it from the
+ * runtime `env` at request time. The resolver form is required wherever the
+ * connection secret only exists per-request — notably Cloudflare Workers,
+ * where `env` (not `process.env`) carries bindings and the config module is
+ * evaluated before any request. The literal form fits Node/Docker, where the
+ * URL (including a `file:` path on shared storage) is known at config time.
+ */
+export type LibsqlConfigInput = LibsqlConfig | ((env: unknown) => LibsqlConfig);
+
+export interface LibsqlDatabaseAdapter extends DatabaseAdapter {
+  readonly config: LibsqlConfigInput;
+}
+
+/**
+ * Database adapter for any libSQL-compatible SQLite endpoint. Lives behind
+ * the `@plumix/core/db/libsql` subpath so the driver only loads when this
+ * adapter is imported — D1 deployments never pull it into their bundle.
+ *
+ * Single endpoint, strong consistency: no `connectRequest` read-replica hook
+ * (that's D1's Sessions API), and no `requiredBindings` since the connection
+ * comes from config rather than a runtime env binding.
+ */
+export function libsql(config: LibsqlConfigInput): LibsqlDatabaseAdapter {
+  // Built on first connect, not in the factory, because a resolver needs the
+  // request-time `env`; reused across requests since the client owns a
+  // connection pipeline. `env` is isolate-stable, so the first value holds.
+  let client: ReturnType<typeof createClient> | undefined;
+  return {
+    kind: "libsql",
+    config,
+    connect: (env, _request, schema) => {
+      if (!client) {
+        const resolved = typeof config === "function" ? config(env) : config;
+        client = createClient({
+          url: resolved.url,
+          authToken: resolved.authToken,
+        });
+      }
+      return { db: drizzle(client, { schema, casing: "snake_case" }) };
+    },
+  };
+}

--- a/packages/plumix/package.json
+++ b/packages/plumix/package.json
@@ -113,6 +113,10 @@
       "types": "./dist/schema/index.d.ts",
       "default": "./dist/schema/index.js"
     },
+    "./db/libsql": {
+      "types": "./dist/db/libsql.d.ts",
+      "default": "./dist/db/libsql.js"
+    },
     "./fields": {
       "types": "./dist/fields/index.d.ts",
       "default": "./dist/fields/index.js"

--- a/packages/plumix/src/db/libsql.ts
+++ b/packages/plumix/src/db/libsql.ts
@@ -1,0 +1,3 @@
+// Own subpath so the libSQL driver stays out of bundles that don't import it.
+
+export * from "@plumix/core/db/libsql";


### PR DESCRIPTION
Lets a plumix deployment run on any libSQL-compatible SQLite endpoint —
Turso, a self-hosted sqld, or a local/Docker file — configured through `plumix`
config, alongside the Cloudflare-native `d1()` default.

```ts
import { libsql } from "plumix/db/libsql";

// Node / Docker — URL known at config time (file: on shared storage)
plumix({ database: libsql({ url: "file:/data/app.db" }) });

// Cloudflare Workers — secret resolved per-request from the runtime env
plumix({ database: libsql((env) => ({ url: env.LIBSQL_URL, authToken: env.LIBSQL_TOKEN })) });
```

**Config is a union: literal values or an `env` resolver**

`libsql()` accepts `{ url, authToken? }` *or* `(env) => ({ url, authToken? })`.
The resolver form exists because on Workers the config module is evaluated
before any request and connection secrets arrive via the request-time `env`,
not `process.env`. The literal form fits Node/Docker, where the URL (including
a `file:` path on shared storage) is known at config time. The client is built
lazily on first `connect()` and memoized — `env` is isolate-stable, so a remote
endpoint keeps its connection pipeline warm instead of reconnecting per request.

**Works on Cloudflare Workers (remote endpoints)**

The bare `@libsql/client` import resolves to its fetch-based web build via the
`workerd` export condition, so no native driver is bundled. Remote only on
Workers (`libsql://` / `https://`) — `file:`/`:memory:` need a filesystem.

**Public surface via the published package, with bundle isolation**

Authored in the private `@plumix/core` package and re-exported from the
published `plumix` package, on a dedicated per-adapter subpath in both so the
driver only loads when `plumix/db/libsql` is imported — D1 deployments never
pull it into their bundle. `@libsql/client` is already a core dependency (the
test harness uses it), so this adds no new dependency.

**Minimum-viable by design**

No read-replica `connectRequest` hook (single endpoint, strong consistency)
and no `requiredBindings` (the connection comes from config, not an env
binding) — the intended divergence from `d1()`.