### PR TITLE
feat: purge edge cache on entry mutations

### DIFF
--- a/packages/core/src/cache/purge.test.ts
+++ b/packages/core/src/cache/purge.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import { requestStore } from "../context/stores.js";
+import { HookRegistry } from "../hooks/registry.js";
+import {
+  enqueuePurgeTags,
+  flushPurgeTags,
+  registerCorePurgeInvalidator,
+} from "./purge.js";
+
+function fakeCtx(withCache = true) {
+  const purgeTags = vi.fn(() => Promise.resolve());
+  const defer = vi.fn((p: Promise<unknown>) => {
+    void p;
+  });
+  const ctx = {
+    cache: withCache ? { match: vi.fn(), put: vi.fn(), purgeTags } : undefined,
+    defer,
+    logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  } as unknown as AppContext;
+  return { ctx, purgeTags, defer };
+}
+
+describe("purge accumulator", () => {
+  it("flushes a single de-duplicated purge for tags from multiple enqueues", () => {
+    const { ctx, purgeTags } = fakeCtx();
+
+    // Two entries of the same type — the bulk-publish shape.
+    enqueuePurgeTags(ctx, ["t:post", "e:1"]);
+    enqueuePurgeTags(ctx, ["t:post", "e:2"]);
+    flushPurgeTags(ctx);
+
+    expect(purgeTags).toHaveBeenCalledTimes(1);
+    expect(purgeTags).toHaveBeenCalledWith(["t:post", "e:1", "e:2"]);
+  });
+
+  it("does nothing on flush when nothing was enqueued", () => {
+    const { ctx, purgeTags, defer } = fakeCtx();
+    flushPurgeTags(ctx);
+    expect(purgeTags).not.toHaveBeenCalled();
+    expect(defer).not.toHaveBeenCalled();
+  });
+
+  it("is inert when no cache is configured", () => {
+    const { ctx, defer } = fakeCtx(false);
+    enqueuePurgeTags(ctx, ["t:post", "e:1"]);
+    flushPurgeTags(ctx);
+    expect(defer).not.toHaveBeenCalled();
+  });
+});
+
+describe("registerCorePurgeInvalidator", () => {
+  const ENTRY_EVENTS = [
+    "entry:published",
+    "entry:updated",
+    "entry:meta_changed",
+    "entry:trashed",
+    "entry:restored",
+    "entry:deleted",
+  ] as const;
+
+  it.each(ENTRY_EVENTS)("%s enqueues the entry's purge tags", async (event) => {
+    const hooks = new HookRegistry();
+    registerCorePurgeInvalidator(hooks);
+    const { ctx, purgeTags } = fakeCtx();
+
+    await requestStore.run(ctx, () =>
+      hooks.doAction(
+        event as never,
+        { id: 9, type: "post" } as never,
+        { id: 9, type: "post" } as never,
+      ),
+    );
+    flushPurgeTags(ctx);
+
+    expect(purgeTags).toHaveBeenCalledWith(["t:post", "e:9"]);
+  });
+
+  it("batches a bulk publish into one purge call", async () => {
+    const hooks = new HookRegistry();
+    registerCorePurgeInvalidator(hooks);
+    const { ctx, purgeTags } = fakeCtx();
+
+    await requestStore.run(ctx, async () => {
+      await hooks.doAction("entry:published", { id: 1, type: "post" } as never);
+      await hooks.doAction("entry:published", { id: 2, type: "post" } as never);
+    });
+    flushPurgeTags(ctx);
+
+    expect(purgeTags).toHaveBeenCalledTimes(1);
+    expect(purgeTags).toHaveBeenCalledWith(["t:post", "e:1", "e:2"]);
+  });
+});

