### PR TITLE
feat(core): give the admin bar a user menu and make it mobile-visible

### DIFF
--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -15,6 +15,7 @@ import { RendererError } from "./errors.js";
 export interface RendererUser {
   readonly id: number;
   readonly email: string;
+  readonly name?: string | null;
   readonly role: string;
   readonly meta: Record<string, unknown>;
 }

--- a/packages/core/locales/admin-bar-ar.po
+++ b/packages/core/locales/admin-bar-ar.po
@@ -35,5 +35,15 @@ msgstr "الحساب"
 
 #. js-lingui-explicit-id
 #: src/admin-bar/i18n.ts
+msgid "core.adminBar.profile"
+msgstr "الملف الشخصي"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.signOut"
+msgstr "تسجيل الخروج"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
 msgid "core.adminBar.navAria"
 msgstr "الإدارة"

--- a/packages/core/locales/admin-bar-de.po
+++ b/packages/core/locales/admin-bar-de.po
@@ -35,5 +35,15 @@ msgstr "Konto"
 
 #. js-lingui-explicit-id
 #: src/admin-bar/i18n.ts
+msgid "core.adminBar.profile"
+msgstr "Profil"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.signOut"
+msgstr "Abmelden"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
 msgid "core.adminBar.navAria"
 msgstr "Administration"

--- a/packages/core/locales/admin-bar-en.po
+++ b/packages/core/locales/admin-bar-en.po
@@ -35,5 +35,15 @@ msgstr "Account"
 
 #. js-lingui-explicit-id
 #: src/admin-bar/i18n.ts
+msgid "core.adminBar.profile"
+msgstr "Profile"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.signOut"
+msgstr "Sign out"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
 msgid "core.adminBar.navAria"
 msgstr "Admin"

--- a/packages/core/locales/admin-bar-uk.po
+++ b/packages/core/locales/admin-bar-uk.po
@@ -35,5 +35,15 @@ msgstr "Обліковий запис"
 
 #. js-lingui-explicit-id
 #: src/admin-bar/i18n.ts
+msgid "core.adminBar.profile"
+msgstr "Профіль"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.signOut"
+msgstr "Вийти"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
 msgid "core.adminBar.navAria"
 msgstr "Адміністрування"

--- a/packages/core/locales/admin-bar-zh-CN.po
+++ b/packages/core/locales/admin-bar-zh-CN.po
@@ -35,5 +35,15 @@ msgstr "账户"
 
 #. js-lingui-explicit-id
 #: src/admin-bar/i18n.ts
+msgid "core.adminBar.profile"
+msgstr "个人资料"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
+msgid "core.adminBar.signOut"
+msgstr "退出登录"
+
+#. js-lingui-explicit-id
+#: src/admin-bar/i18n.ts
 msgid "core.adminBar.navAria"
 msgstr "管理"

--- a/packages/core/src/admin-bar/component.test.tsx
+++ b/packages/core/src/admin-bar/component.test.tsx
@@ -355,6 +355,29 @@ describe("PlumixAdminBar", () => {
     );
   });
 
