### PR TITLE
feat(core): purge cached archives on taxonomy term changes

### DIFF
--- a/packages/core/src/cache/purge.test.ts
+++ b/packages/core/src/cache/purge.test.ts
@@ -18,6 +18,9 @@ function fakeCtx(withCache = true) {
     cache: withCache ? { match: vi.fn(), put: vi.fn(), purgeTags } : undefined,
     defer,
     logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    plugins: {
+      termTaxonomies: new Map([["category", { entryTypes: ["post"] }]]),
+    },
   } as unknown as AppContext;
   return { ctx, purgeTags, defer };
 }
@@ -76,6 +79,33 @@ describe("registerCorePurgeInvalidator", () => {
 
     expect(purgeTags).toHaveBeenCalledWith(["t:post", "e:9"]);
   });
+
+  const TERM_EVENTS = [
+    "term:created",
+    "term:updated",
+    "term:meta_changed",
+    "term:deleted",
+  ] as const;
+
+  it.each(TERM_EVENTS)(
+    "%s enqueues purge tags for the taxonomy's entry types",
+    async (event) => {
+      const hooks = new HookRegistry();
+      registerCorePurgeInvalidator(hooks);
+      const { ctx, purgeTags } = fakeCtx();
+
+      await requestStore.run(ctx, () =>
+        hooks.doAction(
+          event as never,
+          { id: 3, taxonomy: "category" } as never,
+          { id: 3, taxonomy: "category" } as never,
+        ),
+      );
+      flushPurgeTags(ctx);
+
+      expect(purgeTags).toHaveBeenCalledWith(["t:post"]);
+    },
+  );
 
   it("batches a bulk publish into one purge call", async () => {
     const hooks = new HookRegistry();

--- a/packages/core/src/cache/purge.ts
+++ b/packages/core/src/cache/purge.ts
@@ -1,7 +1,7 @@
 import type { AppContext } from "../context/app.js";
 import type { HookRegistry } from "../hooks/registry.js";
 import { tryGetContext } from "../context/stores.js";
-import { entryPurgeTags } from "./tags.js";
+import { entryPurgeTags, termPurgeTags } from "./tags.js";
 
 // Per-request purge accumulator. Entry hooks fire one at a time during a
 // request (a bulk publish fires N), each adding tags here; the dispatcher
@@ -49,10 +49,21 @@ const ENTRY_ACTIONS = [
   "entry:deleted",
 ] as const;
 
+// Term lifecycle actions whose payload's leading arg carries `{ taxonomy }`.
+// A term archive is stored under the `t:<type>` tags of its taxonomy's entry
+// types, so creating, renaming, meta-changing, or deleting a term busts those.
+const TERM_ACTIONS = [
+  "term:created",
+  "term:updated",
+  "term:meta_changed",
+  "term:deleted",
+] as const;
+
 /**
  * Register core's edge-cache purge subscribers. Called at app boot when a
- * cache slot is configured; each entry mutation enqueues `t:<type>` + `e:<id>`
- * for the post-request flush.
+ * cache slot is configured; each entry mutation enqueues `t:<type>` + `e:<id>`,
+ * each term mutation enqueues `t:<type>` for the taxonomy's entry types, for
+ * the post-request flush.
  */
 export function registerCorePurgeInvalidator(hooks: HookRegistry): void {
   const onEntry = (entry: { readonly id: number; readonly type: string }) => {
@@ -62,5 +73,16 @@ export function registerCorePurgeInvalidator(hooks: HookRegistry): void {
   };
   for (const action of ENTRY_ACTIONS) {
     hooks.addAction(action as never, onEntry);
+  }
+
+  const onTerm = (term: { readonly taxonomy: string }) => {
+    const ctx = tryGetContext();
+    if (ctx === null) return;
+    const entryTypes =
+      ctx.plugins.termTaxonomies.get(term.taxonomy)?.entryTypes ?? [];
+    enqueuePurgeTags(ctx, termPurgeTags(entryTypes));
+  };
+  for (const action of TERM_ACTIONS) {
+    hooks.addAction(action as never, onTerm as never);
   }
 }

--- a/packages/core/src/cache/tags.test.ts
+++ b/packages/core/src/cache/tags.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from "vitest";
 
-import { entryPurgeTags, pageTags } from "./tags.js";
+import { entryPurgeTags, pageTags, termPurgeTags } from "./tags.js";
 
 describe("entryPurgeTags", () => {
   it("purges the type tag and the entry tag", () => {
     expect(entryPurgeTags("post", 42)).toEqual(["t:post", "e:42"]);
+  });
+});
+
+describe("termPurgeTags", () => {
+  it("purges a type tag for each of the taxonomy's entry types", () => {
+    expect(termPurgeTags(["post", "note"])).toEqual(["t:post", "t:note"]);
+  });
+
+  it("purges nothing for a taxonomy with no entry types", () => {
+    expect(termPurgeTags([])).toEqual([]);
   });
 });
 

--- a/packages/core/src/cache/tags.ts
+++ b/packages/core/src/cache/tags.ts
@@ -50,3 +50,12 @@ export function pageTags(sources: PageTagSources): string[] {
 export function entryPurgeTags(entryType: string, entryId: number): string[] {
   return [typeTag(entryType), entryTag(entryId)];
 }
+
+/**
+ * Tags to purge when a term changes. A term archive carries the `t:<type>`
+ * tags of the entry types its taxonomy lists, so purging those busts the
+ * archive and the listings that show the term's name.
+ */
+export function termPurgeTags(taxonomyEntryTypes: readonly string[]): string[] {
+  return taxonomyEntryTypes.map(typeTag);
+}


### PR DESCRIPTION
Extends the edge-cache purge subscriber to taxonomy-term mutations — the final slice (3 of 3) of the edge-caching PRD (#1080), after read-through (#1081) and entry purge (#1082).

Creating, renaming, meta-changing, or deleting a term in taxonomy `T` purges `t:<type>` for every entry type `T` lists. Because a term archive is *stored* under those same `t:<type>` tags (via the identical `termTaxonomies.get(name).entryTypes` resolution on the read path), and post permalinks showing the term name also carry `t:post`, a term change busts the term archive and every listing/permalink that references it — instead of waiting out the TTL.

Term purges reuse the entry hooks' machinery wholesale: the per-request `WeakMap` accumulator, the one batched `waitUntil` flush at request end, and the non-throwing path (a failed purge logs, never fails the mutation). `term:deleted` is included alongside created/updated/meta_changed for parity with the sitemap invalidator — a deleted term's archive must stop being served, not linger.

Reviewed by senpai + simplifier: no findings, no changes. 2257 core tests green; lint/format/knip clean.

Closes #1083