--- a/packages/core/src/cache/purge.ts
+++ b/packages/core/src/cache/purge.ts
@@ -1,0 +1,66 @@
+import type { AppContext } from "../context/app.js";
+import type { HookRegistry } from "../hooks/registry.js";
+import { tryGetContext } from "../context/stores.js";
+import { entryPurgeTags } from "./tags.js";
+
+// Per-request purge accumulator. Entry hooks fire one at a time during a
+// request (a bulk publish fires N), each adding tags here; the dispatcher
+// flushes once after the request so the whole mutation costs a single
+// purge call. Keyed off the request `AppContext`, which is GC'd with the
+// request — no manual cleanup needed beyond the flush's own delete.
+const pending = new WeakMap<AppContext, Set<string>>();
+
+export function enqueuePurgeTags(
+  ctx: AppContext,
+  tags: readonly string[],
+): void {
+  if (ctx.cache === undefined || tags.length === 0) return;
+  let set = pending.get(ctx);
+  if (set === undefined) {
+    set = new Set();
+    pending.set(ctx, set);
+  }
+  for (const tag of tags) set.add(tag);
+}
+
+/**
+ * Runs through `ctx.defer` so the purge never blocks the response, and
+ * `defer`'s own rejection handler logs a failed purge — a publish never fails
+ * because Cloudflare's purge API hiccupped; TTL/SWR is the backstop.
+ */
+export function flushPurgeTags(ctx: AppContext): void {
+  const set = pending.get(ctx);
+  if (set === undefined) return;
+  pending.delete(ctx);
+  const cache = ctx.cache;
+  if (cache === undefined || set.size === 0) return;
+  ctx.defer(cache.purgeTags([...set]));
+}
+
+// Entry lifecycle actions that change what the public sees — published,
+// edited, meta-changed, or removed from view (trash/delete) / restored. Every
+// payload's leading arg carries `{ id, type }`, so one handler serves them all.
+const ENTRY_ACTIONS = [
+  "entry:published",
+  "entry:updated",
+  "entry:meta_changed",
+  "entry:trashed",
+  "entry:restored",
+  "entry:deleted",
+] as const;
+
+/**
+ * Register core's edge-cache purge subscribers. Called at app boot when a
+ * cache slot is configured; each entry mutation enqueues `t:<type>` + `e:<id>`
+ * for the post-request flush.
+ */
+export function registerCorePurgeInvalidator(hooks: HookRegistry): void {
+  const onEntry = (entry: { readonly id: number; readonly type: string }) => {
+    const ctx = tryGetContext();
+    if (ctx === null) return;
+    enqueuePurgeTags(ctx, entryPurgeTags(entry.type, entry.id));
+  };
+  for (const action of ENTRY_ACTIONS) {
+    hooks.addAction(action as never, onEntry);
+  }
+}

--- a/packages/core/src/cache/read-through.test.ts
+++ b/packages/core/src/cache/read-through.test.ts
@@ -10,12 +10,21 @@ const immediateDefer = (p: Promise<unknown>): void => {
 };
 
 const GET = (url = "https://site.test/hello") => new Request(url);
