### PR TITLE
fix: scope plugin admin CSS to a dedicated cascade layer

### DIFF
--- a/packages/admin/src/styles/globals.css
+++ b/packages/admin/src/styles/globals.css
@@ -1,3 +1,15 @@
+/* Order the plugin-sidecar layer (packages/plumix/src/vite/
+   admin-plugin-bundle.ts emits plugin utilities into `layer(plumix-plugins)`)
+   ABOVE base/components but BELOW the admin's own `utilities`. Two failure
+   modes this avoids: put it in the shared `utilities` layer (the default) and
+   a plugin re-emitting `.hidden` loads after the admin CSS and beats the
+   admin's responsive `md:block`, collapsing the sidebar; put it below `base`
+   and Tailwind's preflight strips the plugin pages' own styling (headings,
+   controls). Between `components` and `utilities` satisfies both. Must precede
+   the Tailwind import so this statement establishes the cross-stylesheet
+   layer order. */
+@layer theme, base, components, plumix-plugins, utilities;
+
 @import "tailwindcss";
 @import "tw-animate-css";
 

--- a/packages/admin/src/styles/globals.test.ts
+++ b/packages/admin/src/styles/globals.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+// Contract with the plugin CSS sidecar (packages/plumix/src/vite/
+// admin-plugin-bundle.ts): it emits plugin utilities into a `plumix-plugins`
+// cascade layer. This file must order that layer ABOVE base/components (so
+// Tailwind's preflight doesn't strip plugin-page styling) but BELOW the
+// admin's own `utilities` (so a plugin re-emitting `.hidden` can't beat the
+// admin's responsive `md:block` and collapse the sidebar) — and declare it
+// before the Tailwind import so the cross-stylesheet layer order is fixed.
+// vitest runs with cwd at the package root.
+const css = readFileSync(
+  resolve(process.cwd(), "src/styles/globals.css"),
+  "utf8",
+);
+
+describe("admin globals.css cascade layers", () => {
+  test("orders plumix-plugins above base/components but below utilities, before the tailwind import", () => {
+    const decl = /@layer\s+([a-z0-9 ,_-]+);/i.exec(css);
+    expect(decl).not.toBeNull();
+    const layers = (decl?.[1] ?? "").split(",").map((s) => s.trim());
+
+    // Every layer must be present (indexOf returns -1 when absent, which
+    // would make the ordering comparisons below pass vacuously).
+    for (const name of ["base", "components", "plumix-plugins", "utilities"]) {
+      expect(layers).toContain(name);
+    }
+    const i = (name: string) => layers.indexOf(name);
+    expect(i("plumix-plugins")).toBeGreaterThan(i("base"));
+    expect(i("plumix-plugins")).toBeGreaterThan(i("components"));
+    expect(i("plumix-plugins")).toBeLessThan(i("utilities"));
+
+    expect(decl!.index).toBeLessThan(css.indexOf('@import "tailwindcss"'));
+  });
+});

--- a/packages/plugins/comments/e2e/comments-admin.spec.ts
+++ b/packages/plugins/comments/e2e/comments-admin.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 // Seeded by globalSetup (see e2e/globalSetup.ts). The specs are read-only
@@ -59,3 +60,43 @@ test("moderator bulk-approves selected comments", async ({ page }) => {
     page.getByTestId(`comment-row-${String(secondId)}`),
   ).toBeHidden();
 });
+
+// Regression for two failures that shipped together: (1) the plugin admin
+// page rendered as bare unstyled HTML (the component had zero `className`),
+// and (2) the plugin CSS sidecar re-emitted base utilities into the shared
+// cascade layer, loaded after the admin stylesheet, and collapsed the
+// admin sidebar to `display:none`. Guards: the sidebar stays visible AND
+// the page ships visibly-styled controls. See packages/admin/src/styles/
+// globals.css + packages/plumix/src/vite/admin-plugin-bundle.ts.
+test("admin page renders styled with the sidebar intact", async ({ page }) => {
+  await page.goto("pages/comments");
+  await expect(page.getByTestId("comments-shell")).toBeVisible();
+
+  const ui = await styledChrome(page, "comments-shell");
+  expect(ui.sidebarVisible).toBe(true);
+  expect(ui.totalControls).toBeGreaterThan(0);
+  expect(ui.styledControls).toBeGreaterThan(0);
+});
+
+// Returns whether the admin sidebar is displayed, and how many of the
+// plugin shell's own interactive controls carry styling classes. The
+// unstyled-page bug was literally zero `className` in the component, so a
+// styled-control count of 0 is the regression signal; the sidebar-display
+// check guards the CSS-sidecar cascade collapse.
+async function styledChrome(page: Page, shellTestId: string) {
+  return page.evaluate((id) => {
+    const sidebar = document.querySelector('[data-slot="sidebar"]');
+    const shell = document.querySelector(`[data-testid="${id}"]`);
+    const controls = shell
+      ? Array.from(shell.querySelectorAll("button, a, input, select, label"))
+      : [];
+    return {
+      sidebarVisible:
+        sidebar !== null && getComputedStyle(sidebar).display !== "none",
+      totalControls: controls.length,
+      styledControls: controls.filter(
+        (el) => (el.getAttribute("class") ?? "").trim().length > 0,
+      ).length,
+    };
+  }, shellTestId);
+}

