### PR TITLE
feat: blog example theme front-page skeleton

### DIFF
--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -12,16 +12,22 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@plumix/blocks": "workspace:*",
     "@plumix/plugin-blog": "workspace:*",
     "@plumix/plugin-media": "workspace:*",
+    "@plumix/plugin-menu": "workspace:*",
     "@plumix/plugin-pages": "workspace:*",
     "@plumix/runtime-cloudflare": "workspace:*",
-    "plumix": "workspace:*"
+    "plumix": "workspace:*",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
     "@plumix/typescript-config": "workspace:*",
+    "@tailwindcss/postcss": "^4.3.1",
     "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "tailwindcss": "^4.3.1",
     "typescript": "catalog:",
     "wrangler": "catalog:"
   }

--- a/examples/blog/plumix.config.ts
+++ b/examples/blog/plumix.config.ts
@@ -1,5 +1,6 @@
 import { blog } from "@plumix/plugin-blog";
 import { media } from "@plumix/plugin-media";
+import { menu } from "@plumix/plugin-menu";
 import { pages } from "@plumix/plugin-pages";
 import {
   cloudflare,
@@ -8,7 +9,9 @@ import {
   images,
   r2,
 } from "@plumix/runtime-cloudflare";
-import { auth, consoleMailer, defineTheme, plumix } from "plumix";
+import { auth, consoleMailer, plumix } from "plumix";
+
+import { blogTheme } from "./theme";
 
 // Derives `rpId` + `origin` from the Workers Builds env (`WORKERS_CI`,
 // `WORKERS_CI_BRANCH`): production deploys → `<worker>.<account>.workers.dev`,
@@ -79,10 +82,18 @@ export default plumix({
     // string in the email subject + body.
     magicLink: { siteName: "Plumix — Blog" },
   }),
-  plugins: [blog, pages, media()],
-  // Noop placeholder — every Plumix app needs a theme. Replace with a
-  // real theme once you start rendering public routes.
-  theme: defineTheme({ templates: { index: () => null } }),
+  plugins: [
+    blog,
+    pages,
+    media(),
+    menu({
+      locations: {
+        primary: { label: "Primary" },
+        footer: { label: "Footer" },
+      },
+    }),
+  ],
+  theme: blogTheme,
 });
 
 function resolveR2S3Credentials():

--- a/examples/blog/postcss.config.mjs
+++ b/examples/blog/postcss.config.mjs
@@ -1,0 +1,8 @@
+// Tailwind v4 is applied through PostCSS so the theme's `css` entry compiles
+// without needing access to plumix's synthesized Vite config. Vite auto-loads
+// this config when processing the theme stylesheet.
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/examples/blog/theme/components/Layout.tsx
+++ b/examples/blog/theme/components/Layout.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { ResolvedMenu } from "@plumix/plugin-menu/server";
+
+import { SiteHeader } from "./SiteHeader";
+import { SiteFooter } from "./SiteFooter";
+
+interface LayoutProps {
+  readonly settings?: Readonly<Record<string, unknown>>;
+  readonly menus?: Readonly<Record<string, ResolvedMenu | null>>;
+  readonly children: ReactNode;
+}
+
+// Page shell shared by every template: chrome (header/footer) wrapping the
+// per-route content.
+export function Layout({ settings, menus, children }: LayoutProps): ReactNode {
+  const site = (settings?.site ?? null) as { readonly title?: string } | null;
+  const siteTitle = site?.title ?? "Plumix Blog";
+
+  return (
+    <div className="flex min-h-screen flex-col" data-testid="blog-layout">
+      <SiteHeader siteTitle={siteTitle} menu={menus?.primary} />
+      <main className="mx-auto w-full max-w-3xl flex-1 px-5 py-10">
+        {children}
+      </main>
+      <SiteFooter siteTitle={siteTitle} menu={menus?.footer} />
+    </div>
+  );
+}

