### PR TITLE
feat: add a <Link> theme component resolving entry/term/href

### DIFF
--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -35,6 +35,8 @@ export interface PlumixContextValue {
   readonly shortcodes?: ShortcodeRegistry;
   /** Queried entry, exposed to body shortcodes via `BlockContext.entry`. */
   readonly entry?: Readonly<Record<string, unknown>> | null;
+  /** Subdirectory prefix for internal links; `""` for a root deployment. */
+  readonly basePath?: string;
 }
 
 const PlumixContext = createContext<PlumixContextValue | null>(null);
@@ -85,3 +87,10 @@ export function useUser(): RendererUser | null {
 export function useQueriedEntry(): RendererQueriedEntry | null {
   return usePlumixContext("useQueriedEntry").queriedEntry ?? null;
 }
+
+export function useBasePath(): string {
+  return usePlumixContext("useBasePath").basePath ?? "";
+}
+
+export { Link } from "./link.js";
+export type { LinkProps, LinkTarget } from "./link.js";

--- a/packages/blocks/src/renderer/link.test.tsx
+++ b/packages/blocks/src/renderer/link.test.tsx
@@ -1,0 +1,95 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry } from "../block-registry.js";
+import { Link, PlumixProvider } from "./index.js";
+
+const registry = createBlockRegistry([]);
+
+function render(node: React.ReactNode, basePath = ""): string {
+  return renderToStaticMarkup(
+    <PlumixProvider value={{ registry, basePath }}>{node}</PlumixProvider>,
+  );
+}
+
+describe("Link", () => {
+  test("renders an anchor for a raw href", () => {
+    expect(render(<Link href="/about">About</Link>)).toBe(
+      '<a href="/about">About</a>',
+    );
+  });
+
+  test("prefixes a raw href with the configured basePath", () => {
+    expect(render(<Link href="/about">About</Link>, "/blog")).toBe(
+      '<a href="/blog/about">About</a>',
+    );
+  });
+
+  test("uses an entry's pre-resolved url as-is, without re-prefixing basePath", () => {
+    expect(
+      render(<Link entry={{ url: "/blog/hello" }}>Hello</Link>, "/blog"),
+    ).toBe('<a href="/blog/hello">Hello</a>');
+  });
+
+  test("uses a term's pre-resolved url", () => {
+    expect(render(<Link term={{ url: "/category/news" }}>News</Link>)).toBe(
+      '<a href="/category/news">News</a>',
+    );
+  });
+
+  test("does not basePath-prefix fragment- or query-only hrefs", () => {
+    expect(render(<Link href="#main">Skip</Link>, "/blog")).toBe(
+      '<a href="#main">Skip</a>',
+    );
+    expect(render(<Link href="?page=2">Next</Link>, "/blog")).toBe(
+      '<a href="?page=2">Next</a>',
+    );
+  });
+
+  test("merges a caller's rel with the safe default on external links", () => {
+    expect(
+      render(
+        <Link href="https://example.com" rel="author">
+          Ext
+        </Link>,
+      ),
+    ).toBe(
+      '<a href="https://example.com" rel="author noopener noreferrer">Ext</a>',
+    );
+  });
+
+  test("renders children unwrapped when the target has no url", () => {
+    expect(render(<Link entry={{ url: null }}>Draft</Link>)).toBe("Draft");
+  });
+
+  test("adds safe rel to an external href and skips basePath", () => {
+    expect(render(<Link href="https://example.com">Ext</Link>, "/blog")).toBe(
+      '<a href="https://example.com" rel="noopener noreferrer">Ext</a>',
+    );
+  });
+
+  test("passes through standard anchor attributes", () => {
+    expect(
+      render(
+        <Link href="/x" className="btn" target="_blank">
+          x
+        </Link>,
+      ),
+    ).toBe('<a href="/x" class="btn" target="_blank">x</a>');
+  });
+
+  test("refuses to render an anchor for a dangerous-scheme href", () => {
+    for (const href of [
+      "javascript:alert(1)",
+      "  javascript:alert(1)",
+      "JAVASCRIPT:alert(1)",
+      "java\tscript:alert(1)",
+      "data:text/html,<script>",
+      "vbscript:msgbox(1)",
+      "blob:https://x/abc",
+      "view-source:javascript:alert(1)",
+    ]) {
+      expect(render(<Link href={href}>x</Link>)).toBe("x");
+    }
+  });
+});

