### PR TITLE
feat: blog example post cards and listing grid

### DIFF
--- a/examples/blog/theme/components/FeaturedImage.tsx
+++ b/examples/blog/theme/components/FeaturedImage.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { ResolvedEntry } from "plumix";
+import { Image } from "@plumix/blocks/renderer";
+
+// Read from `entry.meta` because there's no admin affordance to set a
+// featured image yet (a later slice adds it).
+interface FeaturedImageMeta {
+  readonly src?: string;
+  readonly alt?: string;
+  readonly width?: number;
+  readonly height?: number;
+}
+
+interface FeaturedImageProps {
+  readonly entry: ResolvedEntry;
+  readonly priority?: boolean;
+  // Cards fall back to a neutral block when there's no image; the single
+  // post renders nothing.
+  readonly placeholder?: boolean;
+  readonly className?: string;
+}
+
+export function FeaturedImage({
+  entry,
+  priority,
+  placeholder,
+  className,
+}: FeaturedImageProps): ReactNode {
+  const image = entry.meta?.featuredImage as FeaturedImageMeta | undefined;
+  const content =
+    image?.src && image.width && image.height ? (
+      <Image
+        src={image.src}
+        alt={image.alt ?? ""}
+        width={image.width}
+        height={image.height}
+        priority={priority}
+      />
+    ) : placeholder ? (
+      <div
+        className="aspect-[3/2] w-full rounded bg-line"
+        data-testid="featured-placeholder"
+      />
+    ) : null;
+  if (!content) return null;
+  return <div className={className}>{content}</div>;
+}

--- a/examples/blog/theme/components/PostCard.tsx
+++ b/examples/blog/theme/components/PostCard.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { ResolvedEntry } from "plumix";
+import { Link } from "@plumix/blocks/renderer";
+
+import { FeaturedImage } from "./FeaturedImage";
+import { PostMeta } from "./PostMeta";
+
+interface PostCardProps {
+  readonly entry: ResolvedEntry;
+}
+
+export function PostCard({ entry }: PostCardProps): ReactNode {
+  return (
+    <article data-testid="post-card">
+      <Link entry={entry} className="block">
+        <FeaturedImage entry={entry} placeholder className="mb-4" />
+      </Link>
+      <h2 className="font-serif text-xl leading-snug">
+        <Link
+          entry={entry}
+          className="hover:text-accent"
+          data-testid="post-card-title"
+        >
+          {entry.title}
+        </Link>
+      </h2>
+      {entry.excerpt ? <p className="mt-2 text-muted">{entry.excerpt}</p> : null}
+      <PostMeta entry={entry} className="mt-3 text-sm text-muted" />
+    </article>
+  );
+}

--- a/examples/blog/theme/components/PostList.tsx
+++ b/examples/blog/theme/components/PostList.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import type { ReactNode } from "react";
 import type { ResolvedEntry } from "plumix";
-import { Link } from "@plumix/blocks/renderer";
 
-// Slice 1 renders a bare list of linked titles. The card grid + meta
-// (PostCard) lands in a later slice; everything that lists posts —
-// front page, archive, taxonomy, search — funnels through here.
+import { PostCard } from "./PostCard";
+
+// Backs the front page, archive, taxonomy and search; the heading varies
+// per slot.
 interface PostListProps {
   readonly entries: readonly ResolvedEntry[];
   readonly heading?: string;
@@ -20,19 +20,11 @@ export function PostList({ entries, heading }: PostListProps): ReactNode {
           No posts yet.
         </p>
       ) : (
-        <ul className="space-y-4">
+        <div className="grid gap-10 sm:grid-cols-2">
           {entries.map((entry) => (
-            <li key={entry.id}>
-              <Link
-                entry={entry}
-                className="font-serif text-lg hover:text-accent"
-                data-testid="post-list-item"
-              >
-                {entry.title}
-              </Link>
-            </li>
+            <PostCard key={entry.id} entry={entry} />
           ))}
-        </ul>
+        </div>
       )}
     </section>
   );

--- a/examples/blog/theme/components/PostMeta.tsx
+++ b/examples/blog/theme/components/PostMeta.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { ResolvedEntry } from "plumix";
+
+import { readingTime } from "../reading-time";
+
+function formatDate(value: Date | null): string | null {
+  if (!value) return null;
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(value);
+}
+
+interface PostMetaProps {
+  readonly entry: ResolvedEntry;
+  readonly className?: string;
+}
+
+// The `author · date · reading-time` line, shared by the post card and the
+// single-post header. Each present part is joined; an empty line renders
+// nothing.
+export function PostMeta({ entry, className }: PostMetaProps): ReactNode {
+  const parts = [
+    entry.author.name,
+    formatDate(entry.publishedAt),
+    `${readingTime(entry.contentBlocks)} min read`,
+  ].filter(Boolean);
+  if (parts.length === 0) return null;
+  return (
+    <p className={className} data-testid="post-meta">
+      {parts.join(" · ")}
+    </p>
+  );
+}

