### PR TITLE
fix: serve the post listing only on the front page

### DIFF
--- a/packages/core/src/route/resolve.test.ts
+++ b/packages/core/src/route/resolve.test.ts
@@ -971,3 +971,35 @@ describe("resolvePublicRoute — search query redirect", () => {
     expect(response.status).toBe(200);
   });
 });
+
+describe("resolvePublicRoute — front page", () => {
+  test("lists posts but excludes hierarchical pages", async () => {
+    const h = await createDispatcherHarness({
+      plugins: [blogPlugin, hierarchicalPagesPlugin],
+    });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "a-post",
+      title: "A Post",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+    await h.factory.entry.create({
+      type: "page",
+      slug: "a-page",
+      title: "A Page",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      parentId: null,
+    });
+    const response = await h.dispatch(new Request("https://cms.example/"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("A Post");
+    expect(body).not.toContain("A Page");
+  });
+});

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -135,8 +135,13 @@ async function resolveFrontPage(
   assetManifest: AssetManifest,
 ): Promise<Response> {
   const page = parsePageParam(params.page);
+  // The latest-posts front feed excludes hierarchical types (pages) — they
+  // are standalone content, not blog entries. (A configurable front-page /
+  // posts-page model is the larger follow-up.)
   const publicTypes = Array.from(ctx.plugins.entryTypes.entries())
-    .filter(([, spec]) => spec.isPublic !== false)
+    .filter(
+      ([, spec]) => spec.isPublic !== false && spec.isHierarchical !== true,
+    )
     .map(([key]) => key);
   const where =
     publicTypes.length === 0

--- a/packages/plugins/blog/src/index.test.ts
+++ b/packages/plugins/blog/src/index.test.ts
@@ -18,7 +18,9 @@ describe("@plumix/plugin-blog", () => {
       context: "post type general name",
     });
     expect(post?.isPublic).toBe(true);
-    expect(post?.hasArchive).toBe(true);
+    // No type archive: the front page is the post listing (avoids a
+    // duplicate /posts route).
+    expect(post?.hasArchive).toBe(false);
     expect(post?.termTaxonomies).toEqual(["category", "tag"]);
     expect(post?.registeredBy).toBe("blog");
   });

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -139,7 +139,9 @@ export const blog = definePlugin("blog", {
       termTaxonomies: ["category", "tag"],
       isHierarchical: false,
       isPublic: true,
-      hasArchive: true,
+      // No type archive: the front page is the post listing (WordPress's
+      // default `post` behavior), which avoids a duplicate /posts route.
+      hasArchive: false,
       rewrite: { slug: "posts" },
       capabilityType: "post",
       menuIcon: "file-text",


### PR DESCRIPTION
The blog example served the same post listing on two routes — the home page (`/`) and the post type archive (`/posts`) — a duplicate-content problem for SEO. This makes the front page the single canonical post listing and removes the redundant archive.

**Front-page feed excludes hierarchical types**

The latest-posts feed on `/` filtered only by `isPublic`, so hierarchical pages were pulled into the post listing alongside posts. It now also excludes hierarchical types (`isHierarchical !== true`), keeping pages out of the feed.

**Post type drops `hasArchive`**

The `post` type registered `hasArchive: true`, which emitted the `/posts` archive route. Dropping it matches WordPress's default `post` behavior — the front page is the listing, with no separate type archive. Single-post permalinks (`/posts/:slug`) and the category/tag archives are unaffected.

A configurable front-page / posts-page model (Settings → Reading) is the larger follow-up; this is the minimal stopgap.

Fixes #1065