--- a/packages/blocks/src/renderer/link.tsx
+++ b/packages/blocks/src/renderer/link.tsx
@@ -1,0 +1,95 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+import { useBasePath } from "./index.js";
+
+/**
+ * A domain object (entry/term) carrying a pre-resolved, basePath-correct
+ * permalink; `url` is null when there's no public URL.
+ */
+export interface LinkTarget {
+  readonly url: string | null;
+}
+
+type AnchorAttrs = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href" | "children"
+>;
+
+/** Exactly one of `entry` / `term` / `href`. */
+export type LinkProps = AnchorAttrs & {
+  readonly children?: ReactNode;
+} & (
+    | { readonly href: string; readonly entry?: never; readonly term?: never }
+    | {
+        readonly entry: LinkTarget;
+        readonly href?: never;
+        readonly term?: never;
+      }
+    | {
+        readonly term: LinkTarget;
+        readonly href?: never;
+        readonly entry?: never;
+      }
+  );
+
+// Mirror of core's `withBasePath` — blocks sits below core in the build
+// graph and can't import it.
+function withBasePath(path: string, basePath: string): string {
+  if (basePath === "") return path;
+  return path === "/" ? basePath : `${basePath}${path}`;
+}
+
+// Absolute (`https:`, `mailto:`, `tel:`, …) or protocol-relative (`//`).
+function isExternal(href: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith("//");
+}
+
+// Caller's `rel` plus the safety tokens, de-duplicated — so an explicit
+// `rel` augments rather than drops the external-link protection.
+function externalRel(rel: string | undefined): string {
+  const tokens = new Set((rel ?? "").split(/\s+/).filter(Boolean));
+  tokens.add("noopener");
+  tokens.add("noreferrer");
+  return [...tokens].join(" ");
+}
+
+// Script-capable schemes that must never become a clickable href. Strip
+// whitespace/control chars (browsers ignore them inside the scheme) and peel
+// nested `view-source:` before testing.
+function isDangerousHref(href: string): boolean {
+  // eslint-disable-next-line no-control-regex -- strips the control chars a scheme could hide behind
+  let s = href.replace(/[\u0000-\u0020\u007f-\u009f]/g, "").toLowerCase();
+  while (s.startsWith("view-source:")) s = s.slice("view-source:".length);
+  return /^(?:javascript|data|vbscript|blob):/.test(s);
+}
+
+export function Link(props: LinkProps): ReactNode {
+  const basePath = useBasePath();
+  const { children, entry, term, href, rel, ...rest } = props;
+
+  // Only the `href` member reaches the raw-href branches; `entry`/`term`
+  // carry a pre-resolved, basePath-correct url.
+  let resolved: string | null;
+  let external = false;
+  if (entry) resolved = entry.url;
+  else if (term) resolved = term.url;
+  else if (isDangerousHref(href)) resolved = null;
+  else if (isExternal(href)) {
+    external = true;
+    resolved = href;
+  }
+  // Root-relative hrefs take the basePath; fragment / query / relative hrefs
+  // are already correct (withBasePath only handles root-relative paths).
+  else if (href.startsWith("/")) resolved = withBasePath(href, basePath);
+  else resolved = href;
+
+  // Unresolvable target (draft with no permalink, or a refused href) degrades
+  // to the children with no dead anchor.
+  if (resolved === null) return <>{children}</>;
+
+  return (
+    <a href={resolved} rel={external ? externalRel(rel) : rel} {...rest}>
+      {children}
+    </a>
+  );
+}

--- a/packages/core/src/route/link-wiring.test.tsx
+++ b/packages/core/src/route/link-wiring.test.tsx
@@ -1,0 +1,66 @@
+import { expect, test } from "vitest";
+
+import { Link } from "@plumix/blocks/renderer";
+
+import { definePlugin } from "../plugin/define.js";
+import { defineTemplate } from "../template.js";
+import { createDispatcherHarness } from "../test/dispatcher.js";
+import { defineTheme } from "../theme.js";
+
+const blog = definePlugin("blog", (ctx) => {
+  ctx.registerEntryType("post", {
+    label: "Posts",
+    isPublic: true,
+    hasArchive: true,
+  });
+  ctx.registerTermTaxonomy("topic", { label: "Topics", entryTypes: ["post"] });
+});
+
+// A theme that links to the first front-page entry and its first term — the
+// end-to-end path: resolve attaches url → provider carries basePath → Link.
+const linkTheme = defineTheme({
+  templates: {
+    index: defineTemplate({
+      render: ({ data }) => {
+        const entry = "entries" in data ? data.entries[0] : undefined;
+        const term = entry?.terms[0];
+        return (
+          <main>
+            {entry ? <Link entry={entry}>{entry.title}</Link> : null}
+            {term ? <Link term={term}>{term.name}</Link> : null}
+          </main>
+        );
+      },
+    }),
+  },
+});
+
+test("Link resolves entry/term permalinks with the configured basePath", async () => {
+  const h = await createDispatcherHarness({
+    plugins: [blog],
+    theme: linkTheme,
+    basePath: "/blog",
+  });
+  const author = await h.seedUser("admin");
+  const term = await h.factory.term.create({
+    taxonomy: "topic",
+    slug: "edge",
+    name: "Edge",
+  });
+  const post = await h.factory.entry.create({
+    type: "post",
+    slug: "hello",
+    title: "Hello",
+    content: null,
+    status: "published",
+    authorId: author.id,
+    publishedAt: new Date("2026-04-10"),
+  });
+  await h.factory.entryTerm.create({ entryId: post.id, termId: term.id });
+
+  const response = await h.dispatch(new Request("https://cms.example/blog/"));
+  const body = await response.text();
+
+  expect(body).toContain('<a href="/blog/post/hello">Hello</a>');
+  expect(body).toContain('<a href="/blog/topic/edge">Edge</a>');
+});