--- a/examples/blog/theme/components/Menu.tsx
+++ b/examples/blog/theme/components/Menu.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+// Importing the menu type also pulls the plugin's `menus` template-dep
+// augmentation, so `menus: [...]` is typed on the templates' render args.
+import type { ResolvedMenu } from "@plumix/plugin-menu/server";
+
+// A flat nav of a resolved menu's top-level items. (Nested `children`
+// are ignored for now — the blog chrome only needs a single row.)
+export function Menu({
+  menu,
+}: {
+  readonly menu: ResolvedMenu | null | undefined;
+}): ReactNode {
+  if (!menu || menu.items.length === 0) return null;
+  return (
+    <nav className="flex flex-wrap gap-5 text-sm" data-testid="layout-menu">
+      {menu.items.map((item) => (
+        <a key={item.id} href={item.href} className="text-muted hover:text-ink">
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/examples/blog/theme/components/PostList.tsx
+++ b/examples/blog/theme/components/PostList.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { ResolvedEntry } from "plumix";
+import { Link } from "@plumix/blocks/renderer";
+
+// Slice 1 renders a bare list of linked titles. The card grid + meta
+// (PostCard) lands in a later slice; everything that lists posts —
+// front page, archive, taxonomy, search — funnels through here.
+interface PostListProps {
+  readonly entries: readonly ResolvedEntry[];
+  readonly heading?: string;
+}
+
+export function PostList({ entries, heading }: PostListProps): ReactNode {
+  return (
+    <section data-testid="post-list">
+      {heading ? <h1 className="mb-8 font-serif text-2xl">{heading}</h1> : null}
+      {entries.length === 0 ? (
+        <p className="text-muted" data-testid="post-list-empty">
+          No posts yet.
+        </p>
+      ) : (
+        <ul className="space-y-4">
+          {entries.map((entry) => (
+            <li key={entry.id}>
+              <Link
+                entry={entry}
+                className="font-serif text-lg hover:text-accent"
+                data-testid="post-list-item"
+              >
+                {entry.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/examples/blog/theme/components/SiteFooter.tsx
+++ b/examples/blog/theme/components/SiteFooter.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { ResolvedMenu } from "@plumix/plugin-menu/server";
+
+import { Menu } from "./Menu";
+
+interface SiteFooterProps {
+  readonly siteTitle: string;
+  readonly menu: ResolvedMenu | null | undefined;
+}
+
+export function SiteFooter({ siteTitle, menu }: SiteFooterProps): ReactNode {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="border-t border-line">
+      <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-between gap-6 px-5 py-8 text-sm text-muted">
+        <Menu menu={menu} />
+        <div className="flex items-center gap-4">
+          <a href="/feed" className="hover:text-ink" data-testid="rss-link">
+            RSS
+          </a>
+          <span>
+            © {year} {siteTitle}
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/examples/blog/theme/components/SiteHeader.tsx
+++ b/examples/blog/theme/components/SiteHeader.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import { useUser } from "@plumix/blocks/renderer";
+import type { ResolvedMenu } from "@plumix/plugin-menu/server";
+
+import { Menu } from "./Menu";
+
+interface SiteHeaderProps {
+  readonly siteTitle: string;
+  readonly menu: ResolvedMenu | null | undefined;
+}
+
+export function SiteHeader({ siteTitle, menu }: SiteHeaderProps): ReactNode {
+  const user = useUser();
+  return (
+    <header className="border-b border-line">
+      <div className="mx-auto flex max-w-3xl items-center justify-between gap-6 px-5 py-5">
+        <a href="/" className="font-serif text-xl" data-testid="site-title">
+          {siteTitle}
+        </a>
+        <div className="flex items-center gap-5">
+          <Menu menu={menu} />
+          <form action="/search" method="get" className="hidden sm:block">
+            <input
+              name="q"
+              placeholder="Search…"
+              aria-label="Search"
+              className="rounded border border-line bg-transparent px-2 py-1 text-sm"
+            />
+          </form>
+          {user ? (
+            <a
+              href="/_plumix/admin"
+              className="text-sm text-accent"
+              data-testid="admin-link"
+            >
+              Admin
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/examples/blog/theme/index.ts
+++ b/examples/blog/theme/index.ts
@@ -1,0 +1,17 @@
+import { defineTheme } from "plumix";
+
+import { home } from "./templates/home";
+import { fallback } from "./templates/fallback";
+import { DEFAULT_TOKENS } from "./tokens";
+
+// One consumer (this example's config), so the theme is exported directly
+// rather than behind a factory.
+export const blogTheme = defineTheme({
+  templates: { index: fallback, home },
+  tokens: DEFAULT_TOKENS,
+  css: ["./theme/styles.css"],
+  document: {
+    titleTemplate: (title) => (title ? `${title} — Blog` : "Blog"),
+    meta: [{ name: "theme-color", content: "#fbfaf8" }],
+  },
+});

--- a/examples/blog/theme/styles.css
+++ b/examples/blog/theme/styles.css
@@ -1,0 +1,33 @@
+@import "tailwindcss";
+
+/* The token CSS variables are the single source the chrome (Tailwind
+   utilities below) and rendered block content both read. */
+:root {
+  --plumix-colors-paper: #fbfaf8;
+  --plumix-colors-ink: #1b1a17;
+  --plumix-colors-muted: #6f6b63;
+  --plumix-colors-accent: #b5472d;
+  --plumix-colors-line: #e7e3dc;
+  --plumix-typography-serif:
+    "Iowan Old Style", Georgia, Cambria, "Times New Roman", serif;
+  --plumix-typography-sans:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+/* Map the tokens onto Tailwind's theme so `bg-paper`, `text-ink`,
+   `font-serif`, etc. resolve to the CSS variables above. */
+@theme inline {
+  --color-paper: var(--plumix-colors-paper);
+  --color-ink: var(--plumix-colors-ink);
+  --color-muted: var(--plumix-colors-muted);
+  --color-accent: var(--plumix-colors-accent);
+  --color-line: var(--plumix-colors-line);
+  --font-serif: var(--plumix-typography-serif);
+  --font-sans: var(--plumix-typography-sans);
+}
+
+body {
+  background-color: var(--color-paper);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+}

--- a/examples/blog/theme/templates/fallback.tsx
+++ b/examples/blog/theme/templates/fallback.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { defineTemplate } from "plumix";
+import type { TemplateData } from "plumix";
+
+import { Layout } from "../components/Layout";
+import { PostList } from "../components/PostList";
+
+// Registered as the theme's `index` slot — the ultimate hierarchy
+// fallback. Renders the chrome and lists entries when the node carries
+// them, otherwise just the shell.
+export const fallback = defineTemplate<TemplateData>({
+  settings: ["site"],
+  menus: ["primary", "footer"],
+  render: ({ data, settings, menus }) => (
+    <Layout settings={settings} menus={menus}>
+      {"entries" in data ? <PostList entries={data.entries} /> : null}
+    </Layout>
+  ),
+});

--- a/examples/blog/theme/templates/home.tsx
+++ b/examples/blog/theme/templates/home.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { defineTemplate } from "plumix";
+import type { FrontPageData } from "plumix";
+
+import { Layout } from "../components/Layout";
+import { PostList } from "../components/PostList";
+
+// Front page: latest posts. `settings`/`menus` feed the chrome.
+export const home = defineTemplate<FrontPageData>({
+  settings: ["site"],
+  menus: ["primary", "footer"],
+  render: ({ data, settings, menus }) => (
+    <Layout settings={settings} menus={menus}>
+      <PostList entries={data.entries} />
+    </Layout>
+  ),
+});

--- a/examples/blog/theme/tokens.ts
+++ b/examples/blog/theme/tokens.ts
@@ -1,0 +1,25 @@
+import type { ThemeTokens } from "@plumix/blocks";
+
+// Editorial defaults: warm paper/ink with a single accent, a serif display
+// face over a sans body. These emit `--plumix-<group>-<slug>` CSS variables
+// that the theme's Tailwind config consumes (see styles.css).
+export const DEFAULT_TOKENS = {
+  colors: {
+    paper: { value: "#fbfaf8", label: "Paper" },
+    ink: { value: "#1b1a17", label: "Ink" },
+    muted: { value: "#6f6b63", label: "Muted" },
+    accent: { value: "#b5472d", label: "Accent" },
+    line: { value: "#e7e3dc", label: "Hairline" },
+  },
+  typography: {
+    serif: {
+      value: '"Iowan Old Style", Georgia, Cambria, "Times New Roman", serif',
+      label: "Serif display",
+    },
+    sans: {
+      value:
+        'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+      label: "Sans body",
+    },
+  },
+} satisfies ThemeTokens;

--- a/examples/blog/tsconfig.json
+++ b/examples/blog/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@plumix/typescript-config/base.json",
   "compilerOptions": {
-    "types": ["node", "@cloudflare/workers-types"]
+    "jsx": "react",
+    "types": ["node", "@cloudflare/workers-types", "react"]
   },
-  "include": ["plumix.config.ts", ".plumix"]
+  "include": ["plumix.config.ts", "theme", ".plumix"]
 }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -16,6 +16,12 @@ const config: KnipConfig = {
     // from package.json's exports because examples don't publish.
     "examples/blog": {
       entry: ["plumix.config.ts"],
+      // theme/styles.css is referenced via the theme's `css: []` string array
+      // and postcss.config.mjs is auto-loaded by Vite — neither is a static
+      // import knip can follow. tailwindcss / @tailwindcss/postcss are consumed
+      // through the `@import "tailwindcss"` in that stylesheet, not a TS import.
+      ignore: ["postcss.config.mjs", "theme/styles.css"],
+      ignoreDependencies: ["@tailwindcss/postcss", "tailwindcss"],
     },
     "examples/minimal": {
       entry: ["plumix.config.ts"],

--- a/packages/core/src/route/render/asset-manifest.test.ts
+++ b/packages/core/src/route/render/asset-manifest.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import type { AssetManifest } from "./asset-manifest.js";
-import { bundledCssTags } from "./asset-manifest.js";
+import { bundledCssTags, devThemeStylesTag } from "./asset-manifest.js";
 
 describe("bundledCssTags", () => {
   test("emits a stylesheet <link> for every CSS file linked from an entry chunk", () => {
@@ -148,6 +148,26 @@ describe("bundledCssTags", () => {
     };
     expect(bundledCssTags(manifest)).toBe(
       '<link rel="stylesheet" href="/_plumix/assets/theme.css" />',
+    );
+  });
+});
+
+describe("devThemeStylesTag", () => {
+  test("serve mode loads the client entry so Vite injects the theme CSS", () => {
+    // Dev has no asset manifest, so `bundledCssTags` is empty; the
+    // stylesheets ride in on the Vite-served client entry instead.
+    expect(devThemeStylesTag("serve")).toBe(
+      '<script type="module" src="/.plumix/client-entry.ts"></script>',
+    );
+  });
+
+  test("build mode emits nothing — bundledCssTags links the hashed CSS", () => {
+    expect(devThemeStylesTag("build")).toBe("");
+  });
+
+  test("serve mode prefixes the basePath for a subdirectory install", () => {
+    expect(devThemeStylesTag("serve", "/custom-directory")).toBe(
+      '<script type="module" src="/custom-directory/.plumix/client-entry.ts"></script>',
     );
   });
 });

--- a/packages/core/src/route/render/asset-manifest.ts
+++ b/packages/core/src/route/render/asset-manifest.ts
@@ -19,6 +19,10 @@ export interface AssetManifestEntry {
 
 export type AssetManifest = Readonly<Record<string, AssetManifestEntry>>;
 
+// The Vite lifecycle command the SSR render path branches on: `serve` (dev)
+// vs `build` (production).
+export type ViteCommand = "serve" | "build";
+
 // Walks the import graph starting from every `isEntry: true` chunk and
 // collects CSS from every reachable chunk (including code-split nodes
 // under `imports[]` / `dynamicImports[]`). Dedupes across entries that
@@ -42,6 +46,17 @@ export function bundledCssTags(manifest: AssetManifest, basePath = ""): string {
         `<link rel="stylesheet" href="${withBasePath(`/${href}`, basePath)}" />`,
     )
     .join("");
+}
+
+// CSS counterpart to `injectIslandsBootstrap`: dev has no asset manifest, so
+// load the client entry (which side-effect-imports the theme `css`) and let
+// Vite inject the stylesheets. No-op in build, where `bundledCssTags` links.
+const DEV_CLIENT_ENTRY_PATH = "/.plumix/client-entry.ts";
+
+export function devThemeStylesTag(command: ViteCommand, basePath = ""): string {
+  if (command !== "serve") return "";
+  const src = withBasePath(DEV_CLIENT_ENTRY_PATH, basePath);
+  return `<script type="module" src="${src}"></script>`;
 }
 
 function collectReachableCss(

--- a/packages/core/src/route/render/inject-islands-bootstrap.ts
+++ b/packages/core/src/route/render/inject-islands-bootstrap.ts
@@ -14,7 +14,7 @@
 // `.plumix/islands-entry.ts` in the Vite plugin's
 // `rollupOptions.input`). Read from Vite's `.vite/manifest.json`.
 
-import type { AssetManifest } from "./asset-manifest.js";
+import type { AssetManifest, ViteCommand } from "./asset-manifest.js";
 import { withBasePath } from "../../base-path.js";
 
 const DEV_ENTRY_PATH = "/.plumix/islands-entry.ts";
@@ -30,7 +30,7 @@ const RENDERER_MANIFEST_KEY = ".plumix/islands-renderer-entry.ts";
 export function injectIslandsBootstrap(
   body: string,
   manifest: AssetManifest,
-  command: "serve" | "build",
+  command: ViteCommand,
   basePath = "",
 ): string {
   if (!body.includes("<plumix-island")) return body;
@@ -59,7 +59,7 @@ export function injectIslandsBootstrap(
 // fall back to the source path Vite's dev server serves directly.
 function resolveEntryUrl(
   manifest: AssetManifest,
-  command: "serve" | "build",
+  command: ViteCommand,
   key: string,
   devPath: string,
   basePath: string,

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -24,7 +24,7 @@ import type {
   TemplateRegistry,
   ThemeDescriptor,
 } from "../../theme.js";
-import type { AssetManifest } from "./asset-manifest.js";
+import type { AssetManifest, ViteCommand } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
 import { PlumixAdminBar } from "../../admin-bar/component.js";
@@ -37,7 +37,7 @@ import {
 } from "../../template-deps.js";
 import { normalizeTemplate } from "../../template.js";
 import { validateDocumentManifest } from "../../theme.js";
-import { bundledCssTags } from "./asset-manifest.js";
+import { bundledCssTags, devThemeStylesTag } from "./asset-manifest.js";
 import { injectIslandsBootstrap } from "./inject-islands-bootstrap.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -381,6 +381,11 @@ function renderTree({
 
   // Bundled CSS lands AFTER theme `link[]` so theme-local stylesheets
   // override CDN imports declared in `link[]` (last-wins cascade).
+  // `process.env.PLUMIX_DEV` is Vite-substituted at SSR-bundle time —
+  // non-empty in `plumix dev`, empty in `plumix build`. The plumix Vite
+  // plugin's `define` populates the literal.
+  const command: ViteCommand = process.env.PLUMIX_DEV ? "serve" : "build";
+
   const headContent =
     scripts.headStart.map(scriptToHtml).join("") +
     '<meta charSet="utf-8"/>' +
@@ -389,20 +394,13 @@ function renderTree({
     titleFallback +
     voidTagsToHtml("link", document.link) +
     bundledCssTags(assetManifest, ctx.basePath) +
+    devThemeStylesTag(command, ctx.basePath) +
     voidTagsToHtml("meta", document.meta) +
     scripts.headEnd.map(scriptToHtml).join("");
 
   const bodyContent =
     scripts.bodyStart.map(scriptToHtml).join("") +
-    injectIslandsBootstrap(
-      body,
-      assetManifest,
-      // `process.env.PLUMIX_DEV` is Vite-substituted at SSR-bundle time
-      // — non-empty in `plumix dev`, empty in `plumix build`. The
-      // plumix Vite plugin's `define` populates the literal.
-      process.env.PLUMIX_DEV ? "serve" : "build",
-      ctx.basePath,
-    ) +
+    injectIslandsBootstrap(body, assetManifest, command, ctx.basePath) +
     scripts.bodyEnd.map(scriptToHtml).join("") +
     HYDRATION_SLOT;
 

--- a/packages/plumix/src/cli/load-config.ts
+++ b/packages/plumix/src/cli/load-config.ts
@@ -26,6 +26,11 @@ export async function loadConfig(
   const jiti = createJiti(pathToFileURL(configPath).href, {
     interopDefault: true,
     moduleCache: false,
+    // Themes author templates as JSX, so the config's component graph must
+    // parse at load time. jiti's transform is TS-only by default; enable its
+    // JSX plugin (classic runtime — theme files import React, matching the
+    // worker bundle's esbuild transform).
+    jsx: true,
   });
 
   let imported: unknown;

--- a/packages/plumix/test/load-config.test.ts
+++ b/packages/plumix/test/load-config.test.ts
@@ -71,4 +71,33 @@ describe("loadConfig", () => {
       code: "config_load_failed",
     });
   });
+
+  test("loads a config whose theme imports a JSX (.tsx) module", async () => {
+    // Guards the loader's `jsx: true`: themes author templates as JSX, so
+    // jiti must parse the config's `.tsx` import graph. The stub `React`
+    // keeps the classic-transform output runnable without node_modules.
+    writeFileSync(
+      join(dir, "view.tsx"),
+      [
+        "const React = { createElement: () => null, Fragment: null };",
+        "export const view = () => <div>hello</div>;",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      join(dir, "plumix.config.ts"),
+      [
+        'import { view } from "./view.tsx";',
+        "void view;",
+        "export default {",
+        "  runtime: { name: 'x', buildFetchHandler: () => undefined },",
+        "  database: { kind: 'd1' },",
+        "  auth: { passkey: {} },",
+        "};",
+      ].join("\n"),
+      "utf8",
+    );
+    const { config } = await loadConfig(dir);
+    expect(config.runtime.name).toBe("x");
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,12 +176,18 @@ importers:
 
   examples/blog:
     dependencies:
+      '@plumix/blocks':
+        specifier: workspace:*
+        version: link:../../packages/blocks
       '@plumix/plugin-blog':
         specifier: workspace:*
         version: link:../../packages/plugins/blog
       '@plumix/plugin-media':
         specifier: workspace:*
         version: link:../../packages/plugins/media
+      '@plumix/plugin-menu':
+        specifier: workspace:*
+        version: link:../../packages/plugins/menu
       '@plumix/plugin-pages':
         specifier: workspace:*
         version: link:../../packages/plugins/pages
@@ -191,6 +197,9 @@ importers:
       plumix:
         specifier: workspace:*
         version: link:../../packages/plumix
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -198,9 +207,18 @@ importers:
       '@plumix/typescript-config':
         specifier: workspace:*
         version: link:../../tooling/typescript
+      '@tailwindcss/postcss':
+        specifier: ^4.3.1
+        version: 4.3.1
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.16
+      tailwindcss:
+        specifier: ^4.3.1
+        version: 4.3.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1589,6 +1607,10 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
@@ -4287,6 +4309,9 @@ packages:
   '@tailwindcss/oxide@4.3.1':
     resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
     engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.1':
+    resolution: {integrity: sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==}
 
   '@tailwindcss/vite@4.3.1':
     resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
@@ -7717,6 +7742,8 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@alloc/quick-lru@5.2.0': {}
+
   '@andrewbranch/untar.js@1.0.3': {}
 
   '@arethetypeswrong/cli@0.18.3':
@@ -10230,6 +10257,14 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.3.1
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
+
+  '@tailwindcss/postcss@4.3.1':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.1
+      '@tailwindcss/oxide': 4.3.1
+      postcss: 8.5.15
+      tailwindcss: 4.3.1
 
   '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:


### PR DESCRIPTION
Replaces the blog example's placeholder noop theme with a real, Tailwind-styled blog theme: a shared layout — header with site identity, primary menu and search; footer with menu, RSS and copyright — wrapping a front-page list of the latest posts, over an editorial paper/ink token set. Tailwind reads the theme tokens as CSS variables, so a token swap reskins chrome and rendered content together. The theme lives inline in `examples/blog` so a scaffolded app owns and edits it.

This is the first of seven slices (#1053–#1059) for the blog theme (PRD #1052) — the walking skeleton the rest build on. Building the first real inline example theme surfaced two core gaps, fixed here.

**JSX in config-loaded themes**

Themes author templates as JSX, but jiti (the config loader) is TypeScript-only by default and parsed `<Layout …>` as a generic, failing at config load. Enabling its classic JSX transform (`jsx: true`) lets the config's `.tsx` import graph parse; the worker bundle's esbuild already handled the classic transform (theme files import React).

**Theme stylesheets in `plumix dev`**

Public pages link their CSS from the Vite asset manifest, which is empty in dev — so `plumix dev` rendered every theme unstyled even though production builds were fine. `devThemeStylesTag` (the CSS counterpart to `injectIslandsBootstrap`) loads the Vite-served client entry in `serve` mode so the theme stylesheets inject, and is a no-op in `build`.

Both core changes ship with unit regression tests. The example theme itself ships without tests — there is no example e2e suite, and it is presentational code over the already-tested core render primitives.

Fixes #1053