### PR TITLE
feat: localize the zero-theme welcome screen

### DIFF
--- a/packages/core/lingui.config.ts
+++ b/packages/core/lingui.config.ts
@@ -1,9 +1,17 @@
 import { defineLinguiConfig } from "@plumix/lingui-config";
 
-// Per-surface catalog naming: core hosts the admin bar today and a
-// debug bar later. `admin-bar-{locale}.po` keeps each surface's
-// catalog distinct in one flat locales/ dir.
+// Per-surface catalog naming keeps each translatable surface's catalog
+// distinct in one flat locales/ dir: the SSR admin bar and the zero-theme
+// welcome screen each own a `<surface>-{locale}.po` set.
 export default defineLinguiConfig({
-  catalogPath: "<rootDir>/locales/admin-bar-{locale}",
-  include: ["src/admin-bar"],
+  surfaces: [
+    {
+      catalogPath: "<rootDir>/locales/admin-bar-{locale}",
+      include: ["src/admin-bar"],
+    },
+    {
+      catalogPath: "<rootDir>/locales/welcome-{locale}",
+      include: ["src/welcome"],
+    },
+  ],
 });

--- a/packages/core/locales/welcome-ar.po
+++ b/packages/core/locales/welcome-ar.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (welcome screen renders server-side, no Babel pass)\n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.running"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.heading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.body"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.or"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.openAdmin"
+msgstr ""

--- a/packages/core/locales/welcome-de.po
+++ b/packages/core/locales/welcome-de.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (welcome screen renders server-side, no Babel pass)\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.running"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.heading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.body"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.or"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.openAdmin"
+msgstr ""

--- a/packages/core/locales/welcome-en.po
+++ b/packages/core/locales/welcome-en.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (welcome screen renders server-side, no Babel pass)\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.running"
+msgstr "plumix is running"
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.heading"
+msgstr "Your site is ready."
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.body"
+msgstr "Add a theme in plumix.config.ts to design your public site."
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.or"
+msgstr "or"
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.openAdmin"
+msgstr "Open admin"

--- a/packages/core/locales/welcome-uk.po
+++ b/packages/core/locales/welcome-uk.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (welcome screen renders server-side, no Babel pass)\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.running"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.heading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.body"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.or"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.openAdmin"
+msgstr ""

--- a/packages/core/locales/welcome-zh-CN.po
+++ b/packages/core/locales/welcome-zh-CN.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: hand-authored (welcome screen renders server-side, no Babel pass)\n"
+"Language: zh-CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.running"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.heading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.body"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.or"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/welcome/i18n.ts
+msgid "core.welcome.openAdmin"
+msgstr ""

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "clean": "git clean -xdf .cache .drizzle .turbo dist node_modules",
     "db:generate": "drizzle-kit generate",
     "format": "prettier --check . --ignore-path ../../.gitignore",
-    "i18n:check": "node ../plumix/bin/plumix.mjs i18n verify --src src/admin-bar",
+    "i18n:check": "node ../plumix/bin/plumix.mjs i18n verify --src src/admin-bar --src src/welcome",
     "i18n:compile": "plumix-compile-catalogs --dts",
     "lint": "eslint",
     "test": "vitest run",

--- a/packages/core/src/welcome-theme.tsx
+++ b/packages/core/src/welcome-theme.tsx
@@ -1,6 +1,8 @@
+import type { WelcomeStrings } from "./welcome/i18n.js";
 import { withBasePath } from "./base-path.js";
 import { defineTemplate } from "./template.js";
 import { defineTheme } from "./theme.js";
+import { welcomeMessages } from "./welcome/i18n.js";
 
 const BRAND = "#0ea5e9";
 
