### PR TITLE
feat: blog example page and 404 templates

### DIFF
--- a/examples/blog/theme/components/NotFound.tsx
+++ b/examples/blog/theme/components/NotFound.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+
+export function NotFound(): ReactNode {
+  return (
+    <section className="py-16 text-center" data-testid="not-found">
+      <h1 className="font-serif text-3xl">Page not found</h1>
+      <p className="mt-4 text-muted">
+        The page you're looking for doesn't exist or has moved.
+      </p>
+      <a href="/" className="mt-6 inline-block text-accent hover:underline">
+        ← Back home
+      </a>
+    </section>
+  );
+}

--- a/examples/blog/theme/components/PostSingle.tsx
+++ b/examples/blog/theme/components/PostSingle.tsx
@@ -8,9 +8,13 @@ import { PostMeta } from "./PostMeta";
 
 interface PostSingleProps {
   readonly entry: ResolvedEntry;
+  readonly showMeta?: boolean;
 }
 
-export function PostSingle({ entry }: PostSingleProps): ReactNode {
+export function PostSingle({
+  entry,
+  showMeta = true,
+}: PostSingleProps): ReactNode {
   return (
     <article data-testid="post-single">
       <FeaturedImage entry={entry} priority className="mb-8" />
@@ -21,7 +25,9 @@ export function PostSingle({ entry }: PostSingleProps): ReactNode {
         >
           {entry.title}
         </h1>
-        <PostMeta entry={entry} className="mt-3 text-sm text-muted" />
+        {showMeta ? (
+          <PostMeta entry={entry} className="mt-3 text-sm text-muted" />
+        ) : null}
         {entry.excerpt ? (
           <p className="mt-4 text-lg text-muted">{entry.excerpt}</p>
         ) : null}

--- a/examples/blog/theme/index.ts
+++ b/examples/blog/theme/index.ts
@@ -1,6 +1,8 @@
 import { defineTheme } from "plumix";
 
 import { single } from "./templates/single";
+import { page } from "./templates/page";
+import { notFound } from "./templates/not-found";
 import { fallback } from "./templates/fallback";
 import { DEFAULT_TOKENS } from "./tokens";
 
@@ -9,7 +11,7 @@ import { DEFAULT_TOKENS } from "./tokens";
 // is the only dedicated slot: posts get the richer article view (and, later,
 // comments).
 export const blogTheme = defineTheme({
-  templates: { index: fallback, single },
+  templates: { index: fallback, single, page, "404": notFound },
   tokens: DEFAULT_TOKENS,
   css: ["./theme/styles.css"],
   document: {

--- a/examples/blog/theme/templates/not-found.tsx
+++ b/examples/blog/theme/templates/not-found.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { defineTemplate } from "plumix";
+import type { ErrorData } from "plumix";
+
+import { Layout } from "../components/Layout";
+import { NotFound } from "../components/NotFound";
+
+export const notFound = defineTemplate<ErrorData>({
+  settings: ["site"],
+  menus: ["primary", "footer"],
+  render: ({ settings, menus }) => (
+    <Layout settings={settings} menus={menus}>
+      <NotFound />
+    </Layout>
+  ),
+});

--- a/examples/blog/theme/templates/page.tsx
+++ b/examples/blog/theme/templates/page.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { defineTemplate } from "plumix";
+import type { SingleData } from "plumix";
+
+import { Layout } from "../components/Layout";
+import { PostSingle } from "../components/PostSingle";
+
+// Static page: title + body, no post metadata.
+export const page = defineTemplate<SingleData>({
+  settings: ["site"],
+  menus: ["primary", "footer"],
+  render: ({ data, settings, menus }) => (
+    <Layout settings={settings} menus={menus}>
+      <PostSingle entry={data.entry} showMeta={false} />
+    </Layout>
+  ),
+});


### PR DESCRIPTION
Adds the `page` and `404` slots to the blog example theme.

A **static page** (e.g. `/about`) now renders as a bare title + body — `PostSingle` gained a `showMeta={false}` prop that drops the author/date/reading-time line; posts keep it (default `true`). A **missing URL** renders the theme's `NotFound` shell inside the chrome instead of core's default error page.

Pages previously fell through to `index` and rendered blank; that's now fixed. Sixth of seven slices (#1053–#1059) under PRD #1052.

Fixes #1058