### PR TITLE
feat: make the minimal example theme-less

### DIFF
--- a/examples/minimal/plumix.config.ts
+++ b/examples/minimal/plumix.config.ts
@@ -1,4 +1,4 @@
-import { auth, defineTheme, plumix } from "plumix";
+import { auth, plumix } from "plumix";
 import {
   cloudflare,
   cloudflareDeployOrigin,
@@ -31,7 +31,6 @@ export default plumix({
       origin,
     },
   }),
-  // Noop placeholder — every Plumix app needs a theme. Replace with a
-  // real theme once you start rendering public routes.
-  theme: defineTheme({ templates: { index: () => null } }),
+  // No theme registered: the public site serves plumix's built-in welcome
+  // screen. Add a `theme` once you start rendering your own public routes.
 });


### PR DESCRIPTION
Drops the placeholder noop theme from the minimal example. With themes now optional (#1024), the example boots straight to plumix's built-in welcome screen and becomes a genuine theme-less floor — `create-plumix-app --template minimal` scaffolds a project that runs and shows the welcome page with no theme to author first.

The template under `create-plumix-app` re-syncs from `examples/minimal` at pack time (it's generated, not checked in), so the scaffolded output inherits this automatically. The blog template intentionally keeps its theme — out of scope here.

Closes #1025
Refs #1023