+  test("shows the display name and derives the avatar initial from it", () => {
+    const named = { ...user, name: "Alex Rivera" };
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user: named }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain("<bdi>Alex Rivera</bdi>");
+    expect(html).toMatch(
+      /class="plumix-admin-bar__avatar"[^>]*aria-hidden[^>]*>A</,
+    );
+  });
+
   test("keeps the bar visible on small screens (never sets the bar to display:none)", () => {
     const hooks = new HookRegistry();
     registerCoreAdminBarContributors(hooks);

--- a/packages/core/src/admin-bar/component.test.tsx
+++ b/packages/core/src/admin-bar/component.test.tsx
@@ -145,7 +145,7 @@ describe("PlumixAdminBar", () => {
     const ukUser = { ...user, meta: { locale: "uk" } };
     const hooks = new HookRegistry();
     registerCoreAdminBarContributors(hooks);
-    const types = new Map([["post", { name: "post" } as never]]);
+    const types = new Map([["post", { name: "post", label: "Post" } as never]]);
 
     const html = renderToStaticMarkup(
       <PlumixProvider value={{ registry: emptyRegistry, user: ukUser }}>
@@ -171,7 +171,7 @@ describe("PlumixAdminBar", () => {
     const zhUser = { ...user, meta: { locale: "zh-CN" } };
     const hooks = new HookRegistry();
     registerCoreAdminBarContributors(hooks);
-    const types = new Map([["post", { name: "post" } as never]]);
+    const types = new Map([["post", { name: "post", label: "Post" } as never]]);
 
     const html = renderToStaticMarkup(
       <PlumixProvider value={{ registry: emptyRegistry, user: zhUser }}>
@@ -240,7 +240,7 @@ describe("PlumixAdminBar", () => {
   test("emits a localized +New summary aria-label for screen readers", () => {
     const hooks = new HookRegistry();
     registerCoreAdminBarContributors(hooks);
-    const types = new Map([["post", { name: "post" } as never]]);
+    const types = new Map([["post", { name: "post", label: "Post" } as never]]);
 
     const html = renderToStaticMarkup(
       <PlumixProvider value={{ registry: emptyRegistry, user }}>
@@ -261,8 +261,8 @@ describe("PlumixAdminBar", () => {
     const hooks = new HookRegistry();
     registerCoreAdminBarContributors(hooks);
     const types = new Map([
-      ["post", { name: "post" } as never],
-      ["page", { name: "page" } as never],
+      ["post", { name: "post", label: "Post" } as never],
+      ["page", { name: "page", label: "Page" } as never],
     ]);
 
     const html = renderToStaticMarkup(
@@ -283,6 +283,98 @@ describe("PlumixAdminBar", () => {
     expect(html).toContain('data-testid="plumix-admin-bar-node-+new:page"');
     expect(html).toContain('href="/_plumix/admin/entries/post/create"');
     expect(html).toContain('href="/_plumix/admin/entries/page/create"');
+  });
+
+  test("renders the account as a dropdown with a Profile link and a Sign out button", () => {
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain(
+      'data-testid="plumix-admin-bar-node-account:profile"',
+    );
+    expect(html).toContain('href="/_plumix/admin/profile"');
+    expect(html).toContain(
+      'data-testid="plumix-admin-bar-node-account:signout"',
+    );
+    // Sign out is a button (needs the CSRF header), not a navigation link.
+    expect(html).toMatch(/<button[^>]*data-plumix-signout/);
+  });
+
+  test("emits the inline sign-out island targeting the signout endpoint with the CSRF header", () => {
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).toContain('data-testid="plumix-admin-bar-signout-script"');
+    expect(html).toContain("/_plumix/auth/signout");
+    expect(html).toContain("X-Plumix-Request");
+  });
+
+  test("renders an avatar initial for the mobile account collapse", () => {
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    // editor@cms.example → "E"
+    expect(html).toMatch(
+      /class="plumix-admin-bar__avatar"[^>]*aria-hidden[^>]*>E</,
+    );
+  });
+
+  test("keeps the bar visible on small screens (never sets the bar to display:none)", () => {
+    const hooks = new HookRegistry();
+    registerCoreAdminBarContributors(hooks);
+
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry: emptyRegistry, user }}>
+        <PlumixAdminBar
+          hooks={hooks}
+          request={request}
+          siteName="My Site"
+          auth={auth}
+          entryTypes={entryTypes}
+        />
+      </PlumixProvider>,
+    );
+
+    expect(html).not.toMatch(/\.plumix-admin-bar\s*\{[^}]*display:\s*none/);
+    // It grows for touch instead of disappearing.
+    expect(html).toMatch(/@media\s*\(max-width:\s*639px\)/);
+    expect(html).toContain("height: 46px");
   });
 
   test("renders core contributor nodes as anchors with stable testids", () => {

--- a/packages/core/src/admin-bar/component.tsx
+++ b/packages/core/src/admin-bar/component.tsx
@@ -9,7 +9,12 @@ import type { AdminBarTreeNode, BarRenderContext } from "./types.js";
 import { buildAdminBarTree } from "./build-tree.js";
 import { collectAdminBarNodes } from "./collect.js";
 import { barDirection, barMessages, resolveBarLocale } from "./i18n.js";
-import { ADMIN_BAR_BODY_OFFSET_CSS, ADMIN_BAR_CSS } from "./styles.js";
+import {
+  ADMIN_BAR_BODY_OFFSET_CSS,
+  ADMIN_BAR_CSS,
+  ADMIN_BAR_NOSCRIPT_CSS,
+  ADMIN_BAR_SIGNOUT_SCRIPT,
+} from "./styles.js";
 
 interface PlumixAdminBarProps {
   readonly hooks: HookExecutor;
@@ -54,6 +59,15 @@ export function PlumixAdminBar({
       <style data-testid="plumix-admin-bar-body-offset">
         {ADMIN_BAR_BODY_OFFSET_CSS}
       </style>
+      <script
+        data-testid="plumix-admin-bar-signout-script"
+        dangerouslySetInnerHTML={{ __html: ADMIN_BAR_SIGNOUT_SCRIPT }}
+      />
+      <noscript>
+        <style data-testid="plumix-admin-bar-noscript">
+          {ADMIN_BAR_NOSCRIPT_CSS}
+        </style>
+      </noscript>
       <header
         className="plumix-admin-bar"
         data-testid="plumix-admin-bar"
@@ -89,7 +103,14 @@ function BarItem({
         className={node.id === "account" ? "plumix-admin-bar__end" : undefined}
       >
         <details>
-          <summary aria-label={summaryAria}>{node.title}</summary>
+          <summary aria-label={summaryAria}>
+            {node.id === "account" ? (
+              <span className="plumix-admin-bar__avatar" aria-hidden>
+                {accountInitial(node.title)}
+              </span>
+            ) : null}
+            <BarLabel node={node} />
+          </summary>
           <ul>
             {node.children.map((child) => (
               <BarItem key={child.id} node={child} strings={strings} />
@@ -104,16 +125,40 @@ function BarItem({
       data-testid={`plumix-admin-bar-node-${node.id}`}
       className={node.id === "account" ? "plumix-admin-bar__end" : undefined}
     >
-      {node.href ? (
-        <a href={node.href}>
-          <BarLabel node={node} />
-        </a>
-      ) : (
-        <span>
-          <BarLabel node={node} />
-        </span>
-      )}
+      {renderLeaf(node)}
     </li>
+  );
+}
+
+// Avatar glyph shown in place of the email on mobile (WP collapses the
+// "Howdy, name" item to just the avatar). First code point of the email,
+// uppercased; `Array.from` keeps astral characters intact.
+function accountInitial(email: string): string {
+  return (Array.from(email)[0] ?? "?").toUpperCase();
+}
+
+// `signout` is the bar's only client action — a `<button>` the inline
+// island wires up (the endpoint needs the `X-Plumix-Request` header a
+// plain link can't send). Everything else stays a zero-JS link/span.
+function renderLeaf(node: AdminBarTreeNode): ReactNode {
+  if (node.action === "signout") {
+    return (
+      <button type="button" data-plumix-signout>
+        <BarLabel node={node} />
+      </button>
+    );
+  }
+  if (node.href) {
+    return (
+      <a href={node.href}>
+        <BarLabel node={node} />
+      </a>
+    );
+  }
+  return (
+    <span>
+      <BarLabel node={node} />
+    </span>
   );
 }
 

--- a/packages/core/src/admin-bar/core-contributors.test.ts
+++ b/packages/core/src/admin-bar/core-contributors.test.ts
@@ -28,7 +28,9 @@ function ctx(overrides: Partial<BarRenderContext> = {}): BarRenderContext {
 }
 
 function typesMap(...slugs: readonly string[]): BarRenderContext["entryTypes"] {
-  return new Map(slugs.map((slug) => [slug, { name: slug } as never]));
+  return new Map(
+    slugs.map((slug) => [slug, { name: slug, label: slug } as never]),
+  );
 }
 
 function withCore(): HookRegistry {
@@ -80,6 +82,51 @@ describe("registerCoreAdminBarContributors — +New group", () => {
     ]);
   });
 
+  test("titles each child with the type's human singular label, not the raw slug", () => {
+    const types = new Map([
+      ["post", { name: "post", labels: { singular: "Post" } } as never],
+      ["page", { name: "page", label: "Page" } as never],
+    ]);
+
+    const nodes = collectAdminBarNodes(withCore(), ctx({ entryTypes: types }));
+
+    const titles = nodes.filter((n) => n.parent === "+new").map((n) => n.title);
+    expect(titles).toEqual(["Post", "Page"]);
+  });
+
+  test("omits non-public types (showUI false) such as menu_item", () => {
+    const types = new Map([
+      ["post", { name: "post", label: "Post" } as never],
+      [
+        "menu_item",
+        { name: "menu_item", label: "Menu item", isPublic: false } as never,
+      ],
+    ]);
+
+    const nodes = collectAdminBarNodes(withCore(), ctx({ entryTypes: types }));
+
+    const childIds = nodes.filter((n) => n.parent === "+new").map((n) => n.id);
+    expect(childIds).toEqual(["+new:post"]);
+  });
+
+  test("keeps a private type that explicitly opts back into the UI", () => {
+    const types = new Map([
+      [
+        "secret",
+        {
+          name: "secret",
+          label: "Secret",
+          isPublic: false,
+          showUI: true,
+        } as never,
+      ],
+    ]);
+
+    const nodes = collectAdminBarNodes(withCore(), ctx({ entryTypes: types }));
+
+    expect(nodes.find((n) => n.id === "+new:secret")).toBeDefined();
+  });
+
   test("plugin can suppress its own entry type from the menu via the filter", () => {
     const hooks = withCore();
     hooks.addFilter(
@@ -98,18 +145,57 @@ describe("registerCoreAdminBarContributors — +New group", () => {
   });
 });
 
-describe("registerCoreAdminBarContributors — account link", () => {
-  test("adds an 'account' node titled with the user's email", () => {
+describe("registerCoreAdminBarContributors — account dropdown", () => {
+  test("renders the account as a parent titled with the user's email (no direct link)", () => {
     const nodes = collectAdminBarNodes(withCore(), ctx());
 
     const account = nodes.find((n) => n.id === "account");
     expect(account).toEqual({
       id: "account",
       title: "editor@cms.example",
+      group: "account",
+      position: 100,
+    });
+    expect(account?.href).toBeUndefined();
+    expect(account?.parent).toBeUndefined();
+  });
+
+  test("adds a Profile child linking to the admin profile route", () => {
+    const nodes = collectAdminBarNodes(withCore(), ctx());
+
+    expect(nodes.find((n) => n.id === "account:profile")).toEqual({
+      id: "account:profile",
+      title: "Profile",
       href: "/_plumix/admin/profile",
       group: "account",
+      parent: "account",
       position: 10,
     });
+  });
+
+  test("adds a Sign out child carrying the signout action and no href", () => {
+    const nodes = collectAdminBarNodes(withCore(), ctx());
+
+    expect(nodes.find((n) => n.id === "account:signout")).toEqual({
+      id: "account:signout",
+      title: "Sign out",
+      action: "signout",
+      group: "account",
+      parent: "account",
+      position: 20,
+    });
+  });
+
+  test("translates the dropdown labels via the bar catalog", () => {
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({ locale: "de", direction: "ltr" }),
+    );
+
+    expect(nodes.find((n) => n.id === "account:profile")?.title).toBe("Profil");
+    expect(nodes.find((n) => n.id === "account:signout")?.title).toBe(
+      "Abmelden",
+    );
   });
 });
 

--- a/packages/core/src/admin-bar/core-contributors.test.ts
+++ b/packages/core/src/admin-bar/core-contributors.test.ts
@@ -160,6 +160,42 @@ describe("registerCoreAdminBarContributors — account dropdown", () => {
     expect(account?.parent).toBeUndefined();
   });
 
+  test("titles the account with the display name when the user has one", () => {
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({
+        user: {
+          id: 1,
+          email: "editor@cms.example",
+          name: "Alex Rivera",
+          role: "editor",
+          meta: {},
+        },
+      }),
+    );
+
+    expect(nodes.find((n) => n.id === "account")?.title).toBe("Alex Rivera");
+  });
+
+  test("falls back to the email when the name is empty or null", () => {
+    const nodes = collectAdminBarNodes(
+      withCore(),
+      ctx({
+        user: {
+          id: 1,
+          email: "editor@cms.example",
+          name: null,
+          role: "editor",
+          meta: {},
+        },
+      }),
+    );
+
+    expect(nodes.find((n) => n.id === "account")?.title).toBe(
+      "editor@cms.example",
+    );
+  });
+
   test("adds a Profile child linking to the admin profile route", () => {
     const nodes = collectAdminBarNodes(withCore(), ctx());
 

--- a/packages/core/src/admin-bar/core-contributors.ts
+++ b/packages/core/src/admin-bar/core-contributors.ts
@@ -118,11 +118,15 @@ function accountContributor(
   ctx: BarRenderContext,
 ): readonly AdminBarNode[] {
   const strings = barMessages(ctx.locale);
+  // WP-style "Howdy, {display name}" — fall back to the email when the user
+  // never set a name. Also seeds the mobile avatar initial. Mirrors the
+  // display-name derivation in `rpc/procedures/user/lookup.ts`.
+  const name = ctx.user.name?.trim();
   return [
     ...nodes,
     {
       id: "account",
-      title: ctx.user.email,
+      title: name !== undefined && name !== "" ? name : ctx.user.email,
       group: "account",
       position: ACCOUNT_POSITION,
     },

--- a/packages/core/src/admin-bar/core-contributors.ts
+++ b/packages/core/src/admin-bar/core-contributors.ts
@@ -1,11 +1,15 @@
 import type { HookRegistry } from "../hooks/registry.js";
 import type { AdminBarNode, BarRenderContext } from "./types.js";
+import { labelSourceText } from "../i18n/label.js";
+import { resolveEntryTypeVisibility } from "../plugin/manifest.js";
 import { barMessages } from "./i18n.js";
 
 const SITE_POSITION = 10;
 const EDIT_THIS_POSITION = 20;
 const NEW_GROUP_POSITION = 15;
-const ACCOUNT_POSITION = 10;
+// Sorts last so `margin-inline-start: auto` parks the account at the far
+// right with nothing trailing it — site / +New / Edit cluster on the left.
+const ACCOUNT_POSITION = 100;
 
 /**
  * Registers the four core contributors (`site`, `edit-this`, `+new`,
@@ -88,10 +92,17 @@ function newGroupContributor(
     },
   ];
   let childPosition = 10;
-  for (const [slug] of ctx.entryTypes) {
+  for (const [slug, type] of ctx.entryTypes) {
+    // Private types (e.g. `menu_item`) are managed through their own admin
+    // surface, never quick-created from the bar — mirror their `showUI`
+    // visibility so they don't leak into the +New menu.
+    if (!resolveEntryTypeVisibility(type).showUI) continue;
     additions.push({
       id: `+new:${slug}`,
-      title: slug,
+      // The type's human singular label, not the raw slug. Source-locale
+      // text only (like other SSR label sites — see `route/resolve.ts`):
+      // the bar has no per-plugin i18n catalog to resolve descriptors.
+      title: labelSourceText(type.labels?.singular ?? type.label),
       href: `/_plumix/admin/entries/${slug}/create`,
       group: "+new",
       parent: "+new",
@@ -106,14 +117,30 @@ function accountContributor(
   nodes: readonly AdminBarNode[],
   ctx: BarRenderContext,
 ): readonly AdminBarNode[] {
+  const strings = barMessages(ctx.locale);
   return [
     ...nodes,
     {
       id: "account",
       title: ctx.user.email,
-      href: "/_plumix/admin/profile",
       group: "account",
       position: ACCOUNT_POSITION,
+    },
+    {
+      id: "account:profile",
+      title: strings.profile,
+      href: "/_plumix/admin/profile",
+      group: "account",
+      parent: "account",
+      position: 10,
+    },
+    {
+      id: "account:signout",
+      title: strings.signOut,
+      action: "signout",
+      group: "account",
+      parent: "account",
+      position: 20,
     },
   ];
 }

--- a/packages/core/src/admin-bar/i18n.ts
+++ b/packages/core/src/admin-bar/i18n.ts
@@ -34,6 +34,8 @@ const M = {
   newGroupAria: { id: "core.adminBar.newGroupAria", message: "Create new" },
   edit: { id: "core.adminBar.edit", message: "Edit" },
   account: { id: "core.adminBar.account", message: "Account" },
+  profile: { id: "core.adminBar.profile", message: "Profile" },
+  signOut: { id: "core.adminBar.signOut", message: "Sign out" },
   navAria: { id: "core.adminBar.navAria", message: "Admin" },
 } as const;
 
@@ -43,6 +45,8 @@ export interface BarStrings {
   readonly newGroupAria: string;
   readonly edit: string;
   readonly account: string;
+  readonly profile: string;
+  readonly signOut: string;
   readonly navAria: string;
 }
 
@@ -97,6 +101,8 @@ export function barMessages(locale: BarLocale): BarStrings {
     newGroupAria: resolveMessage(catalog, M.newGroupAria),
     edit: resolveMessage(catalog, M.edit),
     account: resolveMessage(catalog, M.account),
+    profile: resolveMessage(catalog, M.profile),
+    signOut: resolveMessage(catalog, M.signOut),
     navAria: resolveMessage(catalog, M.navAria),
   };
 }

--- a/packages/core/src/admin-bar/styles.ts
+++ b/packages/core/src/admin-bar/styles.ts
@@ -78,7 +78,8 @@ export const ADMIN_BAR_CSS = css`
   }
   .plumix-admin-bar a,
   .plumix-admin-bar summary,
-  .plumix-admin-bar span {
+  .plumix-admin-bar span,
+  .plumix-admin-bar button {
     color: #fff;
     text-decoration: none;
     padding: 0 10px;
@@ -90,9 +91,34 @@ export const ADMIN_BAR_CSS = css`
     text-overflow: ellipsis;
     max-width: 100%;
   }
+  .plumix-admin-bar button {
+    appearance: none;
+    background: none;
+    border: 0;
+    font: inherit;
+    width: 100%;
+    text-align: start;
+  }
   .plumix-admin-bar a:hover,
-  .plumix-admin-bar summary:hover {
+  .plumix-admin-bar summary:hover,
+  .plumix-admin-bar button:hover {
     background: #2c3338;
+  }
+  /* Specificity must beat \`.plumix-admin-bar span\` (0,1,1), which would
+     otherwise re-show the disc and restore its text padding. */
+  .plumix-admin-bar span.plumix-admin-bar__avatar {
+    display: none;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border-radius: 50%;
+    background: #2c3338;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
   }
   .plumix-admin-bar details {
     position: relative;
@@ -126,10 +152,17 @@ export const ADMIN_BAR_CSS = css`
   .plumix-admin-bar details > ul > li {
     max-width: 100%;
   }
-  .plumix-admin-bar details > ul a {
+  .plumix-admin-bar details > ul a,
+  .plumix-admin-bar details > ul button {
     display: block;
     padding: 6px 12px;
     line-height: 1.4;
+  }
+  /* The account menu sits at the row's end — open its dropdown toward the
+     inline-start so it can't spill off the viewport edge. */
+  .plumix-admin-bar__end details > ul {
+    left: auto;
+    right: 0;
   }
   .plumix-admin-bar[dir="rtl"] nav {
     flex-direction: row-reverse;
@@ -138,17 +171,89 @@ export const ADMIN_BAR_CSS = css`
     left: auto;
     right: 0;
   }
+  .plumix-admin-bar[dir="rtl"] .plumix-admin-bar__end details > ul {
+    right: auto;
+    left: 0;
+  }
+  /* Mobile: keep the bar visible (WP does too) but grow it for touch — a
+     taller strip, an avatar disc in place of the long email, and roomier
+     dropdown rows. Submenus already tap-to-open via native <details>. */
   @media (max-width: 639px) {
     .plumix-admin-bar {
+      height: 46px;
+      line-height: 46px;
+    }
+    .plumix-admin-bar nav {
+      padding: 0 4px;
+    }
+    .plumix-admin-bar a,
+    .plumix-admin-bar summary,
+    .plumix-admin-bar span,
+    .plumix-admin-bar button {
+      padding: 0 8px;
+    }
+    .plumix-admin-bar li {
+      max-width: 40vw;
+    }
+    .plumix-admin-bar details > ul {
+      top: 46px;
+    }
+    .plumix-admin-bar details > ul a,
+    .plumix-admin-bar details > ul button {
+      padding: 10px 14px;
+    }
+    .plumix-admin-bar span.plumix-admin-bar__avatar {
+      display: inline-flex;
+    }
+    .plumix-admin-bar__end > details > summary > bdi {
       display: none;
+    }
+    .plumix-admin-bar__end > details > summary {
+      padding-inline: 6px;
     }
   }
 `;
 
 export const ADMIN_BAR_BODY_OFFSET_CSS = css`
-  @media (min-width: 640px) {
+  body {
+    padding-top: 36px;
+  }
+  @media (max-width: 639px) {
     body {
-      padding-top: 36px;
+      padding-top: 46px;
     }
   }
 `;
+
+// Inline sign-out island — the bar's one concession to JS. The signout
+// endpoint is CSRF-gated on the custom `X-Plumix-Request` header (a plain
+// link/form can't set it) and answers with JSON, so a button + fetch is
+// the minimal wiring. `redirectTo` is honored for external-IdP logout;
+// otherwise the current page reloads, now unauthenticated (no bar).
+export const ADMIN_BAR_SIGNOUT_SCRIPT = `
+(function () {
+  var sel = "[data-plumix-signout]";
+  document.addEventListener("click", function (event) {
+    var node = event.target;
+    var trigger = node && node.closest ? node.closest(sel) : null;
+    if (!trigger) return;
+    event.preventDefault();
+    trigger.disabled = true;
+    fetch("/_plumix/auth/signout", {
+      method: "POST",
+      headers: { "X-Plumix-Request": "1" },
+      credentials: "same-origin",
+    })
+      .then(function (res) { return res.ok ? res.json() : null; })
+      .then(function (data) {
+        var to = data && data.redirectTo ? data.redirectTo : location.pathname;
+        location.assign(to);
+      })
+      .catch(function () { location.reload(); });
+  });
+})();
+`;
+
+// With JS off the sign-out button can't do anything (the endpoint needs a
+// fetch with the CSRF header) — hide it rather than show a dead control.
+export const ADMIN_BAR_NOSCRIPT_CSS = "[data-plumix-signout]{display:none}";

--- a/packages/core/src/admin-bar/types.ts
+++ b/packages/core/src/admin-bar/types.ts
@@ -20,6 +20,13 @@ export interface AdminBarNode {
   readonly group: AdminBarGroup;
   readonly parent?: string;
   readonly position?: number;
+  /**
+   * Marks a node as a client action rather than a navigation link. The
+   * bar is otherwise zero-JS server chrome; `"signout"` is the single
+   * exception, rendered as a `<button>` wired to the inline sign-out
+   * island instead of an `<a>`/`<span>`.
+   */
+  readonly action?: "signout";
 }
 
 export interface AdminBarTreeNode extends AdminBarNode {

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -45,6 +45,8 @@ export type Db<TSchema extends Record<string, unknown> = CoreSchema> =
 export interface AuthenticatedUser {
   readonly id: number;
   readonly email: string;
+  /** Display name from `users.name`; null when the user never set one. */
+  readonly name?: string | null;
   readonly role: UserRole;
   readonly meta: Record<string, unknown>;
 }

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -480,9 +480,9 @@ async function dispatchPluginRawRoute(
   const result = await ctx.authenticator.authenticate(ctx.request, ctx.db);
   if (!result) return jsonResponse({ error: "unauthorized" }, { status: 401 });
 
-  const { id, email, role, meta } = result.user;
+  const { id, email, name, role, meta } = result.user;
   const tokenScopes = result.tokenScopes ?? null;
-  const authedCtx = withUser(ctx, { id, email, role, meta }, tokenScopes);
+  const authedCtx = withUser(ctx, { id, email, name, role, meta }, tokenScopes);
 
   if (gate === "authenticated") {
     return route.handler(authedCtx.request, authedCtx);


### PR DESCRIPTION
Reworks the public-site admin bar after reviewing how it actually behaves on the front end: the quick-create menu showed raw type slugs, the user item was a dead-end link showing a raw email, and the whole bar disappeared on phones.

**Human labels in +New, private types dropped**

`+ New` listed raw slugs (`post`, `page`, `media`, `menu_item`). It now renders each type's human singular label via `labelSourceText`, and skips non-public types (`showUI` false) — so `menu_item`, which is only managed through the Menu screen, no longer leaks into quick-create.

**Account is now a dropdown that greets you by name**

The account item was a bare link to the profile titled with the raw email; it's now a menu with Profile and Sign out, titled with the user's display name (`name` → `email` fallback, trimmed). The bar's user context previously dropped `name` — `AuthenticatedUser`/`RendererUser` carried only id/email/role/meta even though the render path passes the whole row through at runtime — so both are widened with an optional `name`. Sign out is the bar's one concession to JS: a `<button>` wired by a small inline island that POSTs `/_plumix/auth/signout` with the `X-Plumix-Request` CSRF header (a plain link can't set it, and the endpoint answers with JSON). With JS off the button is hidden rather than shown dead. The account also sorts last now, so it parks at the far right with site / +New / Edit on the left.

**Visible on mobile**

The bar was hidden below 640px; it now stays visible and grows for touch — a taller strip, roomier dropdown rows, and the name/email collapsing to an initials avatar, mirroring WordPress's mobile treatment. Submenus tap-to-open for free via native `<details>` (no JS).

**Known limitation:** like the bar's existing links, the signout path is root-relative and not `basePath`-aware; subdirectory mounts are a separate follow-up.