+const noTags = () => [];
+
+function spies(
+  match: ConnectedCache["match"] = () => Promise.resolve(undefined),
+) {
+  const matchFn = vi.fn(match);
+  const put = vi.fn<ConnectedCache["put"]>(() => Promise.resolve());
+  const purgeTags = vi.fn(() => Promise.resolve());
+  const cache: ConnectedCache = { match: matchFn, put, purgeTags };
+  return { cache, match: matchFn, put };
+}
 
 describe("readThrough", () => {
-  it("renders and stores on a cache miss for a cacheable request", async () => {
-    const match = vi.fn(() => Promise.resolve(undefined));
-    const put = vi.fn(() => Promise.resolve());
-    const cache: ConnectedCache = { match, put };
+  it("renders and stores the tagged response on a cache miss", async () => {
+    const { cache, match, put } = spies();
     const fresh = new Response("body", { status: 200 });
     const render = vi.fn(() => Promise.resolve(fresh));
 
@@ -25,19 +34,19 @@ describe("readThrough", () => {
       cache,
       defer: immediateDefer,
       render,
+      tags: () => ["e:7"],
     });
 
     expect(result).toBe(fresh);
     expect(render).toHaveBeenCalledOnce();
     expect(match).toHaveBeenCalledOnce();
     expect(put).toHaveBeenCalledOnce();
+    expect(put.mock.calls[0]?.[2]).toEqual(["e:7"]);
   });
 
   it("returns the cached response without rendering on a hit", async () => {
     const cached = new Response("cached", { status: 200 });
-    const match = vi.fn(() => Promise.resolve(cached));
-    const put = vi.fn(() => Promise.resolve());
-    const cache: ConnectedCache = { match, put };
+    const { cache, put } = spies(() => Promise.resolve(cached));
     const render = vi.fn(() => Promise.resolve(new Response("fresh")));
 
     const result = await readThrough({
@@ -46,6 +55,7 @@ describe("readThrough", () => {
       cache,
       defer: immediateDefer,
       render,
+      tags: noTags,
     });
 
     expect(result).toBe(cached);
@@ -54,9 +64,7 @@ describe("readThrough", () => {
   });
 
   it("bypasses the cache entirely for a privileged request", async () => {
-    const match = vi.fn(() => Promise.resolve(undefined));
-    const put = vi.fn(() => Promise.resolve());
-    const cache: ConnectedCache = { match, put };
+    const { cache, match, put } = spies();
     const fresh = new Response("live", { status: 200 });
     const render = vi.fn(() => Promise.resolve(fresh));
 
@@ -68,6 +76,7 @@ describe("readThrough", () => {
       cache,
       defer: immediateDefer,
       render,
+      tags: noTags,
     });
 
     expect(result).toBe(fresh);
@@ -76,9 +85,7 @@ describe("readThrough", () => {
   });
 
   it("renders live without touching the cache for an unmatched route", async () => {
-    const match = vi.fn(() => Promise.resolve(undefined));
-    const put = vi.fn(() => Promise.resolve());
-    const cache: ConnectedCache = { match, put };
+    const { cache, match, put } = spies();
     const render = vi.fn(() =>
       Promise.resolve(new Response("404", { status: 404 })),
     );
@@ -89,6 +96,7 @@ describe("readThrough", () => {
       cache,
       defer: immediateDefer,
       render,
+      tags: noTags,
     });
 
     expect(match).not.toHaveBeenCalled();
@@ -96,9 +104,7 @@ describe("readThrough", () => {
   });
 
   it("does not store a non-200 render", async () => {
-    const match = vi.fn(() => Promise.resolve(undefined));
-    const put = vi.fn(() => Promise.resolve());
-    const cache: ConnectedCache = { match, put };
+    const { cache, match, put } = spies();
     const render = vi.fn(() =>
       Promise.resolve(new Response("nope", { status: 404 })),
     );
@@ -109,6 +115,7 @@ describe("readThrough", () => {
       cache,
       defer: immediateDefer,
       render,
+      tags: noTags,
     });
 
     expect(match).toHaveBeenCalledOnce();

--- a/packages/core/src/cache/read-through.ts
+++ b/packages/core/src/cache/read-through.ts
@@ -18,6 +18,11 @@ interface ReadThroughArgs {
   readonly defer: DeferFn;
   /** Renders the page live. Called once on a miss, never on a hit. */
   readonly render: () => Promise<Response>;
+  /**
+   * The cache tags the stored response should carry. Evaluated after `render`
+   * so it can read the route's resolved entity (e.g. the entry id).
+   */
+  readonly tags: () => readonly string[];
 }
 
 /**
@@ -28,7 +33,7 @@ interface ReadThroughArgs {
  * and touch the cache not at all.
  */
 export async function readThrough(args: ReadThroughArgs): Promise<Response> {
-  const { request, intentKind, cache, defer, render } = args;
+  const { request, intentKind, cache, defer, render, tags } = args;
 
   if (
     intentKind === null ||
@@ -46,7 +51,7 @@ export async function readThrough(args: ReadThroughArgs): Promise<Response> {
 
   const fresh = await render();
   if (responseIsStorable(request.method, fresh.status)) {
-    defer(cache.put(request, fresh.clone()));
+    defer(cache.put(request, fresh.clone(), tags()));
   }
   return fresh;
 }

--- a/packages/core/src/cache/tags.test.ts
+++ b/packages/core/src/cache/tags.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { entryPurgeTags, pageTags } from "./tags.js";
+
+describe("entryPurgeTags", () => {
+  it("purges the type tag and the entry tag", () => {
+    expect(entryPurgeTags("post", 42)).toEqual(["t:post", "e:42"]);
+  });
+});
+
+describe("pageTags", () => {
+  const base = {
+    resolvedEntity: null,
+    frontPageEntryTypes: () => [],
+    taxonomyEntryTypes: () => [],
+  };
+
+  it("tags an entry permalink with both the type and the entry tag", () => {
+    expect(
+      pageTags({
+        ...base,
+        intent: { kind: "single", entryType: "post" },
+        resolvedEntity: { kind: "entry", id: 7 },
+      }),
+    ).toEqual(["t:post", "e:7"]);
+  });
+
+  it("tags a type archive with the type tag", () => {
+    expect(
+      pageTags({ ...base, intent: { kind: "archive", entryType: "post" } }),
+    ).toEqual(["t:post"]);
+  });
+
+  it("tags the front page with each listed type", () => {
+    expect(
+      pageTags({
+        ...base,
+        intent: { kind: "front-page" },
+        frontPageEntryTypes: () => ["post", "note"],
+      }),
+    ).toEqual(["t:post", "t:note"]);
+  });
+
+  it("tags a term archive with the taxonomy's entry types", () => {
+    expect(
+      pageTags({
+        ...base,
+        intent: { kind: "taxonomy", taxonomy: "category" },
+        taxonomyEntryTypes: (taxonomy) =>
+          taxonomy === "category" ? ["post"] : [],
+      }),
+    ).toEqual(["t:post"]);
+  });
+
+  it("tags search pages with nothing", () => {
+    expect(pageTags({ ...base, intent: { kind: "search" } })).toEqual([]);
+  });
+
+  it("tags nothing when a single render resolved no entry", () => {
+    expect(
+      pageTags({ ...base, intent: { kind: "single", entryType: "post" } }),
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/cache/tags.ts
+++ b/packages/core/src/cache/tags.ts
@@ -1,0 +1,52 @@
+import type { ResolvedEntity } from "../route/current.js";
+import type { RouteIntent } from "../route/intent.js";
+
+// Coarse cache-tag vocabulary (PRD #1080). Archive-class pages carry the type
+// tag `t:<type>`; entry permalinks carry the entry tag `e:<id>`. Publishing an
+// entry purges both, busting its permalink and every archive of that type.
+export function typeTag(entryType: string): string {
+  return `t:${entryType}`;
+}
+
+export function entryTag(entryId: number): string {
+  return `e:${String(entryId)}`;
+}
+
+interface PageTagSources {
+  readonly intent: RouteIntent;
+  readonly resolvedEntity: ResolvedEntity | null;
+  /** Entry types the front page lists (public, non-hierarchical). */
+  readonly frontPageEntryTypes: () => readonly string[];
+  /** Entry types attached to the named taxonomy. */
+  readonly taxonomyEntryTypes: (taxonomy: string) => readonly string[];
+}
+
+/**
+ * The cache tags a rendered public page is stored under. Every page that lists
+ * or embeds type-`X` content — its archives, the front page, term archives,
+ * and an entry permalink (which can render sibling content like related posts)
+ * — carries `t:X`, so any publish of that type busts it. A permalink also
+ * carries its own `e:<id>` so an edit to just that entry busts it precisely.
+ */
+export function pageTags(sources: PageTagSources): string[] {
+  const { intent, resolvedEntity } = sources;
+  switch (intent.kind) {
+    case "single":
+      return resolvedEntity?.kind === "entry"
+        ? [typeTag(intent.entryType), entryTag(resolvedEntity.id)]
+        : [];
+    case "archive":
+      return [typeTag(intent.entryType)];
+    case "front-page":
+      return sources.frontPageEntryTypes().map(typeTag);
+    case "taxonomy":
+      return sources.taxonomyEntryTypes(intent.taxonomy).map(typeTag);
+    case "search":
+      return [];
+  }
+}
+
+/** Tags to purge when an entry of `entryType` (id `entryId`) changes. */
+export function entryPurgeTags(entryType: string, entryId: number): string[] {
+  return [typeTag(entryType), entryTag(entryId)];
+}

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -37,6 +37,7 @@ import { defaultAuthenticator } from "../auth/authenticator.js";
 import { resolvePasskeyConfig } from "../auth/passkey/config.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 import { DEFAULT_SESSION_POLICY } from "../auth/sessions.js";
+import { registerCorePurgeInvalidator } from "../cache/purge.js";
 import * as coreSchema from "../db/schema/index.js";
 import { mergeDocumentManifest } from "../document-merge.js";
 import { HookRegistry } from "../hooks/registry.js";
@@ -218,6 +219,9 @@ export async function buildApp(
   registerCoreAdminBarContributors(hooks);
   registerCoreSearchHandlers(hooks);
   registerCoreSitemapInvalidator(hooks);
+  // Only subscribe the edge-cache purge invalidator when a cache is configured;
+  // without one every entry mutation would accumulate tags no flush consumes.
+  if (config.cache !== undefined) registerCorePurgeInvalidator(hooks);
   const seededRegistry = createPluginRegistry();
   registerCoreLookupAdapters(seededRegistry);
   registerCoreTemplateDeps(seededRegistry);

--- a/packages/core/src/runtime/dispatcher.test.ts
+++ b/packages/core/src/runtime/dispatcher.test.ts
@@ -1065,12 +1065,16 @@ describe("dispatcher — imageDelivery slot wiring", () => {
 });
 
 describe("dispatcher — public read-through edge cache", () => {
-  test("a cacheable public GET is served from the edge cache on a hit", async () => {
-    const match = vi.fn(() =>
-      Promise.resolve(new Response("CACHED", { status: 200 })),
-    );
+  function cacheStub(hit?: Response) {
+    const match = vi.fn(() => Promise.resolve(hit));
     const put = vi.fn(() => Promise.resolve());
-    const h = await createDispatcherHarness({ cache: { match, put } });
+    const purgeTags = vi.fn(() => Promise.resolve());
+    return { cache: { match, put, purgeTags }, match, put };
+  }
+
+  test("a cacheable public GET is served from the edge cache on a hit", async () => {
+    const { cache, match } = cacheStub(new Response("CACHED", { status: 200 }));
+    const h = await createDispatcherHarness({ cache });
 
     const response = await h.dispatch(new Request("https://cms.example/"));
 
@@ -1078,12 +1082,18 @@ describe("dispatcher — public read-through edge cache", () => {
     expect(match).toHaveBeenCalledOnce();
   });
 
+  test("a cacheable public GET stores the rendered response on a miss", async () => {
+    const { cache, put } = cacheStub();
+    const h = await createDispatcherHarness({ cache });
+
+    await h.dispatch(new Request("https://cms.example/"));
+
+    expect(put).toHaveBeenCalledOnce();
+  });
+
   test("a request carrying the session cookie bypasses the cache", async () => {
-    const match = vi.fn(() =>
-      Promise.resolve(new Response("CACHED", { status: 200 })),
-    );
-    const put = vi.fn(() => Promise.resolve());
-    const h = await createDispatcherHarness({ cache: { match, put } });
+    const { cache, match } = cacheStub(new Response("CACHED", { status: 200 }));
+    const h = await createDispatcherHarness({ cache });
 
     const response = await h.dispatch(
       new Request("https://cms.example/", {
@@ -1096,11 +1106,8 @@ describe("dispatcher — public read-through edge cache", () => {
   });
 
   test("a request carrying a ?preview= draft grant bypasses the cache", async () => {
-    const match = vi.fn(() =>
-      Promise.resolve(new Response("CACHED", { status: 200 })),
-    );
-    const put = vi.fn(() => Promise.resolve());
-    const h = await createDispatcherHarness({ cache: { match, put } });
+    const { cache, match } = cacheStub(new Response("CACHED", { status: 200 }));
+    const h = await createDispatcherHarness({ cache });
 
     const response = await h.dispatch(
       new Request("https://cms.example/?preview=some-token"),

--- a/packages/core/src/runtime/dispatcher.ts
+++ b/packages/core/src/runtime/dispatcher.ts
@@ -9,7 +9,9 @@ import { readSessionCookie } from "../auth/cookies.js";
 import { hasCsrfHeader, hasMatchingOrigin } from "../auth/csrf.js";
 import { parseOAuthPath } from "../auth/oauth/match.js";
 import { stripBasePath, withBasePath } from "../base-path.js";
+import { flushPurgeTags } from "../cache/purge.js";
 import { readThrough } from "../cache/read-through.js";
+import { pageTags } from "../cache/tags.js";
 import { interfaceEnabled } from "../config.js";
 import { withUser } from "../context/app.js";
 import { resolveLocale } from "../i18n/resolve-locale.js";
@@ -113,7 +115,11 @@ export type PlumixDispatcher = (ctx: AppContext) => Promise<Response>;
 export function createPlumixDispatcher(app: PlumixApp): PlumixDispatcher {
   return async (ctx) => {
     try {
-      return await route(app, ctx);
+      const response = await route(app, ctx);
+      // Request-end seam: fire one batched edge-cache purge for whatever
+      // entry mutations this request accumulated.
+      flushPurgeTags(ctx);
+      return response;
     } catch (error) {
       ctx.logger.error("dispatch_failed", {
         error,
@@ -333,15 +339,22 @@ async function route(app: PlumixApp, ctx: AppContext): Promise<Response> {
   return dispatchPublicRoute(app, ctx, url);
 }
 
-// The cache-decision intent kind for a resolved route match: an unmatched root
-// is the front page, any other unmatched URL is a 404 (never cached).
-function intentKindForMatch(
-  match: RouteMatch | null,
-  url: URL,
-): RouteIntent["kind"] | null {
-  if (match !== null) return match.intent.kind;
-  if (url.pathname === "/") return "front-page";
+// The public route intent for a resolved match: an unmatched root is the front
+// page, any other unmatched URL is a 404 (never cached).
+function publicIntent(match: RouteMatch | null, url: URL): RouteIntent | null {
+  if (match !== null) return match.intent;
+  if (url.pathname === "/") return { kind: "front-page" };
   return null;
+}
+
+// Public, non-hierarchical entry types — the set the front page lists, and so
+// the set of `t:<type>` tags the front page is stored under.
+function frontPageEntryTypes(ctx: AppContext): string[] {
+  return Array.from(ctx.plugins.entryTypes.entries())
+    .filter(
+      ([, spec]) => spec.isPublic !== false && spec.isHierarchical !== true,
+    )
+    .map(([key]) => key);
 }
 
 async function dispatchPublicRoute(
@@ -354,12 +367,25 @@ async function dispatchPublicRoute(
   const match = matchRoute(url, app.routeMap);
   const cache = ctx.cache;
   if (cache === undefined) return renderPublicRoute(app, ctx, url, match);
+  const intent = publicIntent(match, url);
   return readThrough({
     request: ctx.request,
-    intentKind: intentKindForMatch(match, url),
+    intentKind: intent?.kind ?? null,
     cache,
     defer: ctx.defer,
     render: () => renderPublicRoute(app, ctx, url, match),
+    // Evaluated post-render so `ctx.resolvedEntity` (the entry id) is set.
+    // The source thunks run only for the intent kind that needs them.
+    tags: () =>
+      intent === null
+        ? []
+        : pageTags({
+            intent,
+            resolvedEntity: ctx.resolvedEntity,
+            frontPageEntryTypes: () => frontPageEntryTypes(ctx),
+            taxonomyEntryTypes: (taxonomy) =>
+              ctx.plugins.termTaxonomies.get(taxonomy)?.entryTypes ?? [],
+          }),
   });
 }
 

--- a/packages/core/src/runtime/slots.ts
+++ b/packages/core/src/runtime/slots.ts
@@ -175,12 +175,19 @@ export interface KV {
 
 /**
  * An edge cache bound for the current isolate. Backs the public read-through
- * cache: `match` reads a stored response, `put` writes a fresh one. The
- * canonical implementation (Cloudflare's `edge()`) is the Workers Cache API.
+ * cache: `match` reads a stored response, `put` writes a fresh one tagged with
+ * `tags`, and `purgeTags` invalidates every stored response carrying any of the
+ * given tags. The canonical implementation (Cloudflare's `edge()`) is the
+ * Workers Cache API plus the zone purge-by-tag REST API.
  */
 export interface ConnectedCache {
   match(request: Request): Promise<Response | undefined>;
-  put(request: Request, response: Response): Promise<void>;
+  put(
+    request: Request,
+    response: Response,
+    tags: readonly string[],
+  ): Promise<void>;
+  purgeTags(tags: readonly string[]): Promise<void>;
 }
 
 /**

--- a/packages/runtimes/cloudflare/src/edge.test.ts
+++ b/packages/runtimes/cloudflare/src/edge.test.ts
@@ -56,6 +56,7 @@ describe("connected cache put", () => {
     await connect().put(
       new Request("https://site.test/post"),
       new Response("body", { status: 200 }),
+      [],
     );
 
     expect(store.put).toHaveBeenCalledOnce();
@@ -64,11 +65,31 @@ describe("connected cache put", () => {
     );
   });
 
+  it("emits a comma-joined Cache-Tag header from the page tags", async () => {
+    await connect().put(
+      new Request("https://site.test/post"),
+      new Response("body", { status: 200 }),
+      ["t:post", "e:7"],
+    );
+
+    expect(storedResponse().headers.get("cache-tag")).toBe("t:post,e:7");
+  });
+
+  it("omits the Cache-Tag header when there are no tags", async () => {
+    await connect().put(
+      new Request("https://site.test/post"),
+      new Response("body", { status: 200 }),
+      [],
+    );
+
+    expect(storedResponse().headers.get("cache-tag")).toBeNull();
+  });
+
   it("strips Set-Cookie from the stored response", async () => {
     const response = new Response("body", { status: 200 });
     response.headers.set("set-cookie", "plumix_session=secret");
 
-    await connect().put(new Request("https://site.test/post"), response);
+    await connect().put(new Request("https://site.test/post"), response, []);
 
     expect(storedResponse().headers.get("set-cookie")).toBeNull();
   });
@@ -77,6 +98,7 @@ describe("connected cache put", () => {
     await connect().put(
       new Request("https://site.test/post", { method: "HEAD" }),
       new Response("body", { status: 200 }),
+      [],
     );
 
     expect(store.put).not.toHaveBeenCalled();
@@ -86,10 +108,55 @@ describe("connected cache put", () => {
     await connect({ ttl: 30 }).put(
       new Request("https://site.test/post"),
       new Response("body", { status: 200 }),
+      [],
     );
 
     expect(storedResponse().headers.get("cache-control")).toBe(
       "public, s-maxage=30",
+    );
+  });
+});
+
+describe("connected cache purgeTags", () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() =>
+      Promise.resolve(new Response(null, { status: 200 })),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("POSTs the tags to the zone purge_cache endpoint with the bearer token", async () => {
+    await connect().purgeTags(["t:post", "e:7"]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.cloudflare.com/client/v4/zones/zone-1/purge_cache",
+    );
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer token-1");
+    expect(JSON.parse(init.body as string)).toEqual({
+      tags: ["t:post", "e:7"],
+    });
+  });
+
+  it("does not call the API for an empty tag list", async () => {
+    await connect().purgeTags([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when the purge API responds non-ok", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 403 }));
+    await expect(connect().purgeTags(["t:post"])).rejects.toThrow(
+      /purge_cache responded 403/,
     );
   });
 });

--- a/packages/runtimes/cloudflare/src/edge.ts
+++ b/packages/runtimes/cloudflare/src/edge.ts
@@ -1,5 +1,7 @@
 import type { CacheProvider, ConnectedCache } from "plumix";
 
+import { EdgeCacheError } from "./errors.js";
+
 /**
  * Edge-cache policy for {@link edge}. `ttl` is the edge freshness window in
  * seconds (`s-maxage`); `staleWhileRevalidate` lets a colo serve a stale copy
@@ -45,13 +47,18 @@ function cacheControl(config: EdgeConfig): string {
   return directives.join(", ");
 }
 
-// Clone with the edge cache-control applied and any Set-Cookie stripped — a
-// shared cache entry must never carry a per-request cookie, and the Workers
-// Cache API rejects responses that do.
-function forStorage(response: Response, config: EdgeConfig): Response {
+// Clone with the edge cache-control + cache tags applied and any Set-Cookie
+// stripped — a shared cache entry must never carry a per-request cookie, and
+// the Workers Cache API rejects responses that do.
+function forStorage(
+  response: Response,
+  config: EdgeConfig,
+  tags: readonly string[],
+): Response {
   const headers = new Headers(response.headers);
   headers.delete("set-cookie");
   headers.set("cache-control", cacheControl(config));
+  if (tags.length > 0) headers.set("cache-tag", tags.join(","));
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -59,21 +66,56 @@ function forStorage(response: Response, config: EdgeConfig): Response {
   });
 }
 
-function connectedCache(store: EdgeStore, config: EdgeConfig): ConnectedCache {
+interface Credentials {
+  readonly zoneId: string;
+  readonly purgeToken: string;
+}
+
+// Purge by cache-tag is available on all Cloudflare plans (since 2025-04-01),
+// not just Enterprise. Failures bubble to the caller, which defers the call so
+// a rejection is logged rather than failing the publish.
+async function purgeByTag(
+  creds: Credentials,
+  tags: readonly string[],
+): Promise<void> {
+  if (tags.length === 0) return;
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${creds.zoneId}/purge_cache`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${creds.purgeToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ tags }),
+    },
+  );
+  if (!response.ok) {
+    throw EdgeCacheError.purgeFailed({ status: response.status });
+  }
+}
+
+function connectedCache(
+  store: EdgeStore,
+  config: EdgeConfig,
+  creds: Credentials,
+): ConnectedCache {
   return {
     match: (request) => store.match(request),
-    put: async (request, response) => {
+    put: async (request, response, tags) => {
       // The Workers Cache API persists GET responses only.
       if (request.method !== "GET") return;
-      await store.put(request, forStorage(response, config));
+      await store.put(request, forStorage(response, config, tags));
     },
+    purgeTags: (tags) => purgeByTag(creds, tags),
   };
 }
 
 /**
  * Cloudflare edge-cache provider backed by the Workers Cache API
- * (`caches.default`). Disables itself (returns `null` from `connect`) when the
- * deploy lacks the zone credentials needed to purge — pages then render live.
+ * (`caches.default`) plus the zone purge-by-tag REST API. Disables itself
+ * (returns `null` from `connect`) when the deploy lacks the zone credentials
+ * needed to purge — pages then render live.
  */
 export function edge(config: EdgeConfig): CacheProvider {
   return {
@@ -84,7 +126,7 @@ export function edge(config: EdgeConfig): CacheProvider {
       if (zoneId === null || purgeToken === null) return null;
       const store = defaultStore();
       if (store === null) return null;
-      return connectedCache(store, config);
+      return connectedCache(store, config, { zoneId, purgeToken });
     },
   };
 }

--- a/packages/runtimes/cloudflare/src/errors.ts
+++ b/packages/runtimes/cloudflare/src/errors.ts
@@ -168,6 +168,29 @@ export class PlumixRuntimeConfigError extends Error {
   }
 }
 
+export class EdgeCacheError extends Error {
+  static {
+    EdgeCacheError.prototype.name = "EdgeCacheError";
+  }
+
+  readonly code: "purge_failed";
+  readonly status: number;
+
+  private constructor(code: "purge_failed", message: string, status: number) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+
+  static purgeFailed(ctx: { status: number }): EdgeCacheError {
+    return new EdgeCacheError(
+      "purge_failed",
+      `edge(): cloudflare purge_cache responded ${String(ctx.status)}`,
+      ctx.status,
+    );
+  }
+}
+
 export class WranglerConfigError extends Error {
   static {
     WranglerConfigError.prototype.name = "WranglerConfigError";


### PR DESCRIPTION
Tags cached public pages and busts them the instant an entry changes — slice 2 of 3 for the edge-caching PRD (#1080), building on the read-through cache from #1081. Slice 3 (#1083) adds taxonomy-term purge.

**Coarse tag vocabulary.** Every page that lists or embeds type-`X` content carries `t:<type>`: type archives, the front page, term archives, *and* entry permalinks (which can render sibling content like related posts). A permalink also carries its own `e:<id>` so a single-entry edit busts it precisely. Stored responses emit a `Cache-Tag` header.

**Purge on every visibility-changing mutation.** `entry:published` / `updated` / `meta_changed` / `trashed` / `restored` / `deleted` each purge `["t:<type>", "e:<id>"]` — so a trashed or deleted post stops being served at the edge instead of lingering until TTL.

**Batched, non-blocking, fail-safe.** Entry hooks accumulate tags in a per-request `WeakMap<AppContext, Set>`; the dispatcher fires one de-duplicated purge after the request through `waitUntil`. A bulk publish of N entries costs a single `purge_cache` call, and a failed purge logs without failing the mutation (TTL/SWR is the backstop). The subscriber registers at boot only when a `cache` slot is configured.

**Cloudflare transport.** `edge().purgeTags()` POSTs to the zone `purge_cache` REST API with the bearer token from env; a non-ok response raises `EdgeCacheError`. Core owns the tag vocabulary and purge triggers; the provider owns the transport.

Reviewed by senpai + simplifier before commit — fixes applied: entry permalinks now carry `t:<type>` (else sibling-content like related-posts would stale after any publish), trash/restore/delete added to the purge set (else removed content stayed edge-served), and the tag-source resolution was made lazy so the front-page type scan only runs for the front page.

Closes #1082