### PR TITLE
feat: add an <Image> priority prop for the LCP image

### DIFF
--- a/packages/blocks/src/renderer/image.test.tsx
+++ b/packages/blocks/src/renderer/image.test.tsx
@@ -37,6 +37,55 @@ describe("Image", () => {
     expect(html).toContain('height="300"');
     expect(html).toContain('alt="A cat"');
   });
+
+  test("priority makes the image eager + high-priority and emits a preload link", () => {
+    const html = render(
+      <Image src="/a.jpg" alt="Hero" width={400} height={300} priority />,
+      { imageResolver: resolver },
+    );
+    expect(html).toContain('loading="eager"');
+    expect(html).toContain('fetchPriority="high"');
+    expect(html).toContain('decoding="sync"');
+    expect(html).toContain('rel="preload"');
+    expect(html).toContain('as="image"');
+    expect(html).toContain('imageSrcSet="/a.jpg?w=400 1x, /a.jpg?w=800 2x"');
+  });
+
+  test("non-priority images stay lazy with no preload link", () => {
+    const html = render(
+      <Image src="/a.jpg" alt="A" width={400} height={300} />,
+      {
+        imageResolver: resolver,
+      },
+    );
+    expect(html).not.toContain('rel="preload"');
+    expect(html).toContain('loading="lazy"');
+  });
+
+  test("a caller's loading overrides the priority default", () => {
+    const html = render(
+      <Image
+        src="/a.jpg"
+        alt="A"
+        width={400}
+        height={300}
+        priority
+        loading="lazy"
+      />,
+      { imageResolver: resolver },
+    );
+    expect(html).toContain('loading="lazy"');
+  });
+
+  test("priority on an unoptimizable source preloads by href, no imageSrcSet", () => {
+    const html = render(
+      <Image src="/logo.svg" alt="Logo" width={64} height={64} priority />,
+      { imageResolver: resolver },
+    );
+    expect(html).toContain('rel="preload"');
+    expect(html).toContain('href="/logo.svg"');
+    expect(html).not.toContain("imageSrcSet");
+  });
 });
 
 describe("Image — passthrough + unoptimizable", () => {

--- a/packages/blocks/src/renderer/image.tsx
+++ b/packages/blocks/src/renderer/image.tsx
@@ -1,4 +1,5 @@
 import type { ImgHTMLAttributes, ReactNode } from "react";
+import { preload } from "react-dom";
 
 import { buildImageAttrs } from "./image-attrs.js";
 import { useImageConfig } from "./index.js";
@@ -18,12 +19,17 @@ export type ImageProps = ImgAttrs & {
   readonly densities?: readonly number[];
   readonly quality?: number;
   readonly format?: string;
+  /** Mark the LCP image: eager + high fetch-priority + a preload hint. */
+  readonly priority?: boolean;
 };
 
 export function Image(props: ImageProps): ReactNode {
   const { imageResolver, imageRemotePatterns } = useImageConfig();
-  // `densities`/`quality`/`format` are builder inputs, not DOM attributes —
-  // destructure them out so they don't leak onto the <img>.
+  // `densities`/`quality`/`format`/`priority` are component inputs, not DOM
+  // attributes — pull them out so they don't leak onto the <img>.
+  // `loading`/`decoding`/`fetchPriority` are pulled out too so `...rest` can't
+  // clobber the priority-aware defaults applied below (a caller value still
+  // wins via the `??`).
   const {
     src,
     alt,
@@ -33,6 +39,10 @@ export function Image(props: ImageProps): ReactNode {
     densities,
     quality,
     format,
+    priority,
+    loading,
+    decoding,
+    fetchPriority,
     ...rest
   } = props;
   const attrs = buildImageAttrs({
@@ -46,10 +56,19 @@ export function Image(props: ImageProps): ReactNode {
     resolver: imageResolver,
     remotePatterns: imageRemotePatterns,
   });
+  // React 19's imperative preload hoists a single, deduped
+  // `<link rel="preload" as="image">` into <head> for the LCP image — a JSX
+  // <link rel=preload> double-emits under React's resource hoisting.
+  if (priority) {
+    preload(attrs.src, {
+      as: "image",
+      imageSrcSet: attrs.srcSet,
+      imageSizes: attrs.sizes,
+      fetchPriority: "high",
+    });
+  }
   return (
     <img
-      loading="lazy"
-      decoding="async"
       {...rest}
       src={attrs.src}
       srcSet={attrs.srcSet}
@@ -57,6 +76,9 @@ export function Image(props: ImageProps): ReactNode {
       width={attrs.width}
       height={attrs.height}
       alt={alt}
+      loading={loading ?? (priority ? "eager" : "lazy")}
+      decoding={decoding ?? (priority ? "sync" : "async")}
+      fetchPriority={fetchPriority ?? (priority ? "high" : undefined)}
     />
   );
 }

--- a/packages/core/src/route/image-wiring.test.tsx
+++ b/packages/core/src/route/image-wiring.test.tsx
@@ -74,3 +74,34 @@ test("<Image> optimizes allowlisted remote hosts and passes through the rest", a
   expect(body).toContain('src="https://evil.com/no.jpg"');
   expect(body).not.toContain("evil.com/no.jpg?w=");
 });
+
+const priorityTheme = defineTheme({
+  templates: {
+    index: defineTemplate({
+      render: () => (
+        <main>
+          <Image src="/hero.jpg" alt="hero" width={400} height={300} priority />
+        </main>
+      ),
+    }),
+  },
+});
+
+test("priority <Image> hoists a single preload link into <head>", async () => {
+  const h = await createDispatcherHarness({
+    theme: priorityTheme,
+    imageDelivery,
+  });
+  const body = await (
+    await h.dispatch(new Request("https://cms.example/"))
+  ).text();
+  const head = body.slice(body.indexOf("<head>"), body.indexOf("</head>"));
+
+  // Exactly one preload, in <head>, for the responsive image set.
+  expect(body.match(/rel="preload"/g)).toHaveLength(1);
+  expect(head).toContain('rel="preload"');
+  expect(head).toContain('as="image"');
+  expect(head).toContain("/hero.jpg?w=400 1x, /hero.jpg?w=800 2x");
+  // The image itself is eager.
+  expect(body).toContain('loading="eager"');
+});


### PR DESCRIPTION
Final theme-primitives slice (PRD #1041). Lets a theme mark its hero/LCP image.

**`priority`**

`<Image priority>` sets `loading="eager"`, `decoding="sync"`, `fetchPriority="high"`, and emits a single `<link rel="preload" as="image">` hoisted into `<head>` for the responsive image set. `loading`/`decoding`/`fetchPriority` remain caller-overridable.

**Why `preload()` over a JSX `<link>`**

A JSX `<link rel="preload">` double-emits under React 19's resource hoisting (verified: 2 links). React 19's imperative `preload(src, { as: "image", imageSrcSet, imageSizes, fetchPriority })` hoists exactly one deduped link into `<head>` — confirmed end-to-end through the real render path. An unoptimizable source (SVG/`data:`/unauthorized-remote) preloads by `href` alone, no `imageSrcSet`.

Tests: blocks render cases (priority attrs, preload link, caller override, unoptimizable href-only preload) + a core e2e asserting exactly one preload lands in `<head>`.

Closes #1044
Refs #1041