### PR TITLE
feat: read-through edge cache (TTL-only)

### DIFF
--- a/packages/core/src/cache/decision.test.ts
+++ b/packages/core/src/cache/decision.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  requestIsCacheable,
+  requestIsPrivileged,
+  responseIsStorable,
+} from "./decision.js";
+
+describe("requestIsCacheable", () => {
+  it("caches an anonymous GET to a public entry permalink", () => {
+    expect(
+      requestIsCacheable({
+        method: "GET",
+        isPrivileged: false,
+        intentKind: "single",
+      }),
+    ).toBe(true);
+  });
+
+  it("caches anonymous GETs to archive, taxonomy, and front-page intents", () => {
+    for (const intentKind of ["archive", "taxonomy", "front-page"] as const) {
+      expect(
+        requestIsCacheable({ method: "GET", isPrivileged: false, intentKind }),
+      ).toBe(true);
+    }
+  });
+
+  it("bypasses a privileged request", () => {
+    expect(
+      requestIsCacheable({
+        method: "GET",
+        isPrivileged: true,
+        intentKind: "single",
+      }),
+    ).toBe(false);
+  });
+
+  it("bypasses search pages", () => {
+    expect(
+      requestIsCacheable({
+        method: "GET",
+        isPrivileged: false,
+        intentKind: "search",
+      }),
+    ).toBe(false);
+  });
+
+  it("bypasses non-GET/HEAD methods", () => {
+    expect(
+      requestIsCacheable({
+        method: "POST",
+        isPrivileged: false,
+        intentKind: "single",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("requestIsPrivileged", () => {
+  it("treats a plain anonymous GET as not privileged", () => {
+    expect(requestIsPrivileged(new Request("https://site.test/post"))).toBe(
+      false,
+    );
+  });
+
+  it("treats a session-cookie request as privileged", () => {
+    expect(
+      requestIsPrivileged(
+        new Request("https://site.test/post", {
+          headers: { cookie: "plumix_session=abc" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a request with an Authorization header as privileged", () => {
+    expect(
+      requestIsPrivileged(
+        new Request("https://site.test/post", {
+          headers: { authorization: "Bearer pl_pat_x" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a ?preview= draft-grant request as privileged", () => {
+    expect(
+      requestIsPrivileged(new Request("https://site.test/post?preview=tok")),
+    ).toBe(true);
+  });
+});
+
+describe("responseIsStorable", () => {
+  it("stores a 200 GET response", () => {
+    expect(responseIsStorable("GET", 200)).toBe(true);
+  });
+
+  it("does not store non-200 responses", () => {
+    expect(responseIsStorable("GET", 404)).toBe(false);
+    expect(responseIsStorable("GET", 500)).toBe(false);
+    expect(responseIsStorable("GET", 301)).toBe(false);
+  });
+
+  it("does not store HEAD responses (the Cache API only persists GET)", () => {
+    expect(responseIsStorable("HEAD", 200)).toBe(false);
+  });
+});

--- a/packages/core/src/cache/decision.ts
+++ b/packages/core/src/cache/decision.ts
@@ -1,0 +1,57 @@
+import type { RouteIntent } from "../route/intent.js";
+import { readSessionCookie } from "../auth/cookies.js";
+
+// Public route intents whose anonymous render is a shared, cacheable document.
+// `search` is deliberately excluded — its unbounded query space would pollute
+// the cache with one entry per distinct query string.
+const CACHEABLE_INTENTS: ReadonlySet<RouteIntent["kind"]> = new Set([
+  "single",
+  "archive",
+  "taxonomy",
+  "front-page",
+]);
+
+interface CacheableRequest {
+  readonly method: string;
+  /**
+   * True when the request may see content the anonymous public can't — so its
+   * render must never be read from or written to the shared cache.
+   */
+  readonly isPrivileged: boolean;
+  readonly intentKind: RouteIntent["kind"];
+}
+
+/**
+ * Whether a request carries elevated visibility: an authenticated session or
+ * bearer credential, or a `?preview=<token>` draft grant. Any of these can
+ * make the render differ from the shared anonymous document — a logged-in
+ * editor's view, or a draft visible only to a preview-link holder — so such
+ * requests must bypass the cache entirely. The preview case is the load-bearing
+ * one: a draft render is anonymous (no cookie) yet must never be cached, or it
+ * would outlive the token's authorization window in the edge cache.
+ */
+export function requestIsPrivileged(request: Request): boolean {
+  if (readSessionCookie(request) !== null) return true;
+  if (request.headers.has("authorization")) return true;
+  return new URL(request.url).searchParams.has("preview");
+}
+
+/**
+ * Whether the edge cache may participate in this request at all — the gate for
+ * both reading a stored response and storing a fresh one.
+ */
+export function requestIsCacheable(req: CacheableRequest): boolean {
+  if (req.method !== "GET" && req.method !== "HEAD") return false;
+  if (req.isPrivileged) return false;
+  return CACHEABLE_INTENTS.has(req.intentKind);
+}
+
+/**
+ * Whether a rendered response may be written to the edge cache. Only a `200`
+ * is a complete public document worth storing; redirects and errors are never
+ * cached. Restricted to `GET` because the Workers Cache API persists GET
+ * responses only — a HEAD render is served live.
+ */
+export function responseIsStorable(method: string, status: number): boolean {
+  return method === "GET" && status === 200;
+}

--- a/packages/core/src/cache/read-through.test.ts
+++ b/packages/core/src/cache/read-through.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConnectedCache } from "../runtime/slots.js";
+import { readThrough } from "./read-through.js";
+
+// `defer` swallows the promise here so tests can drive the store-write path
+// without a real waitUntil queue.
+const immediateDefer = (p: Promise<unknown>): void => {
+  void p;
+};
+
+const GET = (url = "https://site.test/hello") => new Request(url);
+
+describe("readThrough", () => {
+  it("renders and stores on a cache miss for a cacheable request", async () => {
+    const match = vi.fn(() => Promise.resolve(undefined));
+    const put = vi.fn(() => Promise.resolve());
+    const cache: ConnectedCache = { match, put };
+    const fresh = new Response("body", { status: 200 });
+    const render = vi.fn(() => Promise.resolve(fresh));
+
+    const result = await readThrough({
+      request: GET(),
+      intentKind: "single",
+      cache,
+      defer: immediateDefer,
+      render,
+    });
+
+    expect(result).toBe(fresh);
+    expect(render).toHaveBeenCalledOnce();
+    expect(match).toHaveBeenCalledOnce();
+    expect(put).toHaveBeenCalledOnce();
+  });
+
+  it("returns the cached response without rendering on a hit", async () => {
+    const cached = new Response("cached", { status: 200 });
+    const match = vi.fn(() => Promise.resolve(cached));
+    const put = vi.fn(() => Promise.resolve());
+    const cache: ConnectedCache = { match, put };
+    const render = vi.fn(() => Promise.resolve(new Response("fresh")));
+
+    const result = await readThrough({
+      request: GET(),
+      intentKind: "front-page",
+      cache,
+      defer: immediateDefer,
+      render,
+    });
+
+    expect(result).toBe(cached);
+    expect(render).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("bypasses the cache entirely for a privileged request", async () => {
+    const match = vi.fn(() => Promise.resolve(undefined));
+    const put = vi.fn(() => Promise.resolve());
+    const cache: ConnectedCache = { match, put };
+    const fresh = new Response("live", { status: 200 });
+    const render = vi.fn(() => Promise.resolve(fresh));
+
+    const result = await readThrough({
+      request: new Request("https://site.test/hello", {
+        headers: { cookie: "plumix_session=abc" },
+      }),
+      intentKind: "single",
+      cache,
+      defer: immediateDefer,
+      render,
+    });
+
+    expect(result).toBe(fresh);
+    expect(match).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("renders live without touching the cache for an unmatched route", async () => {
+    const match = vi.fn(() => Promise.resolve(undefined));
+    const put = vi.fn(() => Promise.resolve());
+    const cache: ConnectedCache = { match, put };
+    const render = vi.fn(() =>
+      Promise.resolve(new Response("404", { status: 404 })),
+    );
+
+    await readThrough({
+      request: GET(),
+      intentKind: null,
+      cache,
+      defer: immediateDefer,
+      render,
+    });
+
+    expect(match).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("does not store a non-200 render", async () => {
+    const match = vi.fn(() => Promise.resolve(undefined));
+    const put = vi.fn(() => Promise.resolve());
+    const cache: ConnectedCache = { match, put };
+    const render = vi.fn(() =>
+      Promise.resolve(new Response("nope", { status: 404 })),
+    );
+
+    await readThrough({
+      request: GET(),
+      intentKind: "single",
+      cache,
+      defer: immediateDefer,
+      render,
+    });
+
+    expect(match).toHaveBeenCalledOnce();
+    expect(put).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/cache/read-through.ts
+++ b/packages/core/src/cache/read-through.ts
@@ -1,0 +1,52 @@
+import type { DeferFn } from "../context/app.js";
+import type { RouteIntent } from "../route/intent.js";
+import type { ConnectedCache } from "../runtime/slots.js";
+import {
+  requestIsCacheable,
+  requestIsPrivileged,
+  responseIsStorable,
+} from "./decision.js";
+
+interface ReadThroughArgs {
+  readonly request: Request;
+  /**
+   * Resolved public route intent, or `null` when the URL matches no public
+   * route (a 404) — in which case the cache is never consulted.
+   */
+  readonly intentKind: RouteIntent["kind"] | null;
+  readonly cache: ConnectedCache;
+  readonly defer: DeferFn;
+  /** Renders the page live. Called once on a miss, never on a hit. */
+  readonly render: () => Promise<Response>;
+}
+
+/**
+ * Serve a public page through the edge cache: return a stored response on a
+ * hit, otherwise render live and store the result when it's cacheable. The
+ * store runs through `defer` so it never blocks the response. Requests that
+ * aren't cacheable (privileged, non-GET/HEAD, search, no route) render live
+ * and touch the cache not at all.
+ */
+export async function readThrough(args: ReadThroughArgs): Promise<Response> {
+  const { request, intentKind, cache, defer, render } = args;
+
+  if (
+    intentKind === null ||
+    !requestIsCacheable({
+      method: request.method,
+      isPrivileged: requestIsPrivileged(request),
+      intentKind,
+    })
+  ) {
+    return render();
+  }
+
+  const hit = await cache.match(request);
+  if (hit) return hit;
+
+  const fresh = await render();
+  if (responseIsStorable(request.method, fresh.status)) {
+    defer(cache.put(request, fresh.clone()));
+  }
+  return fresh;
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -7,6 +7,7 @@ import type { I18nInput, ResolvedI18n } from "./i18n/locale-registry.js";
 import type { PluginDescriptor } from "./plugin/define.js";
 import type { RuntimeAdapter } from "./runtime/adapter.js";
 import type {
+  CacheProvider,
   DatabaseAdapter,
   ImageDelivery,
   KV,
@@ -67,6 +68,14 @@ export interface PlumixConfigInput {
   readonly storage?: ObjectStorage;
   readonly imageDelivery?: ImageDelivery;
   readonly kv?: KV;
+  /**
+   * Public read-through edge cache. Optional and default-off: with no `cache`
+   * slot, every public page renders live. The canonical provider is
+   * `edge({ ttl, staleWhileRevalidate })` from `@plumix/runtime-cloudflare`;
+   * it disables itself when the deploy lacks the zone credentials needed to
+   * cache safely (e.g. on `workers.dev`).
+   */
+  readonly cache?: CacheProvider;
   /**
    * Outbound email transport. Implementations conform to the `Mailer`
    * interface from `@plumix/core` — one method, swap in any provider
@@ -134,6 +143,7 @@ export interface PlumixConfig {
   readonly storage?: ObjectStorage;
   readonly imageDelivery?: ImageDelivery;
   readonly kv?: KV;
+  readonly cache?: CacheProvider;
   readonly mailer?: Mailer;
   readonly theme: ThemeDescriptor;
   readonly plugins: readonly AnyPluginDescriptor[];
@@ -169,6 +179,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
     storage: config.storage,
     imageDelivery: config.imageDelivery,
     kv: config.kv,
+    cache: config.cache,
     mailer: config.mailer,
     theme: config.theme ?? welcomeTheme,
     plugins: config.plugins ?? [],

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -21,6 +21,7 @@ import type { OAuthProviderSummary } from "../runtime/app.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
 import type {
   AssetsBinding,
+  ConnectedCache,
   ConnectedObjectStorage,
   ImageDelivery,
 } from "../runtime/slots.js";
@@ -174,6 +175,13 @@ export interface AppContextBase<
    */
   readonly storage?: ConnectedObjectStorage;
   /**
+   * Bound edge cache for this request, when the config declared a `cache:`
+   * slot and the runtime connected it (zone credentials present). The
+   * dispatcher's public-route path reads/writes through this; `undefined`
+   * means caching is off and every public page renders live.
+   */
+  readonly cache?: ConnectedCache;
+  /**
    * On-the-fly image delivery (resize / format / quality URLs). Present
    * when the config declared an `imageDelivery:` slot. Pure URL math —
    * `imageDelivery.url(src, opts)` returns the CDN-transformed URL.
@@ -269,6 +277,7 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly defer?: DeferFn;
   readonly assets?: AssetsBinding;
   readonly storage?: ConnectedObjectStorage;
+  readonly cache?: ConnectedCache;
   readonly imageDelivery?: ImageDelivery;
   readonly imageRemotePatterns?: readonly RemotePattern[];
   readonly mailer?: Mailer;
@@ -372,6 +381,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     defer: wrapDefer(args.logger ?? consoleLogger, args.defer),
     assets: args.assets,
     storage: args.storage,
+    cache: args.cache,
     imageDelivery: args.imageDelivery,
     imageRemotePatterns: args.imageRemotePatterns,
     mailer: args.mailer,

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -1063,3 +1063,50 @@ describe("dispatcher — imageDelivery slot wiring", () => {
     expect(await response.text()).toBe("absent");
   });
 });
+
+describe("dispatcher — public read-through edge cache", () => {
+  test("a cacheable public GET is served from the edge cache on a hit", async () => {
+    const match = vi.fn(() =>
+      Promise.resolve(new Response("CACHED", { status: 200 })),
+    );
+    const put = vi.fn(() => Promise.resolve());
+    const h = await createDispatcherHarness({ cache: { match, put } });
+
+    const response = await h.dispatch(new Request("https://cms.example/"));
+
+    expect(await response.text()).toBe("CACHED");
+    expect(match).toHaveBeenCalledOnce();
+  });
+
+  test("a request carrying the session cookie bypasses the cache", async () => {
+    const match = vi.fn(() =>
+      Promise.resolve(new Response("CACHED", { status: 200 })),
+    );
+    const put = vi.fn(() => Promise.resolve());
+    const h = await createDispatcherHarness({ cache: { match, put } });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/", {
+        headers: { cookie: "plumix_session=anything" },
+      }),
+    );
+
+    expect(await response.text()).not.toBe("CACHED");
+    expect(match).not.toHaveBeenCalled();
+  });
+
+  test("a request carrying a ?preview= draft grant bypasses the cache", async () => {
+    const match = vi.fn(() =>
+      Promise.resolve(new Response("CACHED", { status: 200 })),
+    );
+    const put = vi.fn(() => Promise.resolve());
+    const h = await createDispatcherHarness({ cache: { match, put } });
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/?preview=some-token"),
+    );
+
+    expect(await response.text()).not.toBe("CACHED");
+    expect(match).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -2,11 +2,14 @@ import type * as AuthFlowRoutes from "../auth/flow-routes.js";
 import type { AppContext } from "../context/app.js";
 import type * as McpDispatch from "../mcp/dispatch.js";
 import type { RegisteredRawRoute } from "../plugin/manifest.js";
+import type { RouteIntent } from "../route/intent.js";
+import type { RouteMatch } from "../route/match.js";
 import type { PlumixApp } from "./app.js";
 import { readSessionCookie } from "../auth/cookies.js";
 import { hasCsrfHeader, hasMatchingOrigin } from "../auth/csrf.js";
 import { parseOAuthPath } from "../auth/oauth/match.js";
 import { stripBasePath, withBasePath } from "../base-path.js";
+import { readThrough } from "../cache/read-through.js";
 import { interfaceEnabled } from "../config.js";
 import { withUser } from "../context/app.js";
 import { resolveLocale } from "../i18n/resolve-locale.js";
@@ -330,10 +333,41 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   return dispatchPublicRoute(app, ctx, url);
 }
 
+// The cache-decision intent kind for a resolved route match: an unmatched root
+// is the front page, any other unmatched URL is a 404 (never cached).
+function intentKindForMatch(
+  match: RouteMatch | null,
+  url: URL,
+): RouteIntent["kind"] | null {
+  if (match !== null) return match.intent.kind;
+  if (url.pathname === "/") return "front-page";
+  return null;
+}
+
 async function dispatchPublicRoute(
   app: PlumixApp,
   ctx: AppContext,
   url: URL,
+): Promise<Response> {
+  // Resolve the route once here and thread it into rendering so a cache miss
+  // doesn't re-run `matchRoute` on the hot public-render path.
+  const match = matchRoute(url, app.routeMap);
+  const cache = ctx.cache;
+  if (cache === undefined) return renderPublicRoute(app, ctx, url, match);
+  return readThrough({
+    request: ctx.request,
+    intentKind: intentKindForMatch(match, url),
+    cache,
+    defer: ctx.defer,
+    render: () => renderPublicRoute(app, ctx, url, match),
+  });
+}
+
+async function renderPublicRoute(
+  app: PlumixApp,
+  ctx: AppContext,
+  url: URL,
+  match: RouteMatch | null,
 ): Promise<Response> {
   const theme = app.config.theme;
   const document = app.document;
@@ -342,7 +376,7 @@ async function dispatchPublicRoute(
   const assetManifest = app.assetManifest;
   try {
     ctx = await loadUserForPublicRequest(ctx);
-    const response = await resolvePublicRouteOrFallback(app, ctx, url);
+    const response = await resolvePublicRouteOrFallback(app, ctx, url, match);
     if (response.status === 404) {
       const html = await renderErrorThroughTheme({
         ctx,
@@ -402,13 +436,13 @@ async function resolvePublicRouteOrFallback(
   app: PlumixApp,
   ctx: AppContext,
   url: URL,
+  match: RouteMatch | null,
 ): Promise<Response> {
   const theme = app.config.theme;
   const document = app.document;
   const templateDocuments = app.templateDocuments;
   const templateDeps = app.plugins.templateDeps;
   const assetManifest = app.assetManifest;
-  const match = matchRoute(url, app.routeMap);
   if (match !== null) {
     return resolvePublicRoute(
       ctx,

--- a/packages/core/src/runtime/slots.ts
+++ b/packages/core/src/runtime/slots.ts
@@ -173,6 +173,27 @@ export interface KV {
   readonly kind: string;
 }
 
+/**
+ * An edge cache bound for the current isolate. Backs the public read-through
+ * cache: `match` reads a stored response, `put` writes a fresh one. The
+ * canonical implementation (Cloudflare's `edge()`) is the Workers Cache API.
+ */
+export interface ConnectedCache {
+  match(request: Request): Promise<Response | undefined>;
+  put(request: Request, response: Response): Promise<void>;
+}
+
+/**
+ * Edge-cache slot. `connect(env)` returns a {@link ConnectedCache} when the
+ * runtime has everything it needs to cache safely, or `null` to disable
+ * caching for this deploy (e.g. a Cloudflare deploy with no zone credentials,
+ * where pages must render live). Mirrors the `storage:` slot's connect shape.
+ */
+export interface CacheProvider {
+  readonly kind: string;
+  connect(env: unknown): ConnectedCache | null;
+}
+
 export interface TransformOpts {
   readonly width?: number;
   readonly height?: number;

--- a/packages/core/src/test/dispatcher.ts
+++ b/packages/core/src/test/dispatcher.ts
@@ -24,6 +24,7 @@ import type { PlumixApp } from "../runtime/app.js";
 import type { PlumixEnv } from "../runtime/bindings.js";
 import type {
   AssetsBinding,
+  ConnectedCache,
   ConnectedObjectStorage,
   ImageDelivery,
 } from "../runtime/slots.js";
@@ -85,6 +86,11 @@ export interface CreateDispatcherHarnessOptions {
    * `memoryStorage().connect({})` for a working in-memory backend.
    */
   readonly storage?: ConnectedObjectStorage;
+  /**
+   * Bound edge cache. Stub it in tests that exercise the public read-through
+   * path (`ctx.cache`); the dispatcher consults it for cacheable public GETs.
+   */
+  readonly cache?: ConnectedCache;
   /**
    * Configured OAuth providers for tests exercising the start/callback
    * routes. Pass `{ github: github({ clientId, clientSecret }), google:
@@ -193,6 +199,7 @@ function withRequest(
   env: PlumixEnv,
   assets: AssetsBinding | undefined,
   storage: ConnectedObjectStorage | undefined,
+  cache: ConnectedCache | undefined,
   request: Request,
   user: User | null,
 ): AppContext {
@@ -211,6 +218,7 @@ function withRequest(
       : undefined,
     assets,
     storage,
+    cache,
     imageDelivery: app.config.imageDelivery,
     imageRemotePatterns: app.config.images?.remotePatterns,
     mailer: app.config.mailer,
@@ -258,14 +266,23 @@ export async function createDispatcherHarness(
     devCsrfLocalhost: options.devCsrfLocalhost,
   });
   const dispatcher = createPlumixDispatcher(app);
-  const { assets, storage } = options;
+  const { assets, storage, cache } = options;
 
   const harness: DispatcherHarness = {
     db,
     app,
     env,
     dispatch: async (request, user = null) => {
-      const ctx = withRequest(app, db, env, assets, storage, request, user);
+      const ctx = withRequest(
+        app,
+        db,
+        env,
+        assets,
+        storage,
+        cache,
+        request,
+        user,
+      );
       return dispatcher(ctx);
     },
     fetch: async (path, fetchOptions = {}) => {
@@ -276,6 +293,7 @@ export async function createDispatcherHarness(
         env,
         assets,
         storage,
+        cache,
         request,
         fetchOptions.as ?? null,
       );

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -187,6 +187,10 @@ function buildFetch(app: PlumixApp): FetchHandler {
       // apps without `storage` configured never pay the cost.
       const storage = app.config.storage?.connect(env);
 
+      // Edge cache binds per request. `connect` returns null when the deploy
+      // lacks zone credentials (e.g. workers.dev) — caching off, render live.
+      const cache = app.config.cache?.connect(env) ?? undefined;
+
       const appCtx = createAppContext({
         db: db as Db,
         env: env as PlumixEnv,
@@ -199,6 +203,7 @@ function buildFetch(app: PlumixApp): FetchHandler {
         defer,
         assets: readAssetsBinding(env),
         storage,
+        cache,
         imageDelivery: app.config.imageDelivery,
         imageRemotePatterns: app.config.images?.remotePatterns,
         mailer: app.config.mailer,

--- a/packages/runtimes/cloudflare/src/edge.test.ts
+++ b/packages/runtimes/cloudflare/src/edge.test.ts
@@ -1,0 +1,95 @@
+import type { ConnectedCache } from "plumix";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EdgeConfig } from "./edge.js";
+import { edge } from "./edge.js";
+
+interface FakeStore {
+  match: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+}
+
+let store: FakeStore;
+const originalCaches = (globalThis as { caches?: unknown }).caches;
+
+beforeEach(() => {
+  store = {
+    match: vi.fn(() => Promise.resolve(undefined)),
+    put: vi.fn(() => Promise.resolve()),
+  };
+  (globalThis as { caches?: unknown }).caches = { default: store };
+});
+
+afterEach(() => {
+  (globalThis as { caches?: unknown }).caches = originalCaches;
+});
+
+const CREDS = { CF_ZONE_ID: "zone-1", CF_CACHE_PURGE_TOKEN: "token-1" };
+
+describe("edge().connect", () => {
+  it("returns null when zone credentials are absent", () => {
+    expect(edge({ ttl: 60 }).connect({})).toBeNull();
+    expect(edge({ ttl: 60 }).connect({ CF_ZONE_ID: "zone-1" })).toBeNull();
+  });
+
+  it("returns a connected cache when credentials are present", () => {
+    expect(edge({ ttl: 60 }).connect(CREDS)).not.toBeNull();
+  });
+});
+
+function connect(
+  config: EdgeConfig = { ttl: 60, staleWhileRevalidate: 600 },
+): ConnectedCache {
+  const cache = edge(config).connect(CREDS);
+  if (cache === null) throw new Error("expected a connected cache");
+  return cache;
+}
+
+function storedResponse(): Response {
+  const call = store.put.mock.calls[0];
+  if (call === undefined) throw new Error("store.put was not called");
+  return call[1] as Response;
+}
+
+describe("connected cache put", () => {
+  it("stores a GET with the edge cache-control derived from policy", async () => {
+    await connect().put(
+      new Request("https://site.test/post"),
+      new Response("body", { status: 200 }),
+    );
+
+    expect(store.put).toHaveBeenCalledOnce();
+    expect(storedResponse().headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate=600",
+    );
+  });
+
+  it("strips Set-Cookie from the stored response", async () => {
+    const response = new Response("body", { status: 200 });
+    response.headers.set("set-cookie", "plumix_session=secret");
+
+    await connect().put(new Request("https://site.test/post"), response);
+
+    expect(storedResponse().headers.get("set-cookie")).toBeNull();
+  });
+
+  it("does not store non-GET requests (the Cache API is GET-only)", async () => {
+    await connect().put(
+      new Request("https://site.test/post", { method: "HEAD" }),
+      new Response("body", { status: 200 }),
+    );
+
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it("omits stale-while-revalidate when the policy has none", async () => {
+    await connect({ ttl: 30 }).put(
+      new Request("https://site.test/post"),
+      new Response("body", { status: 200 }),
+    );
+
+    expect(storedResponse().headers.get("cache-control")).toBe(
+      "public, s-maxage=30",
+    );
+  });
+});

--- a/packages/runtimes/cloudflare/src/edge.ts
+++ b/packages/runtimes/cloudflare/src/edge.ts
@@ -1,0 +1,90 @@
+import type { CacheProvider, ConnectedCache } from "plumix";
+
+/**
+ * Edge-cache policy for {@link edge}. `ttl` is the edge freshness window in
+ * seconds (`s-maxage`); `staleWhileRevalidate` lets a colo serve a stale copy
+ * for that many seconds after expiry while it refreshes in the background.
+ */
+export interface EdgeConfig {
+  readonly ttl: number;
+  readonly staleWhileRevalidate?: number;
+}
+
+// Env keys the purge layer (a later slice) needs. Their presence is also the
+// activation gate here: a deploy without a zone + purge token can't safely
+// cache (it could never bust a stale page), so caching stays off — which is
+// the workers.dev story.
+const ZONE_ID = "CF_ZONE_ID";
+const PURGE_TOKEN = "CF_CACHE_PURGE_TOKEN";
+
+// Minimal shape of `caches.default`; typed locally so the runtime stays free
+// of a hard `@cloudflare/workers-types` dependency at this boundary.
+interface EdgeStore {
+  match(request: Request): Promise<Response | undefined>;
+  put(request: Request, response: Response): Promise<void>;
+}
+
+function defaultStore(): EdgeStore | null {
+  const store = (globalThis as { caches?: { default?: EdgeStore } }).caches;
+  return store?.default ?? null;
+}
+
+function readCredential(env: unknown, key: string): string | null {
+  if (typeof env !== "object" || env === null) return null;
+  const value = (env as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function cacheControl(config: EdgeConfig): string {
+  const directives = [`public`, `s-maxage=${String(config.ttl)}`];
+  if (config.staleWhileRevalidate !== undefined) {
+    directives.push(
+      `stale-while-revalidate=${String(config.staleWhileRevalidate)}`,
+    );
+  }
+  return directives.join(", ");
+}
+
+// Clone with the edge cache-control applied and any Set-Cookie stripped — a
+// shared cache entry must never carry a per-request cookie, and the Workers
+// Cache API rejects responses that do.
+function forStorage(response: Response, config: EdgeConfig): Response {
+  const headers = new Headers(response.headers);
+  headers.delete("set-cookie");
+  headers.set("cache-control", cacheControl(config));
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function connectedCache(store: EdgeStore, config: EdgeConfig): ConnectedCache {
+  return {
+    match: (request) => store.match(request),
+    put: async (request, response) => {
+      // The Workers Cache API persists GET responses only.
+      if (request.method !== "GET") return;
+      await store.put(request, forStorage(response, config));
+    },
+  };
+}
+
+/**
+ * Cloudflare edge-cache provider backed by the Workers Cache API
+ * (`caches.default`). Disables itself (returns `null` from `connect`) when the
+ * deploy lacks the zone credentials needed to purge — pages then render live.
+ */
+export function edge(config: EdgeConfig): CacheProvider {
+  return {
+    kind: "cloudflare-edge",
+    connect(env) {
+      const zoneId = readCredential(env, ZONE_ID);
+      const purgeToken = readCredential(env, PURGE_TOKEN);
+      if (zoneId === null || purgeToken === null) return null;
+      const store = defaultStore();
+      if (store === null) return null;
+      return connectedCache(store, config);
+    },
+  };
+}

--- a/packages/runtimes/cloudflare/src/index.ts
+++ b/packages/runtimes/cloudflare/src/index.ts
@@ -7,6 +7,8 @@ export { d1 } from "./d1.js";
 export type { D1Config, D1DatabaseAdapter } from "./d1.js";
 export { cloudflareDeployOrigin } from "./deploy-origin.js";
 export type { DeployOrigin, DeployOriginInput } from "./deploy-origin.js";
+export { edge } from "./edge.js";
+export type { EdgeConfig } from "./edge.js";
 export { images } from "./images.js";
 export type { ImagesConfig } from "./images.js";
 export { kv } from "./kv.js";


### PR DESCRIPTION
Adds an opt-in read-through edge cache so anonymous public pages are served from Cloudflare's Workers Cache API instead of re-rendering on every request. Slice 1 of 3 for the edge-caching PRD (#1080) — TTL-only; tag emission and purge-on-publish follow in #1082 and #1083.

Enable it with a single config slot that mirrors the existing `database`/`storage`/`kv` slots:

```ts
import { cloudflare, d1, edge } from "@plumix/runtime-cloudflare";

export default plumix({
  runtime: cloudflare(),
  database: d1({ binding: "DB" }),
  cache: edge({ ttl: 3600, staleWhileRevalidate: 86400 }), // omit → caching off
});
```

**Draft-safety is the load-bearing invariant.** A request bypasses the cache entirely — no read, no write — when it carries elevated visibility: a `plumix_session` cookie, an `Authorization` header, or a `?preview=<token>` draft grant. The preview case is the subtle one: a preview render is anonymous (no cookie) yet must never be cached, or a draft would outlive the token's authorization window in the edge cache. Beyond that, only `GET`/`HEAD` + `200` responses for `single`/`archive`/`taxonomy`/`front-page` intents are stored; `search` is excluded so its unbounded query space can't pollute the cache.

**The provider is inert without zone credentials.** `edge().connect(env)` returns `null` when `CF_ZONE_ID`/`CF_CACHE_PURGE_TOKEN` are absent (e.g. a `workers.dev` deploy), so those deployments render live. Stored responses carry `Cache-Control: public, s-maxage=<ttl>, stale-while-revalidate=<swr>` and have `Set-Cookie` stripped; the store runs through the runtime's `waitUntil` so it never blocks the response.

**Core owns the logic; the runtime owns the transport.** The pure decision predicates (`requestIsCacheable`/`requestIsPrivileged`/`responseIsStorable`) and the `readThrough` orchestration live in core behind a small `CacheProvider`/`ConnectedCache` slot interface — host-agnostic, so a future Vercel/Netlify runtime implements the same three verbs. The Cloudflare `edge()` provider is the only adapter here.

Closes #1081