### PR TITLE
feat: related posts on the blog single-post view

### DIFF
--- a/examples/blog/theme/components/RelatedPosts.tsx
+++ b/examples/blog/theme/components/RelatedPosts.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import type { ReactNode } from "react";
+import type { ResolvedEntry } from "plumix";
+
+import { PostCard } from "./PostCard";
+
+interface RelatedPostsProps {
+  readonly entries: readonly ResolvedEntry[];
+}
+
+// Sits below the article (and its comments) on the single-post view. The
+// `relatedPosts` dep returns posts sharing a term with the current one, so an
+// empty list means nothing related — hide the strip rather than show it.
+export function RelatedPosts({ entries }: RelatedPostsProps): ReactNode {
+  if (entries.length === 0) return null;
+  return (
+    <section
+      className="mt-16 border-t border-line pt-8"
+      data-testid="related-posts"
+    >
+      <h2 className="font-serif text-2xl">Related posts</h2>
+      <div className="mt-6 grid gap-10 sm:grid-cols-3">
+        {entries.map((entry) => (
+          <PostCard key={entry.id} entry={entry} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/examples/blog/theme/templates/single.tsx
+++ b/examples/blog/theme/templates/single.tsx
@@ -4,21 +4,27 @@ import type { SingleData } from "plumix";
 // Importing the thread type also pulls the plugin's `comments` template-dep
 // augmentation, so `comments: ["current"]` is typed on the render args.
 import type { ResolvedThread } from "@plumix/plugin-comments/server";
+// Likewise pulls the blog plugin's `relatedPosts` dep augmentation.
+import type { RelatedPosts as RelatedPostsData } from "@plumix/plugin-blog";
 
 import { Layout } from "../components/Layout";
 import { PostSingle } from "../components/PostSingle";
 import { Comments } from "../components/Comments";
+import { RelatedPosts } from "../components/RelatedPosts";
 
 export const single = defineTemplate<SingleData>({
   settings: ["site"],
   menus: ["primary", "footer"],
   comments: ["current"],
-  render: ({ data, settings, menus, comments }) => {
+  relatedPosts: ["related"],
+  render: ({ data, settings, menus, comments, relatedPosts }) => {
     const thread: ResolvedThread | null = comments?.current ?? null;
+    const related: RelatedPostsData = relatedPosts?.related ?? [];
     return (
       <Layout settings={settings} menus={menus}>
         <PostSingle entry={data.entry} />
         <Comments thread={thread} />
+        <RelatedPosts entries={related} />
       </Layout>
     );
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export type { MemoryStorageConfig } from "./runtime/memory-storage.js";
 export { runScheduledTasks } from "./runtime/scheduled.js";
 export type * from "./runtime/slots.js";
 export { slugify } from "./slugify.js";
+export { buildResolvedEntries } from "./route/render/build-resolved-entries.js";
 export type {
   ArchiveData,
   ErrorData,

--- a/packages/core/src/route/render/build-resolved-entries.ts
+++ b/packages/core/src/route/render/build-resolved-entries.ts
@@ -1,0 +1,79 @@
+import { eq, inArray } from "drizzle-orm";
+
+import { isEntryContent } from "@plumix/blocks";
+
+import type { AppContext } from "../../context/app.js";
+import type { Entry } from "../../db/schema/entries.js";
+import type { Term } from "../../db/schema/terms.js";
+import type { ResolvedEntry } from "./resolved-entry.js";
+import { entryTerm } from "../../db/schema/entry_term.js";
+import { terms } from "../../db/schema/terms.js";
+import { users } from "../../db/schema/users.js";
+import {
+  buildEntryPermalinkSync,
+  buildTermArchiveUrlSync,
+} from "../permalink.js";
+
+/**
+ * Hydrate raw entry rows into `ResolvedEntry` — author, terms, and the
+ * basePath-correct permalink each entry needs for rendering. Batched
+ * (mirrors WordPress's `update_post_caches`): one `IN(...)` query for
+ * authors, one entry_term×terms join for terms — no N+1 per entry.
+ */
+export async function buildResolvedEntries(
+  ctx: AppContext,
+  rows: readonly Entry[],
+): Promise<readonly ResolvedEntry[]> {
+  if (rows.length === 0) return [];
+  const entryIds = rows.map((r) => r.id);
+  const authorIds = Array.from(new Set(rows.map((r) => r.authorId)));
+  const [authorRows, joinRows] = await Promise.all([
+    ctx.db
+      .select({ id: users.id, name: users.name, avatarUrl: users.avatarUrl })
+      .from(users)
+      .where(inArray(users.id, authorIds)),
+    ctx.db
+      .select({
+        entryId: entryTerm.entryId,
+        id: terms.id,
+        taxonomy: terms.taxonomy,
+        name: terms.name,
+        slug: terms.slug,
+        description: terms.description,
+        meta: terms.meta,
+        parentId: terms.parentId,
+        version: terms.version,
+      })
+      .from(entryTerm)
+      .innerJoin(terms, eq(entryTerm.termId, terms.id))
+      .where(inArray(entryTerm.entryId, entryIds)),
+  ]);
+  const authorById = new Map(authorRows.map((a) => [a.id, a]));
+  const termsByEntryId = new Map<number, Term[]>();
+  for (const row of joinRows) {
+    const { entryId, ...term } = row;
+    const bucket = termsByEntryId.get(entryId) ?? [];
+    bucket.push(term);
+    termsByEntryId.set(entryId, bucket);
+  }
+  return rows.map((row) => {
+    const author = authorById.get(row.authorId);
+    if (!author) {
+      // eslint-disable-next-line no-restricted-syntax -- diagnostic throw
+      throw new Error(
+        `buildResolvedEntries: entry ${String(row.id)} references missing author ${String(row.authorId)}`,
+      );
+    }
+    return {
+      ...row,
+      contentBlocks: isEntryContent(row.content) ? row.content : null,
+      // Sync term URLs — no per-term CTE (nested terms get null, like entries).
+      terms: (termsByEntryId.get(row.id) ?? []).map((term) => ({
+        ...term,
+        url: buildTermArchiveUrlSync(ctx, term),
+      })),
+      author,
+      url: buildEntryPermalinkSync(ctx, row),
+    };
+  });
+}

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -1,7 +1,7 @@
 import type { SQL } from "drizzle-orm";
 import { count } from "drizzle-orm";
 
-import { expandShortcodes, isEntryContent } from "@plumix/blocks";
+import { expandShortcodes } from "@plumix/blocks";
 
 import type { AppContext } from "../context/app.js";
 import type { Entry } from "../db/schema/entries.js";
@@ -14,7 +14,6 @@ import type { AssetManifest } from "./render/asset-manifest.js";
 import type {
   ArchiveData,
   FrontPageData,
-  ResolvedEntry,
   SearchData,
   SingleData,
   TaxonomyData,
@@ -24,17 +23,13 @@ import { and, desc, eq, inArray, isNotNull, sql } from "../db/index.js";
 import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
 import { terms } from "../db/schema/terms.js";
-import { users } from "../db/schema/users.js";
 import { labelSourceText } from "../i18n/label.js";
 import { notFound, permanentRedirect } from "../runtime/http.js";
 import { paginate } from "./paginate.js";
 import { findEntryByPath, findTermByPath } from "./path-chain.js";
-import {
-  buildEntryPermalinkSync,
-  buildTermArchiveUrl,
-  buildTermArchiveUrlSync,
-} from "./permalink.js";
+import { buildTermArchiveUrl } from "./permalink.js";
 import { previewTokenGrantsEntry, readPreviewToken } from "./preview.js";
+import { buildResolvedEntries } from "./render/build-resolved-entries.js";
 import { renderThroughTheme } from "./render/render-template.js";
 
 declare module "../hooks/types.js" {
@@ -468,67 +463,6 @@ async function resolveArchive(
   });
   return new Response(html, {
     headers: { "content-type": "text/html; charset=utf-8" },
-  });
-}
-
-// Batched eager-load mirroring WordPress's `update_post_caches` semantics:
-// one query for authors (IN (...)), one query for the entry_term×terms
-// join (IN (...)). Templates read entry.author + entry.terms without N+1.
-async function buildResolvedEntries(
-  ctx: AppContext,
-  rows: readonly Entry[],
-): Promise<readonly ResolvedEntry[]> {
-  if (rows.length === 0) return [];
-  const entryIds = rows.map((r) => r.id);
-  const authorIds = Array.from(new Set(rows.map((r) => r.authorId)));
-  const [authorRows, joinRows] = await Promise.all([
-    ctx.db
-      .select({ id: users.id, name: users.name, avatarUrl: users.avatarUrl })
-      .from(users)
-      .where(inArray(users.id, authorIds)),
-    ctx.db
-      .select({
-        entryId: entryTerm.entryId,
-        id: terms.id,
-        taxonomy: terms.taxonomy,
-        name: terms.name,
-        slug: terms.slug,
-        description: terms.description,
-        meta: terms.meta,
-        parentId: terms.parentId,
-        version: terms.version,
-      })
-      .from(entryTerm)
-      .innerJoin(terms, eq(entryTerm.termId, terms.id))
-      .where(inArray(entryTerm.entryId, entryIds)),
-  ]);
-  const authorById = new Map(authorRows.map((a) => [a.id, a]));
-  const termsByEntryId = new Map<number, Term[]>();
-  for (const row of joinRows) {
-    const { entryId, ...term } = row;
-    const bucket = termsByEntryId.get(entryId) ?? [];
-    bucket.push(term);
-    termsByEntryId.set(entryId, bucket);
-  }
-  return rows.map((row) => {
-    const author = authorById.get(row.authorId);
-    if (!author) {
-      // eslint-disable-next-line no-restricted-syntax -- diagnostic throw
-      throw new Error(
-        `buildResolvedEntries: entry ${String(row.id)} references missing author ${String(row.authorId)}`,
-      );
-    }
-    return {
-      ...row,
-      contentBlocks: isEntryContent(row.content) ? row.content : null,
-      // Sync term URLs — no per-term CTE (nested terms get null, like entries).
-      terms: (termsByEntryId.get(row.id) ?? []).map((term) => ({
-        ...term,
-        url: buildTermArchiveUrlSync(ctx, term),
-      })),
-      author,
-      url: buildEntryPermalinkSync(ctx, row),
-    };
   });
 }
 

--- a/packages/plugins/blog/package.json
+++ b/packages/plugins/blog/package.json
@@ -51,6 +51,9 @@
     "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
+  "dependencies": {
+    "drizzle-orm": "catalog:"
+  },
   "peerDependencies": {
     "plumix": "workspace:*"
   },

--- a/packages/plugins/blog/src/index.ts
+++ b/packages/plugins/blog/src/index.ts
@@ -2,6 +2,10 @@ import type { EntryTypeLabels, TermTaxonomyLabels } from "plumix/plugin";
 import { withContext } from "plumix/i18n";
 import { definePlugin } from "plumix/plugin";
 
+import { relatedPostsLoader } from "./related.js";
+
+export type { RelatedPosts } from "./related.js";
+
 // Plain descriptor literals — server-side plugin code can't run the
 // Babel macro pipeline, so we author the `{ id, message }` shape
 // directly. The manifest payload is identical to a `defineMessage(...)`
@@ -169,5 +173,10 @@ export const blog = definePlugin("blog", {
       rewrite: { slug: "tag" },
       keywords: ["taxonomy", "tags"],
     });
+
+    // Related-by-term posts for the single-post view. A blog concern (it
+    // reads the category/tag taxonomy registered above), so it ships as a
+    // template dep here rather than in core.
+    ctx.registerTemplateDep("relatedPosts", { load: relatedPostsLoader });
   },
 });

--- a/packages/plugins/blog/src/related.test.ts
+++ b/packages/plugins/blog/src/related.test.ts
@@ -1,0 +1,72 @@
+import type { AppContext } from "plumix/plugin";
+import { createTestDb, factoriesFor } from "plumix/test";
+import { describe, expect, test } from "vitest";
+
+import { findRelatedEntries } from "./related.js";
+
+type TestDb = Awaited<ReturnType<typeof createTestDb>>;
+
+/** Minimal AppContext stand-in — `findRelatedEntries` reads only `db`. */
+function ctxFor(db: TestDb): AppContext {
+  return { db } as unknown as AppContext;
+}
+
+describe("findRelatedEntries", () => {
+  test("returns published posts sharing a term, newest first, current excluded", async () => {
+    const db = await createTestDb();
+    const f = factoriesFor(db);
+    const author = await f.user.create({});
+    const topic = await f.term.create({ taxonomy: "category" });
+    const other = await f.term.create({ taxonomy: "category" });
+
+    const make = async (
+      title: string,
+      status: "published" | "draft",
+      publishedAt: Date | null,
+      termId: number,
+      type = "post",
+    ) => {
+      const entry = await f.entry.create({
+        type,
+        title,
+        status,
+        publishedAt,
+        authorId: author.id,
+      });
+      await f.entryTerm.create({ entryId: entry.id, termId });
+      return entry;
+    };
+
+    const current = await make(
+      "Current",
+      "published",
+      new Date(3000),
+      topic.id,
+    );
+    const newer = await make("Newer", "published", new Date(2000), topic.id);
+    const older = await make("Older", "published", new Date(1000), topic.id);
+    await make("Draft sibling", "draft", null, topic.id);
+    await make("Different topic", "published", new Date(2500), other.id);
+    // Shares the term but is a different type — must not surface as related.
+    await make("Page sibling", "published", new Date(2200), topic.id, "page");
+
+    const related = await findRelatedEntries(ctxFor(db), current.id);
+
+    expect(related.map((e) => e.title)).toEqual(["Newer", "Older"]);
+    expect(related.map((e) => e.id)).toEqual([newer.id, older.id]);
+  });
+
+  test("returns nothing when the entry has no terms", async () => {
+    const db = await createTestDb();
+    const f = factoriesFor(db);
+    const author = await f.user.create({});
+    const entry = await f.entry.create({
+      type: "post",
+      status: "published",
+      publishedAt: new Date(),
+      authorId: author.id,
+    });
+
+    expect(await findRelatedEntries(ctxFor(db), entry.id)).toEqual([]);
+  });
+});

--- a/packages/plugins/blog/src/related.ts
+++ b/packages/plugins/blog/src/related.ts
@@ -1,0 +1,95 @@
+import type { ResolvedEntry } from "plumix";
+import type { AppContext } from "plumix/plugin";
+import type { Entry } from "plumix/schema";
+import { and, desc, eq, inArray, isNotNull, ne } from "drizzle-orm";
+import { buildResolvedEntries } from "plumix";
+import { entries, entryTerm } from "plumix/schema";
+
+// Augment the template-dep registry so a theme can declare
+// `defineTemplate({ relatedPosts: ["related"], render })` and receive the
+// resolved siblings. Related-by-term is a blog concern — it only means
+// anything where the post taxonomy (category/tag) this plugin registers
+// exists — so the dep lives here, not in core. Themes import `RelatedPosts`
+// to pull this augmentation, mirroring the comments plugin's `ResolvedThread`.
+declare module "plumix/plugin" {
+  interface TemplateDepRegistry {
+    relatedPosts: { slug: string; result: readonly ResolvedEntry[] };
+  }
+}
+
+export type RelatedPosts = readonly ResolvedEntry[];
+
+// The single-post "related" strip stays short — three cards below the article.
+const RELATED_POSTS_LIMIT = 3;
+
+/**
+ * Published entries sharing at least one term (category/tag) with the entry
+ * `currentId`, newest first, the current entry excluded. Mirrors WordPress's
+ * `get_posts(['category__in' => …, 'post__not_in' => [$id]])` related recipe
+ * (the Jetpack/YARPP approach) — not the default theme's plain "more posts",
+ * which is just recent.
+ */
+export async function findRelatedEntries(
+  ctx: AppContext,
+  currentId: number,
+): Promise<readonly Entry[]> {
+  const [selfRows, termRows] = await Promise.all([
+    ctx.db
+      .select({ type: entries.type })
+      .from(entries)
+      .where(eq(entries.id, currentId)),
+    ctx.db
+      .select({ termId: entryTerm.termId })
+      .from(entryTerm)
+      .where(eq(entryTerm.entryId, currentId)),
+  ]);
+  const self = selfRows[0];
+  if (!self) return [];
+  const termIds = termRows.map((r) => r.termId);
+  if (termIds.length === 0) return [];
+
+  const siblingRows = await ctx.db
+    .selectDistinct({ id: entryTerm.entryId })
+    .from(entryTerm)
+    .where(
+      and(inArray(entryTerm.termId, termIds), ne(entryTerm.entryId, currentId)),
+    );
+  const siblingIds = siblingRows.map((r) => r.id);
+  if (siblingIds.length === 0) return [];
+
+  // Scope to the current entry's type. The write path doesn't enforce that a
+  // term's entry matches the taxonomy's `entryTypes`, so — like core's
+  // `resolveTaxonomy` — re-filter at read time rather than trust `entry_term`.
+  return ctx.db
+    .select()
+    .from(entries)
+    .where(
+      and(
+        inArray(entries.id, siblingIds),
+        eq(entries.type, self.type),
+        eq(entries.status, "published"),
+        isNotNull(entries.publishedAt),
+      ),
+    )
+    .orderBy(desc(entries.publishedAt), desc(entries.id))
+    .limit(RELATED_POSTS_LIMIT);
+}
+
+/**
+ * `relatedPosts` template-dep loader. Only resolves on a single-entry route
+ * (reads `ctx.resolvedEntity`); a non-entry route or a post with no shared
+ * matches yields no slugs, so the theme's strip stays hidden.
+ */
+export async function relatedPostsLoader(
+  slugs: readonly string[],
+  ctx: AppContext,
+): Promise<Record<string, RelatedPosts>> {
+  const current = ctx.resolvedEntity;
+  if (current?.kind !== "entry") return {};
+
+  const rows = await findRelatedEntries(ctx, current.id);
+  if (rows.length === 0) return {};
+
+  const resolved = await buildResolvedEntries(ctx, rows);
+  return Object.fromEntries(slugs.map((slug) => [slug, resolved]));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,10 @@ importers:
         version: 4.100.0(@cloudflare/workers-types@4.20260526.1)
 
   packages/plugins/blog:
+    dependencies:
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.2(@cloudflare/workers-types@4.20260526.1)(@libsql/client@0.17.3)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'


### PR DESCRIPTION
Adds a "Related posts" strip below the article (and comments) on the blog example theme's single-post view — posts sharing a category or tag with the current one, newest first, the current post excluded, scoped to its type, up to three. The strip hides itself when nothing is related.

This mirrors WordPress's `get_posts(['category__in' => …, 'post__not_in' => [$id]])` related recipe (the Jetpack/YARPP approach), deliberately **not** the latest default theme's plain recent "more posts" (TT5's `more-posts.php` does no taxonomy filtering).

**Ownership: the dep lives in the blog plugin, not core**

Related-by-term only means anything where the post taxonomy (category/tag) exists, so `@plumix/plugin-blog` registers a `relatedPosts` template dep. Template-dep loaders are pull-based — only a template that declares the kind runs the loader — so themes without the blog plugin pay nothing. Core contributes one reusable primitive: `buildResolvedEntries` (raw entry rows → render-ready `ResolvedEntry`), extracted from `resolve.ts` and exported so any plugin building an entry list reuses the batched, no-N+1 hydration.

**Read-time type scoping**

The term write path doesn't enforce that a tagged entry's type matches the taxonomy's `entryTypes`, so — like core's `resolveTaxonomy` — the query re-filters by the current entry's type rather than trusting `entry_term`. A page sharing a category never surfaces under a post.

Verified live in dev: the strip renders self-excluded related cards on a post with a shared category, hides on a post with no shared term, and is absent on pages. Unit-tested query logic (shared-term dedup, exclude-self, type scope, published gate, ordering); full core suite and all gates green.

Closes #1068