### PR TITLE
test: move the sidebar-cascade guard to one admin e2e

### DIFF
--- a/packages/admin/e2e/app-shell.spec.ts
+++ b/packages/admin/e2e/app-shell.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  AUTHED_ADMIN,
+  MANIFEST_WITH_POST,
+  mockManifest,
+  mockRpc,
+} from "./support/rpc-mock.js";
+
+// The sidebar collapse was an admin-chrome bug, not a plugin one: a plugin
+// admin chunk's CSS sidecar re-emitted base utilities (e.g. `.hidden`) and,
+// loading after the admin stylesheet, overrode the sidebar's responsive
+// `md:block`. globals.css fixes it by ordering the `plumix-plugins` layer
+// below the admin's own `utilities`. This guards that end-to-end so the
+// regression can't recur regardless of which plugin is installed. The
+// layer-order *contract* is unit-tested in src/styles/globals.test.ts.
+test.describe("admin shell", () => {
+  test("a plugin CSS sidecar cannot collapse the sidebar", async ({ page }) => {
+    await mockManifest(page, MANIFEST_WITH_POST);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/stats": [],
+      "/entry/recentActivity": [],
+    });
+    await page.goto("");
+
+    const sidebar = page.locator('[data-slot="sidebar"]').first();
+    await expect(sidebar).toBeVisible();
+
+    // Inject exactly what a plugin sidecar emits: a base utility re-declared
+    // in the `plumix-plugins` layer, added after the admin CSS. It must NOT
+    // beat the sidebar's `md:block` — i.e. `plumix-plugins` must stay below
+    // the admin's `utilities` layer.
+    await page.addStyleTag({
+      content: "@layer plumix-plugins{.hidden{display:none}}",
+    });
+
+    await expect(sidebar).toBeVisible();
+    const display = await sidebar.evaluate(
+      (el) => getComputedStyle(el).display,
+    );
+    expect(display).toBe("block");
+  });
+});

--- a/packages/plugins/audit-log/e2e/audit-log.spec.ts
+++ b/packages/plugins/audit-log/e2e/audit-log.spec.ts
@@ -147,40 +147,31 @@ test.describe
   });
 });
 