--- a/packages/core/src/route/permalink.test.ts
+++ b/packages/core/src/route/permalink.test.ts
@@ -11,6 +11,7 @@ import {
   buildEntryPermalink,
   buildEntryPermalinkSync,
   buildTermArchiveUrl,
+  buildTermArchiveUrlSync,
 } from "./permalink.js";
 
 async function buildRegistry(
@@ -483,5 +484,68 @@ describe("buildTermArchiveUrl", () => {
     expect(
       await buildTermArchiveUrl(ctx, { taxonomy: "category", slug: "news" }),
     ).toBe("/topic/news");
+  });
+});
+
+describe("buildTermArchiveUrlSync", () => {
+  test("flat taxonomy: basePath-correct url without a DB hit", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("category", { label: "Categories" });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry, "/blog");
+    expect(
+      buildTermArchiveUrlSync(ctx, {
+        taxonomy: "category",
+        slug: "news",
+        parentId: null,
+      }),
+    ).toBe("/blog/category/news");
+  });
+
+  test("returns null for a nested term that needs an ancestor walk", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("category", {
+          label: "Categories",
+          isHierarchical: true,
+        });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+    expect(
+      buildTermArchiveUrlSync(ctx, {
+        taxonomy: "category",
+        slug: "child",
+        parentId: 5,
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for a private or unknown taxonomy", async () => {
+    const registry = await buildRegistry([
+      definePlugin("blog", (ctx) => {
+        ctx.registerTermTaxonomy("menu", { label: "Menus", isPublic: false });
+      }),
+    ]);
+    const db = await createTestDb();
+    const ctx = ctxFor(db, registry);
+    expect(
+      buildTermArchiveUrlSync(ctx, {
+        taxonomy: "menu",
+        slug: "main",
+        parentId: null,
+      }),
+    ).toBeNull();
+    expect(
+      buildTermArchiveUrlSync(ctx, {
+        taxonomy: "nope",
+        slug: "x",
+        parentId: null,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/core/src/route/permalink.ts
+++ b/packages/core/src/route/permalink.ts
@@ -102,6 +102,28 @@ export function buildEntryPermalinkSync(
   );
 }
 
+/**
+ * Sync subset of `buildTermArchiveUrl` — mirror of `buildEntryPermalinkSync`.
+ * Returns `null` when a nested term needs an ancestor-chain DB walk, so
+ * callers (e.g. `buildResolvedEntries`) attach a `url` without a per-term CTE.
+ */
+export function buildTermArchiveUrlSync(
+  ctx: AppContext,
+  term: {
+    readonly taxonomy: string;
+    readonly slug: string;
+    readonly parentId?: number | null;
+  },
+): string | null {
+  const taxonomy = ctx.plugins.termTaxonomies.get(term.taxonomy);
+  if (!taxonomy || taxonomy.isPublic === false) return null;
+  if (shouldNestUnderTermParent(taxonomy, term.parentId ?? null)) return null;
+  return withBasePath(
+    joinSegments([termTaxonomyBaseSlug(taxonomy), term.slug]),
+    ctx.basePath,
+  );
+}
+
 function entryTypeBaseSlug(entryType: RegisteredEntryType): string {
   return entryType.rewrite?.slug ?? entryType.name;
 }

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -333,6 +333,7 @@ function renderTree({
         locale: ctx.locale.code,
         shortcodes: ctx.shortcodes,
         entry,
+        basePath: ctx.basePath,
       },
     },
     createElement(PlumixAdminBar, {

--- a/packages/core/src/route/render/resolved-entry.ts
+++ b/packages/core/src/route/render/resolved-entry.ts
@@ -10,6 +10,13 @@ export interface ResolvedAuthor {
   readonly avatarUrl: string | null;
 }
 
+// A term plus its pre-resolved archive `url` (basePath-correct). `url` is null
+// for a private taxonomy or a nested term needing an ancestor-chain walk —
+// `<Link term>` then degrades to its children. Mirrors `ResolvedEntry.url`.
+export interface ResolvedTerm extends Term {
+  readonly url: string | null;
+}
+
 // `content` stays loose so non-blocks serializers (TipTap, etc.) keep
 // working; `contentBlocks` is the narrowed `EntryContent` (null when
 // the stored JSON fails the shape check).
@@ -18,7 +25,7 @@ export interface ResolvedAuthor {
 // types with a non-null parentId await a follow-up batched resolver.
 export interface ResolvedEntry extends Entry {
   readonly contentBlocks: EntryContent | null;
-  readonly terms: readonly Term[];
+  readonly terms: readonly ResolvedTerm[];
   readonly author: ResolvedAuthor;
   readonly url: string | null;
 }
@@ -46,7 +53,7 @@ export interface ArchiveData<TEntry extends ResolvedEntry = ResolvedEntry> {
 
 export interface TaxonomyData<TEntry extends ResolvedEntry = ResolvedEntry> {
   readonly taxonomy: string;
-  readonly term: Term;
+  readonly term: ResolvedTerm;
   readonly entries: readonly TEntry[];
   readonly pagination: Pagination;
 }

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -28,7 +28,11 @@ import { labelSourceText } from "../i18n/label.js";
 import { notFound } from "../runtime/http.js";
 import { paginate } from "./paginate.js";
 import { findEntryByPath, findTermByPath } from "./path-chain.js";
-import { buildEntryPermalinkSync } from "./permalink.js";
+import {
+  buildEntryPermalinkSync,
+  buildTermArchiveUrl,
+  buildTermArchiveUrlSync,
+} from "./permalink.js";
 import { previewTokenGrantsEntry, readPreviewToken } from "./preview.js";
 import { renderThroughTheme } from "./render/render-template.js";
 
@@ -294,7 +298,9 @@ async function resolveTaxonomy(
 
   const initial: TaxonomyData = {
     taxonomy: intent.taxonomy,
-    term,
+    // Single archive term: the async builder walks ancestors for the full
+    // nested URL (one call — no N+1).
+    term: { ...term, url: await buildTermArchiveUrl(ctx, term) },
     entries: await buildResolvedEntries(ctx, result.rows),
     pagination: {
       page,
@@ -498,7 +504,11 @@ async function buildResolvedEntries(
     return {
       ...row,
       contentBlocks: isEntryContent(row.content) ? row.content : null,
-      terms: termsByEntryId.get(row.id) ?? [],
+      // Sync term URLs — no per-term CTE (nested terms get null, like entries).
+      terms: (termsByEntryId.get(row.id) ?? []).map((term) => ({
+        ...term,
+        url: buildTermArchiveUrlSync(ctx, term),
+      })),
       author,
       url: buildEntryPermalinkSync(ctx, row),
     };


### PR DESCRIPTION
First of the theme component primitives (PRD #1041). Gives theme authors a zero-JS permalink resolver instead of hand-rolling `<a href={withBasePath(entry.url, ctx.basePath)}>`.

**`<Link>` — a permalink resolver, not an SPA navigator**

Discriminated, exactly-one-of `entry` / `term` / `href`:
- Object targets (`entry`/`term`) render their pre-resolved, basePath-correct `.url` — no double-prefix.
- A raw **root-relative** `href` is basePath-prefixed; `#fragment` / `?query` / relative hrefs pass through untouched.
- **External** hrefs bypass basePath and merge `rel="noopener noreferrer"` with any caller `rel`.
- **Dangerous schemes** (`javascript:`/`data:`/`vbscript:`/`blob:`/`view-source:`, including control-char, whitespace, and nested variants) render no anchor.
- An unresolvable target (e.g. a draft with no permalink) degrades to its children — no dead `<a>`.
- Renders zero client-side JavaScript.

**Wiring**

`PlumixProvider` now carries `basePath` (via a `useBasePath` hook), so `<Link>` reads it ambiently — populated by the core render pass. Resolved **terms** now carry a basePath-correct `.url` (new `ResolvedTerm`), via a new sync `buildTermArchiveUrlSync` that mirrors `buildEntryPermalinkSync`: nested terms return `null` rather than walking ancestors, so attaching `url` across a listing stays **N+1-free**. The single taxonomy-archive term uses the async builder once.

Tests: 10 `<Link>` render cases + the sync term-builder unit tests + an end-to-end dispatch test proving entry/term permalinks resolve correctly under a configured basePath.

Closes #1042
Refs #1041