--- a/examples/blog/theme/components/PostSingle.tsx
+++ b/examples/blog/theme/components/PostSingle.tsx
@@ -1,55 +1,19 @@
 import * as React from "react";
 import type { ReactNode } from "react";
 import type { ResolvedEntry } from "plumix";
-import { BlockRenderer, Image } from "@plumix/blocks/renderer";
+import { BlockRenderer } from "@plumix/blocks/renderer";
 
-import { readingTime } from "../reading-time";
-
-// Forward-looking contract: a featured image seeded onto the post's `meta`
-// renders here; the admin affordance to set one lands in a later slice.
-interface FeaturedImage {
-  readonly src?: string;
-  readonly alt?: string;
-  readonly width?: number;
-  readonly height?: number;
-}
+import { FeaturedImage } from "./FeaturedImage";
+import { PostMeta } from "./PostMeta";
 
 interface PostSingleProps {
   readonly entry: ResolvedEntry;
 }
 
-function formatDate(value: Date | null): string | null {
-  if (!value) return null;
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(value);
-}
-
 export function PostSingle({ entry }: PostSingleProps): ReactNode {
-  const featured = entry.meta?.featuredImage as FeaturedImage | undefined;
-  const featuredSrc = featured?.src;
-  const meta = [
-    entry.author.name,
-    formatDate(entry.publishedAt),
-    `${readingTime(entry.contentBlocks)} min read`,
-  ].filter(Boolean);
-
   return (
     <article data-testid="post-single">
-      {featuredSrc && featured?.width && featured?.height ? (
-        <div className="mb-8">
-          <Image
-            src={featuredSrc}
-            alt={featured.alt ?? ""}
-            width={featured.width}
-            height={featured.height}
-            priority
-          />
-        </div>
-      ) : null}
-
+      <FeaturedImage entry={entry} priority className="mb-8" />
       <header className="mb-8">
         <h1
           className="font-serif text-3xl leading-tight"
@@ -57,11 +21,7 @@ export function PostSingle({ entry }: PostSingleProps): ReactNode {
         >
           {entry.title}
         </h1>
-        {meta.length > 0 ? (
-          <p className="mt-3 text-sm text-muted" data-testid="post-meta">
-            {meta.join(" · ")}
-          </p>
-        ) : null}
+        <PostMeta entry={entry} className="mt-3 text-sm text-muted" />
         {entry.excerpt ? (
           <p className="mt-4 text-lg text-muted">{entry.excerpt}</p>
         ) : null}

--- a/packages/runtimes/cloudflare/src/commands/build.ts
+++ b/packages/runtimes/cloudflare/src/commands/build.ts
@@ -13,6 +13,18 @@ export const buildCommand: CommandDefinition = {
       root,
       plugins,
     });
+
+    // Build the client environment first so its Vite asset manifest exists
+    // before the worker environment bakes `virtual:plumix/asset-manifest`.
+    // @cloudflare/vite-plugin's `buildApp` builds the worker env before the
+    // client, so on a cold build (CI) the worker would otherwise bake an
+    // empty manifest and ship no theme CSS (#528). Client builds are
+    // content-hashed and deterministic, so the manifest read here matches
+    // the assets `buildApp` re-emits.
+    const clientEnv = builder.environments.client;
+    if (clientEnv) {
+      await builder.build(clientEnv);
+    }
     await builder.buildApp();
   },
 };


### PR DESCRIPTION
**Fixes a production CSS regression.** `@cloudflare/vite-plugin` builds the worker env before the client, so on a cold build (CI / Workers Builds) the worker baked an *empty* asset manifest and shipped no theme stylesheets — the deployed blog rendered unstyled after the first theme landed. The build now builds the client environment first so its manifest exists when the worker bakes `virtual:plumix/asset-manifest` (client builds are content-hashed, so the manifest matches what `buildApp` re-emits). This is the production counterpart to the earlier dev-only CSS fix — different layer, not the same mechanism: dev has no manifest at all and injects the client entry at render time, whereas prod needs a real content-hashed `<link>`. Addresses the long-standing #528.

The slice itself turns the front page into a responsive two-column grid of post cards — featured image (or a neutral placeholder), title, excerpt, and the `author · date · reading-time` meta line. `FeaturedImage` and `PostMeta` are extracted as shared components, and the single-post view is refactored to reuse them instead of duplicating the logic.

Third of seven slices (#1053–#1059) under PRD #1052.

Fixes #1055