--- a/packages/plugins/comments/src/admin/CommentsShell.tsx
+++ b/packages/plugins/comments/src/admin/CommentsShell.tsx
@@ -106,8 +106,12 @@ export function CommentsShell(): React.ReactElement {
   }
 
   return (
-    <div data-testid="comments-shell">
-      <div data-testid="comments-tabs" role="tablist">
+    <div data-testid="comments-shell" className="flex flex-col gap-4">
+      <div
+        data-testid="comments-tabs"
+        role="tablist"
+        className="border-border flex items-center gap-1 border-b"
+      >
         {TABS.map((status) => (
           <button
             key={status}
@@ -117,22 +121,29 @@ export function CommentsShell(): React.ReactElement {
             onClick={() => {
               reset(status);
             }}
+            className={`hover:bg-muted rounded px-3 py-1.5 text-sm ${
+              tab === status ? "bg-muted font-medium" : ""
+            }`}
           >
             {i18n._(STATUS_LABELS[status])}{" "}
-            <span data-testid={`comments-count-${status}`}>
+            <span
+              data-testid={`comments-count-${status}`}
+              className="text-muted-foreground"
+            >
               {counts.data?.[status] ?? 0}
             </span>
           </button>
         ))}
       </div>
 
-      <div data-testid="comments-filters">
+      <div data-testid="comments-filters" className="flex items-center gap-2">
         <input
           type="search"
           data-testid="comments-search"
           aria-label={i18n._(M.searchLabel)}
           value={search}
           onChange={(event) => setSearch(event.target.value)}
+          className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
         />
         <input
           type="number"
@@ -140,45 +151,61 @@ export function CommentsShell(): React.ReactElement {
           aria-label={i18n._(M.entryLabel)}
           value={entryFilter}
           onChange={(event) => setEntryFilter(event.target.value)}
+          className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
         />
       </div>
 
       {picked.size > 0 ? (
-        <div data-testid="comments-bulk-bar">
+        <div
+          data-testid="comments-bulk-bar"
+          className="border-border bg-card flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm"
+        >
           <span data-testid="comments-bulk-count">{picked.size}</span>
-          {BULK_ACTIONS.map((action) => (
-            <button
-              key={action}
-              type="button"
-              data-testid={`comments-bulk-${action}`}
-              disabled={bulk.isPending}
-              onClick={() => runBulk(action)}
-            >
-              {i18n._(ACTION_LABELS[action])}
-            </button>
-          ))}
+          <div className="flex items-center gap-1">
+            {BULK_ACTIONS.map((action) => (
+              <button
+                key={action}
+                type="button"
+                data-testid={`comments-bulk-${action}`}
+                disabled={bulk.isPending}
+                onClick={() => runBulk(action)}
+                className={`hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 ${
+                  action === "approve" ? "" : "text-destructive"
+                }`}
+              >
+                {i18n._(ACTION_LABELS[action])}
+              </button>
+            ))}
+          </div>
         </div>
       ) : null}
 
       {list.isLoading ? (
         <div data-testid="comments-loading" />
       ) : list.isError ? (
-        <div data-testid="comments-error">
+        <div data-testid="comments-error" className="text-destructive text-sm">
           <Trans id="plugin.comments.error" message="Failed to load comments" />
         </div>
       ) : (list.data ?? []).length === 0 ? (
         // Tab-agnostic copy on purpose: interpolating the (translated)
         // status word mid-sentence breaks grammatical agreement in
         // several launch locales, so the queue name stays in the tab.
-        <p data-testid="comments-empty">
+        <p
+          data-testid="comments-empty"
+          className="text-muted-foreground text-sm"
+        >
           <Trans id="plugin.comments.empty" message="No comments to show" />
         </p>
       ) : (
-        <table data-testid="comments-table">
-          <tbody>
+        <table data-testid="comments-table" className="w-full">
+          <tbody className="flex flex-col gap-2">
             {(list.data ?? []).map((comment) => (
-              <tr key={comment.id} data-testid={`comment-row-${comment.id}`}>
-                <td>
+              <tr
+                key={comment.id}
+                data-testid={`comment-row-${comment.id}`}
+                className="border-border bg-card flex items-start justify-between gap-3 rounded-lg border p-3"
+              >
+                <td className="flex min-w-0 items-start gap-3">
                   <input
                     type="checkbox"
                     data-testid={`comment-select-${comment.id}`}
@@ -189,21 +216,24 @@ export function CommentsShell(): React.ReactElement {
                     )}
                     checked={picked.has(comment.id)}
                     onChange={() => togglePicked(comment.id)}
+                    className="mt-1"
                   />
-                </td>
-                <td>
                   <button
                     type="button"
                     data-testid={`comment-open-${comment.id}`}
                     onClick={() => setSelected(comment)}
+                    className="hover:bg-muted truncate rounded text-left font-medium"
                   >
                     {comment.authorName}
                   </button>
                 </td>
-                <td data-testid={`comment-excerpt-${comment.id}`}>
+                <td
+                  data-testid={`comment-excerpt-${comment.id}`}
+                  className="text-muted-foreground min-w-0 flex-1 truncate text-xs"
+                >
                   {comment.bodyMd.slice(0, 80)}
                 </td>
-                <td>
+                <td className="flex items-center gap-1">
                   {ACTIONS[tab].map((action) => (
                     <button
                       key={action}
@@ -213,6 +243,11 @@ export function CommentsShell(): React.ReactElement {
                       onClick={() =>
                         moderation.mutate({ action, id: comment.id })
                       }
+                      className={`hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 ${
+                        action === "approve" || action === "restore"
+                          ? ""
+                          : "text-destructive"
+                      }`}
                     >
                       {i18n._(ACTION_LABELS[action])}
                     </button>
@@ -225,27 +260,32 @@ export function CommentsShell(): React.ReactElement {
       )}
 
       {selected ? (
-        <aside data-testid="comment-detail">
+        <aside
+          data-testid="comment-detail"
+          className="border-border bg-card flex flex-col gap-3 rounded-lg border p-3"
+        >
           {/* Moderator sees the raw markdown source as text, not rendered HTML. */}
-          <div data-testid="comment-detail-body">{selected.bodyMd}</div>
-          <dl>
-            <dt>
+          <div data-testid="comment-detail-body" className="text-sm">
+            {selected.bodyMd}
+          </div>
+          <dl className="text-muted-foreground grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+            <dt className="font-medium">
               <Trans id="plugin.comments.detail.author" message="Author" />
             </dt>
             <dd data-testid="comment-detail-author">{selected.authorName}</dd>
-            <dt>
+            <dt className="font-medium">
               <Trans id="plugin.comments.detail.email" message="Email" />
             </dt>
             <dd data-testid="comment-detail-email">{selected.authorEmail}</dd>
-            <dt>
+            <dt className="font-medium">
               <Trans id="plugin.comments.detail.entry" message="Entry" />
             </dt>
             <dd data-testid="comment-detail-entry">{selected.entryId}</dd>
-            <dt>
+            <dt className="font-medium">
               <Trans id="plugin.comments.detail.ipHash" message="IP hash" />
             </dt>
             <dd data-testid="comment-detail-ip">{selected.ipHash ?? "—"}</dd>
-            <dt>
+            <dt className="font-medium">
               <Trans
                 id="plugin.comments.detail.submitted"
                 message="Submitted"

--- a/packages/plugins/media/e2e/media.spec.ts
+++ b/packages/plugins/media/e2e/media.spec.ts
@@ -9,6 +9,7 @@
 // `media.createUploadUrl` returns a same-origin `/_plumix/media/upload/<id>`
 // URL the browser PUTs to. No `**/storage.test/**` mock needed.
 
+import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 // Minimal valid 1×1 transparent PNG — real signature + IHDR + IDAT +
@@ -124,3 +125,43 @@ test.describe.serial("@plumix/plugin-media — worker-driven happy path", () => 
     await expect(cards).toHaveCount(2);
   });
 });
+
+// Regression for two failures that shipped together: (1) a plugin admin
+// page rendering as bare unstyled HTML (the component had zero `className`),
+// and (2) the plugin CSS sidecar re-emitting base utilities into the shared
+// cascade layer, loaded after the admin stylesheet, collapsing the admin
+// sidebar to `display:none`. Guards: the sidebar stays visible AND the page
+// ships visibly-styled controls. See packages/admin/src/styles/globals.css
+// + packages/plumix/src/vite/admin-plugin-bundle.ts.
+test("admin page renders styled with the sidebar intact", async ({ page }) => {
+  await page.goto("pages/media");
+  await expect(page.getByTestId("media-library")).toBeVisible();
+
+  const ui = await styledChrome(page, "media-library");
+  expect(ui.sidebarVisible).toBe(true);
+  expect(ui.totalControls).toBeGreaterThan(0);
+  expect(ui.styledControls).toBeGreaterThan(0);
+});
+
+// Returns whether the admin sidebar is displayed, and how many of the
+// plugin shell's own interactive controls carry styling classes. The
+// unstyled-page bug was literally zero `className` in the component, so a
+// styled-control count of 0 is the regression signal; the sidebar-display
+// check guards the CSS-sidecar cascade collapse.
+async function styledChrome(page: Page, shellTestId: string) {
+  return page.evaluate((id) => {
+    const sidebar = document.querySelector('[data-slot="sidebar"]');
+    const shell = document.querySelector(`[data-testid="${id}"]`);
+    const controls = shell
+      ? Array.from(shell.querySelectorAll("button, a, input, select, label"))
+      : [];
+    return {
+      sidebarVisible:
+        sidebar !== null && getComputedStyle(sidebar).display !== "none",
+      totalControls: controls.length,
+      styledControls: controls.filter(
+        (el) => (el.getAttribute("class") ?? "").trim().length > 0,
+      ).length,
+    };
+  }, shellTestId);
+}

--- a/packages/plugins/menu/e2e/menu.spec.ts
+++ b/packages/plugins/menu/e2e/menu.spec.ts
@@ -303,3 +303,43 @@ async function dragRowOnSelf(
     { selector: handleSelector, startX, startY, dropX, dropY },
   );
 }
+
+// Regression for two failures that shipped together: (1) the plugin admin
+// page rendered as bare unstyled HTML (the component had zero `className`),
+// and (2) the plugin CSS sidecar re-emitted base utilities into the shared
+// cascade layer, loaded after the admin stylesheet, and collapsed the
+// admin sidebar to `display:none`. Guards: the sidebar stays visible AND
+// the page ships visibly-styled controls. See packages/admin/src/styles/
+// globals.css + packages/plumix/src/vite/admin-plugin-bundle.ts.
+test("admin page renders styled with the sidebar intact", async ({ page }) => {
+  await page.goto("pages/menus");
+  await expect(page.getByTestId("menus-shell")).toBeVisible();
+
+  const ui = await styledChrome(page, "menus-shell");
+  expect(ui.sidebarVisible).toBe(true);
+  expect(ui.totalControls).toBeGreaterThan(0);
+  expect(ui.styledControls).toBeGreaterThan(0);
+});
+
+// Returns whether the admin sidebar is displayed, and how many of the
+// plugin shell's own interactive controls carry styling classes. The
+// unstyled-page bug was literally zero `className` in the component, so a
+// styled-control count of 0 is the regression signal; the sidebar-display
+// check guards the CSS-sidecar cascade collapse.
+async function styledChrome(page: Page, shellTestId: string) {
+  return page.evaluate((id) => {
+    const sidebar = document.querySelector('[data-slot="sidebar"]');
+    const shell = document.querySelector(`[data-testid="${id}"]`);
+    const controls = shell
+      ? Array.from(shell.querySelectorAll("button, a, input, select, label"))
+      : [];
+    return {
+      sidebarVisible:
+        sidebar !== null && getComputedStyle(sidebar).display !== "none",
+      totalControls: controls.length,
+      styledControls: controls.filter(
+        (el) => (el.getAttribute("class") ?? "").trim().length > 0,
+      ).length,
+    };
+  }, shellTestId);
+}

--- a/packages/plugins/menu/src/admin/MenuItemEditor.tsx
+++ b/packages/plugins/menu/src/admin/MenuItemEditor.tsx
@@ -98,14 +98,17 @@ export function MenuItemEditor({
     return <div data-testid="menu-item-editor-loading" />;
   }
   return (
-    <div data-testid="menu-item-editor">
+    <div data-testid="menu-item-editor" className="flex flex-col gap-4">
       <ItemsPicker
         tabs={pickerTabs.data ?? []}
         state={state}
         dispatch={dispatch}
       />
       {state.items.length === 0 ? (
-        <div data-testid="menu-item-list-empty">
+        <div
+          data-testid="menu-item-list-empty"
+          className="text-muted-foreground text-sm"
+        >
           <Trans
             id="plugin.menu.itemEditor.emptyState"
             message="No items yet."
@@ -130,13 +133,14 @@ function LocationsBindings({
   const locations = useLocationsList();
   const assign = useAssignLocation();
   return (
-    <div data-testid="menu-settings-locations">
+    <div data-testid="menu-settings-locations" className="flex flex-col gap-1">
       {(locations.data ?? []).map((row) => {
         const isBound = row.boundTermId === termId;
         return (
           <label
             key={row.id}
             data-testid={`menu-settings-location-row-${row.id}`}
+            className="flex items-center gap-2 text-sm"
           >
             <input
               type="checkbox"
@@ -178,11 +182,18 @@ function MenuSettingsPanel({
     save.error instanceof Error && save.error.message === "version_mismatch";
   const conflict = isVersionMismatch && dismissedAt !== state.version;
   return (
-    <div data-testid="menu-settings-panel">
+    <div
+      data-testid="menu-settings-panel"
+      className="border-border bg-card flex flex-col gap-4 rounded-lg border p-4"
+    >
       <LocationsBindings termId={state.termId} slug={state.slug} />
       <MaxDepthField state={state} dispatch={dispatch} />
       {conflict ? (
-        <div data-testid="menu-conflict-banner" role="alert">
+        <div
+          data-testid="menu-conflict-banner"
+          role="alert"
+          className="text-destructive flex items-center justify-between gap-3 text-sm"
+        >
           <Trans
             id="plugin.menu.itemEditor.conflictBanner"
             message="Another editor saved changes since you loaded this menu."
@@ -190,6 +201,7 @@ function MenuSettingsPanel({
           <button
             type="button"
             data-testid="menu-conflict-reload"
+            className="border-border hover:bg-muted rounded border bg-transparent px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             onClick={() => {
               setDismissedAt(state.version);
               save.reset();
@@ -205,40 +217,43 @@ function MenuSettingsPanel({
           </button>
         </div>
       ) : null}
-      <button
-        type="button"
-        data-testid="menu-save-button"
-        disabled={save.isPending}
-        onClick={() => {
-          // Snapshot the keys at click time so onSuccess can reattach
-          // ids to the right items even if the user mutated state
-          // while the save was in flight.
-          const snapshotKeys = state.items.map((item) => item.key);
-          save.mutate(
-            {
-              termId: state.termId,
-              version: state.version,
-              maxDepth: state.maxDepth,
-              items: buildSavePayload(state),
-            },
-            {
-              onSuccess: (result) => {
-                dispatch({
-                  type: "applySaveResult",
-                  result: {
-                    version: result.version,
-                    itemIds: result.itemIds,
-                    snapshotKeys,
-                  },
-                });
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          data-testid="menu-save-button"
+          disabled={save.isPending}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={() => {
+            // Snapshot the keys at click time so onSuccess can reattach
+            // ids to the right items even if the user mutated state
+            // while the save was in flight.
+            const snapshotKeys = state.items.map((item) => item.key);
+            save.mutate(
+              {
+                termId: state.termId,
+                version: state.version,
+                maxDepth: state.maxDepth,
+                items: buildSavePayload(state),
               },
-            },
-          );
-        }}
-      >
-        <Trans id="plugin.menu.itemEditor.saveButton" message="Save menu" />
-      </button>
-      <DeleteMenuButton termId={state.termId} />
+              {
+                onSuccess: (result) => {
+                  dispatch({
+                    type: "applySaveResult",
+                    result: {
+                      version: result.version,
+                      itemIds: result.itemIds,
+                      snapshotKeys,
+                    },
+                  });
+                },
+              },
+            );
+          }}
+        >
+          <Trans id="plugin.menu.itemEditor.saveButton" message="Save menu" />
+        </button>
+        <DeleteMenuButton termId={state.termId} />
+      </div>
     </div>
   );
 }
@@ -269,7 +284,10 @@ function MaxDepthField({
   const parsed = Number.parseInt(draft, 10);
   const rejected = Number.isFinite(parsed) && parsed !== state.maxDepth;
   return (
-    <label data-testid="menu-settings-max-depth-row">
+    <label
+      data-testid="menu-settings-max-depth-row"
+      className="flex items-center gap-2 text-sm font-medium"
+    >
       <Trans id="plugin.menu.itemEditor.maxDepthLabel" message="Max depth" />
       <input
         type="number"
@@ -284,9 +302,13 @@ function MaxDepthField({
             dispatch({ type: "updateMaxDepth", value: nextParsed });
           }
         }}
+        className="border-input bg-background focus-visible:ring-ring h-9 w-20 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
       />
       {rejected ? (
-        <span data-testid="menu-settings-max-depth-error">
+        <span
+          data-testid="menu-settings-max-depth-error"
+          className="text-destructive text-sm font-normal"
+        >
           <Trans
             id="plugin.menu.itemEditor.maxDepthRejected"
             message="Cannot set below the current deepest item."
@@ -305,6 +327,7 @@ function DeleteMenuButton({ termId }: { readonly termId: number }): ReactNode {
       type="button"
       data-testid="menu-delete-button"
       disabled={remove.isPending}
+      className="text-destructive border-border hover:bg-muted rounded border bg-transparent px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
       onClick={() => {
         if (
           typeof window !== "undefined" &&
@@ -337,9 +360,12 @@ function ItemsPicker({
       : (state.items.find((item) => item.key === state.relinkTargetKey) ??
         null);
   return (
-    <div data-testid="menu-items-picker">
+    <div data-testid="menu-items-picker" className="flex flex-col gap-3">
       {relinkTarget !== null ? (
-        <div data-testid="menu-picker-relink-banner">
+        <div
+          data-testid="menu-picker-relink-banner"
+          className="border-border bg-card flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
+        >
           <span>
             {i18n._(
               M.relinkBanner.id,
@@ -350,6 +376,7 @@ function ItemsPicker({
           <button
             type="button"
             data-testid="menu-picker-relink-cancel"
+            className="border-border hover:bg-muted rounded border bg-transparent px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             onClick={() => {
               dispatch({ type: "cancelRelink" });
             }}
@@ -358,7 +385,10 @@ function ItemsPicker({
           </button>
         </div>
       ) : null}
-      <div data-testid="menu-picker-tabs">
+      <div
+        data-testid="menu-picker-tabs"
+        className="border-border flex items-center gap-1 border-b"
+      >
         {tabs.map((tab) => (
           <button
             key={tab.kind + (tab.target ?? "")}
@@ -368,6 +398,9 @@ function ItemsPicker({
             onClick={() => {
               setActiveTab(tab.kind);
             }}
+            className={`hover:bg-muted rounded px-3 py-1.5 text-sm ${
+              activeTab === tab.kind ? "bg-muted font-medium" : ""
+            }`}
           >
             {tab.tabLabel}
           </button>
@@ -394,7 +427,10 @@ function CustomUrlPickerPanel({
   const [label, setLabel] = useState("");
   const isRelink = relinkTargetKey !== null;
   return (
-    <div data-testid="menu-picker-custom-panel">
+    <div
+      data-testid="menu-picker-custom-panel"
+      className="border-border bg-card flex flex-wrap items-center gap-2 rounded-lg border p-4"
+    >
       <input
         type="text"
         data-testid="menu-picker-custom-url"
@@ -402,6 +438,7 @@ function CustomUrlPickerPanel({
         onChange={(event) => {
           setUrl(event.target.value);
         }}
+        className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
       />
       <input
         type="text"
@@ -410,10 +447,12 @@ function CustomUrlPickerPanel({
         onChange={(event) => {
           setLabel(event.target.value);
         }}
+        className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
       />
       <button
         type="button"
         data-testid="menu-picker-custom-add"
+        className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
         onClick={() => {
           if (url.trim() === "") return;
           if (relinkTargetKey !== null) {
@@ -527,7 +566,7 @@ function MenuTree({
       onDragCancel={reset}
     >
       <SortableContext items={itemKeys} strategy={verticalListSortingStrategy}>
-        <div data-testid="menu-tree">
+        <div data-testid="menu-tree" className="flex flex-col gap-1">
           {state.items.map((item) => (
             <SortableTreeRow
               key={item.key}
@@ -585,6 +624,9 @@ function SortableTreeRow({
       onClick={() => {
         dispatch({ type: "selectItem", key: item.key });
       }}
+      className={`border-border bg-card flex items-center gap-2 rounded-md border px-3 py-2 ${
+        selected ? "outline-primary outline-2 outline-offset-1" : ""
+      }`}
     >
       <button
         type="button"
@@ -603,6 +645,7 @@ function SortableTreeRow({
         onClick={(event) => {
           event.stopPropagation();
         }}
+        className="text-muted-foreground hover:bg-muted cursor-grab rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
       >
         ⋮⋮
       </button>
@@ -610,16 +653,20 @@ function SortableTreeRow({
         <span
           data-testid={`menu-item-warning-${String(id)}`}
           aria-label={i18n._(M.brokenLinkAria)}
+          className="text-destructive"
         >
           ⚠
         </span>
       ) : null}
-      <span>{displayLabel}</span>
+      <span className="flex-1 truncate text-sm font-medium">
+        {displayLabel}
+      </span>
       {isBroken ? (
         <>
           <button
             type="button"
             data-testid={`menu-item-relink-${String(id)}`}
+            className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
             onClick={(event) => {
               event.stopPropagation();
               dispatch({ type: "startRelink", key: item.key });
@@ -633,6 +680,7 @@ function SortableTreeRow({
           <button
             type="button"
             data-testid={`menu-item-convert-${String(id)}`}
+            className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
             onClick={(event) => {
               event.stopPropagation();
               dispatch({ type: "convertToCustom", key: item.key });
@@ -649,6 +697,7 @@ function SortableTreeRow({
         type="button"
         data-testid={`menu-item-remove-${String(id)}`}
         disabled={isUnauthorized}
+        className="text-destructive hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
         onClick={(event) => {
           event.stopPropagation();
           dispatch({ type: "removeItem", key: item.key });
@@ -673,11 +722,15 @@ function ItemDetailPanel({
       : (state.items.find((item) => item.key === state.selectedKey) ?? null);
   if (!selected) return <div data-testid="menu-item-detail-empty" />;
   return (
-    <div data-testid="menu-item-detail-panel">
+    <div
+      data-testid="menu-item-detail-panel"
+      className="border-border bg-card flex flex-col gap-1 rounded-lg border p-4"
+    >
       <input
         type="text"
         data-testid="menu-item-detail-title"
         value={selected.title ?? ""}
+        className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
         onChange={(event) => {
           const next = event.target.value;
           dispatch({

--- a/packages/plugins/menu/src/admin/MenusShell.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.tsx
@@ -87,7 +87,7 @@ export function MenusShell(): ReactNode {
   const selectedMenu =
     slug === null ? null : (menuList.find((m) => m.slug === slug) ?? null);
   return (
-    <div data-testid="menus-shell">
+    <div data-testid="menus-shell" className="flex flex-col gap-4">
       <MenuSelector
         menus={menuList}
         onCreate={handleCreate}
@@ -100,7 +100,10 @@ export function MenusShell(): ReactNode {
         <LocationsPanel menus={menuList} />
       )}
       {menuList.length === 0 ? (
-        <div data-testid="menus-empty-cta">
+        <div
+          data-testid="menus-empty-cta"
+          className="text-muted-foreground text-sm"
+        >
           <Trans
             id="plugin.menu.shell.emptyState"
             message="No menus yet. Create your first menu to get started."
@@ -121,7 +124,10 @@ function MenuSelector({
   readonly onSelect: (slug: string) => void;
 }): ReactNode {
   return (
-    <div data-testid="menus-selector">
+    <div
+      data-testid="menus-selector"
+      className="flex flex-wrap items-center gap-2"
+    >
       {menus.map((menu) => (
         <button
           key={menu.id}
@@ -130,6 +136,7 @@ function MenuSelector({
           onClick={() => {
             onSelect(menu.slug);
           }}
+          className="border-border hover:bg-muted rounded border bg-transparent px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
         >
           {menu.name}
         </button>
@@ -138,6 +145,7 @@ function MenuSelector({
         type="button"
         data-testid="menus-selector-create-new"
         onClick={onCreate}
+        className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
       >
         <Trans
           id="plugin.menu.shell.createButton"
@@ -157,7 +165,10 @@ function Tabs({
 }): ReactNode {
   const { i18n } = useLingui();
   return (
-    <div data-testid="menus-tabs">
+    <div
+      data-testid="menus-tabs"
+      className="border-border flex items-center gap-1 border-b"
+    >
       {TABS.map((entry) => (
         <button
           key={entry.id}
@@ -167,6 +178,9 @@ function Tabs({
           onClick={() => {
             onChange(entry.id);
           }}
+          className={`hover:bg-muted rounded px-3 py-1.5 text-sm ${
+            activeTab === entry.id ? "bg-muted font-medium" : ""
+          }`}
         >
           {i18n._(entry.label)}
         </button>
@@ -183,7 +197,10 @@ function EditPanel({
   return (
     <div data-testid="menus-tab-edit-panel">
       {selectedMenu === null ? (
-        <p data-testid="menus-edit-no-selection">
+        <p
+          data-testid="menus-edit-no-selection"
+          className="text-muted-foreground text-sm"
+        >
           <Trans
             id="plugin.menu.shell.editEmpty"
             message="Select a menu to start editing."
@@ -206,7 +223,10 @@ function LocationsPanel({
   const slugFromTermId = new Map(menus.map((m) => [m.id, m.slug]));
 
   return (
-    <div data-testid="menus-tab-locations-panel">
+    <div
+      data-testid="menus-tab-locations-panel"
+      className="flex flex-col gap-2"
+    >
       {(locations.data ?? []).map((row) => (
         <LocationRow
           key={row.id}
@@ -239,8 +259,16 @@ function LocationRow({
 }): ReactNode {
   const { i18n } = useLingui();
   return (
-    <div data-testid={`menus-location-row-${row.id}`}>
-      <span data-testid={`menus-location-label-${row.id}`}>{row.label}</span>
+    <div
+      data-testid={`menus-location-row-${row.id}`}
+      className="border-border bg-card flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+    >
+      <span
+        data-testid={`menus-location-label-${row.id}`}
+        className="text-sm font-medium"
+      >
+        {row.label}
+      </span>
       <select
         data-testid={`menus-location-select-${row.id}`}
         value={currentSlug}
@@ -248,6 +276,7 @@ function LocationRow({
           const value = event.target.value;
           onChange(value === "" ? null : value);
         }}
+        className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
       >
         <option value="">{i18n._(M.unassigned)}</option>
         {menus.map((menu) => (

--- a/packages/plumix/src/vite/admin-plugin-bundle.test.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.test.ts
@@ -190,6 +190,13 @@ describe("assemblePluginAdminBundle", () => {
     expect(css).toContain("var(--card)");
     expect(css).toContain("var(--destructive)");
     expect(css).toContain(".border-dashed");
+    // Utilities must land in the dedicated `plumix-plugins` cascade layer
+    // (the admin's globals.css orders it lowest), NOT the shared `utilities`
+    // layer. Otherwise a plugin re-emitting a base utility like `.hidden`
+    // loads after the admin CSS and overrides its own responsive utilities —
+    // the cascade collision that collapsed the admin sidebar.
+    expect(css).toMatch(/@layer plumix-plugins\s*\{/);
+    expect(css).not.toMatch(/@layer utilities\s*\{/);
   });
 
   test("auto-emits register* calls for ctx-registered admin pages and field types", async () => {

--- a/packages/plumix/src/vite/admin-plugin-bundle.ts
+++ b/packages/plumix/src/vite/admin-plugin-bundle.ts
@@ -250,9 +250,15 @@ async function compilePluginCss({
     .map((d) => `@source ${JSON.stringify(d)};`)
     .join("\n");
 
+  // Emit plugin utilities into a dedicated `plumix-plugins` layer, NOT the
+  // shared `utilities` layer. The admin's globals.css declares this layer
+  // first (lowest priority), so a plugin re-emitting a base utility like
+  // `.hidden` can't override the admin's own utilities (e.g. the sidebar's
+  // responsive `md:block`). Plugin-specific utilities still apply — nothing
+  // in the admin competes with them.
   const input = [
     `@import "tailwindcss/theme" layer(theme);`,
-    `@import "tailwindcss/utilities" layer(utilities);`,
+    `@import "tailwindcss/utilities" layer(plumix-plugins);`,
     themeCss,
     sourceLines,
   ].join("\n");


### PR DESCRIPTION
Fixes the admin sidebar collapsing on every page (reported as "the sidebar doesn't work — clicking just moves it a few pixels"), and styles the plugin admin pages that shipped unstyled.

**Sidebar cascade bug**

Plugin admin chunks emit a CSS sidecar (`site-bundle.css`) compiled from the plugin's component classes. It used to emit plugin utilities into Tailwind's shared `utilities` cascade layer. That stylesheet loads *after* the admin CSS, so a plugin re-emitting a base utility like `.hidden` overrode the sidebar's responsive `md:block` — collapsing the whole admin sidebar to `display:none` whenever plugins were present (which is why the blog example broke but the single-plugin playgrounds didn't).

The fix emits plugin utilities into a dedicated `plumix-plugins` cascade layer, ordered in `packages/admin/src/styles/globals.css` **above** `base`/`components` (so Tailwind's preflight can't strip plugin-page styling) but **below** the admin's own `utilities` (so the admin wins genuine conflicts like the sidebar). Verified end-to-end in a browser: sidebar collapsed before, full nav after.

**Unstyled plugin pages**

The Comments and Menus admin pages shipped with **zero `className`** — bare unstyled HTML (run-together tabs, no headings, plain-text buttons). Styled both to match the media plugin's design system (className-only — data-testids and behavior unchanged; comments 128 + menu 239 unit tests stay green). Media was already styled and is unchanged.

**Regression coverage**

- Unit tests assert the cascade-layer contract: the admin `globals.css` layer order, and the sidecar emitting `layer(plumix-plugins)`.
- An e2e test in each of the comments / menu / media suites asserts the admin sidebar stays visible **and** the plugin page ships styled controls — catching both failure modes (cascade collapse + unstyled component).

**Follow-up:** `audit-log`'s admin page (`AuditLogShell.tsx`) has the same zero-`className` gap. It isn't in the blog example and was out of scope here, but should get the same styling + regression test.