-// Regression for two failures that shipped together: (1) the plugin admin
-// page rendered as bare unstyled HTML (the component had zero `className`),
-// and (2) the plugin CSS sidecar re-emitted base utilities into the shared
-// cascade layer, loaded after the admin stylesheet, and collapsed the
-// admin sidebar to `display:none`. Guards: the sidebar stays visible AND
-// the page ships visibly-styled controls. See packages/admin/src/styles/
-// globals.css + packages/plumix/src/vite/admin-plugin-bundle.ts.
-test("admin page renders styled with the sidebar intact", async ({ page }) => {
+// Regression: the audit-log admin page once shipped as bare unstyled HTML
+// (the component had zero `className`). Assert it ships styled controls.
+// (The admin sidebar's CSS-cascade isolation — the other half of the
+// original incident — is guarded admin-side in packages/admin/e2e/
+// app-shell.spec.ts + packages/admin/src/styles/globals.test.ts.)
+test("admin page ships styled controls", async ({ page }) => {
   await page.goto("pages/audit-log");
   await expect(page.getByTestId("audit-log-shell")).toBeVisible();
 
-  const ui = await styledChrome(page, "audit-log-shell");
-  expect(ui.sidebarVisible).toBe(true);
-  expect(ui.totalControls).toBeGreaterThan(0);
-  expect(ui.styledControls).toBeGreaterThan(0);
+  const ui = await styledControls(page, "audit-log-shell");
+  expect(ui.total).toBeGreaterThan(0);
+  expect(ui.styled).toBeGreaterThan(0);
 });
 
-// Returns whether the admin sidebar is displayed, and how many of the
-// plugin shell's own interactive controls carry styling classes. The
-// unstyled-page bug was literally zero `className` in the component, so a
-// styled-control count of 0 is the regression signal; the sidebar-display
-// check guards the CSS-sidecar cascade collapse.
-async function styledChrome(page: Page, shellTestId: string) {
+// Counts the plugin shell's interactive controls and how many carry a
+// styling class — a count of 0 is the unstyled-component regression signal.
+async function styledControls(page: Page, shellTestId: string) {
   return page.evaluate((id) => {
-    const sidebar = document.querySelector('[data-slot="sidebar"]');
     const shell = document.querySelector(`[data-testid="${id}"]`);
     const controls = shell
       ? Array.from(shell.querySelectorAll("button, a, input, select, label"))
       : [];
     return {
-      sidebarVisible:
-        sidebar !== null && getComputedStyle(sidebar).display !== "none",
-      totalControls: controls.length,
-      styledControls: controls.filter(
+      total: controls.length,
+      styled: controls.filter(
         (el) => (el.getAttribute("class") ?? "").trim().length > 0,
       ).length,
     };

--- a/packages/plugins/comments/e2e/comments-admin.spec.ts
+++ b/packages/plugins/comments/e2e/comments-admin.spec.ts
@@ -61,40 +61,31 @@ test("moderator bulk-approves selected comments", async ({ page }) => {
   ).toBeHidden();
 });
 
-// Regression for two failures that shipped together: (1) the plugin admin
-// page rendered as bare unstyled HTML (the component had zero `className`),
-// and (2) the plugin CSS sidecar re-emitted base utilities into the shared
-// cascade layer, loaded after the admin stylesheet, and collapsed the
-// admin sidebar to `display:none`. Guards: the sidebar stays visible AND
-// the page ships visibly-styled controls. See packages/admin/src/styles/
-// globals.css + packages/plumix/src/vite/admin-plugin-bundle.ts.
-test("admin page renders styled with the sidebar intact", async ({ page }) => {
+// Regression: the comments admin page once shipped as bare unstyled HTML
+// (the component had zero `className`). Assert it ships styled controls.
+// (The admin sidebar's CSS-cascade isolation — the other half of the
+// original incident — is guarded admin-side in packages/admin/e2e/
+// app-shell.spec.ts + packages/admin/src/styles/globals.test.ts.)
+test("admin page ships styled controls", async ({ page }) => {
   await page.goto("pages/comments");
   await expect(page.getByTestId("comments-shell")).toBeVisible();
 
-  const ui = await styledChrome(page, "comments-shell");
-  expect(ui.sidebarVisible).toBe(true);
-  expect(ui.totalControls).toBeGreaterThan(0);
-  expect(ui.styledControls).toBeGreaterThan(0);
+  const ui = await styledControls(page, "comments-shell");
+  expect(ui.total).toBeGreaterThan(0);
+  expect(ui.styled).toBeGreaterThan(0);
 });
 
-// Returns whether the admin sidebar is displayed, and how many of the
-// plugin shell's own interactive controls carry styling classes. The
-// unstyled-page bug was literally zero `className` in the component, so a
-// styled-control count of 0 is the regression signal; the sidebar-display
-// check guards the CSS-sidecar cascade collapse.
-async function styledChrome(page: Page, shellTestId: string) {
+// Counts the plugin shell's interactive controls and how many carry a
+// styling class — a count of 0 is the unstyled-component regression signal.
+async function styledControls(page: Page, shellTestId: string) {
   return page.evaluate((id) => {
-    const sidebar = document.querySelector('[data-slot="sidebar"]');
     const shell = document.querySelector(`[data-testid="${id}"]`);
     const controls = shell
       ? Array.from(shell.querySelectorAll("button, a, input, select, label"))
       : [];
     return {
-      sidebarVisible:
-        sidebar !== null && getComputedStyle(sidebar).display !== "none",
-      totalControls: controls.length,
-      styledControls: controls.filter(
+      total: controls.length,
+      styled: controls.filter(
         (el) => (el.getAttribute("class") ?? "").trim().length > 0,
       ).length,
     };

--- a/packages/plugins/media/e2e/media.spec.ts
+++ b/packages/plugins/media/e2e/media.spec.ts
@@ -126,40 +126,31 @@ test.describe.serial("@plumix/plugin-media — worker-driven happy path", () => 
   });
 });
 
-// Regression for two failures that shipped together: (1) a plugin admin
-// page rendering as bare unstyled HTML (the component had zero `className`),
-// and (2) the plugin CSS sidecar re-emitting base utilities into the shared
-// cascade layer, loaded after the admin stylesheet, collapsing the admin
-// sidebar to `display:none`. Guards: the sidebar stays visible AND the page
-// ships visibly-styled controls. See packages/admin/src/styles/globals.css
-// + packages/plumix/src/vite/admin-plugin-bundle.ts.
-test("admin page renders styled with the sidebar intact", async ({ page }) => {
+// Regression: a plugin admin page once shipped as bare unstyled HTML (the
+// component had zero `className`). Assert this page ships styled controls.
+// (The admin sidebar's CSS-cascade isolation — the other half of the
+// original incident — is guarded admin-side in packages/admin/e2e/
+// app-shell.spec.ts + packages/admin/src/styles/globals.test.ts.)
+test("admin page ships styled controls", async ({ page }) => {
   await page.goto("pages/media");
   await expect(page.getByTestId("media-library")).toBeVisible();
 
-  const ui = await styledChrome(page, "media-library");
-  expect(ui.sidebarVisible).toBe(true);
-  expect(ui.totalControls).toBeGreaterThan(0);
-  expect(ui.styledControls).toBeGreaterThan(0);
+  const ui = await styledControls(page, "media-library");
+  expect(ui.total).toBeGreaterThan(0);
+  expect(ui.styled).toBeGreaterThan(0);
 });
 
-// Returns whether the admin sidebar is displayed, and how many of the
-// plugin shell's own interactive controls carry styling classes. The
-// unstyled-page bug was literally zero `className` in the component, so a
-// styled-control count of 0 is the regression signal; the sidebar-display
-// check guards the CSS-sidecar cascade collapse.
-async function styledChrome(page: Page, shellTestId: string) {
+// Counts the plugin shell's interactive controls and how many carry a
+// styling class — a count of 0 is the unstyled-component regression signal.
+async function styledControls(page: Page, shellTestId: string) {
   return page.evaluate((id) => {
-    const sidebar = document.querySelector('[data-slot="sidebar"]');
     const shell = document.querySelector(`[data-testid="${id}"]`);
     const controls = shell
       ? Array.from(shell.querySelectorAll("button, a, input, select, label"))
       : [];
     return {
-      sidebarVisible:
-        sidebar !== null && getComputedStyle(sidebar).display !== "none",
-      totalControls: controls.length,
-      styledControls: controls.filter(
+      total: controls.length,
+      styled: controls.filter(
         (el) => (el.getAttribute("class") ?? "").trim().length > 0,
       ).length,
     };

--- a/packages/plugins/menu/e2e/menu.spec.ts
+++ b/packages/plugins/menu/e2e/menu.spec.ts
@@ -304,40 +304,31 @@ async function dragRowOnSelf(
   );
 }
 
-// Regression for two failures that shipped together: (1) the plugin admin
-// page rendered as bare unstyled HTML (the component had zero `className`),
-// and (2) the plugin CSS sidecar re-emitted base utilities into the shared
-// cascade layer, loaded after the admin stylesheet, and collapsed the
-// admin sidebar to `display:none`. Guards: the sidebar stays visible AND
-// the page ships visibly-styled controls. See packages/admin/src/styles/
-// globals.css + packages/plumix/src/vite/admin-plugin-bundle.ts.
-test("admin page renders styled with the sidebar intact", async ({ page }) => {
+// Regression: the menus admin page once shipped as bare unstyled HTML (the
+// component had zero `className`). Assert it ships styled controls. (The
+// admin sidebar's CSS-cascade isolation — the other half of the original
+// incident — is guarded admin-side in packages/admin/e2e/app-shell.spec.ts
+// + packages/admin/src/styles/globals.test.ts.)
+test("admin page ships styled controls", async ({ page }) => {
   await page.goto("pages/menus");
   await expect(page.getByTestId("menus-shell")).toBeVisible();
 
-  const ui = await styledChrome(page, "menus-shell");
-  expect(ui.sidebarVisible).toBe(true);
-  expect(ui.totalControls).toBeGreaterThan(0);
-  expect(ui.styledControls).toBeGreaterThan(0);
+  const ui = await styledControls(page, "menus-shell");
+  expect(ui.total).toBeGreaterThan(0);
+  expect(ui.styled).toBeGreaterThan(0);
 });
 
-// Returns whether the admin sidebar is displayed, and how many of the
-// plugin shell's own interactive controls carry styling classes. The
-// unstyled-page bug was literally zero `className` in the component, so a
-// styled-control count of 0 is the regression signal; the sidebar-display
-// check guards the CSS-sidecar cascade collapse.
-async function styledChrome(page: Page, shellTestId: string) {
+// Counts the plugin shell's interactive controls and how many carry a
+// styling class — a count of 0 is the unstyled-component regression signal.
+async function styledControls(page: Page, shellTestId: string) {
   return page.evaluate((id) => {
-    const sidebar = document.querySelector('[data-slot="sidebar"]');
     const shell = document.querySelector(`[data-testid="${id}"]`);
     const controls = shell
       ? Array.from(shell.querySelectorAll("button, a, input, select, label"))
       : [];
     return {
-      sidebarVisible:
-        sidebar !== null && getComputedStyle(sidebar).display !== "none",
-      totalControls: controls.length,
-      styledControls: controls.filter(
+      total: controls.length,
+      styled: controls.filter(
         (el) => (el.getAttribute("class") ?? "").trim().length > 0,
       ).length,
     };


### PR DESCRIPTION
Follow-up addressing review feedback on #1076: the sidebar-collapse assertion shouldn't have been folded into every plugin e2e suite — the cascade is **admin chrome**, not a plugin concern.

**Before:** each of comments/menu/media/audit-log e2e asserted both "sidebar visible" (duplicated 4×) and "page is styled".

**After:**
- One admin-level e2e (`packages/admin/e2e/app-shell.spec.ts`) owns the cascade guard: it mounts the authenticated shell, injects exactly what a plugin sidecar emits — `@layer plumix-plugins{.hidden{display:none}}` after the admin CSS — and asserts the sidebar's `md:block` still wins. Verified it goes **red** when the `globals.css` layer order is removed.
- The four plugin e2e tests now assert only their own concern: the plugin admin page ships styled controls (the zero-`className` regression).

The layer-order *contract* remains unit-tested (`admin/src/styles/globals.test.ts` + the bundler's `admin-plugin-bundle.test.ts`), so the cascade is covered at three levels without per-plugin duplication.

Test-only change; no source touched.