### PR TITLE
feat: blog example post tags and comments

### DIFF
--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@plumix/blocks": "workspace:*",
     "@plumix/plugin-blog": "workspace:*",
+    "@plumix/plugin-comments": "workspace:*",
     "@plumix/plugin-media": "workspace:*",
     "@plumix/plugin-menu": "workspace:*",
     "@plumix/plugin-pages": "workspace:*",

--- a/examples/blog/plumix.config.ts
+++ b/examples/blog/plumix.config.ts
@@ -1,4 +1,5 @@
 import { blog } from "@plumix/plugin-blog";
+import { comments } from "@plumix/plugin-comments";
 import { media } from "@plumix/plugin-media";
 import { menu } from "@plumix/plugin-menu";
 import { pages } from "@plumix/plugin-pages";
@@ -84,6 +85,7 @@ export default plumix({
   }),
   plugins: [
     blog,
+    comments({ entryTypes: ["post"] }),
     pages,
     media(),
     menu({

--- a/examples/blog/theme/components/Comments.tsx
+++ b/examples/blog/theme/components/Comments.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type {
+  ResolvedComment,
+  ResolvedThread,
+} from "@plumix/plugin-comments/server";
+
+interface CommentItemProps {
+  readonly comment: ResolvedComment;
+}
+
+function CommentItem({ comment }: CommentItemProps): ReactNode {
+  return (
+    <li data-testid="comment">
+      <div className="flex items-center gap-2">
+        <img
+          src={comment.avatarUrl}
+          alt=""
+          width={32}
+          height={32}
+          className="rounded-full"
+        />
+        <span className="text-sm font-medium">{comment.authorName}</span>
+      </div>
+      {/* bodyHtml is sanitized server-side (markdown-it, html:false). */}
+      <div
+        className="mt-2 leading-relaxed"
+        dangerouslySetInnerHTML={{ __html: comment.bodyHtml }}
+      />
+      {comment.replies.length > 0 ? (
+        <ul className="mt-4 space-y-4 border-l border-line pl-4">
+          {comment.replies.map((reply) => (
+            <CommentItem key={reply.id} comment={reply} />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+interface CommentsProps {
+  readonly thread: ResolvedThread | null;
+}
+
+export function Comments({ thread }: CommentsProps): ReactNode {
+  // `loadThread` returns null for a post with no comments, so default to an
+  // empty thread rather than hiding the section.
+  const items = thread?.comments ?? [];
+  const count = thread?.count ?? 0;
+  const label = count === 1 ? "comment" : "comments";
+
+  return (
+    <section className="mt-16 border-t border-line pt-8" data-testid="comments">
+      <h2 className="font-serif text-2xl">
+        {count} {label}
+      </h2>
+      {items.length > 0 ? (
+        <ul className="mt-6 space-y-6">
+          {items.map((comment) => (
+            <CommentItem key={comment.id} comment={comment} />
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-4 text-muted">No comments yet.</p>
+      )}
+    </section>
+  );
+}

--- a/examples/blog/theme/components/PostSingle.tsx
+++ b/examples/blog/theme/components/PostSingle.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { ReactNode } from "react";
 import type { ResolvedEntry } from "plumix";
-import { BlockRenderer } from "@plumix/blocks/renderer";
+import { BlockRenderer, Link } from "@plumix/blocks/renderer";
 
 import { FeaturedImage } from "./FeaturedImage";
 import { PostMeta } from "./PostMeta";
@@ -15,9 +15,12 @@ export function PostSingle({
   entry,
   showMeta = true,
 }: PostSingleProps): ReactNode {
+  const tags = entry.terms.filter((term) => term.taxonomy === "tag");
+
   return (
     <article data-testid="post-single">
       <FeaturedImage entry={entry} priority className="mb-8" />
+
       <header className="mb-8">
         <h1
           className="font-serif text-3xl leading-tight"
@@ -38,6 +41,20 @@ export function PostSingle({
           <BlockRenderer content={entry.contentBlocks} />
         ) : null}
       </div>
+
+      {showMeta && tags.length > 0 ? (
+        <div className="mt-10 flex flex-wrap gap-2" data-testid="post-tags">
+          {tags.map((tag) => (
+            <Link
+              key={tag.id}
+              term={tag}
+              className="rounded border border-line px-2.5 py-0.5 text-sm text-muted hover:text-ink"
+            >
+              {tag.name}
+            </Link>
+          ))}
+        </div>
+      ) : null}
     </article>
   );
 }

--- a/examples/blog/theme/templates/single.tsx
+++ b/examples/blog/theme/templates/single.tsx
@@ -1,16 +1,25 @@
 import * as React from "react";
 import { defineTemplate } from "plumix";
 import type { SingleData } from "plumix";
+// Importing the thread type also pulls the plugin's `comments` template-dep
+// augmentation, so `comments: ["current"]` is typed on the render args.
+import type { ResolvedThread } from "@plumix/plugin-comments/server";
 
 import { Layout } from "../components/Layout";
 import { PostSingle } from "../components/PostSingle";
+import { Comments } from "../components/Comments";
 
 export const single = defineTemplate<SingleData>({
   settings: ["site"],
   menus: ["primary", "footer"],
-  render: ({ data, settings, menus }) => (
-    <Layout settings={settings} menus={menus}>
-      <PostSingle entry={data.entry} />
-    </Layout>
-  ),
+  comments: ["current"],
+  render: ({ data, settings, menus, comments }) => {
+    const thread: ResolvedThread | null = comments?.current ?? null;
+    return (
+      <Layout settings={settings} menus={menus}>
+        <PostSingle entry={data.entry} />
+        <Comments thread={thread} />
+      </Layout>
+    );
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@plumix/plugin-blog':
         specifier: workspace:*
         version: link:../../packages/plugins/blog
+      '@plumix/plugin-comments':
+        specifier: workspace:*
+        version: link:../../packages/plugins/comments
       '@plumix/plugin-media':
         specifier: workspace:*
         version: link:../../packages/plugins/media


### PR DESCRIPTION
Final enrichments for the blog example theme.

**Tags** — a post's tag terms (`entry.terms` filtered to `taxonomy === "tag"`) render as chips linked to their term archives via `<Link term>`. Gated on `showMeta`, so pages stay bare.

**Comments** — the example now depends on `@plumix/plugin-comments` (`comments({ entryTypes: ["post"] })`). The `single` template declares the `comments: ["current"]` dep and renders a `<Comments>` section under the article — recursive replies, server-sanitized bodies, and a "No comments yet." empty state (the section shows even at zero).

`more-posts` is intentionally **deferred** — it needs a resolved-recent-posts loader (a small custom template dep), which is disproportionate infra for this slice; tracked as a follow-up.

Last of seven slices (#1053–#1059) under PRD #1052 — the blog example theme is now feature-complete.

Fixes #1059