### PR TITLE
feat: blog example archive and pagination

### DIFF
--- a/examples/blog/theme/components/Pagination.tsx
+++ b/examples/blog/theme/components/Pagination.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { Pagination as PaginationData } from "plumix";
+import { Link } from "@plumix/blocks/renderer";
+
+export interface PaginationInfo {
+  // Root-relative request pathname (the base prefix is stripped upstream).
+  readonly path: string;
+  readonly page: number;
+  readonly pageCount: number;
+}
+
+export function paginationInfo(
+  requestUrl: string,
+  pagination: Pick<PaginationData, "page" | "pageCount">,
+): PaginationInfo {
+  return {
+    path: new URL(requestUrl).pathname,
+    page: pagination.page,
+    pageCount: pagination.pageCount,
+  };
+}
+
+// Page 1 is the bare listing; later pages append /page/N.
+function pageHref(base: string, n: number): string {
+  if (n <= 1) return base;
+  return base === "/" ? `/page/${n}` : `${base}/page/${n}`;
+}
+
+export function Pagination({ path, page, pageCount }: PaginationInfo): ReactNode {
+  if (pageCount <= 1) return null;
+  const base = path.replace(/\/page\/\d+$/, "") || "/";
+
+  return (
+    <nav
+      className="mt-12 flex items-center justify-between text-sm"
+      aria-label="Pagination"
+      data-testid="pagination"
+    >
+      {page > 1 ? (
+        <Link
+          href={pageHref(base, page - 1)}
+          className="text-accent hover:underline"
+          data-testid="pagination-prev"
+        >
+          ← Newer
+        </Link>
+      ) : (
+        <span />
+      )}
+      <span className="text-muted">
+        Page {page} of {pageCount}
+      </span>
+      {page < pageCount ? (
+        <Link
+          href={pageHref(base, page + 1)}
+          className="text-accent hover:underline"
+          data-testid="pagination-next"
+        >
+          Older →
+        </Link>
+      ) : (
+        <span />
+      )}
+    </nav>
+  );
+}

--- a/examples/blog/theme/components/PostList.tsx
+++ b/examples/blog/theme/components/PostList.tsx
@@ -3,15 +3,21 @@ import type { ReactNode } from "react";
 import type { ResolvedEntry } from "plumix";
 
 import { PostCard } from "./PostCard";
+import { Pagination, type PaginationInfo } from "./Pagination";
 
-// Backs the front page, archive, taxonomy and search; the heading varies
-// per slot.
+// Backs the front page, archive, taxonomy and search; the heading and
+// pagination vary per slot.
 interface PostListProps {
   readonly entries: readonly ResolvedEntry[];
   readonly heading?: string;
+  readonly pagination?: PaginationInfo;
 }
 
-export function PostList({ entries, heading }: PostListProps): ReactNode {
+export function PostList({
+  entries,
+  heading,
+  pagination,
+}: PostListProps): ReactNode {
   return (
     <section data-testid="post-list">
       {heading ? <h1 className="mb-8 font-serif text-2xl">{heading}</h1> : null}
@@ -20,11 +26,14 @@ export function PostList({ entries, heading }: PostListProps): ReactNode {
           No posts yet.
         </p>
       ) : (
-        <div className="grid gap-10 sm:grid-cols-2">
-          {entries.map((entry) => (
-            <PostCard key={entry.id} entry={entry} />
-          ))}
-        </div>
+        <>
+          <div className="grid gap-10 sm:grid-cols-2">
+            {entries.map((entry) => (
+              <PostCard key={entry.id} entry={entry} />
+            ))}
+          </div>
+          {pagination ? <Pagination {...pagination} /> : null}
+        </>
       )}
     </section>
   );

--- a/examples/blog/theme/components/SiteHeader.tsx
+++ b/examples/blog/theme/components/SiteHeader.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import type { ReactNode } from "react";
-import { useUser } from "@plumix/blocks/renderer";
 import type { ResolvedMenu } from "@plumix/plugin-menu/server";
 
 import { Menu } from "./Menu";
@@ -11,7 +10,6 @@ interface SiteHeaderProps {
 }
 
 export function SiteHeader({ siteTitle, menu }: SiteHeaderProps): ReactNode {
-  const user = useUser();
   return (
     <header className="border-b border-line">
       <div className="mx-auto flex max-w-3xl items-center justify-between gap-6 px-5 py-5">
@@ -28,15 +26,6 @@ export function SiteHeader({ siteTitle, menu }: SiteHeaderProps): ReactNode {
               className="rounded border border-line bg-transparent px-2 py-1 text-sm"
             />
           </form>
-          {user ? (
-            <a
-              href="/_plumix/admin"
-              className="text-sm text-accent"
-              data-testid="admin-link"
-            >
-              Admin
-            </a>
-          ) : null}
         </div>
       </div>
     </header>

--- a/examples/blog/theme/index.ts
+++ b/examples/blog/theme/index.ts
@@ -2,13 +2,14 @@ import { defineTheme } from "plumix";
 
 import { home } from "./templates/home";
 import { single } from "./templates/single";
+import { archive } from "./templates/archive";
 import { fallback } from "./templates/fallback";
 import { DEFAULT_TOKENS } from "./tokens";
 
 // One consumer (this example's config), so the theme is exported directly
 // rather than behind a factory.
 export const blogTheme = defineTheme({
-  templates: { index: fallback, home, single },
+  templates: { index: fallback, home, single, archive },
   tokens: DEFAULT_TOKENS,
   css: ["./theme/styles.css"],
   document: {

--- a/examples/blog/theme/templates/archive.tsx
+++ b/examples/blog/theme/templates/archive.tsx
@@ -1,19 +1,20 @@
 import * as React from "react";
 import { defineTemplate } from "plumix";
-import type { FrontPageData } from "plumix";
+import type { ArchiveData } from "plumix";
 
 import { Layout } from "../components/Layout";
 import { PostList } from "../components/PostList";
 import { paginationInfo } from "../components/Pagination";
 
-// Front page: latest posts. `settings`/`menus` feed the chrome.
-export const home = defineTemplate<FrontPageData>({
+// Post-type archive (e.g. /posts), paginated.
+export const archive = defineTemplate<ArchiveData>({
   settings: ["site"],
   menus: ["primary", "footer"],
   render: ({ data, settings, menus, ctx }) => (
     <Layout settings={settings} menus={menus}>
       <PostList
         entries={data.entries}
+        heading="Posts"
         pagination={paginationInfo(ctx.request.url, data.pagination)}
       />
     </Layout>


### PR DESCRIPTION
Adds the post-type archive (e.g. `/posts`) to the blog example theme — the shared post-card grid under a "Posts" heading — and a `Pagination` component for prev/next navigation. Pagination builds `{base}/page/{n}` URLs from the current request path (page 1 is the bare listing, so it never emits `/page/1`, which the canonical layer would 301 away), and renders the links through the theme's `<Link>` primitive so a subdirectory base path is applied automatically. The front page paginates too.

Also drops the redundant **"Admin" link** from the site header — authenticated users already get the admin bar at the top of the page, so the link (and the only `useUser()` call in the chrome) is removed.

Fourth of seven slices (#1053–#1059) under PRD #1052.

Fixes #1056