@@ -140,26 +142,32 @@ body {
 }
 `;
 
-function WelcomeScreen({ basePath }: { readonly basePath: string }) {
+function WelcomeScreen({
+  basePath,
+  strings,
+}: {
+  readonly basePath: string;
+  readonly strings: WelcomeStrings;
+}) {
   return (
     <main className="plumix-welcome" data-testid="plumix-welcome">
       <style dangerouslySetInnerHTML={{ __html: styles }} />
       <div className="plumix-welcome__main">
         <div className="plumix-welcome__status">
           <span className="plumix-welcome__dot" />
-          plumix is running
+          {strings.running}
         </div>
-        <h1>Your site is ready.</h1>
-        <p>Add a theme in plumix.config.ts to design your public site.</p>
+        <h1>{strings.heading}</h1>
+        <p>{strings.body}</p>
         <code className="plumix-welcome__chip">
           {"theme: defineTheme({ … })"}
         </code>
-        <div className="plumix-welcome__or">or</div>
+        <div className="plumix-welcome__or">{strings.or}</div>
         <a
           className="plumix-welcome__cta"
           href={withBasePath("/_plumix/admin", basePath)}
         >
-          Open admin →
+          {strings.openAdmin} →
         </a>
       </div>
       <div className="plumix-welcome__footer">
@@ -181,7 +189,12 @@ function WelcomeScreen({ basePath }: { readonly basePath: string }) {
 export const welcomeTheme = defineTheme({
   templates: {
     index: defineTemplate({
-      render: ({ ctx }) => <WelcomeScreen basePath={ctx.basePath} />,
+      render: ({ ctx }) => (
+        <WelcomeScreen
+          basePath={ctx.basePath}
+          strings={welcomeMessages(ctx.locale.code)}
+        />
+      ),
     }),
   },
   // Never index a placeholder — it's a misconfiguration if it reaches prod.

--- a/packages/core/src/welcome/i18n.test.ts
+++ b/packages/core/src/welcome/i18n.test.ts
@@ -1,0 +1,29 @@
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+import { PLUMIX_LOCALES } from "@plumix/lingui-config";
+
+import { welcomeMessages } from "./i18n.js";
+
+const LOCALES_DIR = fileURLToPath(new URL("../../locales", import.meta.url));
+
+describe("welcome catalogs", () => {
+  test("ships a welcome catalog for every PLUMIX_LOCALES locale", () => {
+    // A locale added to the shared config without a welcome catalog would
+    // silently fall back to English — fail loud here instead.
+    const poLocales = readdirSync(LOCALES_DIR)
+      .filter((f) => f.startsWith("welcome-") && f.endsWith(".po"))
+      .map((f) => f.replace(/^welcome-/, "").replace(/\.po$/, ""))
+      .sort();
+    expect(poLocales).toEqual([...PLUMIX_LOCALES].sort());
+  });
+
+  test("resolves the English source strings", () => {
+    expect(welcomeMessages("en").heading).toBe("Your site is ready.");
+  });
+
+  test("falls back to English for a locale with no catalog entry", () => {
+    expect(welcomeMessages("xx").heading).toBe("Your site is ready.");
+  });
+});

--- a/packages/core/src/welcome/i18n.ts
+++ b/packages/core/src/welcome/i18n.ts
@@ -1,0 +1,68 @@
+// Welcome-screen strings follow the admin-bar pattern: hand-authored
+// `locales/welcome-*.po` catalogs compiled to static modules and looked up
+// per-request server-side (no `activate()` singleton). `plumix i18n verify`
+// gates descriptor↔catalog drift. Non-English catalogs ship untranslated;
+// `lingui compile` (no `--strict`) backfills missing entries with the English
+// source, so an untranslated locale renders English until a translator fills
+// its `.po`. The `welcome-` prefix keeps this surface distinct in the flat dir.
+
+import { messages as arMessages } from "@plumix/core/locales/welcome-ar";
+import { messages as deMessages } from "@plumix/core/locales/welcome-de";
+import { messages as enMessages } from "@plumix/core/locales/welcome-en";
+import { messages as ukMessages } from "@plumix/core/locales/welcome-uk";
+import { messages as zhCnMessages } from "@plumix/core/locales/welcome-zh-CN";
+
+type CompiledCatalog = Record<string, string | readonly string[]>;
+
+const CATALOGS: Readonly<Record<string, CompiledCatalog>> = {
+  en: enMessages,
+  de: deMessages,
+  uk: ukMessages,
+  ar: arMessages,
+  "zh-CN": zhCnMessages,
+};
+
+// Source descriptors — `plumix i18n verify` matches these against the po
+// catalogs; `message` is the English source and the runtime fallback.
+const M = {
+  running: { id: "core.welcome.running", message: "plumix is running" },
+  heading: { id: "core.welcome.heading", message: "Your site is ready." },
+  body: {
+    id: "core.welcome.body",
+    message: "Add a theme in plumix.config.ts to design your public site.",
+  },
+  or: { id: "core.welcome.or", message: "or" },
+  openAdmin: { id: "core.welcome.openAdmin", message: "Open admin" },
+} as const;
+
+export interface WelcomeStrings {
+  readonly running: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly or: string;
+  readonly openAdmin: string;
+}
+
+function resolveMessage(
+  catalog: CompiledCatalog,
+  descriptor: { readonly id: string; readonly message: string },
+): string {
+  const value = catalog[descriptor.id];
+  const text = typeof value === "string" ? value : value?.[0];
+  return typeof text === "string" && text.length > 0
+    ? text
+    : descriptor.message;
+}
+
+export function welcomeMessages(locale: string): WelcomeStrings {
+  // `locale` is the resolved `ctx.locale.code` (an arbitrary string), so an
+  // unshipped locale falls back to the English catalog.
+  const catalog = CATALOGS[locale] ?? enMessages;
+  return {
+    running: resolveMessage(catalog, M.running),
+    heading: resolveMessage(catalog, M.heading),
+    body: resolveMessage(catalog, M.body),
+    or: resolveMessage(catalog, M.or),
+    openAdmin: resolveMessage(catalog, M.openAdmin),
+  };
+}

--- a/tooling/lingui/index.ts
+++ b/tooling/lingui/index.ts
@@ -14,6 +14,15 @@ import { formatter } from "@lingui/format-po";
  */
 export const PLUMIX_LOCALES = ["en", "uk", "ar", "de", "zh-CN"] as const;
 
+/** One translatable surface: a catalog path template paired with the
+ *  source dirs scanned for its descriptors. */
+export interface PlumixLinguiSurface {
+  /** Catalog path template (the `{locale}` placeholder is required). */
+  readonly catalogPath: string;
+  /** Source dirs scanned for this surface's descriptors. */
+  readonly include: readonly string[];
+}
+
 export interface PlumixLinguiOptions {
   /** Locale list including the "en" source. Defaults to PLUMIX_LOCALES. */
   readonly locales?: readonly string[];
@@ -27,20 +36,30 @@ export interface PlumixLinguiOptions {
   readonly catalogPath?: string;
   /** Source dirs scanned for descriptors. Defaults to `["src"]`. */
   readonly include?: readonly string[];
+  /**
+   * Multiple catalog surfaces in one package (e.g. core's admin-bar +
+   * welcome screen), each with its own path template and source dirs.
+   * Takes precedence over `catalogPath`/`include` when provided.
+   */
+  readonly surfaces?: readonly PlumixLinguiSurface[];
 }
 
 export function defineLinguiConfig(
   options: PlumixLinguiOptions = {},
 ): ReturnType<typeof defineConfig> {
+  const surfaces = options.surfaces ?? [
+    {
+      catalogPath: options.catalogPath ?? "<rootDir>/locales/{locale}",
+      include: options.include ?? ["src"],
+    },
+  ];
   return defineConfig({
     sourceLocale: "en",
     locales: [...(options.locales ?? PLUMIX_LOCALES)],
-    catalogs: [
-      {
-        path: options.catalogPath ?? "<rootDir>/locales/{locale}",
-        include: [...(options.include ?? ["src"])],
-      },
-    ],
+    catalogs: surfaces.map((surface) => ({
+      path: surface.catalogPath,
+      include: [...surface.include],
+    })),
     format: formatter({ lineNumbers: false }),
   });
 }


### PR DESCRIPTION
Internationalizes the zero-theme welcome screen (follow-up to #1026) using the existing server-side catalog pattern, so a site's configured locale drives the copy — no new public-render i18n machinery.

**Mirrors the admin-bar surface**

Adds `src/welcome/i18n.ts` with explicit `core.welcome.*` descriptor ids and a `welcomeMessages(locale)` resolver keyed by the request's resolved locale (`ctx.locale.code`), exactly like `src/admin-bar/i18n.ts`. The welcome screen renders those strings instead of hardcoded English. RTL is already handled upstream — the renderer emits `<html lang dir>` from `ctx.locale` for every theme.

**Translation-ready, no drafts**

Ships hand-authored `locales/welcome-*.po` for all `PLUMIX_LOCALES`. Only `en` is filled; `uk`/`ar`/`de`/`zh-CN` ship untranslated and `lingui compile` (no `--strict`) backfills them with the English source. A configured locale renders its translation the moment a translator fills its `.po` — consistent with the repo's no-LLM-drafted-translations policy.

**Tooling**

`defineLinguiConfig` gains a `surfaces` array (backward compatible) so core declares its admin-bar and welcome catalogs side by side, and `i18n verify` gains `--src src/welcome` so the descriptor↔catalog drift gate covers the new surface.

Refs #1023