### PR TITLE
fix: forbid imperative registerPluginPage in plugin admin entries

### DIFF
--- a/packages/plugins/audit-log/src/admin/index.test.tsx
+++ b/packages/plugins/audit-log/src/admin/index.test.tsx
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+// Regression (production-build-only, invisible to `plumix dev` e2e):
+// the synthesised admin chunk both runs this entry's module body AND
+// emits its own `registerPluginPage("/audit-log", AuditLogShell)` from
+// the `ctx.registerAdminPage({ component })` declaration. If the entry
+// *also* registers the page imperatively, "/audit-log" is registered
+// twice and AdminPluginRegistryError throws at admin boot. The entry's
+// only job is to expose the export by name.
+const registerPluginPage = vi.fn();
+
+beforeEach(() => {
+  (window as { plumix?: unknown }).plumix = { registerPluginPage };
+  vi.resetModules();
+});
+
+afterEach(() => {
+  registerPluginPage.mockReset();
+  delete (window as { plumix?: unknown }).plumix;
+});
+
+test("exposes AuditLogShell without imperatively registering the page", async () => {
+  const mod = await import("./index.js");
+
+  expect(mod.AuditLogShell).toBeDefined();
+  expect(registerPluginPage).not.toHaveBeenCalled();
+});

--- a/packages/plugins/audit-log/src/admin/index.tsx
+++ b/packages/plugins/audit-log/src/admin/index.tsx
@@ -1,19 +1,11 @@
-import type { ComponentType } from "react";
+// Plugin admin entry. The plumix vite plugin namespace-imports this
+// module and emits a `window.plumix.registerPluginPage("/audit-log",
+// AuditLogShell)` call into the synthesised admin chunk based on the
+// `component: "AuditLogShell"` ref passed to `ctx.registerAdminPage`.
+// All this entry has to do is expose the export by name — registering
+// the page imperatively here as well would double-register it (the
+// synthesised chunk runs this module body *and* its generated call),
+// throwing AdminPluginRegistryError at admin boot. See the media
+// plugin's admin entry for the canonical shape.
 
-import { AuditLogShell } from "./AuditLogShell.js";
-
-interface PlumixWindowGlobal {
-  readonly registerPluginPage: (path: string, component: ComponentType) => void;
-}
-
-declare const window:
-  | {
-      readonly plumix?: PlumixWindowGlobal;
-    }
-  | undefined;
-
-if (typeof window !== "undefined") {
-  window.plumix?.registerPluginPage("/audit-log", AuditLogShell);
-}
-
-export { AuditLogShell };
+export { AuditLogShell } from "./AuditLogShell.js";

--- a/tooling/eslint/plugin.ts
+++ b/tooling/eslint/plugin.ts
@@ -1,8 +1,27 @@
 import type { Linter } from "eslint";
 
-import { baseConfig, noInternalImports } from "./base.js";
+import {
+  baseConfig,
+  NO_THROW_NEW_ERROR_SELECTOR,
+  noInternalImports,
+} from "./base.js";
 import { i18nConfig } from "./i18n.js";
 import { reactConfig } from "./react.js";
+
+// A plugin's admin entry must NOT register its page imperatively. The
+// admin plugin bundler synthesises `registerPluginPage(path, Component)`
+// from each `ctx.registerAdminPage({ component })` declaration AND runs
+// the entry's module body — so an imperative call registers the page a
+// second time, throwing AdminPluginRegistryError at admin boot. This only
+// surfaces in `plumix build` output (never `plumix dev`), so no e2e
+// catches it; the lint guard does. The entry should only re-export its
+// component by name (see the media plugin). Field types / blocks / marks
+// have their own imperative paths and are deliberately not covered here.
+export const NO_IMPERATIVE_REGISTER_PLUGIN_PAGE_SELECTOR = {
+  selector: "CallExpression[callee.property.name='registerPluginPage']",
+  message:
+    "Don't call registerPluginPage in plugin source — the admin bundler synthesises it from ctx.registerAdminPage({ component }). An imperative call double-registers the page and throws AdminPluginRegistryError at admin boot. Re-export the component by name instead (see the media plugin's admin entry).",
+} as const;
 
 /**
  * Shared ESLint flat-config bundle for first-party plumix plugin
@@ -16,6 +35,17 @@ export function pluginConfig(): readonly Linter.Config[] {
     ...reactConfig,
     ...noInternalImports,
     ...i18nConfig,
+    {
+      files: ["src/**/*.ts", "src/**/*.tsx"],
+      ignores: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/test/**"],
+      rules: {
+        "no-restricted-syntax": [
+          "error",
+          NO_THROW_NEW_ERROR_SELECTOR,
+          NO_IMPERATIVE_REGISTER_PLUGIN_PAGE_SELECTOR,
+        ],
+      },
+    },
     // Compiled Lingui catalogs ship with /* eslint-disable */ headers;
     // tripping the unused-disable check on every build adds no signal.
     { ignores: ["locales/**"] },


### PR DESCRIPTION
Follow-up to #1074. That PR fixed the comments and menu plugin admin entries that imperatively called `window.plumix.registerPluginPage(...)` — which double-registers the page in the production build (the synthesised admin chunk runs the entry's module body *and* emits its own generated call from `ctx.registerAdminPage({ component })`), throwing `AdminPluginRegistryError` at admin boot. This adds a systemic guard so it can't recur.

**ESLint guard**

A `no-restricted-syntax` rule in the shared plugin preset (`tooling/eslint/plugin.ts`) forbids `registerPluginPage` calls anywhere in plugin `src/`. The base `throw new Error` selector is re-included since flat config replaces the rule wholesale. Field-type / block / mark imperative registrations are deliberately still allowed — they have no synthesised equivalent (the media plugin relies on them).

**The guard immediately caught audit-log**

audit-log had the exact same latent bug (`registerPluginPage("/audit-log", ...)`), just not exercised by any example. Collapsed its entry to a pure re-export like comments/menu/media, with a matching regression test.

Verified: the guard errors on a violation and is clean otherwise; lint is green across all six plugins (no false positive on media); and the base throw-guard still fires in plugin src.