### PR TITLE
feat(core): make theme optional with a built-in welcome screen

### DIFF
--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -5,6 +5,7 @@ import type { DatabaseAdapter, ImageDelivery } from "./runtime/slots.js";
 import { auth } from "./auth/config.js";
 import { plumix } from "./config.js";
 import { defineTheme } from "./theme.js";
+import { welcomeTheme } from "./welcome-theme.js";
 
 const runtime: RuntimeAdapter = {
   name: "mock",
@@ -25,6 +26,16 @@ const authConfig = auth({
 });
 
 const theme = defineTheme({ templates: { index: () => null } });
+
+test("plumix() defaults a missing theme to the built-in welcome theme", () => {
+  const config = plumix({ runtime, database, auth: authConfig });
+  expect(config.theme).toBe(welcomeTheme);
+});
+
+test("plumix() preserves an explicitly provided theme", () => {
+  const config = plumix({ runtime, database, auth: authConfig, theme });
+  expect(config.theme).toBe(theme);
+});
 
 test("plumix() defaults missing plugins to an empty array", () => {
   const config = plumix({ runtime, database, auth: authConfig, theme });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -14,6 +14,7 @@ import type {
 import type { ThemeDescriptor } from "./theme.js";
 import { normalizeBasePath } from "./base-path.js";
 import { resolveLocales } from "./i18n/locale-registry.js";
+import { welcomeTheme } from "./welcome-theme.js";
 
 /**
  * Re-exported from `./theme.js` so existing `import { Theme } from
@@ -75,7 +76,12 @@ export interface PlumixConfigInput {
    * is the dev default.
    */
   readonly mailer?: Mailer;
-  readonly theme: ThemeDescriptor;
+  /**
+   * The site's theme. Optional: a site that registers none falls back to
+   * the built-in {@link welcomeTheme}, which renders a self-contained
+   * welcome screen on the public site until a real theme is added.
+   */
+  readonly theme?: ThemeDescriptor;
   readonly plugins?: readonly AnyPluginDescriptor[];
   readonly i18n?: I18nInput;
   /**
@@ -152,7 +158,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
     imageDelivery: config.imageDelivery,
     kv: config.kv,
     mailer: config.mailer,
-    theme: config.theme,
+    theme: config.theme ?? welcomeTheme,
     plugins: config.plugins ?? [],
     i18n: resolveLocales(
       config.i18n ?? { defaultLocale: "en", locales: ["en"] },

--- a/packages/core/src/theme.test.ts
+++ b/packages/core/src/theme.test.ts
@@ -338,17 +338,4 @@ describe("buildApp", () => {
       ),
     ).rejects.toThrow(ThemeRegistrationError);
   });
-
-  test("throws ThemeRegistrationError when config has no theme", async () => {
-    await expect(
-      buildApp(
-        // @ts-expect-error -- exercising the JS-caller runtime guard
-        plumix({
-          runtime: stubAdapter,
-          database: stubDatabase,
-          auth: stubAuth,
-        }),
-      ),
-    ).rejects.toThrow(ThemeRegistrationError);
-  });
 });

--- a/packages/core/src/welcome-theme.test.tsx
+++ b/packages/core/src/welcome-theme.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+
+import { createDispatcherHarness } from "./test/dispatcher.js";
+import { welcomeTheme } from "./welcome-theme.js";
+
+test("a theme-less site renders the welcome screen at /", async () => {
+  const h = await createDispatcherHarness({ theme: welcomeTheme });
+  const response = await h.dispatch(new Request("https://cms.example/"));
+  expect(response.status).toBe(200);
+  const body = await response.text();
+  expect(body).toContain('data-testid="plumix-welcome"');
+});
+
+test("the welcome screen is marked noindex", async () => {
+  const h = await createDispatcherHarness({ theme: welcomeTheme });
+  const response = await h.dispatch(new Request("https://cms.example/"));
+  const body = await response.text();
+  expect(body).toContain('name="robots"');
+  expect(body).toContain('content="noindex"');
+});
+
+test("the welcome screen is self-contained — inline style and svg, no external fetch", async () => {
+  const h = await createDispatcherHarness({ theme: welcomeTheme });
+  const response = await h.dispatch(new Request("https://cms.example/"));
+  const body = await response.text();
+  expect(body).toContain("<style");
+  expect(body).toContain("<svg");
+  expect(body).not.toContain('rel="stylesheet"');
+});
+
+test("the welcome screen respects a dark-mode preference", async () => {
+  const h = await createDispatcherHarness({ theme: welcomeTheme });
+  const response = await h.dispatch(new Request("https://cms.example/"));
+  const body = await response.text();
+  expect(body).toContain("prefers-color-scheme: dark");
+});
+
+test("the admin link is prefixed with the configured basePath", async () => {
+  const h = await createDispatcherHarness({
+    theme: welcomeTheme,
+    basePath: "/blog",
+  });
+  const response = await h.dispatch(new Request("https://cms.example/blog/"));
+  const body = await response.text();
+  expect(body).toContain('href="/blog/_plumix/admin"');
+});

--- a/packages/core/src/welcome-theme.tsx
+++ b/packages/core/src/welcome-theme.tsx
@@ -1,0 +1,188 @@
+import { withBasePath } from "./base-path.js";
+import { defineTemplate } from "./template.js";
+import { defineTheme } from "./theme.js";
+
+const BRAND = "#0ea5e9";
+
+// Inline so the screen fetches nothing — no stylesheet, no web font.
+// `dangerouslySetInnerHTML`, not a JSX child: React would HTML-escape the
+// `>`/`&` in the CSS.
+const styles = `
+.plumix-welcome {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  padding: 2rem;
+  text-align: center;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background: #f8fafc;
+}
+.plumix-welcome__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+.plumix-welcome__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+.plumix-welcome__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: #22c55e;
+}
+.plumix-welcome h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+.plumix-welcome p {
+  margin: 0;
+  max-width: 32rem;
+  color: #475569;
+  line-height: 1.6;
+}
+.plumix-welcome__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.plumix-welcome__cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.625rem 1.25rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid ${BRAND};
+}
+.plumix-welcome__cta--primary {
+  background: ${BRAND};
+  color: #fff;
+}
+.plumix-welcome__cta--secondary {
+  color: ${BRAND};
+  background: transparent;
+}
+.plumix-welcome__chip {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8125rem;
+  background: #e2e8f0;
+  color: #0f172a;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+}
+.plumix-welcome__footer {
+  font-size: 0.8125rem;
+  color: #94a3b8;
+}
+.plumix-welcome__footer a {
+  color: inherit;
+}
+@media (prefers-color-scheme: dark) {
+  .plumix-welcome {
+    color: #f1f5f9;
+    background: #020617;
+  }
+  .plumix-welcome p {
+    color: #94a3b8;
+  }
+  .plumix-welcome__chip {
+    background: #1e293b;
+    color: #f1f5f9;
+  }
+}
+`;
+
+function Logo() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 32 32" aria-hidden="true">
+      <rect width="32" height="32" rx="6" fill={BRAND} />
+      <text
+        x="16"
+        y="22"
+        fontFamily="ui-sans-serif, system-ui"
+        fontSize="18"
+        fontWeight="700"
+        textAnchor="middle"
+        fill="#fff"
+      >
+        P
+      </text>
+    </svg>
+  );
+}
+
+function WelcomeScreen({ basePath }: { readonly basePath: string }) {
+  return (
+    <main className="plumix-welcome" data-testid="plumix-welcome">
+      <style dangerouslySetInnerHTML={{ __html: styles }} />
+      <div className="plumix-welcome__brand">
+        <Logo />
+        <span>plumix</span>
+      </div>
+      <span className="plumix-welcome__status">
+        <span className="plumix-welcome__dot" />
+        plumix is running
+      </span>
+      <h1>Your site is ready.</h1>
+      <p>
+        No theme is registered yet — that&apos;s why you&apos;re seeing this.
+        Open the admin to start creating content, or add a theme to design your
+        public site.
+      </p>
+      <div className="plumix-welcome__actions">
+        <a
+          className="plumix-welcome__cta plumix-welcome__cta--primary"
+          href={withBasePath("/_plumix/admin", basePath)}
+        >
+          Open admin →
+        </a>
+        <a
+          className="plumix-welcome__cta plumix-welcome__cta--secondary"
+          href="https://plumix.dev/docs"
+        >
+          Add a theme
+        </a>
+      </div>
+      <code className="plumix-welcome__chip">
+        {"theme: defineTheme({ … })"}
+      </code>
+      <div className="plumix-welcome__footer">
+        <a href="https://plumix.dev/docs">Docs</a> ·{" "}
+        <a href="https://github.com/withplumix/plumix">GitHub</a>
+      </div>
+    </main>
+  );
+}
+
+/**
+ * Built-in theme served when a site registers no `theme`. `plumix()`
+ * substitutes it at config resolution, so to all downstream code a
+ * theme-less site is indistinguishable from one with a user theme.
+ *
+ * The `index` template uses `defineTemplate` (not a plain function) so its
+ * render receives `ctx` — needed for the basePath-aware admin link.
+ */
+export const welcomeTheme = defineTheme({
+  templates: {
+    index: defineTemplate({
+      render: ({ ctx }) => <WelcomeScreen basePath={ctx.basePath} />,
+    }),
+  },
+  // Never index a placeholder — it's a misconfiguration if it reaches prod.
+  document: {
+    title: "plumix",
+    meta: [{ name: "robots", content: "noindex" }],
+  },
+});


### PR DESCRIPTION
Makes `theme` optional in `plumix()`. A site that registers none now boots and serves the public surface against a built-in welcome theme instead of failing — mirroring the zero-config first-run screen every adjacent framework ships, but pointed at plumix's admin.

**Defaulting, not validation**

`plumix()` substitutes the built-in `welcomeTheme` for an absent `theme` at config resolution. The input type relaxes to optional while the resolved `PlumixConfig.theme` stays non-null, so every downstream consumer of `config.theme` is untouched and the welcome theme is indistinguishable from a user theme to the render path.

**The welcome screen**

A single self-contained React component served as the theme's `index` template: system fonts, an inline `<style>` block (with a `prefers-color-scheme: dark` pass) and an inline SVG logo — zero external fetches, no build-time inlining step. It leads with a "plumix is running" diagnostic, a primary admin CTA (basePath-aware via `withBasePath`), a docs link, and a `defineTheme` hint. The theme's document manifest marks it `noindex` so a misconfigured production deploy never gets indexed. It renders on an empty front page, so a fresh content-less install shows it at `/`.

Removes the now-obsolete `theme.test.ts` case that asserted a theme-less config throws — that contract is intentionally reversed here.

Closes #1024
Refs #1023