### PR TITLE
fix: stop plugin admin entries double-registering their page

### DIFF
--- a/packages/plugins/comments/src/admin/index.test.tsx
+++ b/packages/plugins/comments/src/admin/index.test.tsx
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+// Regression (production-build-only, invisible to `plumix dev` e2e):
+// the synthesised admin chunk both runs this entry's module body AND
+// emits its own `registerPluginPage("/comments", CommentsShell)` from
+// the `ctx.registerAdminPage({ component })` declaration. If the entry
+// *also* registers the page imperatively, "/comments" is registered
+// twice and AdminPluginRegistryError throws at admin boot. The entry's
+// only job is to expose the export by name.
+const registerPluginPage = vi.fn();
+
+beforeEach(() => {
+  (window as { plumix?: unknown }).plumix = { registerPluginPage };
+  vi.resetModules();
+});
+
+afterEach(() => {
+  registerPluginPage.mockReset();
+  delete (window as { plumix?: unknown }).plumix;
+});
+
+test("exposes CommentsShell without imperatively registering the page", async () => {
+  const mod = await import("./index.js");
+
+  expect(mod.CommentsShell).toBeDefined();
+  expect(registerPluginPage).not.toHaveBeenCalled();
+});

--- a/packages/plugins/comments/src/admin/index.tsx
+++ b/packages/plugins/comments/src/admin/index.tsx
@@ -1,19 +1,11 @@
-import type { ComponentType } from "react";
+// Plugin admin entry. The plumix vite plugin namespace-imports this
+// module and emits a `window.plumix.registerPluginPage("/comments",
+// CommentsShell)` call into the synthesised admin chunk based on the
+// `component: "CommentsShell"` ref passed to `ctx.registerAdminPage`.
+// All this entry has to do is expose the export by name — registering
+// the page imperatively here as well would double-register it (the
+// synthesised chunk runs this module body *and* its generated call),
+// throwing AdminPluginRegistryError at admin boot. See the media
+// plugin's admin entry for the canonical shape.
 
-import { CommentsShell } from "./CommentsShell.js";
-
-interface PlumixWindowGlobal {
-  readonly registerPluginPage: (path: string, component: ComponentType) => void;
-}
-
-declare const window:
-  | {
-      readonly plumix?: PlumixWindowGlobal;
-    }
-  | undefined;
-
-if (typeof window !== "undefined") {
-  window.plumix?.registerPluginPage("/comments", CommentsShell);
-}
-
-export { CommentsShell };
+export { CommentsShell } from "./CommentsShell.js";

--- a/packages/plugins/menu/src/admin/index.test.tsx
+++ b/packages/plugins/menu/src/admin/index.test.tsx
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+// Regression (production-build-only, invisible to `plumix dev` e2e):
+// the synthesised admin chunk both runs this entry's module body AND
+// emits its own `registerPluginPage("/menus", MenusShell)` from the
+// `ctx.registerAdminPage({ component })` declaration. If the entry
+// *also* registers the page imperatively, "/menus" is registered twice
+// and AdminPluginRegistryError throws at admin boot. The entry's only
+// job is to expose the export by name.
+const registerPluginPage = vi.fn();
+
+beforeEach(() => {
+  (window as { plumix?: unknown }).plumix = { registerPluginPage };
+  vi.resetModules();
+});
+
+afterEach(() => {
+  registerPluginPage.mockReset();
+  delete (window as { plumix?: unknown }).plumix;
+});
+
+test("exposes MenusShell without imperatively registering the page", async () => {
+  const mod = await import("./index.js");
+
+  expect(mod.MenusShell).toBeDefined();
+  expect(registerPluginPage).not.toHaveBeenCalled();
+});

--- a/packages/plugins/menu/src/admin/index.tsx
+++ b/packages/plugins/menu/src/admin/index.tsx
@@ -2,24 +2,10 @@
 // module and emits a `window.plumix.registerPluginPage("/menus",
 // MenusShell)` call into the synthesised admin chunk based on the
 // `component: "MenusShell"` ref we passed to `ctx.registerAdminPage`.
-// All this entry has to do is expose the export by name.
+// All this entry has to do is expose the export by name — registering
+// the page imperatively here as well would double-register it (the
+// synthesised chunk runs this module body *and* its generated call),
+// throwing AdminPluginRegistryError at admin boot. See the media
+// plugin's admin entry for the canonical shape.
 
-import type { ComponentType } from "react";
-
-import { MenusShell } from "./MenusShell.js";
-
-interface PlumixWindowGlobal {
-  readonly registerPluginPage: (path: string, component: ComponentType) => void;
-}
-
-declare const window:
-  | {
-      readonly plumix?: PlumixWindowGlobal;
-    }
-  | undefined;
-
-if (typeof window !== "undefined") {
-  window.plumix?.registerPluginPage("/menus", MenusShell);
-}
-
-export { MenusShell };
+export { MenusShell } from "./MenusShell.js";


### PR DESCRIPTION
The admin shell on Cloudflare boots into an error and the sidebar nav comes up empty because two plugin admin pages register twice.

**Root cause**

The admin plugin bundler synthesises a `window.plumix.registerPluginPage(path, Component)` call from each plugin's `ctx.registerAdminPage({ component })` declaration, **and** namespace-imports the plugin's admin entry (running its module body). The comments and menu entries *also* called `registerPluginPage` imperatively in that body — so in the production build (`plumix build`) `/comments` and `/menus` each registered twice, and the registry's duplicate guard threw `AdminPluginRegistryError: "/comments" is already registered` at admin boot. The media plugin is the correct reference: its entry only re-exports the component and never registers the page imperatively.

The fix collapses both entries to pure re-exports, matching media. Verified against the production build: the assembled `site-bundle.js` now registers `/comments`, `/menus`, and `/media` exactly once each.

**Why the comments plugin's e2e didn't catch it**

This only reproduces in `plumix build` output (the bundle Cloudflare serves). Every plugin e2e — including the comments suite — runs against `plumix dev`, so the production-only registration path is untested. The new regression tests are fast unit assertions (no build needed): each asserts the admin entry exposes its component **without** imperatively registering the page. Confirmed red against the restored imperative call, green after the fix.

**Follow-ups (not in this PR)**

- `AdminPluginRegistryError.duplicateKey` says *"Two plugins are claiming the same key; rename one"* — misleading for this self-double-register case (one plugin, twice). Distinguishing same-`registeredBy` collisions would make the boot failure self-diagnosing.
- A lint guard (`no-restricted-syntax`) forbidding imperative `registerPluginPage` in plugin admin entries would prevent recurrence at the seam, and the bundler comment that says imperative calls "keep working" should be tightened.