### PR TITLE
feat: blog example single post template

### DIFF
--- a/examples/blog/theme/components/PostSingle.tsx
+++ b/examples/blog/theme/components/PostSingle.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { ResolvedEntry } from "plumix";
+import { BlockRenderer, Image } from "@plumix/blocks/renderer";
+
+import { readingTime } from "../reading-time";
+
+// Forward-looking contract: a featured image seeded onto the post's `meta`
+// renders here; the admin affordance to set one lands in a later slice.
+interface FeaturedImage {
+  readonly src?: string;
+  readonly alt?: string;
+  readonly width?: number;
+  readonly height?: number;
+}
+
+interface PostSingleProps {
+  readonly entry: ResolvedEntry;
+}
+
+function formatDate(value: Date | null): string | null {
+  if (!value) return null;
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(value);
+}
+
+export function PostSingle({ entry }: PostSingleProps): ReactNode {
+  const featured = entry.meta?.featuredImage as FeaturedImage | undefined;
+  const featuredSrc = featured?.src;
+  const meta = [
+    entry.author.name,
+    formatDate(entry.publishedAt),
+    `${readingTime(entry.contentBlocks)} min read`,
+  ].filter(Boolean);
+
+  return (
+    <article data-testid="post-single">
+      {featuredSrc && featured?.width && featured?.height ? (
+        <div className="mb-8">
+          <Image
+            src={featuredSrc}
+            alt={featured.alt ?? ""}
+            width={featured.width}
+            height={featured.height}
+            priority
+          />
+        </div>
+      ) : null}
+
+      <header className="mb-8">
+        <h1
+          className="font-serif text-3xl leading-tight"
+          data-testid="post-title"
+        >
+          {entry.title}
+        </h1>
+        {meta.length > 0 ? (
+          <p className="mt-3 text-sm text-muted" data-testid="post-meta">
+            {meta.join(" · ")}
+          </p>
+        ) : null}
+        {entry.excerpt ? (
+          <p className="mt-4 text-lg text-muted">{entry.excerpt}</p>
+        ) : null}
+      </header>
+
+      <div className="space-y-4 leading-relaxed" data-testid="post-body">
+        {entry.contentBlocks ? (
+          <BlockRenderer content={entry.contentBlocks} />
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/examples/blog/theme/index.ts
+++ b/examples/blog/theme/index.ts
@@ -1,13 +1,14 @@
 import { defineTheme } from "plumix";
 
 import { home } from "./templates/home";
+import { single } from "./templates/single";
 import { fallback } from "./templates/fallback";
 import { DEFAULT_TOKENS } from "./tokens";
 
 // One consumer (this example's config), so the theme is exported directly
 // rather than behind a factory.
 export const blogTheme = defineTheme({
-  templates: { index: fallback, home },
+  templates: { index: fallback, home, single },
   tokens: DEFAULT_TOKENS,
   css: ["./theme/styles.css"],
   document: {

--- a/examples/blog/theme/reading-time.ts
+++ b/examples/blog/theme/reading-time.ts
@@ -1,0 +1,9 @@
+import { countProse, type EntryContent } from "@plumix/blocks";
+
+const WORDS_PER_MINUTE = 200;
+
+export function readingTime(content: EntryContent | null): number {
+  if (!content) return 1;
+  const { words } = countProse(content.blocks);
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+}

--- a/examples/blog/theme/templates/single.tsx
+++ b/examples/blog/theme/templates/single.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { defineTemplate } from "plumix";
+import type { SingleData } from "plumix";
+
+import { Layout } from "../components/Layout";
+import { PostSingle } from "../components/PostSingle";
+
+export const single = defineTemplate<SingleData>({
+  settings: ["site"],
+  menus: ["primary", "footer"],
+  render: ({ data, settings, menus }) => (
+    <Layout settings={settings} menus={menus}>
+      <PostSingle entry={data.entry} />
+    </Layout>
+  ),
+});


### PR DESCRIPTION
Adds the single-post view to the blog example theme: clicking a post now renders a full article — an optional featured image, the title, an `author · date · reading-time` meta line, the excerpt, and the post's block body via `<BlockRenderer>` — wrapped in the shared layout chrome. Previously a post fell through to the bare `index` fallback (chrome only).

Reading time reuses `@plumix/blocks`'s `countProse` (which strips HTML, counts only prose attrs, and handles CJK) instead of a hand-rolled tree walk.

The featured-image slot reads a forward-looking `meta.featuredImage` shape and renders only when present; the admin affordance to set one lands in a later slice. Second of seven slices (#1053–#1059) under PRD #1052.

Fixes #1054